### PR TITLE
[SelectionDAG] Fix incorrect fold condition in foldSetCCWithFunnelShift.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -4462,11 +4462,14 @@ static SDValue foldSetCCWithFunnelShift(EVT VT, SDValue N0, SDValue N1,
 
   unsigned BitWidth = N0.getScalarValueSizeInBits();
   auto *ShAmtC = isConstOrConstSplat(N0.getOperand(2));
-  if (!ShAmtC || ShAmtC->getAPIntValue().uge(BitWidth))
+  if (!ShAmtC)
+    return SDValue();
+
+  uint64_t ShAmt = ShAmtC->getAPIntValue().urem(BitWidth);
+  if (ShAmt == 0)
     return SDValue();
 
   // Canonicalize fshr as fshl to reduce pattern-matching.
-  unsigned ShAmt = ShAmtC->getZExtValue();
   if (N0.getOpcode() == ISD::FSHR)
     ShAmt = BitWidth - ShAmt;
 

--- a/llvm/test/CodeGen/AArch64/setcc-fsh.ll
+++ b/llvm/test/CodeGen/AArch64/setcc-fsh.ll
@@ -252,7 +252,8 @@ define i1 @fshl_or_ne_2(i32 %x, i32 %y) {
 define i1 @fshr_0_or_eq_0(i16 %x, i16 %y) {
 ; CHECK-LABEL: fshr_0_or_eq_0:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w0, wzr
+; CHECK-NEXT:    tst w0, #0xffff
+; CHECK-NEXT:    cset w0, eq
 ; CHECK-NEXT:    ret
   %or = or i16 %x, %y
   %f = call i16 @llvm.fshr.i16(i16 %or, i16 %x, i16 0)
@@ -261,7 +262,7 @@ define i1 @fshr_0_or_eq_0(i16 %x, i16 %y) {
 }
 
 define i1 @fshr_32_or_eq_0(i16 %x, i16 %y) {
-; CHECK-LABEL: fshr_16_or_eq_0:
+; CHECK-LABEL: fshr_32_or_eq_0:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    tst w0, #0xffff
 ; CHECK-NEXT:    cset w0, eq

--- a/llvm/test/CodeGen/AArch64/setcc-fsh.ll
+++ b/llvm/test/CodeGen/AArch64/setcc-fsh.ll
@@ -248,3 +248,26 @@ define i1 @fshl_or_ne_2(i32 %x, i32 %y) {
   %r = icmp ne i32 %f, 2
   ret i1 %r
 }
+
+define i1 @fshr_0_or_eq_0(i16 %x, i16 %y) {
+; CHECK-LABEL: fshr_0_or_eq_0:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov w0, wzr
+; CHECK-NEXT:    ret
+  %or = or i16 %x, %y
+  %f = call i16 @llvm.fshr.i16(i16 %or, i16 %x, i16 0)
+  %r = icmp eq i16 %f, 0
+  ret i1 %r
+}
+
+define i1 @fshr_32_or_eq_0(i16 %x, i16 %y) {
+; CHECK-LABEL: fshr_16_or_eq_0:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    tst w0, #0xffff
+; CHECK-NEXT:    cset w0, eq
+; CHECK-NEXT:    ret
+  %or = or i16 %x, %y
+  %f = call i16 @llvm.fshr.i16(i16 %or, i16 %x, i16 32)
+  %r = icmp eq i16 %f, 0
+  ret i1 %r
+}


### PR DESCRIPTION
Proposed by [2ed1598](https://github.com/llvm/llvm-project/commit/2ed15984b49a1af87be37ec8bd6ee3ab7f724767):

`fshl X, (or X, Y), C ==/!= 0 --> or (srl Y, BW-C), X ==/!= 0`

This transformation is valid when (C%Bitwidth) != 0 , as verified by [Alive2](https://alive2.llvm.org/ce/z/TQYM-m).

Fixes #136746 