### PR TITLE
Fix connecting via abstract socket

### DIFF
--- a/lldb/include/lldb/Host/linux/AbstractSocket.h
+++ b/lldb/include/lldb/Host/linux/AbstractSocket.h
@@ -15,6 +15,7 @@ namespace lldb_private {
 class AbstractSocket : public DomainSocket {
 public:
   AbstractSocket();
+  AbstractSocket(NativeSocket socket, bool should_close);
 
 protected:
   size_t GetNameOffset() const override;

--- a/lldb/include/lldb/Host/posix/DomainSocket.h
+++ b/lldb/include/lldb/Host/posix/DomainSocket.h
@@ -31,7 +31,8 @@ public:
 
   std::vector<std::string> GetListeningConnectionURI() const override;
 
-  static Socket *Create(NativeSocket sockfd, bool should_close, Status &error);
+  static llvm::Expected<std::unique_ptr<DomainSocket>>
+  FromBoundNativeSocket(NativeSocket sockfd, bool should_close);
 
 protected:
   DomainSocket(SocketProtocol protocol);

--- a/lldb/include/lldb/Host/posix/DomainSocket.h
+++ b/lldb/include/lldb/Host/posix/DomainSocket.h
@@ -31,6 +31,8 @@ public:
 
   std::vector<std::string> GetListeningConnectionURI() const override;
 
+  static Socket *Create(NativeSocket sockfd, bool should_close, Status &error);
+
 protected:
   DomainSocket(SocketProtocol protocol);
   DomainSocket(SocketProtocol protocol, NativeSocket socket, bool should_close);

--- a/lldb/include/lldb/Host/posix/DomainSocket.h
+++ b/lldb/include/lldb/Host/posix/DomainSocket.h
@@ -33,6 +33,7 @@ public:
 
 protected:
   DomainSocket(SocketProtocol protocol);
+  DomainSocket(SocketProtocol protocol, NativeSocket socket, bool should_close);
 
   virtual size_t GetNameOffset() const;
   virtual void DeleteSocketFile(llvm::StringRef name);

--- a/lldb/source/Host/linux/AbstractSocket.cpp
+++ b/lldb/source/Host/linux/AbstractSocket.cpp
@@ -15,6 +15,9 @@ using namespace lldb_private;
 
 AbstractSocket::AbstractSocket() : DomainSocket(ProtocolUnixAbstract) {}
 
+AbstractSocket::AbstractSocket(NativeSocket socket, bool should_close)
+    : DomainSocket(ProtocolUnixAbstract, socket, should_close) {}
+
 size_t AbstractSocket::GetNameOffset() const { return 1; }
 
 void AbstractSocket::DeleteSocketFile(llvm::StringRef name) {}

--- a/lldb/source/Host/posix/DomainSocket.cpp
+++ b/lldb/source/Host/posix/DomainSocket.cpp
@@ -67,6 +67,12 @@ DomainSocket::DomainSocket(NativeSocket socket,
   m_socket = socket;
 }
 
+DomainSocket::DomainSocket(SocketProtocol protocol, NativeSocket socket,
+                           bool should_close)
+    : Socket(protocol, should_close) {
+  m_socket = socket;
+}
+
 Status DomainSocket::Connect(llvm::StringRef name) {
   sockaddr_un saddr_un;
   socklen_t saddr_un_len;

--- a/lldb/source/Host/posix/DomainSocket.cpp
+++ b/lldb/source/Host/posix/DomainSocket.cpp
@@ -194,7 +194,6 @@ std::vector<std::string> DomainSocket::GetListeningConnectionURI() const {
 
 llvm::Expected<std::unique_ptr<DomainSocket>>
 DomainSocket::FromBoundNativeSocket(NativeSocket sockfd, bool should_close) {
-#ifdef __linux__
   // Check if fd represents domain socket or abstract socket.
   struct sockaddr_un addr;
   socklen_t addr_len = sizeof(addr);
@@ -202,6 +201,7 @@ DomainSocket::FromBoundNativeSocket(NativeSocket sockfd, bool should_close) {
     return llvm::createStringError("not a socket or error occurred");
   if (addr.sun_family != AF_UNIX)
     return llvm::createStringError("Bad socket type");
+#ifdef __linux__
   if (addr_len > offsetof(struct sockaddr_un, sun_path) &&
       addr.sun_path[0] == '\0')
     return std::make_unique<AbstractSocket>(sockfd, should_close);

--- a/lldb/tools/lldb-server/lldb-platform.cpp
+++ b/lldb/tools/lldb-server/lldb-platform.cpp
@@ -472,7 +472,8 @@ int main_platform(int argc, char *argv[]) {
       llvm::Expected<std::unique_ptr<DomainSocket>> domain_socket =
           DomainSocket::FromBoundNativeSocket(sockfd, /*should_close=*/true);
       if (!domain_socket) {
-        LLDB_LOGF(log, "Failed to create socket: %s\n", error.AsCString());
+        LLDB_LOG_ERROR(log, domain_socket.takeError(),
+                       "Failed to create socket: {0}");
         return socket_error;
       }
       socket = std::move(domain_socket.get());

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -15,6 +15,9 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <chrono>
+#if __linux__
+#include <lldb/Host/linux/AbstractSocket.h>
+#endif
 
 using namespace lldb_private;
 
@@ -336,6 +339,48 @@ TEST_F(SocketTest, DomainGetConnectURI) {
             URI::Parse(uri));
 
   EXPECT_EQ(socket_b_up->GetRemoteConnectionURI(), "");
+}
+#endif
+
+#if LLDB_ENABLE_POSIX
+TEST_F(SocketTest, DomainSocketFromBoundNativeSocket) {
+  // Generate a name for the domain socket.
+  llvm::SmallString<64> name;
+  std::error_code EC = llvm::sys::fs::createUniqueDirectory(
+      "DomainSocketFromBoundNativeSocket", name);
+  ASSERT_FALSE(EC);
+  llvm::sys::path::append(name, "test");
+
+  DomainSocket socket(true);
+  Status error = socket.Listen(name, /*backlog=*/10);
+  ASSERT_FALSE(error.ToError());
+  NativeSocket native_socket = socket.GetNativeSocket();
+
+  llvm::Expected<std::unique_ptr<DomainSocket>> sock =
+      DomainSocket::FromBoundNativeSocket(native_socket, /*should_close=*/true);
+  ASSERT_THAT_EXPECTED(sock, llvm::Succeeded());
+  ASSERT_EQ(Socket::ProtocolUnixDomain, sock->get()->GetSocketProtocol());
+}
+#endif
+
+#if __linux__
+TEST_F(SocketTest, AbstractSocketFromBoundNativeSocket) {
+  // Generate a name for the abstract socket.
+  llvm::SmallString<64> name;
+  std::error_code EC = llvm::sys::fs::createUniqueDirectory(
+      "AbstractSocketFromBoundNativeSocket", name);
+  ASSERT_FALSE(EC);
+  llvm::sys::path::append(name, "test");
+
+  AbstractSocket socket;
+  Status error = socket.Listen(name, /*backlog=*/10);
+  ASSERT_FALSE(error.ToError());
+  NativeSocket native_socket = socket.GetNativeSocket();
+
+  llvm::Expected<std::unique_ptr<DomainSocket>> sock =
+      DomainSocket::FromBoundNativeSocket(native_socket, /*should_close=*/true);
+  ASSERT_THAT_EXPECTED(sock, llvm::Succeeded());
+  ASSERT_EQ(Socket::ProtocolUnixAbstract, sock->get()->GetSocketProtocol());
 }
 #endif
 


### PR DESCRIPTION
Commit 82ee31f and Commit 2e893124 added socket sharing, but only for unix domain sockets. That broke Android, which uses unix-abstract sockets.