### PR TITLE
[Clang][NFC] Explicitly delete copy ctor and assignment for CGAtomicOptionsRAII

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -869,6 +869,9 @@ public:
       }
       CGM.setAtomicOpts(AO);
     }
+
+    CGAtomicOptionsRAII(const CGAtomicOptionsRAII &) = delete;
+    CGAtomicOptionsRAII &operator=(const CGAtomicOptionsRAII &) = delete;
     ~CGAtomicOptionsRAII() { CGM.setAtomicOpts(SavedAtomicOpts); }
 
   private:


### PR DESCRIPTION
Static analysis flagged CGAtomicOptionsRAII as having an explicit destructor but not having explicit copy ctor and assignment. Rule of three says we should. We are just using this as an RAII object, no need for either so they will be specified as deleted.