### PR TITLE
[clang][SPIR-V] Addrspace of opencl_global should always be 1

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -58,7 +58,8 @@ static const unsigned SPIRDefIsPrivMap[] = {
 // Used by both the SPIR and SPIR-V targets.
 static const unsigned SPIRDefIsGenMap[] = {
     4, // Default
-    // Some OpenCL address space values for this map are dummy and they can't be used
+    // Some OpenCL address space values for this map are dummy and they can't be
+    // used
     1, // opencl_global
     0, // opencl_local
     0, // opencl_constant

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -58,8 +58,8 @@ static const unsigned SPIRDefIsPrivMap[] = {
 // Used by both the SPIR and SPIR-V targets.
 static const unsigned SPIRDefIsGenMap[] = {
     4, // Default
-    // OpenCL address space values for this map are dummy and they can't be used
-    0, // opencl_global
+    // Some OpenCL address space values for this map are dummy and they can't be used
+    1, // opencl_global
     0, // opencl_local
     0, // opencl_constant
     0, // opencl_private

--- a/clang/test/CodeGenCUDASPIRV/printf.cu
+++ b/clang/test/CodeGenCUDASPIRV/printf.cu
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fcuda-is-device -triple spirv32 -o - -emit-llvm -x cuda %s  | FileCheck --check-prefix=CHECK-SPIRV32 %s
+// RUN: %clang_cc1 -fcuda-is-device -triple spirv64 -o - -emit-llvm -x cuda %s  | FileCheck --check-prefix=CHECK-SPIRV64 %s
+
+// CHECK-SPIRV32: @.str = private unnamed_addr addrspace(4) constant [13 x i8] c"Hello World\0A\00", align 1
+// CHECK-SPIRV64: @.str = private unnamed_addr addrspace(1) constant [13 x i8] c"Hello World\0A\00", align 1
+
+extern "C" __attribute__((device)) int printf(const char* format, ...);
+
+__attribute__((global)) void printf_kernel() {
+  printf("Hello World\n");
+}


### PR DESCRIPTION
This fixes a CUDA SPIR-V regression introduced in https://github.com/llvm/llvm-project/pull/134399. 