### PR TITLE
[compiler-rt][profile][tests][NFC] Avoid using a.out from PATH

### DIFF
--- a/compiler-rt/test/profile/AIX/pgo-lto-bcdtor-function-section.test
+++ b/compiler-rt/test/profile/AIX/pgo-lto-bcdtor-function-section.test
@@ -15,22 +15,22 @@ int main() { return foo() - 3; }
 // RUN: %clang_pgogen -O2 -c -fno-function-sections main.c
 //
 // RUN: %clang_pgogen -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=BOTH
 //
 // RUN: %clang_pgogen -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=BOTH
 
 // RUN: %clang_pgogen -O2 -c -ffunction-sections foo.c
 // RUN: %clang_pgogen -O2 -c -ffunction-sections main.c
 //
 // RUN: %clang_pgogen -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=BOTH
 //
 // RUN: %clang_pgogen -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=BOTH
 
 // ## no PGO at compile step, but PGO at link step.
@@ -38,11 +38,11 @@ int main() { return foo() - 3; }
 // RUN: %clang -O2 -c  main.c
 //
 // RUN: %clang_pgogen -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=NONE
 //
 // RUN: %clang_pgogen -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=NONE
 
 // # LTO, with and without function-sections, and all permutations of -bcdtors
@@ -51,44 +51,44 @@ int main() { return foo() - 3; }
 // RUN: %clang -O2 -c -flto main.c
 //
 // RUN: %clang_pgogen -flto -fno-function-sections -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=NONE
 //
 // RUN: %clang_pgogen -flto -fno-function-sections -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=NONE
 //
 // RUN: %clang_pgogen -flto -ffunction-sections -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=NONE
 //
 // RUN: %clang_pgogen -flto -ffunction-sections -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=NONE
 
 // ## LTO one file, PGO at compile and link
 // RUN: %clang -O2 -c -fno-function-sections foo.c
 // RUN: %clang_pgogen -O2 -c -flto main.c
 // RUN: %clang_pgogen -flto -fno-function-sections -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=MAIN
 
 // RUN: %clang -O2 -c -flto foo.c
 // RUN: %clang_pgogen -O2 -c -fno-function-sections main.c
 // RUN: %clang_pgogen -flto -fno-function-sections -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=MAIN
 
 // RUN: %clang -O2 -c -flto foo.c
 // RUN: %clang_pgogen -O2 -c -ffunction-sections main.c
 // RUN: %clang_pgogen -flto -ffunction-sections -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=MAIN
 
 // RUN: %clang -O2 -c -ffunction-sections foo.c
 // RUN: %clang_pgogen -O2 -c -flto main.c
 // RUN: %clang_pgogen -flto -ffunction-sections -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=MAIN
 
 // ## LTO and PGO both files
@@ -96,19 +96,19 @@ int main() { return foo() - 3; }
 // RUN: %clang_pgogen -O2 -c -flto main.c
 //
 // RUN: %clang_pgogen -flto -fno-function-sections -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=BOTH
 //
 // RUN: %clang_pgogen -flto -fno-function-sections -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=BOTH
 //
 // RUN: %clang_pgogen -flto -ffunction-sections -Wl,-bcdtors:all foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=BOTH
 //
 // RUN: %clang_pgogen -flto -ffunction-sections -Wl,-bcdtors:mbr foo.o main.o
-// RUN: rm -f default* && %run a.out
+// RUN: rm -f default* && %run ./a.out
 // RUN: llvm-profdata show --all-functions default* | FileCheck  %s -check-prefix=BOTH
 
 // BOTH-DAG: foo:


### PR DESCRIPTION
Fix use of `a.out` from the PATH by specifying `./a.out`.