### PR TITLE
[clang-doc] Fix clang-tidy naming diagnostics

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeWriter.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeWriter.cpp
@@ -30,49 +30,50 @@ struct RecordIdToIndexFunctor {
 
 using AbbrevDsc = void (*)(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev);
 
-static void AbbrevGen(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev,
-                      const std::initializer_list<llvm::BitCodeAbbrevOp> Ops) {
+static void
+generateAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev,
+               const std::initializer_list<llvm::BitCodeAbbrevOp> Ops) {
   for (const auto &Op : Ops)
     Abbrev->Add(Op);
 }
 
-static void BoolAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
-  AbbrevGen(Abbrev,
-            {// 0. Boolean
-             llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
-                                   BitCodeConstants::BoolSize)});
+static void genBoolAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
+  generateAbbrev(Abbrev,
+                 {// 0. Boolean
+                  llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
+                                        BitCodeConstants::BoolSize)});
 }
 
-static void IntAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
-  AbbrevGen(Abbrev,
-            {// 0. Fixed-size integer
-             llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
-                                   BitCodeConstants::IntSize)});
+static void genIntAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
+  generateAbbrev(Abbrev,
+                 {// 0. Fixed-size integer
+                  llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
+                                        BitCodeConstants::IntSize)});
 }
 
-static void SymbolIDAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
-  AbbrevGen(Abbrev,
-            {// 0. Fixed-size integer (length of the sha1'd USR)
-             llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
-                                   BitCodeConstants::USRLengthSize),
-             // 1. Fixed-size array of Char6 (USR)
-             llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Array),
-             llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
-                                   BitCodeConstants::USRBitLengthSize)});
+static void genSymbolIdAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
+  generateAbbrev(Abbrev,
+                 {// 0. Fixed-size integer (length of the sha1'd USR)
+                  llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
+                                        BitCodeConstants::USRLengthSize),
+                  // 1. Fixed-size array of Char6 (USR)
+                  llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Array),
+                  llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
+                                        BitCodeConstants::USRBitLengthSize)});
 }
 
-static void StringAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
-  AbbrevGen(Abbrev,
-            {// 0. Fixed-size integer (length of the following string)
-             llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
-                                   BitCodeConstants::StringLengthSize),
-             // 1. The string blob
-             llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Blob)});
+static void genStringAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
+  generateAbbrev(Abbrev,
+                 {// 0. Fixed-size integer (length of the following string)
+                  llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
+                                        BitCodeConstants::StringLengthSize),
+                  // 1. The string blob
+                  llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Blob)});
 }
 
 // Assumes that the file will not have more than 65535 lines.
