### PR TITLE
[flang] Tweak integer output under width-free I/G editing

### DIFF
--- a/flang-rt/lib/runtime/edit-output.cpp
+++ b/flang-rt/lib/runtime/edit-output.cpp
@@ -182,8 +182,11 @@ bool RT_API_ATTRS EditIntegerOutput(IoStatementState &io, const DataEdit &edit,
     leadingSpaces = 1;
   } else if (!edit.width) {
     // Bare 'I' and 'G' are interpreted with various default widths in the
-    // compilers that support them, so there's always some leading space.
-    leadingSpaces = std::max(1, leadingSpaces);
+    // compilers that support them, so there's always some leading space
+    // after column 1.
+    if (io.GetConnectionState().positionInRecord > 0) {
+      leadingSpaces = 1;
+    }
   }
   return EmitRepeated(io, ' ', leadingSpaces) &&
       EmitAscii(io, n < 0 ? "-" : "+", signChars) &&

--- a/flang-rt/unittests/Runtime/NumericalFormatTest.cpp
+++ b/flang-rt/unittests/Runtime/NumericalFormatTest.cpp
@@ -842,6 +842,10 @@ TEST(IOApiTests, FormatIntegerValues) {
       {"(G0.2)", -1, "-1"},
       {"(G0.2)", 999, "999"},
       {"(G0.4)", 999, "999"},
+      {"(I)", 999, "999"},
+      {"(G)", 999, "999"},
+      {"('x',I)", 999, "x 999"},
+      {"('x',G)", 999, "x 999"},
   };
 
   for (auto const &[fmt, value, expect] : intTestCases) {


### PR DESCRIPTION
A recent patch fixed Fujitsu test case 0561_0168 by emitting a leading space for "bare" (no width 'w') I and G output editing of integer values.  This fix has broken another Fujitsu test case (0561_0168), since the leading space should not be produced at the first column of the output record.  Adjust.