### PR TITLE
[CodeGen] Add another method to CFIInstBuilder

### DIFF
--- a/llvm/include/llvm/CodeGen/CFIInstBuilder.h
+++ b/llvm/include/llvm/CodeGen/CFIInstBuilder.h
@@ -71,6 +71,10 @@ public:
     insertCFIInst(MCCFIInstruction::cfiDefCfaOffset(nullptr, Offset));
   }
 
+  void buildAdjustCFAOffset(int64_t Adjustment) const {
+    insertCFIInst(MCCFIInstruction::createAdjustCfaOffset(nullptr, Adjustment));
+  }
+
   void buildOffset(MCRegister Reg, int64_t Offset) const {
     insertCFIInst(MCCFIInstruction::createOffset(
         nullptr, TRI.getDwarfRegNum(Reg, IsEH), Offset));

--- a/llvm/lib/Target/MSP430/MSP430FrameLowering.cpp
+++ b/llvm/lib/Target/MSP430/MSP430FrameLowering.cpp
@@ -14,6 +14,7 @@
 #include "MSP430InstrInfo.h"
 #include "MSP430MachineFunctionInfo.h"
 #include "MSP430Subtarget.h"
+#include "llvm/CodeGen/CFIInstBuilder.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
@@ -406,9 +407,8 @@ MachineBasicBlock::iterator MSP430FrameLowering::eliminateCallFramePseudoInstr(
               .addReg(MSP430::SP)
               .addImm(CalleeAmt);
       if (!hasFP(MF)) {
-        DebugLoc DL = I->getDebugLoc();
-        BuildCFI(MBB, I, DL,
-                 MCCFIInstruction::createAdjustCfaOffset(nullptr, CalleeAmt));
+        CFIInstBuilder(MBB, I, MachineInstr::NoFlags)
+            .buildAdjustCFAOffset(CalleeAmt);
       }
       // The SRW implicit def is dead.
       New->getOperand(3).setIsDead();


### PR DESCRIPTION
Mainly for use by downstream targets, but it can find applications in upstream code as well. Use it in MSP430 so that it doesn't look dead.