### PR TITLE
[mlir] Simplify PreservedAnalyses::isInvalidated (NFC)

### DIFF
--- a/mlir/include/mlir/Pass/AnalysisManager.h
+++ b/mlir/include/mlir/Pass/AnalysisManager.h
@@ -85,17 +85,14 @@ template <typename T, typename... Args>
 using has_is_invalidated = decltype(std::declval<T &>().isInvalidated(
     std::declval<const PreservedAnalyses &>()));
 
-/// Implementation of 'isInvalidated' if the analysis provides a definition.
 template <typename AnalysisT>
-std::enable_if_t<llvm::is_detected<has_is_invalidated, AnalysisT>::value, bool>
-isInvalidated(AnalysisT &analysis, const PreservedAnalyses &pa) {
-  return analysis.isInvalidated(pa);
-}
-/// Default implementation of 'isInvalidated'.
-template <typename AnalysisT>
-std::enable_if_t<!llvm::is_detected<has_is_invalidated, AnalysisT>::value, bool>
-isInvalidated(AnalysisT &analysis, const PreservedAnalyses &pa) {
-  return !pa.isPreserved<AnalysisT>();
+bool isInvalidated(AnalysisT &analysis, const PreservedAnalyses &pa) {
+  if constexpr (llvm::is_detected<has_is_invalidated, AnalysisT>::value)
+    /// Implementation of 'isInvalidated' if the analysis provides a definition.
+    return analysis.isInvalidated(pa);
+  else
+    /// Default implementation of 'isInvalidated'.
+    return !pa.isPreserved<AnalysisT>();
 }
 } // namespace analysis_impl
 


### PR DESCRIPTION
We can use "constexpr if" to combine the two variants of functions.
