### PR TITLE
[BOLT] Optimize the codegen of createLoadImmediate for AArch64.

### DIFF
--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -2186,73 +2186,71 @@ public:
         llvm_unreachable("unhandled!");
         break;
 
+      // ORR <Wd>, <Wn>, #<imm>
+      // ORR <Xd>, <Xn>, #<imm>
       case AArch64::ORRWri:
       case AArch64::ORRXri:
         if (I->Op1 == 0) {
-          MCInst Inst;
-          Inst.setOpcode(I->Opcode);
-          Inst.addOperand(MCOperand::createReg(Dest));
-          Inst.addOperand(MCOperand::createReg(BitSize == 32 ? AArch64::WZR
-                                                             : AArch64::XZR));
-          Inst.addOperand(MCOperand::createImm(I->Op2));
+          MCInst Inst = MCInstBuilder(I->Opcode)
+                            .addReg(Dest)
+                            .addReg(BitSize == 32 ? AArch64::WZR : AArch64::XZR)
+                            .addImm(I->Op2);
           Insts.push_back(Inst);
         } else {
-          MCInst Inst;
-          Inst.setOpcode(I->Opcode);
-          Inst.addOperand(MCOperand::createReg(Dest));
-          Inst.addOperand(MCOperand::createReg(Dest));
-          Inst.addOperand(MCOperand::createImm(I->Op2));
+          MCInst Inst =
+              MCInstBuilder(I->Opcode).addReg(Dest).addReg(Dest).addImm(I->Op2);
           Insts.push_back(Inst);
         }
         break;
+      // ORR <Wd>, <Wn>, <Wm>, <shift> #<amount>
+      // ORR <Xd>, <Xn>, <Xm>, <shift> #<amount>
       case AArch64::ORRWrs:
       case AArch64::ORRXrs: {
-        MCInst Inst;
-        Inst.setOpcode(I->Opcode);
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createImm(I->Op2));
+        MCInst Inst = MCInstBuilder(I->Opcode)
+                          .addReg(Dest)
+                          .addReg(Dest)
+                          .addReg(Dest)
+                          .addImm(I->Op1) // Shift type
+                          .addImm(I->Op2);
         Insts.push_back(Inst);
       } break;
+      // AND Xd, Xn, #imm
+      // EOR Xd, Xn, #imm
       case AArch64::ANDXri:
       case AArch64::EORXri:
         if (I->Op1 == 0) {
-          MCInst Inst;
-          Inst.setOpcode(I->Opcode);
-          Inst.addOperand(MCOperand::createReg(Dest));
-          Inst.addOperand(MCOperand::createReg(BitSize == 32 ? AArch64::WZR
-                                                             : AArch64::XZR));
-          Inst.addOperand(MCOperand::createImm(I->Op2));
+          MCInst Inst = MCInstBuilder(I->Opcode)
+                            .addReg(Dest)
+                            .addReg(BitSize == 32 ? AArch64::WZR : AArch64::XZR)
+                            .addImm(I->Op2);
           Insts.push_back(Inst);
         } else {
-          MCInst Inst;
-          Inst.setOpcode(I->Opcode);
-          Inst.addOperand(MCOperand::createReg(Dest));
-          Inst.addOperand(MCOperand::createReg(Dest));
-          Inst.addOperand(MCOperand::createImm(I->Op2));
+          MCInst Inst =
+              MCInstBuilder(I->Opcode).addReg(Dest).addReg(Dest).addImm(I->Op2);
           Insts.push_back(Inst);
         }
         break;
+      // MOVZ Wd, #imm16, LSL #shift
+      // MOVZ Xd, #imm16, LSL #shift
+      // MOVN Wd, #imm16, LSL #shift
+      // MOVN Xd, #imm16, LSL #shift
       case AArch64::MOVNWi:
       case AArch64::MOVNXi:
       case AArch64::MOVZWi:
       case AArch64::MOVZXi: {
-        MCInst Inst;
-        Inst.setOpcode(I->Opcode);
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createImm(I->Op1));
-        Inst.addOperand(MCOperand::createImm(I->Op2));
+        MCInst Inst =
+            MCInstBuilder(I->Opcode).addReg(Dest).addImm(I->Op1).addImm(I->Op2);
         Insts.push_back(Inst);
       } break;
