### PR TITLE
[lldb] Make the statusline separator configurable

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -303,6 +303,9 @@ public:
   const FormatEntity::Entry *GetStatuslineFormat() const;
   bool SetStatuslineFormat(const FormatEntity::Entry &format);
 
+  llvm::StringRef GetSeparator() const;
+  bool SetSeparator(llvm::StringRef s);
+
   llvm::StringRef GetShowProgressAnsiPrefix() const;
 
   llvm::StringRef GetShowProgressAnsiSuffix() const;

--- a/lldb/include/lldb/Core/FormatEntity.h
+++ b/lldb/include/lldb/Core/FormatEntity.h
@@ -103,6 +103,7 @@ struct Entry {
     CurrentPCArrow,
     ProgressCount,
     ProgressMessage,
+    Separator,
   };
 
   struct Definition {

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -176,10 +176,19 @@ let Definition = "debugger" in {
     Global,
     DefaultTrue,
     Desc<"Whether to show a statusline at the bottom of the terminal.">;
-  def StatuslineFormat: Property<"statusline-format", "FormatEntity">,
-    Global,
-    DefaultStringValue<"${ansi.negative}{${target.file.basename}}{ | ${line.file.basename}:${line.number}:${line.column}}{ | ${thread.stop-reason}}{ | {${progress.count} }${progress.message}}">,
-    Desc<"The default statusline format string.">;
+  def Separator : Property<"separator", "String">,
+                  Global,
+                  DefaultStringValue<"│ ">,
+                  Desc<"A separator used, e.g., in the status line.">;
+  def StatuslineFormat
+      : Property<"statusline-format", "FormatEntity">,
+        Global,
+        DefaultStringValue<
+            "${ansi.negative}{${target.file.basename}}{ "
+            "${separator}${line.file.basename}:${line.number}:${line.column}}{ "
+            "${separator}${thread.stop-reason}}{ "
+            "${separator}{${progress.count} }${progress.message}}">,
+        Desc<"The default statusline format string.">;
   def UseSourceCache: Property<"use-source-cache", "Boolean">,
     Global,
     DefaultTrue,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -500,6 +500,19 @@ bool Debugger::SetStatuslineFormat(const FormatEntity::Entry &format) {
   return ret;
 }
 
+llvm::StringRef Debugger::GetSeparator() const {
+  constexpr uint32_t idx = ePropertySeparator;
+  return GetPropertyAtIndexAs<llvm::StringRef>(
+      idx, g_debugger_properties[idx].default_cstr_value);
+}
+
+bool Debugger::SetSeparator(llvm::StringRef s) {
+  constexpr uint32_t idx = ePropertySeparator;
+  bool ret = SetPropertyAtIndex(idx, s);
+  RedrawStatusline();
+  return ret;
+}
+
 bool Debugger::GetUseAutosuggestion() const {
   const uint32_t idx = ePropertyShowAutosuggestion;
   return GetPropertyAtIndexAs<bool>(
@@ -999,11 +1012,16 @@ Debugger::Debugger(lldb::LogOutputCallback log_callback, void *baton)
 
   // Turn off use-color if this is a dumb terminal.
   const char *term = getenv("TERM");
-  if (term && !strcmp(term, "dumb"))
+  auto disable_color = [&]() {
     SetUseColor(false);
+    SetSeparator("| ");
+  };
+
+  if (term && !strcmp(term, "dumb"))
+    disable_color();
   // Turn off use-color if we don't write to a terminal with color support.
   if (!GetOutputFileSP()->GetIsTerminalWithColors())
-    SetUseColor(false);
+    disable_color();
 
   if (Diagnostics::Enabled()) {
     m_diagnostics_callback_id = Diagnostics::Instance().AddCallback(

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -266,6 +266,7 @@ constexpr Definition g_top_level_entries[] = {
                                   g_var_child_entries, true),
     Entry::DefinitionWithChildren("progress", EntryType::Invalid,
                                   g_progress_child_entries),
+    Definition("separator", EntryType::Separator),
 };
 
 constexpr Definition g_root = Entry::DefinitionWithChildren(
@@ -367,6 +368,7 @@ const char *FormatEntity::Entry::TypeToCString(Type t) {
     ENUM_TO_CSTR(CurrentPCArrow);
     ENUM_TO_CSTR(ProgressCount);
     ENUM_TO_CSTR(ProgressMessage);
+    ENUM_TO_CSTR(Separator);
   }
   return "???";
 }
@@ -1899,6 +1901,13 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
         s.PutCString(progress->message);
         return true;
       }
+    }
+    return false;
+
+  case Entry::Type::Separator:
+    if (Target *target = Target::GetTargetFromContexts(exe_ctx, sc)) {
+      s << target->GetDebugger().GetSeparator();
+      return true;
     }
     return false;
   }

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -32,6 +32,7 @@ class TestStatusline(PExpectTest):
 
         # Enable the statusline and check for the control character and that we
         # can see the target, the location and the stop reason.
+        self.expect('set set separator "| "')
         self.expect(
             "set set show-statusline true",
             [
@@ -46,10 +47,12 @@ class TestStatusline(PExpectTest):
         self.child.setwinsize(terminal_height, terminal_width)
 
         # Change the format.
+        self.expect('set set separator "S"')
         self.expect(
-            'set set statusline-format "target = {${target.file.basename}}"',
-            ["target = a.out"],
+            'set set statusline-format "target = {${target.file.basename}} ${separator}"',
+            ["target = a.out S"],
         )
+        self.expect('set set separator "| "')
 
         # Hide the statusline and check or the control character.
         self.expect(


### PR DESCRIPTION
And use this functionality to replace the ASCII "|" with the same full-geight line-drawing character used in diagnostics rendering on a color terminal.