### PR TITLE
[sanitizer] Allow use-after-scope front-end argument to take effect with -fsanitize=kernel-address

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1099,7 +1099,13 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
     }
 
   } else {
-    AsanUseAfterScope = false;
+    if (AllAddedKinds & SanitizerKind::KernelAddress) {
+      AsanUseAfterScope = Args.hasFlag(
+          options::OPT_fsanitize_address_use_after_scope,
+          options::OPT_fno_sanitize_address_use_after_scope, AsanUseAfterScope);
+    } else {
+      AsanUseAfterScope = false;
+    }
     // -fsanitize=pointer-compare/pointer-subtract requires -fsanitize=address.
     SanitizerMask DetectInvalidPointerPairs =
         SanitizerKind::PointerCompare | SanitizerKind::PointerSubtract;

--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1034,10 +1034,6 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
     StableABI = Args.hasFlag(options::OPT_fsanitize_stable_abi,
                              options::OPT_fno_sanitize_stable_abi, false);
 
-    AsanUseAfterScope = Args.hasFlag(
-        options::OPT_fsanitize_address_use_after_scope,
-        options::OPT_fno_sanitize_address_use_after_scope, AsanUseAfterScope);
-
     AsanPoisonCustomArrayCookie = Args.hasFlag(
         options::OPT_fsanitize_address_poison_custom_array_cookie,
         options::OPT_fno_sanitize_address_poison_custom_array_cookie,
@@ -1099,13 +1095,6 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
     }
 
   } else {
-    if (AllAddedKinds & SanitizerKind::KernelAddress) {
-      AsanUseAfterScope = Args.hasFlag(
-          options::OPT_fsanitize_address_use_after_scope,
-          options::OPT_fno_sanitize_address_use_after_scope, AsanUseAfterScope);
-    } else {
-      AsanUseAfterScope = false;
-    }
     // -fsanitize=pointer-compare/pointer-subtract requires -fsanitize=address.
     SanitizerMask DetectInvalidPointerPairs =
         SanitizerKind::PointerCompare | SanitizerKind::PointerSubtract;
@@ -1117,6 +1106,15 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
                                      SanitizerKind::PointerSubtract)
           << "-fsanitize=address";
     }
+  }
+
+  if (AllAddedKinds &
+      (SanitizerKind::Address | SanitizerKind::KernelAddress)) {
+    AsanUseAfterScope = Args.hasFlag(
+        options::OPT_fsanitize_address_use_after_scope,
+        options::OPT_fno_sanitize_address_use_after_scope, AsanUseAfterScope);
+  } else {
+    AsanUseAfterScope = false;
   }
 
   if (AllAddedKinds & SanitizerKind::HWAddress) {

--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1108,8 +1108,7 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
     }
   }
 
-  if (AllAddedKinds &
-      (SanitizerKind::Address | SanitizerKind::KernelAddress)) {
+  if (AllAddedKinds & (SanitizerKind::Address | SanitizerKind::KernelAddress)) {
     AsanUseAfterScope = Args.hasFlag(
         options::OPT_fsanitize_address_use_after_scope,
         options::OPT_fno_sanitize_address_use_after_scope, AsanUseAfterScope);

--- a/clang/test/CodeGen/lifetime-sanitizer.c
+++ b/clang/test/CodeGen/lifetime-sanitizer.c
@@ -4,6 +4,9 @@
 // RUN:     -fsanitize=address -fsanitize-address-use-after-scope \
 // RUN:     -Xclang -disable-llvm-passes %s | FileCheck %s -check-prefix=LIFETIME
 // RUN: %clang -target x86_64-linux-gnu -S -emit-llvm -o - -O0 \
+// RUN:     -fsanitize=kernel-address -fsanitize-address-use-after-scope \
+// RUN:     -Xclang -disable-llvm-passes %s | FileCheck %s -check-prefix=LIFETIME
+// RUN: %clang -target x86_64-linux-gnu -S -emit-llvm -o - -O0 \
 // RUN:     -fsanitize=memory -Xclang -disable-llvm-passes %s | \
 // RUN:     FileCheck %s -check-prefix=LIFETIME
 // RUN: %clang -target aarch64-linux-gnu -S -emit-llvm -o - -O0 \

--- a/clang/test/CodeGenCXX/lifetime-sanitizer.cpp
+++ b/clang/test/CodeGenCXX/lifetime-sanitizer.cpp
@@ -5,6 +5,9 @@
 // RUN:     -fsanitize=address -fsanitize-address-use-after-scope \
 // RUN:     -Xclang -disable-llvm-passes %s | FileCheck %s -check-prefixes=CHECK,LIFETIME
 // RUN: %clang -w -target x86_64-linux-gnu -S -emit-llvm -o - -fno-exceptions -O0 \
+// RUN:     -fsanitize=kernel-address -fsanitize-address-use-after-scope \
+// RUN:     -Xclang -disable-llvm-passes %s | FileCheck %s -check-prefixes=CHECK,LIFETIME
+// RUN: %clang -w -target x86_64-linux-gnu -S -emit-llvm -o - -fno-exceptions -O0 \
 // RUN:     -fsanitize=memory -Xclang -disable-llvm-passes %s | \
 // RUN:     FileCheck %s -check-prefixes=CHECK,LIFETIME
 // RUN: %clang -w -target aarch64-linux-gnu -S -emit-llvm -o - -fno-exceptions -O0 \


### PR DESCRIPTION
Lifetime intrinsics required for detection of use-after-scope are not emitted under kernel-address sanitizer (`-fsanitize=kernel-address`) when paired with `-O0` & `-fsanitize-address-use-after-scope`.

This is because with `-fsanitize=kernel-address -O0` under `shouldEmitLifetimeMarkers` in `clang\lib\CodeGen\CodeGenFunction.cpp`, `CGOpts.SanitizeAddressUseAfterScope` is set to `false`. Therefore, the following check, `CGOpts.OptimizationLevel != 0`, is run which evaluates to `false` thus preventing the emission of lifetime markers:
https://github.com/llvm/llvm-project/blob/24c860547e8e595f8bf8d87b52544e2aff243f2e/clang/lib/CodeGen/CodeGenFunction.cpp#L60-L75


The reason `CGOpts.SanitizeAddressUseAfterScope` is false stems from the fact that this variable is normally set via the frontend flag `-fsanitize-address-use-after-scope`, however, this flag only takes effect under normal address sanitizer due to the gated logic in `clang\lib\Driver\SanitizerArgs.cpp`, specifically, `if (AllAddedKinds & SanitizerKind::Address)`:
https://github.com/llvm/llvm-project/blob/24c860547e8e595f8bf8d87b52544e2aff243f2e/clang/lib/Driver/SanitizerArgs.cpp#L1004
And later on down in this block:
https://github.com/llvm/llvm-project/blob/24c860547e8e595f8bf8d87b52544e2aff243f2e/clang/lib/Driver/SanitizerArgs.cpp#L1037-L1039

This check excludes `SanitizerKind::KernelAddress` from consideration, so even if `-fsanitize-address-use-after-scope` is supplied as a front-end argument, it won't be passed to `cc1` thus preventing `use-after-scope` checks from being emitted under `-fsanitize-kernel-address -O0`. Higher optimization levels will allow emission of lifetime markers regardless thanks to the logic in `shouldEmitLifetimeMarkers`.

This PR allows `-fsanitize-address-use-after-scope` to take effect under kernel-address sanitizer.