### PR TITLE
[clang][bytecode] Allow memory leaks before C++20

### DIFF
--- a/clang/lib/AST/ByteCode/InterpState.cpp
+++ b/clang/lib/AST/ByteCode/InterpState.cpp
@@ -113,7 +113,9 @@ bool InterpState::maybeDiagnoseDanglingAllocations() {
           << (It.second.size() - 1) << Source->getSourceRange();
     }
   }
-  return NoAllocationsLeft;
+  // Keep evaluating before C++20, since the CXXNewExpr wasn't valid there
+  // in the first place.
+  return NoAllocationsLeft || !getLangOpts().CPlusPlus20;
 }
 
 StdAllocatorCaller InterpState::getStdAllocatorCaller(StringRef Name) const {

--- a/clang/test/AST/ByteCode/cxx11-pedantic.cpp
+++ b/clang/test/AST/ByteCode/cxx11-pedantic.cpp
@@ -20,3 +20,10 @@ namespace DynamicCast {
                                            // both-note {{dynamic_cast}}
   };
 }
+
+namespace NewDelete {
+  struct T {
+    int n : *new int(4); // both-warning {{constant expression}} \
+                         // both-note {{until C++20}}
+  };
+}


### PR DESCRIPTION
The expression allocating the memory wasn't valid in the first place. This matches the diagnostic behavior of the current interpreter.