### PR TITLE
[flang][cuda][rt] Track asynchronous allocation stream for deallocation

### DIFF
--- a/flang-rt/lib/cuda/allocator.cpp
+++ b/flang-rt/lib/cuda/allocator.cpp
@@ -11,6 +11,7 @@
 #include "flang-rt/runtime/derived.h"
 #include "flang-rt/runtime/descriptor.h"
 #include "flang-rt/runtime/environment.h"
+#include "flang-rt/runtime/lock.h"
 #include "flang-rt/runtime/stat.h"
 #include "flang-rt/runtime/terminator.h"
 #include "flang-rt/runtime/type-info.h"
@@ -21,6 +22,106 @@
 #include "cuda_runtime.h"
 
 namespace Fortran::runtime::cuda {
+
+struct DeviceAllocation {
+  void *ptr;
+  std::size_t size;
+  cudaStream_t stream;
+};
+
+// Compare address values. nullptr will be sorted at the end of the array.
+int compareDeviceAlloc(const void *a, const void *b) {
+  const DeviceAllocation *deva = (const DeviceAllocation *)a;
+  const DeviceAllocation *devb = (const DeviceAllocation *)b;
+  if (deva->ptr == nullptr && devb->ptr == nullptr)
+    return 0;
+  if (deva->ptr == nullptr)
+    return 1;
+  if (devb->ptr == nullptr)
+    return -1;
+  return deva->ptr < devb->ptr ? -1 : (deva->ptr > devb->ptr ? 1 : 0);
+}
+
+// Dynamic array for tracking asynchronous allocations.
+static DeviceAllocation *deviceAllocations = nullptr;
+Lock lock;
+static int maxDeviceAllocations{512}; // Initial size
+static int numDeviceAllocations{0};
+static constexpr int allocNotFound{-1};
+
+static void initAllocations() {
+  if (!deviceAllocations) {
+    deviceAllocations = static_cast<DeviceAllocation *>(
+        malloc(maxDeviceAllocations * sizeof(DeviceAllocation)));
+    if (!deviceAllocations) {
+      Terminator terminator{__FILE__, __LINE__};
+      terminator.Crash("Failed to allocate tracking array");
+    }
+  }
+}
+
+// Double the size of the allocation array when size if
+static void doubleAllocationArray() {
+  unsigned newSize = maxDeviceAllocations * 2;
+  DeviceAllocation *newArray = static_cast<DeviceAllocation *>(
+      realloc(deviceAllocations, newSize * sizeof(DeviceAllocation)));
+  if (!newArray) {
+    Terminator terminator{__FILE__, __LINE__};
+    terminator.Crash("Failed to reallocate tracking array");
+  }
+  deviceAllocations = newArray;
+  maxDeviceAllocations = newSize;
+}
+
+static unsigned findAllocation(void *ptr) {
+  if (numDeviceAllocations == 0) {
+    return allocNotFound;
+  }
+
+  int left{0};
+  int right{numDeviceAllocations - 1};
+
+  if (left == right) {
+    return left;
+  }
+
+  while (left <= right) {
+    int mid = left + (right - left) / 2;
+    if (deviceAllocations[mid].ptr == ptr) {
+      return mid;
+    }
+    if (deviceAllocations[mid].ptr < ptr) {
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+  return allocNotFound;
+}
+
+static void insertAllocation(void *ptr, std::size_t size, std::int64_t stream) {
+  CriticalSection critical{lock};
+  initAllocations();
+  if (numDeviceAllocations >= maxDeviceAllocations) {
+    doubleAllocationArray();
+  }
+  deviceAllocations[numDeviceAllocations].ptr = ptr;
+  deviceAllocations[numDeviceAllocations].size = size;
+  deviceAllocations[numDeviceAllocations].stream = (cudaStream_t)stream;
+  ++numDeviceAllocations;
+  qsort(deviceAllocations, numDeviceAllocations, sizeof(DeviceAllocation),
+      compareDeviceAlloc);
+}
+
+static void eraseAllocation(int pos) {
+  deviceAllocations[pos].ptr = nullptr;
+  deviceAllocations[pos].size = 0;
+  deviceAllocations[pos].stream = (cudaStream_t)0;
+  qsort(deviceAllocations, numDeviceAllocations, sizeof(DeviceAllocation),
+      compareDeviceAlloc);
+  --numDeviceAllocations;
+}
+
 extern "C" {
 
 void RTDEF(CUFRegisterAllocator)() {
@@ -55,12 +156,23 @@ void *CUFAllocDevice(std::size_t sizeInBytes, std::int64_t asyncId) {
     } else {
       CUDA_REPORT_IF_ERROR(
           cudaMallocAsync(&p, sizeInBytes, (cudaStream_t)asyncId));
+      insertAllocation(p, sizeInBytes, asyncId);
     }
   }
   return p;
 }
 
-void CUFFreeDevice(void *p) { CUDA_REPORT_IF_ERROR(cudaFree(p)); }
+void CUFFreeDevice(void *p) {
+  CriticalSection critical{lock};
+  int pos = findAllocation(p);
+  if (pos >= 0) {
+    cudaStream_t stream = deviceAllocations[pos].stream;
+    eraseAllocation(pos);
+    CUDA_REPORT_IF_ERROR(cudaFreeAsync(p, stream));
+  } else {
+    CUDA_REPORT_IF_ERROR(cudaFree(p));
+  }
+}
 
 void *CUFAllocManaged(
     std::size_t sizeInBytes, [[maybe_unused]] std::int64_t asyncId) {

--- a/flang-rt/lib/cuda/allocator.cpp
+++ b/flang-rt/lib/cuda/allocator.cpp
@@ -60,7 +60,6 @@ static void initAllocations() {
   }
 }
 
-// Double the size of the allocation array when size if
 static void doubleAllocationArray() {
   unsigned newSize = maxDeviceAllocations * 2;
   DeviceAllocation *newArray = static_cast<DeviceAllocation *>(


### PR DESCRIPTION
When an asynchronous allocation is made, we call `cudaMallocAsync` with a stream. For deallocation, we need to call `cudaFreeAsync` with the same stream. in order to achieve that, we need to track the allocation and their respective stream.

This patch adds a simple sorted array of asynchronous allocations. A binary search is performed to retrieve the allocation when deallocation is needed. 