### PR TITLE
[WebKit checkers] Treat std::bit_cast as a pointer conversion

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -645,6 +645,10 @@ public:
     auto *Callee = CE->getDirectCallee();
     if (!Callee)
       return false;
+
+    if (isPtrConversion(Callee))
+      return true;
+
     const auto &Name = safeGetName(Callee);
 
     if (Callee->isInStdNamespace() &&
@@ -658,7 +662,7 @@ public:
         Name == "isMainThreadOrGCThread" || Name == "isMainRunLoop" ||
         Name == "isWebThread" || Name == "isUIThread" ||
         Name == "mayBeGCThread" || Name == "compilerFenceForCrash" ||
-        Name == "bitwise_cast" || isTrivialBuiltinFunction(Callee))
+        isTrivialBuiltinFunction(Callee))
       return true;
 
     return IsFunctionTrivial(Callee);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -462,7 +462,7 @@ bool isPtrConversion(const FunctionDecl *F) {
   const auto FunctionName = safeGetName(F);
   if (FunctionName == "getPtr" || FunctionName == "WeakPtr" ||
       FunctionName == "dynamicDowncast" || FunctionName == "downcast" ||
-      FunctionName == "checkedDowncast" ||
+      FunctionName == "checkedDowncast" || FunctionName == "bit_cast" ||
       FunctionName == "uncheckedDowncast" || FunctionName == "bitwise_cast" ||
       FunctionName == "bridge_cast" || FunctionName == "bridge_id_cast" ||
       FunctionName == "dynamic_cf_cast" || FunctionName == "checked_cf_cast" ||

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked-ptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked-ptr.cpp
@@ -173,14 +173,14 @@ namespace param_formarding_function {
 
   namespace casts {
 
-  CheckedObj* downcast(CheckedObj*) { return nullptr; }
-
-  template<class T>
-  T* bitwise_cast(T*) { return nullptr; }
+  CheckedObj* downcast(CheckedObj*);
+  template<class T> T* bitwise_cast(T*);
+  template<class T> T* bit_cast(T*);
 
     void foo(CheckedObj* param) {
       consume_ref_countable_ptr(downcast(param));
       consume_ref_countable_ptr(bitwise_cast(param));
+      consume_ref_countable_ptr(bit_cast(param));
      }
   }
 }

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -173,15 +173,15 @@ namespace param_formarding_function {
 
   namespace casts {
 
-  RefCountable* downcast(RefCountable*) { return nullptr; }
+  RefCountable* downcast(RefCountable*);
+  template<class T> T* bitwise_cast(T*);
+  template<class T> T* bit_cast(T*);
 
-  template<class T>
-  T* bitwise_cast(T*) { return nullptr; }
-
-    void foo(RefCountable* param) {
-      consume_ref_countable_ptr(downcast(param));
-      consume_ref_countable_ptr(bitwise_cast(param));
-     }
+  void foo(RefCountable* param) {
+    consume_ref_countable_ptr(downcast(param));
+    consume_ref_countable_ptr(bitwise_cast(param));
+    consume_ref_countable_ptr(bit_cast(param));
+   }
   }
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -205,6 +205,20 @@ void foo2() {
 }
 } // namespace guardian_casts
 
+namespace casts {
+
+RefCountable* provide() { return nullptr; }
+RefCountable* downcast(RefCountable*);
+template<class T> T* bitwise_cast(T*);
+template<class T> T* bit_cast(T*);
+
+  void foo() {
+    auto* cast1 = downcast(provide());
+    auto* cast2 = bitwise_cast(provide());
+    auto* cast3 = bit_cast(provide());
+   }
+} // namespace casts
+
 namespace guardian_ref_conversion_operator {
 void foo() {
   Ref<RefCountable> rc;

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -77,6 +77,9 @@ T&& forward(T& arg);
 template<typename T>
 T&& move( T&& t );
 
+template<typename ToType, typename FromType>
+ToType bit_cast(FromType from);
+
 #define offsetof(t, d) __builtin_offsetof(t, d)
 
 } // namespace std
@@ -386,6 +389,7 @@ public:
   void trivial68() { point pt = { 1.0 }; }
   unsigned trivial69() { return offsetof(OtherObj, children); }
   DerivedNumber* trivial70() { [[clang::suppress]] return static_cast<DerivedNumber*>(number); }
+  unsigned trivial71() { return std::bit_cast<unsigned>(nullptr); }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;
@@ -577,6 +581,7 @@ public:
     getFieldTrivial().trivial68(); // no-warning
     getFieldTrivial().trivial69(); // no-warning
     getFieldTrivial().trivial70(); // no-warning
+    getFieldTrivial().trivial71(); // no-warning
 
     RefCounted::singleton().trivial18(); // no-warning
     RefCounted::singleton().someFunction(); // no-warning


### PR DESCRIPTION
WebKit repalced its use of WTF::bitwise_cast with std::bit_cast. Add the support for recognizing it as a pointer conversion.