### PR TITLE
[clang][bytecode] Allow forming pointers to fields of extern globals

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1323,8 +1323,6 @@ static bool getField(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
       !CheckNull(S, OpPC, Ptr, CSK_Field))
     return false;
 
-  if (!CheckExtern(S, OpPC, Ptr))
-    return false;
   if (!CheckRange(S, OpPC, Ptr, CSK_Field))
     return false;
   if (!CheckArray(S, OpPC, Ptr))

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -202,3 +202,9 @@ namespace GlobalInitializer {
                // both-note {{initializer of 'g' is unknown}}
   };
 }
+
+namespace ExternPointer {
+  struct S { int a; };
+  extern const S pu;
+  constexpr const int *pua = &pu.a; // Ok.
+}


### PR DESCRIPTION
This should be fine as long as we're not reading from it.

Note that this regresses
CXX/special/class.init/class.inhctor.init/p1.cpp, which used to work fine with the bytecode interpreter.

That's because this code now fails:

```c++
  struct Param;
  struct A {
    constexpr A(Param);
    int a;
  };

  struct B : A { B(); using A::A; int b = 2; };
  struct Wrap1 : B { constexpr Wrap1(); };
  struct Wrap2 : Wrap1 {};
  extern const Wrap2 b;

  struct Param {
    constexpr Param(int c) : n(4 * b.a + b.b + c) {}
    int n;
  };
```
and reports that the Param() constructor is never a valid constant expression. But that's true and the current interpeter should report that as well. It also fails when calling at compile time.