### PR TITLE
[BOLT] Fix the inaccurate profile data check

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -4658,10 +4658,18 @@ MCInst *BinaryFunction::getInstructionAtOffset(uint64_t Offset) {
     if (!BB)
       return nullptr;
 
+    MCInst preInst;
     for (MCInst &Inst : *BB) {
       constexpr uint32_t InvalidOffset = std::numeric_limits<uint32_t>::max();
       if (Offset == BC.MIB->getOffsetWithDefault(Inst, InvalidOffset))
         return &Inst;
+      // If it's a RISCV PseudoCALL - fix it
+      if (BC.isRISCV() &&
+          Offset == BC.MIB->getOffsetWithDefault(Inst, InvalidOffset) - 4) {
+        if (BC.MIB->isRISCVCall(preInst, Inst))
+          return &Inst;
+      }
+      preInst = Inst;
     }
 
     if (MCInst *LastInstr = BB->getLastNonPseudoInstr()) {

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -524,6 +524,9 @@ float DataReader::evaluateProfileData(BinaryFunction &BF,
       // when we identify tail calls, so they are still represented
       // by regular branch instructions and we need isBranch() here.
       MCInst *Instr = BF.getInstructionAtOffset(BI.From.Offset);
+      // If it's a RISCV PseudoCALL - fix it
+      if (!Instr && BC.isRISCV())
+        Instr = BF.getInstructionAtOffset(BI.From.Offset + 4);
       // If it's a prefix - skip it.
       if (Instr && BC.MIB->isPrefix(*Instr))
         Instr = BF.getInstructionAtOffset(BI.From.Offset + 1);

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -524,9 +524,6 @@ float DataReader::evaluateProfileData(BinaryFunction &BF,
       // when we identify tail calls, so they are still represented
       // by regular branch instructions and we need isBranch() here.
       MCInst *Instr = BF.getInstructionAtOffset(BI.From.Offset);
-      // If it's a RISCV PseudoCALL - fix it
-      if (!Instr && BC.isRISCV())
-        Instr = BF.getInstructionAtOffset(BI.From.Offset + 4);
       // If it's a prefix - skip it.
       if (Instr && BC.MIB->isPrefix(*Instr))
         Instr = BF.getInstructionAtOffset(BI.From.Offset + 1);


### PR DESCRIPTION
The error is caused by the fact that when acquiring the profile data, the instruction at offset is PseudoCALL, but when performing profile verification, PseudoCALL is converted to AUIPC and JALR instructions, and the offset obtained is JALR; therefore, the profile data is considered invalid.