### PR TITLE
    SPIRV: Set NoPHIs property after rewriting them

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -2029,6 +2029,8 @@ static void patchPhis(const Module &M, SPIRVGlobalRegistry *GR,
                   {MachineOperand::CreateReg(ResTypeReg, false)});
       }
     }
+
+    MF->getProperties().set(MachineFunctionProperties::Property::NoPHIs);
   }
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -269,6 +269,12 @@ class SPIRVInstructionSelect : public InstructionSelect {
     return InstructionSelect::getRequiredProperties().reset(
         MachineFunctionProperties::Property::RegBankSelected);
   }
+
+  MachineFunctionProperties getClearedProperties() const override {
+    // No generic Phis remain, replaced with OpPhi
+    return InstructionSelect::getClearedProperties().reset(
+        MachineFunctionProperties::Property::NoPHIs);
+  }
 };
 } // namespace
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -269,12 +269,6 @@ class SPIRVInstructionSelect : public InstructionSelect {
     return InstructionSelect::getRequiredProperties().reset(
         MachineFunctionProperties::Property::RegBankSelected);
   }
-
-  MachineFunctionProperties getClearedProperties() const override {
-    // No generic Phis remain, replaced with OpPhi
-    return InstructionSelect::getClearedProperties().reset(
-        MachineFunctionProperties::Property::NoPHIs);
-  }
 };
 } // namespace
 


### PR DESCRIPTION
There should be no PHIs after selection, as OpPhi is used
 instead. This hopefully avoids errors in #135277.