### PR TITLE
[lldb] print a notice when `source list` paging reaches the end of th…

### DIFF
--- a/lldb/include/lldb/Core/SourceManager.h
+++ b/lldb/include/lldb/Core/SourceManager.h
@@ -155,6 +155,9 @@ public:
   ~SourceManager();
 
   FileSP GetLastFile() { return GetFile(m_last_support_file_sp); }
+  bool AtLastLine(bool reverse) {
+    return m_last_line == UINT32_MAX || (reverse && m_last_line == 1);
+  }
 
   size_t DisplaySourceLinesWithLineNumbers(
       lldb::SupportFileSP support_file_sp, uint32_t line, uint32_t column,

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -1067,7 +1067,16 @@ protected:
                 &result.GetOutputStream(), m_options.num_lines,
                 m_options.reverse, GetBreakpointLocations())) {
           result.SetStatus(eReturnStatusSuccessFinishResult);
+        } else {
+          if (target.GetSourceManager().AtLastLine(m_options.reverse)) {
+            result.AppendNoteWithFormatv(
+                "Reached {0} of the file, no more to page",
+                m_options.reverse ? "beginning" : "end");
+          } else {
+            result.AppendNote("No source available");
+          }
         }
+
       } else {
         if (m_options.num_lines == 0)
           m_options.num_lines = 10;

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -360,10 +360,7 @@ size_t SourceManager::DisplayMoreWithLineNumbers(
     GetDefaultFileAndLine();
 
   if (last_file_sp) {
-    if (m_last_line == UINT32_MAX)
-      return 0;
-
-    if (reverse && m_last_line == 1)
+    if (AtLastLine(reverse))
       return 0;
 
     if (count > 0)

--- a/lldb/test/Shell/Commands/command-list-reach-beginning-of-file.test
+++ b/lldb/test/Shell/Commands/command-list-reach-beginning-of-file.test
@@ -1,0 +1,29 @@
+# RUN: %clang_host -g -O0 %S/Inputs/sigchld.c -o %t.out
+# RUN: %lldb %t.out -b -s %s 2>&1 | FileCheck %s
+
+list
+# CHECK: note: No source available 
+
+b main
+# CHECK: Breakpoint 1:
+
+r
+# CHECK: int main()
+
+list
+# CHECK: if (child_pid == 0)
+
+list -
+# CHECK: int main()
+
+list -10
+# CHECK: #include <assert.h>
+
+list -
+# CHECK: note: Reached beginning of the file, no more to page
+
+list -
+# CHECK: note: Reached beginning of the file, no more to page
+
+list
+# CHECK: int main()

--- a/lldb/test/Shell/Commands/command-list-reach-end-of-file.test
+++ b/lldb/test/Shell/Commands/command-list-reach-end-of-file.test
@@ -1,0 +1,26 @@
+# RUN: %clang_host -g -O0 %S/Inputs/sigchld.c -o %t.out
+# RUN: %lldb %t.out -b -s %s 2>&1 | FileCheck %s
+
+list
+# CHECK: note: No source available 
+
+b main
+# CHECK: Breakpoint 1:
+
+r
+# CHECK: int main()
+
+list
+# CHECK: if (child_pid == 0)
+
+list
+# CHECK: printf("signo = %d\n", SIGCHLD);
+
+list
+# CHECK: return 0;
+
+list 
+# CHECK: note: Reached end of the file, no more to page
+
+list 
+# CHECK: note: Reached end of the file, no more to page


### PR DESCRIPTION
This PR fixes the issue where the `list` command does not output a prompt when reaching the end of the file.  
Closes #128507.