### PR TITLE
[VPlan] Remove no longer needed VP intrinsic handling in VPWidenIntrinsicRecipe::computeCost. NFCI

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1333,15 +1333,6 @@ InstructionCost VPWidenIntrinsicRecipe::computeCost(ElementCount VF,
   for (const auto &[Idx, Op] : enumerate(operands())) {
     auto *V = Op->getUnderlyingValue();
     if (!V) {
-      // Push all the VP Intrinsic's ops into the Argments even if is nullptr.
-      // Some VP Intrinsic's cost will assert the number of parameters.
-      // Mainly appears in the following two scenarios:
-      // 1. EVL Op is nullptr
-      // 2. The Argmunt of the VP Intrinsic is also the VP Intrinsic
-      if (VPIntrinsic::isVPIntrinsic(VectorIntrinsicID)) {
-        Arguments.push_back(V);
-        continue;
-      }
       if (auto *UI = dyn_cast_or_null<CallBase>(getUnderlyingValue())) {
         Arguments.push_back(UI->getArgOperand(Idx));
         continue;


### PR DESCRIPTION
Whenever calls were transformed to VP intrinsics with EVL tail folding in #110412, this workaround was added in computeCost to avoid an assertion when checking ICA.getArgs().

However it turned out that the actual arguments were never used and this assertion was removed in #115983 afterwards, so it's now fine to leave the arguments empty and use the type based cost instead.

The type based cost and value based cost are the same for these VP intrinsics.

This was tested by adding back in the transformation code in #110412 and checking that no assertions were still hit.
