### PR TITLE
[PassSupport] Simplify callDefaultCtor (NFC)

### DIFF
--- a/llvm/include/llvm/PassSupport.h
+++ b/llvm/include/llvm/PassSupport.h
@@ -64,20 +64,13 @@ class Pass;
   INITIALIZE_PASS_WITH_OPTIONS_BEGIN(PassName, Arg, Name, Cfg, Analysis)       \
   INITIALIZE_PASS_END(PassName, Arg, Name, Cfg, Analysis)
 
-template <
-    class PassName,
-    std::enable_if_t<std::is_default_constructible<PassName>{}, bool> = true>
-Pass *callDefaultCtor() {
-  return new PassName();
-}
-
-template <
-    class PassName,
-    std::enable_if_t<!std::is_default_constructible<PassName>{}, bool> = true>
-Pass *callDefaultCtor() {
-  // Some codegen passes should only be testable via
-  // `llc -{start|stop}-{before|after}=<passname>`, not via `opt -<passname>`.
-  report_fatal_error("target-specific codegen-only pass");
+template <class PassName> Pass *callDefaultCtor() {
+  if constexpr (std::is_default_constructible_v<PassName>)
+    return new PassName();
+  else
+    // Some codegen passes should only be testable via
+    // `llc -{start|stop}-{before|after}=<passname>`, not via `opt -<passname>`.
+    report_fatal_error("target-specific codegen-only pass");
 }
 
 //===---------------------------------------------------------------------------


### PR DESCRIPTION
We can use "constexpr if" to combine the two variants of functions.
