### PR TITLE
[AMDGPU] Simplify GetMember...::Get (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
@@ -72,17 +72,14 @@ using namespace llvm::AMDGPU;
   class GetMember##member {                                                    \
   public:                                                                      \
     static const MCExpr *Phony;                                                \
-    template <typename U, typename std::enable_if_t<IsMCExpr##member::RESULT,  \
-                                                    U> * = nullptr>            \
-    static const MCExpr *&Get(U &C) {                                          \
-      assert(IsMCExpr##member::RESULT &&                                       \
-             "Trying to retrieve member that does not exist.");                \
-      return C.member;                                                         \
-    }                                                                          \
-    template <typename U, typename std::enable_if_t<!IsMCExpr##member::RESULT, \
-                                                    U> * = nullptr>            \
-    static const MCExpr *&Get(U &C) {                                          \
-      return Phony;                                                            \
+    template <typename U> static const MCExpr *&Get(U &C) {                    \
+      if constexpr (IsMCExpr##member::RESULT) {                                \
+        assert(IsMCExpr##member::RESULT &&                                     \
+               "Trying to retrieve member that does not exist.");              \
+        return C.member;                                                       \
+      } else {                                                                 \
+        return Phony;                                                          \
+      }                                                                        \
     }                                                                          \
   };                                                                           \
   const MCExpr *GetMember##member::Phony = nullptr;

--- a/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
@@ -73,13 +73,10 @@ using namespace llvm::AMDGPU;
   public:                                                                      \
     static const MCExpr *Phony;                                                \
     template <typename U> static const MCExpr *&Get(U &C) {                    \
-      if constexpr (IsMCExpr##member::RESULT) {                                \
-        assert(IsMCExpr##member::RESULT &&                                     \
-               "Trying to retrieve member that does not exist.");              \
+      if constexpr (IsMCExpr##member::RESULT)                                  \
         return C.member;                                                       \
-      } else {                                                                 \
+      else                                                                     \
         return Phony;                                                          \
-      }                                                                        \
     }                                                                          \
   };                                                                           \
   const MCExpr *GetMember##member::Phony = nullptr;


### PR DESCRIPTION
We can use "constexpr if" to combine the two variants of functions.
