### PR TITLE
Revert "[RISCV] Allow spilling to unused Zcmp Stack (#125959)"

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -1795,15 +1795,10 @@ bool RISCVFrameLowering::assignCalleeSavedSpillSlots(
     MFI.CreateFixedSpillStackObject(
         QCIInterruptPushAmount, -static_cast<int64_t>(QCIInterruptPushAmount));
   } else if (RVFI->isPushable(MF)) {
-    // Allocate a fixed object that covers all the registers that are pushed.
-    if (unsigned PushedRegs = RVFI->getRVPushRegs()) {
-      int64_t PushedRegsBytes =
-          static_cast<int64_t>(PushedRegs) * (STI.getXLen() / 8);
-      MFI.CreateFixedSpillStackObject(PushedRegsBytes, -PushedRegsBytes);
-    }
+    // Allocate a fixed object that covers the full push.
+    if (int64_t PushSize = RVFI->getRVPushStackSize())
+      MFI.CreateFixedSpillStackObject(PushSize, -PushSize);
   } else if (int LibCallRegs = getLibCallID(MF, CSI) + 1) {
-    // Allocate a fixed object that covers all of the stack allocated by the
-    // libcall.
     int64_t LibCallFrameSize =
         alignTo((STI.getXLen() / 8) * LibCallRegs, getStackAlign());
     MFI.CreateFixedSpillStackObject(LibCallFrameSize, -LibCallFrameSize);

--- a/llvm/test/CodeGen/RISCV/callee-saved-gprs.ll
+++ b/llvm/test/CodeGen/RISCV/callee-saved-gprs.ll
@@ -419,8 +419,8 @@ define void @callee() {
 ;
 ; RV32IZCMP-LABEL: callee:
 ; RV32IZCMP:       # %bb.0:
-; RV32IZCMP-NEXT:    cm.push {ra, s0-s11}, -80
-; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 80
+; RV32IZCMP-NEXT:    cm.push {ra, s0-s11}, -96
+; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 96
 ; RV32IZCMP-NEXT:    .cfi_offset ra, -52
 ; RV32IZCMP-NEXT:    .cfi_offset s0, -48
 ; RV32IZCMP-NEXT:    .cfi_offset s1, -44
@@ -436,18 +436,18 @@ define void @callee() {
 ; RV32IZCMP-NEXT:    .cfi_offset s11, -4
 ; RV32IZCMP-NEXT:    lui t0, %hi(var)
 ; RV32IZCMP-NEXT:    lw a0, %lo(var)(t0)
-; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var+4)(t0)
-; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var+8)(t0)
-; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var+12)(t0)
-; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    addi a5, t0, %lo(var)
 ; RV32IZCMP-NEXT:    lw a0, 16(a5)
-; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 20(a5)
-; RV32IZCMP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw t4, 24(a5)
 ; RV32IZCMP-NEXT:    lw t5, 28(a5)
 ; RV32IZCMP-NEXT:    lw t6, 32(a5)
@@ -500,19 +500,19 @@ define void @callee() {
 ; RV32IZCMP-NEXT:    sw t6, 32(a5)
 ; RV32IZCMP-NEXT:    sw t5, 28(a5)
 ; RV32IZCMP-NEXT:    sw t4, 24(a5)
-; RV32IZCMP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 16(a5)
+; RV32IZCMP-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var+12)(t0)
+; RV32IZCMP-NEXT:    sw a0, 16(a5)
 ; RV32IZCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var+8)(t0)
+; RV32IZCMP-NEXT:    sw a0, %lo(var+12)(t0)
 ; RV32IZCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var+4)(t0)
+; RV32IZCMP-NEXT:    sw a0, %lo(var+8)(t0)
 ; RV32IZCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var+4)(t0)
+; RV32IZCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IZCMP-NEXT:    sw a0, %lo(var)(t0)
-; RV32IZCMP-NEXT:    cm.popret {ra, s0-s11}, 80
+; RV32IZCMP-NEXT:    cm.popret {ra, s0-s11}, 96
 ;
 ; RV32IZCMP-WITH-FP-LABEL: callee:
 ; RV32IZCMP-WITH-FP:       # %bb.0:
@@ -1055,18 +1055,18 @@ define void @callee() {
 ; RV64IZCMP-NEXT:    .cfi_offset s11, -8
 ; RV64IZCMP-NEXT:    lui t0, %hi(var)
 ; RV64IZCMP-NEXT:    lw a0, %lo(var)(t0)
-; RV64IZCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var+4)(t0)
 ; RV64IZCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var+8)(t0)
+; RV64IZCMP-NEXT:    lw a0, %lo(var+4)(t0)
 ; RV64IZCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var+12)(t0)
+; RV64IZCMP-NEXT:    lw a0, %lo(var+8)(t0)
 ; RV64IZCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var+12)(t0)
+; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    addi a5, t0, %lo(var)
 ; RV64IZCMP-NEXT:    lw a0, 16(a5)
-; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 20(a5)
 ; RV64IZCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 20(a5)
+; RV64IZCMP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    lw t4, 24(a5)
 ; RV64IZCMP-NEXT:    lw t5, 28(a5)
 ; RV64IZCMP-NEXT:    lw t6, 32(a5)
@@ -1119,17 +1119,17 @@ define void @callee() {
 ; RV64IZCMP-NEXT:    sw t6, 32(a5)
 ; RV64IZCMP-NEXT:    sw t5, 28(a5)
 ; RV64IZCMP-NEXT:    sw t4, 24(a5)
-; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 20(a5)
-; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 16(a5)
-; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var+12)(t0)
-; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var+8)(t0)
-; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var+4)(t0)
-; RV64IZCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var)(t0)
 ; RV64IZCMP-NEXT:    cm.popret {ra, s0-s11}, 160
 ;
@@ -1798,54 +1798,54 @@ define void @caller() {
 ; RV32IZCMP-NEXT:    .cfi_offset s9, -12
 ; RV32IZCMP-NEXT:    .cfi_offset s10, -8
 ; RV32IZCMP-NEXT:    .cfi_offset s11, -4
-; RV32IZCMP-NEXT:    addi sp, sp, -32
-; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 144
+; RV32IZCMP-NEXT:    addi sp, sp, -48
+; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 160
 ; RV32IZCMP-NEXT:    lui s0, %hi(var)
 ; RV32IZCMP-NEXT:    lw a0, %lo(var)(s0)
-; RV32IZCMP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var+4)(s0)
-; RV32IZCMP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var+8)(s0)
-; RV32IZCMP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var+12)(s0)
-; RV32IZCMP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    addi s1, s0, %lo(var)
 ; RV32IZCMP-NEXT:    lw a0, 16(s1)
-; RV32IZCMP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 20(s1)
-; RV32IZCMP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 24(s1)
-; RV32IZCMP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 28(s1)
-; RV32IZCMP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 32(s1)
-; RV32IZCMP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 36(s1)
-; RV32IZCMP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 40(s1)
-; RV32IZCMP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 44(s1)
-; RV32IZCMP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 48(s1)
-; RV32IZCMP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 52(s1)
-; RV32IZCMP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 56(s1)
-; RV32IZCMP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 60(s1)
-; RV32IZCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 64(s1)
-; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 68(s1)
-; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 72(s1)
-; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 76(s1)
-; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 80(s1)
-; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 84(s1)
-; RV32IZCMP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw s4, 88(s1)
 ; RV32IZCMP-NEXT:    lw s5, 92(s1)
 ; RV32IZCMP-NEXT:    lw s6, 96(s1)
@@ -1867,51 +1867,51 @@ define void @caller() {
 ; RV32IZCMP-NEXT:    sw s6, 96(s1)
 ; RV32IZCMP-NEXT:    sw s5, 92(s1)
 ; RV32IZCMP-NEXT:    sw s4, 88(s1)
-; RV32IZCMP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 84(s1)
 ; RV32IZCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 80(s1)
+; RV32IZCMP-NEXT:    sw a0, 84(s1)
 ; RV32IZCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 76(s1)
+; RV32IZCMP-NEXT:    sw a0, 80(s1)
 ; RV32IZCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 72(s1)
+; RV32IZCMP-NEXT:    sw a0, 76(s1)
 ; RV32IZCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 68(s1)
+; RV32IZCMP-NEXT:    sw a0, 72(s1)
 ; RV32IZCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 64(s1)
+; RV32IZCMP-NEXT:    sw a0, 68(s1)
 ; RV32IZCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 60(s1)
+; RV32IZCMP-NEXT:    sw a0, 64(s1)
 ; RV32IZCMP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 56(s1)
+; RV32IZCMP-NEXT:    sw a0, 60(s1)
 ; RV32IZCMP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 52(s1)
+; RV32IZCMP-NEXT:    sw a0, 56(s1)
 ; RV32IZCMP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 48(s1)
+; RV32IZCMP-NEXT:    sw a0, 52(s1)
 ; RV32IZCMP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 44(s1)
+; RV32IZCMP-NEXT:    sw a0, 48(s1)
 ; RV32IZCMP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 40(s1)
+; RV32IZCMP-NEXT:    sw a0, 44(s1)
 ; RV32IZCMP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 36(s1)
+; RV32IZCMP-NEXT:    sw a0, 40(s1)
 ; RV32IZCMP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 32(s1)
+; RV32IZCMP-NEXT:    sw a0, 36(s1)
 ; RV32IZCMP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 28(s1)
+; RV32IZCMP-NEXT:    sw a0, 32(s1)
 ; RV32IZCMP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 24(s1)
+; RV32IZCMP-NEXT:    sw a0, 28(s1)
 ; RV32IZCMP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 20(s1)
+; RV32IZCMP-NEXT:    sw a0, 24(s1)
 ; RV32IZCMP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 16(s1)
+; RV32IZCMP-NEXT:    sw a0, 20(s1)
 ; RV32IZCMP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var+12)(s0)
+; RV32IZCMP-NEXT:    sw a0, 16(s1)
 ; RV32IZCMP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var+8)(s0)
+; RV32IZCMP-NEXT:    sw a0, %lo(var+12)(s0)
 ; RV32IZCMP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var+4)(s0)
+; RV32IZCMP-NEXT:    sw a0, %lo(var+8)(s0)
 ; RV32IZCMP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var+4)(s0)
+; RV32IZCMP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
 ; RV32IZCMP-NEXT:    sw a0, %lo(var)(s0)
-; RV32IZCMP-NEXT:    addi sp, sp, 32
+; RV32IZCMP-NEXT:    addi sp, sp, 48
 ; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 112
 ; RV32IZCMP-NEXT:    cm.popret {ra, s0-s11}, 112
 ;
@@ -2609,50 +2609,50 @@ define void @caller() {
 ; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 288
 ; RV64IZCMP-NEXT:    lui s0, %hi(var)
 ; RV64IZCMP-NEXT:    lw a0, %lo(var)(s0)
-; RV64IZCMP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var+4)(s0)
 ; RV64IZCMP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var+8)(s0)
+; RV64IZCMP-NEXT:    lw a0, %lo(var+4)(s0)
 ; RV64IZCMP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var+12)(s0)
+; RV64IZCMP-NEXT:    lw a0, %lo(var+8)(s0)
 ; RV64IZCMP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var+12)(s0)
+; RV64IZCMP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    addi s1, s0, %lo(var)
 ; RV64IZCMP-NEXT:    lw a0, 16(s1)
-; RV64IZCMP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 20(s1)
 ; RV64IZCMP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 24(s1)
+; RV64IZCMP-NEXT:    lw a0, 20(s1)
 ; RV64IZCMP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 28(s1)
+; RV64IZCMP-NEXT:    lw a0, 24(s1)
 ; RV64IZCMP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 32(s1)
+; RV64IZCMP-NEXT:    lw a0, 28(s1)
 ; RV64IZCMP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 36(s1)
+; RV64IZCMP-NEXT:    lw a0, 32(s1)
 ; RV64IZCMP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 40(s1)
+; RV64IZCMP-NEXT:    lw a0, 36(s1)
 ; RV64IZCMP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 44(s1)
+; RV64IZCMP-NEXT:    lw a0, 40(s1)
 ; RV64IZCMP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 48(s1)
+; RV64IZCMP-NEXT:    lw a0, 44(s1)
 ; RV64IZCMP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 52(s1)
+; RV64IZCMP-NEXT:    lw a0, 48(s1)
 ; RV64IZCMP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 56(s1)
+; RV64IZCMP-NEXT:    lw a0, 52(s1)
 ; RV64IZCMP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 60(s1)
+; RV64IZCMP-NEXT:    lw a0, 56(s1)
 ; RV64IZCMP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 64(s1)
+; RV64IZCMP-NEXT:    lw a0, 60(s1)
 ; RV64IZCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 68(s1)
+; RV64IZCMP-NEXT:    lw a0, 64(s1)
 ; RV64IZCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 72(s1)
+; RV64IZCMP-NEXT:    lw a0, 68(s1)
 ; RV64IZCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 76(s1)
+; RV64IZCMP-NEXT:    lw a0, 72(s1)
 ; RV64IZCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 80(s1)
+; RV64IZCMP-NEXT:    lw a0, 76(s1)
 ; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 84(s1)
+; RV64IZCMP-NEXT:    lw a0, 80(s1)
 ; RV64IZCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 84(s1)
+; RV64IZCMP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    lw s4, 88(s1)
 ; RV64IZCMP-NEXT:    lw s5, 92(s1)
 ; RV64IZCMP-NEXT:    lw s6, 96(s1)
@@ -2674,49 +2674,49 @@ define void @caller() {
 ; RV64IZCMP-NEXT:    sw s6, 96(s1)
 ; RV64IZCMP-NEXT:    sw s5, 92(s1)
 ; RV64IZCMP-NEXT:    sw s4, 88(s1)
-; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 84(s1)
-; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 80(s1)
-; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 76(s1)
-; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 72(s1)
-; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 68(s1)
-; RV64IZCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 64(s1)
-; RV64IZCMP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 60(s1)
-; RV64IZCMP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 56(s1)
-; RV64IZCMP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 52(s1)
-; RV64IZCMP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 48(s1)
-; RV64IZCMP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 44(s1)
-; RV64IZCMP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 40(s1)
-; RV64IZCMP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 36(s1)
-; RV64IZCMP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 32(s1)
-; RV64IZCMP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 28(s1)
-; RV64IZCMP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 24(s1)
-; RV64IZCMP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 20(s1)
-; RV64IZCMP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 16(s1)
-; RV64IZCMP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var+12)(s0)
-; RV64IZCMP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var+8)(s0)
-; RV64IZCMP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var+4)(s0)
-; RV64IZCMP-NEXT:    ld a0, 176(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var)(s0)
 ; RV64IZCMP-NEXT:    addi sp, sp, 128
 ; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 160

