### PR TITLE
[HLSL] Put tests for compatibility overloads for 'clamp', 'isinf', 'min', and 'max' in own files

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/clamp-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/clamp-overloads.hlsl
@@ -1,0 +1,63 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:  -fnative-half-type -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK,NATIVE_HALF \
+// RUN:  -DTARGET=dx -DFNATTRS=noundef -DFFNATTRS="nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:  -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK,NO_HALF \
+// RUN:  -DTARGET=dx -DFNATTRS=noundef -DFFNATTRS="nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple spirv-unknown-vulkan-compute %s \
+// RUN:  -fnative-half-type -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK,NATIVE_HALF \
+// RUN:  -DTARGET=spv -DFNATTRS="spir_func noundef" -DFFNATTRS="nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple spirv-unknown-vulkan-compute %s \
+// RUN:  -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK,NO_HALF \
+// RUN:  -DTARGET=spv -DFNATTRS="spir_func noundef" -DFFNATTRS="nofpclass(nan inf)"
+
+#ifdef __HLSL_ENABLE_16_BIT
+// NATIVE_HALF: define [[FNATTRS]] <4 x i16> {{.*}}test_clamp_short4_mismatch
+// NATIVE_HALF: call <4 x i16> @llvm.[[TARGET]].sclamp.v4i16
+int16_t4 test_clamp_short4_mismatch(int16_t4 p0, int16_t p1) { return clamp(p0, p0,p1); }
+
+// NATIVE_HALF: define [[FNATTRS]] <4 x i16> {{.*}}test_clamp_ushort4_mismatch
+// NATIVE_HALF: call <4 x i16> @llvm.[[TARGET]].uclamp.v4i16
+uint16_t4 test_clamp_ushort4_mismatch(uint16_t4 p0, uint16_t p1) { return clamp(p0, p0,p1); }
+#endif
+
+// CHECK: define [[FNATTRS]] <4 x i32> {{.*}}test_clamp_int4_mismatch
+// CHECK: call <4 x i32> @llvm.[[TARGET]].sclamp.v4i32
+int4 test_clamp_int4_mismatch(int4 p0, int p1) { return clamp(p0, p0,p1); }
+
+// CHECK: define [[FNATTRS]] <4 x i32> {{.*}}test_clamp_uint4_mismatch
+// CHECK: call <4 x i32> @llvm.[[TARGET]].uclamp.v4i32
+uint4 test_clamp_uint4_mismatch(uint4 p0, uint p1) { return clamp(p0, p0,p1); }
+
+// CHECK: define [[FNATTRS]] <4 x i64> {{.*}}test_clamp_long4_mismatch
+// CHECK: call <4 x i64> @llvm.[[TARGET]].sclamp.v4i64
+int64_t4 test_clamp_long4_mismatch(int64_t4 p0, int64_t p1) { return clamp(p0, p0,p1); }
+
+// CHECK: define [[FNATTRS]] <4 x i64> {{.*}}test_clamp_ulong4_mismatch
+// CHECK: call <4 x i64> @llvm.[[TARGET]].uclamp.v4i64
+uint64_t4 test_clamp_ulong4_mismatch(uint64_t4 p0, uint64_t p1) { return clamp(p0, p0,p1); }
+
+// NATIVE_HALF: define [[FNATTRS]] [[FFNATTRS]] <4 x half> {{.*}}test_clamp_half4_mismatch
+// NATIVE_HALF: call reassoc nnan ninf nsz arcp afn <4 x half> @llvm.[[TARGET]].nclamp.v4f16
+// NO_HALF: define [[FNATTRS]] [[FFNATTRS]] <4 x float> {{.*}}test_clamp_half4_mismatch
+// NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].nclamp.v4f32(
+half4 test_clamp_half4_mismatch(half4 p0, half p1) { return clamp(p0, p0,p1); }
+
+// CHECK: define [[FNATTRS]] [[FFNATTRS]] <4 x float> {{.*}}test_clamp_float4_mismatch
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].nclamp.v4f32
+float4 test_clamp_float4_mismatch(float4 p0, float p1) { return clamp(p0, p0,p1); }
+
+// CHECK: define [[FNATTRS]] [[FFNATTRS]] <4 x double> {{.*}}test_clamp_double4_mismatch
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.[[TARGET]].nclamp.v4f64
+double4 test_clamp_double4_mismatch(double4 p0, double p1) { return clamp(p0, p0,p1); }
+// CHECK: define [[FNATTRS]] [[FFNATTRS]] <4 x double> {{.*}}test_clamp_double4_mismatch2
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.[[TARGET]].nclamp.v4f64
+double4 test_clamp_double4_mismatch2(double4 p0, double p1) { return clamp(p0, p1,p0); }
+
+// CHECK: define [[FNATTRS]] <3 x i32> {{.*}}test_overloads3
+// CHECK: call <3 x i32> @llvm.[[TARGET]].uclamp.v3i32
+uint3 test_overloads3(uint3 p0, uint p1, uint p2) { return clamp(p0, p1, p2); }

