### PR TITLE
[mlir][gpu] Fix breaking constructor from GPUSubgroupSizeToROCDL

### DIFF
--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -455,9 +455,7 @@ void mlir::populateGpuToROCDLConversionPatterns(
   // TODO: Add alignment for workgroup memory
   patterns.add<GPUDynamicSharedMemoryOpLowering>(converter);
 
-  patterns
-      .add<GPUShuffleOpLowering, GPULaneIdOpToROCDL, GPUSubgroupSizeOpToROCDL>(
-          converter);
+  patterns.add<GPUShuffleOpLowering, GPULaneIdOpToROCDL>(converter);
   patterns.add<GPUSubgroupSizeOpToROCDL>(converter, chipset);
 
   populateMathToROCDLConversionPatterns(converter, patterns);


### PR DESCRIPTION
This PR addressed a bug from llvm/llvm-project#137360. which was using GPUSubgroupSizeToROCDL to patterns function that do not have a valid constructor for it. This is causing compilation error below:

error: constructor inherited by 'GPUSubgroupSizeOpToROCDL' from base class 'ConvertOpToLLVMPattern<mlir::gpu::SubgroupSizeOp>' is implicitly deleted