### PR TITLE
[ASan] Limits the conditions of the deadlock patch

### DIFF
--- a/compiler-rt/lib/asan/asan_report.cpp
+++ b/compiler-rt/lib/asan/asan_report.cpp
@@ -21,6 +21,7 @@
 #include "asan_scariness_score.h"
 #include "asan_stack.h"
 #include "asan_thread.h"
+#include "lsan/lsan_common.h"
 #include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_flags.h"
 #include "sanitizer_common/sanitizer_interface_internal.h"
@@ -149,7 +150,7 @@ class ScopedInErrorReport {
     // 2. Subsequent error reporting avoids nested lock acquisition patterns.
     // 3. Eliminates the lock order inversion risk between libdl and ASan's
     //    thread registry.
-#if !SANITIZER_SYMBOLIZER_MARKUP
+#if CAN_SANITIZE_LEAKS && (SANITIZER_LINUX || SANITIZER_NETBSD)
     Symbolizer::GetOrInit()->GetRefreshedListOfModules();
 #endif
 


### PR DESCRIPTION
PR #131756 introduced a patch to fix a deadlock between LSan and ASan.

The relevant deadlock only occurs when LSan is enabled and `dl_iterate_phdr` is used for Stop-the-World, i.e., under the condition `CAN_SANITIZE_LEAKS && (SANITIZER_LINUX || SANITIZER_NETBSD)`.

Therefore, this commit also sets the effective condition of this patch to the above condition, avoiding unnecessary problems in other environments, e.g., stack overflow on MSVC/Windows.