### PR TITLE
[clang][bytecode] Compute pointer differences as 64bit integers

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2161,16 +2161,22 @@ inline bool SubPtr(InterpState &S, CodePtr OpPC) {
     }
   }
 
-  T A = LHS.isBlockPointer()
-            ? (LHS.isElementPastEnd() ? T::from(LHS.getNumElems())
-                                      : T::from(LHS.getIndex()))
-            : T::from(LHS.getIntegerRepresentation());
-  T B = RHS.isBlockPointer()
-            ? (RHS.isElementPastEnd() ? T::from(RHS.getNumElems())
-                                      : T::from(RHS.getIndex()))
-            : T::from(RHS.getIntegerRepresentation());
+  int64_t A64 =
+      LHS.isBlockPointer()
+          ? (LHS.isElementPastEnd() ? LHS.getNumElems() : LHS.getIndex())
+          : LHS.getIntegerRepresentation();
 
-  return AddSubMulHelper<T, T::sub, std::minus>(S, OpPC, A.bitWidth(), A, B);
+  int64_t B64 =
+      RHS.isBlockPointer()
+          ? (RHS.isElementPastEnd() ? RHS.getNumElems() : RHS.getIndex())
+          : RHS.getIntegerRepresentation();
+
+  int64_t R64 = A64 - B64;
+  if (static_cast<int64_t>(T::from(R64)) != R64)
+    return handleOverflow(S, OpPC, R64);
+
+  S.Stk.push<T>(T::from(R64));
+  return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/AST/ByteCode/i686.cpp
+++ b/clang/test/AST/ByteCode/i686.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple i686-pc-linux-gnu -fexperimental-new-constant-interpreter -verify=expected,both %s
+// RUN: %clang_cc1 -triple i686-pc-linux-gnu                                         -verify=ref,both      %s
+
+
+char melchizedek[2200000000];
+typedef decltype(melchizedek[1] - melchizedek[0]) ptrdiff_t;
+constexpr ptrdiff_t d1 = &melchizedek[0x7fffffff] - &melchizedek[0];
+constexpr ptrdiff_t d2 = &melchizedek[0x80000000u] - &melchizedek[0]; // both-error {{constant expression}} \
+                                                                      // both-note {{ 2147483648 }}
+constexpr ptrdiff_t d3 = &melchizedek[0] - &melchizedek[0x80000000u];
+constexpr ptrdiff_t d4 = &melchizedek[0] - &melchizedek[0x80000001u]; // both-error {{constant expression}} \
+                                                                      // both-note {{ -2147483649 }}
+
+


### PR DESCRIPTION
And only convert to the target type after that.