### PR TITLE
[CIR] Introduce type aliases for records

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -36,9 +36,9 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
     if (auto recordType = dyn_cast<cir::RecordType>(type)) {
       StringAttr nameAttr = recordType.getName();
       if (!nameAttr)
-        os << "ty_anon_" << recordType.getKindAsStr();
+        os << "rec_anon_" << recordType.getKindAsStr();
       else
-        os << "ty_" << nameAttr.getValue();
+        os << "rec_" << nameAttr.getValue();
       return AliasResult::OverridableAlias;
     }
     if (auto intType = dyn_cast<cir::IntType>(type)) {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -33,6 +33,14 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
 
   AliasResult getAlias(Type type, raw_ostream &os) const final {
+    if (auto recordType = dyn_cast<cir::RecordType>(type)) {
+      StringAttr nameAttr = recordType.getName();
+      if (!nameAttr)
+        os << "ty_anon_" << recordType.getKindAsStr();
+      else
+        os << "ty_" << nameAttr.getValue();
+      return AliasResult::OverridableAlias;
+    }
     if (auto intType = dyn_cast<cir::IntType>(type)) {
       // We only provide alias for standard integer types (i.e. integer types
       // whose width is a power of 2 and at least 8).

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -7,12 +7,12 @@
 
 // For LLVM IR checks, the structs are defined before the variables, so these
 // checks are at the top.
-// CIR-DAG: !ty_IncompleteS = !cir.record<struct "IncompleteS" incomplete>
-// CIR-DAG: !ty_CompleteS = !cir.record<struct "CompleteS" {!s32i, !s8i}>
-// CIR-DAG: !ty_OuterS = !cir.record<struct "OuterS" {!ty_InnerS, !s32i}>  
-// CIR-DAG: !ty_InnerS = !cir.record<struct "InnerS" {!s32i, !s8i}>
-// CIR-DAG: !ty_PackedS = !cir.record<struct "PackedS" packed {!s32i, !s8i}>
-// CIR-DAG: !ty_PackedAndPaddedS = !cir.record<struct "PackedAndPaddedS" packed padded {!s32i, !s8i, !u8i}>
+// CIR-DAG: !rec_IncompleteS = !cir.record<struct "IncompleteS" incomplete>
+// CIR-DAG: !rec_CompleteS = !cir.record<struct "CompleteS" {!s32i, !s8i}>
+// CIR-DAG: !rec_OuterS = !cir.record<struct "OuterS" {!ty_InnerS, !s32i}>  
+// CIR-DAG: !rec_InnerS = !cir.record<struct "InnerS" {!s32i, !s8i}>
+// CIR-DAG: !rec_PackedS = !cir.record<struct "PackedS" packed {!s32i, !s8i}>
+// CIR-DAG: !rec_PackedAndPaddedS = !cir.record<struct "PackedAndPaddedS" packed padded {!s32i, !s8i, !u8i}>
 // LLVM-DAG: %struct.CompleteS = type { i32, i8 }
 // LLVM-DAG: %struct.OuterS = type { %struct.InnerS, i32 }
 // LLVM-DAG: %struct.InnerS = type { i32, i8 }
@@ -36,7 +36,7 @@ struct CompleteS {
   char b;
 } cs;
 
-// CIR:       cir.global external @cs = #cir.zero : !ty_CompleteS
+// CIR:       cir.global external @cs = #cir.zero : !rec_CompleteS
 // LLVM-DAG:  @cs = dso_local global %struct.CompleteS zeroinitializer
 // OGCG-DAG:  @cs = global %struct.CompleteS zeroinitializer, align 4
 
@@ -52,7 +52,7 @@ struct OuterS {
 
 struct OuterS os;
 
-// CIR:       cir.global external @os = #cir.zero : !ty_OuterS
+// CIR:       cir.global external @os = #cir.zero : !rec_OuterS
 // LLVM-DAG:  @os = dso_local global %struct.OuterS zeroinitializer
 // OGCG-DAG:  @os = global %struct.OuterS zeroinitializer, align 4
 
@@ -64,7 +64,7 @@ struct PackedS {
   char a1;
 } ps;
 
-// CIR:       cir.global external @ps = #cir.zero : !ty_PackedS
+// CIR:       cir.global external @ps = #cir.zero : !rec_PackedS
 // LLVM-DAG:  @ps = dso_local global %struct.PackedS zeroinitializer
 // OGCG-DAG:  @ps = global %struct.PackedS zeroinitializer, align 1
 
@@ -73,7 +73,7 @@ struct PackedAndPaddedS {
   char b1;
 } __attribute__((aligned(2))) pps;
 
-// CIR:       cir.global external @pps = #cir.zero : !ty_PackedAndPaddedS
+// CIR:       cir.global external @pps = #cir.zero : !rec_PackedAndPaddedS
 // LLVM-DAG:  @pps = dso_local global %struct.PackedAndPaddedS zeroinitializer
 // OGCG-DAG:  @pps = global %struct.PackedAndPaddedS zeroinitializer, align 2
 
@@ -84,7 +84,7 @@ void f(void) {
 }
 
 // CIR:      cir.func @f()
-// CIR-NEXT:   cir.alloca !cir.ptr<!ty_IncompleteS>, !cir.ptr<!cir.ptr<!ty_IncompleteS>>, ["p"] {alignment = 8 : i64}
+// CIR-NEXT:   cir.alloca !cir.ptr<!rec_IncompleteS>, !cir.ptr<!cir.ptr<!rec_IncompleteS>>, ["p"] {alignment = 8 : i64}
 // CIR-NEXT:   cir.return
 
 // LLVM:      define void @f()
@@ -101,7 +101,7 @@ void f2(void) {
 }
 
 // CIR:      cir.func @f2()
-// CIR-NEXT:   cir.alloca !ty_CompleteS, !cir.ptr<!ty_CompleteS>, ["s"] {alignment = 4 : i64}
+// CIR-NEXT:   cir.alloca !rec_CompleteS, !cir.ptr<!rec_CompleteS>, ["s"] {alignment = 4 : i64}
 // CIR-NEXT:   cir.return
 
 // LLVM:      define void @f2()

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -9,7 +9,7 @@
 // checks are at the top.
 // CIR-DAG: !rec_IncompleteS = !cir.record<struct "IncompleteS" incomplete>
 // CIR-DAG: !rec_CompleteS = !cir.record<struct "CompleteS" {!s32i, !s8i}>
-// CIR-DAG: !rec_OuterS = !cir.record<struct "OuterS" {!ty_InnerS, !s32i}>  
+// CIR-DAG: !rec_OuterS = !cir.record<struct "OuterS" {!rec_InnerS, !s32i}>  
 // CIR-DAG: !rec_InnerS = !cir.record<struct "InnerS" {!s32i, !s8i}>
 // CIR-DAG: !rec_PackedS = !cir.record<struct "PackedS" packed {!s32i, !s8i}>
 // CIR-DAG: !rec_PackedAndPaddedS = !cir.record<struct "PackedAndPaddedS" packed padded {!s32i, !s8i, !u8i}>
@@ -26,8 +26,7 @@
 
 struct IncompleteS *p;
 
-// CIR:      cir.global external @p = #cir.ptr<null> : !cir.ptr<!cir.record<struct
-// CIR-SAME:     "IncompleteS" incomplete>>
+// CIR:      cir.global external @p = #cir.ptr<null> : !cir.ptr<!rec_IncompleteS>
 // LLVM-DAG: @p = dso_local global ptr null
 // OGCG-DAG: @p = global ptr null, align 8
 
@@ -158,7 +157,7 @@ char f4(int a, struct CompleteS *p) {
   return p->b;
 }
 
-// CIR:      cir.func @f4(%[[ARG_A:.*]]: !s32i {{.*}}, %[[ARG_P:.*]]: !cir.ptr<!cir.record<struct "CompleteS" {!s32i, !s8i}>>
+// CIR:      cir.func @f4(%[[ARG_A:.*]]: !s32i {{.*}}, %[[ARG_P:.*]]: !cir.ptr<!rec_CompleteS>
 // CIR-NEXT:   %[[A_ADDR:.*]] = cir.alloca {{.*}} ["a", init] {alignment = 4 : i64}
 // CIR-NEXT:   %[[P_ADDR:.*]] = cir.alloca {{.*}} ["p", init] {alignment = 8 : i64}
 // CIR-NEXT:   %[[RETVAL_ADDR:.*]] = cir.alloca {{.*}} ["__retval"] {alignment = 1 : i64}

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -8,7 +8,7 @@
 struct IncompleteS;
 IncompleteS *p;
 
-// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!cir.record<struct "IncompleteS" incomplete>>
+// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!ty_IncompleteS>
 // LLVM: @p = dso_local global ptr null
 // OGCG: @p = global ptr null, align 8
 
@@ -17,8 +17,7 @@ void f(void) {
 }
 
 // CIR:      cir.func @f()
-// CIR-NEXT:   cir.alloca !cir.ptr<!cir.record<struct "IncompleteS" incomplete>>,
-// CIR-SAME:       !cir.ptr<!cir.ptr<!cir.record<struct "IncompleteS" incomplete>>>, ["p"]
+// CIR-NEXT:   cir.alloca !cir.ptr<!ty_IncompleteS>, !cir.ptr<!cir.ptr<!ty_IncompleteS>>, ["p"]
 // CIR-NEXT:   cir.return
 
 // LLVM:      define void @f()

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -8,7 +8,7 @@
 struct IncompleteS;
 IncompleteS *p;
 
-// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!ty_IncompleteS>
+// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!rec_IncompleteS>
 // LLVM: @p = dso_local global ptr null
 // OGCG: @p = global ptr null, align 8
 
@@ -17,7 +17,7 @@ void f(void) {
 }
 
 // CIR:      cir.func @f()
-// CIR-NEXT:   cir.alloca !cir.ptr<!ty_IncompleteS>, !cir.ptr<!cir.ptr<!ty_IncompleteS>>, ["p"]
+// CIR-NEXT:   cir.alloca !cir.ptr<!rec_IncompleteS>, !cir.ptr<!cir.ptr<!rec_IncompleteS>>, ["p"]
 // CIR-NEXT:   cir.return
 
 // LLVM:      define void @f()

--- a/clang/test/CIR/CodeGen/typedef.c
+++ b/clang/test/CIR/CodeGen/typedef.c
@@ -11,9 +11,7 @@ void local_typedef(void) {
 }
 
 // CIR:      cir.func @local_typedef()
-// CIR:        cir.alloca !cir.record<struct "Struct" {!s32i}>,
-// CIR-SAME:       !cir.ptr<!cir.record<struct "Struct" {!s32i}>>, ["s"]
-// CIR-SAME:       {alignment = 4 : i64}
+// CIR:        cir.alloca !ty_Struct, !cir.ptr<!ty_Struct>, ["s"] {alignment = 4 : i64}
 // CIR:        cir.return
 
 // LLVM: %struct.Struct = type { i32 }

--- a/clang/test/CIR/CodeGen/typedef.c
+++ b/clang/test/CIR/CodeGen/typedef.c
@@ -11,7 +11,7 @@ void local_typedef(void) {
 }
 
 // CIR:      cir.func @local_typedef()
-// CIR:        cir.alloca !ty_Struct, !cir.ptr<!ty_Struct>, ["s"] {alignment = 4 : i64}
+// CIR:        cir.alloca !rec_Struct, !cir.ptr<!rec_Struct>, ["s"] {alignment = 4 : i64}
 // CIR:        cir.return
 
 // LLVM: %struct.Struct = type { i32 }

--- a/clang/test/CIR/CodeGen/union.c
+++ b/clang/test/CIR/CodeGen/union.c
@@ -7,7 +7,7 @@
 
 union IncompleteU *p;
 
-// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!ty_IncompleteU>
+// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!rec_IncompleteU>
 // LLVM: @p = dso_local global ptr null
 // OGCG: @p = global ptr null, align 8
 
@@ -16,7 +16,7 @@ void f(void) {
 }
 
 // CIR: cir.func @f()
-// CIR-NEXT: cir.alloca !cir.ptr<!ty_IncompleteU>, !cir.ptr<!cir.ptr<!ty_IncompleteU>>, ["p"]
+// CIR-NEXT: cir.alloca !cir.ptr<!rec_IncompleteU>, !cir.ptr<!cir.ptr<!rec_IncompleteU>>, ["p"]
 // CIR-NEXT: cir.return
 
 // LLVM:      define void @f()

--- a/clang/test/CIR/CodeGen/union.c
+++ b/clang/test/CIR/CodeGen/union.c
@@ -7,7 +7,7 @@
 
 union IncompleteU *p;
 
-// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!cir.record<union "IncompleteU" incomplete>>
+// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!ty_IncompleteU>
 // LLVM: @p = dso_local global ptr null
 // OGCG: @p = global ptr null, align 8
 
@@ -16,8 +16,7 @@ void f(void) {
 }
 
 // CIR: cir.func @f()
-// CIR-NEXT: cir.alloca !cir.ptr<!cir.record<union "IncompleteU" incomplete>>,
-// CIR-SAME:     !cir.ptr<!cir.ptr<!cir.record<union "IncompleteU" incomplete>>>, ["p"]
+// CIR-NEXT: cir.alloca !cir.ptr<!ty_IncompleteU>, !cir.ptr<!cir.ptr<!ty_IncompleteU>>, ["p"]
 // CIR-NEXT: cir.return
 
 // LLVM:      define void @f()

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -1,9 +1,15 @@
 // RUN: cir-opt %s | FileCheck %s
 
+!ty_S = !cir.record<struct "S" incomplete>
+!ty_U = !cir.record<union "U" incomplete>
+
+// CHECK: !ty_S = !cir.record<struct "S" incomplete>
+// CHECK: !ty_U = !cir.record<union "U" incomplete>
+
 module  {
-    cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!cir.record<struct "S" incomplete>>
-    cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!cir.record<union "U" incomplete>>
+    cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!ty_S>
+    cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!ty_U>
 }
 
-// CHECK: cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!cir.record<struct "S" incomplete>>
-// CHECK: cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!cir.record<union "U" incomplete>>
+// CHECK: cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!ty_S>
+// CHECK: cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!ty_U>

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -1,15 +1,15 @@
 // RUN: cir-opt %s | FileCheck %s
 
-!ty_S = !cir.record<struct "S" incomplete>
-!ty_U = !cir.record<union "U" incomplete>
+!rec_S = !cir.record<struct "S" incomplete>
+!rec_U = !cir.record<union "U" incomplete>
 
-// CHECK: !ty_S = !cir.record<struct "S" incomplete>
-// CHECK: !ty_U = !cir.record<union "U" incomplete>
+// CHECK: !rec_S = !cir.record<struct "S" incomplete>
+// CHECK: !rec_U = !cir.record<union "U" incomplete>
 
 module  {
-    cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!ty_S>
-    cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!ty_U>
+    cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!rec_S>
+    cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!rec_U>
 }
 
-// CHECK: cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!ty_S>
-// CHECK: cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!ty_U>
+// CHECK: cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!rec_S>
+// CHECK: cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!rec_U>


### PR DESCRIPTION
This introduces MLIR aliases for ClangIR record types. These are used in the incubator and having skipped over them upstream is causing the tests to diverge.