### PR TITLE
[debugserver] Migrate MachThreadList away from PThreadMutex (NFC)

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachThreadList.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachThreadList.h
@@ -98,7 +98,7 @@ protected:
   //  const_iterator  FindThreadByID (thread_t tid) const;
 
   collection m_threads;
-  mutable PThreadMutex m_threads_mutex;
+  mutable std::recursive_mutex m_threads_mutex;
   MachThreadSP m_current_thread;
   bool m_is_64_bit;
 };


### PR DESCRIPTION
The debugserver code predates modern C++, but with C++11 and later there's no need to have something like PThreadMutex. This migrates MachThreadList away from that class in preparation for removing PThreadMutex.