### PR TITLE
Reland [SelectionDAG] Folding ZERO-EXTEND/SIGN_EXTEND poison to Poison value in getNode

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6322,6 +6322,10 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
         Flags.setNonNeg(N1->getFlags().hasNonNeg());
       return getNode(OpOpcode, DL, VT, N1.getOperand(0), Flags);
     }
+
+    if (OpOpcode == ISD::POISON)
+      return getPOISON(VT);
+
     if (N1.isUndef())
       // sext(undef) = 0, because the top bits will all be the same.
       return getConstant(0, DL, VT);
@@ -6342,6 +6346,10 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
       Flags.setNonNeg(N1->getFlags().hasNonNeg());
       return getNode(ISD::ZERO_EXTEND, DL, VT, N1.getOperand(0), Flags);
     }
+
+    if (OpOpcode == ISD::POISON)
+      return getPOISON(VT);
+
     if (N1.isUndef())
       // zext(undef) = 0, because the top bits will be zero.
       return getConstant(0, DL, VT);

--- a/llvm/test/CodeGen/AArch64/arm64-bitfield-extract.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-bitfield-extract.ll
@@ -1019,7 +1019,7 @@ define i16 @test_ignored_rightbits(i32 %dst, i32 %in) {
 define void @sameOperandBFI(i64 %src, i64 %src2, ptr %ptr) {
 ; LLC-LABEL: sameOperandBFI:
 ; LLC:       // %bb.0: // %entry
-; LLC-NEXT:    cbnz wzr, .LBB30_2
+; LLC-NEXT:    cbnz w8, .LBB30_2
 ; LLC-NEXT:  // %bb.1: // %if.else
 ; LLC-NEXT:    lsr x8, x0, #47
 ; LLC-NEXT:    and w9, w1, #0x3

--- a/llvm/test/CodeGen/AArch64/optimize-cond-branch.ll
+++ b/llvm/test/CodeGen/AArch64/optimize-cond-branch.ll
@@ -16,7 +16,7 @@ define void @func() uwtable {
 ; CHECK-NEXT:    mov w8, #1 // =0x1
 ; CHECK-NEXT:    cbnz w8, .LBB0_3
 ; CHECK-NEXT:  // %bb.1: // %b1
-; CHECK-NEXT:    cbz wzr, .LBB0_4
+; CHECK-NEXT:    cbz w8, .LBB0_4
 ; CHECK-NEXT:  // %bb.2: // %b3
 ; CHECK-NEXT:    ldr w8, [x8]
 ; CHECK-NEXT:    and w0, w8, #0x100

--- a/llvm/test/CodeGen/AArch64/sve-extract-element.ll
+++ b/llvm/test/CodeGen/AArch64/sve-extract-element.ll
@@ -523,7 +523,6 @@ define double @test_lanex_2xf64(<vscale x 2 x double> %a, i32 %x) #0 {
 define i32 @test_undef_lane_4xi32(<vscale x 4 x i32> %a) #0 {
 ; CHECK-LABEL: test_undef_lane_4xi32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    fmov w0, s0
 ; CHECK-NEXT:    ret
   %b = extractelement <vscale x 4 x i32> %a, i32 poison
   ret i32 %b

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.16bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.16bit.ll
@@ -92,27 +92,17 @@ define i16 @bitcast_f16_to_i16(half %a, i32 %b) {
 ; GCN-LABEL: bitcast_f16_to_i16:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v2, v0
-; GCN-NEXT:    v_mov_b32_e32 v0, 0
 ; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
-; GCN-NEXT:    v_cvt_f16_f32_e32 v1, v2
+; GCN-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GCN-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GCN-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GCN-NEXT:    s_cbranch_execnz .LBB1_3
-; GCN-NEXT:  ; %bb.1: ; %Flow
-; GCN-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GCN-NEXT:    s_cbranch_execnz .LBB1_4
-; GCN-NEXT:  .LBB1_2: ; %end
-; GCN-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GCN-NEXT:    s_setpc_b64 s[30:31]
-; GCN-NEXT:  .LBB1_3: ; %cmp.false
-; GCN-NEXT:    v_mov_b32_e32 v0, v1
 ; GCN-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
 ; GCN-NEXT:    s_cbranch_execz .LBB1_2
-; GCN-NEXT:  .LBB1_4: ; %cmp.true
-; GCN-NEXT:    v_cvt_f32_f16_e32 v0, v1
+; GCN-NEXT:  ; %bb.1:
+; GCN-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GCN-NEXT:    v_add_f32_e32 v0, 0x38000000, v0
 ; GCN-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GCN-NEXT:  .LBB1_2:
 ; GCN-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -249,10 +239,9 @@ define i16 @bitcast_bf16_to_i16(bfloat %a, i32 %b) {
 ; GCN-LABEL: bitcast_bf16_to_i16:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v2, v0
-; GCN-NEXT:    v_mov_b32_e32 v0, 0
 ; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
-; GCN-NEXT:    v_mul_f32_e32 v1, 1.0, v2
+; GCN-NEXT:    v_mul_f32_e32 v1, 1.0, v0
+; GCN-NEXT:    ; implicit-def: $vgpr0
 ; GCN-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GCN-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
 ; GCN-NEXT:    s_cbranch_execnz .LBB3_3

--- a/llvm/test/CodeGen/AMDGPU/atomic_optimizations_global_pointer.ll
+++ b/llvm/test/CodeGen/AMDGPU/atomic_optimizations_global_pointer.ll
@@ -8383,10 +8383,10 @@ define amdgpu_kernel void @uniform_or_i16(ptr addrspace(1) %result, ptr addrspac
 ; GFX7LESS:       ; %bb.0:
 ; GFX7LESS-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
 ; GFX7LESS-NEXT:    s_load_dword s6, s[4:5], 0xd
-; GFX7LESS-NEXT:    v_mov_b32_e32 v0, 0
-; GFX7LESS-NEXT:    v_mbcnt_lo_u32_b32_e64 v1, exec_lo, 0
-; GFX7LESS-NEXT:    v_mbcnt_hi_u32_b32_e32 v1, exec_hi, v1
-; GFX7LESS-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v1
+; GFX7LESS-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, exec_lo, 0
+; GFX7LESS-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, exec_hi, v0
+; GFX7LESS-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
+; GFX7LESS-NEXT:                       ; implicit-def: $vgpr0
 ; GFX7LESS-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX7LESS-NEXT:    s_cbranch_execz .LBB15_2
 ; GFX7LESS-NEXT:  ; %bb.1:
@@ -8731,10 +8731,10 @@ define amdgpu_kernel void @uniform_add_i16(ptr addrspace(1) %result, ptr addrspa
 ; GFX7LESS-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX7LESS-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
 ; GFX7LESS-NEXT:    s_load_dword s10, s[4:5], 0xd
-; GFX7LESS-NEXT:    v_mov_b32_e32 v0, 0
-; GFX7LESS-NEXT:    v_mbcnt_lo_u32_b32_e64 v1, s6, 0
-; GFX7LESS-NEXT:    v_mbcnt_hi_u32_b32_e32 v4, s7, v1
+; GFX7LESS-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, s6, 0
+; GFX7LESS-NEXT:    v_mbcnt_hi_u32_b32_e32 v4, s7, v0
 ; GFX7LESS-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v4
+; GFX7LESS-NEXT:                               ; implicit-def: $vgpr0
 ; GFX7LESS-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX7LESS-NEXT:    s_cbranch_execz .LBB16_4
 ; GFX7LESS-NEXT:  ; %bb.1:

--- a/llvm/test/CodeGen/AMDGPU/ctpop16.ll
+++ b/llvm/test/CodeGen/AMDGPU/ctpop16.ll
@@ -1292,7 +1292,7 @@ define amdgpu_kernel void @ctpop_i16_in_br(ptr addrspace(1) %out, ptr addrspace(
 ; SI-NEXT:    buffer_store_short v0, off, s[0:3], 0
 ; SI-NEXT:    s_endpgm
 ; SI-NEXT:  .LBB14_4:
-; SI-NEXT:    v_mov_b32_e32 v0, 0
+; SI-NEXT:                    ; implicit-def: $vgpr0
 ; SI-NEXT:    s_branch .LBB14_2
 ;
 ; VI-LABEL: ctpop_i16_in_br:
@@ -1329,48 +1329,47 @@ define amdgpu_kernel void @ctpop_i16_in_br(ptr addrspace(1) %out, ptr addrspace(
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @20, KC0[], KC1[]
 ; EG-NEXT:    TEX 0 @14
-; EG-NEXT:    ALU_PUSH_BEFORE 4, @21, KC0[], KC1[]
+; EG-NEXT:    ALU_PUSH_BEFORE 3, @21, KC0[], KC1[]
 ; EG-NEXT:    JUMP @7 POP:1
-; EG-NEXT:    ALU 0, @26, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 0, @25, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @16
-; EG-NEXT:    ALU_POP_AFTER 1, @27, KC0[], KC1[]
-; EG-NEXT:    ALU_PUSH_BEFORE 2, @29, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU_POP_AFTER 1, @26, KC0[], KC1[]
+; EG-NEXT:    ALU_PUSH_BEFORE 2, @28, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    JUMP @11 POP:1
 ; EG-NEXT:    TEX 0 @18
-; EG-NEXT:    ALU_POP_AFTER 0, @32, KC0[], KC1[]
-; EG-NEXT:    ALU 11, @33, KC0[], KC1[]
+; EG-NEXT:    ALU_POP_AFTER 0, @31, KC0[], KC1[]
+; EG-NEXT:    ALU 11, @32, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT MSKOR T1.XW, T0.X
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 14:
-; EG-NEXT:     VTX_READ_16 T2.X, T1.X, 46, #3
+; EG-NEXT:     VTX_READ_16 T1.X, T0.X, 46, #3
 ; EG-NEXT:    Fetch clause starting at 16:
-; EG-NEXT:     VTX_READ_16 T0.X, T0.X, 2, #1
+; EG-NEXT:     VTX_READ_16 T1.X, T1.X, 2, #1
 ; EG-NEXT:    Fetch clause starting at 18:
-; EG-NEXT:     VTX_READ_16 T0.X, T1.X, 44, #3
+; EG-NEXT:     VTX_READ_16 T0.X, T0.X, 44, #3
 ; EG-NEXT:    ALU clause starting at 20:
-; EG-NEXT:     MOV * T1.X, 0.0,
+; EG-NEXT:     MOV * T0.X, 0.0,
 ; EG-NEXT:    ALU clause starting at 21:
-; EG-NEXT:     MOV T0.X, literal.x,
-; EG-NEXT:     MOV T1.W, literal.y,
-; EG-NEXT:     SETNE_INT * T0.W, T2.X, 0.0,
-; EG-NEXT:    0(0.000000e+00), 1(1.401298e-45)
+; EG-NEXT:     MOV T1.W, literal.x,
+; EG-NEXT:     SETNE_INT * T0.W, T1.X, 0.0,
+; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
 ; EG-NEXT:     PRED_SETNE_INT * ExecMask,PredicateBit (MASKED), PS, 0.0,
+; EG-NEXT:    ALU clause starting at 25:
+; EG-NEXT:     MOV * T1.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 26:
-; EG-NEXT:     MOV * T0.X, KC0[2].Z,
-; EG-NEXT:    ALU clause starting at 27:
 ; EG-NEXT:     MOV * T1.W, literal.x,
 ; EG-NEXT:    0(0.000000e+00), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 29:
+; EG-NEXT:    ALU clause starting at 28:
 ; EG-NEXT:     MOV T0.W, KC0[2].Y,
 ; EG-NEXT:     SETE_INT * T1.W, T1.W, 0.0,
 ; EG-NEXT:     PRED_SETE_INT * ExecMask,PredicateBit (MASKED), PS, 0.0,
+; EG-NEXT:    ALU clause starting at 31:
+; EG-NEXT:     BCNT_INT * T1.X, T0.X,
 ; EG-NEXT:    ALU clause starting at 32:
-; EG-NEXT:     BCNT_INT * T0.X, T0.X,
-; EG-NEXT:    ALU clause starting at 33:
 ; EG-NEXT:     LSHL * T1.W, T0.W, literal.x,
 ; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T1.W, PV.W, literal.x,
-; EG-NEXT:     AND_INT * T2.W, T0.X, literal.y,
+; EG-NEXT:     AND_INT * T2.W, T1.X, literal.y,
 ; EG-NEXT:    24(3.363116e-44), 65535(9.183409e-41)
 ; EG-NEXT:     LSHL T1.X, PS, PV.W,
 ; EG-NEXT:     LSHL * T1.W, literal.x, PV.W,

--- a/llvm/test/CodeGen/AMDGPU/dead-machine-elim-after-dead-lane.ll
+++ b/llvm/test/CodeGen/AMDGPU/dead-machine-elim-after-dead-lane.ll
@@ -6,15 +6,16 @@
 define amdgpu_kernel void @foo() {
 ; CHECK-LABEL: foo:
 ; CHECK:       ; %bb.0: ; %entry
-; CHECK-NEXT:    s_cbranch_execnz .LBB0_2
-; CHECK-NEXT:  ; %bb.1: ; %LeafBlock1
-; CHECK-NEXT:  .LBB0_2: ; %foo.exit
+; CHECK-NEXT:   ; %bb.1:                                ; %LeafBlock1
+; CHECK-NEXT:    s_cmp_eq_u32 s0, 10
+; CHECK-NEXT:    s_cbranch_scc1 .LBB0_3
+; CHECK-NEXT:  ; %bb.2:
 ; CHECK-NEXT:    s_mov_b32 s3, 0xf000
 ; CHECK-NEXT:    s_mov_b32 s2, -1
 ; CHECK-NEXT:    v_mov_b32_e32 v0, 0
 ; CHECK-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; CHECK-NEXT:    s_endpgm
-; CHECK-NEXT:  ; %bb.3: ; %sw.bb10
+; CHECK-NEXT: .LBB0_3:
 entry:
   switch i8 poison, label %foo.exit [
     i8 4, label %sw.bb4

--- a/llvm/test/CodeGen/AMDGPU/mdt-preserving-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/mdt-preserving-crash.ll
@@ -29,17 +29,13 @@ define protected amdgpu_kernel void @_RSENC_PRInit______________________________
 ; CHECK-NEXT:    s_cmp_eq_u32 s4, 0
 ; CHECK-NEXT:    s_cbranch_scc1 .LBB0_2
 ; CHECK-NEXT:  ; %bb.3: ; %if.end60
-; CHECK-NEXT:    s_mov_b64 vcc, exec
 ; CHECK-NEXT:    s_cbranch_execz .LBB0_11
 ; CHECK-NEXT:  ; %bb.4: ; %if.end5.i
-; CHECK-NEXT:    s_mov_b64 vcc, vcc
-; CHECK-NEXT:    s_cbranch_vccz .LBB0_11
+; CHECK-NEXT:    s_cbranch_scc0 .LBB0_11
 ; CHECK-NEXT:  ; %bb.5: ; %if.end5.i314
-; CHECK-NEXT:    s_mov_b64 vcc, exec
-; CHECK-NEXT:    s_cbranch_execz .LBB0_11
+; CHECK-NEXT:    s_cbranch_scc0 .LBB0_11
 ; CHECK-NEXT:  ; %bb.6: ; %if.end5.i338
-; CHECK-NEXT:    s_mov_b64 vcc, vcc
-; CHECK-NEXT:    s_cbranch_vccz .LBB0_11
+; CHECK-NEXT:    s_cbranch_scc0 .LBB0_11
 ; CHECK-NEXT:  ; %bb.7: ; %if.end5.i362
 ; CHECK-NEXT:    v_mov_b32_e32 v0, 0
 ; CHECK-NEXT:    s_getpc_b64 s[4:5]
@@ -50,7 +46,7 @@ define protected amdgpu_kernel void @_RSENC_PRInit______________________________
 ; CHECK-NEXT:    buffer_store_byte v0, v0, s[0:3], 0 offen
 ; CHECK-NEXT:    s_waitcnt vmcnt(1)
 ; CHECK-NEXT:    buffer_store_byte v1, off, s[0:3], 0 offset:257
-; CHECK-NEXT:    s_cbranch_execz .LBB0_11
+; CHECK-NEXT:    s_cbranch_scc0 .LBB0_11
 ; CHECK-NEXT:  ; %bb.8: ; %if.end5.i400
 ; CHECK-NEXT:    flat_load_ubyte v0, v[0:1]
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)

--- a/llvm/test/CodeGen/PowerPC/undef-args.ll
+++ b/llvm/test/CodeGen/PowerPC/undef-args.ll
@@ -1,5 +1,7 @@
-;; Tests that extending poison results in undef.
-;; Also tests that there are redundant instructions loading 0 into argument registers for unused arguments.
+;; Tests that extending poison results in poison.
+;; Also tests that there are no redundant instructions loading 0 into argument registers for unused arguments.
+
+; REQUIRES: asserts
 
 ; REQUIRES: asserts
 
@@ -62,7 +64,7 @@ entry:
 ; CHECKISEL64-NEXT:   t7: i64 = Register $x1
 ; CHECKISEL64-NEXT:       t0: ch,glue = EntryToken
 ; CHECKISEL64-NEXT:     t6: ch,glue = callseq_start t0, TargetConstant:i64<112>, TargetConstant:i64<0>
-; CHECKISEL64-NEXT:   t11: ch,glue = CopyToReg t6, Register:i64 $x3, Constant:i64<0> 
+; CHECKISEL64-NEXT:   t11: ch,glue = CopyToReg t6, Register:i64 $x3, poison:i64
 ; CHECKISEL64-NEXT:   t13: ch,glue = CopyToReg t11, Register:i64 $x4, Constant:i64<255>, t11:1
 ; CHECKISEL64-NEXT:   t17: ch,glue = PPCISD::CALL_NOP t13, MCSymbol:i64, Register:i64 $x3, Register:i64 $x4, Register:i64 $x2, RegisterMask:Untyped, t13:1
 ; CHECKISEL64-NEXT:     t18: ch,glue = callseq_end t17, TargetConstant:i64<112>, TargetConstant:i64<0>, t17:1
@@ -72,7 +74,6 @@ entry:
 ; CHECKASM64-NEXT: # %bb.0:                                # %entry
 ; CHECKASM64-NEXT:         mflr 0
 ; CHECKASM64-NEXT:         stdu 1, -112(1)
-; CHECKASM64-NEXT:         li 3, 0
 ; CHECKASM64-NEXT:         li 4, 255
 ; CHECKASM64-NEXT:         std 0, 128(1)
 ; CHECKASM64-NEXT:         bl .bar32
@@ -104,7 +105,7 @@ entry:
 ; CHECKISEL32-NEXT:   t9: i32 = Register $r1
 ; CHECKISEL32-NEXT:       t0: ch,glue = EntryToken
 ; CHECKISEL32-NEXT:     t8: ch,glue = callseq_start t0, TargetConstant:i32<56>, TargetConstant:i32<0>
-; CHECKISEL32-NEXT:   t11: ch,glue = CopyToReg t8, Register:i32 $r3, Constant:i32<0> 
+; CHECKISEL32-NEXT:   t11: ch,glue = CopyToReg t8, Register:i32 $r3, poison:i32
 ; CHECKISEL32-NEXT:   t13: ch,glue = CopyToReg t11, Register:i32 $r4, Constant:i32<255>, t11:1
 ; CHECKISEL32-NEXT:   t17: ch,glue = PPCISD::CALL_NOP t13, MCSymbol:i32, Register:i32 $r3, Register:i32 $r4, Register:i32 $r2, RegisterMask:Untyped, t13:1
 ; CHECKISEL32-NEXT:     t18: ch,glue = callseq_end t17, TargetConstant:i32<56>, TargetConstant:i32<0>, t17:1
@@ -114,7 +115,6 @@ entry:
 ; CHECKASM32-NEXT: # %bb.0:                                # %entry
 ; CHECKASM32-NEXT:         mflr 0
 ; CHECKASM32-NEXT:         stwu 1, -64(1)
-; CHECKASM32-NEXT:         li 3, 0
 ; CHECKASM32-NEXT:         li 4, 255
 ; CHECKASM32-NEXT:         stw 0, 72(1)
 ; CHECKASM32-NEXT:         bl .bar8
@@ -128,7 +128,6 @@ entry:
 ; CHECKASM64-NEXT: # %bb.0:                                # %entry
 ; CHECKASM64-NEXT:         mflr 0
 ; CHECKASM64-NEXT:         stdu 1, -112(1)
-; CHECKASM64-NEXT:         li 3, 0
 ; CHECKASM64-NEXT:         li 4, 255
 ; CHECKASM64-NEXT:         std 0, 128(1)
 ; CHECKASM64-NEXT:         bl .bar8
@@ -143,12 +142,12 @@ entry:
 ; CHECKISEL64-NEXT:   t1: i64 = GlobalAddress<ptr @bar8> 0
 ; CHECKISEL64-NEXT:   t2: i8 = poison
 ; CHECKISEL64-NEXT:   t3: i8 = Constant<-1>
-; CHECKISEL64-NEXT:   t4: i32 = Constant<0> 
+; CHECKISEL64-NEXT:   t4: i32 = poison
 ; CHECKISEL64-NEXT:   t5: i32 = Constant<255>
 ; CHECKISEL64-NEXT:   t9: i64 = Register $x1
 ; CHECKISEL64-NEXT:       t0: ch,glue = EntryToken
 ; CHECKISEL64-NEXT:     t8: ch,glue = callseq_start t0, TargetConstant:i64<112>, TargetConstant:i64<0>
-; CHECKISEL64-NEXT:   t13: ch,glue = CopyToReg t8, Register:i64 $x3, Constant:i64<0> 
+; CHECKISEL64-NEXT:   t13: ch,glue = CopyToReg t8, Register:i64 $x3, poison:i64
 ; CHECKISEL64-NEXT:   t15: ch,glue = CopyToReg t13, Register:i64 $x4, Constant:i64<255>, t13:1
 ; CHECKISEL64-NEXT:   t19: ch,glue = PPCISD::CALL_NOP t15, MCSymbol:i64, Register:i64 $x3, Register:i64 $x4, Register:i64 $x2, RegisterMask:Untyped, t15:1
 ; CHECKISEL64-NEXT:     t20: ch,glue = callseq_end t19, TargetConstant:i64<112>, TargetConstant:i64<0>, t19:1

--- a/llvm/test/CodeGen/RISCV/miss-sp-restore-eh.ll
+++ b/llvm/test/CodeGen/RISCV/miss-sp-restore-eh.ll
@@ -27,14 +27,6 @@ define signext i32 @foo() #1 personality ptr @__gxx_personality_v0 {
 ; CHECK-NEXT:    .cfi_remember_state
 ; CHECK-NEXT:  .Ltmp0:
 ; CHECK-NEXT:    addi sp, sp, -32
-; CHECK-NEXT:    li a0, 0
-; CHECK-NEXT:    li a1, 0
-; CHECK-NEXT:    li a2, 0
-; CHECK-NEXT:    li a3, 0
-; CHECK-NEXT:    li a4, 0
-; CHECK-NEXT:    li a5, 0
-; CHECK-NEXT:    li a6, 0
-; CHECK-NEXT:    li a7, 0
 ; CHECK-NEXT:    call _Z3fooiiiiiiiiiiPi
 ; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:  .Ltmp1:

--- a/llvm/test/CodeGen/VE/Vector/ticket-64420.ll
+++ b/llvm/test/CodeGen/VE/Vector/ticket-64420.ll
@@ -20,6 +20,7 @@
 
 ; SCALAR-LABEL: func:
 ; SCALAR:       # %bb.1:
+; SCALAR:         or %s1, 0, (0)1
 ; SCALAR-NEXT:    st %s1, 8(, %s0)
 ; SCALAR-NEXT:    st %s1, (, %s0)
 ; SCALAR-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/X86/avx512-i1test.ll
+++ b/llvm/test/CodeGen/X86/avx512-i1test.ll
@@ -8,18 +8,19 @@ target triple = "x86_64-unknown-linux-gnu"
 define void @func() {
 ; CHECK-LABEL: func:
 ; CHECK:       # %bb.0: # %bb1
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB0_1
 ; CHECK-NEXT:  # %bb.3: # %L_30
 ; CHECK-NEXT:    retq
-; CHECK-NEXT:  .LBB0_1: # %bb56
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  .LBB0_2: # %bb33
-; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    testb %al, %al
-; CHECK-NEXT:    jmp .LBB0_2
+; CHECK-NEXT:  .LBB0_1: # %bb33
+; CHECK-NEXT:   # =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    testb   %al, %al
+; CHECK-NEXT:    jne     .LBB0_1
+; CHECK-NEXT:  # %bb.2:                                # %bb35
+; CHECK-NEXT:  #   in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    testb   %al, %al
+; CHECK-NEXT:    jmp     .LBB0_1
 bb1:
   br i1 poison, label %L_10, label %L_10
 

--- a/llvm/test/CodeGen/X86/bfloat.ll
+++ b/llvm/test/CodeGen/X86/bfloat.ll
@@ -842,7 +842,6 @@ define <32 x bfloat> @pr63017_2() nounwind {
 ;
 ; SSE2-LABEL: pr63017_2:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb %al, %al
 ; SSE2-NEXT:    jne .LBB16_1
 ; SSE2-NEXT:  # %bb.2: # %cond.load
@@ -1087,7 +1086,6 @@ define <32 x bfloat> @pr63017_2() nounwind {
 ; AVXNC-LABEL: pr63017_2:
 ; AVXNC:       # %bb.0:
 ; AVXNC-NEXT:    vbroadcastss {{.*#+}} ymm0 = [49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024,49024]
-; AVXNC-NEXT:    xorl %eax, %eax
 ; AVXNC-NEXT:    testb %al, %al
 ; AVXNC-NEXT:    jne .LBB16_2
 ; AVXNC-NEXT:  # %bb.1: # %cond.load

--- a/llvm/test/CodeGen/X86/clobber_frame_ptr.ll
+++ b/llvm/test/CodeGen/X86/clobber_frame_ptr.ll
@@ -157,7 +157,6 @@ define ghccc void @test5() {
 ; CHECK-NEXT:    movq %rsp, %rbp
 ; CHECK-NEXT:    .cfi_def_cfa_register %rbp
 ; CHECK-NEXT:    andq $-8, %rsp
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB3_2
 ; CHECK-NEXT:  # %bb.1: # %then

--- a/llvm/test/CodeGen/X86/concat-fpext-v2bf16.ll
+++ b/llvm/test/CodeGen/X86/concat-fpext-v2bf16.ll
@@ -4,7 +4,6 @@
 define void @test(<2 x ptr> %ptr) {
 ; CHECK-LABEL: test:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB0_1
 ; CHECK-NEXT:  # %bb.2: # %loop.127.preheader

--- a/llvm/test/CodeGen/X86/jump_sign.ll
+++ b/llvm/test/CodeGen/X86/jump_sign.ll
@@ -215,15 +215,12 @@ define i32 @func_n(i32 %x, i32 %y) nounwind {
 define void @func_o() nounwind uwtable {
 ; CHECK-LABEL: func_o:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB12_1
 ; CHECK-NEXT:  # %bb.2: # %if.end.i
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB12_5
 ; CHECK-NEXT:  # %bb.3: # %sw.bb
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB12_8
 ; CHECK-NEXT:  # %bb.4: # %if.end29
@@ -234,13 +231,11 @@ define void @func_o() nounwind uwtable {
 ; CHECK-NEXT:    cmpl $6554, %eax # imm = 0x199A
 ; CHECK-NEXT:    jae .LBB12_5
 ; CHECK-NEXT:  .LBB12_8: # %if.then44
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB12_9
 ; CHECK-NEXT:  # %bb.10: # %if.else.i104
 ; CHECK-NEXT:    retl
 ; CHECK-NEXT:  .LBB12_5: # %sw.default
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB12_7
 ; CHECK-NEXT:  # %bb.6: # %if.then.i96

--- a/llvm/test/CodeGen/X86/machine-trace-metrics-crash.ll
+++ b/llvm/test/CodeGen/X86/machine-trace-metrics-crash.ll
@@ -15,7 +15,6 @@ define void @PR24199(i32 %a0) {
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-NEXT:    .cfi_offset %rbx, -16
 ; CHECK-NEXT:    movl %edi, %ebx
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB0_2
 ; CHECK-NEXT:  # %bb.1:

--- a/llvm/test/CodeGen/X86/pr50254.ll
+++ b/llvm/test/CodeGen/X86/pr50254.ll
@@ -8,8 +8,7 @@ define void @PR50254() {
 ; X86-LABEL: PR50254:
 ; X86:       # %bb.0: # %entry
 ; X86-NEXT:    movswl d.e, %eax
-; X86-NEXT:    xorl %ecx, %ecx
-; X86-NEXT:    testb %cl, %cl
+; X86-NEXT:    testb %al, %al
 ; X86-NEXT:    jne .LBB0_2
 ; X86-NEXT:  # %bb.1: # %for.end
 ; X86-NEXT:    movw %ax, d.e
@@ -19,8 +18,7 @@ define void @PR50254() {
 ; X64-LABEL: PR50254:
 ; X64:       # %bb.0: # %entry
 ; X64-NEXT:    movswq d.e(%rip), %rax
-; X64-NEXT:    xorl %ecx, %ecx
-; X64-NEXT:    testb %cl, %cl
+; X64-NEXT:    testb %al, %al
 ; X64-NEXT:    jne .LBB0_2
 ; X64-NEXT:  # %bb.1: # %for.end
 ; X64-NEXT:    movw %ax, d.e(%rip)

--- a/llvm/test/CodeGen/X86/pr57673.ll
+++ b/llvm/test/CodeGen/X86/pr57673.ll
@@ -20,15 +20,16 @@ define void @foo() {
   ; NORMAL: bb.0.bb_entry:
   ; NORMAL-NEXT:   successors: %bb.1(0x80000000)
   ; NORMAL-NEXT: {{  $}}
-  ; NORMAL-NEXT:   [[MOV32r0_:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
-  ; NORMAL-NEXT:   [[COPY:%[0-9]+]]:gr8 = COPY [[MOV32r0_]].sub_8bit
+  ; NORMAL-NEXT:   [[MOV32r0_:%[0-9]+]]:gr8 = IMPLICIT_DEF
+  ; NORMAL-NEXT:   [[COPY:%[0-9]+]]:gr8 = IMPLICIT_DEF
+ ; NORMAL-NEXT:    [[MOV32r0_1:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
   ; NORMAL-NEXT:   [[LEA64r:%[0-9]+]]:gr64 = LEA64r %stack.1.i, 1, $noreg, 0, $noreg
   ; NORMAL-NEXT:   [[DEF:%[0-9]+]]:gr64 = IMPLICIT_DEF
   ; NORMAL-NEXT: {{  $}}
   ; NORMAL-NEXT: bb.1.bb_8:
   ; NORMAL-NEXT:   successors: %bb.3(0x40000000), %bb.2(0x40000000)
   ; NORMAL-NEXT: {{  $}}
-  ; NORMAL-NEXT:   TEST8rr [[COPY]], [[COPY]], implicit-def $eflags
+  ; NORMAL-NEXT:   TEST8rr [[MOV32r0_]], [[COPY]], implicit-def $eflags
   ; NORMAL-NEXT:   JCC_1 %bb.3, 5, implicit $eflags
   ; NORMAL-NEXT:   JMP_1 %bb.2
   ; NORMAL-NEXT: {{  $}}
@@ -45,11 +46,11 @@ define void @foo() {
   ; NORMAL-NEXT:   successors: %bb.1(0x80000000)
   ; NORMAL-NEXT: {{  $}}
   ; NORMAL-NEXT:   ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
-  ; NORMAL-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, [[MOV32r0_]], %subreg.sub_32bit
+  ; NORMAL-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, [[MOV32r0_1]], %subreg.sub_32bit
   ; NORMAL-NEXT:   $rdi = COPY [[SUBREG_TO_REG]]
   ; NORMAL-NEXT:   $rsi = COPY [[SUBREG_TO_REG]]
   ; NORMAL-NEXT:   $rdx = COPY [[SUBREG_TO_REG]]
-  ; NORMAL-NEXT:   $ecx = COPY [[MOV32r0_]]
+  ; NORMAL-NEXT:   $ecx = COPY [[MOV32r0_1]]
   ; NORMAL-NEXT:   $r8 = COPY [[LEA64r]]
   ; NORMAL-NEXT:   CALL64r [[DEF]], csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $rsi, implicit $rdx, implicit $ecx, implicit $r8, implicit-def $rsp, implicit-def $ssp
   ; NORMAL-NEXT:   ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
@@ -59,15 +60,16 @@ define void @foo() {
   ; INSTRREF: bb.0.bb_entry:
   ; INSTRREF-NEXT:   successors: %bb.1(0x80000000)
   ; INSTRREF-NEXT: {{  $}}
-  ; INSTRREF-NEXT:   [[MOV32r0_:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
-  ; INSTRREF-NEXT:   [[COPY:%[0-9]+]]:gr8 = COPY [[MOV32r0_]].sub_8bit
+  ; INSTRREF-NEXT:   [[MOV32r0_:%[0-9]+]]:gr8 = IMPLICIT_DEF
+  ; INSTRREF-NEXT:   [[COPY:%[0-9]+]]:gr8 = IMPLICIT_DEF
+  ; INSTRREF-NEXT:   [[MOV32r0_1:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
   ; INSTRREF-NEXT:   [[LEA64r:%[0-9]+]]:gr64 = LEA64r %stack.1.i, 1, $noreg, 0, $noreg
   ; INSTRREF-NEXT:   [[DEF:%[0-9]+]]:gr64 = IMPLICIT_DEF
   ; INSTRREF-NEXT: {{  $}}
   ; INSTRREF-NEXT: bb.1.bb_8:
   ; INSTRREF-NEXT:   successors: %bb.3(0x40000000), %bb.2(0x40000000)
   ; INSTRREF-NEXT: {{  $}}
-  ; INSTRREF-NEXT:   TEST8rr [[COPY]], [[COPY]], implicit-def $eflags
+  ; INSTRREF-NEXT:   TEST8rr [[MOV32r0_]], [[COPY]], implicit-def $eflags
   ; INSTRREF-NEXT:   JCC_1 %bb.3, 5, implicit $eflags
   ; INSTRREF-NEXT:   JMP_1 %bb.2
   ; INSTRREF-NEXT: {{  $}}
@@ -84,11 +86,11 @@ define void @foo() {
   ; INSTRREF-NEXT:   successors: %bb.1(0x80000000)
   ; INSTRREF-NEXT: {{  $}}
   ; INSTRREF-NEXT:   ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
-  ; INSTRREF-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, [[MOV32r0_]], %subreg.sub_32bit
+  ; INSTRREF-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, [[MOV32r0_1]], %subreg.sub_32bit
   ; INSTRREF-NEXT:   $rdi = COPY [[SUBREG_TO_REG]]
   ; INSTRREF-NEXT:   $rsi = COPY [[SUBREG_TO_REG]]
   ; INSTRREF-NEXT:   $rdx = COPY [[SUBREG_TO_REG]]
-  ; INSTRREF-NEXT:   $ecx = COPY [[MOV32r0_]]
+  ; INSTRREF-NEXT:   $ecx = COPY [[MOV32r0_1]]
   ; INSTRREF-NEXT:   $r8 = COPY [[LEA64r]]
   ; INSTRREF-NEXT:   CALL64r [[DEF]], csr_64, implicit $rsp, implicit $ssp, implicit $rdi, implicit $rsi, implicit $rdx, implicit $ecx, implicit $r8, implicit-def $rsp, implicit-def $ssp
   ; INSTRREF-NEXT:   ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp

--- a/llvm/test/CodeGen/X86/pr63108.ll
+++ b/llvm/test/CodeGen/X86/pr63108.ll
@@ -7,7 +7,6 @@
 define i32 @PR63108() {
 ; SSE-LABEL: PR63108:
 ; SSE:       # %bb.0: # %entry
-; SSE-NEXT:    xorl %eax, %eax
 ; SSE-NEXT:    testb %al, %al
 ; SSE-NEXT:    je .LBB0_2
 ; SSE-NEXT:  # %bb.1:
@@ -16,7 +15,7 @@ define i32 @PR63108() {
 ; SSE-NEXT:  .LBB0_2: # %vector.body.preheader
 ; SSE-NEXT:    pxor %xmm0, %xmm0
 ; SSE-NEXT:    movd {{.*#+}} xmm1 = [57339,0,0,0]
-; SSE-NEXT:    xorl %eax, %eax
+; SSE-NEXT:    xorl    %eax, %eax
 ; SSE-NEXT:    .p2align 4
 ; SSE-NEXT:  .LBB0_3: # %vector.body
 ; SSE-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -43,7 +42,6 @@ define i32 @PR63108() {
 ;
 ; AVX1-LABEL: PR63108:
 ; AVX1:       # %bb.0: # %entry
-; AVX1-NEXT:    xorl %eax, %eax
 ; AVX1-NEXT:    testb %al, %al
 ; AVX1-NEXT:    je .LBB0_2
 ; AVX1-NEXT:  # %bb.1:
@@ -80,7 +78,6 @@ define i32 @PR63108() {
 ;
 ; AVX2-LABEL: PR63108:
 ; AVX2:       # %bb.0: # %entry
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb %al, %al
 ; AVX2-NEXT:    je .LBB0_2
 ; AVX2-NEXT:  # %bb.1:
@@ -117,7 +114,6 @@ define i32 @PR63108() {
 ;
 ; AVX512-LABEL: PR63108:
 ; AVX512:       # %bb.0: # %entry
-; AVX512-NEXT:    xorl %eax, %eax
 ; AVX512-NEXT:    testb %al, %al
 ; AVX512-NEXT:    je .LBB0_2
 ; AVX512-NEXT:  # %bb.1:

--- a/llvm/test/CodeGen/X86/pr91005.ll
+++ b/llvm/test/CodeGen/X86/pr91005.ll
@@ -4,7 +4,6 @@
 define void @PR91005(ptr %0) minsize {
 ; CHECK-LABEL: PR91005:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je .LBB0_2
 ; CHECK-NEXT:  # %bb.1:

--- a/llvm/test/CodeGen/X86/ragreedy-hoist-spill.ll
+++ b/llvm/test/CodeGen/X86/ragreedy-hoist-spill.ll
@@ -44,11 +44,9 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne LBB0_5
 ; CHECK-NEXT:  ## %bb.2: ## %if.then4
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je LBB0_54
 ; CHECK-NEXT:  ## %bb.3: ## %SyTime.exit
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je LBB0_54
 ; CHECK-NEXT:  LBB0_4: ## %cleanup
@@ -61,7 +59,6 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    popq %rbp
 ; CHECK-NEXT:    retq
 ; CHECK-NEXT:  LBB0_5: ## %if.end25
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je LBB0_54
 ; CHECK-NEXT:  ## %bb.6: ## %SyTime.exit2720
@@ -94,7 +91,7 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-NEXT:    xorl %ebp, %ebp
-; CHECK-NEXT:    testb %bpl, %bpl
+; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne LBB0_11
 ; CHECK-NEXT:  ## %bb.12: ## %while.body200.preheader
 ; CHECK-NEXT:    xorl %r12d, %r12d
@@ -155,14 +152,14 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:  ## %bb.29: ## %cond.true.i.i2780
 ; CHECK-NEXT:    ## in Loop: Header=BB0_28 Depth=2
 ; CHECK-NEXT:    movq %rax, %rbx
-; CHECK-NEXT:    testb %r12b, %r12b
+; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne LBB0_31
 ; CHECK-NEXT:  ## %bb.30: ## %lor.rhs500
 ; CHECK-NEXT:    ## in Loop: Header=BB0_28 Depth=2
 ; CHECK-NEXT:    movl $256, %esi ## imm = 0x100
 ; CHECK-NEXT:    callq ___maskrune
 ; CHECK-NEXT:    movb $1, %sil
-; CHECK-NEXT:    testb %r12b, %r12b
+; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne LBB0_31
 ; CHECK-NEXT:    jmp LBB0_33
 ; CHECK-NEXT:    .p2align 4
@@ -231,7 +228,7 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    jne LBB0_37
 ; CHECK-NEXT:  ## %bb.38: ## %for.cond542.preheader
 ; CHECK-NEXT:    ## in Loop: Header=BB0_13 Depth=1
-; CHECK-NEXT:    testb %r12b, %r12b
+; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    movb $0, (%rbx)
 ; CHECK-NEXT:    leaq LJTI0_0(%rip), %rdx
 ; CHECK-NEXT:    jmp LBB0_20
@@ -276,7 +273,6 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    movq %r14, %rbx
 ; CHECK-NEXT:    jmp LBB0_47
 ; CHECK-NEXT:  LBB0_16: ## %while.cond635.preheader
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je LBB0_40
 ; CHECK-NEXT:    .p2align 4
@@ -309,7 +305,6 @@ define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 ; CHECK-NEXT:    testb %bl, %bl
 ; CHECK-NEXT:    jne LBB0_52
 ; CHECK-NEXT:  LBB0_53: ## %while.cond1683.preheader
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:  LBB0_54: ## %if.then.i
 ; CHECK-NEXT:    ud2

--- a/llvm/test/CodeGen/X86/shift-combine.ll
+++ b/llvm/test/CodeGen/X86/shift-combine.ll
@@ -390,7 +390,6 @@ define dso_local i32 @ashr_add_shl_i32_i8_extra_use3(i32 %r, ptr %p1, ptr %p2) n
 define dso_local void @PR42880(i32 %t0) {
 ; X86-LABEL: PR42880:
 ; X86:       # %bb.0:
-; X86-NEXT:    xorl %eax, %eax
 ; X86-NEXT:    testb %al, %al
 ; X86-NEXT:    je .LBB16_1
 ; X86-NEXT:  # %bb.2: # %if
@@ -398,7 +397,6 @@ define dso_local void @PR42880(i32 %t0) {
 ;
 ; X64-LABEL: PR42880:
 ; X64:       # %bb.0:
-; X64-NEXT:    xorl %eax, %eax
 ; X64-NEXT:    testb %al, %al
 ; X64-NEXT:    je .LBB16_1
 ; X64-NEXT:  # %bb.2: # %if

--- a/llvm/test/CodeGen/X86/shuffle-combine-crash.ll
+++ b/llvm/test/CodeGen/X86/shuffle-combine-crash.ll
@@ -18,7 +18,6 @@
 define void @sample_test() {
 ; CHECK-LABEL: sample_test:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB0_2
 ; CHECK-NEXT:  # %bb.1:

--- a/llvm/test/CodeGen/X86/shuffle-half.ll
+++ b/llvm/test/CodeGen/X86/shuffle-half.ll
@@ -5,7 +5,6 @@ define <32 x half> @dump_vec() {
 ; CHECK-LABEL: dump_vec:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vxorps %xmm0, %xmm0, %xmm0
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB0_2
 ; CHECK-NEXT:  # %bb.1: # %cond.load

--- a/llvm/test/CodeGen/X86/swifterror.ll
+++ b/llvm/test/CodeGen/X86/swifterror.ll
@@ -931,7 +931,6 @@ define void @swifterror_isel(ptr) {
 ; CHECK-APPLE-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-APPLE-NEXT:    .cfi_offset %r12, -24
 ; CHECK-APPLE-NEXT:    .cfi_offset %r13, -16
-; CHECK-APPLE-NEXT:    xorl %eax, %eax
 ; CHECK-APPLE-NEXT:    testb %al, %al
 ; CHECK-APPLE-NEXT:    jne LBB8_3
 ; CHECK-APPLE-NEXT:  ## %bb.1: ## %.preheader
@@ -993,7 +992,6 @@ define void @swifterror_isel(ptr) {
 ; CHECK-i386-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-i386-NEXT:    .cfi_offset %esi, -12
 ; CHECK-i386-NEXT:    .cfi_offset %edi, -8
-; CHECK-i386-NEXT:    xorl %eax, %eax
 ; CHECK-i386-NEXT:    testb %al, %al
 ; CHECK-i386-NEXT:    jne LBB8_3
 ; CHECK-i386-NEXT:  ## %bb.1: ## %.preheader

--- a/llvm/test/CodeGen/X86/tailcall-cgp-dup.ll
+++ b/llvm/test/CodeGen/X86/tailcall-cgp-dup.ll
@@ -107,7 +107,6 @@ declare ptr @bar(ptr) uwtable optsize noinline ssp
 define hidden ptr @thingWithValue(ptr %self) uwtable ssp {
 ; CHECK-LABEL: thingWithValue:
 ; CHECK:       ## %bb.0: ## %entry
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    je _bar ## TAILCALL
 ; CHECK-NEXT:  ## %bb.1: ## %someThingWithValue.exit

--- a/llvm/test/CodeGen/X86/vaargs-prolog-insert.ll
+++ b/llvm/test/CodeGen/X86/vaargs-prolog-insert.ll
@@ -7,8 +7,14 @@ define void @reduce(i32, i32, i32, i32, i32, i32, ...) nounwind {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    subq $56, %rsp
 ; CHECK-NEXT:    testb %al, %al
-; CHECK-NEXT:    je .LBB0_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    jne .LBB0_3
+; CHECK-NEXT:  # %bb.4:
+; CHECK-NEXT:    testb   %al, %al
+; CHECK-NEXT:    je      .LBB0_1
+; CHECK-NEXT: .LBB0_2:
+; CHECK-NEXT:    addq    $56, %rsp
+; CHECK-NEXT:    retq
+; CHECK-NEXT: .LBB0_3:
 ; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm1, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm2, -{{[0-9]+}}(%rsp)
@@ -17,18 +23,15 @@ define void @reduce(i32, i32, i32, i32, i32, i32, ...) nounwind {
 ; CHECK-NEXT:    movaps %xmm5, (%rsp)
 ; CHECK-NEXT:    movaps %xmm6, {{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm7, {{[0-9]+}}(%rsp)
-; CHECK-NEXT:  .LBB0_4:
-; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    testb %al, %al
 ; CHECK-NEXT:    jne .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT: .LBB0_1:
 ; CHECK-NEXT:    leaq -{{[0-9]+}}(%rsp), %rax
 ; CHECK-NEXT:    movq %rax, 16
 ; CHECK-NEXT:    leaq {{[0-9]+}}(%rsp), %rax
 ; CHECK-NEXT:    movq %rax, 8
 ; CHECK-NEXT:    movl $48, 4
 ; CHECK-NEXT:    movl $48, 0
-; CHECK-NEXT:  .LBB0_2:
 ; CHECK-NEXT:    addq $56, %rsp
 ; CHECK-NEXT:    retq
   br i1 poison, label %8, label %7

--- a/llvm/test/CodeGen/X86/vector-shuffle-combining-avx512bwvl.ll
+++ b/llvm/test/CodeGen/X86/vector-shuffle-combining-avx512bwvl.ll
@@ -268,19 +268,17 @@ define <8 x i32> @PR46393(<8 x i16> %a0, i8 %a1) {
 define i64 @PR55050() {
 ; X86-LABEL: PR55050:
 ; X86:       # %bb.0: # %entry
-; X86-NEXT:    xorl %edx, %edx
 ; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    testb %dl, %dl
+; X86-NEXT:    testb %al, %al
 ; X86-NEXT:    jne .LBB15_2
 ; X86-NEXT:  # %bb.1: # %if
 ; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    xorl %edx, %edx
 ; X86-NEXT:  .LBB15_2: # %exit
+; X86-NEXT:    movl    %eax, %edx
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: PR55050:
 ; X64:       # %bb.0: # %entry
-; X64-NEXT:    xorl %eax, %eax
 ; X64-NEXT:    testb %al, %al
 ; X64-NEXT:    xorl %eax, %eax
 ; X64-NEXT:    retq

--- a/llvm/test/CodeGen/X86/x86-shrink-wrapping.ll
+++ b/llvm/test/CodeGen/X86/x86-shrink-wrapping.ll
@@ -814,21 +814,21 @@ define void @infiniteloop() {
 ; ENABLE-NEXT:    pushq %rbx
 ; ENABLE-NEXT:    pushq %rax
 ; ENABLE-NEXT:    .cfi_offset %rbx, -24
-; ENABLE-NEXT:    xorl %eax, %eax
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB10_3
 ; ENABLE-NEXT:  ## %bb.1: ## %if.then
-; ENABLE-NEXT:    movq %rsp, %rcx
-; ENABLE-NEXT:    addq $-16, %rcx
-; ENABLE-NEXT:    movq %rcx, %rsp
+; ENABLE-NEXT:    movq %rsp, %rax
+; ENABLE-NEXT:    addq $-16, %rax
+; ENABLE-NEXT:    movq %rax, %rsp
+; ENABLE-NEXT:    xorl    %ecx, %ecx
 ; ENABLE-NEXT:    .p2align 4
 ; ENABLE-NEXT:  LBB10_2: ## %for.body
 ; ENABLE-NEXT:    ## =>This Inner Loop Header: Depth=1
 ; ENABLE-NEXT:    ## InlineAsm Start
 ; ENABLE-NEXT:    movl $1, %edx
 ; ENABLE-NEXT:    ## InlineAsm End
-; ENABLE-NEXT:    addl %edx, %eax
-; ENABLE-NEXT:    movl %eax, (%rcx)
+; ENABLE-NEXT:    addl %edx, %ecx
+; ENABLE-NEXT:    movl %ecx, (%rax)
 ; ENABLE-NEXT:    jmp LBB10_2
 ; ENABLE-NEXT:  LBB10_3: ## %if.end
 ; ENABLE-NEXT:    leaq -8(%rbp), %rsp
@@ -846,21 +846,21 @@ define void @infiniteloop() {
 ; DISABLE-NEXT:    pushq %rbx
 ; DISABLE-NEXT:    pushq %rax
 ; DISABLE-NEXT:    .cfi_offset %rbx, -24
-; DISABLE-NEXT:    xorl %eax, %eax
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB10_3
 ; DISABLE-NEXT:  ## %bb.1: ## %if.then
-; DISABLE-NEXT:    movq %rsp, %rcx
-; DISABLE-NEXT:    addq $-16, %rcx
-; DISABLE-NEXT:    movq %rcx, %rsp
+; DISABLE-NEXT:    movq %rsp, %rax
+; DISABLE-NEXT:    addq $-16, %rax
+; DISABLE-NEXT:    %rax, %rsp
+; DISABLE-NEXT:    xorl    %ecx, %ecx
 ; DISABLE-NEXT:    .p2align 4
 ; DISABLE-NEXT:  LBB10_2: ## %for.body
 ; DISABLE-NEXT:    ## =>This Inner Loop Header: Depth=1
 ; DISABLE-NEXT:    ## InlineAsm Start
 ; DISABLE-NEXT:    movl $1, %edx
 ; DISABLE-NEXT:    ## InlineAsm End
-; DISABLE-NEXT:    addl %edx, %eax
-; DISABLE-NEXT:    movl %eax, (%rcx)
+; DISABLE-NEXT:    addl %edx, %ecx
+; DISABLE-NEXT:    movl %ecx, (%rax)
 ; DISABLE-NEXT:    jmp LBB10_2
 ; DISABLE-NEXT:  LBB10_3: ## %if.end
 ; DISABLE-NEXT:    leaq -8(%rbp), %rsp
@@ -897,14 +897,13 @@ define void @infiniteloop2() {
 ; ENABLE-NEXT:    pushq %rbx
 ; ENABLE-NEXT:    pushq %rax
 ; ENABLE-NEXT:    .cfi_offset %rbx, -24
-; ENABLE-NEXT:    xorl %eax, %eax
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB11_5
 ; ENABLE-NEXT:  ## %bb.1: ## %if.then
-; ENABLE-NEXT:    movq %rsp, %rcx
-; ENABLE-NEXT:    addq $-16, %rcx
-; ENABLE-NEXT:    movq %rcx, %rsp
-; ENABLE-NEXT:    xorl %edx, %edx
+; ENABLE-NEXT:    movq %rsp, %rax
+; ENABLE-NEXT:    addq $-16, %rax
+; ENABLE-NEXT:    movq %rax, %rsp
+; ENABLE-NEXT:    xorl %ecx, %ecx
 ; ENABLE-NEXT:    jmp LBB11_2
 ; ENABLE-NEXT:    .p2align 4
 ; ENABLE-NEXT:  LBB11_4: ## %body2
@@ -912,15 +911,15 @@ define void @infiniteloop2() {
 ; ENABLE-NEXT:    ## InlineAsm Start
 ; ENABLE-NEXT:    nop
 ; ENABLE-NEXT:    ## InlineAsm End
-; ENABLE-NEXT:    movl $1, %edx
+; ENABLE-NEXT:    movl $1, %ecx
 ; ENABLE-NEXT:  LBB11_2: ## %for.body
 ; ENABLE-NEXT:    ## =>This Inner Loop Header: Depth=1
-; ENABLE-NEXT:    movl %edx, %esi
+; ENABLE-NEXT:    movl %ecx, %edx
 ; ENABLE-NEXT:    ## InlineAsm Start
-; ENABLE-NEXT:    movl $1, %edx
+; ENABLE-NEXT:    movl $1, %ecx
 ; ENABLE-NEXT:    ## InlineAsm End
-; ENABLE-NEXT:    addl %esi, %edx
-; ENABLE-NEXT:    movl %edx, (%rcx)
+; ENABLE-NEXT:    addl %edx, %ecx
+; ENABLE-NEXT:    movl %ecx, (%rax)
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB11_4
 ; ENABLE-NEXT:  ## %bb.3: ## %body1
@@ -945,14 +944,13 @@ define void @infiniteloop2() {
 ; DISABLE-NEXT:    pushq %rbx
 ; DISABLE-NEXT:    pushq %rax
 ; DISABLE-NEXT:    .cfi_offset %rbx, -24
-; DISABLE-NEXT:    xorl %eax, %eax
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB11_5
 ; DISABLE-NEXT:  ## %bb.1: ## %if.then
-; DISABLE-NEXT:    movq %rsp, %rcx
-; DISABLE-NEXT:    addq $-16, %rcx
-; DISABLE-NEXT:    movq %rcx, %rsp
-; DISABLE-NEXT:    xorl %edx, %edx
+; DISABLE-NEXT:    movq %rsp, %rax
+; DISABLE-NEXT:    addq $-16, %rax
+; DISABLE-NEXT:    movq %rax, %rsp
+; DISABLE-NEXT:    xorl %ecx, %ecx
 ; DISABLE-NEXT:    jmp LBB11_2
 ; DISABLE-NEXT:    .p2align 4
 ; DISABLE-NEXT:  LBB11_4: ## %body2
@@ -960,15 +958,15 @@ define void @infiniteloop2() {
 ; DISABLE-NEXT:    ## InlineAsm Start
 ; DISABLE-NEXT:    nop
 ; DISABLE-NEXT:    ## InlineAsm End
-; DISABLE-NEXT:    movl $1, %edx
+; DISABLE-NEXT:    movl $1, %ecx
 ; DISABLE-NEXT:  LBB11_2: ## %for.body
 ; DISABLE-NEXT:    ## =>This Inner Loop Header: Depth=1
-; DISABLE-NEXT:    movl %edx, %esi
+; DISABLE-NEXT:    movl %ecx, %edx
 ; DISABLE-NEXT:    ## InlineAsm Start
-; DISABLE-NEXT:    movl $1, %edx
+; DISABLE-NEXT:    movl $1, %ecx
 ; DISABLE-NEXT:    ## InlineAsm End
-; DISABLE-NEXT:    addl %esi, %edx
-; DISABLE-NEXT:    movl %edx, (%rcx)
+; DISABLE-NEXT:    addl %edx, %ecx
+; DISABLE-NEXT:    movl %ecx, (%rax)
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB11_4
 ; DISABLE-NEXT:  ## %bb.3: ## %body1
@@ -1012,11 +1010,9 @@ if.end:
 define void @infiniteloop3() {
 ; ENABLE-LABEL: infiniteloop3:
 ; ENABLE:       ## %bb.0: ## %entry
-; ENABLE-NEXT:    xorl %eax, %eax
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB12_2
 ; ENABLE-NEXT:  ## %bb.1: ## %body
-; ENABLE-NEXT:    xorl %eax, %eax
 ; ENABLE-NEXT:    testb %al, %al
 ; ENABLE-NEXT:    jne LBB12_7
 ; ENABLE-NEXT:  LBB12_2: ## %loop2a.preheader
@@ -1044,11 +1040,9 @@ define void @infiniteloop3() {
 ;
 ; DISABLE-LABEL: infiniteloop3:
 ; DISABLE:       ## %bb.0: ## %entry
-; DISABLE-NEXT:    xorl %eax, %eax
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB12_2
 ; DISABLE-NEXT:  ## %bb.1: ## %body
-; DISABLE-NEXT:    xorl %eax, %eax
 ; DISABLE-NEXT:    testb %al, %al
 ; DISABLE-NEXT:    jne LBB12_7
 ; DISABLE-NEXT:  LBB12_2: ## %loop2a.preheader


### PR DESCRIPTION
Reland the https://github.com/llvm/llvm-project/pull/122741 after fix fail test cases https://github.com/llvm/llvm-project/pull/136636

The PR will fix the issue https://github.com/llvm/llvm-project/issues/122728

This patch addresses the signed/zero extension of poison by using a poison value of the extended type instead of a constant zero of the extended type.