### PR TITLE
[libc++][NFC] Use early returns in basic_string::operator=

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -2867,23 +2867,21 @@ basic_string<_CharT, _Traits, _Allocator>::operator=(value_type __c) {
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::operator=(const basic_string& __str) {
-  if (this != std::addressof(__str)) {
-    __copy_assign_alloc(__str);
-    if (!__is_long()) {
-      if (!__str.__is_long()) {
-        size_type __old_size = __get_short_size();
-        if (__old_size < __str.__get_short_size())
-          __annotate_increase(__str.__get_short_size() - __old_size);
-        __rep_ = __str.__rep_;
-        if (__old_size > __get_short_size())
-          __annotate_shrink(__old_size);
-      } else {
-        return __assign_no_alias<true>(__str.data(), __str.size());
-      }
-    } else {
-      return __assign_no_alias<false>(__str.data(), __str.size());
-    }
-  }
+  if (this == std::addressof(__str))
+    return *this;
+
+  __copy_assign_alloc(__str);
+
+  if (__is_long())
+    return __assign_no_alias<false>(__str.data(), __str.size());
+
+  if (__str.__is_long())
+    return __assign_no_alias<true>(__str.data(), __str.size());
+
+  __annotate_delete();
+  auto __guard = std::__make_scope_guard(__annotate_new_size(*this));
+  __rep_       = __str.__rep_;
+
   return *this;
 }
 


### PR DESCRIPTION
This makes the code a lot easier to read.
