### PR TITLE
[debugserver] Migrate MachThread away from PThreadMutex (NFC)

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachThread.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/MachThread.cpp
@@ -28,11 +28,11 @@ MachThread::MachThread(MachProcess *process, bool is_64_bit,
                        uint64_t unique_thread_id, thread_t mach_port_num)
     : m_process(process), m_unique_id(unique_thread_id),
       m_mach_port_number(mach_port_num), m_seq_id(GetSequenceID()),
-      m_state(eStateUnloaded), m_state_mutex(PTHREAD_MUTEX_RECURSIVE),
-      m_suspend_count(0), m_stop_exception(),
-      m_arch_up(DNBArchProtocol::Create(this)), m_reg_sets(NULL),
-      m_num_reg_sets(0), m_extended_info(), m_dispatch_queue_name(),
-      m_is_64_bit(is_64_bit), m_pthread_qos_class_decode(nullptr) {
+      m_state(eStateUnloaded), m_state_mutex(), m_suspend_count(0),
+      m_stop_exception(), m_arch_up(DNBArchProtocol::Create(this)),
+      m_reg_sets(NULL), m_num_reg_sets(0), m_extended_info(),
+      m_dispatch_queue_name(), m_is_64_bit(is_64_bit),
+      m_pthread_qos_class_decode(nullptr) {
   nub_size_t num_reg_sets = 0;
   m_reg_sets = m_arch_up->GetRegisterSetInfo(&num_reg_sets);
   m_num_reg_sets = num_reg_sets;
@@ -469,13 +469,12 @@ bool MachThread::NotifyException(MachException::Data &exc) {
 }
 
 nub_state_t MachThread::GetState() {
-  // If any other threads access this we will need a mutex for it
-  PTHREAD_MUTEX_LOCKER(locker, m_state_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_state_mutex);
   return m_state;
 }
 
 void MachThread::SetState(nub_state_t state) {
-  PTHREAD_MUTEX_LOCKER(locker, m_state_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_state_mutex);
   m_state = state;
   DNBLogThreadedIf(LOG_THREAD,
                    "MachThread::SetState ( %s ) for tid = 0x%8.8" PRIx64 "",

--- a/lldb/tools/debugserver/source/MacOSX/MachThread.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachThread.h
@@ -24,8 +24,6 @@
 #include "DNBArch.h"
 #include "DNBRegisterInfo.h"
 #include "MachException.h"
-#include "PThreadCondition.h"
-#include "PThreadMutex.h"
 
 #include "ThreadInfo.h"
 
@@ -139,7 +137,7 @@ protected:
                                // namesp.
   uint32_t m_seq_id;   // A Sequential ID that increments with each new thread
   nub_state_t m_state; // The state of our process
-  PThreadMutex m_state_mutex;            // Multithreaded protection for m_state
+  std::recursive_mutex m_state_mutex;    // Multithreaded protection for m_state
   struct thread_basic_info m_basic_info; // Basic information for a thread used
                                          // to see if a thread is valid
   int32_t m_suspend_count; // The current suspend count > 0 means we have


### PR DESCRIPTION
The debugserver code predates modern C++, but with C++11 and later there's no need to have something like PThreadMutex. This migrates MachThread away from PThreadMutex in preparation for removing it.