### PR TITLE
[mlir][ptr] Add the `ptradd` and `type_offset` ops, and `generic_space` attr

### DIFF
--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrAttrDefs.td
@@ -12,6 +12,7 @@
 include "mlir/Dialect/Ptr/IR/PtrDialect.td"
 include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 // All of the attributes will extend this class.
 class Ptr_Attr<string name, string attrMnemonic,
@@ -22,35 +23,28 @@ class Ptr_Attr<string name, string attrMnemonic,
 }
 
 //===----------------------------------------------------------------------===//
-// IAddressSpaceAttr
+// GenericSpaceAttr
 //===----------------------------------------------------------------------===//
 
-def Ptr_IAddressSpaceAttr :
-    Ptr_Attr<"IAddressSpace", "int_space", [
+def Ptr_GenericSpaceAttr :
+    Ptr_Attr<"GenericSpace", "generic_space", [
       DeclareAttrInterfaceMethods<MemorySpaceAttrInterface>
     ]> {
-  let summary = "Int memory space";
+  let summary = "Generic memory space";
   let description = [{
-    The `int_as` attribute defines a memory space attribute with the following
-    properties:
+    The `generic_space` attribute defines a memory space attribute with the
+    following properties:
     - Load and store operations are always valid, regardless of the type.
     - Atomic operations are always valid, regardless of the type.
-    - Cast operations are valid between pointers with `int_space` memory space,
-    or between non-scalable `vector` of pointers with `int_space` memory space.
-
-    The default address spaces is 0.
-
+    - Cast operations to `generic_space` are always valid.
+  
     Example:
 
     ```mlir
-    // Default address space: 0.
-    #ptr.int_space
-    // Address space 3.
-    #ptr.int_space<3>
+    #ptr.generic_space
     ```
   }];
-  let parameters = (ins DefaultValuedParameter<"int64_t", "0">:$value);
-  let assemblyFormat = "(`<` $value^ `>`)?";
+  let assemblyFormat = "";
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrAttrDefs.td
@@ -10,6 +10,7 @@
 #define PTR_ATTRDEFS
 
 include "mlir/Dialect/Ptr/IR/PtrDialect.td"
+include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 
 // All of the attributes will extend this class.
@@ -18,6 +19,38 @@ class Ptr_Attr<string name, string attrMnemonic,
                 string baseCppClass = "::mlir::Attribute">
     : AttrDef<Ptr_Dialect, name, traits, baseCppClass> {
   let mnemonic = attrMnemonic;
+}
+
+//===----------------------------------------------------------------------===//
+// IAddressSpaceAttr
+//===----------------------------------------------------------------------===//
+
+def Ptr_IAddressSpaceAttr :
+    Ptr_Attr<"IAddressSpace", "int_space", [
+      DeclareAttrInterfaceMethods<MemorySpaceAttrInterface>
+    ]> {
+  let summary = "Int memory space";
+  let description = [{
+    The `int_as` attribute defines a memory space attribute with the following
+    properties:
+    - Load and store operations are always valid, regardless of the type.
+    - Atomic operations are always valid, regardless of the type.
+    - Cast operations are valid between pointers with `int_space` memory space,
+    or between non-scalable `vector` of pointers with `int_space` memory space.
+
+    The default address spaces is 0.
+
+    Example:
+
+    ```mlir
+    // Default address space: 0.
+    #ptr.int_space
+    // Address space 3.
+    #ptr.int_space<3>
+    ```
+  }];
+  let parameters = (ins DefaultValuedParameter<"int64_t", "0">:$value);
+  let assemblyFormat = "(`<` $value^ `>`)?";
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrAttrs.h
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrAttrs.h
@@ -15,6 +15,8 @@
 
 #include "mlir/IR/OpImplementation.h"
 
+#include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"
+
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/Ptr/IR/PtrOpsAttrs.h.inc"
 

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrAttrs.h
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrAttrs.h
@@ -13,7 +13,10 @@
 #ifndef MLIR_DIALECT_PTR_IR_PTRATTRS_H
 #define MLIR_DIALECT_PTR_IR_PTRATTRS_H
 
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "llvm/Support/TypeSize.h"
 
 #include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"
 

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrEnums.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrEnums.td
@@ -67,12 +67,12 @@ def AtomicOrdering : I64EnumAttr<
 }
 
 //===----------------------------------------------------------------------===//
-// Ptr add flags enum attr.
+// Ptr add flags enum properties.
 //===----------------------------------------------------------------------===//
 
 def Ptr_PtrAddFlags : I32Enum<"PtrAddFlags", "Pointer add flags", [
-    I32EnumAttrCase<"none", 0>, I32EnumAttrCase<"nusw", 1>,
-    I32EnumAttrCase<"nuw", 2>, I32EnumAttrCase<"inbounds", 3>
+    I32EnumCase<"none", 0>, I32EnumCase<"nusw", 1>, I32EnumCase<"nuw", 2>,
+    I32EnumCase<"inbounds", 3>
   ]> {
   let cppNamespace = "::mlir::ptr";
 }

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrEnums.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrEnums.td
@@ -66,4 +66,15 @@ def AtomicOrdering : I64EnumAttr<
   let cppNamespace = "::mlir::ptr";
 }
 
+//===----------------------------------------------------------------------===//
+// Ptr add flags enum attr.
+//===----------------------------------------------------------------------===//
+
+def Ptr_PtrAddFlags : I32EnumAttr<"PtrAddFlags", "Pointer add flags", [
+    I32EnumAttrCase<"none", 0>, I32EnumAttrCase<"nusw", 1>,
+    I32EnumAttrCase<"nuw", 2>, I32EnumAttrCase<"inbounds", 3>
+  ]> {
+  let cppNamespace = "::mlir::ptr";
+}
+
 #endif // PTR_ENUMS

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrEnums.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrEnums.td
@@ -70,7 +70,7 @@ def AtomicOrdering : I64EnumAttr<
 // Ptr add flags enum attr.
 //===----------------------------------------------------------------------===//
 
-def Ptr_PtrAddFlags : I32EnumAttr<"PtrAddFlags", "Pointer add flags", [
+def Ptr_PtrAddFlags : I32Enum<"PtrAddFlags", "Pointer add flags", [
     I32EnumAttrCase<"none", 0>, I32EnumAttrCase<"nusw", 1>,
     I32EnumAttrCase<"nuw", 2>, I32EnumAttrCase<"inbounds", 3>
   ]> {

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.h
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.h
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Ptr/IR/PtrTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 #define GET_OP_CLASSES
 #include "mlir/Dialect/Ptr/IR/PtrOps.h.inc"

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.h
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.h
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Ptr/IR/PtrDialect.h"
 #include "mlir/Dialect/Ptr/IR/PtrTypes.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES
 #include "mlir/Dialect/Ptr/IR/PtrOps.h.inc"

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
@@ -21,40 +21,42 @@ include "mlir/IR/OpAsmInterface.td"
 // PtrAddOp
 //===----------------------------------------------------------------------===//
 
-def Ptr_PtrAddOp : Pointer_Op<"ptradd", [
-    Pure, AllTypesMatch<["base", "result"]>,
-    DeclareOpInterfaceMethods<ViewLikeOpInterface>
+def Ptr_PtrAddOp : Pointer_Op<"ptr_add", [
+    Pure, AllTypesMatch<["base", "result"]>, ViewLikeOpInterface
   ]> {
   let summary = "Pointer add operation";
   let description = [{
-    The `ptradd` operation adds an integer offset to a pointer to produce a new
+    The `ptr_add` operation adds an integer offset to a pointer to produce a new
     pointer. The input and output pointer types are always the same.
 
     Example:
 
     ```mlir
-    %x_off  = ptr.ptradd %x, %off : !ptr.ptr<0>, i32
-    %x_off0 = ptr.ptradd nusw %x, %off : !ptr.ptr<0>, i32
+    %x_off  = ptr.ptr_add %x, %off : !ptr.ptr<0>, i32
+    %x_off0 = ptr.ptr_add nusw %x, %off : !ptr.ptr<0>, i32
     ```
   }];
 
   let arguments = (ins
     Ptr_PtrType:$base,
     AnySignlessIntegerOrIndex:$offset,
-    DefaultValuedAttr<Ptr_PtrAddFlags,
-        "::mlir::ptr::PtrAddFlags::none">:$flags);
+    DefaultValuedProp<EnumProp<Ptr_PtrAddFlags>, "PtrAddFlags::none">:$flags);
   let results = (outs Ptr_PtrType:$result);
   let assemblyFormat = [{
     ($flags^)? $base `,` $offset attr-dict `:` type($base) `,` type($offset)
   }];
   let hasFolder = 1;
+  let extraClassDeclaration = [{
+    /// `ViewLikeOp::getViewSource` method. 
+    Value getViewSource() { return getBase(); }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
 // TypeOffsetOp
 //===----------------------------------------------------------------------===//
 
-def Ptr_TypeOffsetOp : Pointer_Op<"type_offset", [ConstantLike, Pure]> {
+def Ptr_TypeOffsetOp : Pointer_Op<"type_offset", [Pure]> {
   let summary = "Type offset operation";
   let description = [{
     The `type_offset` operation produces an int or index-typed SSA value
@@ -64,25 +66,26 @@ def Ptr_TypeOffsetOp : Pointer_Op<"type_offset", [ConstantLike, Pure]> {
     Example:
 
     ```mlir
+    // Return the offset between two f32 stored in memory
     %0 = ptr.type_offset f32 : index
+    // Return the offset between two memref descriptors stored in memory
     %1 = ptr.type_offset memref<12 x f64> : i32
     ```
   }];
 
-  let arguments = (ins TypeAttr:$element_type);
+  let arguments = (ins TypeAttr:$elementType);
   let results = (outs AnySignlessIntegerOrIndex:$result);
   let builders = [
-    OpBuilder<(ins "TypeAttr":$element_type)>
+    OpBuilder<(ins "Type":$elementType)>
   ];
   let assemblyFormat = [{
-    $element_type attr-dict `:` type($result)
+    $elementType attr-dict `:` type($result)
   }];
   let extraClassDeclaration = [{
     /// Returns the type offset according to `maybeLayout`. If `maybeLayout` is
     /// `nullopt` the nearest layout the op will be used for the computation.
     llvm::TypeSize getTypeSize(std::optional<DataLayout> layout = std::nullopt);
   }];
-  let hasFolder = 1;
 }
 
 #endif // PTR_OPS

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
@@ -82,8 +82,8 @@ def Ptr_TypeOffsetOp : Pointer_Op<"type_offset", [Pure]> {
     $elementType attr-dict `:` type($result)
   }];
   let extraClassDeclaration = [{
-    /// Returns the type offset according to `layout`. If `layout` is
-    /// `nullopt` the nearest layout the op will be used for the computation.
+    /// Returns the type offset according to `layout`. If `layout` is `nullopt`
+    /// the nearest layout the op will be used for the computation.
     llvm::TypeSize getTypeSize(std::optional<DataLayout> layout = std::nullopt);
   }];
 }

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
@@ -82,7 +82,7 @@ def Ptr_TypeOffsetOp : Pointer_Op<"type_offset", [Pure]> {
     $elementType attr-dict `:` type($result)
   }];
   let extraClassDeclaration = [{
-    /// Returns the type offset according to `maybeLayout`. If `maybeLayout` is
+    /// Returns the type offset according to `layout`. If `layout` is
     /// `nullopt` the nearest layout the op will be used for the computation.
     llvm::TypeSize getTypeSize(std::optional<DataLayout> layout = std::nullopt);
   }];

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
@@ -12,6 +12,69 @@
 include "mlir/Dialect/Ptr/IR/PtrDialect.td"
 include "mlir/Dialect/Ptr/IR/PtrAttrDefs.td"
 include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
+
+//===----------------------------------------------------------------------===//
+// PtrAddOp
+//===----------------------------------------------------------------------===//
+
+def Ptr_PtrAddOp : Pointer_Op<"ptradd", [
+    Pure, AllTypesMatch<["base", "result"]>
+  ]> {
+  let summary = "Pointer add operation";
+  let description = [{
+    The `ptradd` operation adds an integer offset to a pointer to produce a new
+    pointer. The input and output pointer types are always the same.
+
+    Example:
+
+    ```mlir
+    %x_off = ptr.ptradd %x, %off : !ptr.ptr<0>, i32
+    ```
+  }];
+
+  let arguments = (ins Ptr_PtrType:$base, AnySignlessIntegerOrIndex:$offset);
+  let results = (outs Ptr_PtrType:$result);
+  let assemblyFormat = [{
+    $base `,` $offset attr-dict `:` type($base) `,` type($offset)
+  }];
+  let hasFolder = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// TypeOffsetOp
+//===----------------------------------------------------------------------===//
+
+def Ptr_TypeOffsetOp : Pointer_Op<"type_offset", [ConstantLike, Pure]> {
+  let summary = "Type offset operation";
+  let description = [{
+    The `type_offset` operation produces an int or index-typed SSA value
+    equal to a target-specific constant representing the offset of a single
+    element of the given type.
+
+    Example:
+
+    ```mlir
+    %0 = ptr.type_offset f32 : index
+    %1 = ptr.type_offset memref<12 x f64> : i32
+    ```
+  }];
+
+  let arguments = (ins TypeAttr:$element_type);
+  let results = (outs AnySignlessIntegerOrIndex:$result);
+  let builders = [
+    OpBuilder<(ins "TypeAttr":$element_type)>
+  ];
+  let assemblyFormat = [{
+    $element_type attr-dict `:` type($result)
+  }];
+  let extraClassDeclaration = [{
+    /// Returns the type offset according to `maybeLayout`. If `maybeLayout` is
+    /// `nullopt` the nearest layout the op will be used for the computation.
+    llvm::TypeSize getTypeSize(std::optional<DataLayout> layout = std::nullopt);
+  }];
+  let hasFolder = 1;
+}
 
 #endif // PTR_OPS

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
@@ -11,8 +11,10 @@
 
 include "mlir/Dialect/Ptr/IR/PtrDialect.td"
 include "mlir/Dialect/Ptr/IR/PtrAttrDefs.td"
+include "mlir/Dialect/Ptr/IR/PtrEnums.td"
 include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 include "mlir/IR/OpAsmInterface.td"
 
 //===----------------------------------------------------------------------===//
@@ -20,7 +22,8 @@ include "mlir/IR/OpAsmInterface.td"
 //===----------------------------------------------------------------------===//
 
 def Ptr_PtrAddOp : Pointer_Op<"ptradd", [
-    Pure, AllTypesMatch<["base", "result"]>
+    Pure, AllTypesMatch<["base", "result"]>,
+    DeclareOpInterfaceMethods<ViewLikeOpInterface>
   ]> {
   let summary = "Pointer add operation";
   let description = [{
@@ -30,14 +33,19 @@ def Ptr_PtrAddOp : Pointer_Op<"ptradd", [
     Example:
 
     ```mlir
-    %x_off = ptr.ptradd %x, %off : !ptr.ptr<0>, i32
+    %x_off  = ptr.ptradd %x, %off : !ptr.ptr<0>, i32
+    %x_off0 = ptr.ptradd nusw %x, %off : !ptr.ptr<0>, i32
     ```
   }];
 
-  let arguments = (ins Ptr_PtrType:$base, AnySignlessIntegerOrIndex:$offset);
+  let arguments = (ins
+    Ptr_PtrType:$base,
+    AnySignlessIntegerOrIndex:$offset,
+    DefaultValuedAttr<Ptr_PtrAddFlags,
+        "::mlir::ptr::PtrAddFlags::none">:$flags);
   let results = (outs Ptr_PtrType:$result);
   let assemblyFormat = [{
-    $base `,` $offset attr-dict `:` type($base) `,` type($offset)
+    ($flags^)? $base `,` $offset attr-dict `:` type($base) `,` type($offset)
   }];
   let hasFolder = 1;
 }

--- a/mlir/lib/Dialect/Ptr/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Ptr/IR/CMakeLists.txt
@@ -14,4 +14,5 @@ add_mlir_dialect_library(
   MLIRIR
   MLIRDataLayoutInterfaces
   MLIRMemorySlotInterfaces
+  MLIRViewLikeInterface
 )

--- a/mlir/lib/Dialect/Ptr/IR/PtrAttrs.cpp
+++ b/mlir/lib/Dialect/Ptr/IR/PtrAttrs.cpp
@@ -11,12 +11,58 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Ptr/IR/PtrAttrs.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
 using namespace mlir::ptr;
 
 constexpr const static unsigned kBitsInByte = 8;
+
+//===----------------------------------------------------------------------===//
+// IAddressSpaceAttr
+//===----------------------------------------------------------------------===//
+
+LogicalResult IAddressSpaceAttr::isValidLoad(
+    Type type, ptr::AtomicOrdering ordering, IntegerAttr alignment,
+    function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult IAddressSpaceAttr::isValidStore(
+    Type type, ptr::AtomicOrdering ordering, IntegerAttr alignment,
+    function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult IAddressSpaceAttr::isValidAtomicOp(
+    ptr::AtomicBinOp op, Type type, ptr::AtomicOrdering ordering,
+    IntegerAttr alignment, function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult IAddressSpaceAttr::isValidAtomicXchg(
+    Type type, ptr::AtomicOrdering successOrdering,
+    ptr::AtomicOrdering failureOrdering, IntegerAttr alignment,
+    function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult IAddressSpaceAttr::isValidAddrSpaceCast(
+    Type tgt, Type src, function_ref<InFlightDiagnostic()> emitError) const {
+  // TODO: update this method once the `addrspace_cast` op is added to the
+  // dialect.
+  assert(false && "unimplemented, see TODO in the source.");
+  return failure();
+}
+
+LogicalResult IAddressSpaceAttr::isValidPtrIntCast(
+    Type intLikeTy, Type ptrLikeTy,
+    function_ref<InFlightDiagnostic()> emitError) const {
+  // TODO: update this method once the int-cast ops are added to the dialect.
+  assert(false && "unimplemented, see TODO in the source.");
+  return failure();
+}
 
 //===----------------------------------------------------------------------===//
 // SpecAttr

--- a/mlir/lib/Dialect/Ptr/IR/PtrAttrs.cpp
+++ b/mlir/lib/Dialect/Ptr/IR/PtrAttrs.cpp
@@ -20,35 +20,35 @@ using namespace mlir::ptr;
 constexpr const static unsigned kBitsInByte = 8;
 
 //===----------------------------------------------------------------------===//
-// IAddressSpaceAttr
+// GenericSpaceAttr
 //===----------------------------------------------------------------------===//
 
-LogicalResult IAddressSpaceAttr::isValidLoad(
+LogicalResult GenericSpaceAttr::isValidLoad(
     Type type, ptr::AtomicOrdering ordering, IntegerAttr alignment,
     function_ref<InFlightDiagnostic()> emitError) const {
   return success();
 }
 
-LogicalResult IAddressSpaceAttr::isValidStore(
+LogicalResult GenericSpaceAttr::isValidStore(
     Type type, ptr::AtomicOrdering ordering, IntegerAttr alignment,
     function_ref<InFlightDiagnostic()> emitError) const {
   return success();
 }
 
-LogicalResult IAddressSpaceAttr::isValidAtomicOp(
+LogicalResult GenericSpaceAttr::isValidAtomicOp(
     ptr::AtomicBinOp op, Type type, ptr::AtomicOrdering ordering,
     IntegerAttr alignment, function_ref<InFlightDiagnostic()> emitError) const {
   return success();
 }
 
-LogicalResult IAddressSpaceAttr::isValidAtomicXchg(
+LogicalResult GenericSpaceAttr::isValidAtomicXchg(
     Type type, ptr::AtomicOrdering successOrdering,
     ptr::AtomicOrdering failureOrdering, IntegerAttr alignment,
     function_ref<InFlightDiagnostic()> emitError) const {
   return success();
 }
 
-LogicalResult IAddressSpaceAttr::isValidAddrSpaceCast(
+LogicalResult GenericSpaceAttr::isValidAddrSpaceCast(
     Type tgt, Type src, function_ref<InFlightDiagnostic()> emitError) const {
   // TODO: update this method once the `addrspace_cast` op is added to the
   // dialect.
@@ -56,7 +56,7 @@ LogicalResult IAddressSpaceAttr::isValidAddrSpaceCast(
   return failure();
 }
 
-LogicalResult IAddressSpaceAttr::isValidPtrIntCast(
+LogicalResult GenericSpaceAttr::isValidPtrIntCast(
     Type intLikeTy, Type ptrLikeTy,
     function_ref<InFlightDiagnostic()> emitError) const {
   // TODO: update this method once the int-cast ops are added to the dialect.

--- a/mlir/lib/Dialect/Ptr/IR/PtrDialect.cpp
+++ b/mlir/lib/Dialect/Ptr/IR/PtrDialect.cpp
@@ -45,7 +45,7 @@ void PtrDialect::initialize() {
 // PtrAddOp
 //===----------------------------------------------------------------------===//
 
-/// Fold the op to the base ptr when the offset is 0.
+/// Fold: ptradd ptr + 0 ->  ptr
 OpFoldResult PtrAddOp::fold(FoldAdaptor adaptor) {
   Attribute attr = adaptor.getOffset();
   if (!attr)

--- a/mlir/lib/Dialect/Ptr/IR/PtrDialect.cpp
+++ b/mlir/lib/Dialect/Ptr/IR/PtrDialect.cpp
@@ -55,6 +55,8 @@ OpFoldResult PtrAddOp::fold(FoldAdaptor adaptor) {
   return nullptr;
 }
 
+Value PtrAddOp::getViewSource() { return getBase(); }
+
 //===----------------------------------------------------------------------===//
 // TypeOffsetOp
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Ptr/IR/PtrDialect.cpp
+++ b/mlir/lib/Dialect/Ptr/IR/PtrDialect.cpp
@@ -55,15 +55,9 @@ OpFoldResult PtrAddOp::fold(FoldAdaptor adaptor) {
   return nullptr;
 }
 
-Value PtrAddOp::getViewSource() { return getBase(); }
-
 //===----------------------------------------------------------------------===//
 // TypeOffsetOp
 //===----------------------------------------------------------------------===//
-
-OpFoldResult TypeOffsetOp::fold(FoldAdaptor adaptor) {
-  return TypeAttr::get(getElementType());
-}
 
 llvm::TypeSize TypeOffsetOp::getTypeSize(std::optional<DataLayout> layout) {
   if (layout)

--- a/mlir/test/Dialect/Ptr/canonicalize.mlir
+++ b/mlir/test/Dialect/Ptr/canonicalize.mlir
@@ -1,33 +1,15 @@
 // RUN: mlir-opt --canonicalize %s | FileCheck %s
 
-/// Check `ptradd` and `type_offset` canonicalizer patterns.
+/// Check `ptr_add` canonicalizer patterns.
 
 // CHECK-LABEL: @ops0
-func.func @ops0(%ptr: !ptr.ptr<#ptr.int_space<3>>, %c: i1) -> !ptr.ptr<#ptr.int_space<3>> {
-  // CHECK: (%[[PTR_0:.*]]: !ptr.ptr<#ptr.int_space<3>>,
-  // CHECK: %[[F32_OFF:.*]] = ptr.type_offset f32 : index
-  // CHECK: %[[PTR_1:.*]] = ptr.ptradd %[[PTR_0]], %[[F32_OFF]] : <#ptr.int_space<3>>, index
-  // CHECK: %[[PTR_2:.*]] = ptr.ptradd %[[PTR_1]], %[[F32_OFF]] : <#ptr.int_space<3>>, index
-  // CHECK: %[[PTR_3:.*]] = scf.if %{{.*}} -> (!ptr.ptr<#ptr.int_space<3>>) {
-  // CHECK: %[[PTR_4:.*]] = ptr.ptradd %[[PTR_2]], %[[F32_OFF]] : <#ptr.int_space<3>>, index
-  // CHECK: scf.yield %[[PTR_4]] : !ptr.ptr<#ptr.int_space<3>>
-  // CHECK: } else {
-  // CHECK: scf.yield %[[PTR_0]] : !ptr.ptr<#ptr.int_space<3>>
+func.func @ops0(%ptr: !ptr.ptr<#ptr.generic_space>) -> !ptr.ptr<#ptr.generic_space> {
+  // CHECK: (%[[PTR_0:.*]]: !ptr.ptr<#ptr.generic_space>)
+  // CHECK-NOT: index.constant
+  // CHECK-NOT: ptr.ptr_add
+  // CHECK: return %[[PTR_0]] : !ptr.ptr<#ptr.generic_space>
   // CHECK: }
-  // CHECK: return %[[PTR_3]] : !ptr.ptr<#ptr.int_space<3>>
-  // CHECK: }
-  %off0 = ptr.type_offset f32 : index
-  %res0 = ptr.ptradd %ptr, %off0 : !ptr.ptr<#ptr.int_space<3>>, index
-  %off1 = ptr.type_offset f32 : index
-  %res1 = ptr.ptradd %res0, %off1 : !ptr.ptr<#ptr.int_space<3>>, index
-  %res3 = scf.if %c -> !ptr.ptr<#ptr.int_space<3>> {
-    %off2 = ptr.type_offset f32 : index
-    %res2 = ptr.ptradd %res1, %off2 : !ptr.ptr<#ptr.int_space<3>>, index
-    scf.yield %res2 : !ptr.ptr<#ptr.int_space<3>>
-  } else {
-    scf.yield %ptr : !ptr.ptr<#ptr.int_space<3>>
-  }
-  %off3 = index.constant 0
-  %res4 = ptr.ptradd %res3, %off3 : !ptr.ptr<#ptr.int_space<3>>, index
-  return %res4 : !ptr.ptr<#ptr.int_space<3>>
+  %off = index.constant 0
+  %res0 = ptr.ptr_add %ptr, %off : !ptr.ptr<#ptr.generic_space>, index
+  return %res0 : !ptr.ptr<#ptr.generic_space>
 }

--- a/mlir/test/Dialect/Ptr/canonicalize.mlir
+++ b/mlir/test/Dialect/Ptr/canonicalize.mlir
@@ -2,9 +2,9 @@
 
 /// Check `ptr_add` canonicalizer patterns.
 
-// CHECK-LABEL: @ops0
-func.func @ops0(%ptr: !ptr.ptr<#ptr.generic_space>) -> !ptr.ptr<#ptr.generic_space> {
-  // CHECK: (%[[PTR_0:.*]]: !ptr.ptr<#ptr.generic_space>)
+// CHECK-LABEL: @zero_offset
+// CHECK-SAME: (%[[PTR_0:.*]]: !ptr.ptr<#ptr.generic_space>)
+func.func @zero_offset(%ptr: !ptr.ptr<#ptr.generic_space>) -> !ptr.ptr<#ptr.generic_space> {
   // CHECK-NOT: index.constant
   // CHECK-NOT: ptr.ptr_add
   // CHECK: return %[[PTR_0]] : !ptr.ptr<#ptr.generic_space>

--- a/mlir/test/Dialect/Ptr/canonicalize.mlir
+++ b/mlir/test/Dialect/Ptr/canonicalize.mlir
@@ -1,0 +1,31 @@
+// RUN: mlir-opt --canonicalize %s | FileCheck %s
+
+/// Check `ptradd` and `type_offset` canonicalizer patterns.
+
+// CHECK-LABEL: @ops0
+func.func @ops0(%ptr: !ptr.ptr<#ptr.int_space<3>>, %c: i1) -> !ptr.ptr<#ptr.int_space<3>> {
+  // CHECK: (%[[PTR_0:.*]]: !ptr.ptr<#ptr.int_space<3>>,
+  // CHECK: %[[F32_OFF:.*]] = ptr.type_offset f32 : index
+  // CHECK: %[[PTR_1:.*]] = ptr.ptradd %[[PTR_0]], %[[F32_OFF]] : <#ptr.int_space<3>>, index
+  // CHECK: %[[PTR_2:.*]] = ptr.ptradd %[[PTR_1]], %[[F32_OFF]] : <#ptr.int_space<3>>, index
+  // CHECK: %[[PTR_3:.*]] = scf.if %{{.*}} -> (!ptr.ptr<#ptr.int_space<3>>) {
+  // CHECK: %[[PTR_4:.*]] = ptr.ptradd %[[PTR_2]], %[[F32_OFF]] : <#ptr.int_space<3>>, index
+  // CHECK: scf.yield %[[PTR_4]] : !ptr.ptr<#ptr.int_space<3>>
+  // CHECK: } else {
+  // CHECK: scf.yield %[[PTR_0]] : !ptr.ptr<#ptr.int_space<3>>
+  // CHECK: }
+  // CHECK: return %[[PTR_3]] : !ptr.ptr<#ptr.int_space<3>>
+  // CHECK: }
+  %off0 = ptr.type_offset f32 : index
+  %res0 = ptr.ptradd %ptr, %off0 : !ptr.ptr<#ptr.int_space<3>>, index
+  %off1 = ptr.type_offset f32 : index
+  %res1 = ptr.ptradd %res0, %off1 : !ptr.ptr<#ptr.int_space<3>>, index
+  %res = scf.if %c -> !ptr.ptr<#ptr.int_space<3>> {
+    %off2 = ptr.type_offset f32 : index
+    %res2 = ptr.ptradd %res1, %off2 : !ptr.ptr<#ptr.int_space<3>>, index
+    scf.yield %res2 : !ptr.ptr<#ptr.int_space<3>>
+  } else {
+    scf.yield %ptr : !ptr.ptr<#ptr.int_space<3>>
+  }
+  return %res : !ptr.ptr<#ptr.int_space<3>>
+}

--- a/mlir/test/Dialect/Ptr/canonicalize.mlir
+++ b/mlir/test/Dialect/Ptr/canonicalize.mlir
@@ -20,12 +20,14 @@ func.func @ops0(%ptr: !ptr.ptr<#ptr.int_space<3>>, %c: i1) -> !ptr.ptr<#ptr.int_
   %res0 = ptr.ptradd %ptr, %off0 : !ptr.ptr<#ptr.int_space<3>>, index
   %off1 = ptr.type_offset f32 : index
   %res1 = ptr.ptradd %res0, %off1 : !ptr.ptr<#ptr.int_space<3>>, index
-  %res = scf.if %c -> !ptr.ptr<#ptr.int_space<3>> {
+  %res3 = scf.if %c -> !ptr.ptr<#ptr.int_space<3>> {
     %off2 = ptr.type_offset f32 : index
     %res2 = ptr.ptradd %res1, %off2 : !ptr.ptr<#ptr.int_space<3>>, index
     scf.yield %res2 : !ptr.ptr<#ptr.int_space<3>>
   } else {
     scf.yield %ptr : !ptr.ptr<#ptr.int_space<3>>
   }
-  return %res : !ptr.ptr<#ptr.int_space<3>>
+  %off3 = index.constant 0
+  %res4 = ptr.ptradd %res3, %off3 : !ptr.ptr<#ptr.int_space<3>>, index
+  return %res4 : !ptr.ptr<#ptr.int_space<3>>
 }

--- a/mlir/test/Dialect/Ptr/ops.mlir
+++ b/mlir/test/Dialect/Ptr/ops.mlir
@@ -1,0 +1,11 @@
+// RUN: mlir-opt %s | FileCheck %s
+
+/// Check op assembly.
+func.func @ops0(%ptr: !ptr.ptr<#ptr.int_space>) -> !ptr.ptr<#ptr.int_space> {
+  // CHECK-LABEL: @ops0
+  // CHECK: ptr.type_offset f32 : index
+  // CHECK-NEXT: ptr.ptradd %{{.*}}, %{{.*}} : <#ptr.int_space>, index
+  %off = ptr.type_offset f32 : index
+  %res = ptr.ptradd %ptr, %off : !ptr.ptr<#ptr.int_space>, index
+  return %res : !ptr.ptr<#ptr.int_space>
+}

--- a/mlir/test/Dialect/Ptr/ops.mlir
+++ b/mlir/test/Dialect/Ptr/ops.mlir
@@ -1,15 +1,19 @@
 // RUN: mlir-opt %s --verify-roundtrip | FileCheck %s
 
 /// Check op assembly.
-func.func @ops0(%ptr: !ptr.ptr<#ptr.int_space>) -> !ptr.ptr<#ptr.int_space> {
+func.func @ops0(%ptr: !ptr.ptr<#ptr.generic_space>) -> !ptr.ptr<#ptr.generic_space> {
   // CHECK-LABEL: @ops0
   // CHECK: ptr.type_offset f32 : index
-  // CHECK-NEXT: ptr.ptradd %{{.*}}, %{{.*}} : <#ptr.int_space>, index
+  // CHECK-NEXT: ptr.ptr_add %{{.*}}, %{{.*}} : <#ptr.generic_space>, index
+  // CHECK-NEXT: ptr.ptr_add %{{.*}}, %{{.*}} : <#ptr.generic_space>, index
+  // CHECK-NEXT: ptr.ptr_add nusw %{{.*}}, %{{.*}} : <#ptr.generic_space>, index
+  // CHECK-NEXT: ptr.ptr_add nuw %{{.*}}, %{{.*}} : <#ptr.generic_space>, index
+  // CHECK-NEXT: ptr.ptr_add inbounds %{{.*}}, %{{.*}} : <#ptr.generic_space>, index
   %off = ptr.type_offset f32 : index
-  %res = ptr.ptradd %ptr, %off : !ptr.ptr<#ptr.int_space>, index
-  %res0 = ptr.ptradd none %ptr, %off : !ptr.ptr<#ptr.int_space>, index
-  %res1 = ptr.ptradd nusw %ptr, %off : !ptr.ptr<#ptr.int_space>, index
-  %res2 = ptr.ptradd nuw %ptr, %off : !ptr.ptr<#ptr.int_space>, index
-  %res3 = ptr.ptradd inbounds %ptr, %off : !ptr.ptr<#ptr.int_space>, index
-  return %res : !ptr.ptr<#ptr.int_space>
+  %res = ptr.ptr_add %ptr, %off : !ptr.ptr<#ptr.generic_space>, index
+  %res0 = ptr.ptr_add none %ptr, %off : !ptr.ptr<#ptr.generic_space>, index
+  %res1 = ptr.ptr_add nusw %ptr, %off : !ptr.ptr<#ptr.generic_space>, index
+  %res2 = ptr.ptr_add nuw %ptr, %off : !ptr.ptr<#ptr.generic_space>, index
+  %res3 = ptr.ptr_add inbounds %ptr, %off : !ptr.ptr<#ptr.generic_space>, index
+  return %res : !ptr.ptr<#ptr.generic_space>
 }

--- a/mlir/test/Dialect/Ptr/ops.mlir
+++ b/mlir/test/Dialect/Ptr/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s | FileCheck %s
+// RUN: mlir-opt %s --verify-roundtrip | FileCheck %s
 
 /// Check op assembly.
 func.func @ops0(%ptr: !ptr.ptr<#ptr.int_space>) -> !ptr.ptr<#ptr.int_space> {
@@ -7,5 +7,9 @@ func.func @ops0(%ptr: !ptr.ptr<#ptr.int_space>) -> !ptr.ptr<#ptr.int_space> {
   // CHECK-NEXT: ptr.ptradd %{{.*}}, %{{.*}} : <#ptr.int_space>, index
   %off = ptr.type_offset f32 : index
   %res = ptr.ptradd %ptr, %off : !ptr.ptr<#ptr.int_space>, index
+  %res0 = ptr.ptradd none %ptr, %off : !ptr.ptr<#ptr.int_space>, index
+  %res1 = ptr.ptradd nusw %ptr, %off : !ptr.ptr<#ptr.int_space>, index
+  %res2 = ptr.ptradd nuw %ptr, %off : !ptr.ptr<#ptr.int_space>, index
+  %res3 = ptr.ptradd inbounds %ptr, %off : !ptr.ptr<#ptr.int_space>, index
   return %res : !ptr.ptr<#ptr.int_space>
 }

--- a/mlir/test/Dialect/Ptr/ops.mlir
+++ b/mlir/test/Dialect/Ptr/ops.mlir
@@ -1,8 +1,8 @@
 // RUN: mlir-opt %s --verify-roundtrip | FileCheck %s
 
 /// Check op assembly.
-func.func @ops0(%ptr: !ptr.ptr<#ptr.generic_space>) -> !ptr.ptr<#ptr.generic_space> {
-  // CHECK-LABEL: @ops0
+// CHECK-LABEL: @ptr_add_type_offset
+func.func @ptr_add_type_offset(%ptr: !ptr.ptr<#ptr.generic_space>) -> !ptr.ptr<#ptr.generic_space> {
   // CHECK: ptr.type_offset f32 : index
   // CHECK-NEXT: ptr.ptr_add %{{.*}}, %{{.*}} : <#ptr.generic_space>, index
   // CHECK-NEXT: ptr.ptr_add %{{.*}}, %{{.*}} : <#ptr.generic_space>, index


### PR DESCRIPTION
This patch adds the `ptr.ptradd` and `ptr.type_offset` operations. Given a `ptr` value these operations can be used to compute new addresses. For example:

```mlir
func.func @ops0(%ptr: !ptr.ptr<#ptr.int_space>) -> !ptr.ptr<#ptr.int_space> {
  %off = ptr.type_offset f32 : index
  %res = ptr.ptradd %ptr, %off : !ptr.ptr<#ptr.int_space>, index
  return %res : !ptr.ptr<#ptr.int_space>
}
```

Additionally, this patch also adds the `#ptr.generic_space`. This memory space allows loading and storing values to all types.