### PR TITLE
[mlir][NFC] Use Builder for getReassociationIndicesAttribute method.

### DIFF
--- a/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h
@@ -57,7 +57,7 @@ getSymbolLessAffineMaps(ArrayRef<ReassociationExprs> reassociation);
 
 /// Wraps a list of reassociations in an ArrayAttr.
 ArrayAttr
-getReassociationIndicesAttribute(OpBuilder &b,
+getReassociationIndicesAttribute(Builder &b,
                                  ArrayRef<ReassociationIndices> reassociation);
 
 /// Convert Array<Array<AffineExpr>> to Array<Array<int64_t>>.

--- a/mlir/lib/Dialect/Utils/ReshapeOpsUtils.cpp
+++ b/mlir/lib/Dialect/Utils/ReshapeOpsUtils.cpp
@@ -158,7 +158,7 @@ unsigned getMaxPosOfType(ArrayRef<ReassociationExprs> exprArrays) {
 }
 
 ArrayAttr mlir::getReassociationIndicesAttribute(
-    OpBuilder &b, ArrayRef<ReassociationIndices> reassociation) {
+    Builder &b, ArrayRef<ReassociationIndices> reassociation) {
   SmallVector<Attribute, 4> reassociationAttr =
       llvm::to_vector<4>(llvm::map_range(
           reassociation, [&](const ReassociationIndices &indices) -> Attribute {


### PR DESCRIPTION
The method does not need to create any operation, so we can use Builder. It can be reused by any attribute getter implementation, so it does not need to declare OpBuilder in the implementation.