### PR TITLE
[compiler-rt] Don't exclude ubsan-asan tests on Windows/x86_64

### DIFF
--- a/compiler-rt/test/ubsan/CMakeLists.txt
+++ b/compiler-rt/test/ubsan/CMakeLists.txt
@@ -49,11 +49,9 @@ foreach(arch ${UBSAN_TEST_ARCH})
   add_ubsan_testsuites("Standalone" ubsan ${arch})
 
   if(COMPILER_RT_HAS_ASAN AND ";${ASAN_SUPPORTED_ARCH};" MATCHES ";${arch};")
-    # TODO(wwchrome): Re-enable ubsan for asan win 64-bit when ready.
-    # Disable ubsan with AddressSanitizer tests for Windows 64-bit,
-    # 64-bit Solaris/x86 and 64-bit SPARC.
-    if((NOT (OS_NAME MATCHES "Windows" AND CMAKE_SIZEOF_VOID_P EQUAL 8)) AND
-       (NOT (OS_NAME MATCHES "SunOS" AND ${arch} MATCHES x86_64)) AND
+    # Disable ubsan with AddressSanitizer tests for 64-bit Solaris/x86 and
+    # 64-bit SPARC.
+    if((NOT (OS_NAME MATCHES "SunOS" AND ${arch} MATCHES x86_64)) AND
        (NOT ${arch} MATCHES sparcv9))
       add_ubsan_testsuites("AddressSanitizer" asan ${arch})
     endif()


### PR DESCRIPTION
This removes a leftover workaround from
00f3f6e296d49eb261e1ad47868a50122bfc111e from 2016. Currently the tests seem to work fine on x86_64 in both MSVC and mingw configurations with this workaround removed.

(On aarch64, asan isn't functional at all; this workaround used to hide that issue when running "check-ubsan", but the issue is apparent if running all tests with "check-compiler-rt" anyway.)