### PR TITLE
Revert "[CodeGen] Use OwningArrayRef in NodeMetadata (NFC)"

### DIFF
--- a/llvm/include/llvm/CodeGen/RegAllocPBQP.h
+++ b/llvm/include/llvm/CodeGen/RegAllocPBQP.h
@@ -15,7 +15,6 @@
 #ifndef LLVM_CODEGEN_REGALLOCPBQP_H
 #define LLVM_CODEGEN_REGALLOCPBQP_H
 
-#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/CodeGen/PBQP/CostAllocator.h"
@@ -184,14 +183,18 @@ public:
   NodeMetadata() = default;
 
   NodeMetadata(const NodeMetadata &Other)
-      : RS(Other.RS), DeniedOpts(Other.DeniedOpts),
-        OptUnsafeEdges(ArrayRef<unsigned>(Other.OptUnsafeEdges)),
-        VReg(Other.VReg), AllowedRegs(Other.AllowedRegs)
+      : RS(Other.RS), NumOpts(Other.NumOpts), DeniedOpts(Other.DeniedOpts),
+        OptUnsafeEdges(new unsigned[NumOpts]), VReg(Other.VReg),
+        AllowedRegs(Other.AllowedRegs)
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS
         ,
         everConservativelyAllocatable(Other.everConservativelyAllocatable)
 #endif
   {
+    if (NumOpts > 0) {
+      std::copy(&Other.OptUnsafeEdges[0], &Other.OptUnsafeEdges[NumOpts],
+                &OptUnsafeEdges[0]);
+    }
   }
 
   NodeMetadata(NodeMetadata &&) = default;
@@ -206,7 +209,8 @@ public:
   const AllowedRegVector& getAllowedRegs() const { return *AllowedRegs; }
 
   void setup(const Vector& Costs) {
-    OptUnsafeEdges = OwningArrayRef<unsigned>(Costs.getLength() - 1);
+    NumOpts = Costs.getLength() - 1;
+    OptUnsafeEdges = std::unique_ptr<unsigned[]>(new unsigned[NumOpts]());
   }
 
   ReductionState getReductionState() const { return RS; }
@@ -226,7 +230,7 @@ public:
     DeniedOpts += Transpose ? MD.getWorstRow() : MD.getWorstCol();
     const bool* UnsafeOpts =
       Transpose ? MD.getUnsafeCols() : MD.getUnsafeRows();
-    for (unsigned i = 0; i < OptUnsafeEdges.size(); ++i)
+    for (unsigned i = 0; i < NumOpts; ++i)
       OptUnsafeEdges[i] += UnsafeOpts[i];
   }
 
@@ -234,13 +238,14 @@ public:
     DeniedOpts -= Transpose ? MD.getWorstRow() : MD.getWorstCol();
     const bool* UnsafeOpts =
       Transpose ? MD.getUnsafeCols() : MD.getUnsafeRows();
-    for (unsigned i = 0; i < OptUnsafeEdges.size(); ++i)
+    for (unsigned i = 0; i < NumOpts; ++i)
       OptUnsafeEdges[i] -= UnsafeOpts[i];
   }
 
   bool isConservativelyAllocatable() const {
-    return (DeniedOpts < OptUnsafeEdges.size()) ||
-           llvm::is_contained(OptUnsafeEdges, 0);
+    return (DeniedOpts < NumOpts) ||
+      (std::find(&OptUnsafeEdges[0], &OptUnsafeEdges[NumOpts], 0) !=
+       &OptUnsafeEdges[NumOpts]);
   }
 
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS
@@ -251,8 +256,9 @@ public:
 
 private:
   ReductionState RS = Unprocessed;
+  unsigned NumOpts = 0;
   unsigned DeniedOpts = 0;
-  OwningArrayRef<unsigned> OptUnsafeEdges;
+  std::unique_ptr<unsigned[]> OptUnsafeEdges;
   Register VReg;
   GraphMetadata::AllowedRegVecRef AllowedRegs;
 


### PR DESCRIPTION
Reverts llvm/llvm-project#137539

This breaks the MSan buildbot. Please either fix the build or merge this revert.