### PR TITLE
[mlir][acc] Use consistent name for device_num operand

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenACC.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenACC.cpp
@@ -291,12 +291,7 @@ public:
   }
 
   void VisitDeviceNumClause(const OpenACCDeviceNumClause &clause) {
-    if constexpr (isOneOfTypes<OpTy, InitOp, ShutdownOp>) {
-      operation.getDeviceNumOperandMutable().append(
-          createIntExpr(clause.getIntExpr()));
-    } else if constexpr (isOneOfTypes<OpTy, SetOp>) {
-      // This is only a separate case because the getter name is different in
-      // 'set' for some reason.
+    if constexpr (isOneOfTypes<OpTy, InitOp, ShutdownOp, SetOp>) {
       operation.getDeviceNumMutable().append(
           createIntExpr(clause.getIntExpr()));
     } else {

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
@@ -2611,11 +2611,11 @@ def OpenACC_InitOp : OpenACC_Op<"init", [AttrSizedOperandSegments]> {
   }];
 
   let arguments = (ins OptionalAttr<TypedArrayAttrBase<OpenACC_DeviceTypeAttr, "Device type attributes">>:$device_types,
-                       Optional<IntOrIndex>:$deviceNumOperand,
+                       Optional<IntOrIndex>:$deviceNum,
                        Optional<I1>:$ifCond);
 
   let assemblyFormat = [{
-    oilist(`device_num` `(` $deviceNumOperand `:` type($deviceNumOperand) `)`
+    oilist(`device_num` `(` $deviceNum `:` type($deviceNum) `)`
       | `if` `(` $ifCond `)`
     ) attr-dict-with-keyword
   }];
@@ -2642,11 +2642,11 @@ def OpenACC_ShutdownOp : OpenACC_Op<"shutdown", [AttrSizedOperandSegments]> {
   }];
 
   let arguments = (ins OptionalAttr<TypedArrayAttrBase<OpenACC_DeviceTypeAttr, "Device type attributes">>:$device_types,
-                       Optional<IntOrIndex>:$deviceNumOperand,
+                       Optional<IntOrIndex>:$deviceNum,
                        Optional<I1>:$ifCond);
 
   let assemblyFormat = [{
-    oilist(`device_num` `(` $deviceNumOperand `:` type($deviceNumOperand) `)`
+    oilist(`device_num` `(` $deviceNum `:` type($deviceNum) `)`
     |`if` `(` $ifCond `)`
     ) attr-dict-with-keyword
   }];


### PR DESCRIPTION
`acc.set`, `acc.init`, and `acc.shutdown` take a `device_num` operand. However, this was named inconsistently. Give it the same consistent name for all aforementioned operations.