### PR TITLE
[msan] Add experimental '-mllvm -msan-embed-faulting-instruction' and MSAN_OPTIONS=print_faulting_instruction

### DIFF
--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -352,26 +352,28 @@ void __sanitizer::BufferedStackTrace::UnwindImpl(
 
 using namespace __msan;
 
-#define PRINT_FAULTING_INSTRUCTION(instname)                            \
-  if (__msan::flags()->print_faulting_instruction) {                    \
-    Printf("Instruction that failed the shadow check: %s\n", instname); \
-    Printf("\n");                                                       \
+static inline void PrintFaultingInstruction(char *instname) {
+  if (__msan::flags()->print_faulting_instruction) {
+    Printf("Instruction that failed the shadow check: %s\n", instname);
+    Printf("\n");
   }
+}
 
-#define WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED                    \
-  if (__msan::flags()->print_faulting_instruction) {                    \
-    Printf(                                                             \
-        "Error: print_faulting_instruction requested but code was not " \
-        "instrumented with -mllvm -embed-faulting-instruction.\n");     \
-    Printf("\n");                                                       \
+static inline void WarnIfPrintFaultingInstructionRequested() {
+  if (__msan::flags()->print_faulting_instruction) {
+    Printf(
+        "Error: print_faulting_instruction requested but code was not "
+        "instrumented with -mllvm -embed-faulting-instruction.\n");
+    Printf("\n");
   }
+}
 
 #define MSAN_MAYBE_WARNING_INSTNAME(type, size, instname)                    \
   void __msan_maybe_warning_instname_##size(type s, u32 o, char *instname) { \
     GET_CALLER_PC_BP;                                                        \
     if (UNLIKELY(s)) {                                                       \
       if (instname)                                                          \
-        PRINT_FAULTING_INSTRUCTION(instname);                                \
+        PrintFaultingInstruction(instname);                                  \
       PrintWarningWithOrigin(pc, bp, o);                                     \
       if (__msan::flags()->halt_on_error) {                                  \
         Printf("Exiting\n");                                                 \
@@ -389,7 +391,7 @@ MSAN_MAYBE_WARNING_INSTNAME(u64, 8, instname)
   void __msan_maybe_warning_##size(type s, u32 o) { \
     GET_CALLER_PC_BP;                               \
     if (UNLIKELY(s)) {                              \
-      WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED; \
+      WarnIfPrintFaultingInstructionRequested();    \
       PrintWarningWithOrigin(pc, bp, o);            \
       if (__msan::flags()->halt_on_error) {         \
         Printf("Exiting\n");                        \
@@ -439,12 +441,12 @@ MSAN_MAYBE_STORE_ORIGIN(u64, 8)
   }
 
 void __msan_warning() {
-  WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED;
+  WarnIfPrintFaultingInstructionRequested();
   __MSAN_WARNING_BODY
 }
 
 void __msan_warning_instname(char *instname) {
-  PRINT_FAULTING_INSTRUCTION(instname);
+  PrintFaultingInstruction(instname);
   __MSAN_WARNING_BODY
 }
 
@@ -457,12 +459,12 @@ void __msan_warning_instname(char *instname) {
   Die();
 
 void __msan_warning_noreturn() {
-  WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED;
+  WarnIfPrintFaultingInstructionRequested();
   __MSAN_WARNING_NORETURN_BODY
 }
 
 void __msan_warning_noreturn_instname(char *instname) {
-  PRINT_FAULTING_INSTRUCTION(instname);
+  PrintFaultingInstruction(instname);
   __MSAN_WARNING_NORETURN_BODY
 }
 
@@ -477,12 +479,12 @@ void __msan_warning_noreturn_instname(char *instname) {
   }
 
 void __msan_warning_with_origin(u32 origin) {
-  WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED;
+  WarnIfPrintFaultingInstructionRequested();
   __MSAN_WARNING_WITH_ORIGIN_BODY(origin)
 }
 
 void __msan_warning_with_origin_instname(u32 origin, char *instname) {
-  PRINT_FAULTING_INSTRUCTION(instname);
+  PrintFaultingInstruction(instname);
   __MSAN_WARNING_WITH_ORIGIN_BODY(origin)
 }
 
@@ -495,12 +497,12 @@ void __msan_warning_with_origin_instname(u32 origin, char *instname) {
   Die();
 
 void __msan_warning_with_origin_noreturn(u32 origin) {
-  WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED;
+  WarnIfPrintFaultingInstructionRequested();
   __MSAN_WARNING_WITH_ORIGIN_NORETURN_BODY(origin)
 }
 
 void __msan_warning_with_origin_noreturn_instname(u32 origin, char *instname) {
-  PRINT_FAULTING_INSTRUCTION(instname);
+  PrintFaultingInstruction(instname);
   __MSAN_WARNING_WITH_ORIGIN_NORETURN_BODY(origin)
 }
 

--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -420,8 +420,8 @@ MSAN_MAYBE_STORE_ORIGIN(u16, 2)
 MSAN_MAYBE_STORE_ORIGIN(u32, 4)
 MSAN_MAYBE_STORE_ORIGIN(u64, 8)
 
-// These macros to reuse the function body are kludgy, but are the better than
-// the alternatives:
+// These macros to reuse the function body are kludgy, but are better than the
+// alternatives:
 // - call a common function: this pollutes the stack traces
 // - have x_instname() be a simple macro wrapper around x(): the
 //   instrumentation pass expects function symbols

--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -352,7 +352,7 @@ void __sanitizer::BufferedStackTrace::UnwindImpl(
 
 using namespace __msan;
 
-static inline void PrintFaultingInstruction(char *instname) {
+static inline void PrintFaultingInstructionIfRequested(char *instname) {
   if (__msan::flags()->print_faulting_instruction) {
     Printf("Instruction that failed the shadow check: %s\n", instname);
     Printf("\n");
@@ -373,7 +373,7 @@ static inline void WarnIfPrintFaultingInstructionRequested() {
     GET_CALLER_PC_BP;                                                        \
     if (UNLIKELY(s)) {                                                       \
       if (instname)                                                          \
-        PrintFaultingInstruction(instname);                                  \
+        PrintFaultingInstructionIfRequested(instname);                       \
       PrintWarningWithOrigin(pc, bp, o);                                     \
       if (__msan::flags()->halt_on_error) {                                  \
         Printf("Exiting\n");                                                 \
@@ -446,7 +446,7 @@ void __msan_warning() {
 }
 
 void __msan_warning_instname(char *instname) {
-  PrintFaultingInstruction(instname);
+  PrintFaultingInstructionIfRequested(instname);
   __MSAN_WARNING_BODY
 }
 
@@ -464,7 +464,7 @@ void __msan_warning_noreturn() {
 }
 
 void __msan_warning_noreturn_instname(char *instname) {
-  PrintFaultingInstruction(instname);
+  PrintFaultingInstructionIfRequested(instname);
   __MSAN_WARNING_NORETURN_BODY
 }
 
@@ -484,7 +484,7 @@ void __msan_warning_with_origin(u32 origin) {
 }
 
 void __msan_warning_with_origin_instname(u32 origin, char *instname) {
-  PrintFaultingInstruction(instname);
+  PrintFaultingInstructionIfRequested(instname);
   __MSAN_WARNING_WITH_ORIGIN_BODY(origin)
 }
 
@@ -502,7 +502,7 @@ void __msan_warning_with_origin_noreturn(u32 origin) {
 }
 
 void __msan_warning_with_origin_noreturn_instname(u32 origin, char *instname) {
-  PrintFaultingInstruction(instname);
+  PrintFaultingInstructionIfRequested(instname);
   __MSAN_WARNING_WITH_ORIGIN_NORETURN_BODY(origin)
 }
 

--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -358,7 +358,7 @@ using namespace __msan;
     Printf("\n");                                                       \
   }
 
-#define CANNOT_PRINT_FAULTING_INSTRUCTION                               \
+#define WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED                    \
   if (__msan::flags()->print_faulting_instruction) {                    \
     Printf(                                                             \
         "Error: print_faulting_instruction requested but code was not " \
@@ -421,7 +421,7 @@ MSAN_MAYBE_STORE_ORIGIN(u32, 4)
 MSAN_MAYBE_STORE_ORIGIN(u64, 8)
 
 void __msan_warning() {
-  CANNOT_PRINT_FAULTING_INSTRUCTION;
+  WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED;
   GET_CALLER_PC_BP;
   PrintWarningWithOrigin(pc, bp, 0);
   if (__msan::flags()->halt_on_error) {
@@ -433,7 +433,7 @@ void __msan_warning() {
 }
 
 void __msan_warning_noreturn() {
-  CANNOT_PRINT_FAULTING_INSTRUCTION;
+  WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED;
   GET_CALLER_PC_BP;
   PrintWarningWithOrigin(pc, bp, 0);
   if (__msan::flags()->print_stats)
@@ -443,7 +443,7 @@ void __msan_warning_noreturn() {
 }
 
 void __msan_warning_with_origin(u32 origin) {
-  CANNOT_PRINT_FAULTING_INSTRUCTION;
+  WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED;
   GET_CALLER_PC_BP;
   PrintWarningWithOrigin(pc, bp, origin);
   if (__msan::flags()->halt_on_error) {
@@ -455,7 +455,7 @@ void __msan_warning_with_origin(u32 origin) {
 }
 
 void __msan_warning_with_origin_noreturn(u32 origin) {
-  CANNOT_PRINT_FAULTING_INSTRUCTION;
+  WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED;
   GET_CALLER_PC_BP;
   PrintWarningWithOrigin(pc, bp, origin);
   if (__msan::flags()->print_stats)

--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -428,14 +428,14 @@ MSAN_MAYBE_STORE_ORIGIN(u64, 8)
 // - add instname as a parameter everywhere (with a check whether instname is
 //   null): this pollutes the fastpath
 // - duplicate the function body: redundancy is redundant
-#define __MSAN_WARNING_BODY \
-  GET_CALLER_PC_BP; \
-  PrintWarningWithOrigin(pc, bp, 0); \
+#define __MSAN_WARNING_BODY             \
+  GET_CALLER_PC_BP;                     \
+  PrintWarningWithOrigin(pc, bp, 0);    \
   if (__msan::flags()->halt_on_error) { \
-    if (__msan::flags()->print_stats) \
-      ReportStats(); \
-    Printf("Exiting\n"); \
-    Die(); \
+    if (__msan::flags()->print_stats)   \
+      ReportStats();                    \
+    Printf("Exiting\n");                \
+    Die();                              \
   }
 
 void __msan_warning() {
@@ -449,11 +449,11 @@ void __msan_warning_instname(char *instname) {
 }
 
 #define __MSAN_WARNING_NORETURN_BODY \
-  GET_CALLER_PC_BP; \
+  GET_CALLER_PC_BP;                  \
   PrintWarningWithOrigin(pc, bp, 0); \
-  if (__msan::flags()->print_stats) \
-    ReportStats(); \
-  Printf("Exiting\n"); \
+  if (__msan::flags()->print_stats)  \
+    ReportStats();                   \
+  Printf("Exiting\n");               \
   Die();
 
 void __msan_warning_noreturn() {
@@ -467,13 +467,13 @@ void __msan_warning_noreturn_instname(char *instname) {
 }
 
 #define __MSAN_WARNING_WITH_ORIGIN_BODY(origin) \
-  GET_CALLER_PC_BP; \
-  PrintWarningWithOrigin(pc, bp, origin); \
-  if (__msan::flags()->halt_on_error) { \
-    if (__msan::flags()->print_stats) \
-      ReportStats(); \
-    Printf("Exiting\n"); \
-    Die(); \
+  GET_CALLER_PC_BP;                             \
+  PrintWarningWithOrigin(pc, bp, origin);       \
+  if (__msan::flags()->halt_on_error) {         \
+    if (__msan::flags()->print_stats)           \
+      ReportStats();                            \
+    Printf("Exiting\n");                        \
+    Die();                                      \
   }
 
 void __msan_warning_with_origin(u32 origin) {
@@ -487,11 +487,11 @@ void __msan_warning_with_origin_instname(u32 origin, char *instname) {
 }
 
 #define __MSAN_WARNING_WITH_ORIGIN_NORETURN_BODY(origin) \
-  GET_CALLER_PC_BP; \
-  PrintWarningWithOrigin(pc, bp, origin); \
-  if (__msan::flags()->print_stats) \
-    ReportStats(); \
-  Printf("Exiting\n"); \
+  GET_CALLER_PC_BP;                                      \
+  PrintWarningWithOrigin(pc, bp, origin);                \
+  if (__msan::flags()->print_stats)                      \
+    ReportStats();                                       \
+  Printf("Exiting\n");                                   \
   Die();
 
 void __msan_warning_with_origin_noreturn(u32 origin) {

--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -389,7 +389,7 @@ MSAN_MAYBE_WARNING_INSTNAME(u64, 8, instname)
   void __msan_maybe_warning_##size(type s, u32 o) { \
     GET_CALLER_PC_BP;                               \
     if (UNLIKELY(s)) {                              \
-      CANNOT_PRINT_FAULTING_INSTRUCTION;            \
+      WARN_IF_PRINT_FAULTING_INSTRUCTION_REQUESTED; \
       PrintWarningWithOrigin(pc, bp, o);            \
       if (__msan::flags()->halt_on_error) {         \
         Printf("Exiting\n");                        \

--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -464,13 +464,13 @@ void __msan_warning_with_origin_noreturn(u32 origin) {
   Die();
 }
 
-// We duplicate the non _instname function's body because we don't want to
-// pollute the stack traces with an additional function call.
-//
-// We can't use a simple macro wrapper, because the instrumentation pass
-// expects function symbols.
-// We don't add instname as a parameter everywhere (with a check whether the
-// value is null) to avoid polluting the fastpath.
+// We duplicate the non _instname function's body because:
+// - we don't want to pollute the stack traces with an additional function
+//   call.
+// - we can't use a simple macro wrapper, because the instrumentation pass
+//   expects function symbols.
+// - we don't add instname as a parameter everywhere (with a check whether the
+//   value is null) to avoid polluting the fastpath.
 void __msan_warning_instname(char *instname) {
   PRINT_FAULTING_INSTRUCTION(instname);
   GET_CALLER_PC_BP;

--- a/compiler-rt/lib/msan/msan_flags.inc
+++ b/compiler-rt/lib/msan/msan_flags.inc
@@ -25,6 +25,10 @@ MSAN_FLAG(bool, poison_stack_with_zeroes, false, "")
 MSAN_FLAG(bool, poison_in_malloc, true, "")
 MSAN_FLAG(bool, poison_in_free, true, "")
 MSAN_FLAG(bool, poison_in_dtor, true, "")
+MSAN_FLAG(bool, print_faulting_instruction, false,
+          "When reporting a UUM, print the name of the faulting instruction. "
+          "Note: requires code to be instrumented with -mllvm "
+          "-msan-embed-faulting-instruction.")
 MSAN_FLAG(bool, report_umrs, true, "")
 MSAN_FLAG(bool, wrap_signals, true, "")
 MSAN_FLAG(bool, print_stats, false, "")

--- a/compiler-rt/lib/msan/msan_flags.inc
+++ b/compiler-rt/lib/msan/msan_flags.inc
@@ -26,7 +26,8 @@ MSAN_FLAG(bool, poison_in_malloc, true, "")
 MSAN_FLAG(bool, poison_in_free, true, "")
 MSAN_FLAG(bool, poison_in_dtor, true, "")
 MSAN_FLAG(bool, print_faulting_instruction, false,
-          "When reporting a UUM, print the name of the faulting instruction. "
+          "[EXPERIMENTAL] When reporting a UUM, print the name of the faulting "
+          "instruction. "
           "Note: requires code to be instrumented with -mllvm "
           "-msan-embed-faulting-instruction.")
 MSAN_FLAG(bool, report_umrs, true, "")

--- a/compiler-rt/lib/msan/msan_interface_internal.h
+++ b/compiler-rt/lib/msan/msan_interface_internal.h
@@ -30,11 +30,17 @@ void __msan_init();
 SANITIZER_INTERFACE_ATTRIBUTE
 void __msan_warning();
 
+SANITIZER_INTERFACE_ATTRIBUTE
+void __msan_warning_instname(char *instname);
+
 // Print a warning and die.
 // Instrumentation inserts calls to this function when building in "fast" mode
 // (i.e. -mllvm -msan-keep-going)
 SANITIZER_INTERFACE_ATTRIBUTE __attribute__((noreturn))
 void __msan_warning_noreturn();
+
+SANITIZER_INTERFACE_ATTRIBUTE __attribute__((noreturn)) void
+__msan_warning_noreturn_instname(char *instname);
 
 using __sanitizer::uptr;
 using __sanitizer::sptr;
@@ -49,8 +55,13 @@ using __sanitizer::u8;
 // Versions of the above which take Origin as a parameter
 SANITIZER_INTERFACE_ATTRIBUTE
 void __msan_warning_with_origin(u32 origin);
+SANITIZER_INTERFACE_ATTRIBUTE
+void __msan_warning_with_origin_instname(u32 origin, char *instname);
+
 SANITIZER_INTERFACE_ATTRIBUTE __attribute__((noreturn)) void
 __msan_warning_with_origin_noreturn(u32 origin);
+SANITIZER_INTERFACE_ATTRIBUTE __attribute__((noreturn)) void
+__msan_warning_with_origin_noreturn_instname(u32 origin, char *instname);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __msan_maybe_warning_1(u8 s, u32 o);
@@ -60,6 +71,15 @@ SANITIZER_INTERFACE_ATTRIBUTE
 void __msan_maybe_warning_4(u32 s, u32 o);
 SANITIZER_INTERFACE_ATTRIBUTE
 void __msan_maybe_warning_8(u64 s, u32 o);
+
+SANITIZER_INTERFACE_ATTRIBUTE
+void __msan_maybe_warning_1_instname(u8 s, u32 o, char *instname);
+SANITIZER_INTERFACE_ATTRIBUTE
+void __msan_maybe_warning_2_instname(u16 s, u32 o, char *instname);
+SANITIZER_INTERFACE_ATTRIBUTE
+void __msan_maybe_warning_4_instname(u32 s, u32 o, char *instname);
+SANITIZER_INTERFACE_ATTRIBUTE
+void __msan_maybe_warning_8_instname(u64 s, u32 o, char *instname);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __msan_maybe_store_origin_1(u8 s, void *p, u32 o);

--- a/compiler-rt/lib/msan/msan_interface_internal.h
+++ b/compiler-rt/lib/msan/msan_interface_internal.h
@@ -73,13 +73,13 @@ SANITIZER_INTERFACE_ATTRIBUTE
 void __msan_maybe_warning_8(u64 s, u32 o);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __msan_maybe_warning_1_instname(u8 s, u32 o, char *instname);
+void __msan_maybe_warning_instname_1(u8 s, u32 o, char *instname);
 SANITIZER_INTERFACE_ATTRIBUTE
-void __msan_maybe_warning_2_instname(u16 s, u32 o, char *instname);
+void __msan_maybe_warning_instname_2(u16 s, u32 o, char *instname);
 SANITIZER_INTERFACE_ATTRIBUTE
-void __msan_maybe_warning_4_instname(u32 s, u32 o, char *instname);
+void __msan_maybe_warning_instname_4(u32 s, u32 o, char *instname);
 SANITIZER_INTERFACE_ATTRIBUTE
-void __msan_maybe_warning_8_instname(u64 s, u32 o, char *instname);
+void __msan_maybe_warning_instname_8(u64 s, u32 o, char *instname);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __msan_maybe_store_origin_1(u8 s, void *p, u32 o);

--- a/compiler-rt/test/msan/print_faulting_inst.cpp
+++ b/compiler-rt/test/msan/print_faulting_inst.cpp
@@ -38,7 +38,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define THRICE(o,t) twice(o,t)
+#define THRICE(o, t) twice(o, t)
 
 __attribute__((noinline)) extern "C" int twice(int o, int t) {
   return o + t < 3;
@@ -57,7 +57,8 @@ int main(int argc, char *argv[]) {
   int index = atoi(argv[1]);
   int val = buf[index];
 
-  printf("index %d, abs(val) %d, THRICE(val,5) %d\n", index, abs(val), THRICE(val,5));
+  printf("index %d, abs(val) %d, THRICE(val,5) %d\n", index, abs(val),
+         THRICE(val, 5));
   // VERY-VERBOSE-PARAM-CHECK: Instruction that failed the shadow check: %{{.*}} = call noundef i32 @twice(i32 noundef %{{.*}}, i32 noundef 5)
   // VERBOSE-PARAM-CHECK: Instruction that failed the shadow check: call twice
   // PARAM-CHECK: WARNING: MemorySanitizer: use-of-uninitialized-value
@@ -73,7 +74,7 @@ int main(int argc, char *argv[]) {
     printf("Variable is zero\n");
 
   int nextval = buf[index + 1];
-  buf[nextval + abs(index)] = twice(index,6);
+  buf[nextval + abs(index)] = twice(index, 6);
   // VERY-VERBOSE-STORE-CHECK: Instruction that failed the shadow check: store i32 %{{.*}}, ptr %{{.*}}
   // VERBOSE-STORE-CHECK: Instruction that failed the shadow check: store
   // STORE-CHECK: WARNING: MemorySanitizer: use-of-uninitialized-value

--- a/compiler-rt/test/msan/print_faulting_inst.cpp
+++ b/compiler-rt/test/msan/print_faulting_inst.cpp
@@ -1,16 +1,19 @@
 // Try parameter '0' (program runs cleanly)
 // -------------------------------------------------------
-// RUN: env MSAN_OPTIONS=print_faulting_instruction=true %clangxx_msan -g %s -o %t && env MSAN_OPTIONS=print_faulting_instruction=true %run %t 0
+// RUN: %clangxx_msan -g %s -o %t && env MSAN_OPTIONS=print_faulting_instruction=true %run %t 0
 
 // Try parameter '1'
 // -------------------------------------------------------
 // RUN: %clangxx_msan -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
 // RUN: FileCheck --check-prefix STORE-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -mllvm -msan-embed-faulting-instruction=1 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
+// RUN: %clangxx_msan -mllvm -msan-embed-faulting-instruction=none -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
+// RUN: FileCheck --check-prefix STORE-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -mllvm -msan-embed-faulting-instruction=name -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERBOSE-STORE-CHECK,STORE-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -mllvm -msan-embed-faulting-instruction=2 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
+// RUN: %clangxx_msan -mllvm -msan-embed-faulting-instruction=full -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERY-VERBOSE-STORE-CHECK,STORE-CHECK %s < %t.out
 
 // Try parameter '2', with -fsanitize-memory-param-retval
@@ -18,10 +21,13 @@
 // RUN: %clangxx_msan -fsanitize-memory-param-retval -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefix PARAM-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=1 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=none -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
+// RUN: FileCheck --check-prefix PARAM-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=name -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERBOSE-PARAM-CHECK,PARAM-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=2 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=full -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERY-VERBOSE-PARAM-CHECK,PARAM-CHECK %s < %t.out
 
 // Try parameter '2', with -fno-sanitize-memory-param-retval
@@ -29,10 +35,13 @@
 // RUN: %clangxx_msan -fno-sanitize-memory-param-retval -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefix NO-PARAM-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=1 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=none -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
+// RUN: FileCheck --check-prefix NO-PARAM-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=name -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERBOSE-NO-PARAM-CHECK,NO-PARAM-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=2 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=full -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERY-VERBOSE-NO-PARAM-CHECK,NO-PARAM-CHECK %s < %t.out
 
 #include <stdio.h>

--- a/compiler-rt/test/msan/print_faulting_inst.cpp
+++ b/compiler-rt/test/msan/print_faulting_inst.cpp
@@ -1,38 +1,38 @@
 // Try parameter '0' (program runs cleanly)
 // -------------------------------------------------------
-// RUN: %clangxx_msan -g %s -o %t && %run %t 0
+// RUN: env MSAN_OPTIONS=print_faulting_instruction=true %clangxx_msan -g %s -o %t && env MSAN_OPTIONS=print_faulting_instruction=true %run %t 0
 
 // Try parameter '1'
 // -------------------------------------------------------
-// RUN: %clangxx_msan -g %s -o %t && not %run %t 1 >%t.out 2>&1
+// RUN: %clangxx_msan -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
 // RUN: FileCheck --check-prefix STORE-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -mllvm -msan-print-faulting-instruction=1 -g %s -o %t && not %run %t 1 >%t.out 2>&1
+// RUN: %clangxx_msan -mllvm -msan-embed-faulting-instruction=1 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERBOSE-STORE-CHECK,STORE-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -mllvm -msan-print-faulting-instruction=2 -g %s -o %t && not %run %t 1 >%t.out 2>&1
+// RUN: %clangxx_msan -mllvm -msan-embed-faulting-instruction=2 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 1 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERY-VERBOSE-STORE-CHECK,STORE-CHECK %s < %t.out
 
 // Try parameter '2', with -fsanitize-memory-param-retval
 // -------------------------------------------------------
-// RUN: %clangxx_msan -fsanitize-memory-param-retval -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefix PARAM-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-print-faulting-instruction=1 -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=1 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERBOSE-PARAM-CHECK,PARAM-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-print-faulting-instruction=2 -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=2 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERY-VERBOSE-PARAM-CHECK,PARAM-CHECK %s < %t.out
 
 // Try parameter '2', with -fno-sanitize-memory-param-retval
 // -------------------------------------------------------
-// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefix NO-PARAM-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-print-faulting-instruction=1 -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=1 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERBOSE-NO-PARAM-CHECK,NO-PARAM-CHECK %s < %t.out
 
-// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-print-faulting-instruction=2 -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-embed-faulting-instruction=2 -g %s -o %t && not env MSAN_OPTIONS=print_faulting_instruction=true %run %t 2 >%t.out 2>&1
 // RUN: FileCheck --check-prefixes VERY-VERBOSE-NO-PARAM-CHECK,NO-PARAM-CHECK %s < %t.out
 
 #include <stdio.h>

--- a/compiler-rt/test/msan/print_faulting_inst.cpp
+++ b/compiler-rt/test/msan/print_faulting_inst.cpp
@@ -1,0 +1,83 @@
+// Try parameter '0' (program runs cleanly)
+// -------------------------------------------------------
+// RUN: %clangxx_msan -g %s -o %t && %run %t 0
+
+// Try parameter '1'
+// -------------------------------------------------------
+// RUN: %clangxx_msan -g %s -o %t && not %run %t 1 >%t.out 2>&1
+// RUN: FileCheck --check-prefix STORE-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -mllvm -msan-print-faulting-instruction=1 -g %s -o %t && not %run %t 1 >%t.out 2>&1
+// RUN: FileCheck --check-prefixes VERBOSE-STORE-CHECK,STORE-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -mllvm -msan-print-faulting-instruction=2 -g %s -o %t && not %run %t 1 >%t.out 2>&1
+// RUN: FileCheck --check-prefixes VERY-VERBOSE-STORE-CHECK,STORE-CHECK %s < %t.out
+
+// Try parameter '2', with -fsanitize-memory-param-retval
+// -------------------------------------------------------
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: FileCheck --check-prefix PARAM-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-print-faulting-instruction=1 -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: FileCheck --check-prefixes VERBOSE-PARAM-CHECK,PARAM-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -fsanitize-memory-param-retval -mllvm -msan-print-faulting-instruction=2 -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: FileCheck --check-prefixes VERY-VERBOSE-PARAM-CHECK,PARAM-CHECK %s < %t.out
+
+// Try parameter '2', with -fno-sanitize-memory-param-retval
+// -------------------------------------------------------
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: FileCheck --check-prefix NO-PARAM-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-print-faulting-instruction=1 -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: FileCheck --check-prefixes VERBOSE-NO-PARAM-CHECK,NO-PARAM-CHECK %s < %t.out
+
+// RUN: %clangxx_msan -fno-sanitize-memory-param-retval -mllvm -msan-print-faulting-instruction=2 -g %s -o %t && not %run %t 2 >%t.out 2>&1
+// RUN: FileCheck --check-prefixes VERY-VERBOSE-NO-PARAM-CHECK,NO-PARAM-CHECK %s < %t.out
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define THRICE(o,t) twice(o,t)
+
+__attribute__((noinline)) extern "C" int twice(int o, int t) {
+  return o + t < 3;
+}
+
+int main(int argc, char *argv[]) {
+  int buf[100];
+  buf[0] = 42;
+  buf[1] = 43;
+
+  if (argc != 2) {
+    printf("Usage: %s index\n", argv[0]);
+    return 1;
+  }
+
+  int index = atoi(argv[1]);
+  int val = buf[index];
+
+  printf("index %d, abs(val) %d, THRICE(val,5) %d\n", index, abs(val), THRICE(val,5));
+  // VERY-VERBOSE-PARAM-CHECK: Instruction that failed the shadow check: %{{.*}} = call noundef i32 @twice(i32 noundef %{{.*}}, i32 noundef 5)
+  // VERBOSE-PARAM-CHECK: Instruction that failed the shadow check: call twice
+  // PARAM-CHECK: WARNING: MemorySanitizer: use-of-uninitialized-value
+  // PARAM-CHECK: {{#0 0x.* in main .*print_faulting_inst.cpp:}}[[@LINE-4]]
+
+  if (val)
+    // VERY-VERBOSE-NO-PARAM-CHECK: Instruction that failed the shadow check:  br i1 %{{.*}}, label %{{.*}}, label %{{.*}}
+    // VERBOSE-NO-PARAM-CHECK: Instruction that failed the shadow check: br
+    // NO-PARAM-CHECK: WARNING: MemorySanitizer: use-of-uninitialized-value
+    // NO-PARAM-CHECK: {{#0 0x.* in main .*print_faulting_inst.cpp:}}[[@LINE-4]]
+    printf("Variable is non-zero\n");
+  else
+    printf("Variable is zero\n");
+
+  int nextval = buf[index + 1];
+  buf[nextval + abs(index)] = twice(index,6);
+  // VERY-VERBOSE-STORE-CHECK: Instruction that failed the shadow check: store i32 %{{.*}}, ptr %{{.*}}
+  // VERBOSE-STORE-CHECK: Instruction that failed the shadow check: store
+  // STORE-CHECK: WARNING: MemorySanitizer: use-of-uninitialized-value
+  // STORE-CHECK: {{#0 0x.* in main .*print_faulting_inst.cpp:}}[[@LINE-4]]
+
+  return 0;
+}

--- a/llvm/include/llvm/Transforms/Instrumentation/MemorySanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/MemorySanitizer.h
@@ -21,6 +21,13 @@ class Module;
 class StringRef;
 class raw_ostream;
 
+/// Mode of MSan -embed-faulting-instruction
+enum class MSanEmbedFaultingInstructionMode {
+  None, ///< Do not embed the faulting instruction information
+  Name, ///< Embed the LLVM IR instruction name (excluding operands)
+  Full, ///< Embed the complete LLVM IR instruction (including operands)
+};
+
 struct MemorySanitizerOptions {
   MemorySanitizerOptions() : MemorySanitizerOptions(0, false, false, false){};
   MemorySanitizerOptions(int TrackOrigins, bool Recover, bool Kernel)

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -1514,6 +1514,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
   Value *getInstName(Instruction *Instruction) {
     Value *InstName = nullptr;
+
     if (ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None) {
       IRBuilder<> IRB(Instruction);
       StringRef InstNameStrRef;

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -1516,13 +1516,13 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     Value *InstName = nullptr;
     if (ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None) {
       IRBuilder<> IRB0(Instruction);
-      std::string str;
       StringRef InstNameStrRef;
 
       // Dumping the full instruction is expensive because the operands etc.
       // likely make the string unique per instruction instance, hence we
       // offer a choice whether to only print the instruction name.
       if (ClEmbedFaultingInst == MSanEmbedFaultingInstructionMode::Full) {
+        std::string str;
         llvm::raw_string_ostream buf(str);
         Instruction->print(buf);
         InstNameStrRef = StringRef(str);

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -1517,12 +1517,14 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     if (ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None) {
       IRBuilder<> IRB0(Instruction);
       StringRef InstNameStrRef;
+      // Keep str at this scope level because it is indirectly needed by
+      // CreateGlobalString
+      std::string str;
 
       // Dumping the full instruction is expensive because the operands etc.
       // likely make the string unique per instruction instance, hence we
       // offer a choice whether to only print the instruction name.
       if (ClEmbedFaultingInst == MSanEmbedFaultingInstructionMode::Full) {
-        std::string str;
         llvm::raw_string_ostream buf(str);
         Instruction->print(buf);
         InstNameStrRef = StringRef(str);

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -1515,7 +1515,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
   Value *getInstName(Instruction *Instruction) {
     Value *InstName = nullptr;
     if (ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None) {
-      IRBuilder<> IRB0(Instruction);
+      IRBuilder<> IRB(Instruction);
       StringRef InstNameStrRef;
       // Keep str and maybeBuf at this scope level because they may be
       // indirectly needed by CreateGlobalString
@@ -1543,7 +1543,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
         }
       }
 
-      InstName = IRB0.CreateGlobalString(InstNameStrRef);
+      InstName = IRB.CreateGlobalString(InstNameStrRef);
     }
 
     return InstName;

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -817,18 +817,16 @@ MemorySanitizer::getOrInsertMsanMetadataFunction(Module &M, StringRef Name,
                                std::forward<ArgsTy>(Args)...);
 }
 
-StringRef getWarningFnName(bool TrackOrigins, bool Recover, bool EmbedFaultingInst) {
-  StringRef warningFnName [2][2][2]
-    = {
-       {
-        {"__msan_warning_noreturn", "__msan_warning_noreturn_instname"},
-        {"__msan_warning", "__msan_warning_instname"}
-       },
-       {
-        {"__msan_warning_with_origin_noreturn", "__msan_warning_with_origin_noreturn_instname"},
-        {"__msan_warning_with_origin", "__msan_warning_with_origin_instname"},
-       }
-      };
+StringRef getWarningFnName(bool TrackOrigins, bool Recover,
+                           bool EmbedFaultingInst) {
+  StringRef warningFnName[2][2][2] = {
+      {{"__msan_warning_noreturn", "__msan_warning_noreturn_instname"},
+       {"__msan_warning", "__msan_warning_instname"}},
+      {
+          {"__msan_warning_with_origin_noreturn",
+           "__msan_warning_with_origin_noreturn_instname"},
+          {"__msan_warning_with_origin", "__msan_warning_with_origin_instname"},
+      }};
 
   return warningFnName[TrackOrigins][Recover][EmbedFaultingInst];
 }
@@ -847,7 +845,9 @@ void MemorySanitizer::createKernelApi(Module &M, const TargetLibraryInfo &TLI) {
   VAArgOverflowSizeTLS = nullptr;
 
   SmallVector<Type *, 4> ArgsTy = {IRB.getInt32Ty()};
-  StringRef FnName = getWarningFnName(/*TrackOrigins=*/ false, /*Recover=*/ true, ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None);
+  StringRef FnName = getWarningFnName(
+      /*TrackOrigins=*/false, /*Recover=*/true,
+      ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None);
   if (ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None)
     ArgsTy.push_back(IRB.getPtrTy());
   WarningFn = M.getOrInsertFunction(
@@ -907,10 +907,12 @@ void MemorySanitizer::createUserspaceApi(Module &M,
   // Create the callback.
   // FIXME: this function should have "Cold" calling conv,
   // which is not yet implemented.
-  StringRef WarningFnName = getWarningFnName(TrackOrigins, Recover, ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None);
+  StringRef WarningFnName = getWarningFnName(
+      TrackOrigins, Recover,
+      ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None);
   SmallVector<Type *, 4> ArgsTy = {};
   if (TrackOrigins) {
-    ArgsTy.push_back (IRB.getInt32Ty());
+    ArgsTy.push_back(IRB.getInt32Ty());
     if (ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None)
       ArgsTy.push_back(IRB.getPtrTy());
     WarningFn = M.getOrInsertFunction(

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -286,7 +286,7 @@ static cl::opt<MSanEmbedFaultingInstructionMode> ClEmbedFaultingInst(
         clEnumValN(
             MSanEmbedFaultingInstructionMode::Full, "full",
             "Embed the complete LLVM IR instruction (including operands).")),
-    cl::Hidden, cl::init(MSanEmbedFaultingInstructionMode::None));
+    cl::Hidden, cl::init(MSanEmbedFaultingInstructionMode::Name));
 
 static cl::opt<bool>
     ClHandleICmpExact("msan-handle-icmp-exact",

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -820,12 +820,31 @@ MemorySanitizer::getOrInsertMsanMetadataFunction(Module &M, StringRef Name,
 StringRef getWarningFnName(bool TrackOrigins, bool Recover,
                            bool EmbedFaultingInst) {
   StringRef warningFnName[2][2][2] = {
-      {{"__msan_warning_noreturn", "__msan_warning_noreturn_instname"},
-       {"__msan_warning", "__msan_warning_instname"}},
       {
-          {"__msan_warning_with_origin_noreturn",
-           "__msan_warning_with_origin_noreturn_instname"},
-          {"__msan_warning_with_origin", "__msan_warning_with_origin_instname"},
+          // TrackOrigins=false
+          {
+              // Recover=false
+              "__msan_warning_noreturn",         // EmbedFaultingInst=false
+              "__msan_warning_noreturn_instname" // EmbedFaultingInst=true
+          },
+          {
+              // Recover=true
+              "__msan_warning",         // EmbedFaultingInst=false
+              "__msan_warning_instname" // EmbedFaultingInst=true
+          },
+      },
+      {
+          // TrackOrigins=true
+          {
+              // Recover=false
+              "__msan_warning_with_origin_noreturn", // EmbedFaultingInst=false
+              "__msan_warning_with_origin_noreturn_instname" // EmbedFaultingInst=true
+          },
+          {
+              // Recover=true
+              "__msan_warning_with_origin",         // EmbedFaultingInst=false
+              "__msan_warning_with_origin_instname" // EmbedFaultingInst=true
+          },
       }};
 
   return warningFnName[TrackOrigins][Recover][EmbedFaultingInst];

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -1517,9 +1517,10 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     if (ClEmbedFaultingInst != MSanEmbedFaultingInstructionMode::None) {
       IRBuilder<> IRB0(Instruction);
       StringRef InstNameStrRef;
-      // Keep str at this scope level because it is indirectly needed by
-      // CreateGlobalString
+      // Keep str and maybeBuf at this scope level because they may be
+      // indirectly needed by CreateGlobalString
       std::string str;
+      SmallVector<char> maybeBuf;
 
       // Dumping the full instruction is expensive because the operands etc.
       // likely make the string unique per instruction instance, hence we
@@ -1533,7 +1534,6 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
         if (CallInst *CI = dyn_cast<CallInst>(Instruction)) {
           if (CI->getCalledFunction()) {
             Twine description = "call " + CI->getCalledFunction()->getName();
-            SmallVector<char> maybeBuf;
             InstNameStrRef = description.toStringRef(maybeBuf);
           } else {
             InstNameStrRef = StringRef("Unknown call");


### PR DESCRIPTION
This adds an experimental flag, -mllvm -msan-embed-faulting-instruction, which changes the instrumentation to embed the LLVM instruction that resulted in an MSan UUM report. The embedded instruction can be printed using a new experimental MSAN_OPTION, 'print_faulting_instruction'.
    
Although MSan UUM reports will print out the line and column number (assuming symbolization is available), inlining, macros and LLVM "auto-upgraded" intrinsics can obscure the root cause.

This patch also adds a test case, compiler-rt/test/msan/print_faulting_inst.cpp, which illustrates that printing the faulting instruction can provide more information than line and column number.

Future work could extend the runtime to use the embedded instruction in other ways, such as an ignorelist for particular instructions (e.g., to avoid incorrectly instrumented intrinsics, or to skip over a particular line of LLVM IR).