### PR TITLE
[AMDGPU] Simplify PrintField::printField (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
@@ -222,22 +222,17 @@ static int get_amd_kernel_code_t_FieldIndex(StringRef name) {
 
 class PrintField {
 public:
-  template <typename T, T AMDGPUMCKernelCodeT::*ptr,
-            typename std::enable_if_t<!std::is_integral_v<T>, T> * = nullptr>
+  template <typename T, T AMDGPUMCKernelCodeT::*ptr>
   static void printField(StringRef Name, const AMDGPUMCKernelCodeT &C,
                          raw_ostream &OS, MCContext &Ctx,
                          AMDGPUMCKernelCodeT::PrintHelper Helper) {
-    OS << Name << " = ";
-    const MCExpr *Value = C.*ptr;
-    Helper(Value, OS, Ctx.getAsmInfo());
-  }
-
-  template <typename T, T AMDGPUMCKernelCodeT::*ptr,
-            typename std::enable_if_t<std::is_integral_v<T>, T> * = nullptr>
-  static void printField(StringRef Name, const AMDGPUMCKernelCodeT &C,
-                         raw_ostream &OS, MCContext &,
-                         AMDGPUMCKernelCodeT::PrintHelper) {
-    OS << Name << " = " << (int)(C.*ptr);
+    if constexpr (!std::is_integral_v<T>) {
+      OS << Name << " = ";
+      const MCExpr *Value = C.*ptr;
+      Helper(Value, OS, Ctx.getAsmInfo());
+    } else {
+      OS << Name << " = " << (int)(C.*ptr);
+    }
   }
 };
 


### PR DESCRIPTION
We can use "constexpr if" to combine the two variants of functions.
