### PR TITLE
[AMDGPU] Partially revert my llvm::less_second patch

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -589,7 +589,7 @@ void PipelineSolver::populateReadyList(
   }
 
   if (UseCostHeur)
-    llvm::sort(ReadyList, llvm::less_second());
+    std::sort(ReadyList.begin(), ReadyList.end(), llvm::less_second());
 
   assert(ReadyList.size() == CurrSU.second.size());
 }


### PR DESCRIPTION
This patch partially reverts:

  commit 5e1b0f97735083b6762834b83fdbb35e76002e03
  Author: Kazu Hirata <kazu@google.com>
  Date:   Fri Apr 18 10:05:55 2025 -0700

to fix:

  LLVM :: CodeGen/AMDGPU/sched-group-barrier-pipeline-solver.mir
  LLVM :: CodeGen/AMDGPU/sched-group-barrier-pre-RA.mir

under LLVM_ENABLE_EXPENSIVE_CHECKS.
