### PR TITLE
[libc] Special case PPC double double for print

### DIFF
--- a/libc/src/stdio/printf_core/core_structs.h
+++ b/libc/src/stdio/printf_core/core_structs.h
@@ -55,8 +55,13 @@ struct FormatSection {
   int min_width = 0;
   int precision = -1;
 
-  // Needs to be large enough to hold a long double.
+  // Needs to be large enough to hold a long double. Special case handling for
+  // the PowerPC double double type because it has no FPBits interface.
+#ifdef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+  Uint128 conv_val_raw;
+#else
   fputil::FPBits<long double>::StorageType conv_val_raw;
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
   void *conv_val_ptr;
 
   char conv_name;


### PR DESCRIPTION
Summary:
We use the storage class for `long double` in the printing
implementations. We don't fully support the PPC double double type,
which that maps to, but we can stub out just the support needed for the
print interface to works. This required using the internal interface for
storage type, but it should be good enough.

Fixes: https://github.com/llvm/llvm-project/issues/136596
