### PR TITLE
[lldb] Upgrade `GetIndexOfChildWithName` to use `llvm::Expected`

### DIFF
--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -13,6 +13,8 @@
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBType.h"
 
+#include "lldb/Core/Value.h"
+
 class ValueImpl;
 class ValueLocker;
 

--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -13,8 +13,6 @@
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBType.h"
 
-#include "lldb/Core/Value.h"
-
 class ValueImpl;
 class ValueLocker;
 

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -51,7 +51,7 @@ public:
 
   virtual lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) = 0;
 
-  virtual size_t GetIndexOfChildWithName(ConstString name) = 0;
+  virtual llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) = 0;
 
   /// This function is assumed to always succeed and if it fails, the front-end
   /// should know to deal with it in the correct way (most probably, by refusing
@@ -117,8 +117,9 @@ public:
 
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override { return nullptr; }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
-    return UINT32_MAX;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   }
 
   lldb::ChildCacheState Update() override {
@@ -343,7 +344,7 @@ public:
 
     bool MightHaveChildren() override { return filter->GetCount() > 0; }
 
-    size_t GetIndexOfChildWithName(ConstString name) override;
+    llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
     typedef std::shared_ptr<SyntheticChildrenFrontEnd> SharedPointer;
 
@@ -442,7 +443,7 @@ public:
 
     bool MightHaveChildren() override;
 
-    size_t GetIndexOfChildWithName(ConstString name) override;
+    llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
     lldb::ValueObjectSP GetSyntheticValue() override;
 

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -118,8 +118,10 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override { return nullptr; }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::SyntheticValueProviderFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   }
 
   lldb::ChildCacheState Update() override {

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -118,7 +118,8 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override { return nullptr; }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
 
   lldb::ChildCacheState Update() override {

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -118,10 +118,7 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override { return nullptr; }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::SyntheticValueProviderFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
 
   lldb::ChildCacheState Update() override {

--- a/lldb/include/lldb/DataFormatters/VectorIterator.h
+++ b/lldb/include/lldb/DataFormatters/VectorIterator.h
@@ -30,7 +30,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ExecutionContextRef m_exe_ctx_ref;

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -368,10 +368,11 @@ public:
     return lldb::ValueObjectSP();
   }
 
-  virtual int
+  virtual llvm::Expected<int>
   GetIndexOfChildWithName(const StructuredData::ObjectSP &implementor,
                           const char *child_name) {
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   child_name);
   }
 
   virtual bool

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -371,8 +371,9 @@ public:
   virtual llvm::Expected<int>
   GetIndexOfChildWithName(const StructuredData::ObjectSP &implementor,
                           const char *child_name) {
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   child_name);
+    return llvm::createStringError(
+        "'PluginInterface::ScriptInterpreter' cannot find index of child '%s'",
+        child_name);
   }
 
   virtual bool

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -371,9 +371,7 @@ public:
   virtual llvm::Expected<int>
   GetIndexOfChildWithName(const StructuredData::ObjectSP &implementor,
                           const char *child_name) {
-    return llvm::createStringError(
-        "'PluginInterface::ScriptInterpreter' cannot find index of child '%s'",
-        child_name);
+    return llvm::createStringError("Type has no child named '%s'", child_name);
   }
 
   virtual bool

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -444,8 +444,9 @@ public:
 
   /// Lookup a child given a name. This function will match base class names and
   /// member member names in "clang_type" only, not descendants.
-  uint32_t GetIndexOfChildWithName(llvm::StringRef name,
-                                   bool omit_empty_base_classes) const;
+  llvm::Expected<uint32_t>
+  GetIndexOfChildWithName(llvm::StringRef name,
+                          bool omit_empty_base_classes) const;
 
   /// Lookup a child member given a name. This function will match member names
   /// only and will descend into "clang_type" children in search for the first

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -373,9 +373,12 @@ public:
       bool &child_is_base_class, bool &child_is_deref_of_parent,
       ValueObject *valobj, uint64_t &language_flags) = 0;
 
-  virtual uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                           llvm::StringRef name,
-                                           bool omit_empty_base_classes) = 0;
+  // Lookup a child given a name. This function will match base class names and
+  // member member names in "clang_type" only, not descendants.
+  virtual llvm::Expected<uint32_t>
+  GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
+                          llvm::StringRef name,
+                          bool omit_empty_base_classes) = 0;
 
   virtual size_t GetIndexOfChildMemberWithName(
       lldb::opaque_compiler_type_t type, llvm::StringRef name,

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -498,7 +498,7 @@ public:
   virtual lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
                                                      bool can_create = true);
 
-  virtual size_t GetIndexOfChildWithName(llvm::StringRef name);
+  virtual llvm::Expected<size_t> GetIndexOfChildWithName(llvm::StringRef name);
 
   llvm::Expected<uint32_t> GetNumChildren(uint32_t max = UINT32_MAX);
   /// Like \c GetNumChildren but returns 0 on error.  You probably

--- a/lldb/include/lldb/ValueObject/ValueObjectRegister.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectRegister.h
@@ -52,7 +52,7 @@ public:
   lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
                                              bool can_create = true) override;
 
-  size_t GetIndexOfChildWithName(llvm::StringRef name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(llvm::StringRef name) override;
 
 protected:
   bool UpdateValue() override;

--- a/lldb/include/lldb/ValueObject/ValueObjectSyntheticFilter.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectSyntheticFilter.h
@@ -57,7 +57,7 @@ public:
   lldb::ValueObjectSP GetChildMemberWithName(llvm::StringRef name,
                                              bool can_create = true) override;
 
-  size_t GetIndexOfChildWithName(llvm::StringRef name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(llvm::StringRef name) override;
 
   lldb::ValueObjectSP
   GetDynamicValue(lldb::DynamicValueType valueType) override;

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -707,12 +707,10 @@ uint32_t SBValue::GetIndexOfChildWithName(const char *name) {
   ValueLocker locker;
   lldb::ValueObjectSP value_sp(GetSP(locker));
   if (value_sp) {
-    auto idx_or_err = value_sp->GetIndexOfChildWithName(name);
-    if (!idx_or_err) {
+    if (auto idx_or_err = value_sp->GetIndexOfChildWithName(name))
+      return *idx_or_err;
+    else
       llvm::consumeError(idx_or_err.takeError());
-      return UINT32_MAX;
-    }
-    return *idx_or_err;
   }
   return UINT32_MAX;
 }

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -704,13 +704,17 @@ SBValue SBValue::GetChildAtIndex(uint32_t idx,
 uint32_t SBValue::GetIndexOfChildWithName(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
 
-  uint32_t idx = UINT32_MAX;
   ValueLocker locker;
   lldb::ValueObjectSP value_sp(GetSP(locker));
   if (value_sp) {
-    idx = value_sp->GetIndexOfChildWithName(name);
+    auto idx_or_err = value_sp->GetIndexOfChildWithName(name);
+    if (!idx_or_err) {
+      llvm::consumeError(idx_or_err.takeError());
+      return UINT32_MAX;
+    }
+    return *idx_or_err;
   }
-  return idx;
+  return UINT32_MAX;
 }
 
 SBValue SBValue::GetChildMemberWithName(const char *name) {

--- a/lldb/source/DataFormatters/FormatterBytecode.cpp
+++ b/lldb/source/DataFormatters/FormatterBytecode.cpp
@@ -9,12 +9,12 @@
 #include "FormatterBytecode.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/ValueObject/ValueObject.h"
+#include "lldb/ValueObject/ValueObjectConstResult.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/FormatProviders.h"
 #include "llvm/Support/FormatVariadicDetails.h"
-#include <lldb/ValueObject/ValueObjectConstResult.h>
 
 using namespace lldb;
 namespace lldb_private {
@@ -490,10 +490,10 @@ llvm::Error Interpret(std::vector<ControlStackElement> &control,
         TYPE_CHECK(Object, String);
         auto name = data.Pop<std::string>();
         POP_VALOBJ(valobj);
-        auto index_or_err = valobj->GetIndexOfChildWithName(name);
-        if (!index_or_err)
+        if (auto index_or_err = valobj->GetIndexOfChildWithName(name))
+          data.Push((uint64_t)*index_or_err);
+        else
           return index_or_err.takeError();
-        data.Push((uint64_t)*index_or_err);
         break;
       }
       case sel_get_type: {

--- a/lldb/source/DataFormatters/FormatterBytecode.cpp
+++ b/lldb/source/DataFormatters/FormatterBytecode.cpp
@@ -491,11 +491,8 @@ llvm::Error Interpret(std::vector<ControlStackElement> &control,
         auto name = data.Pop<std::string>();
         POP_VALOBJ(valobj);
         auto index_or_err = valobj->GetIndexOfChildWithName(name);
-        if (!index_or_err) {
-          data.Push(ValueObjectConstResult::Create(
-              nullptr, Status::FromError(index_or_err.takeError())));
-          break;
-        }
+        if (!index_or_err)
+          return index_or_err.takeError();
         data.Push((uint64_t)*index_or_err);
         break;
       }

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -67,7 +67,9 @@ TypeFilterImpl::FrontEnd::GetIndexOfChildWithName(ConstString name) {
       }
     }
   }
-  return UINT32_MAX;
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::FrontEnd' cannot find index of child '%s'",
+      name.AsCString());
 }
 
 std::string TypeFilterImpl::GetDescription() {

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -221,8 +221,9 @@ bool ScriptedSyntheticChildren::FrontEnd::MightHaveChildren() {
 llvm::Expected<size_t>
 ScriptedSyntheticChildren::FrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_wrapper_sp || m_interpreter == nullptr)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'ScriptedSyntheticChildren::FrontEnd' cannot find index of child '%s'",
+        name.AsCString());
   return m_interpreter->GetIndexOfChildWithName(m_wrapper_sp,
                                                 name.GetCString());
 }

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -49,7 +49,7 @@ bool TypeFilterImpl::SetExpressionPathAtIndex(size_t i,
   return true;
 }
 
-size_t
+llvm::Expected<size_t>
 TypeFilterImpl::FrontEnd::GetIndexOfChildWithName(ConstString name) {
   const char *name_cstr = name.GetCString();
   if (name_cstr) {
@@ -218,10 +218,11 @@ bool ScriptedSyntheticChildren::FrontEnd::MightHaveChildren() {
   return m_interpreter->MightHaveChildrenSynthProviderInstance(m_wrapper_sp);
 }
 
-size_t ScriptedSyntheticChildren::FrontEnd::GetIndexOfChildWithName(
-    ConstString name) {
+llvm::Expected<size_t>
+ScriptedSyntheticChildren::FrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_wrapper_sp || m_interpreter == nullptr)
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return m_interpreter->GetIndexOfChildWithName(m_wrapper_sp,
                                                 name.GetCString());
 }

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -67,9 +67,7 @@ TypeFilterImpl::FrontEnd::GetIndexOfChildWithName(ConstString name) {
       }
     }
   }
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::FrontEnd' cannot find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 std::string TypeFilterImpl::GetDescription() {
@@ -223,9 +221,7 @@ bool ScriptedSyntheticChildren::FrontEnd::MightHaveChildren() {
 llvm::Expected<size_t>
 ScriptedSyntheticChildren::FrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_wrapper_sp || m_interpreter == nullptr)
-    return llvm::createStringError(
-        "'ScriptedSyntheticChildren::FrontEnd' cannot find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return m_interpreter->GetIndexOfChildWithName(m_wrapper_sp,
                                                 name.GetCString());
 }

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -67,7 +67,8 @@ TypeFilterImpl::FrontEnd::GetIndexOfChildWithName(ConstString name) {
       }
     }
   }
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 std::string TypeFilterImpl::GetDescription() {
@@ -221,7 +222,8 @@ bool ScriptedSyntheticChildren::FrontEnd::MightHaveChildren() {
 llvm::Expected<size_t>
 ScriptedSyntheticChildren::FrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_wrapper_sp || m_interpreter == nullptr)
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return m_interpreter->GetIndexOfChildWithName(m_wrapper_sp,
                                                 name.GetCString());
 }

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -273,8 +273,10 @@ public:
     const char *item_name = name.GetCString();
     uint32_t idx = ExtractIndexFromString(item_name);
     if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-      return llvm::createStringError("Cannot find index of child '%s'",
-                                     name.AsCString());
+      return llvm::createStringError(
+          "'SyntheticChildrenFrontEnd::VectorTypeSyntheticFrontEnd' cannot "
+          "find index of child '%s'",
+          name.AsCString());
     return idx;
   }
 

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -269,11 +269,12 @@ public:
     return lldb::ChildCacheState::eRefetch;
   }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     const char *item_name = name.GetCString();
     uint32_t idx = ExtractIndexFromString(item_name);
     if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-      return UINT32_MAX;
+      return llvm::createStringError("Cannot find index of child '%s'",
+                                     name.AsCString());
     return idx;
   }
 

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -272,7 +272,8 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     const char *item_name = name.GetCString();
     uint32_t idx = ExtractIndexFromString(item_name);
