### PR TITLE
[bazel] Depend on full Utility library in lldb

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -830,7 +830,7 @@ cc_binary(
     deps = [
         ":APIHeaders",
         ":Host",
-        ":UtilityHeaders",
+        ":Utility",
         ":liblldb.wrapper",
         ":lldb_options_inc_gen",
         "//llvm:Option",


### PR DESCRIPTION
Since 6493345c5ab96f60ab5ee38272fb6635f2083318 the utility library is
needed by the driver. Since liblldb's exports are limited with
-exports_symbols_list on macOS, some symbols like
`__ZN12SelectHelper10FDSetWriteEi` are not exported from liblldb and
therefore cause linker failures on macOS only. In the cmake the driver
now depends on the full utility library, even though that leads to some
duplication of symbols, so it should be safe for us to do in bazel as
well.
