### PR TITLE
[debugserver] Migrate DNBLog away from PThreadMutex (NFC)

### DIFF
--- a/lldb/tools/debugserver/source/DNBLog.cpp
+++ b/lldb/tools/debugserver/source/DNBLog.cpp
@@ -17,7 +17,6 @@ static int g_verbose = 0;
 
 #if defined(DNBLOG_ENABLED)
 
-#include "PThreadMutex.h"
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -64,8 +63,8 @@ bool DNBLogEnabledForAny(uint32_t mask) {
 }
 static inline void _DNBLogVAPrintf(uint32_t flags, const char *format,
                                    va_list args) {
-  static PThreadMutex g_LogThreadedMutex(PTHREAD_MUTEX_RECURSIVE);
-  PTHREAD_MUTEX_LOCKER(locker, g_LogThreadedMutex);
+  static std::recursive_mutex g_LogThreadedMutex;
+  std::lock_guard<std::recursive_mutex> guard(g_LogThreadedMutex);
 
   if (g_log_callback)
     g_log_callback(g_log_baton, flags, format, args);


### PR DESCRIPTION
The debugserver code predates modern C++, but with C++11 and later there's no need to have something like PThreadMutex. This migrates DNBLog away from that class in preparation for removing PThreadMutex.