### PR TITLE
[libc] build fix for sigsetjmp

### DIFF
--- a/libc/src/setjmp/CMakeLists.txt
+++ b/libc/src/setjmp/CMakeLists.txt
@@ -1,13 +1,12 @@
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
+  add_object_library(
+    sigsetjmp_epilogue
+    ALIAS
+    DEPENDS
+      .${LIBC_TARGET_OS}.sigsetjmp_epilogue
+  )
 endif()
-
-add_object_library(
-  sigsetjmp_epilogue
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.sigsetjmp_epilogue
-)
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_ARCHITECTURE})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_ARCHITECTURE})

--- a/libc/src/setjmp/x86_64/sigsetjmp.cpp
+++ b/libc/src/setjmp/x86_64/sigsetjmp.cpp
@@ -37,8 +37,8 @@ LLVM_LIBC_FUNCTION(int, sigsetjmp, (sigjmp_buf buf)) {
       
 .Lnosave:
       jmp %P[setjmp])" ::[retaddr] "i"(offsetof(__jmp_buf, sig_retaddr)),
-      [extra] "i"(offsetof(__jmp_buf, sig_extra)), [setjmp] "i"(setjmp),
-      [epilogue] "i"(sigsetjmp_epilogue)
+      [extra] "i"(offsetof(__jmp_buf, sig_extra)), [setjmp] "X"(setjmp),
+      [epilogue] "X"(sigsetjmp_epilogue)
       : "eax", "ebx", "ecx");
 }
 #endif
@@ -60,8 +60,8 @@ LLVM_LIBC_FUNCTION(int, sigsetjmp, (sigjmp_buf, int)) {
       
 .Lnosave:
       jmp %P[setjmp])" ::[retaddr] "i"(offsetof(__jmp_buf, sig_retaddr)),
-      [extra] "i"(offsetof(__jmp_buf, sig_extra)), [setjmp] "i"(setjmp),
-      [epilogue] "i"(sigsetjmp_epilogue)
+      [extra] "i"(offsetof(__jmp_buf, sig_extra)), [setjmp] "X"(setjmp),
+      [epilogue] "X"(sigsetjmp_epilogue)
       : "rax", "rbx");
 }
 


### PR DESCRIPTION
This PR fixes the build failure due to the `sigsetjmp` implementation.

1. Use a most relaxed input constraint to fix `clang` build.
2. Avoid create alias target if os directory for `sigsetjmp_epilogue` does not exist.


