### PR TITLE
[OpenMP][NFC] Fix -Wsign-compare warning in kmp_collapse.cpp

### DIFF
--- a/openmp/runtime/src/kmp_collapse.cpp
+++ b/openmp/runtime/src/kmp_collapse.cpp
@@ -1314,7 +1314,8 @@ kmp_identify_nested_loop_structure(/*in*/ bounds_info_t *original_bounds_nest,
                                         original_bounds_nest[1].ub1_u64);
   // lower triangle loop inner bounds need to be {0,0}:{0/-1,1}
   if (inner_lb0_u64 == 0 && inner_lb1_u64 == 0 &&
-      (inner_ub0_u64 == 0 || inner_ub0_u64 == -1) && inner_ub1_u64 == 1) {
+      (inner_ub0_u64 == 0 || inner_ub0_u64 == (kmp_uint64)-1) &&
+      inner_ub1_u64 == 1) {
     return nested_loop_type_lower_triangular_matrix;
   }
   // upper triangle loop inner bounds need to be {0,1}:{N,0}


### PR DESCRIPTION
Fix a signed/unsigned comparison warning in `kmp_collapse.cpp`.

`inner_ub0_u64` is of type `kmp_uint64`, but was being compared against `-1`, a signed integer literal, triggering a `-Wsign-compare` warning.

This patch explicitly casts `-1` to `(kmp_uint64)-1` to avoid the warning and ensure correct comparison behavior.

```
llvm-project/openmp/runtime/src/kmp_collapse.cpp:1317:44: warning: comparison of integer expressions of different signedness: ‘kmp_uint64’ {aka ‘long long unsigned int’} and ‘int’ [-Wsign-compare]
 1317 |       (inner_ub0_u64 == 0 || inner_ub0_u64 == -1) && inner_ub1_u64 == 1) {
```