### PR TITLE
[lldb] Fix error that lead Windows to think it could reverse execute

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -239,14 +239,14 @@ ProcessWindows::DoAttachToProcessWithID(lldb::pid_t pid,
 Status ProcessWindows::DoResume(RunDirection direction) {
   Log *log = GetLog(WindowsLog::Process);
   llvm::sys::ScopedLock lock(m_mutex);
-  Status error;
 
   if (direction == RunDirection::eRunReverse) {
-    error.FromErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support reverse execution of processes",
         GetPluginName());
-    return error;
   }
+
+  Status error;
 
   StateType private_state = GetPrivateState();
   if (private_state == eStateStopped || private_state == eStateCrashed) {

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1410,7 +1410,7 @@ Status ProcessGDBRemote::DoResume(RunDirection direction) {
           LLDB_LOGF(log, "ProcessGDBRemote::DoResume: target does not "
                          "support reverse-continue");
           return Status::FromErrorString(
-              "target does not support reverse-continue");
+              "target does not support reverse execution of processes");
         }
 
         if (num_continue_C_tids > 0) {

--- a/lldb/test/API/commands/process/reverse-continue/TestReverseContinueNotSupported.py
+++ b/lldb/test/API/commands/process/reverse-continue/TestReverseContinueNotSupported.py
@@ -11,7 +11,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestReverseContinueNotSupported(TestBase):
-    @skipIfWindows
     def test_reverse_continue_not_supported(self):
         target = self.connect()
 
@@ -26,7 +25,9 @@ class TestReverseContinueNotSupported(TestBase):
         self.expect(
             "process continue --reverse",
             error=True,
-            substrs=["target does not support reverse-continue"],
+            # This error is "<plugin name> does not support...". The plugin name changes
+            # between platforms.
+            substrs=["does not support reverse execution of processes"],
         )
 
     def test_reverse_continue_forward_and_reverse(self):


### PR DESCRIPTION
The new test added in https://github.com/llvm/llvm-project/pull/132783 was failing on Windows because it created a new error to say it did not support the feature, but then returned the existing, default constructed error. Which was a success value.

This also changes the GDBRemote error message to the same phrasing used in all the other places so we don't have to special case any platform.