### PR TITLE
[Clang] Fix crash when building a module with CC_PRINT_HEADERS_FORMAT=json

### DIFF
--- a/clang/lib/Frontend/HeaderIncludeGen.cpp
+++ b/clang/lib/Frontend/HeaderIncludeGen.cpp
@@ -260,8 +260,11 @@ void HeaderIncludesCallback::FileSkipped(const FileEntryRef &SkippedFile, const
 
 void HeaderIncludesJSONCallback::EndOfMainFile() {
   OptionalFileEntryRef FE = SM.getFileEntryRefForID(SM.getMainFileID());
-  SmallString<256> MainFile(FE->getName());
-  SM.getFileManager().makeAbsolutePath(MainFile);
+  SmallString<256> MainFile;
+  if (FE) {
+    MainFile += FE->getName();
+    SM.getFileManager().makeAbsolutePath(MainFile);
+  }
 
   std::string Str;
   llvm::raw_string_ostream OS(Str);

--- a/clang/test/Preprocessor/print-header-crash.modulemap
+++ b/clang/test/Preprocessor/print-header-crash.modulemap
@@ -1,0 +1,2 @@
+// RUN: %clang_cc1 -header-include-format=json -header-include-filtering=only-direct-system -header-include-file %t.txt -emit-module -x c -fmodules -fmodule-name=X %s -o /dev/null
+module X {}


### PR DESCRIPTION
There is no main file when building a module, so the code in HeaderIncludesJSONCallback::EndOfMainFile() needs to check for that to avoid crashing.