### PR TITLE
Bug fix in FindModuleUUID

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -289,7 +289,7 @@ void ProcessElfCore::UpdateBuildIdForNTFileEntries() {
 UUID ProcessElfCore::FindModuleUUID(const llvm::StringRef path) {
   // Returns the gnu uuid from matched NT_FILE entry
   for (NT_FILE_Entry &entry : m_nt_file_entries)
-    if (path == entry.path)
+    if (path == entry.path && entry.uuid.IsValid())
       return entry.uuid;
   return UUID();
 }


### PR DESCRIPTION
In some core file, we are seeing that it's not always the case that the ELF header would exist in the first region in NT_FILES section. Therefore the FindModuleUUID is not able to find the module UUID by just returning the first entry with path matching. 

This fix change the behavior to continue search the NT_FILE entries until finding a valid UUID with path matching.