### PR TITLE
[NFC] Fixed test case fail caused by the patch [SelectionDAG] Folding ZERO-EXTEND/SIGN_EXTEND poison to Poison value in getNode #122741

### DIFF
--- a/llvm/test/CodeGen/VE/Vector/ticket-64420.ll
+++ b/llvm/test/CodeGen/VE/Vector/ticket-64420.ll
@@ -20,6 +20,7 @@
 
 ; SCALAR-LABEL: func:
 ; SCALAR:       # %bb.1:
+; SCALAR:         or %s1, 0, (0)1
 ; SCALAR-NEXT:    st %s1, 8(, %s0)
 ; SCALAR-NEXT:    st %s1, (, %s0)
 ; SCALAR-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/X86/avx512-i1test.ll
+++ b/llvm/test/CodeGen/X86/avx512-i1test.ll
@@ -8,18 +8,19 @@ target triple = "x86_64-unknown-linux-gnu"
 define void @func() {
 ; CHECK-LABEL: func:
 ; CHECK:       # %bb.0: # %bb1
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB0_1
 ; CHECK-NEXT:  # %bb.3: # %L_30
 ; CHECK-NEXT:    retq
-; CHECK-NEXT:  .LBB0_1: # %bb56
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  .LBB0_2: # %bb33
-; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    testb %al, %al
-; CHECK-NEXT:    jmp .LBB0_2
+; CHECK-NEXT:  .LBB0_1: # %bb33
+; CHECK-NEXT:   # =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    testb   %al, %al
+; CHECK-NEXT:    jne     .LBB0_1
+; CHECK-NEXT:  # %bb.2:                                # %bb35
+; CHECK-NEXT:  #   in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    testb   %al, %al
+; CHECK-NEXT:    jmp     .LBB0_1
 bb1:
   br i1 poison, label %L_10, label %L_10
 

--- a/llvm/test/CodeGen/X86/bfloat.ll
+++ b/llvm/test/CodeGen/X86/bfloat.ll
@@ -842,7 +842,6 @@ define <32 x bfloat> @pr63017_2() nounwind {
 ;
 ; SSE2-LABEL: pr63017_2:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb %al, %al
 ; SSE2-NEXT:    jne .LBB16_1
 ; SSE2-NEXT:  # %bb.2: # %cond.load
@@ -1087,7 +1086,6 @@ define <32 x bfloat> @pr63017_2() nounwind {
 ; AVXNC-LABEL: pr63017_2:
 ; AVXNC:       # %bb.0:
 ; AVXNC-NEXT:    vbroadcastss {{.*#+}} ymm0 = [49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024]
-; AVXNC-NEXT:    xorl %eax, %eax
 ; AVXNC-NEXT:    testb %al, %al
 ; AVXNC-NEXT:    jne .LBB16_2
 ; AVXNC-NEXT:  # %bb.1: # %cond.load

--- a/llvm/test/CodeGen/X86/clobber_frame_ptr.ll
+++ b/llvm/test/CodeGen/X86/clobber_frame_ptr.ll
@@ -157,7 +157,6 @@ define ghccc void @test5() {
 ; CHECK-NEXT:    movq %rsp, %rbp
 ; CHECK-NEXT:    .cfi_def_cfa_register %rbp
 ; CHECK-NEXT:    andq $-8, %rsp
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB3_2
 ; CHECK-NEXT:  # %bb.1: # %then

--- a/llvm/test/CodeGen/X86/concat-fpext-v2bf16.ll
+++ b/llvm/test/CodeGen/X86/concat-fpext-v2bf16.ll
@@ -4,7 +4,6 @@
 define void @test(<2 x ptr> %ptr) {
 ; CHECK-LABEL: test:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB0_1
 ; CHECK-NEXT:  # %bb.2: # %loop.127.preheader

--- a/llvm/test/CodeGen/X86/jump_sign.ll
+++ b/llvm/test/CodeGen/X86/jump_sign.ll
@@ -215,15 +215,12 @@ define i32 @func_n(i32 %x, i32 %y) nounwind {
 define void @func_o() nounwind uwtable {
 ; CHECK-LABEL: func_o:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB12_1
 ; CHECK-NEXT:  # %bb.2: # %if.end.i
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB12_5
 ; CHECK-NEXT:  # %bb.3: # %sw.bb
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB12_8
 ; CHECK-NEXT:  # %bb.4: # %if.end29
@@ -234,13 +231,11 @@ define void @func_o() nounwind uwtable {
 ; CHECK-NEXT:    cmpl $6554, %eax # imm = 0x199A
 ; CHECK-NEXT:    jae .LBB12_5
 ; CHECK-NEXT:  .LBB12_8: # %if.then44
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB12_9
 ; CHECK-NEXT:  # %bb.10: # %if.else.i104
 ; CHECK-NEXT:    retl
 ; CHECK-NEXT:  .LBB12_5: # %sw.default
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB12_7
 ; CHECK-NEXT:  # %bb.6: # %if.then.i96

--- a/llvm/test/CodeGen/X86/machine-trace-metrics-crash.ll
+++ b/llvm/test/CodeGen/X86/machine-trace-metrics-crash.ll
@@ -15,7 +15,6 @@ define void @PR24199(i32 %a0) {
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-NEXT:    .cfi_offset %rbx, -16
 ; CHECK-NEXT:    movl %edi, %ebx
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB0_2
 ; CHECK-NEXT:  # %bb.1:

--- a/llvm/test/CodeGen/X86/pr50254.ll
+++ b/llvm/test/CodeGen/X86/pr50254.ll
@@ -8,8 +8,7 @@ define void @PR50254() {
 ; X86-LABEL: PR50254:
 ; X86:       # %bb.0: # %entry
 ; X86-NEXT:    movswl d.e, %eax
-; X86-NEXT:    xorl %ecx, %ecx
-; X86-NEXT:    testb %cl, %cl
+; X86-NEXT:    testb %al, %al
 ; X86-NEXT:    jne .LBB0_2
 ; X86-NEXT:  # %bb.1: # %for.end
 ; X86-NEXT:    movw %ax, d.e
@@ -19,8 +18,7 @@ define void @PR50254() {
 ; X64-LABEL: PR50254:
 ; X64:       # %bb.0: # %entry
 ; X64-NEXT:    movswq d.e(%rip), %rax
-; X64-NEXT:    xorl %ecx, %ecx
-; X64-NEXT:    testb %cl, %cl
+; X64-NEXT:    testb %al, %al
 ; X64-NEXT:    jne .LBB0_2
 ; X64-NEXT:  # %bb.1: # %for.end
 ; X64-NEXT:    movw %ax, d.e(%rip)

--- a/llvm/test/CodeGen/X86/pr57673.ll
+++ b/llvm/test/CodeGen/X86/pr57673.ll
@@ -20,15 +20,16 @@ define void @foo() {
   ; NORMAL: bb.0.bb_entry:
   ; NORMAL-NEXT:   successors: %bb.1(0x80000000)
   ; NORMAL-NEXT: {{  $}}
-  ; NORMAL-NEXT:   [[MOV32r0_:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
-  ; NORMAL-NEXT:   [[COPY:%[0-9]+]]:gr8 = COPY [[MOV32r0_]].sub_8bit
+  ; NORMAL-NEXT:   [[MOV32r0_:%[0-9]+]]:gr8 = IMPLICIT_DEF
+  ; NORMAL-NEXT:   [[COPY:%[0-9]+]]:gr8 = IMPLICIT_DEF
+ ; NORMAL-NEXT:    [[MOV32r0_1:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
   ; NORMAL-NEXT:   [[LEA64r:%[0-9]+]]:gr64 = LEA64r %stack.1.i, 1, $noreg, 0, $noreg
   ; NORMAL-NEXT:   [[DEF:%[0-9]+]]:gr64 = IMPLICIT_DEF
   ; NORMAL-NEXT: {{  $}}
   ; NORMAL-NEXT: bb.1.bb_8:
   ; NORMAL-NEXT:   successors: %bb.3(0x40000000), %bb.2(0x40000000)
   ; NORMAL-NEXT: {{  $}}
-  ; NORMAL-NEXT:   TEST8rr [[COPY]], [[COPY]], implicit-def $eflags
+  ; NORMAL-NEXT:   TEST8rr [[MOV32r0_]], [[COPY]], implicit-def $eflags
   ; NORMAL-NEXT:   JCC_1 %bb.3, 5, implicit $eflags
   ; NORMAL-NEXT:   JMP_1 %bb.2
   ; NORMAL-NEXT: {{  $}}
@@ -45,11 +46,11 @@ define void @foo() {
   ; NORMAL-NEXT:   successors: %bb.1(0x80000000)
   ; NORMAL-NEXT: {{  $}}
   ; NORMAL-NEXT:   ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
-  ; NORMAL-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, [[MOV32r0_]], %subreg.sub_32bit
+  ; NORMAL-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, [[MOV32r0_1]], %subreg.sub_32bit
   ; NORMAL-NEXT:   $rdi = COPY [[SUBREG_TO_REG]]
   ; NORMAL-NEXT:   $rsi = COPY [[SUBREG_TO_REG]]
   ; NORMAL-NEXT:   $rdx = COPY [[SUBREG_TO_REG]]
-  ; NORMAL-NEXT:   $ecx = COPY [[MOV32r0_]]
+  ; NORMAL-NEXT:   $ecx = COPY [[MOV32r0_1]]
   ; NORMAL-NEXT:   $r8 = COPY [[LEA64r]]
   ; NORMAL-NEXT:   CALL64r [[DEF]], csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $rsi, implicit $rdx, implicit $ecx, implicit $r8, implicit-def $rsp, implicit-def $ssp
   ; NORMAL-NEXT:   ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
@@ -59,15 +60,16 @@ define void @foo() {
   ; INSTRREF: bb.0.bb_entry:
   ; INSTRREF-NEXT:   successors: %bb.1(0x80000000)
   ; INSTRREF-NEXT: {{  $}}
-  ; INSTRREF-NEXT:   [[MOV32r0_:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
-  ; INSTRREF-NEXT:   [[COPY:%[0-9]+]]:gr8 = COPY [[MOV32r0_]].sub_8bit
+  ; INSTRREF-NEXT:   [[MOV32r0_:%[0-9]+]]:gr8 = IMPLICIT_DEF
+  ; INSTRREF-NEXT:   [[COPY:%[0-9]+]]:gr8 = IMPLICIT_DEF
+  ; INSTRREF-NEXT:   [[MOV32r0_1:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
   ; INSTRREF-NEXT:   [[LEA64r:%[0-9]+]]:gr64 = LEA64r %stack.1.i, 1, $noreg, 0, $noreg
   ; INSTRREF-NEXT:   [[DEF:%[0-9]+]]:gr64 = IMPLICIT_DEF
   ; INSTRREF-NEXT: {{  $}}
   ; INSTRREF-NEXT: bb.1.bb_8:
   ; INSTRREF-NEXT:   successors: %bb.3(0x40000000), %bb.2(0x40000000)
   ; INSTRREF-NEXT: {{  $}}
-  ; INSTRREF-NEXT:   TEST8rr [[COPY]], [[COPY]], implicit-def $eflags
+  ; INSTRREF-NEXT:   TEST8rr [[MOV32r0_]], [[COPY]], implicit-def $eflags
   ; INSTRREF-NEXT:   JCC_1 %bb.3, 5, implicit $eflags
   ; INSTRREF-NEXT:   JMP_1 %bb.2
   ; INSTRREF-NEXT: {{  $}}
@@ -84,11 +86,11 @@ define void @foo() {
   ; INSTRREF-NEXT:   successors: %bb.1(0x80000000)
   ; INSTRREF-NEXT: {{  $}}
   ; INSTRREF-NEXT:   ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
-  ; INSTRREF-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, [[MOV32r0_]], %subreg.sub_32bit
+  ; INSTRREF-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, [[MOV32r0_1]], %subreg.sub_32bit
   ; INSTRREF-NEXT:   $rdi = COPY [[SUBREG_TO_REG]]
   ; INSTRREF-NEXT:   $rsi = COPY [[SUBREG_TO_REG]]
   ; INSTRREF-NEXT:   $rdx = COPY [[SUBREG_TO_REG]]
-  ; INSTRREF-NEXT:   $ecx = COPY [[MOV32r0_]]
+  ; INSTRREF-NEXT:   $ecx = COPY [[MOV32r0_1]]
   ; INSTRREF-NEXT:   $r8 = COPY [[LEA64r]]
   ; INSTRREF-NEXT:   CALL64r [[DEF]], csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $rsi, implicit $rdx, implicit $ecx, implicit $r8, implicit-def $rsp, implicit-def $ssp
   ; INSTRREF-NEXT:   ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp

--- a/llvm/test/CodeGen/X86/pr63108.ll
+++ b/llvm/test/CodeGen/X86/pr63108.ll
@@ -7,7 +7,6 @@
 define i32 @PR63108() {
 ; SSE-LABEL: PR63108:
 ; SSE:       # %bb.0: # %entry
-; SSE-NEXT:    xorl %eax, %eax
 ; SSE-NEXT:    testb %al, %al
 ; SSE-NEXT:    je .LBB0_2
 ; SSE-NEXT:  # %bb.1:
@@ -16,7 +15,7 @@ define i32 @PR63108() {
 ; SSE-NEXT:  .LBB0_2: # %vector.body.preheader
 ; SSE-NEXT:    pxor %xmm0, %xmm0
 ; SSE-NEXT:    movd {{.*#+}} xmm1 = [57339,0,0,0]
-; SSE-NEXT:    xorl %eax, %eax
+; SSE-NEXT:    xorl    %eax, %eax
 ; SSE-NEXT:    .p2align 4
 ; SSE-NEXT:  .LBB0_3: # %vector.body
 ; SSE-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -43,7 +42,6 @@ define i32 @PR63108() {
 ;
 ; AVX1-LABEL: PR63108:
 ; AVX1:       # %bb.0: # %entry
-; AVX1-NEXT:    xorl %eax, %eax
 ; AVX1-NEXT:    testb %al, %al
 ; AVX1-NEXT:    je .LBB0_2
 ; AVX1-NEXT:  # %bb.1:
@@ -80,7 +78,6 @@ define i32 @PR63108() {
 ;
 ; AVX2-LABEL: PR63108:
 ; AVX2:       # %bb.0: # %entry
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb %al, %al
 ; AVX2-NEXT:    je .LBB0_2
 ; AVX2-NEXT:  # %bb.1:
@@ -117,7 +114,6 @@ define i32 @PR63108() {
 ;
 ; AVX512-LABEL: PR63108:
 ; AVX512:       # %bb.0: # %entry
-; AVX512-NEXT:    xorl %eax, %eax
 ; AVX512-NEXT:    testb %al, %al
 ; AVX512-NEXT:    je .LBB0_2
 ; AVX512-NEXT:  # %bb.1:

--- a/llvm/test/CodeGen/X86/pr91005.ll
+++ b/llvm/test/CodeGen/X86/pr91005.ll
@@ -4,7 +4,6 @@
 define void @PR91005(ptr %0) minsize {
 ; CHECK-LABEL: PR91005:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB0_2
 ; CHECK-NEXT:  # %bb.1:

--- a/llvm/test/CodeGen/X86/ragreedy-hoist-spill.ll
+++ b/llvm/test/CodeGen/X86/ragreedy-hoist-spill.ll
@@ -44,11 +44,9 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne LBB0_5
 ; CHECK-NEXT:  ## %bb.2: ## %if.then4
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je LBB0_54
 ; CHECK-NEXT:  ## %bb.3: ## %SyTime.exit
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je LBB0_54
 ; CHECK-NEXT:  LBB0_4: ## %cleanup
@@ -61,7 +59,6 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    popq %rbp
 ; CHECK-NEXT:    retq
 ; CHECK-NEXT:  LBB0_5: ## %if.end25
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je LBB0_54
 ; CHECK-NEXT:  ## %bb.6: ## %SyTime.exit2720
@@ -94,7 +91,7 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-NEXT:    xorl %ebp, %ebp
-; CHECK-NEXT:    testb %bpl, %bpl
+; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne LBB0_11
 ; CHECK-NEXT:  ## %bb.12: ## %while.body200.preheader
 ; CHECK-NEXT:    xorl %r12d, %r12d
@@ -155,14 +152,14 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:  ## %bb.29: ## %cond.true.i.i2780
 ; CHECK-NEXT:    ## in Loop: Header=BB0_28 Depth=2
 ; CHECK-NEXT:    movq %rax, %rbx
-; CHECK-NEXT:    testb %r12b, %r12b
+; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne LBB0_31
 ; CHECK-NEXT:  ## %bb.30: ## %lor.rhs500
 ; CHECK-NEXT:    ## in Loop: Header=BB0_28 Depth=2
 ; CHECK-NEXT:    movl $256, %esi ## imm = 0x100
 ; CHECK-NEXT:    callq ___maskrune
 ; CHECK-NEXT:    movb $1, %sil
-; CHECK-NEXT:    testb %r12b, %r12b
+; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne LBB0_31
 ; CHECK-NEXT:    jmp LBB0_33
 ; CHECK-NEXT:    .p2align 4
@@ -231,7 +228,7 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    jne LBB0_37
 ; CHECK-NEXT:  ## %bb.38: ## %for.cond542.preheader
 ; CHECK-NEXT:    ## in Loop: Header=BB0_13 Depth=1
-; CHECK-NEXT:    testb %r12b, %r12b
+; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    movb $0, (%rbx)
 ; CHECK-NEXT:    leaq LJTI0_0(%rip), %rdx
 ; CHECK-NEXT:    jmp LBB0_20
@@ -276,7 +273,6 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    movq %r14, %rbx
 ; CHECK-NEXT:    jmp LBB0_47
 ; CHECK-NEXT:  LBB0_16: ## %while.cond635.preheader
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je LBB0_40
 ; CHECK-NEXT:    .p2align 4
@@ -309,7 +305,6 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    testb %bl, %bl
 ; CHECK-NEXT:    jne LBB0_52
 ; CHECK-NEXT:  LBB0_53: ## %while.cond1683.preheader
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:  LBB0_54: ## %if.then.i
 ; CHECK-NEXT:    ud2

--- a/llvm/test/CodeGen/X86/shift-combine.ll
+++ b/llvm/test/CodeGen/X86/shift-combine.ll
@@ -390,7 +390,6 @@ define dso_local i32 @ashr_add_shl_i32_i8_extra_use3(i32 %r, ptr %p1, ptr %p2) n
 define dso_local void @PR42880(i32 %t0) {
 ; X86-LABEL: PR42880:
 ; X86:       # %bb.0:
-; X86-NEXT:    xorl %eax, %eax
 ; X86-NEXT:    testb %al, %al
 ; X86-NEXT:    je .LBB16_1
 ; X86-NEXT:  # %bb.2: # %if
@@ -398,7 +397,6 @@ define dso_local void @PR42880(i32 %t0) {
 ;
 ; X64-LABEL: PR42880:
 ; X64:       # %bb.0:
-; X64-NEXT:    xorl %eax, %eax
 ; X64-NEXT:    testb %al, %al
 ; X64-NEXT:    je .LBB16_1
 ; X64-NEXT:  # %bb.2: # %if

--- a/llvm/test/CodeGen/X86/shuffle-combine-crash.ll
+++ b/llvm/test/CodeGen/X86/shuffle-combine-crash.ll
@@ -18,7 +18,6 @@
 define void @sample_test() {
 ; CHECK-LABEL: sample_test:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB0_2
 ; CHECK-NEXT:  # %bb.1:

--- a/llvm/test/CodeGen/X86/shuffle-half.ll
+++ b/llvm/test/CodeGen/X86/shuffle-half.ll
@@ -5,7 +5,6 @@ define <32 x half> @dump_vec() {
 ; CHECK-LABEL: dump_vec:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vxorps %xmm0, %xmm0, %xmm0
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB0_2
 ; CHECK-NEXT:  # %bb.1: # %cond.load

--- a/llvm/test/CodeGen/X86/swifterror.ll
+++ b/llvm/test/CodeGen/X86/swifterror.ll
@@ -931,7 +931,6 @@ define void @swifterror_isel(ptr) {
 ; CHECK-APPLE-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-APPLE-NEXT:    .cfi_offset %r12, -24
 ; CHECK-APPLE-NEXT:    .cfi_offset %r13, -16
-; CHECK-APPLE-NEXT:    xorl %eax, %eax
 ; CHECK-APPLE-NEXT:    testb %al, %al
 ; CHECK-APPLE-NEXT:    jne LBB8_3
 ; CHECK-APPLE-NEXT:  ## %bb.1: ## %.preheader
@@ -993,7 +992,6 @@ define void @swifterror_isel(ptr) {
 ; CHECK-i386-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-i386-NEXT:    .cfi_offset %esi, -12
 ; CHECK-i386-NEXT:    .cfi_offset %edi, -8
-; CHECK-i386-NEXT:    xorl %eax, %eax
 ; CHECK-i386-NEXT:    testb %al, %al
 ; CHECK-i386-NEXT:    jne LBB8_3
 ; CHECK-i386-NEXT:  ## %bb.1: ## %.preheader

--- a/llvm/test/CodeGen/X86/tailcall-cgp-dup.ll
+++ b/llvm/test/CodeGen/X86/tailcall-cgp-dup.ll
@@ -107,7 +107,6 @@ declare ptr @bar(ptr) uwtable optsize noinline ssp
 define hidden ptr @thingWithValue(ptr %self) uwtable ssp {
 ; CHECK-LABEL: thingWithValue:
 ; CHECK:       ## %bb.0: ## %entry
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je _bar ## TAILCALL
 ; CHECK-NEXT:  ## %bb.1: ## %someThingWithValue.exit

--- a/llvm/test/CodeGen/X86/vaargs-prolog-insert.ll
+++ b/llvm/test/CodeGen/X86/vaargs-prolog-insert.ll
@@ -7,8 +7,14 @@ define void @reduce(i32, i32, i32, i32, i32, i32, ...) nounwind {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    subq $56, %rsp
 ; CHECK-NEXT:    testb %al, %al
-; CHECK-NEXT:    je .LBB0_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    jne .LBB0_3
+; CHECK-NEXT:  # %bb.4:
+; CHECK-NEXT:    testb   %al, %al
+; CHECK-NEXT:    je      .LBB0_1
+; CHECK-NEXT: .LBB0_2:
+; CHECK-NEXT:    addq    $56, %rsp
+; CHECK-NEXT:    retq
+; CHECK-NEXT: .LBB0_3:
 ; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm1, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm2, -{{[0-9]+}}(%rsp)
@@ -17,18 +23,15 @@ define void @reduce(i32, i32, i32, i32, i32, i32, ...) nounwind {
 ; CHECK-NEXT:    movaps %xmm5, (%rsp)
 ; CHECK-NEXT:    movaps %xmm6, {{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm7, {{[0-9]+}}(%rsp)
-; CHECK-NEXT:  .LBB0_4:
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT: .LBB0_1:
 ; CHECK-NEXT:    leaq -{{[0-9]+}}(%rsp), %rax
 ; CHECK-NEXT:    movq %rax, 16
 ; CHECK-NEXT:    leaq {{[0-9]+}}(%rsp), %rax
 ; CHECK-NEXT:    movq %rax, 8
 ; CHECK-NEXT:    movl $48, 4
 ; CHECK-NEXT:    movl $48, 0
-; CHECK-NEXT:  .LBB0_2:
 ; CHECK-NEXT:    addq $56, %rsp
 ; CHECK-NEXT:    retq
   br i1 poison, label %8, label %7

--- a/llvm/test/CodeGen/X86/vector-shuffle-combining-avx512bwvl.ll
+++ b/llvm/test/CodeGen/X86/vector-shuffle-combining-avx512bwvl.ll
@@ -268,19 +268,17 @@ define <8 x i32> @PR46393(<8 x i16> %a0, i8 %a1) {
 define i64 @PR55050() {
 ; X86-LABEL: PR55050:
 ; X86:       # %bb.0: # %entry
-; X86-NEXT:    xorl %edx, %edx
 ; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    testb %dl, %dl
+; X86-NEXT:    testb %al, %al
 ; X86-NEXT:    jne .LBB15_2
 ; X86-NEXT:  # %bb.1: # %if
 ; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    xorl %edx, %edx
 ; X86-NEXT:  .LBB15_2: # %exit
+; X86-NEXT:    movl    %eax, %edx
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: PR55050:
 ; X64:       # %bb.0: # %entry
-; X64-NEXT:    xorl %eax, %eax
 ; X64-NEXT:    testb %al, %al
 ; X64-NEXT:    xorl %eax, %eax
 ; X64-NEXT:    retq

--- a/llvm/test/CodeGen/X86/x86-shrink-wrapping.ll
+++ b/llvm/test/CodeGen/X86/x86-shrink-wrapping.ll
@@ -814,21 +814,21 @@ define void @infiniteloop() {
 ; ENABLE-NEXT:    pushq %rbx
 ; ENABLE-NEXT:    pushq %rax
 ; ENABLE-NEXT:    .cfi_offset %rbx, -24
-; ENABLE-NEXT:    xorl %eax, %eax
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB10_3
 ; ENABLE-NEXT:  ## %bb.1: ## %if.then
-; ENABLE-NEXT:    movq %rsp, %rcx
-; ENABLE-NEXT:    addq $-16, %rcx
-; ENABLE-NEXT:    movq %rcx, %rsp
+; ENABLE-NEXT:    movq %rsp, %rax
+; ENABLE-NEXT:    addq $-16, %rax
+; ENABLE-NEXT:    movq %rax, %rsp
+; ENABLE-NEXT:    xorl    %ecx, %ecx
 ; ENABLE-NEXT:    .p2align 4
 ; ENABLE-NEXT:  LBB10_2: ## %for.body
 ; ENABLE-NEXT:    ## =>This Inner Loop Header: Depth=1
 ; ENABLE-NEXT:    ## InlineAsm Start
 ; ENABLE-NEXT:    movl $1, %edx
 ; ENABLE-NEXT:    ## InlineAsm End
-; ENABLE-NEXT:    addl %edx, %eax
-; ENABLE-NEXT:    movl %eax, (%rcx)
+; ENABLE-NEXT:    addl %edx, %ecx
+; ENABLE-NEXT:    movl %ecx, (%rax)
 ; ENABLE-NEXT:    jmp LBB10_2
 ; ENABLE-NEXT:  LBB10_3: ## %if.end
 ; ENABLE-NEXT:    leaq -8(%rbp), %rsp
@@ -846,21 +846,21 @@ define void @infiniteloop() {
 ; DISABLE-NEXT:    pushq %rbx
 ; DISABLE-NEXT:    pushq %rax
 ; DISABLE-NEXT:    .cfi_offset %rbx, -24
-; DISABLE-NEXT:    xorl %eax, %eax
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB10_3
 ; DISABLE-NEXT:  ## %bb.1: ## %if.then
-; DISABLE-NEXT:    movq %rsp, %rcx
-; DISABLE-NEXT:    addq $-16, %rcx
-; DISABLE-NEXT:    movq %rcx, %rsp
+; DISABLE-NEXT:    movq %rsp, %rax
+; DISABLE-NEXT:    addq $-16, %rax
+; DISABLE-NEXT:    %rax, %rsp
+; DISABLE-NEXT:    xorl    %ecx, %ecx
 ; DISABLE-NEXT:    .p2align 4
 ; DISABLE-NEXT:  LBB10_2: ## %for.body
 ; DISABLE-NEXT:    ## =>This Inner Loop Header: Depth=1
 ; DISABLE-NEXT:    ## InlineAsm Start
 ; DISABLE-NEXT:    movl $1, %edx
 ; DISABLE-NEXT:    ## InlineAsm End
-; DISABLE-NEXT:    addl %edx, %eax
-; DISABLE-NEXT:    movl %eax, (%rcx)
+; DISABLE-NEXT:    addl %edx, %ecx
+; DISABLE-NEXT:    movl %ecx, (%rax)
 ; DISABLE-NEXT:    jmp LBB10_2
 ; DISABLE-NEXT:  LBB10_3: ## %if.end
 ; DISABLE-NEXT:    leaq -8(%rbp), %rsp
@@ -897,14 +897,13 @@ define void @infiniteloop2() {
 ; ENABLE-NEXT:    pushq %rbx
 ; ENABLE-NEXT:    pushq %rax
 ; ENABLE-NEXT:    .cfi_offset %rbx, -24
-; ENABLE-NEXT:    xorl %eax, %eax
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB11_5
 ; ENABLE-NEXT:  ## %bb.1: ## %if.then
-; ENABLE-NEXT:    movq %rsp, %rcx
-; ENABLE-NEXT:    addq $-16, %rcx
-; ENABLE-NEXT:    movq %rcx, %rsp
-; ENABLE-NEXT:    xorl %edx, %edx
+; ENABLE-NEXT:    movq %rsp, %rax
+; ENABLE-NEXT:    addq $-16, %rax
+; ENABLE-NEXT:    movq %rax, %rsp
+; ENABLE-NEXT:    xorl %ecx, %ecx
 ; ENABLE-NEXT:    jmp LBB11_2
 ; ENABLE-NEXT:    .p2align 4
 ; ENABLE-NEXT:  LBB11_4: ## %body2
@@ -912,15 +911,15 @@ define void @infiniteloop2() {
 ; ENABLE-NEXT:    ## InlineAsm Start
 ; ENABLE-NEXT:    nop
 ; ENABLE-NEXT:    ## InlineAsm End
-; ENABLE-NEXT:    movl $1, %edx
+; ENABLE-NEXT:    movl $1, %ecx
 ; ENABLE-NEXT:  LBB11_2: ## %for.body
 ; ENABLE-NEXT:    ## =>This Inner Loop Header: Depth=1
-; ENABLE-NEXT:    movl %edx, %esi
+; ENABLE-NEXT:    movl %ecx, %edx
 ; ENABLE-NEXT:    ## InlineAsm Start
-; ENABLE-NEXT:    movl $1, %edx
+; ENABLE-NEXT:    movl $1, %ecx
 ; ENABLE-NEXT:    ## InlineAsm End
-; ENABLE-NEXT:    addl %esi, %edx
-; ENABLE-NEXT:    movl %edx, (%rcx)
+; ENABLE-NEXT:    addl %edx, %ecx
+; ENABLE-NEXT:    movl %ecx, (%rax)
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB11_4
 ; ENABLE-NEXT:  ## %bb.3: ## %body1
@@ -945,14 +944,13 @@ define void @infiniteloop2() {
 ; DISABLE-NEXT:    pushq %rbx
 ; DISABLE-NEXT:    pushq %rax
 ; DISABLE-NEXT:    .cfi_offset %rbx, -24
-; DISABLE-NEXT:    xorl %eax, %eax
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB11_5
 ; DISABLE-NEXT:  ## %bb.1: ## %if.then
-; DISABLE-NEXT:    movq %rsp, %rcx
-; DISABLE-NEXT:    addq $-16, %rcx
-; DISABLE-NEXT:    movq %rcx, %rsp
-; DISABLE-NEXT:    xorl %edx, %edx
+; DISABLE-NEXT:    movq %rsp, %rax
+; DISABLE-NEXT:    addq $-16, %rax
+; DISABLE-NEXT:    movq %rax, %rsp
+; DISABLE-NEXT:    xorl %ecx, %ecx
 ; DISABLE-NEXT:    jmp LBB11_2
 ; DISABLE-NEXT:    .p2align 4
 ; DISABLE-NEXT:  LBB11_4: ## %body2
@@ -960,15 +958,15 @@ define void @infiniteloop2() {
 ; DISABLE-NEXT:    ## InlineAsm Start
 ; DISABLE-NEXT:    nop
 ; DISABLE-NEXT:    ## InlineAsm End
-; DISABLE-NEXT:    movl $1, %edx
+; DISABLE-NEXT:    movl $1, %ecx
 ; DISABLE-NEXT:  LBB11_2: ## %for.body
 ; DISABLE-NEXT:    ## =>This Inner Loop Header: Depth=1
-; DISABLE-NEXT:    movl %edx, %esi
+; DISABLE-NEXT:    movl %ecx, %edx
 ; DISABLE-NEXT:    ## InlineAsm Start
-; DISABLE-NEXT:    movl $1, %edx
+; DISABLE-NEXT:    movl $1, %ecx
 ; DISABLE-NEXT:    ## InlineAsm End
-; DISABLE-NEXT:    addl %esi, %edx
-; DISABLE-NEXT:    movl %edx, (%rcx)
+; DISABLE-NEXT:    addl %edx, %ecx
+; DISABLE-NEXT:    movl %ecx, (%rax)
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB11_4
 ; DISABLE-NEXT:  ## %bb.3: ## %body1
@@ -1012,11 +1010,9 @@ if.end:
 define void @infiniteloop3() {
 ; ENABLE-LABEL: infiniteloop3:
 ; ENABLE:       ## %bb.0: ## %entry
-; ENABLE-NEXT:    xorl %eax, %eax
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB12_2
 ; ENABLE-NEXT:  ## %bb.1: ## %body
-; ENABLE-NEXT:    xorl %eax, %eax
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB12_7
 ; ENABLE-NEXT:  LBB12_2: ## %loop2a.preheader
@@ -1044,11 +1040,9 @@ define void @infiniteloop3() {
 ;
 ; DISABLE-LABEL: infiniteloop3:
 ; DISABLE:       ## %bb.0: ## %entry
-; DISABLE-NEXT:    xorl %eax, %eax
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB12_2
 ; DISABLE-NEXT:  ## %bb.1: ## %body
-; DISABLE-NEXT:    xorl %eax, %eax
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB12_7
 ; DISABLE-NEXT:  LBB12_2: ## %loop2a.preheader


### PR DESCRIPTION
fixed test case fail caused by the patch [SelectionDAG] Folding ZERO-EXTEND/SIGN_EXTEND poison to Poison value in getNode #122741

