### PR TITLE
[CMake] Support using precompiled headers with ccache in flang

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -452,6 +452,10 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-semantic-interposition")
   endif()
 
+  # GCC requires this flag in order for precompiled headers to work with ccache
+  if (CMAKE_CXX_COMPILER_ID MATCHES GCC AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpch-preprocess")
+  endif()
 endif()
 
 # Clang on Darwin enables non-POSIX extensions by default, which allows the
@@ -460,6 +464,11 @@ endif()
 # Set _POSIX_C_SOURCE to avoid including these extensions.
 if (APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_POSIX_C_SOURCE=200809")
+endif()
+
+# Clang requires this flag in order for precompiled headers to work with ccache
+if (CMAKE_CXX_COMPILER_ID MATCHES Clang AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fno-pch-timestamp")
 endif()
 
 list(REMOVE_DUPLICATES CMAKE_CXX_FLAGS)

--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -453,7 +453,7 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
   endif()
 
   # GCC requires this flag in order for precompiled headers to work with ccache
-  if (CMAKE_CXX_COMPILER_ID MATCHES GCC AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpch-preprocess")
   endif()
 endif()
@@ -467,7 +467,7 @@ if (APPLE)
 endif()
 
 # Clang requires this flag in order for precompiled headers to work with ccache
-if (CMAKE_CXX_COMPILER_ID MATCHES Clang AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fno-pch-timestamp")
 endif()
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -273,7 +273,7 @@ if(LLVM_CCACHE_BUILD)
   if(CCACHE_PROGRAM)
     set(LLVM_CCACHE_MAXSIZE "" CACHE STRING "Size of ccache")
     set(LLVM_CCACHE_DIR "" CACHE STRING "Directory to keep ccached data")
-    set(LLVM_CCACHE_PARAMS "CCACHE_CPP2=yes CCACHE_HASHDIR=yes"
+    set(LLVM_CCACHE_PARAMS "CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros"
         CACHE STRING "Parameters to pass through to ccache")
 
     if(NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
@@ -287,7 +287,7 @@ if(LLVM_CCACHE_BUILD)
       set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
     else()
       if(LLVM_CCACHE_MAXSIZE OR LLVM_CCACHE_DIR OR
-         NOT LLVM_CCACHE_PARAMS MATCHES "CCACHE_CPP2=yes CCACHE_HASHDIR=yes")
+         NOT LLVM_CCACHE_PARAMS MATCHES "CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros")
         message(FATAL_ERROR "Ccache configuration through CMake is not supported on Windows. Please use environment variables.")
       endif()
       # RULE_LAUNCH_COMPILE should work with Ninja but currently has issues


### PR DESCRIPTION
In order for precompiled headers to work with ccache, a specific flag needs to be passed to the compiler and ccache's sloppiness configuration option needs to be set appropriately.

Due to issues with configuring CMake on certain Windows platforms, set the required ccache option only on non-Windows systems for the time being.

----

Background:

Originally, this was tried as part of this PR here, which had to be reverted on account of buildbot failures.
https://github.com/llvm/llvm-project/pull/131397

I then tried to rework the way we configure ccache on its own in this PR, which resulted in similar buildbot failures and also had to be reverted. The issue appears to stem from issues with the behaviour of CMake on certain Windows platforms.
https://github.com/llvm/llvm-project/pull/134857

Here, I suggest we try to do this the other way around. This PR is supposed to do the bare minimum to get precompiled headers to work with ccache, without touching anything else around how we do the configuration. This is enough for precompiled headers in flang to be able to work at least on non-Windows platforms.
If this does not cause any issues on its own, we could then roll out precompiled headers while setting CMAKE_DISABLE_PRECOMPILE_HEADERS for ccache builds on Windows, pending a solution to the problem of reliably configuring ccache on Windows. It seems unnecessary to block the entire effort on account of a subset of Windows platforms having issues with configuring ccache through CMake.

Any feedback or different ideas would be appreciated, the specific issues with CMake on Windows that lead me to thinking it might be better to try it this way can be found in the PRs linked above.