### PR TITLE
[CIR] Create CIR_TypedAttr common class

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -27,6 +27,20 @@ class CIR_Attr<string name, string attrMnemonic, list<Trait> traits = []>
   let mnemonic = attrMnemonic;
 }
 
+class CIR_TypedAttr<string name, string attrMnemonic, list<Trait> traits = []>
+    : CIR_Attr<name, attrMnemonic, !listconcat(traits, [TypedAttrInterface])> {
+
+  let parameters = (ins AttributeSelfTypeParameter<"">:$type);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "mlir::Type":$type), [{
+      return $_get(type.getContext(), type);
+    }]>
+  ];
+
+  let assemblyFormat = [{}];
+}
+
 class CIRUnitAttr<string name, string attrMnemonic, list<Trait> traits = []>
     : CIR_Attr<name, attrMnemonic, traits> {
   let returnType = "bool";
@@ -64,43 +78,23 @@ def CIR_BoolAttr : CIR_Attr<"Bool", "bool", [TypedAttrInterface]> {
 // ZeroAttr
 //===----------------------------------------------------------------------===//
 
-def ZeroAttr : CIR_Attr<"Zero", "zero", [TypedAttrInterface]> {
+def ZeroAttr : CIR_TypedAttr<"Zero", "zero"> {
   let summary = "Attribute to represent zero initialization";
   let description = [{
     The ZeroAttr is used to indicate zero initialization on structs.
   }];
-
-  let parameters = (ins AttributeSelfTypeParameter<"">:$type);
-
-  let builders = [
-    AttrBuilderWithInferredContext<(ins "mlir::Type":$type), [{
-      return $_get(type.getContext(), type);
-    }]>
-  ];
-
-  let assemblyFormat = [{}];
 }
 
 //===----------------------------------------------------------------------===//
 // UndefAttr
 //===----------------------------------------------------------------------===//
 
-def UndefAttr : CIR_Attr<"Undef", "undef", [TypedAttrInterface]> {
+def UndefAttr : CIR_TypedAttr<"Undef", "undef"> {
   let summary = "Represent an undef constant";
   let description = [{
     The UndefAttr represents an undef constant, corresponding to LLVM's notion
     of undef.
   }];
-
-  let parameters = (ins AttributeSelfTypeParameter<"">:$type);
-
-  let builders = [
-    AttrBuilderWithInferredContext<(ins "mlir::Type":$type), [{
-      return $_get(type.getContext(), type);
-    }]>
-  ];
-
-  let assemblyFormat = [{}];
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Introduce common base class for attributes with single type parameter.
This mirrors incubator changes introduced in https://github.com/llvm/clangir/pull/1583