-    if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+    if (idx == UINT32_MAX ||
+        (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
       return llvm::createStringError(
           "'SyntheticChildrenFrontEnd::VectorTypeSyntheticFrontEnd' cannot "
           "find index of child '%s'",

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -276,8 +276,8 @@ public:
         (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
       return llvm::createStringError(
           "'SyntheticChildrenFrontEnd::VectorTypeSyntheticFrontEnd' cannot "
-          "find index of child '%s'",
-          name.AsCString());
+          "find index of child '%s'. (idx='" PRIu32 "')",
+          name.AsCString(), idx);
     return idx;
   }
 

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -274,10 +274,7 @@ public:
     uint32_t idx = ExtractIndexFromString(item_name);
     if (idx == UINT32_MAX ||
         (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-      return llvm::createStringError(
-          "'SyntheticChildrenFrontEnd::VectorTypeSyntheticFrontEnd' cannot "
-          "find index of child '%s'. (idx='" PRIu32 "')",
-          name.AsCString(), idx);
+      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
     return idx;
   }
 

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -274,7 +274,8 @@ public:
     uint32_t idx = ExtractIndexFromString(item_name);
     if (idx == UINT32_MAX ||
         (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -144,9 +144,10 @@ public:
     return lldb::ChildCacheState::eRefetch;
   }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (!m_block_struct_type.IsValid())
-      return UINT32_MAX;
+      return llvm::createStringError("Cannot find index of child '%s'",
+                                     name.AsCString());
 
     const bool omit_empty_base_classes = false;
     return m_block_struct_type.GetIndexOfChildWithName(name.AsCString(),
@@ -172,8 +173,15 @@ bool lldb_private::formatters::BlockPointerSummaryProvider(
 
   static const ConstString s_FuncPtr_name("__FuncPtr");
 
-  lldb::ValueObjectSP child_sp = synthetic_children->GetChildAtIndex(
-      synthetic_children->GetIndexOfChildWithName(s_FuncPtr_name));
+  auto index_or_err =
+      synthetic_children->GetIndexOfChildWithName(s_FuncPtr_name);
+
+  if (!index_or_err) {
+    return false;
+  }
+
+  lldb::ValueObjectSP child_sp =
+      synthetic_children->GetChildAtIndex(*index_or_err);
 
   if (!child_sp) {
     return false;

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -146,8 +146,10 @@ public:
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (!m_block_struct_type.IsValid())
-      return llvm::createStringError("Cannot find index of child '%s'",
-                                     name.AsCString());
+      return llvm::createStringError(
+          "'SyntheticChildrenFrontend::BlockPointerSyntheticFrontEnd' cannot "
+          "find index of child '%s'",
+          name.AsCString());
 
     const bool omit_empty_base_classes = false;
     return m_block_struct_type.GetIndexOfChildWithName(name.AsCString(),
@@ -177,6 +179,7 @@ bool lldb_private::formatters::BlockPointerSummaryProvider(
       synthetic_children->GetIndexOfChildWithName(s_FuncPtr_name);
 
   if (!index_or_err) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), index_or_err.takeError(), "{0}");
     return false;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -146,7 +146,8 @@ public:
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (!m_block_struct_type.IsValid())
-      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
 
     const bool omit_empty_base_classes = false;
     return m_block_struct_type.GetIndexOfChildWithName(name.AsCString(),

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -178,7 +178,8 @@ bool lldb_private::formatters::BlockPointerSummaryProvider(
       synthetic_children->GetIndexOfChildWithName(s_FuncPtr_name);
 
   if (!index_or_err) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters), index_or_err.takeError(), "{0}");
+    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters), index_or_err.takeError(),
+                   "{0}");
     return false;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -146,9 +146,7 @@ public:
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (!m_block_struct_type.IsValid())
-      return llvm::createStringError("'BlockPointerSyntheticFrontEnd' cannot "
-                                     "find index of child '%s'",
-                                     name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 
     const bool omit_empty_base_classes = false;
     return m_block_struct_type.GetIndexOfChildWithName(name.AsCString(),

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -146,10 +146,9 @@ public:
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (!m_block_struct_type.IsValid())
-      return llvm::createStringError(
-          "'SyntheticChildrenFrontend::BlockPointerSyntheticFrontEnd' cannot "
-          "find index of child '%s'",
-          name.AsCString());
+      return llvm::createStringError("'BlockPointerSyntheticFrontEnd' cannot "
+                                     "find index of child '%s'",
+                                     name.AsCString());
 
     const bool omit_empty_base_classes = false;
     return m_block_struct_type.GetIndexOfChildWithName(name.AsCString(),
@@ -179,7 +178,7 @@ bool lldb_private::formatters::BlockPointerSummaryProvider(
       synthetic_children->GetIndexOfChildWithName(s_FuncPtr_name);
 
   if (!index_or_err) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), index_or_err.takeError(), "{0}");
+    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters), index_or_err.takeError(), "{0}");
     return false;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
@@ -203,8 +203,12 @@ llvm::Expected<size_t>
 StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   if (!m_resume_ptr_sp || !m_destroy_ptr_sp)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::StdlibCoroutineHandleSyntheticFrontEnd' "
+        "cannot find index of child '%s'. (m_resume_ptr_sp='%p', "
+        "m_destroy_ptr_sp='%p')",
+        name.AsCString(), static_cast<void *>(m_resume_ptr_sp.get()),
+        static_cast<void *>(m_destroy_ptr_sp.get()));
 
   if (name == ConstString("resume"))
     return 0;
@@ -213,8 +217,10 @@ StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
   if (name == ConstString("promise_ptr") && m_promise_ptr_sp)
     return 2;
 
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontend::StdlibCoroutineHandleSyntheticFrontEnd' "
+      "cannot find index of child '%s'",
+      name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
@@ -199,10 +199,12 @@ lldb_private::formatters::StdlibCoroutineHandleSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
+llvm::Expected<size_t>
+StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   if (!m_resume_ptr_sp || !m_destroy_ptr_sp)
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
 
   if (name == ConstString("resume"))
     return 0;
@@ -211,7 +213,8 @@ size_t StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
   if (name == ConstString("promise_ptr") && m_promise_ptr_sp)
     return 2;
 
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
@@ -207,8 +207,7 @@ StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
         "'SyntheticChildrenFrontend::StdlibCoroutineHandleSyntheticFrontEnd' "
         "cannot find index of child '%s'. (m_resume_ptr_sp='%p', "
         "m_destroy_ptr_sp='%p')",
-        name.AsCString(), static_cast<void *>(m_resume_ptr_sp.get()),
-        static_cast<void *>(m_destroy_ptr_sp.get()));
+        name.AsCString(), m_resume_ptr_sp.get(), m_destroy_ptr_sp.get());
 
   if (name == ConstString("resume"))
     return 0;

--- a/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
@@ -203,11 +203,7 @@ llvm::Expected<size_t>
 StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   if (!m_resume_ptr_sp || !m_destroy_ptr_sp)
-    return llvm::createStringError(
-        "'StdlibCoroutineHandleSyntheticFrontEnd' "
-        "cannot find index of child '%s'. (m_resume_ptr_sp='%p', "
-        "m_destroy_ptr_sp='%p')",
-        name.AsCString(), m_resume_ptr_sp.get(), m_destroy_ptr_sp.get());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 
   if (name == ConstString("resume"))
     return 0;
@@ -216,9 +212,7 @@ StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
   if (name == ConstString("promise_ptr") && m_promise_ptr_sp)
     return 2;
 
-  return llvm::createStringError("'StdlibCoroutineHandleSyntheticFrontEnd' "
-                                 "cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
@@ -204,7 +204,7 @@ StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   if (!m_resume_ptr_sp || !m_destroy_ptr_sp)
     return llvm::createStringError(
-        "'SyntheticChildrenFrontend::StdlibCoroutineHandleSyntheticFrontEnd' "
+        "'StdlibCoroutineHandleSyntheticFrontEnd' "
         "cannot find index of child '%s'. (m_resume_ptr_sp='%p', "
         "m_destroy_ptr_sp='%p')",
         name.AsCString(), m_resume_ptr_sp.get(), m_destroy_ptr_sp.get());
@@ -216,10 +216,9 @@ StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
   if (name == ConstString("promise_ptr") && m_promise_ptr_sp)
     return 2;
 
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontend::StdlibCoroutineHandleSyntheticFrontEnd' "
-      "cannot find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("'StdlibCoroutineHandleSyntheticFrontEnd' "
+                                 "cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Coroutines.cpp
@@ -203,7 +203,8 @@ llvm::Expected<size_t>
 StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   if (!m_resume_ptr_sp || !m_destroy_ptr_sp)
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
 
   if (name == ConstString("resume"))
     return 0;
@@ -212,7 +213,8 @@ StdlibCoroutineHandleSyntheticFrontEnd::GetIndexOfChildWithName(
   if (name == ConstString("promise_ptr") && m_promise_ptr_sp)
     return 2;
 
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/Coroutines.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/Coroutines.h
@@ -40,7 +40,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   lldb::ValueObjectSP m_resume_ptr_sp;

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -28,7 +28,7 @@ public:
 
   GenericBitsetFrontEnd(ValueObject &valobj, StdLib stdlib);
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     return formatters::ExtractIndexFromString(name.GetCString());
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -29,7 +29,14 @@ public:
   GenericBitsetFrontEnd(ValueObject &valobj, StdLib stdlib);
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return formatters::ExtractIndexFromString(name.GetCString());
+    size_t idx = formatters::ExtractIndexFromString(name.GetCString());
+    if (idx == UINT32_MAX) {
+      return llvm::createStringError(
+          "'SyntheticChildrenFrontend::GenericBitsetFrontEnd' cannot find "
+          "index of child '%s'",
+          name.AsCString());
+    }
+    return idx;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -31,7 +31,8 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
     if (idx == UINT32_MAX)
-      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -31,10 +31,9 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
     if (idx == UINT32_MAX) {
-      return llvm::createStringError(
-          "'SyntheticChildrenFrontend::GenericBitsetFrontEnd' cannot find "
-          "index of child '%s'",
-          name.AsCString());
+      return llvm::createStringError("'GenericBitsetFrontEnd' cannot find "
+                                     "index of child '%s'",
+                                     name.AsCString());
     }
     return idx;
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -30,11 +30,8 @@ public:
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (idx == UINT32_MAX) {
-      return llvm::createStringError("'GenericBitsetFrontEnd' cannot find "
-                                     "index of child '%s'",
-                                     name.AsCString());
-    }
+    if (idx == UINT32_MAX)
+      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -39,7 +39,14 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (name == "$$dereference$$")
       return 0;
-    return formatters::ExtractIndexFromString(name.GetCString());
+    size_t idx = formatters::ExtractIndexFromString(name.GetCString());
+    if (idx == UINT32_MAX) {
+      return llvm::createStringError(
+          "'SyntheticChildrenFrontend::GenericOptionalFrontend' cannot find "
+          "index of child '%s'",
+          name.AsCString());
+    }
+    return idx;
   }
 
   llvm::Expected<uint32_t> CalculateNumChildren() override {

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -36,7 +36,7 @@ public:
 
   GenericOptionalFrontend(ValueObject &valobj, StdLib stdlib);
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (name == "$$dereference$$")
       return 0;
     return formatters::ExtractIndexFromString(name.GetCString());

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -41,7 +41,8 @@ public:
       return 0;
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
     if (idx == UINT32_MAX)
-      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -41,10 +41,9 @@ public:
       return 0;
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
     if (idx == UINT32_MAX) {
-      return llvm::createStringError(
-          "'SyntheticChildrenFrontend::GenericOptionalFrontend' cannot find "
-          "index of child '%s'",
-          name.AsCString());
+      return llvm::createStringError("'GenericOptionalFrontend' cannot find "
+                                     "index of child '%s'",
+                                     name.AsCString());
     }
     return idx;
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -40,11 +40,8 @@ public:
     if (name == "$$dereference$$")
       return 0;
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (idx == UINT32_MAX) {
-      return llvm::createStringError("'GenericOptionalFrontend' cannot find "
-                                     "index of child '%s'",
-                                     name.AsCString());
-    }
+    if (idx == UINT32_MAX)
+      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -466,7 +466,8 @@ ExtractLibcxxStringInfo(ValueObject &valobj) {
 
   auto index_or_err = l->GetIndexOfChildWithName("__data_");
   if (!index_or_err) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), index_or_err.takeError(), "{0}");
+    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters), index_or_err.takeError(),
+                   "{0}");
     return {};
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -465,9 +465,10 @@ ExtractLibcxxStringInfo(ValueObject &valobj) {
     return {};
 
   auto index_or_err = l->GetIndexOfChildWithName("__data_");
-  if (!index_or_err)
+  if (!index_or_err) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Types), index_or_err.takeError(), "{0}");
-  return {};
+    return {};
+  }
 
   StringLayout layout =
       *index_or_err == 0 ? StringLayout::DSC : StringLayout::CSD;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -309,13 +309,15 @@ lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (name == "__ptr_")
     return 0;
   if (name == "$$dereference$$")
     return 1;
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
@@ -407,7 +409,8 @@ lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (name == "pointer")
     return 0;
@@ -415,7 +418,8 @@ size_t lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::
     return 1;
   if (name == "$$dereference$$")
     return 2;
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 bool lldb_private::formatters::LibcxxContainerSummaryProvider(
@@ -456,7 +460,7 @@ ExtractLibcxxStringInfo(ValueObject &valobj) {
   if (!l)
     return {};
 
-  StringLayout layout = l->GetIndexOfChildWithName("__data_") == 0
+  StringLayout layout = l->GetIndexOfChildWithName("__data_").get() == 0
                             ? StringLayout::DSC
                             : StringLayout::CSD;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -316,8 +316,10 @@ lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
     return 0;
   if (name == "$$dereference$$")
     return 1;
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontend::LibcxxSharedPtrSyntheticFrontEnd' cannot "
+      "find index of child '%s'",
+      name.AsCString());
 }
 
 lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
