### PR TITLE
[lldb] Remove Function null checks in Block.cpp

### DIFF
--- a/lldb/include/lldb/Symbol/Block.h
+++ b/lldb/include/lldb/Symbol/Block.h
@@ -78,6 +78,8 @@ public:
 
   Block *CalculateSymbolContextBlock() override;
 
+  Function &GetFunction();
+
   /// Check if an offset is in one of the block offset ranges.
   ///
   /// \param[in] range_offset


### PR DESCRIPTION
As of #117683, Blocks are always enclosed in a function, so these checks never fail. We can't change the signature of
`CalculateSymbolContextFunction` as it's an abstract function (and some of its implementations can return nullptr), but we can create a different function that we can call when we know we're dealing with a block.