### PR TITLE
[mlir][linalg] fix indexOp folder to work in genericOp build with createOrFold

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -2284,7 +2284,10 @@ LogicalResult IndexOp::verify() {
 }
 
 OpFoldResult IndexOp::fold(FoldAdaptor adaptor) {
-  auto linalgOp = cast<LinalgOp>((*this)->getParentOp());
+  auto linalgOp = dyn_cast_or_null<LinalgOp>((*this)->getParentOp());
+  // Early exit if parent op is not linalgOp.
+  if (!linalgOp)
+    return OpFoldResult{};
 
   // Index of unit dims is always 0.
   SmallVector<int64_t, 4> loopBounds = linalgOp.getStaticLoopRanges();

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -2286,7 +2286,8 @@ LogicalResult IndexOp::verify() {
 OpFoldResult IndexOp::fold(FoldAdaptor adaptor) {
   auto linalgOp = dyn_cast_or_null<LinalgOp>((*this)->getParentOp());
   // Bail out if `linalg.index` does not have a proper parent yet at this
-  // point, e.g., when calling `createOrFold` during IR construction in `genericOp::build`.
+  // point, e.g., when calling `createOrFold` during IR construction in
+  // `genericOp::build`.
   if (!linalgOp)
     return OpFoldResult{};
 

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -2285,7 +2285,8 @@ LogicalResult IndexOp::verify() {
 
 OpFoldResult IndexOp::fold(FoldAdaptor adaptor) {
   auto linalgOp = dyn_cast_or_null<LinalgOp>((*this)->getParentOp());
-  // Early exit if parent op is not linalgOp.
+  // Early exit if linalg.index does not have a proper parent yet
+  // at this point. (e.g createOrFold in a genericOp::build)
   if (!linalgOp)
     return OpFoldResult{};
 

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -2285,8 +2285,8 @@ LogicalResult IndexOp::verify() {
 
 OpFoldResult IndexOp::fold(FoldAdaptor adaptor) {
   auto linalgOp = dyn_cast_or_null<LinalgOp>((*this)->getParentOp());
-  // Early exit if linalg.index does not have a proper parent yet
-  // at this point. (e.g createOrFold in a genericOp::build)
+  // Bail out if `linalg.index` does not have a proper parent yet at this
+  // point, e.g., when calling `createOrFold` during IR construction in `genericOp::build`.
   if (!linalgOp)
     return OpFoldResult{};
 


### PR DESCRIPTION
Currently in torch-mlir, indexOp folder is segfaulting when we call createOrFold in a genericOp builder. (*this)->getParentOp ended up with null which is causing the issue.

This is seen in poolSizeCalculator.getPoolSize
being called from createAvgPoolValueCountIncludePadFalseCase. link:
https://github.com/llvm/torch-mlir/blob/80a3dfddd341c72ab9bd6c6688b872bf3a5e4ddb/lib/Conversion/TorchToLinalg/Pooling.cpp#L918-L921