### PR TITLE
[CIR][NFC] Fix an unused variable warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -311,7 +311,7 @@ LValue CIRGenFunction::emitLValueForField(LValue base, const FieldDecl *field) {
   assert(!cir::MissingFeatures::opTBAA());
 
   Address addr = base.getAddress();
-  if (auto *classDef = dyn_cast<CXXRecordDecl>(rec)) {
+  if (isa<CXXRecordDecl>(rec)) {
     cgm.errorNYI(field->getSourceRange(), "emitLValueForField: C++ class");
     return LValue();
   }
@@ -701,7 +701,7 @@ CIRGenFunction::emitArraySubscriptExpr(const clang::ArraySubscriptExpr *e) {
 }
 
 LValue CIRGenFunction::emitMemberExpr(const MemberExpr *e) {
-  if (auto *vd = dyn_cast<VarDecl>(e->getMemberDecl())) {
+  if (isa<VarDecl>(e->getMemberDecl())) {
     cgm.errorNYI(e->getSourceRange(), "emitMemberExpr: VarDecl");
     return LValue();
   }
@@ -734,7 +734,7 @@ LValue CIRGenFunction::emitMemberExpr(const MemberExpr *e) {
     return lv;
   }
 
-  if (const auto *fd = dyn_cast<FunctionDecl>(nd)) {
+  if (isa<FunctionDecl>(nd)) {
     cgm.errorNYI(e->getSourceRange(), "emitMemberExpr: FunctionDecl");
     return LValue();
   }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -366,7 +366,7 @@ void CIRGenModule::emitGlobalVarDefinition(const clang::VarDecl *vd,
                                            bool isTentative) {
   const QualType astTy = vd->getType();
   const mlir::Type type = convertType(vd->getType());
-  if (clang::IdentifierInfo *identifier = vd->getIdentifier()) {
+  if (vd->getIdentifier()) {
     StringRef name = getMangledName(GlobalDecl(vd));
     auto varOp =
         builder.create<cir::GlobalOp>(getLoc(vd->getSourceRange()), name, type);


### PR DESCRIPTION
This fixes a warning where a variable assigned in 'if' statement wasn't referenced again.