### PR TITLE
[lldb] Deploy Python DLL on Windows

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -183,16 +183,21 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
                              DEPENDS ${python_scripts_target})
   endif()
 
-  # Add a Post-Build Event to copy the custom Python DLL to the lldb binaries dir so that Windows can find it when launching
-  # lldb.exe or any other executables that were linked with liblldb.
-  if (WIN32 AND NOT "${PYTHON_DLL}" STREQUAL "")
+  # Copy the custom Python DLL to the lldb binary dir so that Windows can find it when launching
+  # lldb.exe or any other executables that were linked with liblldb (both during development and when installing).
+  if (WIN32 AND NOT "${Python3_RUNTIME_LIBRARY}" STREQUAL "")
     # When using the Visual Studio CMake generator the lldb binaries end up in Release/bin, Debug/bin etc.
     file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin" LLDB_BIN_DIR)
-    file(TO_NATIVE_PATH "${PYTHON_DLL}" PYTHON_DLL_NATIVE_PATH)
+    file(TO_NATIVE_PATH "${Python3_RUNTIME_LIBRARY}" PYTHON_DLL_NATIVE_PATH)
     add_custom_command(
       TARGET ${swig_target}
       POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy ${PYTHON_DLL_NATIVE_PATH} ${LLDB_BIN_DIR} VERBATIM
       COMMENT "Copying Python DLL to LLDB binaries directory.")
+    install(
+      FILES "${Python3_RUNTIME_LIBRARY}"
+      TYPE BIN
+      COMPONENT lldb
+    )
   endif()
 endfunction()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/f0248ca54531125599af8f22e686e1c77de0416a initially added a post build event to copy the Python DLL to the `bin` directory. This relied on `PYTHON_DLL` being present, which was removed in https://github.com/llvm/llvm-project/commit/2046d72e91670114625c87e122db6e013ba089d5, which moved to `FindPython3`.

CMake's `FindPython3` sets `Python3_RUNTIME_LIBRARY` (https://github.com/Kitware/CMake/blob/1cd89e65d76339e6be23fc9bb0d417655a9c06ea/Modules/FindPython/Support.cmake#L3866-L3873) even though it's not documented. This is used to deploy the `python3{version}(_d).dll`.
I wasn't sure what the correct way to specify the destination path is. From CMake's documentation, it seemed like `TYPE BIN` would do the correct thing (i.e. deploy it to the `bin` directory), but I don't know all the customization points - maybe this should be `LLVM_TOOLS_INSTALL_DIR`(?).

It would be great if someone else could test this locally. Building LLDB (e.g. `ninja lldb`) should have `python3{version}(_d).dll` show up in the `bin` build directory and a `cmake --install <build-directory> --component lldb` should install the DLL to `<install-prefix>/bin`.

I don't know how the prebuilt binaries are built, but I'd guess they will install and zip the install-directory. In that case, this should work.

Related issues:
- https://github.com/llvm/llvm-project/issues/43432
- https://github.com/llvm/llvm-project/issues/47381
- https://github.com/llvm/llvm-project/issues/53646
- https://github.com/llvm/llvm-project/issues/58095
- https://github.com/llvm/llvm-project/issues/59524
- https://github.com/llvm/llvm-project/issues/74073
- https://github.com/llvm/llvm-project/issues/85764

I hope all of them are fixed by this PR (but that depends on how the prebuilt binaries are built).