### PR TITLE
[bazel] Use non_arc_srcs instead of passing -fno-objc-arc

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -484,10 +484,8 @@ cc_library(
 
 objc_library(
     name = "HostMacOSXObjCXX",
-    srcs = glob([
-        "source/Host/macosx/objcxx/*.mm",
-    ]),
     copts = OBJCPP_COPTS,
+    non_arc_srcs = glob(["source/Host/macosx/objcxx/*.mm"]),
     tags = ["nobuildkite"],
     target_compatible_with = select({
         "@platforms//os:macos": [],
@@ -832,9 +830,9 @@ cc_binary(
     deps = [
         ":APIHeaders",
         ":Host",
+        ":UtilityHeaders",
         ":liblldb.wrapper",
         ":lldb_options_inc_gen",
-        ":UtilityHeaders",
         "//llvm:Option",
         "//llvm:Support",
     ],
@@ -855,8 +853,8 @@ cc_library(
 
 objc_library(
     name = "DebugServerMacOSX",
-    srcs = glob(["tools/debugserver/source/MacOSX/*.mm"]),
     copts = OBJCPP_COPTS,
+    non_arc_srcs = glob(["tools/debugserver/source/MacOSX/*.mm"]),
     tags = ["nobuildkite"],
     target_compatible_with = select({
         "@platforms//os:macos": [],

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -238,8 +238,8 @@ cc_library(
 
 objc_library(
     name = "PluginPlatformMacOSXObjCXX",
-    srcs = glob(["Platform/MacOSX/objcxx/*.mm"]),
     copts = OBJCPP_COPTS,
+    non_arc_srcs = glob(["Platform/MacOSX/objcxx/*.mm"]),
     tags = ["nobuildkite"],
     target_compatible_with = select({
         "@platforms//os:macos": [],

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
@@ -99,6 +99,5 @@ DEFAULT_SCRIPT_PLUGINS = [
 OBJCPP_COPTS = [
     "-std=c++{}".format(CMAKE_CXX_STANDARD),
     "-fno-objc-exceptions",
-    "-fno-objc-arc",
     "-Wno-shorten-64-to-32",
 ]


### PR DESCRIPTION
This is the recommended way in bazel to differentiate between files that
require arc and those that require it be disabled. This matters
depending on the toolchain since the order of these flags may not have
been correct and we were relying on overwriting the default.
