### PR TITLE
[SPIRV] Stop unconditionally emitting SPV_INTEL_arbitrary_precision_integers when allowed

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -27,6 +27,7 @@
 #include "llvm/IR/IntrinsicsSPIRV.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/MathExtras.h"
 #include <cassert>
 #include <functional>
 
@@ -175,7 +176,8 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeInt(unsigned Width,
   const SPIRVSubtarget &ST =
       cast<SPIRVSubtarget>(MIRBuilder.getMF().getSubtarget());
   return createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
-    if (ST.canUseExtension(
+    if ((!isPowerOf2_32(Width) || Width < 8) &&
+        ST.canUseExtension(
             SPIRV::Extension::SPV_INTEL_arbitrary_precision_integers)) {
       MIRBuilder.buildInstr(SPIRV::OpExtension)
           .addImm(SPIRV::Extension::SPV_INTEL_arbitrary_precision_integers);

--- a/llvm/test/CodeGen/SPIRV/extensions/unused-but-allowed-SPV_INTEL_arbitrary_precision_integers.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/unused-but-allowed-SPV_INTEL_arbitrary_precision_integers.ll
@@ -1,0 +1,19 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown --spirv-ext=+SPV_INTEL_arbitrary_precision_integers %s -o - | FileCheck %s
+
+define i8 @getConstantI8() {
+  ret i8 2
+}
+define i16 @getConstantI16() {
+  ret i16 2
+}
+define i32 @getConstantI32() {
+  ret i32 2
+}
+
+define i64 @getConstantI64() {
+  ret i64 42
+}
+
+;; Capabilities:
+; CHECK-NOT: OpExtension "SPV_INTEL_arbitrary_precision_integers"
+; CHECK-NOT: OpCapability ArbitraryPrecisionIntegersINTEL


### PR DESCRIPTION
When the SPV_INTEL_arbitrary_precision_integers extension is allowed to be used, the backend will unconditionnally add it to the module used extensions.

The patch prevent SPV_INTEL_arbitrary_precision_integers from being declared if unneeded.