-static void LocationAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
-  AbbrevGen(
+static void genLocationAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> &Abbrev) {
+  generateAbbrev(
       Abbrev,
       {// 0. Fixed-size integer (line number)
        llvm::BitCodeAbbrevOp(llvm::BitCodeAbbrevOp::Fixed,
@@ -140,67 +141,68 @@ static const llvm::IndexedMap<RecordIdDsc, RecordIdToIndexFunctor>
       // There is no init-list constructor for the IndexedMap, so have to
       // improvise
       static const std::vector<std::pair<RecordId, RecordIdDsc>> Inits = {
-          {VERSION, {"Version", &IntAbbrev}},
-          {COMMENT_KIND, {"Kind", &StringAbbrev}},
-          {COMMENT_TEXT, {"Text", &StringAbbrev}},
-          {COMMENT_NAME, {"Name", &StringAbbrev}},
-          {COMMENT_DIRECTION, {"Direction", &StringAbbrev}},
-          {COMMENT_PARAMNAME, {"ParamName", &StringAbbrev}},
-          {COMMENT_CLOSENAME, {"CloseName", &StringAbbrev}},
-          {COMMENT_SELFCLOSING, {"SelfClosing", &BoolAbbrev}},
-          {COMMENT_EXPLICIT, {"Explicit", &BoolAbbrev}},
-          {COMMENT_ATTRKEY, {"AttrKey", &StringAbbrev}},
-          {COMMENT_ATTRVAL, {"AttrVal", &StringAbbrev}},
-          {COMMENT_ARG, {"Arg", &StringAbbrev}},
-          {FIELD_TYPE_NAME, {"Name", &StringAbbrev}},
-          {FIELD_DEFAULT_VALUE, {"DefaultValue", &StringAbbrev}},
-          {MEMBER_TYPE_NAME, {"Name", &StringAbbrev}},
-          {MEMBER_TYPE_ACCESS, {"Access", &IntAbbrev}},
-          {MEMBER_TYPE_IS_STATIC, {"IsStatic", &BoolAbbrev}},
-          {NAMESPACE_USR, {"USR", &SymbolIDAbbrev}},
-          {NAMESPACE_NAME, {"Name", &StringAbbrev}},
-          {NAMESPACE_PATH, {"Path", &StringAbbrev}},
-          {ENUM_USR, {"USR", &SymbolIDAbbrev}},
-          {ENUM_NAME, {"Name", &StringAbbrev}},
-          {ENUM_DEFLOCATION, {"DefLocation", &LocationAbbrev}},
-          {ENUM_LOCATION, {"Location", &LocationAbbrev}},
-          {ENUM_SCOPED, {"Scoped", &BoolAbbrev}},
-          {ENUM_VALUE_NAME, {"Name", &StringAbbrev}},
-          {ENUM_VALUE_VALUE, {"Value", &StringAbbrev}},
-          {ENUM_VALUE_EXPR, {"Expr", &StringAbbrev}},
-          {RECORD_USR, {"USR", &SymbolIDAbbrev}},
-          {RECORD_NAME, {"Name", &StringAbbrev}},
-          {RECORD_PATH, {"Path", &StringAbbrev}},
-          {RECORD_DEFLOCATION, {"DefLocation", &LocationAbbrev}},
-          {RECORD_LOCATION, {"Location", &LocationAbbrev}},
-          {RECORD_TAG_TYPE, {"TagType", &IntAbbrev}},
-          {RECORD_IS_TYPE_DEF, {"IsTypeDef", &BoolAbbrev}},
-          {BASE_RECORD_USR, {"USR", &SymbolIDAbbrev}},
-          {BASE_RECORD_NAME, {"Name", &StringAbbrev}},
-          {BASE_RECORD_PATH, {"Path", &StringAbbrev}},
-          {BASE_RECORD_TAG_TYPE, {"TagType", &IntAbbrev}},
-          {BASE_RECORD_IS_VIRTUAL, {"IsVirtual", &BoolAbbrev}},
-          {BASE_RECORD_ACCESS, {"Access", &IntAbbrev}},
-          {BASE_RECORD_IS_PARENT, {"IsParent", &BoolAbbrev}},
-          {FUNCTION_USR, {"USR", &SymbolIDAbbrev}},
-          {FUNCTION_NAME, {"Name", &StringAbbrev}},
-          {FUNCTION_DEFLOCATION, {"DefLocation", &LocationAbbrev}},
-          {FUNCTION_LOCATION, {"Location", &LocationAbbrev}},
-          {FUNCTION_ACCESS, {"Access", &IntAbbrev}},
-          {FUNCTION_IS_METHOD, {"IsMethod", &BoolAbbrev}},
-          {FUNCTION_IS_STATIC, {"IsStatic", &BoolAbbrev}},
-          {REFERENCE_USR, {"USR", &SymbolIDAbbrev}},
-          {REFERENCE_NAME, {"Name", &StringAbbrev}},
-          {REFERENCE_QUAL_NAME, {"QualName", &StringAbbrev}},
-          {REFERENCE_TYPE, {"RefType", &IntAbbrev}},
-          {REFERENCE_PATH, {"Path", &StringAbbrev}},
-          {REFERENCE_FIELD, {"Field", &IntAbbrev}},
-          {TEMPLATE_PARAM_CONTENTS, {"Contents", &StringAbbrev}},
-          {TEMPLATE_SPECIALIZATION_OF, {"SpecializationOf", &SymbolIDAbbrev}},
-          {TYPEDEF_USR, {"USR", &SymbolIDAbbrev}},
-          {TYPEDEF_NAME, {"Name", &StringAbbrev}},
-          {TYPEDEF_DEFLOCATION, {"DefLocation", &LocationAbbrev}},
-          {TYPEDEF_IS_USING, {"IsUsing", &BoolAbbrev}}};
+          {VERSION, {"Version", &genIntAbbrev}},
+          {COMMENT_KIND, {"Kind", &genStringAbbrev}},
+          {COMMENT_TEXT, {"Text", &genStringAbbrev}},
+          {COMMENT_NAME, {"Name", &genStringAbbrev}},
+          {COMMENT_DIRECTION, {"Direction", &genStringAbbrev}},
+          {COMMENT_PARAMNAME, {"ParamName", &genStringAbbrev}},
+          {COMMENT_CLOSENAME, {"CloseName", &genStringAbbrev}},
+          {COMMENT_SELFCLOSING, {"SelfClosing", &genBoolAbbrev}},
+          {COMMENT_EXPLICIT, {"Explicit", &genBoolAbbrev}},
+          {COMMENT_ATTRKEY, {"AttrKey", &genStringAbbrev}},
+          {COMMENT_ATTRVAL, {"AttrVal", &genStringAbbrev}},
+          {COMMENT_ARG, {"Arg", &genStringAbbrev}},
+          {FIELD_TYPE_NAME, {"Name", &genStringAbbrev}},
+          {FIELD_DEFAULT_VALUE, {"DefaultValue", &genStringAbbrev}},
+          {MEMBER_TYPE_NAME, {"Name", &genStringAbbrev}},
+          {MEMBER_TYPE_ACCESS, {"Access", &genIntAbbrev}},
+          {MEMBER_TYPE_IS_STATIC, {"IsStatic", &genBoolAbbrev}},
+          {NAMESPACE_USR, {"USR", &genSymbolIdAbbrev}},
+          {NAMESPACE_NAME, {"Name", &genStringAbbrev}},
+          {NAMESPACE_PATH, {"Path", &genStringAbbrev}},
+          {ENUM_USR, {"USR", &genSymbolIdAbbrev}},
+          {ENUM_NAME, {"Name", &genStringAbbrev}},
+          {ENUM_DEFLOCATION, {"DefLocation", &genLocationAbbrev}},
+          {ENUM_LOCATION, {"Location", &genLocationAbbrev}},
+          {ENUM_SCOPED, {"Scoped", &genBoolAbbrev}},
+          {ENUM_VALUE_NAME, {"Name", &genStringAbbrev}},
+          {ENUM_VALUE_VALUE, {"Value", &genStringAbbrev}},
+          {ENUM_VALUE_EXPR, {"Expr", &genStringAbbrev}},
+          {RECORD_USR, {"USR", &genSymbolIdAbbrev}},
+          {RECORD_NAME, {"Name", &genStringAbbrev}},
+          {RECORD_PATH, {"Path", &genStringAbbrev}},
+          {RECORD_DEFLOCATION, {"DefLocation", &genLocationAbbrev}},
+          {RECORD_LOCATION, {"Location", &genLocationAbbrev}},
+          {RECORD_TAG_TYPE, {"TagType", &genIntAbbrev}},
+          {RECORD_IS_TYPE_DEF, {"IsTypeDef", &genBoolAbbrev}},
+          {BASE_RECORD_USR, {"USR", &genSymbolIdAbbrev}},
+          {BASE_RECORD_NAME, {"Name", &genStringAbbrev}},
+          {BASE_RECORD_PATH, {"Path", &genStringAbbrev}},
+          {BASE_RECORD_TAG_TYPE, {"TagType", &genIntAbbrev}},
+          {BASE_RECORD_IS_VIRTUAL, {"IsVirtual", &genBoolAbbrev}},
+          {BASE_RECORD_ACCESS, {"Access", &genIntAbbrev}},
+          {BASE_RECORD_IS_PARENT, {"IsParent", &genBoolAbbrev}},
+          {FUNCTION_USR, {"USR", &genSymbolIdAbbrev}},
+          {FUNCTION_NAME, {"Name", &genStringAbbrev}},
+          {FUNCTION_DEFLOCATION, {"DefLocation", &genLocationAbbrev}},
+          {FUNCTION_LOCATION, {"Location", &genLocationAbbrev}},
+          {FUNCTION_ACCESS, {"Access", &genIntAbbrev}},
+          {FUNCTION_IS_METHOD, {"IsMethod", &genBoolAbbrev}},
+          {FUNCTION_IS_STATIC, {"IsStatic", &genBoolAbbrev}},
+          {REFERENCE_USR, {"USR", &genSymbolIdAbbrev}},
+          {REFERENCE_NAME, {"Name", &genStringAbbrev}},
+          {REFERENCE_QUAL_NAME, {"QualName", &genStringAbbrev}},
+          {REFERENCE_TYPE, {"RefType", &genIntAbbrev}},
+          {REFERENCE_PATH, {"Path", &genStringAbbrev}},
+          {REFERENCE_FIELD, {"Field", &genIntAbbrev}},
+          {TEMPLATE_PARAM_CONTENTS, {"Contents", &genStringAbbrev}},
+          {TEMPLATE_SPECIALIZATION_OF,
+           {"SpecializationOf", &genSymbolIdAbbrev}},
+          {TYPEDEF_USR, {"USR", &genSymbolIdAbbrev}},
+          {TYPEDEF_NAME, {"Name", &genStringAbbrev}},
+          {TYPEDEF_DEFLOCATION, {"DefLocation", &genLocationAbbrev}},
+          {TYPEDEF_IS_USING, {"IsUsing", &genBoolAbbrev}}};
       assert(Inits.size() == RecordIdCount);
       for (const auto &Init : Inits) {
         RecordIdNameMap[Init.first] = Init.second;
@@ -327,7 +329,7 @@ void ClangDocBitcodeWriter::emitAbbrev(RecordId ID, BlockId Block) {
 
 void ClangDocBitcodeWriter::emitRecord(const SymbolID &Sym, RecordId ID) {
   assert(RecordIdNameMap[ID] && "Unknown RecordId.");
-  assert(RecordIdNameMap[ID].Abbrev == &SymbolIDAbbrev &&
+  assert(RecordIdNameMap[ID].Abbrev == &genSymbolIdAbbrev &&
          "Abbrev type mismatch.");
   if (!prepRecordData(ID, Sym != EmptySID))
     return;
@@ -339,7 +341,7 @@ void ClangDocBitcodeWriter::emitRecord(const SymbolID &Sym, RecordId ID) {
 
 void ClangDocBitcodeWriter::emitRecord(llvm::StringRef Str, RecordId ID) {
   assert(RecordIdNameMap[ID] && "Unknown RecordId.");
-  assert(RecordIdNameMap[ID].Abbrev == &StringAbbrev &&
+  assert(RecordIdNameMap[ID].Abbrev == &genStringAbbrev &&
          "Abbrev type mismatch.");
   if (!prepRecordData(ID, !Str.empty()))
     return;
@@ -350,7 +352,7 @@ void ClangDocBitcodeWriter::emitRecord(llvm::StringRef Str, RecordId ID) {
 
 void ClangDocBitcodeWriter::emitRecord(const Location &Loc, RecordId ID) {
   assert(RecordIdNameMap[ID] && "Unknown RecordId.");
-  assert(RecordIdNameMap[ID].Abbrev == &LocationAbbrev &&
+  assert(RecordIdNameMap[ID].Abbrev == &genLocationAbbrev &&
          "Abbrev type mismatch.");
   if (!prepRecordData(ID, true))
     return;
@@ -364,7 +366,8 @@ void ClangDocBitcodeWriter::emitRecord(const Location &Loc, RecordId ID) {
 
 void ClangDocBitcodeWriter::emitRecord(bool Val, RecordId ID) {
   assert(RecordIdNameMap[ID] && "Unknown RecordId.");
-  assert(RecordIdNameMap[ID].Abbrev == &BoolAbbrev && "Abbrev type mismatch.");
+  assert(RecordIdNameMap[ID].Abbrev == &genBoolAbbrev &&
+         "Abbrev type mismatch.");
   if (!prepRecordData(ID, Val))
     return;
   Record.push_back(Val);
@@ -373,7 +376,8 @@ void ClangDocBitcodeWriter::emitRecord(bool Val, RecordId ID) {
 
 void ClangDocBitcodeWriter::emitRecord(int Val, RecordId ID) {
   assert(RecordIdNameMap[ID] && "Unknown RecordId.");
-  assert(RecordIdNameMap[ID].Abbrev == &IntAbbrev && "Abbrev type mismatch.");
+  assert(RecordIdNameMap[ID].Abbrev == &genIntAbbrev &&
+         "Abbrev type mismatch.");
   if (!prepRecordData(ID, Val))
     return;
   // FIXME: Assert that the integer is of the appropriate size.
@@ -383,7 +387,8 @@ void ClangDocBitcodeWriter::emitRecord(int Val, RecordId ID) {
 
 void ClangDocBitcodeWriter::emitRecord(unsigned Val, RecordId ID) {
   assert(RecordIdNameMap[ID] && "Unknown RecordId.");
-  assert(RecordIdNameMap[ID].Abbrev == &IntAbbrev && "Abbrev type mismatch.");
+  assert(RecordIdNameMap[ID].Abbrev == &genIntAbbrev &&
+         "Abbrev type mismatch.");
   if (!prepRecordData(ID, Val))
     return;
   assert(Val < (1U << BitCodeConstants::IntSize));

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -105,12 +105,10 @@ struct TagNode : public HTMLNode {
   void render(llvm::raw_ostream &OS, int IndentationLevel) override;
 };
 
-constexpr const char *kDoctypeDecl = "<!DOCTYPE html>";
-
 struct HTMLFile {
   std::vector<std::unique_ptr<HTMLNode>> Children; // List of child nodes
   void render(llvm::raw_ostream &OS) {
-    OS << kDoctypeDecl << "\n";
+    OS << "<!DOCTYPE html>\n";
     for (const auto &C : Children) {
       C->render(OS, 0);
       OS << "\n";


### PR DESCRIPTION
In quite a few places we were not following the project naming
conventions. This patch applies clang-tidy fixes, and updates
some additional names to follow more typical project wide patterns.