### PR TITLE
[VPlan] Use correct non-FMF constructor in VPInstructionWithType createNaryOp

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -177,8 +177,11 @@ public:
                               Type *ResultTy,
                               std::optional<FastMathFlags> FMFs = {},
                               DebugLoc DL = {}, const Twine &Name = "") {
-    return tryInsertInstruction(new VPInstructionWithType(
-        Opcode, Operands, ResultTy, FMFs.value_or(FastMathFlags()), DL, Name));
+    if (FMFs)
+      return tryInsertInstruction(new VPInstructionWithType(
+          Opcode, Operands, ResultTy, *FMFs, DL, Name));
+    return tryInsertInstruction(
+        new VPInstructionWithType(Opcode, Operands, ResultTy, DL, Name));
   }
 
   VPInstruction *createOverflowingOp(unsigned Opcode,


### PR DESCRIPTION
Currently if we try to create a VPInstructionWithType without a FMF via VPBuilder::createNaryOp we will use the constructor that asserts `assert(isFPMathOp() && "this op can't take fast-math flags");`.

This fixes it by checking if FMFs have a value, similar to the other createNaryOp overloads.

This is needed by #129508
