### PR TITLE
[llvm][ir]: fix llc crashes on function definitions with label parameters

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2931,6 +2931,8 @@ void Verifier::visitFunction(const Function &F) {
           FT->getParamType(i));
     Check(Arg.getType()->isFirstClassType(),
           "Function arguments must have first-class types!", &Arg);
+    Check(!Arg.getType()->isLabelTy(),
+          "Function argument cannot be of label type!", &Arg);
     if (!IsIntrinsic) {
       Check(!Arg.getType()->isMetadataTy(),
             "Function takes metadata but isn't an intrinsic", &Arg, &F);

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2932,7 +2932,7 @@ void Verifier::visitFunction(const Function &F) {
     Check(Arg.getType()->isFirstClassType(),
           "Function arguments must have first-class types!", &Arg);
     Check(!Arg.getType()->isLabelTy(),
-          "Function argument cannot be of label type!", &Arg);
+          "Function argument cannot be of label type!", &Arg, &F);
     if (!IsIntrinsic) {
       Check(!Arg.getType()->isMetadataTy(),
             "Function takes metadata but isn't an intrinsic", &Arg, &F);

--- a/llvm/test/Verifier/invalid-label-param.ll
+++ b/llvm/test/Verifier/invalid-label-param.ll
@@ -1,0 +1,7 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+
+define void @invalid_arg_type(label %p) {
+; CHECK: Function argument cannot be of label type!
+  ret void
+}
+

--- a/llvm/test/Verifier/invalid-label-param.ll
+++ b/llvm/test/Verifier/invalid-label-param.ll
@@ -1,7 +1,14 @@
 ; RUN: not llvm-as < %s 2>&1 | FileCheck %s
 
-define void @invalid_arg_type(label %p) {
-; CHECK: Function argument cannot be of label type!
+define void @invalid_arg_type(i32 %0) {
+1:
+  call void @foo(label %1)
   ret void
 }
+
+declare void @foo(label)
+; CHECK: Function argument cannot be of label type!
+; CHECK-NEXT: label %0
+; CHECK-NEXT: ptr @foo
+
 


### PR DESCRIPTION
Closes #136144.

After the patch:
```llvm
; label-crash.ll
define void @invalid_arg_type(i32 %0) {
1:
  call void @foo(label %1)
  ret void
}

declare void @foo(label)
```
```
lambda@ubuntu22:~/test$ llc -o out.s label-crash.ll 
Function argument cannot be of label type!
label %0
ptr @foo
llc: error: 'label-crash.ll': input module cannot be verified
```