### PR TITLE
[Clang][NFC] Remove unused debug macro

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -67,8 +67,6 @@
 #include <functional>
 #include <optional>
 
-#define DEBUG_TYPE "exprconstant"
-
 using namespace clang;
 using llvm::APFixedPoint;
 using llvm::APInt;


### PR DESCRIPTION
This macro appears to have been introduced accidentally and isn't used anywhere.