### PR TITLE
clang-format: Add -disable-format option

### DIFF
--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -58,6 +58,8 @@ to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.
                                        Verilog: .sv .svh .v .vh
     --cursor=<uint>                - The position of the cursor when invoking
                                      clang-format from an editor integration
+    --disable-format               - If set, only sort includes if include sorting
+                                     is enabled
     --dry-run                      - If set, do not actually make the formatting changes
     --dump-config                  - Dump configuration options to stdout and exit.
                                      Can be used with -style option.

--- a/clang/test/Format/disable-format-enable-include-sorting.cpp
+++ b/clang/test/Format/disable-format-enable-include-sorting.cpp
@@ -1,0 +1,9 @@
+// RUN: clang-format %s -sort-includes -style=LLVM -disable-format | FileCheck %s
+
+#include <b>
+#include <a>
+// CHECK: <a>
+// CHECK-NEXT: <b>
+
+// CHECK: int *a  ;
+int *a  ;


### PR DESCRIPTION
When https://github.com/llvm/llvm-project/issues/27416 was fixed it became impossible to only use clang-format for include sorting. Let's introduce an option -disable-format to make it possible again to only sort includes with clang-format without doing any other formatting.