### PR TITLE
[clangd] Add CodePatterns config option under Completion

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -457,6 +457,7 @@ void ClangdServer::codeComplete(PathRef File, Position Pos,
     CodeCompleteOpts.ArgumentLists = Config::current().Completion.ArgumentLists;
     CodeCompleteOpts.InsertIncludes =
         Config::current().Completion.HeaderInsertion;
+    CodeCompleteOpts.CodePatterns = Config::current().Completion.CodePatterns;
     // FIXME(ibiryukov): even if Preamble is non-null, we may want to check
     // both the old and the new version in case only one of them matches.
     CodeCompleteResult Result = clangd::codeComplete(

--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -926,7 +926,8 @@ struct CompletionRecorder : public CodeCompleteConsumer {
     // FIXME: in case there is no future sema completion callback after the
     // recovery mode, we might still want to provide some results (e.g. trivial
     // identifier-based completion).
-    if (Context.getKind() == CodeCompletionContext::CCC_Recovery) {
+    CodeCompletionContext::Kind ContextKind = Context.getKind();
+    if (ContextKind == CodeCompletionContext::CCC_Recovery) {
       log("Code complete: Ignoring sema code complete callback with Recovery "
           "context.");
       return;
@@ -952,7 +953,8 @@ struct CompletionRecorder : public CodeCompleteConsumer {
       auto &Result = InResults[I];
       if (Config::current().Completion.CodePatterns ==
               Config::CodePatternsPolicy::None &&
-          Result.Kind == CodeCompletionResult::RK_Pattern)
+          Result.Kind == CodeCompletionResult::RK_Pattern &&
+          ContextKind != CodeCompletionContext::CCC_IncludedFile)
         continue;
       // Class members that are shadowed by subclasses are usually noise.
       if (Result.Hidden && Result.Declaration &&

--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -950,6 +950,10 @@ struct CompletionRecorder : public CodeCompleteConsumer {
     // Retain the results we might want.
     for (unsigned I = 0; I < NumResults; ++I) {
       auto &Result = InResults[I];
+      if (Config::current().Completion.CodePatterns ==
+              Config::CodePatternsPolicy::None &&
+          Result.Kind == CodeCompletionResult::RK_Pattern)
+        continue;
       // Class members that are shadowed by subclasses are usually noise.
       if (Result.Hidden && Result.Declaration &&
           Result.Declaration->isCXXClassMember())
@@ -2153,7 +2157,8 @@ private:
 
 clang::CodeCompleteOptions CodeCompleteOptions::getClangCompleteOpts() const {
   clang::CodeCompleteOptions Result;
-  Result.IncludeCodePatterns = EnableSnippets;
+  Result.IncludeCodePatterns =
+      EnableSnippets && (CodePatterns != Config::CodePatternsPolicy::None);
   Result.IncludeMacros = true;
   Result.IncludeGlobals = true;
   // We choose to include full comments and not do doxygen parsing in

--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -954,6 +954,7 @@ struct CompletionRecorder : public CodeCompleteConsumer {
       if (Config::current().Completion.CodePatterns ==
               Config::CodePatternsPolicy::None &&
           Result.Kind == CodeCompletionResult::RK_Pattern &&
+          // keep allowing the include files autocomplete suggestions
           ContextKind != CodeCompletionContext::CCC_IncludedFile)
         continue;
       // Class members that are shadowed by subclasses are usually noise.

--- a/clang-tools-extra/clangd/CodeComplete.h
+++ b/clang-tools-extra/clangd/CodeComplete.h
@@ -111,6 +111,9 @@ struct CodeCompleteOptions {
   Config::ArgumentListsPolicy ArgumentLists =
       Config::ArgumentListsPolicy::FullPlaceholders;
 
+  /// Whether to suggest code patterns & snippets or not in completion
+  Config::CodePatternsPolicy CodePatterns = Config::CodePatternsPolicy::All;
+
   /// Whether to use the clang parser, or fallback to text-based completion
   /// (using identifiers in the current file and symbol indexes).
   enum CodeCompletionParse {

--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -152,6 +152,11 @@ struct Config {
     NeverInsert // Never insert headers as part of code completion
   };
 
+  enum class CodePatternsPolicy {
+    All, // Suggest all code patterns and snippets
+    None // Suggest none of the code patterns and snippets
+  };
+
   /// Configures code completion feature.
   struct {
     /// Whether code completion includes results that are not visible in current
@@ -161,6 +166,8 @@ struct Config {
     ArgumentListsPolicy ArgumentLists = ArgumentListsPolicy::FullPlaceholders;
     /// Controls if headers should be inserted when completions are accepted
     HeaderInsertionPolicy HeaderInsertion = HeaderInsertionPolicy::IWYU;
+    /// Enables code patterns & snippets suggestions
+    CodePatternsPolicy CodePatterns = CodePatternsPolicy::All;
   } Completion;
 
   /// Configures hover feature.

--- a/clang-tools-extra/clangd/ConfigCompile.cpp
+++ b/clang-tools-extra/clangd/ConfigCompile.cpp
@@ -707,6 +707,17 @@ struct FragmentCompiler {
           C.Completion.HeaderInsertion = *Val;
         });
     }
+
+    if (F.CodePatterns) {
+      if (auto Val = compileEnum<Config::CodePatternsPolicy>("CodePatterns",
+                                                             *F.CodePatterns)
+                         .map("All", Config::CodePatternsPolicy::All)
+                         .map("None", Config::CodePatternsPolicy::None)
+                         .value())
+        Out.Apply.push_back([Val](const Params &, Config &C) {
+          C.Completion.CodePatterns = *Val;
+        });
+    }
   }
 
   void compile(Fragment::HoverBlock &&F) {

--- a/clang-tools-extra/clangd/ConfigFragment.h
+++ b/clang-tools-extra/clangd/ConfigFragment.h
@@ -349,6 +349,12 @@ struct Fragment {
     ///     symbol is forward-declared
     ///   "Never": Never insert headers
     std::optional<Located<std::string>> HeaderInsertion;
+    /// Will suggest code patterns & snippets.
+    /// CLI option available '--code-patterns':
+    /// Values are Config::CodePatternsPolicy:
+    ///   all  => enable all code patterns and snippets suggestion
+    ///   none => disable all code patterns and snippets suggestion
+    std::optional<Located<std::string>> CodePatterns;
   };
   CompletionBlock Completion;
 

--- a/clang-tools-extra/clangd/ConfigFragment.h
+++ b/clang-tools-extra/clangd/ConfigFragment.h
@@ -351,8 +351,8 @@ struct Fragment {
     std::optional<Located<std::string>> HeaderInsertion;
     /// Will suggest code patterns & snippets.
     /// Values are Config::CodePatternsPolicy:
-    ///   all  => enable all code patterns and snippets suggestion
-    ///   none => disable all code patterns and snippets suggestion
+    ///   All  => enable all code patterns and snippets suggestion
+    ///   None => disable all code patterns and snippets suggestion
     std::optional<Located<std::string>> CodePatterns;
   };
   CompletionBlock Completion;

--- a/clang-tools-extra/clangd/ConfigFragment.h
+++ b/clang-tools-extra/clangd/ConfigFragment.h
@@ -350,7 +350,6 @@ struct Fragment {
     ///   "Never": Never insert headers
     std::optional<Located<std::string>> HeaderInsertion;
     /// Will suggest code patterns & snippets.
-    /// CLI option available '--code-patterns':
     /// Values are Config::CodePatternsPolicy:
     ///   all  => enable all code patterns and snippets suggestion
     ///   none => disable all code patterns and snippets suggestion

--- a/clang-tools-extra/clangd/ConfigYAML.cpp
+++ b/clang-tools-extra/clangd/ConfigYAML.cpp
@@ -249,6 +249,10 @@ private:
       if (auto HeaderInsertion = scalarValue(N, "HeaderInsertion"))
         F.HeaderInsertion = *HeaderInsertion;
     });
+    Dict.handle("CodePatterns", [&](Node &N) {
+      if (auto CodePatterns = scalarValue(N, "CodePatterns"))
+        F.CodePatterns = *CodePatterns;
+    });
     Dict.parse(N);
   }
 

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -267,17 +267,6 @@ opt<Config::HeaderInsertionPolicy> HeaderInsertion{
             "Never insert #include directives as part of code completion")),
 };
 
-opt<Config::CodePatternsPolicy> CodePatterns{
-    "code-patterns",
-    cat(Features),
-    desc("Code completion menu will suggest code patterns and snippets."),
-    init(CodeCompleteOptions().CodePatterns),
-    values(clEnumValN(Config::CodePatternsPolicy::All, "all",
-                      "Enable all code patterns and snippets."),
-           clEnumValN(Config::CodePatternsPolicy::None, "none",
-                      "Disable all code patterns and snippets.")),
-};
-
 opt<bool> ImportInsertions{
     "import-insertions",
     cat(Features),
@@ -680,7 +669,6 @@ public:
     std::optional<Config::BackgroundPolicy> BGPolicy;
     std::optional<Config::ArgumentListsPolicy> ArgumentLists;
     std::optional<Config::HeaderInsertionPolicy> HeaderInsertionPolicy;
-    std::optional<Config::CodePatternsPolicy> CodePatternsPolicy;
 
     // If --compile-commands-dir arg was invoked, check value and override
     // default path.
@@ -735,10 +723,6 @@ public:
                               : Config::ArgumentListsPolicy::Delimiters;
     }
 
-    if (CodePatterns == Config::CodePatternsPolicy::None) {
-      CodePatternsPolicy = Config::CodePatternsPolicy::None;
-    }
-
     Frag = [=](const config::Params &, Config &C) {
       if (CDBSearch)
         C.CompileFlags.CDBSearch = *CDBSearch;
@@ -752,8 +736,6 @@ public:
         C.Completion.HeaderInsertion = *HeaderInsertionPolicy;
       if (AllScopesCompletion.getNumOccurrences())
         C.Completion.AllScopes = AllScopesCompletion;
-      if (CodePatternsPolicy)
-        C.Completion.CodePatterns = *CodePatternsPolicy;
 
       if (Test)
         C.Index.StandardLibrary = false;
@@ -967,7 +949,6 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
     Opts.CodeComplete.BundleOverloads = CompletionStyle != Detailed;
   Opts.CodeComplete.ShowOrigins = ShowOrigins;
   Opts.CodeComplete.InsertIncludes = HeaderInsertion;
-  Opts.CodeComplete.CodePatterns = CodePatterns;
   Opts.CodeComplete.ImportInsertions = ImportInsertions;
   if (!HeaderInsertionDecorators) {
     Opts.CodeComplete.IncludeIndicator.Insert.clear();

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -3326,6 +3326,24 @@ TEST(CompletionTest, AllScopesCompletion) {
                                  kind(CompletionItemKind::EnumMember))));
 }
 
+TEST(CompletionTest, NoCodePatternsIfDisabled) {
+  clangd::CodeCompleteOptions Opts = {};
+  Opts.EnableSnippets = true;
+  Opts.CodePatterns = Config::CodePatternsPolicy::None;
+
+  auto Results = completions(R"cpp(
+    void function() {
+      /// Trying to trigger "for (init-statement; condition; inc-expression)
+      /// {statements}~" code pattern
+      for^
+    }
+  )cpp",
+                             {}, Opts);
+
+  EXPECT_THAT(Results.Completions,
+              Not(Contains(kind(CompletionItemKind::Snippet))));
+}
+
 TEST(CompletionTest, NoQualifierIfShadowed) {
   clangd::CodeCompleteOptions Opts = {};
   Opts.AllScopes = true;

--- a/clang-tools-extra/clangd/unittests/ConfigYAMLTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ConfigYAMLTests.cpp
@@ -217,6 +217,19 @@ Completion:
   EXPECT_THAT(Results[0].Completion.AllScopes, testing::Eq(std::nullopt));
 }
 
+TEST(ParseYAML, CodePatterns) {
+  CapturedDiags Diags;
+  Annotations YAML(R"yaml(
+    Completion:
+      CodePatterns: None
+  )yaml");
+  auto Results =
+      Fragment::parseYAML(YAML.code(), "config.yaml", Diags.callback());
+  ASSERT_THAT(Diags.Diagnostics, IsEmpty());
+  ASSERT_EQ(Results.size(), 1u);
+  EXPECT_THAT(Results[0].Completion.CodePatterns, llvm::ValueIs(val("None")));
+}
+
 TEST(ParseYAML, ShowAKA) {
   CapturedDiags Diags;
   Annotations YAML(R"yaml(


### PR DESCRIPTION
Allows enabling/disabling code patterns & snippets suggestion from completion.
This can be done either with YAML config or CLI with --code-patterns

You can refer to this discussion for more context: https://github.com/clangd/clangd/discussions/1867