### PR TITLE
[clang-format] Add ApplyAlwaysOnePerLineToTemplateArguments option

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -2226,6 +2226,47 @@ the configuration (without a prefix: ``Auto``).
 **AlwaysBreakTemplateDeclarations** (``deprecated``) :versionbadge:`clang-format 3.4` :ref:`¶ <AlwaysBreakTemplateDeclarations>`
   This option is renamed to ``BreakTemplateDeclarations``.
 
+.. _ApplyAlwaysOnePerLineToTemplateArguments:
+
+**ApplyAlwaysOnePerLineToTemplateArguments** (``Boolean``) :versionbadge:`clang-format 21` :ref:`¶ <ApplyAlwaysOnePerLineToTemplateArguments>`
+  If ``BinPackParameters`` is set to ``AlwaysOnePerLine``, specifies whether
+  template argument lists should also be split across multiple lines.
+
+  When set to ``true``, each template argument will be placed on its own
+  line. When set to ``false``, template argument lists remain compact even
+  when function parameters are broken one per line.
+
+
+  .. code-block:: c++
+
+    true:
+    template <typename T, int N>
+    struct Foo {
+        T mData[N];
+
+        Foo<T,
+            N>
+        operator+(const Foo<T,
+                            N> &other) const {}
+
+        Foo<T,
+            N>
+        bar(const Foo<T,
+                      N> &other,
+            float t) const {}
+        };
+
+    false:
+    template <typename T, int N>
+    struct Foo {
+        T mData[N];
+
+        Foo<T, N> operator+(const Foo<T, N> &other) const {}
+
+        Foo<T, N> bar(const Foo<T, N> &other,
+                  float t) const {}
+    };
+
 .. _AttributeMacros:
 
 **AttributeMacros** (``List of Strings``) :versionbadge:`clang-format 12` :ref:`¶ <AttributeMacros>`

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1361,6 +1361,45 @@ struct FormatStyle {
   /// \version 3.7
   BinPackParametersStyle BinPackParameters;
 
+  /// If ``BinPackParameters`` is set to ``AlwaysOnePerLine``, specifies whether
+  /// template argument lists should also be split across multiple lines.
+  ///
+  /// When set to ``true``, each template argument will be placed on its own
+  /// line. When set to ``false``, template argument lists remain compact even
+  /// when function parameters are broken one per line.
+  ///
+  /// \code
+  ///   true:
+  ///   template <typename T, int N>
+  ///   struct Foo {
+  ///       T mData[N];
+  ///
+  ///       Foo<T,
+  ///           N>
+  ///       operator+(const Foo<T,
+  ///                           N> &other) const {}
+  ///
+  ///       Foo<T,
+  ///           N>
+  ///       bar(const Foo<T,
+  ///                     N> &other,
+  ///           float t) const {}
+  ///       };
+  ///
+  ///   false:
+  ///   template <typename T, int N>
+  ///   struct Foo {
+  ///       T mData[N];
+  ///
+  ///       Foo<T, N> operator+(const Foo<T, N> &other) const {}
+  ///
+  ///       Foo<T, N> bar(const Foo<T, N> &other,
+  ///                 float t) const {}
+  ///   };
+  /// \endcode
+  /// \version 21
+  bool ApplyAlwaysOnePerLineToTemplateArguments;
+
   /// Styles for adding spacing around ``:`` in bitfield definitions.
   enum BitFieldColonSpacingStyle : int8_t {
     /// Add one space on each side of the ``:``
@@ -5952,6 +5991,8 @@ struct FormatStyle {
            BinPackArguments == R.BinPackArguments &&
            BinPackLongBracedList == R.BinPackLongBracedList &&
            BinPackParameters == R.BinPackParameters &&
+           ApplyAlwaysOnePerLineToTemplateArguments ==
+               R.ApplyAlwaysOnePerLineToTemplateArguments &&
            BitFieldColonSpacing == R.BitFieldColonSpacing &&
            BracedInitializerIndentWidth == R.BracedInitializerIndentWidth &&
            BreakAdjacentStringLiterals == R.BreakAdjacentStringLiterals &&

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1216,6 +1216,8 @@ template <> struct MappingTraits<FormatStyle> {
     IO.mapOptional("BinPackArguments", Style.BinPackArguments);
     IO.mapOptional("BinPackLongBracedList", Style.BinPackLongBracedList);
     IO.mapOptional("BinPackParameters", Style.BinPackParameters);
+    IO.mapOptional("ApplyAlwaysOnePerLineToTemplateArguments",
+                   Style.ApplyAlwaysOnePerLineToTemplateArguments);
     IO.mapOptional("BitFieldColonSpacing", Style.BitFieldColonSpacing);
     IO.mapOptional("BracedInitializerIndentWidth",
                    Style.BracedInitializerIndentWidth);
@@ -1784,6 +1786,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.BinPackArguments = true;
   LLVMStyle.BinPackLongBracedList = true;
   LLVMStyle.BinPackParameters = FormatStyle::BPPS_BinPack;
+  LLVMStyle.ApplyAlwaysOnePerLineToTemplateArguments = true;
   LLVMStyle.BitFieldColonSpacing = FormatStyle::BFCS_Both;
   LLVMStyle.BracedInitializerIndentWidth = -1;
   LLVMStyle.BraceWrapping = {/*AfterCaseLabel=*/false,

--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -324,11 +324,11 @@ struct FormatToken {
         IsUnterminatedLiteral(false), CanBreakBefore(false),
         ClosesTemplateDeclaration(false), StartsBinaryExpression(false),
         EndsBinaryExpression(false), PartOfMultiVariableDeclStmt(false),
-        ContinuesLineCommentSection(false), Finalized(false),
-        ClosesRequiresClause(false), EndsCppAttributeGroup(false),
-        BlockKind(BK_Unknown), Decision(FD_Unformatted),
-        PackingKind(PPK_Inconclusive), TypeIsFinalized(false),
-        Type(TT_Unknown) {}
+        InTemplateArgumentList(false), ContinuesLineCommentSection(false),
+        Finalized(false), ClosesRequiresClause(false),
+        EndsCppAttributeGroup(false), BlockKind(BK_Unknown),
+        Decision(FD_Unformatted), PackingKind(PPK_Inconclusive),
+        TypeIsFinalized(false), Type(TT_Unknown) {}
 
   /// The \c Token.
   Token Tok;
@@ -387,6 +387,9 @@ struct FormatToken {
   ///
   /// Only set if \c Type == \c TT_StartOfName.
   unsigned PartOfMultiVariableDeclStmt : 1;
+
+  /// \c true if this token is part of a template argument list.
+  unsigned InTemplateArgumentList : 1;
 
   /// Does this line comment continue a line comment section?
   ///

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1992,6 +1992,19 @@ private:
     return Type;
   }
 
+  void markTokenAsTemplateArgumentInLine() {
+    int TemplateDepth = 0;
+    for (FormatToken *Tok = Line.First; Tok; Tok = Tok->Next) {
+      if (Tok->is(TT_TemplateCloser))
+        --TemplateDepth;
+
+      Tok->InTemplateArgumentList = (TemplateDepth > 0);
+
+      if (Tok->is(TT_TemplateOpener))
+        ++TemplateDepth;
+    }
+  }
+
 public:
   LineType parseLine() {
     if (!CurrentToken)
@@ -2089,6 +2102,7 @@ public:
       if (ctx.ContextType == Context::StructArrayInitializer)
         return LT_ArrayOfStructInitializer;
 
+    markTokenAsTemplateArgumentInLine();
     return LT_Other;
   }
 
@@ -5745,6 +5759,8 @@ bool TokenAnnotator::mustBreakBefore(AnnotatedLine &Line,
   // BreakFunctionDefinitionParameters or AlignAfterOpenBracket.
   if (Style.BinPackParameters == FormatStyle::BPPS_AlwaysOnePerLine &&
       Line.MightBeFunctionDecl && !Left.opensScope() &&
+      (Style.ApplyAlwaysOnePerLineToTemplateArguments ||
+       !Left.InTemplateArgumentList) &&
       startsNextParameter(Right, Style)) {
     return true;
   }

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -186,6 +186,9 @@ public:
   bool MightBeFunctionDecl;
   bool IsMultiVariableDeclStmt;
 
+  /// \c True if this token is part o a template declaration.
+  bool InTemplateDecl = false;
+
   /// \c True if this line contains a macro call for which an expansion exists.
   bool ContainsMacroCall = false;
 

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -547,6 +547,12 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("BinPackParameters: false", BinPackParameters,
               FormatStyle::BPPS_OnePerLine);
 
+  Style.ApplyAlwaysOnePerLineToTemplateArguments = false;
+  CHECK_PARSE("ApplyAlwaysOnePerLineToTemplateArguments: true",
+              ApplyAlwaysOnePerLineToTemplateArguments, true);
+  CHECK_PARSE("ApplyAlwaysOnePerLineToTemplateArguments: false",
+              ApplyAlwaysOnePerLineToTemplateArguments, false);
+
   Style.PackConstructorInitializers = FormatStyle::PCIS_BinPack;
   CHECK_PARSE("PackConstructorInitializers: Never", PackConstructorInitializers,
               FormatStyle::PCIS_Never);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -9132,6 +9132,146 @@ TEST_F(FormatTest, FormatsOneParameterPerLineIfNecessary) {
       NoBinPacking);
 }
 
+TEST_F(FormatTest, FormatsDeclarationBreakAlways) {
+  FormatStyle BreakAlways = getGoogleStyle();
+  BreakAlways.BinPackParameters = FormatStyle::BPPS_AlwaysOnePerLine;
+  verifyFormat("void f(int a,\n"
+               "       int b);",
+               BreakAlways);
+  verifyFormat("void f(int aaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+               "       int bbbbbbbbbbbbbbbbbbbbbbbbb,\n"
+               "       int cccccccccccccccccccccccc);",
+               BreakAlways);
+
+  // Ensure AlignAfterOpenBracket interacts correctly with BinPackParameters set
+  // to BPPS_AlwaysOnePerLine.
+  BreakAlways.AlignAfterOpenBracket = FormatStyle::BAS_AlwaysBreak;
+  verifyFormat(
+      "void someLongFunctionName(\n"
+      "    int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+      "    int b);",
+      BreakAlways);
+  BreakAlways.AlignAfterOpenBracket = FormatStyle::BAS_BlockIndent;
+  verifyFormat(
+      "void someLongFunctionName(\n"
+      "    int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+      "    int b\n"
+      ");",
+      BreakAlways);
+}
+
+TEST_F(FormatTest, ApplyAlwaysOnePerLineToTemplateArguments) {
+  FormatStyle Style = getGoogleStyle();
+  Style.BinPackParameters = FormatStyle::BPPS_AlwaysOnePerLine;
+
+  // Case 1: Template arguments split by AlwaysOnePerLine
+  Style.ApplyAlwaysOnePerLineToTemplateArguments = true;
+  verifyFormat("template <typename T, int N>\n"
+               "struct Foo {\n"
+               "  T mData[N];\n"
+               "  Foo<T,\n"
+               "      N>\n"
+               "  operator+(const Foo<T,\n"
+               "                      N> &other) const {}\n"
+               "  Foo<T,\n"
+               "      N>\n"
+               "  bar(const Foo<T,\n"
+               "                N> &other,\n"
+               "      float t) const {}\n"
+               "};\n",
+               Style);
+
+  // Case 2: Template arguments not split by The
+  // ApplyAlwaysOnePerLineToTemplateArguments
+  Style.ApplyAlwaysOnePerLineToTemplateArguments = false;
+  verifyFormat("template <typename T, int N>\n"
+               "struct Foo {\n"
+               "  T mData[N];\n"
+               "  Foo<T, N> operator+(const Foo<T, N> &other) const {}\n"
+               "  Foo<T, N> bar(const Foo<T, N> &other,\n"
+               "                float t) const {}\n"
+               "};\n",
+               Style);
+
+  // Case 3: Template arguments not split by the
+  // ApplyAlwaysOnePerLineToTemplateArguments but using the
+  // BreakFunctionDefinitionParameters flag
+  Style.BreakFunctionDefinitionParameters = true;
+  verifyFormat("template <typename T, int N>\n"
+               "struct Foo {\n"
+               "  T mData[N];\n"
+               "  Foo<T, N> operator+(\n"
+               "      const Foo<T, N> &other) const {}\n"
+               "  Foo<T, N> bar(\n"
+               "      const Foo<T, N> &other,\n"
+               "      float t) const {}\n"
+               "};\n",
+               Style);
+}
+
+TEST_F(FormatTest, FormatsDefinitionBreakAlways) {
+  FormatStyle BreakAlways = getGoogleStyle();
+  BreakAlways.BinPackParameters = FormatStyle::BPPS_AlwaysOnePerLine;
+  verifyFormat("void f(int a,\n"
+               "       int b) {\n"
+               "  f(a, b);\n"
+               "}",
+               BreakAlways);
+
+  // Ensure BinPackArguments interact correctly when BinPackParameters is set to
+  // BPPS_AlwaysOnePerLine.
+  verifyFormat("void f(int aaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+               "       int bbbbbbbbbbbbbbbbbbbbbbbbb,\n"
+               "       int cccccccccccccccccccccccc) {\n"
+               "  f(aaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbb,\n"
+               "    cccccccccccccccccccccccc);\n"
+               "}",
+               BreakAlways);
+  BreakAlways.BinPackArguments = false;
+  verifyFormat("void f(int aaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+               "       int bbbbbbbbbbbbbbbbbbbbbbbbb,\n"
+               "       int cccccccccccccccccccccccc) {\n"
+               "  f(aaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+               "    bbbbbbbbbbbbbbbbbbbbbbbbb,\n"
+               "    cccccccccccccccccccccccc);\n"
+               "}",
+               BreakAlways);
+
+  // Ensure BreakFunctionDefinitionParameters interacts correctly when
+  // BinPackParameters is set to BPPS_AlwaysOnePerLine.
+  BreakAlways.BreakFunctionDefinitionParameters = true;
+  verifyFormat("void f(\n"
+               "    int a,\n"
+               "    int b) {\n"
+               "  f(a, b);\n"
+               "}",
+               BreakAlways);
+  BreakAlways.BreakFunctionDefinitionParameters = false;
+
+  // Ensure AlignAfterOpenBracket interacts correctly with BinPackParameters set
+  // to BPPS_AlwaysOnePerLine.
+  BreakAlways.AlignAfterOpenBracket = FormatStyle::BAS_AlwaysBreak;
+  verifyFormat(
+      "void someLongFunctionName(\n"
+      "    int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+      "    int b) {\n"
+      "  someLongFunctionName(\n"
+      "      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, b);\n"
+      "}",
+      BreakAlways);
+  BreakAlways.AlignAfterOpenBracket = FormatStyle::BAS_BlockIndent;
+  verifyFormat(
+      "void someLongFunctionName(\n"
+      "    int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+      "    int b\n"
+      ") {\n"
+      "  someLongFunctionName(\n"
+      "      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, b\n"
+      "  );\n"
+      "}",
+      BreakAlways);
+}
+
 TEST_F(FormatTest, AdaptiveOnePerLineFormatting) {
   FormatStyle Style = getLLVMStyleWithColumns(15);
   Style.ExperimentalAutoDetectBinPacking = true;

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -428,6 +428,66 @@ TEST_F(FormatTestComments, UnderstandsBlockComments) {
                      "  int jjj; /*b*/");
 }
 
+TEST_F(FormatTestComments,
+       AlwaysOnePerLineRespectsTemplateArgumentsFlagWithComments) {
+  FormatStyle Style = getGoogleStyle();
+  Style.BinPackParameters = FormatStyle::BPPS_AlwaysOnePerLine;
+
+  // Case 1: Template arguments split by AlwaysOnePerLine
+  Style.ApplyAlwaysOnePerLineToTemplateArguments = true;
+  verifyFormat("template <typename T,  // comment\n"
+               "          int N>       // comment\n"
+               "struct Foo {\n"
+               "  T mData[N];\n"
+               "  Foo<T,\n"
+               "      N>\n"
+               "  operator+(const Foo<T,\n"
+               "                      N> &other) const {  // comment\n"
+               "  }\n"
+               "  Foo<T,\n"
+               "      N>\n"
+               "  bar(const Foo<T,\n"
+               "                N> &other,  // comment\n"
+               "      float t) const {      // comment\n"
+               "  }\n"
+               "};\n",
+               Style);
+
+  // Case 2: Template arguments not split by The
+  // ApplyAlwaysOnePerLineToTemplateArguments
+  Style.ApplyAlwaysOnePerLineToTemplateArguments = false;
+  verifyFormat(
+      "template <typename T,  // comment\n"
+      "          int N>       // comment\n"
+      "struct Foo {\n"
+      "  T mData[N];\n"
+      "  Foo<T, N> operator+(const Foo<T, N> &other) const {  // comment\n"
+      "  }\n"
+      "  Foo<T, N> bar(const Foo<T, N> &other,  // comment\n"
+      "                float t) const {         // comment\n"
+      "  }\n"
+      "};\n",
+      Style);
+
+  // Case 3: Template arguments not split by the
+  // ApplyAlwaysOnePerLineToTemplateArguments but using the
+  // BreakFunctionDefinitionParameters flag
+  Style.BreakFunctionDefinitionParameters = true;
+  verifyFormat("template <typename T,  // comment\n"
+               "          int N>       // comment\n"
+               "struct Foo {\n"
+               "  T mData[N];\n"
+               "  Foo<T, N> operator+(\n"
+               "      const Foo<T, N> &other) const {  // comment\n"
+               "  }\n"
+               "  Foo<T, N> bar(\n"
+               "      const Foo<T, N> &other,  // comment\n"
+               "      float t) const {         // comment\n"
+               "  }\n"
+               "};\n",
+               Style);
+}
+
 TEST_F(FormatTestComments, AlignsBlockComments) {
   verifyFormat("/*\n"
                " * Really multi-line\n"


### PR DESCRIPTION
Introduce a new FormatStyle option, `ApplyAlwaysOnePerLineToTemplateArguments`,  
which controls whether `BinPackParameters=AlwaysOnePerLine` also applies to template argument lists.

This allows users to enforce one-per-line formatting for function parameters without unintentionally splitting template arguments.

Includes unit tests covering function declarations, definitions, and template instantiations, both with and without trailing comments.

---

## Behavior

If `BinPackParameters` is set to `AlwaysOnePerLine`, this option controls whether template arguments are split across multiple lines.

- When `true`, which is the current only behaviour, each template argument is placed on its own line:

```cpp
template <typename T, int N>
struct Foo {
  T mData[N];

  Foo<T,
      N>
  operator+(const Foo<T,
                      N> &other) const {}

  Foo<T,
      N>
  bar(const Foo<T,
                N> &other,
      float t) const {}
};

```

- When `false`, template argument lists remain compact even if function parameters are broken one per line:

```cpp
template <typename T, int N>
struct Foo {
  T mData[N];

  Foo<T, N> operator+(const Foo<T, N> &other) const {}

  Foo<T, N> bar(const Foo<T, N> &other,
                float t) const {}
};
```