### PR TITLE
[lldb] Expose language plugin commands based based on language of current frame

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -730,6 +730,12 @@ private:
   bool EchoCommandNonInteractive(llvm::StringRef line,
                                  const Flags &io_handler_flags) const;
 
+  /// Return the language specific command object for the current frame.
+  ///
+  /// For example, when stopped on a C++ frame, this returns the command object
+  /// for "language cplusplus" (`CommandObjectMultiwordItaniumABI`).
+  lldb::CommandObjectSP GetFrameLanguageCommand() const;
+
   // A very simple state machine which models the command handling transitions
   enum class CommandHandlingState {
     eIdle,

--- a/lldb/source/Commands/CommandObjectLanguage.cpp
+++ b/lldb/source/Commands/CommandObjectLanguage.cpp
@@ -23,15 +23,15 @@ CommandObjectLanguage::CommandObjectLanguage(CommandInterpreter &interpreter)
   LanguageRuntime::InitializeCommands(this);
   SetHelpLong(
       R"(
-      Language specific subcommands may be used directly (without the `language
-      <language-name>` prefix), when stopped on a frame written in that
-      language. For example, from a C++ frame, users may run `demangle`
-      directly, instead of `language cplusplus demangle`.
+Language specific subcommands may be used directly (without the `language
+<language-name>` prefix), when stopped on a frame written in that language. For
+example, from a C++ frame, users may run `demangle` directly, instead of
+`language cplusplus demangle`.
 
-      Language specific subcommands are only available when the command name
-      cannot be misinterpreted. Take the `demangle` command for example, if a
-      Python command named `demangle-tree` were loaded, then the invocation
-      `demangle` would run `demangle-tree`, not `language cplusplus demangle`.
+Language specific subcommands are only available when the command name cannot be
+misinterpreted. Take the `demangle` command for example, if a Python command
+named `demangle-tree` were loaded, then the invocation `demangle` would run
+`demangle-tree`, not `language cplusplus demangle`.
       )");
 }
 

--- a/lldb/source/Commands/CommandObjectLanguage.cpp
+++ b/lldb/source/Commands/CommandObjectLanguage.cpp
@@ -21,6 +21,18 @@ CommandObjectLanguage::CommandObjectLanguage(CommandInterpreter &interpreter)
           "language <language-name> <subcommand> [<subcommand-options>]") {
   // Let the LanguageRuntime populates this command with subcommands
   LanguageRuntime::InitializeCommands(this);
+  SetHelpLong(
+      R"(
+      Language specific subcommands may be used directly (without the `language
+      <language-name>` prefix), when stopped on a frame written in that
+      language. For example, from a C++ frame, users may run `demangle`
+      directly, instead of `language cplusplus demangle`.
+
+      Language specific subcommands are only available when the command name
+      cannot be misinterpreted. Take the `demangle` command for example, if a
+      Python command named `demangle-tree` were loaded, then the invocation
+      `demangle` would run `demangle-tree`, not `language cplusplus demangle`.
+      )");
 }
 
 CommandObjectLanguage::~CommandObjectLanguage() = default;

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1019,23 +1019,25 @@ CommandInterpreter::VerifyUserMultiwordCmdPath(Args &path, bool leaf_is_command,
 }
 
 CommandObjectSP CommandInterpreter::GetFrameLanguageCommand() const {
-  if (auto frame_sp = GetExecutionContext().GetFrameSP()) {
-    auto frame_language = Language::GetPrimaryLanguage(
-        frame_sp->GuessLanguage().AsLanguageType());
+  auto frame_sp = GetExecutionContext().GetFrameSP();
+  if (!frame_sp)
+    return {};
+  auto frame_language =
+      Language::GetPrimaryLanguage(frame_sp->GuessLanguage().AsLanguageType());
 
-    auto it = m_command_dict.find("language");
-    if (it != m_command_dict.end()) {
-      // The root "language" command.
-      CommandObjectSP language_cmd_sp = it->second;
+  auto it = m_command_dict.find("language");
+  if (it == m_command_dict.end())
+    return {};
+  // The root "language" command.
+  CommandObjectSP language_cmd_sp = it->second;
 
-      if (auto *plugin = Language::FindPlugin(frame_language)) {
-        // "cplusplus", "objc", etc.
-        auto lang_name = plugin->GetPluginName();
-        return language_cmd_sp->GetSubcommandSPExact(lang_name);
-      }
-    }
-  }
-  return {};
+  auto *plugin = Language::FindPlugin(frame_language);
+  if (!plugin)
+    return {};
+  // "cplusplus", "objc", etc.
+  auto lang_name = plugin->GetPluginName();
+
+  return language_cmd_sp->GetSubcommandSPExact(lang_name);
 }
 
 CommandObjectSP
