### PR TITLE
[clang-format] Add --fallback-style to git-clang-format

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -172,6 +172,10 @@ def main():
         ),
     ),
     p.add_argument(
+        "--fallback-style",
+        help="passed to clang-format",
+    ),
+    p.add_argument(
         "-f",
         "--force",
         action="store_true",
@@ -279,7 +283,11 @@ def main():
         old_tree = create_tree_from_workdir(changed_lines)
         revision = None
     new_tree = run_clang_format_and_save_to_tree(
-        changed_lines, revision, binary=opts.binary, style=opts.style
+        changed_lines,
+        revision,
+        binary=opts.binary,
+        style=opts.style,
+        fallback_style=opts.fallback_style,
     )
     if opts.verbose >= 1:
         print("old tree: %s" % old_tree)
@@ -531,7 +539,11 @@ def create_tree_from_index(filenames):
 
 
 def run_clang_format_and_save_to_tree(
-    changed_lines, revision=None, binary="clang-format", style=None
+    changed_lines,
+    revision=None,
+    binary="clang-format",
+    style=None,
+    fallback_style=None,
 ):
     """Run clang-format on each file and save the result to a git tree.
 
@@ -583,6 +595,7 @@ def run_clang_format_and_save_to_tree(
                 revision=revision,
                 binary=binary,
                 style=style,
+                fallback_style=fallback_style,
                 env=env,
             )
             yield "%s %s\t%s" % (mode, blob_id, filename)
@@ -616,6 +629,7 @@ def clang_format_to_blob(
     revision=None,
     binary="clang-format",
     style=None,
+    fallback_style=None,
     env=None,
 ):
     """Run clang-format on the given file and save the result to a git blob.
@@ -628,6 +642,8 @@ def clang_format_to_blob(
     clang_format_cmd = [binary]
     if style:
         clang_format_cmd.extend(["--style=" + style])
+    if fallback_style:
+        clang_format_cmd.extend(["--fallback-style=" + fallback_style])
     clang_format_cmd.extend(
         [
             "--lines=%s:%s" % (start_line, start_line + line_count - 1)

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -150,6 +150,15 @@ def main():
         help="print a diff instead of applying the changes",
     )
     p.add_argument(
+        "--diff_from_common_commit",
+        action="store_true",
+        help=(
+            "diff from the last common commit for commits in "
+            "separate branches rather than the exact point of the "
+            "commits"
+        ),
+    )
+    p.add_argument(
         "--diffstat",
         action="store_true",
         help="print a diffstat instead of applying the changes",
@@ -195,15 +204,6 @@ def main():
         action="count",
         default=0,
         help="print extra information",
-    )
-    p.add_argument(
-        "--diff_from_common_commit",
-        action="store_true",
-        help=(
-            "diff from the last common commit for commits in "
-            "separate branches rather than the exact point of the "
-            "commits"
-        ),
     )
     # We gather all the remaining positional arguments into 'args' since we need
     # to use some heuristics to determine whether or not <commit> was present.


### PR DESCRIPTION
This MR implements a fallback style option for the cases when no `.clang-format`  is available. 

I need a pipeline workflow where some repositories don't have a `.clang-format` file. I want to allow specifying a fallback style so that formatting can still run consistently in those cases.