### PR TITLE
[RISCV] Make xrivosvizip interleave2 and deinterleave2 undef safe

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -11543,7 +11543,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
       EVT NewVT = VT.getDoubleNumVectorElementsVT();
       SDValue ZeroIdx = DAG.getVectorIdxConstant(0, DL);
       Src = DAG.getNode(ISD::EXTRACT_SUBVECTOR, DL, NewVT, Src, ZeroIdx);
-      // Freeze the source so we can increase it's use count.
+      // Freeze the source so we can increase its use count.
       Src = DAG.getFreeze(Src);
       SDValue Even = lowerVZIP(RISCVISD::RI_VUNZIP2A_VL, Src,
                                DAG.getUNDEF(NewVT), DL, DAG, Subtarget);

--- a/llvm/test/CodeGen/RISCV/rvv/vector-interleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-interleave.ll
@@ -260,18 +260,18 @@ define <vscale x 128 x i1> @vector_interleave_nxv128i1_nxv64i1(<vscale x 64 x i1
 ; ZIP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
 ; ZIP-NEXT:    vmv1r.v v9, v0
 ; ZIP-NEXT:    vmv1r.v v0, v8
-; ZIP-NEXT:    vmv.v.i v24, 0
-; ZIP-NEXT:    vmerge.vim v16, v24, 1, v0
+; ZIP-NEXT:    vmv.v.i v16, 0
+; ZIP-NEXT:    vmerge.vim v24, v16, 1, v0
 ; ZIP-NEXT:    vmv1r.v v0, v9
-; ZIP-NEXT:    vmerge.vim v8, v24, 1, v0
+; ZIP-NEXT:    vmerge.vim v8, v16, 1, v0
 ; ZIP-NEXT:    vsetvli a0, zero, e8, m4, ta, ma
-; ZIP-NEXT:    ri.vzip2b.vv v4, v8, v16
-; ZIP-NEXT:    ri.vzip2b.vv v28, v12, v20
-; ZIP-NEXT:    ri.vzip2a.vv v0, v8, v16
-; ZIP-NEXT:    ri.vzip2a.vv v24, v12, v20
+; ZIP-NEXT:    ri.vzip2b.vv v4, v8, v24
+; ZIP-NEXT:    ri.vzip2b.vv v20, v12, v28
+; ZIP-NEXT:    ri.vzip2a.vv v0, v8, v24
+; ZIP-NEXT:    ri.vzip2a.vv v16, v12, v28
 ; ZIP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
 ; ZIP-NEXT:    vmsne.vi v9, v0, 0
-; ZIP-NEXT:    vmsne.vi v8, v24, 0
+; ZIP-NEXT:    vmsne.vi v8, v16, 0
 ; ZIP-NEXT:    vmv1r.v v0, v9
 ; ZIP-NEXT:    ret
   %res = call <vscale x 128 x i1> @llvm.vector.interleave2.nxv128i1(<vscale x 64 x i1> %a, <vscale x 64 x i1> %b)


### PR DESCRIPTION
We're duplicating uses here, so we need to freeze the inputs.