### PR TITLE
[CIR] Upstream support for name mangling

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -151,7 +151,6 @@ struct MissingFeatures {
   static bool weakRefReference() { return false; }
   static bool hip() { return false; }
   static bool setObjCGCLValueClass() { return false; }
-  static bool mangledNames() { return false; }
   static bool setDLLStorageClass() { return false; }
   static bool openMP() { return false; }
   static bool emitCheckedInBoundsGEP() { return false; }
@@ -159,6 +158,8 @@ struct MissingFeatures {
   static bool bitfields() { return false; }
   static bool typeChecks() { return false; }
   static bool lambdaFieldToName() { return false; }
+  static bool targetSpecificCXXABI() { return false; }
+  static bool moduleNameHash() { return false; }
 
   // Missing types
   static bool dataMemberType() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This provides an abstract class for C++ code generation. Concrete subclasses
+// of this implement code generation for specific C++ ABIs.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_CIR_CIRGENCXXABI_H
+#define LLVM_CLANG_LIB_CIR_CIRGENCXXABI_H
+
+#include "CIRGenModule.h"
+
+#include "clang/AST/Mangle.h"
+
+namespace clang::CIRGen {
+
+/// Implements C++ ABI-specific code generation functions.
+class CIRGenCXXABI {
+protected:
+  CIRGenModule &cgm;
+  std::unique_ptr<clang::MangleContext> mangleContext;
+
+public:
+  // TODO(cir): make this protected when target-specific CIRGenCXXABIs are
+  // implemented.
+  CIRGenCXXABI(CIRGenModule &cgm)
+      : cgm(cgm), mangleContext(cgm.getASTContext().createMangleContext()) {}
+  ~CIRGenCXXABI();
+
+public:
+  /// Gets the mangle context.
+  clang::MangleContext &getMangleContext() { return *mangleContext; }
+};
+
+/// Creates and Itanium-family ABI
+CIRGenCXXABI *CreateCIRGenItaniumCXXABI(CIRGenModule &cgm);
+
+} // namespace clang::CIRGen
+
+#endif

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -700,13 +700,11 @@ static std::string getMangledNameImpl(CIRGenModule &cgm, GlobalDecl gd,
     if (fd &&
         fd->getType()->castAs<FunctionType>()->getCallConv() == CC_X86RegCall) {
       cgm.errorNYI(nd->getSourceRange(), "getMangledName: X86RegCall");
-      out << ii->getName();
     } else if (fd && fd->hasAttr<CUDAGlobalAttr>() &&
                gd.getKernelReferenceKind() == KernelReferenceKind::Stub) {
-      out << "__device_stub__" << ii->getName();
-    } else {
-      out << ii->getName();
+      cgm.errorNYI(nd->getSourceRange(), "getMangledName: CUDA device stub");
     }
+    out << ii->getName();
   }
 
   // Check if the module name hash should be appended for internal linkage

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -367,8 +367,9 @@ void CIRGenModule::emitGlobalVarDefinition(const clang::VarDecl *vd,
   const QualType astTy = vd->getType();
   const mlir::Type type = convertType(vd->getType());
   if (clang::IdentifierInfo *identifier = vd->getIdentifier()) {
+    StringRef name = getMangledName(GlobalDecl(vd));
     auto varOp = builder.create<cir::GlobalOp>(getLoc(vd->getSourceRange()),
-                                               identifier->getName(), type);
+                                               name, type);
     // TODO(CIR): This code for processing initial values is a placeholder
     // until class ConstantEmitter is upstreamed and the code for processing
     // constant expressions is filled out.  Only the most basic handling of

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CIRGenModule.h"
+#include "CIRGenCXXABI.h"
 #include "CIRGenConstantEmitter.h"
 #include "CIRGenFunction.h"
 
@@ -30,6 +31,37 @@
 using namespace clang;
 using namespace clang::CIRGen;
 
+static CIRGenCXXABI *createCXXABI(CIRGenModule &cgm) {
+  switch (cgm.getASTContext().getCXXABIKind()) {
+  case TargetCXXABI::GenericItanium:
+  case TargetCXXABI::GenericAArch64:
+  case TargetCXXABI::AppleARM64:
+    return CreateCIRGenItaniumCXXABI(cgm);
+
+  case TargetCXXABI::Fuchsia:
+  case TargetCXXABI::GenericARM:
+  case TargetCXXABI::iOS:
+  case TargetCXXABI::WatchOS:
+  case TargetCXXABI::GenericMIPS:
+  case TargetCXXABI::WebAssembly:
+  case TargetCXXABI::XL:
+  case TargetCXXABI::Microsoft:
+    cgm.errorNYI("C++ ABI kind not yet implemented");
+    return nullptr;
+  }
+
+  llvm_unreachable("invalid C++ ABI kind");
+}
+
+namespace clang::CIRGen {
+// TODO(cir): Implement target-specific CIRGenCXXABIs
+CIRGenCXXABI *CreateCIRGenItaniumCXXABI(CIRGenModule &cgm) {
+  assert(!cir::MissingFeatures::targetSpecificCXXABI());
+  return new CIRGenCXXABI(cgm);
+}
+} // namespace clang::CIRGen
+CIRGenCXXABI::~CIRGenCXXABI() {}
+
 CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
                            clang::ASTContext &astContext,
                            const clang::CodeGenOptions &cgo,
@@ -37,7 +69,8 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
     : builder(mlirContext, *this), astContext(astContext),
       langOpts(astContext.getLangOpts()), codeGenOpts(cgo),
       theModule{mlir::ModuleOp::create(mlir::UnknownLoc::get(&mlirContext))},
-      diags(diags), target(astContext.getTargetInfo()), genTypes(*this) {
+      diags(diags), target(astContext.getTargetInfo()),
+      abi(createCXXABI(*this)), genTypes(*this) {
 
   // Initialize cached types
   VoidTy = cir::VoidType::get(&getMLIRContext());
@@ -73,6 +106,8 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
   theModule->setAttr(cir::CIRDialect::getTripleAttrName(),
                      builder.getStringAttr(getTriple().str()));
 }
+
+CIRGenModule::~CIRGenModule() = default;
 
 CharUnits CIRGenModule::getNaturalTypeAlignment(QualType t,
                                                 LValueBaseInfo *baseInfo) {
@@ -301,9 +336,9 @@ CIRGenModule::getOrCreateCIRGlobal(const VarDecl *d, mlir::Type ty,
   if (!ty)
     ty = getTypes().convertTypeForMem(astTy);
 
-  assert(!cir::MissingFeatures::mangledNames());
-  return getOrCreateCIRGlobal(d->getIdentifier()->getName(), ty,
-                              astTy.getAddressSpace(), d, isForDefinition);
+  StringRef mangledName = getMangledName(d);
+  return getOrCreateCIRGlobal(mangledName, ty, astTy.getAddressSpace(), d,
+                              isForDefinition);
 }
 
 /// Return the mlir::Value for the address of the given global variable. If
@@ -639,11 +674,80 @@ cir::FuncOp CIRGenModule::getAddrOfFunction(clang::GlobalDecl gd,
     funcType = convertType(fd->getType());
   }
 
-  assert(!cir::MissingFeatures::mangledNames());
-  cir::FuncOp func = getOrCreateCIRFunction(
-      cast<NamedDecl>(gd.getDecl())->getIdentifier()->getName(), funcType, gd,
-      forVTable, dontDefer, /*isThunk=*/false, isForDefinition);
+  StringRef mangledName = getMangledName(gd);
+  cir::FuncOp func =
+      getOrCreateCIRFunction(mangledName, funcType, gd, forVTable, dontDefer,
+                             /*isThunk=*/false, isForDefinition);
   return func;
+}
+
+static std::string getMangledNameImpl(CIRGenModule &cgm, GlobalDecl gd,
+                                      const NamedDecl *nd) {
+  SmallString<256> buffer;
+
+  llvm::raw_svector_ostream out(buffer);
+  MangleContext &mc = cgm.getCXXABI().getMangleContext();
+
+  assert(!cir::MissingFeatures::moduleNameHash());
+
+  if (mc.shouldMangleDeclName(nd)) {
+    mc.mangleName(gd.getWithDecl(nd), out);
+  } else {
+    IdentifierInfo *ii = nd->getIdentifier();
+    assert(ii && "Attempt to mangle unnamed decl.");
+
+    const auto *fd = dyn_cast<FunctionDecl>(nd);
+    if (fd &&
+        fd->getType()->castAs<FunctionType>()->getCallConv() == CC_X86RegCall) {
+      cgm.errorNYI(nd->getSourceRange(), "getMangledName: X86RegCall");
+      out << ii->getName();
+    } else if (fd && fd->hasAttr<CUDAGlobalAttr>() &&
+               gd.getKernelReferenceKind() == KernelReferenceKind::Stub) {
+      out << "__device_stub__" << ii->getName();
+    } else {
+      out << ii->getName();
+    }
+  }
+
+  // Check if the module name hash should be appended for internal linkage
+  // symbols. This should come before multi-version target suffixes are
+  // appendded. This is to keep the name and module hash suffix of the internal
+  // linkage function together. The unique suffix should only be added when name
+  // mangling is done to make sure that the final name can be properly
+  // demangled. For example, for C functions without prototypes, name mangling
+  // is not done and the unique suffix should not be appended then.
+  assert(!cir::MissingFeatures::moduleNameHash());
+
+  if (const auto *fd = dyn_cast<FunctionDecl>(nd)) {
+    if (fd->isMultiVersion()) {
+      cgm.errorNYI(nd->getSourceRange(),
+                   "getMangledName: multi-version functions");
+    }
+  }
+  if (cgm.getLangOpts().GPURelocatableDeviceCode) {
+    cgm.errorNYI(nd->getSourceRange(),
+                 "getMangledName: GPU relocatable device code");
+  }
+
+  return std::string(out.str());
+}
+
+StringRef CIRGenModule::getMangledName(GlobalDecl gd) {
+  GlobalDecl canonicalGd = gd.getCanonicalDecl();
+
+  // Some ABIs don't have constructor variants. Make sure that base and complete
+  // constructors get mangled the same.
+  if (const auto *cd = dyn_cast<CXXConstructorDecl>(canonicalGd.getDecl())) {
+    errorNYI(cd->getSourceRange(), "getMangledName: C++ constructor");
+    return cast<NamedDecl>(gd.getDecl())->getIdentifier()->getName();
+  }
+
+  // Keep the first result in the case of a mangling collision.
+  const auto *nd = cast<NamedDecl>(gd.getDecl());
+  std::string mangledName = getMangledNameImpl(*this, gd, nd);
+
+  auto result = manglings.insert(std::make_pair(mangledName, gd));
+  return mangledDeclNames[canonicalGd] = result.first->first();
 }
 
 cir::FuncOp CIRGenModule::getOrCreateCIRFunction(

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -368,8 +368,8 @@ void CIRGenModule::emitGlobalVarDefinition(const clang::VarDecl *vd,
   const mlir::Type type = convertType(vd->getType());
   if (clang::IdentifierInfo *identifier = vd->getIdentifier()) {
     StringRef name = getMangledName(GlobalDecl(vd));
-    auto varOp = builder.create<cir::GlobalOp>(getLoc(vd->getSourceRange()),
-                                               name, type);
+    auto varOp =
+        builder.create<cir::GlobalOp>(getLoc(vd->getSourceRange()), name, type);
     // TODO(CIR): This code for processing initial values is a placeholder
     // until class ConstantEmitter is upstreamed and the code for processing
     // constant expressions is filled out.  Only the most basic handling of

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -93,7 +93,7 @@ void func() {
 // CIR: %[[TMP:.*]] = cir.load %[[ELE_PTR]] : !cir.ptr<!s32i>, !s32i
 // CIR" cir.store %[[TMP]], %[[INIT_2]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @func()
+// LLVM: define void @_Z4funcv()
 // LLVM-NEXT: %[[ARR:.*]] = alloca [10 x i32], i64 1, align 16
 // LLVM-NEXT: %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT: %[[INIT_2:.*]] = alloca i32, i64 1, align 4
@@ -135,7 +135,7 @@ void func2() {
 // CIR: %[[ELE_1_PTR:.*]] = cir.ptr_stride(%[[LOAD_1]] : !cir.ptr<!s32i>, %[[OFFSET_1]] : !s64i), !cir.ptr<!s32i>
 // CIR: cir.store %[[ELE_1_PTR]], %[[ELE_ALLOCA]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 
-// LLVM: define void @func2()
+// LLVM: define void @_Z5func2v()
 // LLVM:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
 // LLVM:  %[[TMP:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[ARR_PTR:.*]] = getelementptr i32, ptr %[[ARR]], i32 0
@@ -175,7 +175,7 @@ void func3() {
 // CIR: %[[ELE_TMP:.*]] = cir.load %[[ELE_PTR]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.store %[[ELE_TMP]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @func3()
+// LLVM: define void @_Z5func3v()
 // LLVM:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
 // LLVM:  %[[IDX:.*]] = alloca i32, i64 1, align 4
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
@@ -227,7 +227,7 @@ void func4() {
 // CIR: %[[TMP:.*]] = cir.load %[[ELE_0]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.store %[[TMP]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @func4()
+// LLVM: define void @_Z5func4v()
 // LLVM:  %[[ARR:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM:  %[[ARR_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR]], i32 0
@@ -271,7 +271,7 @@ void func5() {
 // CIR: %10 = cir.ptr_stride(%7 : !cir.ptr<!cir.array<!s32i x 1>>, %[[OFFSET_1]] : !s64i), !cir.ptr<!cir.array<!s32i x 1>>
 // CIR: cir.store %10, %[[ARR_PTR]] : !cir.ptr<!cir.array<!s32i x 1>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 1>>>
 
-// LLVM: define void @func5()
+// LLVM: define void @_Z5func5v()
 // LLVM:  %[[ARR:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
 // LLVM:  %[[TMP:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[ARR_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR]], i32 0
@@ -304,7 +304,7 @@ void func6() {
 // CIR: %[[V1:.*]] = cir.const #cir.int<5> : !s32i
 // CIR: cir.store %[[V1]], %[[ELE_PTR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @func6()
+// LLVM: define void @_Z5func6v()
 // LLVM:  %[[VAR:.*]] = alloca i32, i64 1, align 4
 // LLVM:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
 // LLVM:  store i32 4, ptr %[[VAR]], align 4
@@ -337,7 +337,7 @@ void func7() {
 // CIR: %[[ELE_PTR:.*]] = cir.ptr_stride(%[[TMP]] : !cir.ptr<!cir.ptr<!s32i>>, %[[OFFSET]] : !s64i), !cir.ptr<!cir.ptr<!s32i>>
 // CIR: cir.store %[[ELE_PTR]], %[[ARR_TMP]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!cir.ptr<!cir.ptr<!s32i>>>
 
-// LLVM: define void @func7()
+// LLVM: define void @_Z5func7v()
 // LLVM:  %[[ARR:.*]] = alloca [1 x ptr], i64 1, align 8
 // LLVM:  %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[ELE_PTR:.*]] = getelementptr ptr, ptr %[[ARR]], i32 0
@@ -355,7 +355,7 @@ void func8(int arr[10]) {
   int e2 = arr[1];
 }
 
-// CIR: cir.func @func8(%[[ARG:.*]]: !cir.ptr<!s32i>
+// CIR: cir.func @_Z5func8Pi(%[[ARG:.*]]: !cir.ptr<!s32i>
 // CIR:  %[[ARR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arr", init]
 // CIR:  %[[INIT:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e", init]
 // CIR:  %[[INIT_2:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e2", init]
@@ -371,7 +371,7 @@ void func8(int arr[10]) {
 // CIR:  %[[TMP_4:.*]] = cir.load %[[ELE_1]] : !cir.ptr<!s32i>, !s32i
 // CIR:  cir.store %[[TMP_4]], %[[INIT_2]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @func8(ptr %[[ARG:.*]])
+// LLVM: define void @_Z5func8Pi(ptr %[[ARG:.*]])
 // LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM:  %[[INIT_2:.*]] = alloca i32, i64 1, align 4
@@ -402,7 +402,7 @@ void func9(int arr[10][5]) {
   int e = arr[1][2];
 }
 
-// CIR: cir.func @func9(%[[ARG:.*]]: !cir.ptr<!cir.array<!s32i x 5>>
+// CIR: cir.func @_Z5func9PA5_i(%[[ARG:.*]]: !cir.ptr<!cir.array<!s32i x 5>>
 // CIR:  %[[ARR:.*]] = cir.alloca !cir.ptr<!cir.array<!s32i x 5>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 5>>>, ["arr", init]
 // CIR:  %[[INIT:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e", init]
 // CIR:  cir.store %[[ARG]], %[[ARR]] : !cir.ptr<!cir.array<!s32i x 5>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 5>>>
@@ -415,7 +415,7 @@ void func9(int arr[10][5]) {
 // CIR:  %[[TMP_2:.*]] = cir.load %[[ARR_1_2]] : !cir.ptr<!s32i>, !s32i
 // CIR:  cir.store %[[TMP_2]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @func9(ptr %[[ARG:.*]])
+// LLVM: define void @_Z5func9PA5_i(ptr %[[ARG:.*]])
 // LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM:  store ptr %[[ARG]], ptr %[[ARR]], align 8
@@ -439,7 +439,7 @@ void func10(int *a) {
   int e = a[5];
 }
 
-// CIR: cir.func @func10(%[[ARG:.*]]: !cir.ptr<!s32i>
+// CIR: cir.func @_Z6func10Pi(%[[ARG:.*]]: !cir.ptr<!s32i>
 // CIR: %[[ARR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["a", init]
 // CIR: %[[INIT:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e", init]
 // CIR: cir.store %[[ARG]], %[[ARR]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
@@ -449,7 +449,7 @@ void func10(int *a) {
 // CIR: %[[TMP_2:.*]] = cir.load %[[ELE]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.store %[[TMP_2]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @func10(ptr %[[ARG:.*]]) {
+// LLVM: define void @_Z6func10Pi(ptr %[[ARG:.*]]) {
 // LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM:  store ptr %[[ARG]], ptr %[[ARR]], align 8

--- a/clang/test/CIR/CodeGen/basic.cpp
+++ b/clang/test/CIR/CodeGen/basic.cpp
@@ -6,7 +6,7 @@ int f1() {
 }
 
 // CHECK: module
-// CHECK: cir.func @f1() -> !s32i
+// CHECK: cir.func @_Z2f1v() -> !s32i
 // CHECK:    %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i"] {alignment = 4 : i64}
 // CHECK:    %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
@@ -19,7 +19,7 @@ int f2() {
   return i;
 }
 
-// CHECK: cir.func @f2() -> !s32i
+// CHECK: cir.func @_Z2f2v() -> !s32i
 // CHECK:    %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init, const] {alignment = 4 : i64}
 // CHECK:    %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
@@ -33,7 +33,7 @@ int f3(int i) {
   return i;
 }
 
-// CHECK: cir.func @f3(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
+// CHECK: cir.func @_Z2f3i(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
 // CHECK:   %[[ARG_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   cir.store %[[ARG]], %[[ARG_ALLOCA]] : !s32i, !cir.ptr<!s32i>
@@ -46,7 +46,7 @@ int f4(const int i) {
   return i;
 }
 
-// CHECK: cir.func @f4(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
+// CHECK: cir.func @_Z2f4i(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
 // CHECK:   %[[ARG_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init, const] {alignment = 4 : i64}
 // CHECK:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   cir.store %[[ARG]], %[[ARG_ALLOCA]] : !s32i, !cir.ptr<!s32i>
@@ -66,7 +66,7 @@ int *f5() {
   return p;
 }
 
-// CHECK:      cir.func @f5() -> !cir.ptr<!s32i>
+// CHECK:      cir.func @_Z2f5v() -> !cir.ptr<!s32i>
 // CHECK-NEXT:   %[[RET_ADDR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["__retval"] {alignment = 8 : i64}
 // CHECK-NEXT:   %[[P_ADDR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init] {alignment = 8 : i64}
 // CHECK-NEXT:   %[[NULLPTR:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i>
@@ -95,7 +95,7 @@ size_type max_size() {
   return size_type(~0) / sizeof(_Tp);
 }
 
-// CHECK: cir.func @max_size()
+// CHECK: cir.func @_Z8max_sizev() -> !u64i
 // CHECK:   %0 = cir.alloca !u64i, !cir.ptr<!u64i>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.int<0> : !s32i
 // CHECK:   %2 = cir.unary(not, %1) : !s32i, !s32i

--- a/clang/test/CIR/CodeGen/binop.cpp
+++ b/clang/test/CIR/CodeGen/binop.cpp
@@ -16,7 +16,7 @@ void b0(int a, int b) {
   x = x | b;
 }
 
-// CIR-LABEL: cir.func @b0(
+// CIR-LABEL: cir.func @_Z2b0ii(
 // CIR: %{{.+}} = cir.binop(mul, %{{.+}}, %{{.+}}) nsw : !s32i
 // CIR: %{{.+}} = cir.binop(div, %{{.+}}, %{{.+}}) : !s32i
 // CIR: %{{.+}} = cir.binop(rem, %{{.+}}, %{{.+}}) : !s32i
@@ -27,7 +27,7 @@ void b0(int a, int b) {
 // CIR: %{{.+}} = cir.binop(or, %{{.+}}, %{{.+}}) : !s32i
 // CIR: cir.return
 
-// LLVM-LABEL: define void @b0(
+// LLVM-LABEL: define void @_Z2b0ii(
 // LLVM-SAME: i32 %[[A:.*]], i32 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i32
@@ -133,14 +133,14 @@ void testFloatingPointBinOps(float a, float b) {
   a - b;
 }
 
-// CIR-LABEL: cir.func @testFloatingPointBinOps(
+// CIR-LABEL: cir.func @_Z23testFloatingPointBinOpsff(
 // CIR: cir.binop(mul, %{{.+}}, %{{.+}}) : !cir.float
 // CIR: cir.binop(div, %{{.+}}, %{{.+}}) : !cir.float
 // CIR: cir.binop(add, %{{.+}}, %{{.+}}) : !cir.float
 // CIR: cir.binop(sub, %{{.+}}, %{{.+}}) : !cir.float
 // CIR: cir.return
 
-// LLVM-LABEL: define void @testFloatingPointBinOps(
+// LLVM-LABEL: define void @_Z23testFloatingPointBinOpsff(
 // LLVM-SAME: float %[[A:.*]], float %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca float, i64 1
 // LLVM:         %[[B_ADDR:.*]] = alloca float, i64 1
@@ -194,7 +194,7 @@ void signed_shift(int a, int b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @signed_shift(
+// CIR-LABEL: cir.func @_Z12signed_shiftii(
 // CIR-SAME: %[[ARG0:.*]]: !s32i{{.*}}, %[[ARG1:.*]]: !s32i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
@@ -215,7 +215,7 @@ void signed_shift(int a, int b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @signed_shift
+// LLVM-LABEL: define void @_Z12signed_shiftii
 // LLVM-SAME: (i32 %[[A:.*]], i32 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i32
@@ -260,7 +260,7 @@ void unsigned_shift(unsigned a, unsigned b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @unsigned_shift(
+// CIR-LABEL: cir.func @_Z14unsigned_shiftjj(
 // CIR-SAME: %[[ARG0:.*]]: !u32i{{.*}}, %[[ARG1:.*]]: !u32i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["b", init]
@@ -281,7 +281,7 @@ void unsigned_shift(unsigned a, unsigned b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @unsigned_shift
+// LLVM-LABEL: define void @_Z14unsigned_shiftjj
 // LLVM-SAME: (i32 %[[A:.*]], i32 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i32
@@ -326,7 +326,7 @@ void zext_shift_example(int a, unsigned char b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @zext_shift_example(
+// CIR-LABEL: cir.func @_Z18zext_shift_exampleih(
 // CIR-SAME: %[[ARG0:.*]]: !s32i{{.*}}, %[[ARG1:.*]]: !u8i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !u8i, !cir.ptr<!u8i>, ["b", init]
@@ -349,7 +349,7 @@ void zext_shift_example(int a, unsigned char b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @zext_shift_example
+// LLVM-LABEL: define void @_Z18zext_shift_exampleih
 // LLVM-SAME: (i32 %[[A:.*]], i8 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i8
@@ -398,7 +398,7 @@ void sext_shift_example(int a, signed char b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @sext_shift_example(
+// CIR-LABEL: cir.func @_Z18sext_shift_exampleia(
 // CIR-SAME: %[[ARG0:.*]]: !s32i{{.*}}, %[[ARG1:.*]]: !s8i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !s8i, !cir.ptr<!s8i>, ["b", init]
@@ -421,7 +421,7 @@ void sext_shift_example(int a, signed char b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @sext_shift_example
+// LLVM-LABEL: define void @_Z18sext_shift_exampleia
 // LLVM-SAME: (i32 %[[A:.*]], i8 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i8
@@ -470,7 +470,7 @@ void long_shift_example(long long a, short b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @long_shift_example(
+// CIR-LABEL: cir.func @_Z18long_shift_examplexs(
 // CIR-SAME: %[[ARG0:.*]]: !s64i{{.*}}, %[[ARG1:.*]]: !s16i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !s64i, !cir.ptr<!s64i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !s16i, !cir.ptr<!s16i>, ["b", init]
@@ -493,7 +493,7 @@ void long_shift_example(long long a, short b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @long_shift_example
+// LLVM-LABEL: define void @_Z18long_shift_examplexs
 // LLVM-SAME: (i64 %[[A:.*]], i16 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i64
 // LLVM:         %[[B_ADDR:.*]] = alloca i16

--- a/clang/test/CIR/CodeGen/call.cpp
+++ b/clang/test/CIR/CodeGen/call.cpp
@@ -5,8 +5,8 @@ void f2() {
   f1();
 }
 
-// CHECK-LABEL: cir.func @f2
-// CHECK:         cir.call @f1() : () -> ()
+// CHECK-LABEL: cir.func @_Z2f1v
+// CHECK:         cir.call @_Z2f1v() : () -> ()
 
 int f3();
 int f4() {
@@ -14,6 +14,6 @@ int f4() {
   return x;
 }
 
-// CHECK-LABEL: cir.func @f4() -> !s32i
-// CHECK:         %[[#x:]] = cir.call @f3() : () -> !s32i
+// CHECK-LABEL: cir.func @_Z2f4v() -> !s32i
+// CHECK:         %[[#x:]] = cir.call @_Z2f3v() : () -> !s32i
 // CHECK-NEXT:    cir.store %[[#x]], %{{.+}} : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -7,7 +7,7 @@ unsigned char cxxstaticcast_0(unsigned int x) {
   return static_cast<unsigned char>(x);
 }
 
-// CIR: cir.func @cxxstaticcast_0
+// CIR: cir.func @_Z15cxxstaticcast_0j
 // CIR:    %[[XPTR:[0-9]+]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["x", init] {alignment = 4 : i64}
 // CIR:    %[[RV:[0-9]+]] = cir.alloca !u8i, !cir.ptr<!u8i>, ["__retval"] {alignment = 1 : i64}
 // CIR:    cir.store %arg0, %[[XPTR]] : !u32i, !cir.ptr<!u32i>
@@ -18,7 +18,7 @@ unsigned char cxxstaticcast_0(unsigned int x) {
 // CIR:    cir.return %[[R]] : !u8i
 // CIR:  }
 
-// LLVM: define i8 @cxxstaticcast_0(i32 %{{[0-9]+}})
+// LLVM: define i8 @_Z15cxxstaticcast_0j(i32 %{{[0-9]+}})
 // LLVM: %[[LOAD:[0-9]+]] = load i32, ptr %{{[0-9]+}}, align 4
 // LLVM: %[[TRUNC:[0-9]+]] = trunc i32 %[[LOAD]] to i8
 // LLVM: store i8 %[[TRUNC]], ptr %[[RV:[0-9]+]], align 1
@@ -27,8 +27,8 @@ unsigned char cxxstaticcast_0(unsigned int x) {
 
 
 int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
-// CIR: cir.func @cStyleCasts_0
-// LLVM: define i32 @cStyleCasts_0
+// CIR: cir.func @_Z13cStyleCasts_0jifsd
+// LLVM: define i32 @_Z13cStyleCasts_0jifsd
 
   char a = (char)x1; // truncate
   // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !u32i), !s8i
@@ -82,13 +82,13 @@ bool cptr(void *d) {
   return x;
 }
 
-// CIR: cir.func @cptr(%arg0: !cir.ptr<!void>
+// CIR: cir.func @_Z4cptrPv(%arg0: !cir.ptr<!void>
 // CIR:   %[[DPTR:[0-9]+]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["d", init] {alignment = 8 : i64}
 
 // CIR:   %[[DVAL:[0-9]+]] = cir.load %[[DPTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR:   %{{[0-9]+}} = cir.cast(ptr_to_bool, %[[DVAL]] : !cir.ptr<!void>), !cir.bool
 
-// LLVM-LABEL: define i1 @cptr(ptr %0)
+// LLVM-LABEL: define i1 @_Z4cptrPv(ptr %0)
 // LLVM:         %[[ARG_STORAGE:.*]] = alloca ptr, i64 1
 // LLVM:         %[[RETVAL:.*]] = alloca i8, i64 1
 // LLVM:         %[[X_STORAGE:.*]] = alloca i8, i64 1
@@ -107,6 +107,6 @@ void should_not_cast() {
   (void) ib; // void cast
 }
 
-// CIR:     cir.func @should_not_cast
+// CIR:     cir.func @_Z15should_not_castv
 // CIR-NOT:   cir.cast
 // CIR:     cir.return

--- a/clang/test/CIR/CodeGen/cmp.cpp
+++ b/clang/test/CIR/CodeGen/cmp.cpp
@@ -14,7 +14,7 @@ void c0(int a, int b) {
   x = a == b;
 }
 
-// CIR-LABEL: cir.func @c0(
+// CIR-LABEL: cir.func @_Z2c0ii(
 
 // CIR: %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
@@ -45,7 +45,7 @@ void c0(int a, int b) {
 // CIR: %[[B6:.*]] = cir.load %[[B_PTR]]
 // CIR: %{{.*}} = cir.cmp(eq, %[[A6]], %[[B6]]) : !s32i, !cir.bool
 
-// LLVM-LABEL: define void @c0(i32 %0, i32 %1) {
+// LLVM-LABEL: define void @_Z2c0ii(i32 %0, i32 %1) {
 // LLVM: %[[PTR1:.*]] = alloca i32, i64 1
 // LLVM: %[[PTR2:.*]] = alloca i32, i64 1
 // LLVM: %[[BOOL_PTR:.*]] = alloca i8, i64 1
@@ -140,7 +140,7 @@ void c0_unsigned(unsigned int a, unsigned int b) {
   x = a == b;
 }
 
-// CIR-LABEL: cir.func @c0_unsigned(
+// CIR-LABEL: cir.func @_Z11c0_unsignedjj(
 
 // CIR: %[[U_A_PTR:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CIR: %[[U_B_PTR:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["b", init]
@@ -170,7 +170,7 @@ void c0_unsigned(unsigned int a, unsigned int b) {
 // CIR: %[[UB6:.*]] = cir.load %[[U_B_PTR]]
 // CIR: %{{.*}} = cir.cmp(eq, %[[UA6]], %[[UB6]]) : !u32i, !cir.bool
 
-// LLVM-LABEL: define void @c0_unsigned(i32 %0, i32 %1) {
+// LLVM-LABEL: define void @_Z11c0_unsignedjj(i32 %0, i32 %1) {
 // LLVM: %[[U_PTR1:.*]] = alloca i32, i64 1
 // LLVM: %[[U_PTR2:.*]] = alloca i32, i64 1
 // LLVM: %[[U_BOOL_PTR:.*]] = alloca i8, i64 1
@@ -265,7 +265,7 @@ void c0_float(float a, float b) {
   x = a == b;
 }
 
-// CIR-LABEL: cir.func @c0_float(%arg0: !cir.float{{.*}}, %arg1: !cir.float{{.*}}) {
+// CIR-LABEL: cir.func @_Z8c0_floatff(%arg0: !cir.float{{.*}}, %arg1: !cir.float{{.*}}) {
 // CIR: %[[A_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["b", init]
 // CIR: %[[X_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init]
@@ -303,7 +303,7 @@ void c0_float(float a, float b) {
 // CIR: %[[CMP6:.*]] = cir.cmp(eq, %[[A6]], %[[B6]]) : !cir.float, !cir.bool
 // CIR: cir.store %[[CMP6]], %[[X_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM-LABEL: define void @c0_float(float %0, float %1) {
+// LLVM-LABEL: define void @_Z8c0_floatff(float %0, float %1) {
 // LLVM: %[[A_PTR:.*]] = alloca float
 // LLVM: %[[B_PTR:.*]] = alloca float
 // LLVM: store float %0, ptr %[[A_PTR]]
@@ -346,7 +346,7 @@ void pointer_cmp(int *a, int *b) {
   x = a != b;
 }
 
-// CIR-LABEL: cir.func @pointer_cmp(%arg0: !cir.ptr<!s32i>{{.*}}, %arg1: !cir.ptr<!s32i>{{.*}}) {
+// CIR-LABEL: cir.func @_Z11pointer_cmpPiS_(%arg0: !cir.ptr<!s32i>{{.*}}, %arg1: !cir.ptr<!s32i>{{.*}}) {
 // CIR: %[[A_PTR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["b", init]
 
@@ -360,7 +360,7 @@ void pointer_cmp(int *a, int *b) {
 // CIR: cir.cmp(eq, {{.*}}, {{.*}}) : !cir.ptr<!s32i>, !cir.bool
 // CIR: cir.cmp(ne, {{.*}}, {{.*}}) : !cir.ptr<!s32i>, !cir.bool
 
-// LLVM-LABEL: define void @pointer_cmp(ptr %0, ptr %1) {
+// LLVM-LABEL: define void @_Z11pointer_cmpPiS_(ptr %0, ptr %1) {
 // LLVM: %[[A_PTR:.*]] = alloca ptr
 // LLVM: %[[B_PTR:.*]] = alloca ptr
 // LLVM: store ptr %0, ptr %[[A_PTR]]
@@ -401,7 +401,7 @@ void bool_cmp(bool a, bool b) {
   x = a != b;
 }
 
-// CIR-LABEL: cir.func @bool_cmp(%arg0: !cir.bool{{.*}}, %arg1: !cir.bool{{.*}}) {
+// CIR-LABEL: cir.func @_Z8bool_cmpbb(%arg0: !cir.bool{{.*}}, %arg1: !cir.bool{{.*}}) {
 // CIR: %[[A_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b", init]
 // CIR: %[[X_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init]
@@ -419,7 +419,7 @@ void bool_cmp(bool a, bool b) {
 // CIR: cir.cmp(eq
 // CIR: cir.cmp(ne
 
-// LLVM-LABEL: define void @bool_cmp(i1 %0, i1 %1) {
+// LLVM-LABEL: define void @_Z8bool_cmpbb(i1 %0, i1 %1) {
 // LLVM: %[[A_PTR:.*]] = alloca i8
 // LLVM: %[[B_PTR:.*]] = alloca i8
 // LLVM: %[[X_PTR:.*]] = alloca i8

--- a/clang/test/CIR/CodeGen/if.cpp
+++ b/clang/test/CIR/CodeGen/if.cpp
@@ -14,7 +14,7 @@ int if0(bool a) {
 
 }
 
-// CIR: cir.func @if0(%arg0: !cir.bool loc({{.*}})) -> !s32i
+// CIR: cir.func @_Z3if0b(%arg0: !cir.bool loc({{.*}})) -> !s32i
 // CIR: cir.scope {
 // CIR:   %4 = cir.load %0 : !cir.ptr<!cir.bool>, !cir.bool
 // CIR-NEXT: cir.if %4 {
@@ -26,7 +26,7 @@ int if0(bool a) {
 // CIR-NEXT:  }
 
 
-// LLVM: define i32 @if0(i1 %0)
+// LLVM: define i32 @_Z3if0b(i1 %0)
 // LLVM:   br label %[[ENTRY:.*]]
 // LLVM: [[ENTRY]]:
 // LLVM:   %6 = load i8, ptr %2, align 1
@@ -71,7 +71,7 @@ void if1(int a) {
   }
 }
 
-// CIR: cir.func @if1(%arg0: !s32i loc({{.*}}))
+// CIR: cir.func @_Z3if1i(%arg0: !s32i loc({{.*}}))
 // CIR: cir.scope {
 // CIR:   %3 = cir.load %0 : !cir.ptr<!s32i>, !s32i
 // CIR:   %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
@@ -84,7 +84,7 @@ void if1(int a) {
 // CIR-NEXT:   }
 // CIR: }
 
-// LLVM: define void @if1(i32 %0)
+// LLVM: define void @_Z3if1i(i32 %0)
 // LLVM: %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM: %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM: store i32 %0, ptr %[[A]], align 4
@@ -138,7 +138,7 @@ void if2(int a, bool b, bool c) {
   }
 }
 
-// CIR: cir.func @if2(%arg0: !s32i loc({{.*}}), %arg1: !cir.bool loc({{.*}}), %arg2: !cir.bool loc({{.*}}))
+// CIR: cir.func @_Z3if2ibb(%arg0: !s32i loc({{.*}}), %arg1: !cir.bool loc({{.*}}), %arg2: !cir.bool loc({{.*}}))
 // CIR: cir.scope {
 // CIR:   %5 = cir.load %0 : !cir.ptr<!s32i>, !s32i
 // CIR:   %6 = cir.cast(int_to_bool, %5 : !s32i), !cir.bool
@@ -165,7 +165,7 @@ void if2(int a, bool b, bool c) {
 // CIR:   }
 // CIR: }
 
-// LLVM: define void @if2(i32 %[[A:.*]], i1 %[[B:.*]], i1 %[[C:.*]])
+// LLVM: define void @_Z3if2ibb(i32 %[[A:.*]], i1 %[[B:.*]], i1 %[[C:.*]])
 // LLVM:   %[[VARA:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[VARB:.*]] = alloca i8, i64 1, align 1
 // LLVM:   %[[VARC:.*]] = alloca i8, i64 1, align 1
@@ -260,7 +260,7 @@ int if_init() {
   }
 }
 
-// CIR: cir.func @if_init() -> !s32i
+// CIR: cir.func @_Z7if_initv() -> !s32i
 // CIR: %[[RETVAL:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>
 // CIR: cir.scope {
 // CIR:   %[[X:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>,
@@ -285,7 +285,7 @@ int if_init() {
 // CIR:   }
 // CIR: }
 
-// LLVM: define i32 @if_init()
+// LLVM: define i32 @_Z7if_initv()
 // LLVM: %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM: %[[RETVAL:.*]] = alloca i32, i64 1, align 4
 // LLVM: store i32 42, ptr %[[X]], align 4

--- a/clang/test/CIR/CodeGen/int-to-bool.cpp
+++ b/clang/test/CIR/CodeGen/int-to-bool.cpp
@@ -9,14 +9,14 @@ bool f1(unsigned char c) {
   return c;
 }
 
-// CIR: cir.func @f1
+// CIR: cir.func @_Z2f1h
 // CIR:   cir.cast(int_to_bool, %{{.*}} : !u8i), !cir.bool
 
 // Note: The full zext/store/load/trunc sequence is checked here to show what
 // CIR is being lowered to. There's no need to check it for every function since
 // the lowering is the same for all of them.
 
-// LLVM: define i1 @f1
+// LLVM: define i1 @_Z2f1h
 // LLVM:   %[[CMP:.*]] = icmp ne i8 %4, 0
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[CMP]] to i8
 // LLVM:   store i8 %[[ZEXT]], ptr %{{.*}}
@@ -32,10 +32,10 @@ bool f2(short s) {
   return s;
 }
 
-// CIR: cir.func @f2
+// CIR: cir.func @_Z2f2s
 // CIR:   cir.cast(int_to_bool, %{{.*}} : !s16i), !cir.bool
 
-// LLVM: define i1 @f2
+// LLVM: define i1 @_Z2f2s
 // LLVM:   %[[CMP:.*]] = icmp ne i16 %4, 0
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[CMP]] to i8
 
@@ -47,10 +47,10 @@ bool f3(unsigned u) {
   return u;
 }
 
-// CIR: cir.func @f3
+// CIR: cir.func @_Z2f3j
 // CIR:   cir.cast(int_to_bool, %{{.*}} : !u32i), !cir.bool
 
-// LLVM: define i1 @f3
+// LLVM: define i1 @_Z2f3j
 // LLVM:   %[[CMP:.*]] = icmp ne i32 %4, 0
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[CMP]] to i8
 
@@ -62,10 +62,10 @@ bool f4(long l) {
   return l;
 }
 
-// CIR: cir.func @f4
+// CIR: cir.func @_Z2f4l
 // CIR:   cir.cast(int_to_bool, %{{.*}} : !s64i), !cir.bool
 
-// LLVM: define i1 @f4
+// LLVM: define i1 @_Z2f4l
 // LLVM:   %[[CMP:.*]] = icmp ne i64 %4, 0
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[CMP]] to i8
 

--- a/clang/test/CIR/CodeGen/local-vars.cpp
+++ b/clang/test/CIR/CodeGen/local-vars.cpp
@@ -21,7 +21,7 @@ void test() {
 }
 
 // CHECK: module
-// CHECK: cir.func @test()
+// CHECK: cir.func @_Z4testv()
 // CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK:    %[[L_PTR:.*]] = cir.alloca !s64i, !cir.ptr<!s64i>, ["l", init] {alignment = 8 : i64}
 // CHECK:    %[[F_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -10,7 +10,7 @@ void l0() {
   }
 }
 
-// CIR: cir.func @l0
+// CIR: cir.func @_Z2l0v
 // CIR:   cir.scope {
 // CIR:     cir.for : cond {
 // CIR:       %[[TRUE:.*]] = cir.const #true
@@ -24,7 +24,7 @@ void l0() {
 // CIR:   cir.return
 // CIR: }
 
-// LLVM: define void @l0()
+// LLVM: define void @_Z2l0v()
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL2:.*]]
@@ -50,7 +50,7 @@ void l1() {
   }
 }
 
-// CIR:      cir.func @l1
+// CIR:      cir.func @_Z2l1v
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CIR-NEXT:     %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
@@ -67,7 +67,7 @@ void l1() {
 // CIR-NEXT:   cir.return
 // CIR-NEXT: }
 
-// LLVM: define void @l1()
+// LLVM: define void @_Z2l1v()
 // LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
@@ -98,7 +98,7 @@ void l2() {
   }
 }
 
-// CIR:      cir.func @l2
+// CIR:      cir.func @_Z2l2v
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     cir.for : cond {
 // CIR-NEXT:       %[[TRUE:.*]] = cir.const #true
@@ -117,7 +117,7 @@ void l2() {
 // CIR-NEXT:   cir.return
 // CIR-NEXT: }
 
-// LLVM: define void @l2()
+// LLVM: define void @_Z2l2v()
 // LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
@@ -148,7 +148,7 @@ void l3() {
     int i = 0;
 }
 
-// CIR:      cir.func @l3
+// CIR:      cir.func @_Z2l3v
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CIR-NEXT:     cir.for : cond {
@@ -165,7 +165,7 @@ void l3() {
 // CIR-NEXT:   cir.return
 // CIR-NEXT: }
 
-// LLVM: define void @l3()
+// LLVM: define void @_Z2l3v()
 // LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
@@ -195,7 +195,7 @@ void test_do_while_false() {
   } while (0);
 }
 
-// CIR: cir.func @test_do_while_false()
+// CIR: cir.func @_Z19test_do_while_falsev()
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     cir.do {
 // CIR-NEXT:       cir.yield
@@ -204,7 +204,7 @@ void test_do_while_false() {
 // CIR-NEXT:       %[[FALSE:.*]] = cir.cast(int_to_bool, %[[ZERO]] : !s32i), !cir.bool
 // CIR-NEXT:       cir.condition(%[[FALSE]])
 
-// LLVM: define void @test_do_while_false()
+// LLVM: define void @_Z19test_do_while_falsev()
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL3:.*]]
@@ -231,7 +231,7 @@ void test_empty_while_true() {
   }
 }
 
-// CIR: cir.func @test_empty_while_true()
+// CIR: cir.func @_Z21test_empty_while_truev()
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     cir.while {
 // CIR-NEXT:       %[[TRUE:.*]] = cir.const #true
@@ -242,7 +242,7 @@ void test_empty_while_true() {
 // CIR-NEXT:       }
 // CIR-NEXT:       cir.yield
 
-// LLVM: define void @test_empty_while_true()
+// LLVM: define void @_Z21test_empty_while_truev()
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL2:.*]]
@@ -273,7 +273,7 @@ void unreachable_after_continue() {
   }
 }
 
-// CIR: cir.func @unreachable_after_continue
+// CIR: cir.func @_Z26unreachable_after_continuev()
 // CIR:   cir.scope {
 // CIR:     cir.for : cond {
 // CIR:       %[[TRUE:.*]] = cir.const #true
@@ -295,7 +295,7 @@ void unreachable_after_continue() {
 // CIR:   cir.return
 // CIR: }
 
-// LLVM: define void @unreachable_after_continue()
+// LLVM: define void @_Z26unreachable_after_continuev()
 // LLVM:   %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
@@ -333,7 +333,7 @@ void unreachable_after_break() {
   }
 }
 
-// CIR: cir.func @unreachable_after_break
+// CIR: cir.func @_Z23unreachable_after_breakv()
 // CIR:   cir.scope {
 // CIR:     cir.for : cond {
 // CIR:       %[[TRUE:.*]] = cir.const #true
@@ -355,7 +355,7 @@ void unreachable_after_break() {
 // CIR:   cir.return
 // CIR: }
 
-// LLVM: define void @unreachable_after_break()
+// LLVM: define void @_Z23unreachable_after_breakv()
 // LLVM:   %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:

--- a/clang/test/CIR/CodeGen/nullptr-init.cpp
+++ b/clang/test/CIR/CodeGen/nullptr-init.cpp
@@ -11,7 +11,7 @@ void t1() {
   int *p3 = (int*)0;
 }
 
-// CIR:      cir.func @t1()
+// CIR:      cir.func @_Z2t1v()
 // CIR-NEXT:     %[[P1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p1", init] {alignment = 8 : i64}
 // CIR-NEXT:     %[[P2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p2", init] {alignment = 8 : i64}
 // CIR-NEXT:     %[[P3:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p3", init] {alignment = 8 : i64}
@@ -24,7 +24,7 @@ void t1() {
 // CIR-NEXT:     cir.return
 // CIR-NEXT: }
 
-// LLVM:      define{{.*}} @t1()
+// LLVM:      define{{.*}} @_Z2t1v()
 // LLVM-NEXT:     %[[P1:.*]] = alloca ptr, i64 1, align 8
 // LLVM-NEXT:     %[[P2:.*]] = alloca ptr, i64 1, align 8
 // LLVM-NEXT:     %[[P3:.*]] = alloca ptr, i64 1, align 8

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -16,11 +16,11 @@ void f(void) {
   IncompleteS *p;
 }
 
-// CIR:      cir.func @f()
+// CIR:      cir.func @_Z1fv()
 // CIR-NEXT:   cir.alloca !cir.ptr<!rec_IncompleteS>, !cir.ptr<!cir.ptr<!rec_IncompleteS>>, ["p"]
 // CIR-NEXT:   cir.return
 
-// LLVM:      define void @f()
+// LLVM:      define void @_Z1fv()
 // LLVM-NEXT:   %[[P:.*]] = alloca ptr, i64 1, align 8
 // LLVM-NEXT:   ret void
 

--- a/clang/test/CIR/CodeGen/unary.cpp
+++ b/clang/test/CIR/CodeGen/unary.cpp
@@ -10,12 +10,12 @@ unsigned up0() {
   return +a;
 }
 
-// CHECK: cir.func @up0() -> !u32i
+// CHECK: cir.func @_Z3up0v() -> !u32i
 // CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(plus, %[[INPUT]])
 
-// LLVM: define i32 @up0()
+// LLVM: define i32 @_Z3up0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -31,12 +31,12 @@ unsigned um0() {
   return -a;
 }
 
-// CHECK: cir.func @um0() -> !u32i
+// CHECK: cir.func @_Z3um0v() -> !u32i
 // CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(minus, %[[INPUT]])
 
-// LLVM: define i32 @um0()
+// LLVM: define i32 @_Z3um0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -54,12 +54,12 @@ unsigned un0() {
   return ~a; // a ^ -1 , not
 }
 
-// CHECK: cir.func @un0() -> !u32i
+// CHECK: cir.func @_Z3un0v() -> !u32i
 // CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(not, %[[INPUT]])
 
-// LLVM: define i32 @un0()
+// LLVM: define i32 @_Z3un0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -78,7 +78,7 @@ int inc0() {
   return a;
 }
 
-// CHECK: cir.func @inc0() -> !s32i
+// CHECK: cir.func @_Z4inc0v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
@@ -87,7 +87,7 @@ int inc0() {
 // CHECK:   cir.store %[[INCREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load %[[A]]
 
-// LLVM: define i32 @inc0()
+// LLVM: define i32 @_Z4inc0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -106,7 +106,7 @@ int dec0() {
   return a;
 }
 
-// CHECK: cir.func @dec0() -> !s32i
+// CHECK: cir.func @_Z4dec0v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
@@ -115,7 +115,7 @@ int dec0() {
 // CHECK:   cir.store %[[DECREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load %[[A]]
 
-// LLVM: define i32 @dec0()
+// LLVM: define i32 @_Z4dec0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -134,7 +134,7 @@ int inc1() {
   return a;
 }
 
-// CHECK: cir.func @inc1() -> !s32i
+// CHECK: cir.func @_Z4inc1v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
@@ -143,7 +143,7 @@ int inc1() {
 // CHECK:   cir.store %[[INCREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load %[[A]]
 
-// LLVM: define i32 @inc1()
+// LLVM: define i32 @_Z4inc1v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -162,7 +162,7 @@ int dec1() {
   return a;
 }
 
-// CHECK: cir.func @dec1() -> !s32i
+// CHECK: cir.func @_Z4dec1v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
@@ -171,7 +171,7 @@ int dec1() {
 // CHECK:   cir.store %[[DECREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load %[[A]]
 
-// LLVM: define i32 @dec1()
+// LLVM: define i32 @_Z4dec1v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -191,7 +191,7 @@ int inc2() {
   return b;
 }
 
-// CHECK: cir.func @inc2() -> !s32i
+// CHECK: cir.func @_Z4inc2v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[B:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
@@ -202,7 +202,7 @@ int inc2() {
 // CHECK:   cir.store %[[ATOB]], %[[B]]
 // CHECK:   %[[B_TO_OUTPUT:.*]] = cir.load %[[B]]
 
-// LLVM: define i32 @inc2()
+// LLVM: define i32 @_Z4inc2v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[B:.*]] = alloca i32, i64 1, align 4
@@ -228,12 +228,12 @@ float fpPlus() {
   return +a;
 }
 
-// CHECK: cir.func @fpPlus() -> !cir.float
+// CHECK: cir.func @_Z6fpPlusv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(plus, %[[INPUT]])
 
-// LLVM: define float @fpPlus()
+// LLVM: define float @_Z6fpPlusv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -249,12 +249,12 @@ float fpMinus() {
   return -a;
 }
 
-// CHECK: cir.func @fpMinus() -> !cir.float
+// CHECK: cir.func @_Z7fpMinusv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(minus, %[[INPUT]])
 
-// LLVM: define float @fpMinus()
+// LLVM: define float @_Z7fpMinusv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -272,14 +272,14 @@ float fpPreInc() {
   return ++a;
 }
 
-// CHECK: cir.func @fpPreInc() -> !cir.float
+// CHECK: cir.func @_Z8fpPreIncv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
 // CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.float
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(inc, %[[INPUT]])
 
-// LLVM: define float @fpPreInc()
+// LLVM: define float @_Z8fpPreIncv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -297,14 +297,14 @@ float fpPreDec() {
   return --a;
 }
 
-// CHECK: cir.func @fpPreDec() -> !cir.float
+// CHECK: cir.func @_Z8fpPreDecv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
 // CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.float
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[DECREMENTED:.*]] = cir.unary(dec, %[[INPUT]])
 
-// LLVM: define float @fpPreDec()
+// LLVM: define float @_Z8fpPreDecv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -322,14 +322,14 @@ float fpPostInc() {
   return a++;
 }
 
-// CHECK: cir.func @fpPostInc() -> !cir.float
+// CHECK: cir.func @_Z9fpPostIncv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
 // CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.float
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(inc, %[[INPUT]])
 
-// LLVM: define float @fpPostInc()
+// LLVM: define float @_Z9fpPostIncv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -347,14 +347,14 @@ float fpPostDec() {
   return a--;
 }
 
-// CHECK: cir.func @fpPostDec() -> !cir.float
+// CHECK: cir.func @_Z9fpPostDecv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
 // CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.float
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[DECREMENTED:.*]] = cir.unary(dec, %[[INPUT]])
 
-// LLVM: define float @fpPostDec()
+// LLVM: define float @_Z9fpPostDecv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -374,7 +374,7 @@ float fpPostInc2() {
   return b;
 }
 
-// CHECK: cir.func @fpPostInc2() -> !cir.float
+// CHECK: cir.func @_Z10fpPostInc2v() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[B:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["b", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
@@ -385,7 +385,7 @@ float fpPostInc2() {
 // CHECK:   cir.store %[[ATOB]], %[[B]]
 // CHECK:   %[[B_TO_OUTPUT:.*]] = cir.load %[[B]]
 
-// LLVM: define float @fpPostInc2()
+// LLVM: define float @_Z10fpPostInc2v()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[B:.*]] = alloca float, i64 1, align 4
@@ -407,7 +407,7 @@ float fpPostInc2() {
 // OGCG:   %[[B_TO_OUTPUT:.*]] = load float, ptr %[[B]], align 4
 
 void chars(char c) {
-// CHECK: cir.func @chars
+// CHECK: cir.func @_Z5charsc
 
   int c1 = +c;
   // CHECK: %[[PROMO:.*]] = cir.cast(integral, %{{.+}} : !s8i), !s32i
@@ -429,13 +429,13 @@ _Float16 fp16UPlus(_Float16 f) {
   return +f;
 }
 
-// CHECK: cir.func @fp16UPlus({{.*}}) -> !cir.f16
+// CHECK: cir.func @_Z9fp16UPlusDF16_({{.*}}) -> !cir.f16
 // CHECK:   %[[INPUT:.*]] = cir.load %[[F:.*]]
 // CHECK:   %[[PROMOTED:.*]] = cir.cast(floating, %[[INPUT]] : !cir.f16), !cir.float
 // CHECK:   %[[RESULT:.*]] = cir.unary(plus, %[[PROMOTED]])
 // CHECK:   %[[UNPROMOTED:.*]] = cir.cast(floating, %[[RESULT]] : !cir.float), !cir.f16
 
-// LLVM: define half @fp16UPlus({{.*}})
+// LLVM: define half @_Z9fp16UPlusDF16_({{.*}})
 // LLVM:   %[[F_LOAD:.*]] = load half, ptr %{{.*}}, align 2
 // LLVM:   %[[PROMOTED:.*]] = fpext half %[[F_LOAD]] to float
 // LLVM:   %[[UNPROMOTED:.*]] = fptrunc float %[[PROMOTED]] to half
@@ -449,13 +449,13 @@ _Float16 fp16UMinus(_Float16 f) {
   return -f;
 }
 
-// CHECK: cir.func @fp16UMinus({{.*}}) -> !cir.f16
+// CHECK: cir.func @_Z10fp16UMinusDF16_({{.*}}) -> !cir.f16
 // CHECK:   %[[INPUT:.*]] = cir.load %[[F:.*]]
 // CHECK:   %[[PROMOTED:.*]] = cir.cast(floating, %[[INPUT]] : !cir.f16), !cir.float
 // CHECK:   %[[RESULT:.*]] = cir.unary(minus, %[[PROMOTED]])
 // CHECK:   %[[UNPROMOTED:.*]] = cir.cast(floating, %[[RESULT]] : !cir.float), !cir.f16
 
-// LLVM: define half @fp16UMinus({{.*}})
+// LLVM: define half @_Z10fp16UMinusDF16_({{.*}})
 // LLVM:   %[[F_LOAD:.*]] = load half, ptr %{{.*}}, align 2
 // LLVM:   %[[PROMOTED:.*]] = fpext half %[[F_LOAD]] to float
 // LLVM:   %[[RESULT:.*]] = fneg float %[[PROMOTED]]
@@ -480,7 +480,7 @@ void test_logical_not() {
   b = !d;
 }
 
-// CHECK: cir.func @test_logical_not()
+// CHECK: cir.func @_Z16test_logical_notv()
 // CHECK:   %[[A:.*]] = cir.load %[[A_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   %[[A_BOOL:.*]] = cir.cast(int_to_bool, %[[A]] : !s32i), !cir.bool
 // CHECK:   %[[A_NOT:.*]] = cir.unary(not, %[[A_BOOL]]) : !cir.bool, !cir.bool
@@ -503,7 +503,7 @@ void test_logical_not() {
 // CHECK:   %[[D_NOT:.*]] = cir.unary(not, %[[D_BOOL]]) : !cir.bool, !cir.bool
 // CHECK:   cir.store %[[D_NOT]], %[[B_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: define void @test_logical_not()
+// LLVM: define void @_Z16test_logical_notv()
 // LLVM:   %[[A:.*]] = load i32, ptr %[[A_ADDR:.*]], align 4
 // LLVM:   %[[A_BOOL:.*]] = icmp ne i32 %[[A]], 0
 // LLVM:   %[[A_NOT:.*]] = xor i1 %[[A_BOOL]], true

--- a/clang/test/CIR/Lowering/array.cpp
+++ b/clang/test/CIR/Lowering/array.cpp
@@ -34,7 +34,7 @@ void func() {
   int e = arr[0];
   int e2 = arr[1];
 }
-// CHECK: define void @func()
+// CHECK: define void @_Z4funcv()
 // CHECK-NEXT: %[[ARR_ALLOCA:.*]] = alloca [10 x i32], i64 1, align 16
 // CHECK-NEXT: %[[INIT:.*]] = alloca i32, i64 1, align 4
 // CHECK-NEXT: %[[INIT_2:.*]] = alloca i32, i64 1, align 4
@@ -50,7 +50,7 @@ void func() {
 void func2() {
   int arr[2] = {5};
 }
-// CHECK: define void @func2()
+// CHECK: define void @_Z5func2v()
 // CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x i32], i64 1, align 4
 // CHECK:  %[[TMP:.*]] = alloca ptr, i64 1, align 8
 // CHECK:  %[[ARR_PTR:.*]] = getelementptr i32, ptr %[[ARR_ALLOCA]], i32 0
@@ -65,7 +65,7 @@ void func2() {
 void func3() {
   int arr3[2] = {5, 6};
 }
-// CHECK: define void @func3()
+// CHECK: define void @_Z5func3v()
 // CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x i32], i64 1, align 4
 // CHECK:  %[[ARR_PTR:.*]] = getelementptr i32, ptr %[[ARR_ALLOCA]], i32 0
 // CHECK:  store i32 5, ptr %[[ARR_PTR]], align 4
@@ -76,7 +76,7 @@ void func4() {
   int arr[2][1] = {{5}, {6}};
   int e = arr[1][0];
 }
-// CHECK: define void @func4()
+// CHECK: define void @_Z5func4v()
 // CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
 // CHECK:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // CHECK:  %[[ARR_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR_ALLOCA]], i32 0
@@ -95,7 +95,7 @@ void func4() {
 void func5() {
   int arr[2][1] = {{5}};
 }
-// CHECK: define void @func5()
+// CHECK: define void @_Z5func5v()
 // CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
 // CHECK:  %[[TMP:.*]] = alloca ptr, i64 1, align 8
 // CHECK:  %[[ARR_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR_ALLOCA]], i32 0
@@ -112,7 +112,7 @@ void func6() {
   int x = 4;
   int arr[2] = { x, 5 };
 }
-// CHECK: define void @func6()
+// CHECK: define void @_Z5func6v()
 // CHECK:  %[[VAR:.*]] = alloca i32, i64 1, align 4
 // CHECK:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
 // CHECK:  store i32 4, ptr %[[VAR]], align 4
@@ -125,7 +125,7 @@ void func6() {
 void func7() {
   int* arr[1] = {};
 }
-// CHECK: define void @func7()
+// CHECK: define void @_Z5func7v()
 // CHECK:  %[[ARR:.*]] = alloca [1 x ptr], i64 1, align 8
 // CHECK:  %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
 // CHECK:  %[[ELE_PTR:.*]] = getelementptr ptr, ptr %[[ARR]], i32 0
@@ -136,9 +136,9 @@ void func7() {
 // CHECK:  store ptr %[[ELE]], ptr %[[ALLOCA]], align 8
 
 void func8(int p[10]) {}
-// CHECK: define void @func8(ptr {{%.*}})
+// CHECK: define void @_Z5func8Pi(ptr {{%.*}})
 // CHECK-NEXT: alloca ptr, i64 1, align 8
 
 void func9(int pp[10][5]) {}
-// CHECK: define void @func9(ptr {{%.*}})
+// CHECK: define void @_Z5func9PA5_i(ptr {{%.*}})
 // CHECK-NEXT: alloca ptr, i64 1, align 8

--- a/clang/test/CIR/Lowering/basic.cpp
+++ b/clang/test/CIR/Lowering/basic.cpp
@@ -5,7 +5,7 @@ int f1() {
   return i;
 }
 
-// CHECK: define{{.*}} i32 @f1() {
+// CHECK: define{{.*}} i32 @_Z2f1v() {
 // CHECK:    %[[RV:.*]] = alloca i32, i64 1, align 4
 // CHECK:    %[[I_PTR:.*]] = alloca i32, i64 1, align 4
 // CHECK:    %[[I:.*]] = load i32, ptr %[[I_PTR]], align 4
@@ -18,7 +18,7 @@ int f2() {
   return i;
 }
 
-// CHECK: define{{.*}} i32 @f2() {
+// CHECK: define{{.*}} i32 @_Z2f2v() {
 // CHECK:    %[[RV:.*]] = alloca i32, i64 1, align 4
 // CHECK:    %[[I_PTR:.*]] = alloca i32, i64 1, align 4
 // CHECK:    store i32 2, ptr %[[I_PTR]], align 4
@@ -31,7 +31,7 @@ int f3(int i) {
     return i;
   }
 
-// CHECK: define{{.*}} i32 @f3(i32 %[[ARG:.*]])
+// CHECK: define{{.*}} i32 @_Z2f3i(i32 %[[ARG:.*]])
 // CHECK:   %[[ARG_ALLOCA:.*]] = alloca i32, i64 1, align 4
 // CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // CHECK:   store i32 %[[ARG]], ptr %[[ARG_ALLOCA]], align 4
@@ -44,7 +44,7 @@ int f4(const int i) {
   return i;
 }
 
-// CHECK: define{{.*}} i32 @f4(i32 %[[ARG:.*]])
+// CHECK: define{{.*}} i32 @_Z2f4i(i32 %[[ARG:.*]])
 // CHECK:   %[[ARG_ALLOCA:.*]] = alloca i32, i64 1, align 4
 // CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // CHECK:   store i32 %[[ARG]], ptr %[[ARG_ALLOCA]], align 4

--- a/clang/test/CIR/Lowering/func-simple.cpp
+++ b/clang/test/CIR/Lowering/func-simple.cpp
@@ -2,15 +2,15 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o -  | FileCheck %s
 
 void empty() { }
-// CHECK: define{{.*}} void @empty()
+// CHECK: define{{.*}} void @_Z5emptyv()
 // CHECK:   ret void
 
 void voidret() { return; }
-// CHECK: define{{.*}} void @voidret()
+// CHECK: define{{.*}} void @_Z7voidretv()
 // CHECK:   ret void
 
 int intfunc() { return 42; }
-// CHECK: define{{.*}} i32 @intfunc()
+// CHECK: define{{.*}} i32 @_Z7intfuncv()
 // CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // CHECK:   store i32 42, ptr %[[RV]], align 4
 // CHECK:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
@@ -23,7 +23,7 @@ int scopes() {
     }
   }
 }
-// CHECK: define{{.*}} i32 @scopes() {
+// CHECK: define{{.*}} i32 @_Z6scopesv() {
 // CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // CHECK:   br label %[[LABEL1:.*]]
 // CHECK: [[LABEL1]]:
@@ -40,7 +40,7 @@ int scopes() {
 // CHECK: }
 
 long longfunc() { return 42l; }
-// CHECK: define{{.*}} i64 @longfunc() {
+// CHECK: define{{.*}} i64 @_Z8longfuncv() {
 // CHECK:   %[[RV]] = alloca i64, i64 1, align 8
 // CHECK:   store i64 42, ptr %[[RV]], align 4
 // CHECK:   %[[R:.*]] = load i64, ptr %[[RV]], align 4
@@ -48,7 +48,7 @@ long longfunc() { return 42l; }
 // CHECK: }
 
 unsigned unsignedfunc() { return 42u; }
-// CHECK: define{{.*}} i32 @unsignedfunc() {
+// CHECK: define{{.*}} i32 @_Z12unsignedfuncv() {
 // CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // CHECK:   store i32 42, ptr %[[RV]], align 4
 // CHECK:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
@@ -56,7 +56,7 @@ unsigned unsignedfunc() { return 42u; }
 // CHECK: }
 
 unsigned long long ullfunc() { return 42ull; }
-// CHECK: define{{.*}} i64 @ullfunc() {
+// CHECK: define{{.*}} i64 @_Z7ullfuncv() {
 // CHECK:   %[[RV:.*]] = alloca i64, i64 1, align 8
 // CHECK:   store i64 42, ptr %[[RV]], align 4
 // CHECK:   %[[R:.*]] = load i64, ptr %[[RV]], align 4
@@ -64,7 +64,7 @@ unsigned long long ullfunc() { return 42ull; }
 // CHECK: }
 
 bool boolfunc() { return true; }
-// CHECK: define{{.*}} i1 @boolfunc() {
+// CHECK: define{{.*}} i1 @_Z8boolfuncv() {
 // CHECK:   %[[RV:.*]] = alloca i8, i64 1, align 1
 // CHECK:   store i8 1, ptr %[[RV]], align 1
 // CHECK:   %[[R8:.*]] = load i8, ptr %[[RV]], align 1

--- a/clang/test/CIR/Lowering/local-vars.cpp
+++ b/clang/test/CIR/Lowering/local-vars.cpp
@@ -23,7 +23,7 @@ void test() {
 // Note: The alignment of i64 stores below is wrong. That should be fixed
 //       when we add alignment attributes to the load/store ops.
 
-// CHECK: define{{.*}} void @test()
+// CHECK: define{{.*}} void @_Z4testv()
 // CHECK:    %[[I_PTR:.*]] = alloca i32, i64 1, align 4
 // CHECK:    %[[L_PTR:.*]] = alloca i64, i64 1, align 8
 // CHECK:    %[[F_PTR:.*]] = alloca float, i64 1, align 4

--- a/clang/test/CIR/func-simple.cpp
+++ b/clang/test/CIR/func-simple.cpp
@@ -2,17 +2,17 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s
 
 void empty() { }
-// CHECK: cir.func @empty() {
+// CHECK: cir.func @_Z5emptyv() {
 // CHECK:   cir.return
 // CHECK: }
 
 void voidret() { return; }
-// CHECK: cir.func @voidret() {
+// CHECK: cir.func @_Z7voidretv() {
 // CHECK:   cir.return
 // CHECK: }
 
 int intfunc() { return 42; }
-// CHECK: cir.func @intfunc() -> !s32i {
+// CHECK: cir.func @_Z7intfuncv() -> !s32i {
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.const #cir.int<42> : !s32i
 // CHECK:   cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
@@ -27,7 +27,7 @@ int scopes() {
     }
   }
 }
-// CHECK: cir.func @scopes() -> !s32i {
+// CHECK: cir.func @_Z6scopesv() -> !s32i {
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   cir.scope {
 // CHECK:     cir.scope {
@@ -41,7 +41,7 @@ int scopes() {
 // CHECK: }
 
 long longfunc() { return 42l; }
-// CHECK: cir.func @longfunc() -> !s64i
+// CHECK: cir.func @_Z8longfuncv() -> !s64i
 // CHECK:   %0 = cir.alloca !s64i, !cir.ptr<!s64i>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.int<42> : !s64i
 // CHECK:   cir.store %1, %0 : !s64i, !cir.ptr<!s64i>
@@ -50,7 +50,7 @@ long longfunc() { return 42l; }
 // CHECK: }
 
 unsigned unsignedfunc() { return 42u; }
-// CHECK: cir.func @unsignedfunc() -> !u32i
+// CHECK: cir.func @_Z12unsignedfuncv() -> !u32i
 // CHECK:   %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.const #cir.int<42> : !u32i
 // CHECK:   cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
@@ -59,7 +59,7 @@ unsigned unsignedfunc() { return 42u; }
 // CHECK: }
 
 unsigned long long ullfunc() { return 42ull; }
-// CHECK: cir.func @ullfunc() -> !u64i
+// CHECK: cir.func @_Z7ullfuncv() -> !u64i
 // CHECK:   %0 = cir.alloca !u64i, !cir.ptr<!u64i>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.int<42> : !u64i
 // CHECK:   cir.store %1, %0 : !u64i, !cir.ptr<!u64i>
@@ -68,7 +68,7 @@ unsigned long long ullfunc() { return 42ull; }
 // CHECK: }
 
 bool boolfunc() { return true; }
-// CHECK: cir.func @boolfunc() -> !cir.bool {
+// CHECK: cir.func @_Z8boolfuncv() -> !cir.bool {
 // CHECK:   %0 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["__retval"] {alignment = 1 : i64}
 // CHECK:   %1 = cir.const #true
 // CHECK:   cir.store %1, %0 : !cir.bool, !cir.ptr<!cir.bool>
@@ -77,7 +77,7 @@ bool boolfunc() { return true; }
 // CHECK: }
 
 float floatfunc() { return 42.42f; }
-// CHECK: cir.func @floatfunc() -> !cir.float {
+// CHECK: cir.func @_Z9floatfuncv() -> !cir.float {
 // CHECK:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.const #cir.fp<4.242
 // CHECK:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>
@@ -86,7 +86,7 @@ float floatfunc() { return 42.42f; }
 // CHECK: }
 
 double doublefunc() { return 42.42; }
-// CHECK: cir.func @doublefunc() -> !cir.double {
+// CHECK: cir.func @_Z10doublefuncv() -> !cir.double {
 // CHECK:   %0 = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.fp<4.242
 // CHECK:   cir.store %1, %0 : !cir.double, !cir.ptr<!cir.double>

--- a/clang/test/CIR/global-var-linkage.cpp
+++ b/clang/test/CIR/global-var-linkage.cpp
@@ -4,7 +4,7 @@
 int aaaa;
 // CHECK: cir.global external @aaaa
 static int bbbb;
-// CHECK: cir.global internal @bbbb
+// CHECK: cir.global internal @_ZL4bbbb
 inline int cccc;
 // CHECK: cir.global linkonce_odr @cccc
 [[gnu::selectany]] int dddd;


### PR DESCRIPTION
We have been using the default names for global symbols to this point. This change introduces proper name mangling for functions.

This requires introducing a CXXABI class in the CIRGenModule. Because only target independent name mangling is handled in this patch, the CXXABI class does not require a target-specific implementation. The general mechanism for selecting an implementation is introduced here, but the actual target-specific subclasses are deferred until needed.