### PR TITLE
[Offload] Override linker for device build

### DIFF
--- a/offload/DeviceRTL/CMakeLists.txt
+++ b/offload/DeviceRTL/CMakeLists.txt
@@ -132,9 +132,9 @@ function(compileDeviceRTLLibrary target_name target_triple)
     BUILD_RPATH ""
     INSTALL_RPATH ""
     RUNTIME_OUTPUT_NAME libomptarget-${target_name}.bc)
-  target_compile_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}" "-march=")
+  target_compile_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}" "-fuse-ld=lld" "-march=")
   target_link_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}"
-                      "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm" "-march=")
+                      "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm" "-fuse-ld=lld" "-march=")
   install(TARGETS libomptarget-${target_name}
           PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
           DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${target_triple}")
@@ -151,6 +151,8 @@ function(compileDeviceRTLLibrary target_name target_triple)
     LINKER_LANGUAGE CXX
   )
   target_link_libraries(omptarget.${target_name} PRIVATE omptarget.${target_name}.all_objs)
+  target_link_options(omptarget.${target_name} PRIVATE "--target=${target_triple}"
+                      "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm" "-fuse-ld=lld" "-march=")
 
   install(TARGETS omptarget.${target_name}
           ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${target_triple}")


### PR DESCRIPTION
Summary:
Override the default linker in case the user is passing it separately.
This requires `lld` but it always did. This will be fixed *properly*
when https://github.com/llvm/llvm-project/pull/136729 lands.

Fixes https://github.com/llvm/llvm-project/issues/136822
