### PR TITLE
[HLSL] XFAIL `smoothstep.ll` and `SV_GroupIndex.ll` SPIR-V backend tests

### DIFF
--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll
@@ -1,8 +1,8 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
-; TODO: This test currently fails when --target-env vulkan1.3 is specified.
-; XFAIL: *
+; TODO(#136344): This test currently fails when --target-env vulkan1.3 is specified.
+; XFAIL: spirv-tools
 
 ; CHECK-DAG:        %[[#int:]] = OpTypeInt 32 0
 ; CHECK-DAG:        %[[#ptr_Input_int:]] = OpTypePointer Input %[[#int]]

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll
@@ -1,6 +1,9 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
+; TODO: This test currently fails when --target-env vulkan1.3 is specified.
+; XFAIL: *
+
 ; CHECK-DAG:        %[[#int:]] = OpTypeInt 32 0
 ; CHECK-DAG:        %[[#ptr_Input_int:]] = OpTypePointer Input %[[#int]]
 ; CHECK-DAG:        %[[#LocalInvocationIndex:]] = OpVariable %[[#ptr_Input_int]] Input

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll
@@ -1,6 +1,9 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
+; TODO: This test currently fails when --target-env vulkan1.3 is specified.
+; XFAIL: *
+
 ; Make sure SPIRV operation function calls for smoothstep are lowered correctly.
 
 ; CHECK-DAG: %[[#op_ext_glsl:]] = OpExtInstImport "GLSL.std.450"

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll
@@ -1,8 +1,8 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
-; TODO: This test currently fails when --target-env vulkan1.3 is specified.
-; XFAIL: *
+; TODO(#136344): This test currently fails when --target-env vulkan1.3 is specified.
+; XFAIL: spirv-tools
 
 ; Make sure SPIRV operation function calls for smoothstep are lowered correctly.
 


### PR DESCRIPTION
When SPIRV-Tools is enabled, tests that specify the target environment `vulkan1.3` in the validation step fail. This is because SPIRV-Tools seems to have [grown some capability checks for vulkan 1.3](https://github.com/KhronosGroup/SPIRV-Tools/commit/7e41c7130f8258bf2d62179d8d6dbf3b68a7978b). The failing tests are:
- `CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll`
- `CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll`

For now, the fix is to XFAIL these tests to unblock the pipeline.

Issue #136344 tracks the long-term solution for this.