### PR TITLE
[lldb-dap] fix wrong assembly line number x64

### DIFF
--- a/lldb/test/API/tools/lldb-dap/stackTrace-x86/Makefile
+++ b/lldb/test/API/tools/lldb-dap/stackTrace-x86/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/stackTrace-x86/TestDAP_source_x86.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace-x86/TestDAP_source_x86.py
@@ -1,0 +1,64 @@
+"""
+Test lldb-dap stack trace containing x86 assembly
+"""
+
+import lldbdap_testcase
+from lldbsuite.test.decorators import skipUnlessArch, skipUnlessPlatform
+from lldbsuite.test.lldbtest import line_number
+
+
+class TestDAP_stacktrace_x86(lldbdap_testcase.DAPTestCaseBase):
+    @skipUnlessArch("x86_64")
+    @skipUnlessPlatform(["linux"])
+    def test_stacktrace_x86(self):
+        """
+        Tests that lldb-dap steps through correctly and the source lines are correct in x86 assembly.
+        """
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(
+            program,
+            initCommands=[
+                "settings set target.process.thread.step-in-avoid-nodebug false"
+            ],
+        )
+
+        source = "main.c"
+        breakpoint_ids = self.set_source_breakpoints(
+            source,
+            [line_number(source, "// Break here")],
+        )
+        self.continue_to_breakpoints(breakpoint_ids)
+        self.stepIn()
+
+        frame = self.get_stackFrames()[0]
+        self.assertEqual(
+            frame["name"],
+            "no_branch_func",
+            "verify we are in the no_branch_func function",
+        )
+
+        self.assertEqual(frame["line"], 1, "verify we are at the start of the function")
+        minimum_assembly_lines = (
+            line_number(source, "Assembly end")
+            - line_number(source, "Assembly start")
+            + 1
+        )
+        self.assertLessEqual(
+            10,
+            minimum_assembly_lines,
+            "verify we have a reasonable number of assembly lines",
+        )
+
+        for i in range(2, minimum_assembly_lines):
+            self.stepIn()
+            frame = self.get_stackFrames()[0]
+            self.assertEqual(
+                frame["name"],
+                "no_branch_func",
+                "verify we are still in the no_branch_func function",
+            )
+            self.assertEqual(
+                frame["line"],
+                i,
+                f"step in should advance a single line in the function to {i}",
+            )

--- a/lldb/test/API/tools/lldb-dap/stackTrace-x86/TestDAP_source_x86.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace-x86/TestDAP_source_x86.py
@@ -3,13 +3,14 @@ Test lldb-dap stack trace containing x86 assembly
 """
 
 import lldbdap_testcase
+from lldbsuite.test import lldbplatformutil
 from lldbsuite.test.decorators import skipUnlessArch, skipUnlessPlatform
 from lldbsuite.test.lldbtest import line_number
 
 
 class TestDAP_stacktrace_x86(lldbdap_testcase.DAPTestCaseBase):
     @skipUnlessArch("x86_64")
-    @skipUnlessPlatform(["linux"])
+    @skipUnlessPlatform(["linux"] + lldbplatformutil.getDarwinOSTriples())
     def test_stacktrace_x86(self):
         """
         Tests that lldb-dap steps through correctly and the source lines are correct in x86 assembly.

--- a/lldb/test/API/tools/lldb-dap/stackTrace-x86/main.c
+++ b/lldb/test/API/tools/lldb-dap/stackTrace-x86/main.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+
+__attribute__((nodebug)) int no_branch_func(void) {
+  int result = 0;
+
+  __asm__ __volatile__("movl $0, %%eax;" // Assembly start
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "incl %%eax;"
+                       "movl %%eax, %0;" // Assembly end
+                       : "=r"(result)
+                       :
+                       : "%eax");
+
+  return result;
+}
+
+int main(void) {
+  int result = no_branch_func(); // Break here
+  printf("Result: %d\n", result);
+  return 0;
+}


### PR DESCRIPTION
Fix  wrong assembly line number calculation that assumes the instruction size is `GetAddressByteSize() / 2`

Fixes #136495