### PR TITLE
[NFC][UBSAN] Fix minimal UBSAN test names

### DIFF
--- a/compiler-rt/test/ubsan_minimal/CMakeLists.txt
+++ b/compiler-rt/test/ubsan_minimal/CMakeLists.txt
@@ -10,6 +10,7 @@ set(UBSAN_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS})
 list(APPEND UBSAN_TEST_DEPS ubsan-minimal)
 
 foreach(arch ${UBSAN_TEST_ARCH})
+  string(TOLOWER "-${arch}-${OS_NAME}" UBSAN_TEST_CONFIG_SUFFIX)
   get_test_cc_for_arch(${arch} UBSAN_TEST_TARGET_CC UBSAN_TEST_TARGET_CFLAGS)
   set(CONFIG_NAME ${arch})
   configure_lit_site_cfg(

--- a/compiler-rt/test/ubsan_minimal/lit.common.cfg.py
+++ b/compiler-rt/test/ubsan_minimal/lit.common.cfg.py
@@ -16,7 +16,7 @@ def get_required_attr(config, attr_name):
 
 # Setup source root.
 config.test_source_root = os.path.dirname(__file__)
-config.name = "UBSan-Minimal-" + config.target_arch
+config.name = "UBSan-Minimal" + config.name_suffix
 
 
 def build_invocation(compile_flags):

--- a/compiler-rt/test/ubsan_minimal/lit.site.cfg.py.in
+++ b/compiler-rt/test/ubsan_minimal/lit.site.cfg.py.in
@@ -1,5 +1,7 @@
 @LIT_SITE_CFG_IN_HEADER@
 
+config.name_suffix = "@UBSAN_TEST_CONFIG_SUFFIX@"
+
 # Tool-specific config options.
 config.target_cflags = "@UBSAN_TEST_TARGET_CFLAGS@"
 config.target_arch = "@UBSAN_TEST_TARGET_ARCH@"


### PR DESCRIPTION
Same approach as in Asan.

Now it's going to print:
```
Failed Tests (2):
  UBSan-Minimal-i386-linux :: TestCases/icall.c
  UBSan-Minimal-x86_64-linux :: TestCases/icall.c
```

Before it was:
```
Failed Tests (2):
  UBSan-Minimal-x86_64 :: TestCases/icall.c
  UBSan-Minimal-x86_64 :: TestCases/icall.c
```
