### PR TITLE
[lldb] Fix offset computation in RegisterContextUnwind

### DIFF
--- a/lldb/include/lldb/Core/Address.h
+++ b/lldb/include/lldb/Core/Address.h
@@ -371,22 +371,15 @@ public:
   bool ResolveAddressUsingFileSections(lldb::addr_t addr,
                                        const SectionList *sections);
 
-  /// Resolve this address to its containing function and optionally get
-  /// that function's address range.
+  /// Resolve this address to its containing function.
   ///
   /// \param[out] sym_ctx
   ///     The symbol context describing the function in which this address lies
   ///
-  /// \parm[out] addr_range_ptr
-  ///     Pointer to the AddressRange to fill in with the function's address
-  ///     range.  Caller may pass null if they don't need the address range.
-  ///
   /// \return
-  ///     Returns \b false if the function/symbol could not be resolved
-  ///     or if the address range was requested and could not be resolved;
+  ///     Returns \b false if the function/symbol could not be resolved;
   ///     returns \b true otherwise.
-  bool ResolveFunctionScope(lldb_private::SymbolContext &sym_ctx,
-                            lldb_private::AddressRange *addr_range_ptr = nullptr);
+  bool ResolveFunctionScope(lldb_private::SymbolContext &sym_ctx);
 
   /// Set the address to represent \a load_addr.
   ///

--- a/lldb/source/Core/Address.cpp
+++ b/lldb/source/Core/Address.cpp
@@ -263,22 +263,11 @@ bool Address::ResolveAddressUsingFileSections(addr_t file_addr,
   return false; // Failed to resolve this address to a section offset value
 }
 
-/// if "addr_range_ptr" is not NULL, then fill in with the address range of the function.
-bool Address::ResolveFunctionScope(SymbolContext &sym_ctx,
-                                   AddressRange *addr_range_ptr) {
+bool Address::ResolveFunctionScope(SymbolContext &sym_ctx) {
   constexpr SymbolContextItem resolve_scope =
     eSymbolContextFunction | eSymbolContextSymbol;
 
-  if (!(CalculateSymbolContext(&sym_ctx, resolve_scope) & resolve_scope)) {
-    if (addr_range_ptr)
-      addr_range_ptr->Clear();
-   return false;
-  }
-
-  if (!addr_range_ptr)
-    return true;
-
-  return sym_ctx.GetAddressRange(resolve_scope, 0, false, *addr_range_ptr);
+  return CalculateSymbolContext(&sym_ctx, resolve_scope) & resolve_scope;
 }
 
 ModuleSP Address::GetModule() const {

--- a/lldb/test/Shell/Unwind/basic-block-sections-with-dwarf-static.test
+++ b/lldb/test/Shell/Unwind/basic-block-sections-with-dwarf-static.test
@@ -22,15 +22,17 @@ image show-unwind --cached true -n foo
 # CHECK-NEXT: This UnwindPlan is sourced from the compiler: yes.
 # CHECK-NEXT: This UnwindPlan is valid at all instruction locations: no.
 # CHECK-NEXT: This UnwindPlan is for a trap handler function: no.
-# CHECK-NEXT: Address range of this UnwindPlan: [{{.*}}.text + 6-0x0000000000000010)[{{.*}}.text + 17-0x000000000000001c)[{{.*}}.text + 44-0x0000000000000037)[{{.*}}.text + 56-0x000000000000003d)
-# CHECK-NEXT: row[0]:    0: CFA=rsp +8 => rip=[CFA-8]
-# CHECK-NEXT: row[1]:    1: CFA=rsp+16 => rbx=[CFA-16] rip=[CFA-8]
-# CHECK-NEXT: row[2]:   11: CFA=rsp+16 => rbx=[CFA-16] rip=[CFA-8]
-# CHECK-NEXT: row[3]:   15: CFA=rsp+32 => rbx=[CFA-16] rip=[CFA-8]
-# CHECK-NEXT: row[4]:   38: CFA=rsp+16 => rbx=[CFA-16] rip=[CFA-8]
-# CHECK-NEXT: row[5]:   42: CFA=rsp+32 => rbx=[CFA-16] rip=[CFA-8]
-# CHECK-NEXT: row[6]:   50: CFA=rsp+32 => rbx=[CFA-16] rip=[CFA-8]
-# CHECK-NEXT: row[7]:   54: CFA=rsp +8 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: Address range of this UnwindPlan: [{{.*}}.text + 6-0x000000000000000b)[{{.*}}.text + 12-0x000000000000001b)[{{.*}}.text + 43-0x0000000000000039)[{{.*}}.text + 58-0x0000000000000045)
+# CHECK-NEXT: row[0]:  -37: CFA=rsp+32 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: row[1]:  -33: CFA=rsp +8 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: row[2]:  -31: CFA=rsp+32 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: row[3]:  -27: CFA=rsp+48 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: row[4]:  -18: CFA=rsp+32 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: row[5]:    0: CFA=rsp +8 => rip=[CFA-8]
+# CHECK-NEXT: row[6]:    1: CFA=rsp+16 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: row[7]:   12: CFA=rsp+32 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: row[8]:   15: CFA=rsp+16 => rbx=[CFA-16] rip=[CFA-8]
+# CHECK-NEXT: row[9]:   19: CFA=rsp+32 => rbx=[CFA-16] rip=[CFA-8]
 # CHECK-EMPTY:
 
 image show-unwind --cached true -n bar
@@ -41,8 +43,8 @@ image show-unwind --cached true -n bar
 # CHECK-NEXT: This UnwindPlan is sourced from the compiler: yes.
 # CHECK-NEXT: This UnwindPlan is valid at all instruction locations: no.
 # CHECK-NEXT: This UnwindPlan is for a trap handler function: no.
-# CHECK-NEXT: Address range of this UnwindPlan: [{{.*}}.text + 28-0x000000000000002c)
+# CHECK-NEXT: Address range of this UnwindPlan: [{{.*}}.text + 27-0x000000000000002b)
 # CHECK-NEXT: row[0]:    0: CFA=rsp +8 => rip=[CFA-8]
-# CHECK-NEXT: row[1]:    4: CFA=rsp+32 => rip=[CFA-8]
+# CHECK-NEXT: row[1]:    4: CFA=rsp+96 => rip=[CFA-8]
 # CHECK-NEXT: row[2]:   15: CFA=rsp +8 => rip=[CFA-8]
 # CHECK-EMPTY:


### PR DESCRIPTION
AddressFunctionScope was always returning the first address range of the
function (assuming it was the only one). This doesn't work for
RegisterContextUnwind (it's only caller), when the function doesn't
start at the lowest address because it throws off the 'how many bytes
"into" a function I am' computation. This patch replaces the result with
a call to (recently introduced)
SymbolContext::GetFunctionOrSymbolAddress.
