### PR TITLE
[NFC][LLVM][CodeGen] Refactor MachineInstr operand accessors

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_MACHINEINSTR_H
 #define LLVM_CODEGEN_MACHINEINSTR_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/PointerSumType.h"
 #include "llvm/ADT/ilist.h"
@@ -43,7 +44,6 @@ class Instruction;
 class MDNode;
 class AAResults;
 class BatchAAResults;
-template <typename T> class ArrayRef;
 class DIExpression;
 class DILocalVariable;
 class LiveRegUnits;
@@ -340,6 +340,13 @@ private:
     return Op.isReg() && Op.isUse();
   }
 
+  MutableArrayRef<MachineOperand> operands_impl() {
+    return {Operands, NumOperands};
+  }
+  ArrayRef<MachineOperand> operands_impl() const {
+    return {Operands, NumOperands};
+  }
+
 public:
   MachineInstr(const MachineInstr &) = delete;
   MachineInstr &operator=(const MachineInstr &) = delete;
@@ -580,18 +587,12 @@ public:
   unsigned getNumOperands() const { return NumOperands; }
 
   /// Returns the total number of operands which are debug locations.
-  unsigned getNumDebugOperands() const {
-    return std::distance(debug_operands().begin(), debug_operands().end());
-  }
+  unsigned getNumDebugOperands() const { return size(debug_operands()); }
 
