### PR TITLE
[X86][GlobalIsel] add strictfp attribute from ir into mir

### DIFF
--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -630,6 +630,10 @@ uint32_t MachineInstr::copyFlagsFromInstruction(const Instruction &I) {
   if (I.getMetadata(LLVMContext::MD_unpredictable))
     MIFlags |= MachineInstr::MIFlag::Unpredictable;
 
+  if (const CallInst *CI = dyn_cast<CallInst>(&I)) {
+    MIFlags |=
+        CI->hasFnAttr(llvm::Attribute::StrictFP) ? MachineInstr::NoFPExcept : 0;
+  }
   return MIFlags;
 }
 


### PR DESCRIPTION
I am supporting `G_IS_FPCLASS` opcode and noticed `strictfp` attribute was not forwarded into MIFlag.
This patch adds attribute to MIR in GISEL-IRTranslator.
Requirement comes from `G_IS_FPCLASS`  PR https://github.com/mahesh-attarde/llvm-project/pull/4 for strictfp.
