### PR TITLE
[LLDB] Ptrace seize dead processes on Linux

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -320,7 +320,8 @@ NativeProcessLinux::Manager::Attach(
                                          llvm::inconvertibleErrorCode());
 
   std::vector<::pid_t> tids;
-  if (process_info.IsCoreDumping()) {
+  // IsCoreDumping is an optional, so check for value then true/false.
+  if (process_info.IsCoreDumping() && *process_info.IsCoreDumping()) {
     auto attached_or = NativeProcessLinux::Seize(pid);
     if (!attached_or)
       return attached_or.takeError();

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.h
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.h
@@ -190,8 +190,6 @@ private:
 
   // Returns a list of process threads that we have attached to.
   static llvm::Expected<std::vector<::pid_t>> Attach(::pid_t pid);
-  // Returns a list of process threads that we have seized and interrupted.
-  static llvm::Expected<std::vector<::pid_t>> Seize(::pid_t pid);
 
   static Status SetDefaultPtraceOpts(const lldb::pid_t);
 

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.h
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.h
@@ -175,7 +175,6 @@ protected:
 private:
   Manager &m_manager;
   ArchSpec m_arch;
-
   LazyBool m_supports_mem_region = eLazyBoolCalculate;
   std::vector<std::pair<MemoryRegionInfo, FileSpec>> m_mem_region_cache;
 
@@ -191,8 +190,12 @@ private:
 
   // Returns a list of process threads that we have attached to.
   static llvm::Expected<std::vector<::pid_t>> Attach(::pid_t pid);
+  // Returns a list of process threads that we have seized and interrupted.
+  static llvm::Expected<std::vector<::pid_t>> Seize(::pid_t pid);
 
   static Status SetDefaultPtraceOpts(const lldb::pid_t);
+
+  static uint64_t GetDefaultPtraceOpts();
 
   bool TryHandleWaitStatus(lldb::pid_t pid, WaitStatus status);
 


### PR DESCRIPTION
This the actual PR to my [SEIZE RFC](https://discourse.llvm.org/t/rfc-ptrace-seize-when-attaching-to-dead-processes/85825/8). This is currently the bare bones on seizing a dead process, and being able to attach and introspect with LLDB.

Additionally, right now I only check proc status before seize, and we should double check after seize that the process has not changed. Worth noting is once you seize a coredumping process (and it hits trace stop), Coredumping in status will now report 0.

This is pretty complicated to test because it requires integration with the Kernel, thankfully the setup only involves some very simple toy programs.


We will want to create a program to be our 'coredumper' and then hold the pipe until we send a CONT

```
ptrace.c
// We use this coredumper to nicely hold a pipe
// so we can test if lldb can attach to the dead process.
// to kill this program run
// sudo pkill "ptrace" -CONT
int main(int argc, char* argv[]) {
  raise(SIGSTOP);
  fclose(STDIN_FILENO);
  raise(SIGSTOP);
  return 0;
}
```

Then once we compile/build our test coredumper, we will need to configure the kernel to pipe to our core holder

```
set_up_ptrace.sh
// One word of warning, this path needs to be < 128b bytes to my knowledge
echo "|{path_to_our_toy_coredumper} %p" | sudo tee /proc/sys/kernel/core_pattern > /dev/null
```

This sets the kernel to pipe to our program, with %p getting replaced with the pid.

Then lastly we need a program to throw a signal

```
sigabrt.c
// Our mini sigabrt program, I call it sigabrt
int main() {
  int x = 42; // the meaning of life
  int y = 0;
  int result = x / y; // raises sigabrt
  return 0;
}
```

So then we can attach lldb to this coreing program!
