### PR TITLE
[lldb-dap] Correcting the types for launch and attach requests.

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -189,9 +189,11 @@
               },
               "args": {
                 "type": [
-                  "array",
-                  "string"
+                  "array"
                 ],
+                "items": {
+                  "type": "string"
+                },
                 "description": "Program arguments.",
                 "default": []
               },
@@ -293,36 +295,57 @@
               },
               "initCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Initialization commands executed upon debugger startup.",
                 "default": []
               },
               "preRunCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed just before the program is launched.",
                 "default": []
               },
               "postRunCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed just as soon as the program is successfully launched when it's in a stopped state prior to any automatic continuation.",
                 "default": []
               },
               "launchCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Custom commands that are executed instead of launching a process. A target will be created with the launch arguments prior to executing these commands. The commands may optionally create a new target and must perform a launch. A valid process must exist after these commands complete or the \"launch\" will fail. Launch the process with \"process launch -s\" to make the process to at the entry point since lldb-dap will auto resume if necessary.",
                 "default": []
               },
               "stopCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed each time the program stops.",
                 "default": []
               },
               "exitCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed when the program exits.",
                 "default": []
               },
               "terminateCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed when the debugging session ends.",
                 "default": []
               },
@@ -332,7 +355,7 @@
                 "default": false
               },
               "timeout": {
-                "type": "string",
+                "type": "number",
                 "description": "The time in seconds to wait for a program to stop at entry point when launching with \"launchCommands\". Defaults to 30 seconds."
               },
               "enableAutoVariableSummaries": {
@@ -449,36 +472,57 @@
               },
               "attachCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Custom commands that are executed instead of attaching to a process ID or to a process by name. These commands may optionally create a new target and must perform an attach. A valid process must exist after these commands complete or the \"attach\" will fail.",
                 "default": []
               },
               "initCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Initialization commands executed upon debugger startup.",
                 "default": []
               },
               "preRunCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed just before the program is attached to.",
                 "default": []
               },
               "postRunCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed just as soon as the program is successfully attached when it's in a stopped state prior to any automatic continuation.",
                 "default": []
               },
               "stopCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed each time the program stops.",
                 "default": []
               },
               "exitCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed when the program exits.",
                 "default": []
               },
               "terminateCommands": {
                 "type": "array",
+                "items": {
+                  "type": "string"
+                },
                 "description": "Commands executed when the debugging session ends.",
                 "default": []
               },
@@ -487,7 +531,7 @@
                 "description": "Path to the core file to debug."
               },
               "timeout": {
-                "type": "string",
+                "type": "number",
                 "description": "The time in seconds to wait for a program to stop when attaching using \"attachCommands\". Defaults to 30 seconds."
               },
               "gdb-remote-port": {


### PR DESCRIPTION
There were a few types that were incorrectly specified in the lldb-dap/package.json. The 'timeout' field was set to 'string' but is interpreted as an integer number of seconds and 'args' for launch is handled as an array of strings, not a single string.

Also added a type for the '*Commands' for the items in the arrays.