### PR TITLE
Fix a crash in constant evaluation of ExtVectorElementExprs

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -9197,7 +9197,10 @@ bool LValueExprEvaluator::VisitExtVectorElementExpr(
 
   if (Success) {
     Result.setFrom(Info.Ctx, Val);
-    const auto *VT = E->getBase()->getType()->castAs<VectorType>();
+    QualType BaseType = E->getBase()->getType();
+    if (E->isArrow())
+      BaseType = BaseType->getPointeeType();
+    const auto *VT = BaseType->castAs<VectorType>();
     HandleLValueVectorElement(Info, E, Result, VT->getElementType(),
                               VT->getNumElements(), Indices[0]);
   }

--- a/clang/test/SemaCXX/constexpr-vectors-access-elements.cpp
+++ b/clang/test/SemaCXX/constexpr-vectors-access-elements.cpp
@@ -43,4 +43,6 @@ static_assert(b.lo.lo == 1); // expected-error {{not an integral constant expres
 // make sure clang rejects taking address of a vector element
 static_assert(&b[1]); // expected-error {{address of vector element requested}}
 
+constexpr const FourIntsExtVec *p = &b;
+static_assert(p->x == 1);
 }


### PR DESCRIPTION
Handle the case where the base expression is a pointer to a vector type.

rdar://149223362