### PR TITLE
[AArch64] Correctly detect X reg from w reg in isCopyImpl

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -10053,8 +10053,7 @@ AArch64InstrInfo::isCopyInstrImpl(const MachineInstr &MI) const {
       (!MI.getOperand(0).getReg().isVirtual() ||
        MI.getOperand(0).getSubReg() == 0) &&
       (!MI.getOperand(0).getReg().isPhysical() ||
-       MI.findRegisterDefOperandIdx(MI.getOperand(0).getReg() - AArch64::W0 +
-                                        AArch64::X0,
+       MI.findRegisterDefOperandIdx(getXRegFromWReg(MI.getOperand(0).getReg()),
                                     /*TRI=*/nullptr) == -1))
     return DestSourcePair{MI.getOperand(0), MI.getOperand(2)};
 

--- a/llvm/test/CodeGen/AArch64/copyprop.mir
+++ b/llvm/test/CodeGen/AArch64/copyprop.mir
@@ -113,3 +113,16 @@ body: |
     $w9 = ORRWrs $wzr, $wzr, 0
     STRBBui killed renamable $w9, killed renamable $x8, 36
 ...
+---
+# CHECK-LABEL: name: make_sure_w29_and_fp_isnt_removed
+# CHECK: $w29 = ORRWrs $wzr, $w29, 0, implicit $fp, implicit-def $fp
+name:            make_sure_w29_and_fp_isnt_removed
+tracksRegLiveness: true
+frameInfo:
+  maxCallFrameSize: 32
+body: |
+  bb.0:
+    liveins: $x8, $fp
+    $w29 = ORRWrs $wzr, $w29, 0, implicit $fp, implicit-def $fp
+    renamable $q0 = LDRQroX killed renamable $x8, $fp, 0, 1
+...


### PR DESCRIPTION
The MachineCopyPropagation pass was incorrectly removing copy (ORRWrs) instruction that appeared to be a nop. The instruction should not have been marked as a copy though, the code was incorrectly assuming that w29 - w0 + x0 == x29, but as x29 is fp it was out of order with the other registers.

Fixes an issue reported on #129889.