### PR TITLE
[clang] Enable making `CompilerInstance` diagnostics thread-safe

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -825,6 +825,23 @@ public:
   bool loadModuleFile(StringRef FileName,
                       serialization::ModuleFile *&LoadedModuleFile);
 
+  /// Configuration object for making the result of \c cloneForModuleCompile()
+  /// thread-safe.
+  class ThreadSafeCloneConfig {
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS;
+    DiagnosticConsumer &DiagConsumer;
+
+  public:
+    ThreadSafeCloneConfig(IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
+                          DiagnosticConsumer &DiagConsumer)
+        : VFS(std::move(VFS)), DiagConsumer(DiagConsumer) {
+      assert(this->VFS && "Clone config requires non-null VFS");
+    }
+
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> getVFS() const { return VFS; }
+    DiagnosticConsumer &getDiagConsumer() const { return DiagConsumer; }
+  };
+
 private:
   /// Find a module, potentially compiling it, before reading its AST.  This is
   /// the guts of loadModule.
@@ -845,16 +862,10 @@ private:
   /// Creates a \c CompilerInstance for compiling a module.
   ///
   /// This expects a properly initialized \c FrontendInputFile.
-  ///
-  /// Explicitly-specified \c VFS takes precedence over the VFS of this instance
-  /// when creating the clone and also prevents \c FileManager sharing.
-  /// Explicitly-specified \c DiagConsumer takes precedence over forwarding to
-  /// this instance.
   std::unique_ptr<CompilerInstance> cloneForModuleCompileImpl(
       SourceLocation ImportLoc, StringRef ModuleName, FrontendInputFile Input,
       StringRef OriginalModuleMapFile, StringRef ModuleFileName,
-      IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr,
-      DiagnosticConsumer *DiagConsumer = nullptr);
+      std::optional<ThreadSafeCloneConfig> ThreadSafeConfig = std::nullopt);
 
 public:
   /// Creates a new \c CompilerInstance for compiling a module.
@@ -862,15 +873,11 @@ public:
   /// This takes care of creating appropriate \c FrontendInputFile for
   /// public/private frameworks, inferred modules and such.
   ///
-  /// Explicitly-specified \c VFS takes precedence over the VFS of this instance
-  /// when creating the clone and also prevents \c FileManager sharing.
-  /// Explicitly-specified \c DiagConsumer takes precedence over forwarding to
-  /// this instance.
-  std::unique_ptr<CompilerInstance>
-  cloneForModuleCompile(SourceLocation ImportLoc, Module *Module,
-                        StringRef ModuleFileName,
-                        IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr,
-                        DiagnosticConsumer *DiagConsumer = nullptr);
+  /// The \c ThreadSafeConfig takes precedence over the \c DiagnosticConsumer
+  /// and \c FileSystem of this instance (and disables \c FileManager sharing).
+  std::unique_ptr<CompilerInstance> cloneForModuleCompile(
+      SourceLocation ImportLoc, Module *Module, StringRef ModuleFileName,
+      std::optional<ThreadSafeCloneConfig> ThreadSafeConfig = std::nullopt);
 
   /// Compile a module file for the given module, using the options
   /// provided by the importing compiler instance. Returns true if the module

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -848,10 +848,13 @@ private:
   ///
   /// Explicitly-specified \c VFS takes precedence over the VFS of this instance
   /// when creating the clone and also prevents \c FileManager sharing.
+  /// Explicitly-specified \c DiagConsumer takes precedence over forwarding to
+  /// this instance.
   std::unique_ptr<CompilerInstance> cloneForModuleCompileImpl(
       SourceLocation ImportLoc, StringRef ModuleName, FrontendInputFile Input,
       StringRef OriginalModuleMapFile, StringRef ModuleFileName,
-      IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr);
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr,
+      DiagnosticConsumer *DiagConsumer = nullptr);
 
 public:
   /// Creates a new \c CompilerInstance for compiling a module.
@@ -861,9 +864,13 @@ public:
   ///
   /// Explicitly-specified \c VFS takes precedence over the VFS of this instance
   /// when creating the clone and also prevents \c FileManager sharing.
