### PR TITLE
[DirectX] Allow llvm lifetime intrinsics to pass on to the DirectX backend

### DIFF
--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -753,6 +753,8 @@ public:
       case Intrinsic::dx_resource_casthandle:
       // NOTE: llvm.dbg.value is supported as is in DXIL.
       case Intrinsic::dbg_value:
+      case Intrinsic::lifetime_start:
+      case Intrinsic::lifetime_end:
       case Intrinsic::not_intrinsic:
         continue;
       default: {

--- a/llvm/test/CodeGen/DirectX/legalize-lifetimes.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-lifetimes.ll
@@ -1,7 +1,5 @@
 ; RUN: opt -S -passes='dxil-op-lower' -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s
 
-; CHECK-NOT: error: Unsupported intrinsic llvm.lifetime.start.p0 for DXIL lowering
-; CHECK-NOT: error: Unsupported intrinsic llvm.lifetime.end.p0 for DXIL lowering
 ; CHECK-LABEL: define void @test_legal_lifetime() {
 ; CHECK-NEXT:    [[ACCUM_I_FLAT:%.*]] = alloca [1 x i32], align 4
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i32, ptr [[ACCUM_I_FLAT]], i32 0

--- a/llvm/test/CodeGen/DirectX/legalize-lifetimes.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-lifetimes.ll
@@ -1,0 +1,20 @@
+; RUN: opt -S -passes='dxil-op-lower' -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s
+
+; CHECK-NOT: error: Unsupported intrinsic llvm.lifetime.start.p0 for DXIL lowering
+; CHECK-NOT: error: Unsupported intrinsic llvm.lifetime.end.p0 for DXIL lowering
+; CHECK-LABEL: define void @test_legal_lifetime() {
+; CHECK-NEXT:    [[ACCUM_I_FLAT:%.*]] = alloca [1 x i32], align 4
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i32, ptr [[ACCUM_I_FLAT]], i32 0
+; CHECK-NEXT:    call void @llvm.lifetime.start.p0(i64 4, ptr nonnull [[ACCUM_I_FLAT]])
+; CHECK-NEXT:    store i32 0, ptr [[GEP]], align 4
+; CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 4, ptr nonnull [[ACCUM_I_FLAT]])
+; CHECK-NEXT:    ret void
+;
+define void @test_legal_lifetime()  {
+  %accum.i.flat = alloca [1 x i32], align 4
+  %gep = getelementptr i32, ptr %accum.i.flat, i32 0
+  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %accum.i.flat)
+  store i32 0, ptr %gep, align 4
+  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %accum.i.flat)
+  ret void
+}


### PR DESCRIPTION
fixes #136620

It was determined that the lifetime intrinsics generated by clang are likely more correct than the ones in DXC hence explaining the missing lifetimes between the IR diffs.

As such we are legalizing lllvm lifetime intrinsics by letting them all pass on through.