### PR TITLE
[flang] Retrieve shape from selector when generating assoc sym type

### DIFF
--- a/flang/test/Lower/do_concurrent_local_assoc_entity.f90
+++ b/flang/test/Lower/do_concurrent_local_assoc_entity.f90
@@ -1,0 +1,22 @@
+! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck %s
+
+subroutine local_assoc
+  implicit none
+  integer  i
+  real, dimension(2:11) :: aa
+
+  associate(a => aa(4:))
+    do concurrent (i = 4:11) local(a)
+      a(i) = 0
+    end do
+  end associate
+end subroutine local_assoc
+
+! CHECK: %[[C8:.*]] = arith.constant 8 : index
+
+! CHECK: fir.do_loop {{.*}} unordered {
+! CHECK:   %[[LOCAL_ALLOC:.*]] = fir.alloca !fir.array<8xf32> {bindc_name = "a", pinned, uniq_name = "{{.*}}local_assocEa"}
+! CHECK:   %[[LOCAL_SHAPE:.*]] = fir.shape %[[C8]] :
+! CHECK:   %[[LOCAL_DECL:.*]]:2 = hlfir.declare %[[LOCAL_ALLOC]](%[[LOCAL_SHAPE]])
+! CHECK:   hlfir.designate %[[LOCAL_DECL]]#0 (%{{.*}})
+! CHECK: }

--- a/flang/test/Lower/do_concurrent_local_assoc_entity.f90
+++ b/flang/test/Lower/do_concurrent_local_assoc_entity.f90
@@ -14,7 +14,7 @@ end subroutine local_assoc
 
 ! CHECK: %[[C8:.*]] = arith.constant 8 : index
 
-! CHECK: fir.do_loop {{.*}} unordered {
+! CHECK: fir.do_concurrent.loop {{.*}} {
 ! CHECK:   %[[LOCAL_ALLOC:.*]] = fir.alloca !fir.array<8xf32> {bindc_name = "a", pinned, uniq_name = "{{.*}}local_assocEa"}
 ! CHECK:   %[[LOCAL_SHAPE:.*]] = fir.shape %[[C8]] :
 ! CHECK:   %[[LOCAL_DECL:.*]]:2 = hlfir.declare %[[LOCAL_ALLOC]](%[[LOCAL_SHAPE]])


### PR DESCRIPTION
This PR extends `genSymbolType` so that the type of an associating symbol carries the shape of the selector expression, if any. This is a fix for a bug that triggered when an associating symbol is used in a locality specifier. For example, given the following input:

```fortran
  associate(a => aa(4:))
    do concurrent (i = 4:11) local(a)
      a(i) = 0
    end do
  end associate
```
before the changes in the PR, flang would assert that we are casting between incompatible types. The issue happened since for the associating symbol (`a`), flang generated its type as `f32` rather than `!fir.array<8xf32>` as it should be in this case.