### PR TITLE
[lldb-dap] Show load addresses in disassembly

### DIFF
--- a/lldb/include/lldb/API/SBExecutionContext.h
+++ b/lldb/include/lldb/API/SBExecutionContext.h
@@ -55,6 +55,7 @@ public:
   SBFrame GetFrame() const;
 
 protected:
+  friend class SBInstructionList;
   friend class lldb_private::python::SWIGBridge;
   friend class lldb_private::ScriptInterpreter;
 

--- a/lldb/include/lldb/API/SBFrame.h
+++ b/lldb/include/lldb/API/SBFrame.h
@@ -221,6 +221,7 @@ protected:
   friend class SBBlock;
   friend class SBExecutionContext;
   friend class SBInstruction;
+  friend class SBInstructionList;
   friend class SBThread;
   friend class SBValue;
 

--- a/lldb/include/lldb/API/SBFrame.h
+++ b/lldb/include/lldb/API/SBFrame.h
@@ -221,7 +221,6 @@ protected:
   friend class SBBlock;
   friend class SBExecutionContext;
   friend class SBInstruction;
-  friend class SBInstructionList;
   friend class SBThread;
   friend class SBValue;
 

--- a/lldb/include/lldb/API/SBInstructionList.h
+++ b/lldb/include/lldb/API/SBInstructionList.h
@@ -55,8 +55,9 @@ public:
   bool GetDescription(lldb::SBStream &description);
 
   // Writes assembly instructions to `description` with load addresses using
-  // `frame`.
-  bool GetDescription(lldb::SBStream &description, lldb::SBFrame &frame);
+  // `exe_ctx`.
+  bool GetDescription(lldb::SBStream &description,
+                      lldb::SBExecutionContext &exe_ctx);
 
   bool DumpEmulationForAllInstructions(const char *triple);
 
@@ -66,7 +67,8 @@ protected:
   friend class SBTarget;
 
   void SetDisassembler(const lldb::DisassemblerSP &opaque_sp);
-  bool GetDescription(lldb_private::Stream &description, lldb::SBFrame *frame);
+  bool GetDescription(lldb_private::Stream &description,
+                      lldb::SBExecutionContext *exe_ctx = nullptr);
 
 private:
   lldb::DisassemblerSP m_opaque_sp;

--- a/lldb/include/lldb/API/SBInstructionList.h
+++ b/lldb/include/lldb/API/SBInstructionList.h
@@ -68,7 +68,7 @@ protected:
 
   void SetDisassembler(const lldb::DisassemblerSP &opaque_sp);
   bool GetDescription(lldb_private::Stream &description,
-                      lldb::SBExecutionContext *exe_ctx = nullptr);
+                      lldb_private::ExecutionContext *exe_ctx = nullptr);
 
 private:
   lldb::DisassemblerSP m_opaque_sp;

--- a/lldb/include/lldb/API/SBInstructionList.h
+++ b/lldb/include/lldb/API/SBInstructionList.h
@@ -54,6 +54,10 @@ public:
 
   bool GetDescription(lldb::SBStream &description);
 
+  // Writes assembly instructions to `description` with load addresses using
+  // `frame`.
+  bool GetDescription(lldb::SBStream &description, lldb::SBFrame &frame);
+
   bool DumpEmulationForAllInstructions(const char *triple);
 
 protected:
@@ -62,8 +66,7 @@ protected:
   friend class SBTarget;
 
   void SetDisassembler(const lldb::DisassemblerSP &opaque_sp);
-  bool GetDescription(lldb_private::Stream &description);
-
+  bool GetDescription(lldb_private::Stream &description, lldb::SBFrame *frame);
 
 private:
   lldb::DisassemblerSP m_opaque_sp;

--- a/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
@@ -43,7 +43,7 @@ SourceRequestHandler::Run(const protocol::SourceArguments &args) const {
 
   lldb::SBInstructionList insts = frame.GetSymbol().GetInstructions(dap.target);
   lldb::SBStream stream;
-  insts.GetDescription(stream);
+  insts.GetDescription(stream, frame);
 
   return protocol::SourceResponseBody{/*content=*/stream.GetData(),
                                       /*mimeType=*/"text/x-lldb.disassembly"};

--- a/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
@@ -11,6 +11,7 @@
 #include "LLDBUtils.h"
 #include "Protocol/ProtocolRequests.h"
 #include "Protocol/ProtocolTypes.h"
+#include "lldb/API/SBExecutionContext.h"
 #include "lldb/API/SBFrame.h"
 #include "lldb/API/SBInstructionList.h"
 #include "lldb/API/SBProcess.h"
@@ -43,7 +44,8 @@ SourceRequestHandler::Run(const protocol::SourceArguments &args) const {
 
   lldb::SBInstructionList insts = frame.GetSymbol().GetInstructions(dap.target);
   lldb::SBStream stream;
-  insts.GetDescription(stream, frame);
+  lldb::SBExecutionContext exe_ctx(frame);
+  insts.GetDescription(stream, exe_ctx);
 
   return protocol::SourceResponseBody{/*content=*/stream.GetData(),
                                       /*mimeType=*/"text/x-lldb.disassembly"};


### PR DESCRIPTION
Improves the lldb-dap disassembly by showing load addresses in disassembly, same as in a regular LLDB `disassemble` command by default.

Before:

![Screenshot From 2025-04-22 21-33-56](https://github.com/user-attachments/assets/c3febd48-8335-4932-a270-5a87f48122fe)


After:

![Screenshot From 2025-04-22 21-54-51](https://github.com/user-attachments/assets/b2f44595-8ab2-4f28-aded-9233c53a589b)
