### PR TITLE
[libc] Update assert for C23

### DIFF
--- a/libc/include/assert.h.def
+++ b/libc/include/assert.h.def
@@ -19,14 +19,14 @@
 
 #undef assert
 #ifdef NDEBUG
-#define assert(e) (void)0
+#define assert(...) ((void)0)
 #else
 #ifdef __cplusplus
 extern "C"
 #endif
 _Noreturn void __assert_fail(const char *, const char *, unsigned, const char *) __NOEXCEPT;
-#define assert(e)  \
-  ((e) ? (void)0 : __assert_fail(#e, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+#define assert(...)  \
+  ((__VA_ARGS__) ? ((void)0) : __assert_fail(#__VA_ARGS__, __FILE__, __LINE__, __PRETTY_FUNCTION__))
 #endif
 
 %%public_api()


### PR DESCRIPTION
Previously the assert macro took one argument named "e", but this led to
possible errors if the caller had commas in their input. C23 changed the
definition of assert to use `__VA_ARGS__` to ensure comma cases are
handled properly. This patch doesn't introduce the enforcement function
mentioned in the standard update, though that may be done in a followup.

Fixes #136184