@@ -1070,20 +1072,11 @@ CommandInterpreter::GetCommandSP(llvm::StringRef cmd_str, bool include_aliases,
       command_sp = pos->second;
   }
 
-  // The `language` subcommand ("language objc", "language cplusplus", etc).
-  CommandObjectMultiword *lang_subcmd = nullptr;
-  if (!command_sp) {
-    if (auto subcmd_sp = GetFrameLanguageCommand()) {
-      lang_subcmd = subcmd_sp->GetAsMultiwordCommand();
-      command_sp = subcmd_sp->GetSubcommandSPExact(cmd_str);
-    }
-  }
-
   if (!exact && !command_sp) {
     // We will only get into here if we didn't find any exact matches.
 
     CommandObjectSP user_match_sp, user_mw_match_sp, alias_match_sp,
-        real_match_sp, lang_match_sp;
+        real_match_sp;
 
     StringList local_matches;
     if (matches == nullptr)
@@ -1093,7 +1086,6 @@ CommandInterpreter::GetCommandSP(llvm::StringRef cmd_str, bool include_aliases,
     unsigned int num_alias_matches = 0;
     unsigned int num_user_matches = 0;
     unsigned int num_user_mw_matches = 0;
-    unsigned int num_lang_matches = 0;
 
     // Look through the command dictionaries one by one, and if we get only one
     // match from any of them in toto, then return that, otherwise return an
@@ -1151,28 +1143,11 @@ CommandInterpreter::GetCommandSP(llvm::StringRef cmd_str, bool include_aliases,
         user_mw_match_sp = pos->second;
     }
 
-    if (lang_subcmd) {
-      num_lang_matches =
-          AddNamesMatchingPartialString(lang_subcmd->GetSubcommandDictionary(),
-                                        cmd_str, *matches, descriptions);
-    }
-
-    if (num_lang_matches == 1) {
-      cmd.assign(matches->GetStringAtIndex(num_cmd_matches + num_alias_matches +
-                                           num_user_matches +
-                                           num_user_mw_matches));
-
-      auto &lang_dict = lang_subcmd->GetSubcommandDictionary();
-      auto pos = lang_dict.find(cmd);
-      if (pos != lang_dict.end())
-        lang_match_sp = pos->second;
-    }
-
     // If we got exactly one match, return that, otherwise return the match
     // list.
 
     if (num_user_matches + num_user_mw_matches + num_cmd_matches +
-            num_alias_matches + num_lang_matches ==
+            num_alias_matches ==
         1) {
       if (num_cmd_matches)
         return real_match_sp;
@@ -1180,12 +1155,37 @@ CommandInterpreter::GetCommandSP(llvm::StringRef cmd_str, bool include_aliases,
         return alias_match_sp;
       else if (num_user_mw_matches)
         return user_mw_match_sp;
-      else if (num_user_matches)
-        return user_match_sp;
       else
-        return lang_match_sp;
+        return user_match_sp;
     }
-  } else if (matches && command_sp) {
+  }
+
+  // When no single match is found, attempt to resolve the command as a language
+  // plugin subcommand.
+  if (!command_sp) {
+    // The `language` subcommand ("language objc", "language cplusplus", etc).
+    CommandObjectMultiword *lang_subcmd = nullptr;
+    if (auto lang_subcmd_sp = GetFrameLanguageCommand()) {
+      lang_subcmd = lang_subcmd_sp->GetAsMultiwordCommand();
+      command_sp = lang_subcmd_sp->GetSubcommandSPExact(cmd_str);
+    }
+
+    if (!command_sp && !exact && lang_subcmd) {
+      StringList lang_matches;
+      AddNamesMatchingPartialString(lang_subcmd->GetSubcommandDictionary(),
+                                    cmd_str, lang_matches, descriptions);
+      if (matches)
+        matches->AppendList(lang_matches);
+      if (lang_matches.GetSize() == 1) {
+        const auto &lang_dict = lang_subcmd->GetSubcommandDictionary();
+        auto pos = lang_dict.find(lang_matches[0]);
+        if (pos != lang_dict.end())
+          return pos->second;
+      }
+    }
+  }
+
+  if (matches && command_sp) {
     matches->AppendString(cmd_str);
     if (descriptions)
       descriptions->AppendString(command_sp->GetHelp());

--- a/lldb/test/API/commands/command/language/Makefile
+++ b/lldb/test/API/commands/command/language/Makefile
@@ -1,0 +1,3 @@
+OBJCXX_SOURCES := main.mm
+CXX_SOURCES := lib.cpp
+include Makefile.rules

--- a/lldb/test/API/commands/command/language/Makefile
+++ b/lldb/test/API/commands/command/language/Makefile
@@ -1,5 +1,4 @@
 OBJCXX_SOURCES := main.mm
-CFLAGS_EXTRAS := -fobjc-arc
 CXX_SOURCES := lib.cpp
 LD_EXTRAS := -lobjc
 include Makefile.rules

--- a/lldb/test/API/commands/command/language/Makefile
+++ b/lldb/test/API/commands/command/language/Makefile
@@ -1,3 +1,5 @@
 OBJCXX_SOURCES := main.mm
+CFLAGS_EXTRAS := -fobjc-arc
 CXX_SOURCES := lib.cpp
+LD_EXTRAS := -lobjc
 include Makefile.rules

--- a/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
+++ b/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
@@ -25,7 +25,7 @@ class TestCase(TestBase):
         )
 
         # Run a `language cplusplus` command.
-        self.expect(f"demangle _Z1fv", startstr="_Z1fv ---> f()")
+        self.expect("demangle _Z1fv", startstr="_Z1fv ---> f()")
         # Test prefix matching.
         self.expect("dem _Z1fv", startstr="_Z1fv ---> f()")
 

--- a/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
+++ b/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
@@ -3,6 +3,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
+
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
+++ b/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
@@ -3,7 +3,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-
 class TestCase(TestBase):
     def test(self):
         self.build()
@@ -48,3 +47,14 @@ class TestCase(TestBase):
                 "info -- Dump information on a tagged pointer.",
             ],
         )
