### PR TITLE
[Clang][Driver] Fix condition in combineBackendCompile when using -no-integrated-cpp

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5609,19 +5609,20 @@ class ToolSelector final {
     if (!BJ || !CJ)
       return nullptr;
 
+    auto HasBitcodeInput = [](const JobActionInfo &AI) {
+      for (auto &Input : AI.JA->getInputs())
+        if (!types::isLLVMIR(Input->getType()))
+          return false;
+      return true;
+    };
+
     // Check if the initial input (to the compile job or its predessor if one
     // exists) is LLVM bitcode. In that case, no preprocessor step is required
     // and we can still collapse the compile and backend jobs when we have
     // -save-temps. I.e. there is no need for a separate compile job just to
     // emit unoptimized bitcode.
-    bool InputIsBitcode = true;
-    for (size_t i = 1; i < ActionInfo.size(); i++)
-      if (ActionInfo[i].JA->getType() != types::TY_LLVM_BC &&
-          ActionInfo[i].JA->getType() != types::TY_LTO_BC) {
-        InputIsBitcode = false;
-        break;
-      }
-    if (!InputIsBitcode && !canCollapsePreprocessorAction())
+    bool InputIsBitcode = all_of(ActionInfo, HasBitcodeInput);
+    if (SaveTemps && !InputIsBitcode)
       return nullptr;
 
     // Get compiler tool.
@@ -5635,7 +5636,7 @@ class ToolSelector final {
     if (!T->hasIntegratedBackend() && !(OutputIsLLVM && T->canEmitIR()))
       return nullptr;
 
-    if (T->canEmitIR() && ((SaveTemps && !InputIsBitcode) || EmbedBitcode))
+    if (T->canEmitIR() && EmbedBitcode)
       return nullptr;
 
     Inputs = CJ->getInputs();

--- a/clang/test/Driver/no-integrated-cpp.c
+++ b/clang/test/Driver/no-integrated-cpp.c
@@ -1,0 +1,80 @@
+// RUN: %clang -O2 %s -E -o %t.i
+//
+// RUN: %clang -O2 %s -c -o a.o -no-integrated-cpp -### 2>&1 | FileCheck %s --check-prefixes=SRC
+// SRC: "-E"
+// SRC-SAME: "-o" "[[PREPROC:.*.i]]"
+// SRC-SAME: "-x" "c" "{{.*}}no-integrated-cpp.c"
+//
+// SRC-NEXT: "-emit-obj"
+// SRC-SAME: "-o" "a.o"
+// SRC-SAME: "-x" "cpp-output" "[[PREPROC]]"
+//
+// RUN: %clang -O2 %s -c -o a.o -no-integrated-cpp -save-temps -### 2>&1 | FileCheck %s --check-prefixes=SRC-SAVE
+// SRC-SAVE: "-E"
+// SRC-SAVE-SAME: "-o" "[[PREPROC:.*.i]]"
+// SRC-SAVE-SAME: "-x" "c" "{{.*}}no-integrated-cpp.c"
+//
+// SRC-SAVE-NEXT: "-emit-llvm-bc"
+// SRC-SAVE-SAME: "-o" "[[BITCODE:.*.bc]]"
+// SRC-SAVE-SAME: "-x" "cpp-output" "[[PREPROC]]"
+//
+// SRC-SAVE-NEXT: "-S"
+// SRC-SAVE-SAME: "-o" "[[ASM:.*.s]]"
+// SRC-SAVE-SAME: "-x" "ir" "[[BITCODE]]"
+//
+// SRC-SAVE-NEXT: "-cc1as"
+// SRC-SAVE-SAME: "-o" "a.o" "[[ASM]]"
+//
+// RUN: %clang -O2 %t.i  -c -o a.o -no-integrated-cpp -### 2>&1 | FileCheck %s --check-prefixes=PRE
+// PRE-NOT: "-E"
+// PRE: "-emit-obj"
+// PRE-SAME: "-o" "a.o"
+// PRE-SAME: "-x" "cpp-output" "{{.*}}no-integrated-cpp.c.tmp.i"
+//
+// RUN: %clang -O2 %t.i  -c -o a.o -no-integrated-cpp -save-temps -### 2>&1 | FileCheck %s --check-prefixes=PRE-SAVE
+// PRE-SAVE-NOT: "-E"
+// PRE-SAVE-NOT: "-emit-llvm-bc"
+// PRE-SAVE: "-S"
+// PRE-SAVE-SAME: "-o" "[[ASM:.*.s]]"
+// PRE-SAVE-SAME: "-x" "cpp-output" "{{.*}}no-integrated-cpp.c.tmp.i"
+//
+// PRE-SAVE-NEXT: "-cc1as"
+// PRE-SAVE-SAME: "-o" "a.o" "[[ASM]]"
+//
+// RUN: %clang -O2 %s -c -emit-llvm -o a.bc -no-integrated-cpp -### 2>&1 | FileCheck %s --check-prefixes=LLVM
+// LLVM: "-E"
+// LLVM-SAME: "-o" "[[PREPROC:.*.i]]"
+// LLVM-SAME: "-x" "c" "{{.*}}no-integrated-cpp.c"
+//
+// LLVM-NEXT: "-emit-llvm-bc"
+// LLVM-SAME: "-o" "[[BITCODE:.*.bc]]"
+// LLVM-SAME: "-x" "cpp-output" "[[PREPROC]]"
+//
+// LLVM-NEXT: "-emit-llvm-bc"
+// LLVM-SAME: "-o" "a.bc"
+// LLVM-SAME: "-x" "ir" "[[BITCODE]]"
+//
+// RUN: %clang -O2 %s -c -emit-llvm -o a.bc -no-integrated-cpp -save-temps -### 2>&1 | FileCheck %s --check-prefixes=LLVM-SAVE
+// LLVM-SAVE: "-E"
+// LLVM-SAVE-SAME: "-o" "[[PREPROC:.*.i]]"
+// LLVM-SAVE-SAME: "-x" "c" "{{.*}}no-integrated-cpp.c"
+//
+// LLVM-SAVE-NEXT: "-emit-llvm-bc"
+// LLVM-SAVE-SAME: "-o" "[[BITCODE:.*.bc]]"
+// LLVM-SAVE-SAME: "-x" "cpp-output" "[[PREPROC]]"
+//
+// LLVM-SAVE-NEXT: "-emit-llvm-bc"
+// LLVM-SAVE-SAME: "-o" "a.bc"
+// LLVM-SAVE-SAME: "-x" "ir" "[[BITCODE]]"
+//
+// RUN: %clang -O2 %t.i -c -emit-llvm -o a.bc -no-integrated-cpp -### 2>&1 | FileCheck %s --check-prefixes=PRE-LLVM
+// PRE-LLVM-NOT: "-E"
+// PRE-LLVM: "-emit-llvm-bc"
+// PRE-LLVM-SAME: "-o" "a.bc"
+// PRE-LLVM-SAME: "-x" "cpp-output" "{{.*}}no-integrated-cpp.c.tmp.i"
+//
+// RUN: %clang -O2 %t.i -c -emit-llvm -o a.bc -no-integrated-cpp -save-temps -### 2>&1 | FileCheck %s --check-prefixes=PRE-LLVM-SAVE
+// PRE-LLVM-SAVE-NOT: "-E"
+// PRE-LLVM-SAVE: "-emit-llvm-bc"
+// PRE-LLVM-SAVE-SAME: "-o" "a.bc"
+// PRE-LLVM-SAVE-SAME: "-x" "cpp-output" "{{.*}}no-integrated-cpp.c.tmp.i"

--- a/clang/test/Driver/no-integrated-cpp.c
+++ b/clang/test/Driver/no-integrated-cpp.c
@@ -33,10 +33,13 @@
 //
 // RUN: %clang -O2 %t.i  -c -o a.o -no-integrated-cpp -save-temps -### 2>&1 | FileCheck %s --check-prefixes=PRE-SAVE
 // PRE-SAVE-NOT: "-E"
-// PRE-SAVE-NOT: "-emit-llvm-bc"
-// PRE-SAVE: "-S"
-// PRE-SAVE-SAME: "-o" "[[ASM:.*.s]]"
+// PRE-SAVE: "-emit-llvm-bc"
+// PRE-SAVE-SAME: "-o" "[[BITCODE:.*.bc]]"
 // PRE-SAVE-SAME: "-x" "cpp-output" "{{.*}}no-integrated-cpp.c.tmp.i"
+//
+// PRE-SAVE-NEXT: "-S"
+// PRE-SAVE-SAME: "-o" "[[ASM:.*.s]]"
+// PRE-SAVE-SAME: "-x" "ir" "[[BITCODE]]"
 //
 // PRE-SAVE-NEXT: "-cc1as"
 // PRE-SAVE-SAME: "-o" "a.o" "[[ASM]]"
@@ -47,12 +50,8 @@
 // LLVM-SAME: "-x" "c" "{{.*}}no-integrated-cpp.c"
 //
 // LLVM-NEXT: "-emit-llvm-bc"
-// LLVM-SAME: "-o" "[[BITCODE:.*.bc]]"
-// LLVM-SAME: "-x" "cpp-output" "[[PREPROC]]"
-//
-// LLVM-NEXT: "-emit-llvm-bc"
 // LLVM-SAME: "-o" "a.bc"
-// LLVM-SAME: "-x" "ir" "[[BITCODE]]"
+// LLVM-SAME: "-x" "cpp-output" "[[PREPROC]]"
 //
 // RUN: %clang -O2 %s -c -emit-llvm -o a.bc -no-integrated-cpp -save-temps -### 2>&1 | FileCheck %s --check-prefixes=LLVM-SAVE
 // LLVM-SAVE: "-E"
@@ -76,5 +75,9 @@
 // RUN: %clang -O2 %t.i -c -emit-llvm -o a.bc -no-integrated-cpp -save-temps -### 2>&1 | FileCheck %s --check-prefixes=PRE-LLVM-SAVE
 // PRE-LLVM-SAVE-NOT: "-E"
 // PRE-LLVM-SAVE: "-emit-llvm-bc"
-// PRE-LLVM-SAVE-SAME: "-o" "a.bc"
+// PRE-LLVM-SAVE-SAME: "-o" "[[BITCODE:.*.bc]]"
 // PRE-LLVM-SAVE-SAME: "-x" "cpp-output" "{{.*}}no-integrated-cpp.c.tmp.i"
+
+// PRE-LLVM-SAVE-NEXT: "-emit-llvm-bc"
+// PRE-LLVM-SAVE-SAME: "-o" "a.bc"
+// PRE-LLVM-SAVE-SAME: "-x" "ir" "[[BITCODE]]"


### PR DESCRIPTION
When using -no-integrated-cpp, before, the driver won't collapse actions when the input was not llvm-ir
or it would collapse them too aggressively with -save-temps

The original code was checking the action type (which is IR too for preprocessed->bc actions) instead of the action inputs.