### PR TITLE
[VPlan] Fix MayReadFromMemory/MayWriteToMemory on VPWidenIntrinsicRecipe

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1322,8 +1322,8 @@ public:
     LLVMContext &Ctx = Ty->getContext();
     AttributeSet Attrs = Intrinsic::getFnAttributes(Ctx, VectorIntrinsicID);
     MemoryEffects ME = Attrs.getMemoryEffects();
-    MayReadFromMemory = ME.onlyWritesMemory();
-    MayWriteToMemory = ME.onlyReadsMemory();
+    MayReadFromMemory = !ME.onlyWritesMemory();
+    MayWriteToMemory = !ME.onlyReadsMemory();
     MayHaveSideEffects = MayWriteToMemory ||
                          !Attrs.hasAttribute(Attribute::NoUnwind) ||
                          !Attrs.hasAttribute(Attribute::WillReturn);


### PR DESCRIPTION
These seem to be the wrong way round, e.g. see the definition at Instruction::mayReadFromMemory().
If an instruction only writes to memory then it's known to not read memory, and so on.

Only noticed this when using VPWidenIntrinsicRecipe in a local patch and wondered why it kept on getting DCEd despite the intrinsic writing to memory.
