### PR TITLE
[Driver] Fix _XOPEN_SOURCE definition on Solaris

### DIFF
--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -618,14 +618,7 @@ protected:
     DefineStd(Builder, "unix", Opts);
     Builder.defineMacro("__svr4__");
     Builder.defineMacro("__SVR4");
-    // Solaris headers require _XOPEN_SOURCE to be set to 600 for C99 and
-    // newer, but to 500 for everything else.  feature_test.h has a check to
-    // ensure that you are not using C99 with an old version of X/Open or C89
-    // with a new version.
-    if (Opts.C99)
-      Builder.defineMacro("_XOPEN_SOURCE", "600");
-    else
-      Builder.defineMacro("_XOPEN_SOURCE", "500");
+    Builder.defineMacro("_XOPEN_SOURCE", "600");
     if (Opts.CPlusPlus) {
       Builder.defineMacro("__C99FEATURES__");
       Builder.defineMacro("_FILE_OFFSET_BITS", "64");


### PR DESCRIPTION
Since commit 613a077b05b8352a48695be295037306f5fca151, `flang` doesn't build any longer on Solaris/amd64:
```
flang/lib/Evaluate/intrinsics-library.cpp:225:26:
error: address of overloaded function 'acos' does not match required type '__float128 (__float128)'
  225 |       FolderFactory<F, F{std::acos}>::Create("acos"),
      |                          ^~~~~~~~~
```
That patch led to the version of `quadmath.h` deep inside `/usr/gcc/<N>` to be found, thus `HAS_QUADMATHLIB` is defined.  However, the `struct HostRuntimeLibrary<__float128, LibraryVersion::Libm>` template is guarded by `_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600`, while `clang` only predefines `_XOPEN_SOURCE=500`.

This code dates back to commit 0c1941cb055fcf008e17faa6605969673211bea3 back in 2012.  Currently, this is long obsolete and `gcc` prefefines `_XOPEN_SOURCE=600` instead since GCC 4.6 back in 2011.

This patch follows that.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11`.