### PR TITLE
[clang][CompundLiteralExpr] Don't defer evaluation for CLEs

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -3535,8 +3535,7 @@ class CompoundLiteralExpr : public Expr {
   llvm::PointerIntPair<TypeSourceInfo *, 1, bool> TInfoAndScope;
   Stmt *Init;
 
-  /// Value of constant literals with static storage duration. Used only for
-  /// constant folding as CompoundLiteralExpr is not an ICE.
+  /// Value of constant literals with static storage duration.
   mutable APValue *StaticValue = nullptr;
 
 public:
@@ -3569,11 +3568,8 @@ public:
   }
 
   bool hasStaticStorage() const { return isFileScope() && isGLValue(); }
-  APValue *getOrCreateStaticValue(ASTContext &Ctx) const;
-  APValue &getStaticValue() const {
-    assert(StaticValue);
-    return *StaticValue;
-  }
+  APValue &getOrCreateStaticValue(ASTContext &Ctx) const;
+  APValue &getStaticValue() const;
 
   SourceLocation getBeginLoc() const LLVM_READONLY {
     // FIXME: Init should never be null.

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -5446,3 +5446,12 @@ ConvertVectorExpr *ConvertVectorExpr::Create(
   return new (Mem) ConvertVectorExpr(SrcExpr, TI, DstType, VK, OK, BuiltinLoc,
                                      RParenLoc, FPFeatures);
 }
+
+APValue *CompoundLiteralExpr::getOrCreateStaticValue(ASTContext &Ctx) const {
+  assert(hasStaticStorage());
+  if (!StaticValue) {
+    StaticValue = new (Ctx) APValue;
+    Ctx.addDestruction(StaticValue);
+  }
+  return StaticValue;
+}

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -5447,11 +5447,16 @@ ConvertVectorExpr *ConvertVectorExpr::Create(
                                      RParenLoc, FPFeatures);
 }
 
