### PR TITLE
[clangd] Turn `Path` and `PathRef` into classes

### DIFF
--- a/clang-tools-extra/clangd/ASTSignals.cpp
+++ b/clang-tools-extra/clangd/ASTSignals.cpp
@@ -19,7 +19,7 @@ ASTSignals ASTSignals::derive(const ParsedAST &AST) {
   trace::Span Span("ASTSignals::derive");
   ASTSignals Signals;
   Signals.InsertionDirective = preferredIncludeDirective(
-      AST.tuPath(), AST.getLangOpts(),
+      AST.tuPath().raw(), AST.getLangOpts(),
       AST.getIncludeStructure().MainFileIncludes, AST.getLocalTopLevelDecls());
   const SourceManager &SM = AST.getSourceManager();
   findExplicitReferences(

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -935,11 +935,11 @@ void ClangdLSPServer::onDocumentDidClose(
 
   {
     std::lock_guard<std::mutex> Lock(DiagRefMutex);
-    DiagRefMap.erase(File);
+    DiagRefMap.erase(File.raw());
   }
   {
     std::lock_guard<std::mutex> HLock(SemanticTokensMutex);
-    LastSemanticTokens.erase(File);
+    LastSemanticTokens.erase(File.raw());
   }
   // clangd will not send updates for this file anymore, so we empty out the
   // list of diagnostics shown on the client (e.g. in the "Problems" pane of
@@ -1832,7 +1832,7 @@ void ClangdLSPServer::onDiagnosticsReady(PathRef File, llvm::StringRef Version,
   // Cache DiagRefMap
   {
     std::lock_guard<std::mutex> Lock(DiagRefMutex);
-    DiagRefMap[File] = LocalDiagMap;
+    DiagRefMap[File.raw()] = LocalDiagMap;
   }
 
   // Send a notification to the LSP client.

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -934,11 +934,11 @@ void ClangdLSPServer::onDocumentDidClose(
 
   {
     std::lock_guard<std::mutex> Lock(DiagRefMutex);
-    DiagRefMap.erase(File);
+    DiagRefMap.erase(File.raw());
   }
   {
     std::lock_guard<std::mutex> HLock(SemanticTokensMutex);
-    LastSemanticTokens.erase(File);
+    LastSemanticTokens.erase(File.raw());
   }
   // clangd will not send updates for this file anymore, so we empty out the
   // list of diagnostics shown on the client (e.g. in the "Problems" pane of
@@ -1837,7 +1837,7 @@ void ClangdLSPServer::onDiagnosticsReady(PathRef File, llvm::StringRef Version,
   // Cache DiagRefMap
   {
     std::lock_guard<std::mutex> Lock(DiagRefMutex);
-    DiagRefMap[File] = std::move(LocalDiagMap);
+    DiagRefMap[File.raw()] = std::move(LocalDiagMap);
   }
 
   // Send a notification to the LSP client.

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -88,15 +88,15 @@ struct UpdateIndexCallbacks : public ParsingCallbacks {
       indexStdlib(CI, std::move(*Loc));
 
     // FIndex outlives the UpdateIndexCallbacks.
-    auto Task = [FIndex(FIndex), Path(Path.str()), Version(Version.str()),
+    auto Task = [FIndex(FIndex), Path(Path.owned()), Version(Version.str()),
                  ASTCtx(std::move(ASTCtx)), PI(std::move(PI))]() mutable {
       trace::Span Tracer("PreambleIndexing");
-      FIndex->updatePreamble(Path, Version, ASTCtx.getASTContext(),
+      FIndex->updatePreamble(Path.raw(), Version, ASTCtx.getASTContext(),
                              ASTCtx.getPreprocessor(), *PI);
     };
 
     if (Tasks) {
-      Tasks->runAsync("Preamble indexing for:" + Path + Version,
+      Tasks->runAsync("Preamble indexing for:" + Path.raw() + Version,
                       std::move(Task));
     } else
       Task();
@@ -264,7 +264,7 @@ ClangdServer::ClangdServer(const GlobalCompilationDatabase &CDB,
     BackgroundIdx = std::make_unique<BackgroundIndex>(
         TFS, CDB,
         BackgroundIndexStorage::createDiskBackedStorageFactory(
-            [&CDB](llvm::StringRef File) { return CDB.getProjectInfo(File); }),
+            [&CDB](PathRef File) { return CDB.getProjectInfo(File); }),
         std::move(BGOpts));
     AddIndex(BackgroundIdx.get());
   }
@@ -321,17 +321,17 @@ void ClangdServer::addDocument(PathRef File, llvm::StringRef Contents,
   bool NewFile = WorkScheduler->update(File, Inputs, WantDiags);
   // If we loaded Foo.h, we want to make sure Foo.cpp is indexed.
   if (NewFile && BackgroundIdx)
-    BackgroundIdx->boostRelated(File);
+    BackgroundIdx->boostRelated(File.raw());
   if (NewModule)
     reparseOpenFilesIfNeeded(
-        [&](PathRef OpenFile) { return !pathEqual(OpenFile, File); });
+        [&](PathRef OpenFile) { return OpenFile != File; });
 }
 
 void ClangdServer::reparseOpenFilesIfNeeded(
     llvm::function_ref<bool(llvm::StringRef File)> Filter) {
   // Reparse only opened files that were modified.
   for (const Path &FilePath : DraftMgr.getActiveFiles())
-    if (Filter(FilePath))
+    if (Filter(FilePath.raw()))
       if (auto Draft = DraftMgr.getDraft(FilePath)) // else disappeared in race?
         addDocument(FilePath, *Draft->Contents, Draft->Version,
                     WantDiagnostics::Auto);
@@ -348,7 +348,7 @@ std::function<Context(PathRef)>
 ClangdServer::createConfiguredContextProvider(const config::Provider *Provider,
                                               Callbacks *Publish) {
   if (!Provider)
-    return [](llvm::StringRef) { return Context::current().clone(); };
+    return [](PathRef) { return Context::current().clone(); };
 
   struct Impl {
     const config::Provider *Provider;
@@ -416,8 +416,8 @@ ClangdServer::createConfiguredContextProvider(const config::Provider *Provider,
   };
 
   // Copyable wrapper.
-  return [I(std::make_shared<Impl>(Provider, Publish))](llvm::StringRef Path) {
-    return (*I)(Path);
+  return [I(std::make_shared<Impl>(Provider, Publish))](PathRef Path) {
+    return (*I)(Path.raw());
   };
 }
 
@@ -434,7 +434,7 @@ void ClangdServer::codeComplete(PathRef File, Position Pos,
   if (!CodeCompleteOpts.Index) // Respect overridden index.
     CodeCompleteOpts.Index = Index;
 
-  auto Task = [Pos, CodeCompleteOpts, File = File.str(), CB = std::move(CB),
+  auto Task = [Pos, CodeCompleteOpts, File = File.owned(), CB = std::move(CB),
                this](llvm::Expected<InputsAndPreamble> IP) mutable {
     if (!IP)
       return CB(IP.takeError());
@@ -450,7 +450,8 @@ void ClangdServer::codeComplete(PathRef File, Position Pos,
       SpecFuzzyFind.emplace();
       {
         std::lock_guard<std::mutex> Lock(CachedCompletionFuzzyFindRequestMutex);
-        SpecFuzzyFind->CachedReq = CachedCompletionFuzzyFindRequestByFile[File];
+        SpecFuzzyFind->CachedReq =
+            CachedCompletionFuzzyFindRequestByFile[File.raw()];
       }
     }
     ParseInputs ParseInput{IP->Command, &getHeaderFS(), IP->Contents.str()};
@@ -484,7 +485,8 @@ void ClangdServer::codeComplete(PathRef File, Position Pos,
       return;
     if (SpecFuzzyFind->NewReq) {
       std::lock_guard<std::mutex> Lock(CachedCompletionFuzzyFindRequestMutex);
-      CachedCompletionFuzzyFindRequestByFile[File] = *SpecFuzzyFind->NewReq;
+      CachedCompletionFuzzyFindRequestByFile[File.raw()] =
+          *SpecFuzzyFind->NewReq;
     }
     // Explicitly block until async task completes, this is fine as we've
     // already provided reply to the client and running as a preamble task
@@ -506,7 +508,7 @@ void ClangdServer::signatureHelp(PathRef File, Position Pos,
                                  MarkupKind DocumentationFormat,
                                  Callback<SignatureHelp> CB) {
 
-  auto Action = [Pos, File = File.str(), CB = std::move(CB),
+  auto Action = [Pos, File = File.owned(), CB = std::move(CB),
                  DocumentationFormat,
                  this](llvm::Expected<InputsAndPreamble> IP) mutable {
     if (!IP)
@@ -554,12 +556,13 @@ void ClangdServer::formatFile(PathRef File, const std::vector<Range> &Rngs,
   }
 
   // Call clang-format.
-  auto Action = [File = File.str(), Code = std::move(*Code),
+  auto Action = [File = File.owned(), Code = std::move(*Code),
                  Ranges = std::move(RequestedRanges), CB = std::move(CB),
                  this]() mutable {
-    format::FormatStyle Style = getFormatStyleForFile(File, Code, TFS, true);
+    format::FormatStyle Style =
+        getFormatStyleForFile(File.raw(), Code, TFS, true);
     tooling::Replacements IncludeReplaces =
-        format::sortIncludes(Style, Code, Ranges, File);
+        format::sortIncludes(Style, Code, Ranges, File.raw());
     auto Changed = tooling::applyAllReplacements(Code, IncludeReplaces);
     if (!Changed)
       return CB(Changed.takeError());
@@ -567,9 +570,9 @@ void ClangdServer::formatFile(PathRef File, const std::vector<Range> &Rngs,
     CB(IncludeReplaces.merge(format::reformat(
         Style, *Changed,
         tooling::calculateRangesAfterReplacements(IncludeReplaces, Ranges),
-        File)));
+        File.raw())));
   };
-  WorkScheduler->runQuick("Format", File, std::move(Action));
+  WorkScheduler->runQuick("Format", File.raw(), std::move(Action));
 }
 
 void ClangdServer::formatOnType(PathRef File, Position Pos,
@@ -582,24 +585,24 @@ void ClangdServer::formatOnType(PathRef File, Position Pos,
   llvm::Expected<size_t> CursorPos = positionToOffset(*Code, Pos);
   if (!CursorPos)
     return CB(CursorPos.takeError());
-  auto Action = [File = File.str(), Code = std::move(*Code),
+  auto Action = [File = File.owned(), Code = std::move(*Code),
                  TriggerText = TriggerText.str(), CursorPos = *CursorPos,
                  CB = std::move(CB), this]() mutable {
-    auto Style = getFormatStyleForFile(File, Code, TFS, false);
+    auto Style = getFormatStyleForFile(File.raw(), Code, TFS, false);
     std::vector<TextEdit> Result;
     for (const tooling::Replacement &R :
          formatIncremental(Code, CursorPos, TriggerText, Style))
       Result.push_back(replacementToEdit(Code, R));
     return CB(Result);
   };
-  WorkScheduler->runQuick("FormatOnType", File, std::move(Action));
+  WorkScheduler->runQuick("FormatOnType", File.raw(), std::move(Action));
 }
 
 void ClangdServer::prepareRename(PathRef File, Position Pos,
                                  std::optional<std::string> NewName,
                                  const RenameOptions &RenameOpts,
                                  Callback<RenameResult> CB) {
-  auto Action = [Pos, File = File.str(), CB = std::move(CB),
+  auto Action = [Pos, File = File.owned(), CB = std::move(CB),
                  NewName = std::move(NewName),
                  RenameOpts](llvm::Expected<InputsAndAST> InpAST) mutable {
     if (!InpAST)
@@ -608,7 +611,7 @@ void ClangdServer::prepareRename(PathRef File, Position Pos,
     // only need main-file references
     auto Results =
         clangd::rename({Pos, NewName.value_or("__clangd_rename_placeholder"),
-                        InpAST->AST, File, /*FS=*/nullptr,
+                        InpAST->AST, File.raw(), /*FS=*/nullptr,
                         /*Index=*/nullptr, RenameOpts});
     if (!Results) {
       // LSP says to return null on failure, but that will result in a generic
@@ -624,7 +627,7 @@ void ClangdServer::prepareRename(PathRef File, Position Pos,
 void ClangdServer::rename(PathRef File, Position Pos, llvm::StringRef NewName,
                           const RenameOptions &Opts,
                           Callback<RenameResult> CB) {
-  auto Action = [File = File.str(), NewName = NewName.str(), Pos, Opts,
+  auto Action = [File = File.owned(), NewName = NewName.str(), Pos, Opts,
                  CB = std::move(CB),
                  this](llvm::Expected<InputsAndAST> InpAST) mutable {
     // Tracks number of files edited per invocation.
@@ -632,13 +635,13 @@ void ClangdServer::rename(PathRef File, Position Pos, llvm::StringRef NewName,
                                                trace::Metric::Distribution);
     if (!InpAST)
       return CB(InpAST.takeError());
-    auto R = clangd::rename({Pos, NewName, InpAST->AST, File,
+    auto R = clangd::rename({Pos, NewName, InpAST->AST, File.raw(),
                              DirtyFS->view(std::nullopt), Index, Opts});
     if (!R)
       return CB(R.takeError());
 
     if (Opts.WantFormat) {
-      auto Style = getFormatStyleForFile(File, InpAST->Inputs.Contents,
+      auto Style = getFormatStyleForFile(File.raw(), InpAST->Inputs.Contents,
                                          *InpAST->Inputs.TFS, false);
       llvm::Error Err = llvm::Error::success();
       for (auto &E : R->GlobalChanges)
@@ -770,7 +773,7 @@ void ClangdServer::applyTweak(PathRef File, Range Sel, StringRef TweakID,
   static constexpr trace::Metric TweakFailed(
       "tweak_failed", trace::Metric::Counter, "tweak_id");
   TweakAttempt.record(1, TweakID);
-  auto Action = [File = File.str(), Sel, TweakID = TweakID.str(),
+  auto Action = [File = File.owned(), Sel, TweakID = TweakID.str(),
                  CB = std::move(CB),
                  this](Expected<InputsAndAST> InpAST) mutable {
     if (!InpAST)
@@ -796,7 +799,7 @@ void ClangdServer::applyTweak(PathRef File, Range Sel, StringRef TweakID,
       for (auto &It : (*Effect)->ApplyEdits) {
         Edit &E = It.second;
         format::FormatStyle Style =
-            getFormatStyleForFile(File, E.InitialCode, TFS, false);
+            getFormatStyleForFile(File.raw(), E.InitialCode, TFS, false);
         if (llvm::Error Err = reformatEdit(E, Style))
           elog("Failed to format {0}: {1}", It.first(), std::move(Err));
       }
@@ -831,7 +834,7 @@ void ClangdServer::switchSourceHeader(
   if (auto CorrespondingFile =
           getCorrespondingHeaderOrSource(Path, TFS.view(std::nullopt)))
     return CB(std::move(CorrespondingFile));
-  auto Action = [Path = Path.str(), CB = std::move(CB),
+  auto Action = [Path = Path.owned(), CB = std::move(CB),
                  this](llvm::Expected<InputsAndAST> InpAST) mutable {
     if (!InpAST)
       return CB(InpAST.takeError());
@@ -854,12 +857,12 @@ void ClangdServer::findDocumentHighlights(
 
 void ClangdServer::findHover(PathRef File, Position Pos,
                              Callback<std::optional<HoverInfo>> CB) {
-  auto Action = [File = File.str(), Pos, CB = std::move(CB),
+  auto Action = [File = File.owned(), Pos, CB = std::move(CB),
                  this](llvm::Expected<InputsAndAST> InpAST) mutable {
     if (!InpAST)
       return CB(InpAST.takeError());
     format::FormatStyle Style = getFormatStyleForFile(
-        File, InpAST->Inputs.Contents, *InpAST->Inputs.TFS, false);
+        File.raw(), InpAST->Inputs.Contents, *InpAST->Inputs.TFS, false);
     CB(clangd::getHover(InpAST->AST, Pos, std::move(Style), Index));
   };
 
@@ -869,7 +872,8 @@ void ClangdServer::findHover(PathRef File, Position Pos,
 void ClangdServer::typeHierarchy(PathRef File, Position Pos, int Resolve,
                                  TypeHierarchyDirection Direction,
                                  Callback<std::vector<TypeHierarchyItem>> CB) {
-  auto Action = [File = File.str(), Pos, Resolve, Direction, CB = std::move(CB),
+  auto Action = [File = File.owned(), Pos, Resolve, Direction,
+                 CB = std::move(CB),
                  this](Expected<InputsAndAST> InpAST) mutable {
     if (!InpAST)
       return CB(InpAST.takeError());
@@ -908,7 +912,7 @@ void ClangdServer::resolveTypeHierarchy(
 
 void ClangdServer::prepareCallHierarchy(
     PathRef File, Position Pos, Callback<std::vector<CallHierarchyItem>> CB) {
-  auto Action = [File = File.str(), Pos,
+  auto Action = [File = File.owned(), Pos,
                  CB = std::move(CB)](Expected<InputsAndAST> InpAST) mutable {
     if (!InpAST)
       return CB(InpAST.takeError());
@@ -995,7 +999,7 @@ void ClangdServer::foldingRanges(llvm::StringRef File,
   WorkScheduler->runQuick("FoldingRanges", File, std::move(Action));
 }
 
-void ClangdServer::findType(llvm::StringRef File, Position Pos,
+void ClangdServer::findType(PathRef File, Position Pos,
                             Callback<std::vector<LocatedSymbol>> CB) {
   auto Action = [Pos, CB = std::move(CB),
                  this](llvm::Expected<InputsAndAST> InpAST) mutable {

--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -1399,14 +1399,14 @@ bool semaCodeComplete(std::unique_ptr<CodeCompleteConsumer> Consumer,
   CI->getLangOpts().DelayedTemplateParsing = false;
   // Setup code completion.
   FrontendOpts.CodeCompleteOpts = Options;
-  FrontendOpts.CodeCompletionAt.FileName = std::string(Input.FileName);
+  FrontendOpts.CodeCompletionAt.FileName = Input.FileName.owned().raw();
   std::tie(FrontendOpts.CodeCompletionAt.Line,
            FrontendOpts.CodeCompletionAt.Column) =
       offsetToClangLineColumn(Input.ParseInput.Contents, Input.Offset);
 
   std::unique_ptr<llvm::MemoryBuffer> ContentsBuffer =
       llvm::MemoryBuffer::getMemBuffer(Input.ParseInput.Contents,
-                                       Input.FileName);
+                                       Input.FileName.raw());
   // The diagnostic options must be set before creating a CompilerInstance.
   CI->getDiagnosticOpts().IgnoreWarnings = true;
   // We reuse the preamble whether it's valid or not. This is a
@@ -1628,7 +1628,7 @@ public:
       assert(Recorder && "Recorder is not set");
       CCContextKind = Recorder->CCContext.getKind();
       IsUsingDeclaration = Recorder->CCContext.isUsingDeclaration();
-      auto Style = getFormatStyleForFile(SemaCCInput.FileName,
+      auto Style = getFormatStyleForFile(SemaCCInput.FileName.raw(),
                                          SemaCCInput.ParseInput.Contents,
                                          *SemaCCInput.ParseInput.TFS, false);
       const auto &SM = Recorder->CCSema->getSourceManager();
@@ -1648,7 +1648,7 @@ public:
       // If preprocessor was run, inclusions from preprocessor callback should
       // already be added to Includes.
       Inserter.emplace(
-          SemaCCInput.FileName, SemaCCInput.ParseInput.Contents, Style,
+          SemaCCInput.FileName.raw(), SemaCCInput.ParseInput.Contents, Style,
           SemaCCInput.ParseInput.CompileCommand.Directory,
           &Recorder->CCSema->getPreprocessor().getHeaderSearchInfo(),
           Config::current().Style.QuotedHeaders,
@@ -1739,12 +1739,12 @@ public:
     }
 
     llvm::StringMap<SourceParams> ProxSources;
-    ProxSources[FileName].Cost = 0;
+    ProxSources[FileName.raw()].Cost = 0;
     FileProximity.emplace(ProxSources);
 
-    auto Style = getFormatStyleForFile(FileName, Content, TFS, false);
+    auto Style = getFormatStyleForFile(FileName.raw(), Content, TFS, false);
     // This will only insert verbatim headers.
-    Inserter.emplace(FileName, Content, Style,
+    Inserter.emplace(FileName.raw(), Content, Style,
                      /*BuildDir=*/"", /*HeaderSearchInfo=*/nullptr,
                      Config::current().Style.QuotedHeaders,
                      Config::current().Style.AngledHeaders);
@@ -1942,7 +1942,7 @@ private:
     Req.Scopes = QueryScopes;
     Req.AnyScope = AllScopes;
     // FIXME: we should send multiple weighted paths here.
-    Req.ProximityPaths.push_back(std::string(FileName));
+    Req.ProximityPaths.push_back(FileName.owned().raw());
     if (PreferredType)
       Req.PreferredTypes.push_back(std::string(PreferredType->raw()));
     vlog("Code complete: fuzzyFind({0:2})", toJSON(Req));
@@ -1997,8 +1997,9 @@ private:
         assert(IdentifierResult);
         C.Name = IdentifierResult->Name;
       }
-      if (auto OverloadSet = C.overloadSet(
-              Opts, FileName, Inserter ? &*Inserter : nullptr, CCContextKind)) {
+      if (auto OverloadSet =
+              C.overloadSet(Opts, FileName.raw(),
+                            Inserter ? &*Inserter : nullptr, CCContextKind)) {
         auto Ret = BundleLookup.try_emplace(OverloadSet, Bundles.size());
         if (Ret.second)
           Bundles.emplace_back();
@@ -2180,8 +2181,9 @@ private:
                           : nullptr;
       if (!Builder)
         Builder.emplace(Recorder ? &Recorder->CCSema->getASTContext() : nullptr,
-                        Item, SemaCCS, AccessibleScopes, *Inserter, FileName,
-                        CCContextKind, Opts, IsUsingDeclaration, NextTokenKind);
+                        Item, SemaCCS, AccessibleScopes, *Inserter,
+                        FileName.raw(), CCContextKind, Opts, IsUsingDeclaration,
+                        NextTokenKind);
       else
         Builder->add(Item, SemaCCS, CCContextKind);
     }
@@ -2244,7 +2246,7 @@ maybeFunctionArgumentCommentEnd(const PathRef FileName, const unsigned Offset,
   if (Offset > Content.size())
     return std::nullopt;
 
-  SourceManagerForFile FileSM(FileName, Content);
+  SourceManagerForFile FileSM(FileName.raw(), Content);
   const SourceManager &SM = FileSM.get();
   const SourceLocation Cursor = SM.getComposedLoc(SM.getMainFileID(), Offset);
   const SourceLocation EndOfSuffix =
@@ -2293,7 +2295,7 @@ codeCompleteComment(PathRef FileName, const unsigned CursorOffset,
   semaCodeComplete(
       std::make_unique<ParamNameCollector>(Options, ParamNames), Options,
       {FileName, OutsideStartOffset, *Preamble,
-       PreamblePatch::createFullPatch(FileName, ParseInput, *Preamble),
+       PreamblePatch::createFullPatch(FileName.raw(), ParseInput, *Preamble),
        ParseInput},
       /*Includes=*/nullptr, std::move(CI));
   if (ParamNames.empty())
@@ -2379,7 +2381,7 @@ CodeCompleteResult codeComplete(PathRef FileName, Position Pos,
              : std::move(Flow).run({FileName, *Offset, *Preamble,
                                     /*PreamblePatch=*/
                                     PreamblePatch::createMacroPatch(
-                                        FileName, ParseInput, *Preamble),
+                                        FileName.raw(), ParseInput, *Preamble),
                                     ParseInput});
 }
 
@@ -2403,7 +2405,7 @@ SignatureHelp signatureHelp(PathRef FileName, Position Pos,
                                                ParseInput.Index, Result),
       Options,
       {FileName, *Offset, Preamble,
-       PreamblePatch::createFullPatch(FileName, ParseInput, Preamble),
+       PreamblePatch::createFullPatch(FileName.raw(), ParseInput, Preamble),
        ParseInput});
   return Result;
 }

--- a/clang-tools-extra/clangd/ConfigCompile.cpp
+++ b/clang-tools-extra/clangd/ConfigCompile.cpp
@@ -412,8 +412,9 @@ struct FragmentCompiler {
         C.Index.External = Spec;
         return;
       }
-      if (P.Path.empty() || !pathStartsWith(Spec.MountPoint, P.Path,
-                                            llvm::sys::path::Style::posix))
+      if (P.Path.empty() ||
+          !PathRef(Spec.MountPoint)
+               .startsWith(P.Path, llvm::sys::path::Style::posix))
         return;
       C.Index.External = Spec;
       // Disable background indexing for the files under the mountpoint.

--- a/clang-tools-extra/clangd/ConfigProvider.cpp
+++ b/clang-tools-extra/clangd/ConfigProvider.cpp
@@ -43,7 +43,8 @@ public:
         [&](std::optional<llvm::StringRef> Data) {
           CachedValue.clear();
           if (Data)
-            for (auto &Fragment : Fragment::parseYAML(*Data, path(), DC)) {
+            for (auto &Fragment :
+                 Fragment::parseYAML(*Data, path().raw(), DC)) {
               Fragment.Source.Directory = Directory;
               Fragment.Source.Trusted = Trusted;
               CachedValue.push_back(std::move(Fragment).compile(DC));
@@ -103,9 +104,9 @@ Provider::fromAncestorRelativeYAMLFiles(llvm::StringRef RelPath,
 
       // Compute absolute paths to all ancestors (substrings of P.Path).
       llvm::SmallVector<llvm::StringRef, 8> Ancestors;
-      for (auto Ancestor = absoluteParent(P.Path); !Ancestor.empty();
-           Ancestor = absoluteParent(Ancestor)) {
-        Ancestors.emplace_back(Ancestor);
+      for (auto Ancestor = PathRef(P.Path).absoluteParent(); !Ancestor.empty();
+           Ancestor = Ancestor.absoluteParent()) {
+        Ancestors.emplace_back(Ancestor.raw());
       }
       // Ensure corresponding cache entries exist in the map.
       llvm::SmallVector<FileConfigCache *, 8> Caches;

--- a/clang-tools-extra/clangd/DraftStore.cpp
+++ b/clang-tools-extra/clangd/DraftStore.cpp
@@ -19,7 +19,7 @@ namespace clangd {
 std::optional<DraftStore::Draft> DraftStore::getDraft(PathRef File) const {
   std::lock_guard<std::mutex> Lock(Mutex);
 
-  auto It = Drafts.find(File);
+  auto It = Drafts.find(File.raw());
   if (It == Drafts.end())
     return std::nullopt;
 
@@ -76,7 +76,7 @@ std::string DraftStore::addDraft(PathRef File, llvm::StringRef Version,
                                  llvm::StringRef Contents) {
   std::lock_guard<std::mutex> Lock(Mutex);
 
-  auto &D = Drafts[File];
+  auto &D = Drafts[File.raw()];
   updateVersion(D.D, Version);
   std::time(&D.MTime);
   D.D.Contents = std::make_shared<std::string>(Contents);
@@ -86,7 +86,7 @@ std::string DraftStore::addDraft(PathRef File, llvm::StringRef Version,
 void DraftStore::removeDraft(PathRef File) {
   std::lock_guard<std::mutex> Lock(Mutex);
 
-  Drafts.erase(File);
+  Drafts.erase(File.raw());
 }
 
 namespace {

--- a/clang-tools-extra/clangd/FS.cpp
+++ b/clang-tools-extra/clangd/FS.cpp
@@ -113,11 +113,5 @@ PreambleFileStatusCache::getConsumingFS(
   return llvm::IntrusiveRefCntPtr<CacheVFS>(new CacheVFS(std::move(FS), *this));
 }
 
-Path removeDots(PathRef File) {
-  llvm::SmallString<128> CanonPath(File);
-  llvm::sys::path::remove_dots(CanonPath, /*remove_dot_dot=*/true);
-  return CanonPath.str().str();
-}
-
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/FS.h
+++ b/clang-tools-extra/clangd/FS.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANGD_FS_H
 #define LLVM_CLANG_TOOLS_EXTRA_CLANGD_FS_H
 
-#include "support/Path.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -67,13 +66,6 @@ private:
   std::string MainFilePath;
   llvm::StringMap<llvm::vfs::Status> StatCache;
 };
-
-/// Returns a version of \p File that doesn't contain dots and dot dots.
-/// e.g /a/b/../c -> /a/c
-///     /a/b/./c -> /a/b/c
-/// FIXME: We should avoid encountering such paths in clangd internals by
-/// filtering everything we get over LSP, CDB, etc.
-Path removeDots(PathRef File);
 
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/GlobalCompilationDatabase.cpp
+++ b/clang-tools-extra/clangd/GlobalCompilationDatabase.cpp
@@ -46,8 +46,8 @@ namespace {
 // deepest directory and going up to root. Stops whenever action succeeds.
 void actOnAllParentDirectories(PathRef FileName,
                                llvm::function_ref<bool(PathRef)> Action) {
-  for (auto Path = absoluteParent(FileName); !Path.empty() && !Action(Path);
-       Path = absoluteParent(Path))
+  for (auto Path = FileName.absoluteParent(); !Path.empty() && !Action(Path);
+       Path = Path.absoluteParent())
     ;
 }
 
@@ -59,14 +59,14 @@ GlobalCompilationDatabase::getFallbackCommand(PathRef File) const {
   // Clang treats .h files as C by default and files without extension as linker
   // input, resulting in unhelpful diagnostics.
   // Parsing as Objective C++ is friendly to more cases.
-  auto FileExtension = llvm::sys::path::extension(File);
+  auto FileExtension = File.extension();
   if (FileExtension.empty() || FileExtension == ".h")
     Argv.push_back("-xobjective-c++-header");
-  Argv.push_back(std::string(File));
+  Argv.push_back(std::string(File.raw()));
   tooling::CompileCommand Cmd(FallbackWorkingDirectory
                                   ? *FallbackWorkingDirectory
-                                  : llvm::sys::path::parent_path(File),
-                              llvm::sys::path::filename(File), std::move(Argv),
+                                  : File.parentPath().raw(),
+                              File.filename(), std::move(Argv),
                               /*Output=*/"");
   Cmd.Heuristic = "clangd fallback";
   return Cmd;
@@ -266,7 +266,7 @@ parseJSON(PathRef Path, llvm::StringRef Data, std::string &Error) {
 static std::unique_ptr<tooling::CompilationDatabase>
 parseFixed(PathRef Path, llvm::StringRef Data, std::string &Error) {
   return tooling::FixedCompilationDatabase::loadFromBuffer(
-      llvm::sys::path::parent_path(Path), Data, Error);
+      Path.parentPath().raw(), Data, Error);
 }
 
 bool DirectoryBasedGlobalCompilationDatabase::DirectoryCache::load(
@@ -376,7 +376,7 @@ DirectoryBasedGlobalCompilationDatabase::getCompileCommand(PathRef File) const {
     return std::nullopt;
   }
 
-  auto Candidates = Res->CDB->getCompileCommands(File);
+  auto Candidates = Res->CDB->getCompileCommands(File.raw());
   if (!Candidates.empty())
     return std::move(Candidates.front());
 
@@ -390,10 +390,10 @@ DirectoryBasedGlobalCompilationDatabase::getDirectoryCaches(
   FoldedDirs.reserve(Dirs.size());
   for (const auto &Dir : Dirs) {
 #ifndef NDEBUG
-    if (!llvm::sys::path::is_absolute(Dir))
+    if (!PathRef(Dir).isAbsolute())
       elog("Trying to cache CDB for relative {0}");
 #endif
-    FoldedDirs.push_back(maybeCaseFoldPath(Dir));
+    FoldedDirs.push_back(PathRef(Dir).caseFolded().raw());
   }
 
   std::vector<DirectoryCache *> Ret;
@@ -408,15 +408,15 @@ DirectoryBasedGlobalCompilationDatabase::getDirectoryCaches(
 std::optional<DirectoryBasedGlobalCompilationDatabase::CDBLookupResult>
 DirectoryBasedGlobalCompilationDatabase::lookupCDB(
     CDBLookupRequest Request) const {
-  assert(llvm::sys::path::is_absolute(Request.FileName) &&
-         "path must be absolute");
+  assert(Request.FileName.isAbsolute() && "path must be absolute");
 
   std::string Storage;
   std::vector<llvm::StringRef> SearchDirs;
   if (Opts.CompileCommandsDir) // FIXME: unify this case with config.
-    SearchDirs = {*Opts.CompileCommandsDir};
+    SearchDirs = {Opts.CompileCommandsDir->raw()};
   else {
-    WithContext WithProvidedContext(Opts.ContextProvider(Request.FileName));
+    WithContext WithProvidedContext(
+        Opts.ContextProvider(Request.FileName.raw()));
     const auto &Spec = Config::current().CompileFlags.CDBSearch;
     switch (Spec.Policy) {
     case Config::CDBSearchSpec::NoCDBSearch:
@@ -429,9 +429,9 @@ DirectoryBasedGlobalCompilationDatabase::lookupCDB(
       // Traverse the canonical version to prevent false positives. i.e.:
       // src/build/../a.cc can detect a CDB in /src/build if not
       // canonicalized.
-      Storage = removeDots(Request.FileName);
-      actOnAllParentDirectories(Storage, [&](llvm::StringRef Dir) {
-        SearchDirs.push_back(Dir);
+      Storage = Request.FileName.removeDots().raw();
+      actOnAllParentDirectories(Storage, [&](PathRef Dir) {
+        SearchDirs.push_back(Dir.raw());
         return false;
       });
     }
@@ -598,8 +598,8 @@ class DirectoryBasedGlobalCompilationDatabase::BroadcastThread::Filter {
   DirInfo *addParents(llvm::StringRef FilePath) {
     DirInfo *Leaf = nullptr;
     DirInfo *Child = nullptr;
-    actOnAllParentDirectories(FilePath, [&](llvm::StringRef Dir) {
-      auto &Info = Dirs[Dir];
+    actOnAllParentDirectories(FilePath, [&](PathRef Dir) {
+      auto &Info = Dirs[Dir.raw()];
       // If this is the first iteration, then this node is the overall result.
       if (!Leaf)
         Leaf = &Info;
@@ -694,7 +694,7 @@ public:
     std::vector<SearchPath> SearchPaths(AllFiles.size());
     for (unsigned I = 0; I < AllFiles.size(); ++I) {
       if (Parent.Opts.CompileCommandsDir) { // FIXME: unify with config
-        SearchPaths[I].setPointer(&Dirs[*Parent.Opts.CompileCommandsDir]);
+        SearchPaths[I].setPointer(&Dirs[Parent.Opts.CompileCommandsDir->raw()]);
         continue;
       }
       if (ExitEarly()) // loading config may be slow
@@ -786,7 +786,7 @@ OverlayCDB::getCompileCommand(PathRef File) const {
   std::optional<tooling::CompileCommand> Cmd;
   {
     std::lock_guard<std::mutex> Lock(Mutex);
-    auto It = Commands.find(removeDots(File));
+    auto It = Commands.find(File.removeDots().raw());
     if (It != Commands.end())
       Cmd = It->second;
   }
@@ -811,7 +811,7 @@ OverlayCDB::getCompileCommand(PathRef File) const {
   if (!Cmd)
     return std::nullopt;
   if (Mangler)
-    Mangler(*Cmd, File);
+    Mangler(*Cmd, File.raw());
   return Cmd;
 }
 
@@ -821,7 +821,7 @@ tooling::CompileCommand OverlayCDB::getFallbackCommand(PathRef File) const {
   Cmd.CommandLine.insert(Cmd.CommandLine.end(), FallbackFlags.begin(),
                          FallbackFlags.end());
   if (Mangler)
-    Mangler(Cmd, File);
+    Mangler(Cmd, File.raw());
   return Cmd;
 }
 
@@ -830,7 +830,7 @@ bool OverlayCDB::setCompileCommand(PathRef File,
   // We store a canonical version internally to prevent mismatches between set
   // and get compile commands. Also it assures clients listening to broadcasts
   // doesn't receive different names for the same file.
-  std::string CanonPath = removeDots(File);
+  std::string CanonPath = File.removeDots().raw();
   {
     std::unique_lock<std::mutex> Lock(Mutex);
     if (Cmd) {
@@ -857,7 +857,7 @@ OverlayCDB::getProjectModules(PathRef File) const {
   }
   MDB->setCommandMangler([&Mangler = Mangler](tooling::CompileCommand &Command,
                                               PathRef CommandPath) {
-    Mangler(Command, CommandPath);
+    Mangler(Command, CommandPath.raw());
   });
   return MDB;
 }

--- a/clang-tools-extra/clangd/HeaderSourceSwitch.cpp
+++ b/clang-tools-extra/clangd/HeaderSourceSwitch.cpp
@@ -26,16 +26,16 @@ std::optional<Path> getCorrespondingHeaderOrSource(
       ".hpp",  ".hh",  ".hxx",  ".h++",  ".h",  ".inc",
       ".cppm", ".ccm", ".cxxm", ".c++m", ".ixx"};
 
-  llvm::StringRef PathExt = llvm::sys::path::extension(OriginalFile);
+  llvm::StringRef PathExt = OriginalFile.extension();
 
   // Lookup in a list of known extensions.
   const bool IsSource =
-      llvm::any_of(SourceExtensions, [&PathExt](PathRef SourceExt) {
+      llvm::any_of(SourceExtensions, [&PathExt](StringRef SourceExt) {
         return SourceExt.equals_insensitive(PathExt);
       });
 
   const bool IsHeader =
-      llvm::any_of(HeaderExtensions, [&PathExt](PathRef HeaderExt) {
+      llvm::any_of(HeaderExtensions, [&PathExt](StringRef HeaderExt) {
         return HeaderExt.equals_insensitive(PathExt);
       });
 
@@ -52,7 +52,7 @@ std::optional<Path> getCorrespondingHeaderOrSource(
     NewExts = SourceExtensions;
 
   // Storage for the new path.
-  llvm::SmallString<128> NewPath = OriginalFile;
+  llvm::SmallString<128> NewPath = OriginalFile.raw();
 
   // Loop through switched extension candidates.
   for (llvm::StringRef NewExt : NewExts) {
@@ -83,8 +83,8 @@ std::optional<Path> getCorrespondingHeaderOrSource(PathRef OriginalFile,
   }
   llvm::StringMap<int> Candidates; // Target path => score.
   auto AwardTarget = [&](const char *TargetURI) {
-    if (auto TargetPath = URI::resolve(TargetURI, OriginalFile)) {
-      if (!pathEqual(*TargetPath, OriginalFile)) // exclude the original file.
+    if (auto TargetPath = URI::resolve(TargetURI, OriginalFile.raw())) {
+      if (PathRef(*TargetPath) != OriginalFile) // exclude the original file.
         ++Candidates[*TargetPath];
     } else {
       elog("Failed to resolve URI {0}: {1}", TargetURI, TargetPath.takeError());
@@ -96,7 +96,7 @@ std::optional<Path> getCorrespondingHeaderOrSource(PathRef OriginalFile,
   //
   // For each symbol in the original file, we get its target location (decl or
   // def) from the index, then award that target file.
-  const bool IsHeader = isHeaderFile(OriginalFile, AST.getLangOpts());
+  const bool IsHeader = isHeaderFile(OriginalFile.raw(), AST.getLangOpts());
   Index->lookup(Request, [&](const Symbol &Sym) {
     if (IsHeader)
       AwardTarget(Sym.Definition.FileURI);

--- a/clang-tools-extra/clangd/Headers.cpp
+++ b/clang-tools-extra/clangd/Headers.cpp
@@ -263,7 +263,7 @@ IncludeStructure::mainFileIncludesWithSpelling(llvm::StringRef Spelling) const {
 void IncludeInserter::addExisting(const Inclusion &Inc) {
   IncludedHeaders.insert(Inc.Written);
   if (!Inc.Resolved.empty())
-    IncludedHeaders.insert(Inc.Resolved);
+    IncludedHeaders.insert(Inc.Resolved.raw());
 }
 
 /// FIXME(ioeric): we might not want to insert an absolute include path if the
@@ -278,7 +278,7 @@ bool IncludeInserter::shouldInsertInclude(
   auto Included = [&](llvm::StringRef Header) {
     return IncludedHeaders.contains(Header);
   };
-  return !Included(DeclaringHeader) && !Included(InsertedHeader.File);
+  return !Included(DeclaringHeader.raw()) && !Included(InsertedHeader.File);
 }
 
 std::optional<std::string>
@@ -349,7 +349,7 @@ IncludeInserter::insert(llvm::StringRef VerbatimHeader,
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Inclusion &Inc) {
   return OS << Inc.Written << " = "
-            << (!Inc.Resolved.empty() ? Inc.Resolved : "[unresolved]")
+            << (!Inc.Resolved.empty() ? Inc.Resolved.raw() : "[unresolved]")
             << " at line" << Inc.HashLine;
 }
 

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -1274,7 +1274,7 @@ std::optional<HoverInfo> getHover(ParsedAST &AST, Position Pos,
       continue;
     HoverCountMetric.record(1, "include");
     HoverInfo HI;
-    HI.Name = std::string(llvm::sys::path::filename(Inc.Resolved));
+    HI.Name = Inc.Resolved.ref().filename().str();
     HI.Definition =
         URIForFile::canonicalize(Inc.Resolved, AST.tuPath()).file().str();
     HI.DefinitionLanguage = "";

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -1330,7 +1330,7 @@ std::optional<HoverInfo> getHover(ParsedAST &AST, Position Pos,
       continue;
     HoverCountMetric.record(1, "include");
     HoverInfo HI;
-    HI.Name = std::string(llvm::sys::path::filename(Inc.Resolved));
+    HI.Name = Inc.Resolved.ref().filename().str();
     HI.Definition =
         URIForFile::canonicalize(Inc.Resolved, AST.tuPath()).file().str();
     HI.DefinitionLanguage = "";

--- a/clang-tools-extra/clangd/ModulesBuilder.cpp
+++ b/clang-tools-extra/clangd/ModulesBuilder.cpp
@@ -72,9 +72,7 @@ std::string hashStringForCache(llvm::StringRef Content) {
 }
 
 std::string normalizePathForCache(PathRef Path) {
-  llvm::SmallString<256> Normalized(Path);
-  llvm::sys::path::remove_dots(Normalized, /*remove_dot_dot=*/true);
-  return maybeCaseFoldPath(Normalized);
+  return Path.normalized().raw();
 }
 
 /// Returns the root directory used for persistent module cache storage.
@@ -118,7 +116,7 @@ std::string getModuleUnitSourcePathHash(PathRef ModuleUnitFileName) {
 }
 
 std::string getModuleUnitSourceDirectoryName(PathRef ModuleUnitFileName) {
-  std::string Result = llvm::sys::path::filename(ModuleUnitFileName).str();
+  std::string Result = ModuleUnitFileName.filename().str();
   Result.push_back('-');
   Result.append(getModuleUnitSourcePathHash(ModuleUnitFileName));
   return Result;
@@ -170,7 +168,7 @@ getModuleSourceHashLockPath(PathRef ModuleUnitFileName,
 /// Returns a unique temporary path used to stage a BMI before atomically
 /// publishing it to the stable cache path.
 llvm::SmallString<256> getTemporaryModuleFilePath(PathRef ModuleFilePath) {
-  llvm::SmallString<256> ResultPattern(ModuleFilePath);
+  llvm::SmallString<256> ResultPattern(ModuleFilePath.raw());
   ResultPattern.append(".tmp-%%-%%-%%-%%-%%-%%");
   llvm::SmallString<256> Result;
   llvm::sys::fs::createUniquePath(ResultPattern, Result,
@@ -200,21 +198,20 @@ std::string getModuleFileVersionTimestamp() {
 
 llvm::SmallString<256>
 getCopyOnReadModuleFilePath(PathRef PublishedModuleFile) {
-  llvm::SmallString<256> Result(PublishedModuleFile);
+  llvm::SmallString<256> Result(PublishedModuleFile.raw());
   llvm::sys::path::remove_filename(Result);
-  llvm::sys::path::append(
-      Result,
-      llvm::formatv("{0}-{1}{2}", llvm::sys::path::stem(PublishedModuleFile),
-                    getModuleFileVersionTimestamp(),
-                    llvm::sys::path::extension(PublishedModuleFile))
-          .str());
+  llvm::sys::path::append(Result, llvm::formatv("{0}-{1}{2}",
+                                                PublishedModuleFile.stem(),
+                                                getModuleFileVersionTimestamp(),
+                                                PublishedModuleFile.extension())
+                                      .str());
   return Result;
 }
 
 /// Ensures the lock anchor file exists before LockFileManager tries to acquire
 /// ownership, creating parent directories as needed.
 llvm::Error ensureLockAnchorFileExists(PathRef LockPath) {
-  llvm::SmallString<256> LockParent(LockPath);
+  llvm::SmallString<256> LockParent(LockPath.raw());
   llvm::sys::path::remove_filename(LockParent);
   if (std::error_code EC = llvm::sys::fs::create_directories(LockParent))
     return llvm::createStringError(llvm::formatv(
@@ -222,7 +219,7 @@ llvm::Error ensureLockAnchorFileExists(PathRef LockPath) {
 
   int FD = -1;
   if (std::error_code EC = llvm::sys::fs::openFileForWrite(
-          LockPath, FD, llvm::sys::fs::CD_OpenAlways))
+          LockPath.raw(), FD, llvm::sys::fs::CD_OpenAlways))
     return llvm::createStringError(llvm::formatv(
         "Failed to open lock file anchor {0}: {1}", LockPath, EC.message()));
   llvm::sys::Process::SafelyCloseFileDescriptor(FD);
@@ -293,7 +290,7 @@ private:
 // Get the stable published module file path under \param ModuleFilesPrefix.
 std::string getModuleFilePath(llvm::StringRef ModuleName,
                               PathRef ModuleFilesPrefix) {
-  llvm::SmallString<256> ModuleFilePath(ModuleFilesPrefix);
+  llvm::SmallString<256> ModuleFilePath(ModuleFilesPrefix.raw());
   auto [PrimaryModuleName, PartitionName] = ModuleName.split(':');
   llvm::sys::path::append(ModuleFilePath, PrimaryModuleName);
   if (!PartitionName.empty()) {
@@ -334,7 +331,7 @@ public:
 class ModuleFile {
 protected:
   ModuleFile(StringRef ModuleName, PathRef ModuleFilePath)
-      : ModuleName(ModuleName.str()), ModuleFilePath(ModuleFilePath.str()) {}
+      : ModuleName(ModuleName.str()), ModuleFilePath(ModuleFilePath.raw()) {}
 
 public:
   ModuleFile() = delete;
@@ -576,7 +573,7 @@ bool IsModuleFileUpToDate(PathRef ModuleFilePath,
   // without treating it as a hard error.
   // ReadAST will validate all input files internally and return OutOfDate
   // if any file is modified.
-  return Reader.ReadAST(ModuleFileName::makeExplicit(ModuleFilePath),
+  return Reader.ReadAST(ModuleFileName::makeExplicit(ModuleFilePath.str()),
                         serialization::MK_MainFile, SourceLocation(),
                         ASTReader::ARR_OutOfDate) == ASTReader::Success;
 }
@@ -601,7 +598,7 @@ buildModuleFile(llvm::StringRef ModuleName, PathRef ModuleUnitFileName,
                 const ReusablePrerequisiteModules &BuiltModuleFiles,
                 bool &PublishedExistingModuleFile) {
   PublishedExistingModuleFile = false;
-  llvm::SmallString<256> ModuleFilesPrefix(ModuleFilePath);
+  llvm::SmallString<256> ModuleFilesPrefix(ModuleFilePath.raw());
   llvm::sys::path::remove_filename(ModuleFilesPrefix);
   if (std::error_code EC = llvm::sys::fs::create_directories(ModuleFilesPrefix))
     return llvm::createStringError(
@@ -678,9 +675,9 @@ buildModuleFile(llvm::StringRef ModuleName, PathRef ModuleUnitFileName,
                       ModuleUnitFileName));
   }
 
-  if (std::error_code EC =
-          llvm::sys::fs::rename(TemporaryModuleFilePath, ModuleFilePath)) {
-    if (!llvm::sys::fs::exists(ModuleFilePath))
+  if (std::error_code EC = llvm::sys::fs::rename(TemporaryModuleFilePath,
+                                                 ModuleFilePath.raw())) {
+    if (!ModuleFilePath.exists())
       return llvm::createStringError(
           llvm::formatv("Failed to publish module file {0}: {1}",
                         ModuleFilePath, EC.message()));
@@ -701,8 +698,8 @@ copyModuleFileForRead(llvm::StringRef ModuleName,
                       PathRef PublishedModuleFilePath) {
   llvm::SmallString<256> VersionedModuleFilePath =
       getCopyOnReadModuleFilePath(PublishedModuleFilePath);
-  if (std::error_code EC = llvm::sys::fs::copy_file(PublishedModuleFilePath,
-                                                    VersionedModuleFilePath))
+  if (std::error_code EC = llvm::sys::fs::copy_file(
+          PublishedModuleFilePath.raw(), VersionedModuleFilePath))
     return llvm::createStringError(llvm::formatv(
         "Failed to copy module file {0} to {1}: {2}", PublishedModuleFilePath,
         VersionedModuleFilePath, EC.message()));
@@ -715,7 +712,7 @@ bool ReusablePrerequisiteModules::canReuse(
   if (RequiredModules.empty())
     return true;
 
-  llvm::SmallVector<llvm::StringRef> BMIPaths;
+  llvm::SmallVector<PathRef> BMIPaths;
   for (auto &MF : RequiredModules)
     BMIPaths.push_back(MF->getModuleFilePath());
   return IsModuleFilesUpToDate(BMIPaths, *this, VFS);
@@ -772,7 +769,7 @@ private:
                 CommandHash.size() + 2);
     Key.append(ModuleName);
     Key.push_back('\0');
-    Key.append(maybeCaseFoldPath(ModuleUnitSource));
+    Key.append(ModuleUnitSource.caseFolded().raw());
     Key.push_back('\0');
     Key.append(CommandHash);
     return Key;
@@ -833,7 +830,7 @@ public:
     auto Outer = ModuleNameToMultipleSourceCache.find(ModuleName);
     if (Outer == ModuleNameToMultipleSourceCache.end())
       return "";
-    auto Inner = Outer->second.find(maybeCaseFoldPath(RequiredSrcFile));
+    auto Inner = Outer->second.find(RequiredSrcFile.caseFolded().raw());
     if (Inner == Outer->second.end())
       return "";
     return Inner->second;
@@ -843,7 +840,7 @@ public:
                         PathRef Source) {
     std::lock_guard<std::mutex> Lock(CacheMutex);
     ModuleNameToMultipleSourceCache[ModuleName]
-                                   [maybeCaseFoldPath(RequiredSrcFile)] =
+                                   [RequiredSrcFile.caseFolded().raw()] =
                                        Source.str();
   }
 
@@ -852,7 +849,7 @@ public:
     auto Outer = ModuleNameToMultipleSourceCache.find(ModuleName);
     if (Outer == ModuleNameToMultipleSourceCache.end())
       return;
-    Outer->second.erase(maybeCaseFoldPath(RequiredSrcFile));
+    Outer->second.erase(RequiredSrcFile.caseFolded().raw());
     if (Outer->second.empty())
       ModuleNameToMultipleSourceCache.erase(Outer);
   }
@@ -875,8 +872,7 @@ private:
 // the actual module declaration.
 bool isCXXModuleFile(PathRef File) {
   namespace types = clang::driver::types;
-  auto Lang =
-      types::lookupTypeForExtension(llvm::sys::path::extension(File).substr(1));
+  auto Lang = types::lookupTypeForExtension(File.extension().substr(1));
   return Lang == types::TY_CXXModule;
 }
 
@@ -890,19 +886,19 @@ public:
 
   bool add(PathRef File) {
     std::lock_guard<std::mutex> Lock(Mutex);
-    return Sources.try_emplace(maybeCaseFoldPath(File), File.str()).second;
+    return Sources.try_emplace(File.caseFolded().raw(), File.str()).second;
   }
 
   bool remove(PathRef File) {
     std::lock_guard<std::mutex> Lock(Mutex);
-    return Sources.erase(maybeCaseFoldPath(File));
+    return Sources.erase(File.caseFolded().raw());
   }
 
   std::vector<Path> sourcesFor(PathRef File) const {
     auto PI = CDB.getProjectInfo(File);
     if (!PI || PI->SourceRoot.empty())
       return {};
-    const std::string ProjectRoot = maybeCaseFoldPath(PI->SourceRoot);
+    const std::string ProjectRoot = PathRef(PI->SourceRoot).caseFolded().raw();
 
     std::vector<Path> Observed;
     {
@@ -915,7 +911,7 @@ public:
     std::vector<Path> Result;
     for (const auto &Source : Observed) {
       auto SourcePI = CDB.getProjectInfo(Source);
-      if (SourcePI && maybeCaseFoldPath(SourcePI->SourceRoot) == ProjectRoot)
+      if (SourcePI && PathRef(SourcePI->SourceRoot) == ProjectRoot)
         Result.push_back(Source);
     }
     return Result;
@@ -1009,7 +1005,7 @@ private:
       return Result;
     for (const auto &Source : ObservedFiles.sourcesFor(RequiredSrcFile))
       if (MDB->getModuleNameForSource(Source) == ModuleName)
-        return Source;
+        return Source.raw();
     return std::nullopt;
   }
 
@@ -1047,7 +1043,7 @@ llvm::SmallVector<std::string> getAllRequiredModules(PathRef RequiredSource,
 std::vector<std::string> collectModuleFiles(PathRef CacheRoot) {
   std::vector<std::string> Result;
   std::error_code EC;
-  for (llvm::sys::fs::recursive_directory_iterator It(CacheRoot, EC), End;
+  for (llvm::sys::fs::recursive_directory_iterator It(CacheRoot.raw(), EC), End;
        It != End && !EC; It.increment(EC)) {
     if (llvm::sys::path::extension(It->path()) != ".pcm")
       continue;
@@ -1160,7 +1156,7 @@ void ModulesBuilder::ModulesBuilderImpl::
       return;
   }
 
-  llvm::SmallString<256> CacheRoot(ProjectRoot);
+  llvm::SmallString<256> CacheRoot(ProjectRoot.raw());
   llvm::sys::path::append(CacheRoot, ".cache", "clangd", "modules");
   log("Running GC pass for clangd built module files under {0} with age "
       "threshold {1} seconds (adjust with --modules-builder-versioned-gc-"

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -196,8 +196,9 @@ private:
   void replay() {
     for (const auto &Inc : Includes) {
       OptionalFileEntryRef File;
-      if (Inc.Resolved != "")
-        File = expectedToOptional(SM.getFileManager().getFileRef(Inc.Resolved));
+      if (!Inc.Resolved.empty())
+        File = expectedToOptional(
+            SM.getFileManager().getFileRef(Inc.Resolved.ref().raw()));
 
       // Re-lex the #include directive to find its interesting parts.
       auto HashLoc = SM.getComposedLoc(SM.getMainFileID(), Inc.HashOffset);

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -222,8 +222,9 @@ private:
     }
     for (const auto &Inc : Includes) {
       OptionalFileEntryRef File;
-      if (Inc.Resolved != "")
-        File = expectedToOptional(SM.getFileManager().getFileRef(Inc.Resolved));
+      if (!Inc.Resolved.empty())
+        File = expectedToOptional(
+            SM.getFileManager().getFileRef(Inc.Resolved.ref().raw()));
 
       // Re-lex the #include directive to find its interesting parts.
       auto HashLoc = SM.getComposedLoc(SM.getMainFileID(), Inc.HashOffset);

--- a/clang-tools-extra/clangd/Preamble.cpp
+++ b/clang-tools-extra/clangd/Preamble.cpp
@@ -595,11 +595,11 @@ buildPreamble(PathRef FileName, CompilerInvocation CI,
   // Note that we don't need to copy the input contents, preamble can live
   // without those.
   auto ContentsBuffer =
-      llvm::MemoryBuffer::getMemBuffer(Inputs.Contents, FileName);
+      llvm::MemoryBuffer::getMemBuffer(Inputs.Contents, FileName.raw());
   auto Bounds = ComputePreambleBounds(CI.getLangOpts(), *ContentsBuffer, 0);
 
   trace::Span Tracer("BuildPreamble");
-  SPAN_ATTACH(Tracer, "File", FileName);
+  SPAN_ATTACH(Tracer, "File", FileName.raw());
   std::vector<std::unique_ptr<FeatureModule::ASTListener>> ASTListeners;
   if (Inputs.FeatureModules) {
     for (auto &M : *Inputs.FeatureModules) {
@@ -650,7 +650,7 @@ buildPreamble(PathRef FileName, CompilerInvocation CI,
         for (const auto &L : ASTListeners)
           L->beforeExecute(CI);
       });
-  llvm::SmallString<32> AbsFileName(FileName);
+  llvm::SmallString<32> AbsFileName(FileName.raw());
   VFS->makeAbsolute(AbsFileName);
   auto StatCache = std::make_shared<PreambleFileStatusCache>(AbsFileName);
   auto StatCacheFS = StatCache->getProducingFS(VFS);
@@ -746,7 +746,7 @@ bool isPreambleCompatible(const PreambleData &Preamble,
                           const ParseInputs &Inputs, PathRef FileName,
                           const CompilerInvocation &CI) {
   auto ContentsBuffer =
-      llvm::MemoryBuffer::getMemBuffer(Inputs.Contents, FileName);
+      llvm::MemoryBuffer::getMemBuffer(Inputs.Contents, FileName.raw());
   auto Bounds = ComputePreambleBounds(CI.getLangOpts(), *ContentsBuffer, 0);
   auto VFS = Inputs.TFS->view(Inputs.CompileCommand.Directory);
   return compileCommandsAreEqual(Inputs.CompileCommand,

--- a/clang-tools-extra/clangd/Preamble.cpp
+++ b/clang-tools-extra/clangd/Preamble.cpp
@@ -577,12 +577,12 @@ buildPreamble(PathRef FileName, CompilerInvocation CI,
   // Note that we don't need to copy the input contents, preamble can live
   // without those.
   auto ContentsBuffer =
-      llvm::MemoryBuffer::getMemBuffer(Inputs.Contents, FileName);
+      llvm::MemoryBuffer::getMemBuffer(Inputs.Contents, FileName.raw());
   auto Bounds = computePreambleBounds(CI.getLangOpts(), *ContentsBuffer,
                                       Inputs.Opts.SkipPreambleBuild);
 
   trace::Span Tracer("BuildPreamble");
-  SPAN_ATTACH(Tracer, "File", FileName);
+  SPAN_ATTACH(Tracer, "File", FileName.raw());
   std::vector<std::unique_ptr<FeatureModule::ASTListener>> ASTListeners;
   if (Inputs.FeatureModules) {
     for (auto &M : *Inputs.FeatureModules) {
@@ -628,7 +628,7 @@ buildPreamble(PathRef FileName, CompilerInvocation CI,
         for (const auto &L : ASTListeners)
           L->beforeExecute(CI);
       });
-  llvm::SmallString<32> AbsFileName(FileName);
+  llvm::SmallString<32> AbsFileName(FileName.raw());
   VFS->makeAbsolute(AbsFileName);
   auto StatCache = std::make_shared<PreambleFileStatusCache>(AbsFileName);
   auto StatCacheFS = StatCache->getProducingFS(VFS);
@@ -724,7 +724,7 @@ bool isPreambleCompatible(const PreambleData &Preamble,
                           const ParseInputs &Inputs, PathRef FileName,
                           const CompilerInvocation &CI) {
   auto ContentsBuffer =
-      llvm::MemoryBuffer::getMemBuffer(Inputs.Contents, FileName);
+      llvm::MemoryBuffer::getMemBuffer(Inputs.Contents, FileName.raw());
   auto Bounds = computePreambleBounds(CI.getLangOpts(), *ContentsBuffer,
                                       Inputs.Opts.SkipPreambleBuild);
   auto VFS = Inputs.TFS->view(Inputs.CompileCommand.Directory);

--- a/clang-tools-extra/clangd/ProjectModules.cpp
+++ b/clang-tools-extra/clangd/ProjectModules.cpp
@@ -24,7 +24,7 @@ namespace clang::clangd {
 namespace {
 
 llvm::SmallString<128> normalizePath(PathRef Path) {
-  llvm::SmallString<128> Result(Path);
+  llvm::SmallString<128> Result(Path.raw());
   llvm::sys::path::remove_dots(Result, /*remove_dot_dot=*/true);
   llvm::sys::path::native(Result, llvm::sys::path::Style::posix);
   return Result;
@@ -35,11 +35,11 @@ std::string normalizePath(PathRef Path, PathRef WorkingDir) {
     return {};
 
   llvm::SmallString<128> Result;
-  if (llvm::sys::path::is_absolute(Path) || WorkingDir.empty())
-    Result = Path;
+  if (Path.isAbsolute() || WorkingDir.empty())
+    Result = Path.raw();
   else {
-    Result = WorkingDir;
-    llvm::sys::path::append(Result, Path);
+    Result = WorkingDir.raw();
+    llvm::sys::path::append(Result, Path.raw());
   }
 
   return normalizePath(Result).str().str();
@@ -115,7 +115,7 @@ std::optional<tooling::CompileCommand>
 getCompileCommandForFile(const clang::tooling::CompilationDatabase &CDB,
                          PathRef FilePath,
                          const ProjectModules::CommandMangler &Mangler) {
-  auto Candidates = CDB.getCompileCommands(FilePath);
+  auto Candidates = CDB.getCompileCommands(FilePath.raw());
   if (Candidates.empty())
     return std::nullopt;
 
@@ -246,10 +246,10 @@ ModuleDependencyScanner::scan(PathRef FilePath,
     Result.ModuleName = ScanningResult->Provides->ModuleName;
 
     auto [Iter, Inserted] = ModuleNameToSource.try_emplace(
-        ScanningResult->Provides->ModuleName, FilePath);
+        ScanningResult->Provides->ModuleName, FilePath.raw());
 
-    if (!Inserted &&
-        !pathEqual(normalizePath(Iter->second), normalizePath(FilePath))) {
+    if (!Inserted && PathRef(normalizePath(Iter->second)) !=
+                         PathRef(normalizePath(FilePath))) {
       elog("Detected multiple source files ({0}, {1}) declaring the same "
            "module: '{2}'. "
            "Now clangd may find the wrong source in such case.",
@@ -396,7 +396,7 @@ public:
   std::string getModuleNameForSource(PathRef File) override {
     indexProducerCommands();
     auto It = SourceToModuleName.find(
-        maybeCaseFoldPath(normalizePath(File, /*WorkingDir=*/{})));
+        PathRef(normalizePath(File, /*WorkingDir=*/{})).caseFolded().raw());
     if (It == SourceToModuleName.end() || It->second.Ambiguous)
       return {};
     return It->second.Name;
@@ -422,7 +422,7 @@ public:
       return {};
 
     indexProducerCommands();
-    auto SourceIt = PCMToSource.find(maybeCaseFoldPath(It->second));
+    auto SourceIt = PCMToSource.find(PathRef(It->second).caseFolded().raw());
     if (SourceIt == PCMToSource.end())
       return {};
 
@@ -467,7 +467,7 @@ private:
         continue;
 
       if (Parsed->OutputModuleFile)
-        PCMToSource[maybeCaseFoldPath(*Parsed->OutputModuleFile)] =
+        PCMToSource[PathRef(*Parsed->OutputModuleFile).caseFolded().raw()] =
             Parsed->SourceFile;
 
       ParsedCommands.push_back(std::move(*Parsed));
@@ -476,14 +476,14 @@ private:
     for (const auto &Parsed : ParsedCommands) {
       for (const auto &Required : Parsed.RequiredModuleFiles) {
         auto SourceIt =
-            PCMToSource.find(maybeCaseFoldPath(Required.getValue()));
+            PCMToSource.find(PathRef(Required.getValue()).caseFolded().raw());
         if (SourceIt == PCMToSource.end())
           continue;
         ModuleNameToDistinctSources[Required.getKey()].insert(
-            maybeCaseFoldPath(SourceIt->second));
+            PathRef(SourceIt->second).caseFolded().raw());
 
         auto &Recovered =
-            SourceToModuleName[maybeCaseFoldPath(SourceIt->second)];
+            SourceToModuleName[PathRef(SourceIt->second).caseFolded().raw()];
         if (Recovered.Name.empty())
           Recovered.Name = Required.getKey().str();
         else if (Recovered.Name != Required.getKey()) {

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -13,6 +13,7 @@
 #include "Protocol.h"
 #include "URI.h"
 #include "support/Logger.h"
+#include "support/Path.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Index/IndexSymbol.h"
 #include "llvm/ADT/StringExtras.h"
@@ -43,15 +44,14 @@ bool mapOptOrNull(const llvm::json::Value &Params, llvm::StringLiteral Prop,
 
 char LSPError::ID;
 
-URIForFile URIForFile::canonicalize(llvm::StringRef AbsPath,
-                                    llvm::StringRef TUPath) {
-  assert(llvm::sys::path::is_absolute(AbsPath) && "the path is relative");
-  auto Resolved = URI::resolvePath(AbsPath, TUPath);
+URIForFile URIForFile::canonicalize(PathRef AbsPath, PathRef TUPath) {
+  assert(AbsPath.isAbsolute() && "the path is relative");
+  auto Resolved = URI::resolvePath(AbsPath.raw(), TUPath.raw());
   if (!Resolved) {
     elog("URIForFile: failed to resolve path {0} with TU path {1}: "
          "{2}.\nUsing unresolved path.",
          AbsPath, TUPath, Resolved.takeError());
-    return URIForFile(std::string(AbsPath));
+    return URIForFile(AbsPath.owned().raw());
   }
   return URIForFile(std::move(*Resolved));
 }

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -26,6 +26,7 @@
 #include "URI.h"
 #include "index/SymbolID.h"
 #include "support/MemoryTree.h"
+#include "support/Path.h"
 #include "clang/Index/IndexSymbol.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/JSON.h"
@@ -94,8 +95,7 @@ struct URIForFile {
   /// Files can be referred to by several paths (e.g. in the presence of links).
   /// Which one we prefer may depend on where we're coming from. \p TUPath is a
   /// hint, and should usually be the main entrypoint file we're processing.
-  static URIForFile canonicalize(llvm::StringRef AbsPath,
-                                 llvm::StringRef TUPath);
+  static URIForFile canonicalize(PathRef AbsPath, PathRef TUPath);
 
   static llvm::Expected<URIForFile> fromURI(const URI &U,
                                             llvm::StringRef HintPath);

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -26,6 +26,7 @@
 #include "URI.h"
 #include "index/SymbolID.h"
 #include "support/MemoryTree.h"
+#include "support/Path.h"
 #include "clang/Index/IndexSymbol.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/JSON.h"
@@ -95,8 +96,7 @@ struct URIForFile {
   /// Files can be referred to by several paths (e.g. in the presence of links).
   /// Which one we prefer may depend on where we're coming from. \p TUPath is a
   /// hint, and should usually be the main entrypoint file we're processing.
-  static URIForFile canonicalize(llvm::StringRef AbsPath,
-                                 llvm::StringRef TUPath);
+  static URIForFile canonicalize(PathRef AbsPath, PathRef TUPath);
 
   static llvm::Expected<URIForFile> fromURI(const URI &U,
                                             llvm::StringRef HintPath);

--- a/clang-tools-extra/clangd/ScanningProjectModules.cpp
+++ b/clang-tools-extra/clangd/ScanningProjectModules.cpp
@@ -92,7 +92,7 @@ private:
 std::optional<ModuleDependencyScanner::ModuleDependencyInfo>
 ModuleDependencyScanner::scan(PathRef FilePath,
                               const ProjectModules::CommandMangler &Mangler) {
-  auto Candidates = CDB->getCompileCommands(FilePath);
+  auto Candidates = CDB->getCompileCommands(FilePath.raw());
   if (Candidates.empty())
     return std::nullopt;
 
@@ -106,7 +106,7 @@ ModuleDependencyScanner::scan(PathRef FilePath,
 
   using namespace clang::tooling::dependencies;
 
-  llvm::SmallString<128> FilePathDir(FilePath);
+  llvm::SmallString<128> FilePathDir(FilePath.raw());
   llvm::sys::path::remove_filename(FilePathDir);
   DependencyScanningTool ScanningTool(Service, TFS.view(FilePathDir));
 
@@ -125,7 +125,7 @@ ModuleDependencyScanner::scan(PathRef FilePath,
     Result.ModuleName = ScanningResult->Provides->ModuleName;
 
     auto [Iter, Inserted] = ModuleNameToSource.try_emplace(
-        ScanningResult->Provides->ModuleName, FilePath);
+        ScanningResult->Provides->ModuleName, FilePath.raw().str());
 
     if (!Inserted && Iter->second != FilePath) {
       elog("Detected multiple source files ({0}, {1}) declaring the same "
@@ -204,7 +204,7 @@ public:
   std::string getSourceForModuleName(llvm::StringRef ModuleName,
                                      PathRef RequiredSourceFile) override {
     Scanner.globalScan(Mangler);
-    return Scanner.getSourceForModuleName(ModuleName).str();
+    return Scanner.getSourceForModuleName(ModuleName).owned().raw();
   }
 
   std::string getModuleNameForSource(PathRef File) override {

--- a/clang-tools-extra/clangd/TUScheduler.cpp
+++ b/clang-tools-extra/clangd/TUScheduler.cpp
@@ -310,7 +310,7 @@ public:
   // Headers not in the list will have their associations removed.
   void update(PathRef MainFile, llvm::ArrayRef<std::string> Headers) {
     std::lock_guard<std::mutex> Lock(Mu);
-    auto It = MainToFirst.try_emplace(MainFile, nullptr);
+    auto It = MainToFirst.try_emplace(MainFile.raw(), nullptr);
     Association *&First = It.first->second;
     if (First)
       invalidate(First);
@@ -323,7 +323,7 @@ public:
   // will be eligible for association with other files that get update()d.
   void remove(PathRef MainFile) {
     std::lock_guard<std::mutex> Lock(Mu);
-    Association *&First = MainToFirst[MainFile];
+    Association *&First = MainToFirst[MainFile.raw()];
     if (First) {
       invalidate(First);
       First = nullptr;
@@ -335,7 +335,7 @@ public:
   /// Get the mainfile associated with Header, or the empty string if none.
   std::string get(PathRef Header) const {
     std::lock_guard<std::mutex> Lock(Mu);
-    return HeaderToMain.lookup(Header).MainFile.str();
+    return HeaderToMain.lookup(Header.raw()).MainFile.str();
   }
 
   size_t getUsedBytes() const {
@@ -483,7 +483,7 @@ public:
           break;
 
         {
-          Throttle.emplace(FileName, Throttler, ReqCV);
+          Throttle.emplace(FileName.raw(), Throttler, ReqCV);
           std::optional<trace::Span> Tracer;
           // If acquire succeeded synchronously, avoid status jitter.
           if (!Throttle->satisfied()) {
@@ -822,9 +822,9 @@ ASTWorker::create(PathRef FileName, const GlobalCompilationDatabase &CDB,
       new ASTWorker(FileName, CDB, IdleASTs, HeaderIncluders, Barrier,
                     /*RunSync=*/!Tasks, Opts, Callbacks));
   if (Tasks) {
-    Tasks->runAsync("ASTWorker:" + llvm::sys::path::filename(FileName),
+    Tasks->runAsync("ASTWorker:" + FileName.filename(),
                     [Worker]() { Worker->run(); });
-    Tasks->runAsync("PreambleWorker:" + llvm::sys::path::filename(FileName),
+    Tasks->runAsync("PreambleWorker:" + FileName.filename(),
                     [Worker]() { Worker->PreamblePeer.run(); });
   }
 
@@ -841,8 +841,9 @@ ASTWorker::ASTWorker(PathRef FileName, const GlobalCompilationDatabase &CDB,
       UpdateDebounce(Opts.UpdateDebounce), FileName(FileName),
       ContextProvider(Opts.ContextProvider), CDB(CDB), Callbacks(Callbacks),
       Barrier(Barrier), Done(false), Status(FileName, Callbacks),
-      PreamblePeer(FileName, Callbacks, Opts.StorePreamblesInMemory, RunSync,
-                   Opts.PreambleThrottler, Status, HeaderIncluders, *this) {
+      PreamblePeer(FileName.raw(), Callbacks, Opts.StorePreamblesInMemory,
+                   RunSync, Opts.PreambleThrottler, Status, HeaderIncluders,
+                   *this) {
   // Set a fallback command because compile command can be accessed before
   // `Inputs` is initialized. Other fields are only used after initialization
   // from client inputs.
@@ -881,7 +882,8 @@ void ASTWorker::update(ParseInputs Inputs, WantDiagnostics WantDiags,
           HeaderIncluders.remove(ProxyFile);
         } else {
           // We have a reliable command for an including file, use it.
-          Cmd = tooling::transferCompileCommand(std::move(*ProxyCmd), FileName);
+          Cmd = tooling::transferCompileCommand(std::move(*ProxyCmd),
+                                                FileName.raw());
         }
       }
     }
@@ -995,9 +997,9 @@ void ASTWorker::runWithAST(
       // return a compatible preamble as ASTWorker::update blocks.
       std::optional<ParsedAST> NewAST;
       if (Invocation) {
-        NewAST = ParsedAST::build(FileName, FileInputs, std::move(Invocation),
-                                  CompilerInvocationDiagConsumer.take(),
-                                  getPossiblyStalePreamble());
+        NewAST = ParsedAST::build(
+            FileName.raw(), FileInputs, std::move(Invocation),
+            CompilerInvocationDiagConsumer.take(), getPossiblyStalePreamble());
         ++ASTBuildCount;
       }
       AST = NewAST ? std::make_unique<ParsedAST>(std::move(*NewAST)) : nullptr;
@@ -1210,8 +1212,9 @@ void ASTWorker::generateDiagnostics(
       IdleASTs.take(this, &ASTAccessForDiag);
   if (!AST || !InputsAreLatest) {
     auto RebuildStartTime = DebouncePolicy::clock::now();
-    std::optional<ParsedAST> NewAST = ParsedAST::build(
-        FileName, Inputs, std::move(Invocation), CIDiags, *LatestPreamble);
+    std::optional<ParsedAST> NewAST =
+        ParsedAST::build(FileName.raw(), Inputs, std::move(Invocation), CIDiags,
+                         *LatestPreamble);
     auto RebuildDuration = DebouncePolicy::clock::now() - RebuildStartTime;
     ++ASTBuildCount;
     // Try to record the AST-build time, to inform future update debouncing.
@@ -1323,7 +1326,7 @@ void ASTWorker::runTask(llvm::StringRef Name, llvm::function_ref<void()> Task) {
     crashDumpParseInputs(llvm::errs(), FileInputs);
   });
   trace::Span Tracer(Name);
-  WithContext WithProvidedContext(ContextProvider(FileName));
+  WithContext WithProvidedContext(ContextProvider(FileName.raw()));
   Task();
 }
 
@@ -1351,7 +1354,7 @@ void ASTWorker::startTask(llvm::StringRef Name,
     }
 
     // Allow this request to be cancelled if invalidated.
-    Context Ctx = Context::current().derive(FileBeingProcessed, FileName);
+    Context Ctx = Context::current().derive(FileBeingProcessed, FileName.raw());
     Canceler Invalidate = nullptr;
     if (Invalidation) {
       WithContext WC(std::move(Ctx));
@@ -1639,7 +1642,7 @@ TUScheduler::TUScheduler(const GlobalCompilationDatabase &CDB,
       HeaderIncluders(std::make_unique<HeaderIncluderCache>()) {
   // Avoid null checks everywhere.
   if (!Opts.ContextProvider) {
-    this->Opts.ContextProvider = [](llvm::StringRef) {
+    this->Opts.ContextProvider = [](PathRef) {
       return Context::current().clone();
     };
   }
@@ -1672,7 +1675,7 @@ bool TUScheduler::blockUntilIdle(Deadline D) const {
 
 bool TUScheduler::update(PathRef File, ParseInputs Inputs,
                          WantDiagnostics WantDiags) {
-  std::unique_ptr<FileData> &FD = Files[File];
+  std::unique_ptr<FileData> &FD = Files[File.raw()];
   bool NewFile = FD == nullptr;
   bool ContentChanged = false;
   if (!FD) {
@@ -1691,12 +1694,12 @@ bool TUScheduler::update(PathRef File, ParseInputs Inputs,
   // There might be synthetic update requests, don't change the LastActiveFile
   // in such cases.
   if (ContentChanged)
-    LastActiveFile = File.str();
+    LastActiveFile = File.owned().raw();
   return NewFile;
 }
 
 void TUScheduler::remove(PathRef File) {
-  bool Removed = Files.erase(File);
+  bool Removed = Files.erase(File.raw());
   if (!Removed)
     elog("Trying to remove file from TUScheduler that is not tracked: {0}",
          File);
@@ -1743,13 +1746,13 @@ void TUScheduler::runWithAST(
     llvm::StringRef Name, PathRef File,
     llvm::unique_function<void(llvm::Expected<InputsAndAST>)> Action,
     TUScheduler::ASTActionInvalidation Invalidation) {
-  auto It = Files.find(File);
+  auto It = Files.find(File.raw());
   if (It == Files.end()) {
     Action(llvm::make_error<LSPError>(
         "trying to get AST for non-added document", ErrorCode::InvalidParams));
     return;
   }
-  LastActiveFile = File.str();
+  LastActiveFile = File.owned().raw();
 
   It->second->Worker->runWithAST(Name, std::move(Action), Invalidation);
 }
@@ -1757,18 +1760,18 @@ void TUScheduler::runWithAST(
 void TUScheduler::runWithPreamble(llvm::StringRef Name, PathRef File,
                                   PreambleConsistency Consistency,
                                   Callback<InputsAndPreamble> Action) {
-  auto It = Files.find(File);
+  auto It = Files.find(File.raw());
   if (It == Files.end()) {
     Action(llvm::make_error<LSPError>(
         "trying to get preamble for non-added document",
         ErrorCode::InvalidParams));
     return;
   }
-  LastActiveFile = File.str();
+  LastActiveFile = File.owned().raw();
 
   if (!PreambleTasks) {
     trace::Span Tracer(Name);
-    SPAN_ATTACH(Tracer, "file", File);
+    SPAN_ATTACH(Tracer, "file", File.raw());
     std::shared_ptr<const ASTSignals> Signals;
     std::shared_ptr<const PreambleData> Preamble =
         It->second->Worker->getPossiblyStalePreamble(&Signals);
@@ -1780,11 +1783,11 @@ void TUScheduler::runWithPreamble(llvm::StringRef Name, PathRef File,
   }
 
   std::shared_ptr<const ASTWorker> Worker = It->second->Worker.lock();
-  auto Task = [Worker, Consistency, Name = Name.str(), File = File.str(),
+  auto Task = [Worker, Consistency, Name = Name.str(), File = File.owned(),
                Contents = It->second->Contents,
                Command = Worker->getCurrentCompileCommand(),
                Ctx = Context::current().derive(FileBeingProcessed,
-                                               std::string(File)),
+                                               File.owned().raw()),
                Action = std::move(Action), this]() mutable {
     clang::noteBottomOfStack();
     ThreadCrashReporter ScopedReporter([&Name, &Contents, &Command]() {
@@ -1810,8 +1813,7 @@ void TUScheduler::runWithPreamble(llvm::StringRef Name, PathRef File,
     Action(InputsAndPreamble{Contents, Command, Preamble.get(), Signals.get()});
   };
 
-  PreambleTasks->runAsync("task:" + llvm::sys::path::filename(File),
-                          std::move(Task));
+  PreambleTasks->runAsync("task:" + File.filename(), std::move(Task));
 }
 
 llvm::StringMap<TUScheduler::FileStats> TUScheduler::fileStats() const {

--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -226,7 +226,7 @@ std::optional<LocatedSymbol> locateFileReferent(const Position &Pos,
   for (auto &Inc : AST.getIncludeStructure().MainFileIncludes) {
     if (!Inc.Resolved.empty() && Inc.HashLine == Pos.line) {
       LocatedSymbol File;
-      File.Name = std::string(llvm::sys::path::filename(Inc.Resolved));
+      File.Name = Inc.Resolved.ref().filename().str();
       File.PreferredDeclaration = {
           URIForFile::canonicalize(Inc.Resolved, MainFilePath), Range{}};
       File.Definition = File.PreferredDeclaration;
@@ -514,7 +514,7 @@ std::vector<LocatedSymbol> locateSymbolForType(const ParsedAST &AST,
                                                const QualType &Type,
                                                const SymbolIndex *Index) {
   const auto &SM = AST.getSourceManager();
-  auto MainFilePath = AST.tuPath();
+  auto MainFilePath = AST.tuPath().raw();
 
   // FIXME: this sends unique_ptr<Foo> to unique_ptr<T>.
   // Likely it would be better to send it to Foo (heuristically) or to both.
@@ -776,7 +776,7 @@ const syntax::Token *findNearbyIdentifier(const SpelledWord &Word,
 std::vector<LocatedSymbol> locateSymbolAt(ParsedAST &AST, Position Pos,
                                           const SymbolIndex *Index) {
   const auto &SM = AST.getSourceManager();
-  auto MainFilePath = AST.tuPath();
+  auto MainFilePath = AST.tuPath().raw();
 
   if (auto File = locateFileReferent(Pos, AST, MainFilePath))
     return {std::move(*File)};
@@ -1352,7 +1352,7 @@ std::vector<LocatedSymbol> findImplementations(ParsedAST &AST, Position Pos,
       QueryKind = RelationKind::BaseOf;
     }
   }
-  return findImplementors(std::move(IDs), QueryKind, Index, AST.tuPath());
+  return findImplementors(std::move(IDs), QueryKind, Index, AST.tuPath().raw());
 }
 
 namespace {
@@ -1570,8 +1570,9 @@ ReferencesResult findReferences(ParsedAST &AST, Position Pos, uint32_t Limit,
           return;
         }
         const auto LSPLocDecl =
-            toLSPLocation(Object.CanonicalDeclaration, MainFilePath);
-        const auto LSPLocDef = toLSPLocation(Object.Definition, MainFilePath);
+            toLSPLocation(Object.CanonicalDeclaration, MainFilePath.raw());
+        const auto LSPLocDef =
+            toLSPLocation(Object.Definition, MainFilePath.raw());
         if (LSPLocDecl && LSPLocDecl != LSPLocDef) {
           ReferencesResult::Reference Result;
           Result.Loc = {std::move(*LSPLocDecl), std::nullopt};
@@ -1622,7 +1623,7 @@ ReferencesResult findReferences(ParsedAST &AST, Position Pos, uint32_t Limit,
     LookupRequest ContainerLookup;
     llvm::DenseMap<SymbolID, std::vector<size_t>> RefIndicesForContainer;
     Results.HasMore |= Index->refs(Req, [&](const Ref &R) {
-      auto LSPLoc = toLSPLocation(R.Location, MainFilePath);
+      auto LSPLoc = toLSPLocation(R.Location, MainFilePath.raw());
       // Avoid indexed results for the main file - the AST is authoritative.
       if (!LSPLoc ||
           (!AllowMainFileSymbols && LSPLoc->uri.file() == MainFilePath))
@@ -1700,9 +1701,9 @@ std::vector<SymbolDetails> getSymbolInfo(ParsedAST &AST, Position Pos) {
     }
     if (const NamedDecl *Def = getDefinition(D))
       NewSymbol.definitionRange = makeLocation(
-          AST.getASTContext(), nameLocation(*Def, SM), MainFilePath);
-    NewSymbol.declarationRange =
-        makeLocation(AST.getASTContext(), nameLocation(*D, SM), MainFilePath);
+          AST.getASTContext(), nameLocation(*Def, SM), MainFilePath.raw());
+    NewSymbol.declarationRange = makeLocation(
+        AST.getASTContext(), nameLocation(*D, SM), MainFilePath.raw());
 
     Results.push_back(std::move(NewSymbol));
   }
@@ -1821,7 +1822,7 @@ declToCallHierarchyItem(const NamedDecl &ND, llvm::StringRef TUPath) {
 template <typename HierarchyItem>
 static std::optional<HierarchyItem> symbolToHierarchyItem(const Symbol &S,
                                                           PathRef TUPath) {
-  auto Loc = symbolToLocation(S, TUPath);
+  auto Loc = symbolToLocation(S, TUPath.raw());
   if (!Loc) {
     elog("Failed to convert symbol to hierarchy item: {0}", Loc.takeError());
     return std::nullopt;
@@ -2242,12 +2243,12 @@ getTypeHierarchy(ParsedAST &AST, Position Pos, int ResolveLevels,
     }
 
     std::optional<TypeHierarchyItem> Result =
-        declToTypeHierarchyItem(*CXXRD, AST.tuPath());
+        declToTypeHierarchyItem(*CXXRD, AST.tuPath().raw());
     if (!Result)
       continue;
 
     RecursionProtectionSet RPSet;
-    fillSuperTypes(*CXXRD, AST.tuPath(), *Result, RPSet);
+    fillSuperTypes(*CXXRD, AST.tuPath().raw(), *Result, RPSet);
 
     if (WantChildren && ResolveLevels > 0) {
       Result->children.emplace();
@@ -2328,7 +2329,7 @@ prepareCallHierarchy(ParsedAST &AST, Position Pos, PathRef TUPath) {
         Decl->getKind() != Decl::Kind::Field &&
         Decl->getKind() != Decl::Kind::EnumConstant)
       continue;
-    if (auto CHI = declToCallHierarchyItem(*Decl, AST.tuPath()))
+    if (auto CHI = declToCallHierarchyItem(*Decl, AST.tuPath().raw()))
       Result.emplace_back(std::move(*CHI));
   }
   return Result;

--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -289,7 +289,7 @@ std::optional<LocatedSymbol> locateFileReferent(const Position &Pos,
   for (auto &Inc : AST.getIncludeStructure().MainFileIncludes) {
     if (!Inc.Resolved.empty() && Inc.HashLine == Pos.line) {
       LocatedSymbol File;
-      File.Name = std::string(llvm::sys::path::filename(Inc.Resolved));
+      File.Name = Inc.Resolved.ref().filename().str();
       File.PreferredDeclaration = {
           URIForFile::canonicalize(Inc.Resolved, MainFilePath), Range{}};
       File.Definition = File.PreferredDeclaration;
@@ -610,7 +610,7 @@ std::vector<LocatedSymbol> locateSymbolForType(const ParsedAST &AST,
                                                const QualType &Type,
                                                const SymbolIndex *Index) {
   const auto &SM = AST.getSourceManager();
-  auto MainFilePath = AST.tuPath();
+  auto MainFilePath = AST.tuPath().raw();
 
   // FIXME: this sends unique_ptr<Foo> to unique_ptr<T>.
   // Likely it would be better to send it to Foo (heuristically) or to both.
@@ -872,7 +872,7 @@ const syntax::Token *findNearbyIdentifier(const SpelledWord &Word,
 std::vector<LocatedSymbol> locateSymbolAt(ParsedAST &AST, Position Pos,
                                           const SymbolIndex *Index) {
   const auto &SM = AST.getSourceManager();
-  auto MainFilePath = AST.tuPath();
+  auto MainFilePath = AST.tuPath().raw();
 
   if (auto File = locateFileReferent(Pos, AST, MainFilePath))
     return {std::move(*File)};
@@ -1472,7 +1472,7 @@ std::vector<LocatedSymbol> findImplementations(ParsedAST &AST, Position Pos,
       QueryKind = RelationKind::BaseOf;
     }
   }
-  return findImplementors(std::move(IDs), QueryKind, Index, AST.tuPath());
+  return findImplementors(std::move(IDs), QueryKind, Index, AST.tuPath().raw());
 }
 
 namespace {
@@ -1690,8 +1690,9 @@ ReferencesResult findReferences(ParsedAST &AST, Position Pos, uint32_t Limit,
           return;
         }
         const auto LSPLocDecl =
-            toLSPLocation(Object.CanonicalDeclaration, MainFilePath);
-        const auto LSPLocDef = toLSPLocation(Object.Definition, MainFilePath);
+            toLSPLocation(Object.CanonicalDeclaration, MainFilePath.raw());
+        const auto LSPLocDef =
+            toLSPLocation(Object.Definition, MainFilePath.raw());
         if (LSPLocDecl && LSPLocDecl != LSPLocDef) {
           ReferencesResult::Reference Result;
           Result.Loc = {std::move(*LSPLocDecl), std::nullopt};
@@ -1742,7 +1743,7 @@ ReferencesResult findReferences(ParsedAST &AST, Position Pos, uint32_t Limit,
     LookupRequest ContainerLookup;
     llvm::DenseMap<SymbolID, std::vector<size_t>> RefIndicesForContainer;
     Results.HasMore |= Index->refs(Req, [&](const Ref &R) {
-      auto LSPLoc = toLSPLocation(R.Location, MainFilePath);
+      auto LSPLoc = toLSPLocation(R.Location, MainFilePath.raw());
       // Avoid indexed results for the main file - the AST is authoritative.
       if (!LSPLoc ||
           (!AllowMainFileSymbols && LSPLoc->uri.file() == MainFilePath))
@@ -1820,9 +1821,9 @@ std::vector<SymbolDetails> getSymbolInfo(ParsedAST &AST, Position Pos) {
     }
     if (const NamedDecl *Def = getDefinition(D))
       NewSymbol.definitionRange = makeLocation(
-          AST.getASTContext(), nameLocation(*Def, SM), MainFilePath);
-    NewSymbol.declarationRange =
-        makeLocation(AST.getASTContext(), nameLocation(*D, SM), MainFilePath);
+          AST.getASTContext(), nameLocation(*Def, SM), MainFilePath.raw());
+    NewSymbol.declarationRange = makeLocation(
+        AST.getASTContext(), nameLocation(*D, SM), MainFilePath.raw());
 
     Results.push_back(std::move(NewSymbol));
   }
@@ -1942,7 +1943,7 @@ declToCallHierarchyItem(const NamedDecl &ND, llvm::StringRef TUPath) {
 template <typename HierarchyItem>
 static std::optional<HierarchyItem> symbolToHierarchyItem(const Symbol &S,
                                                           PathRef TUPath) {
-  auto Loc = symbolToLocation(S, TUPath);
+  auto Loc = symbolToLocation(S, TUPath.raw());
   if (!Loc) {
     elog("Failed to convert symbol to hierarchy item: {0}", Loc.takeError());
     return std::nullopt;
@@ -2366,12 +2367,12 @@ getTypeHierarchy(ParsedAST &AST, Position Pos, int ResolveLevels,
     }
 
     std::optional<TypeHierarchyItem> Result =
-        declToTypeHierarchyItem(*CXXRD, AST.tuPath());
+        declToTypeHierarchyItem(*CXXRD, AST.tuPath().raw());
     if (!Result)
       continue;
 
     RecursionProtectionSet RPSet;
-    fillSuperTypes(*CXXRD, AST.tuPath(), *Result, RPSet);
+    fillSuperTypes(*CXXRD, AST.tuPath().raw(), *Result, RPSet);
 
     if (WantChildren && ResolveLevels > 0) {
       Result->children.emplace();
@@ -2451,7 +2452,7 @@ prepareCallHierarchy(ParsedAST &AST, Position Pos, PathRef TUPath) {
         Decl->getKind() != Decl::Kind::Field &&
         Decl->getKind() != Decl::Kind::EnumConstant)
       continue;
-    if (auto CHI = declToCallHierarchyItem(*Decl, AST.tuPath()))
+    if (auto CHI = declToCallHierarchyItem(*Decl, AST.tuPath().raw()))
       Result.emplace_back(std::move(*CHI));
   }
   return Result;

--- a/clang-tools-extra/clangd/index/Background.cpp
+++ b/clang-tools-extra/clangd/index/Background.cpp
@@ -78,7 +78,7 @@ llvm::SmallString<128> getAbsolutePath(const tooling::CompileCommand &Cmd) {
 }
 
 bool shardIsStale(const LoadedShard &LS, llvm::vfs::FileSystem *FS) {
-  auto Buf = FS->getBufferForFile(LS.AbsolutePath);
+  auto Buf = FS->getBufferForFile(LS.AbsolutePath.raw());
   if (!Buf) {
     vlog("Background-index: Couldn't read {0} to validate stored index: {1}",
          LS.AbsolutePath, Buf.getError().message());
@@ -224,14 +224,14 @@ void BackgroundIndex::update(
     // We need to store shards before updating the index, since the latter
     // consumes slabs.
     // FIXME: Also skip serializing the shard if it is already up-to-date.
-    if (auto Error = IndexStorageFactory(Path)->storeShard(Path, *IF))
+    if (auto Error = IndexStorageFactory(Path)->storeShard(Path.raw(), *IF))
       elog("Failed to write background-index shard for file {0}: {1}", Path,
            std::move(Error));
 
     {
       std::lock_guard<std::mutex> Lock(ShardVersionsMu);
       const auto &Hash = FileIt.getValue().second;
-      auto DigestIt = ShardVersions.try_emplace(Path);
+      auto DigestIt = ShardVersions.try_emplace(Path.raw());
       ShardVersion &SV = DigestIt.first->second;
       // Skip if file is already up to date, unless previous index was broken
       // and this one is not.
@@ -383,12 +383,12 @@ BackgroundIndex::loadProject(std::vector<std::string> MainFiles) {
           LS.Shard->Relations
               ? std::make_unique<RelationSlab>(std::move(*LS.Shard->Relations))
               : nullptr;
-      ShardVersion &SV = ShardVersions[LS.AbsolutePath];
+      ShardVersion &SV = ShardVersions[LS.AbsolutePath.raw()];
       SV.Digest = LS.Digest;
       SV.HadErrors = LS.HadErrors;
       ++LoadedShards;
 
-      IndexedSymbols.update(URI::create(LS.AbsolutePath).toString(),
+      IndexedSymbols.update(URI::create(LS.AbsolutePath.raw()).toString(),
                             std::move(SS), std::move(RS), std::move(RelS),
                             LS.CountReferences);
     }
@@ -414,7 +414,9 @@ BackgroundIndex::loadProject(std::vector<std::string> MainFiles) {
     TUsToIndex.insert(TUForFile);
   }
 
-  return {TUsToIndex.begin(), TUsToIndex.end()};
+  auto ToRaw = [](PathRef R) { return R.raw(); };
+  return {llvm::map_iterator(TUsToIndex.begin(), ToRaw),
+          llvm::map_iterator(TUsToIndex.end(), ToRaw)};
 }
 
 void BackgroundIndex::profile(MemoryTree &MT) const {

--- a/clang-tools-extra/clangd/index/Background.h
+++ b/clang-tools-extra/clangd/index/Background.h
@@ -211,6 +211,7 @@ private:
   std::mutex ShardVersionsMu;
 
   BackgroundIndexStorage::Factory IndexStorageFactory;
+  // XXX: `MainFiles` should be a vector of `Path`s
   // Tries to load shards for the MainFiles and their dependencies.
   std::vector<std::string> loadProject(std::vector<std::string> MainFiles);
 

--- a/clang-tools-extra/clangd/index/BackgroundIndexLoader.h
+++ b/clang-tools-extra/clangd/index/BackgroundIndexLoader.h
@@ -39,7 +39,7 @@ struct LoadedShard {
 
 /// Loads all shards for the TU \p MainFile from \p Storage.
 std::vector<LoadedShard>
-loadIndexShards(llvm::ArrayRef<Path> MainFiles,
+loadIndexShards(llvm::ArrayRef<std::string> MainFiles,
                 BackgroundIndexStorage::Factory &IndexStorageFactory,
                 const GlobalCompilationDatabase &CDB);
 

--- a/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
+++ b/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
@@ -109,7 +109,7 @@ public:
   // Creates or fetches to storage from cache for the specified project.
   BackgroundIndexStorage *operator()(PathRef File) {
     std::lock_guard<std::mutex> Lock(*IndexStorageMapMu);
-    llvm::SmallString<128> StorageDir(FallbackDir);
+    llvm::SmallString<128> StorageDir(FallbackDir.raw());
     if (auto PI = GetProjectInfo(File)) {
       StorageDir = PI->SourceRoot;
       llvm::sys::path::append(StorageDir, ".cache", "clangd", "index");
@@ -126,7 +126,7 @@ private:
       elog("Tried to create storage for empty directory!");
       return std::make_unique<NullStorage>();
     }
-    return std::make_unique<DiskBackedIndexStorage>(CDBDirectory);
+    return std::make_unique<DiskBackedIndexStorage>(CDBDirectory.raw());
   }
 
   Path FallbackDir;

--- a/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
+++ b/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
@@ -118,7 +118,7 @@ public:
   // Creates or fetches to storage from cache for the specified project.
   BackgroundIndexStorage *operator()(PathRef File) {
     std::lock_guard<std::mutex> Lock(*IndexStorageMapMu);
-    llvm::SmallString<128> StorageDir(FallbackDir);
+    llvm::SmallString<128> StorageDir(FallbackDir.raw());
     if (auto PI = GetProjectInfo(File)) {
       StorageDir = PI->SourceRoot;
       llvm::sys::path::append(StorageDir, ".cache", "clangd", "index");
@@ -135,7 +135,7 @@ private:
       elog("Tried to create storage for empty directory!");
       return std::make_unique<NullStorage>();
     }
-    return std::make_unique<DiskBackedIndexStorage>(CDBDirectory);
+    return std::make_unique<DiskBackedIndexStorage>(CDBDirectory.raw());
   }
 
   Path FallbackDir;

--- a/clang-tools-extra/clangd/index/FileIndex.cpp
+++ b/clang-tools-extra/clangd/index/FileIndex.cpp
@@ -182,7 +182,7 @@ FileShardedIndex::FileShardedIndex(IndexFileIn Input)
 std::vector<llvm::StringRef> FileShardedIndex::getAllSources() const {
   // It should be enough to construct a vector with {Shards.keys().begin(),
   // Shards.keys().end()} but MSVC fails to compile that.
-  std::vector<PathRef> Result;
+  std::vector<llvm::StringRef> Result;
   Result.reserve(Shards.size());
   for (auto Key : Shards.keys())
     Result.push_back(Key);
@@ -471,7 +471,7 @@ void FileIndex::updatePreamble(PathRef Path, llvm::StringRef Version,
 void FileIndex::updateMain(PathRef Path, ParsedAST &AST) {
   auto Contents = indexMainDecls(AST);
   MainFileSymbols.update(
-      URI::create(Path).toString(),
+      URI::create(Path.raw()).toString(),
       std::make_unique<SymbolSlab>(std::move(std::get<0>(Contents))),
       std::make_unique<RefSlab>(std::move(std::get<1>(Contents))),
       std::make_unique<RelationSlab>(std::move(std::get<2>(Contents))),

--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -783,7 +783,8 @@ renameObjCMethodWithinFile(ParsedAST &AST, const ObjCMethodDecl *MD,
   auto FilePath = AST.tuPath();
   auto RenameRanges = collectRenameIdentifierRanges(
       RenameSymbolName(MD->getDeclName()), Code, LangOpts);
-  auto RenameEdit = buildRenameEdit(FilePath, Code, RenameRanges, NewNames);
+  auto RenameEdit =
+      buildRenameEdit(FilePath.raw(), Code, RenameRanges, NewNames);
   if (!RenameEdit)
     return error("failed to rename in file {0}: {1}", FilePath,
                  RenameEdit.takeError());
@@ -890,7 +891,7 @@ findOccurrencesOutsideFile(const NamedDecl &RenameDecl,
     if ((R.Kind & RefKind::Spelled) == RefKind::Unknown)
       return;
     if (auto RefFilePath = filePath(R.Location, /*HintFilePath=*/MainFile)) {
-      if (!pathEqual(*RefFilePath, MainFile))
+      if (PathRef(*RefFilePath) != MainFile)
         AffectedFiles[*RefFilePath].push_back(toRange(R.Location));
     }
   });

--- a/clang-tools-extra/clangd/refactor/Tweak.cpp
+++ b/clang-tools-extra/clangd/refactor/Tweak.cpp
@@ -100,7 +100,7 @@ prepareTweak(StringRef ID, const Tweak::Selection &S,
   return error("tweak ID {0} is invalid", ID);
 }
 
-llvm::Expected<std::pair<Path, Edit>>
+llvm::Expected<std::pair<std::string, Edit>>
 Tweak::Effect::fileEdit(const SourceManager &SM, FileID FID,
                         tooling::Replacements Replacements) {
   Edit Ed(SM.getBufferData(FID), std::move(Replacements));

--- a/clang-tools-extra/clangd/refactor/Tweak.h
+++ b/clang-tools-extra/clangd/refactor/Tweak.h
@@ -85,10 +85,11 @@ public:
       return E;
     }
 
+    /// XXX: This should return Path instead of std::string
     /// Path is the absolute, symlink-resolved path for the file pointed by FID
     /// in SM. Edit is generated from Replacements.
     /// Fails if cannot figure out absolute path for FID.
-    static llvm::Expected<std::pair<Path, Edit>>
+    static llvm::Expected<std::pair<std::string, Edit>>
     fileEdit(const SourceManager &SM, FileID FID,
              tooling::Replacements Replacements);
 

--- a/clang-tools-extra/clangd/refactor/tweaks/DefineInline.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/DefineInline.cpp
@@ -474,7 +474,7 @@ public:
     const tooling::Replacement DeleteFuncBody(SM, DefRange->getBegin(),
                                               SourceLen, "");
 
-    llvm::SmallVector<std::pair<std::string, Edit>> Edits;
+    llvm::SmallVector<std::pair<Path, Edit>> Edits;
     // Edit for Target.
     auto FE = Effect::fileEdit(SM, SM.getFileID(*Semicolon),
                                std::move(TargetFileReplacements));
@@ -499,7 +499,8 @@ public:
 
     Effect E;
     for (auto &Pair : Edits)
-      E.ApplyEdits.try_emplace(std::move(Pair.first), std::move(Pair.second));
+      E.ApplyEdits.try_emplace(std::move(Pair.first).raw(),
+                               std::move(Pair.second));
     return E;
   }
 

--- a/clang-tools-extra/clangd/refactor/tweaks/DefineOutline.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/DefineOutline.cpp
@@ -475,7 +475,7 @@ public:
   }
 
   bool prepare(const Selection &Sel) override {
-    SameFile = !isHeaderFile(Sel.AST->tuPath(), Sel.AST->getLangOpts());
+    SameFile = !isHeaderFile(Sel.AST->tuPath().raw(), Sel.AST->getLangOpts());
     Source = getSelectedFunction(Sel.ASTSelection.commonAncestor());
 
     // Bail out if the selection is not a function declaration.
@@ -561,22 +561,22 @@ public:
     std::optional<Path> CCFile;
     auto Anchor = getDefinitionOfAdjacentDecl(Sel);
     if (Anchor) {
-      CCFile = Anchor->Loc.uri.file();
+      CCFile = Path(Anchor->Loc.uri.file());
     } else {
-      CCFile = SameFile ? Sel.AST->tuPath().str()
-                        : getSourceFile(Sel.AST->tuPath(), Sel);
+      CCFile = SameFile ? Sel.AST->tuPath().owned()
+                        : getSourceFile(Sel.AST->tuPath().raw(), Sel);
     }
     if (!CCFile)
       return error("Couldn't find a suitable implementation file.");
     assert(Sel.FS && "FS Must be set in apply");
-    auto Buffer = Sel.FS->getBufferForFile(*CCFile);
+    auto Buffer = Sel.FS->getBufferForFile(CCFile->raw());
     // FIXME: Maybe we should consider creating the implementation file if it
     // doesn't exist?
     if (!Buffer)
       return llvm::errorCodeToError(Buffer.getError());
 
     auto Contents = Buffer->get()->getBuffer();
-    SourceManagerForFile SMFF(*CCFile, Contents);
+    SourceManagerForFile SMFF(CCFile->raw(), Contents);
 
     std::optional<Position> InsertionPos;
     if (Anchor) {
@@ -622,14 +622,16 @@ public:
     assert(Offset);
     assert(EnclosingNamespace);
 
-    auto FuncDef = getFunctionSourceCode(
-        Source, EnclosingNamespace, Sel.AST->getTokens(),
-        Sel.AST->getHeuristicResolver(),
-        SameFile && isHeaderFile(Sel.AST->tuPath(), Sel.AST->getLangOpts()));
+    auto FuncDef =
+        getFunctionSourceCode(Source, EnclosingNamespace, Sel.AST->getTokens(),
+                              Sel.AST->getHeuristicResolver(),
+                              SameFile && isHeaderFile(Sel.AST->tuPath().raw(),
+                                                       Sel.AST->getLangOpts()));
     if (!FuncDef)
       return FuncDef.takeError();
 
-    const tooling::Replacement InsertFunctionDef(*CCFile, *Offset, 0, *FuncDef);
+    const tooling::Replacement InsertFunctionDef(CCFile->raw(), *Offset, 0,
+                                                 *FuncDef);
     auto Effect = Effect::mainFileEdit(
         SMFF.get(), tooling::Replacements(InsertFunctionDef));
     if (!Effect)
@@ -657,7 +659,7 @@ public:
     }
 
     if (SameFile) {
-      tooling::Replacements &R = Effect->ApplyEdits[*CCFile].Replacements;
+      tooling::Replacements &R = Effect->ApplyEdits[CCFile->raw()].Replacements;
       R = R.merge(HeaderUpdates);
     } else {
       auto HeaderFE = Effect::fileEdit(SM, SM.getMainFileID(), HeaderUpdates);
@@ -674,7 +676,7 @@ public:
     if (!Sel.Index)
       return {};
     std::optional<Location> Anchor;
-    std::string TuURI = URI::createFile(Sel.AST->tuPath()).toString();
+    std::string TuURI = URI::createFile(Sel.AST->tuPath().raw()).toString();
     auto CheckCandidate = [&](Decl *Candidate) {
       assert(Candidate != Source);
       if (auto Func = llvm::dyn_cast_or_null<FunctionDecl>(Candidate);
@@ -684,7 +686,8 @@ public:
       std::optional<Location> CandidateLoc;
       Sel.Index->lookup({{getSymbolID(Candidate)}}, [&](const Symbol &S) {
         if (S.Definition) {
-          if (auto Loc = indexToLSPLocation(S.Definition, Sel.AST->tuPath()))
+          if (auto Loc =
+                  indexToLSPLocation(S.Definition, Sel.AST->tuPath().raw()))
             CandidateLoc = *Loc;
           else
             log("getDefinitionOfAdjacentDecl: {0}", Loc.takeError());

--- a/clang-tools-extra/clangd/support/FileCache.cpp
+++ b/clang-tools-extra/clangd/support/FileCache.cpp
@@ -22,10 +22,10 @@ static constexpr uint64_t CacheDiskMismatch =
 // The cached value reflects that the file doesn't exist.
 static constexpr uint64_t FileNotFound = CacheDiskMismatch - 1;
 
-FileCache::FileCache(llvm::StringRef Path)
-    : Path(Path), ValidTime(std::chrono::steady_clock::time_point::min()),
+FileCache::FileCache(PathRef Path)
+    : Path(Path.raw()), ValidTime(std::chrono::steady_clock::time_point::min()),
       ModifiedTime(), Size(CacheDiskMismatch) {
-  assert(llvm::sys::path::is_absolute(Path));
+  assert(Path.isAbsolute());
 }
 
 void FileCache::read(

--- a/clang-tools-extra/clangd/support/Path.cpp
+++ b/clang-tools-extra/clangd/support/Path.cpp
@@ -7,47 +7,151 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/Path.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+
+#include <ostream>
+
 namespace clang {
 namespace clangd {
 
-#ifdef CLANGD_PATH_CASE_INSENSITIVE
-std::string maybeCaseFoldPath(PathRef Path) { return Path.lower(); }
-bool pathEqual(PathRef A, PathRef B) { return A.equals_insensitive(B); }
-#else  // NOT CLANGD_PATH_CASE_INSENSITIVE
-std::string maybeCaseFoldPath(PathRef Path) { return Path.str(); }
-bool pathEqual(PathRef A, PathRef B) { return A == B; }
-#endif // CLANGD_PATH_CASE_INSENSITIVE
-
-PathRef absoluteParent(PathRef Path) {
-  assert(llvm::sys::path::is_absolute(Path));
+PathRef PathRef::absoluteParent() const {
+  assert(llvm::sys::path::is_absolute(Data));
 #if defined(_WIN32)
   // llvm::sys says "C:\" is absolute, and its parent is "C:" which is relative.
   // This unhelpful behavior seems to have been inherited from boost.
-  if (llvm::sys::path::relative_path(Path).empty()) {
+  if (llvm::sys::path::relative_path(Data).empty()) {
     return PathRef();
   }
 #endif
-  PathRef Result = llvm::sys::path::parent_path(Path);
+  llvm::StringRef Result = llvm::sys::path::parent_path(Data);
   assert(Result.empty() || llvm::sys::path::is_absolute(Result));
   return Result;
 }
 
-bool pathStartsWith(PathRef Ancestor, PathRef Path,
-                    llvm::sys::path::Style Style) {
-  assert(llvm::sys::path::is_absolute(Ancestor) &&
-         llvm::sys::path::is_absolute(Path));
+PathRef PathRef::parentPath(Style Style) const {
+  return llvm::sys::path::parent_path(Data, Style);
+}
+
+bool PathRef::startsWith(PathRef Path, Style Style) const {
+  assert(isAbsolute() && Path.isAbsolute()); // XXX: this doesn't pass the Style
+
   // If ancestor ends with a separator drop that, so that we can match /foo/ as
   // a parent of /foo.
-  if (llvm::sys::path::is_separator(Ancestor.back(), Style))
-    Ancestor = Ancestor.drop_back();
+  PathRef Ancestor = withoutTrailingSeparator(Style);
   // Ensure Path starts with Ancestor.
-  if (!pathEqual(Ancestor, Path.take_front(Ancestor.size())))
+  if (Ancestor != PathRef(Path.raw().take_front(Ancestor.size())))
     return false;
-  Path = Path.drop_front(Ancestor.size());
+  Path = Path.Data.drop_front(Ancestor.size());
   // Then make sure either two paths are equal or Path has a separator
   // afterwards.
-  return Path.empty() || llvm::sys::path::is_separator(Path.front(), Style);
+  return Path.empty() ||
+         llvm::sys::path::is_separator(Path.raw().front(), Style);
 }
+
+llvm::StringRef PathRef::filename(Style Style) const {
+  return llvm::sys::path::filename(raw(), Style);
+}
+
+llvm::StringRef PathRef::extension(Style Style) const {
+  return llvm::sys::path::extension(raw(), Style);
+}
+
+PathRef PathRef::stem(Style Style) const {
+  return llvm::sys::path::stem(raw(), Style);
+}
+
+PathRef PathRef::withoutTrailingSeparator(Style Style) const {
+  if (llvm::sys::path::is_separator(Data.back(), Style))
+    return Data.drop_back();
+  return Data;
+}
+
+Path PathRef::removeDots() const {
+  llvm::SmallString<128> CanonPath(Data);
+  llvm::sys::path::remove_dots(CanonPath, /*remove_dot_dot=*/true);
+  return CanonPath.str().str();
+}
+
+Path PathRef::caseFolded() const {
+#ifdef CLANGD_PATH_CASE_INSENSITIVE
+  return Data.lower();
+#else
+  return Data.str();
+#endif
+}
+
+bool PathRef::isAbsolute(Style Style) const {
+  return llvm::sys::path::is_absolute(Data, Style);
+}
+
+bool PathRef::isRelative(Style Style) const {
+  return llvm::sys::path::is_relative(Data, Style);
+}
+
+bool PathRef::exists() const { return llvm::sys::fs::exists(Data); }
+
+std::ostream &operator<<(std::ostream &OS, PathRef Path) {
+  OS << std::string_view(Path.raw());
+  return OS;
+}
+
+bool operator==(PathRef LHS, PathRef RHS) {
+#ifdef CLANGD_PATH_CASE_INSENSITIVE
+  return LHS.raw().equals_insensitive(RHS.raw());
+#else
+  return LHS.raw() == RHS.raw();
+#endif
+}
+
+llvm::hash_code hash_value(PathRef P) {
+#ifdef CLANGD_PATH_CASE_INSENSITIVE
+  return hash_combine_range(llvm::map_iterator(P.raw().begin(), llvm::toLower),
+                            llvm::map_iterator(P.raw().end(), llvm::toLower));
+#else
+  return hash_value(P.raw());
+#endif
+}
+
 } // namespace clangd
 } // namespace clang
+
+namespace llvm {
+
+unsigned DenseMapInfo<clang::clangd::PathRef, void>::getHashValue(
+    clang::clangd::PathRef Val) {
+  assert(Val.Data.data() != getEmptyKey().Data.data() &&
+         "Cannot hash the empty key!");
+  assert(Val.Data.data() != getTombstoneKey().Data.data() &&
+         "Cannot hash the tombstone key!");
+  return (unsigned)(hash_value(Val));
+}
+
+namespace cl {
+
+void parser<clang::clangd::Path>::printOptionDiff(const Option &O,
+                                                  clang::clangd::PathRef V,
+                                                  const OptVal &Default,
+                                                  size_t GlobalWidth) const {
+  constexpr static const size_t MaxOptWidth = 8;
+
+  printOptionName(O, GlobalWidth);
+  outs() << "= " << V.raw();
+  size_t NumSpaces = MaxOptWidth > V.size() ? MaxOptWidth - V.size() : 0;
+  outs().indent(NumSpaces) << " (default: ";
+  if (Default.hasValue())
+    outs() << Default.getValue().raw();
+  else
+    outs() << "*no default*";
+  outs() << ")\n";
+}
+
+void parser<clang::clangd::Path>::anchor() {}
+
+} // namespace cl
+
+} // namespace llvm

--- a/clang-tools-extra/clangd/support/Path.cpp
+++ b/clang-tools-extra/clangd/support/Path.cpp
@@ -1,4 +1,4 @@
-//===--- Path.cpp -------------------------------------------*- C++-*------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,47 +7,155 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/Path.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+
+#include <ostream>
+
 namespace clang {
 namespace clangd {
 
-#ifdef CLANGD_PATH_CASE_INSENSITIVE
-std::string maybeCaseFoldPath(PathRef Path) { return Path.lower(); }
-bool pathEqual(PathRef A, PathRef B) { return A.equals_insensitive(B); }
-#else  // NOT CLANGD_PATH_CASE_INSENSITIVE
-std::string maybeCaseFoldPath(PathRef Path) { return Path.str(); }
-bool pathEqual(PathRef A, PathRef B) { return A == B; }
-#endif // CLANGD_PATH_CASE_INSENSITIVE
-
-PathRef absoluteParent(PathRef Path) {
-  assert(llvm::sys::path::is_absolute(Path));
+PathRef PathRef::absoluteParent() const {
+  assert(llvm::sys::path::is_absolute(Data));
 #if defined(_WIN32)
   // llvm::sys says "C:\" is absolute, and its parent is "C:" which is relative.
   // This unhelpful behavior seems to have been inherited from boost.
-  if (llvm::sys::path::relative_path(Path).empty()) {
+  if (llvm::sys::path::relative_path(Data).empty()) {
     return PathRef();
   }
 #endif
-  PathRef Result = llvm::sys::path::parent_path(Path);
+  llvm::StringRef Result = llvm::sys::path::parent_path(Data);
   assert(Result.empty() || llvm::sys::path::is_absolute(Result));
   return Result;
 }
 
-bool pathStartsWith(PathRef Ancestor, PathRef Path,
-                    llvm::sys::path::Style Style) {
-  assert(llvm::sys::path::is_absolute(Ancestor) &&
-         llvm::sys::path::is_absolute(Path));
+PathRef PathRef::parentPath(Style Style) const {
+  return llvm::sys::path::parent_path(Data, Style);
+}
+
+bool PathRef::startsWith(PathRef Path, Style Style) const {
+  assert(isAbsolute() && Path.isAbsolute()); // XXX: this doesn't pass the Style
+
   // If ancestor ends with a separator drop that, so that we can match /foo/ as
   // a parent of /foo.
-  if (llvm::sys::path::is_separator(Ancestor.back(), Style))
-    Ancestor = Ancestor.drop_back();
+  PathRef Ancestor = withoutTrailingSeparator(Style);
   // Ensure Path starts with Ancestor.
-  if (!pathEqual(Ancestor, Path.take_front(Ancestor.size())))
+  if (Ancestor != PathRef(Path.raw().take_front(Ancestor.size())))
     return false;
-  Path = Path.drop_front(Ancestor.size());
+  Path = Path.Data.drop_front(Ancestor.size());
   // Then make sure either two paths are equal or Path has a separator
   // afterwards.
-  return Path.empty() || llvm::sys::path::is_separator(Path.front(), Style);
+  return Path.empty() ||
+         llvm::sys::path::is_separator(Path.raw().front(), Style);
 }
+
+llvm::StringRef PathRef::filename(Style Style) const {
+  return llvm::sys::path::filename(raw(), Style);
+}
+
+llvm::StringRef PathRef::extension(Style Style) const {
+  return llvm::sys::path::extension(raw(), Style);
+}
+
+PathRef PathRef::stem(Style Style) const {
+  return llvm::sys::path::stem(raw(), Style);
+}
+
+PathRef PathRef::withoutTrailingSeparator(Style Style) const {
+  if (llvm::sys::path::is_separator(Data.back(), Style))
+    return Data.drop_back();
+  return Data;
+}
+
+Path PathRef::removeDots() const {
+  llvm::SmallString<128> CanonPath(Data);
+  llvm::sys::path::remove_dots(CanonPath, /*remove_dot_dot=*/true);
+  return CanonPath.str().str();
+}
+
+Path PathRef::caseFolded() const {
+#ifdef CLANGD_PATH_CASE_INSENSITIVE
+  return Data.lower();
+#else
+  return Data.str();
+#endif
+}
+
+Path PathRef::normalized() const {
+  llvm::SmallString<128> CanonPath(Data);
+  llvm::sys::path::remove_dots(CanonPath, /*remove_dot_dot=*/true);
+  return PathRef(CanonPath.str()).caseFolded();
+}
+
+bool PathRef::isAbsolute(Style Style) const {
+  return llvm::sys::path::is_absolute(Data, Style);
+}
+
+bool PathRef::isRelative(Style Style) const {
+  return llvm::sys::path::is_relative(Data, Style);
+}
+
+bool PathRef::exists() const { return llvm::sys::fs::exists(Data); }
+
+std::ostream &operator<<(std::ostream &OS, PathRef Path) {
+  OS << std::string_view(Path.raw());
+  return OS;
+}
+
+bool operator==(PathRef LHS, PathRef RHS) {
+#ifdef CLANGD_PATH_CASE_INSENSITIVE
+  // FIXME: On Windows, this should also compare forward and backward slashes as
+  // equal.
+  return LHS.raw().equals_insensitive(RHS.raw());
+#else
+  return LHS.raw() == RHS.raw();
+#endif
+}
+
+llvm::hash_code hash_value(PathRef P) {
+#ifdef CLANGD_PATH_CASE_INSENSITIVE
+  return hash_combine_range(llvm::map_iterator(P.raw().begin(), llvm::toLower),
+                            llvm::map_iterator(P.raw().end(), llvm::toLower));
+#else
+  return hash_value(P.raw());
+#endif
+}
+
 } // namespace clangd
 } // namespace clang
+
+namespace llvm {
+
+unsigned DenseMapInfo<clang::clangd::PathRef, void>::getHashValue(
+    clang::clangd::PathRef Val) {
+  return (unsigned)(hash_value(Val));
+}
+
+namespace cl {
+
+void parser<clang::clangd::Path>::printOptionDiff(const Option &O,
+                                                  clang::clangd::PathRef V,
+                                                  const OptVal &Default,
+                                                  size_t GlobalWidth) const {
+  constexpr static const size_t MaxOptWidth = 8;
+
+  printOptionName(O, GlobalWidth);
+  outs() << "= " << V.raw();
+  size_t NumSpaces = MaxOptWidth > V.size() ? MaxOptWidth - V.size() : 0;
+  outs().indent(NumSpaces) << " (default: ";
+  if (Default.hasValue())
+    outs() << Default.getValue().raw();
+  else
+    outs() << "*no default*";
+  outs() << ")\n";
+}
+
+void parser<clang::clangd::Path>::anchor() {}
+
+} // namespace cl
+
+} // namespace llvm

--- a/clang-tools-extra/clangd/support/Path.h
+++ b/clang-tools-extra/clangd/support/Path.h
@@ -9,8 +9,15 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANGD_SUPPORT_PATH_H
 #define LLVM_CLANG_TOOLS_EXTRA_CLANGD_SUPPORT_PATH_H
 
+#include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FormatProviders.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/Path.h"
+
 #include <string>
 
 /// Whether current platform treats paths case insensitively.
@@ -21,30 +28,179 @@
 namespace clang {
 namespace clangd {
 
-/// A typedef to represent a file path. Used solely for more descriptive
-/// signatures.
-using Path = std::string;
-/// A typedef to represent a ref to file path. Used solely for more descriptive
-/// signatures.
-using PathRef = llvm::StringRef;
+class PathRef;
+class Path {
+public:
+  Path() = default;
+  Path(std::string Data) : Data(std::move(Data)) {}
+  Path(const char *Data) : Data(Data) {}
 
-// For platforms where paths are case-insensitive (but case-preserving),
-// we need to do case-insensitive comparisons and use lowercase keys.
-// FIXME: Make Path a real class with desired semantics instead.
-std::string maybeCaseFoldPath(PathRef Path);
-bool pathEqual(PathRef, PathRef);
+  explicit Path(PathRef Ref);
 
-/// Checks if \p Ancestor is a proper ancestor of \p Path. This is just a
-/// smarter lexical prefix match, e.g: foo/bar/baz doesn't start with foo/./bar.
-/// Both \p Ancestor and \p Path must be absolute.
-bool pathStartsWith(
-    PathRef Ancestor, PathRef Path,
-    llvm::sys::path::Style Style = llvm::sys::path::Style::native);
+  operator PathRef() const;
+  PathRef ref() const;
 
-/// Variant of parent_path that operates only on absolute paths.
-/// Unlike parent_path doesn't consider C: a parent of C:\.
-PathRef absoluteParent(PathRef Path);
+  [[nodiscard]] const std::string &raw() const & { return Data; }
+  [[nodiscard]] std::string &&raw() && { return std::move(Data); }
+
+  [[nodiscard]] size_t size() const { return Data.size(); }
+  [[nodiscard]] bool empty() const { return Data.empty(); }
+
+private:
+  std::string Data;
+
+  friend llvm::json::Value toJSON(const Path &Path) { return Path.Data; }
+
+  friend bool fromJSON(const llvm::json::Value &Value, Path &Path,
+                       llvm::json::Path Cursor) {
+    return fromJSON(Value, Path.Data, Cursor);
+  }
+};
+
+class LLVM_GSL_POINTER PathRef {
+public:
+  using Style = llvm::sys::path::Style;
+
+  PathRef() = default;
+  PathRef(llvm::StringRef Ref) : Data(Ref) {}
+  PathRef(const std::string &Str) : Data(Str) {}
+  PathRef(const char *Str) : Data(Str) {}
+  template <unsigned int N>
+  PathRef(const llvm::SmallString<N> &Str) : Data(Str) {}
+
+  /// Variant of parent_path that operates only on absolute paths.
+  /// Unlike parent_path doesn't consider C: a parent of C:\.
+  [[nodiscard]] PathRef absoluteParent() const;
+
+  [[nodiscard]] PathRef parentPath(Style Style = Style::native) const;
+
+  /// Checks if \p this is a proper ancestor of \p Path. This is just a
+  /// smarter lexical prefix match, e.g: foo/bar/baz doesn't start with
+  /// foo/./bar. Both \p this and \p Path must be absolute.
+  [[nodiscard]] bool startsWith(PathRef Path,
+                                Style Style = Style::native) const;
+
+  [[nodiscard]] llvm::StringRef filename(Style Style = Style::native) const;
+
+  [[nodiscard]] llvm::StringRef extension(Style Style = Style::native) const;
+
+  [[nodiscard]] PathRef stem(Style Style = Style::native) const;
+
+  /// Returns a version of \p File that doesn't contain dots and dot dots.
+  /// e.g /a/b/../c -> /a/c
+  ///     /a/b/./c -> /a/b/c
+  /// FIXME: We should avoid encountering such paths in clangd internals by
+  /// filtering everything we get over LSP, CDB, etc.
+  [[nodiscard]] Path removeDots() const;
+
+  [[nodiscard]] Path caseFolded() const;
+
+  [[nodiscard]] Path owned() const { return Path(*this); }
+  [[nodiscard]] llvm::StringRef raw() const { return Data; }
+
+  [[nodiscard]] PathRef
+  withoutTrailingSeparator(Style Style = Style::native) const;
+
+  [[nodiscard]] size_t size() const { return Data.size(); }
+
+  [[nodiscard]] bool empty() const { return Data.empty(); }
+
+  [[nodiscard]] bool isAbsolute(Style Style = Style::native) const;
+  [[nodiscard]] bool isRelative(Style Style = Style::native) const;
+
+  [[nodiscard]] bool exists() const;
+
+private:
+  llvm::StringRef Data;
+
+  friend llvm::DenseMapInfo<clang::clangd::PathRef, void>;
+};
+
+inline Path::Path(PathRef Ref) : Data(Ref.raw().str()) {}
+
+// for gtest
+std::ostream &operator<<(std::ostream &OS, PathRef Path);
+
+inline Path::operator PathRef() const { return PathRef(Data); }
+inline PathRef Path::ref() const { return PathRef(Data); }
+
+bool operator==(PathRef LHS, PathRef RHS);
+inline bool operator!=(PathRef LHS, PathRef RHS) { return !(LHS == RHS); }
+
+inline bool operator==(Path LHS, Path RHS) {
+  return clang::clangd::PathRef(LHS) == clang::clangd::PathRef(RHS);
+}
+inline bool operator!=(Path LHS, Path RHS) { return !(LHS == RHS); }
+
+[[nodiscard]] llvm::hash_code hash_value(PathRef P);
+[[nodiscard]] inline llvm::hash_code hash_value(const Path &P) {
+  return hash_value(PathRef(P));
+}
+
+inline llvm::json::Value toJson(PathRef Path) { return Path.raw(); }
+
 } // namespace clangd
 } // namespace clang
+
+namespace llvm {
+
+template <> struct format_provider<clang::clangd::PathRef> {
+  static void format(const clang::clangd::PathRef &V, llvm::raw_ostream &Stream,
+                     StringRef Style) {
+    format_provider<llvm::StringRef>::format(V.raw(), Stream, Style);
+  }
+};
+
+template <> struct format_provider<clang::clangd::Path> {
+  static void format(const clang::clangd::Path &V, llvm::raw_ostream &Stream,
+                     StringRef Style) {
+    format_provider<clang::clangd::PathRef>::format(V, Stream, Style);
+  }
+};
+
+template <> struct DenseMapInfo<clang::clangd::PathRef, void> {
+  static inline clang::clangd::PathRef getEmptyKey() {
+    return DenseMapInfo<llvm::StringRef>::getEmptyKey();
+  }
+
+  static inline clang::clangd::PathRef getTombstoneKey() {
+    return DenseMapInfo<llvm::StringRef>::getTombstoneKey();
+  }
+
+  static unsigned getHashValue(clang::clangd::PathRef Val);
+
+  static bool isEqual(clang::clangd::PathRef LHS, clang::clangd::PathRef RHS) {
+    if (RHS.Data.data() == getEmptyKey().Data.data())
+      return LHS.Data.data() == getEmptyKey().Data.data();
+    if (RHS.Data.data() == getTombstoneKey().Data.data())
+      return LHS.Data.data() == getTombstoneKey().Data.data();
+    return LHS == RHS;
+  }
+};
+
+namespace cl {
+
+template <>
+struct parser<clang::clangd::Path> : public basic_parser<clang::clangd::Path> {
+public:
+  parser(Option &O) : basic_parser(O) {}
+
+  bool parse(cl::Option &O, StringRef ArgName, StringRef ArgValue,
+             clang::clangd::Path &Val) {
+    Val = ArgValue.str();
+    return false;
+  }
+
+  StringRef getValueName() const override { return "path"; }
+
+  void printOptionDiff(const Option &O, clang::clangd::PathRef V,
+                       const OptVal &Default, size_t GlobalWidth) const;
+
+  void anchor() override;
+};
+
+} // namespace cl
+
+} // namespace llvm
 
 #endif

--- a/clang-tools-extra/clangd/support/Path.h
+++ b/clang-tools-extra/clangd/support/Path.h
@@ -1,4 +1,4 @@
-//===--- Path.h - Helper typedefs --------------------------------*- C++-*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,8 +9,15 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANGD_SUPPORT_PATH_H
 #define LLVM_CLANG_TOOLS_EXTRA_CLANGD_SUPPORT_PATH_H
 
+#include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FormatProviders.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/Path.h"
+
 #include <string>
 
 /// Whether current platform treats paths case insensitively.
@@ -21,30 +28,171 @@
 namespace clang {
 namespace clangd {
 
-/// A typedef to represent a file path. Used solely for more descriptive
-/// signatures.
-using Path = std::string;
-/// A typedef to represent a ref to file path. Used solely for more descriptive
-/// signatures.
-using PathRef = llvm::StringRef;
+class PathRef;
+class Path {
+public:
+  Path() = default;
+  Path(std::string Data) : Data(std::move(Data)) {}
+  Path(const char *Data) : Data(Data) {}
 
-// For platforms where paths are case-insensitive (but case-preserving),
-// we need to do case-insensitive comparisons and use lowercase keys.
-// FIXME: Make Path a real class with desired semantics instead.
-std::string maybeCaseFoldPath(PathRef Path);
-bool pathEqual(PathRef, PathRef);
+  explicit Path(PathRef Ref);
 
-/// Checks if \p Ancestor is a proper ancestor of \p Path. This is just a
-/// smarter lexical prefix match, e.g: foo/bar/baz doesn't start with foo/./bar.
-/// Both \p Ancestor and \p Path must be absolute.
-bool pathStartsWith(
-    PathRef Ancestor, PathRef Path,
-    llvm::sys::path::Style Style = llvm::sys::path::Style::native);
+  operator PathRef() const;
+  PathRef ref() const;
 
-/// Variant of parent_path that operates only on absolute paths.
-/// Unlike parent_path doesn't consider C: a parent of C:\.
-PathRef absoluteParent(PathRef Path);
+  [[nodiscard]] const std::string &raw() const & { return Data; }
+  [[nodiscard]] std::string &&raw() && { return std::move(Data); }
+
+  [[nodiscard]] size_t size() const { return Data.size(); }
+  [[nodiscard]] bool empty() const { return Data.empty(); }
+
+private:
+  std::string Data;
+
+  friend llvm::json::Value toJSON(const Path &Path) { return Path.Data; }
+
+  friend bool fromJSON(const llvm::json::Value &Value, Path &Path,
+                       llvm::json::Path Cursor) {
+    return fromJSON(Value, Path.Data, Cursor);
+  }
+};
+
+class LLVM_GSL_POINTER PathRef {
+public:
+  using Style = llvm::sys::path::Style;
+
+  PathRef() = default;
+  PathRef(llvm::StringRef Ref) : Data(Ref) {}
+  PathRef(const std::string &Str) : Data(Str) {}
+  PathRef(const char *Str) : Data(Str) {}
+  template <unsigned int N>
+  PathRef(const llvm::SmallString<N> &Str) : Data(Str) {}
+
+  /// Variant of parent_path that operates only on absolute paths.
+  /// Unlike parent_path doesn't consider C: a parent of C:\.
+  [[nodiscard]] PathRef absoluteParent() const;
+
+  [[nodiscard]] PathRef parentPath(Style Style = Style::native) const;
+
+  /// Checks if \p this is a proper ancestor of \p Path. This is just a
+  /// smarter lexical prefix match, e.g: foo/bar/baz doesn't start with
+  /// foo/./bar. Both \p this and \p Path must be absolute.
+  [[nodiscard]] bool startsWith(PathRef Path,
+                                Style Style = Style::native) const;
+
+  [[nodiscard]] llvm::StringRef filename(Style Style = Style::native) const;
+
+  [[nodiscard]] llvm::StringRef extension(Style Style = Style::native) const;
+
+  [[nodiscard]] PathRef stem(Style Style = Style::native) const;
+
+  /// Returns a version of \p File that doesn't contain dots and dot-dots.
+  /// e.g /a/b/../c -> /a/c
+  ///     /a/b/./c -> /a/b/c
+  /// FIXME: We should avoid encountering such paths in clangd internals by
+  /// filtering everything we get over LSP, CDB, etc.
+  [[nodiscard]] Path removeDots() const;
+
+  [[nodiscard]] Path caseFolded() const;
+
+  /// Removes dots and dot-dots followed by case folding.
+  [[nodiscard]] Path normalized() const;
+
+  [[nodiscard]] Path owned() const { return Path(*this); }
+  [[nodiscard]] llvm::StringRef raw() const { return Data; }
+  [[nodiscard]] std::string str() const { return Data.str(); }
+
+  [[nodiscard]] PathRef
+  withoutTrailingSeparator(Style Style = Style::native) const;
+
+  [[nodiscard]] size_t size() const { return Data.size(); }
+
+  [[nodiscard]] bool empty() const { return Data.empty(); }
+
+  [[nodiscard]] bool isAbsolute(Style Style = Style::native) const;
+  [[nodiscard]] bool isRelative(Style Style = Style::native) const;
+
+  [[nodiscard]] bool exists() const;
+
+private:
+  llvm::StringRef Data;
+
+  friend llvm::DenseMapInfo<clang::clangd::PathRef, void>;
+};
+
+inline Path::Path(PathRef Ref) : Data(Ref.raw().str()) {}
+
+// for gtest
+std::ostream &operator<<(std::ostream &OS, PathRef Path);
+
+inline Path::operator PathRef() const { return PathRef(Data); }
+inline PathRef Path::ref() const { return PathRef(Data); }
+
+bool operator==(PathRef LHS, PathRef RHS);
+inline bool operator!=(PathRef LHS, PathRef RHS) { return !(LHS == RHS); }
+
+inline bool operator==(Path LHS, Path RHS) {
+  return clang::clangd::PathRef(LHS) == clang::clangd::PathRef(RHS);
+}
+inline bool operator!=(Path LHS, Path RHS) { return !(LHS == RHS); }
+
+[[nodiscard]] llvm::hash_code hash_value(PathRef P);
+[[nodiscard]] inline llvm::hash_code hash_value(const Path &P) {
+  return hash_value(PathRef(P));
+}
+
+inline llvm::json::Value toJson(PathRef Path) { return Path.raw(); }
+
 } // namespace clangd
 } // namespace clang
+
+namespace llvm {
+
+template <> struct format_provider<clang::clangd::PathRef> {
+  static void format(const clang::clangd::PathRef &V, llvm::raw_ostream &Stream,
+                     StringRef Style) {
+    format_provider<llvm::StringRef>::format(V.raw(), Stream, Style);
+  }
+};
+
+template <> struct format_provider<clang::clangd::Path> {
+  static void format(const clang::clangd::Path &V, llvm::raw_ostream &Stream,
+                     StringRef Style) {
+    format_provider<clang::clangd::PathRef>::format(V, Stream, Style);
+  }
+};
+
+template <> struct DenseMapInfo<clang::clangd::PathRef, void> {
+  static unsigned getHashValue(clang::clangd::PathRef Val);
+
+  static bool isEqual(clang::clangd::PathRef LHS, clang::clangd::PathRef RHS) {
+    return LHS == RHS;
+  }
+};
+
+namespace cl {
+
+template <>
+struct parser<clang::clangd::Path> : public basic_parser<clang::clangd::Path> {
+public:
+  parser(Option &O) : basic_parser(O) {}
+
+  bool parse(cl::Option &O, StringRef ArgName, StringRef ArgValue,
+             clang::clangd::Path &Val) {
+    Val = ArgValue.str();
+    return false;
+  }
+
+  StringRef getValueName() const override { return "path"; }
+
+  void printOptionDiff(const Option &O, clang::clangd::PathRef V,
+                       const OptVal &Default, size_t GlobalWidth) const;
+
+  void anchor() override;
+};
+
+} // namespace cl
+
+} // namespace llvm
 
 #endif

--- a/clang-tools-extra/clangd/support/ThreadsafeFS.cpp
+++ b/clang-tools-extra/clangd/support/ThreadsafeFS.cpp
@@ -74,7 +74,7 @@ private:
 llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 ThreadsafeFS::view(PathRef CWD) const {
   auto FS = view(std::nullopt);
-  if (auto EC = FS->setCurrentWorkingDirectory(CWD))
+  if (auto EC = FS->setCurrentWorkingDirectory(CWD.raw()))
     elog("VFS: failed to set CWD to {0}: {1}", CWD, EC.message());
   return FS;
 }

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -693,12 +693,12 @@ public:
     // If --compile-commands-dir arg was invoked, check value and override
     // default path.
     if (!CompileCommandsDir.empty()) {
-      if (llvm::sys::fs::exists(CompileCommandsDir)) {
+      if (CompileCommandsDir.ref().exists()) {
         // We support passing both relative and absolute paths to the
         // --compile-commands-dir argument, but we assume the path is absolute
         // in the rest of clangd so we make sure the path is absolute before
         // continuing.
-        llvm::SmallString<128> Path(CompileCommandsDir);
+        llvm::SmallString<128> Path(CompileCommandsDir.raw());
         if (std::error_code EC = llvm::sys::fs::make_absolute(Path)) {
           elog("Error while converting the relative path specified by "
                "--compile-commands-dir to an absolute path: {0}. The argument "
@@ -715,7 +715,7 @@ public:
     if (!IndexFile.empty()) {
       Config::ExternalIndexSpec Spec;
       Spec.Kind = Spec.File;
-      Spec.Location = IndexFile;
+      Spec.Location = IndexFile.raw();
       IndexSpec = std::move(Spec);
     }
 #if CLANGD_ENABLE_REMOTE
@@ -841,7 +841,7 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
   std::optional<llvm::raw_fd_ostream> InputMirrorStream;
   if (!InputMirrorFile.empty()) {
     std::error_code EC;
-    InputMirrorStream.emplace(InputMirrorFile, /*ref*/ EC,
+    InputMirrorStream.emplace(InputMirrorFile.raw(), /*ref*/ EC,
                               llvm::sys::fs::FA_Read | llvm::sys::fs::FA_Write);
     if (EC) {
       InputMirrorStream.reset();
@@ -946,7 +946,7 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
     break;
   }
   if (!ResourceDir.empty())
-    Opts.ResourceDir = ResourceDir;
+    Opts.ResourceDir = ResourceDir.raw();
   Opts.StrongWorkspaceMode = StrongWorkspaceMode;
   Opts.BuildDynamicSymbolIndex = true;
 #if CLANGD_ENABLE_REMOTE
@@ -1049,9 +1049,9 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
 
   if (CheckFile.getNumOccurrences()) {
     llvm::SmallString<256> Path;
-    if (auto Error =
-            llvm::sys::fs::real_path(CheckFile, Path, /*expand_tilde=*/true)) {
-      elog("Failed to resolve path {0}: {1}", CheckFile, Error.message());
+    if (auto Error = llvm::sys::fs::real_path(CheckFile.raw(), Path,
+                                              /*expand_tilde=*/true)) {
+      elog("Failed to resolve path {0}: {1}", CheckFile.raw(), Error.message());
       return 1;
     }
     log("Entering check mode (no LSP server)");

--- a/clang-tools-extra/clangd/unittests/ASTTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ASTTests.cpp
@@ -624,7 +624,7 @@ TEST(ClangdAST, HasReservedName) {
 TEST(ClangdAST, PreferredIncludeDirective) {
   auto ComputePreferredDirective = [](TestTU &TU) {
     auto AST = TU.build();
-    return preferredIncludeDirective(AST.tuPath(), AST.getLangOpts(),
+    return preferredIncludeDirective(AST.tuPath().raw(), AST.getLangOpts(),
                                      AST.getIncludeStructure().MainFileIncludes,
                                      AST.getLocalTopLevelDecls());
   };

--- a/clang-tools-extra/clangd/unittests/ASTTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ASTTests.cpp
@@ -625,7 +625,7 @@ TEST(ClangdAST, HasReservedName) {
 TEST(ClangdAST, PreferredIncludeDirective) {
   auto ComputePreferredDirective = [](TestTU &TU) {
     auto AST = TU.build();
-    return preferredIncludeDirective(AST.tuPath(), AST.getLangOpts(),
+    return preferredIncludeDirective(AST.tuPath().raw(), AST.getLangOpts(),
                                      AST.getIncludeStructure().MainFileIncludes,
                                      AST.getLocalTopLevelDecls());
   };

--- a/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
+++ b/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
@@ -98,7 +98,7 @@ TEST_F(BackgroundIndexTest, NoCrashOnErrorFile) {
   size_t CacheHits = 0;
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
-  BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                       /*Opts=*/{});
 
   tooling::CompileCommand Cmd;
@@ -132,11 +132,11 @@ TEST_F(BackgroundIndexTest, Config) {
   BackgroundIndex::Options Opts;
   Opts.ContextProvider = [](PathRef P) {
     Config C;
-    if (P.ends_with("foo.cpp"))
+    if (P.raw().ends_with("foo.cpp"))
       C.CompileFlags.Edits.push_back([](std::vector<std::string> &Argv) {
         Argv = tooling::getInsertArgumentAdjuster("-Done=two")(Argv, "");
       });
-    if (P.ends_with("baz.cpp"))
+    if (P.raw().ends_with("baz.cpp"))
       C.Index.Background = Config::BackgroundPolicy::Skip;
     return Context::current().derive(Config::Key, std::move(C));
   };
@@ -148,8 +148,7 @@ TEST_F(BackgroundIndexTest, Config) {
   OverlayCDB CDB(/*Base=*/nullptr, /*FallbackFlags=*/{},
                  CommandMangler::forTests());
 
-  BackgroundIndex Idx(
-      FS, CDB, [&](llvm::StringRef) { return &MSS; }, std::move(Opts));
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; }, std::move(Opts));
   // Index the two files.
   for (auto &Cmd : Cmds) {
     std::string FullPath = testPath(Cmd.Filename);
@@ -191,8 +190,7 @@ TEST_F(BackgroundIndexTest, IndexTwoFiles) {
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
   BackgroundIndex::Options Opts;
-  BackgroundIndex Idx(
-      FS, CDB, [&](llvm::StringRef) { return &MSS; }, Opts);
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; }, Opts);
 
   tooling::CompileCommand Cmd;
   Cmd.Filename = testPath("root/A.cc");
@@ -258,7 +256,7 @@ TEST_F(BackgroundIndexTest, ConstructorForwarding) {
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
   BackgroundIndex::Options Opts;
-  BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; }, Opts);
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; }, Opts);
 
   FS.Files[testPath("root/header.hpp")] = Header.code();
   FS.Files[testPath("root/test.cpp")] = Main.code();
@@ -318,7 +316,7 @@ TEST_F(BackgroundIndexTest, ConstructorForwardingMultiFile) {
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
   BackgroundIndex::Options Opts;
-  BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; }, Opts);
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; }, Opts);
 
   FS.Files[testPath("root/header.hpp")] = Header.code();
   FS.Files[testPath("root/first.cpp")] = First.code();
@@ -366,8 +364,7 @@ TEST_F(BackgroundIndexTest, MainFileRefs) {
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
   BackgroundIndex::Options Opts;
-  BackgroundIndex Idx(
-      FS, CDB, [&](llvm::StringRef) { return &MSS; }, Opts);
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; }, Opts);
 
   tooling::CompileCommand Cmd;
   Cmd.Filename = testPath("root/A.cc");
@@ -406,7 +403,7 @@ TEST_F(BackgroundIndexTest, ShardStorageTest) {
   // Check nothing is loaded from Storage, but A.cc and A.h has been stored.
   {
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -416,7 +413,7 @@ TEST_F(BackgroundIndexTest, ShardStorageTest) {
 
   {
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -475,7 +472,7 @@ TEST_F(BackgroundIndexTest, DirectIncludesTest) {
   Cmd.CommandLine = {"clang++", testPath("root/A.cc")};
   {
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -525,7 +522,7 @@ TEST_F(BackgroundIndexTest, ShardStorageLoad) {
   // Check nothing is loaded from Storage, but A.cc and A.h has been stored.
   {
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -540,7 +537,7 @@ TEST_F(BackgroundIndexTest, ShardStorageLoad) {
       )cpp";
   {
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -558,7 +555,7 @@ TEST_F(BackgroundIndexTest, ShardStorageLoad) {
   {
     CacheHits = 0;
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -599,7 +596,7 @@ TEST_F(BackgroundIndexTest, ShardStorageEmptyFile) {
   // Check that A.cc, A.h and B.h has been stored.
   {
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -615,7 +612,7 @@ TEST_F(BackgroundIndexTest, ShardStorageEmptyFile) {
   {
     CacheHits = 0;
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -631,7 +628,7 @@ TEST_F(BackgroundIndexTest, ShardStorageEmptyFile) {
   {
     CacheHits = 0;
     OverlayCDB CDB(/*Base=*/nullptr);
-    BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+    BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                         /*Opts=*/{});
     CDB.setCompileCommand(testPath("root/A.cc"), Cmd);
     ASSERT_TRUE(Idx.blockUntilIdleForTest());
@@ -649,7 +646,7 @@ TEST_F(BackgroundIndexTest, NoDotsInAbsPath) {
   size_t CacheHits = 0;
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
-  BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                       /*Opts=*/{});
   ASSERT_TRUE(Idx.blockUntilIdleForTest());
 
@@ -680,7 +677,7 @@ TEST_F(BackgroundIndexTest, UncompilableFiles) {
   size_t CacheHits = 0;
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
-  BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                       /*Opts=*/{});
 
   tooling::CompileCommand Cmd;
@@ -744,7 +741,7 @@ TEST_F(BackgroundIndexTest, CmdLineHash) {
   size_t CacheHits = 0;
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
-  BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                       /*Opts=*/{});
 
   tooling::CompileCommand Cmd;
@@ -772,7 +769,7 @@ TEST_F(BackgroundIndexTest, Reindex) {
   size_t CacheHits = 0;
   MemoryShardStorage MSS(Storage, CacheHits);
   OverlayCDB CDB(/*Base=*/nullptr);
-  BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; },
+  BackgroundIndex Idx(FS, CDB, [&](PathRef) { return &MSS; },
                       /*Opts=*/{});
 
   // Index a file.
@@ -1021,7 +1018,7 @@ TEST(BackgroundQueueTest, Progress) {
 TEST(BackgroundIndex, Profile) {
   MockFS FS;
   MockCompilationDatabase CDB;
-  BackgroundIndex Idx(FS, CDB, [](llvm::StringRef) { return nullptr; },
+  BackgroundIndex Idx(FS, CDB, [](PathRef) { return nullptr; },
                       /*Opts=*/{});
 
   llvm::BumpPtrAllocator Alloc;

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -147,7 +147,7 @@ CodeCompleteResult completions(llvm::StringRef Text,
   Annotations Test(Text);
   auto TU = TestTU::withCode(Test.code());
   // To make sure our tests for completiopns inside templates work on Windows.
-  TU.Filename = FilePath.str();
+  TU.Filename = FilePath.owned().raw();
   return completions(TU, Test.point(), std::move(IndexSymbols),
                      std::move(Opts));
 }

--- a/clang-tools-extra/clangd/unittests/GlobalCompilationDatabaseTests.cpp
+++ b/clang-tools-extra/clangd/unittests/GlobalCompilationDatabaseTests.cpp
@@ -55,23 +55,23 @@ TEST(GlobalCompilationDatabaseTest, FallbackCommand) {
                                            testPath("foo/bar")));
 }
 
-static tooling::CompileCommand cmd(llvm::StringRef File, llvm::StringRef Arg) {
+static tooling::CompileCommand cmd(PathRef File, llvm::StringRef Arg) {
   return tooling::CompileCommand(
-      testRoot(), File, {"clang", std::string(Arg), std::string(File)}, "");
+      testRoot(), File.owned().raw(),
+      {"clang", std::string(Arg), File.owned().raw()}, "");
 }
 
 class OverlayCDBTest : public ::testing::Test {
   class BaseCDB : public GlobalCompilationDatabase {
   public:
     std::optional<tooling::CompileCommand>
-    getCompileCommand(llvm::StringRef File) const override {
+    getCompileCommand(PathRef File) const override {
       if (File == testPath("foo.cc"))
         return cmd(File, "-DA=1");
       return std::nullopt;
     }
 
-    tooling::CompileCommand
-    getFallbackCommand(llvm::StringRef File) const override {
+    tooling::CompileCommand getFallbackCommand(PathRef File) const override {
       return cmd(File, "-DA=2");
     }
 

--- a/clang-tools-extra/clangd/unittests/GlobalCompilationDatabaseTests.cpp
+++ b/clang-tools-extra/clangd/unittests/GlobalCompilationDatabaseTests.cpp
@@ -69,23 +69,23 @@ TEST(GlobalCompilationDatabaseTest, FallbackWorkingDirectory) {
   EXPECT_EQ(Cmd.Output, "");
 }
 
-static tooling::CompileCommand cmd(llvm::StringRef File, llvm::StringRef Arg) {
+static tooling::CompileCommand cmd(PathRef File, llvm::StringRef Arg) {
   return tooling::CompileCommand(
-      testRoot(), File, {"clang", std::string(Arg), std::string(File)}, "");
+      testRoot(), File.owned().raw(),
+      {"clang", std::string(Arg), File.owned().raw()}, "");
 }
 
 class OverlayCDBTest : public ::testing::Test {
   class BaseCDB : public GlobalCompilationDatabase {
   public:
     std::optional<tooling::CompileCommand>
-    getCompileCommand(llvm::StringRef File) const override {
+    getCompileCommand(PathRef File) const override {
       if (File == testPath("foo.cc"))
         return cmd(File, "-DA=1");
       return std::nullopt;
     }
 
-    tooling::CompileCommand
-    getFallbackCommand(llvm::StringRef File) const override {
+    tooling::CompileCommand getFallbackCommand(PathRef File) const override {
       return cmd(File, "-DA=2");
     }
 

--- a/clang-tools-extra/clangd/unittests/HeaderSourceSwitchTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HeaderSourceSwitchTests.cpp
@@ -334,17 +334,17 @@ TEST(HeaderSourceSwitchTest, CaseSensitivity) {
   // index, check if we can still find the source file, which defines less
   // symbols than the header.
   auto HeaderAbsPath = testPath("HEADER.H");
-  // We expect the heuristics to pick:
-  // - header on case sensitive file systems, because the HeaderAbsPath doesn't
-  //   match what we've seen through index.
-  // - source on case insensitive file systems, as the HeaderAbsPath would match
-  //   the filename in index.
+// We expect the heuristics to pick:
+// - header on case sensitive file systems, because the HeaderAbsPath doesn't
+//   match what we've seen through index.
+// - source on case insensitive file systems, as the HeaderAbsPath would match
+//   the filename in index.
 #ifdef CLANGD_PATH_CASE_INSENSITIVE
   EXPECT_THAT(getCorrespondingHeaderOrSource(HeaderAbsPath, AST, Index.get()),
-              llvm::ValueIs(testing::StrCaseEq(testPath(TU.Filename))));
+              llvm::ValueIs(Path(testPath(TU.Filename))));
 #else
   EXPECT_THAT(getCorrespondingHeaderOrSource(HeaderAbsPath, AST, Index.get()),
-              llvm::ValueIs(testing::StrCaseEq(testPath(TU.HeaderFilename))));
+              llvm::ValueIs(Path(testPath(TU.HeaderFilename))));
 #endif
 }
 

--- a/clang-tools-extra/clangd/unittests/HeaderSourceSwitchTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HeaderSourceSwitchTests.cpp
@@ -351,17 +351,17 @@ TEST(HeaderSourceSwitchTest, CaseSensitivity) {
   // index, check if we can still find the source file, which defines less
   // symbols than the header.
   auto HeaderAbsPath = testPath("HEADER.H");
-  // We expect the heuristics to pick:
-  // - header on case sensitive file systems, because the HeaderAbsPath doesn't
-  //   match what we've seen through index.
-  // - source on case insensitive file systems, as the HeaderAbsPath would match
-  //   the filename in index.
+// We expect the heuristics to pick:
+// - header on case sensitive file systems, because the HeaderAbsPath doesn't
+//   match what we've seen through index.
+// - source on case insensitive file systems, as the HeaderAbsPath would match
+//   the filename in index.
 #ifdef CLANGD_PATH_CASE_INSENSITIVE
   EXPECT_THAT(getCorrespondingHeaderOrSource(HeaderAbsPath, AST, Index.get()),
-              llvm::ValueIs(testing::StrCaseEq(testPath(TU.Filename))));
+              llvm::ValueIs(Path(testPath(TU.Filename))));
 #else
   EXPECT_THAT(getCorrespondingHeaderOrSource(HeaderAbsPath, AST, Index.get()),
-              llvm::ValueIs(testing::StrCaseEq(testPath(TU.HeaderFilename))));
+              llvm::ValueIs(Path(testPath(TU.HeaderFilename))));
 #endif
 }
 

--- a/clang-tools-extra/clangd/unittests/HeadersTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HeadersTests.cpp
@@ -111,7 +111,7 @@ protected:
                              QuotedHeaders, AngledHeaders);
     for (const auto &Inc : Inclusions)
       Inserter.addExisting(Inc);
-    auto Inserted = ToHeaderFile(Preferred);
+    auto Inserted = ToHeaderFile(Preferred.raw());
     if (!Inserter.shouldInsertInclude(Original, Inserted))
       return "";
     auto Path = Inserter.calculateIncludePath(Inserted, MainFile);

--- a/clang-tools-extra/clangd/unittests/PreambleTests.cpp
+++ b/clang-tools-extra/clangd/unittests/PreambleTests.cpp
@@ -883,14 +883,14 @@ TEST(PreamblePatch, PatchFileEntry) {
 #define FOO)cpp");
   {
     auto AST = createPatchedAST(Code.code(), Code.code());
-    EXPECT_EQ(
-        PreamblePatch::getPatchEntry(AST->tuPath(), AST->getSourceManager()),
-        nullptr);
+    EXPECT_EQ(PreamblePatch::getPatchEntry(AST->tuPath().raw(),
+                                           AST->getSourceManager()),
+              nullptr);
   }
   {
     auto AST = createPatchedAST(Code.code(), NewCode.code());
-    auto FE =
-        PreamblePatch::getPatchEntry(AST->tuPath(), AST->getSourceManager());
+    auto FE = PreamblePatch::getPatchEntry(AST->tuPath().raw(),
+                                           AST->getSourceManager());
     ASSERT_NE(FE, std::nullopt);
     EXPECT_THAT(FE->getName().str(),
                 testing::EndsWith(PreamblePatch::HeaderName.str()));

--- a/clang-tools-extra/clangd/unittests/PreambleTests.cpp
+++ b/clang-tools-extra/clangd/unittests/PreambleTests.cpp
@@ -872,14 +872,14 @@ TEST(PreamblePatch, PatchFileEntry) {
 #define FOO)cpp");
   {
     auto AST = createPatchedAST(Code.code(), Code.code());
-    EXPECT_EQ(
-        PreamblePatch::getPatchEntry(AST->tuPath(), AST->getSourceManager()),
-        nullptr);
+    EXPECT_EQ(PreamblePatch::getPatchEntry(AST->tuPath().raw(),
+                                           AST->getSourceManager()),
+              nullptr);
   }
   {
     auto AST = createPatchedAST(Code.code(), NewCode.code());
-    auto FE =
-        PreamblePatch::getPatchEntry(AST->tuPath(), AST->getSourceManager());
+    auto FE = PreamblePatch::getPatchEntry(AST->tuPath().raw(),
+                                           AST->getSourceManager());
     ASSERT_NE(FE, std::nullopt);
     EXPECT_THAT(FE->getName().str(),
                 testing::EndsWith(PreamblePatch::HeaderName.str()));

--- a/clang-tools-extra/clangd/unittests/PrerequisiteModulesTest.cpp
+++ b/clang-tools-extra/clangd/unittests/PrerequisiteModulesTest.cpp
@@ -98,14 +98,14 @@ public:
     CommandLine.insert(CommandLine.end(), ExtraFlags.begin(), ExtraFlags.end());
     CommandLine.push_back(std::string(AbsPath));
 
-    Commands[maybeCaseFoldPath(AbsPath)] = tooling::CompileCommand(
+    Commands[PathRef(AbsPath).caseFolded().raw()] = tooling::CompileCommand(
         Directory, std::string(AbsPath), std::move(CommandLine), "");
     Files.push_back(std::string(AbsPath));
   }
 
   std::optional<tooling::CompileCommand>
   getCompileCommand(PathRef File) const override {
-    auto It = Commands.find(maybeCaseFoldPath(File));
+    auto It = Commands.find(PathRef(File).caseFolded().raw());
     if (It == Commands.end())
       return std::nullopt;
     tooling::CompileCommand Cmd = It->second;
@@ -165,7 +165,7 @@ public:
   std::optional<ProjectInfo> getProjectInfo(PathRef File) const override {
     // Treat each module-unit directory as its own project root so tests can
     // verify that the persistent cache follows the providing module unit.
-    llvm::SmallString<256> Root(File);
+    llvm::SmallString<256> Root(File.raw());
     llvm::sys::path::remove_filename(Root);
     return ProjectInfo{std::string(Root)};
   }

--- a/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
@@ -79,7 +79,7 @@ MATCHER_P2(TUState, PreambleActivity, ASTActivity, "") {
 // Simple ContextProvider to verify the provider is invoked & contexts are used.
 static Key<std::string> BoundPath;
 Context bindPath(PathRef F) {
-  return Context::current().derive(BoundPath, F.str());
+  return Context::current().derive(BoundPath, F.owned().raw());
 }
 llvm::StringRef boundPath() {
   const std::string *V = Context::current().get(BoundPath);
@@ -155,7 +155,7 @@ protected:
   void updateWithDiags(TUScheduler &S, PathRef File, ParseInputs Inputs,
                        WantDiagnostics WD,
                        llvm::unique_function<void(std::vector<Diag>)> CB) {
-    Path OrigFile = File.str();
+    Path OrigFile = File.owned();
     WithContextValue Ctx(DiagsCallbackKey,
                          [OrigFile, CB = std::move(CB)](
                              PathRef File, std::vector<Diag> Diags) mutable {
@@ -1569,7 +1569,7 @@ TEST_F(TUSchedulerTests, PreambleThrottle) {
       // Deliberately no synchronization.
       // The PreambleThrottler should serialize these calls, if not then tsan
       // will find a bug here.
-      Filenames.emplace_back(Path);
+      Filenames.emplace_back(Path.owned().raw());
     }
   };
 

--- a/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
@@ -66,7 +66,7 @@ using ::testing::UnorderedElementsAre;
 // Simple ContextProvider to verify the provider is invoked & contexts are used.
 static Key<std::string> BoundPath;
 Context bindPath(PathRef F) {
-  return Context::current().derive(BoundPath, F.str());
+  return Context::current().derive(BoundPath, F.owned().raw());
 }
 llvm::StringRef boundPath() {
   const std::string *V = Context::current().get(BoundPath);
@@ -142,7 +142,7 @@ protected:
   void updateWithDiags(TUScheduler &S, PathRef File, ParseInputs Inputs,
                        WantDiagnostics WD,
                        llvm::unique_function<void(std::vector<Diag>)> CB) {
-    Path OrigFile = File.str();
+    Path OrigFile = File.owned();
     WithContextValue Ctx(DiagsCallbackKey,
                          [OrigFile, CB = std::move(CB)](
                              PathRef File, std::vector<Diag> Diags) mutable {
@@ -1556,7 +1556,7 @@ TEST_F(TUSchedulerTests, PreambleThrottle) {
       // Deliberately no synchronization.
       // The PreambleThrottler should serialize these calls, if not then tsan
       // will find a bug here.
-      Filenames.emplace_back(Path);
+      Filenames.emplace_back(Path.owned().raw());
     }
   };
 

--- a/clang-tools-extra/clangd/unittests/TestFS.cpp
+++ b/clang-tools-extra/clangd/unittests/TestFS.cpp
@@ -21,8 +21,8 @@ namespace {
 
 // Tries to strip \p Prefix from beginning of \p Path. Returns true on success.
 // If \p Prefix doesn't match, leaves \p Path untouched and returns false.
-bool pathConsumeFront(PathRef &Path, PathRef Prefix) {
-  if (!pathStartsWith(Prefix, Path))
+bool pathConsumeFront(llvm::StringRef &Path, PathRef Prefix) {
+  if (!Prefix.startsWith(Path))
     return false;
   Path = Path.drop_front(Prefix.size());
   return true;
@@ -61,14 +61,14 @@ MockCompilationDatabase::getCompileCommand(PathRef File) const {
   if (ExtraClangFlags.empty())
     return std::nullopt;
 
-  auto FileName = llvm::sys::path::filename(File);
+  auto FileName = File.filename();
 
   // Build the compile command.
   auto CommandLine = ExtraClangFlags;
   CommandLine.insert(CommandLine.begin(), "clang");
   if (RelPathPrefix.empty()) {
     // Use the absolute path in the compile command.
-    CommandLine.push_back(std::string(File));
+    CommandLine.push_back(File.owned().raw());
   } else {
     // Build a relative path using RelPathPrefix.
     llvm::SmallString<32> RelativeFilePath(RelPathPrefix);
@@ -76,10 +76,9 @@ MockCompilationDatabase::getCompileCommand(PathRef File) const {
     CommandLine.push_back(std::string(RelativeFilePath.str()));
   }
 
-  return {tooling::CompileCommand(Directory != llvm::StringRef()
-                                      ? Directory
-                                      : llvm::sys::path::parent_path(File),
-                                  FileName, std::move(CommandLine), "")};
+  return {tooling::CompileCommand(
+      Directory != llvm::StringRef() ? Directory : File.parentPath().raw(),
+      FileName, std::move(CommandLine), "")};
 }
 
 const char *testRoot() {
@@ -92,9 +91,9 @@ const char *testRoot() {
 }
 
 std::string testPath(PathRef File, llvm::sys::path::Style Style) {
-  assert(llvm::sys::path::is_relative(File) && "FileName should be relative");
+  assert(File.isRelative() && "FileName should be relative");
 
-  llvm::SmallString<32> NativeFile = File;
+  llvm::SmallString<32> NativeFile = File.raw();
   llvm::sys::path::native(NativeFile, Style);
   llvm::SmallString<32> Path;
   llvm::sys::path::append(Path, Style, testRoot(), NativeFile);
@@ -111,7 +110,7 @@ public:
   llvm::Expected<std::string>
   getAbsolutePath(llvm::StringRef /*Authority*/, llvm::StringRef Body,
                   llvm::StringRef HintPath) const override {
-    if (!HintPath.empty() && !pathStartsWith(testRoot(), HintPath))
+    if (!HintPath.empty() && !PathRef(testRoot()).startsWith(HintPath))
       return error("Hint path is not empty and doesn't start with {0}: {1}",
                    testRoot(), HintPath);
     if (!Body.consume_front("/"))

--- a/clang-tools-extra/clangd/unittests/support/PathTests.cpp
+++ b/clang-tools-extra/clangd/unittests/support/PathTests.cpp
@@ -15,21 +15,21 @@ namespace clang {
 namespace clangd {
 namespace {
 TEST(PathTests, IsAncestor) {
-  EXPECT_TRUE(pathStartsWith(testPath("foo"), testPath("foo")));
-  EXPECT_TRUE(pathStartsWith(testPath("foo/"), testPath("foo")));
+  EXPECT_TRUE(PathRef(testPath("foo")).startsWith(testPath("foo")));
+  EXPECT_TRUE(PathRef(testPath("foo/")).startsWith(testPath("foo")));
 
-  EXPECT_FALSE(pathStartsWith(testPath("foo"), testPath("fooz")));
-  EXPECT_FALSE(pathStartsWith(testPath("foo/"), testPath("fooz")));
+  EXPECT_FALSE(PathRef(testPath("foo")).startsWith(testPath("fooz")));
+  EXPECT_FALSE(PathRef(testPath("foo/")).startsWith(testPath("fooz")));
 
-  EXPECT_TRUE(pathStartsWith(testPath("foo"), testPath("foo/bar")));
-  EXPECT_TRUE(pathStartsWith(testPath("foo/"), testPath("foo/bar")));
+  EXPECT_TRUE(PathRef(testPath("foo")).startsWith(testPath("foo/bar")));
+  EXPECT_TRUE(PathRef(testPath("foo/")).startsWith(testPath("foo/bar")));
 
 #ifdef CLANGD_PATH_CASE_INSENSITIVE
-  EXPECT_TRUE(pathStartsWith(testPath("fOo"), testPath("foo/bar")));
-  EXPECT_TRUE(pathStartsWith(testPath("foo"), testPath("fOo/bar")));
+  EXPECT_TRUE(PathRef(testPath("fOo")).startsWith(testPath("foo/bar")));
+  EXPECT_TRUE(PathRef(testPath("foo")).startsWith(testPath("fOo/bar")));
 #else
-  EXPECT_FALSE(pathStartsWith(testPath("fOo"), testPath("foo/bar")));
-  EXPECT_FALSE(pathStartsWith(testPath("foo"), testPath("fOo/bar")));
+  EXPECT_FALSE(PathRef(testPath("fOo")).startsWith(testPath("foo/bar")));
+  EXPECT_FALSE(PathRef(testPath("foo")).startsWith(testPath("fOo/bar")));
 #endif
 }
 } // namespace


### PR DESCRIPTION
This is the initial step towards https://github.com/clangd/clangd/issues/108.
It introduces the `Path` and `PathRef` classes as wrappers for `std::string` and `llvm::StringRef` respectively (`Path` and `PathRef` were aliases to `std::string` and `llvm::StringRef` before). The classes compare and hash case-insensitive based on the platform (based on `CLANGD_PATH_CASE_INSENSITIVE` - set on Windows and macOS). They can be implicitly constructed from strings but can't be implicitly converted back. Both require `.raw()` to convert them to the underlying types. One can go from a `PathRef` to `Path` using `.owned()` (that naming is very Rust-y, feel free to suggest something better).

Because of disallowing implicit conversions back to strings, this PR is quite large. My main goal with this is to only introduce the types, but not to refactor code to use them (i.e. it should be functionally the same). Thus, it shouldn't fix the issue yet, but make it possible to adopt the wrappers in multiple parts in parallel. As a first step, by getting rid of as many `.raw()` calls as possible. I left some todos where I turned a `Path(Ref)` into a `string(ref)`, because these locations aren't visible when X-Ref searching.

There are many string maps that are actually path maps and would need their keys to be compared and hashed case-insensitively. This isn't possible with a `StringMap`. I'm not that involved with clangd/LLVM, so I'm not sure what the ideal map type would be.