### PR TITLE
[NFC][RootSignatures] Conform to new std::optional calling conventions

### DIFF
--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -71,8 +71,9 @@ private:
   // expected, or, there is a lexing error
 
   /// Root Element parse methods:
-  bool parseDescriptorTable();
-  bool parseDescriptorTableClause();
+  std::optional<llvm::hlsl::rootsig::DescriptorTable> parseDescriptorTable();
+  std::optional<llvm::hlsl::rootsig::DescriptorTableClause>
+  parseDescriptorTableClause();
 
   /// Parameter arguments (eg. `bReg`, `space`, ...) can be specified in any
   /// order and only exactly once. `ParsedClauseParams` denotes the current


### PR DESCRIPTION
- It was determined to define the parsing methods much more inline with a recursive descent parser to follow the EBNF notation better
- As part of this change, we decided to go with a calling convention to the parse.* methods of returning an optional rather than a bool and a reference to the parsed struct

This is a clean-up task from https://github.com/llvm/llvm-project/pull/133800