### PR TITLE
github-automation.py: Add debug output to the commit-request-greeter

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -270,6 +270,7 @@ class CommitRequestGreeter:
         merged_by = {}
         reviewed_by = {}
         for i in self.repo.get_issues(creator=self.issue.user.login, state="all"):
+            print("Looking at issue:", i)
             issue_reviewed_by = set()
             try:
                 pr = i.as_pull_request()
@@ -292,7 +293,8 @@ class CommitRequestGreeter:
                         merged_by[merger] += 1
                     continue
 
-            except github.GithubException:
+            except github.GithubException as e:
+                print(e)
                 continue
 
         comment = f"""


### PR DESCRIPTION
This script is not working any more in the GitHub actions jobs and I can't reproduce this locally, so I've added some debug output to try to help find the problem.