### PR TITLE
[lldb-dap] Make lldb-dap.executable-path machine specific

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -74,7 +74,8 @@
         "lldb-dap.executable-path": {
           "scope": "resource",
           "type": "string",
-          "description": "The path to the lldb-dap binary."
+          "scope": "machine-overridable",
+          "description": "The path to the lldb-dap binary, e.g. /usr/local/bin/lldb-dap"
         },
         "lldb-dap.arguments": {
           "scope": "resource",


### PR DESCRIPTION
Change the scope [1] of lldb-dap.executable-path to "machine-overridable":

> Machine specific settings that can be overridden by workspace or
> folder settings.

Practically speaking, this means that the path won't be synced across machines and "(Not synced)" will show up next to the setting. I believe it doesn't make sense to sync this setting (and I remember a bug report where this caused trouble when using VS Code remotely), plus it matches what clangd does for its corresponding setting. The extension has logic to find the binary in your path or with `xcrun` which in most cases should do the right thing and prevent you from having to override this setting. 

[1] https://code.visualstudio.com/api/references/contribution-points#Configuration-property-schema