### PR TITLE
[clang][bytecode] Fix two small builtin_constant_p cases

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -321,8 +321,11 @@ bool CheckBCPResult(InterpState &S, const Pointer &Ptr) {
   if (Ptr.isTypeidPointer())
     return true;
 
+  if (Ptr.getType()->isAnyComplexType())
+    return true;
+
   if (const Expr *Base = Ptr.getDeclDesc()->asExpr())
-    return isa<StringLiteral>(Base);
+    return isa<StringLiteral>(Base) && Ptr.getIndex() == 0;
   return false;
 }
 


### PR DESCRIPTION
Only accept string literals if we're pointing to the first index and do accept complex literals.