### PR TITLE
[flang][openacc] Make num_gangs, num_workers and vector_length behavior homogenous with parallel

### DIFF
--- a/flang/test/Semantics/OpenACC/acc-kernels.f90
+++ b/flang/test/Semantics/OpenACC/acc-kernels.f90
@@ -61,10 +61,43 @@ program openacc_kernels_validity
   !$acc kernels num_gangs(8)
   !$acc end kernels
 
+  !ERROR: At most one NUM_GANGS clause can appear on the KERNELS directive or in group separated by the DEVICE_TYPE clause
+  !$acc kernels num_gangs(8) num_gangs(10)
+  !$acc end kernels
+
+  !ERROR: At most one NUM_GANGS clause can appear on the KERNELS directive or in group separated by the DEVICE_TYPE clause
+  !$acc kernels device_type(nvidia) num_gangs(8) num_gangs(10)
+  !$acc end kernels
+
+  !$acc kernels device_type(nvidia) num_gangs(8) device_type(radeon) num_gangs(10)
+  !$acc end kernels
+
   !$acc kernels num_workers(8)
   !$acc end kernels
 
+  !ERROR: At most one NUM_WORKERS clause can appear on the KERNELS directive or in group separated by the DEVICE_TYPE clause
+  !$acc kernels num_workers(8) num_workers(4)
+  !$acc end kernels
+
+  !ERROR: At most one NUM_WORKERS clause can appear on the KERNELS directive or in group separated by the DEVICE_TYPE clause
+  !$acc kernels device_type(nvidia) num_workers(8) num_workers(4)
+  !$acc end kernels
+
+  !$acc kernels device_type(nvidia) num_workers(8) device_type(radeon) num_workers(4)
+  !$acc end kernels
+
   !$acc kernels vector_length(128)
+  !$acc end kernels
+
+  !ERROR: At most one VECTOR_LENGTH clause can appear on the KERNELS directive or in group separated by the DEVICE_TYPE clause
+  !$acc kernels vector_length(128) vector_length(124)
+  !$acc end kernels
+
+  !ERROR: At most one VECTOR_LENGTH clause can appear on the KERNELS directive or in group separated by the DEVICE_TYPE clause
+  !$acc kernels device_type(nvidia) vector_length(256) vector_length(128)
+  !$acc end kernels
+
+  !$acc kernels device_type(nvidia) vector_length(256) device_type(radeon) vector_length(128)
   !$acc end kernels
 
   !$acc kernels if(.true.)

--- a/llvm/include/llvm/Frontend/OpenACC/ACC.td
+++ b/llvm/include/llvm/Frontend/OpenACC/ACC.td
@@ -319,27 +319,23 @@ def ACC_Declare : Directive<"declare"> {
 
 // 2.5.3
 def ACC_Kernels : Directive<"kernels"> {
-  let allowedClauses = [
-    VersionedClause<ACCC_Attach>,
-    VersionedClause<ACCC_Copy>,
-    VersionedClause<ACCC_Copyin>,
-    VersionedClause<ACCC_Copyout>,
-    VersionedClause<ACCC_Create>,
-    VersionedClause<ACCC_DeviceType>,
-    VersionedClause<ACCC_NoCreate>,
-    VersionedClause<ACCC_Present>,
-    VersionedClause<ACCC_DevicePtr>,
-    VersionedClause<ACCC_Wait>
-  ];
-  let allowedOnceClauses = [
-    VersionedClause<ACCC_Async>,
-    VersionedClause<ACCC_Default>,
-    VersionedClause<ACCC_If>,
-    VersionedClause<ACCC_NumGangs>,
-    VersionedClause<ACCC_NumWorkers>,
-    VersionedClause<ACCC_Self>,
-    VersionedClause<ACCC_VectorLength>
-  ];
+  let allowedClauses = [VersionedClause<ACCC_Attach>,
+                        VersionedClause<ACCC_Copy>,
+                        VersionedClause<ACCC_Copyin>,
+                        VersionedClause<ACCC_Copyout>,
+                        VersionedClause<ACCC_Create>,
+                        VersionedClause<ACCC_DeviceType>,
+                        VersionedClause<ACCC_NoCreate>,
+                        VersionedClause<ACCC_NumGangs>,
+                        VersionedClause<ACCC_NumWorkers>,
+                        VersionedClause<ACCC_Present>,
+                        VersionedClause<ACCC_DevicePtr>,
+                        VersionedClause<ACCC_VectorLength>,
+                        VersionedClause<ACCC_Wait>];
+  let allowedOnceClauses = [VersionedClause<ACCC_Async>,
+                            VersionedClause<ACCC_Default>,
+                            VersionedClause<ACCC_If>,
+                            VersionedClause<ACCC_Self>];
   let association = AS_Block;
   let category = CA_Executable;
 }


### PR DESCRIPTION
The num_gangs, num_workers and vector_length clauses should behave the same way as with the parallel directive. Update the ACC.td file to allow the clauses multiple times and let the semantic check the device_type sections.

Add some tests. 