### PR TITLE
[clang][frontend] Require invocation to construct `CompilerInstance`

### DIFF
--- a/clang-tools-extra/clang-include-fixer/IncludeFixer.cpp
+++ b/clang-tools-extra/clang-include-fixer/IncludeFixer.cpp
@@ -89,8 +89,7 @@ bool IncludeFixerActionFactory::runInvocation(
   assert(Invocation->getFrontendOpts().Inputs.size() == 1);
 
   // Set up Clang.
-  clang::CompilerInstance Compiler(PCHContainerOps);
-  Compiler.setInvocation(std::move(Invocation));
+  CompilerInstance Compiler(std::move(Invocation), std::move(PCHContainerOps));
   Compiler.setFileManager(Files);
 
   // Create the compiler's actual diagnostics engine. We want to drop all

--- a/clang-tools-extra/clangd/Compiler.cpp
+++ b/clang-tools-extra/clangd/Compiler.cpp
@@ -145,9 +145,7 @@ prepareCompilerInstance(std::unique_ptr<clang::CompilerInvocation> CI,
         CI->getFrontendOpts().Inputs[0].getFile(), Buffer.get());
   }
 
-  auto Clang = std::make_unique<CompilerInstance>(
-      std::make_shared<PCHContainerOperations>());
-  Clang->setInvocation(std::move(CI));
+  auto Clang = std::make_unique<CompilerInstance>(std::move(CI));
   Clang->createDiagnostics(*VFS, &DiagsClient, false);
 
   if (auto VFSWithRemapping = createVFSFromCompilerInvocation(

--- a/clang-tools-extra/include-cleaner/unittests/RecordTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/RecordTest.cpp
@@ -618,14 +618,14 @@ TEST_F(PragmaIncludeTest, ExportInUnnamedBuffer) {
                  llvm::MemoryBuffer::getMemBufferCopy(Extra.getValue(),
                                                       /*BufferName=*/""));
 
-  auto Clang = std::make_unique<CompilerInstance>(
-      std::make_shared<PCHContainerOperations>());
-  Clang->createDiagnostics(*VFS);
+  auto DiagOpts = llvm::makeIntrusiveRefCnt<DiagnosticOptions>();
+  auto Diags = CompilerInstance::createDiagnostics(*VFS, DiagOpts.get());
+  auto Invocation = std::make_unique<CompilerInvocation>();
+  ASSERT_TRUE(CompilerInvocation::CreateFromArgs(*Invocation, {Filename.data()},
+                                                 *Diags, "clang"));
 
-  Clang->setInvocation(std::make_unique<CompilerInvocation>());
-  ASSERT_TRUE(CompilerInvocation::CreateFromArgs(
-      Clang->getInvocation(), {Filename.data()}, Clang->getDiagnostics(),
-      "clang"));
+  auto Clang = std::make_unique<CompilerInstance>(std::move(Invocation));
+  Clang->createDiagnostics(*VFS);
 
   auto *FM = Clang->createFileManager(VFS);
   ASSERT_TRUE(Clang->ExecuteAction(*Inputs.MakeAction()));

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -204,6 +204,8 @@ class CompilerInstance : public ModuleLoader {
   void operator=(const CompilerInstance &) = delete;
 public:
   explicit CompilerInstance(
+      std::shared_ptr<CompilerInvocation> Invocation =
+          std::make_shared<CompilerInvocation>(),
       std::shared_ptr<PCHContainerOperations> PCHContainerOps =
           std::make_shared<PCHContainerOperations>(),
       ModuleCache *ModCache = nullptr);
@@ -251,17 +253,9 @@ public:
   /// @name Compiler Invocation and Options
   /// @{
 
-  bool hasInvocation() const { return Invocation != nullptr; }
-
-  CompilerInvocation &getInvocation() {
-    assert(Invocation && "Compiler instance has no invocation!");
-    return *Invocation;
-  }
+  CompilerInvocation &getInvocation() { return *Invocation; }
 
   std::shared_ptr<CompilerInvocation> getInvocationPtr() { return Invocation; }
-
-  /// setInvocation - Replace the current invocation.
-  void setInvocation(std::shared_ptr<CompilerInvocation> Value);
 
   /// Indicates whether we should (re)build the global module index.
   bool shouldBuildGlobalModuleIndex() const;

--- a/clang/lib/Frontend/ChainedIncludesSource.cpp
+++ b/clang/lib/Frontend/ChainedIncludesSource.cpp
@@ -122,9 +122,8 @@ IntrusiveRefCntPtr<ExternalSemaSource> clang::createChainedIncludesSource(
     IntrusiveRefCntPtr<DiagnosticsEngine> Diags(
         new DiagnosticsEngine(DiagID, &CI.getDiagnosticOpts(), DiagClient));
 
-    std::unique_ptr<CompilerInstance> Clang(
-        new CompilerInstance(CI.getPCHContainerOperations()));
-    Clang->setInvocation(std::move(CInvok));
+    auto Clang = std::make_unique<CompilerInstance>(
+        std::move(CInvok), CI.getPCHContainerOperations());
     Clang->setDiagnostics(Diags.get());
     Clang->setTarget(TargetInfo::CreateTargetInfo(
         Clang->getDiagnostics(), Clang->getInvocation().getTargetOpts()));

--- a/clang/lib/Frontend/PrecompiledPreamble.cpp
+++ b/clang/lib/Frontend/PrecompiledPreamble.cpp
@@ -454,8 +454,8 @@ llvm::ErrorOr<PrecompiledPreamble> PrecompiledPreamble::Build(
   PreprocessorOpts.GeneratePreamble = true;
 
   // Create the compiler instance to use for building the precompiled preamble.
-  auto Clang = std::make_unique<CompilerInstance>(
-      std::move(PreambleInvocation), std::move(PCHContainerOps));
+  auto Clang = std::make_unique<CompilerInstance>(std::move(PreambleInvocation),
+                                                  std::move(PCHContainerOps));
 
   // Recover resources if we crash before exiting this method.
   llvm::CrashRecoveryContextCleanupRegistrar<CompilerInstance> CICleanup(

--- a/clang/lib/Frontend/PrecompiledPreamble.cpp
+++ b/clang/lib/Frontend/PrecompiledPreamble.cpp
@@ -454,14 +454,13 @@ llvm::ErrorOr<PrecompiledPreamble> PrecompiledPreamble::Build(
   PreprocessorOpts.GeneratePreamble = true;
 
   // Create the compiler instance to use for building the precompiled preamble.
-  std::unique_ptr<CompilerInstance> Clang(
-      new CompilerInstance(std::move(PCHContainerOps)));
+  auto Clang = std::make_unique<CompilerInstance>(
+      std::move(PreambleInvocation), std::move(PCHContainerOps));
 
   // Recover resources if we crash before exiting this method.
   llvm::CrashRecoveryContextCleanupRegistrar<CompilerInstance> CICleanup(
       Clang.get());
 
-  Clang->setInvocation(std::move(PreambleInvocation));
   Clang->setDiagnostics(&Diagnostics);
 
   // Create the target instance.

--- a/clang/lib/Frontend/Rewrite/FrontendActions.cpp
+++ b/clang/lib/Frontend/Rewrite/FrontendActions.cpp
@@ -242,9 +242,9 @@ public:
     (*OS) << '\n';
 
     // Rewrite the contents of the module in a separate compiler instance.
-    CompilerInstance Instance(std::make_shared<CompilerInvocation>(CI.getInvocation()),
-                              CI.getPCHContainerOperations(),
-                              &CI.getModuleCache());
+    CompilerInstance Instance(
+        std::make_shared<CompilerInvocation>(CI.getInvocation()),
+        CI.getPCHContainerOperations(), &CI.getModuleCache());
     Instance.createDiagnostics(
         CI.getVirtualFileSystem(),
         new ForwardingDiagnosticConsumer(CI.getDiagnosticClient()),

--- a/clang/lib/Frontend/Rewrite/FrontendActions.cpp
+++ b/clang/lib/Frontend/Rewrite/FrontendActions.cpp
@@ -242,10 +242,9 @@ public:
     (*OS) << '\n';
 
     // Rewrite the contents of the module in a separate compiler instance.
-    CompilerInstance Instance(CI.getPCHContainerOperations(),
+    CompilerInstance Instance(std::make_shared<CompilerInvocation>(CI.getInvocation()),
+                              CI.getPCHContainerOperations(),
                               &CI.getModuleCache());
-    Instance.setInvocation(
-        std::make_shared<CompilerInvocation>(CI.getInvocation()));
     Instance.createDiagnostics(
         CI.getVirtualFileSystem(),
         new ForwardingDiagnosticConsumer(CI.getDiagnosticClient()),

--- a/clang/lib/StaticAnalyzer/Frontend/ModelInjector.cpp
+++ b/clang/lib/StaticAnalyzer/Frontend/ModelInjector.cpp
@@ -75,8 +75,8 @@ void ModelInjector::onBodySynthesis(const NamedDecl *D) {
 
   // Modules are parsed by a separate CompilerInstance, so this code mimics that
   // behavior for models
-  CompilerInstance Instance(CI.getPCHContainerOperations());
-  Instance.setInvocation(std::move(Invocation));
+  CompilerInstance Instance(std::move(Invocation),
+                            CI.getPCHContainerOperations());
   Instance.createDiagnostics(
       CI.getVirtualFileSystem(),
       new ForwardingDiagnosticConsumer(CI.getDiagnosticClient()),

--- a/clang/lib/Testing/TestAST.cpp
+++ b/clang/lib/Testing/TestAST.cpp
@@ -75,8 +75,7 @@ void createMissingComponents(CompilerInstance &Clang) {
 } // namespace
 
 TestAST::TestAST(const TestInputs &In) {
-  Clang = std::make_unique<CompilerInstance>(
-      std::make_shared<PCHContainerOperations>());
+  Clang = std::make_unique<CompilerInstance>();
   // If we don't manage to finish parsing, create CompilerInstance components
   // anyway so that the test will see an empty AST instead of crashing.
   auto RecoverFromEarlyExit =
@@ -109,7 +108,6 @@ TestAST::TestAST(const TestInputs &In) {
   for (const auto &S : In.ExtraArgs)
     Argv.push_back(S.c_str());
   Argv.push_back(Filename.c_str());
-  Clang->setInvocation(std::make_unique<CompilerInvocation>());
   if (!CompilerInvocation::CreateFromArgs(Clang->getInvocation(), Argv,
                                           Clang->getDiagnostics(), "clang")) {
     ADD_FAILURE() << "Failed to create invocation";

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -412,9 +412,9 @@ public:
 
     // Create a compiler instance to handle the actual work.
     auto ModCache = makeInProcessModuleCache(Service.getModuleCacheMutexes());
-    ScanInstanceStorage.emplace(std::move(PCHContainerOps), ModCache.get());
+    ScanInstanceStorage.emplace(std::move(Invocation),
+                                std::move(PCHContainerOps), ModCache.get());
     CompilerInstance &ScanInstance = *ScanInstanceStorage;
-    ScanInstance.setInvocation(std::move(Invocation));
     ScanInstance.setBuildingModule(false);
 
     // Create the compiler's actual diagnostics engine.

--- a/clang/lib/Tooling/Tooling.cpp
+++ b/clang/lib/Tooling/Tooling.cpp
@@ -447,8 +447,7 @@ bool FrontendActionFactory::runInvocation(
     std::shared_ptr<PCHContainerOperations> PCHContainerOps,
     DiagnosticConsumer *DiagConsumer) {
   // Create a compiler instance to handle the actual work.
-  CompilerInstance Compiler(std::move(PCHContainerOps));
-  Compiler.setInvocation(std::move(Invocation));
+  CompilerInstance Compiler(std::move(Invocation), std::move(PCHContainerOps));
   Compiler.setFileManager(Files);
 
   // The FrontendAction can have lifetime requirements for Compiler or its

--- a/clang/tools/clang-import-test/clang-import-test.cpp
+++ b/clang/tools/clang-import-test/clang-import-test.cpp
@@ -162,18 +162,18 @@ private:
 };
 
 std::unique_ptr<CompilerInstance> BuildCompilerInstance() {
-  auto Ins = std::make_unique<CompilerInstance>();
+  auto DiagOpts = llvm::makeIntrusiveRefCnt<DiagnosticOptions>();
   auto DC = std::make_unique<TestDiagnosticConsumer>();
-  const bool ShouldOwnClient = true;
-  Ins->createDiagnostics(*llvm::vfs::getRealFileSystem(), DC.release(),
-                         ShouldOwnClient);
+  auto Diags = CompilerInstance::createDiagnostics(
+      *llvm::vfs::getRealFileSystem(), DiagOpts.get(), DC.get(),
+      /*ShouldOwnClient=*/false);
 
   auto Inv = std::make_unique<CompilerInvocation>();
 
   std::vector<const char *> ClangArgv(ClangArgs.size());
   std::transform(ClangArgs.begin(), ClangArgs.end(), ClangArgv.begin(),
                  [](const std::string &s) -> const char * { return s.data(); });
-  CompilerInvocation::CreateFromArgs(*Inv, ClangArgv, Ins->getDiagnostics());
+  CompilerInvocation::CreateFromArgs(*Inv, ClangArgv, *Diags);
 
   {
     using namespace driver::types;
@@ -205,7 +205,10 @@ std::unique_ptr<CompilerInstance> BuildCompilerInstance() {
   Inv->getCodeGenOpts().setDebugInfo(llvm::codegenoptions::FullDebugInfo);
   Inv->getTargetOpts().Triple = llvm::sys::getDefaultTargetTriple();
 
-  Ins->setInvocation(std::move(Inv));
+  auto Ins = std::make_unique<CompilerInstance>(std::move(Inv));
+
+  Ins->createDiagnostics(*llvm::vfs::getRealFileSystem(), DC.release(),
+                         /*ShouldOwnClient=*/true);
 
   TargetInfo *TI = TargetInfo::CreateTargetInfo(
       Ins->getDiagnostics(), Ins->getInvocation().getTargetOpts());

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -217,11 +217,10 @@ static int PrintEnabledExtensions(const TargetOptions& TargetOpts) {
 int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
   ensureSufficientStack();
 
-  std::unique_ptr<CompilerInstance> Clang(new CompilerInstance());
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
 
   // Register the support for object-file-wrapped Clang modules.
-  auto PCHOps = Clang->getPCHContainerOperations();
+  auto PCHOps = std::make_shared<PCHContainerOperations>();
   PCHOps->registerWriter(std::make_unique<ObjectFilePCHContainerWriter>());
   PCHOps->registerReader(std::make_unique<ObjectFilePCHContainerReader>());
 
@@ -242,8 +241,12 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
     Diags.setSeverity(diag::remark_cc1_round_trip_generated,
                       diag::Severity::Remark, {});
 
-  bool Success = CompilerInvocation::CreateFromArgs(Clang->getInvocation(),
+  auto Invocation = std::make_shared<CompilerInvocation>();
+  bool Success = CompilerInvocation::CreateFromArgs(*Invocation,
                                                     Argv, Diags, Argv0);
+
+  auto Clang = std::make_unique<CompilerInstance>(std::move(Invocation),
+                                                  std::move(PCHOps));
 
   if (!Clang->getFrontendOpts().TimeTracePath.empty()) {
     llvm::timeTraceProfilerInitialize(

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -242,8 +242,8 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
                       diag::Severity::Remark, {});
 
   auto Invocation = std::make_shared<CompilerInvocation>();
-  bool Success = CompilerInvocation::CreateFromArgs(*Invocation,
-                                                    Argv, Diags, Argv0);
+  bool Success =
+      CompilerInvocation::CreateFromArgs(*Invocation, Argv, Diags, Argv0);
 
   auto Clang = std::make_unique<CompilerInstance>(std::move(Invocation),
                                                   std::move(PCHOps));

--- a/clang/unittests/AST/ExternalASTSourceTest.cpp
+++ b/clang/unittests/AST/ExternalASTSourceTest.cpp
@@ -44,8 +44,7 @@ private:
   IntrusiveRefCntPtr<ExternalASTSource> Source;
 };
 
-bool testExternalASTSource(ExternalASTSource *Source,
-                           StringRef FileContents) {
+bool testExternalASTSource(ExternalASTSource *Source, StringRef FileContents) {
 
   auto Invocation = std::make_shared<CompilerInvocation>();
   Invocation->getPreprocessorOpts().addRemappedFile(
@@ -63,7 +62,6 @@ bool testExternalASTSource(ExternalASTSource *Source,
   TestFrontendAction Action(Source);
   return Compiler.ExecuteAction(Action);
 }
-
 
 // Ensure that a failed name lookup into an external source only occurs once.
 TEST(ExternalASTSourceTest, FailedLookupOccursOnce) {

--- a/clang/unittests/Frontend/CodeGenActionTest.cpp
+++ b/clang/unittests/Frontend/CodeGenActionTest.cpp
@@ -51,8 +51,7 @@ TEST(CodeGenTest, TestNullCodeGen) {
       FrontendInputFile("test.cc", Language::CXX));
   Invocation->getFrontendOpts().ProgramAction = EmitLLVM;
   Invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance Compiler;
-  Compiler.setInvocation(std::move(Invocation));
+  CompilerInstance Compiler(std::move(Invocation));
   Compiler.createDiagnostics(*llvm::vfs::getRealFileSystem());
   EXPECT_TRUE(Compiler.hasDiagnostics());
 
@@ -69,8 +68,7 @@ TEST(CodeGenTest, CodeGenFromIRMemBuffer) {
       FrontendInputFile(*MemBuffer, Language::LLVM_IR));
   Invocation->getFrontendOpts().ProgramAction = frontend::EmitLLVMOnly;
   Invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance Compiler;
-  Compiler.setInvocation(std::move(Invocation));
+  CompilerInstance Compiler(std::move(Invocation));
   Compiler.createDiagnostics(*llvm::vfs::getRealFileSystem());
   EXPECT_TRUE(Compiler.hasDiagnostics());
 
@@ -97,11 +95,10 @@ TEST(CodeGenTest, DebugInfoCWDCodeGen) {
   Invocation->getFrontendOpts().ProgramAction = EmitLLVM;
   Invocation->getTargetOpts().Triple = "x86_64-unknown-linux-gnu";
   Invocation->getCodeGenOpts().setDebugInfo(codegenoptions::FullDebugInfo);
-  CompilerInstance Compiler;
+  CompilerInstance Compiler(std::move(Invocation));
 
   SmallString<256> IRBuffer;
   Compiler.setOutputStream(std::make_unique<raw_svector_ostream>(IRBuffer));
-  Compiler.setInvocation(std::move(Invocation));
   Compiler.createDiagnostics(*VFS);
   Compiler.createFileManager(std::move(VFS));
 

--- a/clang/unittests/Frontend/CompilerInstanceTest.cpp
+++ b/clang/unittests/Frontend/CompilerInstanceTest.cpp
@@ -66,9 +66,8 @@ TEST(CompilerInstance, DefaultVFSOverlayFromInvocation) {
     FAIL() << "could not create compiler invocation";
   // Create a minimal CompilerInstance which should use the VFS we specified
   // in the CompilerInvocation (as we don't explicitly set our own).
-  CompilerInstance Instance;
+  CompilerInstance Instance(std::move(CInvok));
   Instance.setDiagnostics(Diags.get());
-  Instance.setInvocation(CInvok);
   Instance.createFileManager();
 
   // Check if the virtual file exists which means that our VFS is used by the

--- a/clang/unittests/Frontend/FrontendActionTest.cpp
+++ b/clang/unittests/Frontend/FrontendActionTest.cpp
@@ -90,8 +90,7 @@ TEST(ASTFrontendAction, Sanity) {
       FrontendInputFile("test.cc", Language::CXX));
   invocation->getFrontendOpts().ProgramAction = frontend::ParseSyntaxOnly;
   invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance compiler;
-  compiler.setInvocation(std::move(invocation));
+  CompilerInstance compiler(std::move(invocation));
   compiler.createDiagnostics(*llvm::vfs::getRealFileSystem());
 
   TestASTFrontendAction test_action;
@@ -110,8 +109,7 @@ TEST(ASTFrontendAction, IncrementalParsing) {
       FrontendInputFile("test.cc", Language::CXX));
   invocation->getFrontendOpts().ProgramAction = frontend::ParseSyntaxOnly;
   invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance compiler;
-  compiler.setInvocation(std::move(invocation));
+  CompilerInstance compiler(std::move(invocation));
   compiler.createDiagnostics(*llvm::vfs::getRealFileSystem());
 
   TestASTFrontendAction test_action(/*enableIncrementalProcessing=*/true);
@@ -137,8 +135,7 @@ TEST(ASTFrontendAction, LateTemplateIncrementalParsing) {
       FrontendInputFile("test.cc", Language::CXX));
   invocation->getFrontendOpts().ProgramAction = frontend::ParseSyntaxOnly;
   invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance compiler;
-  compiler.setInvocation(std::move(invocation));
+  CompilerInstance compiler(std::move(invocation));
   compiler.createDiagnostics(*llvm::vfs::getRealFileSystem());
 
   TestASTFrontendAction test_action(/*enableIncrementalProcessing=*/true,
@@ -183,8 +180,7 @@ TEST(PreprocessorFrontendAction, EndSourceFile) {
       FrontendInputFile("test.cc", Language::CXX));
   Invocation->getFrontendOpts().ProgramAction = frontend::ParseSyntaxOnly;
   Invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance Compiler;
-  Compiler.setInvocation(std::move(Invocation));
+  CompilerInstance Compiler(std::move(Invocation));
   Compiler.createDiagnostics(*llvm::vfs::getRealFileSystem());
 
   TestPPCallbacks *Callbacks = new TestPPCallbacks;
@@ -244,8 +240,7 @@ TEST(ASTFrontendAction, ExternalSemaSource) {
       FrontendInputFile("test.cc", Language::CXX));
   Invocation->getFrontendOpts().ProgramAction = frontend::ParseSyntaxOnly;
   Invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance Compiler;
-  Compiler.setInvocation(std::move(Invocation));
+  CompilerInstance Compiler(std::move(Invocation));
   auto *TDC = new TypoDiagnosticConsumer;
   Compiler.createDiagnostics(*llvm::vfs::getRealFileSystem(), TDC,
                              /*ShouldOwnClient=*/true);
@@ -278,8 +273,7 @@ TEST(GeneratePCHFrontendAction, CacheGeneratedPCH) {
     Invocation->getFrontendOpts().OutputFile = PCHFilename.str().str();
     Invocation->getFrontendOpts().ProgramAction = frontend::GeneratePCH;
     Invocation->getTargetOpts().Triple = "x86_64-apple-darwin19.0.0";
-    CompilerInstance Compiler;
-    Compiler.setInvocation(std::move(Invocation));
+    CompilerInstance Compiler(std::move(Invocation));
     Compiler.createDiagnostics(*llvm::vfs::getRealFileSystem());
 
     GeneratePCHAction TestAction;

--- a/clang/unittests/Frontend/OutputStreamTest.cpp
+++ b/clang/unittests/Frontend/OutputStreamTest.cpp
@@ -31,14 +31,13 @@ TEST(FrontendOutputTests, TestOutputStream) {
       FrontendInputFile("test.cc", Language::CXX));
   Invocation->getFrontendOpts().ProgramAction = EmitBC;
   Invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance Compiler;
+  CompilerInstance Compiler(std::move(Invocation));
 
   SmallVector<char, 256> IRBuffer;
   std::unique_ptr<raw_pwrite_stream> IRStream(
       new raw_svector_ostream(IRBuffer));
 
   Compiler.setOutputStream(std::move(IRStream));
-  Compiler.setInvocation(std::move(Invocation));
   Compiler.createDiagnostics(*llvm::vfs::getRealFileSystem());
 
   bool Success = ExecuteCompilerInvocation(&Compiler);
@@ -56,13 +55,12 @@ TEST(FrontendOutputTests, TestVerboseOutputStreamShared) {
       FrontendInputFile("test.cc", Language::CXX));
   Invocation->getFrontendOpts().ProgramAction = EmitBC;
   Invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-  CompilerInstance Compiler;
+  CompilerInstance Compiler(std::move(Invocation));
 
   std::string VerboseBuffer;
   raw_string_ostream VerboseStream(VerboseBuffer);
 
   Compiler.setOutputStream(std::make_unique<raw_null_ostream>());
-  Compiler.setInvocation(std::move(Invocation));
   IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
   Compiler.createDiagnostics(
       *llvm::vfs::getRealFileSystem(),
@@ -87,13 +85,12 @@ TEST(FrontendOutputTests, TestVerboseOutputStreamOwned) {
         FrontendInputFile("test.cc", Language::CXX));
     Invocation->getFrontendOpts().ProgramAction = EmitBC;
     Invocation->getTargetOpts().Triple = "i386-unknown-linux-gnu";
-    CompilerInstance Compiler;
+    CompilerInstance Compiler(std::move(Invocation));
 
     std::unique_ptr<raw_ostream> VerboseStream =
         std::make_unique<raw_string_ostream>(VerboseBuffer);
 
     Compiler.setOutputStream(std::make_unique<raw_null_ostream>());
-    Compiler.setInvocation(std::move(Invocation));
     IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
     Compiler.createDiagnostics(
         *llvm::vfs::getRealFileSystem(),

--- a/clang/unittests/Sema/SemaNoloadLookupTest.cpp
+++ b/clang/unittests/Sema/SemaNoloadLookupTest.cpp
@@ -81,9 +81,8 @@ public:
         createInvocation(Args, CIOpts);
     EXPECT_TRUE(Invocation);
 
-    CompilerInstance Instance;
+    CompilerInstance Instance(std::move(Invocation));
     Instance.setDiagnostics(Diags.get());
-    Instance.setInvocation(Invocation);
     Instance.getFrontendOpts().OutputFile = CacheBMIPath;
     GenerateReducedModuleInterfaceAction Action;
     EXPECT_TRUE(Instance.ExecuteAction(Action));

--- a/clang/unittests/Serialization/ForceCheckFileInputTest.cpp
+++ b/clang/unittests/Serialization/ForceCheckFileInputTest.cpp
@@ -86,9 +86,8 @@ export int aa = 43;
 
     Buf->release();
 
-    CompilerInstance Instance;
+    CompilerInstance Instance(std::move(Invocation));
     Instance.setDiagnostics(Diags.get());
-    Instance.setInvocation(Invocation);
 
     Instance.getFrontendOpts().OutputFile = BMIPath;
 
@@ -121,9 +120,8 @@ export int aa = 43;
     EXPECT_TRUE(Invocation);
     Invocation->getFrontendOpts().DisableFree = false;
 
-    CompilerInstance Clang;
+    CompilerInstance Clang(std::move(Invocation));
 
-    Clang.setInvocation(Invocation);
     Clang.setDiagnostics(Diags.get());
     FileManager *FM = Clang.createFileManager(CIOpts.VFS);
     Clang.createSourceManager(*FM);

--- a/clang/unittests/Serialization/LoadSpecLazilyTest.cpp
+++ b/clang/unittests/Serialization/LoadSpecLazilyTest.cpp
@@ -78,9 +78,8 @@ public:
         createInvocation(Args, CIOpts);
     EXPECT_TRUE(Invocation);
 
-    CompilerInstance Instance;
+    CompilerInstance Instance(std::move(Invocation));
     Instance.setDiagnostics(Diags.get());
-    Instance.setInvocation(Invocation);
     Instance.getFrontendOpts().OutputFile = CacheBMIPath;
     // Avoid memory leaks.
     Instance.getFrontendOpts().DisableFree = false;

--- a/clang/unittests/Serialization/ModuleCacheTest.cpp
+++ b/clang/unittests/Serialization/ModuleCacheTest.cpp
@@ -119,9 +119,8 @@ TEST_F(ModuleCacheTest, CachedModuleNewPath) {
   std::shared_ptr<CompilerInvocation> Invocation =
       createInvocationAndEnableFree(Args, CIOpts);
   ASSERT_TRUE(Invocation);
-  CompilerInstance Instance;
+  CompilerInstance Instance(std::move(Invocation));
   Instance.setDiagnostics(Diags.get());
-  Instance.setInvocation(Invocation);
   SyntaxOnlyAction Action;
   ASSERT_TRUE(Instance.ExecuteAction(Action));
   ASSERT_FALSE(Diags->hasErrorOccurred());
@@ -142,10 +141,10 @@ TEST_F(ModuleCacheTest, CachedModuleNewPath) {
   std::shared_ptr<CompilerInvocation> Invocation2 =
       createInvocationAndEnableFree(Args2, CIOpts);
   ASSERT_TRUE(Invocation2);
-  CompilerInstance Instance2(Instance.getPCHContainerOperations(),
+  CompilerInstance Instance2(std::move(Invocation2),
+                             Instance.getPCHContainerOperations(),
                              &Instance.getModuleCache());
   Instance2.setDiagnostics(Diags.get());
-  Instance2.setInvocation(Invocation2);
   SyntaxOnlyAction Action2;
   ASSERT_FALSE(Instance2.ExecuteAction(Action2));
   ASSERT_TRUE(Diags->hasErrorOccurred());
@@ -169,9 +168,8 @@ TEST_F(ModuleCacheTest, CachedModuleNewPathAllowErrors) {
   std::shared_ptr<CompilerInvocation> Invocation =
       createInvocationAndEnableFree(Args, CIOpts);
   ASSERT_TRUE(Invocation);
-  CompilerInstance Instance;
+  CompilerInstance Instance(std::move(Invocation));
   Instance.setDiagnostics(Diags.get());
-  Instance.setInvocation(Invocation);
   SyntaxOnlyAction Action;
   ASSERT_TRUE(Instance.ExecuteAction(Action));
   ASSERT_FALSE(Diags->hasErrorOccurred());
@@ -186,10 +184,10 @@ TEST_F(ModuleCacheTest, CachedModuleNewPathAllowErrors) {
   std::shared_ptr<CompilerInvocation> Invocation2 =
       createInvocationAndEnableFree(Args2, CIOpts);
   ASSERT_TRUE(Invocation2);
-  CompilerInstance Instance2(Instance.getPCHContainerOperations(),
+  CompilerInstance Instance2(std::move(Invocation2),
+                             Instance.getPCHContainerOperations(),
                              &Instance.getModuleCache());
   Instance2.setDiagnostics(Diags.get());
-  Instance2.setInvocation(Invocation2);
   SyntaxOnlyAction Action2;
   ASSERT_FALSE(Instance2.ExecuteAction(Action2));
   ASSERT_TRUE(Diags->hasErrorOccurred());

--- a/clang/unittests/Serialization/NoCommentsTest.cpp
+++ b/clang/unittests/Serialization/NoCommentsTest.cpp
@@ -97,9 +97,8 @@ void foo() {}
       createInvocation(Args, CIOpts);
   ASSERT_TRUE(Invocation);
 
-  CompilerInstance Instance;
+  CompilerInstance Instance(std::move(Invocation));
   Instance.setDiagnostics(Diags.get());
-  Instance.setInvocation(Invocation);
   Instance.getFrontendOpts().OutputFile = CacheBMIPath;
   GenerateReducedModuleInterfaceAction Action;
   ASSERT_TRUE(Instance.ExecuteAction(Action));

--- a/clang/unittests/Serialization/PreambleInNamedModulesTest.cpp
+++ b/clang/unittests/Serialization/PreambleInNamedModulesTest.cpp
@@ -110,9 +110,7 @@ export using ::E;
   EXPECT_TRUE(BuiltPreamble->CanReuse(*Invocation, *Buffer, Bounds, *VFS));
   BuiltPreamble->OverridePreamble(*Invocation, VFS, Buffer.get());
 
-  auto Clang = std::make_unique<CompilerInstance>(
-      std::make_shared<PCHContainerOperations>());
-  Clang->setInvocation(std::move(Invocation));
+  auto Clang = std::make_unique<CompilerInstance>(std::move(Invocation));
   Clang->setDiagnostics(Diags.get());
 
   if (auto VFSWithRemapping = createVFSFromCompilerInvocation(

--- a/clang/unittests/Serialization/VarDeclConstantInitTest.cpp
+++ b/clang/unittests/Serialization/VarDeclConstantInitTest.cpp
@@ -104,9 +104,8 @@ export namespace Fibonacci
   ASSERT_TRUE(Invocation);
   Invocation->getFrontendOpts().DisableFree = false;
 
-  CompilerInstance Instance;
+  CompilerInstance Instance(std::move(Invocation));
   Instance.setDiagnostics(Diags.get());
-  Instance.setInvocation(Invocation);
 
   std::string CacheBMIPath = llvm::Twine(TestDir + "/Cached.pcm").str();
   Instance.getFrontendOpts().OutputFile = CacheBMIPath;

--- a/clang/unittests/Tooling/DependencyScanning/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScanning/DependencyScannerTest.cpp
@@ -57,8 +57,8 @@ public:
                      FileManager *FileMgr,
                      std::shared_ptr<PCHContainerOperations> PCHContainerOps,
                      DiagnosticConsumer *DiagConsumer) override {
-    CompilerInstance Compiler(std::move(PCHContainerOps));
-    Compiler.setInvocation(std::move(Invocation));
+    CompilerInstance Compiler(std::move(Invocation),
+                              std::move(PCHContainerOps));
     Compiler.setFileManager(FileMgr);
 
     Compiler.createDiagnostics(FileMgr->getVirtualFileSystem(), DiagConsumer,

--- a/clang/unittests/Tooling/Syntax/TokensTest.cpp
+++ b/clang/unittests/Tooling/Syntax/TokensTest.cpp
@@ -132,8 +132,7 @@ public:
     CI->getFrontendOpts().DisableFree = false;
     CI->getPreprocessorOpts().addRemappedFile(
         FileName, llvm::MemoryBuffer::getMemBufferCopy(Code).release());
-    CompilerInstance Compiler;
-    Compiler.setInvocation(std::move(CI));
+    CompilerInstance Compiler(std::move(CI));
     Compiler.setDiagnostics(Diags.get());
     Compiler.setFileManager(FileMgr.get());
     Compiler.setSourceManager(SourceMgr.get());

--- a/clang/unittests/Tooling/Syntax/TreeTestBase.cpp
+++ b/clang/unittests/Tooling/Syntax/TreeTestBase.cpp
@@ -151,8 +151,7 @@ SyntaxTreeTest::buildTree(StringRef Code, const TestClangConfig &ClangConfig) {
   Invocation->getFrontendOpts().DisableFree = false;
   Invocation->getPreprocessorOpts().addRemappedFile(
       FileName, llvm::MemoryBuffer::getMemBufferCopy(Code).release());
-  CompilerInstance Compiler;
-  Compiler.setInvocation(Invocation);
+  CompilerInstance Compiler(Invocation);
   Compiler.setDiagnostics(Diags.get());
   Compiler.setFileManager(FileMgr.get());
   Compiler.setSourceManager(SourceMgr.get());

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -2208,11 +2208,9 @@ protected:
       return;
     }
 
-    clang::CompilerInstance compiler;
-    compiler.createDiagnostics(*FileSystem::Instance().GetVirtualFileSystem());
-
     const char *clang_args[] = {"clang", pcm_path};
-    compiler.setInvocation(clang::createInvocation(clang_args));
+    clang::CompilerInstance compiler(clang::createInvocation(clang_args));
+    compiler.createDiagnostics(*FileSystem::Instance().GetVirtualFileSystem());
 
     // Pass empty deleter to not attempt to free memory that was allocated
     // outside of the current scope, possibly statically.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -731,13 +731,11 @@ ClangModulesDeclVendor::Create(Target &target) {
   invocation->getPreprocessorOpts().addRemappedFile(ModuleImportBufferName,
                                                     source_buffer.release());
 
-  std::unique_ptr<clang::CompilerInstance> instance(
-      new clang::CompilerInstance);
+  auto instance = std::make_unique<clang::CompilerInstance>(invocation);
 
   // Make sure clang uses the same VFS as LLDB.
   instance->createFileManager(FileSystem::Instance().GetVirtualFileSystem());
   instance->setDiagnostics(diagnostics_engine.get());
-  instance->setInvocation(invocation);
 
   std::unique_ptr<clang::FrontendAction> action(new clang::SyntaxOnlyAction);
 


### PR DESCRIPTION
This PR makes it so that `CompilerInvocation` needs to be provided to `CompilerInstance` on construction. There are a couple of benefits in my view:
* Making it impossible to mis-use some `CompilerInstance` APIs. For example there are cases, where `createDiagnostics()` was called before `setInvocation()`, causing the `DiagnosticEngine` to use the default-constructed `DiagnosticOptions` instead of the intended ones.
* This shrinks `CompilerInstance`'s state space.
* This makes it possible to access **the** invocation in `CompilerInstance`'s constructor (to be used in a follow-up).