### PR TITLE
[Clang][kcfi] Sign extend KCFI typeid rather than zero extend

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2931,7 +2931,7 @@ void CodeGenModule::finalizeKCFITypes() {
       continue;
 
     std::string Asm = (".weak __kcfi_typeid_" + Name + "\n.set __kcfi_typeid_" +
-                       Name + ", " + Twine(Type->getZExtValue()) + "\n")
+                       Name + ", " + Twine(Type->getSExtValue()) + "\n")
                           .str();
     M.appendModuleInlineAsm(Asm);
   }


### PR DESCRIPTION
The KCFI typeid may be negative, but will result in this type of bitcode:

    module asm ".weak __kcfi_typeid_func"
    module asm ".set __kcfi_typeid_func, 2874394057"

    // ...

    define dso_local i32 @call_unsigned(ptr noundef %f) #0 !kcfi_type !6 {
      // ...
      %call = call i32 %0(i32 noundef 37) [ "kcfi"(i32 -1420573239) ]
      ret i32 %call
    }

    declare !kcfi_type !7 noundef i32 @foo(i32 noundef)

    // ...

    !7 = !{i32 -1420573239}

The __kcfi_typeid_func value doesn't equal the metadata value. Therefore, we sign extend the typeid value rather than zero extend.

This also reorganizes the testcase to remove the "-DAG" checks, which are a bit confusing at first.