### PR TITLE
[flang] Make -fsave-main-program default

### DIFF
--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -820,7 +820,7 @@ static bool parseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
   opts.features.Enable(
       Fortran::common::LanguageFeature::SaveMainProgram,
       args.hasFlag(clang::driver::options::OPT_fsave_main_program,
-                   clang::driver::options::OPT_fno_save_main_program, false));
+                   clang::driver::options::OPT_fno_save_main_program, true));
 
   if (args.hasArg(
           clang::driver::options::OPT_falternative_parameter_statement)) {


### PR DESCRIPTION
There are many Fortran tests that assume that the variables in Fortran main program have implicit SAVE attribute. These tests don't initialize such variables in some cases, relying on them having been automatically initialized to zero. With -fno-save-main-program being the default, such tests encounter undefined behavior.