@@ -418,8 +420,10 @@ lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::
     return 1;
   if (name == "$$dereference$$")
     return 2;
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'ScriptedSyntheticChildren::LibcxxUniquePtrSyntheticFrontEnd' cannot "
+      "find index of child '%s'",
+      name.AsCString());
 }
 
 bool lldb_private::formatters::LibcxxContainerSummaryProvider(
@@ -460,9 +464,13 @@ ExtractLibcxxStringInfo(ValueObject &valobj) {
   if (!l)
     return {};
 
-  StringLayout layout = l->GetIndexOfChildWithName("__data_").get() == 0
-                            ? StringLayout::DSC
-                            : StringLayout::CSD;
+  auto index_or_err = l->GetIndexOfChildWithName("__data_");
+  if (!index_or_err)
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), index_or_err.takeError(), "{0}");
+  return {};
+
+  StringLayout layout =
+      *index_or_err == 0 ? StringLayout::DSC : StringLayout::CSD;
 
   bool short_mode = false; // this means the string is in short-mode and the
                            // data is stored inline

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -316,7 +316,8 @@ lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
     return 0;
   if (name == "$$dereference$$")
     return 1;
-  return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
@@ -417,7 +418,8 @@ lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::
     return 1;
   if (name == "$$dereference$$")
     return 2;
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 bool lldb_private::formatters::LibcxxContainerSummaryProvider(

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -316,10 +316,9 @@ lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
     return 0;
   if (name == "$$dereference$$")
     return 1;
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontend::LibcxxSharedPtrSyntheticFrontEnd' cannot "
-      "find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("'LibcxxSharedPtrSyntheticFrontEnd' cannot "
+                                 "find index of child '%s'",
+                                 name.AsCString());
 }
 
 lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -316,9 +316,7 @@ lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
     return 0;
   if (name == "$$dereference$$")
     return 1;
-  return llvm::createStringError("'LibcxxSharedPtrSyntheticFrontEnd' cannot "
-                                 "find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",name.AsCString());
 }
 
 lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
@@ -419,10 +417,7 @@ lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::
     return 1;
   if (name == "$$dereference$$")
     return 2;
-  return llvm::createStringError(
-      "'ScriptedSyntheticChildren::LibcxxUniquePtrSyntheticFrontEnd' cannot "
-      "find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 bool lldb_private::formatters::LibcxxContainerSummaryProvider(

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
@@ -102,7 +102,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
   ~LibcxxSharedPtrSyntheticFrontEnd() override;
 
@@ -120,7 +120,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
   ~LibcxxUniquePtrSyntheticFrontEnd() override;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
@@ -133,11 +133,12 @@ lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::GetChildAtIndex(
 llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  if (name == "Value") {
+  if (name == "Value")
     return 0;
-  }
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontend::LibcxxStdAtomicSyntheticFrontEnd' cannot "
+      "find index of child '%s'",
+      name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
@@ -96,7 +96,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ValueObject *m_real_child = nullptr;
@@ -130,9 +130,14 @@ lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::GetChildAtIndex(
   return nullptr;
 }
 
-size_t lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  return name == "Value" ? 0 : UINT32_MAX;
+  if (name == "Value") {
+    return 0;
+  }
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
@@ -135,10 +135,9 @@ lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (name == "Value")
     return 0;
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontend::LibcxxStdAtomicSyntheticFrontEnd' cannot "
-      "find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("'LibcxxStdAtomicSyntheticFrontEnd' cannot "
+                                 "find index of child '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
@@ -135,9 +135,7 @@ lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (name == "Value")
     return 0;
-  return llvm::createStringError("'LibcxxStdAtomicSyntheticFrontEnd' cannot "
-                                 "find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
@@ -135,7 +135,8 @@ lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (name == "Value")
     return 0;
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -103,9 +103,20 @@ lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::Update() {
 llvm::Expected<size_t>
 lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  if (!m_start)
-    return UINT32_MAX;
-  return ExtractIndexFromString(name.GetCString());
+  if (!m_start) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxInitializerListSyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
+  }
+  size_t idx = ExtractIndexFromString(name.GetCString());
+  if (idx == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxInitializerListSyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
+  }
+  return idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -106,7 +106,7 @@ lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
   if (!m_start) {
     return llvm::createStringError(
         "'SyntheticChildrenFrontend::LibcxxInitializerListSyntheticFrontEnd' "
-        "cannot find index of child '%s'",
+        "cannot find index of child '%s': Invalid start pointer.",
         name.AsCString());
   }
   size_t idx = ExtractIndexFromString(name.GetCString());

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -32,7 +32,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ValueObject *m_start = nullptr;
@@ -100,7 +100,8 @@ lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
     return UINT32_MAX;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -104,16 +104,11 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start) {
-    return llvm::createStringError(
-        "'LibcxxInitializerListSyntheticFrontEnd' "
-        "cannot find index of child '%s': Invalid start pointer.",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("'LibcxxInitializerListSyntheticFrontEnd' "
-                                   "cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -104,11 +104,13 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start) {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -105,16 +105,15 @@ lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start) {
     return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxInitializerListSyntheticFrontEnd' "
+        "'LibcxxInitializerListSyntheticFrontEnd' "
         "cannot find index of child '%s': Invalid start pointer.",
         name.AsCString());
   }
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxInitializerListSyntheticFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("'LibcxxInitializerListSyntheticFrontEnd' "
+                                   "cannot find index of child '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -107,7 +107,14 @@ private:
 class AbstractListFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return ExtractIndexFromString(name.GetCString());
+    size_t idx = ExtractIndexFromString(name.GetCString());
+    if (idx == UINT32_MAX) {
+      return llvm::createStringError(
+          "'SyntheticChildrenFrontend::AbstractListFrontEnd' cannot find index "
+          "of child '%s'",
+          name.AsCString());
+    }
+    return idx;
   }
   lldb::ChildCacheState Update() override;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -106,7 +106,7 @@ private:
 
 class AbstractListFrontEnd : public SyntheticChildrenFrontEnd {
 public:
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     return ExtractIndexFromString(name.GetCString());
   }
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -108,11 +108,8 @@ class AbstractListFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = ExtractIndexFromString(name.GetCString());
-    if (idx == UINT32_MAX) {
-      return llvm::createStringError("'AbstractListFrontEnd' cannot find index "
-                                     "of child '%s'",
-                                     name.AsCString());
-    }
+    if (idx == UINT32_MAX)
+      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
     return idx;
   }
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -109,7 +109,8 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = ExtractIndexFromString(name.GetCString());
     if (idx == UINT32_MAX)
-      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
     return idx;
   }
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -109,10 +109,9 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = ExtractIndexFromString(name.GetCString());
     if (idx == UINT32_MAX) {
-      return llvm::createStringError(
-          "'SyntheticChildrenFrontend::AbstractListFrontEnd' cannot find index "
-          "of child '%s'",
-          name.AsCString());
+      return llvm::createStringError("'AbstractListFrontEnd' cannot find index "
+                                     "of child '%s'",
+                                     name.AsCString());
     }
     return idx;
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -492,8 +492,11 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_pair_sp)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibCxxMapIteratorSyntheticFrontEnd' "
+        "cannot find index of child '%s'. Underlying pair is invalid: "
+        "m_pair_sp=%p",
+        name.AsCString(), static_cast<void *>(m_pair_sp.get()));
 
   return m_pair_sp->GetIndexOfChildWithName(name);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -501,9 +501,8 @@ lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::
   if (!m_pair_sp)
     return llvm::createStringError(
         "'SyntheticChildrenFrontend::LibCxxMapIteratorSyntheticFrontEnd' "
-        "cannot find index of child '%s'. Underlying pair is invalid: "
-        "m_pair_sp=%p",
-        name.AsCString(), static_cast<void *>(m_pair_sp.get()));
+        "cannot find index of child '%s': Invalid underlying pair.",
+        name.AsCString());
 
   return m_pair_sp->GetIndexOfChildWithName(name);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -395,7 +395,14 @@ lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::Update() {
 
 llvm::Expected<size_t> lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  return ExtractIndexFromString(name.GetCString());
+  size_t idx = ExtractIndexFromString(name.GetCString());
+  if (idx == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxStdMapSyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
+  }
+  return idx;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -197,7 +197,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   llvm::Expected<uint32_t> CalculateNumChildrenForOldCompressedPairLayout();
@@ -235,7 +235,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
   ~LibCxxMapIteratorSyntheticFrontEnd() override = default;
 
@@ -393,7 +393,7 @@ lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
+llvm::Expected<size_t> lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   return ExtractIndexFromString(name.GetCString());
 }
@@ -488,10 +488,12 @@ lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::GetChildAtIndex(
   return m_pair_sp->GetChildAtIndex(idx);
 }
 
-size_t lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_pair_sp)
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
 
   return m_pair_sp->GetIndexOfChildWithName(name);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -397,10 +397,9 @@ llvm::Expected<size_t> lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxStdMapSyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("'LibcxxStdMapSyntheticFrontEnd' cannot "
+                                   "find index of child '%s'",
+                                   name.AsCString());
   }
   return idx;
 }
@@ -500,7 +499,7 @@ lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_pair_sp)
     return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibCxxMapIteratorSyntheticFrontEnd' "
+        "'LibCxxMapIteratorSyntheticFrontEnd' "
         "cannot find index of child '%s': Invalid underlying pair.",
         name.AsCString());
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -397,7 +397,8 @@ llvm::Expected<size_t> lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   return idx;
 }
@@ -496,7 +497,8 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_pair_sp)
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
 
   return m_pair_sp->GetIndexOfChildWithName(name);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -397,9 +397,7 @@ llvm::Expected<size_t> lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("'LibcxxStdMapSyntheticFrontEnd' cannot "
-                                   "find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
   return idx;
 }
@@ -498,10 +496,7 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_pair_sp)
-    return llvm::createStringError(
-        "'LibCxxMapIteratorSyntheticFrontEnd' "
-        "cannot find index of child '%s': Invalid underlying pair.",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 
   return m_pair_sp->GetIndexOfChildWithName(name);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -177,7 +177,10 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_base)
-    return std::numeric_limits<size_t>::max();
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxStdProxyArraySyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
   return ExtractIndexFromString(name.GetCString());
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -181,7 +181,14 @@ lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
         "'SyntheticChildrenFrontend::LibcxxStdProxyArraySyntheticFrontEnd' "
         "cannot find index of child '%s'",
         name.AsCString());
