### PR TITLE
[lldb] Add symbol/table count into statistics

### DIFF
--- a/lldb/include/lldb/Target/Statistics.h
+++ b/lldb/include/lldb/Target/Statistics.h
@@ -120,6 +120,7 @@ struct ModuleStats {
   llvm::StringMap<llvm::json::Value> type_system_stats;
   double symtab_parse_time = 0.0;
   double symtab_index_time = 0.0;
+  uint32_t num_symbols_loaded = 0;
   double debug_parse_time = 0.0;
   double debug_index_time = 0.0;
   uint64_t debug_info_size = 0;

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -323,7 +323,7 @@ llvm::json::Value DebuggerStats::ReportStatistics(
     if (symtab) {
       module_stat.num_symbols_loaded = symtab->GetNumSymbols();
       num_symbols_loaded += module_stat.num_symbols_loaded;
-      symtabs_loaded++;
+      ++symtabs_loaded;
       module_stat.symtab_loaded_from_cache = symtab->GetWasLoadedFromCache();
       if (module_stat.symtab_loaded_from_cache)
         ++symtabs_loaded_from_cache;

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -71,6 +71,7 @@ json::Value ModuleStats::ToJSON() const {
   module.try_emplace("debugInfoHadIncompleteTypes",
                      debug_info_had_incomplete_types);
   module.try_emplace("symbolTableStripped", symtab_stripped);
+  module.try_emplace("symbolsLoaded", num_symbols_loaded);
   if (!symfile_path.empty())
     module.try_emplace("symbolFilePath", symfile_path);
 
@@ -293,7 +294,8 @@ llvm::json::Value DebuggerStats::ReportStatistics(
   double debug_parse_time = 0.0;
   double debug_index_time = 0.0;
   uint32_t symtabs_loaded = 0;
-  uint32_t symtabs_saved = 0;
+  uint32_t symtabs_loaded_from_cache = 0;
+  uint32_t symtabs_saved_to_cache = 0;
   uint32_t debug_index_loaded = 0;
   uint32_t debug_index_saved = 0;
   uint64_t debug_info_size = 0;
@@ -309,6 +311,7 @@ llvm::json::Value DebuggerStats::ReportStatistics(
   uint32_t num_modules_with_variable_errors = 0;
   uint32_t num_modules_with_incomplete_types = 0;
   uint32_t num_stripped_modules = 0;
+  uint32_t num_symbols_loaded = 0;
   for (size_t image_idx = 0; image_idx < num_modules; ++image_idx) {
     Module *module = target != nullptr
                          ? target->GetImages().GetModuleAtIndex(image_idx).get()
@@ -318,12 +321,15 @@ llvm::json::Value DebuggerStats::ReportStatistics(
     module_stat.symtab_index_time = module->GetSymtabIndexTime().get().count();
     Symtab *symtab = module->GetSymtab(/*can_create=*/false);
     if (symtab) {
+      module_stat.num_symbols_loaded = symtab->GetNumSymbols();
+      num_symbols_loaded += module_stat.num_symbols_loaded;
+      symtabs_loaded++;
       module_stat.symtab_loaded_from_cache = symtab->GetWasLoadedFromCache();
       if (module_stat.symtab_loaded_from_cache)
-        ++symtabs_loaded;
+        ++symtabs_loaded_from_cache;
       module_stat.symtab_saved_to_cache = symtab->GetWasSavedToCache();
       if (module_stat.symtab_saved_to_cache)
-        ++symtabs_saved;
+        ++symtabs_saved_to_cache;
     }
     SymbolFile *sym_file = module->GetSymbolFile(/*can_create=*/false);
     if (sym_file) {
@@ -393,8 +399,9 @@ llvm::json::Value DebuggerStats::ReportStatistics(
   json::Object global_stats{
       {"totalSymbolTableParseTime", symtab_parse_time},
       {"totalSymbolTableIndexTime", symtab_index_time},
-      {"totalSymbolTablesLoadedFromCache", symtabs_loaded},
-      {"totalSymbolTablesSavedToCache", symtabs_saved},
+      {"totalSymbolTablesLoaded", symtabs_loaded},
+      {"totalSymbolTablesLoadedFromCache", symtabs_loaded_from_cache},
+      {"totalSymbolTablesSavedToCache", symtabs_saved_to_cache},
       {"totalDebugInfoParseTime", debug_parse_time},
       {"totalDebugInfoIndexTime", debug_index_time},
       {"totalDebugInfoIndexLoadedFromCache", debug_index_loaded},
@@ -407,6 +414,7 @@ llvm::json::Value DebuggerStats::ReportStatistics(
        num_modules_with_incomplete_types},
       {"totalDebugInfoEnabled", num_debug_info_enabled_modules},
       {"totalSymbolTableStripped", num_stripped_modules},
+      {"totalSymbolsLoaded", num_symbols_loaded},
   };
 
   if (include_targets) {

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -171,6 +171,7 @@ class TestCase(TestBase):
             "totalSymbolTablesLoadedFromCache",
             "totalSymbolTablesSavedToCache",
             "totalSymbolsLoaded",
+            "totalSymbolTablesLoaded",
             "totalDebugInfoByteSize",
             "totalDebugInfoIndexTime",
             "totalDebugInfoIndexLoadedFromCache",
@@ -178,6 +179,8 @@ class TestCase(TestBase):
             "totalDebugInfoParseTime",
         ]
         self.verify_keys(debug_stats, '"debug_stats"', debug_stat_keys, None)
+        self.assertGreater(debug_stats["totalSymbolsLoaded"], 0)
+        self.assertGreater(debug_stats["totalSymbolTablesLoaded"], 0)
 
         # Verify target stats keys.
         target_stats = debug_stats["targets"][0]
@@ -188,7 +191,12 @@ class TestCase(TestBase):
             "targetCreateTime",
         ]
         target_stat_keys_missing = ["firstStopTime", "launchOrAttachTime"]
-        self.verify_keys(target_stats, '"target_stats"', target_stat_keys_exist, target_stat_keys_missing)
+        self.verify_keys(
+            target_stats,
+            '"target_stats"',
+            target_stat_keys_exist,
+            target_stat_keys_missing,
+        )
         self.assertGreater(target_stats["targetCreateTime"], 0.0)
 
         # Verify module stats keys.
@@ -196,8 +204,10 @@ class TestCase(TestBase):
             module_stat_keys_exist = [
                 "symbolsLoaded",
             ]
-            self.verify_keys(module_stats, '"module_stats"', module_stat_keys_exist, None)
-
+            self.verify_keys(
+                module_stats, '"module_stats"', module_stat_keys_exist, None
+            )
+            self.assertGreater(module_stats["symbolsLoaded"], 0)
 
     def test_default_with_run(self):
         """Test "statistics dump" when running the target to a breakpoint.

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -159,6 +159,8 @@ class TestCase(TestBase):
         """
         self.build()
         target = self.createTestTarget()
+
+        # Verify top-level keys.
         debug_stats = self.get_stats()
         debug_stat_keys = [
             "memory",
@@ -168,6 +170,7 @@ class TestCase(TestBase):
             "totalSymbolTableIndexTime",
             "totalSymbolTablesLoadedFromCache",
             "totalSymbolTablesSavedToCache",
+            "totalSymbolsLoaded",
             "totalDebugInfoByteSize",
             "totalDebugInfoIndexTime",
             "totalDebugInfoIndexLoadedFromCache",
@@ -175,16 +178,26 @@ class TestCase(TestBase):
             "totalDebugInfoParseTime",
         ]
         self.verify_keys(debug_stats, '"debug_stats"', debug_stat_keys, None)
-        stats = debug_stats["targets"][0]
-        keys_exist = [
+
+        # Verify target stats keys.
+        target_stats = debug_stats["targets"][0]
+        target_stat_keys_exist = [
             "expressionEvaluation",
             "frameVariable",
             "moduleIdentifiers",
             "targetCreateTime",
         ]
-        keys_missing = ["firstStopTime", "launchOrAttachTime"]
-        self.verify_keys(stats, '"stats"', keys_exist, keys_missing)
-        self.assertGreater(stats["targetCreateTime"], 0.0)
+        target_stat_keys_missing = ["firstStopTime", "launchOrAttachTime"]
+        self.verify_keys(target_stats, '"target_stats"', target_stat_keys_exist, target_stat_keys_missing)
+        self.assertGreater(target_stats["targetCreateTime"], 0.0)
+
+        # Verify module stats keys.
+        for module_stats in debug_stats["modules"]:
+            module_stat_keys_exist = [
+                "symbolsLoaded",
+            ]
+            self.verify_keys(module_stats, '"module_stats"', module_stat_keys_exist, None)
+
 
     def test_default_with_run(self):
         """Test "statistics dump" when running the target to a breakpoint.


### PR DESCRIPTION
# New stats

The following stats are added and are available in both "statistics dump" command and in python API.

1. In summary:
    1. Add `totalSymbolsLoaded`. The total number of symbols loaded in all modules.
    2. Add `totalSymbolTablesLoaded `. The total number symbol tables loaded in all modules.
2. In each module's stats:
    1. Add `symbolsLoaded`. The number of symbols loaded in the current module.


# Example

Example `statistics dump` output:
```
(lldb) statistics dump
{
  ...,
  "modules": [
    {
      "path": "/Users/<username>/demo/simple/a.out",
      "symbolsLoaded": 6,
      ...
    },
    ...
  ],
  ...
  "totalSymbolTablesLoaded": 42,
  "totalSymbolsLoaded": 32198
}
```

# Tests

**Manual test**: Built and ran lldb on a helloworld program. Ran `statistics dump`. Verified the above stats.

**Unit test**: Ran the following tests:
```
$ bin/lldb-dotest -p TestStats.py ~/llvm-sand/external/llvm-project/lldb/test/API/commands/statistics/basic/
...
Ran 18 tests in 192.676s

OK (skipped=3)
```
