### PR TITLE
[compiler-rt] Make sure __clzdi2 doesn't call itself recursively on sparc64

### DIFF
--- a/compiler-rt/lib/builtins/clzdi2.c
+++ b/compiler-rt/lib/builtins/clzdi2.c
@@ -17,9 +17,9 @@
 #if ((defined(__sparc__) && defined(__arch64__)) || defined(__mips64) ||       \
      (defined(__riscv) && __SIZEOF_POINTER__ >= 8))
 // On 64-bit architectures with neither a native clz instruction nor a native
-// ctz instruction, resolves __builtin_clz resolves to __clzdi2 rather than
-// __clzsi2, leading to infinite recursion.
-// This is because on those platforms, libgcc doesn't ship with __clzsi2.
+// ctz instruction, `__builtin_clz` resolves to `__clzdi2` rather than
+// __clzsi2 as libgcc does not ship with `__clzsi2`, leading to infinite
+// recursion.
 #define __builtin_clz(a) __clzsi2(a)
 extern int __clzsi2(si_int);
 #endif

--- a/compiler-rt/lib/builtins/clzdi2.c
+++ b/compiler-rt/lib/builtins/clzdi2.c
@@ -14,12 +14,12 @@
 
 // Returns: the number of leading 0-bits
 
-#if !defined(__clang__) &&                                                     \
-    ((defined(__sparc__) && defined(__arch64__)) || defined(__mips64) ||       \
+#if ((defined(__sparc__) && defined(__arch64__)) || defined(__mips64) ||       \
      (defined(__riscv) && __SIZEOF_POINTER__ >= 8))
 // On 64-bit architectures with neither a native clz instruction nor a native
-// ctz instruction, gcc resolves __builtin_clz to __clzdi2 rather than
+// ctz instruction, resolves __builtin_clz resolves to __clzdi2 rather than
 // __clzsi2, leading to infinite recursion.
+// This is because on those platforms, libgcc doesn't ship with __clzsi2.
 #define __builtin_clz(a) __clzsi2(a)
 extern int __clzsi2(si_int);
 #endif


### PR DESCRIPTION
On 64-bit platforms, libgcc doesn't ship with __clzsi2, so __builtin_clz gets lowered to __clzdi2. A check already exists for GCC, but as of commit 8210ca019839fc5430b3a95d7caf5c829df3232a clang also lowers __builtin_clz to __clzdi2 on sparc64.

Update the check so that building __clzdi2 with clang/sparc64 also works.