### PR TITLE
[mlir][utils] Update generate-test-checks.py

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -295,6 +295,12 @@ def main():
         help="Names to be used in FileCheck regular expression to represent "
         "attributes in the order they are defined. Separate names with commas,"
         "commas, and leave empty entries for default names (e.g.: 'MAP0,,,MAP1')")
+    parser.add_argument(
+        "--strict_name_re",
+        type=bool,
+        default=False,
+        help="Set to true to use stricter regex for CHECK-SAME directives. "
+        "Use when Greedy matching causes issues with the generic '.*'")
 
     args = parser.parse_args()
 
@@ -406,7 +412,7 @@ def main():
 
                 # Process the rest of the line.
                 output_line += process_line(
-                    [argument], variable_namer, strict_name_re=True
+                    [argument], variable_namer, args.strict_name_re
                 )
 
         # Append the output line.

--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -300,7 +300,8 @@ def main():
         type=bool,
         default=False,
         help="Set to true to use stricter regex for CHECK-SAME directives. "
-        "Use when Greedy matching causes issues with the generic '.*'")
+        "Use when Greedy matching causes issues with the generic '.*'",
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Following #128083, all `CHECK-SAME` lines generated by
generate-test-checks.py use a strict regex:

```mlir
// CHECK-SAME:  %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<128x256x512xf32>,
```

However, in most cases this strict form is unnecessary and can obscure
readability. In such cases, the following would be sufficient:

```mlir
// CHECK-SAME:  %[[VAL_0:.*]]: memref<128x256x512xf32>,
```

This patch adds a command-line flag to make the strict mode optional. To
enable strict regex matching, use:

```bash
generate-test-checks.py --strict_name_re=true file.mlir
```
