### PR TITLE
[Clang] disallow use of attributes before extern template declarations

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -301,6 +301,9 @@ related warnings within the method body.
   particularly relevant for AMDGPU targets, where they map to corresponding IR
   metadata.
 
+- Clang now disallows the use of attributes applied before an
+  ``extern template`` declaration (#GH79893).
+
 Improvements to Clang's diagnostics
 -----------------------------------
 

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1049,6 +1049,7 @@ Parser::ParseExternalDeclaration(ParsedAttributes &Attrs,
 
   case tok::kw_extern:
     if (getLangOpts().CPlusPlus && NextToken().is(tok::kw_template)) {
+      ProhibitAttributes(Attrs);
       // Extern templates
       SourceLocation ExternLoc = ConsumeToken();
       SourceLocation TemplateLoc = ConsumeToken();

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1050,6 +1050,7 @@ Parser::ParseExternalDeclaration(ParsedAttributes &Attrs,
   case tok::kw_extern:
     if (getLangOpts().CPlusPlus && NextToken().is(tok::kw_template)) {
       ProhibitAttributes(Attrs);
+      ProhibitAttributes(DeclSpecAttrs);
       // Extern templates
       SourceLocation ExternLoc = ConsumeToken();
       SourceLocation TemplateLoc = ConsumeToken();

--- a/clang/test/Parser/extern-template-attributes.cpp
+++ b/clang/test/Parser/extern-template-attributes.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -std=c++17 -verify %s
+
+template <class>
+struct S {};
+
+[[deprecated]] extern template struct S<int>; // expected-error {{an attribute list cannot appear here}}

--- a/clang/test/Parser/extern-template-attributes.cpp
+++ b/clang/test/Parser/extern-template-attributes.cpp
@@ -1,6 +1,8 @@
-// RUN: %clang_cc1 -std=c++17 -verify %s
+// RUN: %clang_cc1 -std=c++17 -fms-extensions -verify %s
 
 template <class>
 struct S {};
 
-[[deprecated]] extern template struct S<int>; // expected-error {{an attribute list cannot appear here}}
+[[deprecated]] extern template struct S<int>;              // expected-error {{an attribute list cannot appear here}}
+__attribute__((deprecated)) extern template struct S<int>; // expected-error {{an attribute list cannot appear here}}
+__declspec(deprecated) extern template struct S<int>;      // expected-error {{expected unqualified-id}}


### PR DESCRIPTION
Fixes #79893 


--- 

This PR addresses the issue of _attributes_ being incorrectly allowed on `extern template` declarations

```cpp
[[deprecated]] extern template struct S<int>;
```

