### PR TITLE
[LLD][COFF] Add support for including native ARM64 objects in ARM64EC images

### DIFF
--- a/lld/COFF/COFFLinkerContext.h
+++ b/lld/COFF/COFFLinkerContext.h
@@ -50,6 +50,14 @@ public:
     f(symtab);
   }
 
+  // Invoke the specified callback for each active symbol table,
+  // skipping the native symbol table on pure ARM64EC targets.
+  void forEachActiveSymtab(std::function<void(SymbolTable &symtab)> f) {
+    if (symtab.ctx.config.machine == ARM64X)
+      f(*hybridSymtab);
+    f(symtab);
+  }
+
   std::vector<ObjFile *> objFileInstances;
   std::map<std::string, PDBInputFile *> pdbInputFileInstances;
   std::vector<ImportFile *> importFileInstances;

--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -580,7 +580,7 @@ void SectionChunk::getBaserels(std::vector<Baserel> *res) {
   // to match the value in the EC load config, which is expected to be
   // a relocatable pointer to the __chpe_metadata symbol.
   COFFLinkerContext &ctx = file->symtab.ctx;
-  if (ctx.hybridSymtab && ctx.hybridSymtab->loadConfigSym &&
+  if (ctx.config.machine == ARM64X && ctx.hybridSymtab->loadConfigSym &&
       ctx.hybridSymtab->loadConfigSym->getChunk() == this &&
       ctx.symtab.loadConfigSym &&
       ctx.hybridSymtab->loadConfigSize >=

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -659,6 +659,10 @@ void LinkerDriver::setMachine(MachineTypes machine) {
   if (!isArm64EC(machine)) {
     ctx.symtab.machine = machine;
   } else {
+    // Set up a hybrid symbol table on ARM64EC/ARM64X. This is primarily useful
+    // on ARM64X, where both the native and EC symbol tables are meaningful.
+    // However, since ARM64EC can include native object files, we also need to
+    // support a hybrid symbol table there.
     ctx.symtab.machine = ARM64EC;
     ctx.hybridSymtab.emplace(ctx, ARM64);
   }
@@ -2551,6 +2555,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
           for (auto *s : lto::LTO::getRuntimeLibcallSymbols(TT))
             symtab.addLibcall(s);
         }
+
         // Windows specific -- if __load_config_used can be resolved, resolve
         // it.
         if (symtab.findUnderscore("_load_config_used"))

--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -137,10 +137,8 @@ void ArchiveFile::parse() {
         ctx.symtab.addLazyArchive(this, sym);
 
       // Read both EC and native symbols on ARM64X.
-      if (!ctx.hybridSymtab)
-        return;
       archiveSymtab = &*ctx.hybridSymtab;
-    } else if (ctx.hybridSymtab) {
+    } else {
       // If the ECSYMBOLS section is missing in the archive, the archive could
       // be either a native-only ARM64 or x86_64 archive. Check the machine type
       // of the object containing a symbol to determine which symbol table to

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -551,7 +551,7 @@ void SymbolTable::initializeLoadConfig() {
       Warn(ctx) << "EC version of '_load_config_used' is missing";
       return;
     }
-    if (ctx.hybridSymtab) {
+    if (ctx.config.machine == ARM64X) {
       Warn(ctx) << "native version of '_load_config_used' is missing for "
                    "ARM64X target";
       return;

--- a/lld/test/COFF/arm64ec-entry-mangle.test
+++ b/lld/test/COFF/arm64ec-entry-mangle.test
@@ -97,7 +97,7 @@ RUN: not lld-link -machine:arm64ec -dll -out:test.dll demangled-func.obj loadcon
 RUN:              "-entry:#func" 2>&1 | FileCheck -check-prefix=FUNC-NOT-FOUND %s
 RUN: not lld-link -machine:arm64ec -dll -out:test.dll demangled-func.obj loadconfig-arm64ec.obj \
 RUN:              -noentry "-export:#func" 2>&1 | FileCheck -check-prefix=FUNC-NOT-FOUND %s
-FUNC-NOT-FOUND: undefined symbol: #func
+FUNC-NOT-FOUND: undefined symbol: #func (EC symbol)
 
 Verify that the linker recognizes the demangled x86_64 _DllMainCRTStartup.
 RUN: lld-link -machine:arm64ec -dll -out:test.dll x64-dll-main.obj loadconfig-arm64ec.obj

--- a/lld/test/COFF/arm64ec-hybmp.s
+++ b/lld/test/COFF/arm64ec-hybmp.s
@@ -62,7 +62,7 @@ thunk:
 
 // RUN: llvm-mc -filetype=obj -triple=arm64ec-windows undef-func.s -o undef-func.obj
 // RUN: not lld-link -machine:arm64ec -dll -noentry -out:test.dll undef-func.obj 2>&1 | FileCheck -check-prefix=UNDEF-FUNC %s
-// UNDEF-FUNC: error: undefined symbol: func
+// UNDEF-FUNC: error: undefined symbol: func (EC symbol)
 
 #--- undef-thunk.s
     .section .text,"xr",discard,func
@@ -79,7 +79,7 @@ func:
 
 // RUN: llvm-mc -filetype=obj -triple=arm64ec-windows undef-thunk.s -o undef-thunk.obj
 // RUN: not lld-link -machine:arm64ec -dll -noentry -out:test.dll undef-thunk.obj 2>&1 | FileCheck -check-prefix=UNDEF-THUNK %s
-// UNDEF-THUNK: error: undefined symbol: thunk
+// UNDEF-THUNK: error: undefined symbol: thunk (EC symbol)
 
 #--- invalid-type.s
     .section .text,"xr",discard,func

--- a/lld/test/COFF/arm64ec-lib.test
+++ b/lld/test/COFF/arm64ec-lib.test
@@ -29,11 +29,13 @@ RUN: lld-link -machine:arm64ec -dll -noentry -out:test2.dll symref-arm64ec.obj s
 Verify that both native and EC symbols can be referenced in a hybrid target.
 RUN: lld-link -machine:arm64x -dll -noentry -out:test3.dll symref-arm64ec.obj nsymref-aarch64.obj sym-arm64ec.lib \
 RUN:          loadconfig-arm64.obj loadconfig-arm64ec.obj
+RUN: lld-link -machine:arm64ec -dll -noentry -out:test3ec.dll symref-arm64ec.obj nsymref-aarch64.obj sym-arm64ec.lib \
+RUN:          loadconfig-arm64.obj loadconfig-arm64ec.obj
 
 Ensure that an EC symbol is not resolved using a regular symbol map.
 RUN: not lld-link -machine:arm64ec -dll -noentry -out:test-err.dll nsymref-arm64ec.obj sym-arm64ec.lib loadconfig-arm64ec.obj 2>&1 |\
 RUN:              FileCheck --check-prefix=ERR %s
-ERR: error: undefined symbol: nsym
+ERR: error: undefined symbol: nsym (EC symbol)
 
 Verify that a library symbol can be referenced, even if its name conflicts with an anti-dependency alias.
 RUN: lld-link -machine:arm64ec -dll -noentry -out:ref-alias-1.dll ref-alias.obj func.lib loadconfig-arm64ec.obj

--- a/lld/test/COFF/arm64ec-patchable-thunks.test
+++ b/lld/test/COFF/arm64ec-patchable-thunks.test
@@ -57,7 +57,7 @@ RUN: llvm-readobj --coff-load-config test3.dll | FileCheck -check-prefix=PATCH-C
 
 
 RUN: not lld-link -out:test4.dll -machine:arm64ec test-sec.obj loadconfig-arm64ec.obj -dll -noentry 2>&1 | FileCheck --check-prefix=ERR %s
-ERR: error: undefined symbol: EXP+#patchable_func
+ERR: error: undefined symbol: EXP+#patchable_func (EC symbol)
 
 
 RUN: lld-link -out:testx.dll -machine:arm64x arm64ec-patchable.obj test-sec.obj \

--- a/lld/test/COFF/arm64ec-range-thunks.s
+++ b/lld/test/COFF/arm64ec-range-thunks.s
@@ -79,7 +79,11 @@
 # RUN:           -out:testx2.dll -verbose 2>&1 | FileCheck -check-prefix=VERBOSEX %s
 # VERBOSEX: Added 5 thunks with margin {{.*}} in 1 passes
 
+# RUN: lld-link -machine:arm64ec -noentry -dll funcs-arm64ec.obj funcs-aarch64.obj loadconfig-arm64.obj loadconfig-arm64ec.obj \
+# RUN:           -out:testx2ec.dll -verbose 2>&1 | FileCheck -check-prefix=VERBOSEX %s
+
 # RUN: llvm-objdump -d testx2.dll | FileCheck --check-prefix=DISASMX %s
+# RUN: llvm-objdump -d testx2ec.dll | FileCheck --check-prefix=DISASMX %s
 
 # DISASMX:      Disassembly of section .code1:
 # DISASMX-EMPTY:
@@ -126,6 +130,7 @@
 # DISASMX-NEXT: 180016010: d61f0200     br      x16
 
 # RUN: llvm-readobj --coff-load-config testx2.dll | FileCheck --check-prefix=LOADCFGX2 %s
+# RUN: llvm-readobj --coff-load-config testx2ec.dll | FileCheck --check-prefix=LOADCFGX2 %s
 
 # LOADCFGX2:       CodeMap [
 # LOADCFGX2-NEXT:    0x4000 - 0x4014  ARM64EC

--- a/lld/test/COFF/arm64ec.test
+++ b/lld/test/COFF/arm64ec.test
@@ -35,13 +35,14 @@ RUN: llvm-readobj --file-headers test.dll | FileCheck -check-prefix=ARM64X-HEADE
 RUN: llvm-readobj --hex-dump=.data test.dll | FileCheck -check-prefix=ARM64X-DATA %s
 ARM64X-DATA: 03030303 01010101 02020202
 
+RUN: lld-link -out:test.dll -machine:arm64ec x86_64-data-sym.obj arm64-data-sym.obj \
+RUN:          arm64ec-data-sym.obj arm64x-resource.obj -dll -noentry
+RUN: llvm-readobj --file-headers test.dll | FileCheck -check-prefix=ARM64EC-HEADER %s
+RUN: llvm-readobj --hex-dump=.data test.dll | FileCheck -check-prefix=ARM64X-DATA %s
+
 RUN: not lld-link -out:test.dll -machine:arm64 arm64-data-sym.obj arm64ec-data-sym.obj \
 RUN:              -dll -noentry 2>&1 | FileCheck -check-prefix=INCOMPAT1 %s
 INCOMPAT1: lld-link: error: arm64ec-data-sym.obj: machine type arm64ec conflicts with arm64
-
-RUN: not lld-link -out:test.dll -machine:arm64ec arm64ec-data-sym.obj arm64-data-sym.obj \
-RUN:              -dll -noentry 2>&1 | FileCheck -check-prefix=INCOMPAT2 %s
-INCOMPAT2: lld-link: error: arm64-data-sym.obj: machine type arm64 conflicts with arm64ec
 
 RUN: not lld-link -out:test.dll -machine:arm64 arm64-data-sym.obj x86_64-data-sym.obj \
 RUN:              -dll -noentry 2>&1 | FileCheck -check-prefix=INCOMPAT3 %s

--- a/lld/test/COFF/arm64x-altnames.s
+++ b/lld/test/COFF/arm64x-altnames.s
@@ -10,6 +10,8 @@
 
 // RUN: not lld-link -out:out.dll -machine:arm64x -dll -noentry test-arm64.obj test-arm64ec.obj -alternatename:sym=altsym \
 // RUN:              2>&1 | FileCheck --check-prefix=ERR-NATIVE %s
+// RUN: not lld-link -out:out.dll -machine:arm64ec -dll -noentry test-arm64.obj test-arm64ec.obj -alternatename:sym=altsym \
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-NATIVE %s
 
 // ERR-NATIVE-NOT:  test-arm64ec.obj
 // ERR-NATIVE:      lld-link: error: undefined symbol: sym (native symbol)
@@ -20,8 +22,12 @@
 
 // RUN: not lld-link -out:out.dll -machine:arm64x -dll -noentry test-arm64.obj test-arm64ec.obj drectve-arm64ec.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=ERR-NATIVE %s
+// RUN: not lld-link -out:out.dll -machine:arm64ec -dll -noentry test-arm64.obj test-arm64ec.obj drectve-arm64ec.obj \
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-NATIVE %s
 
 // RUN: not lld-link -out:out.dll -machine:arm64x -dll -noentry test-arm64.obj test-arm64ec.obj drectve-arm64.obj \
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-EC %s
+// RUN: not lld-link -out:out.dll -machine:arm64ec -dll -noentry test-arm64.obj test-arm64ec.obj drectve-arm64.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=ERR-EC %s
 
 // ERR-EC-NOT:  test-arm64.obj

--- a/lld/test/COFF/arm64x-buildid.s
+++ b/lld/test/COFF/arm64x-buildid.s
@@ -6,6 +6,9 @@
 # RUN: llvm-readobj --hex-dump=.test %t.dll | FileCheck %s
 # CHECK: 0x180003000 3c100000 3c100000
 
+# RUN: lld-link -machine:arm64ec -dll -noentry %t-arm64.obj %t-arm64ec.obj -debug -build-id -Brepro -out:%t-ec.dll
+# RUN: llvm-readobj --hex-dump=.test %t-ec.dll | FileCheck %s
+
 .section .test,"dr"
 .rva __buildid
 

--- a/lld/test/COFF/arm64x-comm.s
+++ b/lld/test/COFF/arm64x-comm.s
@@ -8,6 +8,9 @@
 // RUN: llvm-readobj --hex-dump=.test %t.dll | FileCheck %s
 // CHECK: 0x180004000 10200000 18200000 20200000 28200000
 
+// RUN: lld-link -machine:arm64ec -lldmingw -dll -noentry -out:%t-ec.dll %t-arm64.obj %t-arm64ec.obj
+// RUN: llvm-readobj --hex-dump=.test %t-ec.dll | FileCheck %s
+
         .data
         .word 0
 

--- a/lld/test/COFF/arm64x-crt-sec.s
+++ b/lld/test/COFF/arm64x-crt-sec.s
@@ -17,6 +17,9 @@
 // RUN: lld-link -out:out3.dll -machine:arm64x -dll -noentry crt2-amd64.obj crt1-arm64ec.obj crt2-arm64.obj crt1-arm64.obj
 // RUN: llvm-readobj --hex-dump=.CRT out3.dll | FileCheck %s
 
+// RUN: lld-link -out:out4.dll -machine:arm64ec -dll -noentry crt2-amd64.obj crt1-arm64ec.obj crt2-arm64.obj crt1-arm64.obj
+// RUN: llvm-readobj --hex-dump=.CRT out4.dll | FileCheck %s
+
 // CHECK:      0x180002000 01000000 00000000 02000000 00000000
 // CHECK-NEXT: 0x180002010 03000000 00000000 11000000 00000000
 // CHECK-NEXT: 0x180002020 12000000 00000000 13000000 00000000

--- a/lld/test/COFF/arm64x-ctors-sec.s
+++ b/lld/test/COFF/arm64x-ctors-sec.s
@@ -22,6 +22,10 @@
 // RUN:           ctor2-arm64.obj ctor1-arm64ec.obj ctor2-amd64.obj ctor1-arm64.obj
 // RUN: llvm-readobj --hex-dump=.rdata --hex-dump=.test out3.dll | FileCheck %s
 
+// RUN: lld-link -out:out4.dll -machine:arm64ec -lldmingw -dll -noentry test-arm64.obj test-arm64ec.obj \
+// RUN:           ctor2-arm64.obj ctor1-arm64ec.obj ctor2-amd64.obj ctor1-arm64.obj
+// RUN: llvm-readobj --hex-dump=.rdata --hex-dump=.test out4.dll | FileCheck %s
+
 // CHECK:      Hex dump of section '.rdata':
 // CHECK-NEXT: 0x180001000 ffffffff ffffffff 01000000 00000000
 // CHECK-NEXT: 0x180001010 02000000 00000000 03000000 00000000

--- a/lld/test/COFF/arm64x-guardcf.s
+++ b/lld/test/COFF/arm64x-guardcf.s
@@ -16,7 +16,7 @@
 
 // RUN: lld-link -dll -noentry -machine:arm64x func-gfids-arm64.obj func-gfids-arm64ec.obj func-amd64.obj -guard:cf -out:out.dll \
 // RUN:          loadconfig-arm64ec.obj loadconfig-arm64.obj
-// RUN: llvm-readobj --coff-load-config out.dll | FileCheck --check-prefix=LOADCFG %s
+// RUN: llvm-readobj --coff-load-config out.dll | FileCheck --check-prefixes=LOADCFG,LOADCFGX %s
 
 // LOADCFG:      LoadConfig [
 // LOADCFG:        GuardCFFunctionCount: 3
@@ -31,28 +31,36 @@
 // LOADCFG-NEXT:   0x180002000
 // LOADCFG-NEXT:   0x180003000
 // LOADCFG-NEXT: ]
-// LOADCFG:      HybridObject {
-// LOADCFG:        LoadConfig [
-// LOADCFG:          GuardCFFunctionCount: 3
-// LOADCFG-NEXT:     GuardFlags [ (0x10500)
-// LOADCFG-NEXT:       CF_FUNCTION_TABLE_PRESENT (0x400)
-// LOADCFG-NEXT:       CF_INSTRUMENTED (0x100)
-// LOADCFG-NEXT:       CF_LONGJUMP_TABLE_PRESENT (0x10000)
-// LOADCFG-NEXT:     ]
-// LOADCFG:        ]
-// LOADCFG:        GuardFidTable [
-// LOADCFG-NEXT:     0x180001000
-// LOADCFG-NEXT:     0x180002000
-// LOADCFG-NEXT:     0x180003000
-// LOADCFG-NEXT:   ]
-// LOADCFG:      ]
+// LOADCFGX:     HybridObject {
+// LOADCFGX:       LoadConfig [
+// LOADCFGX:         GuardCFFunctionCount: 3
+// LOADCFG-NEXTX:    GuardFlags [ (0x10500)
+// LOADCFG-NEXTX:      CF_FUNCTION_TABLE_PRESENT (0x400)
+// LOADCFG-NEXTX:      CF_INSTRUMENTED (0x100)
+// LOADCFG-NEXTX:      CF_LONGJUMP_TABLE_PRESENT (0x10000)
+// LOADCFG-NEXTX:    ]
+// LOADCFGX:       ]
+// LOADCFGX:       GuardFidTable [
+// LOADCFG-NEXTX:    0x180001000
+// LOADCFG-NEXTX:    0x180002000
+// LOADCFG-NEXTX:    0x180003000
+// LOADCFG-NEXTX:  ]
+// LOADCFGX:     ]
+
+// RUN: lld-link -dll -noentry -machine:arm64ec func-gfids-arm64.obj func-gfids-arm64ec.obj func-amd64.obj -guard:cf -out:out-ec.dll \
+// RUN:          loadconfig-arm64ec.obj loadconfig-arm64.obj
+// RUN: llvm-readobj --coff-load-config out-ec.dll | FileCheck --check-prefix=LOADCFG %s
 
 
 // Check that exports from both views are present in CF guard tables.
 
 // RUN: lld-link -dll -noentry -machine:arm64x func-exp-arm64.obj func-exp-arm64ec.obj -guard:cf -out:out-exp.dll \
 // RUN:          loadconfig-arm64ec.obj loadconfig-arm64.obj
-// RUN: llvm-readobj --coff-load-config out-exp.dll | FileCheck --check-prefix=LOADCFG %s
+// RUN: llvm-readobj --coff-load-config out-exp.dll | FileCheck --check-prefixes=LOADCFG,LOADCFGX %s
+
+// RUN: lld-link -dll -noentry -machine:arm64ec func-exp-arm64.obj func-exp-arm64ec.obj -guard:cf -out:out-exp-ec.dll \
+// RUN:          loadconfig-arm64ec.obj loadconfig-arm64.obj
+// RUN: llvm-readobj --coff-load-config out-exp-ec.dll | FileCheck --check-prefixes=LOADCFG %s
 
 
 // Check that entry points from both views are present in CF guard tables.

--- a/lld/test/COFF/arm64x-import.test
+++ b/lld/test/COFF/arm64x-import.test
@@ -56,7 +56,7 @@ DISASM-12T-NEXT: 180002040: d65f03c0     ret
 DISASM-12T-NEXT:                 ...
 DISASM-12T-NEXT: 180003000: ff 25 fa 0f 00 00            jmpq    *0xffa(%rip)            # 0x180004000
 
-RUN: llvm-readobj --coff-imports test-12-thunks.dll | FileCheck --check-prefix=IMPORTS-12 %s
+RUN: llvm-readobj --coff-imports test-12-thunks.dll | FileCheck --check-prefixes=IMPORTS-12,IMPORTS-12-EC %s
 IMPORTS-12:      Import {
 IMPORTS-12-NEXT:   Name: test.dll
 IMPORTS-12-NEXT:   ImportLookupTableRVA: 0x5348
@@ -65,13 +65,13 @@ IMPORTS-12-NEXT:   Symbol: func1 (0)
 IMPORTS-12-NEXT:   Symbol: func2 (0)
 IMPORTS-12-NEXT: }
 IMPORTS-12-NEXT: HybridObject {
-IMPORTS-12:        Import {
-IMPORTS-12-NEXT:     Name: test.dll
-IMPORTS-12-NEXT:     ImportLookupTableRVA: 0x5348
-IMPORTS-12-NEXT:     ImportAddressTableRVA: 0x4000
-IMPORTS-12-NEXT:     Symbol: func1 (0)
-IMPORTS-12-NEXT:     Symbol: func2 (0)
-IMPORTS-12-NEXT:   }
+IMPORTS-12-EC:     Import {
+IMPORTS-12-EC-NEXT:  Name: test.dll
+IMPORTS-12-EC-NEXT:  ImportLookupTableRVA: 0x5348
+IMPORTS-12-EC-NEXT:  ImportAddressTableRVA: 0x4000
+IMPORTS-12-EC-NEXT:  Symbol: func1 (0)
+IMPORTS-12-EC-NEXT:  Symbol: func2 (0)
+IMPORTS-12-EC-NEXT:}
 IMPORTS-12-NEXT: }
 
 RUN: llvm-readobj --hex-dump=.test test-12-thunks.dll | FileCheck --check-prefix=FUNC-12-THUNKS %s
@@ -80,6 +80,13 @@ FUNC-12-THUNKS-NEXT: 0x180009010 08600000 08400000
 
 RUN: llvm-readobj --hex-dump=.testa test-12-thunks.dll | FileCheck --check-prefix=FUNC-12-THUNKSA %s
 FUNC-12-THUNKSA: 0x18000a000 00400000 08400000 00100000
+
+RUN: lld-link -machine:arm64ec -dll -noentry -out:test-12-thunks-ec.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          icall.obj func12-thunks-arm64ec.obj func12-thunks-arm64.obj imp-arm64ec.lib imp-arm64.lib
+RUN: llvm-objdump -d test-12-thunks-ec.dll | FileCheck --check-prefix=DISASM-12T %s
+RUN: llvm-readobj --hex-dump=.test test-12-thunks-ec.dll | FileCheck --check-prefix=FUNC-12-THUNKS %s
+RUN: llvm-readobj --hex-dump=.testa test-12-thunks-ec.dll | FileCheck --check-prefix=FUNC-12-THUNKSA %s
+RUN: llvm-readobj --coff-imports test-12-thunks-ec.dll | FileCheck --check-prefix=IMPORTS-12-EC %s
 
 
 # If the ordinals of named imports don't match, use the EC value.
@@ -146,7 +153,7 @@ IMPORTS-ORD2-NEXT: }
 RUN: lld-link -machine:arm64x -dll -noentry -out:test2.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
 RUN:          icall.obj func12-arm64ec.obj func123-arm64.obj imp-arm64x.lib
 
-RUN: llvm-readobj --coff-imports test2.dll | FileCheck --check-prefix=IMPORTS-123-12 %s
+RUN: llvm-readobj --coff-imports test2.dll | FileCheck --check-prefixes=IMPORTS-123-12,IMPORTS-123-12-EC %s
 IMPORTS-123-12:      Import {
 IMPORTS-123-12-NEXT:   Name: test.dll
 IMPORTS-123-12-NEXT:   ImportLookupTableRVA: 0x3338
@@ -156,13 +163,13 @@ IMPORTS-123-12-NEXT:   Symbol: func1 (0)
 IMPORTS-123-12-NEXT:   Symbol: func2 (0)
 IMPORTS-123-12-NEXT: }
 IMPORTS-123-12-NEXT: HybridObject {
-IMPORTS-123-12:        Import {
-IMPORTS-123-12-NEXT:     Name: test.dll
-IMPORTS-123-12-NEXT:     ImportLookupTableRVA: 0x3340
-IMPORTS-123-12-NEXT:     ImportAddressTableRVA: 0x2008
-IMPORTS-123-12-NEXT:     Symbol: func1 (0)
-IMPORTS-123-12-NEXT:     Symbol: func2 (0)
-IMPORTS-123-12-NEXT:   }
+IMPORTS-123-12-EC:     Import {
+IMPORTS-123-12-EC-NEXT:  Name: test.dll
+IMPORTS-123-12-EC-NEXT:  ImportLookupTableRVA: 0x3340
+IMPORTS-123-12-EC-NEXT:  ImportAddressTableRVA: 0x2008
+IMPORTS-123-12-EC-NEXT:  Symbol: func1 (0)
+IMPORTS-123-12-EC-NEXT:  Symbol: func2 (0)
+IMPORTS-123-12-EC-NEXT:}
 IMPORTS-123-12-NEXT: }
 
 RUN: llvm-readobj --hex-dump=.test test2.dll | FileCheck --check-prefix=TEST-123-12 %s
@@ -175,13 +182,20 @@ RUN: llvm-readobj --hex-dump=.rdata test2.dll | FileCheck --check-prefix=TEST-12
 TEST-123-12AUX:      0x180004000 00000000 00000000 08100080 01000000
 TEST-123-12AUX-NEXT: 0x180004010 1c100080 01000000 00000000 00000000
 
+RUN: lld-link -machine:arm64ec -dll -noentry -out:test2-ec.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          icall.obj func12-arm64ec.obj func123-arm64.obj imp-arm64x.lib
+RUN: llvm-readobj --coff-imports test2-ec.dll | FileCheck --check-prefix=IMPORTS-123-12-EC %s
+RUN: llvm-readobj --hex-dump=.test test2-ec.dll | FileCheck --check-prefix=TEST-123-12 %s
+RUN: llvm-readobj --hex-dump=.testa test2-ec.dll | FileCheck --check-prefix=TEST-123-12A %s
+RUN: llvm-readobj --hex-dump=.rdata test2-ec.dll | FileCheck --check-prefix=TEST-123-12AUX %s
+
 
 # Link to the imported func1 and func2 from both native and EC code, and func3 from EC code.
 
 RUN: lld-link -machine:arm64x -dll -noentry -out:func-12-123.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
 RUN:          icall.obj func123-arm64ec.obj func12-arm64.obj imp-arm64x.lib
 
-RUN: llvm-readobj --coff-imports func-12-123.dll | FileCheck --check-prefix=IMPORTS-12-123 %s
+RUN: llvm-readobj --coff-imports func-12-123.dll | FileCheck --check-prefixes=IMPORTS-12-123,IMPORTS-12-123-EC %s
 IMPORTS-12-123:      Import {
 IMPORTS-12-123-NEXT:   Name: test.dll
 IMPORTS-12-123-NEXT:   ImportLookupTableRVA: 0x3338
@@ -190,14 +204,14 @@ IMPORTS-12-123-NEXT:   Symbol: func1 (0)
 IMPORTS-12-123-NEXT:   Symbol: func2 (0)
 IMPORTS-12-123-NEXT: }
 IMPORTS-12-123-NEXT: HybridObject {
-IMPORTS-12-123:        Import {
-IMPORTS-12-123-NEXT:     Name: test.dll
-IMPORTS-12-123-NEXT:     ImportLookupTableRVA: 0x3338
-IMPORTS-12-123-NEXT:     ImportAddressTableRVA: 0x2000
-IMPORTS-12-123-NEXT:     Symbol: func1 (0)
-IMPORTS-12-123-NEXT:     Symbol: func2 (0)
-IMPORTS-12-123-NEXT:     Symbol: func3 (0)
-IMPORTS-12-123-NEXT:   }
+IMPORTS-12-123-EC:     Import {
+IMPORTS-12-123-EC-NEXT:  Name: test.dll
+IMPORTS-12-123-EC-NEXT:  ImportLookupTableRVA: 0x3338
+IMPORTS-12-123-EC-NEXT:  ImportAddressTableRVA: 0x2000
+IMPORTS-12-123-EC-NEXT:  Symbol: func1 (0)
+IMPORTS-12-123-EC-NEXT:  Symbol: func2 (0)
+IMPORTS-12-123-EC-NEXT:  Symbol: func3 (0)
+IMPORTS-12-123-EC-NEXT:}
 IMPORTS-12-123-NEXT: }
 
 RUN: llvm-readobj --hex-dump=.test func-12-123.dll | FileCheck --check-prefix=TEST-12-123 %s
@@ -211,6 +225,12 @@ RUN: llvm-readobj --hex-dump=.rdata func-12-123.dll | FileCheck --check-prefix=T
 TEST-12-123AUX:      0x180004000 08100080 01000000 1c100080 01000000
 TEST-12-123AUX-NEXT: 0x180004010 30100080 01000000 00000000 00000000
 
+RUN: lld-link -machine:arm64ec -dll -noentry -out:func-12-123-ec.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          icall.obj func123-arm64ec.obj func12-arm64.obj imp-arm64x.lib
+RUN: llvm-readobj --coff-imports func-12-123-ec.dll | FileCheck --check-prefix=IMPORTS-12-123-EC %s
+RUN: llvm-readobj --hex-dump=.test func-12-123-ec.dll | FileCheck --check-prefix=TEST-12-123 %s
+RUN: llvm-readobj --hex-dump=.testa func-12-123-ec.dll | FileCheck --check-prefix=TEST-12-123A %s
+RUN: llvm-readobj --hex-dump=.rdata func-12-123-ec.dll | FileCheck --check-prefix=TEST-12-123AUX %s
 
 # Link to the imported func2 and func3 from both native and EC code, func4 from native code,
 # and func1 from EC code.
@@ -218,7 +238,7 @@ TEST-12-123AUX-NEXT: 0x180004010 30100080 01000000 00000000 00000000
 RUN: lld-link -machine:arm64x -dll -noentry -out:test-234-123.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
 RUN:          icall.obj func123-arm64ec.obj func234-arm64.obj imp-arm64x.lib
 
-RUN: llvm-readobj --coff-imports test-234-123.dll | FileCheck --check-prefix=IMPORTS-234-123 %s
+RUN: llvm-readobj --coff-imports test-234-123.dll | FileCheck --check-prefixes=IMPORTS-234-123,IMPORTS-234-123-EC %s
 IMPORTS-234-123:      Import {
 IMPORTS-234-123-NEXT:   Name: test.dll
 IMPORTS-234-123-NEXT:   ImportLookupTableRVA: 0x3338
@@ -228,14 +248,14 @@ IMPORTS-234-123-NEXT:   Symbol: func2 (0)
 IMPORTS-234-123-NEXT:   Symbol: func3 (0)
 IMPORTS-234-123-NEXT: }
 IMPORTS-234-123-NEXT: HybridObject {
-IMPORTS-234-123:        Import {
-IMPORTS-234-123-NEXT:     Name: test.dll
-IMPORTS-234-123-NEXT:     ImportLookupTableRVA: 0x3340
-IMPORTS-234-123-NEXT:     ImportAddressTableRVA: 0x2008
-IMPORTS-234-123-NEXT:     Symbol: func2 (0)
-IMPORTS-234-123-NEXT:     Symbol: func3 (0)
-IMPORTS-234-123-NEXT:     Symbol: func1 (0)
-IMPORTS-234-123-NEXT:   }
+IMPORTS-234-123-EC:     Import {
+IMPORTS-234-123-EC-NEXT:  Name: test.dll
+IMPORTS-234-123-EC-NEXT:  ImportLookupTableRVA: 0x3340
+IMPORTS-234-123-EC-NEXT:  ImportAddressTableRVA: 0x2008
+IMPORTS-234-123-EC-NEXT:  Symbol: func2 (0)
+IMPORTS-234-123-EC-NEXT:  Symbol: func3 (0)
+IMPORTS-234-123-EC-NEXT:  Symbol: func1 (0)
+IMPORTS-234-123-EC-NEXT:}
 IMPORTS-234-123-NEXT: }
 
 RUN: llvm-readobj --hex-dump=.test test-234-123.dll | FileCheck --check-prefix=TEST-234-123 %s
@@ -245,13 +265,19 @@ TEST-234-123-NEXT: 0x180007010 10400000 1020000
 RUN: llvm-readobj --hex-dump=.testa test-234-123.dll | FileCheck --check-prefix=TEST-234-123A %s
 TEST-234-123A: 0x180008000 08200000 10200000 00200000
 
+RUN: lld-link -machine:arm64ec -dll -noentry -out:test-234-123-ec.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          icall.obj func123-arm64ec.obj func234-arm64.obj imp-arm64x.lib
+RUN: llvm-readobj --coff-imports test-234-123-ec.dll | FileCheck --check-prefix=IMPORTS-234-123-EC %s
+RUN: llvm-readobj --hex-dump=.test test-234-123-ec.dll | FileCheck --check-prefix=TEST-234-123 %s
+RUN: llvm-readobj --hex-dump=.testa test-234-123-ec.dll | FileCheck --check-prefix=TEST-234-123A %s
+
 
 # Link to the imported func3 and func4 from native code, and func1 and func2 from EC code.
 
 RUN: lld-link -machine:arm64x -dll -noentry -out:test-34-12.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
 RUN:          icall.obj func12o-arm64ec.obj func34o-arm64.obj imp-arm64x.lib imp2.lib
 
-RUN: llvm-readobj --coff-imports test-34-12.dll | FileCheck --check-prefix=IMPORTS-34-12 %s
+RUN: llvm-readobj --coff-imports test-34-12.dll | FileCheck --check-prefixes=IMPORTS-34-12,IMPORTS-34-12-EC %s
 IMPORTS-34-12:      Import {
 IMPORTS-34-12-NEXT:   Name: test.dll
 IMPORTS-34-12-NEXT:   ImportLookupTableRVA: 0x3350
@@ -266,19 +292,19 @@ IMPORTS-34-12-NEXT:   ImportAddressTableRVA: 0x2028
 IMPORTS-34-12-NEXT:   Symbol: otherfunc (0)
 IMPORTS-34-12-NEXT: }
 IMPORTS-34-12-NEXT: HybridObject {
-IMPORTS-34-12:        Import {
-IMPORTS-34-12-NEXT:     Name: test.dll
-IMPORTS-34-12-NEXT:     ImportLookupTableRVA: 0x3360
-IMPORTS-34-12-NEXT:     ImportAddressTableRVA: 0x2010
-IMPORTS-34-12-NEXT:     Symbol: func1 (0)
-IMPORTS-34-12-NEXT:     Symbol: func2 (0)
-IMPORTS-34-12-NEXT:   }
-IMPORTS-34-12-NEXT:   Import {
-IMPORTS-34-12-NEXT:     Name: test2.dll
-IMPORTS-34-12-NEXT:     ImportLookupTableRVA: 0x3378
-IMPORTS-34-12-NEXT:     ImportAddressTableRVA: 0x2028
-IMPORTS-34-12-NEXT:     Symbol: otherfunc (0)
-IMPORTS-34-12-NEXT:   }
+IMPORTS-34-12-EC:     Import {
+IMPORTS-34-12-EC-NEXT:  Name: test.dll
+IMPORTS-34-12-EC-NEXT:  ImportLookupTableRVA: 0x3360
+IMPORTS-34-12-EC-NEXT:  ImportAddressTableRVA: 0x2010
+IMPORTS-34-12-EC-NEXT:  Symbol: func1 (0)
+IMPORTS-34-12-EC-NEXT:  Symbol: func2 (0)
+IMPORTS-34-12-EC-NEXT:}
+IMPORTS-34-12-EC-NEXT:Import {
+IMPORTS-34-12-EC-NEXT:  Name: test2.dll
+IMPORTS-34-12-EC-NEXT:  ImportLookupTableRVA: 0x3378
+IMPORTS-34-12-EC-NEXT:  ImportAddressTableRVA: 0x2028
+IMPORTS-34-12-EC-NEXT:  Symbol: otherfunc (0)
+IMPORTS-34-12-EC-NEXT:}
 IMPORTS-34-12-NEXT: }
 
 RUN: llvm-readobj --hex-dump=.test test-34-12.dll | FileCheck --check-prefix=TEST-23-12 %s
@@ -287,6 +313,12 @@ TEST-23-12-NEXT: 0x180007010 28400000 28200000
 
 RUN: llvm-readobj --hex-dump=.testa test-34-12.dll | FileCheck --check-prefix=TEST-23-12A %s
 TEST-23-12A: 0x180008000 00200000 08200000 28200000
+
+RUN: lld-link -machine:arm64ec -dll -noentry -out:test-34-12-ec.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          icall.obj func12o-arm64ec.obj func34o-arm64.obj imp-arm64x.lib imp2.lib
+RUN: llvm-readobj --coff-imports test-34-12-ec.dll | FileCheck --check-prefix=IMPORTS-34-12-EC %s
+RUN: llvm-readobj --hex-dump=.test test-34-12-ec.dll | FileCheck --check-prefix=TEST-23-12 %s
+RUN: llvm-readobj --hex-dump=.testa test-34-12-ec.dll | FileCheck --check-prefix=TEST-23-12A %s
 
 
 # Link only to imported EC functions, with no native imports.
@@ -335,7 +367,7 @@ IMPORTS-EC12-NEXT: }
 RUN: lld-link -machine:arm64x -dll -noentry -out:test-n12.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
 RUN:          func12-arm64.obj imp-arm64x.lib
 
-RUN: llvm-readobj --coff-imports test-n12.dll | FileCheck --check-prefix=IMPORTS-N12 %s
+RUN: llvm-readobj --coff-imports test-n12.dll | FileCheck --check-prefixes=IMPORTS-N12,IMPORTS-N12-EC %s
 
 IMPORTS-N12:      Arch: aarch64
 IMPORTS-N12-NEXT: AddressSize: 64bit
@@ -347,15 +379,19 @@ IMPORTS-N12-NEXT:   Symbol: func1 (0)
 IMPORTS-N12-NEXT:   Symbol: func2 (0)
 IMPORTS-N12-NEXT: }
 IMPORTS-N12-NEXT: HybridObject {
-IMPORTS-N12-NEXT:   Format: COFF-ARM64EC
-IMPORTS-N12-NEXT:   Arch: aarch64
-IMPORTS-N12-NEXT:   AddressSize: 64bit
-IMPORTS-N12-NEXT:   Import {
-IMPORTS-N12-NEXT:     Name: test.dll
-IMPORTS-N12-NEXT:     ImportLookupTableRVA: 0x2340
-IMPORTS-N12-NEXT:     ImportAddressTableRVA: 0x1010
-IMPORTS-N12-NEXT:   }
+IMPORTS-N12-EC:      Format: COFF-ARM64EC
+IMPORTS-N12-EC-NEXT: Arch: aarch64
+IMPORTS-N12-EC-NEXT: AddressSize: 64bit
+IMPORTS-N12-EC-NEXT: Import {
+IMPORTS-N12-EC-NEXT:   Name: test.dll
+IMPORTS-N12-EC-NEXT:   ImportLookupTableRVA: 0x2340
+IMPORTS-N12-EC-NEXT:   ImportAddressTableRVA: 0x1010
+IMPORTS-N12-EC-NEXT: }
 IMPORTS-N12-NEXT: }
+
+RUN: lld-link -machine:arm64ec -dll -noentry -out:test-n12-ec.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          func12-arm64.obj imp-arm64x.lib
+RUN: llvm-readobj --coff-imports test-n12-ec.dll | FileCheck --check-prefix=IMPORTS-N12-EC %s
 
 
 RUN: lld-link -machine:arm64x -dll -noentry -out:test-dup.dll loadconfig-arm64.obj loadconfig-arm64ec.obj icall.obj \

--- a/lld/test/COFF/arm64x-symtab.s
+++ b/lld/test/COFF/arm64x-symtab.s
@@ -18,6 +18,8 @@
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:err1.dll symref-aarch64.obj sym-arm64ec.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEF %s
+// RUN: not lld-link -machine:arm64ec -dll -noentry -out:err1.dll symref-aarch64.obj sym-arm64ec.obj \
+// RUN:              2>&1 | FileCheck --check-prefix=UNDEF %s
 // UNDEF:      lld-link: error: undefined symbol: sym (native symbol)
 // UNDEF-NEXT: >>> referenced by symref-aarch64.obj:(.data)
 
@@ -25,25 +27,34 @@
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:out.dll symref-arm64ec.obj sym-aarch64.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEFEC %s
+// RUN: not lld-link -machine:arm64ec -dll -noentry -out:out.dll symref-arm64ec.obj sym-aarch64.obj \
+// RUN:              2>&1 | FileCheck --check-prefix=UNDEFEC %s
 // UNDEFEC:      lld-link: error: undefined symbol: sym (EC symbol)
 // UNDEFEC-NEXT: >>> referenced by symref-arm64ec.obj:(.data)
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:out.dll symref-x86_64.obj sym-aarch64.obj \
+// RUN:              2>&1 | FileCheck --check-prefix=UNDEFX86 %s
+// RUN: not lld-link -machine:arm64ec -dll -noentry -out:out.dll symref-x86_64.obj sym-aarch64.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEFX86 %s
 // UNDEFX86:      lld-link: error: undefined symbol: sym (EC symbol)
 // UNDEFX86-NEXT: >>> referenced by symref-x86_64.obj:(.data)
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:err2.dll symref-aarch64.obj sym-x86_64.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEF %s
+// RUN: not lld-link -machine:arm64ec -dll -noentry -out:err2.dll symref-aarch64.obj sym-x86_64.obj \
+// RUN:              2>&1 | FileCheck --check-prefix=UNDEF %s
 
 // Check that ARM64X target can have the same symbol names in both native and EC namespaces.
 
 // RUN: lld-link -machine:arm64x -dll -noentry -out:out.dll symref-aarch64.obj sym-aarch64.obj \
 // RUN:           symref-arm64ec.obj sym-x86_64.obj
+// RUN: lld-link -machine:arm64ec -dll -noentry -out:out.dll symref-aarch64.obj sym-aarch64.obj \
+// RUN:           symref-arm64ec.obj sym-x86_64.obj
 
 // Check that ARM64X target can reference both native and EC symbols from an archive.
 
 // RUN: lld-link -machine:arm64x -dll -noentry -out:out2.dll symref-aarch64.obj symref-arm64ec.obj sym.lib
+// RUN: lld-link -machine:arm64ec -dll -noentry -out:out2.dll symref-aarch64.obj symref-arm64ec.obj sym.lib
 
 // Check that EC object files can reference x86_64 library symbols.
 
@@ -55,14 +66,19 @@
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:err3.dll symref-aarch64.obj sym-x86_64.lib \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEF %s
+// RUN: not lld-link -machine:arm64ec -dll -noentry -out:err3.dll symref-aarch64.obj sym-x86_64.lib \
+// RUN:              2>&1 | FileCheck --check-prefix=UNDEF %s
 
 // Check that native object files can reference native library symbols.
 
 // RUN: lld-link -machine:arm64x -dll -noentry -out:out6.dll symref-aarch64.obj sym-aarch64.lib
+// RUN: lld-link -machine:arm64ec -dll -noentry -out:out6.dll symref-aarch64.obj sym-aarch64.lib
 
 // Check that EC object files can't reference native ARM64 library symbols.
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:err4.dll symref-arm64ec.obj sym-aarch64.lib \
+// RUN:              2>&1 | FileCheck --check-prefix=UNDEFEC %s
+// RUN: not lld-link -machine:arm64ec -dll -noentry -out:err4.dll symref-arm64ec.obj sym-aarch64.lib \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEFEC %s
 
 #--- symref.s

--- a/lld/test/COFF/arm64x-wrap.s
+++ b/lld/test/COFF/arm64x-wrap.s
@@ -15,6 +15,10 @@
 // CHECK: 0x180004000 02000000 02000000 01000000 02000000
 // CHECK: 0x180004010 02000000 01000000
 
+// RUN: lld-link -machine:arm64ec -dll -noentry test-arm64.obj test-arm64ec.obj other-arm64.obj other-arm64ec.obj \
+// RUN:          loadconfig-arm64.obj loadconfig-arm64ec.obj -out:out-ec.dll -wrap:sym -wrap:nosuchsym
+// RUN: llvm-readobj --hex-dump=.test out-ec.dll | FileCheck %s
+
 #--- test.s
         .section .test,"dr"
         .word sym

--- a/lld/test/COFF/autoimport-arm64ec-data.test
+++ b/lld/test/COFF/autoimport-arm64ec-data.test
@@ -12,7 +12,7 @@ RUN: llvm-objdump -s out.dll | FileCheck --check-prefix=CONTENTS %s
 
 IMPORTS:      Import {
 IMPORTS-NEXT:   Name: test.dll
-IMPORTS-NEXT:   ImportLookupTableRVA: 0x40E0
+IMPORTS-NEXT:   ImportLookupTableRVA: 0x4100
 IMPORTS-NEXT:   ImportAddressTableRVA: 0x3000
 IMPORTS-NEXT:   Symbol: variable (0)
 IMPORTS-NEXT: }


### PR DESCRIPTION
MSVC linker accepts native ARM64 object files as input with `-machine:arm64ec`, similar to `-machine:arm64x`. Its usefulness is very limited; for example, both exports and imports are not reflected in the PE structures and can't work. However, their symbol tables are otherwise functional.

Since we already have handling of multiple symbol tables implemented for ARM64X, the required changes are mostly about adjusting relevant checks to account for them on the ARM64EC target.

Delay-load helper handling is a bit of a shortcut. The patch never pulls it for native object files and just ensures that the code is fine with that. In general, I think it would be nice to adjust the driver to pull it only when it's actually referenced, which would allow applying the same logic to the native symbol table on ARM64EC without worrying about pulling too much.