### PR TITLE
[Clang][NFC] Use temporary instead of one use local variable when creating APValue

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -6147,9 +6147,8 @@ static APValue EvaluateSizeTTypeTrait(Sema &S, TypeTrait Kind,
       S.Diag(KWLoc, diag::err_arg_is_not_destructurable) << T << ArgRange;
       return APValue();
     }
-    llvm::APSInt V =
-        S.getASTContext().MakeIntValue(*Size, S.getASTContext().getSizeType());
-    return APValue{V};
+    return APValue(
+        S.getASTContext().MakeIntValue(*Size, S.getASTContext().getSizeType()));
     break;
   }
   default:


### PR DESCRIPTION
Static analysis flagged this code b/c we should have been using std::move when passing by value since the value is not used anymore. In this case the simpler fix is just to use a temporary value as many of the other cases where we simply use MakeIntValue to then create an APValue result from it.