### PR TITLE
[debugserver] Migrate MachProcess away from PThreadMutex (NFC)

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -34,7 +34,6 @@
 #include "MachVMMemory.h"
 #include "PThreadCondition.h"
 #include "PThreadEvent.h"
-#include "PThreadMutex.h"
 #include "RNBContext.h"
 #include "ThreadInfo.h"
 
@@ -413,7 +412,7 @@ private:
   uint32_t m_stop_count; // A count of many times have we stopped
   pthread_t m_stdio_thread;   // Thread ID for the thread that watches for child
                               // process stdio
-  PThreadMutex m_stdio_mutex; // Multithreaded protection for stdio
+  std::recursive_mutex m_stdio_mutex; // Multithreaded protection for stdio
   std::string m_stdout_data;
 
   bool m_profile_enabled; // A flag to indicate if profiling is enabled
@@ -423,7 +422,7 @@ private:
       m_profile_scan_type; // Indicates what needs to be profiled
   pthread_t
       m_profile_thread; // Thread ID for the thread that profiles the inferior
-  PThreadMutex
+  std::recursive_mutex
       m_profile_data_mutex; // Multithreaded protection for profile info data
   std::vector<std::string>
       m_profile_data; // Profile data, must be protected by m_profile_data_mutex
@@ -435,15 +434,16 @@ private:
                                                            // caught when
                                                            // listening to the
                                                            // exception port
-  PThreadMutex m_exception_and_signal_mutex; // Multithreaded protection for
-                                             // exceptions and signals.
+  std::recursive_mutex
+      m_exception_and_signal_mutex; // Multithreaded protection for
+                                    // exceptions and signals.
 
   MachThreadList m_thread_list; // A list of threads that is maintained/updated
                                 // after each stop
   Genealogy m_activities; // A list of activities that is updated after every
                           // stop lazily
   nub_state_t m_state;    // The state of our process
-  PThreadMutex m_state_mutex; // Multithreaded protection for m_state
+  std::recursive_mutex m_state_mutex; // Multithreaded protection for m_state
   PThreadEvent m_events;      // Process related events in the child processes
                               // lifetime can be waited upon
   PThreadEvent m_private_events; // Used to coordinate running and stopping the

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -522,19 +522,17 @@ static CallOpenApplicationFunction FBSCallOpenApplicationFunction =
 MachProcess::MachProcess()
     : m_pid(0), m_cpu_type(0), m_child_stdin(-1), m_child_stdout(-1),
       m_child_stderr(-1), m_path(), m_args(), m_task(this),
-      m_flags(eMachProcessFlagsNone), m_stdio_thread(0),
-      m_stdio_mutex(PTHREAD_MUTEX_RECURSIVE), m_stdout_data(),
-      m_profile_enabled(false), m_profile_interval_usec(0), m_profile_thread(0),
-      m_profile_data_mutex(PTHREAD_MUTEX_RECURSIVE), m_profile_data(),
+      m_flags(eMachProcessFlagsNone), m_stdio_thread(0), m_stdio_mutex(),
+      m_stdout_data(), m_profile_enabled(false), m_profile_interval_usec(0),
+      m_profile_thread(0), m_profile_data_mutex(), m_profile_data(),
       m_profile_events(0, eMachProcessProfileCancel), m_thread_actions(),
-      m_exception_messages(),
-      m_exception_and_signal_mutex(PTHREAD_MUTEX_RECURSIVE), m_thread_list(),
-      m_activities(), m_state(eStateUnloaded),
-      m_state_mutex(PTHREAD_MUTEX_RECURSIVE), m_events(0, kAllEventsMask),
-      m_private_events(0, kAllEventsMask), m_breakpoints(), m_watchpoints(),
-      m_name_to_addr_callback(NULL), m_name_to_addr_baton(NULL),
-      m_image_infos_callback(NULL), m_image_infos_baton(NULL),
-      m_sent_interrupt_signo(0), m_auto_resume_signo(0), m_did_exec(false),
+      m_exception_messages(), m_exception_and_signal_mutex(), m_thread_list(),
+      m_activities(), m_state(eStateUnloaded), m_state_mutex(),
+      m_events(0, kAllEventsMask), m_private_events(0, kAllEventsMask),
+      m_breakpoints(), m_watchpoints(), m_name_to_addr_callback(NULL),
+      m_name_to_addr_baton(NULL), m_image_infos_callback(NULL),
+      m_image_infos_baton(NULL), m_sent_interrupt_signo(0),
+      m_auto_resume_signo(0), m_did_exec(false),
       m_dyld_process_info_create(nullptr),
       m_dyld_process_info_for_each_image(nullptr),
       m_dyld_process_info_release(nullptr),
