### PR TITLE
[Clang] Do not warn for serialized builtin or command-line definitions

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -371,8 +371,12 @@ bool Preprocessor::CheckMacroName(Token &MacroNameTok, MacroUse isDefineUndef,
   SourceLocation MacroNameLoc = MacroNameTok.getLocation();
   if (ShadowFlag)
     *ShadowFlag = false;
-  if (!SourceMgr.isInSystemHeader(MacroNameLoc) &&
-      (SourceMgr.getBufferName(MacroNameLoc) != "<built-in>")) {
+  // Macro names with reserved identifiers are accepted if built-in or passed
+  // through the command line (the later may be present if -dD was used to
+  // generate the preprocessed file).
+  bool IsBuiltinOrCmd = SourceMgr.isWrittenInBuiltinFile(MacroNameLoc) ||
+                        SourceMgr.isWrittenInCommandLineFile(MacroNameLoc);
+  if (!IsBuiltinOrCmd && !SourceMgr.isInSystemHeader(MacroNameLoc)) {
     MacroDiag D = MD_NoWarn;
     if (isDefineUndef == MU_Define) {
       D = shouldWarnOnMacroDef(*this, II);

--- a/clang/test/Preprocessor/macro_reserved.i
+++ b/clang/test/Preprocessor/macro_reserved.i
@@ -2,9 +2,9 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic warning "-Wreserved-macro-identifier"
 # 1 "<built-in>" 1
-#define __BUILTIN__ // expected-warning {{macro name is a reserved identifier}}
+#define __BUILTIN__
 # 2 "<command line>" 1
-#define __CMD__ // expected-warning {{macro name is a reserved identifier}}
+#define __CMD__
 # 3 "biz.cpp" 1
 #define __SOME_FILE__ // expected-warning {{macro name is a reserved identifier}}
 int v;

--- a/clang/test/Preprocessor/macro_reserved.i
+++ b/clang/test/Preprocessor/macro_reserved.i
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -x cpp-output %s
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wreserved-macro-identifier"
+# 1 "<built-in>" 1
+#define __BUILTIN__ // expected-warning {{macro name is a reserved identifier}}
+# 2 "<command line>" 1
+#define __CMD__ // expected-warning {{macro name is a reserved identifier}}
+# 3 "biz.cpp" 1
+#define __SOME_FILE__ // expected-warning {{macro name is a reserved identifier}}
+int v;
+#pragma clang diagnostic pop


### PR DESCRIPTION
When using `-dD` to generate a preprocessed output, the `#define` directives
are preserved. This includes built-in and command-line definitions.

Before, clang would warn for reserved identifiers for serialized built-in
and command-line definitions.
This patch adds an exception to these cases.