### PR TITLE
[libc][bazel] Add a helper library with all deps of generated headers.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -90,6 +90,18 @@ py_binary(
     main = "utils/hdrgen/hdrgen/main.py",
 )
 
+# Library containing all headers that can be transitively included by generated llvm-libc
+# public headers (or by the unit tests).
+libc_support_library(
+    name = "public_headers_deps",
+    textual_hdrs = [
+        "include/__llvm-libc-common.h",
+    ] + glob([
+        "include/llvm-libc-types/**/*.h",
+        "include/llvm-libc-macros/**/*.h",
+    ]),
+)
+
 ################################## Base Config #################################
 
 libc_support_library(
@@ -1898,11 +1910,11 @@ libc_support_library(
     name = "atan_utils",
     hdrs = ["src/math/generic/atan_utils.h"],
     deps = [
-        ":__support_integer_literals",
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_integer_literals",
         ":__support_macros_optimization",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/include/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/include/BUILD.bazel
@@ -1,0 +1,20 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tests for LLVM libc public headers.
+
+load("//libc/test:libc_test_rules.bzl", "libc_test")
+
+licenses(["notice"])
+
+libc_test(
+    name = "stdbit_test",
+    srcs = [
+        "stdbit_stub.h",
+        "stdbit_test.cpp",
+    ],
+    deps = [
+        "//libc:public_headers_deps",
+    ],
+)


### PR DESCRIPTION
Create "public_header_deps" that is a convenient way to express dependencies of a generated headers as a single (and same) target. It's also convenient to use it in unit tests - which is also demonstrated in this PR by adding the BUILD.bazel placeholder for test/include unit tests, and creating a libc_test target for one of these tests.

See issue #134780.