### PR TITLE
[mlir][linalg] Fix memory leak in `runtime-verification.mlir`

### DIFF
--- a/mlir/test/Integration/Dialect/Linalg/CPU/runtime-verification.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/runtime-verification.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-opt %s -generate-runtime-verification \
 // RUN: -one-shot-bufferize="bufferize-function-boundaries" \
+// RUN: -buffer-deallocation-pipeline \
 // RUN: -convert-linalg-to-loops \
 // RUN: -expand-strided-metadata \
 // RUN: -lower-affine \


### PR DESCRIPTION
This fixes the test when running with ASAN.