### PR TITLE
[clang][bytecode] Check live-ness when calling dtors

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1375,6 +1375,9 @@ static bool checkConstructor(InterpState &S, CodePtr OpPC, const Function *Func,
 }
 
 bool CheckDestructor(InterpState &S, CodePtr OpPC, const Pointer &Ptr) {
+  if (!CheckLive(S, OpPC, Ptr, AK_Destroy))
+    return false;
+
   // Can't call a dtor on a global variable.
   if (Ptr.block()->isStatic()) {
     const SourceInfo &E = S.Current->getSource(OpPC);

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -1819,3 +1819,14 @@ namespace GlobalDtor {
     a.~A(); // both-note {{cannot modify an object that is visible outside}}
   }
 }
+
+namespace NullDtor {
+  struct S {};
+  constexpr int foo() { // both-error {{never produces a constant expression}}
+     S *s = nullptr;
+     s->~S(); // both-note 2{{destruction of dereferenced null pointer is not allowed in a constant expression}}
+     return 10;
+  }
+  static_assert(foo() == 10, ""); // both-error {{not an integral constant expression}} \
+                                  // both-note {{in call to}}
+}


### PR DESCRIPTION
We can't call a destructor on a dead pointer.