### PR TITLE
[clang][uefi] add arm, aarch64, x86, loongarch64, riscv64 targets

### DIFF
--- a/clang/include/clang/Basic/TargetOSMacros.def
+++ b/clang/include/clang/Basic/TargetOSMacros.def
@@ -53,4 +53,7 @@ TARGET_OS(TARGET_OS_NANO, Triple.isWatchOS())
 TARGET_OS(TARGET_IPHONE_SIMULATOR, Triple.isSimulatorEnvironment())
 TARGET_OS(TARGET_OS_UIKITFORMAC, Triple.isMacCatalystEnvironment())
 
+// UEFI target.
+TARGET_OS(TARGET_OS_UEFI, Triple.isUEFI())
+
 #undef TARGET_OS

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -166,8 +166,7 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       }
 
     case llvm::Triple::UEFI:
-      return std::make_unique<UEFITargetInfo<AArch64leTargetInfo>>(Triple,
-                                                                   Opts);
+      return std::make_unique<UEFIAArch64TargetInfo>(Triple, Opts);
 
     case llvm::Triple::NetBSD:
       return std::make_unique<NetBSDTargetInfo<AArch64leTargetInfo>>(Triple,

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -164,6 +164,11 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
         return std::make_unique<OHOSTargetInfo<AArch64leTargetInfo>>(Triple,
                                                                      Opts);
       }
+
+    case llvm::Triple::UEFI:
+      return std::make_unique<UEFITargetInfo<AArch64leTargetInfo>>(Triple,
+                                                                   Opts);
+
     case llvm::Triple::NetBSD:
       return std::make_unique<NetBSDTargetInfo<AArch64leTargetInfo>>(Triple,
                                                                      Opts);
@@ -227,6 +232,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       return std::make_unique<HaikuTargetInfo<ARMleTargetInfo>>(Triple, Opts);
     case llvm::Triple::NaCl:
       return std::make_unique<NaClTargetInfo<ARMleTargetInfo>>(Triple, Opts);
+    case llvm::Triple::UEFI:
+      return std::make_unique<UEFITargetInfo<ARMleTargetInfo>>(Triple, Opts);
     case llvm::Triple::Win32:
       switch (Triple.getEnvironment()) {
       case llvm::Triple::Cygnus:
@@ -457,6 +464,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     case llvm::Triple::Haiku:
       return std::make_unique<HaikuTargetInfo<RISCV64TargetInfo>>(Triple,
                                                                   Opts);
+    case llvm::Triple::UEFI:
+      return std::make_unique<UEFITargetInfo<RISCV64TargetInfo>>(Triple, Opts);
     case llvm::Triple::Linux:
       switch (Triple.getEnvironment()) {
       default:
@@ -569,6 +578,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     case llvm::Triple::Solaris:
       return std::make_unique<SolarisTargetInfo<X86_32TargetInfo>>(Triple,
                                                                    Opts);
+    case llvm::Triple::UEFI:
+      return std::make_unique<UEFITargetInfo<X86_32TargetInfo>>(Triple, Opts);
     case llvm::Triple::Win32: {
       switch (Triple.getEnvironment()) {
       case llvm::Triple::Cygnus:
@@ -760,6 +771,9 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     case llvm::Triple::FreeBSD:
       return std::make_unique<FreeBSDTargetInfo<LoongArch64TargetInfo>>(Triple,
                                                                         Opts);
+    case llvm::Triple::UEFI:
+      return std::make_unique<UEFITargetInfo<LoongArch64TargetInfo>>(Triple,
+                                                                     Opts);
     default:
       return std::make_unique<LoongArch64TargetInfo>(Triple, Opts);
     }

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1824,3 +1824,32 @@ TargetInfo::BuiltinVaListKind
 DarwinAArch64TargetInfo::getBuiltinVaListKind() const {
   return TargetInfo::CharPtrBuiltinVaList;
 }
+
+UEFIAArch64TargetInfo::UEFIAArch64TargetInfo(const llvm::Triple &Triple,
+                                             const TargetOptions &Opts)
+    : UEFITargetInfo<AArch64leTargetInfo>(Triple, Opts), Triple(Triple) {
+
+  // This is an LLP64 platform.
+  // int:4, long:4, long long:8, long double:8.
+  IntWidth = IntAlign = 32;
+  LongWidth = LongAlign = 32;
+  DoubleAlign = LongLongAlign = 64;
+  LongDoubleWidth = LongDoubleAlign = 64;
+  LongDoubleFormat = &llvm::APFloat::IEEEdouble();
+  IntMaxType = SignedLongLong;
+  Int64Type = SignedLongLong;
+  SizeType = UnsignedLongLong;
+  PtrDiffType = SignedLongLong;
+  IntPtrType = SignedLongLong;
+}
+
+void UEFIAArch64TargetInfo::setDataLayout() {
+  assert(Triple.isOSBinFormatCOFF());
+  resetDataLayout("e-m:w-p270:32:32-p271:32:32-p272:64:64-p:64:64-i32:"
+                  "32-i64:64-i128:128-n32:64-S128-Fn32");
+}
+
+TargetInfo::BuiltinVaListKind
+UEFIAArch64TargetInfo::getBuiltinVaListKind() const {
+  return TargetInfo::CharPtrBuiltinVaList;
+}

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -341,6 +341,18 @@ public:
                     MacroBuilder &Builder) const override;
 };
 
+class LLVM_LIBRARY_VISIBILITY UEFIAArch64TargetInfo
+    : public UEFITargetInfo<AArch64leTargetInfo> {
+  const llvm::Triple Triple;
+
+public:
+  UEFIAArch64TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts);
+
+  void setDataLayout() override;
+
+  BuiltinVaListKind getBuiltinVaListKind() const override;
+};
+
 } // namespace targets
 } // namespace clang
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -699,10 +699,6 @@ static llvm::Triple computeTargetTriple(const Driver &D,
     }
   }
 
