### PR TITLE
[lldb] Make sure changing the separator takes immediate effect

### DIFF
--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -257,7 +257,9 @@ Status Debugger::SetPropertyValue(const ExecutionContext *exe_ctx,
       else
         m_statusline.reset();
     } else if (property_path ==
-               g_debugger_properties[ePropertyStatuslineFormat].name) {
+                   g_debugger_properties[ePropertyStatuslineFormat].name ||
+               property_path ==
+                   g_debugger_properties[ePropertySeparator].name) {
       // Statusline format changed. Redraw the statusline.
       RedrawStatusline();
     } else if (property_path ==

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -46,8 +46,10 @@ class TestStatusline(PExpectTest):
         self.child.expect(re.escape("a.out | main.c:2:11 | bre"))
         self.child.setwinsize(terminal_height, terminal_width)
 
+        # Change the separator.
+        self.expect('set set separator "S "', ["a.out S main.c:2:11"])
+
         # Change the format.
-        self.expect('set set separator "S"')
         self.expect(
             'set set statusline-format "target = {${target.file.basename}} ${separator}"',
             ["target = a.out S"],


### PR DESCRIPTION
The setter is only used when changing the setting programmatically. When using the settings command, we need to monitor SetPropertyValue.