### PR TITLE
[libc][bazel] Make top section of BUILD.bazel files more uniform.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/BUILD.bazel
@@ -7,6 +7,8 @@ load("//libc:libc_build_rules.bzl", "libc_release_library")
 
 package(default_visibility = ["//visibility:public"])
 
+licenses(["notice"])
+
 exports_files(["libc_test_rules.bzl"])
 
 # Smoke test verifying libc_release_library macro functionality.

--- a/utils/bazel/llvm-project-overlay/libc/test/include/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/include/BUILD.bazel
@@ -6,6 +6,8 @@
 
 load("//libc/test:libc_test_rules.bzl", "libc_test")
 
+package(default_visibility = ["//visibility:public"])
+
 licenses(["notice"])
 
 libc_test(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/complex/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/complex/BUILD.bazel
@@ -1,4 +1,14 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tests for LLVM libc complex.h functions.
+
 load("//libc/test:libc_test_rules.bzl", "libc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 [
     libc_test(


### PR DESCRIPTION
Make sure all BUILD.bazel files under llvm-libc are specifying package-level default_visibility and licenses.

Add top-level license notice and comment to new BUILD.bazel for complex.h functions.