### PR TITLE
[lldb][lldb-dap] Redirect LLDB's messages to the right output category.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -82,7 +82,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
 
         blocking_seq = self.async_blocking_request(duration=self.timeoutval / 2)
         # Wait for the sleep to start to cancel the inflight request.
-        self.collect_stdout(
+        self.collect_console(
             timeout_secs=self.timeoutval,
             pattern="starting sleep",
         )

--- a/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
+++ b/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
@@ -40,7 +40,12 @@ class TestDAP_output(lldbdap_testcase.DAPTestCaseBase):
         output += self.get_stdout(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
         self.assertTrue(output and len(output) > 0, "expect program stdout")
         self.assertIn(
-            "abcdefghi\r\nhello world\r\nfinally\0\0out\0\0\r\nerr\0\0",
+            "abcdefghi\r\nhello world\r\nfinally\0\0",
             output,
             "full stdout not found in: " + repr(output),
+        )
+        console = self.get_console(timeout=self.timeoutval)
+        self.assertTrue(console and len(console) > 0, "expect dap messages")
+        self.assertIn(
+            "out\0\0\r\nerr\0\0\r\n", console, f"full console message not found"
         )

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -209,12 +209,12 @@ llvm::Error DAP::ConfigureIO(std::FILE *overrideOut, std::FILE *overrideErr) {
   in = lldb::SBFile(std::fopen(DEV_NULL, "r"), /*transfer_ownership=*/true);
 
   if (auto Error = out.RedirectTo(overrideOut, [this](llvm::StringRef output) {
-        SendOutput(OutputType::Stdout, output);
+        SendOutput(OutputType::Console, output);
       }))
     return Error;
 
   if (auto Error = err.RedirectTo(overrideErr, [this](llvm::StringRef output) {
-        SendOutput(OutputType::Stderr, output);
+        SendOutput(OutputType::Console, output);
       }))
     return Error;
 


### PR DESCRIPTION
Based on the DAP specification.
The output categories stdout and stderr should only be used for the debuggee's stdout and stderr.

```jsonc
 /**
     * The output category. If not specified or if the category is not
     * understood by the client, `console` is assumed.
     * Values:
     * 'console': Show the output in the client's default message UI, e.g. a
     * 'debug console'. This category should only be used for informational
     * output from the debugger (as opposed to the debuggee).
     * 'important': A hint for the client to show the output in the client's UI
     * for important and highly visible information, e.g. as a popup
     * notification. This category should only be used for important messages
     * from the debugger (as opposed to the debuggee). Since this category value
     * is a hint, clients might ignore the hint and assume the `console`
     * category.
     * 'stdout': Show the output as normal program output from the debuggee.
     * 'stderr': Show the output as error program output from the debuggee.
     * 'telemetry': Send the output to telemetry instead of showing it to the
     * user.
     * etc.
     */
    category?: 'console' | 'important' | 'stdout' | 'stderr' | 'telemetry' | string;
```
What I am not sure if error should use the important category ? 