### PR TITLE
[LangRef] Clarify the behavior of select with FP poison-generating flags

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -12880,7 +12880,10 @@ class <t_firstclass>` type.
    :ref:`fast-math flags <fastmath>`. These are optimization hints to enable
    otherwise unsafe floating-point optimizations. Fast-math flags are only valid
    for selects that return :ref:`supported floating-point types
-   <fastmath_return_types>`.
+   <fastmath_return_types>`. Note that the violation of poison-generating flags on
+   non-selected arm may not result in :ref:`poison <poisonvalues>` return value.
+   For simplicity, if :ref:`fast-math flags <fastmath>` are present, they are only
+   applied to the result, not both arms.
 
 Semantics:
 """"""""""
@@ -12894,9 +12897,6 @@ vectors of the same size, and the selection is done element by element.
 
 If the condition is an i1 and the value arguments are vectors of the
 same size, then an entire vector is selected.
-
-Note that violations of poison-generating flags for both arms may not result in poison return values.
-For simplicity, if :ref:`fast-math flags <fastmath>` are present, they are only applied to the result, not both arms.
 
 Example:
 """"""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -12895,12 +12895,16 @@ vectors of the same size, and the selection is done element by element.
 If the condition is an i1 and the value arguments are vectors of the
 same size, then an entire vector is selected.
 
+Note that violations of poison-generating flags for both arms may not result in poison return values.
+For simplicity, if :ref:`fast-math flags <fastmath>` are present, they are only applied to the result, not both arms.
+
 Example:
 """"""""
 
 .. code-block:: llvm
 
-      %X = select i1 true, i8 17, i8 42          ; yields i8:17
+      %X = select i1 true, i8 17, i8 42                   ; yields i8:17
+      %Y = select nnan i1 true, float 0.0, float NaN      ; yields float:0.0
 
 
 .. _i_freeze:

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -12881,9 +12881,9 @@ class <t_firstclass>` type.
    otherwise unsafe floating-point optimizations. Fast-math flags are only valid
    for selects that return :ref:`supported floating-point types
    <fastmath_return_types>`. Note that the violation of poison-generating flags on
-   non-selected arm may not result in :ref:`poison <poisonvalues>` return value.
-   For simplicity, if :ref:`fast-math flags <fastmath>` are present, they are only
-   applied to the result, not both arms.
+   the non-selected arm does not result in a :ref:`poison <poisonvalues>` return value.
+   If :ref:`fast-math flags <fastmath>` are present, they are only applied to the result,
+   not both arms.
 
 Semantics:
 """"""""""
@@ -12905,6 +12905,7 @@ Example:
 
       %X = select i1 true, i8 17, i8 42                   ; yields i8:17
       %Y = select nnan i1 true, float 0.0, float NaN      ; yields float:0.0
+      %Z = select nnan i1 false, float 0.0, float NaN     ; yields float:poison
 
 
 .. _i_freeze:

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -12880,8 +12880,8 @@ class <t_firstclass>` type.
    :ref:`fast-math flags <fastmath>`. These are optimization hints to enable
    otherwise unsafe floating-point optimizations. Fast-math flags are only valid
    for selects that return :ref:`supported floating-point types
-   <fastmath_return_types>`. Note that the violation of poison-generating flags on
-   the non-selected arm does not result in a :ref:`poison <poisonvalues>` return value.
+   <fastmath_return_types>`. Note that the presence of value which would otherwise result
+   in poison does not cause the result to be poison if the value is on the non-selected arm.
    If :ref:`fast-math flags <fastmath>` are present, they are only applied to the result,
    not both arms.
 


### PR DESCRIPTION
RFC link: https://discourse.llvm.org/t/rfc-clarify-the-behavior-of-select-with-fp-poison-generating-flags/85974

Actually, it does not conflict with the definition of FMF if we interpret a select as `applyFMF(select cond, applyFMF(TrueArm), applyFMF(FalseArm))`.
