### PR TITLE
llvm-reduce: Avoid using constantdata uselistorder in thinlto test

### DIFF
--- a/llvm/test/tools/llvm-reduce/thinlto-preserve-uselistorder.ll
+++ b/llvm/test/tools/llvm-reduce/thinlto-preserve-uselistorder.ll
@@ -1,19 +1,48 @@
-; RUN: opt --thinlto-bc --thinlto-split-lto-unit %s -o %t.0
-; RUN: llvm-reduce -write-tmp-files-as-bitcode --delta-passes=instructions %t.0 -o %t.1 \
+; RUN: opt --preserve-bc-uselistorder --thinlto-bc --thinlto-split-lto-unit %s -o %t.0
+
+; RUN: llvm-reduce -j=2 --delta-passes=instructions %t.0 -o %t.1 \
 ; RUN:     --test %python --test-arg %p/Inputs/llvm-dis-and-filecheck.py --test-arg llvm-dis --test-arg FileCheck --test-arg --check-prefix=INTERESTING --test-arg %s
 ; RUN: llvm-dis --preserve-ll-uselistorder %t.1 -o %t.2
-; RUN: FileCheck --check-prefix=RESULT %s < %t.2
+; RUN: FileCheck --check-prefixes=RESULT,RESULT-PARALLEL %s < %t.2
 
-define i32 @func(i32 %arg0, i32 %arg1) {
-entry:
-  %add0 = add i32 %arg0, 0
-  %add1 = add i32 %add0, 0
-  %add2 = add i32 %add1, 0
-  %add3 = add i32 %arg1, 0
-  %add4 = add i32 %add2, %add3
-  ret i32 %add4
+; FIXME: The single thread path uses CloneModule, which does not
+; preserve uselistorder. Consequently it is incapable of reducing
+; anything a case that depends on uselistorder.
+
+; RUN: llvm-reduce -j=1 --delta-passes=instructions %t.0 -o %t.3 \
+; RUN:     --test %python --test-arg %p/Inputs/llvm-dis-and-filecheck.py --test-arg llvm-dis --test-arg FileCheck --test-arg --check-prefix=INTERESTING --test-arg %s
+; RUN: llvm-dis --preserve-ll-uselistorder %t.3 -o %t.4
+; RUN: FileCheck --check-prefixes=RESULT,RESULT-SINGLE %s < %t.4
+
+@gv0 = external global [0 x i8]
+
+; RESULT-LABEL: @func(
+; RESULT-PARALLEL-NEXT: %gep0 = getelementptr i8, ptr @gv0, i32 %arg0
+; RESULT-PARALLEL-NEXT: %gep1 = getelementptr i8, ptr @gv0, i32 %arg1
+; RESULT-PARALLEL-NEXT: ret void
+
+; RESULT-SINGLE: ptr @gv0
+; RESULT-SINGLE: ptr @gv0
+; RESULT-SINGLE: ptr @gv0
+; RESULT-SINGLE: ptr @gv0
+; RESULT-SINGLE: ptr @gv0
+define void @func(i32 %arg0, i32 %arg1, i32 %arg2, i32 %arg3) {
+  %gep0 = getelementptr i8, ptr @gv0, i32 %arg0
+  %gep1 = getelementptr i8, ptr @gv0, i32 %arg1
+  %gep2 = getelementptr i8, ptr @gv0, i32 %arg2
+  %gep3 = getelementptr i8, ptr @gv0, i32 %arg3
+  store i32 0, ptr %gep0
+  store i32 0, ptr %gep1
+  store i32 0, ptr %gep2
+  store i32 0, ptr %gep3
+  store i32 0, ptr @gv0
+  ret void
 }
 
-; INTERESTING: uselistorder i32 0
-; RESULT: uselistorder i32 0, { 0, 2, 1 }
-uselistorder i32 0, { 3, 2, 1, 0 }
+; INTERESTING: uselistorder ptr
+
+; RESULT: uselistorder directives
+; RESULT-PARALLEL: uselistorder ptr @gv0, { 1, 0 }
+; RESULT-SINGLE: uselistorder ptr @gv0, { 3, 4, 2, 1, 0 }
+
+uselistorder ptr @gv0, { 3, 4, 2, 1, 0 }


### PR DESCRIPTION
This also demonstrates a bug that's a consequence of the two different
paths for the single and multithreaded cases. The parallel path goes
through bitcode serialization and does preserve the uselistorder. It
therefore survives and we can observe a reduced uselistorder with deleted
instructions. In the CloneModule case, nothing is reduced.