### PR TITLE
Fix crash with -ast-dump=json

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -211,6 +211,8 @@ Non-comprehensive list of changes in this release
 - Added `__builtin_elementwise_exp10`.
 - For AMDPGU targets, added `__builtin_v_cvt_off_f32_i4` that maps to the `v_cvt_off_f32_i4` instruction.
 - Added `__builtin_elementwise_minnum` and `__builtin_elementwise_maxnum`.
+- No longer crashing on invalid Objective-C extensions when dumping the AST as
+  JSON. (#GH137320)
 
 New Compiler Flags
 ------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -211,8 +211,8 @@ Non-comprehensive list of changes in this release
 - Added `__builtin_elementwise_exp10`.
 - For AMDPGU targets, added `__builtin_v_cvt_off_f32_i4` that maps to the `v_cvt_off_f32_i4` instruction.
 - Added `__builtin_elementwise_minnum` and `__builtin_elementwise_maxnum`.
-- No longer crashing on invalid Objective-C extensions when dumping the AST as
-  JSON. (#GH137320)
+- No longer crashing on invalid Objective-C categories and extensions when
+  dumping the AST as JSON. (#GH137320)
 
 New Compiler Flags
 ------------------

--- a/clang/lib/AST/Mangle.cpp
+++ b/clang/lib/AST/Mangle.cpp
@@ -367,9 +367,11 @@ void MangleContext::mangleObjCMethodName(const ObjCMethodDecl *MD,
   }
   OS << (MD->isInstanceMethod() ? '-' : '+') << '[';
   if (const auto *CID = MD->getCategory()) {
-    OS << CID->getClassInterface()->getName();
-    if (includeCategoryNamespace) {
-      OS << '(' << *CID << ')';
+    if (const auto *CI = CID->getClassInterface()) {
+      OS << CI->getName();
+      if (includeCategoryNamespace) {
+        OS << '(' << *CID << ')';
+      }
     }
   } else if (const auto *CD =
                  dyn_cast<ObjCContainerDecl>(MD->getDeclContext())) {

--- a/clang/test/AST/ast-crash-dump-mangled-name-json.m
+++ b/clang/test/AST/ast-crash-dump-mangled-name-json.m
@@ -1,0 +1,14 @@
+// RUN: not %clang_cc1 -ast-dump=json %s 2>&1 | FileCheck %s
+
+// Ensure that dumping this does not crash when emitting the mangled name.
+// See GH137320 for details.
+// Note, this file does not compile and so we also check the error.
+
+@interface SomeClass (SomeExtension)
++ (void)someMethod;
+@end
+
+// CHECK: error: cannot find interface declaration for 'SomeClass'
+
+// CHECK: "name": "someMethod"
+// CHECK-NEXT: "mangledName": "+[ someMethod]",


### PR DESCRIPTION
When given an invalid Objective-C extension, Clang would crash when trying to emit the mangled name of the method to the JSON dump output.

Fixes #137320