### PR TITLE
[libc++] Add _LIBCPP_NO_UNIQUE_ADDRESS to flat_{,multi}map::value_compare

### DIFF
--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -114,7 +114,7 @@ public:
 
   class value_compare {
   private:
-    key_compare __comp_;
+    _LIBCPP_NO_UNIQUE_ADDRESS key_compare __comp_;
     _LIBCPP_HIDE_FROM_ABI value_compare(key_compare __c) : __comp_(__c) {}
     friend flat_map;
 

--- a/libcxx/include/__flat_map/flat_multimap.h
+++ b/libcxx/include/__flat_map/flat_multimap.h
@@ -115,7 +115,7 @@ public:
 
   class value_compare {
   private:
-    key_compare __comp_;
+    _LIBCPP_NO_UNIQUE_ADDRESS key_compare __comp_;
     _LIBCPP_HIDE_FROM_ABI value_compare(key_compare __c) : __comp_(__c) {}
     friend flat_multimap;
 


### PR DESCRIPTION
This breaks the ABI of `flat_{,multi}map::value_compare`, but this type has only been introduced in LLVM 20, so it should be very unlikely that we break anybody if we back-port this now.
