### PR TITLE
[AArch64] Utilize `XAR` for certain vector rotates

### DIFF
--- a/llvm/test/CodeGen/AArch64/sve2-xar.ll
+++ b/llvm/test/CodeGen/AArch64/sve2-xar.ll
@@ -169,17 +169,84 @@ define <vscale x 2 x i64> @xar_nxv2i64_l_neg1(<vscale x 2 x i64> %x, <vscale x 2
 
 ; OR instead of an XOR.
 ; TODO: We could use usra instruction here for SVE2.
-define <vscale x 2 x i64> @xar_nxv2i64_l_neg2(<vscale x 2 x i64> %x, <vscale x 2 x i64> %y) {
-; CHECK-LABEL: xar_nxv2i64_l_neg2:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
-; CHECK-NEXT:    lsr z1.d, z0.d, #4
-; CHECK-NEXT:    lsl z0.d, z0.d, #60
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
-; CHECK-NEXT:    ret
+define <vscale x 2 x i64> @xar_nxv2i64_l_neg2_1(<vscale x 2 x i64> %x, <vscale x 2 x i64> %y) {
+; SVE-LABEL: xar_nxv2i64_l_neg2_1:
+; SVE:       // %bb.0:
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    lsr z1.d, z0.d, #4
+; SVE-NEXT:    lsl z0.d, z0.d, #60
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    ret
+;
+; SVE2-LABEL: xar_nxv2i64_l_neg2_1:
+; SVE2:       // %bb.0:
+; SVE2-NEXT:    movi v2.2d, #0000000000000000
+; SVE2-NEXT:    orr z0.d, z0.d, z1.d
+; SVE2-NEXT:    xar z0.d, z0.d, z2.d, #4
+; SVE2-NEXT:    ret
     %a = or <vscale x 2 x i64> %x, %y
     %b = call <vscale x 2 x i64> @llvm.fshl.nxv2i64(<vscale x 2 x i64> %a, <vscale x 2 x i64> %a, <vscale x 2 x i64> splat (i64 60))
     ret <vscale x 2 x i64> %b
+}
+
+define <vscale x 4 x i32> @xar_nxv2i32_l_neg2_2(<vscale x 4 x i32> %x, <vscale x 4 x i32> %y) {
+; SVE-LABEL: xar_nxv2i32_l_neg2_2:
+; SVE:       // %bb.0:
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    lsr z1.s, z0.s, #4
+; SVE-NEXT:    lsl z0.s, z0.s, #28
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    ret
+;
+; SVE2-LABEL: xar_nxv2i32_l_neg2_2:
+; SVE2:       // %bb.0:
+; SVE2-NEXT:    movi v2.2d, #0000000000000000
+; SVE2-NEXT:    orr z0.d, z0.d, z1.d
+; SVE2-NEXT:    xar z0.s, z0.s, z2.s, #4
+; SVE2-NEXT:    ret
+    %a = or <vscale x 4 x i32> %x, %y
+    %b = call <vscale x 4 x i32> @llvm.fshl.nxv4i32(<vscale x 4 x i32> %a, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat (i32 60))
+    ret <vscale x 4 x i32> %b
+}
+
+define <vscale x 8 x i16> @xar_nxv2i16_l_neg2_3(<vscale x 8 x i16> %x, <vscale x 8 x i16> %y) {
+; SVE-LABEL: xar_nxv2i16_l_neg2_3:
+; SVE:       // %bb.0:
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    lsr z1.h, z0.h, #4
+; SVE-NEXT:    lsl z0.h, z0.h, #12
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    ret
+;
+; SVE2-LABEL: xar_nxv2i16_l_neg2_3:
+; SVE2:       // %bb.0:
+; SVE2-NEXT:    movi v2.2d, #0000000000000000
+; SVE2-NEXT:    orr z0.d, z0.d, z1.d
+; SVE2-NEXT:    xar z0.h, z0.h, z2.h, #4
+; SVE2-NEXT:    ret
+    %a = or <vscale x 8 x i16> %x, %y
+    %b = call <vscale x 8 x i16> @llvm.fshl.nxv8i16(<vscale x 8 x i16> %a, <vscale x 8 x i16> %a, <vscale x 8 x i16> splat (i16 60))
+    ret <vscale x 8 x i16> %b
+}
+
+define <vscale x 16 x i8> @xar_nxv2i8_l_neg2_4(<vscale x 16 x i8> %x, <vscale x 16 x i8> %y) {
+; SVE-LABEL: xar_nxv2i8_l_neg2_4:
+; SVE:       // %bb.0:
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    lsr z1.b, z0.b, #4
+; SVE-NEXT:    lsl z0.b, z0.b, #4
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    ret
+;
+; SVE2-LABEL: xar_nxv2i8_l_neg2_4:
+; SVE2:       // %bb.0:
+; SVE2-NEXT:    movi v2.2d, #0000000000000000
+; SVE2-NEXT:    orr z0.d, z0.d, z1.d
+; SVE2-NEXT:    xar z0.b, z0.b, z2.b, #4
+; SVE2-NEXT:    ret
+    %a = or <vscale x 16 x i8> %x, %y
+    %b = call <vscale x 16 x i8> @llvm.fshl.nxv16i8(<vscale x 16 x i8> %a, <vscale x 16 x i8> %a, <vscale x 16 x i8> splat (i8 60))
+    ret <vscale x 16 x i8> %b
 }
 
 ; Rotate amount is 0.

--- a/llvm/test/CodeGen/AArch64/xar.ll
+++ b/llvm/test/CodeGen/AArch64/xar.ll
@@ -19,4 +19,82 @@ define <2 x i64> @xar(<2 x i64> %x, <2 x i64> %y) {
     ret <2 x i64> %b
 }
 
+define <2 x i64> @xar_instead_of_or1(<2 x i64> %r) {
+; SHA3-LABEL: xar_instead_of_or1:
+; SHA3:       // %bb.0: // %entry
+; SHA3-NEXT:    movi v1.2d, #0000000000000000
+; SHA3-NEXT:    xar v0.2d, v0.2d, v1.2d, #39
+; SHA3-NEXT:    ret
+;
+; NOSHA3-LABEL: xar_instead_of_or1:
+; NOSHA3:       // %bb.0: // %entry
+; NOSHA3-NEXT:    shl v1.2d, v0.2d, #25
+; NOSHA3-NEXT:    usra v1.2d, v0.2d, #39
+; NOSHA3-NEXT:    mov v0.16b, v1.16b
+; NOSHA3-NEXT:    ret
+entry:
+  %or = call <2 x i64> @llvm.fshl.v2i64(<2 x i64> %r, <2 x i64> %r, <2 x i64> splat (i64 25))
+  ret <2 x i64> %or
+}
+
+define <4 x i32> @xar_instead_of_or2(<4 x i32> %r) {
+; SHA3-LABEL: xar_instead_of_or2:
+; SHA3:       // %bb.0: // %entry
+; SHA3-NEXT:    shl v1.4s, v0.4s, #25
+; SHA3-NEXT:    usra v1.4s, v0.4s, #7
+; SHA3-NEXT:    mov v0.16b, v1.16b
+; SHA3-NEXT:    ret
+;
+; NOSHA3-LABEL: xar_instead_of_or2:
+; NOSHA3:       // %bb.0: // %entry
+; NOSHA3-NEXT:    shl v1.4s, v0.4s, #25
+; NOSHA3-NEXT:    usra v1.4s, v0.4s, #7
+; NOSHA3-NEXT:    mov v0.16b, v1.16b
+; NOSHA3-NEXT:    ret
+entry:
+  %or = call <4 x i32> @llvm.fshl.v2i32(<4 x i32> %r, <4 x i32> %r, <4 x i32> splat (i32 25))
+  ret <4 x i32> %or
+}
+
+define <8 x i16> @xar_instead_of_or3(<8 x i16> %r) {
+; SHA3-LABEL: xar_instead_of_or3:
+; SHA3:       // %bb.0: // %entry
+; SHA3-NEXT:    shl v1.8h, v0.8h, #9
+; SHA3-NEXT:    usra v1.8h, v0.8h, #7
+; SHA3-NEXT:    mov v0.16b, v1.16b
+; SHA3-NEXT:    ret
+;
+; NOSHA3-LABEL: xar_instead_of_or3:
+; NOSHA3:       // %bb.0: // %entry
+; NOSHA3-NEXT:    shl v1.8h, v0.8h, #9
+; NOSHA3-NEXT:    usra v1.8h, v0.8h, #7
+; NOSHA3-NEXT:    mov v0.16b, v1.16b
+; NOSHA3-NEXT:    ret
+entry:
+  %or = call <8 x i16> @llvm.fshl.v2i16(<8 x i16> %r, <8 x i16> %r, <8 x i16> splat (i16 25))
+  ret <8 x i16> %or
+}
+
+define <16 x i8> @xar_instead_of_or4(<16 x i8> %r) {
+; SHA3-LABEL: xar_instead_of_or4:
+; SHA3:       // %bb.0: // %entry
+; SHA3-NEXT:    add v1.16b, v0.16b, v0.16b
+; SHA3-NEXT:    usra v1.16b, v0.16b, #7
+; SHA3-NEXT:    mov v0.16b, v1.16b
+; SHA3-NEXT:    ret
+;
+; NOSHA3-LABEL: xar_instead_of_or4:
+; NOSHA3:       // %bb.0: // %entry
+; NOSHA3-NEXT:    add v1.16b, v0.16b, v0.16b
+; NOSHA3-NEXT:    usra v1.16b, v0.16b, #7
+; NOSHA3-NEXT:    mov v0.16b, v1.16b
+; NOSHA3-NEXT:    ret
+entry:
+  %or = call <16 x i8> @llvm.fshl.v2i8(<16 x i8> %r, <16 x i8> %r, <16 x i8> splat (i8 25))
+  ret <16 x i8> %or
+}
+
 declare <2 x i64> @llvm.fshl.v2i64(<2 x i64>, <2 x i64>, <2 x i64>)
+declare <4 x i32> @llvm.fshl.v4i32(<4 x i32>, <4 x i32>, <4 x i32>)
+declare <8 x i16> @llvm.fshl.v8i16(<8 x i16>, <8 x i16>, <8 x i16>)
+declare <16 x i8> @llvm.fshl.v16i8(<16 x i8>, <16 x i8>, <16 x i8>)


### PR DESCRIPTION
Resolves #137162

For cases when there isn't any `XOR` in the transformation, replace with a zero register.