### PR TITLE
[clang][bytecode] Diagnose failed MemberPtrPtr casts differently

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -1932,7 +1932,7 @@ inline bool CastMemberPtrPtr(InterpState &S, CodePtr OpPC) {
     S.Stk.push<Pointer>(*Ptr);
     return true;
   }
-  return false;
+  return Invalid(S, OpPC);
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/AST/ByteCode/memberpointers.cpp
+++ b/clang/test/AST/ByteCode/memberpointers.cpp
@@ -249,3 +249,21 @@ namespace CallExprTypeMismatch {
   }
   static_assert(test(), "");
 }
+
+namespace CastMemberPtrPtrFailed{
+  struct S {
+    constexpr S() {}
+    constexpr int f() const;
+    constexpr int g() const;
+  };
+  struct T : S {
+    constexpr T(int n) : S(), n(n) {}
+    int n;
+  };
+
+  constexpr int S::g() const {
+    return this->*(int(S::*))&T::n; // both-note {{subexpression}}
+  }
+  static_assert(S().g(), ""); // both-error {{constant expression}} \
+                              // both-note {{in call to 'S().g()'}}
+}


### PR DESCRIPTION
Return Invalid() here instead of just false to match the diagnostic output of the current interpreter.