### PR TITLE
[libclc] Re-enable compiler warning

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -441,8 +441,6 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 
     list( APPEND build_flags
       -I${CMAKE_CURRENT_SOURCE_DIR}/generic/include
-      # FIXME: Fix libclc to not require disabling this noisy warning
-      -Wno-bitwise-conditional-parentheses
     )
 
     add_libclc_builtin_set(


### PR DESCRIPTION
libclc is now clean of code that triggers the bitwise-conditional-parentheses warning, so we can finally remove the workaround.