--- a/llvm/test/CodeGen/RISCV/push-pop-popret.ll
+++ b/llvm/test/CodeGen/RISCV/push-pop-popret.ll
@@ -24,7 +24,7 @@ define i32 @foo() {
 ; RV32IZCMP-NEXT:    .cfi_offset ra, -4
 ; RV32IZCMP-NEXT:    addi sp, sp, -464
 ; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 528
-; RV32IZCMP-NEXT:    addi a0, sp, 12
+; RV32IZCMP-NEXT:    mv a0, sp
 ; RV32IZCMP-NEXT:    call test
 ; RV32IZCMP-NEXT:    addi sp, sp, 464
 ; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 64
@@ -37,7 +37,7 @@ define i32 @foo() {
 ; RV64IZCMP-NEXT:    .cfi_offset ra, -8
 ; RV64IZCMP-NEXT:    addi sp, sp, -464
 ; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 528
-; RV64IZCMP-NEXT:    addi a0, sp, 8
+; RV64IZCMP-NEXT:    mv a0, sp
 ; RV64IZCMP-NEXT:    call test
 ; RV64IZCMP-NEXT:    addi sp, sp, 464
 ; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 64
@@ -50,7 +50,7 @@ define i32 @foo() {
 ; RV32IZCMP-SR-NEXT:    .cfi_offset ra, -4
 ; RV32IZCMP-SR-NEXT:    addi sp, sp, -464
 ; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 528
-; RV32IZCMP-SR-NEXT:    addi a0, sp, 12
+; RV32IZCMP-SR-NEXT:    mv a0, sp
 ; RV32IZCMP-SR-NEXT:    call test
 ; RV32IZCMP-SR-NEXT:    addi sp, sp, 464
 ; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 64
@@ -63,7 +63,7 @@ define i32 @foo() {
 ; RV64IZCMP-SR-NEXT:    .cfi_offset ra, -8
 ; RV64IZCMP-SR-NEXT:    addi sp, sp, -464
 ; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 528
-; RV64IZCMP-SR-NEXT:    addi a0, sp, 8
+; RV64IZCMP-SR-NEXT:    mv a0, sp
 ; RV64IZCMP-SR-NEXT:    call test
 ; RV64IZCMP-SR-NEXT:    addi sp, sp, 464
 ; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 64
@@ -1775,52 +1775,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-NEXT:    cm.push {ra}, -64
 ; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 64
 ; RV32IZCMP-NEXT:    .cfi_offset ra, -4
-; RV32IZCMP-NEXT:    sw t0, 56(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t2, 48(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a2, 36(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a5, 24(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a7, 16(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t3, 12(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t4, 8(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t5, 4(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t6, 0(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    .cfi_offset t0, -8
-; RV32IZCMP-NEXT:    .cfi_offset t1, -12
-; RV32IZCMP-NEXT:    .cfi_offset t2, -16
-; RV32IZCMP-NEXT:    .cfi_offset a0, -20
-; RV32IZCMP-NEXT:    .cfi_offset a1, -24
-; RV32IZCMP-NEXT:    .cfi_offset a2, -28
-; RV32IZCMP-NEXT:    .cfi_offset a3, -32
-; RV32IZCMP-NEXT:    .cfi_offset a4, -36
-; RV32IZCMP-NEXT:    .cfi_offset a5, -40
-; RV32IZCMP-NEXT:    .cfi_offset a6, -44
-; RV32IZCMP-NEXT:    .cfi_offset a7, -48
-; RV32IZCMP-NEXT:    .cfi_offset t3, -52
-; RV32IZCMP-NEXT:    .cfi_offset t4, -56
-; RV32IZCMP-NEXT:    .cfi_offset t5, -60
-; RV32IZCMP-NEXT:    .cfi_offset t6, -64
+; RV32IZCMP-NEXT:    addi sp, sp, -16
+; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 80
+; RV32IZCMP-NEXT:    sw t0, 60(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t2, 52(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a5, 28(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a6, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t3, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t4, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t5, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t6, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    .cfi_offset t0, -20
+; RV32IZCMP-NEXT:    .cfi_offset t1, -24
+; RV32IZCMP-NEXT:    .cfi_offset t2, -28
+; RV32IZCMP-NEXT:    .cfi_offset a0, -32
+; RV32IZCMP-NEXT:    .cfi_offset a1, -36
+; RV32IZCMP-NEXT:    .cfi_offset a2, -40
+; RV32IZCMP-NEXT:    .cfi_offset a3, -44
+; RV32IZCMP-NEXT:    .cfi_offset a4, -48
+; RV32IZCMP-NEXT:    .cfi_offset a5, -52
+; RV32IZCMP-NEXT:    .cfi_offset a6, -56
+; RV32IZCMP-NEXT:    .cfi_offset a7, -60
+; RV32IZCMP-NEXT:    .cfi_offset t3, -64
+; RV32IZCMP-NEXT:    .cfi_offset t4, -68
+; RV32IZCMP-NEXT:    .cfi_offset t5, -72
+; RV32IZCMP-NEXT:    .cfi_offset t6, -76
 ; RV32IZCMP-NEXT:    call foo_test_irq
-; RV32IZCMP-NEXT:    lw t0, 56(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t1, 52(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t2, 48(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t3, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t5, 4(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t6, 0(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t0, 60(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a3, 36(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t3, 16(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t4, 12(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t6, 4(sp) # 4-byte Folded Reload
 ; RV32IZCMP-NEXT:    .cfi_restore t0
 ; RV32IZCMP-NEXT:    .cfi_restore t1
 ; RV32IZCMP-NEXT:    .cfi_restore t2
@@ -1836,6 +1838,8 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-NEXT:    .cfi_restore t4
 ; RV32IZCMP-NEXT:    .cfi_restore t5
 ; RV32IZCMP-NEXT:    .cfi_restore t6
+; RV32IZCMP-NEXT:    addi sp, sp, 16
+; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 64
 ; RV32IZCMP-NEXT:    cm.pop {ra}, 64
 ; RV32IZCMP-NEXT:    .cfi_restore ra
 ; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 0
@@ -1846,54 +1850,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-NEXT:    cm.push {ra}, -64
 ; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 64
 ; RV64IZCMP-NEXT:    .cfi_offset ra, -8
-; RV64IZCMP-NEXT:    addi sp, sp, -64
-; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 128
-; RV64IZCMP-NEXT:    sd t0, 112(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t1, 104(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t2, 96(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a1, 80(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a2, 72(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a3, 64(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a4, 56(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a5, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a6, 40(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a7, 32(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t3, 24(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t4, 16(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t5, 8(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t6, 0(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    .cfi_offset t0, -16
-; RV64IZCMP-NEXT:    .cfi_offset t1, -24
-; RV64IZCMP-NEXT:    .cfi_offset t2, -32
-; RV64IZCMP-NEXT:    .cfi_offset a0, -40
-; RV64IZCMP-NEXT:    .cfi_offset a1, -48
-; RV64IZCMP-NEXT:    .cfi_offset a2, -56
-; RV64IZCMP-NEXT:    .cfi_offset a3, -64
-; RV64IZCMP-NEXT:    .cfi_offset a4, -72
-; RV64IZCMP-NEXT:    .cfi_offset a5, -80
-; RV64IZCMP-NEXT:    .cfi_offset a6, -88
-; RV64IZCMP-NEXT:    .cfi_offset a7, -96
-; RV64IZCMP-NEXT:    .cfi_offset t3, -104
-; RV64IZCMP-NEXT:    .cfi_offset t4, -112
-; RV64IZCMP-NEXT:    .cfi_offset t5, -120
-; RV64IZCMP-NEXT:    .cfi_offset t6, -128
+; RV64IZCMP-NEXT:    addi sp, sp, -80
+; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 144
+; RV64IZCMP-NEXT:    sd t0, 120(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t1, 112(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t2, 104(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a1, 88(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a2, 80(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a3, 72(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a4, 64(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a5, 56(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a6, 48(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a7, 40(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t3, 32(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t4, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t5, 16(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t6, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    .cfi_offset t0, -24
+; RV64IZCMP-NEXT:    .cfi_offset t1, -32
+; RV64IZCMP-NEXT:    .cfi_offset t2, -40
+; RV64IZCMP-NEXT:    .cfi_offset a0, -48
+; RV64IZCMP-NEXT:    .cfi_offset a1, -56
+; RV64IZCMP-NEXT:    .cfi_offset a2, -64
+; RV64IZCMP-NEXT:    .cfi_offset a3, -72
+; RV64IZCMP-NEXT:    .cfi_offset a4, -80
+; RV64IZCMP-NEXT:    .cfi_offset a5, -88
+; RV64IZCMP-NEXT:    .cfi_offset a6, -96
+; RV64IZCMP-NEXT:    .cfi_offset a7, -104
+; RV64IZCMP-NEXT:    .cfi_offset t3, -112
+; RV64IZCMP-NEXT:    .cfi_offset t4, -120
+; RV64IZCMP-NEXT:    .cfi_offset t5, -128
+; RV64IZCMP-NEXT:    .cfi_offset t6, -136
 ; RV64IZCMP-NEXT:    call foo_test_irq
-; RV64IZCMP-NEXT:    ld t0, 112(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t1, 104(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t2, 96(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a1, 80(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a2, 72(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a3, 64(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a4, 56(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a5, 48(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a6, 40(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a7, 32(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t3, 24(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t4, 16(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t5, 8(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t6, 0(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t0, 120(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t1, 112(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t2, 104(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a1, 88(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a2, 80(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a3, 72(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a4, 64(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a5, 56(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a6, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a7, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t3, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t4, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t5, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t6, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    .cfi_restore t0
 ; RV64IZCMP-NEXT:    .cfi_restore t1
 ; RV64IZCMP-NEXT:    .cfi_restore t2
@@ -1909,7 +1913,7 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-NEXT:    .cfi_restore t4
 ; RV64IZCMP-NEXT:    .cfi_restore t5
 ; RV64IZCMP-NEXT:    .cfi_restore t6
-; RV64IZCMP-NEXT:    addi sp, sp, 64
+; RV64IZCMP-NEXT:    addi sp, sp, 80
 ; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 64
 ; RV64IZCMP-NEXT:    cm.pop {ra}, 64
 ; RV64IZCMP-NEXT:    .cfi_restore ra
@@ -1921,52 +1925,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-SR-NEXT:    cm.push {ra}, -64
 ; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 64
 ; RV32IZCMP-SR-NEXT:    .cfi_offset ra, -4
-; RV32IZCMP-SR-NEXT:    sw t0, 56(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t2, 48(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a2, 36(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a5, 24(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a7, 16(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t3, 12(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t4, 8(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t5, 4(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t6, 0(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    .cfi_offset t0, -8
-; RV32IZCMP-SR-NEXT:    .cfi_offset t1, -12
-; RV32IZCMP-SR-NEXT:    .cfi_offset t2, -16
-; RV32IZCMP-SR-NEXT:    .cfi_offset a0, -20
-; RV32IZCMP-SR-NEXT:    .cfi_offset a1, -24
-; RV32IZCMP-SR-NEXT:    .cfi_offset a2, -28
-; RV32IZCMP-SR-NEXT:    .cfi_offset a3, -32
-; RV32IZCMP-SR-NEXT:    .cfi_offset a4, -36
-; RV32IZCMP-SR-NEXT:    .cfi_offset a5, -40
-; RV32IZCMP-SR-NEXT:    .cfi_offset a6, -44
-; RV32IZCMP-SR-NEXT:    .cfi_offset a7, -48
-; RV32IZCMP-SR-NEXT:    .cfi_offset t3, -52
-; RV32IZCMP-SR-NEXT:    .cfi_offset t4, -56
-; RV32IZCMP-SR-NEXT:    .cfi_offset t5, -60
-; RV32IZCMP-SR-NEXT:    .cfi_offset t6, -64
+; RV32IZCMP-SR-NEXT:    addi sp, sp, -16
+; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 80
+; RV32IZCMP-SR-NEXT:    sw t0, 60(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t2, 52(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a5, 28(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a6, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t3, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t4, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t5, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t6, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    .cfi_offset t0, -20
+; RV32IZCMP-SR-NEXT:    .cfi_offset t1, -24
+; RV32IZCMP-SR-NEXT:    .cfi_offset t2, -28
+; RV32IZCMP-SR-NEXT:    .cfi_offset a0, -32
+; RV32IZCMP-SR-NEXT:    .cfi_offset a1, -36
+; RV32IZCMP-SR-NEXT:    .cfi_offset a2, -40
+; RV32IZCMP-SR-NEXT:    .cfi_offset a3, -44
+; RV32IZCMP-SR-NEXT:    .cfi_offset a4, -48
+; RV32IZCMP-SR-NEXT:    .cfi_offset a5, -52
+; RV32IZCMP-SR-NEXT:    .cfi_offset a6, -56
+; RV32IZCMP-SR-NEXT:    .cfi_offset a7, -60
+; RV32IZCMP-SR-NEXT:    .cfi_offset t3, -64
+; RV32IZCMP-SR-NEXT:    .cfi_offset t4, -68
+; RV32IZCMP-SR-NEXT:    .cfi_offset t5, -72
+; RV32IZCMP-SR-NEXT:    .cfi_offset t6, -76
 ; RV32IZCMP-SR-NEXT:    call foo_test_irq
-; RV32IZCMP-SR-NEXT:    lw t0, 56(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t1, 52(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t2, 48(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t3, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t5, 4(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t6, 0(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t0, 60(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a3, 36(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t3, 16(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t4, 12(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t6, 4(sp) # 4-byte Folded Reload
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t0
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t1
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t2
@@ -1982,6 +1988,8 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t4
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t5
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t6
+; RV32IZCMP-SR-NEXT:    addi sp, sp, 16
+; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 64
 ; RV32IZCMP-SR-NEXT:    cm.pop {ra}, 64
 ; RV32IZCMP-SR-NEXT:    .cfi_restore ra
 ; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 0
@@ -1992,54 +2000,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-SR-NEXT:    cm.push {ra}, -64
 ; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 64
 ; RV64IZCMP-SR-NEXT:    .cfi_offset ra, -8
-; RV64IZCMP-SR-NEXT:    addi sp, sp, -64
-; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 128
-; RV64IZCMP-SR-NEXT:    sd t0, 112(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t1, 104(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t2, 96(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a1, 80(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a2, 72(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a3, 64(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a4, 56(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a5, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a6, 40(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a7, 32(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t3, 24(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t4, 16(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t5, 8(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t6, 0(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    .cfi_offset t0, -16
-; RV64IZCMP-SR-NEXT:    .cfi_offset t1, -24
-; RV64IZCMP-SR-NEXT:    .cfi_offset t2, -32
-; RV64IZCMP-SR-NEXT:    .cfi_offset a0, -40
-; RV64IZCMP-SR-NEXT:    .cfi_offset a1, -48
-; RV64IZCMP-SR-NEXT:    .cfi_offset a2, -56
-; RV64IZCMP-SR-NEXT:    .cfi_offset a3, -64
-; RV64IZCMP-SR-NEXT:    .cfi_offset a4, -72
-; RV64IZCMP-SR-NEXT:    .cfi_offset a5, -80
-; RV64IZCMP-SR-NEXT:    .cfi_offset a6, -88
-; RV64IZCMP-SR-NEXT:    .cfi_offset a7, -96
-; RV64IZCMP-SR-NEXT:    .cfi_offset t3, -104
-; RV64IZCMP-SR-NEXT:    .cfi_offset t4, -112
-; RV64IZCMP-SR-NEXT:    .cfi_offset t5, -120
-; RV64IZCMP-SR-NEXT:    .cfi_offset t6, -128
+; RV64IZCMP-SR-NEXT:    addi sp, sp, -80
+; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 144
+; RV64IZCMP-SR-NEXT:    sd t0, 120(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t1, 112(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t2, 104(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a1, 88(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a2, 80(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a3, 72(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a4, 64(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a5, 56(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a6, 48(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a7, 40(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t3, 32(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t4, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t5, 16(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t6, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    .cfi_offset t0, -24
+; RV64IZCMP-SR-NEXT:    .cfi_offset t1, -32
+; RV64IZCMP-SR-NEXT:    .cfi_offset t2, -40
+; RV64IZCMP-SR-NEXT:    .cfi_offset a0, -48
+; RV64IZCMP-SR-NEXT:    .cfi_offset a1, -56
+; RV64IZCMP-SR-NEXT:    .cfi_offset a2, -64
+; RV64IZCMP-SR-NEXT:    .cfi_offset a3, -72
+; RV64IZCMP-SR-NEXT:    .cfi_offset a4, -80
+; RV64IZCMP-SR-NEXT:    .cfi_offset a5, -88
+; RV64IZCMP-SR-NEXT:    .cfi_offset a6, -96
+; RV64IZCMP-SR-NEXT:    .cfi_offset a7, -104
+; RV64IZCMP-SR-NEXT:    .cfi_offset t3, -112
+; RV64IZCMP-SR-NEXT:    .cfi_offset t4, -120
+; RV64IZCMP-SR-NEXT:    .cfi_offset t5, -128
+; RV64IZCMP-SR-NEXT:    .cfi_offset t6, -136
 ; RV64IZCMP-SR-NEXT:    call foo_test_irq
-; RV64IZCMP-SR-NEXT:    ld t0, 112(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t1, 104(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t2, 96(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a1, 80(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a2, 72(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a3, 64(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a4, 56(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a5, 48(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a6, 40(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a7, 32(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t3, 24(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t4, 16(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t5, 8(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t6, 0(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t0, 120(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t1, 112(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t2, 104(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a1, 88(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a2, 80(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a3, 72(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a4, 64(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a5, 56(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a6, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a7, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t3, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t4, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t5, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t6, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t0
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t1
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t2
@@ -2055,7 +2063,7 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t4
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t5
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t6
-; RV64IZCMP-SR-NEXT:    addi sp, sp, 64
+; RV64IZCMP-SR-NEXT:    addi sp, sp, 80
 ; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 64
 ; RV64IZCMP-SR-NEXT:    cm.pop {ra}, 64
 ; RV64IZCMP-SR-NEXT:    .cfi_restore ra
@@ -2291,52 +2299,52 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-NEXT:    .cfi_offset s9, -12
 ; RV32IZCMP-NEXT:    .cfi_offset s10, -8
 ; RV32IZCMP-NEXT:    .cfi_offset s11, -4
-; RV32IZCMP-NEXT:    addi sp, sp, -32
-; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 144
-; RV32IZCMP-NEXT:    sw t0, 88(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t1, 84(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t2, 80(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a2, 68(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a4, 60(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a5, 56(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a6, 52(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw a7, 48(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t3, 44(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t4, 40(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    sw t6, 32(sp) # 4-byte Folded Spill
-; RV32IZCMP-NEXT:    .cfi_offset t0, -56
-; RV32IZCMP-NEXT:    .cfi_offset t1, -60
-; RV32IZCMP-NEXT:    .cfi_offset t2, -64
-; RV32IZCMP-NEXT:    .cfi_offset a0, -68
-; RV32IZCMP-NEXT:    .cfi_offset a1, -72
-; RV32IZCMP-NEXT:    .cfi_offset a2, -76
-; RV32IZCMP-NEXT:    .cfi_offset a3, -80
-; RV32IZCMP-NEXT:    .cfi_offset a4, -84
-; RV32IZCMP-NEXT:    .cfi_offset a5, -88
-; RV32IZCMP-NEXT:    .cfi_offset a6, -92
-; RV32IZCMP-NEXT:    .cfi_offset a7, -96
-; RV32IZCMP-NEXT:    .cfi_offset t3, -100
-; RV32IZCMP-NEXT:    .cfi_offset t4, -104
-; RV32IZCMP-NEXT:    .cfi_offset t5, -108
-; RV32IZCMP-NEXT:    .cfi_offset t6, -112
+; RV32IZCMP-NEXT:    addi sp, sp, -48
+; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 160
+; RV32IZCMP-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t2, 84(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a6, 56(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t3, 48(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t4, 44(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t5, 40(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw t6, 36(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    .cfi_offset t0, -68
+; RV32IZCMP-NEXT:    .cfi_offset t1, -72
+; RV32IZCMP-NEXT:    .cfi_offset t2, -76
+; RV32IZCMP-NEXT:    .cfi_offset a0, -80
+; RV32IZCMP-NEXT:    .cfi_offset a1, -84
+; RV32IZCMP-NEXT:    .cfi_offset a2, -88
+; RV32IZCMP-NEXT:    .cfi_offset a3, -92
+; RV32IZCMP-NEXT:    .cfi_offset a4, -96
+; RV32IZCMP-NEXT:    .cfi_offset a5, -100
+; RV32IZCMP-NEXT:    .cfi_offset a6, -104
+; RV32IZCMP-NEXT:    .cfi_offset a7, -108
+; RV32IZCMP-NEXT:    .cfi_offset t3, -112
+; RV32IZCMP-NEXT:    .cfi_offset t4, -116
+; RV32IZCMP-NEXT:    .cfi_offset t5, -120
+; RV32IZCMP-NEXT:    .cfi_offset t6, -124
 ; RV32IZCMP-NEXT:    lui t0, %hi(var_test_irq)
 ; RV32IZCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV32IZCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV32IZCMP-NEXT:    lw a0, 16(a5)
-; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 20(a5)
-; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw t4, 24(a5)
 ; RV32IZCMP-NEXT:    lw t5, 28(a5)
 ; RV32IZCMP-NEXT:    lw t6, 32(a5)
@@ -2389,33 +2397,33 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-NEXT:    sw t6, 32(a5)
 ; RV32IZCMP-NEXT:    sw t5, 28(a5)
 ; RV32IZCMP-NEXT:    sw t4, 24(a5)
-; RV32IZCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 16(a5)
+; RV32IZCMP-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV32IZCMP-NEXT:    sw a0, 16(a5)
 ; RV32IZCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
 ; RV32IZCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
 ; RV32IZCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IZCMP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV32IZCMP-NEXT:    lw t0, 88(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t1, 84(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t2, 80(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a6, 52(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw a7, 48(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t3, 44(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t4, 40(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t5, 36(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    lw t6, 32(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t0, 92(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t1, 88(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t2, 84(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a2, 72(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t3, 48(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t4, 44(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t5, 40(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    lw t6, 36(sp) # 4-byte Folded Reload
 ; RV32IZCMP-NEXT:    .cfi_restore t0
 ; RV32IZCMP-NEXT:    .cfi_restore t1
 ; RV32IZCMP-NEXT:    .cfi_restore t2
@@ -2431,7 +2439,7 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-NEXT:    .cfi_restore t4
 ; RV32IZCMP-NEXT:    .cfi_restore t5
 ; RV32IZCMP-NEXT:    .cfi_restore t6
-; RV32IZCMP-NEXT:    addi sp, sp, 32
+; RV32IZCMP-NEXT:    addi sp, sp, 48
 ; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 112
 ; RV32IZCMP-NEXT:    cm.pop {ra, s0-s11}, 112
 ; RV32IZCMP-NEXT:    .cfi_restore ra
@@ -2467,52 +2475,52 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-NEXT:    .cfi_offset s9, -24
 ; RV64IZCMP-NEXT:    .cfi_offset s10, -16
 ; RV64IZCMP-NEXT:    .cfi_offset s11, -8
-; RV64IZCMP-NEXT:    addi sp, sp, -112
-; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 272
-; RV64IZCMP-NEXT:    sd t0, 160(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t1, 152(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t2, 144(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a1, 128(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a2, 120(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a3, 112(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a4, 104(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a5, 96(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a6, 88(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd a7, 80(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t3, 72(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t4, 64(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t5, 56(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    sd t6, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    .cfi_offset t0, -112
-; RV64IZCMP-NEXT:    .cfi_offset t1, -120
-; RV64IZCMP-NEXT:    .cfi_offset t2, -128
-; RV64IZCMP-NEXT:    .cfi_offset a0, -136
-; RV64IZCMP-NEXT:    .cfi_offset a1, -144
-; RV64IZCMP-NEXT:    .cfi_offset a2, -152
-; RV64IZCMP-NEXT:    .cfi_offset a3, -160
-; RV64IZCMP-NEXT:    .cfi_offset a4, -168
-; RV64IZCMP-NEXT:    .cfi_offset a5, -176
-; RV64IZCMP-NEXT:    .cfi_offset a6, -184
-; RV64IZCMP-NEXT:    .cfi_offset a7, -192
-; RV64IZCMP-NEXT:    .cfi_offset t3, -200
-; RV64IZCMP-NEXT:    .cfi_offset t4, -208
-; RV64IZCMP-NEXT:    .cfi_offset t5, -216
-; RV64IZCMP-NEXT:    .cfi_offset t6, -224
+; RV64IZCMP-NEXT:    addi sp, sp, -128
+; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 288
+; RV64IZCMP-NEXT:    sd t0, 168(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t1, 160(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t2, 152(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a1, 136(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a2, 128(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a3, 120(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a4, 112(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a5, 104(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a6, 96(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a7, 88(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t3, 80(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t4, 72(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t5, 64(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd t6, 56(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    .cfi_offset t0, -120
+; RV64IZCMP-NEXT:    .cfi_offset t1, -128
+; RV64IZCMP-NEXT:    .cfi_offset t2, -136
+; RV64IZCMP-NEXT:    .cfi_offset a0, -144
+; RV64IZCMP-NEXT:    .cfi_offset a1, -152
+; RV64IZCMP-NEXT:    .cfi_offset a2, -160
+; RV64IZCMP-NEXT:    .cfi_offset a3, -168
+; RV64IZCMP-NEXT:    .cfi_offset a4, -176
+; RV64IZCMP-NEXT:    .cfi_offset a5, -184
+; RV64IZCMP-NEXT:    .cfi_offset a6, -192
+; RV64IZCMP-NEXT:    .cfi_offset a7, -200
+; RV64IZCMP-NEXT:    .cfi_offset t3, -208
+; RV64IZCMP-NEXT:    .cfi_offset t4, -216
+; RV64IZCMP-NEXT:    .cfi_offset t5, -224
+; RV64IZCMP-NEXT:    .cfi_offset t6, -232
 ; RV64IZCMP-NEXT:    lui t0, %hi(var_test_irq)
 ; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV64IZCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV64IZCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV64IZCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV64IZCMP-NEXT:    lw a0, 16(a5)
-; RV64IZCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    lw a0, 20(a5)
-; RV64IZCMP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    lw t4, 24(a5)
 ; RV64IZCMP-NEXT:    lw t5, 28(a5)
 ; RV64IZCMP-NEXT:    lw t6, 32(a5)
@@ -2565,33 +2573,33 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-NEXT:    sw t6, 32(a5)
 ; RV64IZCMP-NEXT:    sw t5, 28(a5)
 ; RV64IZCMP-NEXT:    sw t4, 24(a5)
-; RV64IZCMP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    sw a0, 20(a5)
 ; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    sw a0, 16(a5)
+; RV64IZCMP-NEXT:    sw a0, 20(a5)
 ; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV64IZCMP-NEXT:    sw a0, 16(a5)
 ; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
 ; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
 ; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV64IZCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV64IZCMP-NEXT:    ld t0, 160(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t1, 152(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t2, 144(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a1, 128(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a2, 120(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a3, 112(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a4, 104(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a5, 96(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a6, 88(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld a7, 80(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t3, 72(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t4, 64(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t5, 56(sp) # 8-byte Folded Reload
-; RV64IZCMP-NEXT:    ld t6, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t0, 168(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t1, 160(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t2, 152(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a1, 136(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a2, 128(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a3, 120(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a4, 112(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a5, 104(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a6, 96(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a7, 88(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t3, 80(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t4, 72(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t5, 64(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld t6, 56(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    .cfi_restore t0
 ; RV64IZCMP-NEXT:    .cfi_restore t1
 ; RV64IZCMP-NEXT:    .cfi_restore t2
@@ -2607,7 +2615,7 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-NEXT:    .cfi_restore t4
 ; RV64IZCMP-NEXT:    .cfi_restore t5
 ; RV64IZCMP-NEXT:    .cfi_restore t6
-; RV64IZCMP-NEXT:    addi sp, sp, 112
+; RV64IZCMP-NEXT:    addi sp, sp, 128
 ; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 160
 ; RV64IZCMP-NEXT:    cm.pop {ra, s0-s11}, 160
 ; RV64IZCMP-NEXT:    .cfi_restore ra
@@ -2643,52 +2651,52 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-SR-NEXT:    .cfi_offset s9, -12
 ; RV32IZCMP-SR-NEXT:    .cfi_offset s10, -8
 ; RV32IZCMP-SR-NEXT:    .cfi_offset s11, -4
-; RV32IZCMP-SR-NEXT:    addi sp, sp, -32
-; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 144
-; RV32IZCMP-SR-NEXT:    sw t0, 88(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t1, 84(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t2, 80(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a2, 68(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a4, 60(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a5, 56(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a6, 52(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw a7, 48(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t3, 44(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t4, 40(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    sw t6, 32(sp) # 4-byte Folded Spill
-; RV32IZCMP-SR-NEXT:    .cfi_offset t0, -56
-; RV32IZCMP-SR-NEXT:    .cfi_offset t1, -60
-; RV32IZCMP-SR-NEXT:    .cfi_offset t2, -64
-; RV32IZCMP-SR-NEXT:    .cfi_offset a0, -68
-; RV32IZCMP-SR-NEXT:    .cfi_offset a1, -72
-; RV32IZCMP-SR-NEXT:    .cfi_offset a2, -76
-; RV32IZCMP-SR-NEXT:    .cfi_offset a3, -80
-; RV32IZCMP-SR-NEXT:    .cfi_offset a4, -84
-; RV32IZCMP-SR-NEXT:    .cfi_offset a5, -88
-; RV32IZCMP-SR-NEXT:    .cfi_offset a6, -92
-; RV32IZCMP-SR-NEXT:    .cfi_offset a7, -96
-; RV32IZCMP-SR-NEXT:    .cfi_offset t3, -100
-; RV32IZCMP-SR-NEXT:    .cfi_offset t4, -104
-; RV32IZCMP-SR-NEXT:    .cfi_offset t5, -108
-; RV32IZCMP-SR-NEXT:    .cfi_offset t6, -112
+; RV32IZCMP-SR-NEXT:    addi sp, sp, -48
+; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 160
+; RV32IZCMP-SR-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t2, 84(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a6, 56(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t3, 48(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t4, 44(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t5, 40(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw t6, 36(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    .cfi_offset t0, -68
+; RV32IZCMP-SR-NEXT:    .cfi_offset t1, -72
+; RV32IZCMP-SR-NEXT:    .cfi_offset t2, -76
+; RV32IZCMP-SR-NEXT:    .cfi_offset a0, -80
+; RV32IZCMP-SR-NEXT:    .cfi_offset a1, -84
+; RV32IZCMP-SR-NEXT:    .cfi_offset a2, -88
+; RV32IZCMP-SR-NEXT:    .cfi_offset a3, -92
+; RV32IZCMP-SR-NEXT:    .cfi_offset a4, -96
+; RV32IZCMP-SR-NEXT:    .cfi_offset a5, -100
+; RV32IZCMP-SR-NEXT:    .cfi_offset a6, -104
+; RV32IZCMP-SR-NEXT:    .cfi_offset a7, -108
+; RV32IZCMP-SR-NEXT:    .cfi_offset t3, -112
+; RV32IZCMP-SR-NEXT:    .cfi_offset t4, -116
+; RV32IZCMP-SR-NEXT:    .cfi_offset t5, -120
+; RV32IZCMP-SR-NEXT:    .cfi_offset t6, -124
 ; RV32IZCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
 ; RV32IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV32IZCMP-SR-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV32IZCMP-SR-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV32IZCMP-SR-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV32IZCMP-SR-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV32IZCMP-SR-NEXT:    lw a0, 16(a5)
-; RV32IZCMP-SR-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw a0, 20(a5)
-; RV32IZCMP-SR-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw t4, 24(a5)
 ; RV32IZCMP-SR-NEXT:    lw t5, 28(a5)
 ; RV32IZCMP-SR-NEXT:    lw t6, 32(a5)
@@ -2741,33 +2749,33 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-SR-NEXT:    sw t6, 32(a5)
 ; RV32IZCMP-SR-NEXT:    sw t5, 28(a5)
 ; RV32IZCMP-SR-NEXT:    sw t4, 24(a5)
-; RV32IZCMP-SR-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-SR-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, 16(a5)
+; RV32IZCMP-SR-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-SR-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV32IZCMP-SR-NEXT:    sw a0, 16(a5)
 ; RV32IZCMP-SR-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
 ; RV32IZCMP-SR-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
 ; RV32IZCMP-SR-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IZCMP-SR-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV32IZCMP-SR-NEXT:    lw t0, 88(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t1, 84(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t2, 80(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a6, 52(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw a7, 48(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t3, 44(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t4, 40(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t5, 36(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    lw t6, 32(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t0, 92(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t1, 88(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t2, 84(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a2, 72(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t3, 48(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t4, 44(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t5, 40(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    lw t6, 36(sp) # 4-byte Folded Reload
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t0
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t1
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t2
@@ -2783,7 +2791,7 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t4
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t5
 ; RV32IZCMP-SR-NEXT:    .cfi_restore t6
-; RV32IZCMP-SR-NEXT:    addi sp, sp, 32
+; RV32IZCMP-SR-NEXT:    addi sp, sp, 48
 ; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 112
 ; RV32IZCMP-SR-NEXT:    cm.pop {ra, s0-s11}, 112
 ; RV32IZCMP-SR-NEXT:    .cfi_restore ra
@@ -2819,52 +2827,52 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-SR-NEXT:    .cfi_offset s9, -24
 ; RV64IZCMP-SR-NEXT:    .cfi_offset s10, -16
 ; RV64IZCMP-SR-NEXT:    .cfi_offset s11, -8
-; RV64IZCMP-SR-NEXT:    addi sp, sp, -112
-; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 272
-; RV64IZCMP-SR-NEXT:    sd t0, 160(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t1, 152(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t2, 144(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a1, 128(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a2, 120(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a3, 112(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a4, 104(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a5, 96(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a6, 88(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd a7, 80(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t3, 72(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t4, 64(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t5, 56(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    sd t6, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    .cfi_offset t0, -112
-; RV64IZCMP-SR-NEXT:    .cfi_offset t1, -120
-; RV64IZCMP-SR-NEXT:    .cfi_offset t2, -128
-; RV64IZCMP-SR-NEXT:    .cfi_offset a0, -136
-; RV64IZCMP-SR-NEXT:    .cfi_offset a1, -144
-; RV64IZCMP-SR-NEXT:    .cfi_offset a2, -152
-; RV64IZCMP-SR-NEXT:    .cfi_offset a3, -160
-; RV64IZCMP-SR-NEXT:    .cfi_offset a4, -168
-; RV64IZCMP-SR-NEXT:    .cfi_offset a5, -176
-; RV64IZCMP-SR-NEXT:    .cfi_offset a6, -184
-; RV64IZCMP-SR-NEXT:    .cfi_offset a7, -192
-; RV64IZCMP-SR-NEXT:    .cfi_offset t3, -200
-; RV64IZCMP-SR-NEXT:    .cfi_offset t4, -208
-; RV64IZCMP-SR-NEXT:    .cfi_offset t5, -216
-; RV64IZCMP-SR-NEXT:    .cfi_offset t6, -224
+; RV64IZCMP-SR-NEXT:    addi sp, sp, -128
+; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 288
+; RV64IZCMP-SR-NEXT:    sd t0, 168(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t1, 160(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t2, 152(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a1, 136(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a2, 128(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a3, 120(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a4, 112(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a5, 104(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a6, 96(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a7, 88(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t3, 80(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t4, 72(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t5, 64(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd t6, 56(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    .cfi_offset t0, -120
+; RV64IZCMP-SR-NEXT:    .cfi_offset t1, -128
+; RV64IZCMP-SR-NEXT:    .cfi_offset t2, -136
+; RV64IZCMP-SR-NEXT:    .cfi_offset a0, -144
+; RV64IZCMP-SR-NEXT:    .cfi_offset a1, -152
+; RV64IZCMP-SR-NEXT:    .cfi_offset a2, -160
+; RV64IZCMP-SR-NEXT:    .cfi_offset a3, -168
+; RV64IZCMP-SR-NEXT:    .cfi_offset a4, -176
+; RV64IZCMP-SR-NEXT:    .cfi_offset a5, -184
+; RV64IZCMP-SR-NEXT:    .cfi_offset a6, -192
+; RV64IZCMP-SR-NEXT:    .cfi_offset a7, -200
+; RV64IZCMP-SR-NEXT:    .cfi_offset t3, -208
+; RV64IZCMP-SR-NEXT:    .cfi_offset t4, -216
+; RV64IZCMP-SR-NEXT:    .cfi_offset t5, -224
+; RV64IZCMP-SR-NEXT:    .cfi_offset t6, -232
 ; RV64IZCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
 ; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV64IZCMP-SR-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
 ; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV64IZCMP-SR-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
 ; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV64IZCMP-SR-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
 ; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV64IZCMP-SR-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
 ; RV64IZCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV64IZCMP-SR-NEXT:    lw a0, 16(a5)
-; RV64IZCMP-SR-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64IZCMP-SR-NEXT:    lw a0, 20(a5)
-; RV64IZCMP-SR-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
 ; RV64IZCMP-SR-NEXT:    lw t4, 24(a5)
 ; RV64IZCMP-SR-NEXT:    lw t5, 28(a5)
 ; RV64IZCMP-SR-NEXT:    lw t6, 32(a5)
@@ -2917,33 +2925,33 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-SR-NEXT:    sw t6, 32(a5)
 ; RV64IZCMP-SR-NEXT:    sw t5, 28(a5)
 ; RV64IZCMP-SR-NEXT:    sw t4, 24(a5)
-; RV64IZCMP-SR-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    sw a0, 20(a5)
 ; RV64IZCMP-SR-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    sw a0, 16(a5)
+; RV64IZCMP-SR-NEXT:    sw a0, 20(a5)
 ; RV64IZCMP-SR-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV64IZCMP-SR-NEXT:    sw a0, 16(a5)
 ; RV64IZCMP-SR-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
 ; RV64IZCMP-SR-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
 ; RV64IZCMP-SR-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV64IZCMP-SR-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV64IZCMP-SR-NEXT:    ld t0, 160(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t1, 152(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t2, 144(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a1, 128(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a2, 120(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a3, 112(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a4, 104(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a5, 96(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a6, 88(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld a7, 80(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t3, 72(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t4, 64(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t5, 56(sp) # 8-byte Folded Reload
-; RV64IZCMP-SR-NEXT:    ld t6, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t0, 168(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t1, 160(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t2, 152(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a1, 136(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a2, 128(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a3, 120(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a4, 112(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a5, 104(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a6, 96(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a7, 88(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t3, 80(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t4, 72(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t5, 64(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld t6, 56(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t0
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t1
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t2
@@ -2959,7 +2967,7 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t4
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t5
 ; RV64IZCMP-SR-NEXT:    .cfi_restore t6
-; RV64IZCMP-SR-NEXT:    addi sp, sp, 112
+; RV64IZCMP-SR-NEXT:    addi sp, sp, 128
 ; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 160
 ; RV64IZCMP-SR-NEXT:    cm.pop {ra, s0-s11}, 160
 ; RV64IZCMP-SR-NEXT:    .cfi_restore ra
@@ -3381,8 +3389,8 @@ define void @callee_with_irq() "interrupt"="machine" {
 define void @callee_no_irq() {
 ; RV32IZCMP-LABEL: callee_no_irq:
 ; RV32IZCMP:       # %bb.0:
-; RV32IZCMP-NEXT:    cm.push {ra, s0-s11}, -80
-; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 80
+; RV32IZCMP-NEXT:    cm.push {ra, s0-s11}, -96
+; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 96
 ; RV32IZCMP-NEXT:    .cfi_offset ra, -52
 ; RV32IZCMP-NEXT:    .cfi_offset s0, -48
 ; RV32IZCMP-NEXT:    .cfi_offset s1, -44
@@ -3398,18 +3406,18 @@ define void @callee_no_irq() {
 ; RV32IZCMP-NEXT:    .cfi_offset s11, -4
 ; RV32IZCMP-NEXT:    lui t0, %hi(var_test_irq)
 ; RV32IZCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV32IZCMP-NEXT:    lw a0, 16(a5)
-; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw a0, 20(a5)
-; RV32IZCMP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IZCMP-NEXT:    lw t4, 24(a5)
 ; RV32IZCMP-NEXT:    lw t5, 28(a5)
 ; RV32IZCMP-NEXT:    lw t6, 32(a5)
@@ -3462,19 +3470,19 @@ define void @callee_no_irq() {
 ; RV32IZCMP-NEXT:    sw t6, 32(a5)
 ; RV32IZCMP-NEXT:    sw t5, 28(a5)
 ; RV32IZCMP-NEXT:    sw t4, 24(a5)
-; RV32IZCMP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, 16(a5)
+; RV32IZCMP-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV32IZCMP-NEXT:    sw a0, 16(a5)
 ; RV32IZCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
 ; RV32IZCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
 ; RV32IZCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IZCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IZCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV32IZCMP-NEXT:    cm.popret {ra, s0-s11}, 80
+; RV32IZCMP-NEXT:    cm.popret {ra, s0-s11}, 96
 ;
 ; RV64IZCMP-LABEL: callee_no_irq:
 ; RV64IZCMP:       # %bb.0:
@@ -3495,18 +3503,18 @@ define void @callee_no_irq() {
 ; RV64IZCMP-NEXT:    .cfi_offset s11, -8
 ; RV64IZCMP-NEXT:    lui t0, %hi(var_test_irq)
 ; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV64IZCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
 ; RV64IZCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
+; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
 ; RV64IZCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
+; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
 ; RV64IZCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
+; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV64IZCMP-NEXT:    lw a0, 16(a5)
-; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IZCMP-NEXT:    lw a0, 20(a5)
 ; RV64IZCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 20(a5)
+; RV64IZCMP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
 ; RV64IZCMP-NEXT:    lw t4, 24(a5)
 ; RV64IZCMP-NEXT:    lw t5, 28(a5)
 ; RV64IZCMP-NEXT:    lw t6, 32(a5)
@@ -3559,24 +3567,24 @@ define void @callee_no_irq() {
 ; RV64IZCMP-NEXT:    sw t6, 32(a5)
 ; RV64IZCMP-NEXT:    sw t5, 28(a5)
 ; RV64IZCMP-NEXT:    sw t4, 24(a5)
-; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 20(a5)
-; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, 16(a5)
-; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
-; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
-; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
-; RV64IZCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64IZCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
 ; RV64IZCMP-NEXT:    cm.popret {ra, s0-s11}, 160
 ;
 ; RV32IZCMP-SR-LABEL: callee_no_irq:
 ; RV32IZCMP-SR:       # %bb.0:
-; RV32IZCMP-SR-NEXT:    cm.push {ra, s0-s11}, -80
-; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 80
+; RV32IZCMP-SR-NEXT:    cm.push {ra, s0-s11}, -96
+; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 96
 ; RV32IZCMP-SR-NEXT:    .cfi_offset ra, -52
 ; RV32IZCMP-SR-NEXT:    .cfi_offset s0, -48
 ; RV32IZCMP-SR-NEXT:    .cfi_offset s1, -44
@@ -3592,18 +3600,18 @@ define void @callee_no_irq() {
 ; RV32IZCMP-SR-NEXT:    .cfi_offset s11, -4
 ; RV32IZCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
 ; RV32IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV32IZCMP-SR-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV32IZCMP-SR-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV32IZCMP-SR-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV32IZCMP-SR-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV32IZCMP-SR-NEXT:    lw a0, 16(a5)
-; RV32IZCMP-SR-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw a0, 20(a5)
-; RV32IZCMP-SR-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-SR-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IZCMP-SR-NEXT:    lw t4, 24(a5)
 ; RV32IZCMP-SR-NEXT:    lw t5, 28(a5)
 ; RV32IZCMP-SR-NEXT:    lw t6, 32(a5)
@@ -3656,19 +3664,19 @@ define void @callee_no_irq() {
 ; RV32IZCMP-SR-NEXT:    sw t6, 32(a5)
 ; RV32IZCMP-SR-NEXT:    sw t5, 28(a5)
 ; RV32IZCMP-SR-NEXT:    sw t4, 24(a5)
-; RV32IZCMP-SR-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-SR-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, 16(a5)
+; RV32IZCMP-SR-NEXT:    sw a0, 20(a5)
 ; RV32IZCMP-SR-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV32IZCMP-SR-NEXT:    sw a0, 16(a5)
 ; RV32IZCMP-SR-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
 ; RV32IZCMP-SR-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
 ; RV32IZCMP-SR-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IZCMP-SR-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV32IZCMP-SR-NEXT:    cm.popret {ra, s0-s11}, 80
+; RV32IZCMP-SR-NEXT:    cm.popret {ra, s0-s11}, 96
 ;
 ; RV64IZCMP-SR-LABEL: callee_no_irq:
 ; RV64IZCMP-SR:       # %bb.0:
@@ -3689,18 +3697,18 @@ define void @callee_no_irq() {
 ; RV64IZCMP-SR-NEXT:    .cfi_offset s11, -8
 ; RV64IZCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
 ; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV64IZCMP-SR-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
 ; RV64IZCMP-SR-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
+; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
 ; RV64IZCMP-SR-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
+; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
 ; RV64IZCMP-SR-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
+; RV64IZCMP-SR-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64IZCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV64IZCMP-SR-NEXT:    lw a0, 16(a5)
-; RV64IZCMP-SR-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IZCMP-SR-NEXT:    lw a0, 20(a5)
 ; RV64IZCMP-SR-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-SR-NEXT:    lw a0, 20(a5)
+; RV64IZCMP-SR-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
 ; RV64IZCMP-SR-NEXT:    lw t4, 24(a5)
 ; RV64IZCMP-SR-NEXT:    lw t5, 28(a5)
 ; RV64IZCMP-SR-NEXT:    lw t6, 32(a5)
@@ -3753,17 +3761,17 @@ define void @callee_no_irq() {
 ; RV64IZCMP-SR-NEXT:    sw t6, 32(a5)
 ; RV64IZCMP-SR-NEXT:    sw t5, 28(a5)
 ; RV64IZCMP-SR-NEXT:    sw t4, 24(a5)
-; RV64IZCMP-SR-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    sw a0, 20(a5)
-; RV64IZCMP-SR-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    sw a0, 16(a5)
-; RV64IZCMP-SR-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
-; RV64IZCMP-SR-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
-; RV64IZCMP-SR-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
-; RV64IZCMP-SR-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-SR-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64IZCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
 ; RV64IZCMP-SR-NEXT:    cm.popret {ra, s0-s11}, 160
 ;
@@ -4053,71 +4061,71 @@ declare ptr @llvm.frameaddress.p0(i32 immarg)
 define i32 @use_fp(i32 %x) {
 ; RV32IZCMP-LABEL: use_fp:
 ; RV32IZCMP:       # %bb.0: # %entry
-; RV32IZCMP-NEXT:    cm.push {ra, s0-s1}, -16
-; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 16
+; RV32IZCMP-NEXT:    cm.push {ra, s0-s1}, -32
+; RV32IZCMP-NEXT:    .cfi_def_cfa_offset 32
 ; RV32IZCMP-NEXT:    .cfi_offset ra, -12
 ; RV32IZCMP-NEXT:    .cfi_offset s0, -8
 ; RV32IZCMP-NEXT:    .cfi_offset s1, -4
-; RV32IZCMP-NEXT:    addi s0, sp, 16
+; RV32IZCMP-NEXT:    addi s0, sp, 32
 ; RV32IZCMP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IZCMP-NEXT:    mv s1, a0
-; RV32IZCMP-NEXT:    addi a1, s0, -16
+; RV32IZCMP-NEXT:    addi a1, s0, -20
 ; RV32IZCMP-NEXT:    mv a0, s0
 ; RV32IZCMP-NEXT:    call bar
 ; RV32IZCMP-NEXT:    mv a0, s1
-; RV32IZCMP-NEXT:    .cfi_def_cfa sp, 16
-; RV32IZCMP-NEXT:    cm.popret {ra, s0-s1}, 16
+; RV32IZCMP-NEXT:    .cfi_def_cfa sp, 32
+; RV32IZCMP-NEXT:    cm.popret {ra, s0-s1}, 32
 ;
 ; RV64IZCMP-LABEL: use_fp:
 ; RV64IZCMP:       # %bb.0: # %entry
-; RV64IZCMP-NEXT:    cm.push {ra, s0-s1}, -32
-; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 32
+; RV64IZCMP-NEXT:    cm.push {ra, s0-s1}, -48
+; RV64IZCMP-NEXT:    .cfi_def_cfa_offset 48
 ; RV64IZCMP-NEXT:    .cfi_offset ra, -24
 ; RV64IZCMP-NEXT:    .cfi_offset s0, -16
 ; RV64IZCMP-NEXT:    .cfi_offset s1, -8
-; RV64IZCMP-NEXT:    addi s0, sp, 32
+; RV64IZCMP-NEXT:    addi s0, sp, 48
 ; RV64IZCMP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IZCMP-NEXT:    mv s1, a0
-; RV64IZCMP-NEXT:    addi a1, s0, -28
+; RV64IZCMP-NEXT:    addi a1, s0, -36
 ; RV64IZCMP-NEXT:    mv a0, s0
 ; RV64IZCMP-NEXT:    call bar
 ; RV64IZCMP-NEXT:    mv a0, s1
-; RV64IZCMP-NEXT:    .cfi_def_cfa sp, 32
-; RV64IZCMP-NEXT:    cm.popret {ra, s0-s1}, 32
+; RV64IZCMP-NEXT:    .cfi_def_cfa sp, 48
+; RV64IZCMP-NEXT:    cm.popret {ra, s0-s1}, 48
 ;
 ; RV32IZCMP-SR-LABEL: use_fp:
 ; RV32IZCMP-SR:       # %bb.0: # %entry
-; RV32IZCMP-SR-NEXT:    cm.push {ra, s0-s1}, -16
-; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 16
+; RV32IZCMP-SR-NEXT:    cm.push {ra, s0-s1}, -32
+; RV32IZCMP-SR-NEXT:    .cfi_def_cfa_offset 32
 ; RV32IZCMP-SR-NEXT:    .cfi_offset ra, -12
 ; RV32IZCMP-SR-NEXT:    .cfi_offset s0, -8
 ; RV32IZCMP-SR-NEXT:    .cfi_offset s1, -4
-; RV32IZCMP-SR-NEXT:    addi s0, sp, 16
+; RV32IZCMP-SR-NEXT:    addi s0, sp, 32
 ; RV32IZCMP-SR-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IZCMP-SR-NEXT:    mv s1, a0
-; RV32IZCMP-SR-NEXT:    addi a1, s0, -16
+; RV32IZCMP-SR-NEXT:    addi a1, s0, -20
 ; RV32IZCMP-SR-NEXT:    mv a0, s0
 ; RV32IZCMP-SR-NEXT:    call bar
 ; RV32IZCMP-SR-NEXT:    mv a0, s1
-; RV32IZCMP-SR-NEXT:    .cfi_def_cfa sp, 16
-; RV32IZCMP-SR-NEXT:    cm.popret {ra, s0-s1}, 16
+; RV32IZCMP-SR-NEXT:    .cfi_def_cfa sp, 32
+; RV32IZCMP-SR-NEXT:    cm.popret {ra, s0-s1}, 32
 ;
 ; RV64IZCMP-SR-LABEL: use_fp:
 ; RV64IZCMP-SR:       # %bb.0: # %entry
-; RV64IZCMP-SR-NEXT:    cm.push {ra, s0-s1}, -32
-; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 32
+; RV64IZCMP-SR-NEXT:    cm.push {ra, s0-s1}, -48
+; RV64IZCMP-SR-NEXT:    .cfi_def_cfa_offset 48
 ; RV64IZCMP-SR-NEXT:    .cfi_offset ra, -24
 ; RV64IZCMP-SR-NEXT:    .cfi_offset s0, -16
 ; RV64IZCMP-SR-NEXT:    .cfi_offset s1, -8
-; RV64IZCMP-SR-NEXT:    addi s0, sp, 32
+; RV64IZCMP-SR-NEXT:    addi s0, sp, 48
 ; RV64IZCMP-SR-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IZCMP-SR-NEXT:    mv s1, a0
-; RV64IZCMP-SR-NEXT:    addi a1, s0, -28
+; RV64IZCMP-SR-NEXT:    addi a1, s0, -36
 ; RV64IZCMP-SR-NEXT:    mv a0, s0
 ; RV64IZCMP-SR-NEXT:    call bar
 ; RV64IZCMP-SR-NEXT:    mv a0, s1
-; RV64IZCMP-SR-NEXT:    .cfi_def_cfa sp, 32
-; RV64IZCMP-SR-NEXT:    cm.popret {ra, s0-s1}, 32
+; RV64IZCMP-SR-NEXT:    .cfi_def_cfa sp, 48
+; RV64IZCMP-SR-NEXT:    cm.popret {ra, s0-s1}, 48
 ;
 ; RV32I-LABEL: use_fp:
 ; RV32I:       # %bb.0: # %entry

--- a/llvm/test/CodeGen/RISCV/rvv/rv32-spill-vector-csr.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rv32-spill-vector-csr.ll
@@ -108,35 +108,39 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ;
 ; SPILL-O2-ZCMP-LABEL: foo:
 ; SPILL-O2-ZCMP:       # %bb.0:
-; SPILL-O2-ZCMP-NEXT:    cm.push {ra, s0}, -16
-; SPILL-O2-ZCMP-NEXT:    .cfi_def_cfa_offset 16
+; SPILL-O2-ZCMP-NEXT:    cm.push {ra, s0}, -32
+; SPILL-O2-ZCMP-NEXT:    .cfi_def_cfa_offset 32
 ; SPILL-O2-ZCMP-NEXT:    .cfi_offset ra, -8
 ; SPILL-O2-ZCMP-NEXT:    .cfi_offset s0, -4
 ; SPILL-O2-ZCMP-NEXT:    csrr a1, vlenb
 ; SPILL-O2-ZCMP-NEXT:    slli a1, a1, 1
 ; SPILL-O2-ZCMP-NEXT:    sub sp, sp, a1
-; SPILL-O2-ZCMP-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
+; SPILL-O2-ZCMP-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x20, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 32 + 2 * vlenb
 ; SPILL-O2-ZCMP-NEXT:    mv s0, a0
-; SPILL-O2-ZCMP-NEXT:    vs1r.v v8, (sp) # vscale x 8-byte Folded Spill
+; SPILL-O2-ZCMP-NEXT:    addi a1, sp, 16
+; SPILL-O2-ZCMP-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
 ; SPILL-O2-ZCMP-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; SPILL-O2-ZCMP-NEXT:    vfadd.vv v9, v8, v9
 ; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
 ; SPILL-O2-ZCMP-NEXT:    add a0, a0, sp
+; SPILL-O2-ZCMP-NEXT:    addi a0, a0, 16
 ; SPILL-O2-ZCMP-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
 ; SPILL-O2-ZCMP-NEXT:    lui a0, %hi(.L.str)
 ; SPILL-O2-ZCMP-NEXT:    addi a0, a0, %lo(.L.str)
 ; SPILL-O2-ZCMP-NEXT:    call puts
 ; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
 ; SPILL-O2-ZCMP-NEXT:    add a0, a0, sp
+; SPILL-O2-ZCMP-NEXT:    addi a0, a0, 16
 ; SPILL-O2-ZCMP-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-NEXT:    vl1r.v v9, (sp) # vscale x 8-byte Folded Reload
+; SPILL-O2-ZCMP-NEXT:    addi a0, sp, 16
+; SPILL-O2-ZCMP-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
 ; SPILL-O2-ZCMP-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
 ; SPILL-O2-ZCMP-NEXT:    vfadd.vv v8, v9, v8
 ; SPILL-O2-ZCMP-NEXT:    csrr a0, vlenb
 ; SPILL-O2-ZCMP-NEXT:    slli a0, a0, 1
 ; SPILL-O2-ZCMP-NEXT:    add sp, sp, a0
-; SPILL-O2-ZCMP-NEXT:    .cfi_def_cfa sp, 16
-; SPILL-O2-ZCMP-NEXT:    cm.popret {ra, s0}, 16
+; SPILL-O2-ZCMP-NEXT:    .cfi_def_cfa sp, 32
+; SPILL-O2-ZCMP-NEXT:    cm.popret {ra, s0}, 32
 ;
 ; SPILL-O0-VSETVLI-LABEL: foo:
 ; SPILL-O0-VSETVLI:       # %bb.0:
@@ -227,33 +231,37 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ;
 ; SPILL-O2-ZCMP-VSETVLI-LABEL: foo:
 ; SPILL-O2-ZCMP-VSETVLI:       # %bb.0:
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    cm.push {ra, s0}, -16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_def_cfa_offset 16
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    cm.push {ra, s0}, -32
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_def_cfa_offset 32
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_offset ra, -8
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_offset s0, -4
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    sub sp, sp, a1
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x20, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 32 + 2 * vlenb
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    mv s0, a0
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vs1r.v v8, (sp) # vscale x 8-byte Folded Spill
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a1, sp, 16
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    vs1r.v v8, (a1) # vscale x 8-byte Folded Spill
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    vfadd.vv v9, v8, v9
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    csrr a0, vlenb
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    add a0, a0, sp
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, 16
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    vs1r.v v9, (a0) # vscale x 8-byte Folded Spill
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    lui a0, %hi(.L.str)
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, %lo(.L.str)
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    call puts
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    csrr a0, vlenb
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    add a0, a0, sp
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, a0, 16
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    vl1r.v v8, (a0) # vscale x 8-byte Folded Reload
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    vl1r.v v9, (sp) # vscale x 8-byte Folded Reload
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    addi a0, sp, 16
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli zero, s0, e64, m1, ta, ma
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    vfadd.vv v8, v9, v8
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    vsetvli a0, zero, e8, m2, ta, ma
 ; SPILL-O2-ZCMP-VSETVLI-NEXT:    add sp, sp, a0
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_def_cfa sp, 16
-; SPILL-O2-ZCMP-VSETVLI-NEXT:    cm.popret {ra, s0}, 16
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    .cfi_def_cfa sp, 32
+; SPILL-O2-ZCMP-VSETVLI-NEXT:    cm.popret {ra, s0}, 32
 {
    %x = call <vscale x 1 x double> @llvm.riscv.vfadd.nxv1f64.nxv1f64(<vscale x 1 x double> undef, <vscale x 1 x double> %a, <vscale x 1 x double> %b, i32 7, i32 %gvl)
    %call = call signext i32 @puts(ptr @.str)

--- a/llvm/test/CodeGen/RISCV/xqccmp-additional-stack.ll
+++ b/llvm/test/CodeGen/RISCV/xqccmp-additional-stack.ll
@@ -9,8 +9,8 @@ define ptr @func(ptr %s, i32 %_c, ptr %incdec.ptr, i1 %0, i8 %conv14) #0 {
 ; RV32-NEXT:    .cfi_offset ra, -4
 ; RV32-NEXT:    .cfi_offset s0, -8
 ; RV32-NEXT:    .cfi_offset s1, -12
-; RV32-NEXT:    addi sp, sp, -4
-; RV32-NEXT:    .cfi_def_cfa_offset 20
+; RV32-NEXT:    addi sp, sp, -8
+; RV32-NEXT:    .cfi_def_cfa_offset 24
 ; RV32-NEXT:    sw a4, 4(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sw a2, 0(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv a2, a1
@@ -34,7 +34,7 @@ define ptr @func(ptr %s, i32 %_c, ptr %incdec.ptr, i1 %0, i8 %conv14) #0 {
 ; RV32-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sb a0, 0(s0)
 ; RV32-NEXT:    mv a0, s1
-; RV32-NEXT:    addi sp, sp, 4
+; RV32-NEXT:    addi sp, sp, 8
 ; RV32-NEXT:    .cfi_def_cfa_offset 16
 ; RV32-NEXT:    qc.cm.popret {ra, s0-s1}, 16
 entry:

--- a/llvm/test/CodeGen/RISCV/xqccmp-callee-saved-gprs.ll
+++ b/llvm/test/CodeGen/RISCV/xqccmp-callee-saved-gprs.ll
@@ -16,8 +16,8 @@
 define void @callee() {
 ; RV32IXQCCMP-LABEL: callee:
 ; RV32IXQCCMP:       # %bb.0:
-; RV32IXQCCMP-NEXT:    qc.cm.push {ra, s0-s11}, -80
-; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 80
+; RV32IXQCCMP-NEXT:    qc.cm.push {ra, s0-s11}, -96
+; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 96
 ; RV32IXQCCMP-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-NEXT:    .cfi_offset s0, -8
 ; RV32IXQCCMP-NEXT:    .cfi_offset s1, -12
@@ -33,18 +33,18 @@ define void @callee() {
 ; RV32IXQCCMP-NEXT:    .cfi_offset s11, -52
 ; RV32IXQCCMP-NEXT:    lui t0, %hi(var)
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var+4)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var+8)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var+12)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    addi a5, t0, %lo(var)
 ; RV32IXQCCMP-NEXT:    lw a0, 16(a5)
-; RV32IXQCCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 20(a5)
-; RV32IXQCCMP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw t4, 24(a5)
 ; RV32IXQCCMP-NEXT:    lw t5, 28(a5)
 ; RV32IXQCCMP-NEXT:    lw t6, 32(a5)
@@ -97,24 +97,24 @@ define void @callee() {
 ; RV32IXQCCMP-NEXT:    sw t6, 32(a5)
 ; RV32IXQCCMP-NEXT:    sw t5, 28(a5)
 ; RV32IXQCCMP-NEXT:    sw t4, 24(a5)
-; RV32IXQCCMP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 20(a5)
 ; RV32IXQCCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 16(a5)
+; RV32IXQCCMP-NEXT:    sw a0, 20(a5)
 ; RV32IXQCCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var+12)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, 16(a5)
 ; RV32IXQCCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var+8)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var+12)(t0)
 ; RV32IXQCCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var+4)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var+8)(t0)
 ; RV32IXQCCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var+4)(t0)
+; RV32IXQCCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-NEXT:    sw a0, %lo(var)(t0)
-; RV32IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s11}, 80
+; RV32IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s11}, 96
 ;
 ; RV32IXQCCMP-WITH-FP-LABEL: callee:
 ; RV32IXQCCMP-WITH-FP:       # %bb.0:
-; RV32IXQCCMP-WITH-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -80
-; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 80
+; RV32IXQCCMP-WITH-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -96
+; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 96
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_offset s0, -8
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_offset s1, -12
@@ -131,20 +131,20 @@ define void @callee() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-WITH-FP-NEXT:    lui t1, %hi(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var)(t1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -56(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+4)(t1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -60(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+8)(t1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -64(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+12)(t1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -68(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+4)(t1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+8)(t1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+12)(t1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi a5, t1, %lo(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 16(a5)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -84(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(a5)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -88(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(a5)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -92(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw t5, 28(a5)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw t6, 32(a5)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s2, 36(a5)
@@ -195,22 +195,22 @@ define void @callee() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s2, 36(a5)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw t6, 32(a5)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw t5, 28(a5)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -92(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 24(a5)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -88(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 20(a5)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -84(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(a5)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+12)(t1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -64(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+8)(t1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -60(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+4)(t1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -56(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var)(t1)
-; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
-; RV32IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 80
+; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 96
+; RV32IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 96
 ;
 ; RV64IXQCCMP-LABEL: callee:
 ; RV64IXQCCMP:       # %bb.0:
@@ -231,18 +231,18 @@ define void @callee() {
 ; RV64IXQCCMP-NEXT:    .cfi_offset s11, -104
 ; RV64IXQCCMP-NEXT:    lui t0, %hi(var)
 ; RV64IXQCCMP-NEXT:    lw a0, %lo(var)(t0)
-; RV64IXQCCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var+4)(t0)
 ; RV64IXQCCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var+8)(t0)
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var+4)(t0)
 ; RV64IXQCCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var+12)(t0)
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var+8)(t0)
 ; RV64IXQCCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var+12)(t0)
+; RV64IXQCCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-NEXT:    addi a5, t0, %lo(var)
 ; RV64IXQCCMP-NEXT:    lw a0, 16(a5)
-; RV64IXQCCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 20(a5)
 ; RV64IXQCCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw a0, 20(a5)
+; RV64IXQCCMP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-NEXT:    lw t4, 24(a5)
 ; RV64IXQCCMP-NEXT:    lw t5, 28(a5)
 ; RV64IXQCCMP-NEXT:    lw t6, 32(a5)
@@ -295,17 +295,17 @@ define void @callee() {
 ; RV64IXQCCMP-NEXT:    sw t6, 32(a5)
 ; RV64IXQCCMP-NEXT:    sw t5, 28(a5)
 ; RV64IXQCCMP-NEXT:    sw t4, 24(a5)
-; RV64IXQCCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 20(a5)
-; RV64IXQCCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 16(a5)
-; RV64IXQCCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var+12)(t0)
-; RV64IXQCCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var+8)(t0)
-; RV64IXQCCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var+4)(t0)
-; RV64IXQCCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var)(t0)
 ; RV64IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
 ;
@@ -326,23 +326,25 @@ define void @callee() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_offset s9, -88
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_offset s10, -96
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_offset s11, -104
+; RV64IXQCCMP-WITH-FP-NEXT:    addi sp, sp, -16
+; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 176
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-WITH-FP-NEXT:    lui t1, %hi(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var)(t1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -112(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+4)(t1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -120(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+8)(t1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+4)(t1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -128(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+12)(t1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+8)(t1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -136(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+12)(t1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi a5, t1, %lo(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 16(a5)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 20(a5)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -152(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 24(a5)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 20(a5)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -160(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 24(a5)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -168(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw t5, 28(a5)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw t6, 32(a5)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s2, 36(a5)
@@ -393,21 +395,23 @@ define void @callee() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s2, 36(a5)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw t6, 32(a5)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw t5, 28(a5)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -168(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 24(a5)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 20(a5)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 16(a5)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+12)(t1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+8)(t1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+4)(t1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -112(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var)(t1)
-; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
+; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 176
+; RV64IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 16
+; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 160
 ; RV64IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
   %val = load [32 x i32], ptr @var
   store volatile [32 x i32] %val, ptr @var
@@ -435,54 +439,54 @@ define void @caller() {
 ; RV32IXQCCMP-NEXT:    .cfi_offset s9, -44
 ; RV32IXQCCMP-NEXT:    .cfi_offset s10, -48
 ; RV32IXQCCMP-NEXT:    .cfi_offset s11, -52
-; RV32IXQCCMP-NEXT:    addi sp, sp, -32
-; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 144
+; RV32IXQCCMP-NEXT:    addi sp, sp, -48
+; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 160
 ; RV32IXQCCMP-NEXT:    lui s0, %hi(var)
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var)(s0)
-; RV32IXQCCMP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var+4)(s0)
-; RV32IXQCCMP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var+8)(s0)
-; RV32IXQCCMP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var+12)(s0)
-; RV32IXQCCMP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    addi s1, s0, %lo(var)
 ; RV32IXQCCMP-NEXT:    lw a0, 16(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 20(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 24(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 28(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 32(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 36(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 40(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 44(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 48(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 52(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 56(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 60(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 64(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 68(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 72(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 76(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 80(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 84(s1)
-; RV32IXQCCMP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw s4, 88(s1)
 ; RV32IXQCCMP-NEXT:    lw s5, 92(s1)
 ; RV32IXQCCMP-NEXT:    lw s6, 96(s1)
@@ -504,51 +508,51 @@ define void @caller() {
 ; RV32IXQCCMP-NEXT:    sw s6, 96(s1)
 ; RV32IXQCCMP-NEXT:    sw s5, 92(s1)
 ; RV32IXQCCMP-NEXT:    sw s4, 88(s1)
-; RV32IXQCCMP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 84(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 80(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 84(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 76(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 80(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 72(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 76(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 68(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 72(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 64(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 68(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 60(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 64(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 56(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 60(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 52(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 56(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 48(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 52(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 44(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 48(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 40(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 44(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 36(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 40(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 32(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 36(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 28(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 32(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 24(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 28(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 20(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 24(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 16(s1)
+; RV32IXQCCMP-NEXT:    sw a0, 20(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var+12)(s0)
+; RV32IXQCCMP-NEXT:    sw a0, 16(s1)
 ; RV32IXQCCMP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var+8)(s0)
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var+12)(s0)
 ; RV32IXQCCMP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var+4)(s0)
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var+8)(s0)
 ; RV32IXQCCMP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var+4)(s0)
+; RV32IXQCCMP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-NEXT:    sw a0, %lo(var)(s0)
-; RV32IXQCCMP-NEXT:    addi sp, sp, 32
+; RV32IXQCCMP-NEXT:    addi sp, sp, 48
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 112
 ; RV32IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s11}, 112
 ;
@@ -569,57 +573,57 @@ define void @caller() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_offset s9, -44
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_offset s10, -48
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_offset s11, -52
-; RV32IXQCCMP-WITH-FP-NEXT:    addi sp, sp, -32
-; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 144
+; RV32IXQCCMP-WITH-FP-NEXT:    addi sp, sp, -48
+; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 160
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-WITH-FP-NEXT:    lui s6, %hi(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var)(s6)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -56(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+4)(s6)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -60(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+8)(s6)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -64(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+12)(s6)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -68(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+4)(s6)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+8)(s6)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+12)(s6)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi s1, s6, %lo(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -84(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -88(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -92(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -96(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -100(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -104(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -108(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -112(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -116(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -120(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -124(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -128(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -132(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -136(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -140(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 88(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -144(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -148(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -152(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 88(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -156(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s8, 92(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s9, 96(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s10, 100(s1)
@@ -639,54 +643,54 @@ define void @caller() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s10, 100(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s9, 96(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s8, 92(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -144(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -156(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 88(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -140(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -152(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -136(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -148(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -132(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -144(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -128(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -140(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -124(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -136(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -120(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -132(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -116(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -128(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -112(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -124(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -108(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -120(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -104(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -116(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -100(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -112(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -96(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -108(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -92(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -104(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -88(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -100(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -84(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -96(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -92(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -88(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -84(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+12)(s6)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -64(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+8)(s6)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -60(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+4)(s6)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -56(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var)(s6)
-; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 144
-; RV32IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 32
+; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
+; RV32IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 48
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 112
 ; RV32IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 112
 ;
@@ -711,50 +715,50 @@ define void @caller() {
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 288
 ; RV64IXQCCMP-NEXT:    lui s0, %hi(var)
 ; RV64IXQCCMP-NEXT:    lw a0, %lo(var)(s0)
-; RV64IXQCCMP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var+4)(s0)
 ; RV64IXQCCMP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var+8)(s0)
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var+4)(s0)
 ; RV64IXQCCMP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var+12)(s0)
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var+8)(s0)
 ; RV64IXQCCMP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var+12)(s0)
+; RV64IXQCCMP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-NEXT:    addi s1, s0, %lo(var)
 ; RV64IXQCCMP-NEXT:    lw a0, 16(s1)
-; RV64IXQCCMP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 20(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 24(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 20(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 28(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 24(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 32(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 28(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 36(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 32(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 40(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 36(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 44(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 40(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 48(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 44(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 52(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 48(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 56(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 52(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 60(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 56(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 64(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 60(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 68(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 64(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 72(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 68(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 76(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 72(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 80(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 76(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 84(s1)
+; RV64IXQCCMP-NEXT:    lw a0, 80(s1)
 ; RV64IXQCCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw a0, 84(s1)
+; RV64IXQCCMP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-NEXT:    lw s4, 88(s1)
 ; RV64IXQCCMP-NEXT:    lw s5, 92(s1)
 ; RV64IXQCCMP-NEXT:    lw s6, 96(s1)
@@ -776,49 +780,49 @@ define void @caller() {
 ; RV64IXQCCMP-NEXT:    sw s6, 96(s1)
 ; RV64IXQCCMP-NEXT:    sw s5, 92(s1)
 ; RV64IXQCCMP-NEXT:    sw s4, 88(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 84(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 80(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 76(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 72(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 68(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 64(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 60(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 56(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 52(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 48(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 44(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 40(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 36(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 32(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 28(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 24(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 20(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, 16(s1)
-; RV64IXQCCMP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var+12)(s0)
-; RV64IXQCCMP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var+8)(s0)
-; RV64IXQCCMP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var+4)(s0)
-; RV64IXQCCMP-NEXT:    ld a0, 176(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var)(s0)
 ; RV64IXQCCMP-NEXT:    addi sp, sp, 128
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 160
@@ -841,57 +845,57 @@ define void @caller() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_offset s9, -88
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_offset s10, -96
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_offset s11, -104
-; RV64IXQCCMP-WITH-FP-NEXT:    addi sp, sp, -128
-; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 288
+; RV64IXQCCMP-WITH-FP-NEXT:    addi sp, sp, -144
+; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 304
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-WITH-FP-NEXT:    lui s6, %hi(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var)(s6)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -112(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+4)(s6)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -120(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+8)(s6)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+4)(s6)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -128(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+12)(s6)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+8)(s6)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -136(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, %lo(var+12)(s6)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi s1, s6, %lo(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -152(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -160(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -168(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -176(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -184(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -192(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -200(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -208(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -216(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -224(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -232(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -240(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -248(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -256(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -264(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -272(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -280(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 88(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -288(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 88(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -296(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s8, 92(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s9, 96(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s10, 100(s1)
@@ -911,54 +915,54 @@ define void @caller() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s10, 100(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s9, 96(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s8, 92(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -288(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -296(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 88(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -280(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -288(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -272(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -280(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -264(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -272(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -256(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -264(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -248(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -256(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -240(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -248(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -232(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -240(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -224(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -232(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -216(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -224(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -208(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -216(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -200(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -208(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -192(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -200(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -184(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -192(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -176(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -184(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -168(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -176(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -168(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+12)(s6)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+8)(s6)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var+4)(s6)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -112(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, %lo(var)(s6)
-; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 288
-; RV64IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 128
+; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 304
+; RV64IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 144
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa_offset 160
 ; RV64IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
   %val = load [32 x i32], ptr @var

--- a/llvm/test/CodeGen/RISCV/xqccmp-push-pop-popret.ll
+++ b/llvm/test/CodeGen/RISCV/xqccmp-push-pop-popret.ll
@@ -24,7 +24,7 @@ define i32 @foo() {
 ; RV32IXQCCMP-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-NEXT:    addi sp, sp, -464
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 528
-; RV32IXQCCMP-NEXT:    addi a0, sp, 12
+; RV32IXQCCMP-NEXT:    mv a0, sp
 ; RV32IXQCCMP-NEXT:    call test
 ; RV32IXQCCMP-NEXT:    addi sp, sp, 464
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 64
@@ -37,7 +37,7 @@ define i32 @foo() {
 ; RV64IXQCCMP-NEXT:    .cfi_offset ra, -8
 ; RV64IXQCCMP-NEXT:    addi sp, sp, -464
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 528
-; RV64IXQCCMP-NEXT:    addi a0, sp, 8
+; RV64IXQCCMP-NEXT:    mv a0, sp
 ; RV64IXQCCMP-NEXT:    call test
 ; RV64IXQCCMP-NEXT:    addi sp, sp, 464
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 64
@@ -52,7 +52,7 @@ define i32 @foo() {
 ; RV32IXQCCMP-FP-NEXT:    addi sp, sp, -464
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 528
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
-; RV32IXQCCMP-FP-NEXT:    addi a0, s0, -520
+; RV32IXQCCMP-FP-NEXT:    addi a0, s0, -528
 ; RV32IXQCCMP-FP-NEXT:    call test
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 528
 ; RV32IXQCCMP-FP-NEXT:    addi sp, sp, 464
@@ -82,7 +82,7 @@ define i32 @foo() {
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-SR-NEXT:    addi sp, sp, -464
 ; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 528
-; RV32IXQCCMP-SR-NEXT:    addi a0, sp, 12
+; RV32IXQCCMP-SR-NEXT:    mv a0, sp
 ; RV32IXQCCMP-SR-NEXT:    call test
 ; RV32IXQCCMP-SR-NEXT:    addi sp, sp, 464
 ; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 64
@@ -95,7 +95,7 @@ define i32 @foo() {
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset ra, -8
 ; RV64IXQCCMP-SR-NEXT:    addi sp, sp, -464
 ; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 528
-; RV64IXQCCMP-SR-NEXT:    addi a0, sp, 8
+; RV64IXQCCMP-SR-NEXT:    mv a0, sp
 ; RV64IXQCCMP-SR-NEXT:    call test
 ; RV64IXQCCMP-SR-NEXT:    addi sp, sp, 464
 ; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 64
@@ -1595,52 +1595,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-NEXT:    qc.cm.push {ra}, -64
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 64
 ; RV32IXQCCMP-NEXT:    .cfi_offset ra, -4
-; RV32IXQCCMP-NEXT:    sw t0, 56(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t2, 48(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a2, 36(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a5, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a7, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t3, 12(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t4, 8(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t5, 4(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t6, 0(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    .cfi_offset t0, -8
-; RV32IXQCCMP-NEXT:    .cfi_offset t1, -12
-; RV32IXQCCMP-NEXT:    .cfi_offset t2, -16
-; RV32IXQCCMP-NEXT:    .cfi_offset a0, -20
-; RV32IXQCCMP-NEXT:    .cfi_offset a1, -24
-; RV32IXQCCMP-NEXT:    .cfi_offset a2, -28
-; RV32IXQCCMP-NEXT:    .cfi_offset a3, -32
-; RV32IXQCCMP-NEXT:    .cfi_offset a4, -36
-; RV32IXQCCMP-NEXT:    .cfi_offset a5, -40
-; RV32IXQCCMP-NEXT:    .cfi_offset a6, -44
-; RV32IXQCCMP-NEXT:    .cfi_offset a7, -48
-; RV32IXQCCMP-NEXT:    .cfi_offset t3, -52
-; RV32IXQCCMP-NEXT:    .cfi_offset t4, -56
-; RV32IXQCCMP-NEXT:    .cfi_offset t5, -60
-; RV32IXQCCMP-NEXT:    .cfi_offset t6, -64
+; RV32IXQCCMP-NEXT:    addi sp, sp, -16
+; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 80
+; RV32IXQCCMP-NEXT:    sw t0, 60(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t2, 52(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a5, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a6, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t3, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t4, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t5, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t6, 4(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    .cfi_offset t0, -20
+; RV32IXQCCMP-NEXT:    .cfi_offset t1, -24
+; RV32IXQCCMP-NEXT:    .cfi_offset t2, -28
+; RV32IXQCCMP-NEXT:    .cfi_offset a0, -32
+; RV32IXQCCMP-NEXT:    .cfi_offset a1, -36
+; RV32IXQCCMP-NEXT:    .cfi_offset a2, -40
+; RV32IXQCCMP-NEXT:    .cfi_offset a3, -44
+; RV32IXQCCMP-NEXT:    .cfi_offset a4, -48
+; RV32IXQCCMP-NEXT:    .cfi_offset a5, -52
+; RV32IXQCCMP-NEXT:    .cfi_offset a6, -56
+; RV32IXQCCMP-NEXT:    .cfi_offset a7, -60
+; RV32IXQCCMP-NEXT:    .cfi_offset t3, -64
+; RV32IXQCCMP-NEXT:    .cfi_offset t4, -68
+; RV32IXQCCMP-NEXT:    .cfi_offset t5, -72
+; RV32IXQCCMP-NEXT:    .cfi_offset t6, -76
 ; RV32IXQCCMP-NEXT:    call foo_test_irq
-; RV32IXQCCMP-NEXT:    lw t0, 56(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t1, 52(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t2, 48(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t3, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t5, 4(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t6, 0(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t0, 60(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a3, 36(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t3, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t4, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t6, 4(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-NEXT:    .cfi_restore t0
 ; RV32IXQCCMP-NEXT:    .cfi_restore t1
 ; RV32IXQCCMP-NEXT:    .cfi_restore t2
@@ -1656,6 +1658,8 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-NEXT:    .cfi_restore t4
 ; RV32IXQCCMP-NEXT:    .cfi_restore t5
 ; RV32IXQCCMP-NEXT:    .cfi_restore t6
+; RV32IXQCCMP-NEXT:    addi sp, sp, 16
+; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 64
 ; RV32IXQCCMP-NEXT:    qc.cm.pop {ra}, 64
 ; RV32IXQCCMP-NEXT:    .cfi_restore ra
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 0
@@ -1666,54 +1670,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-NEXT:    qc.cm.push {ra}, -64
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 64
 ; RV64IXQCCMP-NEXT:    .cfi_offset ra, -8
-; RV64IXQCCMP-NEXT:    addi sp, sp, -64
-; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 128
-; RV64IXQCCMP-NEXT:    sd t0, 112(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t1, 104(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t2, 96(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a1, 80(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a2, 72(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a3, 64(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a4, 56(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a5, 48(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a6, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a7, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t3, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t4, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t5, 8(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t6, 0(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    .cfi_offset t0, -16
-; RV64IXQCCMP-NEXT:    .cfi_offset t1, -24
-; RV64IXQCCMP-NEXT:    .cfi_offset t2, -32
-; RV64IXQCCMP-NEXT:    .cfi_offset a0, -40
-; RV64IXQCCMP-NEXT:    .cfi_offset a1, -48
-; RV64IXQCCMP-NEXT:    .cfi_offset a2, -56
-; RV64IXQCCMP-NEXT:    .cfi_offset a3, -64
-; RV64IXQCCMP-NEXT:    .cfi_offset a4, -72
-; RV64IXQCCMP-NEXT:    .cfi_offset a5, -80
-; RV64IXQCCMP-NEXT:    .cfi_offset a6, -88
-; RV64IXQCCMP-NEXT:    .cfi_offset a7, -96
-; RV64IXQCCMP-NEXT:    .cfi_offset t3, -104
-; RV64IXQCCMP-NEXT:    .cfi_offset t4, -112
-; RV64IXQCCMP-NEXT:    .cfi_offset t5, -120
-; RV64IXQCCMP-NEXT:    .cfi_offset t6, -128
+; RV64IXQCCMP-NEXT:    addi sp, sp, -80
+; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 144
+; RV64IXQCCMP-NEXT:    sd t0, 120(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t1, 112(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t2, 104(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a1, 88(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a2, 80(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a3, 72(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a4, 64(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a5, 56(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a6, 48(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a7, 40(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t3, 32(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t4, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t5, 16(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t6, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    .cfi_offset t0, -24
+; RV64IXQCCMP-NEXT:    .cfi_offset t1, -32
+; RV64IXQCCMP-NEXT:    .cfi_offset t2, -40
+; RV64IXQCCMP-NEXT:    .cfi_offset a0, -48
+; RV64IXQCCMP-NEXT:    .cfi_offset a1, -56
+; RV64IXQCCMP-NEXT:    .cfi_offset a2, -64
+; RV64IXQCCMP-NEXT:    .cfi_offset a3, -72
+; RV64IXQCCMP-NEXT:    .cfi_offset a4, -80
+; RV64IXQCCMP-NEXT:    .cfi_offset a5, -88
+; RV64IXQCCMP-NEXT:    .cfi_offset a6, -96
+; RV64IXQCCMP-NEXT:    .cfi_offset a7, -104
+; RV64IXQCCMP-NEXT:    .cfi_offset t3, -112
+; RV64IXQCCMP-NEXT:    .cfi_offset t4, -120
+; RV64IXQCCMP-NEXT:    .cfi_offset t5, -128
+; RV64IXQCCMP-NEXT:    .cfi_offset t6, -136
 ; RV64IXQCCMP-NEXT:    call foo_test_irq
-; RV64IXQCCMP-NEXT:    ld t0, 112(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t1, 104(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t2, 96(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a1, 80(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a2, 72(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a3, 64(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a4, 56(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a5, 48(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a6, 40(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a7, 32(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t3, 24(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t4, 16(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t5, 8(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t6, 0(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t0, 120(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t1, 112(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t2, 104(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a1, 88(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a2, 80(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a3, 72(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a4, 64(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a5, 56(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a6, 48(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a7, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t3, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t4, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t5, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t6, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    .cfi_restore t0
 ; RV64IXQCCMP-NEXT:    .cfi_restore t1
 ; RV64IXQCCMP-NEXT:    .cfi_restore t2
@@ -1729,7 +1733,7 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-NEXT:    .cfi_restore t4
 ; RV64IXQCCMP-NEXT:    .cfi_restore t5
 ; RV64IXQCCMP-NEXT:    .cfi_restore t6
-; RV64IXQCCMP-NEXT:    addi sp, sp, 64
+; RV64IXQCCMP-NEXT:    addi sp, sp, 80
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 64
 ; RV64IXQCCMP-NEXT:    qc.cm.pop {ra}, 64
 ; RV64IXQCCMP-NEXT:    .cfi_restore ra
@@ -1744,54 +1748,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s0, -8
 ; RV32IXQCCMP-FP-NEXT:    addi sp, sp, -16
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 80
-; RV32IXQCCMP-FP-NEXT:    sw t0, 68(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t2, 60(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a1, 52(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a2, 48(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a3, 44(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a4, 40(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a5, 36(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a6, 32(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t3, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t4, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t5, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t6, 12(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t0, -12
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t1, -16
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t2, -20
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a0, -24
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a1, -28
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a2, -32
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a3, -36
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a4, -40
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a5, -44
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a6, -48
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a7, -52
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t3, -56
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t4, -60
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t5, -64
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t6, -68
+; RV32IXQCCMP-FP-NEXT:    sw t0, 60(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t2, 52(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a5, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a6, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t3, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t4, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t5, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t6, 4(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t0, -20
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t1, -24
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t2, -28
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a0, -32
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a1, -36
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a2, -40
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a3, -44
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a4, -48
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a5, -52
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a6, -56
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a7, -60
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t3, -64
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t4, -68
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t5, -72
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t6, -76
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-FP-NEXT:    call foo_test_irq
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 80
-; RV32IXQCCMP-FP-NEXT:    lw t0, 68(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t1, 64(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t2, 60(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a1, 52(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a3, 44(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a7, 28(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t3, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t4, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t5, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t6, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t0, 60(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a3, 36(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t3, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t4, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t6, 4(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    .cfi_restore t0
 ; RV32IXQCCMP-FP-NEXT:    .cfi_restore t1
 ; RV32IXQCCMP-FP-NEXT:    .cfi_restore t2
@@ -1899,52 +1903,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-SR-NEXT:    qc.cm.push {ra}, -64
 ; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 64
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset ra, -4
-; RV32IXQCCMP-SR-NEXT:    sw t0, 56(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t2, 48(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a2, 36(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a5, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a7, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t3, 12(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t4, 8(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t5, 4(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t6, 0(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t0, -8
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t1, -12
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t2, -16
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a0, -20
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a1, -24
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a2, -28
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a3, -32
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a4, -36
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a5, -40
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a6, -44
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a7, -48
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t3, -52
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t4, -56
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t5, -60
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t6, -64
+; RV32IXQCCMP-SR-NEXT:    addi sp, sp, -16
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 80
+; RV32IXQCCMP-SR-NEXT:    sw t0, 60(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t2, 52(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a5, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a6, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t3, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t4, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t5, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t6, 4(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t0, -20
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t1, -24
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t2, -28
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a0, -32
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a1, -36
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a2, -40
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a3, -44
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a4, -48
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a5, -52
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a6, -56
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a7, -60
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t3, -64
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t4, -68
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t5, -72
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t6, -76
 ; RV32IXQCCMP-SR-NEXT:    call foo_test_irq
-; RV32IXQCCMP-SR-NEXT:    lw t0, 56(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t1, 52(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t2, 48(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t3, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t5, 4(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t6, 0(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t0, 60(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a3, 36(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t3, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t4, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t6, 4(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-SR-NEXT:    .cfi_restore t0
 ; RV32IXQCCMP-SR-NEXT:    .cfi_restore t1
 ; RV32IXQCCMP-SR-NEXT:    .cfi_restore t2
@@ -1960,6 +1966,8 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-SR-NEXT:    .cfi_restore t4
 ; RV32IXQCCMP-SR-NEXT:    .cfi_restore t5
 ; RV32IXQCCMP-SR-NEXT:    .cfi_restore t6
+; RV32IXQCCMP-SR-NEXT:    addi sp, sp, 16
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 64
 ; RV32IXQCCMP-SR-NEXT:    qc.cm.pop {ra}, 64
 ; RV32IXQCCMP-SR-NEXT:    .cfi_restore ra
 ; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 0
@@ -1970,54 +1978,54 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-SR-NEXT:    qc.cm.push {ra}, -64
 ; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 64
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset ra, -8
-; RV64IXQCCMP-SR-NEXT:    addi sp, sp, -64
-; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 128
-; RV64IXQCCMP-SR-NEXT:    sd t0, 112(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t1, 104(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t2, 96(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a1, 80(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a2, 72(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a3, 64(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a4, 56(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a5, 48(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a6, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a7, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t3, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t4, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t5, 8(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t6, 0(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t0, -16
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t1, -24
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t2, -32
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a0, -40
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a1, -48
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a2, -56
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a3, -64
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a4, -72
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a5, -80
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a6, -88
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a7, -96
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t3, -104
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t4, -112
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t5, -120
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t6, -128
+; RV64IXQCCMP-SR-NEXT:    addi sp, sp, -80
+; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 144
+; RV64IXQCCMP-SR-NEXT:    sd t0, 120(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t1, 112(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t2, 104(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a1, 88(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a2, 80(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a3, 72(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a4, 64(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a5, 56(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a6, 48(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a7, 40(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t3, 32(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t4, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t5, 16(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t6, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t0, -24
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t1, -32
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t2, -40
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a0, -48
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a1, -56
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a2, -64
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a3, -72
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a4, -80
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a5, -88
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a6, -96
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a7, -104
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t3, -112
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t4, -120
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t5, -128
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t6, -136
 ; RV64IXQCCMP-SR-NEXT:    call foo_test_irq
-; RV64IXQCCMP-SR-NEXT:    ld t0, 112(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t1, 104(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t2, 96(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a1, 80(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a2, 72(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a3, 64(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a4, 56(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a5, 48(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a6, 40(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a7, 32(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t3, 24(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t4, 16(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t5, 8(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t6, 0(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t0, 120(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t1, 112(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t2, 104(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a1, 88(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a2, 80(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a3, 72(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a4, 64(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a5, 56(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a6, 48(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a7, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t3, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t4, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t5, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t6, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-SR-NEXT:    .cfi_restore t0
 ; RV64IXQCCMP-SR-NEXT:    .cfi_restore t1
 ; RV64IXQCCMP-SR-NEXT:    .cfi_restore t2
@@ -2033,7 +2041,7 @@ define void @foo_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-SR-NEXT:    .cfi_restore t4
 ; RV64IXQCCMP-SR-NEXT:    .cfi_restore t5
 ; RV64IXQCCMP-SR-NEXT:    .cfi_restore t6
-; RV64IXQCCMP-SR-NEXT:    addi sp, sp, 64
+; RV64IXQCCMP-SR-NEXT:    addi sp, sp, 80
 ; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 64
 ; RV64IXQCCMP-SR-NEXT:    qc.cm.pop {ra}, 64
 ; RV64IXQCCMP-SR-NEXT:    .cfi_restore ra
@@ -2119,52 +2127,52 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-NEXT:    .cfi_offset s9, -44
 ; RV32IXQCCMP-NEXT:    .cfi_offset s10, -48
 ; RV32IXQCCMP-NEXT:    .cfi_offset s11, -52
-; RV32IXQCCMP-NEXT:    addi sp, sp, -32
-; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 144
-; RV32IXQCCMP-NEXT:    sw t0, 88(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t1, 84(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t2, 80(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a2, 68(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a4, 60(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a5, 56(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a6, 52(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw a7, 48(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t3, 44(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t4, 40(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    sw t6, 32(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    .cfi_offset t0, -56
-; RV32IXQCCMP-NEXT:    .cfi_offset t1, -60
-; RV32IXQCCMP-NEXT:    .cfi_offset t2, -64
-; RV32IXQCCMP-NEXT:    .cfi_offset a0, -68
-; RV32IXQCCMP-NEXT:    .cfi_offset a1, -72
-; RV32IXQCCMP-NEXT:    .cfi_offset a2, -76
-; RV32IXQCCMP-NEXT:    .cfi_offset a3, -80
-; RV32IXQCCMP-NEXT:    .cfi_offset a4, -84
-; RV32IXQCCMP-NEXT:    .cfi_offset a5, -88
-; RV32IXQCCMP-NEXT:    .cfi_offset a6, -92
-; RV32IXQCCMP-NEXT:    .cfi_offset a7, -96
-; RV32IXQCCMP-NEXT:    .cfi_offset t3, -100
-; RV32IXQCCMP-NEXT:    .cfi_offset t4, -104
-; RV32IXQCCMP-NEXT:    .cfi_offset t5, -108
-; RV32IXQCCMP-NEXT:    .cfi_offset t6, -112
+; RV32IXQCCMP-NEXT:    addi sp, sp, -48
+; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 160
+; RV32IXQCCMP-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t2, 84(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a6, 56(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t3, 48(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t4, 44(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t5, 40(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw t6, 36(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    .cfi_offset t0, -68
+; RV32IXQCCMP-NEXT:    .cfi_offset t1, -72
+; RV32IXQCCMP-NEXT:    .cfi_offset t2, -76
+; RV32IXQCCMP-NEXT:    .cfi_offset a0, -80
+; RV32IXQCCMP-NEXT:    .cfi_offset a1, -84
+; RV32IXQCCMP-NEXT:    .cfi_offset a2, -88
+; RV32IXQCCMP-NEXT:    .cfi_offset a3, -92
+; RV32IXQCCMP-NEXT:    .cfi_offset a4, -96
+; RV32IXQCCMP-NEXT:    .cfi_offset a5, -100
+; RV32IXQCCMP-NEXT:    .cfi_offset a6, -104
+; RV32IXQCCMP-NEXT:    .cfi_offset a7, -108
+; RV32IXQCCMP-NEXT:    .cfi_offset t3, -112
+; RV32IXQCCMP-NEXT:    .cfi_offset t4, -116
+; RV32IXQCCMP-NEXT:    .cfi_offset t5, -120
+; RV32IXQCCMP-NEXT:    .cfi_offset t6, -124
 ; RV32IXQCCMP-NEXT:    lui t0, %hi(var_test_irq)
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV32IXQCCMP-NEXT:    lw a0, 16(a5)
-; RV32IXQCCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw a0, 20(a5)
-; RV32IXQCCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-NEXT:    lw t4, 24(a5)
 ; RV32IXQCCMP-NEXT:    lw t5, 28(a5)
 ; RV32IXQCCMP-NEXT:    lw t6, 32(a5)
@@ -2217,33 +2225,33 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-NEXT:    sw t6, 32(a5)
 ; RV32IXQCCMP-NEXT:    sw t5, 28(a5)
 ; RV32IXQCCMP-NEXT:    sw t4, 24(a5)
-; RV32IXQCCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 20(a5)
 ; RV32IXQCCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 16(a5)
+; RV32IXQCCMP-NEXT:    sw a0, 20(a5)
 ; RV32IXQCCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, 16(a5)
 ; RV32IXQCCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
 ; RV32IXQCCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
 ; RV32IXQCCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IXQCCMP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV32IXQCCMP-NEXT:    lw t0, 88(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t1, 84(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t2, 80(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a6, 52(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw a7, 48(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t3, 44(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t4, 40(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t5, 36(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    lw t6, 32(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t0, 92(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t1, 88(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t2, 84(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a2, 72(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t3, 48(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t4, 44(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t5, 40(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    lw t6, 36(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-NEXT:    .cfi_restore t0
 ; RV32IXQCCMP-NEXT:    .cfi_restore t1
 ; RV32IXQCCMP-NEXT:    .cfi_restore t2
@@ -2259,7 +2267,7 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-NEXT:    .cfi_restore t4
 ; RV32IXQCCMP-NEXT:    .cfi_restore t5
 ; RV32IXQCCMP-NEXT:    .cfi_restore t6
-; RV32IXQCCMP-NEXT:    addi sp, sp, 32
+; RV32IXQCCMP-NEXT:    addi sp, sp, 48
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 112
 ; RV32IXQCCMP-NEXT:    qc.cm.pop {ra, s0-s11}, 112
 ; RV32IXQCCMP-NEXT:    .cfi_restore ra
@@ -2295,996 +2303,38 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-NEXT:    .cfi_offset s9, -88
 ; RV64IXQCCMP-NEXT:    .cfi_offset s10, -96
 ; RV64IXQCCMP-NEXT:    .cfi_offset s11, -104
-; RV64IXQCCMP-NEXT:    addi sp, sp, -112
-; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 272
-; RV64IXQCCMP-NEXT:    sd t0, 160(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t1, 152(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t2, 144(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a1, 128(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a2, 120(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a3, 112(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a4, 104(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a5, 96(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a6, 88(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd a7, 80(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t3, 72(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t4, 64(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t5, 56(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    sd t6, 48(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    .cfi_offset t0, -112
-; RV64IXQCCMP-NEXT:    .cfi_offset t1, -120
-; RV64IXQCCMP-NEXT:    .cfi_offset t2, -128
-; RV64IXQCCMP-NEXT:    .cfi_offset a0, -136
-; RV64IXQCCMP-NEXT:    .cfi_offset a1, -144
-; RV64IXQCCMP-NEXT:    .cfi_offset a2, -152
-; RV64IXQCCMP-NEXT:    .cfi_offset a3, -160
-; RV64IXQCCMP-NEXT:    .cfi_offset a4, -168
-; RV64IXQCCMP-NEXT:    .cfi_offset a5, -176
-; RV64IXQCCMP-NEXT:    .cfi_offset a6, -184
-; RV64IXQCCMP-NEXT:    .cfi_offset a7, -192
-; RV64IXQCCMP-NEXT:    .cfi_offset t3, -200
-; RV64IXQCCMP-NEXT:    .cfi_offset t4, -208
-; RV64IXQCCMP-NEXT:    .cfi_offset t5, -216
-; RV64IXQCCMP-NEXT:    .cfi_offset t6, -224
-; RV64IXQCCMP-NEXT:    lui t0, %hi(var_test_irq)
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV64IXQCCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV64IXQCCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV64IXQCCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV64IXQCCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
-; RV64IXQCCMP-NEXT:    lw a0, 16(a5)
-; RV64IXQCCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw a0, 20(a5)
-; RV64IXQCCMP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-NEXT:    lw t4, 24(a5)
-; RV64IXQCCMP-NEXT:    lw t5, 28(a5)
-; RV64IXQCCMP-NEXT:    lw t6, 32(a5)
-; RV64IXQCCMP-NEXT:    lw s2, 36(a5)
-; RV64IXQCCMP-NEXT:    lw s3, 40(a5)
-; RV64IXQCCMP-NEXT:    lw s4, 44(a5)
-; RV64IXQCCMP-NEXT:    lw s5, 48(a5)
-; RV64IXQCCMP-NEXT:    lw s6, 52(a5)
-; RV64IXQCCMP-NEXT:    lw s7, 56(a5)
-; RV64IXQCCMP-NEXT:    lw s8, 60(a5)
-; RV64IXQCCMP-NEXT:    lw s9, 64(a5)
-; RV64IXQCCMP-NEXT:    lw s10, 68(a5)
-; RV64IXQCCMP-NEXT:    lw s11, 72(a5)
-; RV64IXQCCMP-NEXT:    lw ra, 76(a5)
-; RV64IXQCCMP-NEXT:    lw s1, 80(a5)
-; RV64IXQCCMP-NEXT:    lw t3, 84(a5)
-; RV64IXQCCMP-NEXT:    lw t2, 88(a5)
-; RV64IXQCCMP-NEXT:    lw t1, 92(a5)
-; RV64IXQCCMP-NEXT:    lw a7, 112(a5)
-; RV64IXQCCMP-NEXT:    lw s0, 116(a5)
-; RV64IXQCCMP-NEXT:    lw a3, 120(a5)
-; RV64IXQCCMP-NEXT:    lw a0, 124(a5)
-; RV64IXQCCMP-NEXT:    lw a6, 96(a5)
-; RV64IXQCCMP-NEXT:    lw a4, 100(a5)
-; RV64IXQCCMP-NEXT:    lw a2, 104(a5)
-; RV64IXQCCMP-NEXT:    lw a1, 108(a5)
-; RV64IXQCCMP-NEXT:    sw a0, 124(a5)
-; RV64IXQCCMP-NEXT:    sw a3, 120(a5)
-; RV64IXQCCMP-NEXT:    sw s0, 116(a5)
-; RV64IXQCCMP-NEXT:    sw a7, 112(a5)
-; RV64IXQCCMP-NEXT:    sw a1, 108(a5)
-; RV64IXQCCMP-NEXT:    sw a2, 104(a5)
-; RV64IXQCCMP-NEXT:    sw a4, 100(a5)
-; RV64IXQCCMP-NEXT:    sw a6, 96(a5)
-; RV64IXQCCMP-NEXT:    sw t1, 92(a5)
-; RV64IXQCCMP-NEXT:    sw t2, 88(a5)
-; RV64IXQCCMP-NEXT:    sw t3, 84(a5)
-; RV64IXQCCMP-NEXT:    sw s1, 80(a5)
-; RV64IXQCCMP-NEXT:    sw ra, 76(a5)
-; RV64IXQCCMP-NEXT:    sw s11, 72(a5)
-; RV64IXQCCMP-NEXT:    sw s10, 68(a5)
-; RV64IXQCCMP-NEXT:    sw s9, 64(a5)
-; RV64IXQCCMP-NEXT:    sw s8, 60(a5)
-; RV64IXQCCMP-NEXT:    sw s7, 56(a5)
-; RV64IXQCCMP-NEXT:    sw s6, 52(a5)
-; RV64IXQCCMP-NEXT:    sw s5, 48(a5)
-; RV64IXQCCMP-NEXT:    sw s4, 44(a5)
-; RV64IXQCCMP-NEXT:    sw s3, 40(a5)
-; RV64IXQCCMP-NEXT:    sw s2, 36(a5)
-; RV64IXQCCMP-NEXT:    sw t6, 32(a5)
-; RV64IXQCCMP-NEXT:    sw t5, 28(a5)
-; RV64IXQCCMP-NEXT:    sw t4, 24(a5)
-; RV64IXQCCMP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    sw a0, 20(a5)
-; RV64IXQCCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    sw a0, 16(a5)
-; RV64IXQCCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
-; RV64IXQCCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
-; RV64IXQCCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
-; RV64IXQCCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV64IXQCCMP-NEXT:    ld t0, 160(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t1, 152(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t2, 144(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a1, 128(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a2, 120(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a3, 112(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a4, 104(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a5, 96(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a6, 88(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld a7, 80(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t3, 72(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t4, 64(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t5, 56(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    ld t6, 48(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-NEXT:    .cfi_restore t0
-; RV64IXQCCMP-NEXT:    .cfi_restore t1
-; RV64IXQCCMP-NEXT:    .cfi_restore t2
-; RV64IXQCCMP-NEXT:    .cfi_restore a0
-; RV64IXQCCMP-NEXT:    .cfi_restore a1
-; RV64IXQCCMP-NEXT:    .cfi_restore a2
-; RV64IXQCCMP-NEXT:    .cfi_restore a3
-; RV64IXQCCMP-NEXT:    .cfi_restore a4
-; RV64IXQCCMP-NEXT:    .cfi_restore a5
-; RV64IXQCCMP-NEXT:    .cfi_restore a6
-; RV64IXQCCMP-NEXT:    .cfi_restore a7
-; RV64IXQCCMP-NEXT:    .cfi_restore t3
-; RV64IXQCCMP-NEXT:    .cfi_restore t4
-; RV64IXQCCMP-NEXT:    .cfi_restore t5
-; RV64IXQCCMP-NEXT:    .cfi_restore t6
-; RV64IXQCCMP-NEXT:    addi sp, sp, 112
-; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 160
-; RV64IXQCCMP-NEXT:    qc.cm.pop {ra, s0-s11}, 160
-; RV64IXQCCMP-NEXT:    .cfi_restore ra
-; RV64IXQCCMP-NEXT:    .cfi_restore s0
-; RV64IXQCCMP-NEXT:    .cfi_restore s1
-; RV64IXQCCMP-NEXT:    .cfi_restore s2
-; RV64IXQCCMP-NEXT:    .cfi_restore s3
-; RV64IXQCCMP-NEXT:    .cfi_restore s4
-; RV64IXQCCMP-NEXT:    .cfi_restore s5
-; RV64IXQCCMP-NEXT:    .cfi_restore s6
-; RV64IXQCCMP-NEXT:    .cfi_restore s7
-; RV64IXQCCMP-NEXT:    .cfi_restore s8
-; RV64IXQCCMP-NEXT:    .cfi_restore s9
-; RV64IXQCCMP-NEXT:    .cfi_restore s10
-; RV64IXQCCMP-NEXT:    .cfi_restore s11
-; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 0
-; RV64IXQCCMP-NEXT:    mret
-;
-; RV32IXQCCMP-FP-LABEL: callee_with_irq:
-; RV32IXQCCMP-FP:       # %bb.0:
-; RV32IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -112
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 112
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset ra, -4
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s0, -8
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s1, -12
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s2, -16
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s3, -20
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s4, -24
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s5, -28
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s6, -32
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s7, -36
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s8, -40
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s9, -44
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s10, -48
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset s11, -52
-; RV32IXQCCMP-FP-NEXT:    addi sp, sp, -32
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 144
-; RV32IXQCCMP-FP-NEXT:    sw t0, 88(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t1, 84(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t2, 80(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a2, 68(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a4, 60(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a5, 56(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a6, 52(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw a7, 48(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t3, 44(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t4, 40(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    sw t6, 32(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t0, -56
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t1, -60
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t2, -64
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a0, -68
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a1, -72
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a2, -76
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a3, -80
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a4, -84
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a5, -88
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a6, -92
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset a7, -96
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t3, -100
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t4, -104
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t5, -108
-; RV32IXQCCMP-FP-NEXT:    .cfi_offset t6, -112
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
-; RV32IXQCCMP-FP-NEXT:    lui t1, %hi(var_test_irq)
-; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq)(t1)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -116(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+4)(t1)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -120(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+8)(t1)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -124(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+12)(t1)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -128(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    addi a5, t1, %lo(var_test_irq)
-; RV32IXQCCMP-FP-NEXT:    lw a0, 16(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -132(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a0, 20(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -136(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a0, 24(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -140(s0) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw t5, 28(a5)
-; RV32IXQCCMP-FP-NEXT:    lw t6, 32(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s2, 36(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s3, 40(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s4, 44(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s5, 48(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s6, 52(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s7, 56(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s8, 60(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s9, 64(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s10, 68(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s11, 72(a5)
-; RV32IXQCCMP-FP-NEXT:    lw ra, 76(a5)
-; RV32IXQCCMP-FP-NEXT:    lw t4, 80(a5)
-; RV32IXQCCMP-FP-NEXT:    lw t3, 84(a5)
-; RV32IXQCCMP-FP-NEXT:    lw t2, 88(a5)
-; RV32IXQCCMP-FP-NEXT:    lw s1, 92(a5)
-; RV32IXQCCMP-FP-NEXT:    lw t0, 112(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a4, 116(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a3, 120(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, 124(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a7, 96(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a6, 100(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a2, 104(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 108(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a0, 124(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a3, 120(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a4, 116(a5)
-; RV32IXQCCMP-FP-NEXT:    sw t0, 112(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 108(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a2, 104(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a6, 100(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a7, 96(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s1, 92(a5)
-; RV32IXQCCMP-FP-NEXT:    sw t2, 88(a5)
-; RV32IXQCCMP-FP-NEXT:    sw t3, 84(a5)
-; RV32IXQCCMP-FP-NEXT:    sw t4, 80(a5)
-; RV32IXQCCMP-FP-NEXT:    sw ra, 76(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s11, 72(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s10, 68(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s9, 64(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s8, 60(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s7, 56(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s6, 52(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s5, 48(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s4, 44(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s3, 40(a5)
-; RV32IXQCCMP-FP-NEXT:    sw s2, 36(a5)
-; RV32IXQCCMP-FP-NEXT:    sw t6, 32(a5)
-; RV32IXQCCMP-FP-NEXT:    sw t5, 28(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -140(s0) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a0, 24(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -136(s0) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a0, 20(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -132(s0) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a0, 16(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -128(s0) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+12)(t1)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -124(s0) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+8)(t1)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -120(s0) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+4)(t1)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -116(s0) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq)(t1)
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 144
-; RV32IXQCCMP-FP-NEXT:    lw t0, 88(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t1, 84(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t2, 80(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a6, 52(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw a7, 48(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t3, 44(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t4, 40(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t5, 36(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    lw t6, 32(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore t0
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore t1
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore t2
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore a0
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore a1
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore a2
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore a3
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore a4
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore a5
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore a6
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore a7
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore t3
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore t4
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore t5
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore t6
-; RV32IXQCCMP-FP-NEXT:    addi sp, sp, 32
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 112
-; RV32IXQCCMP-FP-NEXT:    qc.cm.pop {ra, s0-s11}, 112
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore ra
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s0
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s1
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s2
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s3
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s4
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s5
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s6
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s7
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s8
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s9
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s10
-; RV32IXQCCMP-FP-NEXT:    .cfi_restore s11
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 0
-; RV32IXQCCMP-FP-NEXT:    mret
-;
-; RV64IXQCCMP-FP-LABEL: callee_with_irq:
-; RV64IXQCCMP-FP:       # %bb.0:
-; RV64IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -160
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 160
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset ra, -8
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s0, -16
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s1, -24
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s2, -32
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s3, -40
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s4, -48
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s5, -56
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s6, -64
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s7, -72
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s8, -80
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s9, -88
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s10, -96
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset s11, -104
-; RV64IXQCCMP-FP-NEXT:    addi sp, sp, -128
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 288
-; RV64IXQCCMP-FP-NEXT:    sd t0, 176(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd t1, 168(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd t2, 160(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd a1, 144(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd a2, 136(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd a3, 128(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd a4, 120(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd a5, 112(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd a6, 104(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd a7, 96(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd t3, 88(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd t4, 80(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd t5, 72(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    sd t6, 64(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset t0, -112
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset t1, -120
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset t2, -128
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset a0, -136
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset a1, -144
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset a2, -152
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset a3, -160
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset a4, -168
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset a5, -176
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset a6, -184
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset a7, -192
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset t3, -200
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset t4, -208
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset t5, -216
-; RV64IXQCCMP-FP-NEXT:    .cfi_offset t6, -224
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
-; RV64IXQCCMP-FP-NEXT:    lui t1, %hi(var_test_irq)
-; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq)(t1)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -232(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+4)(t1)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -240(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+8)(t1)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -248(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+12)(t1)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -256(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    addi a5, t1, %lo(var_test_irq)
-; RV64IXQCCMP-FP-NEXT:    lw a0, 16(a5)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -264(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a0, 20(a5)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -272(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a0, 24(a5)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -280(s0) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw t5, 28(a5)
-; RV64IXQCCMP-FP-NEXT:    lw t6, 32(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s2, 36(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s3, 40(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s4, 44(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s5, 48(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s6, 52(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s7, 56(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s8, 60(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s9, 64(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s10, 68(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s11, 72(a5)
-; RV64IXQCCMP-FP-NEXT:    lw ra, 76(a5)
-; RV64IXQCCMP-FP-NEXT:    lw t4, 80(a5)
-; RV64IXQCCMP-FP-NEXT:    lw t3, 84(a5)
-; RV64IXQCCMP-FP-NEXT:    lw t2, 88(a5)
-; RV64IXQCCMP-FP-NEXT:    lw s1, 92(a5)
-; RV64IXQCCMP-FP-NEXT:    lw t0, 112(a5)
-; RV64IXQCCMP-FP-NEXT:    lw a4, 116(a5)
-; RV64IXQCCMP-FP-NEXT:    lw a3, 120(a5)
-; RV64IXQCCMP-FP-NEXT:    lw a0, 124(a5)
-; RV64IXQCCMP-FP-NEXT:    lw a7, 96(a5)
-; RV64IXQCCMP-FP-NEXT:    lw a6, 100(a5)
-; RV64IXQCCMP-FP-NEXT:    lw a2, 104(a5)
-; RV64IXQCCMP-FP-NEXT:    lw a1, 108(a5)
-; RV64IXQCCMP-FP-NEXT:    sw a0, 124(a5)
-; RV64IXQCCMP-FP-NEXT:    sw a3, 120(a5)
-; RV64IXQCCMP-FP-NEXT:    sw a4, 116(a5)
-; RV64IXQCCMP-FP-NEXT:    sw t0, 112(a5)
-; RV64IXQCCMP-FP-NEXT:    sw a1, 108(a5)
-; RV64IXQCCMP-FP-NEXT:    sw a2, 104(a5)
-; RV64IXQCCMP-FP-NEXT:    sw a6, 100(a5)
-; RV64IXQCCMP-FP-NEXT:    sw a7, 96(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s1, 92(a5)
-; RV64IXQCCMP-FP-NEXT:    sw t2, 88(a5)
-; RV64IXQCCMP-FP-NEXT:    sw t3, 84(a5)
-; RV64IXQCCMP-FP-NEXT:    sw t4, 80(a5)
-; RV64IXQCCMP-FP-NEXT:    sw ra, 76(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s11, 72(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s10, 68(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s9, 64(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s8, 60(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s7, 56(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s6, 52(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s5, 48(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s4, 44(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s3, 40(a5)
-; RV64IXQCCMP-FP-NEXT:    sw s2, 36(a5)
-; RV64IXQCCMP-FP-NEXT:    sw t6, 32(a5)
-; RV64IXQCCMP-FP-NEXT:    sw t5, 28(a5)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -280(s0) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a0, 24(a5)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -272(s0) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a0, 20(a5)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -264(s0) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a0, 16(a5)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -256(s0) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+12)(t1)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -248(s0) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+8)(t1)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -240(s0) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+4)(t1)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -232(s0) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq)(t1)
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 288
-; RV64IXQCCMP-FP-NEXT:    ld t0, 176(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld t1, 168(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld t2, 160(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld a1, 144(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld a2, 136(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld a3, 128(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld a4, 120(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld a5, 112(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld a6, 104(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld a7, 96(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld t3, 88(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld t4, 80(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld t5, 72(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    ld t6, 64(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore t0
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore t1
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore t2
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore a0
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore a1
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore a2
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore a3
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore a4
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore a5
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore a6
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore a7
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore t3
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore t4
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore t5
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore t6
-; RV64IXQCCMP-FP-NEXT:    addi sp, sp, 128
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 160
-; RV64IXQCCMP-FP-NEXT:    qc.cm.pop {ra, s0-s11}, 160
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore ra
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s0
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s1
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s2
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s3
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s4
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s5
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s6
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s7
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s8
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s9
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s10
-; RV64IXQCCMP-FP-NEXT:    .cfi_restore s11
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 0
-; RV64IXQCCMP-FP-NEXT:    mret
-;
-; RV32IXQCCMP-SR-LABEL: callee_with_irq:
-; RV32IXQCCMP-SR:       # %bb.0:
-; RV32IXQCCMP-SR-NEXT:    qc.cm.push {ra, s0-s11}, -112
-; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 112
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset ra, -4
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s0, -8
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s1, -12
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s2, -16
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s3, -20
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s4, -24
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s5, -28
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s6, -32
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s7, -36
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s8, -40
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s9, -44
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s10, -48
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset s11, -52
-; RV32IXQCCMP-SR-NEXT:    addi sp, sp, -32
-; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 144
-; RV32IXQCCMP-SR-NEXT:    sw t0, 88(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t1, 84(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t2, 80(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a2, 68(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a4, 60(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a5, 56(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a6, 52(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw a7, 48(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t3, 44(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t4, 40(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    sw t6, 32(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t0, -56
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t1, -60
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t2, -64
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a0, -68
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a1, -72
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a2, -76
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a3, -80
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a4, -84
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a5, -88
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a6, -92
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset a7, -96
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t3, -100
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t4, -104
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t5, -108
-; RV32IXQCCMP-SR-NEXT:    .cfi_offset t6, -112
-; RV32IXQCCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
-; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 16(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    lw a0, 20(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-SR-NEXT:    lw t4, 24(a5)
-; RV32IXQCCMP-SR-NEXT:    lw t5, 28(a5)
-; RV32IXQCCMP-SR-NEXT:    lw t6, 32(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s2, 36(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s3, 40(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s4, 44(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s5, 48(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s6, 52(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s7, 56(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s8, 60(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s9, 64(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s10, 68(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s11, 72(a5)
-; RV32IXQCCMP-SR-NEXT:    lw ra, 76(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s1, 80(a5)
-; RV32IXQCCMP-SR-NEXT:    lw t3, 84(a5)
-; RV32IXQCCMP-SR-NEXT:    lw t2, 88(a5)
-; RV32IXQCCMP-SR-NEXT:    lw t1, 92(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a7, 112(a5)
-; RV32IXQCCMP-SR-NEXT:    lw s0, 116(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a3, 120(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 124(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a6, 96(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a4, 100(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a2, 104(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a1, 108(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 124(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a3, 120(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s0, 116(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a7, 112(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a1, 108(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a2, 104(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a4, 100(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a6, 96(a5)
-; RV32IXQCCMP-SR-NEXT:    sw t1, 92(a5)
-; RV32IXQCCMP-SR-NEXT:    sw t2, 88(a5)
-; RV32IXQCCMP-SR-NEXT:    sw t3, 84(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s1, 80(a5)
-; RV32IXQCCMP-SR-NEXT:    sw ra, 76(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s11, 72(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s10, 68(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s9, 64(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s8, 60(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s7, 56(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s6, 52(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s5, 48(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s4, 44(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s3, 40(a5)
-; RV32IXQCCMP-SR-NEXT:    sw s2, 36(a5)
-; RV32IXQCCMP-SR-NEXT:    sw t6, 32(a5)
-; RV32IXQCCMP-SR-NEXT:    sw t5, 28(a5)
-; RV32IXQCCMP-SR-NEXT:    sw t4, 24(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, 20(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, 16(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV32IXQCCMP-SR-NEXT:    lw t0, 88(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t1, 84(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t2, 80(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a6, 52(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw a7, 48(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t3, 44(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t4, 40(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t5, 36(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    lw t6, 32(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore t0
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore t1
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore t2
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore a0
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore a1
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore a2
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore a3
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore a4
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore a5
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore a6
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore a7
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore t3
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore t4
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore t5
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore t6
-; RV32IXQCCMP-SR-NEXT:    addi sp, sp, 32
-; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 112
-; RV32IXQCCMP-SR-NEXT:    qc.cm.pop {ra, s0-s11}, 112
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore ra
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s0
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s1
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s2
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s3
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s4
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s5
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s6
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s7
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s8
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s9
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s10
-; RV32IXQCCMP-SR-NEXT:    .cfi_restore s11
-; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 0
-; RV32IXQCCMP-SR-NEXT:    mret
-;
-; RV64IXQCCMP-SR-LABEL: callee_with_irq:
-; RV64IXQCCMP-SR:       # %bb.0:
-; RV64IXQCCMP-SR-NEXT:    qc.cm.push {ra, s0-s11}, -160
-; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 160
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset ra, -8
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s0, -16
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s1, -24
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s2, -32
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s3, -40
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s4, -48
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s5, -56
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s6, -64
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s7, -72
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s8, -80
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s9, -88
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s10, -96
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset s11, -104
-; RV64IXQCCMP-SR-NEXT:    addi sp, sp, -112
-; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 272
-; RV64IXQCCMP-SR-NEXT:    sd t0, 160(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t1, 152(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t2, 144(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a1, 128(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a2, 120(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a3, 112(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a4, 104(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a5, 96(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a6, 88(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd a7, 80(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t3, 72(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t4, 64(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t5, 56(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    sd t6, 48(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t0, -112
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t1, -120
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t2, -128
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a0, -136
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a1, -144
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a2, -152
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a3, -160
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a4, -168
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a5, -176
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a6, -184
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset a7, -192
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t3, -200
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t4, -208
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t5, -216
-; RV64IXQCCMP-SR-NEXT:    .cfi_offset t6, -224
-; RV64IXQCCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
-; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV64IXQCCMP-SR-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV64IXQCCMP-SR-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV64IXQCCMP-SR-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV64IXQCCMP-SR-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
-; RV64IXQCCMP-SR-NEXT:    lw a0, 16(a5)
-; RV64IXQCCMP-SR-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    lw a0, 20(a5)
-; RV64IXQCCMP-SR-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-SR-NEXT:    lw t4, 24(a5)
-; RV64IXQCCMP-SR-NEXT:    lw t5, 28(a5)
-; RV64IXQCCMP-SR-NEXT:    lw t6, 32(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s2, 36(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s3, 40(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s4, 44(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s5, 48(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s6, 52(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s7, 56(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s8, 60(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s9, 64(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s10, 68(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s11, 72(a5)
-; RV64IXQCCMP-SR-NEXT:    lw ra, 76(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s1, 80(a5)
-; RV64IXQCCMP-SR-NEXT:    lw t3, 84(a5)
-; RV64IXQCCMP-SR-NEXT:    lw t2, 88(a5)
-; RV64IXQCCMP-SR-NEXT:    lw t1, 92(a5)
-; RV64IXQCCMP-SR-NEXT:    lw a7, 112(a5)
-; RV64IXQCCMP-SR-NEXT:    lw s0, 116(a5)
-; RV64IXQCCMP-SR-NEXT:    lw a3, 120(a5)
-; RV64IXQCCMP-SR-NEXT:    lw a0, 124(a5)
-; RV64IXQCCMP-SR-NEXT:    lw a6, 96(a5)
-; RV64IXQCCMP-SR-NEXT:    lw a4, 100(a5)
-; RV64IXQCCMP-SR-NEXT:    lw a2, 104(a5)
-; RV64IXQCCMP-SR-NEXT:    lw a1, 108(a5)
-; RV64IXQCCMP-SR-NEXT:    sw a0, 124(a5)
-; RV64IXQCCMP-SR-NEXT:    sw a3, 120(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s0, 116(a5)
-; RV64IXQCCMP-SR-NEXT:    sw a7, 112(a5)
-; RV64IXQCCMP-SR-NEXT:    sw a1, 108(a5)
-; RV64IXQCCMP-SR-NEXT:    sw a2, 104(a5)
-; RV64IXQCCMP-SR-NEXT:    sw a4, 100(a5)
-; RV64IXQCCMP-SR-NEXT:    sw a6, 96(a5)
-; RV64IXQCCMP-SR-NEXT:    sw t1, 92(a5)
-; RV64IXQCCMP-SR-NEXT:    sw t2, 88(a5)
-; RV64IXQCCMP-SR-NEXT:    sw t3, 84(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s1, 80(a5)
-; RV64IXQCCMP-SR-NEXT:    sw ra, 76(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s11, 72(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s10, 68(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s9, 64(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s8, 60(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s7, 56(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s6, 52(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s5, 48(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s4, 44(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s3, 40(a5)
-; RV64IXQCCMP-SR-NEXT:    sw s2, 36(a5)
-; RV64IXQCCMP-SR-NEXT:    sw t6, 32(a5)
-; RV64IXQCCMP-SR-NEXT:    sw t5, 28(a5)
-; RV64IXQCCMP-SR-NEXT:    sw t4, 24(a5)
-; RV64IXQCCMP-SR-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    sw a0, 20(a5)
-; RV64IXQCCMP-SR-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    sw a0, 16(a5)
-; RV64IXQCCMP-SR-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
-; RV64IXQCCMP-SR-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
-; RV64IXQCCMP-SR-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
-; RV64IXQCCMP-SR-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV64IXQCCMP-SR-NEXT:    ld t0, 160(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t1, 152(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t2, 144(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a1, 128(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a2, 120(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a3, 112(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a4, 104(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a5, 96(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a6, 88(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld a7, 80(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t3, 72(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t4, 64(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t5, 56(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    ld t6, 48(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore t0
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore t1
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore t2
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore a0
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore a1
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore a2
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore a3
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore a4
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore a5
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore a6
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore a7
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore t3
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore t4
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore t5
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore t6
-; RV64IXQCCMP-SR-NEXT:    addi sp, sp, 112
-; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 160
-; RV64IXQCCMP-SR-NEXT:    qc.cm.pop {ra, s0-s11}, 160
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore ra
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s0
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s1
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s2
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s3
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s4
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s5
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s6
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s7
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s8
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s9
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s10
-; RV64IXQCCMP-SR-NEXT:    .cfi_restore s11
-; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 0
-; RV64IXQCCMP-SR-NEXT:    mret
-  %val = load [32 x i32], ptr @var_test_irq
-  store volatile [32 x i32] %val, ptr @var_test_irq
-  ret void
-}
-
-define void @callee_no_irq() {
-; RV32IXQCCMP-LABEL: callee_no_irq:
-; RV32IXQCCMP:       # %bb.0:
-; RV32IXQCCMP-NEXT:    qc.cm.push {ra, s0-s11}, -80
-; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 80
-; RV32IXQCCMP-NEXT:    .cfi_offset ra, -4
-; RV32IXQCCMP-NEXT:    .cfi_offset s0, -8
-; RV32IXQCCMP-NEXT:    .cfi_offset s1, -12
-; RV32IXQCCMP-NEXT:    .cfi_offset s2, -16
-; RV32IXQCCMP-NEXT:    .cfi_offset s3, -20
-; RV32IXQCCMP-NEXT:    .cfi_offset s4, -24
-; RV32IXQCCMP-NEXT:    .cfi_offset s5, -28
-; RV32IXQCCMP-NEXT:    .cfi_offset s6, -32
-; RV32IXQCCMP-NEXT:    .cfi_offset s7, -36
-; RV32IXQCCMP-NEXT:    .cfi_offset s8, -40
-; RV32IXQCCMP-NEXT:    .cfi_offset s9, -44
-; RV32IXQCCMP-NEXT:    .cfi_offset s10, -48
-; RV32IXQCCMP-NEXT:    .cfi_offset s11, -52
-; RV32IXQCCMP-NEXT:    lui t0, %hi(var_test_irq)
-; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV32IXQCCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
-; RV32IXQCCMP-NEXT:    lw a0, 16(a5)
-; RV32IXQCCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    lw a0, 20(a5)
-; RV32IXQCCMP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-NEXT:    lw t4, 24(a5)
-; RV32IXQCCMP-NEXT:    lw t5, 28(a5)
-; RV32IXQCCMP-NEXT:    lw t6, 32(a5)
-; RV32IXQCCMP-NEXT:    lw s2, 36(a5)
-; RV32IXQCCMP-NEXT:    lw s3, 40(a5)
-; RV32IXQCCMP-NEXT:    lw s4, 44(a5)
-; RV32IXQCCMP-NEXT:    lw s5, 48(a5)
-; RV32IXQCCMP-NEXT:    lw s6, 52(a5)
-; RV32IXQCCMP-NEXT:    lw s7, 56(a5)
-; RV32IXQCCMP-NEXT:    lw s8, 60(a5)
-; RV32IXQCCMP-NEXT:    lw s9, 64(a5)
-; RV32IXQCCMP-NEXT:    lw s10, 68(a5)
-; RV32IXQCCMP-NEXT:    lw s11, 72(a5)
-; RV32IXQCCMP-NEXT:    lw ra, 76(a5)
-; RV32IXQCCMP-NEXT:    lw s1, 80(a5)
-; RV32IXQCCMP-NEXT:    lw t3, 84(a5)
-; RV32IXQCCMP-NEXT:    lw t2, 88(a5)
-; RV32IXQCCMP-NEXT:    lw t1, 92(a5)
-; RV32IXQCCMP-NEXT:    lw a7, 112(a5)
-; RV32IXQCCMP-NEXT:    lw s0, 116(a5)
-; RV32IXQCCMP-NEXT:    lw a3, 120(a5)
-; RV32IXQCCMP-NEXT:    lw a0, 124(a5)
-; RV32IXQCCMP-NEXT:    lw a6, 96(a5)
-; RV32IXQCCMP-NEXT:    lw a4, 100(a5)
-; RV32IXQCCMP-NEXT:    lw a2, 104(a5)
-; RV32IXQCCMP-NEXT:    lw a1, 108(a5)
-; RV32IXQCCMP-NEXT:    sw a0, 124(a5)
-; RV32IXQCCMP-NEXT:    sw a3, 120(a5)
-; RV32IXQCCMP-NEXT:    sw s0, 116(a5)
-; RV32IXQCCMP-NEXT:    sw a7, 112(a5)
-; RV32IXQCCMP-NEXT:    sw a1, 108(a5)
-; RV32IXQCCMP-NEXT:    sw a2, 104(a5)
-; RV32IXQCCMP-NEXT:    sw a4, 100(a5)
-; RV32IXQCCMP-NEXT:    sw a6, 96(a5)
-; RV32IXQCCMP-NEXT:    sw t1, 92(a5)
-; RV32IXQCCMP-NEXT:    sw t2, 88(a5)
-; RV32IXQCCMP-NEXT:    sw t3, 84(a5)
-; RV32IXQCCMP-NEXT:    sw s1, 80(a5)
-; RV32IXQCCMP-NEXT:    sw ra, 76(a5)
-; RV32IXQCCMP-NEXT:    sw s11, 72(a5)
-; RV32IXQCCMP-NEXT:    sw s10, 68(a5)
-; RV32IXQCCMP-NEXT:    sw s9, 64(a5)
-; RV32IXQCCMP-NEXT:    sw s8, 60(a5)
-; RV32IXQCCMP-NEXT:    sw s7, 56(a5)
-; RV32IXQCCMP-NEXT:    sw s6, 52(a5)
-; RV32IXQCCMP-NEXT:    sw s5, 48(a5)
-; RV32IXQCCMP-NEXT:    sw s4, 44(a5)
-; RV32IXQCCMP-NEXT:    sw s3, 40(a5)
-; RV32IXQCCMP-NEXT:    sw s2, 36(a5)
-; RV32IXQCCMP-NEXT:    sw t6, 32(a5)
-; RV32IXQCCMP-NEXT:    sw t5, 28(a5)
-; RV32IXQCCMP-NEXT:    sw t4, 24(a5)
-; RV32IXQCCMP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 20(a5)
-; RV32IXQCCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, 16(a5)
-; RV32IXQCCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
-; RV32IXQCCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
-; RV32IXQCCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
-; RV32IXQCCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV32IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s11}, 80
-;
-; RV64IXQCCMP-LABEL: callee_no_irq:
-; RV64IXQCCMP:       # %bb.0:
-; RV64IXQCCMP-NEXT:    qc.cm.push {ra, s0-s11}, -160
-; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 160
-; RV64IXQCCMP-NEXT:    .cfi_offset ra, -8
-; RV64IXQCCMP-NEXT:    .cfi_offset s0, -16
-; RV64IXQCCMP-NEXT:    .cfi_offset s1, -24
-; RV64IXQCCMP-NEXT:    .cfi_offset s2, -32
-; RV64IXQCCMP-NEXT:    .cfi_offset s3, -40
-; RV64IXQCCMP-NEXT:    .cfi_offset s4, -48
-; RV64IXQCCMP-NEXT:    .cfi_offset s5, -56
-; RV64IXQCCMP-NEXT:    .cfi_offset s6, -64
-; RV64IXQCCMP-NEXT:    .cfi_offset s7, -72
-; RV64IXQCCMP-NEXT:    .cfi_offset s8, -80
-; RV64IXQCCMP-NEXT:    .cfi_offset s9, -88
-; RV64IXQCCMP-NEXT:    .cfi_offset s10, -96
-; RV64IXQCCMP-NEXT:    .cfi_offset s11, -104
+; RV64IXQCCMP-NEXT:    addi sp, sp, -128
+; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 288
+; RV64IXQCCMP-NEXT:    sd t0, 168(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t1, 160(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t2, 152(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a1, 136(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a2, 128(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a3, 120(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a4, 112(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a5, 104(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a6, 96(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd a7, 88(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t3, 80(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t4, 72(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t5, 64(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    sd t6, 56(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    .cfi_offset t0, -120
+; RV64IXQCCMP-NEXT:    .cfi_offset t1, -128
+; RV64IXQCCMP-NEXT:    .cfi_offset t2, -136
+; RV64IXQCCMP-NEXT:    .cfi_offset a0, -144
+; RV64IXQCCMP-NEXT:    .cfi_offset a1, -152
+; RV64IXQCCMP-NEXT:    .cfi_offset a2, -160
+; RV64IXQCCMP-NEXT:    .cfi_offset a3, -168
+; RV64IXQCCMP-NEXT:    .cfi_offset a4, -176
+; RV64IXQCCMP-NEXT:    .cfi_offset a5, -184
+; RV64IXQCCMP-NEXT:    .cfi_offset a6, -192
+; RV64IXQCCMP-NEXT:    .cfi_offset a7, -200
+; RV64IXQCCMP-NEXT:    .cfi_offset t3, -208
+; RV64IXQCCMP-NEXT:    .cfi_offset t4, -216
+; RV64IXQCCMP-NEXT:    .cfi_offset t5, -224
+; RV64IXQCCMP-NEXT:    .cfi_offset t6, -232
 ; RV64IXQCCMP-NEXT:    lui t0, %hi(var_test_irq)
 ; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
 ; RV64IXQCCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
@@ -3363,12 +2413,59 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
 ; RV64IXQCCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV64IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
+; RV64IXQCCMP-NEXT:    ld t0, 168(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t1, 160(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t2, 152(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a1, 136(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a2, 128(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a3, 120(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a4, 112(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a5, 104(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a6, 96(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld a7, 88(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t3, 80(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t4, 72(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t5, 64(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    ld t6, 56(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    .cfi_restore t0
+; RV64IXQCCMP-NEXT:    .cfi_restore t1
+; RV64IXQCCMP-NEXT:    .cfi_restore t2
+; RV64IXQCCMP-NEXT:    .cfi_restore a0
+; RV64IXQCCMP-NEXT:    .cfi_restore a1
+; RV64IXQCCMP-NEXT:    .cfi_restore a2
+; RV64IXQCCMP-NEXT:    .cfi_restore a3
+; RV64IXQCCMP-NEXT:    .cfi_restore a4
+; RV64IXQCCMP-NEXT:    .cfi_restore a5
+; RV64IXQCCMP-NEXT:    .cfi_restore a6
+; RV64IXQCCMP-NEXT:    .cfi_restore a7
+; RV64IXQCCMP-NEXT:    .cfi_restore t3
+; RV64IXQCCMP-NEXT:    .cfi_restore t4
+; RV64IXQCCMP-NEXT:    .cfi_restore t5
+; RV64IXQCCMP-NEXT:    .cfi_restore t6
+; RV64IXQCCMP-NEXT:    addi sp, sp, 128
+; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 160
+; RV64IXQCCMP-NEXT:    qc.cm.pop {ra, s0-s11}, 160
+; RV64IXQCCMP-NEXT:    .cfi_restore ra
+; RV64IXQCCMP-NEXT:    .cfi_restore s0
+; RV64IXQCCMP-NEXT:    .cfi_restore s1
+; RV64IXQCCMP-NEXT:    .cfi_restore s2
+; RV64IXQCCMP-NEXT:    .cfi_restore s3
+; RV64IXQCCMP-NEXT:    .cfi_restore s4
+; RV64IXQCCMP-NEXT:    .cfi_restore s5
+; RV64IXQCCMP-NEXT:    .cfi_restore s6
+; RV64IXQCCMP-NEXT:    .cfi_restore s7
+; RV64IXQCCMP-NEXT:    .cfi_restore s8
+; RV64IXQCCMP-NEXT:    .cfi_restore s9
+; RV64IXQCCMP-NEXT:    .cfi_restore s10
+; RV64IXQCCMP-NEXT:    .cfi_restore s11
+; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 0
+; RV64IXQCCMP-NEXT:    mret
 ;
-; RV32IXQCCMP-FP-LABEL: callee_no_irq:
+; RV32IXQCCMP-FP-LABEL: callee_with_irq:
 ; RV32IXQCCMP-FP:       # %bb.0:
-; RV32IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -80
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 80
+; RV32IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -112
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 112
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s0, -8
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s1, -12
@@ -3382,23 +2479,55 @@ define void @callee_no_irq() {
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s9, -44
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s10, -48
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s11, -52
+; RV32IXQCCMP-FP-NEXT:    addi sp, sp, -48
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 160
+; RV32IXQCCMP-FP-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t2, 84(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a6, 56(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t3, 48(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t4, 44(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t5, 40(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw t6, 36(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t0, -68
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t1, -72
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t2, -76
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a0, -80
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a1, -84
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a2, -88
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a3, -92
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a4, -96
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a5, -100
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a6, -104
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset a7, -108
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t3, -112
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t4, -116
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t5, -120
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset t6, -124
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-FP-NEXT:    lui t1, %hi(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq)(t1)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -56(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, -128(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+4)(t1)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -60(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, -132(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+8)(t1)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -64(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, -136(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+12)(t1)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -68(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, -140(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    addi a5, t1, %lo(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    lw a0, 16(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, -144(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a0, 20(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, -148(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a0, 24(a5)
-; RV32IXQCCMP-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a0, -152(s0) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw t5, 28(a5)
 ; RV32IXQCCMP-FP-NEXT:    lw t6, 32(a5)
 ; RV32IXQCCMP-FP-NEXT:    lw s2, 36(a5)
@@ -3449,24 +2578,71 @@ define void @callee_no_irq() {
 ; RV32IXQCCMP-FP-NEXT:    sw s2, 36(a5)
 ; RV32IXQCCMP-FP-NEXT:    sw t6, 32(a5)
 ; RV32IXQCCMP-FP-NEXT:    sw t5, 28(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, -152(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a0, 24(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, -148(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a0, 20(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, -144(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a0, 16(a5)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, -140(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+12)(t1)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -64(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, -136(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+8)(t1)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -60(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, -132(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+4)(t1)
-; RV32IXQCCMP-FP-NEXT:    lw a0, -56(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, -128(s0) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq)(t1)
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 80
-; RV32IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 80
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 160
+; RV32IXQCCMP-FP-NEXT:    lw t0, 92(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t1, 88(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t2, 84(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a2, 72(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t3, 48(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t4, 44(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t5, 40(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw t6, 36(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore t0
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore t1
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore t2
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore a0
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore a1
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore a2
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore a3
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore a4
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore a5
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore a6
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore a7
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore t3
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore t4
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore t5
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore t6
+; RV32IXQCCMP-FP-NEXT:    addi sp, sp, 48
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 112
+; RV32IXQCCMP-FP-NEXT:    qc.cm.pop {ra, s0-s11}, 112
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore ra
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s0
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s1
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s2
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s3
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s4
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s5
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s6
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s7
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s8
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s9
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s10
+; RV32IXQCCMP-FP-NEXT:    .cfi_restore s11
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 0
+; RV32IXQCCMP-FP-NEXT:    mret
 ;
-; RV64IXQCCMP-FP-LABEL: callee_no_irq:
+; RV64IXQCCMP-FP-LABEL: callee_with_irq:
 ; RV64IXQCCMP-FP:       # %bb.0:
 ; RV64IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -160
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 160
@@ -3483,23 +2659,55 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-FP-NEXT:    .cfi_offset s9, -88
 ; RV64IXQCCMP-FP-NEXT:    .cfi_offset s10, -96
 ; RV64IXQCCMP-FP-NEXT:    .cfi_offset s11, -104
+; RV64IXQCCMP-FP-NEXT:    addi sp, sp, -128
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 288
+; RV64IXQCCMP-FP-NEXT:    sd t0, 168(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd t1, 160(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd t2, 152(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 136(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a2, 128(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a3, 120(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a4, 112(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a5, 104(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a6, 96(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a7, 88(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd t3, 80(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd t4, 72(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd t5, 64(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd t6, 56(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset t0, -120
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset t1, -128
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset t2, -136
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset a0, -144
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset a1, -152
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset a2, -160
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset a3, -168
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset a4, -176
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset a5, -184
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset a6, -192
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset a7, -200
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset t3, -208
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset t4, -216
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset t5, -224
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset t6, -232
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-FP-NEXT:    lui t1, %hi(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq)(t1)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -112(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a0, -240(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+4)(t1)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -120(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a0, -248(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+8)(t1)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -128(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a0, -256(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+12)(t1)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -136(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a0, -264(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    addi a5, t1, %lo(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    lw a0, 16(a5)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a0, -272(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a0, 20(a5)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -152(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a0, -280(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a0, 24(a5)
-; RV64IXQCCMP-FP-NEXT:    sd a0, -160(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a0, -288(s0) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw t5, 28(a5)
 ; RV64IXQCCMP-FP-NEXT:    lw t6, 32(a5)
 ; RV64IXQCCMP-FP-NEXT:    lw s2, 36(a5)
@@ -3550,27 +2758,74 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-FP-NEXT:    sw s2, 36(a5)
 ; RV64IXQCCMP-FP-NEXT:    sw t6, 32(a5)
 ; RV64IXQCCMP-FP-NEXT:    sw t5, 28(a5)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a0, -288(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a0, 24(a5)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a0, -280(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a0, 20(a5)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a0, -272(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a0, 16(a5)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a0, -264(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+12)(t1)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a0, -256(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+8)(t1)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a0, -248(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+4)(t1)
-; RV64IXQCCMP-FP-NEXT:    ld a0, -112(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a0, -240(s0) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq)(t1)
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 160
-; RV64IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 288
+; RV64IXQCCMP-FP-NEXT:    ld t0, 168(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld t1, 160(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld t2, 152(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 136(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a2, 128(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a3, 120(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a4, 112(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a5, 104(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a6, 96(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a7, 88(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld t3, 80(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld t4, 72(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld t5, 64(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld t6, 56(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore t0
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore t1
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore t2
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore a0
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore a1
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore a2
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore a3
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore a4
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore a5
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore a6
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore a7
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore t3
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore t4
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore t5
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore t6
+; RV64IXQCCMP-FP-NEXT:    addi sp, sp, 128
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 160
+; RV64IXQCCMP-FP-NEXT:    qc.cm.pop {ra, s0-s11}, 160
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore ra
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s0
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s1
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s2
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s3
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s4
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s5
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s6
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s7
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s8
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s9
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s10
+; RV64IXQCCMP-FP-NEXT:    .cfi_restore s11
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 0
+; RV64IXQCCMP-FP-NEXT:    mret
 ;
-; RV32IXQCCMP-SR-LABEL: callee_no_irq:
+; RV32IXQCCMP-SR-LABEL: callee_with_irq:
 ; RV32IXQCCMP-SR:       # %bb.0:
-; RV32IXQCCMP-SR-NEXT:    qc.cm.push {ra, s0-s11}, -80
-; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 80
+; RV32IXQCCMP-SR-NEXT:    qc.cm.push {ra, s0-s11}, -112
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 112
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset s0, -8
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset s1, -12
@@ -3584,20 +2839,52 @@ define void @callee_no_irq() {
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset s9, -44
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset s10, -48
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset s11, -52
+; RV32IXQCCMP-SR-NEXT:    addi sp, sp, -48
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 160
+; RV32IXQCCMP-SR-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t2, 84(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a6, 56(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t3, 48(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t4, 44(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t5, 40(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw t6, 36(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t0, -68
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t1, -72
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t2, -76
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a0, -80
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a1, -84
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a2, -88
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a3, -92
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a4, -96
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a5, -100
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a6, -104
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset a7, -108
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t3, -112
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t4, -116
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t5, -120
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset t6, -124
 ; RV32IXQCCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
 ; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
 ; RV32IXQCCMP-SR-NEXT:    lw a0, 16(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-SR-NEXT:    lw a0, 20(a5)
-; RV32IXQCCMP-SR-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-SR-NEXT:    lw t4, 24(a5)
 ; RV32IXQCCMP-SR-NEXT:    lw t5, 28(a5)
 ; RV32IXQCCMP-SR-NEXT:    lw t6, 32(a5)
@@ -3650,21 +2937,68 @@ define void @callee_no_irq() {
 ; RV32IXQCCMP-SR-NEXT:    sw t6, 32(a5)
 ; RV32IXQCCMP-SR-NEXT:    sw t5, 28(a5)
 ; RV32IXQCCMP-SR-NEXT:    sw t4, 24(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, 20(a5)
-; RV32IXQCCMP-SR-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, 16(a5)
 ; RV32IXQCCMP-SR-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 20(a5)
 ; RV32IXQCCMP-SR-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 16(a5)
 ; RV32IXQCCMP-SR-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
 ; RV32IXQCCMP-SR-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
-; RV32IXQCCMP-SR-NEXT:    qc.cm.popret {ra, s0-s11}, 80
+; RV32IXQCCMP-SR-NEXT:    lw t0, 92(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t1, 88(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t2, 84(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a2, 72(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t3, 48(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t4, 44(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t5, 40(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    lw t6, 36(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore t0
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore t1
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore t2
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore a0
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore a1
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore a2
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore a3
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore a4
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore a5
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore a6
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore a7
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore t3
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore t4
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore t5
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore t6
+; RV32IXQCCMP-SR-NEXT:    addi sp, sp, 48
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 112
+; RV32IXQCCMP-SR-NEXT:    qc.cm.pop {ra, s0-s11}, 112
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore ra
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s0
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s1
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s2
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s3
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s4
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s5
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s6
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s7
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s8
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s9
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s10
+; RV32IXQCCMP-SR-NEXT:    .cfi_restore s11
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 0
+; RV32IXQCCMP-SR-NEXT:    mret
 ;
-; RV64IXQCCMP-SR-LABEL: callee_no_irq:
+; RV64IXQCCMP-SR-LABEL: callee_with_irq:
 ; RV64IXQCCMP-SR:       # %bb.0:
 ; RV64IXQCCMP-SR-NEXT:    qc.cm.push {ra, s0-s11}, -160
 ; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 160
@@ -3681,6 +3015,38 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset s9, -88
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset s10, -96
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset s11, -104
+; RV64IXQCCMP-SR-NEXT:    addi sp, sp, -128
+; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 288
+; RV64IXQCCMP-SR-NEXT:    sd t0, 168(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t1, 160(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t2, 152(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a1, 136(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a2, 128(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a3, 120(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a4, 112(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a5, 104(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a6, 96(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd a7, 88(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t3, 80(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t4, 72(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t5, 64(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    sd t6, 56(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t0, -120
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t1, -128
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t2, -136
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a0, -144
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a1, -152
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a2, -160
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a3, -168
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a4, -176
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a5, -184
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a6, -192
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset a7, -200
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t3, -208
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t4, -216
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t5, -224
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset t6, -232
 ; RV64IXQCCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
 ; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
 ; RV64IXQCCMP-SR-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
@@ -3759,6 +3125,652 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
 ; RV64IXQCCMP-SR-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
+; RV64IXQCCMP-SR-NEXT:    ld t0, 168(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t1, 160(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t2, 152(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a1, 136(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a2, 128(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a3, 120(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a4, 112(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a5, 104(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a6, 96(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld a7, 88(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t3, 80(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t4, 72(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t5, 64(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    ld t6, 56(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore t0
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore t1
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore t2
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore a0
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore a1
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore a2
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore a3
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore a4
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore a5
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore a6
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore a7
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore t3
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore t4
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore t5
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore t6
+; RV64IXQCCMP-SR-NEXT:    addi sp, sp, 128
+; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 160
+; RV64IXQCCMP-SR-NEXT:    qc.cm.pop {ra, s0-s11}, 160
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore ra
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s0
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s1
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s2
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s3
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s4
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s5
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s6
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s7
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s8
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s9
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s10
+; RV64IXQCCMP-SR-NEXT:    .cfi_restore s11
+; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 0
+; RV64IXQCCMP-SR-NEXT:    mret
+  %val = load [32 x i32], ptr @var_test_irq
+  store volatile [32 x i32] %val, ptr @var_test_irq
+  ret void
+}
+
+define void @callee_no_irq() {
+; RV32IXQCCMP-LABEL: callee_no_irq:
+; RV32IXQCCMP:       # %bb.0:
+; RV32IXQCCMP-NEXT:    qc.cm.push {ra, s0-s11}, -96
+; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 96
+; RV32IXQCCMP-NEXT:    .cfi_offset ra, -4
+; RV32IXQCCMP-NEXT:    .cfi_offset s0, -8
+; RV32IXQCCMP-NEXT:    .cfi_offset s1, -12
+; RV32IXQCCMP-NEXT:    .cfi_offset s2, -16
+; RV32IXQCCMP-NEXT:    .cfi_offset s3, -20
+; RV32IXQCCMP-NEXT:    .cfi_offset s4, -24
+; RV32IXQCCMP-NEXT:    .cfi_offset s5, -28
+; RV32IXQCCMP-NEXT:    .cfi_offset s6, -32
+; RV32IXQCCMP-NEXT:    .cfi_offset s7, -36
+; RV32IXQCCMP-NEXT:    .cfi_offset s8, -40
+; RV32IXQCCMP-NEXT:    .cfi_offset s9, -44
+; RV32IXQCCMP-NEXT:    .cfi_offset s10, -48
+; RV32IXQCCMP-NEXT:    .cfi_offset s11, -52
+; RV32IXQCCMP-NEXT:    lui t0, %hi(var_test_irq)
+; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
+; RV32IXQCCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
+; RV32IXQCCMP-NEXT:    lw a0, 16(a5)
+; RV32IXQCCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    lw a0, 20(a5)
+; RV32IXQCCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-NEXT:    lw t4, 24(a5)
+; RV32IXQCCMP-NEXT:    lw t5, 28(a5)
+; RV32IXQCCMP-NEXT:    lw t6, 32(a5)
+; RV32IXQCCMP-NEXT:    lw s2, 36(a5)
+; RV32IXQCCMP-NEXT:    lw s3, 40(a5)
+; RV32IXQCCMP-NEXT:    lw s4, 44(a5)
+; RV32IXQCCMP-NEXT:    lw s5, 48(a5)
+; RV32IXQCCMP-NEXT:    lw s6, 52(a5)
+; RV32IXQCCMP-NEXT:    lw s7, 56(a5)
+; RV32IXQCCMP-NEXT:    lw s8, 60(a5)
+; RV32IXQCCMP-NEXT:    lw s9, 64(a5)
+; RV32IXQCCMP-NEXT:    lw s10, 68(a5)
+; RV32IXQCCMP-NEXT:    lw s11, 72(a5)
+; RV32IXQCCMP-NEXT:    lw ra, 76(a5)
+; RV32IXQCCMP-NEXT:    lw s1, 80(a5)
+; RV32IXQCCMP-NEXT:    lw t3, 84(a5)
+; RV32IXQCCMP-NEXT:    lw t2, 88(a5)
+; RV32IXQCCMP-NEXT:    lw t1, 92(a5)
+; RV32IXQCCMP-NEXT:    lw a7, 112(a5)
+; RV32IXQCCMP-NEXT:    lw s0, 116(a5)
+; RV32IXQCCMP-NEXT:    lw a3, 120(a5)
+; RV32IXQCCMP-NEXT:    lw a0, 124(a5)
+; RV32IXQCCMP-NEXT:    lw a6, 96(a5)
+; RV32IXQCCMP-NEXT:    lw a4, 100(a5)
+; RV32IXQCCMP-NEXT:    lw a2, 104(a5)
+; RV32IXQCCMP-NEXT:    lw a1, 108(a5)
+; RV32IXQCCMP-NEXT:    sw a0, 124(a5)
+; RV32IXQCCMP-NEXT:    sw a3, 120(a5)
+; RV32IXQCCMP-NEXT:    sw s0, 116(a5)
+; RV32IXQCCMP-NEXT:    sw a7, 112(a5)
+; RV32IXQCCMP-NEXT:    sw a1, 108(a5)
+; RV32IXQCCMP-NEXT:    sw a2, 104(a5)
+; RV32IXQCCMP-NEXT:    sw a4, 100(a5)
+; RV32IXQCCMP-NEXT:    sw a6, 96(a5)
+; RV32IXQCCMP-NEXT:    sw t1, 92(a5)
+; RV32IXQCCMP-NEXT:    sw t2, 88(a5)
+; RV32IXQCCMP-NEXT:    sw t3, 84(a5)
+; RV32IXQCCMP-NEXT:    sw s1, 80(a5)
+; RV32IXQCCMP-NEXT:    sw ra, 76(a5)
+; RV32IXQCCMP-NEXT:    sw s11, 72(a5)
+; RV32IXQCCMP-NEXT:    sw s10, 68(a5)
+; RV32IXQCCMP-NEXT:    sw s9, 64(a5)
+; RV32IXQCCMP-NEXT:    sw s8, 60(a5)
+; RV32IXQCCMP-NEXT:    sw s7, 56(a5)
+; RV32IXQCCMP-NEXT:    sw s6, 52(a5)
+; RV32IXQCCMP-NEXT:    sw s5, 48(a5)
+; RV32IXQCCMP-NEXT:    sw s4, 44(a5)
+; RV32IXQCCMP-NEXT:    sw s3, 40(a5)
+; RV32IXQCCMP-NEXT:    sw s2, 36(a5)
+; RV32IXQCCMP-NEXT:    sw t6, 32(a5)
+; RV32IXQCCMP-NEXT:    sw t5, 28(a5)
+; RV32IXQCCMP-NEXT:    sw t4, 24(a5)
+; RV32IXQCCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, 20(a5)
+; RV32IXQCCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, 16(a5)
+; RV32IXQCCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV32IXQCCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IXQCCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IXQCCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
+; RV32IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s11}, 96
+;
+; RV64IXQCCMP-LABEL: callee_no_irq:
+; RV64IXQCCMP:       # %bb.0:
+; RV64IXQCCMP-NEXT:    qc.cm.push {ra, s0-s11}, -160
+; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 160
+; RV64IXQCCMP-NEXT:    .cfi_offset ra, -8
+; RV64IXQCCMP-NEXT:    .cfi_offset s0, -16
+; RV64IXQCCMP-NEXT:    .cfi_offset s1, -24
+; RV64IXQCCMP-NEXT:    .cfi_offset s2, -32
+; RV64IXQCCMP-NEXT:    .cfi_offset s3, -40
+; RV64IXQCCMP-NEXT:    .cfi_offset s4, -48
+; RV64IXQCCMP-NEXT:    .cfi_offset s5, -56
+; RV64IXQCCMP-NEXT:    .cfi_offset s6, -64
+; RV64IXQCCMP-NEXT:    .cfi_offset s7, -72
+; RV64IXQCCMP-NEXT:    .cfi_offset s8, -80
+; RV64IXQCCMP-NEXT:    .cfi_offset s9, -88
+; RV64IXQCCMP-NEXT:    .cfi_offset s10, -96
+; RV64IXQCCMP-NEXT:    .cfi_offset s11, -104
+; RV64IXQCCMP-NEXT:    lui t0, %hi(var_test_irq)
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq)(t0)
+; RV64IXQCCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
+; RV64IXQCCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
+; RV64IXQCCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
+; RV64IXQCCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    addi a5, t0, %lo(var_test_irq)
+; RV64IXQCCMP-NEXT:    lw a0, 16(a5)
+; RV64IXQCCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw a0, 20(a5)
+; RV64IXQCCMP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-NEXT:    lw t4, 24(a5)
+; RV64IXQCCMP-NEXT:    lw t5, 28(a5)
+; RV64IXQCCMP-NEXT:    lw t6, 32(a5)
+; RV64IXQCCMP-NEXT:    lw s2, 36(a5)
+; RV64IXQCCMP-NEXT:    lw s3, 40(a5)
+; RV64IXQCCMP-NEXT:    lw s4, 44(a5)
+; RV64IXQCCMP-NEXT:    lw s5, 48(a5)
+; RV64IXQCCMP-NEXT:    lw s6, 52(a5)
+; RV64IXQCCMP-NEXT:    lw s7, 56(a5)
+; RV64IXQCCMP-NEXT:    lw s8, 60(a5)
+; RV64IXQCCMP-NEXT:    lw s9, 64(a5)
+; RV64IXQCCMP-NEXT:    lw s10, 68(a5)
+; RV64IXQCCMP-NEXT:    lw s11, 72(a5)
+; RV64IXQCCMP-NEXT:    lw ra, 76(a5)
+; RV64IXQCCMP-NEXT:    lw s1, 80(a5)
+; RV64IXQCCMP-NEXT:    lw t3, 84(a5)
+; RV64IXQCCMP-NEXT:    lw t2, 88(a5)
+; RV64IXQCCMP-NEXT:    lw t1, 92(a5)
+; RV64IXQCCMP-NEXT:    lw a7, 112(a5)
+; RV64IXQCCMP-NEXT:    lw s0, 116(a5)
+; RV64IXQCCMP-NEXT:    lw a3, 120(a5)
+; RV64IXQCCMP-NEXT:    lw a0, 124(a5)
+; RV64IXQCCMP-NEXT:    lw a6, 96(a5)
+; RV64IXQCCMP-NEXT:    lw a4, 100(a5)
+; RV64IXQCCMP-NEXT:    lw a2, 104(a5)
+; RV64IXQCCMP-NEXT:    lw a1, 108(a5)
+; RV64IXQCCMP-NEXT:    sw a0, 124(a5)
+; RV64IXQCCMP-NEXT:    sw a3, 120(a5)
+; RV64IXQCCMP-NEXT:    sw s0, 116(a5)
+; RV64IXQCCMP-NEXT:    sw a7, 112(a5)
+; RV64IXQCCMP-NEXT:    sw a1, 108(a5)
+; RV64IXQCCMP-NEXT:    sw a2, 104(a5)
+; RV64IXQCCMP-NEXT:    sw a4, 100(a5)
+; RV64IXQCCMP-NEXT:    sw a6, 96(a5)
+; RV64IXQCCMP-NEXT:    sw t1, 92(a5)
+; RV64IXQCCMP-NEXT:    sw t2, 88(a5)
+; RV64IXQCCMP-NEXT:    sw t3, 84(a5)
+; RV64IXQCCMP-NEXT:    sw s1, 80(a5)
+; RV64IXQCCMP-NEXT:    sw ra, 76(a5)
+; RV64IXQCCMP-NEXT:    sw s11, 72(a5)
+; RV64IXQCCMP-NEXT:    sw s10, 68(a5)
+; RV64IXQCCMP-NEXT:    sw s9, 64(a5)
+; RV64IXQCCMP-NEXT:    sw s8, 60(a5)
+; RV64IXQCCMP-NEXT:    sw s7, 56(a5)
+; RV64IXQCCMP-NEXT:    sw s6, 52(a5)
+; RV64IXQCCMP-NEXT:    sw s5, 48(a5)
+; RV64IXQCCMP-NEXT:    sw s4, 44(a5)
+; RV64IXQCCMP-NEXT:    sw s3, 40(a5)
+; RV64IXQCCMP-NEXT:    sw s2, 36(a5)
+; RV64IXQCCMP-NEXT:    sw t6, 32(a5)
+; RV64IXQCCMP-NEXT:    sw t5, 28(a5)
+; RV64IXQCCMP-NEXT:    sw t4, 24(a5)
+; RV64IXQCCMP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    sw a0, 20(a5)
+; RV64IXQCCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    sw a0, 16(a5)
+; RV64IXQCCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV64IXQCCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV64IXQCCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV64IXQCCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-NEXT:    sw a0, %lo(var_test_irq)(t0)
+; RV64IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
+;
+; RV32IXQCCMP-FP-LABEL: callee_no_irq:
+; RV32IXQCCMP-FP:       # %bb.0:
+; RV32IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -96
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 96
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset ra, -4
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s0, -8
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s1, -12
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s2, -16
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s3, -20
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s4, -24
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s5, -28
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s6, -32
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s7, -36
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s8, -40
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s9, -44
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s10, -48
+; RV32IXQCCMP-FP-NEXT:    .cfi_offset s11, -52
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
+; RV32IXQCCMP-FP-NEXT:    lui t1, %hi(var_test_irq)
+; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq)(t1)
+; RV32IXQCCMP-FP-NEXT:    sw a0, -68(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+4)(t1)
+; RV32IXQCCMP-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+8)(t1)
+; RV32IXQCCMP-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+12)(t1)
+; RV32IXQCCMP-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    addi a5, t1, %lo(var_test_irq)
+; RV32IXQCCMP-FP-NEXT:    lw a0, 16(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a0, -84(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a0, 20(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a0, -88(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a0, 24(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a0, -92(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw t5, 28(a5)
+; RV32IXQCCMP-FP-NEXT:    lw t6, 32(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s2, 36(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s3, 40(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s4, 44(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s5, 48(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s6, 52(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s7, 56(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s8, 60(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s9, 64(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s10, 68(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s11, 72(a5)
+; RV32IXQCCMP-FP-NEXT:    lw ra, 76(a5)
+; RV32IXQCCMP-FP-NEXT:    lw t4, 80(a5)
+; RV32IXQCCMP-FP-NEXT:    lw t3, 84(a5)
+; RV32IXQCCMP-FP-NEXT:    lw t2, 88(a5)
+; RV32IXQCCMP-FP-NEXT:    lw s1, 92(a5)
+; RV32IXQCCMP-FP-NEXT:    lw t0, 112(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a4, 116(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a3, 120(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a0, 124(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a7, 96(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a6, 100(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a2, 104(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 108(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a0, 124(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a3, 120(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a4, 116(a5)
+; RV32IXQCCMP-FP-NEXT:    sw t0, 112(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 108(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a2, 104(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a6, 100(a5)
+; RV32IXQCCMP-FP-NEXT:    sw a7, 96(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s1, 92(a5)
+; RV32IXQCCMP-FP-NEXT:    sw t2, 88(a5)
+; RV32IXQCCMP-FP-NEXT:    sw t3, 84(a5)
+; RV32IXQCCMP-FP-NEXT:    sw t4, 80(a5)
+; RV32IXQCCMP-FP-NEXT:    sw ra, 76(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s11, 72(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s10, 68(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s9, 64(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s8, 60(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s7, 56(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s6, 52(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s5, 48(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s4, 44(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s3, 40(a5)
+; RV32IXQCCMP-FP-NEXT:    sw s2, 36(a5)
+; RV32IXQCCMP-FP-NEXT:    sw t6, 32(a5)
+; RV32IXQCCMP-FP-NEXT:    sw t5, 28(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a0, -92(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a0, 24(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a0, -88(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a0, 20(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a0, -84(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a0, 16(a5)
+; RV32IXQCCMP-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+12)(t1)
+; RV32IXQCCMP-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+8)(t1)
+; RV32IXQCCMP-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+4)(t1)
+; RV32IXQCCMP-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq)(t1)
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 96
+; RV32IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 96
+;
+; RV64IXQCCMP-FP-LABEL: callee_no_irq:
+; RV64IXQCCMP-FP:       # %bb.0:
+; RV64IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s11}, -160
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 160
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset ra, -8
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s0, -16
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s1, -24
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s2, -32
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s3, -40
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s4, -48
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s5, -56
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s6, -64
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s7, -72
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s8, -80
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s9, -88
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s10, -96
+; RV64IXQCCMP-FP-NEXT:    .cfi_offset s11, -104
+; RV64IXQCCMP-FP-NEXT:    addi sp, sp, -16
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 176
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
+; RV64IXQCCMP-FP-NEXT:    lui t1, %hi(var_test_irq)
+; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq)(t1)
+; RV64IXQCCMP-FP-NEXT:    sd a0, -120(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+4)(t1)
+; RV64IXQCCMP-FP-NEXT:    sd a0, -128(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+8)(t1)
+; RV64IXQCCMP-FP-NEXT:    sd a0, -136(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a0, %lo(var_test_irq+12)(t1)
+; RV64IXQCCMP-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    addi a5, t1, %lo(var_test_irq)
+; RV64IXQCCMP-FP-NEXT:    lw a0, 16(a5)
+; RV64IXQCCMP-FP-NEXT:    sd a0, -152(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a0, 20(a5)
+; RV64IXQCCMP-FP-NEXT:    sd a0, -160(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a0, 24(a5)
+; RV64IXQCCMP-FP-NEXT:    sd a0, -168(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw t5, 28(a5)
+; RV64IXQCCMP-FP-NEXT:    lw t6, 32(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s2, 36(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s3, 40(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s4, 44(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s5, 48(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s6, 52(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s7, 56(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s8, 60(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s9, 64(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s10, 68(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s11, 72(a5)
+; RV64IXQCCMP-FP-NEXT:    lw ra, 76(a5)
+; RV64IXQCCMP-FP-NEXT:    lw t4, 80(a5)
+; RV64IXQCCMP-FP-NEXT:    lw t3, 84(a5)
+; RV64IXQCCMP-FP-NEXT:    lw t2, 88(a5)
+; RV64IXQCCMP-FP-NEXT:    lw s1, 92(a5)
+; RV64IXQCCMP-FP-NEXT:    lw t0, 112(a5)
+; RV64IXQCCMP-FP-NEXT:    lw a4, 116(a5)
+; RV64IXQCCMP-FP-NEXT:    lw a3, 120(a5)
+; RV64IXQCCMP-FP-NEXT:    lw a0, 124(a5)
+; RV64IXQCCMP-FP-NEXT:    lw a7, 96(a5)
+; RV64IXQCCMP-FP-NEXT:    lw a6, 100(a5)
+; RV64IXQCCMP-FP-NEXT:    lw a2, 104(a5)
+; RV64IXQCCMP-FP-NEXT:    lw a1, 108(a5)
+; RV64IXQCCMP-FP-NEXT:    sw a0, 124(a5)
+; RV64IXQCCMP-FP-NEXT:    sw a3, 120(a5)
+; RV64IXQCCMP-FP-NEXT:    sw a4, 116(a5)
+; RV64IXQCCMP-FP-NEXT:    sw t0, 112(a5)
+; RV64IXQCCMP-FP-NEXT:    sw a1, 108(a5)
+; RV64IXQCCMP-FP-NEXT:    sw a2, 104(a5)
+; RV64IXQCCMP-FP-NEXT:    sw a6, 100(a5)
+; RV64IXQCCMP-FP-NEXT:    sw a7, 96(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s1, 92(a5)
+; RV64IXQCCMP-FP-NEXT:    sw t2, 88(a5)
+; RV64IXQCCMP-FP-NEXT:    sw t3, 84(a5)
+; RV64IXQCCMP-FP-NEXT:    sw t4, 80(a5)
+; RV64IXQCCMP-FP-NEXT:    sw ra, 76(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s11, 72(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s10, 68(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s9, 64(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s8, 60(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s7, 56(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s6, 52(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s5, 48(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s4, 44(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s3, 40(a5)
+; RV64IXQCCMP-FP-NEXT:    sw s2, 36(a5)
+; RV64IXQCCMP-FP-NEXT:    sw t6, 32(a5)
+; RV64IXQCCMP-FP-NEXT:    sw t5, 28(a5)
+; RV64IXQCCMP-FP-NEXT:    ld a0, -168(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a0, 24(a5)
+; RV64IXQCCMP-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a0, 20(a5)
+; RV64IXQCCMP-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a0, 16(a5)
+; RV64IXQCCMP-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+12)(t1)
+; RV64IXQCCMP-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+8)(t1)
+; RV64IXQCCMP-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq+4)(t1)
+; RV64IXQCCMP-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a0, %lo(var_test_irq)(t1)
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 176
+; RV64IXQCCMP-FP-NEXT:    addi sp, sp, 16
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 160
+; RV64IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
+;
+; RV32IXQCCMP-SR-LABEL: callee_no_irq:
+; RV32IXQCCMP-SR:       # %bb.0:
+; RV32IXQCCMP-SR-NEXT:    qc.cm.push {ra, s0-s11}, -96
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 96
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset ra, -4
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s0, -8
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s1, -12
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s2, -16
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s3, -20
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s4, -24
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s5, -28
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s6, -32
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s7, -36
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s8, -40
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s9, -44
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s10, -48
+; RV32IXQCCMP-SR-NEXT:    .cfi_offset s11, -52
+; RV32IXQCCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
+; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 16(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    lw a0, 20(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-SR-NEXT:    lw t4, 24(a5)
+; RV32IXQCCMP-SR-NEXT:    lw t5, 28(a5)
+; RV32IXQCCMP-SR-NEXT:    lw t6, 32(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s2, 36(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s3, 40(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s4, 44(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s5, 48(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s6, 52(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s7, 56(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s8, 60(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s9, 64(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s10, 68(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s11, 72(a5)
+; RV32IXQCCMP-SR-NEXT:    lw ra, 76(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s1, 80(a5)
+; RV32IXQCCMP-SR-NEXT:    lw t3, 84(a5)
+; RV32IXQCCMP-SR-NEXT:    lw t2, 88(a5)
+; RV32IXQCCMP-SR-NEXT:    lw t1, 92(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a7, 112(a5)
+; RV32IXQCCMP-SR-NEXT:    lw s0, 116(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a3, 120(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 124(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a6, 96(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a4, 100(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a2, 104(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a1, 108(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a0, 124(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a3, 120(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s0, 116(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a7, 112(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a1, 108(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a2, 104(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a4, 100(a5)
+; RV32IXQCCMP-SR-NEXT:    sw a6, 96(a5)
+; RV32IXQCCMP-SR-NEXT:    sw t1, 92(a5)
+; RV32IXQCCMP-SR-NEXT:    sw t2, 88(a5)
+; RV32IXQCCMP-SR-NEXT:    sw t3, 84(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s1, 80(a5)
+; RV32IXQCCMP-SR-NEXT:    sw ra, 76(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s11, 72(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s10, 68(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s9, 64(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s8, 60(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s7, 56(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s6, 52(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s5, 48(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s4, 44(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s3, 40(a5)
+; RV32IXQCCMP-SR-NEXT:    sw s2, 36(a5)
+; RV32IXQCCMP-SR-NEXT:    sw t6, 32(a5)
+; RV32IXQCCMP-SR-NEXT:    sw t5, 28(a5)
+; RV32IXQCCMP-SR-NEXT:    sw t4, 24(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    sw a0, 20(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    sw a0, 16(a5)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV32IXQCCMP-SR-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
+; RV32IXQCCMP-SR-NEXT:    qc.cm.popret {ra, s0-s11}, 96
+;
+; RV64IXQCCMP-SR-LABEL: callee_no_irq:
+; RV64IXQCCMP-SR:       # %bb.0:
+; RV64IXQCCMP-SR-NEXT:    qc.cm.push {ra, s0-s11}, -160
+; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 160
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset ra, -8
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s0, -16
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s1, -24
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s2, -32
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s3, -40
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s4, -48
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s5, -56
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s6, -64
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s7, -72
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s8, -80
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s9, -88
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s10, -96
+; RV64IXQCCMP-SR-NEXT:    .cfi_offset s11, -104
+; RV64IXQCCMP-SR-NEXT:    lui t0, %hi(var_test_irq)
+; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq)(t0)
+; RV64IXQCCMP-SR-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+4)(t0)
+; RV64IXQCCMP-SR-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+8)(t0)
+; RV64IXQCCMP-SR-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    lw a0, %lo(var_test_irq+12)(t0)
+; RV64IXQCCMP-SR-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    addi a5, t0, %lo(var_test_irq)
+; RV64IXQCCMP-SR-NEXT:    lw a0, 16(a5)
+; RV64IXQCCMP-SR-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    lw a0, 20(a5)
+; RV64IXQCCMP-SR-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-SR-NEXT:    lw t4, 24(a5)
+; RV64IXQCCMP-SR-NEXT:    lw t5, 28(a5)
+; RV64IXQCCMP-SR-NEXT:    lw t6, 32(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s2, 36(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s3, 40(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s4, 44(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s5, 48(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s6, 52(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s7, 56(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s8, 60(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s9, 64(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s10, 68(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s11, 72(a5)
+; RV64IXQCCMP-SR-NEXT:    lw ra, 76(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s1, 80(a5)
+; RV64IXQCCMP-SR-NEXT:    lw t3, 84(a5)
+; RV64IXQCCMP-SR-NEXT:    lw t2, 88(a5)
+; RV64IXQCCMP-SR-NEXT:    lw t1, 92(a5)
+; RV64IXQCCMP-SR-NEXT:    lw a7, 112(a5)
+; RV64IXQCCMP-SR-NEXT:    lw s0, 116(a5)
+; RV64IXQCCMP-SR-NEXT:    lw a3, 120(a5)
+; RV64IXQCCMP-SR-NEXT:    lw a0, 124(a5)
+; RV64IXQCCMP-SR-NEXT:    lw a6, 96(a5)
+; RV64IXQCCMP-SR-NEXT:    lw a4, 100(a5)
+; RV64IXQCCMP-SR-NEXT:    lw a2, 104(a5)
+; RV64IXQCCMP-SR-NEXT:    lw a1, 108(a5)
+; RV64IXQCCMP-SR-NEXT:    sw a0, 124(a5)
+; RV64IXQCCMP-SR-NEXT:    sw a3, 120(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s0, 116(a5)
+; RV64IXQCCMP-SR-NEXT:    sw a7, 112(a5)
+; RV64IXQCCMP-SR-NEXT:    sw a1, 108(a5)
+; RV64IXQCCMP-SR-NEXT:    sw a2, 104(a5)
+; RV64IXQCCMP-SR-NEXT:    sw a4, 100(a5)
+; RV64IXQCCMP-SR-NEXT:    sw a6, 96(a5)
+; RV64IXQCCMP-SR-NEXT:    sw t1, 92(a5)
+; RV64IXQCCMP-SR-NEXT:    sw t2, 88(a5)
+; RV64IXQCCMP-SR-NEXT:    sw t3, 84(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s1, 80(a5)
+; RV64IXQCCMP-SR-NEXT:    sw ra, 76(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s11, 72(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s10, 68(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s9, 64(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s8, 60(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s7, 56(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s6, 52(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s5, 48(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s4, 44(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s3, 40(a5)
+; RV64IXQCCMP-SR-NEXT:    sw s2, 36(a5)
+; RV64IXQCCMP-SR-NEXT:    sw t6, 32(a5)
+; RV64IXQCCMP-SR-NEXT:    sw t5, 28(a5)
+; RV64IXQCCMP-SR-NEXT:    sw t4, 24(a5)
+; RV64IXQCCMP-SR-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    sw a0, 20(a5)
+; RV64IXQCCMP-SR-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    sw a0, 16(a5)
+; RV64IXQCCMP-SR-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+12)(t0)
+; RV64IXQCCMP-SR-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+8)(t0)
+; RV64IXQCCMP-SR-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq+4)(t0)
+; RV64IXQCCMP-SR-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-SR-NEXT:    sw a0, %lo(var_test_irq)(t0)
 ; RV64IXQCCMP-SR-NEXT:    qc.cm.popret {ra, s0-s11}, 160
   %val = load [32 x i32], ptr @var_test_irq
   store volatile [32 x i32] %val, ptr @var_test_irq
@@ -3771,99 +3783,99 @@ declare ptr @llvm.frameaddress.p0(i32 immarg)
 define i32 @use_fp(i32 %x) {
 ; RV32IXQCCMP-LABEL: use_fp:
 ; RV32IXQCCMP:       # %bb.0: # %entry
-; RV32IXQCCMP-NEXT:    qc.cm.pushfp {ra, s0-s1}, -16
-; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 16
+; RV32IXQCCMP-NEXT:    qc.cm.pushfp {ra, s0-s1}, -32
+; RV32IXQCCMP-NEXT:    .cfi_def_cfa_offset 32
 ; RV32IXQCCMP-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-NEXT:    .cfi_offset s0, -8
 ; RV32IXQCCMP-NEXT:    .cfi_offset s1, -12
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-NEXT:    mv s1, a0
-; RV32IXQCCMP-NEXT:    addi a1, s0, -16
+; RV32IXQCCMP-NEXT:    addi a1, s0, -20
 ; RV32IXQCCMP-NEXT:    mv a0, s0
 ; RV32IXQCCMP-NEXT:    call bar
 ; RV32IXQCCMP-NEXT:    mv a0, s1
-; RV32IXQCCMP-NEXT:    .cfi_def_cfa sp, 16
-; RV32IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s1}, 16
+; RV32IXQCCMP-NEXT:    .cfi_def_cfa sp, 32
+; RV32IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s1}, 32
 ;
 ; RV64IXQCCMP-LABEL: use_fp:
 ; RV64IXQCCMP:       # %bb.0: # %entry
-; RV64IXQCCMP-NEXT:    qc.cm.pushfp {ra, s0-s1}, -32
-; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 32
+; RV64IXQCCMP-NEXT:    qc.cm.pushfp {ra, s0-s1}, -48
+; RV64IXQCCMP-NEXT:    .cfi_def_cfa_offset 48
 ; RV64IXQCCMP-NEXT:    .cfi_offset ra, -8
 ; RV64IXQCCMP-NEXT:    .cfi_offset s0, -16
 ; RV64IXQCCMP-NEXT:    .cfi_offset s1, -24
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-NEXT:    mv s1, a0
-; RV64IXQCCMP-NEXT:    addi a1, s0, -28
+; RV64IXQCCMP-NEXT:    addi a1, s0, -36
 ; RV64IXQCCMP-NEXT:    mv a0, s0
 ; RV64IXQCCMP-NEXT:    call bar
 ; RV64IXQCCMP-NEXT:    mv a0, s1
-; RV64IXQCCMP-NEXT:    .cfi_def_cfa sp, 32
-; RV64IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s1}, 32
+; RV64IXQCCMP-NEXT:    .cfi_def_cfa sp, 48
+; RV64IXQCCMP-NEXT:    qc.cm.popret {ra, s0-s1}, 48
 ;
 ; RV32IXQCCMP-FP-LABEL: use_fp:
 ; RV32IXQCCMP-FP:       # %bb.0: # %entry
-; RV32IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s1}, -16
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 16
+; RV32IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s1}, -32
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 32
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s0, -8
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s1, -12
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-FP-NEXT:    mv s1, a0
-; RV32IXQCCMP-FP-NEXT:    addi a1, s0, -16
+; RV32IXQCCMP-FP-NEXT:    addi a1, s0, -20
 ; RV32IXQCCMP-FP-NEXT:    mv a0, s0
 ; RV32IXQCCMP-FP-NEXT:    call bar
 ; RV32IXQCCMP-FP-NEXT:    mv a0, s1
-; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 16
-; RV32IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s1}, 16
+; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 32
+; RV32IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s1}, 32
 ;
 ; RV64IXQCCMP-FP-LABEL: use_fp:
 ; RV64IXQCCMP-FP:       # %bb.0: # %entry
-; RV64IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s1}, -32
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 32
+; RV64IXQCCMP-FP-NEXT:    qc.cm.pushfp {ra, s0-s1}, -48
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 48
 ; RV64IXQCCMP-FP-NEXT:    .cfi_offset ra, -8
 ; RV64IXQCCMP-FP-NEXT:    .cfi_offset s0, -16
 ; RV64IXQCCMP-FP-NEXT:    .cfi_offset s1, -24
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-FP-NEXT:    mv s1, a0
-; RV64IXQCCMP-FP-NEXT:    addi a1, s0, -28
+; RV64IXQCCMP-FP-NEXT:    addi a1, s0, -36
 ; RV64IXQCCMP-FP-NEXT:    mv a0, s0
 ; RV64IXQCCMP-FP-NEXT:    call bar
 ; RV64IXQCCMP-FP-NEXT:    mv a0, s1
-; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 32
-; RV64IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s1}, 32
+; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 48
+; RV64IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s1}, 48
 ;
 ; RV32IXQCCMP-SR-LABEL: use_fp:
 ; RV32IXQCCMP-SR:       # %bb.0: # %entry
-; RV32IXQCCMP-SR-NEXT:    qc.cm.pushfp {ra, s0-s1}, -16
-; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 16
+; RV32IXQCCMP-SR-NEXT:    qc.cm.pushfp {ra, s0-s1}, -32
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 32
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset ra, -4
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset s0, -8
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset s1, -12
 ; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-SR-NEXT:    mv s1, a0
-; RV32IXQCCMP-SR-NEXT:    addi a1, s0, -16
+; RV32IXQCCMP-SR-NEXT:    addi a1, s0, -20
 ; RV32IXQCCMP-SR-NEXT:    mv a0, s0
 ; RV32IXQCCMP-SR-NEXT:    call bar
 ; RV32IXQCCMP-SR-NEXT:    mv a0, s1
-; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa sp, 16
-; RV32IXQCCMP-SR-NEXT:    qc.cm.popret {ra, s0-s1}, 16
+; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa sp, 32
+; RV32IXQCCMP-SR-NEXT:    qc.cm.popret {ra, s0-s1}, 32
 ;
 ; RV64IXQCCMP-SR-LABEL: use_fp:
 ; RV64IXQCCMP-SR:       # %bb.0: # %entry
-; RV64IXQCCMP-SR-NEXT:    qc.cm.pushfp {ra, s0-s1}, -32
-; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 32
+; RV64IXQCCMP-SR-NEXT:    qc.cm.pushfp {ra, s0-s1}, -48
+; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa_offset 48
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset ra, -8
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset s0, -16
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset s1, -24
 ; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-SR-NEXT:    mv s1, a0
-; RV64IXQCCMP-SR-NEXT:    addi a1, s0, -28
+; RV64IXQCCMP-SR-NEXT:    addi a1, s0, -36
 ; RV64IXQCCMP-SR-NEXT:    mv a0, s0
 ; RV64IXQCCMP-SR-NEXT:    call bar
 ; RV64IXQCCMP-SR-NEXT:    mv a0, s1
-; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa sp, 32
-; RV64IXQCCMP-SR-NEXT:    qc.cm.popret {ra, s0-s1}, 32
+; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa sp, 48
+; RV64IXQCCMP-SR-NEXT:    qc.cm.popret {ra, s0-s1}, 48
 entry:
   %var = alloca i32, align 4
   %0 = tail call ptr @llvm.frameaddress.p0(i32 0)

--- a/llvm/test/CodeGen/RISCV/xqccmp-with-float.ll
+++ b/llvm/test/CodeGen/RISCV/xqccmp-with-float.ll
@@ -8,31 +8,31 @@ declare void @callee()
 define float @foo(float %arg) {
 ; XQCCMP32-LABEL: foo:
 ; XQCCMP32:       # %bb.0: # %entry
-; XQCCMP32-NEXT:    qc.cm.push {ra}, -16
-; XQCCMP32-NEXT:    .cfi_def_cfa_offset 16
+; XQCCMP32-NEXT:    qc.cm.push {ra}, -32
+; XQCCMP32-NEXT:    .cfi_def_cfa_offset 32
 ; XQCCMP32-NEXT:    .cfi_offset ra, -4
-; XQCCMP32-NEXT:    fsw fs0, 8(sp) # 4-byte Folded Spill
-; XQCCMP32-NEXT:    .cfi_offset fs0, -8
+; XQCCMP32-NEXT:    fsw fs0, 12(sp) # 4-byte Folded Spill
+; XQCCMP32-NEXT:    .cfi_offset fs0, -20
 ; XQCCMP32-NEXT:    fmv.s fs0, fa0
 ; XQCCMP32-NEXT:    call callee
 ; XQCCMP32-NEXT:    fmv.s fa0, fs0
-; XQCCMP32-NEXT:    flw fs0, 8(sp) # 4-byte Folded Reload
+; XQCCMP32-NEXT:    flw fs0, 12(sp) # 4-byte Folded Reload
 ; XQCCMP32-NEXT:    .cfi_restore fs0
-; XQCCMP32-NEXT:    qc.cm.popret {ra}, 16
+; XQCCMP32-NEXT:    qc.cm.popret {ra}, 32
 ;
 ; XQCCMP64-LABEL: foo:
 ; XQCCMP64:       # %bb.0: # %entry
-; XQCCMP64-NEXT:    qc.cm.push {ra}, -16
-; XQCCMP64-NEXT:    .cfi_def_cfa_offset 16
+; XQCCMP64-NEXT:    qc.cm.push {ra}, -32
+; XQCCMP64-NEXT:    .cfi_def_cfa_offset 32
 ; XQCCMP64-NEXT:    .cfi_offset ra, -8
-; XQCCMP64-NEXT:    fsw fs0, 4(sp) # 4-byte Folded Spill
-; XQCCMP64-NEXT:    .cfi_offset fs0, -12
+; XQCCMP64-NEXT:    fsw fs0, 12(sp) # 4-byte Folded Spill
+; XQCCMP64-NEXT:    .cfi_offset fs0, -20
 ; XQCCMP64-NEXT:    fmv.s fs0, fa0
 ; XQCCMP64-NEXT:    call callee
 ; XQCCMP64-NEXT:    fmv.s fa0, fs0
-; XQCCMP64-NEXT:    flw fs0, 4(sp) # 4-byte Folded Reload
+; XQCCMP64-NEXT:    flw fs0, 12(sp) # 4-byte Folded Reload
 ; XQCCMP64-NEXT:    .cfi_restore fs0
-; XQCCMP64-NEXT:    qc.cm.popret {ra}, 16
+; XQCCMP64-NEXT:    qc.cm.popret {ra}, 32
 entry:
   call void @callee()
   ret float %arg
@@ -41,20 +41,20 @@ entry:
 define void @foo2(i32 %x, float %y) {
 ; XQCCMP32-LABEL: foo2:
 ; XQCCMP32:       # %bb.0: # %entry
-; XQCCMP32-NEXT:    qc.cm.push {ra, s0}, -16
-; XQCCMP32-NEXT:    .cfi_def_cfa_offset 16
+; XQCCMP32-NEXT:    qc.cm.push {ra, s0}, -32
+; XQCCMP32-NEXT:    .cfi_def_cfa_offset 32
 ; XQCCMP32-NEXT:    .cfi_offset ra, -4
 ; XQCCMP32-NEXT:    .cfi_offset s0, -8
-; XQCCMP32-NEXT:    fsw fs0, 4(sp) # 4-byte Folded Spill
-; XQCCMP32-NEXT:    .cfi_offset fs0, -12
+; XQCCMP32-NEXT:    fsw fs0, 12(sp) # 4-byte Folded Spill
+; XQCCMP32-NEXT:    .cfi_offset fs0, -20
 ; XQCCMP32-NEXT:    fmv.s fs0, fa0
 ; XQCCMP32-NEXT:    mv s0, a0
 ; XQCCMP32-NEXT:    call bar
 ; XQCCMP32-NEXT:    mv a0, s0
 ; XQCCMP32-NEXT:    fmv.s fa0, fs0
-; XQCCMP32-NEXT:    flw fs0, 4(sp) # 4-byte Folded Reload
+; XQCCMP32-NEXT:    flw fs0, 12(sp) # 4-byte Folded Reload
 ; XQCCMP32-NEXT:    .cfi_restore fs0
-; XQCCMP32-NEXT:    qc.cm.pop {ra, s0}, 16
+; XQCCMP32-NEXT:    qc.cm.pop {ra, s0}, 32
 ; XQCCMP32-NEXT:    .cfi_restore ra
 ; XQCCMP32-NEXT:    .cfi_restore s0
 ; XQCCMP32-NEXT:    .cfi_def_cfa_offset 0

--- a/llvm/test/CodeGen/RISCV/zcmp-additional-stack.ll
+++ b/llvm/test/CodeGen/RISCV/zcmp-additional-stack.ll
@@ -8,8 +8,8 @@ define ptr @func(ptr %s, i32 %_c, ptr %incdec.ptr, i1 %0, i8 %conv14) #0 {
 ; RV32-NEXT:    .cfi_offset ra, -12
 ; RV32-NEXT:    .cfi_offset s0, -8
 ; RV32-NEXT:    .cfi_offset s1, -4
-; RV32-NEXT:    addi sp, sp, -4
-; RV32-NEXT:    .cfi_def_cfa_offset 20
+; RV32-NEXT:    addi sp, sp, -8
+; RV32-NEXT:    .cfi_def_cfa_offset 24
 ; RV32-NEXT:    sw a4, 4(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sw a2, 0(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv a2, a1
@@ -33,7 +33,7 @@ define ptr @func(ptr %s, i32 %_c, ptr %incdec.ptr, i1 %0, i8 %conv14) #0 {
 ; RV32-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sb a0, 0(s0)
 ; RV32-NEXT:    mv a0, s1
-; RV32-NEXT:    addi sp, sp, 4
+; RV32-NEXT:    addi sp, sp, 8
 ; RV32-NEXT:    .cfi_def_cfa_offset 16
 ; RV32-NEXT:    cm.popret {ra, s0-s1}, 16
 entry:

--- a/llvm/test/CodeGen/RISCV/zcmp-with-float.ll
+++ b/llvm/test/CodeGen/RISCV/zcmp-with-float.ll
@@ -8,31 +8,31 @@ declare void @callee()
 define float @foo(float %arg) {
 ; RV32-LABEL: foo:
 ; RV32:       # %bb.0: # %entry
-; RV32-NEXT:    cm.push {ra}, -16
-; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    cm.push {ra}, -32
+; RV32-NEXT:    .cfi_def_cfa_offset 32
 ; RV32-NEXT:    .cfi_offset ra, -4
-; RV32-NEXT:    fsw fs0, 8(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset fs0, -8
+; RV32-NEXT:    fsw fs0, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset fs0, -20
 ; RV32-NEXT:    fmv.s fs0, fa0
 ; RV32-NEXT:    call callee
 ; RV32-NEXT:    fmv.s fa0, fs0
-; RV32-NEXT:    flw fs0, 8(sp) # 4-byte Folded Reload
+; RV32-NEXT:    flw fs0, 12(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    .cfi_restore fs0
-; RV32-NEXT:    cm.popret {ra}, 16
+; RV32-NEXT:    cm.popret {ra}, 32
 ;
 ; RV64-LABEL: foo:
 ; RV64:       # %bb.0: # %entry
-; RV64-NEXT:    cm.push {ra}, -16
-; RV64-NEXT:    .cfi_def_cfa_offset 16
+; RV64-NEXT:    cm.push {ra}, -32
+; RV64-NEXT:    .cfi_def_cfa_offset 32
 ; RV64-NEXT:    .cfi_offset ra, -8
-; RV64-NEXT:    fsw fs0, 4(sp) # 4-byte Folded Spill
-; RV64-NEXT:    .cfi_offset fs0, -12
+; RV64-NEXT:    fsw fs0, 12(sp) # 4-byte Folded Spill
+; RV64-NEXT:    .cfi_offset fs0, -20
 ; RV64-NEXT:    fmv.s fs0, fa0
 ; RV64-NEXT:    call callee
 ; RV64-NEXT:    fmv.s fa0, fs0
-; RV64-NEXT:    flw fs0, 4(sp) # 4-byte Folded Reload
+; RV64-NEXT:    flw fs0, 12(sp) # 4-byte Folded Reload
 ; RV64-NEXT:    .cfi_restore fs0
-; RV64-NEXT:    cm.popret {ra}, 16
+; RV64-NEXT:    cm.popret {ra}, 32
 entry:
   call void @callee()
   ret float %arg
@@ -41,20 +41,20 @@ entry:
 define void @foo2(i32 %x, float %y) {
 ; RV32-LABEL: foo2:
 ; RV32:       # %bb.0: # %entry
-; RV32-NEXT:    cm.push {ra, s0}, -16
-; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    cm.push {ra, s0}, -32
+; RV32-NEXT:    .cfi_def_cfa_offset 32
 ; RV32-NEXT:    .cfi_offset ra, -8
 ; RV32-NEXT:    .cfi_offset s0, -4
-; RV32-NEXT:    fsw fs0, 4(sp) # 4-byte Folded Spill
-; RV32-NEXT:    .cfi_offset fs0, -12
+; RV32-NEXT:    fsw fs0, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset fs0, -20
 ; RV32-NEXT:    fmv.s fs0, fa0
 ; RV32-NEXT:    mv s0, a0
 ; RV32-NEXT:    call bar
 ; RV32-NEXT:    mv a0, s0
 ; RV32-NEXT:    fmv.s fa0, fs0
-; RV32-NEXT:    flw fs0, 4(sp) # 4-byte Folded Reload
+; RV32-NEXT:    flw fs0, 12(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    .cfi_restore fs0
-; RV32-NEXT:    cm.pop {ra, s0}, 16
+; RV32-NEXT:    cm.pop {ra, s0}, 32
 ; RV32-NEXT:    .cfi_restore ra
 ; RV32-NEXT:    .cfi_restore s0
 ; RV32-NEXT:    .cfi_def_cfa_offset 0


### PR DESCRIPTION
This reverts commit 50cdf6cbc5035345507bb4d23fcb0292272754eb.

This patch causes miscompiles with vector and produces some odd code for ilp32e.