### PR TITLE
[InstCombine] Do not fold logical is_finite test

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -1480,7 +1480,9 @@ Value *InstCombinerImpl::foldLogicOfFCmps(FCmpInst *LHS, FCmpInst *RHS,
     }
   }
 
-  if (IsAnd && stripSignOnlyFPOps(LHS0) == stripSignOnlyFPOps(RHS0)) {
+  // This transform is not valid for a logical select.
+  if (!IsLogicalSelect && IsAnd &&
+      stripSignOnlyFPOps(LHS0) == stripSignOnlyFPOps(RHS0)) {
     // and (fcmp ord x, 0), (fcmp u* x, inf) -> fcmp o* x, inf
     // and (fcmp ord x, 0), (fcmp u* fabs(x), inf) -> fcmp o* x, inf
     if (Value *Left = matchIsFiniteTest(Builder, LHS, RHS))

--- a/llvm/test/Transforms/InstCombine/and-fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/and-fcmp.ll
@@ -4990,6 +4990,32 @@ define i1 @clang_builtin_isnormal_inf_check_copysign(half %x, half %y) {
   ret i1 %and
 }
 
+define i1 @clang_builtin_isnormal_inf_check_copysign_logical_select(half %x, half %y) {
+; CHECK-LABEL: @clang_builtin_isnormal_inf_check_copysign_logical_select(
+; CHECK-NEXT:    [[COPYSIGN_X:%.*]] = call half @llvm.copysign.f16(half [[X:%.*]], half [[Y:%.*]])
+; CHECK-NEXT:    [[AND:%.*]] = fcmp oeq half [[COPYSIGN_X]], 0xH7C00
+; CHECK-NEXT:    ret i1 [[AND]]
+;
+  %copysign.x = call half @llvm.copysign.f16(half %x, half %y)
+  %ord = fcmp ord half %x, 0.0
+  %cmp = fcmp uge half %copysign.x, 0xH7C00
+  %and = select i1 %ord, i1 %cmp, i1 false
+  ret i1 %and
+}
+
+define i1 @clang_builtin_isnormal_inf_check_fabs_nnan_logical_select(half %x) {
+; CHECK-LABEL: @clang_builtin_isnormal_inf_check_fabs_nnan_logical_select(
+; CHECK-NEXT:    [[COPYSIGN_X:%.*]] = call nnan half @llvm.fabs.f16(half [[X:%.*]])
+; CHECK-NEXT:    [[AND:%.*]] = fcmp oeq half [[COPYSIGN_X]], 0xH7C00
+; CHECK-NEXT:    ret i1 [[AND]]
+;
+  %copysign.x = call nnan half @llvm.fabs.f16(half %x)
+  %ord = fcmp ord half %x, 0.0
+  %cmp = fcmp uge half %copysign.x, 0xH7C00
+  %and = select i1 %ord, i1 %cmp, i1 false
+  ret i1 %and
+}
+
 define i1 @isnormal_logical_select_0(half %x) {
 ; CHECK-LABEL: @isnormal_logical_select_0(
 ; CHECK-NEXT:    [[FABS_X:%.*]] = call half @llvm.fabs.f16(half [[X:%.*]])

--- a/llvm/test/Transforms/InstCombine/and-fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/and-fcmp.ll
@@ -4993,7 +4993,9 @@ define i1 @clang_builtin_isnormal_inf_check_copysign(half %x, half %y) {
 define i1 @clang_builtin_isnormal_inf_check_copysign_logical_select(half %x, half %y) {
 ; CHECK-LABEL: @clang_builtin_isnormal_inf_check_copysign_logical_select(
 ; CHECK-NEXT:    [[COPYSIGN_X:%.*]] = call half @llvm.copysign.f16(half [[X:%.*]], half [[Y:%.*]])
-; CHECK-NEXT:    [[AND:%.*]] = fcmp oeq half [[COPYSIGN_X]], 0xH7C00
+; CHECK-NEXT:    [[ORD:%.*]] = fcmp ord half [[X]], 0xH0000
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ueq half [[COPYSIGN_X]], 0xH7C00
+; CHECK-NEXT:    [[AND:%.*]] = select i1 [[ORD]], i1 [[CMP]], i1 false
 ; CHECK-NEXT:    ret i1 [[AND]]
 ;
   %copysign.x = call half @llvm.copysign.f16(half %x, half %y)
@@ -5005,7 +5007,7 @@ define i1 @clang_builtin_isnormal_inf_check_copysign_logical_select(half %x, hal
 
 define i1 @clang_builtin_isnormal_inf_check_fabs_nnan_logical_select(half %x) {
 ; CHECK-LABEL: @clang_builtin_isnormal_inf_check_fabs_nnan_logical_select(
-; CHECK-NEXT:    [[COPYSIGN_X:%.*]] = call nnan half @llvm.fabs.f16(half [[X:%.*]])
+; CHECK-NEXT:    [[COPYSIGN_X:%.*]] = call half @llvm.fabs.f16(half [[X:%.*]])
 ; CHECK-NEXT:    [[AND:%.*]] = fcmp oeq half [[COPYSIGN_X]], 0xH7C00
 ; CHECK-NEXT:    ret i1 [[AND]]
 ;


### PR DESCRIPTION
This patch disables the fold for logical is_finite test (i.e., `and (fcmp ord x, 0), (fcmp u* x, inf) -> fcmp o* x, inf`).
It is still possible to allow this fold for several logical cases (e.g., `stripSignOnlyFPOps(RHS0)` does not strip any operations). Since this patch has no real-world impact, I decided to disable this fold for all logical cases.

Alive2: https://alive2.llvm.org/ce/z/aH4LC7
Closes https://github.com/llvm/llvm-project/issues/136650.
