### PR TITLE
[compiler-rt] Detect arm hardfloat targets via __ARM_PCS_VFP

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -877,6 +877,7 @@ else ()
       # For ARM archs, exclude any VFP builtins if VFP is not supported
       if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em|armv8m.main|armv8.1m.main)$")
         check_compile_definition(__ARM_FP "${CMAKE_C_FLAGS}" COMPILER_RT_HAS_${arch}_VFP)
+        check_compile_definition(__ARM_PCS_VFP "${CMAKE_C_FLAGS}" COMPILER_RT_HAS_${arch}_ARMHF)
         if(NOT COMPILER_RT_HAS_${arch}_VFP)
           list(REMOVE_ITEM ${arch}_SOURCES ${arm_Thumb1_VFPv2_DP_SOURCES} ${arm_Thumb1_VFPv2_SP_SOURCES} ${arm_Thumb1_SjLj_EH_SOURCES})
         else()
@@ -908,7 +909,7 @@ else ()
 
       # Needed for clear_cache on debug mode, due to r7's usage in inline asm.
       # Release mode already sets it via -O2/3, Debug mode doesn't.
-      if (${arch} STREQUAL "armhf")
+      if (COMPILER_RT_HAS_${arch}_ARMHF)
         list(APPEND BUILTIN_CFLAGS_${arch} -fomit-frame-pointer -DCOMPILER_RT_ARMHF_TARGET)
       endif()
 


### PR DESCRIPTION
This makes sure that COMPILER_RT_ARMHF_TARGET is set properly for targets without a specific "armhf" target name, such as armv7 windows.

This fixes the builtins test comparesf2_test.c on Windows on armv7.