-  // Currently the only architecture supported by *-uefi triples are x86_64.
-  if (Target.isUEFI() && Target.getArch() != llvm::Triple::x86_64)
-    D.Diag(diag::err_target_unknown_triple) << Target.str();
-
   // The `-maix[32|64]` flags are only valid for AIX targets.
   if (Arg *A = Args.getLastArgNoClaim(options::OPT_maix32, options::OPT_maix64);
       A && !Target.isOSAIX())

--- a/clang/test/Driver/unsupported-target-arch.c
+++ b/clang/test/Driver/unsupported-target-arch.c
@@ -63,21 +63,3 @@
 // RUN: not %clang --target=powerpc-apple-darwin -o /dev/null %s 2> %t.err
 // RUN: FileCheck --input-file=%t.err --check-prefix=CHECK-PPCMAC %s
 // CHECK-PPCMAC: error: unknown target triple 'unknown-apple-macosx{{.*}}'
-
-// RUN: not %clang --target=aarch64-unknown-uefi -o %t.o %s 2> %t.err
-// RUN: FileCheck --input-file=%t.err --check-prefix=CHECK-AARCH64 %s
-// RUN: not %clang_cl --target=aarch64-unknown-uefi -o %t.o %s 2> %t.err
-// RUN: FileCheck --input-file=%t.err --check-prefix=CHECK-AARCH64 %s
-// CHECK-AARCH64: error: unknown target triple 'aarch64-unknown-uefi'{{$}}
-
-// RUN: not %clang --target=arm-unknown-uefi -o %t.o %s 2> %t.err
-// RUN: FileCheck --input-file=%t.err -check-prefixes=CHECK-ARM %s
-// RUN: not %clang_cl --target=arm-unknown-uefi -o %t.o %s 2> %t.err
-// RUN: FileCheck --input-file=%t.err -check-prefixes=CHECK-ARM %s
-// CHECK-ARM: error: unknown target triple 'arm-unknown-uefi'{{$}}
-
-// RUN: not %clang --target=x86-unknown-uefi -o %t.o %s 2> %t.err
-// RUN: FileCheck --input-file=%t.err -check-prefixes=CHECK-x86 %s
-// RUN: not %clang_cl --target=x86-unknown-uefi -o %t.o %s 2> %t.err
-// RUN: FileCheck --input-file=%t.err -check-prefixes=CHECK-x86 %s
-// CHECK-x86: error: unknown target triple 'x86-unknown-uefi'{{$}}

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -2835,6 +2835,11 @@
 // RISCV64-LINUX: #define unix 1
 
 // RUN: %clang_cc1 -dM -triple=x86_64-uefi -E /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