--- a/clang/test/CodeGenHLSL/builtins/clamp.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/clamp.hlsl
@@ -28,9 +28,6 @@ int16_t3 test_clamp_short3(int16_t3 p0, int16_t3 p1) { return clamp(p0, p1,p1); 
 // NATIVE_HALF: define [[FNATTRS]] <4 x i16> @_Z17test_clamp_short4
 // NATIVE_HALF: call <4 x i16> @llvm.[[TARGET]].sclamp.v4i16
 int16_t4 test_clamp_short4(int16_t4 p0, int16_t4 p1) { return clamp(p0, p1,p1); }
-// NATIVE_HALF: define [[FNATTRS]] <4 x i16> {{.*}}test_clamp_short4_mismatch
-// NATIVE_HALF: call <4 x i16> @llvm.[[TARGET]].sclamp.v4i16
-int16_t4 test_clamp_short4_mismatch(int16_t4 p0, int16_t p1) { return clamp(p0, p0,p1); }
 
 // NATIVE_HALF: define [[FNATTRS]] i16 @_Z17test_clamp_ushort
 // NATIVE_HALF: call i16 @llvm.[[TARGET]].uclamp.i16(
@@ -44,9 +41,6 @@ uint16_t3 test_clamp_ushort3(uint16_t3 p0, uint16_t3 p1) { return clamp(p0, p1,p
 // NATIVE_HALF: define [[FNATTRS]] <4 x i16> @_Z18test_clamp_ushort4
 // NATIVE_HALF: call <4 x i16> @llvm.[[TARGET]].uclamp.v4i16
 uint16_t4 test_clamp_ushort4(uint16_t4 p0, uint16_t4 p1) { return clamp(p0, p1,p1); }
-// NATIVE_HALF: define [[FNATTRS]] <4 x i16> {{.*}}test_clamp_ushort4_mismatch
-// NATIVE_HALF: call <4 x i16> @llvm.[[TARGET]].uclamp.v4i16
-uint16_t4 test_clamp_ushort4_mismatch(uint16_t4 p0, uint16_t p1) { return clamp(p0, p0,p1); }
 #endif
 
 // CHECK: define [[FNATTRS]] i32 @_Z14test_clamp_int
@@ -61,9 +55,6 @@ int3 test_clamp_int3(int3 p0, int3 p1) { return clamp(p0, p1,p1); }
 // CHECK: define [[FNATTRS]] <4 x i32> @_Z15test_clamp_int4
 // CHECK: call <4 x i32> @llvm.[[TARGET]].sclamp.v4i32
 int4 test_clamp_int4(int4 p0, int4 p1) { return clamp(p0, p1,p1); }
-// CHECK: define [[FNATTRS]] <4 x i32> {{.*}}test_clamp_int4_mismatch
-// CHECK: call <4 x i32> @llvm.[[TARGET]].sclamp.v4i32
-int4 test_clamp_int4_mismatch(int4 p0, int p1) { return clamp(p0, p0,p1); }
 
 // CHECK: define [[FNATTRS]] i32 @_Z15test_clamp_uint
 // CHECK: call i32 @llvm.[[TARGET]].uclamp.i32(
@@ -77,9 +68,6 @@ uint3 test_clamp_uint3(uint3 p0, uint3 p1) { return clamp(p0, p1,p1); }
 // CHECK: define [[FNATTRS]] <4 x i32> @_Z16test_clamp_uint4
 // CHECK: call <4 x i32> @llvm.[[TARGET]].uclamp.v4i32
 uint4 test_clamp_uint4(uint4 p0, uint4 p1) { return clamp(p0, p1,p1); }
-// CHECK: define [[FNATTRS]] <4 x i32> {{.*}}test_clamp_uint4_mismatch
-// CHECK: call <4 x i32> @llvm.[[TARGET]].uclamp.v4i32
-uint4 test_clamp_uint4_mismatch(uint4 p0, uint p1) { return clamp(p0, p0,p1); }
 
 // CHECK: define [[FNATTRS]] i64 @_Z15test_clamp_long
 // CHECK: call i64 @llvm.[[TARGET]].sclamp.i64(
@@ -93,9 +81,6 @@ int64_t3 test_clamp_long3(int64_t3 p0, int64_t3 p1) { return clamp(p0, p1,p1); }
 // CHECK: define [[FNATTRS]] <4 x i64> @_Z16test_clamp_long4
 // CHECK: call <4 x i64> @llvm.[[TARGET]].sclamp.v4i64
 int64_t4 test_clamp_long4(int64_t4 p0, int64_t4 p1) { return clamp(p0, p1,p1); }
-// CHECK: define [[FNATTRS]] <4 x i64> {{.*}}test_clamp_long4_mismatch
-// CHECK: call <4 x i64> @llvm.[[TARGET]].sclamp.v4i64
-int64_t4 test_clamp_long4_mismatch(int64_t4 p0, int64_t p1) { return clamp(p0, p0,p1); }
 
 // CHECK: define [[FNATTRS]] i64 @_Z16test_clamp_ulong
 // CHECK: call i64 @llvm.[[TARGET]].uclamp.i64(
@@ -109,9 +94,6 @@ uint64_t3 test_clamp_ulong3(uint64_t3 p0, uint64_t3 p1) { return clamp(p0, p1,p1
 // CHECK: define [[FNATTRS]] <4 x i64> @_Z17test_clamp_ulong4
 // CHECK: call <4 x i64> @llvm.[[TARGET]].uclamp.v4i64
 uint64_t4 test_clamp_ulong4(uint64_t4 p0, uint64_t4 p1) { return clamp(p0, p1,p1); }
-// CHECK: define [[FNATTRS]] <4 x i64> {{.*}}test_clamp_ulong4_mismatch
-// CHECK: call <4 x i64> @llvm.[[TARGET]].uclamp.v4i64
-uint64_t4 test_clamp_ulong4_mismatch(uint64_t4 p0, uint64_t p1) { return clamp(p0, p0,p1); }
 
 // NATIVE_HALF: define [[FNATTRS]] [[FFNATTRS]] half @_Z15test_clamp_half
 // NATIVE_HALF: call reassoc nnan ninf nsz arcp afn half @llvm.[[TARGET]].nclamp.f16(
@@ -133,11 +115,6 @@ half3 test_clamp_half3(half3 p0, half3 p1) { return clamp(p0, p1,p1); }
 // NO_HALF: define [[FNATTRS]] [[FFNATTRS]] <4 x float> @_Z16test_clamp_half4
 // NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].nclamp.v4f32(
 half4 test_clamp_half4(half4 p0, half4 p1) { return clamp(p0, p1,p1); }
-// NATIVE_HALF: define [[FNATTRS]] [[FFNATTRS]] <4 x half> {{.*}}test_clamp_half4_mismatch
-// NATIVE_HALF: call reassoc nnan ninf nsz arcp afn <4 x half> @llvm.[[TARGET]].nclamp.v4f16
-// NO_HALF: define [[FNATTRS]] [[FFNATTRS]] <4 x float> {{.*}}test_clamp_half4_mismatch
-// NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].nclamp.v4f32(
-half4 test_clamp_half4_mismatch(half4 p0, half p1) { return clamp(p0, p0,p1); }
 
 // CHECK: define [[FNATTRS]] [[FFNATTRS]] float @_Z16test_clamp_float
 // CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].nclamp.f32(
@@ -151,9 +128,6 @@ float3 test_clamp_float3(float3 p0, float3 p1) { return clamp(p0, p1,p1); }
 // CHECK: define [[FNATTRS]] [[FFNATTRS]] <4 x float> @_Z17test_clamp_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].nclamp.v4f32
 float4 test_clamp_float4(float4 p0, float4 p1) { return clamp(p0, p1,p1); }
-// CHECK: define [[FNATTRS]] [[FFNATTRS]] <4 x float> {{.*}}test_clamp_float4_mismatch
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].nclamp.v4f32
-float4 test_clamp_float4_mismatch(float4 p0, float p1) { return clamp(p0, p0,p1); }
 
 // CHECK: define [[FNATTRS]] [[FFNATTRS]] double @_Z17test_clamp_double
 // CHECK: call reassoc nnan ninf nsz arcp afn double @llvm.[[TARGET]].nclamp.f64(
@@ -167,13 +141,3 @@ double3 test_clamp_double3(double3 p0, double3 p1) { return clamp(p0, p1,p1); }
 // CHECK: define [[FNATTRS]] [[FFNATTRS]] <4 x double> @_Z18test_clamp_double4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.[[TARGET]].nclamp.v4f64
 double4 test_clamp_double4(double4 p0, double4 p1) { return clamp(p0, p1,p1); }
-// CHECK: define [[FNATTRS]] [[FFNATTRS]] <4 x double> {{.*}}test_clamp_double4_mismatch
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.[[TARGET]].nclamp.v4f64
-double4 test_clamp_double4_mismatch(double4 p0, double p1) { return clamp(p0, p0,p1); }
-// CHECK: define [[FNATTRS]] [[FFNATTRS]] <4 x double> {{.*}}test_clamp_double4_mismatch2
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.[[TARGET]].nclamp.v4f64
-double4 test_clamp_double4_mismatch2(double4 p0, double p1) { return clamp(p0, p1,p0); }
-
-// CHECK: define [[FNATTRS]] <3 x i32> {{.*}}test_overloads3
-// CHECK: call <3 x i32> @llvm.[[TARGET]].uclamp.v3i32
-uint3 test_overloads3(uint3 p0, uint p1, uint p2) { return clamp(p0, p1, p2); }

--- a/clang/test/CodeGenHLSL/builtins/isinf-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/isinf-overloads.hlsl
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s
+
+// CHECK: define noundef i1 @
+// CHECK: %dx.isinf = call i1 @llvm.dx.isinf.f32(
+// CHECK: ret i1 %dx.isinf
+bool test_isinf_double(double p0) { return isinf(p0); }
+// CHECK: define noundef <2 x i1> @
+// CHECK: %dx.isinf = call <2 x i1> @llvm.dx.isinf.v2f32
+// CHECK: ret <2 x i1> %dx.isinf
+bool2 test_isinf_double2(double2 p0) { return isinf(p0); }
+// CHECK: define noundef <3 x i1> @
+// CHECK: %dx.isinf = call <3 x i1> @llvm.dx.isinf.v3f32
+// CHECK: ret <3 x i1> %dx.isinf
+bool3 test_isinf_double3(double3 p0) { return isinf(p0); }
+// CHECK: define noundef <4 x i1> @
+// CHECK: %dx.isinf = call <4 x i1> @llvm.dx.isinf.v4f32
+// CHECK: ret <4 x i1> %dx.isinf
+bool4 test_isinf_double4(double4 p0) { return isinf(p0); }

--- a/clang/test/CodeGenHLSL/builtins/isinf.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/isinf.hlsl
@@ -43,20 +43,3 @@ bool3 test_isinf_float3(float3 p0) { return isinf(p0); }
 // CHECK: %dx.isinf = call <4 x i1> @llvm.dx.isinf.v4f32
 // CHECK: ret <4 x i1> %dx.isinf
 bool4 test_isinf_float4(float4 p0) { return isinf(p0); }
-
-// CHECK: define noundef i1 @
-// CHECK: %dx.isinf = call i1 @llvm.dx.isinf.f32(
-// CHECK: ret i1 %dx.isinf
-bool test_isinf_double(double p0) { return isinf(p0); }
-// CHECK: define noundef <2 x i1> @
-// CHECK: %dx.isinf = call <2 x i1> @llvm.dx.isinf.v2f32
-// CHECK: ret <2 x i1> %dx.isinf
-bool2 test_isinf_double2(double2 p0) { return isinf(p0); }
-// CHECK: define noundef <3 x i1> @
-// CHECK: %dx.isinf = call <3 x i1> @llvm.dx.isinf.v3f32
-// CHECK: ret <3 x i1> %dx.isinf
-bool3 test_isinf_double3(double3 p0) { return isinf(p0); }
-// CHECK: define noundef <4 x i1> @
-// CHECK: %dx.isinf = call <4 x i1> @llvm.dx.isinf.v4f32
-// CHECK: ret <4 x i1> %dx.isinf
-bool4 test_isinf_double4(double4 p0) { return isinf(p0); }

--- a/clang/test/CodeGenHLSL/builtins/max-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/max-overloads.hlsl
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:  -fnative-half-type -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK,NATIVE_HALF
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:  -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK,NO_HALF
+
+#ifdef __HLSL_ENABLE_16_BIT
+// NATIVE_HALF-LABEL: define noundef <4 x i16> {{.*}}test_max_short4_mismatch
+// NATIVE_HALF: call <4 x i16> @llvm.smax.v4i16
+int16_t4 test_max_short4_mismatch(int16_t4 p0, int16_t p1) { return max(p0, p1); }
+
+// NATIVE_HALF-LABEL: define noundef <4 x i16> {{.*}}test_max_ushort4_mismatch
+// NATIVE_HALF: call <4 x i16> @llvm.umax.v4i16
+uint16_t4 test_max_ushort4_mismatch(uint16_t4 p0, uint16_t p1) { return max(p0, p1); }
+#endif
+
+// CHECK-LABEL: define noundef <4 x i32> {{.*}}test_max_int4_mismatch
+// CHECK: call <4 x i32> @llvm.smax.v4i32
+int4 test_max_int4_mismatch(int4 p0, int p1) { return max(p0, p1); }
+
+// CHECK-LABEL: define noundef <4 x i32> {{.*}}test_max_uint4_mismatch
+// CHECK: call <4 x i32> @llvm.umax.v4i32
+uint4 test_max_uint4_mismatch(uint4 p0, uint p1) { return max(p0, p1); }
+
+// CHECK-LABEL: define noundef <4 x i64> {{.*}}test_max_long4_mismatch
+// CHECK: call <4 x i64> @llvm.smax.v4i64
+int64_t4 test_max_long4_mismatch(int64_t4 p0, int64_t p1) { return max(p0, p1); }
+
+// CHECK-LABEL: define noundef <4 x i64> {{.*}}test_max_ulong4_mismatch
+// CHECK: call <4 x i64> @llvm.umax.v4i64
+uint64_t4 test_max_ulong4_mismatch(uint64_t4 p0, uint64_t p1) { return max(p0, p1); }
+
+// NATIVE_HALF-LABEL: define noundef nofpclass(nan inf) <4 x half> {{.*}}test_max_half4_mismatch
+// NATIVE_HALF: call reassoc nnan ninf nsz arcp afn <4 x half> @llvm.maxnum.v4f16
+// NO_HALF-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_max_half4_mismatch
+// NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.maxnum.v4f32(
+half4 test_max_half4_mismatch(half4 p0, half p1) { return max(p0, p1); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_max_float4_mismatch
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.maxnum.v4f32
+float4 test_max_float4_mismatch(float4 p0, float p1) { return max(p0, p1); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> {{.*}}test_max_double4_mismatch
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.maxnum.v4f64
+double4 test_max_double4_mismatch(double4 p0, double p1) { return max(p0, p1); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> {{.*}}test_max_double4_mismatch2
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.maxnum.v4f64
+double4 test_max_double4_mismatch2(double4 p0, double p1) { return max(p1, p0); }

--- a/clang/test/CodeGenHLSL/builtins/max.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/max.hlsl
@@ -18,9 +18,6 @@ int16_t3 test_max_short3(int16_t3 p0, int16_t3 p1) { return max(p0, p1); }
 // NATIVE_HALF-LABEL: define noundef <4 x i16> @_Z15test_max_short4
 // NATIVE_HALF: call <4 x i16> @llvm.smax.v4i16
 int16_t4 test_max_short4(int16_t4 p0, int16_t4 p1) { return max(p0, p1); }
-// NATIVE_HALF-LABEL: define noundef <4 x i16> {{.*}}test_max_short4_mismatch
-// NATIVE_HALF: call <4 x i16> @llvm.smax.v4i16
-int16_t4 test_max_short4_mismatch(int16_t4 p0, int16_t p1) { return max(p0, p1); }
 
 // NATIVE_HALF-LABEL: define noundef i16 @_Z15test_max_ushort
 // NATIVE_HALF: call i16 @llvm.umax.i16(
@@ -34,9 +31,6 @@ uint16_t3 test_max_ushort3(uint16_t3 p0, uint16_t3 p1) { return max(p0, p1); }
 // NATIVE_HALF-LABEL: define noundef <4 x i16> @_Z16test_max_ushort4
 // NATIVE_HALF: call <4 x i16> @llvm.umax.v4i16
 uint16_t4 test_max_ushort4(uint16_t4 p0, uint16_t4 p1) { return max(p0, p1); }
-// NATIVE_HALF-LABEL: define noundef <4 x i16> {{.*}}test_max_ushort4_mismatch
-// NATIVE_HALF: call <4 x i16> @llvm.umax.v4i16
-uint16_t4 test_max_ushort4_mismatch(uint16_t4 p0, uint16_t p1) { return max(p0, p1); }
 #endif
 
 // CHECK-LABEL: define noundef i32 @_Z12test_max_int
@@ -51,9 +45,6 @@ int3 test_max_int3(int3 p0, int3 p1) { return max(p0, p1); }
 // CHECK-LABEL: define noundef <4 x i32> @_Z13test_max_int4
 // CHECK: call <4 x i32> @llvm.smax.v4i32
 int4 test_max_int4(int4 p0, int4 p1) { return max(p0, p1); }
-// CHECK-LABEL: define noundef <4 x i32> {{.*}}test_max_int4_mismatch
-// CHECK: call <4 x i32> @llvm.smax.v4i32
-int4 test_max_int4_mismatch(int4 p0, int p1) { return max(p0, p1); }
 
 // CHECK-LABEL: define noundef i32 @_Z13test_max_uint
 // CHECK: call i32 @llvm.umax.i32(
@@ -67,9 +58,6 @@ uint3 test_max_uint3(uint3 p0, uint3 p1) { return max(p0, p1); }
 // CHECK-LABEL: define noundef <4 x i32> @_Z14test_max_uint4
 // CHECK: call <4 x i32> @llvm.umax.v4i32
 uint4 test_max_uint4(uint4 p0, uint4 p1) { return max(p0, p1); }
-// CHECK-LABEL: define noundef <4 x i32> {{.*}}test_max_uint4_mismatch
-// CHECK: call <4 x i32> @llvm.umax.v4i32
-uint4 test_max_uint4_mismatch(uint4 p0, uint p1) { return max(p0, p1); }
 
 // CHECK-LABEL: define noundef i64 @_Z13test_max_long
 // CHECK: call i64 @llvm.smax.i64(
@@ -83,9 +71,6 @@ int64_t3 test_max_long3(int64_t3 p0, int64_t3 p1) { return max(p0, p1); }
 // CHECK-LABEL: define noundef <4 x i64> @_Z14test_max_long4
 // CHECK: call <4 x i64> @llvm.smax.v4i64
 int64_t4 test_max_long4(int64_t4 p0, int64_t4 p1) { return max(p0, p1); }
-// CHECK-LABEL: define noundef <4 x i64> {{.*}}test_max_long4_mismatch
-// CHECK: call <4 x i64> @llvm.smax.v4i64
-int64_t4 test_max_long4_mismatch(int64_t4 p0, int64_t p1) { return max(p0, p1); }
 
 // CHECK-LABEL: define noundef i64 @_Z14test_max_ulong
 // CHECK: call i64 @llvm.umax.i64(
@@ -99,9 +84,6 @@ uint64_t3 test_max_ulong3(uint64_t3 p0, uint64_t3 p1) { return max(p0, p1); }
 // CHECK-LABEL: define noundef <4 x i64> @_Z15test_max_ulong4
 // CHECK: call <4 x i64> @llvm.umax.v4i64
 uint64_t4 test_max_ulong4(uint64_t4 p0, uint64_t4 p1) { return max(p0, p1); }
-// CHECK-LABEL: define noundef <4 x i64> {{.*}}test_max_ulong4_mismatch
-// CHECK: call <4 x i64> @llvm.umax.v4i64
-uint64_t4 test_max_ulong4_mismatch(uint64_t4 p0, uint64_t p1) { return max(p0, p1); }
 
 // NATIVE_HALF-LABEL: define noundef nofpclass(nan inf) half @_Z13test_max_half
 // NATIVE_HALF: call reassoc nnan ninf nsz arcp afn half @llvm.maxnum.f16(
@@ -123,11 +105,6 @@ half3 test_max_half3(half3 p0, half3 p1) { return max(p0, p1); }
 // NO_HALF-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z14test_max_half4
 // NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.maxnum.v4f32(
 half4 test_max_half4(half4 p0, half4 p1) { return max(p0, p1); }
-// NATIVE_HALF-LABEL: define noundef nofpclass(nan inf) <4 x half> {{.*}}test_max_half4_mismatch
-// NATIVE_HALF: call reassoc nnan ninf nsz arcp afn <4 x half> @llvm.maxnum.v4f16
-// NO_HALF-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_max_half4_mismatch
-// NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.maxnum.v4f32(
-half4 test_max_half4_mismatch(half4 p0, half p1) { return max(p0, p1); }
 
 // CHECK-LABEL: define noundef nofpclass(nan inf) float @_Z14test_max_float
 // CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.maxnum.f32(
@@ -141,9 +118,6 @@ float3 test_max_float3(float3 p0, float3 p1) { return max(p0, p1); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z15test_max_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.maxnum.v4f32
 float4 test_max_float4(float4 p0, float4 p1) { return max(p0, p1); }
-// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_max_float4_mismatch
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.maxnum.v4f32
-float4 test_max_float4_mismatch(float4 p0, float p1) { return max(p0, p1); }
 
 // CHECK-LABEL: define noundef nofpclass(nan inf) double @_Z15test_max_double
 // CHECK: call reassoc nnan ninf nsz arcp afn double @llvm.maxnum.f64(
@@ -157,9 +131,3 @@ double3 test_max_double3(double3 p0, double3 p1) { return max(p0, p1); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> @_Z16test_max_double4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.maxnum.v4f64
 double4 test_max_double4(double4 p0, double4 p1) { return max(p0, p1); }
-// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> {{.*}}test_max_double4_mismatch
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.maxnum.v4f64
-double4 test_max_double4_mismatch(double4 p0, double p1) { return max(p0, p1); }
-// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> {{.*}}test_max_double4_mismatch2
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.maxnum.v4f64
-double4 test_max_double4_mismatch2(double4 p0, double p1) { return max(p1, p0); }

--- a/clang/test/CodeGenHLSL/builtins/min-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/min-overloads.hlsl
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:  -fnative-half-type -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK,NATIVE_HALF
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:  -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK,NO_HALF
+
+#ifdef __HLSL_ENABLE_16_BIT
+// NATIVE_HALF-LABEL: define noundef <4 x i16> {{.*}}test_min_short4_mismatch
+// NATIVE_HALF: call <4 x i16> @llvm.smin.v4i16
+int16_t4 test_min_short4_mismatch(int16_t4 p0, int16_t p1) { return min(p0, p1); }
+
+// NATIVE_HALF-LABEL: define noundef <4 x i16> {{.*}}test_min_ushort4_mismatch
+// NATIVE_HALF: call <4 x i16> @llvm.umin.v4i16
+uint16_t4 test_min_ushort4_mismatch(uint16_t4 p0, uint16_t p1) { return min(p0, p1); }
+#endif
+
+// CHECK-LABEL: define noundef <4 x i32> {{.*}}test_min_int4_mismatch
+// CHECK: call <4 x i32> @llvm.smin.v4i32
+int4 test_min_int4_mismatch(int4 p0, int p1) { return min(p0, p1); }
+
+// CHECK-LABEL: define noundef <4 x i32> {{.*}}test_min_uint4_mismatch
+// CHECK: call <4 x i32> @llvm.umin.v4i32
+uint4 test_min_uint4_mismatch(uint4 p0, uint p1) { return min(p0, p1); }
+
+// CHECK-LABEL: define noundef <4 x i64> {{.*}}test_min_long4_mismatch
+// CHECK: call <4 x i64> @llvm.smin.v4i64
+int64_t4 test_min_long4_mismatch(int64_t4 p0, int64_t p1) { return min(p0, p1); }
+
+// CHECK-LABEL: define noundef <4 x i64> {{.*}}test_min_ulong4_mismatch
+// CHECK: call <4 x i64> @llvm.umin.v4i64
+uint64_t4 test_min_ulong4_mismatch(uint64_t4 p0, uint64_t p1) { return min(p0, p1); }
+
+// NATIVE_HALF-LABEL: define noundef nofpclass(nan inf) <4 x half> {{.*}}test_min_half4_mismatch
+// NATIVE_HALF: call reassoc nnan ninf nsz arcp afn <4 x half> @llvm.minnum.v4f16
+// NO_HALF-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_min_half4_mismatch
+// NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.minnum.v4f32(
+half4 test_min_half4_mismatch(half4 p0, half p1) { return min(p0, p1); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_min_float4_mismatch
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.minnum.v4f32
+float4 test_min_float4_mismatch(float4 p0, float p1) { return min(p0, p1); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> {{.*}}test_min_double4_mismatch2
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.minnum.v4f64
+double4 test_min_double4_mismatch2(double4 p0, double p1) { return min(p1, p0); }

--- a/clang/test/CodeGenHLSL/builtins/min.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/min.hlsl
@@ -18,9 +18,6 @@ int16_t3 test_min_short3(int16_t3 p0, int16_t3 p1) { return min(p0, p1); }
 // NATIVE_HALF-LABEL: define noundef <4 x i16> @_Z15test_min_short4
 // NATIVE_HALF: call <4 x i16> @llvm.smin.v4i16
 int16_t4 test_min_short4(int16_t4 p0, int16_t4 p1) { return min(p0, p1); }
-// NATIVE_HALF-LABEL: define noundef <4 x i16> {{.*}}test_min_short4_mismatch
-// NATIVE_HALF: call <4 x i16> @llvm.smin.v4i16
-int16_t4 test_min_short4_mismatch(int16_t4 p0, int16_t p1) { return min(p0, p1); }
 
 // NATIVE_HALF-LABEL: define noundef i16 @_Z15test_min_ushort
 // NATIVE_HALF: call i16 @llvm.umin.i16(
@@ -34,9 +31,6 @@ uint16_t3 test_min_ushort3(uint16_t3 p0, uint16_t3 p1) { return min(p0, p1); }
 // NATIVE_HALF-LABEL: define noundef <4 x i16> @_Z16test_min_ushort4
 // NATIVE_HALF: call <4 x i16> @llvm.umin.v4i16
 uint16_t4 test_min_ushort4(uint16_t4 p0, uint16_t4 p1) { return min(p0, p1); }
-// NATIVE_HALF-LABEL: define noundef <4 x i16> {{.*}}test_min_ushort4_mismatch
-// NATIVE_HALF: call <4 x i16> @llvm.umin.v4i16
-uint16_t4 test_min_ushort4_mismatch(uint16_t4 p0, uint16_t p1) { return min(p0, p1); }
 #endif
 
 // CHECK-LABEL: define noundef i32 @_Z12test_min_int
@@ -51,9 +45,6 @@ int3 test_min_int3(int3 p0, int3 p1) { return min(p0, p1); }
 // CHECK-LABEL: define noundef <4 x i32> @_Z13test_min_int4
 // CHECK: call <4 x i32> @llvm.smin.v4i32
 int4 test_min_int4(int4 p0, int4 p1) { return min(p0, p1); }
-// CHECK-LABEL: define noundef <4 x i32> {{.*}}test_min_int4_mismatch
-// CHECK: call <4 x i32> @llvm.smin.v4i32
-int4 test_min_int4_mismatch(int4 p0, int p1) { return min(p0, p1); }
 
 // CHECK-LABEL: define noundef i32 @_Z13test_min_uint
 // CHECK: call i32 @llvm.umin.i32(
@@ -67,9 +58,6 @@ uint3 test_min_uint3(uint3 p0, uint3 p1) { return min(p0, p1); }
 // CHECK-LABEL: define noundef <4 x i32> @_Z14test_min_uint4
 // CHECK: call <4 x i32> @llvm.umin.v4i32
 uint4 test_min_uint4(uint4 p0, uint4 p1) { return min(p0, p1); }
-// CHECK-LABEL: define noundef <4 x i32> {{.*}}test_min_uint4_mismatch
-// CHECK: call <4 x i32> @llvm.umin.v4i32
-uint4 test_min_uint4_mismatch(uint4 p0, uint p1) { return min(p0, p1); }
 
 // CHECK-LABEL: define noundef i64 @_Z13test_min_long
 // CHECK: call i64 @llvm.smin.i64(
@@ -83,9 +71,6 @@ int64_t3 test_min_long3(int64_t3 p0, int64_t3 p1) { return min(p0, p1); }
 // CHECK-LABEL: define noundef <4 x i64> @_Z14test_min_long4
 // CHECK: call <4 x i64> @llvm.smin.v4i64
 int64_t4 test_min_long4(int64_t4 p0, int64_t4 p1) { return min(p0, p1); }
-// CHECK-LABEL: define noundef <4 x i64> {{.*}}test_min_long4_mismatch
-// CHECK: call <4 x i64> @llvm.smin.v4i64
-int64_t4 test_min_long4_mismatch(int64_t4 p0, int64_t p1) { return min(p0, p1); }
 
 // CHECK-LABEL: define noundef i64 @_Z14test_min_ulong
 // CHECK: call i64 @llvm.umin.i64(
@@ -99,9 +84,6 @@ uint64_t3 test_min_ulong3(uint64_t3 p0, uint64_t3 p1) { return min(p0, p1); }
 // CHECK-LABEL: define noundef <4 x i64> @_Z15test_min_ulong4
 // CHECK: call <4 x i64> @llvm.umin.v4i64
 uint64_t4 test_min_ulong4(uint64_t4 p0, uint64_t4 p1) { return min(p0, p1); }
-// CHECK-LABEL: define noundef <4 x i64> {{.*}}test_min_ulong4_mismatch
-// CHECK: call <4 x i64> @llvm.umin.v4i64
-uint64_t4 test_min_ulong4_mismatch(uint64_t4 p0, uint64_t p1) { return min(p0, p1); }
 
 // NATIVE_HALF-LABEL: define noundef nofpclass(nan inf) half @_Z13test_min_half
 // NATIVE_HALF: call reassoc nnan ninf nsz arcp afn half @llvm.minnum.f16(
@@ -123,11 +105,6 @@ half3 test_min_half3(half3 p0, half3 p1) { return min(p0, p1); }
 // NO_HALF-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z14test_min_half4
 // NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.minnum.v4f32(
 half4 test_min_half4(half4 p0, half4 p1) { return min(p0, p1); }
-// NATIVE_HALF-LABEL: define noundef nofpclass(nan inf) <4 x half> {{.*}}test_min_half4_mismatch
-// NATIVE_HALF: call reassoc nnan ninf nsz arcp afn <4 x half> @llvm.minnum.v4f16
-// NO_HALF-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_min_half4_mismatch
-// NO_HALF: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.minnum.v4f32(
-half4 test_min_half4_mismatch(half4 p0, half p1) { return min(p0, p1); }
 
 // CHECK-LABEL: define noundef nofpclass(nan inf) float @_Z14test_min_float
 // CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.minnum.f32(
@@ -141,9 +118,6 @@ float3 test_min_float3(float3 p0, float3 p1) { return min(p0, p1); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z15test_min_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.minnum.v4f32
 float4 test_min_float4(float4 p0, float4 p1) { return min(p0, p1); }
-// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_min_float4_mismatch
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.minnum.v4f32
-float4 test_min_float4_mismatch(float4 p0, float p1) { return min(p0, p1); }
 
 // CHECK-LABEL: define noundef nofpclass(nan inf) double @_Z15test_min_double
 // CHECK: call reassoc nnan ninf nsz arcp afn double @llvm.minnum.f64(
@@ -160,6 +134,3 @@ double4 test_min_double4(double4 p0, double4 p1) { return min(p0, p1); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> {{.*}}test_min_double4_mismatch
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.minnum.v4f64
 double4 test_min_double4_mismatch(double4 p0, double p1) { return min(p0, p1); }
-// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> {{.*}}test_min_double4_mismatch2
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.minnum.v4f64
-double4 test_min_double4_mismatch2(double4 p0, double p1) { return min(p1, p0); }


### PR DESCRIPTION
Put tests for compatibility overloads for 'clamp', 'isinf', 'min', and 'max' in own files which guarantee hlsl version 202x.
Closes #133277 