### PR TITLE
[IR] Require that global value initializers are sized

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -700,7 +700,7 @@ Global Variables
 Global variables define regions of memory allocated at compilation time
 instead of run-time.
 
-Global variable definitions must be initialized.
+Global variable definitions must be initialized with a sized value.
 
 Global variables in other translation units can also be declared, in which
 case they don't have an initializer.

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -835,6 +835,8 @@ void Verifier::visitGlobalVariable(const GlobalVariable &GV) {
           "Global variable initializer type does not match global "
           "variable type!",
           &GV);
+    Check(GV.getInitializer()->getType()->isSized(),
+          "Global variable initializer must be sized", &GV);
     // If the global has common linkage, it must have a zero initializer and
     // cannot be constant.
     if (GV.hasCommonLinkage()) {

--- a/llvm/test/Verifier/global-initializer-sized.ll
+++ b/llvm/test/Verifier/global-initializer-sized.ll
@@ -1,0 +1,5 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+
+@g = global target("opaque") undef
+
+; CHECK: Global variable initializer must be sized

--- a/llvm/test/Verifier/scalable-global-vars.ll
+++ b/llvm/test/Verifier/scalable-global-vars.ll
@@ -13,7 +13,7 @@
 
 ; CHECK-NEXT: Globals cannot contain scalable types
 ; CHECK-NEXT: ptr @ScalableVecStructGlobal
-@ScalableVecStructGlobal = global { i32,  <vscale x 4 x i32> } zeroinitializer
+@ScalableVecStructGlobal = external global { i32,  <vscale x 4 x i32> }
 
 ; CHECK-NEXT: Globals cannot contain scalable types
 ; CHECK-NEXT: ptr @StructTestGlobal
@@ -23,9 +23,9 @@
 ; CHECK-NEXT: Globals cannot contain scalable types
 ; CHECK-NEXT: ptr @StructArrayTestGlobal
 %struct.array.test = type { [2 x <vscale x 1 x double>] }
-@StructArrayTestGlobal = global %struct.array.test zeroinitializer
+@StructArrayTestGlobal = external global %struct.array.test
 
 ; CHECK-NEXT: Globals cannot contain scalable types
 ; CHECK-NEXT: ptr @StructTargetTestGlobal
 %struct.target.test = type { target("aarch64.svcount"), target("aarch64.svcount") }
-@StructTargetTestGlobal = global %struct.target.test zeroinitializer
+@StructTargetTestGlobal = external global %struct.target.test


### PR DESCRIPTION
While external globals can be unsized, I don't think an unsized initializer makes sense.

It seems like the backend currently ends up treating this as a zero-size global. If people want that behavior, they should declare it as such.