### PR TITLE
Fix stmt-seq-macho.test for little endian platforms

### DIFF
--- a/llvm/test/tools/dsymutil/ARM/stmt-seq-macho.test
+++ b/llvm/test/tools/dsymutil/ARM/stmt-seq-macho.test
@@ -83,10 +83,12 @@ ld64.lld \
 
 # Convert executable to YAML for the test
 echo "#--- stmt_seq_macho.o.yaml"
-obj2yaml stmt_seq_macho.o | sed '1a IsLittleEndian: true'
+obj2yaml stmt_seq_macho.o | sed '1a\
+IsLittleEndian: true'
 echo ""
 echo "#--- stmt_seq_macho.exe.yaml"
-obj2yaml stmt_seq_macho.exe | sed '1a IsLittleEndian: true'
+obj2yaml stmt_seq_macho.exe | sed '1a\
+IsLittleEndian: true'
 
 #--- stmt-seq-macho.yaml
 #--- stmt_seq_macho.o.yaml

--- a/llvm/test/tools/dsymutil/ARM/stmt-seq-macho.test
+++ b/llvm/test/tools/dsymutil/ARM/stmt-seq-macho.test
@@ -83,14 +83,15 @@ ld64.lld \
 
 # Convert executable to YAML for the test
 echo "#--- stmt_seq_macho.o.yaml"
-obj2yaml stmt_seq_macho.o
+obj2yaml stmt_seq_macho.o | sed '1a IsLittleEndian: true'
 echo ""
 echo "#--- stmt_seq_macho.exe.yaml"
-obj2yaml stmt_seq_macho.exe
+obj2yaml stmt_seq_macho.exe | sed '1a IsLittleEndian: true'
 
 #--- stmt-seq-macho.yaml
 #--- stmt_seq_macho.o.yaml
 --- !mach-o
+IsLittleEndian: true
 FileHeader:
   magic:           0xFEEDFACF
   cputype:         0x100000C
@@ -1564,6 +1565,7 @@ DWARF:
 
 #--- stmt_seq_macho.exe.yaml
 --- !mach-o
+IsLittleEndian: true
 FileHeader:
   magic:           0xFEEDFACF
   cputype:         0x100000C


### PR DESCRIPTION
The test YAML was created on a little-endian system, so its data is stored in little-endian order. When the test runs on a big-endian host, yaml2obj defaults to the host’s byte order, misreading the file as big-endian and causing a failure.

This change explicitly marks the YAML as little-endian, guaranteeing that yaml2obj always uses the correct byte order, no matter which machine runs the test.

The reason that during creation, obj2yaml doesn't specify the endiadness is because the endiadness is set as an optional parameter and therefore it won't be specified if it matches the platform default. Ref: https://github.com/llvm/llvm-project/blob/d7215c0ee2e4bca1ce87b956335ef6a2cddaf16f/llvm/lib/ObjectYAML/MachOYAML.cpp#L105