### PR TITLE
[SelectionDAG][PowerPC] Remove setTruncatingStore from StoreSDNode.

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -2533,9 +2533,6 @@ public:
   /// For integers this is the same as doing a TRUNCATE and storing the result.
   /// For floats, it is the same as doing an FP_ROUND and storing the result.
   bool isTruncatingStore() const { return StoreSDNodeBits.IsTruncating; }
-  void setTruncatingStore(bool Truncating) {
-    StoreSDNodeBits.IsTruncating = Truncating;
-  }
 
   const SDValue &getValue() const { return getOperand(1); }
   const SDValue &getBasePtr() const { return getOperand(2); }

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -16562,13 +16562,16 @@ SDValue PPCTargetLowering::PerformDAGCombine(SDNode *N,
                                     MemVT.getSizeInBits());
       SDValue Const64 = DAG.getConstant(Val64, dl, MVT::i64);
 
-      // DAG.getTruncStore() can't be used here because it doesn't accept
-      // the general (base + offset) addressing mode.
-      // So we use UpdateNodeOperands and setTruncatingStore instead.
-      DAG.UpdateNodeOperands(N, N->getOperand(0), Const64, N->getOperand(2),
-                             N->getOperand(3));
-      cast<StoreSDNode>(N)->setTruncatingStore(true);
-      return SDValue(N, 0);
+      auto *ST = cast<StoreSDNode>(N);
+      SDValue NewST = DAG.getStore(ST->getChain(), dl, Const64,
+                                   ST->getBasePtr(), ST->getOffset(), MemVT,
+                                   ST->getMemOperand(), ST->getAddressingMode(),
+                                   /*IsTruncating=*/true);
+      // Note we use CombineTo here to prevent DAGCombine from visiting the
+      // new store which will change the constant by removing non-demanded bits.
+      return ST->isUnindexed()
+                 ? DCI.CombineTo(N, NewST, /*AddTo=*/false)
+                 : DCI.CombineTo(N, NewST, NewST.getValue(1), /*AddTo=*/false);
     }
 
     // For little endian, VSX stores require generating xxswapd/lxvd2x.

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -16567,7 +16567,7 @@ SDValue PPCTargetLowering::PerformDAGCombine(SDNode *N,
                                    ST->getBasePtr(), ST->getOffset(), MemVT,
                                    ST->getMemOperand(), ST->getAddressingMode(),
                                    /*IsTruncating=*/true);
-      // Note we use CombineTo here to prevent DAGCombine from visiting the
+      // Note we use CombineTo here to prevent DAGCombiner from visiting the
       // new store which will change the constant by removing non-demanded bits.
       return ST->isUnindexed()
                  ? DCI.CombineTo(N, NewST, /*AddTo=*/false)


### PR DESCRIPTION
Mutating a node after it has been created isn't a good idea. After e17f07c4debbe76f5ebcdeeda619e7438700e2ad, we have a version of setStore that can create a truncating indexed store. Use that instead of MorphNodeTo+setTruncatingStore in PowerPC.

Unfortunately, if we return the newly created node, DAGCombiner will visit the node and change the constant. To prevent this, we use DCI.CombineTo and avoid adding the new node to the worklist.