### PR TITLE
workflows/commit-access-greeter: Add pull-request read permissions

### DIFF
--- a/.github/workflows/commit-access-greeter.yml
+++ b/.github/workflows/commit-access-greeter.yml
@@ -12,6 +12,7 @@ jobs:
   commit-access-greeter:
     permissions:
       issues: write
+      pull-requests: read
     if: >-
       github.repository_owner == 'llvm' &&
       github.event.label.name == 'infra:commit-access-request'


### PR DESCRIPTION
This is now needed in order to list the pull requests for a user.  I'm not sure what changed but this didn't used to be necessary.