### PR TITLE
[SystemZ] Fix compile time regression in adjustInliningThreshold().

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZTargetTransformInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZTargetTransformInfo.cpp
@@ -103,14 +103,14 @@ unsigned SystemZTTIImpl::adjustInliningThreshold(const CallBase *CB) const {
     }
     if (const auto *SI = dyn_cast<StoreInst>(&I)) {
       if (!SI->isVolatile())
-        if (auto GV = dyn_cast<GlobalVariable>(SI->getPointerOperand()))
+        if (auto *GV = dyn_cast<GlobalVariable>(SI->getPointerOperand()))
           Ptr2NumUses[GV]++;
     } else if (const auto *LI = dyn_cast<LoadInst>(&I)) {
       if (!LI->isVolatile())
-        if (auto GV = dyn_cast<GlobalVariable>(LI->getPointerOperand()))
+        if (auto *GV = dyn_cast<GlobalVariable>(LI->getPointerOperand()))
           Ptr2NumUses[GV]++;
     } else if (const auto *GEP = dyn_cast<GetElementPtrInst>(&I)) {
-      if (auto GV = dyn_cast<GlobalVariable>(GEP->getPointerOperand())) {
+      if (auto *GV = dyn_cast<GlobalVariable>(GEP->getPointerOperand())) {
         unsigned NumStores = 0, NumLoads = 0;
         countNumMemAccesses(GEP, NumStores, NumLoads, Callee);
         Ptr2NumUses[GV] += NumLoads + NumStores;


### PR DESCRIPTION
Instead of always iterating over all GlobalVariable:s in the Module to find the case where both Caller and Callee is using the same GV heavily, first scan Callee (only if less than 200 instructions) for all GVs used more than 10 times, and then do the counting for the Caller for just those relevant GVs.

The limit of 200 instructions makes sense as this aims to inline a relatively small function using a GV +10 times. This limit changed only 7 files across 3 SPEC benchmarks . Previously only perlbench performance was affected, and perl is not among these 3 changed benchmarks, so there should not be any difference to consider here. SPEC runs seem to confirm this ("full/home-dir").

Compile time across SPEC shows no difference compared to main. It however resolves the compile time problem with zig where it is on main (compared to removing the heuristic) a 380% increase, but with this change only 2.4% increase (total user compile time with opt).

Fixes #134714.