### PR TITLE
[builtins][AArch32] Fix __gnu_* functions

### DIFF
--- a/compiler-rt/lib/builtins/extendhfsf2.c
+++ b/compiler-rt/lib/builtins/extendhfsf2.c
@@ -24,4 +24,5 @@ AEABI_RTABI float __aeabi_h2f(src_t a) { return __extendhfsf2(a); }
 COMPILER_RT_ALIAS(__extendhfsf2, __gnu_h2f_ieee)
 COMPILER_RT_ALIAS(__extendhfsf2, __aeabi_h2f)
 #endif
+COMPILER_RT_ABI float __gnu_h2f_ieee(src_t a) { return __extendhfsf2(a); }
 #endif

--- a/compiler-rt/lib/builtins/extendhfsf2.c
+++ b/compiler-rt/lib/builtins/extendhfsf2.c
@@ -24,5 +24,6 @@ AEABI_RTABI float __aeabi_h2f(src_t a) { return __extendhfsf2(a); }
 COMPILER_RT_ALIAS(__extendhfsf2, __gnu_h2f_ieee)
 COMPILER_RT_ALIAS(__extendhfsf2, __aeabi_h2f)
 #endif
+#else
 COMPILER_RT_ABI float __gnu_h2f_ieee(src_t a) { return __extendhfsf2(a); }
 #endif

--- a/compiler-rt/lib/builtins/extendhfsf2.c
+++ b/compiler-rt/lib/builtins/extendhfsf2.c
@@ -16,12 +16,12 @@ COMPILER_RT_ABI NOINLINE float __extendhfsf2(src_t a) {
   return __extendXfYf2__(a);
 }
 
-COMPILER_RT_ABI float __gnu_h2f_ieee(src_t a) { return __extendhfsf2(a); }
-
 #if defined(__ARM_EABI__)
 #if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI float __gnu_h2f_ieee(src_t a) { return __extendhfsf2(a); }
 AEABI_RTABI float __aeabi_h2f(src_t a) { return __extendhfsf2(a); }
 #else
+COMPILER_RT_ALIAS(__extendhfsf2, __gnu_h2f_ieee)
 COMPILER_RT_ALIAS(__extendhfsf2, __aeabi_h2f)
 #endif
 #endif

--- a/compiler-rt/lib/builtins/truncsfhf2.c
+++ b/compiler-rt/lib/builtins/truncsfhf2.c
@@ -25,4 +25,5 @@ AEABI_RTABI dst_t __aeabi_f2h(float a) { return __truncsfhf2(a); }
 COMPILER_RT_ALIAS(__truncsfhf2, __gnu_f2h_ieee)
 COMPILER_RT_ALIAS(__truncsfhf2, __aeabi_f2h)
 #endif
+COMPILER_RT_ABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
 #endif

--- a/compiler-rt/lib/builtins/truncsfhf2.c
+++ b/compiler-rt/lib/builtins/truncsfhf2.c
@@ -25,5 +25,6 @@ AEABI_RTABI dst_t __aeabi_f2h(float a) { return __truncsfhf2(a); }
 COMPILER_RT_ALIAS(__truncsfhf2, __gnu_f2h_ieee)
 COMPILER_RT_ALIAS(__truncsfhf2, __aeabi_f2h)
 #endif
+#else
 COMPILER_RT_ABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
 #endif

--- a/compiler-rt/lib/builtins/truncsfhf2.c
+++ b/compiler-rt/lib/builtins/truncsfhf2.c
@@ -16,7 +16,6 @@ COMPILER_RT_ABI NOINLINE dst_t __truncsfhf2(float a) {
   return __truncXfYf2__(a);
 }
 
-
 #if defined(__ARM_EABI__)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 AEABI_RTABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }

--- a/compiler-rt/lib/builtins/truncsfhf2.c
+++ b/compiler-rt/lib/builtins/truncsfhf2.c
@@ -16,12 +16,13 @@ COMPILER_RT_ABI NOINLINE dst_t __truncsfhf2(float a) {
   return __truncXfYf2__(a);
 }
 
-COMPILER_RT_ABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
 
 #if defined(__ARM_EABI__)
 #if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
 AEABI_RTABI dst_t __aeabi_f2h(float a) { return __truncsfhf2(a); }
 #else
+COMPILER_RT_ALIAS(__truncsfhf2, __gnu_f2h_ieee)
 COMPILER_RT_ALIAS(__truncsfhf2, __aeabi_f2h)
 #endif
 #endif


### PR DESCRIPTION
Move to a consistent calling convention for both Clang/GNU such that they can be linked with each other.

All ARM targets now use the soft-float calling convention for `__gnu_h2f_ieee` and `__gnu_f2h_ieee`, as described in https://github.com/ARM-software/abi-aa/blob/main/rtabi32/rtabi32.rst#the-floating-point-helper-functions.