-  return ExtractIndexFromString(name.GetCString());
+  size_t idx = ExtractIndexFromString(name.GetCString());
+  if (idx == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxStdProxyArraySyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
+  }
+  return idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -41,7 +41,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   /// A non-owning pointer to the array's __vp_.
@@ -173,7 +173,8 @@ lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::Update() {
   return ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_base)
     return std::numeric_limits<size_t>::max();

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -179,7 +179,7 @@ lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
   if (!m_base)
     return llvm::createStringError(
         "'SyntheticChildrenFrontend::LibcxxStdProxyArraySyntheticFrontEnd' "
-        "cannot find index of child '%s'",
+        "cannot find index of child '%s': Invalid base pointer.",
         name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -177,10 +177,12 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_base)
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -177,15 +177,10 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_base)
-    return llvm::createStringError(
-        "'LibcxxStdProxyArraySyntheticFrontEnd' "
-        "cannot find index of child '%s': Invalid base pointer.",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("'LibcxxStdProxyArraySyntheticFrontEnd' "
-                                   "cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -178,15 +178,14 @@ lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_base)
     return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxStdProxyArraySyntheticFrontEnd' "
+        "'LibcxxStdProxyArraySyntheticFrontEnd' "
         "cannot find index of child '%s': Invalid base pointer.",
         name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxStdProxyArraySyntheticFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("'LibcxxStdProxyArraySyntheticFrontEnd' "
+                                   "cannot find index of child '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
@@ -21,10 +21,10 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    if (m_container_sp) {
+    if (m_container_sp)
       return m_container_sp->GetIndexOfChildWithName(name);
-    }
-    return llvm::createStringError("Cannot find index of child '%s'",
+    return llvm::createStringError("'SyntheticChildrenFrontend::QueueFrontEnd' "
+                                   "cannot find index of child '%s'",
                                    name.AsCString());
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
@@ -23,9 +23,10 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (m_container_sp)
       return m_container_sp->GetIndexOfChildWithName(name);
-    return llvm::createStringError("'SyntheticChildrenFrontend::QueueFrontEnd' "
-                                   "cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::QueueFrontEnd' "
+        "cannot find index of child '%s': Invalid underlying container.",
+        name.AsCString());
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
@@ -20,9 +20,12 @@ public:
     Update();
   }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
-    return m_container_sp ? m_container_sp->GetIndexOfChildWithName(name)
-                          : UINT32_MAX;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
+    if (m_container_sp) {
+      return m_container_sp->GetIndexOfChildWithName(name);
+    }
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
@@ -23,7 +23,8 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (m_container_sp)
       return m_container_sp->GetIndexOfChildWithName(name);
-    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
@@ -23,10 +23,7 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (m_container_sp)
       return m_container_sp->GetIndexOfChildWithName(name);
-    return llvm::createStringError(
-        "'QueueFrontEnd' "
-        "cannot find index of child '%s': Invalid underlying container.",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxQueue.cpp
@@ -24,7 +24,7 @@ public:
     if (m_container_sp)
       return m_container_sp->GetIndexOfChildWithName(name);
     return llvm::createStringError(
-        "'SyntheticChildrenFrontend::QueueFrontEnd' "
+        "'QueueFrontEnd' "
         "cannot find index of child '%s': Invalid underlying container.",
         name.AsCString());
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxRangesRefView.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxRangesRefView.cpp
@@ -40,7 +40,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     // We only have a single child
     return 0;
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -150,7 +150,7 @@ lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
   if (!m_start)
     return llvm::createStringError(
         "'SyntheticChildrenFrontend::LibcxxStdSliceArraySyntheticFrontEnd' "
-        "cannot find index of child '%s'",
+        "cannot find index of child '%s': Invalid start pointer.",
         name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -148,8 +148,10 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxStdSliceArraySyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
   return ExtractIndexFromString(name.GetCString());
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -62,7 +62,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   /// A non-owning pointer to slice_array.__vp_.
@@ -144,10 +144,12 @@ lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::Update() {
   return ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
-    return std::numeric_limits<size_t>::max();
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return ExtractIndexFromString(name.GetCString());
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -152,7 +152,14 @@ lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
         "'SyntheticChildrenFrontend::LibcxxStdSliceArraySyntheticFrontEnd' "
         "cannot find index of child '%s'",
         name.AsCString());
-  return ExtractIndexFromString(name.GetCString());
+  size_t idx = ExtractIndexFromString(name.GetCString());
+  if (idx == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxStdSliceArraySyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
+  }
+  return idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -148,16 +148,10 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
-    return llvm::createStringError(
-        "'LibcxxStdSliceArraySyntheticFrontEnd' "
-        "cannot find index of child '%s': Invalid start pointer.",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
-  if (idx == UINT32_MAX) {
-    return llvm::createStringError("'LibcxxStdSliceArraySyntheticFrontEnd' "
-                                   "cannot find index of child '%s'",
-                                   name.AsCString());
-  }
+  if (idx == UINT32_MAX)
+    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -148,10 +148,12 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX)
-    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -149,15 +149,14 @@ lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
     return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxStdSliceArraySyntheticFrontEnd' "
+        "'LibcxxStdSliceArraySyntheticFrontEnd' "
         "cannot find index of child '%s': Invalid start pointer.",
         name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxStdSliceArraySyntheticFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("'LibcxxStdSliceArraySyntheticFrontEnd' "
+                                   "cannot find index of child '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -55,7 +55,7 @@ public:
   // from the only other place it can be: the template argument.
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ValueObject *m_start = nullptr; ///< First element of span. Held, not owned.
@@ -127,10 +127,11 @@ lldb_private::formatters::LibcxxStdSpanSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eReuse;
 }
 
-size_t lldb_private::formatters::LibcxxStdSpanSyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::
+    LibcxxStdSpanSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return ExtractIndexFromString(name.GetCString());
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -130,8 +130,10 @@ lldb_private::formatters::LibcxxStdSpanSyntheticFrontEnd::Update() {
 llvm::Expected<size_t> lldb_private::formatters::
     LibcxxStdSpanSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::LibcxxStdSpanSyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   return ExtractIndexFromString(name.GetCString());
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -132,7 +132,7 @@ llvm::Expected<size_t> lldb_private::formatters::
   if (!m_start)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxStdSpanSyntheticFrontEnd' cannot "
-        "find index of child '%s'",
+        "find index of child '%s': Invalid start pointer.",
         name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -134,7 +134,14 @@ llvm::Expected<size_t> lldb_private::formatters::
         "'SyntheticChildrenFrontEnd::LibcxxStdSpanSyntheticFrontEnd' cannot "
         "find index of child '%s'",
         name.AsCString());
-  return ExtractIndexFromString(name.GetCString());
+  size_t idx = ExtractIndexFromString(name.GetCString());
+  if (idx == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxStdSpanSyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
+  }
+  return idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -130,10 +130,12 @@ lldb_private::formatters::LibcxxStdSpanSyntheticFrontEnd::Update() {
 llvm::Expected<size_t> lldb_private::formatters::
     LibcxxStdSpanSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
-    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -136,10 +136,9 @@ llvm::Expected<size_t> lldb_private::formatters::
         name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxStdSpanSyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("'LibcxxStdSpanSyntheticFrontEnd' cannot "
+                                   "find index of child '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -130,15 +130,10 @@ lldb_private::formatters::LibcxxStdSpanSyntheticFrontEnd::Update() {
 llvm::Expected<size_t> lldb_private::formatters::
     LibcxxStdSpanSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_start)
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::LibcxxStdSpanSyntheticFrontEnd' cannot "
-        "find index of child '%s': Invalid start pointer.",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("'LibcxxStdSpanSyntheticFrontEnd' cannot "
-                                   "find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -21,7 +21,14 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return formatters::ExtractIndexFromString(name.GetCString());
+    size_t idx = formatters::ExtractIndexFromString(name.GetCString());
+    if (idx == UINT32_MAX) {
+      return llvm::createStringError(
+          "'SyntheticChildrenFrontend::TupleFrontEnd' cannot find index of "
+          "child '%s'",
+          name.AsCString());
+    }
+    return idx;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -20,7 +20,7 @@ public:
     Update();
   }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     return formatters::ExtractIndexFromString(name.GetCString());
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -23,7 +23,8 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
     if (idx == UINT32_MAX)
-      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -23,10 +23,9 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
     if (idx == UINT32_MAX) {
-      return llvm::createStringError(
-          "'SyntheticChildrenFrontend::TupleFrontEnd' cannot find index of "
-          "child '%s'",
-          name.AsCString());
+      return llvm::createStringError("'TupleFrontEnd' cannot find index of "
+                                     "child '%s'",
+                                     name.AsCString());
     }
     return idx;
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -22,11 +22,8 @@ public:
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (idx == UINT32_MAX) {
-      return llvm::createStringError("'TupleFrontEnd' cannot find index of "
-                                     "child '%s'",
-                                     name.AsCString());
-    }
+    if (idx == UINT32_MAX)
+      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -406,8 +406,10 @@ lldb_private::formatters::LibCxxUnorderedMapIteratorSyntheticFrontEnd::
     return 0;
   if (name == "second")
     return 1;
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::LibCxxUnorderedMapIteratorSyntheticFrontEnd'"
+      " cannot find index of child '%s'",
+      name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -40,7 +40,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   CompilerType GetNodeType();
@@ -68,7 +68,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   lldb::ValueObjectSP m_pair_sp; ///< ValueObject for the key/value pair
@@ -291,7 +291,8 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   return ExtractIndexFromString(name.GetCString());
 }
@@ -398,13 +399,15 @@ lldb::ValueObjectSP lldb_private::formatters::
   return lldb::ValueObjectSP();
 }
 
-size_t lldb_private::formatters::LibCxxUnorderedMapIteratorSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibCxxUnorderedMapIteratorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (name == "first")
     return 0;
   if (name == "second")
     return 1;
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -294,7 +294,14 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::Update() {
 llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  return ExtractIndexFromString(name.GetCString());
+  size_t idx = ExtractIndexFromString(name.GetCString());
+  if (idx == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxStdUnorderedMapSyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
+  }
+  return idx;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -296,10 +296,9 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxStdUnorderedMapSyntheticFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("'LibcxxStdUnorderedMapSyntheticFrontEnd' "
+                                   "cannot find index of child '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -296,7 +296,8 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   return idx;
 }
@@ -410,7 +411,8 @@ lldb_private::formatters::LibCxxUnorderedMapIteratorSyntheticFrontEnd::
     return 0;
   if (name == "second")
     return 1;
-  return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -296,9 +296,7 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("'LibcxxStdUnorderedMapSyntheticFrontEnd' "
-                                   "cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
   return idx;
 }
@@ -412,10 +410,7 @@ lldb_private::formatters::LibCxxUnorderedMapIteratorSyntheticFrontEnd::
     return 0;
   if (name == "second")
     return 1;
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::LibCxxUnorderedMapIteratorSyntheticFrontEnd'"
-      " cannot find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -129,8 +129,8 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxStdValarraySyntheticFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+        "cannot find index of child '%s'. (m_start='%d', m_finish='%d')",
+        name.AsCString(), m_start, m_finish);
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
     return llvm::createStringError(

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -127,8 +127,10 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start || !m_finish)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::LibcxxStdValarraySyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
   return ExtractIndexFromString(name.GetCString());
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -131,7 +131,14 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
         "'SyntheticChildrenFrontEnd::LibcxxStdValarraySyntheticFrontEnd' "
         "cannot find index of child '%s'",
         name.AsCString());
-  return ExtractIndexFromString(name.GetCString());
+  size_t idx = ExtractIndexFromString(name.GetCString());
+  if (idx == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::LibcxxStdValarraySyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
+  }
+  return idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -30,7 +30,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   /// A non-owning pointer to valarray's __begin_ member.
@@ -123,10 +123,12 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::Update() {
   return ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start || !m_finish)
-    return std::numeric_limits<size_t>::max();
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return ExtractIndexFromString(name.GetCString());
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -129,7 +129,8 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxStdValarraySyntheticFrontEnd' "
-        "cannot find index of child '%s'. (m_start='%d', m_finish='%d')",
+        "cannot find index of child '%s'. (m_start='" PRIu32
+        "', m_finish='" PRIu32 "')",
         name.AsCString(), m_start, m_finish);
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -129,8 +129,7 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxStdValarraySyntheticFrontEnd' "
-        "cannot find index of child '%s'. (m_start='" PRIu32
-        "', m_finish='" PRIu32 "')",
+        "cannot find index of child '%s'. (m_start='%p', m_finish='%p')",
         name.AsCString(), m_start, m_finish);
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -127,15 +127,10 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start || !m_finish)
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::LibcxxStdValarraySyntheticFrontEnd' "
-        "cannot find index of child '%s'. (m_start='%p', m_finish='%p')",
-        name.AsCString(), m_start, m_finish);
+    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("'LibcxxStdValarraySyntheticFrontEnd' "
-                                   "cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -127,10 +127,12 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start || !m_finish)
-    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -134,10 +134,9 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
         name.AsCString(), m_start, m_finish);
   size_t idx = ExtractIndexFromString(name.GetCString());
   if (idx == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontend::LibcxxStdValarraySyntheticFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("'LibcxxStdValarraySyntheticFrontEnd' "
+                                   "cannot find index of child '%s'",
+                                   name.AsCString());
   }
   return idx;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -205,8 +205,10 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t index = formatters::ExtractIndexFromString(name.GetCString());
     if (index == UINT32_MAX) {
-      return llvm::createStringError("Cannot find index of child '%s'",
-                                     name.AsCString());
+      return llvm::createStringError(
+          "'SyntheticChildrenFrontEnd::VariantFrontEnd' cannot find index of "
+          "child '%s'",
+          name.AsCString());
     }
     return index;
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -202,8 +202,13 @@ public:
     Update();
   }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
-    return formatters::ExtractIndexFromString(name.GetCString());
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
+    size_t index = formatters::ExtractIndexFromString(name.GetCString());
+    if (index == UINT32_MAX) {
+      return llvm::createStringError("Cannot find index of child '%s'",
+                                     name.AsCString());
+    }
+    return index;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -204,12 +204,8 @@ public:
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t index = formatters::ExtractIndexFromString(name.GetCString());
-    if (index == UINT32_MAX) {
-      return llvm::createStringError(
-          "'SyntheticChildrenFrontEnd::VariantFrontEnd' cannot find index of "
-          "child '%s'",
-          name.AsCString());
-    }
+    if (index == UINT32_MAX)
+      return llvm::createStringError("Type has no child named '%s'",name.AsCString());
     return index;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -205,7 +205,8 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     size_t index = formatters::ExtractIndexFromString(name.GetCString());
     if (index == UINT32_MAX)
-      return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
     return index;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -167,7 +167,10 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start || !m_finish)
-    return UINT32_MAX;
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::LibcxxStdVectorSyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   return ExtractIndexFromString(name.GetCString());
 }
 
@@ -264,13 +267,17 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_count || !m_base_data_address)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -169,8 +169,8 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxStdVectorSyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+        "find index of child '%s'. (m_start='%d', m_finish='%d')",
+        name.AsCString(), m_start, m_finish);
   size_t index = formatters::ExtractIndexFromString(name.GetCString());
   if (index == UINT32_MAX) {
     return llvm::createStringError(
@@ -277,8 +277,8 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
   if (!m_count || !m_base_data_address)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+        "find index of child '%s'. (m_count='%d', m_base_data_address='%d')",
+        name.AsCString(), m_count, m_base_data_address);
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -33,7 +33,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ValueObject *m_start = nullptr;
@@ -52,7 +52,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   CompilerType m_bool_type;
@@ -163,7 +163,8 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start || !m_finish)
     return UINT32_MAX;
@@ -259,14 +260,17 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_count || !m_base_data_address)
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -171,7 +171,15 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
         "'SyntheticChildrenFrontEnd::LibcxxStdVectorSyntheticFrontEnd' cannot "
         "find index of child '%s'",
         name.AsCString());
-  return ExtractIndexFromString(name.GetCString());
+  size_t index = formatters::ExtractIndexFromString(name.GetCString());
+  if (index == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::LibcxxStdVectorSyntheticFrontEnd' cannot "
+        "find index of "
+        "child '%s'",
+        name.AsCString());
+  }
+  return index;
 }
 
 lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