+
+        # To ensure compatability with existing scripts, a language specific
+        # command must not be invoked if another command (such as a python
+        # command) has the language specific command name as its prefix.
+        #
+        # For example, this test loads a `tagged-pointer-collision` command. A
+        # script could exist that invokes this command using its prefix
+        # `tagged-pointer`, under the assumption that "tagged-pointer" uniquely
+        # identifies the python command `tagged-pointer-collision`.
+        self.runCmd("command script import commands.py")
+        self.expect("tagged-pointer", startstr="ran tagged-pointer-collision")

--- a/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
+++ b/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
@@ -1,0 +1,43 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("lib.cpp")
+        )
+
+        frame = thread.selected_frame
+        self.assertEqual(frame.GuessLanguage(), lldb.eLanguageTypeC_plus_plus_11)
+        self.assertEqual(frame.name, "f()")
+        self.expect(
+            "help demangle",
+            substrs=[
+                "Demangle a C++ mangled name.",
+                "Syntax: language cplusplus demangle [<mangled-name> ...]",
+            ],
+        )
+        self.expect("demangle _Z1fv", startstr="_Z1fv ---> f()")
+
+        # Switch the objc caller.
+        self.runCmd("up")
+        frame = thread.selected_frame
+        self.assertEqual(frame.GuessLanguage(), lldb.eLanguageTypeObjC_plus_plus)
+        self.assertEqual(frame.name, "main")
+        self.expect("help demangle", error=True)
+        self.expect(
+            "help tagged-pointer",
+            substrs=[
+                "Commands for operating on Objective-C tagged pointers.",
+                "Syntax: class-table <subcommand> [<subcommand-options>]",
+            ],
+        )
+        self.expect(
+            "tagged-pointer info 0",
+            error=True,
+            startstr="error: could not convert '0' to a valid address",
+        )

