### PR TITLE
[CIR][NFC] Fix an unused variable warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -153,7 +153,7 @@ isSafeToConvert(const RecordDecl *rd, CIRGenTypes &cgt,
   // out, don't do it.  This includes virtual base classes which get laid out
   // when a class is translated, even though they aren't embedded by-value into
   // the class.
-  if (const CXXRecordDecl *crd = dyn_cast<CXXRecordDecl>(rd)) {
+  if (isa<CXXRecordDecl>(rd)) {
     assert(!cir::MissingFeatures::cxxSupport());
     cgt.getCGModule().errorNYI(rd->getSourceRange(),
                                "isSafeToConvert: CXXRecordDecl");
@@ -237,7 +237,7 @@ mlir::Type CIRGenTypes::convertRecordDeclType(const clang::RecordDecl *rd) {
   assert(insertResult && "isSafeToCovert() should have caught this.");
 
   // Force conversion of non-virtual base classes recursively.
-  if (const auto *cxxRecordDecl = dyn_cast<CXXRecordDecl>(rd)) {
+  if (isa<CXXRecordDecl>(rd)) {
     cgm.errorNYI(rd->getSourceRange(), "CXXRecordDecl");
   }
 


### PR DESCRIPTION
This fixes a warning where a variable assigned in 'if' statement wasn't referenced again.