### PR TITLE
[Flang][OpenACC] Make async clause on data consistent with elsewhere

### DIFF
--- a/flang/test/Semantics/OpenACC/acc-data.f90
+++ b/flang/test/Semantics/OpenACC/acc-data.f90
@@ -187,6 +187,17 @@ program openacc_data_validity
   !$acc data copy(aa) device_type(default) wait
   !$acc end data
 
+  !ERROR: At most one ASYNC clause can appear on the DATA directive or in group separated by the DEVICE_TYPE clause
+  !$acc data copy(aa) async(async1) async(2)
+  !$acc end data
+
+  !$acc data copy(aa) async(async1) device_type(multicore) async(2) ! ok
+  !$acc end data
+
+  !ERROR: At most one ASYNC clause can appear on the DATA directive or in group separated by the DEVICE_TYPE clause
+  !$acc data copy(aa) async(async1) device_type(multicore) async(2) async(3)
+  !$acc end data
+
   do i = 1, 100
     !$acc data copy(aa)
     !ERROR: CYCLE to construct outside of DATA construct is not allowed

--- a/llvm/include/llvm/Frontend/OpenACC/ACC.td
+++ b/llvm/include/llvm/Frontend/OpenACC/ACC.td
@@ -284,11 +284,11 @@ def ACC_Atomic : Directive<"atomic"> {
 // 2.6.5
 def ACC_Data : Directive<"data"> {
   let allowedOnceClauses = [
-    VersionedClause<ACCC_Async, 32>,
     VersionedClause<ACCC_If>,
     VersionedClause<ACCC_Default>
   ];
   let allowedClauses = [
+    VersionedClause<ACCC_Async, 32>,
     VersionedClause<ACCC_DeviceType, 32>,
     VersionedClause<ACCC_Wait, 32>
   ];


### PR DESCRIPTION
in #136610 we agreed that all async clauses on compute constructs should act as 'only 1 per device-type-group'.  On `data`, it has the same specification language, and the same real requirements, so it seems sensible to make it work the same way.