### PR TITLE
Attributor: Don't rely on use_empty for constants

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -5746,7 +5746,7 @@ bool AANoCapture::isImpliedByIR(Attributor &A, const IRPosition &IRP,
   assert(ImpliedAttributeKind == Attribute::Captures &&
          "Unexpected attribute kind");
   Value &V = IRP.getAssociatedValue();
-  if (!IRP.isArgumentPosition())
+  if (!isa<Constant>(V) && !IRP.isArgumentPosition())
     return V.use_empty();
 
   // You cannot "capture" null in the default address space.

--- a/llvm/test/Transforms/Attributor/issue87856.ll
+++ b/llvm/test/Transforms/Attributor/issue87856.ll
@@ -4,7 +4,7 @@
 define void @null_ptr_is_valid_call_with_null() #0 {
 ; CHECK-LABEL: define void @null_ptr_is_valid_call_with_null(
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
-; CHECK-NEXT:    call void @store_as0(ptr nofree noundef writeonly null) #[[ATTR4:[0-9]+]]
+; CHECK-NEXT:    call void @store_as0(ptr noalias nofree noundef writeonly null) #[[ATTR4:[0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
   call void @store_as0(ptr null)


### PR DESCRIPTION
This allows inferring noalias on a null argument parameter. This
avoids a non-NFC diff in a future change.