### PR TITLE
Experimental patch for understanding the pre-RA MachineScheduler

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -411,6 +411,24 @@ protected:
 /// ScheduleDAGMILive is an implementation of ScheduleDAGInstrs that schedules
 /// machine instructions while updating LiveIntervals and tracking regpressure.
 class ScheduleDAGMILive : public ScheduleDAGMI {
+
+  // Count register overlaps before and after scheduling in order to print
+  // the difference once per region along with its region ID. Enabled with
+  // -sched-print-pressures.
+  struct RegOverlaps {
+    int GPR;
+    int FP;
+    int GPRMax;
+    int FPMax;
+    RegOverlaps() : GPR(0), FP(0), GPRMax(0), FPMax(0) {}
+  };
+  void countRegOverlaps(RegOverlaps &RO, MachineBasicBlock::iterator FirstItr,
+                        MachineBasicBlock::iterator EndItr) const;
+
+  // Show liveness visually of registers before and after scheduling. Enabled
+  // with -sched-show-ints and -misched-only-block=NUM.
+  void showIntervals(std::string Msg, std::string I, MachineBasicBlock *MBB) const;
+
 protected:
   RegisterClassInfo *RegClassInfo;
 
@@ -1197,8 +1215,10 @@ protected:
   const TargetSchedModel *SchedModel = nullptr;
   const TargetRegisterInfo *TRI = nullptr;
 
+public:
   MachineSchedPolicy RegionPolicy;
 
+protected:
   SchedRemainder Rem;
 
   GenericSchedulerBase(const MachineSchedContext *C) : Context(C) {}

--- a/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
@@ -396,6 +396,9 @@ namespace llvm {
 
     /// Returns true if the def register in \p MO has no uses.
     bool deadDefHasNoUse(const MachineOperand &MO);
+
+  public:
+    unsigned CurrRegionIdx;
   };
 
   /// Creates a new SUnit and return a ptr to it.

--- a/llvm/include/llvm/CodeGen/SlotIndexes.h
+++ b/llvm/include/llvm/CodeGen/SlotIndexes.h
@@ -96,9 +96,11 @@ class raw_ostream;
       return lie.getPointer();
     }
 
+  public:
     unsigned getIndex() const {
       return listEntry()->getIndex() | getSlot();
     }
