### PR TITLE
[-Wunsafe-buffer-usage] Fix a bug that wrongly assumed CXXMethodDecl always has an identifier

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -675,7 +675,7 @@ static bool isNullTermPointer(const Expr *Ptr) {
     const CXXMethodDecl *MD = MCE->getMethodDecl();
     const CXXRecordDecl *RD = MCE->getRecordDecl()->getCanonicalDecl();
 
-    if (MD && RD && RD->isInStdNamespace())
+    if (MD && RD && RD->isInStdNamespace() && MD->getIdentifier())
       if (MD->getName() == "c_str" && RD->getName() == "basic_string")
         return true;
   }

--- a/clang/test/SemaCXX/bug149071318.cpp
+++ b/clang/test/SemaCXX/bug149071318.cpp
@@ -21,6 +21,6 @@ namespace std { // fake std namespace; to reproduce the bug, a CXXConversionDecl
 }
 
 void test(std::Y &y) {
-  // Here `y.x` involves an implicit cast and calls the conversion overloading, which has no identifier:
+  // Here `y.x` involves an implicit cast and calls the overloaded cast operator, which has no identifier:
   printf("%s", y.x); // expected-warning{{function 'printf' is unsafe}} expected-note{{}}
 }

--- a/clang/test/SemaCXX/bug149071318.cpp
+++ b/clang/test/SemaCXX/bug149071318.cpp
@@ -21,5 +21,6 @@ namespace std { // fake std namespace; to reproduce the bug, a CXXConversionDecl
 }
 
 void test(std::Y &y) {
+  // Here `y.x` involves an implicit cast and calls the conversion overloading, which has no identifier:
   printf("%s", y.x); // expected-warning{{function 'printf' is unsafe}} expected-note{{}}
 }

--- a/clang/test/SemaCXX/bug149071318.cpp
+++ b/clang/test/SemaCXX/bug149071318.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage \
+// RUN:            -verify %s
+
+// This example uncovered a bug in UnsafeBufferUsage.cpp, where the
+// code assumed that a CXXMethodDecl always have an identifier.
+
+int printf( const char* format, char *); // <-- Fake decl of `printf`; to reproduce the bug, this example needs an implicit cast within a printf call.
+
+namespace std { // fake std namespace; to reproduce the bug, a CXXConversionDecl needs to be in std namespace.
+  class X {
+    char * p;
+  public:    
+    operator char*() {return p;}
+  };
+
+  class Y {
+  public:
+    X x;
+  };
+
+}
+
+void test(std::Y &y) {
+  printf("%s", y.x); // expected-warning{{function 'printf' is unsafe}} expected-note{{}}
+}


### PR DESCRIPTION
Fix a bug in UnsafeBufferUsage.cpp that wrongly assumed that CXXMethodDecl always has an identifier.

rdar://149071318