### PR TITLE
[mlir][nfc] Replace some `std::vector`s with `SmallVector`

### DIFF
--- a/mlir/include/mlir/IR/BuiltinAttributes.h
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h
@@ -994,7 +994,7 @@ auto SparseElementsAttr::try_value_begin_impl(OverloadToken<T>) const
   auto valueIt = getValues().try_value_begin<T>();
   if (failed(valueIt))
     return failure();
-  const std::vector<ptrdiff_t> flatSparseIndices(getFlattenedSparseIndices());
+  const SmallVector<ptrdiff_t> flatSparseIndices(getFlattenedSparseIndices());
   std::function<T(ptrdiff_t)> mapFn =
       [flatSparseIndices{flatSparseIndices}, valueIt{std::move(*valueIt)},
        zeroValue{std::move(zeroValue)}](ptrdiff_t index) {

--- a/mlir/include/mlir/IR/BuiltinAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinAttributes.td
@@ -164,7 +164,7 @@ def Builtin_DenseArrayRawDataParameter : ArrayRefParameter<
   }];
 }
 
-def Builtin_DenseArray : Builtin_Attr<"DenseArray", "dense_array", 
+def Builtin_DenseArray : Builtin_Attr<"DenseArray", "dense_array",
     [BlobAttrInterface]> {
   let summary = "A dense array of integer or floating point elements.";
   let description = [{
@@ -494,7 +494,7 @@ def Builtin_DenseResourceElementsAttr : Builtin_Attr<"DenseResourceElements",
     /// when building the attribute. The provided `blobName` is used as a hint
     /// for the key of the new handle for the `blob` resource, but may be
     /// changed if necessary to ensure uniqueness during insertion.
-    /// This base class builder does no element type specific size or alignment 
+    /// This base class builder does no element type specific size or alignment
     /// checking. Use the typed subclasses for more safety unless if performing
     /// generic operations.
     AttrBuilderWithInferredContext<(ins
@@ -989,7 +989,7 @@ def Builtin_SparseElementsAttr : Builtin_Attr<
 
     /// Flatten, and return, all of the sparse indices in this attribute in
     /// row-major order.
-    std::vector<ptrdiff_t> getFlattenedSparseIndices() const;
+    SmallVector<ptrdiff_t> getFlattenedSparseIndices() const;
 
   public:
   }];

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -988,7 +988,7 @@ DenseElementsAttr DenseElementsAttr::get(ShapedType type,
   assert(hasSameNumElementsOrSplat(type, values));
   assert(type.getElementType().isInteger(1));
 
-  std::vector<char> buff(llvm::divideCeil(values.size(), CHAR_BIT));
+  SmallVector<char> buff(llvm::divideCeil(values.size(), CHAR_BIT));
 
   if (!values.empty()) {
     bool isSplat = true;
@@ -1306,7 +1306,7 @@ int64_t DenseElementsAttr::getNumElements() const {
 
 /// Utility method to write a range of APInt values to a buffer.
 template <typename APRangeT>
-static void writeAPIntsToBuffer(size_t storageWidth, std::vector<char> &data,
+static void writeAPIntsToBuffer(size_t storageWidth, SmallVector<char> &data,
                                 APRangeT &&values) {
   size_t numValues = llvm::size(values);
   data.resize(llvm::divideCeil(storageWidth * numValues, CHAR_BIT));
@@ -1328,7 +1328,7 @@ static void writeAPIntsToBuffer(size_t storageWidth, std::vector<char> &data,
 DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
                                                    size_t storageWidth,
                                                    ArrayRef<APFloat> values) {
-  std::vector<char> data;
+  SmallVector<char> data;
   auto unwrapFloat = [](const APFloat &val) { return val.bitcastToAPInt(); };
   writeAPIntsToBuffer(storageWidth, data, llvm::map_range(values, unwrapFloat));
   return DenseIntOrFPElementsAttr::getRaw(type, data);
@@ -1340,7 +1340,7 @@ DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
 DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
                                                    size_t storageWidth,
                                                    ArrayRef<APInt> values) {
-  std::vector<char> data;
+  SmallVector<char> data;
   writeAPIntsToBuffer(storageWidth, data, values);
   return DenseIntOrFPElementsAttr::getRaw(type, data);
 }
@@ -1705,8 +1705,8 @@ Attribute SparseElementsAttr::getZeroAttr() const {
 
 /// Flatten, and return, all of the sparse indices in this attribute in
 /// row-major order.
-std::vector<ptrdiff_t> SparseElementsAttr::getFlattenedSparseIndices() const {
-  std::vector<ptrdiff_t> flatSparseIndices;
+SmallVector<ptrdiff_t> SparseElementsAttr::getFlattenedSparseIndices() const {
+  SmallVector<ptrdiff_t> flatSparseIndices;
 
   // The sparse indices are 64-bit integers, so we can reinterpret the raw data
   // as a 1-D index array.

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -1306,7 +1306,8 @@ int64_t DenseElementsAttr::getNumElements() const {
 
 /// Utility method to write a range of APInt values to a buffer.
 template <typename APRangeT>
-static void writeAPIntsToBuffer(size_t storageWidth, SmallVector<char> &data,
+static void writeAPIntsToBuffer(size_t storageWidth,
+                                SmallVectorImpl<char> &data,
                                 APRangeT &&values) {
   size_t numValues = llvm::size(values);
   data.resize(llvm::divideCeil(storageWidth * numValues, CHAR_BIT));


### PR DESCRIPTION
`SmallVector` is preferable to `std::vector` https://llvm.org/docs/ProgrammersManual.html#llvm-adt-smallvector-h