### PR TITLE
[ObjectiveC] -rewrite-objc was treating inputs as preprocessed files

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -521,7 +521,7 @@ static void addDashXForInput(const ArgList &Args, const InputInfo &Input,
 
   CmdArgs.push_back("-x");
   if (Args.hasArg(options::OPT_rewrite_objc))
-    CmdArgs.push_back(types::getTypeName(types::TY_PP_ObjCXX));
+    CmdArgs.push_back(types::getTypeName(types::TY_ObjCXX));
   else {
     // Map the driver type to the frontend type. This is mostly an identity
     // mapping, except that the distinction between module interface units

--- a/clang/test/Driver/rewrite-objc-preproc.m
+++ b/clang/test/Driver/rewrite-objc-preproc.m
@@ -1,0 +1,5 @@
+// RUN: %clang --target=x86_64-apple-macosx10.7.0 -rewrite-objc %s -o - -### 2>&1 | \
+// RUN:   FileCheck %s
+//
+// Check that we're running a preprocessing stage passing a preprocessed file as input
+// CHECK: "-E"{{.*}}"-x"{{.*}}cpp-output

--- a/clang/test/Driver/rewrite-objc-preproc.m
+++ b/clang/test/Driver/rewrite-objc-preproc.m
@@ -1,5 +1,5 @@
 // RUN: %clang --target=x86_64-apple-macosx10.7.0 -rewrite-objc %s -o - -### 2>&1 | \
 // RUN:   FileCheck %s
 //
-// Check that we're running a preprocessing stage passing a preprocessed file as input
-// CHECK: "-E"{{.*}}"-x"{{.*}}cpp-output
+// Check that we're running a preprocessing stage passing a not-preprocessed objective-c++ file as input
+// CHECK: "-E"{{.*}}"-x" "objective-c++"


### PR DESCRIPTION
`-rewrite-objc` passes `-x objective-c++-cpp-output` as input type to the preprocessor job. This is not correct since we would be preprocessing a preprocessed file. The correct input type is `objective-c++`. 