### PR TITLE
[VPlan] Use correct constructor when cloning VPWidenIntrinsicRecipe without underlying CallInst

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1347,8 +1347,11 @@ public:
   ~VPWidenIntrinsicRecipe() override = default;
 
   VPWidenIntrinsicRecipe *clone() override {
-    return new VPWidenIntrinsicRecipe(*cast<CallInst>(getUnderlyingValue()),
-                                      VectorIntrinsicID, {op_begin(), op_end()},
+    if (Value *CI = getUnderlyingValue())
+      return new VPWidenIntrinsicRecipe(*cast<CallInst>(CI), VectorIntrinsicID,
+                                        {op_begin(), op_end()}, ResultTy,
+                                        getDebugLoc());
+    return new VPWidenIntrinsicRecipe(VectorIntrinsicID, {op_begin(), op_end()},
                                       ResultTy, getDebugLoc());
   }
 


### PR DESCRIPTION
I noticed this when working on a patch downstream, and I don't think this is an issue upstream yet.

But if a VPWidenIntrinsicRecipe is created without an underlying CallInst, e.g. in createEVLRecipe, it will crash if you try to clone it because it assumes the CallInst always exists.

This fixes it by using the CallInst-less constructor in this case.
