### PR TITLE
[VE] Add missing dependency on TargetParser

### DIFF
--- a/llvm/lib/Target/VE/CMakeLists.txt
+++ b/llvm/lib/Target/VE/CMakeLists.txt
@@ -38,6 +38,7 @@ add_llvm_target(VECodeGen
   SelectionDAG
   Support
   Target
+  TargetParser
   TransformUtils
   VEDesc
   VEInfo


### PR DESCRIPTION
Resolves a link failure observed in shared library debug build:
```
ld.lld: error: undefined symbol: llvm::Triple::isArch64Bit() const
>>> referenced by BasicTTIImpl.h:626 (../llvm/include/llvm/CodeGen/BasicTTIImpl.h:626)
>>>               lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VETargetMachine.cpp.o:(llvm::BasicTTIImplBase<llvm::VETTIImpl>::shouldBuildRelLookupTables() const)
```
