### PR TITLE
[libclc] Fix unguarded use of image types

### DIFF
--- a/libclc/generic/include/clc/image/image.h
+++ b/libclc/generic/include/clc/image/image.h
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if defined(__opencl_c_images)
+
 _CLC_OVERLOAD _CLC_DECL int get_image_width (image2d_t image);
 _CLC_OVERLOAD _CLC_DECL int get_image_width (image3d_t image);
 
@@ -42,3 +44,5 @@ _CLC_OVERLOAD _CLC_DECL uint4
 read_imageui(image2d_t image, sampler_t sampler, int2 coord);
 _CLC_OVERLOAD _CLC_DECL uint4
 read_imageui(image2d_t image, sampler_t sampler, float2 coord);
+
+#endif


### PR DESCRIPTION
Commit 8292e05 which switched the OpenCL C version to 3.0 exposed this issue, which wasn't caught in pre-commit CI.