-  std::unique_ptr<CompilerInstance> cloneForModuleCompile(
-      SourceLocation ImportLoc, Module *Module, StringRef ModuleFileName,
-      IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr);
+  /// Explicitly-specified \c DiagConsumer takes precedence over forwarding to
+  /// this instance.
+  std::unique_ptr<CompilerInstance>
+  cloneForModuleCompile(SourceLocation ImportLoc, Module *Module,
+                        StringRef ModuleFileName,
+                        IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr,
+                        DiagnosticConsumer *DiagConsumer = nullptr);
 
   /// Compile a module file for the given module, using the options
   /// provided by the importing compiler instance. Returns true if the module

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1153,8 +1153,7 @@ static Language getLanguageFromOptions(const LangOptions &LangOpts) {
 std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompileImpl(
     SourceLocation ImportLoc, StringRef ModuleName, FrontendInputFile Input,
     StringRef OriginalModuleMapFile, StringRef ModuleFileName,
-    IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
-    DiagnosticConsumer *DiagConsumer) {
+    std::optional<ThreadSafeCloneConfig> ThreadSafeConfig) {
   // Construct a compiler invocation for creating this module.
   auto Invocation = std::make_shared<CompilerInvocation>(getInvocation());
 
@@ -1214,16 +1213,17 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompileImpl(
   auto &Inv = *Invocation;
   Instance.setInvocation(std::move(Invocation));
 
-  if (VFS) {
-    Instance.createFileManager(std::move(VFS));
+  if (ThreadSafeConfig) {
+    Instance.createFileManager(ThreadSafeConfig->getVFS());
   } else if (FrontendOpts.ModulesShareFileManager) {
     Instance.setFileManager(&getFileManager());
   } else {
     Instance.createFileManager(&getVirtualFileSystem());
   }
 
-  if (DiagConsumer) {
-    Instance.createDiagnostics(Instance.getVirtualFileSystem(), DiagConsumer,
+  if (ThreadSafeConfig) {
+    Instance.createDiagnostics(Instance.getVirtualFileSystem(),
+                               &ThreadSafeConfig->getDiagConsumer(),
                                /*ShouldOwnClient=*/false);
   } else {
     Instance.createDiagnostics(
@@ -1328,8 +1328,7 @@ static OptionalFileEntryRef getPublicModuleMap(FileEntryRef File,
 
 std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompile(
     SourceLocation ImportLoc, Module *Module, StringRef ModuleFileName,
-    IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
-    DiagnosticConsumer *DiagConsumer) {
+    std::optional<ThreadSafeCloneConfig> ThreadSafeConfig) {
   StringRef ModuleName = Module->getTopLevelModuleName();
 
   InputKind IK(getLanguageFromOptions(getLangOpts()), InputKind::ModuleMap);
@@ -1375,7 +1374,7 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompile(
         ImportLoc, ModuleName,
         FrontendInputFile(ModuleMapFilePath, IK, IsSystem),
         ModMap.getModuleMapFileForUniquing(Module)->getName(), ModuleFileName,
-        std::move(VFS), DiagConsumer);
+        std::move(ThreadSafeConfig));
   }
 
   // FIXME: We only need to fake up an input file here as a way of
@@ -1393,7 +1392,7 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompile(
       ImportLoc, ModuleName,
       FrontendInputFile(FakeModuleMapFile, IK, +Module->IsSystem),
       ModMap.getModuleMapFileForUniquing(Module)->getName(), ModuleFileName,
-      std::move(VFS), DiagConsumer);
+      std::move(ThreadSafeConfig));
 
   std::unique_ptr<llvm::MemoryBuffer> ModuleMapBuffer =
       llvm::MemoryBuffer::getMemBufferCopy(InferredModuleMapContent);


### PR DESCRIPTION
The `DiagnosticConsumer` interface is not thread-safe. To enable thread-safety of `CompilerInstance` objects cloned from the same parent, this PR allows passing an explicit `DiagnosticConsumer` to `cloneForModuleCompile()`. This will be used from the dependency scanner.