### PR TITLE
[lldb][cmake] Add clang resource dir to LLDB shell tests config

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -181,6 +181,17 @@ else ()
 endif ()
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../clang/include")
 
+if(LLDB_BUILT_STANDALONE)
+  if (TARGET clang-resource-headers)
+    get_target_property(CLANG_RESOURCE_DIR clang-resource-headers INTERFACE_INCLUDE_DIRECTORIES)
+    set(CLANG_RESOURCE_DIR "${CLANG_RESOURCE_DIR}/..")
+  else()
+    set(CLANG_RESOURCE_DIR "${LLDB_EXTERNAL_CLANG_RESOURCE_DIR}")
+  endif()
+else()
+  get_clang_resource_dir(CLANG_RESOURCE_DIR PREFIX "${CMAKE_BINARY_DIR}")
+endif()
+
 # GCC silently accepts any -Wno-<foo> option, but warns about those options
 # being unrecognized only if the compilation triggers other warnings to be
 # printed. Therefore, check for whether the compiler supports options in the

--- a/lldb/test/Shell/lit.site.cfg.py.in
+++ b/lldb/test/Shell/lit.site.cfg.py.in
@@ -35,6 +35,7 @@ config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 # The shell tests use their own module caches.
 config.lldb_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_LLDB@", "lldb-shell")
 config.clang_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_CLANG@", "lldb-shell")
+config.clang_resource_dir = os.path.join("@CLANG_RESOURCE_DIR@")
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
We want to be able to access the Clang resources directory in LLDB shell tests, this commit adds the ability to do this by populating the `CLANG_RESOURCE_DIR` CMake cache variable and adding it to the LLDB lit config.