### PR TITLE
[mlir][transform] Clean up prints. NFC.

### DIFF
--- a/mlir/lib/Dialect/Transform/DebugExtension/DebugExtensionOps.cpp
+++ b/mlir/lib/Dialect/Transform/DebugExtension/DebugExtensionOps.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformTypes.h"
 #include "mlir/IR/OpImplementation.h"
+#include "llvm/Support/InterleavedRange.h"
 
 using namespace mlir;
 
@@ -58,7 +59,7 @@ DiagnosedSilenceableFailure transform::DebugEmitParamAsRemarkOp::apply(
   llvm::raw_string_ostream os(str);
   if (getMessage())
     os << *getMessage() << " ";
-  llvm::interleaveComma(state.getParams(getParam()), os);
+  os << llvm::interleaved(state.getParams(getParam()));
   if (!getAnchor()) {
     emitRemark() << str;
     return DiagnosedSilenceableFailure::success();

--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -41,6 +41,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/InterleavedRange.h"
 #include <optional>
 
 #define DEBUG_TYPE "transform-dialect"
@@ -2630,11 +2631,8 @@ static void printSequenceOpOperands(OpAsmPrinter &printer, Operation *op,
     printer << "(";
 
   printer << rootType;
-  if (hasExtras) {
-    printer << ", ";
-    llvm::interleaveComma(extraBindingTypes, printer.getStream());
-    printer << ")";
-  }
+  if (hasExtras)
+    printer << ", " << llvm::interleaved(extraBindingTypes) << ')';
 }
 
 /// Returns `true` if the given op operand may be consuming the handle value in

--- a/mlir/lib/Dialect/Transform/Interfaces/MatchInterfaces.cpp
+++ b/mlir/lib/Dialect/Transform/Interfaces/MatchInterfaces.cpp
@@ -8,6 +8,8 @@
 
 #include "mlir/Dialect/Transform/Interfaces/MatchInterfaces.h"
 
+#include "llvm/Support/InterleavedRange.h"
+
 using namespace mlir;
 
 //===----------------------------------------------------------------------===//
@@ -68,8 +70,7 @@ void transform::printTransformMatchDims(OpAsmPrinter &printer, Operation *op,
   if (isInverted) {
     printer << kDimExceptKeyword << "(";
   }
-  llvm::interleaveComma(rawDimList.asArrayRef(), printer.getStream(),
-                        [&](int64_t value) { printer << value; });
+  printer << llvm::interleaved(rawDimList.asArrayRef());
   if (isInverted) {
     printer << ")";
   }

--- a/mlir/lib/Dialect/Transform/Interfaces/TransformInterfaces.cpp
+++ b/mlir/lib/Dialect/Transform/Interfaces/TransformInterfaces.cpp
@@ -15,8 +15,10 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/iterator.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/InterleavedRange.h"
 
 #define DEBUG_TYPE "transform-dialect"
 #define DEBUG_TYPE_FULL "transform-dialect-full"
@@ -486,11 +488,11 @@ void transform::TransformState::recordOpHandleInvalidationOne(
     return;
 
   FULL_LDBG("--recordOpHandleInvalidationOne\n");
-  DEBUG_WITH_TYPE(
-      DEBUG_TYPE_FULL,
-      llvm::interleaveComma(potentialAncestors, DBGS() << "--ancestors: ",
-                            [](Operation *op) { llvm::dbgs() << *op; });
-      llvm::dbgs() << "\n");
+  DEBUG_WITH_TYPE(DEBUG_TYPE_FULL, {
+    (DBGS() << "--ancestors: "
+            << llvm::interleaved(llvm::make_pointee_range(potentialAncestors))
+            << "\n");
+  });
 
   Operation *owner = consumingHandle.getOwner();
   unsigned operandNo = consumingHandle.getOperandNumber();

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSubgroupDistribute.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSubgroupDistribute.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace mlir {
@@ -58,9 +59,7 @@ struct Layout {
 };
 
 void Layout::print(llvm::raw_ostream &os) const {
-  os << "[";
-  llvm::interleaveComma(layout, os);
-  os << "]";
+  os << llvm::interleaved_array(layout);
 }
 
 int64_t Layout::operator[](size_t idx) const {


### PR DESCRIPTION
Use `llvm::interleaved` from #135517 to simplify printing.