### PR TITLE
[lldb][lldb-dap] Add ToJSON for OptionValueEnumeration

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
+++ b/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
@@ -41,6 +41,8 @@ public:
   void DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
                  uint32_t dump_mask) override;
 
+  llvm::json::Value ToJSON(const ExecutionContext *exe_ctx) override;
+
   Status
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;

--- a/lldb/source/Interpreter/OptionValueEnumeration.cpp
+++ b/lldb/source/Interpreter/OptionValueEnumeration.cpp
@@ -44,7 +44,7 @@ OptionValueEnumeration::ToJSON(const ExecutionContext *exe_ctx) {
       return enums.cstring.GetStringRef();
   }
 
-  return llvm::formatv("%", PRIu64, static_cast<uint64_t>(m_current_value));
+  return std::to_string(static_cast<uint64_t>(m_current_value));
 }
 
 Status OptionValueEnumeration::SetValueFromString(llvm::StringRef value,

--- a/lldb/source/Interpreter/OptionValueEnumeration.cpp
+++ b/lldb/source/Interpreter/OptionValueEnumeration.cpp
@@ -37,6 +37,16 @@ void OptionValueEnumeration::DumpValue(const ExecutionContext *exe_ctx,
   }
 }
 
+llvm::json::Value
+OptionValueEnumeration::ToJSON(const ExecutionContext *exe_ctx) {
+  for (const auto &enums : m_enumerations) {
+    if (enums.value.value == m_current_value)
+      return enums.cstring.GetStringRef();
+  }
+
+  return llvm::formatv("%", PRIu64, static_cast<uint64_t>(m_current_value));
+}
+
 Status OptionValueEnumeration::SetValueFromString(llvm::StringRef value,
                                                   VarSetOperationType op) {
   Status error;
@@ -105,6 +115,6 @@ void OptionValueEnumeration::AutoComplete(CommandInterpreter &interpreter,
     }
     return;
   }
-    for (size_t i = 0; i < num_enumerators; ++i)
-      request.AddCompletion(m_enumerations.GetCStringAtIndex(i).GetStringRef());
+  for (size_t i = 0; i < num_enumerators; ++i)
+    request.AddCompletion(m_enumerations.GetCStringAtIndex(i).GetStringRef());
 }

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -1041,6 +1041,9 @@ class SettingsCommandTestCase(TestBase):
         # Test OptionValueLanguage
         self.verify_setting_value_json("repl-lang", "c++")
 
+        # Test OptionValueEnumeration
+        self.verify_setting_value_json("target.x86-disassembly-flavor", "intel")
+
     def test_global_option(self):
         # This command used to crash the settings because -g was signaled by a
         # NULL execution context (not one with an empty Target...) and in the


### PR DESCRIPTION
This automatically enables dumping enum settings in the python api