### PR TITLE
[libc][stdfix] Fix riscv entrypoints for idivfx

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -779,7 +779,7 @@ if(LIBC_COMPILER_HAS_FIXED_POINT)
     libc.src.stdfix.idivr
     libc.src.stdfix.idivlr
     libc.src.stdfix.idivk
-    libc.src.stdfix.idivulk
+    libc.src.stdfix.idivlk
     libc.src.stdfix.idivur
     libc.src.stdfix.idivulr
     libc.src.stdfix.idivuk


### PR DESCRIPTION
Fixes a typo in riscv entrypoints that caused buildbot failures.

https://lab.llvm.org/buildbot/#/builders/196/builds/7352