### PR TITLE
Add constrained fadd to FP operations

### DIFF
--- a/llvm/include/llvm/IR/FloatingPointOps.def
+++ b/llvm/include/llvm/IR/FloatingPointOps.def
@@ -18,6 +18,7 @@
 // - intrinsic function name,
 // - DAG node corresponding to the intrinsic.
 
+FUNCTION(experimental_constrained_fadd,      FADD)
 FUNCTION(nearbyint,                          FNEARBYINT)
 FUNCTION(trunc,                              FTRUNC)
 

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -636,6 +636,11 @@ RoundingMode CallBase::getRoundingMode() const {
   if (RM)
     return *RM;
 
+  // If this is a constrained intrinsic, get rounding mode from its metadata
+  // arguments.
+  if (auto *CI = dyn_cast<ConstrainedFPIntrinsic>(this))
+    return CI->getRoundingMode().value_or(RoundingMode::Dynamic);
+
   // No FP bundle, try to guess from the current mode.
   if (getParent())
     if (auto *F = getFunction(); F)
@@ -657,6 +662,11 @@ fp::ExceptionBehavior CallBase::getExceptionBehavior() const {
   }
   if (EB)
     return *EB;
+
+  // If this is a constrained intrinsic, get exception behavior from its
+  // metadata arguments.
+  if (auto *CI = dyn_cast<ConstrainedFPIntrinsic>(this))
+    return CI->getExceptionBehavior().value_or(fp::ebStrict);
 
   // No FP bundle, try to guess from the current mode.
   if (getParent())


### PR DESCRIPTION
Constrained intrinsics are treated as regular intrinsicss from the perspective of FP operand bundle mechanism, meaning they can have FP operand bundles. The FP bundle API functions will report properties based on the operand bundles rather than metadata arguments.

These hybrid entities are temporary objects that exist while both alternative mechanisms remain available. Nevertheless, they can be useful for development:

* They can represent FP instructions with bundles. For example, while there is currently no intrinsic that directly represents 'fadd' instruction (and bundles cannot be attached to a plain 'fadd' since it is not a call), a corresponding constrained intrinsic call can represent the operation while still carrying operand bundles.

* Constrained intrinsic with bundles can be assigned properties that otherwise cannot be expressed, such as denormal behavior.

This change adds 'experimental.constrained.fadd' to the list of FP operations, enabling creation of tests for denormal behavior. It also modifies methods `getRoundingMode` and `getExceptionBehavior` so that they report information from metadata arguments if bundles are absent. This adjustment should help incorporating constrained intrinsics into algorithms based on operand bundles.