### PR TITLE
[clang] XFAIL the `Xclangas.s` test on AIX.

### DIFF
--- a/clang/test/Driver/Xclangas.s
+++ b/clang/test/Driver/Xclangas.s
@@ -2,3 +2,4 @@
 // RUN: %clang -### -Werror -Xclangas -target-feature -Xclangas=+v5t %s 2>&1 | FileCheck %s
 // CHECK: -cc1as
 // CHECK-SAME: "-target-feature" "+v5t"
+// XFAIL: target={{.*}}-aix{{.*}}


### PR DESCRIPTION
Clang on AIX does not use the integrated assembler.

https://github.com/llvm/llvm-project/pull/100714#issuecomment-2822056054