### PR TITLE
[clang-doc][NFC] Prefer static functions for internal APIs

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -18,14 +18,15 @@ namespace doc {
 using Record = llvm::SmallVector<uint64_t, 1024>;
 
 // This implements decode for SmallString.
-llvm::Error decodeRecord(const Record &R, llvm::SmallVectorImpl<char> &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R,
+                                llvm::SmallVectorImpl<char> &Field,
+                                llvm::StringRef Blob) {
   Field.assign(Blob.begin(), Blob.end());
   return llvm::Error::success();
 }
 
-llvm::Error decodeRecord(const Record &R, SymbolID &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R, SymbolID &Field,
+                                llvm::StringRef Blob) {
   if (R[0] != BitCodeConstants::USRHashSize)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "incorrect USR size");
@@ -37,12 +38,14 @@ llvm::Error decodeRecord(const Record &R, SymbolID &Field,
   return llvm::Error::success();
 }
 
-llvm::Error decodeRecord(const Record &R, bool &Field, llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R, bool &Field,
+                                llvm::StringRef Blob) {
   Field = R[0] != 0;
   return llvm::Error::success();
 }
 
-llvm::Error decodeRecord(const Record &R, int &Field, llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R, int &Field,
+                                llvm::StringRef Blob) {
   if (R[0] > INT_MAX)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "integer too large to parse");
@@ -50,8 +53,8 @@ llvm::Error decodeRecord(const Record &R, int &Field, llvm::StringRef Blob) {
   return llvm::Error::success();
 }
 
-llvm::Error decodeRecord(const Record &R, AccessSpecifier &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R, AccessSpecifier &Field,
+                                llvm::StringRef Blob) {
   switch (R[0]) {
   case AS_public:
   case AS_private:
@@ -65,8 +68,8 @@ llvm::Error decodeRecord(const Record &R, AccessSpecifier &Field,
   }
 }
 
-llvm::Error decodeRecord(const Record &R, TagTypeKind &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R, TagTypeKind &Field,
+                                llvm::StringRef Blob) {
   switch (static_cast<TagTypeKind>(R[0])) {
   case TagTypeKind::Struct:
   case TagTypeKind::Interface:
@@ -80,8 +83,8 @@ llvm::Error decodeRecord(const Record &R, TagTypeKind &Field,
                                  "invalid value for TagTypeKind");
 }
 
-llvm::Error decodeRecord(const Record &R, std::optional<Location> &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R, std::optional<Location> &Field,
+                                llvm::StringRef Blob) {
   if (R[0] > INT_MAX)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "integer too large to parse");
@@ -89,8 +92,8 @@ llvm::Error decodeRecord(const Record &R, std::optional<Location> &Field,
   return llvm::Error::success();
 }
 
-llvm::Error decodeRecord(const Record &R, InfoType &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R, InfoType &Field,
+                                llvm::StringRef Blob) {
   switch (auto IT = static_cast<InfoType>(R[0])) {
   case InfoType::IT_namespace:
   case InfoType::IT_record:
@@ -105,8 +108,8 @@ llvm::Error decodeRecord(const Record &R, InfoType &Field,
                                  "invalid value for InfoType");
 }
 
-llvm::Error decodeRecord(const Record &R, FieldId &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R, FieldId &Field,
+                                llvm::StringRef Blob) {
   switch (auto F = static_cast<FieldId>(R[0])) {
   case FieldId::F_namespace:
   case FieldId::F_parent:
@@ -122,16 +125,17 @@ llvm::Error decodeRecord(const Record &R, FieldId &Field,
                                  "invalid value for FieldId");
 }
 
-llvm::Error decodeRecord(const Record &R,
-                         llvm::SmallVectorImpl<llvm::SmallString<16>> &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error
+decodeRecord(const Record &R,
+             llvm::SmallVectorImpl<llvm::SmallString<16>> &Field,
+             llvm::StringRef Blob) {
   Field.push_back(Blob);
   return llvm::Error::success();
 }
 
-llvm::Error decodeRecord(const Record &R,
-                         llvm::SmallVectorImpl<Location> &Field,
-                         llvm::StringRef Blob) {
+static llvm::Error decodeRecord(const Record &R,
+                                llvm::SmallVectorImpl<Location> &Field,
+                                llvm::StringRef Blob) {
   if (R[0] > INT_MAX)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "integer too large to parse");
@@ -139,16 +143,16 @@ llvm::Error decodeRecord(const Record &R,
   return llvm::Error::success();
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        const unsigned VersionNo) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, const unsigned VersionNo) {
   if (ID == VERSION && R[0] == VersionNo)
     return llvm::Error::success();
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "mismatched bitcode version number");
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        NamespaceInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, NamespaceInfo *I) {
   switch (ID) {
   case NAMESPACE_USR:
     return decodeRecord(R, I->USR, Blob);
@@ -162,8 +166,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        RecordInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, RecordInfo *I) {
   switch (ID) {
   case RECORD_USR:
     return decodeRecord(R, I->USR, Blob);
@@ -185,8 +189,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        BaseRecordInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, BaseRecordInfo *I) {
   switch (ID) {
   case BASE_RECORD_USR:
     return decodeRecord(R, I->USR, Blob);
@@ -208,8 +212,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        EnumInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, EnumInfo *I) {
   switch (ID) {
   case ENUM_USR:
     return decodeRecord(R, I->USR, Blob);
@@ -227,8 +231,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        TypedefInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, TypedefInfo *I) {
   switch (ID) {
   case TYPEDEF_USR:
     return decodeRecord(R, I->USR, Blob);
@@ -244,8 +248,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        EnumValueInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, EnumValueInfo *I) {
   switch (ID) {
   case ENUM_VALUE_NAME:
     return decodeRecord(R, I->Name, Blob);
@@ -259,8 +263,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        FunctionInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, FunctionInfo *I) {
   switch (ID) {
   case FUNCTION_USR:
     return decodeRecord(R, I->USR, Blob);
@@ -282,13 +286,13 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        TypeInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, TypeInfo *I) {
   return llvm::Error::success();
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        FieldTypeInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, FieldTypeInfo *I) {
   switch (ID) {
   case FIELD_TYPE_NAME:
     return decodeRecord(R, I->Name, Blob);
@@ -300,8 +304,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        MemberTypeInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, MemberTypeInfo *I) {
   switch (ID) {
   case MEMBER_TYPE_NAME:
     return decodeRecord(R, I->Name, Blob);
@@ -315,8 +319,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        CommentInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, CommentInfo *I) {
   switch (ID) {
   case COMMENT_KIND:
     return decodeRecord(R, I->Kind, Blob);
@@ -346,8 +350,8 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        Reference *I, FieldId &F) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, Reference *I, FieldId &F) {
   switch (ID) {
   case REFERENCE_USR:
     return decodeRecord(R, I->USR, Blob);
@@ -367,30 +371,31 @@ llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
   }
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        TemplateInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, TemplateInfo *I) {
   // Currently there are no child records of TemplateInfo (only child blocks).
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "invalid field for TemplateParamInfo");
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        TemplateSpecializationInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob,
+                               TemplateSpecializationInfo *I) {
   if (ID == TEMPLATE_SPECIALIZATION_OF)
     return decodeRecord(R, I->SpecializationOf, Blob);
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "invalid field for TemplateParamInfo");
 }
 
-llvm::Error parseRecord(const Record &R, unsigned ID, llvm::StringRef Blob,
-                        TemplateParamInfo *I) {
+static llvm::Error parseRecord(const Record &R, unsigned ID,
+                               llvm::StringRef Blob, TemplateParamInfo *I) {
   if (ID == TEMPLATE_PARAM_CONTENTS)
     return decodeRecord(R, I->Contents, Blob);
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "invalid field for TemplateParamInfo");
 }
 
-template <typename T> llvm::Expected<CommentInfo *> getCommentInfo(T I) {
+template <typename T> static llvm::Expected<CommentInfo *> getCommentInfo(T I) {
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "invalid type cannot contain CommentInfo");
 }
@@ -437,7 +442,7 @@ llvm::Expected<CommentInfo *> getCommentInfo(std::unique_ptr<CommentInfo> &I) {
 // the parent block to set it. The template specializations define what to do
 // for each supported parent block.
 template <typename T, typename TTypeInfo>
-llvm::Error addTypeInfo(T I, TTypeInfo &&TI) {
+static llvm::Error addTypeInfo(T I, TTypeInfo &&TI) {
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "invalid type cannot contain TypeInfo");
 }
@@ -472,7 +477,8 @@ template <> llvm::Error addTypeInfo(TypedefInfo *I, TypeInfo &&T) {
   return llvm::Error::success();
 }
 
-template <typename T> llvm::Error addReference(T I, Reference &&R, FieldId F) {
+template <typename T>
+static llvm::Error addReference(T I, Reference &&R, FieldId F) {
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "invalid type cannot contain Reference");
 }
@@ -588,7 +594,7 @@ template <> llvm::Error addReference(RecordInfo *I, Reference &&R, FieldId F) {
 }
 
 template <typename T, typename ChildInfoType>
-void addChild(T I, ChildInfoType &&R) {
+static void addChild(T I, ChildInfoType &&R) {
   llvm::errs() << "invalid child type for info";
   exit(1);
 }
@@ -629,7 +635,7 @@ template <> void addChild(BaseRecordInfo *I, FunctionInfo &&R) {
 // TemplateParam children. These go into either a TemplateInfo (for template
 // parameters) or TemplateSpecializationInfo (for the specialization's
 // parameters).
-template <typename T> void addTemplateParam(T I, TemplateParamInfo &&P) {
+template <typename T> static void addTemplateParam(T I, TemplateParamInfo &&P) {
   llvm::errs() << "invalid container for template parameter";
   exit(1);
 }
@@ -642,7 +648,7 @@ void addTemplateParam(TemplateSpecializationInfo *I, TemplateParamInfo &&P) {
 }
 
 // Template info. These apply to either records or functions.
-template <typename T> void addTemplate(T I, TemplateInfo &&P) {
+template <typename T> static void addTemplate(T I, TemplateInfo &&P) {
   llvm::errs() << "invalid container for template info";
   exit(1);
 }
@@ -655,7 +661,7 @@ template <> void addTemplate(FunctionInfo *I, TemplateInfo &&P) {
 
 // Template specializations go only into template records.
 template <typename T>
-void addTemplateSpecialization(T I, TemplateSpecializationInfo &&TSI) {
+static void addTemplateSpecialization(T I, TemplateSpecializationInfo &&TSI) {
   llvm::errs() << "invalid container for template specialization info";
   exit(1);
 }

--- a/clang-tools-extra/clang-doc/Generators.cpp
+++ b/clang-tools-extra/clang-doc/Generators.cpp
@@ -97,9 +97,6 @@ void Generator::addInfoToIndex(Index &Idx, const doc::Info *Info) {
 
 // This anchor is used to force the linker to link in the generated object file
 // and thus register the generators.
-extern volatile int YAMLGeneratorAnchorSource;
-extern volatile int MDGeneratorAnchorSource;
-extern volatile int HTMLGeneratorAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED YAMLGeneratorAnchorDest =
     YAMLGeneratorAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED MDGeneratorAnchorDest =

--- a/clang-tools-extra/clang-doc/Generators.h
+++ b/clang-tools-extra/clang-doc/Generators.h
@@ -52,6 +52,12 @@ findGeneratorByName(llvm::StringRef Format);
 
 std::string getTagType(TagTypeKind AS);
 
+// This anchor is used to force the linker to link in the generated object file
+// and thus register the generators.
+extern volatile int YAMLGeneratorAnchorSource;
+extern volatile int MDGeneratorAnchorSource;
+extern volatile int HTMLGeneratorAnchorSource;
+
 } // namespace doc
 } // namespace clang
 

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -21,7 +21,7 @@ namespace doc {
 static llvm::StringSet<> USRVisited;
 static llvm::sys::SmartMutex<true> USRVisitedGuard;
 
-template <typename T> bool isTypedefAnonRecord(const T *D) {
+template <typename T> static bool isTypedefAnonRecord(const T *D) {
   if (const auto *C = dyn_cast<CXXRecordDecl>(D)) {
     return C->getTypedefNameForAnonDecl();
   }

--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -48,7 +48,7 @@ static void populateMemberTypeInfo(RecordInfo &I, AccessSpecifier &Access,
 //
 // }
 // }
-llvm::SmallString<128>
+static llvm::SmallString<128>
 getInfoRelativePath(const llvm::SmallVectorImpl<doc::Reference> &Namespaces) {
   llvm::SmallString<128> Path;
   for (auto R = Namespaces.rbegin(), E = Namespaces.rend(); R != E; ++R)
@@ -56,7 +56,7 @@ getInfoRelativePath(const llvm::SmallVectorImpl<doc::Reference> &Namespaces) {
   return Path;
 }
 
-llvm::SmallString<128> getInfoRelativePath(const Decl *D) {
+static llvm::SmallString<128> getInfoRelativePath(const Decl *D) {
   llvm::SmallVector<Reference, 4> Namespaces;
   // The third arg in populateParentNamespaces is a boolean passed by reference,
   // its value is not relevant in here so it's not used anywhere besides the
@@ -185,7 +185,7 @@ std::string ClangDocCommentVisitor::getCommandName(unsigned CommandID) const {
 
 // Serializing functions.
 
-std::string getSourceCode(const Decl *D, const SourceRange &R) {
+static std::string getSourceCode(const Decl *D, const SourceRange &R) {
   return Lexer::getSourceText(CharSourceRange::getTokenRange(R),
                               D->getASTContext().getSourceManager(),
                               D->getASTContext().getLangOpts())
@@ -239,7 +239,8 @@ static RecordDecl *getRecordDeclForType(const QualType &T) {
   return nullptr;
 }
 
-TypeInfo getTypeInfoForType(const QualType &T, const PrintingPolicy &Policy) {
+static TypeInfo getTypeInfoForType(const QualType &T,
+                                   const PrintingPolicy &Policy) {
   const TagDecl *TD = getTagDeclForType(T);
   if (!TD)
     return TypeInfo(Reference(SymbolID(), T.getAsString(Policy)));
@@ -319,7 +320,7 @@ static void InsertChild(ScopeChildren &Scope, TypedefInfo Info) {
 // parameter. Since each variant is used once, it's not worth having a more
 // elaborate system to automatically deduce this information.
 template <typename ChildType>
-std::unique_ptr<Info> MakeAndInsertIntoParent(ChildType Child) {
+static std::unique_ptr<Info> MakeAndInsertIntoParent(ChildType Child) {
   if (Child.Namespace.empty()) {
     // Insert into unnamed parent namespace.
     auto ParentNS = std::make_unique<NamespaceInfo>();
@@ -496,8 +497,9 @@ populateParentNamespaces(llvm::SmallVector<Reference, 4> &Namespaces,
                             InfoType::IT_namespace);
 }
 
-void PopulateTemplateParameters(std::optional<TemplateInfo> &TemplateInfo,
-                                const clang::Decl *D) {
+static void
+PopulateTemplateParameters(std::optional<TemplateInfo> &TemplateInfo,
+                           const clang::Decl *D) {
   if (const TemplateParameterList *ParamList =
           D->getDescribedTemplateParams()) {
     if (!TemplateInfo) {
@@ -510,8 +512,8 @@ void PopulateTemplateParameters(std::optional<TemplateInfo> &TemplateInfo,
   }
 }
 
-TemplateParamInfo TemplateArgumentToInfo(const clang::Decl *D,
-                                         const TemplateArgument &Arg) {
+static TemplateParamInfo TemplateArgumentToInfo(const clang::Decl *D,
+                                                const TemplateArgument &Arg) {
   // The TemplateArgument's pretty printing handles all the normal cases
   // well enough for our requirements.
   std::string Str;

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -127,7 +127,7 @@ static llvm::cl::opt<OutputFormatTy>
                llvm::cl::init(OutputFormatTy::yaml),
                llvm::cl::cat(ClangDocCategory));
 
-std::string getFormatString() {
+static std::string getFormatString() {
   switch (FormatEnum) {
   case OutputFormatTy::yaml:
     return "yaml";
@@ -144,11 +144,11 @@ std::string getFormatString() {
 // GetMainExecutable (since some platforms don't support taking the
 // address of main, and some platforms can't implement GetMainExecutable
 // without being given the address of a function in the main executable).
-std::string getExecutablePath(const char *Argv0, void *MainAddr) {
+static std::string getExecutablePath(const char *Argv0, void *MainAddr) {
   return llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
 }
 
-llvm::Error getAssetFiles(clang::doc::ClangDocContext &CDCtx) {
+static llvm::Error getAssetFiles(clang::doc::ClangDocContext &CDCtx) {
   using DirIt = llvm::sys::fs::directory_iterator;
   std::error_code FileErr;
   llvm::SmallString<128> FilePath(UserAssetPath);
@@ -168,8 +168,8 @@ llvm::Error getAssetFiles(clang::doc::ClangDocContext &CDCtx) {
   return llvm::Error::success();
 }
 
-llvm::Error getDefaultAssetFiles(const char *Argv0,
-                                 clang::doc::ClangDocContext &CDCtx) {
+static llvm::Error getDefaultAssetFiles(const char *Argv0,
+                                        clang::doc::ClangDocContext &CDCtx) {
   void *MainAddr = (void *)(intptr_t)getExecutablePath;
   std::string ClangDocPath = getExecutablePath(Argv0, MainAddr);
   llvm::SmallString<128> NativeClangDocPath;
@@ -204,8 +204,8 @@ llvm::Error getDefaultAssetFiles(const char *Argv0,
   return llvm::Error::success();
 }
 
-llvm::Error getHtmlAssetFiles(const char *Argv0,
-                              clang::doc::ClangDocContext &CDCtx) {
+static llvm::Error getHtmlAssetFiles(const char *Argv0,
+                                     clang::doc::ClangDocContext &CDCtx) {
   if (!UserAssetPath.empty() &&
       !llvm::sys::fs::is_directory(std::string(UserAssetPath)))
     llvm::outs() << "Asset path supply is not a directory: " << UserAssetPath
@@ -217,7 +217,8 @@ llvm::Error getHtmlAssetFiles(const char *Argv0,
 
 /// Make the output of clang-doc deterministic by sorting the children of
 /// namespaces and records.
-void sortUsrToInfo(llvm::StringMap<std::unique_ptr<doc::Info>> &USRToInfo) {
+static void
+sortUsrToInfo(llvm::StringMap<std::unique_ptr<doc::Info>> &USRToInfo) {
   for (auto &I : USRToInfo) {
     auto &Info = I.second;
     if (Info->IT == doc::InfoType::IT_namespace) {


### PR DESCRIPTION
Additionally moving the declarations from Generator.cpp
prevents misc-use-internal-linkage warnings from clang-tidy.
We fix those here too, since the static functions are part
of the same diagnostic