### PR TITLE
[PBQP] Add begin and end to Vector (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/PBQP/Math.h
+++ b/llvm/include/llvm/CodeGen/PBQP/Math.h
@@ -48,12 +48,18 @@ public:
     V.Length = 0;
   }
 
+  // Iterator-based access.
+  const PBQPNum *begin() const { return Data.get(); }
+  const PBQPNum *end() const { return Data.get() + Length; }
+  PBQPNum *begin() { return Data.get(); }
+  PBQPNum *end() { return Data.get() + Length; }
+
   /// Comparison operator.
   bool operator==(const Vector &V) const {
     assert(Length != 0 && Data && "Invalid vector");
     if (Length != V.Length)
       return false;
-    return std::equal(Data.get(), Data.get() + Length, V.Data.get());
+    return std::equal(begin(), end(), V.begin());
   }
 
   /// Return the length of the vector
@@ -80,15 +86,14 @@ public:
   Vector& operator+=(const Vector &V) {
     assert(Length != 0 && Data && "Invalid vector");
     assert(Length == V.Length && "Vector length mismatch.");
-    std::transform(Data.get(), Data.get() + Length, V.Data.get(), Data.get(),
-                   std::plus<PBQPNum>());
+    std::transform(begin(), end(), V.begin(), begin(), std::plus<PBQPNum>());
     return *this;
   }
 
   /// Returns the index of the minimum value in this vector
   unsigned minIndex() const {
     assert(Length != 0 && Data && "Invalid vector");
-    return std::min_element(Data.get(), Data.get() + Length) - Data.get();
+    return llvm::min_element(*this) - begin();
   }
 
 private:
@@ -98,8 +103,8 @@ private:
 
 /// Return a hash_value for the given vector.
 inline hash_code hash_value(const Vector &V) {
-  unsigned *VBegin = reinterpret_cast<unsigned*>(V.Data.get());
-  unsigned *VEnd = reinterpret_cast<unsigned*>(V.Data.get() + V.Length);
+  const unsigned *VBegin = reinterpret_cast<const unsigned *>(V.begin());
+  const unsigned *VEnd = reinterpret_cast<const unsigned *>(V.end());
   return hash_combine(V.Length, hash_combine_range(VBegin, VEnd));
 }
 

--- a/llvm/include/llvm/CodeGen/PBQP/Math.h
+++ b/llvm/include/llvm/CodeGen/PBQP/Math.h
@@ -57,9 +57,7 @@ public:
   /// Comparison operator.
   bool operator==(const Vector &V) const {
     assert(Length != 0 && Data && "Invalid vector");
-    if (Length != V.Length)
-      return false;
-    return std::equal(begin(), end(), V.begin());
+    return llvm::equal(*this, V);
   }
 
   /// Return the length of the vector

--- a/llvm/include/llvm/CodeGen/PBQP/Math.h
+++ b/llvm/include/llvm/CodeGen/PBQP/Math.h
@@ -33,13 +33,13 @@ public:
   /// Construct a PBQP vector with initializer.
   Vector(unsigned Length, PBQPNum InitVal)
     : Length(Length), Data(std::make_unique<PBQPNum []>(Length)) {
-    std::fill(Data.get(), Data.get() + Length, InitVal);
+    std::fill(begin(), end(), InitVal);
   }
 
   /// Copy construct a PBQP vector.
   Vector(const Vector &V)
     : Length(V.Length), Data(std::make_unique<PBQPNum []>(Length)) {
-    std::copy(V.Data.get(), V.Data.get() + Length, Data.get());
+    llvm::copy(V, begin());
   }
 
   /// Move construct a PBQP vector.


### PR DESCRIPTION
This patch adds begin and end to Vector.

The new functions will allow us to use llvm::interleaved in operator<<
for example.
