### PR TITLE
[mlir][memref] Fix memory leaks in `print-memref.mlir`

### DIFF
--- a/mlir/test/Integration/Dialect/MemRef/print-memref.mlir
+++ b/mlir/test/Integration/Dialect/MemRef/print-memref.mlir
@@ -1,6 +1,7 @@
 // RUN: mlir-opt %s \
 // RUN: -one-shot-bufferize="bufferize-function-boundaries" --canonicalize \
-// RUN:   -finalize-memref-to-llvm\
+// RUN:   -buffer-deallocation-pipeline \
+// RUN:   -finalize-memref-to-llvm \
 // RUN:   -convert-func-to-llvm -reconcile-unrealized-casts |\
 // RUN: mlir-runner \
 // RUN:  -e entry -entry-point-result=void  \


### PR DESCRIPTION
This fixes the test when running with ASAN.