### PR TITLE
[SPIRV] Fix test with VK1.3 validation

### DIFF
--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll
@@ -1,9 +1,6 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
-; TODO(#136344): This test currently fails when --target-env vulkan1.3 is specified.
-; XFAIL: spirv-tools
-
 ; CHECK-DAG:        %[[#int:]] = OpTypeInt 32 0
 ; CHECK-DAG:        %[[#ptr_Input_int:]] = OpTypePointer Input %[[#int]]
 ; CHECK-DAG:        %[[#LocalInvocationIndex:]] = OpVariable %[[#ptr_Input_int]] Input
@@ -14,7 +11,10 @@
 
 target triple = "spirv-unknown-vulkan-library"
 
-declare void @local_index_user(i32)
+define internal void @local_index_user(i32) {
+entry:
+  ret void
+}
 
 ; Function Attrs: convergent noinline norecurse
 define void @main() #1 {

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/SV_GroupIndex.ll
@@ -1,5 +1,5 @@
-; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-vulkan1.3-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan1.3-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-DAG:        %[[#int:]] = OpTypeInt 32 0
 ; CHECK-DAG:        %[[#ptr_Input_int:]] = OpTypePointer Input %[[#int]]

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll
@@ -1,9 +1,6 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
-; TODO(#136344): This test currently fails when --target-env vulkan1.3 is specified.
-; XFAIL: spirv-tools
-
 ; Make sure SPIRV operation function calls for smoothstep are lowered correctly.
 
 ; CHECK-DAG: %[[#op_ext_glsl:]] = OpExtInstImport "GLSL.std.450"
@@ -12,7 +9,7 @@
 ; CHECK-DAG: %[[#float_32:]] = OpTypeFloat 32
 ; CHECK-DAG: %[[#vec4_float_32:]] = OpTypeVector %[[#float_32]] 4
 
-define noundef half @smoothstep_half(half noundef %a, half noundef %b, half noundef %c) {
+define internal noundef half @smoothstep_half(half noundef %a, half noundef %b, half noundef %c) {
 entry:
   ; CHECK: %[[#]] = OpFunction %[[#float_16]] None %[[#]]
   ; CHECK: %[[#arg0:]] = OpFunctionParameter %[[#float_16]]
@@ -23,7 +20,7 @@ entry:
   ret half %spv.smoothstep
 }
 
-define noundef float @smoothstep_float(float noundef %a, float noundef %b, float noundef %c) {
+define internal noundef float @smoothstep_float(float noundef %a, float noundef %b, float noundef %c) {
 entry:
   ; CHECK: %[[#]] = OpFunction %[[#float_32]] None %[[#]]
   ; CHECK: %[[#arg0:]] = OpFunctionParameter %[[#float_32]]
@@ -34,7 +31,7 @@ entry:
   ret float %spv.smoothstep
 }
 
-define noundef <4 x half> @smoothstep_half4(<4 x half> noundef %a, <4 x half> noundef %b, <4 x half> noundef %c) {
+define internal noundef <4 x half> @smoothstep_half4(<4 x half> noundef %a, <4 x half> noundef %b, <4 x half> noundef %c) {
 entry:
   ; CHECK: %[[#]] = OpFunction %[[#vec4_float_16]] None %[[#]]
   ; CHECK: %[[#arg0:]] = OpFunctionParameter %[[#vec4_float_16]]
@@ -45,7 +42,7 @@ entry:
   ret <4 x half> %spv.smoothstep
 }
 
-define noundef <4 x float> @smoothstep_float4(<4 x float> noundef %a, <4 x float> noundef %b, <4 x float> noundef %c) {
+define internal noundef <4 x float> @smoothstep_float4(<4 x float> noundef %a, <4 x float> noundef %b, <4 x float> noundef %c) {
 entry:
   ; CHECK: %[[#]] = OpFunction %[[#vec4_float_32]] None %[[#]]
   ; CHECK: %[[#arg0:]] = OpFunctionParameter %[[#vec4_float_32]]
@@ -56,8 +53,16 @@ entry:
   ret <4 x float> %spv.smoothstep
 }
 
+; The other fucntions are the test, but a entry point is required to have a valid SPIR-V module.
+define void @main() #1 {
+entry:
+  ret void
+}
+
 declare half @llvm.spv.smoothstep.f16(half, half, half)
 declare float @llvm.spv.smoothstep.f32(float, float, float)
 
 declare <4 x half> @llvm.spv.smoothstep.v4f16(<4 x half>, <4 x half>, <4 x half>)
 declare <4 x float> @llvm.spv.smoothstep.v4f32(<4 x float>, <4 x float>, <4 x float>)
+
+attributes #1 = { convergent noinline norecurse "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/smoothstep.ll
@@ -1,5 +1,5 @@
-; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-vulkan1.3-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan1.3-unknown %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; Make sure SPIRV operation function calls for smoothstep are lowered correctly.
 


### PR DESCRIPTION
An update to the spirv validator is now correctly rejecting vulkan
shaders with the linkage capability. We have a couple tests that need
updating to remove the capability.

Fixes https://github.com/llvm/llvm-project/issues/136344