-  const MachineOperand& getOperand(unsigned i) const {
-    assert(i < getNumOperands() && "getOperand() out of range!");
-    return Operands[i];
+  const MachineOperand &getOperand(unsigned i) const {
+    return operands_impl()[i];
   }
-  MachineOperand& getOperand(unsigned i) {
-    assert(i < getNumOperands() && "getOperand() out of range!");
-    return Operands[i];
-  }
+  MachineOperand &getOperand(unsigned i) { return operands_impl()[i]; }
 
   MachineOperand &getDebugOperand(unsigned Index) {
     assert(Index < getNumDebugOperands() && "getDebugOperand() out of range!");
@@ -667,8 +668,17 @@ public:
   unsigned getNumExplicitDefs() const;
 
   /// iterator/begin/end - Iterate over all operands of a machine instruction.
+
+  // The operands must always be in the following order:
+  // - explicit reg defs,
+  // - other explicit operands (reg uses, immediates, etc.),
+  // - implicit reg defs
+  // - implicit reg uses
   using mop_iterator = MachineOperand *;
   using const_mop_iterator = const MachineOperand *;
+
+  using mop_range = iterator_range<mop_iterator>;
+  using const_mop_range = iterator_range<const_mop_iterator>;
 
   mop_iterator operands_begin() { return Operands; }
   mop_iterator operands_end() { return Operands + NumOperands; }
@@ -676,92 +686,82 @@ public:
   const_mop_iterator operands_begin() const { return Operands; }
   const_mop_iterator operands_end() const { return Operands + NumOperands; }
 
-  iterator_range<mop_iterator> operands() {
-    return make_range(operands_begin(), operands_end());
+  mop_range operands() { return operands_impl(); }
+  const_mop_range operands() const { return operands_impl(); }
+
+  mop_range explicit_operands() {
+    return operands_impl().take_front(getNumExplicitOperands());
   }
-  iterator_range<const_mop_iterator> operands() const {
-    return make_range(operands_begin(), operands_end());
+  const_mop_range explicit_operands() const {
+    return operands_impl().take_front(getNumExplicitOperands());
   }
-  iterator_range<mop_iterator> explicit_operands() {
-    return make_range(operands_begin(),
-                      operands_begin() + getNumExplicitOperands());
+  mop_range implicit_operands() {
+    return operands_impl().drop_front(getNumExplicitOperands());
   }
-  iterator_range<const_mop_iterator> explicit_operands() const {
-    return make_range(operands_begin(),
-                      operands_begin() + getNumExplicitOperands());
-  }
-  iterator_range<mop_iterator> implicit_operands() {
-    return make_range(explicit_operands().end(), operands_end());
-  }
-  iterator_range<const_mop_iterator> implicit_operands() const {
-    return make_range(explicit_operands().end(), operands_end());
-  }
-  /// Returns a range over all operands that are used to determine the variable
-  /// location for this DBG_VALUE instruction.
-  iterator_range<mop_iterator> debug_operands() {
-    assert((isDebugValueLike()) && "Must be a debug value instruction.");
-    return isNonListDebugValue()
-               ? make_range(operands_begin(), operands_begin() + 1)
-               : make_range(operands_begin() + 2, operands_end());
-  }
-  /// \copydoc debug_operands()
-  iterator_range<const_mop_iterator> debug_operands() const {
-    assert((isDebugValueLike()) && "Must be a debug value instruction.");
-    return isNonListDebugValue()
-               ? make_range(operands_begin(), operands_begin() + 1)
-               : make_range(operands_begin() + 2, operands_end());
-  }
-  /// Returns a range over all explicit operands that are register definitions.
-  /// Implicit definition are not included!
-  iterator_range<mop_iterator> defs() {
-    return make_range(operands_begin(),
-                      operands_begin() + getNumExplicitDefs());
-  }
-  /// \copydoc defs()
-  iterator_range<const_mop_iterator> defs() const {
-    return make_range(operands_begin(),
-                      operands_begin() + getNumExplicitDefs());
-  }
-  /// Returns a range that includes all operands which may be register uses.
-  /// This may include unrelated operands which are not register uses.
-  iterator_range<mop_iterator> uses() {
-    return make_range(operands_begin() + getNumExplicitDefs(), operands_end());
-  }
-  /// \copydoc uses()
-  iterator_range<const_mop_iterator> uses() const {
-    return make_range(operands_begin() + getNumExplicitDefs(), operands_end());
-  }
-  iterator_range<mop_iterator> explicit_uses() {
-    return make_range(operands_begin() + getNumExplicitDefs(),
-                      operands_begin() + getNumExplicitOperands());
-  }
-  iterator_range<const_mop_iterator> explicit_uses() const {
-    return make_range(operands_begin() + getNumExplicitDefs(),
-                      operands_begin() + getNumExplicitOperands());
+  const_mop_range implicit_operands() const {
+    return operands_impl().drop_front(getNumExplicitOperands());
   }
 
-  using filtered_mop_iterator =
-      filter_iterator<mop_iterator, bool (*)(const MachineOperand &)>;
-  using filtered_const_mop_iterator =
-      filter_iterator<const_mop_iterator, bool (*)(const MachineOperand &)>;
+  /// Returns all operands that are used to determine the variable
+  /// location for this DBG_VALUE instruction.
+  mop_range debug_operands() {
+    assert(isDebugValueLike() && "Must be a debug value instruction.");
+    return isNonListDebugValue() ? operands_impl().take_front(1)
+                                 : operands_impl().drop_front(2);
+  }
+  /// \copydoc debug_operands()
+  const_mop_range debug_operands() const {
+    assert(isDebugValueLike() && "Must be a debug value instruction.");
+    return isNonListDebugValue() ? operands_impl().take_front(1)
+                                 : operands_impl().drop_front(2);
+  }
+  /// Returns all explicit operands that are register definitions.
+  /// Implicit definition are not included!
+  mop_range defs() { return operands_impl().take_front(getNumExplicitDefs()); }
+  /// \copydoc defs()
+  const_mop_range defs() const {
+    return operands_impl().take_front(getNumExplicitDefs());
+  }
+  /// Returns all operands which may be register uses.
+  /// This may include unrelated operands which are not register uses.
+  mop_range uses() { return operands_impl().drop_front(getNumExplicitDefs()); }
+  /// \copydoc uses()
+  const_mop_range uses() const {
+    return operands_impl().drop_front(getNumExplicitDefs());
+  }
+  mop_range explicit_uses() {
+    return operands_impl()
+        .take_front(getNumExplicitOperands())
+        .drop_front(getNumExplicitDefs());
+  }
+  const_mop_range explicit_uses() const {
+    return operands_impl()
+        .take_front(getNumExplicitOperands())
+        .drop_front(getNumExplicitDefs());
+  }
+
+  using filtered_mop_range = iterator_range<
+      filter_iterator<mop_iterator, bool (*)(const MachineOperand &)>>;
+  using filtered_const_mop_range = iterator_range<
+      filter_iterator<const_mop_iterator, bool (*)(const MachineOperand &)>>;
 
   /// Returns an iterator range over all operands that are (explicit or
   /// implicit) register defs.
-  iterator_range<filtered_mop_iterator> all_defs() {
+  filtered_mop_range all_defs() {
     return make_filter_range(operands(), opIsRegDef);
   }
   /// \copydoc all_defs()
-  iterator_range<filtered_const_mop_iterator> all_defs() const {
+  filtered_const_mop_range all_defs() const {
     return make_filter_range(operands(), opIsRegDef);
   }
 
   /// Returns an iterator range over all operands that are (explicit or
   /// implicit) register uses.
-  iterator_range<filtered_mop_iterator> all_uses() {
+  filtered_mop_range all_uses() {
     return make_filter_range(uses(), opIsRegUse);
   }
   /// \copydoc all_uses()
-  iterator_range<filtered_const_mop_iterator> all_uses() const {
+  filtered_const_mop_range all_uses() const {
     return make_filter_range(uses(), opIsRegUse);
   }
 

--- a/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -229,9 +229,8 @@ public:
   }
 
   const MachineInstrBuilder &add(ArrayRef<MachineOperand> MOs) const {
-    for (const MachineOperand &MO : MOs) {
+    for (const MachineOperand &MO : MOs)
       MI->addOperand(*MF, MO);
-    }
     return *this;
   }
 

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -821,8 +821,7 @@ unsigned MachineInstr::getNumExplicitOperands() const {
   if (!MCID->isVariadic())
     return NumOperands;
 
-  for (unsigned I = NumOperands, E = getNumOperands(); I != E; ++I) {
-    const MachineOperand &MO = getOperand(I);
+  for (const MachineOperand &MO : operands_impl().drop_front(NumOperands)) {
     // The operands must always be in the following order:
     // - explicit reg defs,
     // - other explicit operands (reg uses, immediates, etc.),
@@ -840,8 +839,7 @@ unsigned MachineInstr::getNumExplicitDefs() const {
   if (!MCID->isVariadic())
     return NumDefs;
 
-  for (unsigned I = NumDefs, E = getNumOperands(); I != E; ++I) {
-    const MachineOperand &MO = getOperand(I);
+  for (const MachineOperand &MO : operands_impl().drop_front(NumDefs)) {
     if (!MO.isReg() || !MO.isDef() || MO.isImplicit())
       break;
     ++NumDefs;
@@ -1196,9 +1194,9 @@ void MachineInstr::tieOperands(unsigned DefIdx, unsigned UseIdx) {
   assert(!DefMO.isTied() && "Def is already tied to another use");
   assert(!UseMO.isTied() && "Use is already tied to another def");
 
-  if (DefIdx < TiedMax)
+  if (DefIdx < TiedMax) {
     UseMO.TiedTo = DefIdx + 1;
-  else {
+  } else {
     // Inline asm can use the group descriptors to find tied operands,
     // statepoint tied operands are trivial to match (1-1 reg def with reg use),
     // but on normal instruction, the tied def must be within the first TiedMax


### PR DESCRIPTION
- Change MachineInstr operand accessors to use `ArrayRef` internally to slice the operand array into sub-arrays.
- Minor: remove unnecessary {} on `MachineInstrBuilder::add`.