### PR TITLE
[llvm-cov] Fix semi-random coverage report file order

### DIFF
--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -1144,7 +1144,17 @@ int CodeCoverageTool::doShow(int argc, const char **argv,
       if (!IgnoreFilenameFilters.matchesFilename(Filename))
         SourceFiles.push_back(std::string(Filename));
     }
-
+  // Some file systems return directories and files in a random order,
+  // ensure case-insensitive sorting
+  std::sort(
+    SourceFiles.begin(),
+    SourceFiles.end(),
+    [](const auto& A, const auto& B) {
+      StringRef Sra(A);
+      StringRef Srb(B);
+      return Sra.compare_insensitive(Srb) == -1 ? true : false;
+    }
+  );
   // Create an index out of the source files.
   if (ViewOpts.hasOutputDirectory()) {
     if (Error E = Printer->createIndexFile(SourceFiles, *Coverage, Filters)) {


### PR DESCRIPTION
On Linux, ext4, files are enumerated in an order other than case-insensitive sorted.  This may not be a problem on Windows and macOS.

Ensure that the files in the report are sorted using a case-insensitive string comparison.