### PR TITLE
[lldb][docs] Update instructions to build standalone

### DIFF
--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -204,12 +204,13 @@ checked out above, but now we will have multiple build-trees:
 
 Run CMake with ``-B`` pointing to a new directory for the provided
 build-tree\ :sup:`1` and the positional argument pointing to the ``llvm``
-directory in the source-tree. Note that we leave out LLDB here and only include
+directory in the source-tree.\ :sup:`2` Note that we leave out LLDB here and only include
 Clang. Then we build the ``ALL`` target with ninja:
 
 ::
 
   $ cmake -B /path/to/llvm-build -G Ninja \
+          -DCMAKE_BUILD_TYPE=[<build type>] \
           -DLLVM_ENABLE_PROJECTS=clang \
           -DCMAKE_BUILD_TYPE=Release \
           [<more cmake options>] /path/to/llvm-project/llvm
@@ -238,6 +239,8 @@ remove it from the Ninja command.
    #. The ``-B`` argument was undocumented for a while and is only officially
       supported since `CMake version 3.14
       <https://cmake.org/cmake/help/v3.14/release/3.14.html#command-line>`_
+   #. If you want to have a standalone LLDB build with tests enabled, you also
+      need to pass in ``-DLLVM_ENABLE_RUNTIME='libcxx;libcxxabi;libunwind'`` to your CMake invocation when configuring your LLVM standalone build.
 
 .. _CommonCMakeOptions:
 


### PR DESCRIPTION
The instructions to build LLDB standalone contain a CMake configure step to build LLVM standalone. This configure step needs to also have the CMake build type in order to work.