### PR TITLE
[llvm] Fixed ItaniumDemangle.h compiled by MSVC

### DIFF
--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -610,6 +610,8 @@ public:
   }
 };
 
+class PointerType;
+
 class ObjCProtoName : public Node {
   const Node *Ty;
   std::string_view Protocol;


### PR DESCRIPTION
If the includes tree is big enough, `llvm::itanium_demangle::PointerType` may conflict with `llvm::PointerType` from other headers. This patch fixes the following [error](https://lab.llvm.org/buildbot/#/builders/141/builds/8206):
```
C:\lldb-aarch64-windows\llvm-project\llvm\include\llvm/Demangle/ItaniumDemangle.h(617,16): warning: unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier [-Wmicrosoft-unqualified-friend]
  617 |   friend class PointerType;
      |                ^
      |                ::llvm::
C:\lldb-aarch64-windows\llvm-project\llvm\include\llvm/Demangle/ItaniumDemangle.h(667,24): error: 'Protocol' is a private member of 'llvm::itanium_demangle::ObjCProtoName'
  667 |       OB += objcProto->Protocol;
      |                        ^
C:\lldb-aarch64-windows\llvm-project\llvm\include\llvm/Demangle/ItaniumDemangle.h(615,20): note: implicitly declared private here
  615 |   std::string_view Protocol;
```
Few buildbots broken by #131836 must be green after this patch.