### PR TITLE
[debugserver] Migrate DNBTimer away from PThreadMutex (NFC)

### DIFF
--- a/lldb/tools/debugserver/source/DNBTimer.h
+++ b/lldb/tools/debugserver/source/DNBTimer.h
@@ -14,7 +14,6 @@
 #define LLDB_TOOLS_DEBUGSERVER_SOURCE_DNBTIMER_H
 
 #include "DNBDefs.h"
-#include "PThreadMutex.h"
 #include <cstdint>
 #include <memory>
 #include <sys/time.h>
@@ -22,17 +21,17 @@
 class DNBTimer {
 public:
   // Constructors and Destructors
-  DNBTimer(bool threadSafe) : m_mutexAP() {
+  DNBTimer(bool threadSafe) {
     if (threadSafe)
-      m_mutexAP.reset(new PThreadMutex(PTHREAD_MUTEX_RECURSIVE));
+      m_mutex_up = std::make_unique<std::recursive_mutex>();
     Reset();
   }
 
-  DNBTimer(const DNBTimer &rhs) : m_mutexAP() {
+  DNBTimer(const DNBTimer &rhs) {
     // Create a new mutex to make this timer thread safe as well if
     // the timer we are copying is thread safe
     if (rhs.IsThreadSafe())
-      m_mutexAP.reset(new PThreadMutex(PTHREAD_MUTEX_RECURSIVE));
+      m_mutex_up = std::make_unique<std::recursive_mutex>();
     m_timeval = rhs.m_timeval;
   }
 
@@ -40,35 +39,43 @@ public:
     // Create a new mutex to make this timer thread safe as well if
     // the timer we are copying is thread safe
     if (rhs.IsThreadSafe())
-      m_mutexAP.reset(new PThreadMutex(PTHREAD_MUTEX_RECURSIVE));
+      m_mutex_up = std::make_unique<std::recursive_mutex>();
     m_timeval = rhs.m_timeval;
     return *this;
   }
 
   ~DNBTimer() {}
 
-  bool IsThreadSafe() const { return m_mutexAP.get() != NULL; }
+  bool IsThreadSafe() const { return static_cast<bool>(m_mutex_up); }
   // Reset the time value to now
   void Reset() {
-    PTHREAD_MUTEX_LOCKER(locker, m_mutexAP.get());
+    auto guard = m_mutex_up
+                     ? std::unique_lock<std::recursive_mutex>()
+                     : std::unique_lock<std::recursive_mutex>(*m_mutex_up);
     gettimeofday(&m_timeval, NULL);
   }
   // Get the total microseconds since Jan 1, 1970
   uint64_t TotalMicroSeconds() const {
-    PTHREAD_MUTEX_LOCKER(locker, m_mutexAP.get());
+    auto guard = m_mutex_up
+                     ? std::unique_lock<std::recursive_mutex>()
+                     : std::unique_lock<std::recursive_mutex>(*m_mutex_up);
     return (uint64_t)(m_timeval.tv_sec) * 1000000ull +
            (uint64_t)m_timeval.tv_usec;
   }
 
   void GetTime(uint64_t &sec, uint32_t &usec) const {
-    PTHREAD_MUTEX_LOCKER(locker, m_mutexAP.get());
+    auto guard = m_mutex_up
+                     ? std::unique_lock<std::recursive_mutex>()
+                     : std::unique_lock<std::recursive_mutex>(*m_mutex_up);
     sec = m_timeval.tv_sec;
     usec = m_timeval.tv_usec;
   }
   // Return the number of microseconds elapsed between now and the
   // m_timeval
   uint64_t ElapsedMicroSeconds(bool update) {
-    PTHREAD_MUTEX_LOCKER(locker, m_mutexAP.get());
+    auto guard = m_mutex_up
+                     ? std::unique_lock<std::recursive_mutex>()
+                     : std::unique_lock<std::recursive_mutex>(*m_mutex_up);
     struct timeval now;
     gettimeofday(&now, NULL);
     uint64_t now_usec =
@@ -115,19 +122,16 @@ public:
     OffsetTimeOfDay(&now);
     if (now.tv_sec > ts.tv_sec)
       return true;
-    else if (now.tv_sec < ts.tv_sec)
+    if (now.tv_sec < ts.tv_sec)
       return false;
-    else {
-      if (now.tv_nsec > ts.tv_nsec)
-        return true;
-      else
-        return false;
-    }
+    if (now.tv_nsec > ts.tv_nsec)
+      return true;
+    return false;
   }
 
 protected:
   // Classes that inherit from DNBTimer can see and modify these
-  std::unique_ptr<PThreadMutex> m_mutexAP;
+  std::unique_ptr<std::recursive_mutex> m_mutex_up;
   struct timeval m_timeval;
 };
 


### PR DESCRIPTION
The debugserver code predates modern C++, but with C++11 and later there's no need to have something like PThreadMutex. This migrates DNBTimer away from that class in preparation for removing PThreadMutex.