+  private:
 
     /// Returns the slot for this SlotIndex.
     Slot getSlot() const {

--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -29,6 +29,7 @@
 #include "llvm/Support/Printable.h"
 #include <cassert>
 #include <cstdint>
+#include <set>
 
 namespace llvm {
 
@@ -954,6 +955,20 @@ public:
   /// Get the dimensions of register pressure impacted by this register unit.
   /// Returns a -1 terminated array of pressure set IDs.
   virtual const int *getRegUnitPressureSets(unsigned RegUnit) const = 0;
+
+  /// EXPERIMENTAL: return true if Reg belongs to a prio (FP) register class.
+  /// Add some target specific methods to increase precision in counting of
+  /// live FP/GPR regs.
+private:
+  mutable std::set<unsigned> PrioRegClasses;
+  void initializePrioRegClasses() const;
+public:
+  bool isPrioRC(unsigned RegClassID) const;
+  bool isPrioVirtReg(Register Reg, const MachineRegisterInfo *MRI) const;
+  virtual unsigned getRCCountFactor(unsigned RegClassID) const { return 1; }
+  virtual bool isGPRLoRC(unsigned RegClassID) const { return false; }
+  virtual bool isGPRHiRC(unsigned RegClassID) const { return false; }
+  virtual bool isGPRLoHiRC(unsigned RegClassID) const { return false; }
 
   /// Get the scale factor of spill weight for this register class.
   virtual float getSpillWeightScaleFactor(const TargetRegisterClass *RC) const;

--- a/llvm/lib/CodeGen/RegAllocGreedy.h
+++ b/llvm/lib/CodeGen/RegAllocGreedy.h
@@ -286,6 +286,8 @@ private:
 
   bool ReverseLocalAssignment = false;
 
+  unsigned NumFPSpilled;
+  unsigned NumOtherSpilled;
 public:
   RAGreedy(RequiredAnalyses &Analyses, const RegAllocFilterFunc F = nullptr);
 

--- a/llvm/lib/Target/SystemZ/SystemZRegisterInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZRegisterInfo.h
@@ -146,6 +146,25 @@ public:
   const TargetRegisterClass *
   getCrossCopyRegClass(const TargetRegisterClass *RC) const override;
 
+  /// EXPERIMENTAL
+  unsigned getRCCountFactor(unsigned RegClassID) const override {
+    if (RegClassID == SystemZ::FP128BitRegClassID ||
+        RegClassID == SystemZ::GR128BitRegClassID ||
+        RegClassID == SystemZ::ADDR128BitRegClassID)
+      return 2;
+    return 1;
+  }
+  bool isGPRLoRC(unsigned RegClassID) const override {
+    return (RegClassID == SystemZ::GR32BitRegClassID ||
+            RegClassID == SystemZ::ADDR32BitRegClassID);
+  }
+  bool isGPRHiRC(unsigned RegClassID) const override {
+    return RegClassID == SystemZ::GRH32BitRegClassID;
+  }
+  bool isGPRLoHiRC(unsigned RegClassID) const override {
+    return RegClassID == SystemZ::GRX32BitRegClassID;
+  }
+
   bool getRegAllocationHints(Register VirtReg, ArrayRef<MCPhysReg> Order,
                              SmallVectorImpl<MCPhysReg> &Hints,
                              const MachineFunction &MF, const VirtRegMap *VRM,


### PR DESCRIPTION
When I realized that the GenericScheduler caused a lot *more* spilling to happen in cactus along with a performance penalty (5%), I started to try to understand what was going wrong. After many experiments, this is now my method of how to analyze a test case in regards to the pre-ra scheduler and spilling, which I would like to share (not meant to be merged):

- With this patch applied, build with '-mllvm -sched-print-pressures -mllvm -regalloc-stats' and the output (saved to a log) will have a lot of lines like
```
...
pp_sys.bcOOOOOOOPerl_pp_gmtimeOOOOOOOMBB67Region0       _GPR-3_FP2_GPRMax0_FPMax0_Size11_Stores1_Loads1_FPDefs1_OtherDefs3_FPTotLat4_OtherLat9
pp_sys.bcOOOOOOOPerl_pp_gmtimeOOOOOOOMBB95Region0       _GPR0_FP0_GPRMax0_FPMax0_Size4_Stores0_Loads0_FPDefs0_OtherDefs3_FPTotLat0_OtherLat9
REGALLOCSTAT: pp_sys.bcOOOOOOOPerl_pp_gmtime    _NumInstrs581_NumVirtRegs426_NumFPSpilled0_NumOtherSpilled1
...
```

The regalloc stats are per function, while the others are per scheduling region. The strings with "OOOO..."-delimiters are unique IDs for scheduling regions or functions that a script can parse along with the important numbers to the right.

- So let's say that the interesting file is ML_BSSN_Advect (cactus) as it has more spilling with the pre-ra scheduler than without, and it would be good to see in which regions FP spilling increases:

```
grep ML_BSSN_Advect.bc BUILD.log | grep "_NumFPSpilled[1-9]" 
REGALLOCSTAT: ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPd     _NumInstrs9857_NumVirtRegs10318_NumFPSpilled1848_NumOtherSpilled322
```

Compiling this one file once more per above with -mllvm -misched-inputorder added (same output as -enable-misched=false but with these dumps) shows some but much less FP spilling:
`REGALLOCSTAT: ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPd     _NumInstrs9857_NumVirtRegs10318_NumFPSpilled483_NumOtherSpilled491`

So this one function in the file spills 1848 FP vregs with the scheduler, but only 483 without it. To show the regions where the scheduler has caused more FP regs overlap than what was before scheduling:

```
grep ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPd 2017_main_sched_print_pressures/BUILD.log | grep -v "_FP[0-]"

ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPdOOOOOOOMBB184Region0       _GPR-77_FP66_GPRMax0_FPMax0_Size56_Stores0_Loads28_FPDefs28_OtherDefs27_FPTotLat112_OtherLat27
ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPdOOOOOOOMBB186Region0       _GPR21113_FP81234_GPRMax0_FPMax-16_Size2512_Stores0_Loads787_FPDefs2512_OtherDefs0_FPTotLat13498_OtherLat0
ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPdOOOOOOOMBB187Region0       _GPR15664_FP67158_GPRMax0_FPMax-8_Size2056_Stores0_Loads631_FPDefs2056_OtherDefs0_FPTotLat11074_OtherLat0
ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPdOOOOOOOMBB188Region0       _GPR10214_FP43459_GPRMax0_FPMax-4_Size1603_Stores0_Loads478_FPDefs1603_OtherDefs0_FPTotLat8662_OtherLat0
ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPdOOOOOOOMBB189Region0       _GPR-480_FP16762_GPRMax0_FPMax-3_Size1150_Stores0_Loads325_FPDefs1150_OtherDefs0_FPTotLat6250_OtherLat0
```

The (positive) FP values here (66, 81234, ...) are the differences between the sums of overlapping FP vregs before and after scheduling. This sum is basically counted as the number of live FP regs at each MI in the region, summed together across all MIs in the region.

- It is now time to try to reduce a region into something smaller in order to try to understand what is going wrong. The following will analyze the two logs and find the interesting difference:

```
env PROPERTY=FP compareOLs.pl LOG LOG_inputorder -50 -2
Function : ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPd
Region   : ML_BSSN_Advect.bcOOOOOOO_ZL19ML_BSSN_Advect_BodyPK4_cGHiiPKdS3_S3_PKiS5_iPKPdOOOOOOOMBB184Region0
Overlaping intervals improvement  : -66
Num spilled intervals improvement : -1365
Difference exists.

```
```
LOG:            Built with -mllvm -sched-print-pressures -mllvm -regalloc-stats
LOG_inputorder: Built with -mllvm -sched-print-pressures -mllvm -regalloc-stats -mllvm -misched-inputorder
3rd arg (-50):  The overlap improvement that LOG_inputorder should have for a region
4th arg (-2):   The number of spilled intervals (per REGALLOCSTAT) improvement the containing function should have.
```

With this "interestingness test", llvm-reduce can be used to do the actual reduction. A wrapper for this purpose is reduce_region.sh, that needs LLCBIN in the environment and the input file as an argument. The test uses llc, so the ML_BSSN_Advect.ll passed is the output aftr the middle-end passes have run (clang -emit-llvm...).

```
env LLCBIN=$LLVM_BUILD/bin/llc $LLVM_BUILD/bin/llvm-reduce -j 1  --test=[path-to]/reduce_region.sh ML_BSSN_Advect.ll
```

- Then in order to get a visual overview of the scheduling effects with the reduced test case:

```
llc -O3 -mcpu=z16 -o out.s reduced.ll -sched-show-ints >& show_out   # use 'less -r show_out' for the escape sequences to work.
```

In reduce_region.sh above, the values of -50 and -2 may be good to start with, and as a second step a yet smaller test case could be made by changing the numbers to, let's say -10 -1 or even -10 0, which may be useful. To get a side-by-side overview of the scheduling effects, I use two panes in a tmux session and adjust the llc output to look at both before and after, but there is also a script that doesn't work perfectly (yet) due to escape sequences (may need to adjust some spacing in it): sidebyside_sched.sh show_out.

![Intervals before and after sched m50 m2](https://github.com/user-attachments/assets/13b4608e-c5a8-4b73-9a2a-a25177ef50a6)

It is quite interesting to see visually how the registers have been become more overlapping with each other.
- At the top: Register indexes printed vertically with a color.
- A line below a number represents the register being live, with the same color as the number above it.
- the "F number" to the right is how many FP registers are live/overlapping at that point ("G numbers" are also printed if 
  -showgr is passed to llc).

The schedule has changed to the right with more overlapping lines and higher F values, which should explain the extra spilling. The original schedule had the VL64s (load from memory) scheduled low, while the GenericScheduler has allowed them to float up, which wasn't so good in this case.

This type of reduction/visualization has given me many clues to potential improvements of the scheduler strategy. This file and example shows the probably still most important heuristic, namely to schedule loads (and other instructions defining but not redefining a reg, with no uses becoming live) low in a big region. It seems that this is basically all you need to do to not cause spilling - at least in big regions like this. There are of course a few files that do not like that, so there is still room for improvement in SystemZPreRASchedStrategy. Usually, but not always, can the original problem be understood in the reduced region and if fixed also handles the original file.

In the SystemZPreRASchedStrategy this has evolved into computeSULivenessScore() over a series of many, many experiments with this. I have tried many good and reasonable ideas where only some happened to give good benchmark results as well. I have experimented with (small) DFS trees but removed them again as they where not needed to give good results. It is probably worth another try with them at some point. I also tried reversing this "loads down" heuristic to "stores up", but that didn't work very well for one or other reason (same with bi-directional). This is probably also worth revisting at some point with a careful approach - storing a value right after the last def *should* reduce spilling and be an improvement. There are still many things to be tried, but the current strategy is at a good point with good results. FP benchmarks are improving but Int not so much (no regressions however).

I may be wrong, but my feeling is that to get best performance this probably has to be tuned and benchmarked for a specific target. On the other hand, probably some other target could still get an improvement with this strategy, maybe after some adjustments.

There is also the -schedfile option which I have tried by building all different policies (including disabling) and then recompiled a final time taking for each region the policy that gave the least spill (from a file). This could also be interesting to revisit, but so far it hasn't given any increased performance.

The scripts: 
[sched_scripts.tar.gz](https://github.com/user-attachments/files/19825110/sched_scripts.tar.gz)

@uweigand @dominik-steenken @stefan-sf-ibm @atrick @michaelmaitland @wangpc-pp @mshockwave 