### PR TITLE
Remove a debugging message left in a unit test.

### DIFF
--- a/llvm/unittests/Transforms/Utils/CodeExtractorTest.cpp
+++ b/llvm/unittests/Transforms/Utils/CodeExtractorTest.cpp
@@ -787,7 +787,6 @@ TEST(CodeExtractor, ArgsDebugInfo) {
     CE.findAllocas(CEAC, SinkingCands, HoistingCands, CommonExit);
     CE.findInputsOutputs(Inputs, Outputs, SinkingCands);
     Function *Outlined = CE.extractCodeRegion(CEAC, Inputs, Outputs);
-    Outlined->dump();
     EXPECT_TRUE(Outlined);
     BasicBlock &EB = Outlined->getEntryBlock();
     Instruction *Term = EB.getTerminator();


### PR DESCRIPTION
This should fix the regression reported in https://github.com/llvm/llvm-project/pull/136016#issuecomment-2831987288