### PR TITLE
[CIR] Change 'CIR-int' to use a 'APIntParameter' argument

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -114,7 +114,7 @@ def IntAttr : CIR_Attr<"Int", "int", [TypedAttrInterface]> {
     value of the specified integer type.
   }];
   let parameters = (ins AttributeSelfTypeParameter<"">:$type,
-                        "llvm::APInt":$value);
+                        APIntParameter<"">:$value);
   let builders = [
     AttrBuilderWithInferredContext<(ins "mlir::Type":$type,
                                         "const llvm::APInt &":$value), [{


### PR DESCRIPTION
After 4bcc414af3782c333 an APInt parameter diagnoses, so this switches us to APIntParameter.

I don't believe we need to put this in the incubator, as it'll get this in the same 
pulldown as the diagnostic.

