### PR TITLE
[compiler-rt] Remove struct_termio_sz from sanitizer_platform_limits_posix.cpp

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
@@ -494,9 +494,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
   unsigned struct_input_id_sz = sizeof(struct input_id);
   unsigned struct_mtpos_sz = sizeof(struct mtpos);
   unsigned struct_rtentry_sz = sizeof(struct rtentry);
-#if SANITIZER_GLIBC || SANITIZER_ANDROID
-  unsigned struct_termio_sz = sizeof(struct termio);
-#endif
   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);


### PR DESCRIPTION
Fix #137436 

The `struct termio` and its associated code have been removed from glibc as they are considered obsolete. This change removes the corresponding code in compiler-rt to maintain compatibility. 

Additionally, the check for `struct_termio_sz` specific to Android has been removed. There is no guarantee that the Linux kernel or Google will continue supporting `struct termio`, and its removal aligns with the deprecation in glibc.

Reference: glibc commit e04afb71771710cdc6025fe95908f5f17de7b72d

https://github.com/bminor/glibc/commit/e04afb71771710cdc6025fe95908f5f17de7b72d