### PR TITLE
[lldb-dap] Show assembly depending on `stop-disassembly-display` settings

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -232,14 +232,6 @@ public:
 
   void SetLoggingCallback(lldb::LogOutputCallback log_callback, void *baton);
 
-  // Properties Functions
-  enum StopDisassemblyType {
-    eStopDisassemblyTypeNever = 0,
-    eStopDisassemblyTypeNoDebugInfo,
-    eStopDisassemblyTypeNoSource,
-    eStopDisassemblyTypeAlways
-  };
-
   Status SetPropertyValue(const ExecutionContext *exe_ctx,
                           VarSetOperationType op, llvm::StringRef property_path,
                           llvm::StringRef value) override;
@@ -336,7 +328,7 @@ public:
 
   uint64_t GetStopSourceLineCount(bool before) const;
 
-  StopDisassemblyType GetStopDisassemblyDisplay() const;
+  lldb::StopDisassemblyType GetStopDisassemblyDisplay() const;
 
   uint64_t GetDisassemblyLineCount() const;
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1383,6 +1383,14 @@ enum CommandReturnObjectCallbackResult {
   eCommandReturnObjectPrintCallbackHandled = 1,
 };
 
+/// Used to determine when to show disassembly.
+enum StopDisassemblyType {
+  eStopDisassemblyTypeNever = 0,
+  eStopDisassemblyTypeNoDebugInfo,
+  eStopDisassemblyTypeNoSource,
+  eStopDisassemblyTypeAlways
+};
+
 } // namespace lldb
 
 #endif // LLDB_LLDB_ENUMERATIONS_H

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -91,11 +91,13 @@ let Definition = "debugger" in {
     Global,
     DefaultUnsignedValue<4>,
     Desc<"The number of disassembly lines to show when displaying a stopped context.">;
-  def StopDisassemblyDisplay: Property<"stop-disassembly-display", "Enum">,
-    Global,
-    DefaultEnumValue<"Debugger::eStopDisassemblyTypeNoDebugInfo">,
-    EnumValues<"OptionEnumValues(g_show_disassembly_enum_values)">,
-    Desc<"Control when to display disassembly when displaying a stopped context.">;
+  def StopDisassemblyDisplay
+      : Property<"stop-disassembly-display", "Enum">,
+        Global,
+        DefaultEnumValue<"eStopDisassemblyTypeNoDebugInfo">,
+        EnumValues<"OptionEnumValues(g_show_disassembly_enum_values)">,
+        Desc<"Control when to display disassembly when displaying a stopped "
+             "context.">;
   def StopDisassemblyMaxSize: Property<"stop-disassembly-max-size", "UInt64">,
     Global,
     DefaultUnsignedValue<32000>,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -112,24 +112,24 @@ static llvm::DefaultThreadPool *g_thread_pool = nullptr;
 
 static constexpr OptionEnumValueElement g_show_disassembly_enum_values[] = {
     {
-        Debugger::eStopDisassemblyTypeNever,
+        lldb::eStopDisassemblyTypeNever,
         "never",
         "Never show disassembly when displaying a stop context.",
     },
     {
-        Debugger::eStopDisassemblyTypeNoDebugInfo,
+        lldb::eStopDisassemblyTypeNoDebugInfo,
         "no-debuginfo",
         "Show disassembly when there is no debug information.",
     },
     {
-        Debugger::eStopDisassemblyTypeNoSource,
+        lldb::eStopDisassemblyTypeNoSource,
         "no-source",
         "Show disassembly when there is no source information, or the source "
         "file "
         "is missing when displaying a stop context.",
     },
     {
-        Debugger::eStopDisassemblyTypeAlways,
+        lldb::eStopDisassemblyTypeAlways,
         "always",
         "Always show disassembly when displaying a stop context.",
     },
@@ -611,10 +611,10 @@ uint64_t Debugger::GetStopSourceLineCount(bool before) const {
       idx, g_debugger_properties[idx].default_uint_value);
 }
 
-Debugger::StopDisassemblyType Debugger::GetStopDisassemblyDisplay() const {
+lldb::StopDisassemblyType Debugger::GetStopDisassemblyDisplay() const {
   const uint32_t idx = ePropertyStopDisassemblyDisplay;
-  return GetPropertyAtIndexAs<Debugger::StopDisassemblyType>(
-      idx, static_cast<Debugger::StopDisassemblyType>(
+  return GetPropertyAtIndexAs<lldb::StopDisassemblyType>(
+      idx, static_cast<lldb::StopDisassemblyType>(
                g_debugger_properties[idx].default_uint_value));
 }
 

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -2030,8 +2030,7 @@ bool StackFrame::GetStatus(Stream &strm, bool show_frame_info, bool show_source,
   if (show_source) {
     ExecutionContext exe_ctx(shared_from_this());
     bool have_source = false, have_debuginfo = false;
-    Debugger::StopDisassemblyType disasm_display =
-        Debugger::eStopDisassemblyTypeNever;
+    lldb::StopDisassemblyType disasm_display = lldb::eStopDisassemblyTypeNever;
     Target *target = exe_ctx.GetTargetPtr();
     if (target) {
       Debugger &debugger = target->GetDebugger();
@@ -2064,20 +2063,20 @@ bool StackFrame::GetStatus(Stream &strm, bool show_frame_info, bool show_source,
         }
       }
       switch (disasm_display) {
-      case Debugger::eStopDisassemblyTypeNever:
+      case lldb::eStopDisassemblyTypeNever:
         break;
 
-      case Debugger::eStopDisassemblyTypeNoDebugInfo:
+      case lldb::eStopDisassemblyTypeNoDebugInfo:
         if (have_debuginfo)
           break;
         [[fallthrough]];
 
-      case Debugger::eStopDisassemblyTypeNoSource:
+      case lldb::eStopDisassemblyTypeNoSource:
         if (have_source)
           break;
         [[fallthrough]];
 
-      case Debugger::eStopDisassemblyTypeAlways:
+      case lldb::eStopDisassemblyTypeAlways:
         if (target) {
           const uint32_t disasm_lines = debugger.GetDisassemblyLineCount();
           if (disasm_lines > 0) {

--- a/lldb/test/API/tools/lldb-dap/stackTraceDisassemblyDisplay/Makefile
+++ b/lldb/test/API/tools/lldb-dap/stackTraceDisassemblyDisplay/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c other.c
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/stackTraceDisassemblyDisplay/TestDAP_stackTraceDisassemblyDisplay.py
+++ b/lldb/test/API/tools/lldb-dap/stackTraceDisassemblyDisplay/TestDAP_stackTraceDisassemblyDisplay.py
@@ -1,0 +1,161 @@
+"""
+Test lldb-dap stack trace when some of the source paths are missing
+"""
+
+from lldbsuite.test.lldbtest import line_number
+import lldbdap_testcase
+from contextlib import contextmanager
+import os
+
+
+OTHER_C_SOURCE_CODE = """
+int no_source_func(int n) {
+    return n + 1; // Break here
+}
+"""
+
+
+@contextmanager
+def delete_file_on_exit(path):
+    try:
+        yield path
+    finally:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+class TestDAP_stackTraceMissingSourcePath(lldbdap_testcase.DAPTestCaseBase):
+    def build_and_run_until_breakpoint(self):
+        """
+        Build the program and run until the breakpoint is hit, and return the stack frames.
+        """
+        other_source_file = "other.c"
+        with delete_file_on_exit(other_source_file):
+            with open(other_source_file, "w") as f:
+                f.write(OTHER_C_SOURCE_CODE)
+
+            breakpoint_line = line_number(other_source_file, "// Break here")
+
+            program = self.getBuildArtifact("a.out")
+            self.build_and_launch(program, commandEscapePrefix="")
+
+            breakpoint_ids = self.set_source_breakpoints(
+                other_source_file, [breakpoint_line]
+            )
+            self.assertEqual(
+                len(breakpoint_ids), 1, "expect correct number of breakpoints"
+            )
+
+            self.continue_to_breakpoints(breakpoint_ids)
+
+        frames = self.get_stackFrames()
+        self.assertLessEqual(2, len(frames), "expect at least 2 frames")
+
+        self.assertIn(
+            "path",
+            frames[0]["source"],
+            "Expect source path to always be in frame (other.c)",
+        )
+        self.assertIn(
+            "path",
+            frames[1]["source"],
+            "Expect source path in always be in frame (main.c)",
+        )
+
+        return frames
+
+    def verify_frames_source(
+        self, frames, main_frame_assembly: bool, other_frame_assembly: bool
+    ):
+        if other_frame_assembly:
+            self.assertFalse(
+                frames[0]["source"]["path"].endswith("other.c"),
+                "Expect original source path to not be in unavailable source frame (other.c)",
+            )
+            self.assertIn(
+                "sourceReference",
+                frames[0]["source"],
+                "Expect sourceReference to be in unavailable source frame (other.c)",
+            )
+        else:
+            self.assertTrue(
+                frames[0]["source"]["path"].endswith("other.c"),
+                "Expect original source path to be in normal source frame (other.c)",
+            )
+            self.assertNotIn(
+                "sourceReference",
+                frames[0]["source"],
+                "Expect sourceReference to not be in normal source frame (other.c)",
+            )
+
+        if main_frame_assembly:
+            self.assertFalse(
+                frames[1]["source"]["path"].endswith("main.c"),
+                "Expect original source path to not be in unavailable source frame (main.c)",
+            )
+            self.assertIn(
+                "sourceReference",
+                frames[1]["source"],
+                "Expect sourceReference to be in unavailable source frame (main.c)",
+            )
+        else:
+            self.assertTrue(
+                frames[1]["source"]["path"].endswith("main.c"),
+                "Expect original source path to be in normal source frame (main.c)",
+            )
+            self.assertNotIn(
+                "sourceReference",
+                frames[1]["source"],
+                "Expect sourceReference to not be in normal source code frame (main.c)",
+            )
+
+    def test_stopDisassemblyDisplay(self):
+        """
+        Test that with with all stop-disassembly-display values you get correct assembly / no assembly source code.
+        """
+        self.build_and_run_until_breakpoint()
+        frames = self.get_stackFrames()
+        self.assertLessEqual(2, len(frames), "expect at least 2 frames")
+
+        self.assertIn(
+            "path",
+            frames[0]["source"],
+            "Expect source path to always be in frame (other.c)",
+        )
+        self.assertIn(
+            "path",
+            frames[1]["source"],
+            "Expect source path in always be in frame (main.c)",
+        )
+
+        self.dap_server.request_evaluate(
+            "settings set stop-disassembly-display never", context="repl"
+        )
+        frames = self.get_stackFrames()
+        self.verify_frames_source(
+            frames, main_frame_assembly=False, other_frame_assembly=False
+        )
+
+        self.dap_server.request_evaluate(
+            "settings set stop-disassembly-display always", context="repl"
+        )
+        frames = self.get_stackFrames()
+        self.verify_frames_source(
+            frames, main_frame_assembly=True, other_frame_assembly=True
+        )
+
+        self.dap_server.request_evaluate(
+            "settings set stop-disassembly-display no-source", context="repl"
+        )
+        frames = self.get_stackFrames()
+        self.verify_frames_source(
+            frames, main_frame_assembly=False, other_frame_assembly=True
+        )
+
+        self.dap_server.request_evaluate(
+            "settings set stop-disassembly-display no-debuginfo", context="repl"
+        )
+        frames = self.get_stackFrames()
+        self.verify_frames_source(
+            frames, main_frame_assembly=False, other_frame_assembly=False
+        )

--- a/lldb/test/API/tools/lldb-dap/stackTraceDisassemblyDisplay/main.c
+++ b/lldb/test/API/tools/lldb-dap/stackTraceDisassemblyDisplay/main.c
@@ -1,0 +1,6 @@
+int no_source_func(int n);
+
+int main(int argc, char const *argv[]) {
+  no_source_func(10);
+  return 0;
+}

--- a/lldb/tools/lldb-dap/Handler/StackTraceRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/StackTraceRequestHandler.cpp
@@ -9,7 +9,9 @@
 #include "DAP.h"
 #include "EventHelper.h"
 #include "JSONUtils.h"
+#include "LLDBUtils.h"
 #include "RequestHandler.h"
+#include "lldb/lldb-enumerations.h"
 
 namespace lldb_dap {
 
@@ -53,6 +55,8 @@ static bool FillStackFrames(DAP &dap, lldb::SBThread &thread,
                             llvm::json::Array &stack_frames, int64_t &offset,
                             const int64_t start_frame, const int64_t levels,
                             const bool include_all) {
+  lldb::StopDisassemblyType stop_disassembly_display =
+      GetStopDisassemblyDisplay(dap.debugger);
   bool reached_end_of_stack = false;
   for (int64_t i = start_frame;
        static_cast<int64_t>(stack_frames.size()) < levels; i++) {
@@ -69,7 +73,8 @@ static bool FillStackFrames(DAP &dap, lldb::SBThread &thread,
       break;
     }
 
-    stack_frames.emplace_back(CreateStackFrame(frame, frame_format));
+    stack_frames.emplace_back(
+        CreateStackFrame(frame, frame_format, stop_disassembly_display));
   }
 
   if (include_all && reached_end_of_stack) {

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -346,6 +346,21 @@ llvm::json::Value CreateSource(const lldb::SBLineEntry &line_entry);
 ///     definition outlined by Microsoft.
 llvm::json::Value CreateSource(llvm::StringRef source_path);
 
+/// Return true if the given line entry should be displayed as assembly.
+///
+/// \param[in] line_entry
+///     The LLDB line entry to check.
+///
+/// \param[in] stop_disassembly_display
+///     The value of the "stop-disassembly-display" setting.
+///
+/// \return
+///     True if the line entry should be displayed as assembly, false
+///     otherwise.
+bool ShouldDisplayAssemblySource(
+    const lldb::SBLineEntry &line_entry,
+    lldb::StopDisassemblyType stop_disassembly_display);
+
 /// Create a "StackFrame" object for a LLDB frame object.
 ///
 /// This function will fill in the following keys in the returned
@@ -364,11 +379,14 @@ llvm::json::Value CreateSource(llvm::StringRef source_path);
 ///     The LLDB format to use when populating out the "StackFrame"
 ///     object.
 ///
+/// \param[in] stop_disassembly_display
+///     The value of the "stop-disassembly-display" setting.
+///
 /// \return
 ///     A "StackFrame" JSON object with that follows the formal JSON
 ///     definition outlined by Microsoft.
-llvm::json::Value CreateStackFrame(lldb::SBFrame &frame,
-                                   lldb::SBFormat &format);
+llvm::json::Value CreateStackFrame(lldb::SBFrame &frame, lldb::SBFormat &format,
+                                   lldb::StopDisassemblyType);
 
 /// Create a "StackFrame" label object for a LLDB thread.
 ///

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -186,6 +186,33 @@ GetEnvironmentFromArguments(const llvm::json::Object &arguments) {
   return envs;
 }
 
+lldb::StopDisassemblyType
+GetStopDisassemblyDisplay(lldb::SBDebugger &debugger) {
+  lldb::StopDisassemblyType result =
+      lldb::StopDisassemblyType::eStopDisassemblyTypeNoDebugInfo;
+  lldb::SBStructuredData string_result =
+      debugger.GetSetting("stop-disassembly-display");
+  const size_t result_length = string_result.GetStringValue(nullptr, 0);
+  if (result_length > 0) {
+    std::string result_string(result_length, '\0');
+    string_result.GetStringValue(result_string.data(), result_length + 1);
+
+    result =
+        llvm::StringSwitch<lldb::StopDisassemblyType>(result_string)
+            .Case("never", lldb::StopDisassemblyType::eStopDisassemblyTypeNever)
+            .Case("always",
+                  lldb::StopDisassemblyType::eStopDisassemblyTypeAlways)
+            .Case("no-source",
+                  lldb::StopDisassemblyType::eStopDisassemblyTypeNoSource)
+            .Case("no-debuginfo",
+                  lldb::StopDisassemblyType::eStopDisassemblyTypeNoDebugInfo)
+            .Default(
+                lldb::StopDisassemblyType::eStopDisassemblyTypeNoDebugInfo);
+  }
+
+  return result;
+}
+
 llvm::Error ToError(const lldb::SBError &error) {
   if (error.Success())
     return llvm::Error::success();

--- a/lldb/tools/lldb-dap/LLDBUtils.h
+++ b/lldb/tools/lldb-dap/LLDBUtils.h
@@ -159,6 +159,15 @@ uint32_t GetLLDBFrameID(uint64_t dap_frame_id);
 lldb::SBEnvironment
 GetEnvironmentFromArguments(const llvm::json::Object &arguments);
 
+/// Get the stop-disassembly-display settings
+///
+/// \param[in] debugger
+///     The debugger that will execute the lldb commands.
+///
+/// \return
+///     The value of the stop-disassembly-display setting
+lldb::StopDisassemblyType GetStopDisassemblyDisplay(lldb::SBDebugger &debugger);
+
 /// Take ownership of the stored error.
 llvm::Error ToError(const lldb::SBError &error);
 


### PR DESCRIPTION
Show assembly code when the source code for a frame is not available in the debugger machine

Edit: this functionality will work only when using `stop-disassembly-display = no-source` in the settings

Fix #136492

After the fix:

[Screencast From 2025-04-20 18-00-30.webm](https://github.com/user-attachments/assets/1ce41715-cf4f-42a1-8f5c-6196b9d685dc)
