### PR TITLE
[msan] Handle x86.avx512fp16.{add,sub.mul,div,min,max}.ph.512

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -5022,6 +5022,12 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     }
 
     // Packed
+    case Intrinsic::x86_avx512fp16_add_ph_512:
+    case Intrinsic::x86_avx512fp16_sub_ph_512:
+    case Intrinsic::x86_avx512fp16_mul_ph_512:
+    case Intrinsic::x86_avx512fp16_div_ph_512:
+    case Intrinsic::x86_avx512fp16_max_ph_512:
+    case Intrinsic::x86_avx512fp16_min_ph_512:
     case Intrinsic::x86_avx512_min_ps_512:
     case Intrinsic::x86_avx512_min_pd_512:
     case Intrinsic::x86_avx512_max_ps_512:


### PR DESCRIPTION
These are handled similarly to x86_avx512_(min|max)_p[sd]_512 intrinsics (https://github.com/llvm/llvm-project/pull/124421) i.e., using maybeHandleSimpleNomemIntrinsic, with the last parameter being the rounding method.

Updates the test from https://github.com/llvm/llvm-project/pull/136260