### PR TITLE
[Offload] Adding missing Offload unit tests for event entry points

### DIFF
--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -69,7 +69,6 @@ struct ol_queue_impl_t {
 struct ol_event_impl_t {
   ol_event_impl_t(void *EventInfo, ol_queue_handle_t Queue)
       : EventInfo(EventInfo), Queue(Queue) {}
-  ~ol_event_impl_t() { (void)Queue->Device->Device->destroyEvent(EventInfo); }
   void *EventInfo;
   ol_queue_handle_t Queue;
 };
@@ -381,6 +380,10 @@ ol_impl_result_t olWaitEvent_impl(ol_event_handle_t Event) {
 }
 
 ol_impl_result_t olDestroyEvent_impl(ol_event_handle_t Event) {
+  auto Res = Event->Queue->Device->Device->destroyEvent(Event->EventInfo);
+  if (Res)
+    return {OL_ERRC_INVALID_EVENT, "The event could not be destroyed"};
+
   return olDestroy(Event);
 }
 

--- a/offload/unittests/OffloadAPI/CMakeLists.txt
+++ b/offload/unittests/OffloadAPI/CMakeLists.txt
@@ -21,6 +21,8 @@ add_offload_unittest("offload.unittests"
     ${CMAKE_CURRENT_SOURCE_DIR}/program/olDestroyProgram.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernel/olGetKernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernel/olLaunchKernel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/event/olDestroyEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/event/olWaitEvent.cpp
     )
 add_dependencies("offload.unittests" ${PLUGINS_TEST_COMMON} OffloadUnitTestsDeviceBins)
 target_compile_definitions("offload.unittests" PRIVATE DEVICE_CODE_PATH="${OFFLOAD_TEST_DEVICE_CODE_PATH}")

--- a/offload/unittests/OffloadAPI/event/olDestroyEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olDestroyEvent.cpp
@@ -1,0 +1,32 @@
+//===------- Offload API tests - olDestroyEvent ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../common/Fixtures.hpp"
+#include <OffloadAPI.h>
+#include <gtest/gtest.h>
+
+using olDestroyEventTest = OffloadQueueTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olDestroyEventTest);
+
+TEST_P(olDestroyEventTest, Success) {
+  uint32_t Src = 42;
+  void *DstPtr;
+
+  ol_event_handle_t Event = nullptr;
+  ASSERT_SUCCESS(
+      olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, sizeof(uint32_t), &DstPtr));
+  ASSERT_SUCCESS(
+      olMemcpy(Queue, DstPtr, Device, &Src, Host, sizeof(Src), &Event));
+  ASSERT_NE(Event, nullptr);
+  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olDestroyEvent(Event));
+}
+
+TEST_P(olDestroyEventTest, InvalidNullEvent) {
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olDestroyEvent(nullptr));
+}

--- a/offload/unittests/OffloadAPI/event/olWaitEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olWaitEvent.cpp
@@ -1,0 +1,32 @@
+//===------- Offload API tests - olWaitEvent -====-------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../common/Fixtures.hpp"
+#include <OffloadAPI.h>
+#include <gtest/gtest.h>
+
+using olWaitEventTest = OffloadQueueTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olWaitEventTest);
+
+TEST_P(olWaitEventTest, Success) {
+  uint32_t Src = 42;
+  void *DstPtr;
+
+  ol_event_handle_t Event = nullptr;
+  ASSERT_SUCCESS(
+      olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, sizeof(uint32_t), &DstPtr));
+  ASSERT_SUCCESS(
+      olMemcpy(Queue, DstPtr, Device, &Src, Host, sizeof(Src), &Event));
+  ASSERT_NE(Event, nullptr);
+  ASSERT_SUCCESS(olWaitEvent(Event));
+  ASSERT_SUCCESS(olDestroyEvent(Event));
+}
+
+TEST_P(olWaitEventTest, InvalidNullEvent) {
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olWaitEvent(nullptr));
+}


### PR DESCRIPTION
A couple of liboffload entry points were missed out from the tests, and unsurprisingly a crash in one of them made it in. Add the tests and fix the unchecked error in `olDestroyEvent`.