### PR TITLE
[RawPtrRefMemberChecker] Member variable checker should allow T* in smart pointer classes

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -436,6 +436,13 @@ bool isRetainPtr(const CXXRecordDecl *R) {
   return false;
 }
 
+bool isSmartPtr(const CXXRecordDecl *R) {
+  assert(R);
+  if (auto *TmplR = R->getTemplateInstantiationPattern())
+    return isSmartPtrClass(safeGetName(TmplR));
+  return false;
+}
+
 bool isPtrConversion(const FunctionDecl *F) {
   assert(F);
   if (isCtorOfRefCounted(F))

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -58,6 +58,10 @@ bool isCheckedPtr(const clang::CXXRecordDecl *Class);
 /// \returns true if \p Class is a RetainPtr, false if not.
 bool isRetainPtr(const clang::CXXRecordDecl *Class);
 
+/// \returns true if \p Class is a smart pointer (RefPtr, WeakPtr, etc...),
+/// false if not.
+bool isSmartPtr(const clang::CXXRecordDecl *Class);
+
 /// \returns true if \p Class is ref-countable AND not ref-counted, false if
 /// not, std::nullopt if inconclusive.
 std::optional<bool> isUncounted(const clang::QualType T);

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-members.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-members.cpp
@@ -50,3 +50,12 @@ namespace ignore_unions {
   void forceTmplToInstantiate(FooTmpl<CheckedObj>) { }
 
 } // namespace ignore_unions
+
+namespace checked_ptr_ref_ptr_capable {
+
+  RefCountableAndCheckable* provide();
+  void foo() {
+    RefPtr<RefCountableAndCheckable> foo = provide();
+  }
+
+} // checked_ptr_ref_ptr_capable

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
@@ -34,7 +34,7 @@ namespace members {
   private:
     RefCountable* a = nullptr;
   };
-}
+} // members
 
 namespace ignore_unions {
   union Foo {
@@ -49,7 +49,7 @@ namespace ignore_unions {
   };
 
   void forceTmplToInstantiate(RefPtr<RefCountable>) {}
-}
+} // ignore_unions
 
 namespace ignore_system_header {
 
@@ -67,4 +67,13 @@ namespace ignore_non_ref_countable {
   struct Bar {
     Foo* foo;
   };
-}
+} // ignore_non_ref_countable
+
+namespace checked_ptr_ref_ptr_capable {
+
+  RefCountableAndCheckable* provide();
+  void foo() {
+    CheckedPtr<RefCountableAndCheckable> foo = provide();
+  }
+
+} // checked_ptr_ref_ptr_capable


### PR DESCRIPTION
This PR fixes member variable checker to allow the usage of T* in smart pointer classes. e.g. alpha.webkit.NoUncheckedPtrMemberChecker should allow T* to appear within RefPtr.