### PR TITLE
[lldb] Fix crash after second run when set a previous watchpoint.

### DIFF
--- a/lldb/test/Shell/Watchpoint/ReuseWatchpointAfterReExecProcess.test
+++ b/lldb/test/Shell/Watchpoint/ReuseWatchpointAfterReExecProcess.test
@@ -1,0 +1,21 @@
+# RUN: %clangxx_host %p/Inputs/languages.cpp -g -o %t.out
+# RUN: %lldb -b -o 'settings set interpreter.stop-command-source-on-error false' -s %s %t.out 2>&1 | FileCheck %s
+
+b main
+run
+# CHECK: stopped
+# CHECK-NEXT: stop reason = breakpoint
+
+watchpoint set variable val
+# CHECK: Watchpoint created:
+
+kill
+run
+# CHECK: stopped
+# CHECK-NEXT: stop reason = breakpoint
+
+watchpoint set variable val
+# CHECK: Watchpoint created:
+
+continue
+# CHECK: Watchpoint 1 hit:


### PR DESCRIPTION
This PR fixes a crash in `LLDB` caused by a dangling pointer to a reused `ValueObjectSP` when re-running the debuggee and setting the same watchpoint again.

As described by @jasonmolenda, the fix is to reinitialize the dangling pointer in `Watchpoint::SetEnabled`.

This PR closes [#135590](https://github.com/llvm/llvm-project/issues/135590).