### PR TITLE
[lldb-dap] Mitigate a build error on Windows.

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -844,8 +844,10 @@ static std::optional<T> getArgumentsIfRequest(const Message &pm,
 }
 
 llvm::Error DAP::Loop() {
-  std::future<llvm::Error> queue_reader =
-      std::async(std::launch::async, [&]() -> llvm::Error {
+  // Can't use \a std::future<llvm::Error> because it doesn't compile on
+  // Windows.
+  std::future<lldb::SBError> queue_reader =
+      std::async(std::launch::async, [&]() -> lldb::SBError {
         llvm::set_thread_name(transport.GetClientName() + ".transport_handler");
         auto cleanup = llvm::make_scope_exit([&]() {
           // Ensure we're marked as disconnecting when the reader exits.
@@ -867,8 +869,11 @@ llvm::Error DAP::Loop() {
             continue;
           }
 
-          if (llvm::Error err = next.takeError())
-            return err;
+          if (llvm::Error err = next.takeError()) {
+            lldb::SBError errWrapper;
+            errWrapper.SetErrorString(llvm::toString(std::move(err)).c_str());
+            return errWrapper;
+          }
 
           if (const protocol::Request *req =
                   std::get_if<protocol::Request>(&*next);
@@ -906,7 +911,7 @@ llvm::Error DAP::Loop() {
           m_queue_cv.notify_one();
         }
 
-        return llvm::Error::success();
+        return lldb::SBError();
       });
 
   auto cleanup = llvm::make_scope_exit([&]() {
@@ -930,7 +935,7 @@ llvm::Error DAP::Loop() {
                                      "unhandled packet");
   }
 
-  return queue_reader.get();
+  return ToError(queue_reader.get());
 }
 
 lldb::SBError DAP::WaitForProcessToStop(std::chrono::seconds seconds) {


### PR DESCRIPTION
When building with MSVC 2019 using `std::future<llvm::Error>` causes a compile time build error.

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\future(196): error C2248: 'llvm::Error::Error': cannot access protected member declared in class 'llvm::Error'

C:\work\main\llvm-project\llvm\include\llvm/Support/Error.h(181): note: see declaration of 'llvm::Error::Error'

C:\work\main\llvm-project\llvm\include\llvm/Support/FormatVariadicDetails.h(20): note: see declaration of 'llvm::Error'

C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\future(193): note: while compiling class template member function 'std::_Associated_state<_Ty>::_Associated_state(std::_Deleter_base<_Ty> *)'

        with

        [

            _Ty=llvm::Error

        ]

C:\work\main\llvm-project\lldb\tools\lldb-dap\DAP.cpp(854): note: see reference to class template instantiation 'std::future<llvm::Error>' being compiled
```

To work around this, swapping to a lldb::SBError for now.