### PR TITLE
[compiler-rt] [test] Look for the right file name suffix for arm targets

### DIFF
--- a/compiler-rt/test/lit.common.configured.in
+++ b/compiler-rt/test/lit.common.configured.in
@@ -69,7 +69,13 @@ elif config.android:
   else:
     set_default("target_suffix", "-%s-android" % config.target_arch)
 else:
-  set_default("target_suffix", "-%s" % config.target_arch)
+  if config.target_arch.startswith("arm"):
+    if config.target_arch.endswith("hf"):
+      set_default("target_suffix", "-armhf")
+    else:
+      set_default("target_suffix", "-arm")
+  else:
+    set_default("target_suffix", "-%s" % config.target_arch)
 
 set_default("have_internal_symbolizer", @COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER_PYBOOL@)
 set_default("have_disable_symbolizer_path_search", @SANITIZER_DISABLE_SYMBOLIZER_PATH_SEARCH_PYBOOL@)


### PR DESCRIPTION
Compiler-rt libraries on arm use "arm" or "armhf" as suffix, not the full exact arch name like "armv7".

This matches what was done for the build system in 8e11bede3a6ac11ebcc05c82fac39899feaf9534, to match the names that Clang expects (in getArchNameForCompilerRTLib in Clang).

This fixes building a large number of the compiler-rt tests for Windows/armv7.