### PR TITLE
[mlir][utils] Update generate-test-checks.py (use SSA names)

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """A script to generate FileCheck statements for mlir unit tests.
+
 This script is a utility to add FileCheck patterns to an mlir file.
 
 NOTE: The input .mlir is expected to be the output from the parser, not a
@@ -81,7 +82,11 @@ class VariableNamer:
         # Compute variable name
         variable_name = self.variable_names.pop(0) if len(self.variable_names) > 0 else ''
         if variable_name == '':
-            if use_ssa_name:
+            # If `use_ssa_name` is set, use the MLIR SSA value name to generate
+            # a FileCHeck substation string. As FileCheck requires these
+            # strings to start with a character, skip MLIR variables starting
+            # with a digit (e.g. `%0`).
+            if use_ssa_name and source_variable_name[0].isalpha():
                 variable_name = source_variable_name.upper()
             else:
                 variable_name = "VAL_" + str(self.name_counter)


### PR DESCRIPTION
This patch updates generate-test-checks.py to preserve original SSA
names (capitalized) when generating LIT variable names for function
arguments (i.e. for `CHECK-SAME` lines). This improves readability and
helps maintain consistency between the input MLIR and the expected
FileCheck/LIT output.

For example, given the following function:

```mlir
func.func @example(
    %input: memref<4x6x3xf32>,
    %filter: memref<1x3x8xf32>,
    %output: memref<4x2x8xf32>) {

  linalg.conv_1d_nwc_wcf
    {dilations = dense<1> : tensor<1xi64>, strides = dense<3> : tensor<1xi64>}
    ins(%input, %filter : memref<4x6x3xf32>, memref<1x3x8xf32>)
    outs(%output : memref<4x2x8xf32>)

  return
}
```

The generated output becomes:

```mlir
// CHECK-LABEL: func.func @conv1d_nwc_4x2x8_memref(
// CHECK-SAME:      %[[INPUT:.*]]: memref<4x6x3xf32>,
// CHECK-SAME:      %[[FILTER:.*]]: memref<1x3x8xf32>,
// CHECK-SAME:      %[[OUTPUT:.*]]: memref<4x2x8xf32>) {
// CHECK:         linalg.conv_1d_nwc_wcf
// CHECK:           {dilations = dense<1> : tensor<1xi64>, strides = dense<3> : tensor<1xi64>}
// CHECK:           ins(%[[INPUT]], %[[FILTER]] : memref<4x6x3xf32>, memref<1x3x8xf32>)
// CHECK:           outs(%[[OUTPUT]] : memref<4x2x8xf32>)
// CHECK:         return
// CHECK:       }
```

By contrast, the current version of the script would generate:

```mlir
// CHECK-LABEL: func.func @conv1d_nwc_4x2x8_memref(
// CHECK-SAME:      %[[VAL_0:.*]]: memref<4x6x3xf32>,
// CHECK-SAME:      %[[VAL_1:.*]]: memref<1x3x8xf32>,
// CHECK-SAME:      %[[VAL_2:.*]]: memref<4x2x8xf32>) {
// CHECK:         linalg.conv_1d_nwc_wcf
// CHECK:           {dilations = dense<1> : tensor<1xi64>, strides = dense<3> : tensor<1xi64>}
// CHECK:           ins(%[[VAL_0]], %[[VAL_1]] : memref<4x6x3xf32>, memref<1x3x8xf32>)
// CHECK:           outs(%[[VAL_2]] : memref<4x2x8xf32>)
// CHECK:         return
// CHECK:       }
```