-APValue *CompoundLiteralExpr::getOrCreateStaticValue(ASTContext &Ctx) const {
+APValue &CompoundLiteralExpr::getOrCreateStaticValue(ASTContext &Ctx) const {
   assert(hasStaticStorage());
   if (!StaticValue) {
     StaticValue = new (Ctx) APValue;
     Ctx.addDestruction(StaticValue);
   }
-  return StaticValue;
+  return *StaticValue;
+}
+
+APValue &CompoundLiteralExpr::getStaticValue() const {
+  assert(StaticValue);
+  return *StaticValue;
 }

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -4547,14 +4547,6 @@ static CompleteObject findCompleteObject(EvalInfo &Info, const Expr *E,
         assert(BaseVal && "got reference to unevaluated temporary");
       } else if (const CompoundLiteralExpr *CLE =
                      dyn_cast_or_null<CompoundLiteralExpr>(Base)) {
-        // In C99, a CompoundLiteralExpr is an lvalue, and we defer evaluating
-        // the initializer until now for such expressions. Such an expression
-        // can't be an ICE in C, so this only matters for fold.
-        if (LValType.isVolatileQualified()) {
-          Info.FFDiag(E);
-          return CompleteObject();
-        }
-
         // According to GCC info page:
         //
         // 6.28 Compound Literals

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -9162,6 +9162,9 @@ LValueExprEvaluator::VisitCompoundLiteralExpr(const CompoundLiteralExpr *E) {
     Lit = &Info.CurrentCall->createTemporary(E, E->getInitializer()->getType(),
                                              ScopeKind::Block, Result);
   }
+  // FIXME: Evaluating in place isn't always right. We should figure out how to
+  // use appropriate evaluation context here, see
+  // clang/test/AST/static-compound-literals-reeval.cpp for a failure.
   if (!EvaluateInPlace(*Lit, Info, Result, E->getInitializer())) {
     *Lit = APValue();
     return false;

--- a/clang/test/AST/static-compound-literals-crash.cpp
+++ b/clang/test/AST/static-compound-literals-crash.cpp
@@ -1,0 +1,17 @@
+// FIXME: These test cases currently crash during codegen, despite initializers
+// for CLEs being constant.
+// RUN: not --crash %clang_cc1 -verify -std=c++20 -emit-llvm %s
+// expected-no-diagnostics
+namespace case1 {
+struct RR { int&& r; };
+struct Z { RR* x; };
+constinit Z z = { (RR[1]){1} };
+}
+
+
+namespace case2 {
+struct RR { int r; };
+struct Z { int x; const RR* y; int z; };
+inline int f() { return 0; }
+Z z2 = { 10, (const RR[1]){__builtin_constant_p(z2.x)}, z2.y->r+f() };
+}

--- a/clang/test/AST/static-compound-literals-reeval.cpp
+++ b/clang/test/AST/static-compound-literals-reeval.cpp
@@ -6,4 +6,4 @@ constinit Z z = { 10, (const RR[1]){__builtin_constant_p(z.x)}, z.y->r };
 // Check that we zero-initialize z.y->r.
 // CHECK: @.compoundliteral = internal constant [1 x %struct.RR] zeroinitializer
 // FIXME: Despite of z.y->r being 0, we evaluate z.z to 1.
-// CHECK: @z = global %struct.Z { i32 10, ptr @.compoundliteral, i32 1 }
+// CHECK: @z ={{.*}} global %struct.Z { i32 10, ptr @.compoundliteral, i32 1 }

--- a/clang/test/AST/static-compound-literals-reeval.cpp
+++ b/clang/test/AST/static-compound-literals-reeval.cpp
@@ -6,4 +6,4 @@ constinit Z z = { 10, (const RR[1]){__builtin_constant_p(z.x)}, z.y->r };
 // Check that we zero-initialize z.y->r.
 // CHECK: @.compoundliteral = internal constant [1 x %struct.RR] zeroinitializer
 // FIXME: Despite of z.y->r being 0, we evaluate z.z to 1.
-// CHECK: @z ={{.*}} global %struct.Z { i32 10, ptr @.compoundliteral, i32 1 }
+// CHECK: global %struct.Z { i32 10, ptr @.compoundliteral, i32 1 }

--- a/clang/test/AST/static-compound-literals-reeval.cpp
+++ b/clang/test/AST/static-compound-literals-reeval.cpp
@@ -1,0 +1,9 @@
+// Test that we can successfully compile this code, especially under ASAN.
+// RUN: %clang_cc1 -emit-llvm -std=c++20 %s -o- | FileCheck %s
+struct RR { int r; };
+struct Z { int x; const RR* y; int z; };
+constinit Z z = { 10, (const RR[1]){__builtin_constant_p(z.x)}, z.y->r };
+// Check that we zero-initialize z.y->r.
+// CHECK: @.compoundliteral = internal constant [1 x %struct.RR] zeroinitializer
+// FIXME: Despite of z.y->r being 0, we evaluate z.z to 1.
+// CHECK: @z = global %struct.Z { i32 10, ptr @.compoundliteral, i32 1 }

--- a/clang/test/AST/static-compound-literals.cpp
+++ b/clang/test/AST/static-compound-literals.cpp
@@ -1,0 +1,12 @@
+// Test that we can successfully compile this code, especially under ASAN.
+// RUN: %clang_cc1 -verify -std=c++20 -fsyntax-only %s
+// expected-no-diagnostics
+struct Foo {
+  Foo* f;
+  operator bool() const { return true; }
+};
+constexpr Foo f((Foo[]){});
+int foo() {
+  if (Foo(*f.f)) return 1;
+  return 0;
+}


### PR DESCRIPTION
Previously we would defer evaluation of CLEs until LValue to RValue
conversions, which would result in creating values within wrong scope
and triggering use-after-frees.

This patch instead eagerly evaluates CLEs, within the scope requiring
them. This requires storing an extra pointer for CLE expressions with
static storage.

Fixes https://github.com/llvm/llvm-project/issues/137165