@@ -273,7 +281,8 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
         name.AsCString());
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
         "find index of child '%s'",

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -278,8 +278,8 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
   if (!m_count || !m_base_data_address)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (m_count='" PRIu32
-        "', m_base_data_address='" PRIu32 "')",
+        "find index of child '%s'. (m_count='" PRIu64
+        "', m_base_data_address='" PRIu64 "')",
         name.AsCString(), m_count, m_base_data_address);
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -167,17 +167,10 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start || !m_finish)
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::LibcxxStdVectorSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (m_start='%p', m_finish='%p')",
-        name.AsCString(), m_start, m_finish);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   size_t index = formatters::ExtractIndexFromString(name.GetCString());
   if (index == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::LibcxxStdVectorSyntheticFrontEnd' cannot "
-        "find index of "
-        "child '%s'",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
   }
   return index;
 }
@@ -275,19 +268,12 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_count || !m_base_data_address)
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (m_count='" PRIu64
-        "', m_base_data_address='" PRIu64 "')",
-        name.AsCString(), m_count, m_base_data_address);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -169,8 +169,7 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxStdVectorSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (m_start='" PRIu32 "', m_finish='" PRIu32
-        "')",
+        "find index of child '%s'. (m_start='%p', m_finish='%p')",
         name.AsCString(), m_start, m_finish);
   size_t index = formatters::ExtractIndexFromString(name.GetCString());
   if (index == UINT32_MAX) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -169,7 +169,8 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxStdVectorSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (m_start='%d', m_finish='%d')",
+        "find index of child '%s'. (m_start='" PRIu32 "', m_finish='" PRIu32
+        "')",
         name.AsCString(), m_start, m_finish);
   size_t index = formatters::ExtractIndexFromString(name.GetCString());
   if (index == UINT32_MAX) {
@@ -277,7 +278,8 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
   if (!m_count || !m_base_data_address)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (m_count='%d', m_base_data_address='%d')",
+        "find index of child '%s'. (m_count='" PRIu32
+        "', m_base_data_address='" PRIu32 "')",
         name.AsCString(), m_count, m_base_data_address);
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
@@ -285,8 +287,8 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::LibcxxVectorBoolSyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+        "find index of child '%s'. (idx='" PRIu32 "')",
+        name.AsCString(), idx);
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -167,10 +167,12 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_start || !m_finish)
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   size_t index = formatters::ExtractIndexFromString(name.GetCString());
   if (index == UINT32_MAX) {
-    return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   return index;
 }
@@ -268,12 +270,14 @@ llvm::Expected<size_t>
 lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_count || !m_base_data_address)
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -153,8 +153,10 @@ LibstdcppMapIteratorSyntheticFrontEnd::GetIndexOfChildWithName(
     return 0;
   if (name == "second")
     return 1;
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::LibstdcppMapIteratorSyntheticFrontEnd' "
+      "cannot find index of child '%s'",
+      name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *
@@ -233,8 +235,10 @@ llvm::Expected<size_t>
 VectorIteratorSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (name == "item")
     return 0;
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::VectorIteratorSyntheticFrontEnd' cannot "
+      "find index of child '%s'",
+      name.AsCString());
 }
 
 bool lldb_private::formatters::LibStdcppStringSummaryProvider(
@@ -419,8 +423,10 @@ LibStdcppSharedPtrSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
     return 0;
   if (name == "object" || name == "$$dereference$$")
     return 1;
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::LibStdcppSharedPtrSyntheticFrontEnd' cannot "
+      "find index of child '%s'",
+      name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -49,7 +49,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ExecutionContextRef m_exe_ctx_ref;
@@ -68,7 +68,8 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
+
 private:
 
   // The lifetime of a ValueObject and all its derivative ValueObjects
@@ -145,13 +146,15 @@ LibstdcppMapIteratorSyntheticFrontEnd::GetChildAtIndex(uint32_t idx) {
   return lldb::ValueObjectSP();
 }
 
-size_t LibstdcppMapIteratorSyntheticFrontEnd::GetIndexOfChildWithName(
+llvm::Expected<size_t>
+LibstdcppMapIteratorSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   if (name == "first")
     return 0;
   if (name == "second")
     return 1;
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *
@@ -226,11 +229,12 @@ VectorIteratorSyntheticFrontEnd::GetChildAtIndex(uint32_t idx) {
   return lldb::ValueObjectSP();
 }
 
-size_t VectorIteratorSyntheticFrontEnd::GetIndexOfChildWithName(
-    ConstString name) {
+llvm::Expected<size_t>
+VectorIteratorSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (name == "item")
     return 0;
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 bool lldb_private::formatters::LibStdcppStringSummaryProvider(
@@ -409,13 +413,14 @@ lldb::ChildCacheState LibStdcppSharedPtrSyntheticFrontEnd::Update() {
   return lldb::ChildCacheState::eRefetch;
 }
 
-size_t LibStdcppSharedPtrSyntheticFrontEnd::GetIndexOfChildWithName(
-    ConstString name) {
+llvm::Expected<size_t>
+LibStdcppSharedPtrSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (name == "pointer")
     return 0;
   if (name == "object" || name == "$$dereference$$")
     return 1;
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -153,10 +153,7 @@ LibstdcppMapIteratorSyntheticFrontEnd::GetIndexOfChildWithName(
     return 0;
   if (name == "second")
     return 1;
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::LibstdcppMapIteratorSyntheticFrontEnd' "
-      "cannot find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *
@@ -235,10 +232,7 @@ llvm::Expected<size_t>
 VectorIteratorSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (name == "item")
     return 0;
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::VectorIteratorSyntheticFrontEnd' cannot "
-      "find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 bool lldb_private::formatters::LibStdcppStringSummaryProvider(
@@ -423,10 +417,7 @@ LibStdcppSharedPtrSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
     return 0;
   if (name == "object" || name == "$$dereference$$")
     return 1;
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::LibStdcppSharedPtrSyntheticFrontEnd' cannot "
-      "find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -153,7 +153,8 @@ LibstdcppMapIteratorSyntheticFrontEnd::GetIndexOfChildWithName(
     return 0;
   if (name == "second")
     return 1;
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *
@@ -232,7 +233,8 @@ llvm::Expected<size_t>
 VectorIteratorSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (name == "item")
     return 0;
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 bool lldb_private::formatters::LibStdcppStringSummaryProvider(
@@ -417,7 +419,8 @@ LibStdcppSharedPtrSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
     return 0;
   if (name == "object" || name == "$$dereference$$")
     return 1;
-  return llvm::createStringError("Type has no child named '%s'",name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
@@ -98,7 +98,15 @@ LibStdcppTupleSyntheticFrontEnd::CalculateNumChildren() {
 
 llvm::Expected<size_t>
 LibStdcppTupleSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  return ExtractIndexFromString(name.GetCString());
+  size_t index = formatters::ExtractIndexFromString(name.GetCString());
+  if (index == UINT32_MAX) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::LibStdcppTupleSyntheticFrontEnd' cannot "
+        "find index of "
+        "child '%s'",
+        name.AsCString());
+  }
+  return index;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
@@ -32,7 +32,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   // The lifetime of a ValueObject and all its derivative ValueObjects
@@ -96,8 +96,8 @@ LibStdcppTupleSyntheticFrontEnd::CalculateNumChildren() {
   return m_members.size();
 }
 
-size_t LibStdcppTupleSyntheticFrontEnd::GetIndexOfChildWithName(
-    ConstString name) {
+llvm::Expected<size_t>
+LibStdcppTupleSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   return ExtractIndexFromString(name.GetCString());
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
@@ -100,7 +100,8 @@ llvm::Expected<size_t>
 LibStdcppTupleSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   size_t index = formatters::ExtractIndexFromString(name.GetCString());
   if (index == UINT32_MAX) {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
   return index;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
@@ -100,11 +100,7 @@ llvm::Expected<size_t>
 LibStdcppTupleSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   size_t index = formatters::ExtractIndexFromString(name.GetCString());
   if (index == UINT32_MAX) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::LibStdcppTupleSyntheticFrontEnd' cannot "
-        "find index of "
-        "child '%s'",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
   return index;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
@@ -32,7 +32,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
   bool GetSummary(Stream &stream, const TypeSummaryOptions &options);
 
@@ -139,15 +139,16 @@ LibStdcppUniquePtrSyntheticFrontEnd::CalculateNumChildren() {
   return 1;
 }
 
-size_t LibStdcppUniquePtrSyntheticFrontEnd::GetIndexOfChildWithName(
-    ConstString name) {
+llvm::Expected<size_t>
+LibStdcppUniquePtrSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (name == "ptr" || name == "pointer")
     return 0;
   if (name == "del" || name == "deleter")
     return 1;
   if (name == "obj" || name == "object" || name == "$$dereference$$")
     return 2;
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 bool LibStdcppUniquePtrSyntheticFrontEnd::GetSummary(

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
@@ -147,8 +147,10 @@ LibStdcppUniquePtrSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
     return 1;
   if (name == "obj" || name == "object" || name == "$$dereference$$")
     return 2;
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::LibStdcppUniquePtrSyntheticFrontEnd' cannot "
+      "find index of child '%s'",
+      name.AsCString());
 }
 
 bool LibStdcppUniquePtrSyntheticFrontEnd::GetSummary(

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
@@ -147,7 +147,8 @@ LibStdcppUniquePtrSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
     return 1;
   if (name == "obj" || name == "object" || name == "$$dereference$$")
     return 2;
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 bool LibStdcppUniquePtrSyntheticFrontEnd::GetSummary(

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
@@ -147,10 +147,7 @@ LibStdcppUniquePtrSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
     return 1;
   if (name == "obj" || name == "object" || name == "$$dereference$$")
     return 2;
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::LibStdcppUniquePtrSyntheticFrontEnd' cannot "
-      "find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 bool LibStdcppUniquePtrSyntheticFrontEnd::GetSummary(

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1049,8 +1049,9 @@ public:
 
   bool MightHaveChildren() override { return false; }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
-    return UINT32_MAX;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   }
 };
 

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1050,8 +1050,10 @@ public:
   bool MightHaveChildren() override { return false; }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::ObjCClassSyntheticChildrenFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
   }
 };
 

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1050,10 +1050,7 @@ public:
   bool MightHaveChildren() override { return false; }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::ObjCClassSyntheticChildrenFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
 };
 

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1050,7 +1050,8 @@ public:
   bool MightHaveChildren() override { return false; }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
 };
 

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -534,8 +534,8 @@ llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontend::NSArrayMSyntheticFrontEndBase' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+        "find index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 
@@ -624,8 +624,8 @@ lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::ObjCClassSyntheticChildrenFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+        "cannot find index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -56,7 +56,7 @@ public:
 
   lldb::ChildCacheState Update() override = 0;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 protected:
   virtual lldb::addr_t GetDataAddress() = 0;
@@ -218,7 +218,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ExecutionContextRef m_exe_ctx_ref;
@@ -306,7 +306,7 @@ public:
 
   bool MightHaveChildren() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 };
 
 class NSArray1SyntheticFrontEnd : public SyntheticChildrenFrontEnd {
@@ -321,7 +321,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 };
 } // namespace formatters
 } // namespace lldb_private
@@ -526,9 +526,8 @@ lldb_private::formatters::GenericNSArrayMSyntheticFrontEnd<D32, D64>::Update() {
                          : lldb::ChildCacheState::eRefetch;
 }
 
-size_t
-lldb_private::formatters::NSArrayMSyntheticFrontEndBase::GetIndexOfChildWithName(
-    ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
+    GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
@@ -612,9 +611,9 @@ lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<D32, D64, Inline>::
 }
 
 template <typename D32, typename D64, bool Inline>
-size_t
-lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<D32, D64, Inline>::
-  GetIndexOfChildWithName(ConstString name) {
+llvm::Expected<size_t>
+lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<
+    D32, D64, Inline>::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
@@ -695,7 +694,7 @@ lldb_private::formatters::NSArray0SyntheticFrontEnd::NSArray0SyntheticFrontEnd(
     lldb::ValueObjectSP valobj_sp)
     : SyntheticChildrenFrontEnd(*valobj_sp) {}
 
-size_t
+llvm::Expected<size_t>
 lldb_private::formatters::NSArray0SyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   return UINT32_MAX;
@@ -725,7 +724,7 @@ lldb_private::formatters::NSArray1SyntheticFrontEnd::NSArray1SyntheticFrontEnd(
     lldb::ValueObjectSP valobj_sp)
     : SyntheticChildrenFrontEnd(*valobj_sp.get()) {}
 
-size_t
+llvm::Expected<size_t>
 lldb_private::formatters::NSArray1SyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   static const ConstString g_zero("[0]");

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -529,9 +529,13 @@ lldb_private::formatters::GenericNSArrayMSyntheticFrontEnd<D32, D64>::Update() {
 llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
     GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
-  uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+  size_t idx = ExtractIndexFromString(item_name);
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontend::NSArrayMSyntheticFrontEndBase' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 
@@ -616,8 +620,12 @@ lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<
     D32, D64, Inline>::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::ObjCClassSyntheticChildrenFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -532,10 +532,7 @@ llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
   size_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("'NSArrayMSyntheticFrontEndBase' cannot "
-                                   "find index of child '%s'. (idx='" PRIu32
-                                   "')",
-                                   name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 
@@ -622,10 +619,7 @@ lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::ObjCClassSyntheticChildrenFrontEnd' "
-        "cannot find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -532,10 +532,10 @@ llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
   size_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontend::NSArrayMSyntheticFrontEndBase' cannot "
-        "find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("'NSArrayMSyntheticFrontEndBase' cannot "
+                                   "find index of child '%s'. (idx='" PRIu32
+                                   "')",
+                                   name.AsCString(), idx);
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -532,7 +532,8 @@ llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
   size_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -619,7 +620,8 @@ lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -534,7 +534,7 @@ llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontend::NSArrayMSyntheticFrontEndBase' cannot "
-        "find index of child '%s'. (idx='%d')",
+        "find index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }
@@ -624,7 +624,7 @@ lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::ObjCClassSyntheticChildrenFrontEnd' "
-        "cannot find index of child '%s'. (idx='%d')",
+        "cannot find index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -589,7 +589,8 @@ llvm::Expected<size_t> lldb_private::formatters::
     NSDictionaryISyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSDictionaryISyntheticFrontEnd' cannot "
         "find index of child '%s'",
@@ -725,7 +726,8 @@ llvm::Expected<size_t> lldb_private::formatters::
     NSCFDictionarySyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   const uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSCFDictionarySyntheticFrontEnd' cannot "
         "find index of child '%s'",
@@ -860,7 +862,8 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSConstantDictionarySyntheticFrontEnd' "
         "cannot find index of child '%s'",
@@ -1065,7 +1068,8 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
     D32, D64>::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::GenericNSDictionaryMSyntheticFrontEnd' "
         "cannot find index of child '%s'",
@@ -1225,7 +1229,8 @@ llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
     NSDictionaryMSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSDictionaryMSyntheticFrontEnd' cannot "
         "find index of child '%s'",

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -590,8 +590,10 @@ llvm::Expected<size_t> lldb_private::formatters::
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::NSDictionaryISyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 
@@ -724,8 +726,10 @@ llvm::Expected<size_t> lldb_private::formatters::
   const char *item_name = name.GetCString();
   const uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::NSCFDictionarySyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 
@@ -857,8 +861,10 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::NSConstantDictionarySyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 
@@ -970,8 +976,10 @@ llvm::Expected<size_t> lldb_private::formatters::
   static const ConstString g_zero("[0]");
   if (name == g_zero)
     return 0;
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.AsCString());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::NSDictionary1SyntheticFrontEnd' cannot find "
+      "index of child '%s'",
+      name.AsCString());
 }
 
 llvm::Expected<uint32_t> lldb_private::formatters::
@@ -1058,8 +1066,10 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::GenericNSDictionaryMSyntheticFrontEnd' "
+        "cannot find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 
@@ -1216,8 +1226,10 @@ llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::NSDictionaryMSyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -593,8 +593,8 @@ llvm::Expected<size_t> lldb_private::formatters::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSDictionaryISyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+        "find index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 
@@ -730,8 +730,8 @@ llvm::Expected<size_t> lldb_private::formatters::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSCFDictionarySyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+        "find index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 
@@ -866,8 +866,8 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSConstantDictionarySyntheticFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+        "cannot find index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 
@@ -1072,8 +1072,8 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::GenericNSDictionaryMSyntheticFrontEnd' "
-        "cannot find index of child '%s'",
-        name.AsCString());
+        "cannot find index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 
@@ -1233,8 +1233,8 @@ llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSDictionaryMSyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+        "find index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -109,7 +109,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   struct DataDescriptor_32 {
@@ -148,7 +148,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ExecutionContextRef m_exe_ctx_ref;
@@ -178,7 +178,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   struct DictionaryItemDescriptor {
@@ -209,7 +209,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ValueObjectSP m_pair;
@@ -228,7 +228,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   struct DictionaryItemDescriptor {
@@ -259,8 +259,8 @@ namespace Foundation1100 {
 
     lldb::ChildCacheState Update() override;
 
-    size_t GetIndexOfChildWithName(ConstString name) override;
-    
+    llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
+
   private:
     struct DataDescriptor_32 {
       uint32_t _used : 26;
@@ -585,12 +585,13 @@ lldb_private::formatters::NSDictionaryISyntheticFrontEnd::
   m_data_64 = nullptr;
 }
 
-size_t lldb_private::formatters::NSDictionaryISyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::
+    NSDictionaryISyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -718,12 +719,13 @@ lldb_private::formatters::NSCFDictionarySyntheticFrontEnd::
     : SyntheticChildrenFrontEnd(*valobj_sp), m_exe_ctx_ref(), m_hashtable(),
       m_pair_type() {}
 
-size_t lldb_private::formatters::NSCFDictionarySyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::
+    NSCFDictionarySyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   const uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -849,12 +851,14 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
     NSConstantDictionarySyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
     : SyntheticChildrenFrontEnd(*valobj_sp) {}
 
-size_t lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
+llvm::Expected<size_t>
+lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -961,10 +965,13 @@ lldb_private::formatters::NSDictionary1SyntheticFrontEnd::
     NSDictionary1SyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
     : SyntheticChildrenFrontEnd(*valobj_sp.get()), m_pair(nullptr) {}
 
-size_t lldb_private::formatters::NSDictionary1SyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::
+    NSDictionary1SyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   static const ConstString g_zero("[0]");
-  return name == g_zero ? 0 : UINT32_MAX;
+  if (name == g_zero)
+    return 0;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.AsCString());
 }
 
 llvm::Expected<uint32_t> lldb_private::formatters::
@@ -1045,12 +1052,14 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
 }
 
 template <typename D32, typename D64>