@@ -577,7 +575,7 @@ pid_t MachProcess::SetProcessID(pid_t pid) {
 
 nub_state_t MachProcess::GetState() {
   // If any other threads access this we will need a mutex for it
-  PTHREAD_MUTEX_LOCKER(locker, m_state_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_state_mutex);
   return m_state;
 }
 
@@ -1279,7 +1277,7 @@ void MachProcess::SetState(nub_state_t new_state) {
 
   // Scope for mutex locker
   {
-    PTHREAD_MUTEX_LOCKER(locker, m_state_mutex);
+    std::lock_guard<std::recursive_mutex> guard(m_state_mutex);
     const nub_state_t old_state = m_state;
 
     if (old_state == eStateExited) {
@@ -1338,7 +1336,7 @@ void MachProcess::Clear(bool detaching) {
   m_stop_count = 0;
   m_thread_list.Clear();
   {
-    PTHREAD_MUTEX_LOCKER(locker, m_exception_and_signal_mutex);
+    std::lock_guard<std::recursive_mutex> guard(m_exception_and_signal_mutex);
     m_exception_messages.clear();
     m_sent_interrupt_signo = 0;
     m_auto_resume_signo = 0;
@@ -1578,7 +1576,7 @@ bool MachProcess::Kill(const struct timespec *timeout_abstime) {
 bool MachProcess::Interrupt() {
   nub_state_t state = GetState();
   if (IsRunning(state)) {
-    PTHREAD_MUTEX_LOCKER(locker, m_exception_and_signal_mutex);
+    std::lock_guard<std::recursive_mutex> guard(m_exception_and_signal_mutex);
     if (m_sent_interrupt_signo == 0) {
       m_sent_interrupt_signo = SIGSTOP;
       if (Signal(m_sent_interrupt_signo)) {
@@ -1736,7 +1734,7 @@ bool MachProcess::Detach() {
     m_thread_actions.Append(thread_action);
     m_thread_actions.SetDefaultThreadActionIfNeeded(eStateRunning, 0);
 
-    PTHREAD_MUTEX_LOCKER(locker, m_exception_and_signal_mutex);
+    std::lock_guard<std::recursive_mutex> guard(m_exception_and_signal_mutex);
 
     ReplyToAllExceptions();
   }
@@ -1862,7 +1860,7 @@ nub_size_t MachProcess::WriteMemory(nub_addr_t addr, nub_size_t size,
 }
 
 void MachProcess::ReplyToAllExceptions() {
-  PTHREAD_MUTEX_LOCKER(locker, m_exception_and_signal_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_exception_and_signal_mutex);
   if (!m_exception_messages.empty()) {
     MachException::Message::iterator pos;
     MachException::Message::iterator begin = m_exception_messages.begin();
@@ -1896,7 +1894,7 @@ void MachProcess::ReplyToAllExceptions() {
   }
 }
 void MachProcess::PrivateResume() {
-  PTHREAD_MUTEX_LOCKER(locker, m_exception_and_signal_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_exception_and_signal_mutex);
 
   m_auto_resume_signo = m_sent_interrupt_signo;
   if (m_auto_resume_signo)
@@ -2298,7 +2296,7 @@ bool MachProcess::EnableWatchpoint(nub_addr_t addr) {
 // data has already been copied.
 void MachProcess::ExceptionMessageReceived(
     const MachException::Message &exceptionMessage) {
-  PTHREAD_MUTEX_LOCKER(locker, m_exception_and_signal_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_exception_and_signal_mutex);
 
   if (m_exception_messages.empty())
     m_task.Suspend();
@@ -2312,7 +2310,7 @@ void MachProcess::ExceptionMessageReceived(
 
 task_t MachProcess::ExceptionMessageBundleComplete() {
   // We have a complete bundle of exceptions for our child process.
-  PTHREAD_MUTEX_LOCKER(locker, m_exception_and_signal_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_exception_and_signal_mutex);
   DNBLogThreadedIf(LOG_EXCEPTIONS, "%s: %llu exception messages.",
                    __PRETTY_FUNCTION__, (uint64_t)m_exception_messages.size());
   bool auto_resume = false;
@@ -2495,7 +2493,7 @@ void MachProcess::SetExitInfo(const char *info) {
 void MachProcess::AppendSTDOUT(char *s, size_t len) {
   DNBLogThreadedIf(LOG_PROCESS, "MachProcess::%s (<%llu> %s) ...", __FUNCTION__,
                    (uint64_t)len, s);
-  PTHREAD_MUTEX_LOCKER(locker, m_stdio_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_stdio_mutex);
   m_stdout_data.append(s, len);
   m_events.SetEvents(eEventStdioAvailable);
 
@@ -2506,7 +2504,7 @@ void MachProcess::AppendSTDOUT(char *s, size_t len) {
 size_t MachProcess::GetAvailableSTDOUT(char *buf, size_t buf_size) {
   DNBLogThreadedIf(LOG_PROCESS, "MachProcess::%s (&%p[%llu]) ...", __FUNCTION__,
                    static_cast<void *>(buf), (uint64_t)buf_size);
-  PTHREAD_MUTEX_LOCKER(locker, m_stdio_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_stdio_mutex);
   size_t bytes_available = m_stdout_data.size();
   if (bytes_available > 0) {
     if (bytes_available > buf_size) {
@@ -2733,7 +2731,7 @@ void *MachProcess::STDIOThread(void *arg) {
 
 void MachProcess::SignalAsyncProfileData(const char *info) {
   DNBLogThreadedIf(LOG_PROCESS, "MachProcess::%s (%s) ...", __FUNCTION__, info);
-  PTHREAD_MUTEX_LOCKER(locker, m_profile_data_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_profile_data_mutex);
   m_profile_data.push_back(info);
   m_events.SetEvents(eEventProfileDataAvailable);
 
@@ -2744,7 +2742,7 @@ void MachProcess::SignalAsyncProfileData(const char *info) {
 size_t MachProcess::GetAsyncProfileData(char *buf, size_t buf_size) {
   DNBLogThreadedIf(LOG_PROCESS, "MachProcess::%s (&%p[%llu]) ...", __FUNCTION__,
                    static_cast<void *>(buf), (uint64_t)buf_size);
-  PTHREAD_MUTEX_LOCKER(locker, m_profile_data_mutex);
+  std::lock_guard<std::recursive_mutex> guard(m_profile_data_mutex);
   if (m_profile_data.empty())
     return 0;
 


### PR DESCRIPTION
The debugserver code predates modern C++, but with C++11 and later there's no need to have something like PThreadMutex. This migrates MachProcess away from PThreadMutex in preparation for removing it.