### PR TITLE
[BOLT][NFCI] Emit uniform diagnostics in DataAggregator

### DIFF
--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -223,7 +223,8 @@ private:
   bool recordExit(BinaryFunction &BF, uint64_t From, bool Mispred,
                   uint64_t Count = 1) const;
 
-  /// Aggregation statistics
+  /// Branch stacks aggregation statistics
+  uint64_t NumTraces{0};
   uint64_t NumInvalidTraces{0};
   uint64_t NumLongRangeTraces{0};
   /// Specifies how many samples were recorded in cold areas if we are dealing
@@ -328,8 +329,8 @@ private:
   /// Parse a single LBR entry as output by perf script -Fbrstack
   ErrorOr<LBREntry> parseLBREntry();
 
-  /// Parse LBR sample, returns the number of traces.
-  uint64_t parseLBRSample(const PerfBranchSample &Sample, bool NeedsSkylakeFix);
+  /// Parse LBR sample.
+  void parseLBRSample(const PerfBranchSample &Sample, bool NeedsSkylakeFix);
 
   /// Parse and pre-aggregate branch events.
   std::error_code parseBranchEvents();
@@ -487,6 +488,13 @@ private:
   void dump(const LBREntry &LBR) const;
   void dump(const PerfBranchSample &Sample) const;
   void dump(const PerfMemSample &Sample) const;
+
+  /// Profile diagnostics print methods
+  void printColdSamplesDiagnostic() const;
+  void printLongRangeTracesDiagnostic() const;
+  void printBranchSamplesDiagnostics() const;
+  void printBasicSamplesDiagnostics(uint64_t OutOfRangeSamples) const;
+  void printBranchStacksDiagnostics(uint64_t IgnoredSamples) const;
 
 public:
   /// If perf.data was collected without build ids, the buildid-list may contain

--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -231,6 +231,7 @@ private:
   /// for the source of the branch to avoid counting cold activity twice (one
   /// for source and another for destination).
   uint64_t NumColdSamples{0};
+  uint64_t NumTotalSamples{0};
 
   /// Looks into system PATH for Linux Perf and set up the aggregator to use it
   void findPerfExecutable();

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -756,7 +756,8 @@ bool DataAggregator::doBranch(uint64_t From, uint64_t To, uint64_t Count,
       Addr = BAT->translate(Func->getAddress(), Addr, IsFrom);
 
     BinaryFunction *ParentFunc = getBATParentFunction(*Func);
-    if (IsFrom && (ParentFunc || (BAT && !BAT->isBATFunction(Func->getAddress()))))
+    if (IsFrom &&
+        (ParentFunc || (BAT && !BAT->isBATFunction(Func->getAddress()))))
       NumColdSamples += Count;
 
     if (!ParentFunc)

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -1499,7 +1499,7 @@ void DataAggregator::printColdSamplesDiagnostic() const {
       outs()
           << "WARNING: The BOLT-processed binary where samples were collected "
              "likely used bad data or your service observed a large shift in "
-             "profile. You may want to audit this.\n";
+             "profile. You may want to audit this\n";
   }
 }
 
@@ -1541,7 +1541,7 @@ void DataAggregator::printBranchSamplesDiagnostics() const {
     outs() << "\n !! WARNING !! This high mismatch ratio indicates the input "
               "binary is probably not the same binary used during profiling "
               "collection. The generated data may be ineffective for improving "
-              "performance.\n\n";
+              "performance\n\n";
   printLongRangeTracesDiagnostic();
   printColdSamplesDiagnostic();
 }
@@ -1554,7 +1554,7 @@ void DataAggregator::printBasicSamplesDiagnostics(
     outs() << "\n !! WARNING !! This high mismatch ratio indicates the input "
               "binary is probably not the same binary used during profiling "
               "collection. The generated data may be ineffective for improving "
-              "performance.\n\n";
+              "performance\n\n";
   printColdSamplesDiagnostic();
 }
 


### PR DESCRIPTION
DataAggregator supports reading different kinds of profile data:
- perf data: branch records or IP samples,
- pre-aggregated branch data.

Make profile quality reporting uniform across all kinds of input:
- out-of-range and mismatching samples,
- samples in cold code in BAT mode (profiled BOLTed binary).

Test Plan: NFCI
