### PR TITLE
[offload] Unset `-march` when building GPU libraries

### DIFF
--- a/offload/DeviceRTL/CMakeLists.txt
+++ b/offload/DeviceRTL/CMakeLists.txt
@@ -137,9 +137,9 @@ function(compileDeviceRTLLibrary target_name target_triple)
     BUILD_RPATH ""
     INSTALL_RPATH ""
     RUNTIME_OUTPUT_NAME libomptarget-${target_name}.bc)
-  target_compile_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}")
+  target_compile_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}" "-march=")
   target_link_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}"
-                      "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm")
+                      "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm" "-march=")
   install(TARGETS libomptarget-${target_name}
           PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
           DESTINATION ${OFFLOAD_INSTALL_LIBDIR})


### PR DESCRIPTION
Unset `-march` when invoking the compiler and linker to build the GPU libraries.  These libraries use GPU targets rather than the CPU targets, and an incidental `-march=native` causes Clang to be able to determine the GPU used — which causes the build to fail when there is no GPU available.  Resetting `-march=` should suffice to revert to building generic code for the time being.

See the discussion in:
https://github.com/llvm/llvm-project/pull/126143#issuecomment-2816718492