### PR TITLE
[alpha.webkit.UncheckedCallArgsChecker] Checker fails to recognize CanMakeCheckedPtrBase

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -46,8 +46,18 @@ hasPublicMethodInBase(const CXXBaseSpecifier *Base, StringRef NameToMatch) {
     return std::nullopt;
 
   const CXXRecordDecl *R = T->getAsCXXRecordDecl();
-  if (!R)
-    return std::nullopt;
+  if (!R) {
+    auto CT = Base->getType().getCanonicalType();
+    if (auto *TST = dyn_cast<TemplateSpecializationType>(CT)) {
+      auto TmplName = TST->getTemplateName();
+      if (!TmplName.isNull()) {
+        if (auto *TD = TmplName.getAsTemplateDecl())
+          R = dyn_cast_or_null<CXXRecordDecl>(TD->getTemplatedDecl());
+      }
+    }
+    if (!R)
+      return std::nullopt;
+  }
   if (!R->hasDefinition())
     return std::nullopt;
 

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncheckedCallArgsChecker -verify %s
+
+void WTFCrash(void);
+
+enum class Tag : bool { Value };
+
+template <typename StorageType, Tag> class CanMakeCheckedPtrBase {
+public:
+  void incrementCheckedPtrCount() const { ++m_checkedPtrCount; }
+  inline void decrementCheckedPtrCount() const
+  {
+      if (!m_checkedPtrCount)
+        WTFCrash();
+      --m_checkedPtrCount;
+  }
+
+private:
+  mutable StorageType m_checkedPtrCount { 0 };
+};
+
+template<typename T, Tag tag>
+class CanMakeCheckedPtr : public CanMakeCheckedPtrBase<unsigned int, tag> {
+};
+
+class CheckedObject : public CanMakeCheckedPtr<CheckedObject, Tag::Value> {
+public:
+  void doWork();
+};
+
+CheckedObject* provide();
+void foo() {
+  provide()->doWork();
+  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+}


### PR DESCRIPTION
This PR fixes the bug that alpha.webkit.UncheckedCallArgsChecker did not recognize CanMakeCheckedPtrBase due to getAsCXXRecordDecl returning nullptr for it in hasPublicMethodInBase. Manually grab getTemplatedDecl out of TemplateSpecializationType then CXXRecordDecl to workaround this bug in clang frontend.