### PR TITLE
[clang][AVR] Improve compatibility of inline assembly with avr-gcc

### DIFF
--- a/clang/lib/Basic/Targets/AVR.h
+++ b/clang/lib/Basic/Targets/AVR.h
@@ -125,7 +125,7 @@ public:
       return true;
     case 'I': // 6-bit positive integer constant
       // Due to issue https://github.com/llvm/llvm-project/issues/51513, we
-      // allow value 64 in the frontend and let it be dinied in the backend.
+      // allow value 64 in the frontend and let it be denied in the backend.
       Info.setRequiresImmediate(0, 64);
       return true;
     case 'J': // 6-bit negative integer constant

--- a/clang/lib/Basic/Targets/AVR.h
+++ b/clang/lib/Basic/Targets/AVR.h
@@ -124,6 +124,8 @@ public:
       Info.setAllowsRegister();
       return true;
     case 'I': // 6-bit positive integer constant
+      // Due to issue https://github.com/llvm/llvm-project/issues/51513, we
+      // allow value 64 in the frontend and let it be dinied in the backend.
       Info.setRequiresImmediate(0, 64);
       return true;
     case 'J': // 6-bit negative integer constant

--- a/clang/lib/Basic/Targets/AVR.h
+++ b/clang/lib/Basic/Targets/AVR.h
@@ -124,7 +124,7 @@ public:
       Info.setAllowsRegister();
       return true;
     case 'I': // 6-bit positive integer constant
-      Info.setRequiresImmediate(0, 63);
+      Info.setRequiresImmediate(0, 64);
       return true;
     case 'J': // 6-bit negative integer constant
       Info.setRequiresImmediate(-63, 0);

--- a/clang/test/CodeGen/avr/avr-inline-asm-constraints.c
+++ b/clang/test/CodeGen/avr/avr-inline-asm-constraints.c
@@ -71,6 +71,8 @@ void z() {
 void I() {
   // CHECK: call addrspace(0) void asm sideeffect "subi r30, $0", "I"(i16 50)
   asm("subi r30, %0" :: "I"(50));
+  // CHECK: call addrspace(0) void asm sideeffect "subi r30, $0", "I"(i16 64)
+  asm("subi r30, %0" :: "I"(64));
 }
 
 void J() {

--- a/clang/test/CodeGen/avr/avr-unsupported-inline-asm-constraints.c
+++ b/clang/test/CodeGen/avr/avr-unsupported-inline-asm-constraints.c
@@ -6,4 +6,5 @@ int foo(void) {
   __asm__ volatile("foo %0, 1" : : "fo" (val)); // expected-error {{invalid input constraint 'fo' in asm}}
   __asm__ volatile("foo %0, 1" : : "Nd" (val)); // expected-error {{invalid input constraint 'Nd' in asm}}
   __asm__ volatile("subi r30, %0" : : "G" (1)); // expected-error {{value '1' out of range for constraint 'G'}}
+  __asm__ volatile("out %0, r20" : : "I" (65)); // expected-error {{value '65' out of range for constraint 'I'}}
 }

--- a/llvm/test/CodeGen/AVR/inline-asm/inline-asm-invalid.ll
+++ b/llvm/test/CodeGen/AVR/inline-asm/inline-asm-invalid.ll
@@ -21,3 +21,9 @@ define void @foo2() {
   call void asm sideeffect "ldd r24, X+2", ""()
   ret void
 }
+
+define void @foo3() {
+  ; AVR6: error: value out of range for constraint 'I'
+  call void asm sideeffect "out $0, r20", "I"(i16 64)
+  ret void
+}


### PR DESCRIPTION
Allow the value 64 to be round up to 0 for constraint 'I'.