### PR TITLE
[BOLT][AArch64] Allow binary-analysis and heatmap tool to run with pac-ret binaries

### DIFF
--- a/bolt/docs/BinaryAnalysis.md
+++ b/bolt/docs/BinaryAnalysis.md
@@ -180,12 +180,6 @@ The following are current known cases of false negatives:
    [prototype branch](
    https://github.com/llvm/llvm-project/compare/main...kbeyls:llvm-project:bolt-gadget-scanner-prototype).
 
-BOLT cannot currently handle functions with `cfi_negate_ra_state` correctly,
-i.e. any binaries built with `-mbranch-protection=pac-ret`. The scanner is meant
-to be used on specifically such binaries, so this is a major limitation! Work is
-going on in PR [#120064](https://github.com/llvm/llvm-project/pull/120064) to
-fix this.
-
 ## How to add your own binary analysis
 
 _TODO: this section needs to be written. Ideally, we should have a simple


### PR DESCRIPTION
Quoting `bolt/docs/BinaryAnalysis.md`:
> BOLT cannot currently handle functions with cfi_negate_ra_state correctly, i.e. any binaries built with -mbranch-protection=pac-ret. The scanner is meant to be used on specifically such binaries, so this is a major limitation! Work is going on in PR https://github.com/llvm/llvm-project/pull/120064 to fix this.

For pac-ret analysis to work, we don't actually need the whole work in #120064 to be merged. 

## Some context
The BOLT codebase holds different tools: BOLT itself is used to optimize the layout of a binary, while other tools only need to generate the same internal representation to aid in that process.

The `.cfi_negate_ra_state` Call Frame Instruction needs to be read, tracked, and eventually emitted by tools that produce a binary: this CFI signals to the unwinder if it needs to strip the PAC bits from pointers or not.

This means we can ignore these CFIs in `llvm-bolt-binary-analysis` and the `heatmaptool`.

## Solution
In places where previously BOLT would run to an `llvm_unreachable("Unsupported CFI opcode")` for `OpNegateRAState`, we first check from options which tool is running, and only crash with unreachable when needed.
