### PR TITLE
[NVPTX] Small NVVMReflect bug

### DIFF
--- a/llvm/lib/Target/NVPTX/NVVMReflect.cpp
+++ b/llvm/lib/Target/NVPTX/NVVMReflect.cpp
@@ -217,7 +217,7 @@ bool NVVMReflect::runOnModule(Module &M) {
   if (!NVVMReflectEnabled)
     return false;
   populateReflectMap(M);
-  bool Changed = true;
+  bool Changed = false;
   Changed |= handleReflectFunction(M, NVVM_REFLECT_FUNCTION);
   Changed |= handleReflectFunction(M, NVVM_REFLECT_OCL_FUNCTION);
   Changed |=


### PR DESCRIPTION
I noticed a small bug I introduced in the NVVMReflect pass. The `Changed` variable should be initialized to false, because by default the pass doesn't modify the IR.