### PR TITLE
[MC] Use StringTable for MCSchedClassDesc names

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
@@ -69,7 +69,7 @@ protected: // Can only create subclasses...
                       const MCWriteProcResEntry *WPR,
                       const MCWriteLatencyEntry *WL,
                       const MCReadAdvanceEntry *RA, const InstrStage *IS,
-                      const unsigned *OC, const unsigned *FP);
+                      const unsigned *OC, const unsigned *FP, StringTable NT);
 
 public:
   // AntiDepBreakMode - Type of anti-dependence breaking that should

--- a/llvm/include/llvm/MC/MCSchedule.h
+++ b/llvm/include/llvm/MC/MCSchedule.h
@@ -15,6 +15,7 @@
 #define LLVM_MC_MCSCHEDULE_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringTable.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
@@ -123,7 +124,7 @@ struct MCSchedClassDesc {
   static const unsigned short VariantNumMicroOps = InvalidNumMicroOps - 1;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  const char* Name;
+  unsigned NameOffset;
 #endif
   uint16_t NumMicroOps : 13;
   uint16_t BeginGroup : 1;
@@ -321,6 +322,9 @@ struct MCSchedModel {
   unsigned ProcID;
   const MCProcResourceDesc *ProcResourceTable;
   const MCSchedClassDesc *SchedClassTable;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  StringTable SchedClassNameTable = "";
+#endif
   unsigned NumProcResourceKinds;
   unsigned NumSchedClasses;
   // Instruction itinerary tables used by InstrItineraryData.
@@ -408,6 +412,12 @@ struct MCSchedModel {
 
   /// Returns the default initialized model.
   static const MCSchedModel Default;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  StringRef getSchedClassName(const MCSchedClassDesc *SCDesc) const {
+    return SchedClassNameTable[SCDesc->NameOffset];
+  }
+#endif
 };
 
 // The first three are only template'd arguments so we can get away with leaving

--- a/llvm/include/llvm/MC/MCSchedule.h
+++ b/llvm/include/llvm/MC/MCSchedule.h
@@ -15,7 +15,6 @@
 #define LLVM_MC_MCSCHEDULE_H
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/StringTable.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
@@ -322,9 +321,6 @@ struct MCSchedModel {
   unsigned ProcID;
   const MCProcResourceDesc *ProcResourceTable;
   const MCSchedClassDesc *SchedClassTable;
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  StringTable SchedClassNameTable = "";
-#endif
   unsigned NumProcResourceKinds;
   unsigned NumSchedClasses;
   // Instruction itinerary tables used by InstrItineraryData.
@@ -412,12 +408,6 @@ struct MCSchedModel {
 
   /// Returns the default initialized model.
   static const MCSchedModel Default;
-
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  StringRef getSchedClassName(const MCSchedClassDesc *SCDesc) const {
-    return SchedClassNameTable[SCDesc->NameOffset];
-  }
-#endif
 };
 
 // The first three are only template'd arguments so we can get away with leaving

--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringTable.h"
 #include "llvm/MC/MCInstrItineraries.h"
 #include "llvm/MC/MCSchedule.h"
 #include "llvm/TargetParser/SubtargetFeature.h"
@@ -93,6 +94,10 @@ class MCSubtargetInfo {
   FeatureBitset FeatureBits;           // Feature bits for current CPU + FS
   std::string FeatureString;           // Feature string
 
+  // General purpose name table, currently only used to store MCSchedClassDesc
+  // names when assertions are enabled.
+  StringTable NameTable;
+
 public:
   MCSubtargetInfo(const MCSubtargetInfo &) = default;
   MCSubtargetInfo(const Triple &TT, StringRef CPU, StringRef TuneCPU,
@@ -101,7 +106,7 @@ public:
                   ArrayRef<SubtargetSubTypeKV> PD,
                   const MCWriteProcResEntry *WPR, const MCWriteLatencyEntry *WL,
                   const MCReadAdvanceEntry *RA, const InstrStage *IS,
-                  const unsigned *OC, const unsigned *FP);
+                  const unsigned *OC, const unsigned *FP, StringTable NT);
   MCSubtargetInfo() = delete;
   MCSubtargetInfo &operator=(const MCSubtargetInfo &) = delete;
   MCSubtargetInfo &operator=(MCSubtargetInfo &&) = delete;
@@ -225,6 +230,12 @@ public:
                                             unsigned CPUID) const {
     return 0;
   }
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  StringRef getSchedClassName(const MCSchedClassDesc *SCDesc) const {
+    return NameTable[SCDesc->NameOffset];
+  }
+#endif
 
   /// Check whether the CPU string is valid.
   virtual bool isCPUStringValid(StringRef CPU) const {

--- a/llvm/include/llvm/TableGen/StringToOffsetTable.h
+++ b/llvm/include/llvm/TableGen/StringToOffsetTable.h
@@ -57,7 +57,8 @@ public:
   // `static` and `constexpr`. Both `Name` and (`Name` + "Storage") must be
   // valid identifiers to declare.
   void EmitStringTableDef(raw_ostream &OS, const Twine &Name,
-                          const Twine &Indent = "") const;
+                          const Twine &Indent = "",
+                          StringRef Linkage = "static") const;
 
   // Emit the string as one single string.
   void EmitString(raw_ostream &O) const;

--- a/llvm/lib/CodeGen/TargetSubtargetInfo.cpp
+++ b/llvm/lib/CodeGen/TargetSubtargetInfo.cpp
@@ -19,9 +19,10 @@ TargetSubtargetInfo::TargetSubtargetInfo(
     ArrayRef<StringRef> PN, ArrayRef<SubtargetFeatureKV> PF,
     ArrayRef<SubtargetSubTypeKV> PD, const MCWriteProcResEntry *WPR,
     const MCWriteLatencyEntry *WL, const MCReadAdvanceEntry *RA,
-    const InstrStage *IS, const unsigned *OC, const unsigned *FP)
-    : MCSubtargetInfo(TT, CPU, TuneCPU, FS, PN, PF, PD, WPR, WL, RA, IS, OC,
-                      FP) {}
+    const InstrStage *IS, const unsigned *OC, const unsigned *FP,
+    StringTable NT)
+    : MCSubtargetInfo(TT, CPU, TuneCPU, FS, PN, PF, PD, WPR, WL, RA, IS, OC, FP,
+                      NT) {}
 
 TargetSubtargetInfo::~TargetSubtargetInfo() = default;
 

--- a/llvm/lib/MC/MCSchedule.cpp
+++ b/llvm/lib/MC/MCSchedule.cpp
@@ -20,24 +20,25 @@
 
 using namespace llvm;
 
-static_assert(std::is_trivial_v<MCSchedModel>,
-              "MCSchedModel is required to be a trivial type");
-const MCSchedModel MCSchedModel::Default = {DefaultIssueWidth,
-                                            DefaultMicroOpBufferSize,
-                                            DefaultLoopMicroOpBufferSize,
-                                            DefaultLoadLatency,
-                                            DefaultHighLatency,
-                                            DefaultMispredictPenalty,
-                                            false,
-                                            true,
-                                            /*EnableIntervals=*/false,
-                                            0,
-                                            nullptr,
-                                            nullptr,
-                                            0,
-                                            0,
-                                            nullptr,
-                                            nullptr};
+constexpr MCSchedModel MCSchedModel::Default = {DefaultIssueWidth,
+                                                DefaultMicroOpBufferSize,
+                                                DefaultLoopMicroOpBufferSize,
+                                                DefaultLoadLatency,
+                                                DefaultHighLatency,
+                                                DefaultMispredictPenalty,
+                                                false,
+                                                true,
+                                                /*EnableIntervals=*/false,
+                                                0,
+                                                nullptr,
+                                                nullptr,
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+                                                "",
+#endif
+                                                0,
+                                                0,
+                                                nullptr,
+                                                nullptr};
 
 int MCSchedModel::computeInstrLatency(const MCSubtargetInfo &STI,
                                       const MCSchedClassDesc &SCDesc) {

--- a/llvm/lib/MC/MCSchedule.cpp
+++ b/llvm/lib/MC/MCSchedule.cpp
@@ -20,25 +20,24 @@
 
 using namespace llvm;
 
-constexpr MCSchedModel MCSchedModel::Default = {DefaultIssueWidth,
-                                                DefaultMicroOpBufferSize,
-                                                DefaultLoopMicroOpBufferSize,
-                                                DefaultLoadLatency,
-                                                DefaultHighLatency,
-                                                DefaultMispredictPenalty,
-                                                false,
-                                                true,
-                                                /*EnableIntervals=*/false,
-                                                0,
-                                                nullptr,
-                                                nullptr,
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-                                                "",
-#endif
-                                                0,
-                                                0,
-                                                nullptr,
-                                                nullptr};
+static_assert(std::is_trivial_v<MCSchedModel>,
+              "MCSchedModel is required to be a trivial type");
+const MCSchedModel MCSchedModel::Default = {DefaultIssueWidth,
+                                            DefaultMicroOpBufferSize,
+                                            DefaultLoopMicroOpBufferSize,
+                                            DefaultLoadLatency,
+                                            DefaultHighLatency,
+                                            DefaultMispredictPenalty,
+                                            false,
+                                            true,
+                                            /*EnableIntervals=*/false,
+                                            0,
+                                            nullptr,
+                                            nullptr,
+                                            0,
+                                            0,
+                                            nullptr,
+                                            nullptr};
 
 int MCSchedModel::computeInstrLatency(const MCSubtargetInfo &STI,
                                       const MCSchedClassDesc &SCDesc) {

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -245,16 +245,19 @@ void MCSubtargetInfo::setDefaultFeatures(StringRef CPU, StringRef TuneCPU,
   FeatureString = std::string(FS);
 }
 
-MCSubtargetInfo::MCSubtargetInfo(
-    const Triple &TT, StringRef C, StringRef TC, StringRef FS,
-    ArrayRef<StringRef> PN, ArrayRef<SubtargetFeatureKV> PF,
-    ArrayRef<SubtargetSubTypeKV> PD, const MCWriteProcResEntry *WPR,
-    const MCWriteLatencyEntry *WL, const MCReadAdvanceEntry *RA,
-    const InstrStage *IS, const unsigned *OC, const unsigned *FP)
+MCSubtargetInfo::MCSubtargetInfo(const Triple &TT, StringRef C, StringRef TC,
+                                 StringRef FS, ArrayRef<StringRef> PN,
+                                 ArrayRef<SubtargetFeatureKV> PF,
+                                 ArrayRef<SubtargetSubTypeKV> PD,
+                                 const MCWriteProcResEntry *WPR,
+                                 const MCWriteLatencyEntry *WL,
+                                 const MCReadAdvanceEntry *RA,
+                                 const InstrStage *IS, const unsigned *OC,
+                                 const unsigned *FP, StringTable NT)
     : TargetTriple(TT), CPU(std::string(C)), TuneCPU(std::string(TC)),
       ProcNames(PN), ProcFeatures(PF), ProcDesc(PD), WriteProcResTable(WPR),
       WriteLatencyTable(WL), ReadAdvanceTable(RA), Stages(IS),
-      OperandCycles(OC), ForwardingPaths(FP) {
+      OperandCycles(OC), ForwardingPaths(FP), NameTable(NT) {
   InitMCProcessorInfo(CPU, TuneCPU, FS);
 }
 

--- a/llvm/lib/MCA/InstrBuilder.cpp
+++ b/llvm/lib/MCA/InstrBuilder.cpp
@@ -75,8 +75,9 @@ static void initializeUsedResources(InstrDesc &ID,
       WithColor::warning()
           << "Ignoring invalid write of zero cycles on processor resource "
           << PR.Name << "\n";
-      WithColor::note() << "found in scheduling class " << SCDesc.Name
-                        << " (write index #" << I << ")\n";
+      WithColor::note() << "found in scheduling class "
+                        << SM.getSchedClassName(&SCDesc) << " (write index #"
+                        << I << ")\n";
 #endif
       continue;
     }

--- a/llvm/lib/MCA/InstrBuilder.cpp
+++ b/llvm/lib/MCA/InstrBuilder.cpp
@@ -76,7 +76,7 @@ static void initializeUsedResources(InstrDesc &ID,
           << "Ignoring invalid write of zero cycles on processor resource "
           << PR.Name << "\n";
       WithColor::note() << "found in scheduling class "
-                        << SM.getSchedClassName(&SCDesc) << " (write index #"
+                        << STI.getSchedClassName(&SCDesc) << " (write index #"
                         << I << ")\n";
 #endif
       continue;

--- a/llvm/lib/TableGen/StringToOffsetTable.cpp
+++ b/llvm/lib/TableGen/StringToOffsetTable.cpp
@@ -27,7 +27,8 @@ unsigned StringToOffsetTable::GetOrAddStringOffset(StringRef Str,
 }
 
 void StringToOffsetTable::EmitStringTableDef(raw_ostream &OS, const Twine &Name,
-                                             const Twine &Indent) const {
+                                             const Twine &Indent,
+                                             StringRef Linkage) const {
   OS << formatv(R"(
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -78,10 +79,10 @@ void StringToOffsetTable::EmitStringTableDef(raw_ostream &OS, const Twine &Name,
 #pragma GCC diagnostic pop
 #endif
 
-{0}static constexpr llvm::StringTable {1} =
+{0}{2} constexpr llvm::StringTable {1} =
 {0}    {1}Storage;
 )",
-                Indent, Name);
+                Indent, Name, Linkage);
 }
 
 void StringToOffsetTable::EmitString(raw_ostream &O) const {

--- a/llvm/test/TableGen/CompressWriteLatencyEntry.td
+++ b/llvm/test/TableGen/CompressWriteLatencyEntry.td
@@ -33,10 +33,10 @@ def Read_D : SchedRead;
 // CHECK-NEXT: }; // MyTargetReadAdvanceTable
 
 // CHECK:  static const llvm::MCSchedClassDesc SchedModel_ASchedClasses[] = {
-// CHECK-NEXT:  {DBGFIELD("InvalidSchedClass")  8191, false, false, false, 0, 0,  0, 0,  0, 0},
-// CHECK-NEXT:  {DBGFIELD("Inst_A")             1, false, false, false,  0, 0,  1, 1,  0, 0}, // #1
-// CHECK-NEXT:  {DBGFIELD("Inst_B")             1, false, false, false,  0, 0,  2, 1,  0, 0}, // #2
-// CHECK-NEXT:  {DBGFIELD("Inst_C")             1, false, false, false,  0, 0,  1, 1,  1, 1}, // #3
+// CHECK-NEXT:  {DBGFIELD(1 /* InvalidSchedClass */) 8191, false, false, false, 0, 0,  0, 0,  0, 0},
+// CHECK-NEXT:  {DBGFIELD(19 /* Inst_A */) 1, false, false, false,  0, 0,  1, 1,  0, 0}, // #1
+// CHECK-NEXT:  {DBGFIELD(26 /* Inst_B */) 1, false, false, false,  0, 0,  2, 1,  0, 0}, // #2
+// CHECK-NEXT:  {DBGFIELD(33 /* Inst_C */) 1, false, false, false,  0, 0,  1, 1,  1, 1}, // #3
 // CHECK-NEXT: }; // SchedModel_ASchedClasses
 
 let SchedModel = SchedModel_A in {

--- a/llvm/test/TableGen/InvalidMCSchedClassDesc.td
+++ b/llvm/test/TableGen/InvalidMCSchedClassDesc.td
@@ -18,8 +18,8 @@ let CompleteModel = 0 in {
 
 // Inst_B didn't have the resoures, and it is invalid.
 // CHECK: SchedModel_ASchedClasses[] = {
-// CHECK: {DBGFIELD("Inst_A")             1
-// CHECK-NEXT: {DBGFIELD("Inst_B")             8191
+// CHECK: {DBGFIELD(19 /* Inst_A */) 1
+// CHECK-NEXT: {DBGFIELD(26 /* Inst_B */) 8191
 let SchedModel = SchedModel_A in {
   def Write_A : SchedWriteRes<[]>;
   def : InstRW<[Write_A], (instrs Inst_A)>;
@@ -27,16 +27,16 @@ let SchedModel = SchedModel_A in {
 
 // Inst_A didn't have the resoures, and it is invalid.
 // CHECK: SchedModel_BSchedClasses[] = {
-// CHECK: {DBGFIELD("Inst_A")             8191
-// CHECK-NEXT: {DBGFIELD("Inst_B")             1 
+// CHECK: {DBGFIELD(19 /* Inst_A */) 8191
+// CHECK-NEXT: {DBGFIELD(26 /* Inst_B */) 1
 let SchedModel = SchedModel_B in {
   def Write_B: SchedWriteRes<[]>; 
   def : InstRW<[Write_B], (instrs Inst_B)>;
 }
 
 // CHECK: SchedModel_CSchedClasses[] = {
-// CHECK: {DBGFIELD("Inst_A")             1
-// CHECK-NEXT: {DBGFIELD("Inst_B")             1
+// CHECK: {DBGFIELD(19 /* Inst_A */) 1
+// CHECK-NEXT: {DBGFIELD(26 /* Inst_B */) 1
 let SchedModel = SchedModel_C in {
   def Write_C: SchedWriteRes<[]>; 
   def : InstRW<[Write_C], (instrs Inst_A, Inst_B)>;

--- a/llvm/tools/llvm-exegesis/lib/Analysis.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Analysis.cpp
@@ -137,9 +137,9 @@ void Analysis::printInstructionRowCsv(const size_t PointId,
   std::tie(SchedClassId, std::ignore) = ResolvedSchedClass::resolveSchedClassId(
       State_.getSubtargetInfo(), State_.getInstrInfo(), MCI);
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  const MCSchedClassDesc *const SCDesc =
-      State_.getSubtargetInfo().getSchedModel().getSchedClassDesc(SchedClassId);
-  writeEscaped<kEscapeCsv>(OS, SCDesc->Name);
+  const MCSchedModel &SM = State_.getSubtargetInfo().getSchedModel();
+  const MCSchedClassDesc *const SCDesc = SM.getSchedClassDesc(SchedClassId);
+  writeEscaped<kEscapeCsv>(OS, SM.getSchedClassName(SCDesc));
 #else
   OS << SchedClassId;
 #endif
@@ -563,7 +563,9 @@ Error Analysis::run<Analysis::PrintSchedClassInconsistencies>(
     OS << "<div class=\"inconsistency\"><p>Sched Class <span "
           "class=\"sched-class-name\">";
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-    writeEscaped<kEscapeHtml>(OS, RSCAndPoints.RSC.SCDesc->Name);
+    const auto &SM = SI.getSchedModel();
+    writeEscaped<kEscapeHtml>(OS,
+                              SM.getSchedClassName(RSCAndPoints.RSC.SCDesc));
 #else
     OS << RSCAndPoints.RSC.SchedClassId;
 #endif

--- a/llvm/tools/llvm-exegesis/lib/Analysis.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Analysis.cpp
@@ -137,9 +137,10 @@ void Analysis::printInstructionRowCsv(const size_t PointId,
   std::tie(SchedClassId, std::ignore) = ResolvedSchedClass::resolveSchedClassId(
       State_.getSubtargetInfo(), State_.getInstrInfo(), MCI);
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  const MCSchedModel &SM = State_.getSubtargetInfo().getSchedModel();
-  const MCSchedClassDesc *const SCDesc = SM.getSchedClassDesc(SchedClassId);
-  writeEscaped<kEscapeCsv>(OS, SM.getSchedClassName(SCDesc));
+  const auto &SI = State_.getSubtargetInfo();
+  const MCSchedClassDesc *const SCDesc =
+      SI.getSchedModel().getSchedClassDesc(SchedClassId);
+  writeEscaped<kEscapeCsv>(OS, SI.getSchedClassName(SCDesc));
 #else
   OS << SchedClassId;
 #endif
@@ -563,9 +564,8 @@ Error Analysis::run<Analysis::PrintSchedClassInconsistencies>(
     OS << "<div class=\"inconsistency\"><p>Sched Class <span "
           "class=\"sched-class-name\">";
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-    const auto &SM = SI.getSchedModel();
     writeEscaped<kEscapeHtml>(OS,
-                              SM.getSchedClassName(RSCAndPoints.RSC.SCDesc));
+                              SI.getSchedClassName(RSCAndPoints.RSC.SCDesc));
 #else
     OS << RSCAndPoints.RSC.SchedClassId;
 #endif

--- a/llvm/unittests/CodeGen/MFCommon.inc
+++ b/llvm/unittests/CodeGen/MFCommon.inc
@@ -79,7 +79,7 @@ class BogusSubtarget : public TargetSubtargetInfo {
 public:
   BogusSubtarget(TargetMachine &TM)
       : TargetSubtargetInfo(Triple(""), "", "", "", {}, {}, {}, nullptr,
-                            nullptr, nullptr, nullptr, nullptr, nullptr),
+                            nullptr, nullptr, nullptr, nullptr, nullptr, ""),
         FL(), TL(TM) {}
   ~BogusSubtarget() override {}
 

--- a/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
@@ -39,7 +39,7 @@ static std::string AArch64InstPrinterTestPrintAlignedLabel(uint64_t value) {
   MCSubtargetInfo STI(Triple(""), "", "", "", {},
                       ArrayRef((SubtargetFeatureKV *)NULL, (size_t)0),
                       ArrayRef((SubtargetSubTypeKV *)NULL, (size_t)0), NULL,
-                      NULL, NULL, NULL, NULL, NULL);
+                      NULL, NULL, NULL, NULL, NULL, "");
   MCContext Ctx(Triple(""), &MAI, &MRI, &STI);
   MCInst MI;
 


### PR DESCRIPTION
Use StringTable for the name strings so that large arrays of
MCSchedClassDesc can live in read-only data. This only affects builds
with assertions enabled, otherwise these strings are compiled out.

This improves startup times for llc on my Ubuntu system where PIE is
enabled by default. In a Release+Asserts build it reduced the check-llvm
time from 159 to 112 seconds.
