### PR TITLE
[docs][CoC] Update verbiage about appeal process

### DIFF
--- a/llvm/docs/ResponseGuide.rst
+++ b/llvm/docs/ResponseGuide.rst
@@ -218,11 +218,13 @@ Appeal Process
 ===============
 
 Any individual(s) determined to have violated the CoC have the right to appeal
-a decision. An appeal can be made directly to the committee by sending an email
-to conduct@llvm.org with subject line Code of Conduct Incident Appeal.
+a resolution decision. An appeal can be made directly to the committee by sending an 
+email to conduct@llvm.org with subject line Code of Conduct Incident Appeal.
 
-The email should include documentation related to the incident to support the
-appeal. The said documentation may include, but does not have to be limited to:
+This process is intended to consider new or different evidence from the 
+initial incident investigation. The email should include documentation related 
+to the incident to support the appeal. The said documentation may include, 
+but does not have to be limited to:
 
 * Information from the reportee justifying reasoning for the appeal.
 * Statements from other individuals involved in the incident to support the


### PR DESCRIPTION
Often, when the CoC investigates incidents, most members are available to discuss & come to a unanimous decision. In the event of an appeal, we agreed that the effective way to investigate would be for the committee to consider evidence that was missed in the initial decision-making. Update the Response guide to reflect this.