### PR TITLE
[mlir][spirv] Switch to `llvm::interleaved`. NFC.

### DIFF
--- a/mlir/lib/Dialect/SPIRV/IR/ControlFlowOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/ControlFlowOps.cpp
@@ -15,6 +15,8 @@
 #include "mlir/Dialect/SPIRV/IR/SPIRVTypes.h"
 #include "mlir/Interfaces/CallInterfaces.h"
 
+#include "llvm/Support/InterleavedRange.h"
+
 #include "SPIRVOpUtils.h"
 #include "SPIRVParsingUtils.h"
 
@@ -119,12 +121,9 @@ ParseResult BranchConditionalOp::parse(OpAsmParser &parser,
 void BranchConditionalOp::print(OpAsmPrinter &printer) {
   printer << ' ' << getCondition();
 
-  if (auto weights = getBranchWeights()) {
-    printer << " [";
-    llvm::interleaveComma(weights->getValue(), printer, [&](Attribute a) {
-      printer << llvm::cast<IntegerAttr>(a).getInt();
-    });
-    printer << "]";
+  if (std::optional<ArrayAttr> weights = getBranchWeights()) {
+    printer << ' '
+            << llvm::interleaved_array(weights->getAsValueRange<IntegerAttr>());
   }
 
   printer << ", ";

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVAttributes.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVAttributes.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/InterleavedRange.h"
 
 using namespace mlir;
 using namespace mlir::spirv;
@@ -621,17 +622,14 @@ Attribute SPIRVDialect::parseAttribute(DialectAsmParser &parser,
 //===----------------------------------------------------------------------===//
 
 static void print(spirv::VerCapExtAttr triple, DialectAsmPrinter &printer) {
-  auto &os = printer.getStream();
   printer << spirv::VerCapExtAttr::getKindName() << "<"
-          << spirv::stringifyVersion(triple.getVersion()) << ", [";
-  llvm::interleaveComma(
-      triple.getCapabilities(), os,
-      [&](spirv::Capability cap) { os << spirv::stringifyCapability(cap); });
-  printer << "], [";
-  llvm::interleaveComma(triple.getExtensionsAttr(), os, [&](Attribute attr) {
-    os << llvm::cast<StringAttr>(attr).getValue();
-  });
-  printer << "]>";
+          << spirv::stringifyVersion(triple.getVersion()) << ", "
+          << llvm::interleaved_array(llvm::map_range(
+                 triple.getCapabilities(), spirv::stringifyCapability))
+          << ", "
+          << llvm::interleaved_array(
+                 triple.getExtensionsAttr().getAsValueRange<StringAttr>())
+          << ">";
 }
 
 static void print(spirv::TargetEnvAttr targetEnv, DialectAsmPrinter &printer) {

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
@@ -808,9 +808,8 @@ void spirv::EntryPointOp::print(OpAsmPrinter &printer) {
   printer << " \"" << stringifyExecutionModel(getExecutionModel()) << "\" ";
   printer.printSymbolName(getFn());
   auto interfaceVars = getInterface().getValue();
-  if (!interfaceVars.empty()) {
+  if (!interfaceVars.empty())
     printer << ", " << llvm::interleaved(interfaceVars);
-  }
 }
 
 LogicalResult spirv::EntryPointOp::verify() {


### PR DESCRIPTION
Clean up printing code by switching to `llvm::interleaved` from https://github.com/llvm/llvm-project/pull/135517.