### PR TITLE
[compiler-rt] Only include asan on x86 architectures on Windows

### DIFF
--- a/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
+++ b/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
@@ -44,6 +44,10 @@ else()
   set(OS_NAME "${CMAKE_SYSTEM_NAME}")
 endif()
 
+if (OS_NAME MATCHES "Windows")
+  set(ALL_ASAN_SUPPORTED_ARCH ${X86} ${X86_64})
+endif()
+
 if(OS_NAME MATCHES "Linux")
   set(ALL_FUZZER_SUPPORTED_ARCH ${X86} ${X86_64} ${ARM32} ${ARM64} ${S390X}
       ${RISCV64} ${LOONGARCH64})


### PR DESCRIPTION
This avoids building asan when targeting Windows on armv7 or aarch64. It is possible to build asan successfully for those configurations (since 5ea9dd8c7076270695a1d90b9c73718e7d95e0bf and 0c391133c9201ef29273554a1505ef855ce17668), but asan isn't functional there.

This change skips building asan for targets other than x86_32 and x86_64.

By excluding asan from the build, we fix the "check-ubsan" target for armv7 and aarch64 Windows. If asan is included in the build, an ubsan-asan configuration gets added to the tests, and as asan isn't functional for these targets, it produces a lot of test failures even when just trying to run "check-ubsan".