### PR TITLE
[LLD][COFF] Handle --start-lib/--end-lib group in the same way as other archives

### DIFF
--- a/lld/COFF/Driver.h
+++ b/lld/COFF/Driver.h
@@ -95,7 +95,7 @@ public:
 
   // Schedule a input file for reading.
   void enqueuePath(StringRef path, bool wholeArchive = false,
-                   std::optional<std::shared_future<CmdLineArchive *>>
+                   std::optional<std::shared_ptr<CmdLineArchive *>>
                        inCmdLineArchive = std::nullopt);
 
   void pullArm64ECIcallHelper();
@@ -175,7 +175,7 @@ private:
 
   std::set<std::string> visitedLibs;
 
-  void addBuffer(std::unique_ptr<MemoryBuffer> mb, bool wholeArchive,
+  void addBuffer(std::unique_ptr<MemoryBuffer> mb, bool wholeArchive = false,
                  CmdLineArchive *inCmdLineArchive = nullptr);
   void addArchiveBuffer(MemoryBufferRef mbref, StringRef symName,
                         StringRef parentName, uint64_t offsetInArchive);

--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -226,8 +226,19 @@ lld::coff::getArchiveMembers(COFFLinkerContext &ctx, Archive *file) {
   return v;
 }
 
-ObjFile::ObjFile(SymbolTable &symtab, COFFObjectFile *coffObj, bool lazy)
-    : InputFile(symtab, ObjectKind, coffObj->getMemoryBufferRef(), lazy),
+void CmdLineArchive::parse() {
+  for (InputFile *f : files) {
+    if (auto *o = dyn_cast<ObjFile>(f))
+      o->parseLazy();
+    else if (auto *b = dyn_cast<BitcodeFile>(f))
+      b->parseLazy();
+  }
+}
+
+void CmdLineArchive::addInputFile(InputFile *f) { files.push_back(f); }
+
+ObjFile::ObjFile(SymbolTable &symtab, COFFObjectFile *coffObj)
+    : InputFile(symtab, ObjectKind, coffObj->getMemoryBufferRef()),
       coffObj(coffObj) {}
 
 ObjFile *ObjFile::create(COFFLinkerContext &ctx, MemoryBufferRef m, bool lazy) {
@@ -241,8 +252,7 @@ ObjFile *ObjFile::create(COFFLinkerContext &ctx, MemoryBufferRef m, bool lazy) {
     Fatal(ctx) << m.getBufferIdentifier() << " is not a COFF file";
 
   bin->release();
-  return make<ObjFile>(ctx.getSymtab(MachineTypes(obj->getMachine())), obj,
-                       lazy);
+  return make<ObjFile>(ctx.getSymtab(MachineTypes(obj->getMachine())), obj);
 }
 
 void ObjFile::parseLazy() {
@@ -257,8 +267,6 @@ void ObjFile::parseLazy() {
     if (coffSym.isAbsolute() && ignoredSymbolName(name))
       continue;
     symtab.addLazyObject(this, name);
-    if (!lazy)
-      return;
     i += coffSym.getNumberOfAuxSymbols();
   }
 }
@@ -299,6 +307,8 @@ void ObjFile::initializeECThunks() {
 }
 
 void ObjFile::parse() {
+  symtab.ctx.objFileInstances.push_back(this);
+
   // Read section and symbol tables.
   initializeChunks();
   initializeSymbols();
@@ -1201,6 +1211,8 @@ ImportThunkChunk *ImportFile::makeImportThunk() {
 }
 
 void ImportFile::parse() {
+  symtab.ctx.importFileInstances.push_back(this);
+
   const auto *hdr =
       reinterpret_cast<const coff_import_header *>(mb.getBufferStart());
 
@@ -1307,14 +1319,14 @@ void ImportFile::parse() {
 }
 
 BitcodeFile::BitcodeFile(SymbolTable &symtab, MemoryBufferRef mb,
-                         std::unique_ptr<lto::InputFile> &o, bool lazy)
-    : InputFile(symtab, BitcodeKind, mb, lazy) {
+                         std::unique_ptr<lto::InputFile> &o)
+    : InputFile(symtab, BitcodeKind, mb) {
   obj.swap(o);
 }
 
 BitcodeFile *BitcodeFile::create(COFFLinkerContext &ctx, MemoryBufferRef mb,
                                  StringRef archiveName,
-                                 uint64_t offsetInArchive, bool lazy) {
+                                 uint64_t offsetInArchive) {
   std::string path = mb.getBufferIdentifier().str();
   if (ctx.config.thinLTOIndexOnly)
     path = replaceThinLTOSuffix(mb.getBufferIdentifier(),
@@ -1335,13 +1347,18 @@ BitcodeFile *BitcodeFile::create(COFFLinkerContext &ctx, MemoryBufferRef mb,
                                                utostr(offsetInArchive)));
 
   std::unique_ptr<lto::InputFile> obj = check(lto::InputFile::create(mbref));
-  return make<BitcodeFile>(ctx.getSymtab(getMachineType(obj.get())), mb, obj,
-                           lazy);
+  return make<BitcodeFile>(ctx.getSymtab(getMachineType(obj.get())), mb, obj);
 }
 
 BitcodeFile::~BitcodeFile() = default;
 
 void BitcodeFile::parse() {
+  if (symtab.ctx.driver.ltoCompilationDone) {
+    Err(symtab.ctx) << "LTO object file " << toString(this)
+                    << " linked in after doing LTO compilation.";
+  }
+  symtab.bitcodeFileInstances.push_back(this);
+
   llvm::StringSaver &saver = lld::saver();
 
   std::vector<std::pair<Symbol *, bool>> comdat(obj->getComdatTable().size());
@@ -1406,11 +1423,8 @@ void BitcodeFile::parse() {
 
 void BitcodeFile::parseLazy() {
   for (const lto::InputFile::Symbol &sym : obj->symbols())
-    if (!sym.isUndefined()) {
+    if (!sym.isUndefined())
       symtab.addLazyObject(this, sym.getName());
-      if (!lazy)
-        return;
-    }
 }
 
 MachineTypes BitcodeFile::getMachineType(const llvm::lto::InputFile *obj) {

--- a/lld/COFF/InputFiles.h
+++ b/lld/COFF/InputFiles.h
@@ -139,16 +139,21 @@ private:
   llvm::DenseSet<uint64_t> seen;
 };
 
-// A synthetic --start-lib/--end-lib archive.
+// A synthetic -start-lib/-end-lib archive.
 class CmdLineArchive : public InputFile {
 public:
-  explicit CmdLineArchive(SymbolTable &s, MemoryBufferRef m)
-      : InputFile(s, CmdLineArchiveKind, m) {}
+  explicit CmdLineArchive(SymbolTable &s, MemoryBufferRef m, StringRef startLib,
+                          StringRef endLib)
+      : InputFile(s, CmdLineArchiveKind, m), startLibArg(startLib),
+        endLibArg(endLib) {}
   static bool classof(const InputFile *f) {
     return f->kind() == CmdLineArchiveKind;
   }
   void parse() override;
   void addInputFile(InputFile *f);
+
+  StringRef startLibArg;
+  StringRef endLibArg;
 
 private:
   std::vector<InputFile *> files;

--- a/lld/Common/Args.cpp
+++ b/lld/Common/Args.cpp
@@ -90,3 +90,13 @@ StringRef lld::args::getFilenameWithoutExe(StringRef path) {
     return sys::path::stem(path);
   return sys::path::filename(path);
 }
+
+StringRef lld::args::getOptionSpellingLikeArg(llvm::opt::OptTable &optTable,
+                                              llvm::opt::OptSpecifier opt,
+                                              llvm::opt::Arg *arg,
+                                              llvm::StringSaver &saver) {
+  StringRef prefix = arg->getSpelling();
+  prefix.consume_back(arg->getOption().getName());
+  auto option = optTable.getOption(opt);
+  return saver.save((prefix + option.getName()).str());
+}

--- a/lld/include/lld/Common/Args.h
+++ b/lld/include/lld/Common/Args.h
@@ -15,9 +15,13 @@
 #include <vector>
 
 namespace llvm {
+class StringSaver;
 namespace opt {
+class Arg;
 class InputArgList;
-}
+class OptSpecifier;
+class OptTable;
+} // namespace opt
 } // namespace llvm
 
 namespace lld {
@@ -39,6 +43,11 @@ uint64_t getZOptionValue(llvm::opt::InputArgList &args, int id, StringRef key,
 std::vector<StringRef> getLines(MemoryBufferRef mb);
 
 StringRef getFilenameWithoutExe(StringRef path);
+
+StringRef getOptionSpellingLikeArg(llvm::opt::OptTable &optTable,
+                                   llvm::opt::OptSpecifier opt,
+                                   llvm::opt::Arg *arg,
+                                   llvm::StringSaver &saver);
 
 } // namespace args
 } // namespace lld

--- a/lld/test/COFF/start-lib-warn.ll
+++ b/lld/test/COFF/start-lib-warn.ll
@@ -1,0 +1,55 @@
+; REQUIRES: x86
+;
+; RUN: split-file %s %t.dir
+;
+; We need an input file to lld, so create one.
+; RUN: llc -filetype=obj %t.dir/main.ll -o %t.obj
+
+; RUN: lld-link -start-lib %t.obj /subsystem:console /force 2>&1 \
+; RUN:     | FileCheck --check-prefix=MISSING_END %s
+; MISSING_END: -start-lib without -end-lib
+
+; RUN: not lld-link %t.obj -end-lib /subsystem:console /force 2>&1 \
+; RUN:     | FileCheck --check-prefix=STRAY_END %s
+; STRAY_END: stray -end-lib
+
+; RUN: not lld-link -start-lib -start-lib %t.obj /subsystem:console /force 2>&1 \
+; RUN:     | FileCheck --check-prefix=NESTED_START %s
+; NESTED_START: nested -start-lib
+
+; RUN: lld-link -start-lib %t.obj %S/Inputs/resource.res -end-lib /subsystem:console /force 2>&1 \
+; RUN:     | FileCheck --check-prefix=WARN_RES %s
+; WARN_RES: .res file provided between -start-lib/-end-lib will not be lazy
+
+; RUN: lld-link -start-lib %t.obj %S/Inputs/ret42.lib -end-lib /subsystem:console /force 2>&1 \
+; RUN:     | FileCheck --check-prefix=WARN_LIB %s
+; WARN_LIB: .lib/.a file provided between -start-lib/-end-lib has no effect
+
+; RUN: lld-link -start-lib %t.obj %S/Inputs/pdb-diff-cl.pdb -end-lib /subsystem:console /force 2>&1 \
+; RUN:     | FileCheck --check-prefix=WARN_PDB %s
+; WARN_PDB: .pdb file provided between -start-lib/-end-lib will not be lazy
+
+; RUN: llvm-mc -filetype=obj -triple=x86_64-windows-gnu %t.dir/lib.s -o %t.lib.o
+; RUN: lld-link -noentry -dll -def:%t.dir/lib.def %t.lib.o -out:%t.lib.dll -implib:%t.implib.lib
+; RUN: lld-link -lldmingw -start-lib %t.lib.dll -end-lib /force 2>&1 \
+; RUN:     | FileCheck --check-prefix=WARN_EXE %s
+; WARN_EXE: .dll file provided between -start-lib/-end-lib will not be lazy
+
+#--- main.ll
+target datalayout = "e-m:w-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+define void @main() {
+  ret void
+}
+
+#--- lib.s
+.text
+.global func1
+func1:
+  ret
+
+#--- lib.def
+NAME lib.dll
+EXPORTS
+    func1


### PR DESCRIPTION
This introduces `CmdLineArchive` which is inteded as a virtual object files (.OBJ/.O) container, in the same way as `ArchiveFile` is. The purpose of this container is to later track its position on the command line, in regards to other archives (.LIBs) present on the command line, which is important for landing https://github.com/llvm/llvm-project/pull/85290

This PR is an attempt to split https://github.com/llvm/llvm-project/pull/85290 into smaller pieces.
