### PR TITLE
[clang-tidy] Do not pass any file when listing checks in run_clang_ti…

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -87,7 +87,7 @@ def find_compilation_database(path: str) -> str:
 
 
 def get_tidy_invocation(
-    f: str,
+    f: Optional[str],
     clang_tidy_binary: str,
     checks: str,
     tmpdir: Optional[str],
@@ -147,7 +147,8 @@ def get_tidy_invocation(
         start.append(f"--warnings-as-errors={warnings_as_errors}")
     if allow_no_checks:
         start.append("--allow-no-checks")
-    start.append(f)
+    if f:
+        start.append(f)
     return start
 
 
@@ -490,7 +491,7 @@ async def main() -> None:
 
     try:
         invocation = get_tidy_invocation(
-            "",
+            None,
             clang_tidy_binary,
             args.checks,
             None,

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -103,6 +103,9 @@ Improvements to clang-tidy
 - Fixed bug in :program:`clang-tidy` by which `HeaderFilterRegex` did not take
   effect when passed via the `.clang-tidy` file.
 
+- Fixed bug in :program:`run_clang_tidy.py` where the program would not
+  correctly display the checks enabled by the top-level `.clang-tidy` file.
+
 New checks
 ^^^^^^^^^^
 


### PR DESCRIPTION
…dy.py

Currently, run_clang_tidy.py does not correctly display the list of checks picked up from the top-level .clang-tidy file. The reason for that is that we are passing an empty string as input file.

However, that's not how we are supposed to use clang-tidy to list checks. Per https://github.com/llvm/llvm-project/commit/65eccb463df7fe511c813ee6a1794c80d7489ff2, we simply should not pass any file at all - the internal code of clang-tidy will pass a "dummy" file if that's the case and get the .clang-tidy file from the current working directory.

Fixes #136659