### PR TITLE
[JITLink][i386] Avoid 'i386' name clashing with built-in macro

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
@@ -466,7 +466,7 @@ AnonymousPointerCreator getAnonymousPointerCreator(const Triple &TT) {
   case Triple::x86_64:
     return x86_64::createAnonymousPointer;
   case Triple::x86:
-    return i386::createAnonymousPointer;
+    return i386_::createAnonymousPointer;
   case Triple::loongarch32:
   case Triple::loongarch64:
     return loongarch::createAnonymousPointer;
@@ -482,7 +482,7 @@ PointerJumpStubCreator getPointerJumpStubCreator(const Triple &TT) {
   case Triple::x86_64:
     return x86_64::createAnonymousPointerJumpStub;
   case Triple::x86:
-    return i386::createAnonymousPointerJumpStub;
+    return i386_::createAnonymousPointerJumpStub;
   case Triple::loongarch32:
   case Triple::loongarch64:
     return loongarch::createAnonymousPointerJumpStub;

--- a/llvm/lib/ExecutionEngine/JITLink/i386.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/i386.cpp
@@ -14,7 +14,7 @@
 
 #define DEBUG_TYPE "jitlink"
 
-namespace llvm::jitlink::i386 {
+namespace llvm::jitlink::i386_ {
 
 const char *getEdgeKindName(Edge::Kind K) {
   switch (K) {
@@ -55,7 +55,7 @@ Error optimizeGOTAndStubAccesses(LinkGraph &G) {
 
   for (auto *B : G.blocks())
     for (auto &E : B->edges()) {
-      if (E.getKind() == i386::BranchPCRel32ToPtrJumpStubBypassable) {
+      if (E.getKind() == i386_::BranchPCRel32ToPtrJumpStubBypassable) {
         auto &StubBlock = E.getTarget().getBlock();
         assert(StubBlock.getSize() == sizeof(PointerJumpStubContent) &&
                "Stub block should be stub sized");
@@ -74,7 +74,7 @@ Error optimizeGOTAndStubAccesses(LinkGraph &G) {
 
         int64_t Displacement = TargetAddr - EdgeAddr + 4;
         if (isInt<32>(Displacement)) {
-          E.setKind(i386::BranchPCRel32);
+          E.setKind(i386_::BranchPCRel32);
           E.setTarget(GOTTarget);
           LLVM_DEBUG({
             dbgs() << "  Replaced stub branch with direct branch:\n    ";
@@ -88,4 +88,4 @@ Error optimizeGOTAndStubAccesses(LinkGraph &G) {
   return Error::success();
 }
 
-} // namespace llvm::jitlink::i386
+} // namespace llvm::jitlink::i386_

--- a/llvm/unittests/ExecutionEngine/JITLink/StubsTests.cpp
+++ b/llvm/unittests/ExecutionEngine/JITLink/StubsTests.cpp
@@ -102,13 +102,13 @@ TEST(StubsTest, StubsGeneration_i386) {
   LinkGraph G("foo", std::make_shared<orc::SymbolStringPool>(),
               Triple("i386-unknown-linux-gnu"), SubtargetFeatures(),
               getGenericEdgeKindName);
-  auto [PointerSym, StubSym] = GenerateStub(G, 4U, i386::Pointer32);
+  auto [PointerSym, StubSym] = GenerateStub(G, 4U, i386_::Pointer32);
 
   EXPECT_EQ(std::distance(StubSym.getBlock().edges().begin(),
                           StubSym.getBlock().edges().end()),
             1U);
   auto &JumpEdge = *StubSym.getBlock().edges().begin();
-  EXPECT_EQ(JumpEdge.getKind(), i386::Pointer32);
+  EXPECT_EQ(JumpEdge.getKind(), i386_::Pointer32);
   EXPECT_EQ(&JumpEdge.getTarget(), &PointerSym);
   EXPECT_EQ(StubSym.getBlock().getContent(),
             ArrayRef<char>(PointerJumpStubContent));


### PR DESCRIPTION
When compiling llvm on an actual i386 platform, both clang and gcc define a built-in macro `i386` to the value 1. This clashes with the `llvm::jitlink::i386` namespace:

```
In file included from llvm/lib/ExecutionEngine/JITLink/ELF_i386.cpp:18:
llvm/include/llvm/ExecutionEngine/JITLink/i386.h:19:24: error: expected '{'
   19 | namespace llvm::jitlink::i386 {
      |                        ^
llvm/include/llvm/ExecutionEngine/JITLink/i386.h:19:26: error: expected unqualified-id
   19 | namespace llvm::jitlink::i386 {
      |                          ^
```

The macro name 'i386' is obviously a historical bad choice, but since it existed long before llvm, llvm should either rename its namespace, or actively undefine the macro in `i386.h` (similar to e.g. https://github.com/google/swiftshader/blob/master/third_party/llvm-16.0/Android.bp#L1510).

This particular pull request implements the rename, but is meant to gauge opinions on how to solve this issue.