### PR TITLE
Clarify ban evasion policy

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -722,6 +722,8 @@ Indirect contributions are permissible only by someone taking full ownership of
 such a contribution and they are responsible for all related interactions with
 the community regarding that contribution.
 
+Trying to evade a non-permanent ban results in getting banned permanently.
+
 When in doubt how to act in a specific instance, please reach out to
 conduct@llvm.org for advice.
 


### PR DESCRIPTION
This documents what the Code of Conduct committee has decided to do when an attempt to evade a ban is detected.