-size_t lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
+llvm::Expected<size_t>
+lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
     D32, D64>::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -1202,13 +1211,13 @@ lldb_private::formatters::Foundation1100::
   m_data_64 = nullptr;
 }
 
-size_t
-lldb_private::formatters::Foundation1100::
-  NSDictionaryMSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
+    NSDictionaryMSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -591,10 +591,7 @@ llvm::Expected<size_t> lldb_private::formatters::
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::NSDictionaryISyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 
@@ -728,10 +725,7 @@ llvm::Expected<size_t> lldb_private::formatters::
   const uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::NSCFDictionarySyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString(), idx);
   return idx;
 }
 
@@ -864,10 +858,7 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::NSConstantDictionarySyntheticFrontEnd' "
-        "cannot find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 
@@ -979,10 +970,7 @@ llvm::Expected<size_t> lldb_private::formatters::
   static const ConstString g_zero("[0]");
   if (name == g_zero)
     return 0;
-  return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::NSDictionary1SyntheticFrontEnd' cannot find "
-      "index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 llvm::Expected<uint32_t> lldb_private::formatters::
@@ -1070,10 +1058,7 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::GenericNSDictionaryMSyntheticFrontEnd' "
-        "cannot find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 
@@ -1231,10 +1216,7 @@ llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::NSDictionaryMSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -593,7 +593,7 @@ llvm::Expected<size_t> lldb_private::formatters::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSDictionaryISyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='%d')",
+        "find index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }
@@ -730,7 +730,7 @@ llvm::Expected<size_t> lldb_private::formatters::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSCFDictionarySyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='%d')",
+        "find index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }
@@ -866,7 +866,7 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSConstantDictionarySyntheticFrontEnd' "
-        "cannot find index of child '%s'. (idx='%d')",
+        "cannot find index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }
@@ -1072,7 +1072,7 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::GenericNSDictionaryMSyntheticFrontEnd' "
-        "cannot find index of child '%s'. (idx='%d')",
+        "cannot find index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }
@@ -1233,7 +1233,7 @@ llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSDictionaryMSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='%d')",
+        "find index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -591,7 +591,8 @@ llvm::Expected<size_t> lldb_private::formatters::
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -725,7 +726,8 @@ llvm::Expected<size_t> lldb_private::formatters::
   const uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString(), idx);
   return idx;
 }
 
@@ -858,7 +860,8 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -970,7 +973,8 @@ llvm::Expected<size_t> lldb_private::formatters::
   static const ConstString g_zero("[0]");
   if (name == g_zero)
     return 0;
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 llvm::Expected<uint32_t> lldb_private::formatters::
@@ -1058,7 +1062,8 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -1216,7 +1221,8 @@ llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSError.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSError.cpp
@@ -165,11 +165,12 @@ public:
     return lldb::ChildCacheState::eRefetch;
   }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     static ConstString g_userInfo("_userInfo");
     if (name == g_userInfo)
       return 0;
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   }
 
 private:

--- a/lldb/source/Plugins/Language/ObjC/NSError.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSError.cpp
@@ -169,8 +169,10 @@ public:
     static ConstString g_userInfo("_userInfo");
     if (name == g_userInfo)
       return 0;
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::NSErrorSyntheticFrontEnd' cannot find "
+        "index of child '%s'",
+        name.AsCString());
   }
 
 private:

--- a/lldb/source/Plugins/Language/ObjC/NSError.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSError.cpp
@@ -169,10 +169,7 @@ public:
     static ConstString g_userInfo("_userInfo");
     if (name == g_userInfo)
       return 0;
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::NSErrorSyntheticFrontEnd' cannot find "
-        "index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
 
 private:

--- a/lldb/source/Plugins/Language/ObjC/NSError.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSError.cpp
@@ -169,7 +169,8 @@ public:
     static ConstString g_userInfo("_userInfo");
     if (name == g_userInfo)
       return 0;
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
 
 private:

--- a/lldb/source/Plugins/Language/ObjC/NSException.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSException.cpp
@@ -148,7 +148,7 @@ public:
                : lldb::ChildCacheState::eRefetch;
   }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     // NSException has 4 members:
     //   NSString *name;
     //   NSString *reason;
@@ -162,7 +162,8 @@ public:
     if (name == g_reason) return 1;
     if (name == g_userInfo) return 2;
     if (name == g_reserved) return 3;
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   }
 
 private:

--- a/lldb/source/Plugins/Language/ObjC/NSException.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSException.cpp
@@ -162,8 +162,10 @@ public:
     if (name == g_reason) return 1;
     if (name == g_userInfo) return 2;
     if (name == g_reserved) return 3;
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::NSExceptionSyntheticFrontEnd' cannot find "
+        "index of child '%s'",
+        name.AsCString());
   }
 
 private:

--- a/lldb/source/Plugins/Language/ObjC/NSException.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSException.cpp
@@ -162,7 +162,8 @@ public:
     if (name == g_reason) return 1;
     if (name == g_userInfo) return 2;
     if (name == g_reserved) return 3;
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
 
 private:

--- a/lldb/source/Plugins/Language/ObjC/NSException.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSException.cpp
@@ -162,10 +162,7 @@ public:
     if (name == g_reason) return 1;
     if (name == g_userInfo) return 2;
     if (name == g_reserved) return 3;
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::NSExceptionSyntheticFrontEnd' cannot find "
-        "index of child '%s'",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   }
 
 private:

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -130,8 +130,10 @@ public:
     const char *item_name = name.GetCString();
     uint32_t idx = ExtractIndexFromString(item_name);
     if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-      return llvm::createStringError("Cannot find index of child '%s'",
-                                     name.AsCString());
+      return llvm::createStringError(
+          "'SyntheticChildrenFrontEnd::NSIndexPathSyntheticFrontEnd' cannot "
+          "find index of child '%s'",
+          name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -126,11 +126,12 @@ public:
 
   bool MightHaveChildren() override { return m_impl.m_mode != Mode::Invalid; }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     const char *item_name = name.GetCString();
     uint32_t idx = ExtractIndexFromString(item_name);
     if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-      return UINT32_MAX;
+      return llvm::createStringError("Cannot find index of child '%s'",
+                                     name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -129,7 +129,8 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     const char *item_name = name.GetCString();
     uint32_t idx = ExtractIndexFromString(item_name);
-    if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+    if (idx == UINT32_MAX ||
+        (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
       return llvm::createStringError(
           "'SyntheticChildrenFrontEnd::NSIndexPathSyntheticFrontEnd' cannot "
           "find index of child '%s'",

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -133,8 +133,8 @@ public:
         (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
       return llvm::createStringError(
           "'SyntheticChildrenFrontEnd::NSIndexPathSyntheticFrontEnd' cannot "
-          "find index of child '%s'",
-          name.AsCString());
+          "find index of child '%s'. (idx='%d')",
+          name.AsCString(), idx);
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -131,7 +131,8 @@ public:
     uint32_t idx = ExtractIndexFromString(item_name);
     if (idx == UINT32_MAX ||
         (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -133,7 +133,7 @@ public:
         (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
       return llvm::createStringError(
           "'SyntheticChildrenFrontEnd::NSIndexPathSyntheticFrontEnd' cannot "
-          "find index of child '%s'. (idx='%d')",
+          "find index of child '%s'. (idx='" PRIu32 "')",
           name.AsCString(), idx);
     return idx;
   }

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -131,10 +131,7 @@ public:
     uint32_t idx = ExtractIndexFromString(item_name);
     if (idx == UINT32_MAX ||
         (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-      return llvm::createStringError(
-          "'SyntheticChildrenFrontEnd::NSIndexPathSyntheticFrontEnd' cannot "
-          "find index of child '%s'. (idx='" PRIu32 "')",
-          name.AsCString(), idx);
+      return llvm::createStringError("Type has no child named '%s'", name.AsCString());
     return idx;
   }
 

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -395,8 +395,8 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSSetISyntheticFrontEnd' cannot find "
-        "index of child '%s'",
-        name.AsCString());
+        "index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 
@@ -532,8 +532,8 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSCFSetSyntheticFrontEnd' cannot find "
-        "index of child '%s'",
-        name.AsCString());
+        "index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 
@@ -670,8 +670,8 @@ llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::GenericNSSetMSyntheticFrontEnd' cannot "
-        "find index of child '%s'",
-        name.AsCString());
+        "find index of child '%s'. (idx='%d')",
+        name.AsCString(), idx);
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -392,8 +392,10 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::NSSetISyntheticFrontEnd' cannot find "
+        "index of child '%s'",
+        name.AsCString());
   return idx;
 }
 
@@ -526,8 +528,10 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
   const char *item_name = name.GetCString();
   const uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::NSCFSetSyntheticFrontEnd' cannot find "
+        "index of child '%s'",
+        name.AsCString());
   return idx;
 }
 
