### PR TITLE
[lldb][CPlusPlus] Always use CPlusPlusNameParser for parsing C++ function names

### DIFF
--- a/lldb/test/API/lang/cpp/operators/main.cpp
+++ b/lldb/test/API/lang/cpp/operators/main.cpp
@@ -125,6 +125,7 @@ int main(int argc, char **argv) {
   C *c2 = new C();
   C *c3 = new C[3];
 
+  // clang-format off
   //% self.expect("expr c->dummy", endstr=" 2324\n")
   //% self.expect("expr c->*2", endstr=" 2\n")
   //% self.expect("expr c + 44", endstr=" 44\n")
@@ -174,6 +175,9 @@ int main(int argc, char **argv) {
   //% self.expect("expr (new struct C[1]); side_effect", endstr=" = 4\n")
   //% self.expect("expr delete c2; side_effect", endstr=" = 1\n")
   //% self.expect("expr delete[] c3; side_effect", endstr=" = 2\n")
+  //% self.expect("image lookup -n operator()", substrs=["C::operator()(int)"])
+  //% self.expect("image lookup -n C::operator()", substrs=["C::operator()(int)"])
+  // clang-format on
   delete c2;
   delete[] c3;
   return 0;


### PR DESCRIPTION
When doing function lookup in an LLDB module by name, we may need to hand-parse C++ method names to determine properties such as their "basename". LLDB currently has two ways of parsing methods:
1. Using `TrySimplifiedParse`, which was historically the go-to parser
2. Using the `CPlusPlusNameParser`, which is the more recent parser and has more knowledge of C++ syntax

When `CPlusPlusNameParser` was introduced (https://reviews.llvm.org/D31451), `TrySimplifiedParse` was kept around as the first parser in order to keep performance in check. Though the performance difference didn't seem very convincing from the numbers provided. 11s vs 10s when setting a breakpoint in a project with 500k functions. The main difference being that we're invoking the clang::Lexer in the new parser.

It would be nice to just get rid of it entirely. There's an edge-case for which I added a test-case where the `TrySimplifiedParse` code-path succeeds but incorrectly deduces the basename of `operator()`.

Happy to do benchmarking to see what the performance impact of this is these days.