### PR TITLE
[Clang][NFC] Const correctness fix for range based for loop

### DIFF
--- a/clang/utils/TableGen/ClangBuiltinTemplatesEmitter.cpp
+++ b/clang/utils/TableGen/ClangBuiltinTemplatesEmitter.cpp
@@ -107,7 +107,7 @@ ParseTemplateParameterList(ParserState &PS,
   }
 
   bool First = true;
-  for (auto e : Params) {
+  for (const auto &e : Params) {
     if (First) {
       First = false;
       Code << e;


### PR DESCRIPTION
Static analysis flagged that we did not make const a item declaration b/c we did not modify it all during the loop.