### PR TITLE
[mlir][vector] Update ApplyVectorReductionToContractPatternsOp

### DIFF
--- a/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
+++ b/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
@@ -67,10 +67,6 @@ void transform::ApplyFoldElementwiseToVectorPatternsOp::populatePatterns(
 void transform::ApplyVectorReductionToContractPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
   vector::populateVectorReductionToContractPatterns(patterns);
-
-  // TODO: As we now have a dedicated transform for
-  // `populateSinkVectorOpsPatterns` we can remove it from here.
-  vector::populateSinkVectorOpsPatterns(patterns);
 }
 
 void transform::ApplyLowerCreateMaskPatternsOp::populatePatterns(

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
@@ -79,6 +79,7 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.vector.lower_masked_transfers
       transform.apply_patterns.vector.transfer_permutation_patterns
       transform.apply_patterns.vector.reduction_to_contract
+      transform.apply_patterns.vector.sink_ops
     } : !transform.any_op
 
     // Step 5: Lower vector.contract to vector.outerproduct. Also drop unit

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/multi-tile-matmul-mixed-types.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/multi-tile-matmul-mixed-types.mlir
@@ -94,6 +94,7 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.vector.lower_masked_transfers
       transform.apply_patterns.vector.transfer_permutation_patterns
       transform.apply_patterns.vector.reduction_to_contract
+      transform.apply_patterns.vector.sink_ops
     } : !transform.any_op
 
     // Step 5: Lower vector.contract to vector.outerproduct. Also drop unit


### PR DESCRIPTION
This PR removes the use of `populateSinkVectorOpsPatterns` from the
definition of:
  * `transform.apply_patterns.vector.reduction_to_contract`

As of #131462, there is now a dedicated transform op for this pattern:
  * `transform.apply_patterns.vector.sink_op`

Given that, we should now use the new TD op directly instead of relying
on unrelated TD ops to include it.

NOTE TO DOWNSTREAM USERS:
Please add the following to your TD scripts:
  * `transform.apply_patterns.vector.sink_op`

See the updated test for an example.
