### PR TITLE
[Clang][NFC] Move temp variable back into the source

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5980,7 +5980,7 @@ bool ASTReader::readASTFileControlBlock(
        }
       }
     }
-    Stream = SavedStream;
+    Stream = std::move(SavedStream);
   }
 
   // Scan for the UNHASHED_CONTROL_BLOCK_ID block.


### PR DESCRIPTION
Static analysis flagged this code b/c we are copying the temp variable back in when we could move it instead.