### PR TITLE
[Support] Simplify mapOptionalWithContext (NFC)

### DIFF
--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -904,7 +904,7 @@ public:
   void mapOptionalWithContext(const char *Key, T &Val, Context &Ctx) {
     if constexpr (has_SequenceTraits<T>::value) {
       // omit key/value instead of outputting empty sequence
-      if (this->canElideEmptySequence() && !(Val.begin() != Val.end()))
+      if (this->canElideEmptySequence() && Val.begin() == Val.end())
         return;
     }
     this->processKey(Key, Val, false, Ctx);

--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -901,11 +901,12 @@ public:
   }
 
   template <typename T, typename Context>
-  std::enable_if_t<has_SequenceTraits<T>::value, void>
-  mapOptionalWithContext(const char *Key, T &Val, Context &Ctx) {
-    // omit key/value instead of outputting empty sequence
-    if (this->canElideEmptySequence() && !(Val.begin() != Val.end()))
-      return;
+  void mapOptionalWithContext(const char *Key, T &Val, Context &Ctx) {
+    if constexpr (has_SequenceTraits<T>::value) {
+      // omit key/value instead of outputting empty sequence
+      if (this->canElideEmptySequence() && !(Val.begin() != Val.end()))
+        return;
+    }
     this->processKey(Key, Val, false, Ctx);
   }
 
@@ -914,12 +915,6 @@ public:
                               Context &Ctx) {
     this->processKeyWithDefault(Key, Val, std::optional<T>(),
                                 /*Required=*/false, Ctx);
-  }
-
-  template <typename T, typename Context>
-  std::enable_if_t<!has_SequenceTraits<T>::value, void>
-  mapOptionalWithContext(const char *Key, T &Val, Context &Ctx) {
-    this->processKey(Key, Val, false, Ctx);
   }
 
   template <typename T, typename Context, typename DefaultT>


### PR DESCRIPTION
We can use "constexpt if" to combine the two variants of functions.
