### PR TITLE
[HLSL] Allow non `.hlsl` files as source files

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3001,6 +3001,8 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
               Ty = types::TY_CXX;
             else if (CCCIsCPP() || CCGenDiagnostics)
               Ty = types::TY_C;
+            else if (IsDXCMode())
+              Ty = types::TY_HLSL;
             else
               Ty = types::TY_Object;
           }

--- a/clang/test/Driver/dxc_I.test
+++ b/clang/test/Driver/dxc_I.test
@@ -1,0 +1,4 @@
+// RUN: %clang_dxc -Tlib_6_3  -### %s 2>&1 | FileCheck %s
+
+// Make sure a non `.hlsl` file is considered an HLSL source file in dxc mode.
+// CHECK: "-x" "hlsl" "{{.*}}/dxc_I.test"

--- a/clang/test/Driver/dxc_I.test
+++ b/clang/test/Driver/dxc_I.test
@@ -1,4 +1,4 @@
 // RUN: %clang_dxc -Tlib_6_3  -### %s 2>&1 | FileCheck %s
 
 // Make sure a non `.hlsl` file is considered an HLSL source file in dxc mode.
-// CHECK: "-x" "hlsl" "{{.*}}/dxc_I.test"
+// CHECK: "-x" "hlsl" "{{.*}}dxc_I.test"


### PR DESCRIPTION
Changes the driver to assume input file with an unknown extension are
HLSL source files instead of object files.

Fixes https://github.com/llvm/llvm-project/issues/137370