--- a/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
+++ b/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
@@ -14,6 +14,8 @@ class TestCase(TestBase):
         frame = thread.selected_frame
         self.assertEqual(frame.GuessLanguage(), lldb.eLanguageTypeC_plus_plus_11)
         self.assertEqual(frame.name, "f()")
+
+        # Test `help`.
         self.expect(
             "help demangle",
             substrs=[
@@ -21,21 +23,21 @@ class TestCase(TestBase):
                 "Syntax: language cplusplus demangle [<mangled-name> ...]",
             ],
         )
-        self.expect("demangle _Z1fv", startstr="_Z1fv ---> f()")
 
-        # Switch the objc caller.
+        # Run a `language cplusplus` command.
+        self.expect(f"demangle _Z1fv", startstr="_Z1fv ---> f()")
+        # Test prefix matching.
+        self.expect("dem _Z1fv", startstr="_Z1fv ---> f()")
+
+        # Select the objc caller.
         self.runCmd("up")
         frame = thread.selected_frame
         self.assertEqual(frame.GuessLanguage(), lldb.eLanguageTypeObjC_plus_plus)
         self.assertEqual(frame.name, "main")
+
+        # Ensure `demangle` doesn't resolve from the objc frame.
         self.expect("help demangle", error=True)
-        self.expect(
-            "help tagged-pointer",
-            substrs=[
-                "Commands for operating on Objective-C tagged pointers.",
-                "Syntax: class-table <subcommand> [<subcommand-options>]",
-            ],
-        )
+        # Run a `language objc` command.
         self.expect(
             "tagged-pointer info 0",
             error=True,

--- a/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
+++ b/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
@@ -37,9 +37,14 @@ class TestCase(TestBase):
 
         # Ensure `demangle` doesn't resolve from the objc frame.
         self.expect("help demangle", error=True)
+
         # Run a `language objc` command.
         self.expect(
-            "tagged-pointer info 0",
-            error=True,
-            startstr="error: could not convert '0' to a valid address",
+            "tagged-pointer",
+            substrs=[
+                "Commands for operating on Objective-C tagged pointers.",
+                "Syntax: tagged-pointer <subcommand> [<subcommand-options>]",
+                "The following subcommands are supported:",
+                "info -- Dump information on a tagged pointer.",
+            ],
         )

--- a/lldb/test/API/commands/command/language/commands.py
+++ b/lldb/test/API/commands/command/language/commands.py
@@ -1,5 +1,6 @@
 import lldb
 
+
 @lldb.command("tagged-pointer-collision")
 def noop(dbg, cmdstr, ctx, result, _):
     print("ran tagged-pointer-collision", file=result)

--- a/lldb/test/API/commands/command/language/commands.py
+++ b/lldb/test/API/commands/command/language/commands.py
@@ -1,0 +1,5 @@
+import lldb
+
+@lldb.command("tagged-pointer-collision")
+def noop(dbg, cmdstr, ctx, result, _):
+    print("ran tagged-pointer-collision", file=result)

--- a/lldb/test/API/commands/command/language/lib.cpp
+++ b/lldb/test/API/commands/command/language/lib.cpp
@@ -1,0 +1,3 @@
+#include <stdio.h>
+extern void f();
+void f() { puts("break here"); }

--- a/lldb/test/API/commands/command/language/main.mm
+++ b/lldb/test/API/commands/command/language/main.mm
@@ -1,0 +1,6 @@
+extern void f();
+
+int main() {
+  f();
+  return 0;
+}


### PR DESCRIPTION
Use the current frame's language to lookup commands provided by language plugins.

This means commands like `language {objc,cplusplus} <command>` can be used directly, without using the `language <lang>` prefix.

For example, when stopped on a C++ frame, `demangle _Z1fv` will run `language cplusplus demangle _Z1fv`.

rdar://149882520