@@ -661,8 +665,10 @@ llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   name.AsCString());
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::GenericNSSetMSyntheticFrontEnd' cannot "
+        "find index of child '%s'",
+        name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -52,7 +52,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   struct DataDescriptor_32 {
@@ -88,7 +88,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   struct SetItemDescriptor {
@@ -119,7 +119,7 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
 
@@ -386,13 +386,14 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::~NSSetISyntheticFrontEnd() {
   m_data_64 = nullptr;
 }
 
-size_t
+llvm::Expected<size_t>
 lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -519,13 +520,14 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::NSCFSetSyntheticFrontEnd(
     : SyntheticChildrenFrontEnd(*valobj_sp), m_exe_ctx_ref(), m_hashtable(),
       m_pair_type() {}
 
-size_t
+llvm::Expected<size_t>
 lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   const char *item_name = name.GetCString();
   const uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -654,14 +656,13 @@ lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<D32, D64>::
 }
 
 template <typename D32, typename D64>
-size_t
-lldb_private::formatters::
-  GenericNSSetMSyntheticFrontEnd<D32, D64>::GetIndexOfChildWithName(
-    ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
+    D32, D64>::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -391,7 +391,8 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSSetISyntheticFrontEnd' cannot find "
         "index of child '%s'",
@@ -527,7 +528,8 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   const char *item_name = name.GetCString();
   const uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSCFSetSyntheticFrontEnd' cannot find "
         "index of child '%s'",
@@ -664,7 +666,8 @@ llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
     D32, D64>::GetIndexOfChildWithName(ConstString name) {
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
+  if (idx == UINT32_MAX ||
+      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::GenericNSSetMSyntheticFrontEnd' cannot "
         "find index of child '%s'",

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -393,7 +393,8 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -527,7 +528,8 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
   const uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -662,7 +664,8 @@ llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -393,10 +393,7 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::NSSetISyntheticFrontEnd' cannot find "
-        "index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 
@@ -530,10 +527,7 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
   const uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::NSCFSetSyntheticFrontEnd' cannot find "
-        "index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 
@@ -668,10 +662,7 @@ llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
   uint32_t idx = ExtractIndexFromString(item_name);
   if (idx == UINT32_MAX ||
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::GenericNSSetMSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='" PRIu32 "')",
-        name.AsCString(), idx);
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -395,7 +395,7 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSSetISyntheticFrontEnd' cannot find "
-        "index of child '%s'. (idx='%d')",
+        "index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }
@@ -532,7 +532,7 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::NSCFSetSyntheticFrontEnd' cannot find "
-        "index of child '%s'. (idx='%d')",
+        "index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }
@@ -670,7 +670,7 @@ llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
       (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::GenericNSSetMSyntheticFrontEnd' cannot "
-        "find index of child '%s'. (idx='%d')",
+        "find index of child '%s'. (idx='" PRIu32 "')",
         name.AsCString(), idx);
   return idx;
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2042,21 +2042,21 @@ llvm::Expected<int> ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
   if (!implementor_sp)
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
-        "index of child '%s'",
-        child_name);
+        "index of child '%s'. Invalid implementor (implementor_sp='%p').",
+        child_name, implementor_sp.get());
 
   StructuredData::Generic *generic = implementor_sp->GetAsGeneric();
   if (!generic)
     return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
-        "index of child '%s'",
-        child_name);
+        "'ScriptInterpreterPythonImpl' cannot find index of child '%s'. Could "
+        "not get generic from implementor  (generic='%p').",
+        child_name, generic);
   auto *implementor = static_cast<PyObject *>(generic->GetValue());
   if (!implementor)
     return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
-        "index of child '%s'",
-        child_name);
+        "'ScriptInterpreterPythonImpl' cannot find index of child '%s'. Could "
+        "not cast to PyObject (implementor='%p')",
+        child_name, implementor);
 
   int ret_val = INT32_MAX;
 
@@ -2069,8 +2069,7 @@ llvm::Expected<int> ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
 
   if (ret_val == INT32_MAX)
     return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
-        "index of child '%s'",
+        "'ScriptInterpreterPythonImpl' cannot find index of child '%s'",
         child_name);
   return ret_val;
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2037,19 +2037,22 @@ lldb::ValueObjectSP ScriptInterpreterPythonImpl::GetChildAtIndex(
   return ret_val;
 }
 
-int ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
+llvm::Expected<int> ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
     const StructuredData::ObjectSP &implementor_sp, const char *child_name) {
   if (!implementor_sp)
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   child_name);
 
   StructuredData::Generic *generic = implementor_sp->GetAsGeneric();
   if (!generic)
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   child_name);
   auto *implementor = static_cast<PyObject *>(generic->GetValue());
   if (!implementor)
-    return UINT32_MAX;
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   child_name);
 
-  int ret_val = UINT32_MAX;
+  int ret_val = INT32_MAX;
 
   {
     Locker py_lock(this,
@@ -2058,6 +2061,9 @@ int ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
                                                                  child_name);
   }
 
+  if (ret_val == INT32_MAX)
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   child_name);
   return ret_val;
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2040,17 +2040,23 @@ lldb::ValueObjectSP ScriptInterpreterPythonImpl::GetChildAtIndex(
 llvm::Expected<int> ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
     const StructuredData::ObjectSP &implementor_sp, const char *child_name) {
   if (!implementor_sp)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   child_name);
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
+        "index of child '%s'",
+        child_name);
 
   StructuredData::Generic *generic = implementor_sp->GetAsGeneric();
   if (!generic)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   child_name);
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
+        "index of child '%s'",
+        child_name);
   auto *implementor = static_cast<PyObject *>(generic->GetValue());
   if (!implementor)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   child_name);
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
+        "index of child '%s'",
+        child_name);
 
   int ret_val = INT32_MAX;
 
@@ -2062,8 +2068,10 @@ llvm::Expected<int> ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
   }
 
   if (ret_val == INT32_MAX)
-    return llvm::createStringError("Cannot find index of child '%s'",
-                                   child_name);
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
+        "index of child '%s'",
+        child_name);
   return ret_val;
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2040,23 +2040,14 @@ lldb::ValueObjectSP ScriptInterpreterPythonImpl::GetChildAtIndex(
 llvm::Expected<int> ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
     const StructuredData::ObjectSP &implementor_sp, const char *child_name) {
   if (!implementor_sp)
-    return llvm::createStringError(
-        "'ScriptInterpreterPythonImpl' cannot find index of child '%s'. "
-        "Invalid implementor (implementor_sp='%p').",
-        child_name, implementor_sp.get());
+    return llvm::createStringError("Type has no child named '%s'", child_name);
 
   StructuredData::Generic *generic = implementor_sp->GetAsGeneric();
   if (!generic)
-    return llvm::createStringError(
-        "'ScriptInterpreterPythonImpl' cannot find index of child '%s'. Could "
-        "not get generic from implementor  (generic='%p').",
-        child_name, generic);
+    return llvm::createStringError("Type has no child named '%s'", child_name);
   auto *implementor = static_cast<PyObject *>(generic->GetValue());
   if (!implementor)
-    return llvm::createStringError(
-        "'ScriptInterpreterPythonImpl' cannot find index of child '%s'. Could "
-        "not cast to PyObject (implementor='%p')",
-        child_name, implementor);
+    return llvm::createStringError("Type has no child named '%s'", child_name);
 
   int ret_val = INT32_MAX;
 
@@ -2068,9 +2059,7 @@ llvm::Expected<int> ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
   }
 
   if (ret_val == INT32_MAX)
-    return llvm::createStringError(
-        "'ScriptInterpreterPythonImpl' cannot find index of child '%s'",
-        child_name);
+    return llvm::createStringError("Type has no child named '%s'", child_name);
   return ret_val;
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2041,8 +2041,8 @@ llvm::Expected<int> ScriptInterpreterPythonImpl::GetIndexOfChildWithName(
     const StructuredData::ObjectSP &implementor_sp, const char *child_name) {
   if (!implementor_sp)
     return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::ScriptInterpreterPythonImpl' cannot find "
-        "index of child '%s'. Invalid implementor (implementor_sp='%p').",
+        "'ScriptInterpreterPythonImpl' cannot find index of child '%s'. "
+        "Invalid implementor (implementor_sp='%p').",
         child_name, implementor_sp.get());
 
   StructuredData::Generic *generic = implementor_sp->GetAsGeneric();

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
@@ -128,8 +128,9 @@ public:
   GetChildAtIndex(const StructuredData::ObjectSP &implementor,
                   uint32_t idx) override;
 
-  int GetIndexOfChildWithName(const StructuredData::ObjectSP &implementor,
-                              const char *child_name) override;
+  llvm::Expected<int>
+  GetIndexOfChildWithName(const StructuredData::ObjectSP &implementor,
+                          const char *child_name) override;
 
   bool UpdateSynthProviderInstance(
       const StructuredData::ObjectSP &implementor) override;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6969,7 +6969,7 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
 // doesn't descend into the children, but only looks one level deep and name
 // matches can include base class names.
 
-uint32_t
+llvm::Expected<uint32_t>
 TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
                                          llvm::StringRef name,
                                          bool omit_empty_base_classes) {

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -7159,9 +7159,8 @@ TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
       break;
     }
   }
-  return llvm::createStringError("'SyntheticChildrenFrontEnd::TypeSystemClang' "
-                                 "cannot find index of child '%s'",
-                                 name.str().c_str());
+  return llvm::createStringError(
+      "'TypeSystemClang' cannot find index of child '%s'", name.str().c_str());
 }
 
 CompilerType

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -7159,7 +7159,9 @@ TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
       break;
     }
   }
-  return UINT32_MAX;
+  return llvm::createStringError("'SyntheticChildrenFrontEnd::TypeSystemClang' "
+                                 "cannot find index of child '%s'",
+                                 name.str().c_str());
 }
 
 CompilerType

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -7159,8 +7159,7 @@ TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
       break;
     }
   }
-  return llvm::createStringError(
-      "'TypeSystemClang' cannot find index of child '%s'", name.str().c_str());
+  return llvm::createStringError("Type has no child named '%s'", name.str().c_str());
 }
 
 CompilerType

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -7159,7 +7159,8 @@ TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
       break;
     }
   }
-  return llvm::createStringError("Type has no child named '%s'", name.str().c_str());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.str().c_str());
 }
 
 CompilerType

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -900,9 +900,10 @@ public:
 
   // Lookup a child given a name. This function will match base class names and
   // member member names in "clang_type" only, not descendants.
-  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                   llvm::StringRef name,
-                                   bool omit_empty_base_classes) override;
+  llvm::Expected<uint32_t>
+  GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
+                          llvm::StringRef name,
+                          bool omit_empty_base_classes) override;
 
   // Lookup a child member given a name. This function will match member names
   // only and will descend into "clang_type" children in search for the first

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -1023,7 +1023,7 @@ bool CompilerType::IsMeaninglessWithoutDynamicResolution() const {
 // doesn't descend into the children, but only looks one level deep and name
 // matches can include base class names.
 
-uint32_t
+llvm::Expected<uint32_t>
 CompilerType::GetIndexOfChildWithName(llvm::StringRef name,
                                       bool omit_empty_base_classes) const {
   if (IsValid() && !name.empty()) {
@@ -1031,7 +1031,8 @@ CompilerType::GetIndexOfChildWithName(llvm::StringRef name,
       return type_system_sp->GetIndexOfChildWithName(m_type, name,
                                                      omit_empty_base_classes);
   }
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.str().c_str());
 }
 
 // Dumping types

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -1031,9 +1031,8 @@ CompilerType::GetIndexOfChildWithName(llvm::StringRef name,
       return type_system_sp->GetIndexOfChildWithName(m_type, name,
                                                      omit_empty_base_classes);
   }
-  return llvm::createStringError("'SyntheticChildrenFrontEnd::CompilerType' "
-                                 "cannot find index of child '%s'",
-                                 name.str().c_str());
+  return llvm::createStringError(
+      "'CompilerType' cannot find index of child '%s'", name.str().c_str());
 }
 
 // Dumping types

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -1031,7 +1031,8 @@ CompilerType::GetIndexOfChildWithName(llvm::StringRef name,
       return type_system_sp->GetIndexOfChildWithName(m_type, name,
                                                      omit_empty_base_classes);
   }