+      // MOVK Wd, #imm16, LSL #shift
+      // MOVK Xd, #imm16, LSL #shift
       case AArch64::MOVKWi:
       case AArch64::MOVKXi: {
-        MCInst Inst;
-        Inst.setOpcode(I->Opcode);
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createImm(I->Op1));
-        Inst.addOperand(MCOperand::createImm(I->Op2));
+        MCInst Inst = MCInstBuilder(I->Opcode)
+                          .addReg(Dest)
+                          .addReg(Dest)
+                          .addImm(I->Op1)
+                          .addImm(I->Op2);
         Insts.push_back(Inst);
       } break;
       }

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -2174,24 +2174,34 @@ public:
   InstructionListType createLoadImmediate(const MCPhysReg Dest,
                                           uint64_t Imm) const override {
     InstructionListType Insts;
-    for (int I = 0, Shift = 0; I < 4; I++, Shift += 16) {
-      uint16_t HalfWord = (Imm >> Shift) & 0xFFFF;
-      if (!HalfWord)
-        continue;
+    if (Imm == 0) {
       MCInst Inst;
-      if (Insts.size() == 0) {
-        Inst.setOpcode(AArch64::MOVZXi);
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createImm(HalfWord));
-        Inst.addOperand(MCOperand::createImm(Shift));
-        Insts.push_back(Inst);
-      } else {
-        Inst.setOpcode(AArch64::MOVKXi);
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createReg(Dest));
-        Inst.addOperand(MCOperand::createImm(HalfWord));
-        Inst.addOperand(MCOperand::createImm(Shift));
-        Insts.push_back(Inst);
+      Inst.setOpcode(AArch64::ORRXrs);
+      Inst.addOperand(MCOperand::createReg(Dest));
+      Inst.addOperand(MCOperand::createReg(AArch64::XZR));
+      Inst.addOperand(MCOperand::createReg(AArch64::XZR));
+      Inst.addOperand(MCOperand::createImm(0));
+      Insts.push_back(Inst);
+    } else {
+      for (int I = 0, Shift = 0; I < 4; I++, Shift += 16) {
+        uint16_t HalfWord = (Imm >> Shift) & 0xFFFF;
+        if (!HalfWord)
+          continue;
+        MCInst Inst;
+        if (Insts.size() == 0) {
+          Inst.setOpcode(AArch64::MOVZXi);
+          Inst.addOperand(MCOperand::createReg(Dest));
+          Inst.addOperand(MCOperand::createImm(HalfWord));
+          Inst.addOperand(MCOperand::createImm(Shift));
+          Insts.push_back(Inst);
+        } else {
+          Inst.setOpcode(AArch64::MOVKXi);
+          Inst.addOperand(MCOperand::createReg(Dest));
+          Inst.addOperand(MCOperand::createReg(Dest));
+          Inst.addOperand(MCOperand::createImm(HalfWord));
+          Inst.addOperand(MCOperand::createImm(Shift));
+          Insts.push_back(Inst);
+        }
       }
     }
     return Insts;

--- a/bolt/unittests/Core/MCPlusBuilder.cpp
+++ b/bolt/unittests/Core/MCPlusBuilder.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #ifdef AARCH64_AVAILABLE
-#include "AArch64Subtarget.h"
-#include "MCTargetDesc/AArch64MCTargetDesc.h"
 #include "AArch64.h"
+#include "AArch64Subtarget.h"
 #include "MCTargetDesc/AArch64AddressingModes.h"
+#include "MCTargetDesc/AArch64MCTargetDesc.h"
 #endif // AARCH64_AVAILABLE
 
 #ifdef X86_AVAILABLE

--- a/bolt/unittests/Core/MCPlusBuilder.cpp
+++ b/bolt/unittests/Core/MCPlusBuilder.cpp
@@ -167,7 +167,26 @@ TEST_P(MCPlusBuilderTester, AArch64_CmpJNE) {
   ASSERT_EQ(Label, BB->getLabel());
 }
 
-TEST_P(MCPlusBuilderTester, AArch64_LoadImm32) {
+TEST_P(MCPlusBuilderTester, AArch64_LoadZero) {
+  if (GetParam() != Triple::aarch64)
+    GTEST_SKIP();
+  BinaryFunction *BF = BC->createInjectedBinaryFunction("BF", true);
+  std::unique_ptr<BinaryBasicBlock> BB = BF->createBasicBlock();
+
+  InstructionListType Instrs = BC->MIB->createLoadImmediate(AArch64::X0, 0);
+  BB->addInstructions(Instrs.begin(), Instrs.end());
+
+  ASSERT_EQ(BB->size(), 1);
+  auto II = BB->begin();
+  // mov x0, xzr <=> orr x0, xzr, xzr, lsl #0
+  ASSERT_EQ(II->getOpcode(), AArch64::ORRXrs);
+  ASSERT_EQ(II->getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(II->getOperand(1).getReg(), AArch64::XZR);
+  ASSERT_EQ(II->getOperand(2).getReg(), AArch64::XZR);
+  ASSERT_EQ(II->getOperand(3).getImm(), 0);
+}
+
+TEST_P(MCPlusBuilderTester, AArch64_LoadImm16) {
   if (GetParam() != Triple::aarch64)
     GTEST_SKIP();
   BinaryFunction *BF = BC->createInjectedBinaryFunction("BF", true);


### PR DESCRIPTION
The code generation of createLoadImmediate for AArch64 was always emitting 4 instructions, regardless of the immediate value being loaded into the 64-bit register. This patch makes sure that only the necessary number of instructions are used depending on the value of the immediate being loaded into a register (ranging from 1 to 4 instructions).
The unit tests created help us to verify this new capability. 