### PR TITLE
[mlir][linalg] Fix memory leak in `pack-dynamic-inner-tile.mlir`

### DIFF
--- a/mlir/test/Integration/Dialect/Linalg/CPU/pack-dynamic-inner-tile.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/pack-dynamic-inner-tile.mlir
@@ -125,9 +125,13 @@ module @transforms attributes { transform.with_named_sequence } {
     %bufferize = transform.bufferization.one_shot_bufferize %module
       {bufferize_function_boundaries=true} : (!transform.any_op) -> !transform.any_op
 
-    // 5. Canonicalize
+    // 5. Deallocate buffers.
     %func_op_bufferized = transform.structured.match ops{["func.func"]} in %bufferize : (!transform.any_op) -> !transform.op<"func.func">
-    transform.apply_patterns to %func_op_bufferized {
+    %func_op_deallocated = transform.apply_registered_pass "buffer-deallocation-pipeline" to %func_op_bufferized
+      : (!transform.op<"func.func">) -> !transform.op<"func.func">
+
+    // 6. Canonicalize
+    transform.apply_patterns to %func_op_deallocated {
       transform.apply_patterns.canonicalization
     } : !transform.op<"func.func">
 


### PR DESCRIPTION
This fixes the test when running with ASAN.