### PR TITLE
[clang][bytecode] Diagnose delete of non-heap-allocated blocks

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1641,6 +1641,13 @@ static bool interp__builtin_operator_delete(InterpState &S, CodePtr OpPC,
 
     Source = Ptr.getDeclDesc()->asExpr();
     BlockToDelete = Ptr.block();
+
+    if (!BlockToDelete->isDynamic()) {
+      S.FFDiag(Call, diag::note_constexpr_delete_not_heap_alloc)
+          << Ptr.toDiagnosticString(S.getASTContext());
+      if (const auto *D = Ptr.getFieldDesc()->asDecl())
+        S.Note(D->getLocation(), diag::note_declared_at);
+    }
   }
   assert(BlockToDelete);
 

--- a/clang/test/AST/ByteCode/new-delete.cpp
+++ b/clang/test/AST/ByteCode/new-delete.cpp
@@ -610,7 +610,8 @@ namespace std {
     }
     constexpr void deallocate(void *p) {
       __builtin_operator_delete(p); // both-note 2{{std::allocator<...>::deallocate' used to delete pointer to object allocated with 'new'}} \
-                                    // both-note {{used to delete a null pointer}}
+                                    // both-note {{used to delete a null pointer}} \
+                                    // both-note {{delete of pointer '&no_deallocate_nonalloc' that does not point to a heap-allocated object}}
     }
   };
   template<typename T, typename ...Args>
@@ -1003,6 +1004,10 @@ namespace WrongFrame {
                         // both-note {{in call to}}
 
 }
+
+constexpr int no_deallocate_nonalloc = (std::allocator<int>().deallocate((int*)&no_deallocate_nonalloc), 1); // both-error {{constant expression}} \
+                                                                                                             // both-note {{in call}} \
+                                                                                                             // both-note {{declared here}}
 
 #else
 /// Make sure we reject this prior to C++20


### PR DESCRIPTION
With std::allocator::deallocate() calls