-  return llvm::createStringError("Cannot find index of child '%s'",
+  return llvm::createStringError("'SyntheticChildrenFrontEnd::CompilerType' "
+                                 "cannot find index of child '%s'",
                                  name.str().c_str());
 }
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -1031,8 +1031,7 @@ CompilerType::GetIndexOfChildWithName(llvm::StringRef name,
       return type_system_sp->GetIndexOfChildWithName(m_type, name,
                                                      omit_empty_base_classes);
   }
-  return llvm::createStringError(
-      "'CompilerType' cannot find index of child '%s'", name.str().c_str());
+  return llvm::createStringError("Type has no child named '%s'", name.str().c_str());
 }
 
 // Dumping types

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -1031,7 +1031,8 @@ CompilerType::GetIndexOfChildWithName(llvm::StringRef name,
       return type_system_sp->GetIndexOfChildWithName(m_type, name,
                                                      omit_empty_base_classes);
   }
-  return llvm::createStringError("Type has no child named '%s'", name.str().c_str());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.str().c_str());
 }
 
 // Dumping types

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -403,7 +403,8 @@ ValueObject::GetChildAtNamePath(llvm::ArrayRef<llvm::StringRef> names) {
   return root;
 }
 
-size_t ValueObject::GetIndexOfChildWithName(llvm::StringRef name) {
+llvm::Expected<size_t>
+ValueObject::GetIndexOfChildWithName(llvm::StringRef name) {
   bool omit_empty_base_classes = true;
   return GetCompilerType().GetIndexOfChildWithName(name,
                                                    omit_empty_base_classes);

--- a/lldb/source/ValueObject/ValueObjectRegister.cpp
+++ b/lldb/source/ValueObject/ValueObjectRegister.cpp
@@ -147,8 +147,7 @@ ValueObjectRegisterSet::GetIndexOfChildWithName(llvm::StringRef name) {
       return reg_info->kinds[eRegisterKindLLDB];
   }
   return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::ValueObjectRegisterSet' cannot find index "
-      "of child '%s'",
+      "'ValueObjectRegisterSet' cannot find index of child '%s'",
       name.str().c_str());
 }
 

--- a/lldb/source/ValueObject/ValueObjectRegister.cpp
+++ b/lldb/source/ValueObject/ValueObjectRegister.cpp
@@ -146,8 +146,10 @@ ValueObjectRegisterSet::GetIndexOfChildWithName(llvm::StringRef name) {
     if (reg_info != nullptr)
       return reg_info->kinds[eRegisterKindLLDB];
   }
-  return llvm::createStringError("Cannot find index of child '%s'",
-                                 name.str().c_str());
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::ValueObjectRegisterSet' cannot find index "
+      "of child '%s'",
+      name.str().c_str());
 }
 
 #pragma mark -

--- a/lldb/source/ValueObject/ValueObjectRegister.cpp
+++ b/lldb/source/ValueObject/ValueObjectRegister.cpp
@@ -139,13 +139,15 @@ ValueObjectRegisterSet::GetChildMemberWithName(llvm::StringRef name,
     return ValueObjectSP();
 }
 
-size_t ValueObjectRegisterSet::GetIndexOfChildWithName(llvm::StringRef name) {
+llvm::Expected<size_t>
+ValueObjectRegisterSet::GetIndexOfChildWithName(llvm::StringRef name) {
   if (m_reg_ctx_sp && m_reg_set) {
     const RegisterInfo *reg_info = m_reg_ctx_sp->GetRegisterInfoByName(name);
     if (reg_info != nullptr)
       return reg_info->kinds[eRegisterKindLLDB];
   }
-  return UINT32_MAX;
+  return llvm::createStringError("Cannot find index of child '%s'",
+                                 name.str().c_str());
 }
 
 #pragma mark -

--- a/lldb/source/ValueObject/ValueObjectRegister.cpp
+++ b/lldb/source/ValueObject/ValueObjectRegister.cpp
@@ -146,9 +146,7 @@ ValueObjectRegisterSet::GetIndexOfChildWithName(llvm::StringRef name) {
     if (reg_info != nullptr)
       return reg_info->kinds[eRegisterKindLLDB];
   }
-  return llvm::createStringError(
-      "'ValueObjectRegisterSet' cannot find index of child '%s'",
-      name.str().c_str());
+  return llvm::createStringError("Type has no child named '%s'", name.str().c_str());
 }
 
 #pragma mark -

--- a/lldb/source/ValueObject/ValueObjectRegister.cpp
+++ b/lldb/source/ValueObject/ValueObjectRegister.cpp
@@ -146,7 +146,8 @@ ValueObjectRegisterSet::GetIndexOfChildWithName(llvm::StringRef name) {
     if (reg_info != nullptr)
       return reg_info->kinds[eRegisterKindLLDB];
   }
-  return llvm::createStringError("Type has no child named '%s'", name.str().c_str());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.str().c_str());
 }
 
 #pragma mark -

--- a/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
@@ -350,13 +350,18 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
     std::lock_guard<std::mutex> guard(m_child_mutex);
     m_name_toindex[name.GetCString()] = *index_or_err;
     return *index_or_err;
-  } else if (!found_index && m_synth_filter_up == nullptr)
+  } else if (!found_index && m_synth_filter_up == nullptr) {
+    return llvm::createStringError(
+        "'SyntheticChildrenFrontEnd::ValueObjectSynthetic' cannot find index "
+        "of child '%s'. m_synth_filter_up is null.",
+        name.AsCString());
+  } else if (found_index) {
+    return *found_index;
+  } else /*if (iter != m_name_toindex.end())*/
     return llvm::createStringError(
         "'SyntheticChildrenFrontEnd::ValueObjectSynthetic' cannot find index "
         "of child '%s'",
         name.AsCString());
-  else /*if (iter != m_name_toindex.end())*/
-    return *found_index;
 }
 
 bool ValueObjectSynthetic::IsInScope() { return m_parent->IsInScope(); }

--- a/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
@@ -39,7 +39,7 @@ public:
     return m_backend.GetChildAtIndex(idx);
   }
 
-  size_t GetIndexOfChildWithName(ConstString name) override {
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     return m_backend.GetIndexOfChildWithName(name);
   }
 
@@ -319,40 +319,41 @@ ValueObjectSynthetic::GetChildMemberWithName(llvm::StringRef name,
                                              bool can_create) {
   UpdateValueIfNeeded();
 
-  uint32_t index = GetIndexOfChildWithName(name);
+  auto index_or_err = GetIndexOfChildWithName(name);
 
-  if (index == UINT32_MAX)
+  if (!index_or_err)
     return lldb::ValueObjectSP();
 
-  return GetChildAtIndex(index, can_create);
+  return GetChildAtIndex(*index_or_err, can_create);
 }
 
-size_t ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
+llvm::Expected<size_t>
+ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
   UpdateValueIfNeeded();
 
   ConstString name(name_ref);
 
-  uint32_t found_index = UINT32_MAX;
-  bool did_find;
+  std::optional<uint32_t> found_index = std::nullopt;
   {
     std::lock_guard<std::mutex> guard(m_child_mutex);
     auto name_to_index = m_name_toindex.find(name.GetCString());
-    did_find = name_to_index != m_name_toindex.end();
-    if (did_find)
+    if (name_to_index != m_name_toindex.end())
       found_index = name_to_index->second;
   }
 
-  if (!did_find && m_synth_filter_up != nullptr) {
-    uint32_t index = m_synth_filter_up->GetIndexOfChildWithName(name);
-    if (index == UINT32_MAX)
-      return index;
+  if (!found_index.has_value() && m_synth_filter_up != nullptr) {
+    auto index_or_err = m_synth_filter_up->GetIndexOfChildWithName(name);
+    if (!index_or_err)
+      return llvm::createStringError("Cannot find index of child '%s'",
+                                     name.AsCString());
     std::lock_guard<std::mutex> guard(m_child_mutex);
-    m_name_toindex[name.GetCString()] = index;
-    return index;
-  } else if (!did_find && m_synth_filter_up == nullptr)
-    return UINT32_MAX;
+    m_name_toindex[name.GetCString()] = *index_or_err;
+    return *index_or_err;
+  } else if (!found_index.has_value() && m_synth_filter_up == nullptr)
+    return llvm::createStringError("Cannot find index of child '%s'",
+                                   name.AsCString());
   else /*if (iter != m_name_toindex.end())*/
-    return found_index;
+    return found_index.value();
 }
 
 bool ValueObjectSynthetic::IsInScope() { return m_parent->IsInScope(); }

--- a/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
@@ -351,16 +351,11 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
     m_name_toindex[name.GetCString()] = *index_or_err;
     return *index_or_err;
   } else if (!found_index && m_synth_filter_up == nullptr) {
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::ValueObjectSynthetic' cannot find index "
-        "of child '%s'. m_synth_filter_up is null.",
-        name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
   } else if (found_index)
     return *found_index;
 
-  return llvm::createStringError(
-      "'ValueObjectSynthetic' cannot find index of child '%s'",
-      name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
 }
 
 bool ValueObjectSynthetic::IsInScope() { return m_parent->IsInScope(); }

--- a/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
@@ -355,13 +355,13 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
         "'SyntheticChildrenFrontEnd::ValueObjectSynthetic' cannot find index "
         "of child '%s'. m_synth_filter_up is null.",
         name.AsCString());
-  } else if (found_index) {
+  } else if (found_index)
     return *found_index;
-  } else /*if (iter != m_name_toindex.end())*/
-    return llvm::createStringError(
-        "'SyntheticChildrenFrontEnd::ValueObjectSynthetic' cannot find index "
-        "of child '%s'",
-        name.AsCString());
+
+  return llvm::createStringError(
+      "'SyntheticChildrenFrontEnd::ValueObjectSynthetic' cannot find index "
+      "of child '%s'",
+      name.AsCString());
 }
 
 bool ValueObjectSynthetic::IsInScope() { return m_parent->IsInScope(); }

--- a/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
@@ -359,8 +359,7 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
     return *found_index;
 
   return llvm::createStringError(
-      "'ValueObjectSynthetic' cannot find index "
-      "of child '%s'",
+      "'ValueObjectSynthetic' cannot find index of child '%s'",
       name.AsCString());
 }
 

--- a/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
@@ -351,11 +351,13 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
     m_name_toindex[name.GetCString()] = *index_or_err;
     return *index_or_err;
   } else if (!found_index && m_synth_filter_up == nullptr) {
-    return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   } else if (found_index)
     return *found_index;
 
-  return llvm::createStringError("Type has no child named '%s'", name.AsCString());
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 bool ValueObjectSynthetic::IsInScope() { return m_parent->IsInScope(); }

--- a/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
@@ -359,7 +359,7 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
     return *found_index;
 
   return llvm::createStringError(
-      "'SyntheticChildrenFrontEnd::ValueObjectSynthetic' cannot find index "
+      "'ValueObjectSynthetic' cannot find index "
       "of child '%s'",
       name.AsCString());
 }

--- a/lldb/unittests/Platform/PlatformSiginfoTest.cpp
+++ b/lldb/unittests/Platform/PlatformSiginfoTest.cpp
@@ -62,7 +62,7 @@ public:
       uint64_t bit_offset;
       std::string name;
       field_type = field_type.GetFieldAtIndex(
-          field_type.GetIndexOfChildWithName(field_name, false), name,
+          *field_type.GetIndexOfChildWithName(field_name, false), name,
           &bit_offset, nullptr, nullptr);
       ASSERT_TRUE(field_type);
       total_offset += bit_offset;

--- a/lldb/unittests/Platform/PlatformSiginfoTest.cpp
+++ b/lldb/unittests/Platform/PlatformSiginfoTest.cpp
@@ -61,9 +61,10 @@ public:
     for (auto field_name : llvm::split(path, '.')) {
       uint64_t bit_offset;
       std::string name;
-      field_type = field_type.GetFieldAtIndex(
-          *field_type.GetIndexOfChildWithName(field_name, false), name,
-          &bit_offset, nullptr, nullptr);
+      auto index_or_err = field_type.GetIndexOfChildWithName(field_name, false);
+      ASSERT_TRUE(index_or_err);
+      field_type = field_type.GetFieldAtIndex(*index_or_err, name, &bit_offset,
+                                              nullptr, nullptr);
       ASSERT_TRUE(field_type);
       total_offset += bit_offset;
     }

--- a/lldb/unittests/Platform/PlatformSiginfoTest.cpp
+++ b/lldb/unittests/Platform/PlatformSiginfoTest.cpp
@@ -62,7 +62,7 @@ public:
       uint64_t bit_offset;
       std::string name;
       auto index_or_err = field_type.GetIndexOfChildWithName(field_name, false);
-      ASSERT_TRUE(index_or_err);
+      ASSERT_FALSE(!index_or_err);
       field_type = field_type.GetFieldAtIndex(*index_or_err, name, &bit_offset,
                                               nullptr, nullptr);
       ASSERT_TRUE(field_type);


### PR DESCRIPTION
This patch replaces the use of `UINT32_MAX` as the error return value of `GetIndexOfChildWithName` with `llvm::Expected`.


# Tasks to do in another PR

1. Replace `CalculateNumChildrenIgnoringErrors` with `CalculateNumChildren`. See [this comment](https://github.com/llvm/llvm-project/pull/136693#discussion_r2056319358).
2. Update `lldb_private::formatters::ExtractIndexFromString` to use `llvm::Expected`. See [this comment](https://github.com/llvm/llvm-project/pull/136693#discussion_r2054217536).
3. Create a new class which carries both user and internal errors. See [this comment](https://github.com/llvm/llvm-project/pull/136693#discussion_r2056439608).