### PR TITLE
[CIR] Upstream limited support for nested structures

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenTypes.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.h
@@ -89,7 +89,11 @@ public:
   mlir::MLIRContext &getMLIRContext() const;
   clang::ASTContext &getASTContext() const { return astContext; }
 
+  bool isRecordLayoutComplete(const clang::Type *ty) const;
   bool noRecordsBeingLaidOut() const { return recordsBeingLaidOut.empty(); }
+  bool isRecordBeingLaidOut(const clang::Type *ty) const {
+    return recordsBeingLaidOut.count(ty);
+  }
 
   const ABIInfo &getABIInfo() const { return theABIInfo; }
 

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -8,9 +8,13 @@
 // For LLVM IR checks, the structs are defined before the variables, so these
 // checks are at the top.
 // LLVM: %struct.CompleteS = type { i32, i8 }
+// LLVM: %struct.OuterS = type { %struct.InnerS, i32 }
+// LLVM: %struct.InnerS = type { i32, i8 }
 // LLVM: %struct.PackedS = type <{ i32, i8 }>
 // LLVM: %struct.PackedAndPaddedS = type <{ i32, i8, i8 }>
 // OGCG: %struct.CompleteS = type { i32, i8 }
+// OGCG: %struct.OuterS = type { %struct.InnerS, i32 }
+// OGCG: %struct.InnerS = type { i32, i8 }
 // OGCG: %struct.PackedS = type <{ i32, i8 }>
 // OGCG: %struct.PackedAndPaddedS = type <{ i32, i8, i8 }>
 
@@ -30,6 +34,23 @@ struct CompleteS {
 // CIR-SAME:      "CompleteS" {!s32i, !s8i}>
 // LLVM:      @cs = dso_local global %struct.CompleteS zeroinitializer
 // OGCG:      @cs = global %struct.CompleteS zeroinitializer, align 4
+
+struct InnerS {
+  int a;
+  char b;
+};
+
+struct OuterS {
+  struct InnerS is;
+  int c;
+};
+
+struct OuterS os;
+
+// CIR:       cir.global external @os = #cir.zero : !cir.record<struct
+// CIR-SAME:      "OuterS" {!cir.record<struct "InnerS" {!s32i, !s8i}>, !s32i}>
+// LLVM:      @os = dso_local global %struct.OuterS zeroinitializer
+// OGCG:      @os = global %struct.OuterS zeroinitializer, align 4
 
 #pragma pack(push)
 #pragma pack(1)


### PR DESCRIPTION
Previously when we checked to see if it was safe to create CIR for a structure type, we were conservatively saying no if any structure was in the process of being converted. That prevented handling nested structures, even when it would have actually been safe to handle them. Handling structures which recursively reference structures currently being processed requires deferring the handling of the recursively referenced structure, and that still isn't implemented after this change.

This change adds the less conservative check that allows handling of non-recursive nested structures.