+// RUN: %clang_cc1 -dM -triple=armv7l-unknown-uefi -E < /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
+// RUN: %clang_cc1 -dM -triple=aarch64-unknown-uefi -E < /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
+// RUN: %clang_cc1 -dM -triple=loongarch64-unknown-uefi -E < /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
+// RUN: %clang_cc1 -dM -triple=riscv64-unknown-uefi -E < /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
+// RUN: %clang_cc1 -dM -triple=x86_64-unknown-uefi -E /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
 
 // UEFI: #define __UEFI__ 1
 

--- a/llvm/lib/Target/AArch64/AArch64MCInstLower.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MCInstLower.cpp
@@ -49,8 +49,8 @@ MCSymbol *AArch64MCInstLower::GetGlobalValueSymbol(const GlobalValue *GV,
   if (!TheTriple.isOSBinFormatCOFF())
     return Printer.getSymbolPreferLocal(*GV);
 
-  assert(TheTriple.isOSWindows() &&
-         "Windows is the only supported COFF target");
+  assert((TheTriple.isOSWindows() || TheTriple.isUEFI()) &&
+         "Windows and UEFI are the only supported COFF target");
 
   bool IsIndirect =
       (TargetFlags & (AArch64II::MO_DLLIMPORT | AArch64II::MO_COFFSTUB));

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
@@ -352,6 +352,8 @@ static MCAsmInfo *createAArch64MCAsmInfo(const MCRegisterInfo &MRI,
     MAI = new AArch64MCAsmInfoMicrosoftCOFF();
   else if (TheTriple.isOSBinFormatCOFF())
     MAI = new AArch64MCAsmInfoGNUCOFF();
+  else if (TheTriple.isUEFI())
+    MAI = new AArch64MCAsmInfoMicrosoftCOFF();
   else {
     assert(TheTriple.isOSBinFormatELF() && "Invalid target");
     MAI = new AArch64MCAsmInfoELF(TheTriple);

--- a/llvm/unittests/IR/DataLayoutTest.cpp
+++ b/llvm/unittests/IR/DataLayoutTest.cpp
@@ -682,6 +682,11 @@ TEST(DataLayoutTest, UEFI) {
 
   // Test UEFI X86_64 Mangling Component.
   EXPECT_STREQ(DataLayout::getManglingComponent(TT), "-m:w");
+
+  TT = Triple("aarch64-unknown-uefi");
+
+  // Test UEFI AArch64 Mangling Component.
+  EXPECT_STREQ(DataLayout::getManglingComponent(TT), "-m:w");
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Adds the rest of the targets which support UEFI according to the [spec](https://uefi.org/sites/default/files/resources/UEFI_Spec_2_10_Aug29.pdf).

To test:
```sh
$ mkdir -p build
$ cd build
$ cmake ../llvm/ -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-uefi-llvm -DLLVM_RUNTIME_TARGETS="x86_64-unknown-uefi-llvm;aarch64-unknown-uefi-llvm;loongarch64-unknown-uefi-llvm;riscv64-unknown-uefi-llvm" -DRUNTIMES_x86_64-unknown-uefi-llvm_LLVM_ENABLE_RUNTIMES="libc" -DRUNTIMES_x86_64-unknown-uefi-llvm_LLVM_LIBC_FULL_BUILD=true -DRUNTIMES_aarch64-unknown-uefi-llvm_LLVM_ENABLE_RUNTIMES="libc" -DRUNTIMES_aarch64-unknown-uefi-llvm_LLVM_LIBC_FULL_BUILD=true -DRUNTIMES_loongarch64-unknown-uefi-llvm_LLVM_ENABLE_RUNTIMES=libc -DRUNTIMES_loongarch64-unknown-uefi-llvm_LLVM_LIBC_FULL_BUILD=true -DRUNTIMES_riscv64-unknown-uefi-llvm_LLVM_ENABLE_RUNTIMES=libc -DRUNTIMES_riscv64-unknown-uefi-llvm_LLVM_LIBC_FULL_BUILD=true -G Ninja
$ ninja all install
```

Check these files exist:
- `build/install/lib/aarch64-unknown-uefi-llvm/libc.a`
- `build/install/lib/x86_64-unknown-uefi-llvm/libc.a`
- `build/install/lib/loongarch64-unknown-uefi-llvm/libc.a`
- `build/install/lib/riscv64-unknown-uefi-llvm/libc.a`