### PR TITLE
[lldb] Fix logic error in AppleObjCTypeEncodingParser

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.h
@@ -63,7 +63,7 @@ private:
 
   uint32_t ReadNumber(StringLexer &type);
 
-  std::string ReadQuotedString(StringLexer &type);
+  std::optional<std::string> ReadQuotedString(StringLexer &type);
 
   ObjCLanguageRuntime &m_runtime;
 };


### PR DESCRIPTION
Fixes parsing of an ObjC type encoding such as `{?="a""b"}`. Parsing of such a type
encoding would lead to an assert. This was observed when running `language objc
class-table dump`.

The function `ReadQuotedString` consumes the closing quote, however one of its two
callers (`ReadStructElement`) was also consuming a quote. For the above type encoding,
where two quoted strings occur back to back, the parser would unintentionally consume
the opening quote of the second quoted string - leaving the remaining text with an
unbalanced quote.

This changes fixes `ReadStructElement` to not consume a quote after calling
`ReadQuotedString`.

For callers to know whether a string was successfully parsed, `ReadQuotedString` now returns an optional string.
