### PR TITLE
Skip tests if socket name is longer than 107 bytes

### DIFF
--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -349,6 +349,10 @@ TEST_F(SocketTest, DomainSocketFromBoundNativeSocket) {
   ASSERT_FALSE(EC);
   llvm::sys::path::append(name, "test");
 
+  // Skip the test if the $TMPDIR is too long to hold a domain socket.
+  if (name.size() > 107u)
+    return;
+
   DomainSocket socket(true);
   Status error = socket.Listen(name, /*backlog=*/10);
   ASSERT_THAT_ERROR(error.takeError(), llvm::Succeeded());
@@ -369,6 +373,10 @@ TEST_F(SocketTest, AbstractSocketFromBoundNativeSocket) {
   llvm::sys::fs::createUniquePath("AbstractSocketFromBoundNativeSocket", name,
                                   true);
   llvm::sys::path::append(name, "test");
+
+  // Skip the test if the $TMPDIR is too long to hold a domain socket.
+  if (name.size() > 107u)
+    return;
 
   AbstractSocket socket;
   Status error = socket.Listen(name, /*backlog=*/10);

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -351,7 +351,7 @@ TEST_F(SocketTest, DomainSocketFromBoundNativeSocket) {
 
   // Skip the test if the $TMPDIR is too long to hold a domain socket.
   if (name.size() > 107u)
-    return;
+    GTEST_SKIP() << "$TMPDIR is too long to hold a domain socket";
 
   DomainSocket socket(true);
   Status error = socket.Listen(name, /*backlog=*/10);
@@ -376,7 +376,7 @@ TEST_F(SocketTest, AbstractSocketFromBoundNativeSocket) {
 
   // Skip the test if the $TMPDIR is too long to hold a domain socket.
   if (name.size() > 107u)
-    return;
+    GTEST_SKIP() << "$TMPDIR is too long to hold a domain socket";
 
   AbstractSocket socket;
   Status error = socket.Listen(name, /*backlog=*/10);


### PR DESCRIPTION
To fix the test failures introduced in Commit 488eeb3