### PR TITLE
[lldb] Minor improvements to AddNamesMatchingPartialString (NFC)

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandObject.h
+++ b/lldb/include/lldb/Interpreter/CommandObject.h
@@ -40,12 +40,11 @@ int AddNamesMatchingPartialString(
     StringList *descriptions = nullptr) {
   int number_added = 0;
 
-  const bool add_all = cmd_str.empty();
-
-  for (auto iter = in_map.begin(), end = in_map.end(); iter != end; iter++) {
-    if (add_all || (iter->first.find(std::string(cmd_str), 0) == 0)) {
+  for (const auto &iter : in_map) {
+    llvm::StringRef full_cmd = iter->first;
+    if (full_cmd.starts_with(cmd_str)) {
       ++number_added;
-      matches.AppendString(iter->first.c_str());
+      matches.AppendString(iter->first);
       if (descriptions)
         descriptions->AppendString(iter->second->GetHelp());
     }

--- a/lldb/include/lldb/Interpreter/CommandObject.h
+++ b/lldb/include/lldb/Interpreter/CommandObject.h
@@ -41,12 +41,12 @@ int AddNamesMatchingPartialString(
   int number_added = 0;
 
   for (const auto &iter : in_map) {
-    llvm::StringRef full_cmd = iter->first;
+    llvm::StringRef full_cmd = iter.first;
     if (full_cmd.starts_with(cmd_str)) {
       ++number_added;
-      matches.AppendString(iter->first);
+      matches.AppendString(iter.first);
       if (descriptions)
-        descriptions->AppendString(iter->second->GetHelp());
+        descriptions->AppendString(iter.second->GetHelp());
     }
   }
 

--- a/lldb/include/lldb/Interpreter/CommandObject.h
+++ b/lldb/include/lldb/Interpreter/CommandObject.h
@@ -40,13 +40,13 @@ int AddNamesMatchingPartialString(
     StringList *descriptions = nullptr) {
   int number_added = 0;
 
-  for (const auto &iter : in_map) {
-    llvm::StringRef full_cmd = iter.first;
-    if (full_cmd.starts_with(cmd_str)) {
+  for (const auto &[name, cmd] : in_map) {
+    llvm::StringRef cmd_name = name;
+    if (cmd_name.starts_with(cmd_str)) {
       ++number_added;
-      matches.AppendString(iter.first);
+      matches.AppendString(name);
       if (descriptions)
-        descriptions->AppendString(iter.second->GetHelp());
+        descriptions->AppendString(cmd->GetHelp());
     }
   }
 


### PR DESCRIPTION
The primary changes are:

1. Avoid allocating a temporary `std::string` each time in the loop
2. Use `starts_with` instead of `find(...) == 0`