### PR TITLE
[clangd] IncludeCleaner include not found error now contains path

### DIFF
--- a/clang-tools-extra/clangd/IncludeCleaner.cpp
+++ b/clang-tools-extra/clangd/IncludeCleaner.cpp
@@ -345,8 +345,9 @@ include_cleaner::Includes convertIncludes(const ParsedAST &AST) {
     // which is based on FileManager::getCanonicalName(ParentDir).
     auto FE = SM.getFileManager().getFileRef(Inc.Resolved);
     if (!FE) {
-      elog("IncludeCleaner: Failed to get an entry for resolved path {0}: {1}",
-           Inc.Resolved, FE.takeError());
+      elog("IncludeCleaner: Failed to get an entry for resolved path '{0}' "
+           "from include {1} : {2}",
+           Inc.Resolved, Inc.Written, FE.takeError());
       continue;
     }
     TransformedInc.Resolved = *FE;


### PR DESCRIPTION
IncludeCleaner header not found messages now show file path.

[https://github.com/clangd/clangd/issues/2334](https://github.com/clangd/clangd/issues/2334)

New error messages:
```
E[03:32:43.219] IncludeCleaner: Failed to get an entry for resolved path '' from include <doesntexist> : No such file or directory
E[03:32:43.219] IncludeCleaner: Failed to get an entry for resolved path '' from include "doesntexist.hpp" : No such file or directory
E[03:32:43.219] IncludeCleaner: Failed to get an entry for resolved path '' from include "/path/doesnt/exist" : No such file or directory
```
Old error messages:
```
E[03:34:47.752] IncludeCleaner: Failed to get an entry for resolved path : No such file or directory
```