### PR TITLE
[NFC][LLVM][TableGen] Eliminate inheritance from std::vector

### DIFF
--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -127,20 +127,32 @@ typedef std::vector<FixupList> FixupScopeList;
 typedef SmallSetVector<CachedHashString, 16> PredicateSet;
 typedef SmallSetVector<CachedHashString, 16> DecoderSet;
 
-struct DecoderTable : public std::vector<uint8_t> {
+class DecoderTable {
+public:
+  DecoderTable() { Data.reserve(16384); }
+
+  void clear() { Data.clear(); }
+  void push_back(uint8_t Item) { Data.push_back(Item); }
+  size_t size() const { return Data.size(); }
+  const uint8_t *data() const { return Data.data(); }
+
+  using const_iterator = std::vector<uint8_t>::const_iterator;
+  const_iterator begin() const { return Data.begin(); }
+  const_iterator end() const { return Data.end(); }
+
   // Insert a ULEB128 encoded value into the table.
   void insertULEB128(uint64_t Value) {
     // Encode and emit the value to filter against.
     uint8_t Buffer[16];
     unsigned Len = encodeULEB128(Value, Buffer);
-    insert(end(), Buffer, Buffer + Len);
+    Data.insert(Data.end(), Buffer, Buffer + Len);
   }
 
   // Insert space for `NumToSkip` and return the position
   // in the table for patching.
   size_t insertNumToSkip() {
-    size_t Size = size();
-    insert(end(), getNumToSkipInBytes(), 0);
+    size_t Size = Data.size();
+    Data.insert(Data.end(), getNumToSkipInBytes(), 0);
     return Size;
   }
 
@@ -156,11 +168,14 @@ struct DecoderTable : public std::vector<uint8_t> {
       PrintFatalError(
           "disassembler decoding table too large, try --large-decoder-table");
 
-    (*this)[FixupIdx] = static_cast<uint8_t>(Delta);
-    (*this)[FixupIdx + 1] = static_cast<uint8_t>(Delta >> 8);
+    Data[FixupIdx] = static_cast<uint8_t>(Delta);
+    Data[FixupIdx + 1] = static_cast<uint8_t>(Delta >> 8);
     if (getNumToSkipInBytes() == 3)
-      (*this)[FixupIdx + 2] = static_cast<uint8_t>(Delta >> 16);
+      Data[FixupIdx + 2] = static_cast<uint8_t>(Delta >> 16);
   }
+
+private:
+  std::vector<uint8_t> Data;
 };
 
 struct DecoderTableInfo {
@@ -2517,7 +2532,6 @@ namespace {
     // decoders to give more opportunities for uniqueing.
     TableInfo.Table.clear();
     TableInfo.FixupStack.clear();
-    TableInfo.Table.reserve(16384);
     TableInfo.FixupStack.emplace_back();
     FC.emitTableEntries(TableInfo);
     // Any NumToSkip fixups in the top level scope can resolve to the


### PR DESCRIPTION
Fix `DecoderTable` to not inherit directly from std::vector and use composition instead.