### PR TITLE
[lldb-dap] Ensure we acquire the SB API lock while handling requests.

### DIFF
--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -14,6 +14,7 @@
 #include "Protocol/ProtocolBase.h"
 #include "RunInTerminal.h"
 #include "llvm/Support/Error.h"
+#include <mutex>
 
 #if !defined(_WIN32)
 #include <unistd.h>
@@ -179,6 +180,9 @@ void BaseRequestHandler::Run(const Request &request) {
     dap.Send(cancelled);
     return;
   }
+
+  lldb::SBMutex lock = dap.GetAPIMutex();
+  std::lock_guard<lldb::SBMutex> guard(lock);
 
   // FIXME: After all the requests have migrated from LegacyRequestHandler >
   // RequestHandler<> we should be able to move this into


### PR DESCRIPTION
Acquiring the lock for the target should help ensure consistency with other background operations, like the thread monitoring events that can trigger run commands from a different thread.