### PR TITLE
[clang] Adding an API to create a `CXStringSet` from a Vector of `StringRef`s

### DIFF
--- a/clang/tools/libclang/CXString.cpp
+++ b/clang/tools/libclang/CXString.cpp
@@ -107,7 +107,8 @@ CXString createCXString(CXStringBuf *buf) {
   return Str;
 }
 
-CXStringSet *createSet(const std::vector<std::string> &Strings) {
+template <typename StringTy>
+static CXStringSet *createSetImpl(const std::vector<StringTy> &Strings) {
   CXStringSet *Set = new CXStringSet;
   Set->Count = Strings.size();
   Set->Strings = new CXString[Set->Count];
@@ -116,6 +117,13 @@ CXStringSet *createSet(const std::vector<std::string> &Strings) {
   return Set;
 }
 
+CXStringSet *createSet(const std::vector<std::string> &Strings) {
+  return createSetImpl(Strings);
+}
+
+CXStringSet *createSet(const std::vector<StringRef> &Strings) {
+  return createSetImpl(Strings);
+}
 
 //===----------------------------------------------------------------------===//
 // String pools.

--- a/clang/tools/libclang/CXString.cpp
+++ b/clang/tools/libclang/CXString.cpp
@@ -123,7 +123,7 @@ static CXStringSet *createSetImpl(ArrayRef<StringTy> Strings) {
 }
 
 CXStringSet *createSet(const std::vector<std::string> &Strings) {
-  return createSetImpl<std::string, true>(ArrayRef<std::string>(Strings));
+  return createSetImpl<std::string, true>(Strings);
 }
 
 CXStringSet *createRefSet(ArrayRef<StringRef> Strings) {

--- a/clang/tools/libclang/CXString.h
+++ b/clang/tools/libclang/CXString.h
@@ -67,7 +67,10 @@ CXString createRef(std::string String) = delete;
 /// Create a CXString object that is backed by a string buffer.
 CXString createCXString(CXStringBuf *buf);
 
+/// Create a CXStringSet object owns the strings. Such an object should be
+/// disposed with clang_disposeStringSet.
 CXStringSet *createSet(const std::vector<std::string> &Strings);
+CXStringSet *createSet(const std::vector<StringRef> &Strings);
 
 /// A string pool used for fast allocation/deallocation of strings.
 class CXStringPool {

--- a/clang/tools/libclang/CXString.h
+++ b/clang/tools/libclang/CXString.h
@@ -70,7 +70,7 @@ CXString createCXString(CXStringBuf *buf);
 /// Create a CXStringSet object owns the strings. Such an object should be
 /// disposed with clang_disposeStringSet.
 CXStringSet *createSet(const std::vector<std::string> &Strings);
-CXStringSet *createSet(const std::vector<StringRef> &Strings);
+CXStringSet *createRefSet(ArrayRef<StringRef> Strings);
 
 /// A string pool used for fast allocation/deallocation of strings.
 class CXStringPool {

--- a/clang/tools/libclang/CXString.h
+++ b/clang/tools/libclang/CXString.h
@@ -67,9 +67,12 @@ CXString createRef(std::string String) = delete;
 /// Create a CXString object that is backed by a string buffer.
 CXString createCXString(CXStringBuf *buf);
 
-/// Create a CXStringSet object owns the strings. Such an object should be
+/// Create a CXStringSet object that owns the strings. Such an object should be
 /// disposed with clang_disposeStringSet.
 CXStringSet *createSet(const std::vector<std::string> &Strings);
+
+/// Create a CXStringSet object that does not own the strings. Such an object
+/// should still be disposed with clang_disposeStringSet.
 CXStringSet *createRefSet(ArrayRef<StringRef> Strings);
 
 /// A string pool used for fast allocation/deallocation of strings.
@@ -108,4 +111,3 @@ static inline StringRef getContents(const CXUnsavedFile &UF) {
 }
 
 #endif
-


### PR DESCRIPTION
The newly added API avoids converting `StringRef`s to `std::string`s when the input is a vector of `StringRef`. 