### PR TITLE
[libc][NFC] add remarks to the setjmp implementation

### DIFF
--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // We use naked functions to avoid compiler-generated prologue and epilogue.
-// Despite GCC documentation listing this as a unsupported case for extended 
+// Despite GCC documentation listing this as an unsupported case for extended 
 // asm, the generated code is not wrong as we only pass in constant operands 
 // to extended asm.
 // See https://github.com/llvm/llvm-project/issues/137055 for related remarks.

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -6,6 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+// We use naked functions to avoid compiler-generated prologue and epilogue.
+// Despite GCC document list this as an supported case for extended asm, the 
+// generated code is not wrong as we only pass in constant operands to 
+// extended asm.
+// See https://github.com/llvm/llvm-project/issues/137055 for related remarks.
+
 #include "hdr/offsetof_macros.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // We use naked functions to avoid compiler-generated prologue and epilogue.
-// Despite GCC document list this as an supported case for extended asm, the 
+// Despite GCC documentation listing this as a supported case for extended asm, the 
 // generated code is not wrong as we only pass in constant operands to 
 // extended asm.
 // See https://github.com/llvm/llvm-project/issues/137055 for related remarks.

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // We use naked functions to avoid compiler-generated prologue and epilogue.
-// Despite GCC documentation listing this as a supported case for extended asm, the 
-// generated code is not wrong as we only pass in constant operands to 
-// extended asm.
+// Despite GCC documentation listing this as a unsupported case for extended 
+// asm, the generated code is not wrong as we only pass in constant operands 
+// to extended asm.
 // See https://github.com/llvm/llvm-project/issues/137055 for related remarks.
 
 #include "hdr/offsetof_macros.h"

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // We use naked functions to avoid compiler-generated prologue and epilogue.
-// Despite GCC documentation listing this as an unsupported case for extended 
-// asm, the generated code is not wrong as we only pass in constant operands 
+// Despite GCC documentation listing this as an unsupported case for extended
+// asm, the generated code is not wrong as we only pass in constant operands
 // to extended asm.
 // See https://github.com/llvm/llvm-project/issues/137055 for related remarks.
 


### PR DESCRIPTION
We use naked functions to avoid compiler-generated prologue and epilogue.

Despite GCC documentation listing this as an unsupported case for extended asm, the generated code is not wrong as we only pass in constant operands to extended asm.

See https://github.com/llvm/llvm-project/issues/137055 for related remarks.