### PR TITLE
[HLSL][RootSignature] Define and integrate rootsig clang attr and decl

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -5179,22 +5179,35 @@ public:
   friend class ASTDeclWriter;
 };
 
-class HLSLRootSignatureDecl final : public NamedDecl {
-  ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements;
+class HLSLRootSignatureDecl final
+    : public NamedDecl,
+      private llvm::TrailingObjects<HLSLRootSignatureDecl,
+                                    llvm::hlsl::rootsig::RootElement> {
+  friend TrailingObjects;
 
-  HLSLRootSignatureDecl(
-      DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
-      ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements);
+  unsigned NumElems;
+
+  llvm::hlsl::rootsig::RootElement *getElems() {
+    return getTrailingObjects<llvm::hlsl::rootsig::RootElement>();
+  }
+
+  const llvm::hlsl::rootsig::RootElement *getElems() const {
+    return getTrailingObjects<llvm::hlsl::rootsig::RootElement>();
+  }
+
+  HLSLRootSignatureDecl(DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+                        unsigned NumElems);
 
 public:
   static HLSLRootSignatureDecl *
   Create(ASTContext &C, DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
          ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements);
+
   static HLSLRootSignatureDecl *CreateDeserialized(ASTContext &C,
                                                    GlobalDeclID ID);
 
-  ArrayRef<llvm::hlsl::rootsig::RootElement> &getRootElements() {
-    return RootElements;
+  ArrayRef<llvm::hlsl::rootsig::RootElement> getRootElements() const {
+    return {getElems(), NumElems};
   }
 
   // Implement isa/cast/dyncast/etc.

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -41,6 +41,7 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Frontend/HLSL/HLSLRootSignature.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -5176,6 +5177,29 @@ public:
 
   friend class ASTDeclReader;
   friend class ASTDeclWriter;
+};
+
+class HLSLRootSignatureDecl final : public NamedDecl {
+  ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements;
+
+  HLSLRootSignatureDecl(
+      DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+      ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements);
+
+public:
+  static HLSLRootSignatureDecl *
+  Create(ASTContext &C, DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+         ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements);
+  static HLSLRootSignatureDecl *CreateDeserialized(ASTContext &C,
+                                                   GlobalDeclID ID);
+
+  ArrayRef<llvm::hlsl::rootsig::RootElement> &getRootElements() {
+    return RootElements;
+  }
+
+  // Implement isa/cast/dyncast/etc.
+  static bool classof(const Decl *D) { return classofKind(D->getKind()); }
+  static bool classofKind(Kind K) { return K == HLSLRootSignature; }
 };
 
 /// Insertion operator for diagnostics.  This allows sending NamedDecl's

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -1599,6 +1599,8 @@ DEF_TRAVERSE_DECL(EmptyDecl, {})
 
 DEF_TRAVERSE_DECL(HLSLBufferDecl, {})
 
+DEF_TRAVERSE_DECL(HLSLRootSignatureDecl, {})
+
 DEF_TRAVERSE_DECL(LifetimeExtendedTemporaryDecl, {
   TRY_TO(TraverseStmt(D->getTemporaryExpr()));
 })

--- a/clang/include/clang/AST/TextNodeDumper.h
+++ b/clang/include/clang/AST/TextNodeDumper.h
@@ -408,6 +408,7 @@ public:
   void
   VisitLifetimeExtendedTemporaryDecl(const LifetimeExtendedTemporaryDecl *D);
   void VisitHLSLBufferDecl(const HLSLBufferDecl *D);
+  void VisitHLSLRootSignatureDecl(const HLSLRootSignatureDecl *D);
   void VisitHLSLOutArgExpr(const HLSLOutArgExpr *E);
   void VisitOpenACCConstructStmt(const OpenACCConstructStmt *S);
   void VisitOpenACCLoopConstruct(const OpenACCLoopConstruct *S);

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4735,6 +4735,17 @@ def Error : InheritableAttr {
   let Documentation = [ErrorAttrDocs];
 }
 
+/// HLSL Root Signature Attribute
+def RootSignature : Attr {
+  /// [RootSignature(Signature)]
+  let Spellings = [Microsoft<"RootSignature">];
+  let Args = [IdentifierArgument<"Signature">];
+  let Subjects = SubjectList<[Function],
+                             ErrorDiag, "'function'">;
+  let LangOpts = [HLSL];
+  let Documentation = [RootSignatureDocs];
+}
+
 def HLSLNumThreads: InheritableAttr {
   let Spellings = [Microsoft<"numthreads">];
   let Args = [IntArgument<"X">, IntArgument<"Y">, IntArgument<"Z">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -8195,6 +8195,17 @@ and https://microsoft.github.io/hlsl-specs/proposals/0013-wave-size-range.html
   }];
 }
 
+def RootSignatureDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``RootSignature`` attribute applies to HLSL entry functions to define what
+types of resources are bound to the graphics pipeline.
+
+For details about the use and specification of Root Signatures please see here:
+https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signatures
+  }];
+}
+
 def NumThreadsDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/clang/include/clang/Basic/DeclNodes.td
+++ b/clang/include/clang/Basic/DeclNodes.td
@@ -111,5 +111,6 @@ def Empty : DeclNode<Decl>;
 def RequiresExprBody : DeclNode<Decl>, DeclContext;
 def LifetimeExtendedTemporary : DeclNode<Decl>;
 def HLSLBuffer : DeclNode<Named, "HLSLBuffer">, DeclContext;
+def HLSLRootSignature : DeclNode<Named, "HLSLRootSignature">;
 def OpenACCDeclare : DeclNode<Decl, "#pragma acc declare">;
 def OpenACCRoutine : DeclNode<Decl, "#pragma acc routine">;

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3093,6 +3093,7 @@ private:
     return AttrsParsed;
   }
   void ParseMicrosoftUuidAttributeArgs(ParsedAttributes &Attrs);
+  void ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs);
   void ParseMicrosoftAttributes(ParsedAttributes &Attrs);
   bool MaybeParseMicrosoftDeclSpecs(ParsedAttributes &Attrs) {
     if (getLangOpts().DeclSpecKeyword && Tok.is(tok::kw___declspec)) {

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -119,6 +119,7 @@ public:
                                        bool IsCompAssign);
   void emitLogicalOperatorFixIt(Expr *LHS, Expr *RHS, BinaryOperatorKind Opc);
 
+  void handleRootSignatureAttr(Decl *D, const ParsedAttr &AL);
   void handleNumThreadsAttr(Decl *D, const ParsedAttr &AL);
   void handleWaveSizeAttr(Decl *D, const ParsedAttr &AL);
   void handleSV_DispatchThreadIDAttr(Decl *D, const ParsedAttr &AL);

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   BinaryFormat
   Core
   FrontendOpenMP
+  FrontendHLSL
   Support
   TargetParser
   )

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5848,6 +5848,31 @@ bool HLSLBufferDecl::buffer_decls_empty() {
 }
 
 //===----------------------------------------------------------------------===//
+// HLSLRootSignatureDecl Implementation
+//===----------------------------------------------------------------------===//
+
+HLSLRootSignatureDecl::HLSLRootSignatureDecl(
+    DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+    ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements)
+    : NamedDecl(Decl::Kind::HLSLRootSignature, DC, Loc, DeclarationName(ID)),
+      RootElements(RootElements) {}
+
+HLSLRootSignatureDecl *HLSLRootSignatureDecl::Create(
+    ASTContext &C, DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+    ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements) {
+  HLSLRootSignatureDecl *Result =
+      new (C, DC) HLSLRootSignatureDecl(DC, Loc, ID, RootElements);
+  return Result;
+}
+
+HLSLRootSignatureDecl *
+HLSLRootSignatureDecl::CreateDeserialized(ASTContext &C, GlobalDeclID ID) {
+  HLSLRootSignatureDecl *Result =
+      new (C, ID) HLSLRootSignatureDecl(nullptr, SourceLocation(), nullptr, {});
+  return Result;
+}
+
+//===----------------------------------------------------------------------===//
 // ImportDecl Implementation
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -886,6 +886,7 @@ unsigned Decl::getIdentifierNamespaceForKind(Kind DeclKind) {
     case ObjCProperty:
     case MSProperty:
     case HLSLBuffer:
+    case HLSLRootSignature:
       return IDNS_Ordinary;
     case Label:
       return IDNS_Label;

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -24,6 +24,7 @@
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TypeTraits.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Frontend/HLSL/HLSLRootSignature.h"
 
 #include <algorithm>
 #include <utility>
@@ -3040,6 +3041,7 @@ void TextNodeDumper::VisitHLSLBufferDecl(const HLSLBufferDecl *D) {
 void TextNodeDumper::VisitHLSLRootSignatureDecl(
     const HLSLRootSignatureDecl *D) {
   dumpName(D);
+  llvm::hlsl::rootsig::dumpRootElements(OS, D->getRootElements());
 }
 
 void TextNodeDumper::VisitHLSLOutArgExpr(const HLSLOutArgExpr *E) {

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -3037,6 +3037,10 @@ void TextNodeDumper::VisitHLSLBufferDecl(const HLSLBufferDecl *D) {
   dumpName(D);
 }
 
+void TextNodeDumper::VisitHLSLRootSignatureDecl(const HLSLRootSignatureDecl *D) {
+  dumpName(D);
+}
+
 void TextNodeDumper::VisitHLSLOutArgExpr(const HLSLOutArgExpr *E) {
   OS << (E->isInOut() ? " inout" : " out");
 }

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -3037,7 +3037,8 @@ void TextNodeDumper::VisitHLSLBufferDecl(const HLSLBufferDecl *D) {
   dumpName(D);
 }
 
-void TextNodeDumper::VisitHLSLRootSignatureDecl(const HLSLRootSignatureDecl *D) {
+void TextNodeDumper::VisitHLSLRootSignatureDecl(
+    const HLSLRootSignatureDecl *D) {
   dumpName(D);
 }
 

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -106,6 +106,7 @@ void CodeGenFunction::EmitDecl(const Decl &D, bool EvaluateConditionDecl) {
   case Decl::Binding:
   case Decl::UnresolvedUsingIfExists:
   case Decl::HLSLBuffer:
+  case Decl::HLSLRootSignature:
     llvm_unreachable("Declaration should not be in declstmts!");
   case Decl::Record:    // struct/union/class X;
   case Decl::CXXRecord: // struct/union/class X; [C++]

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -5365,7 +5365,8 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
   // then parse the root signature string and construct the in-memory elements
   if (!Actions.LookupQualifiedName(R, Actions.CurContext)) {
     SourceLocation SignatureLoc =
-      StrLiteral.value()->getExprLoc().getLocWithOffset(1); // offset 1 for '"'
+        StrLiteral.value()->getExprLoc().getLocWithOffset(
+            1); // offset 1 for '"'
     // Invoke the root signature parser to construct the in-memory constructs
     hlsl::RootSignatureLexer Lexer(Signature, SignatureLoc);
     SmallVector<llvm::hlsl::rootsig::RootElement> Elements;

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -5348,9 +5348,8 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
   if (!StrLiteral.has_value()) {
     Diag(Tok, diag::err_expected_string_literal)
         << /*in attributes...*/ 4 << RootSignatureIdent->getName();
-    SkipUntil(tok::r_square, StopAtSemi | StopBeforeMatch);
-    if (Tok.is(tok::r_paren))
-      T.consumeClose();
+    SkipUntil(tok::r_paren, StopAtSemi | StopBeforeMatch);
+    T.consumeClose();
     return;
   }
 
@@ -5372,9 +5371,7 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
     SmallVector<llvm::hlsl::rootsig::RootElement> Elements;
     hlsl::RootSignatureParser Parser(Elements, Lexer, PP);
     if (Parser.parse()) {
-      SkipUntil(tok::r_square, StopAtSemi | StopBeforeMatch);
-      if (Tok.is(tok::r_paren))
-        T.consumeClose();
+      T.consumeClose();
       return;
     }
 

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -5314,10 +5314,11 @@ void Parser::ParseMicrosoftUuidAttributeArgs(ParsedAttributes &Attrs) {
 }
 
 void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
-  assert(Tok.is(tok::identifier) && "Not a Microsoft attribute list");
+  assert(Tok.is(tok::identifier) &&
+         "Expected an identifier to denote which MS attribute to consider");
   IdentifierInfo *RootSignatureIdent = Tok.getIdentifierInfo();
   assert(RootSignatureIdent->getName() == "RootSignature" &&
-         "Not a Microsoft attribute list");
+         "Expected RootSignature identifier for root signature attribute");
 
   SourceLocation RootSignatureLoc = Tok.getLocation();
   ConsumeToken();

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -5381,7 +5381,7 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
 
       // Create the Root Signature
       auto *SignatureDecl = HLSLRootSignatureDecl::Create(
-          Actions.getASTContext(), /*FIXME?*/ Actions.CurContext,
+          Actions.getASTContext(), /*DeclContext=*/Actions.CurContext,
           RootSignatureLoc, DeclIdent, RootElements);
       SignatureDecl->setImplicit();
       Actions.PushOnScopeChains(SignatureDecl, getCurScope());

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -5369,19 +5369,12 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
             1); // offset 1 for '"'
     // Invoke the root signature parser to construct the in-memory constructs
     hlsl::RootSignatureLexer Lexer(Signature, SignatureLoc);
-    SmallVector<llvm::hlsl::rootsig::RootElement> Elements;
-    hlsl::RootSignatureParser Parser(Elements, Lexer, PP);
+    SmallVector<llvm::hlsl::rootsig::RootElement> RootElements;
+    hlsl::RootSignatureParser Parser(RootElements, Lexer, PP);
     if (Parser.parse()) {
       T.consumeClose();
       return;
     }
-
-    // Allocate the root elements onto ASTContext
-    unsigned N = Elements.size();
-    auto RootElements = MutableArrayRef<llvm::hlsl::rootsig::RootElement>(
-        ::new (Actions.getASTContext()) llvm::hlsl::rootsig::RootElement[N], N);
-    for (unsigned I = 0; I < N; ++I)
-      RootElements[I] = Elements[I];
 
     // Create the Root Signature
     auto *SignatureDecl = HLSLRootSignatureDecl::Create(

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -5365,8 +5365,10 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
   // Check if we have already found a decl of the same name, if we haven't
   // then parse the root signature string and construct the in-memory elements
   if (!Actions.LookupQualifiedName(R, Actions.CurContext)) {
+    SourceLocation SignatureLoc =
+      StrLiteral.value()->getExprLoc().getLocWithOffset(1); // offset 1 for '"'
     // Invoke the root signature parser to construct the in-memory constructs
-    hlsl::RootSignatureLexer Lexer(Signature, RootSignatureLoc);
+    hlsl::RootSignatureLexer Lexer(Signature, SignatureLoc);
     SmallVector<llvm::hlsl::rootsig::RootElement> Elements;
     hlsl::RootSignatureParser Parser(Elements, Lexer, PP);
     if (Parser.parse()) {

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -5337,7 +5337,7 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
     ExprResult StringResult = ParseUnevaluatedStringLiteralExpression();
     if (StringResult.isInvalid())
       return std::nullopt;
-    
+
     if (auto Lit = dyn_cast<StringLiteral>(StringResult.get()))
       return Lit;
 
@@ -5353,7 +5353,7 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
       T.consumeClose();
     return;
   }
-  
+
   // Construct our identifier
   StringRef Signature = StrLiteral.value()->getString();
   auto Hash = llvm::hash_value(Signature);
@@ -5379,8 +5379,7 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
     // Allocate the root elements onto ASTContext
     unsigned N = Elements.size();
     auto RootElements = MutableArrayRef<llvm::hlsl::rootsig::RootElement>(
-        ::new (Actions.getASTContext()) llvm::hlsl::rootsig::RootElement[N],
-        N);
+        ::new (Actions.getASTContext()) llvm::hlsl::rootsig::RootElement[N], N);
     for (unsigned I = 0; I < N; ++I)
       RootElements[I] = Elements[I];
 
@@ -5396,7 +5395,7 @@ void Parser::ParseMicrosoftRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
   IdentifierLoc *ILoc = ::new (Actions.getASTContext())
       IdentifierLoc(RootSignatureLoc, DeclIdent);
 
-  ArgsVector Args = { ILoc };
+  ArgsVector Args = {ILoc};
 
   if (!T.consumeClose())
     Attrs.addNew(RootSignatureIdent,

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7481,6 +7481,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     break;
 
   // HLSL attributes:
+  case ParsedAttr::AT_RootSignature:
+    S.HLSL().handleRootSignatureAttr(D, AL);
+    break;
   case ParsedAttr::AT_HLSLNumThreads:
     S.HLSL().handleNumThreadsAttr(D, AL);
     break;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -958,6 +958,16 @@ void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
   }
 
   IdentifierInfo *Ident = AL.getArgAsIdent(0)->getIdentifierInfo();
+  if (auto *RS = D->getAttr<RootSignatureAttr>()) {
+    if (RS->getSignature() != Ident) {
+      Diag(AL.getLoc(), diag::err_disallowed_duplicate_attribute) << RS;
+      return;
+    }
+
+    Diag(AL.getLoc(), diag::warn_duplicate_attribute_exact) << RS;
+    return;
+  }
+
   LookupResult R(SemaRef, Ident, SourceLocation(), Sema::LookupOrdinaryName);
   if (SemaRef.LookupQualifiedName(R, D->getDeclContext()))
     if (auto *SignatureDecl =

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -29,6 +29,7 @@
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Sema/Initialization.h"
+#include "clang/Sema/Lookup.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/Template.h"
@@ -948,6 +949,23 @@ void SemaHLSL::emitLogicalOperatorFixIt(Expr *LHS, Expr *RHS,
   SourceRange FullRange = SourceRange(LHS->getBeginLoc(), RHS->getEndLoc());
   SemaRef.Diag(LHS->getBeginLoc(), diag::note_function_suggestion)
       << NewFnName << FixItHint::CreateReplacement(FullRange, OS.str());
+}
+
+void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
+  if (AL.getNumArgs() != 1) {
+    Diag(AL.getLoc(), diag::err_attribute_wrong_number_arguments) << AL << 1;
+    return;
+  }
+
+  IdentifierInfo *Ident = AL.getArgAsIdent(0)->getIdentifierInfo();
+  LookupResult R(SemaRef, Ident, SourceLocation(), Sema::LookupOrdinaryName);
+  if (SemaRef.LookupQualifiedName(R, D->getDeclContext()))
+    if (auto *SignatureDecl =
+            dyn_cast<HLSLRootSignatureDecl>(R.getFoundDecl())) {
+      // Perform validation of constructs here
+      D->addAttr(::new (getASTContext())
+                     RootSignatureAttr(getASTContext(), AL, Ident));
+    }
 }
 
 void SemaHLSL::handleNumThreadsAttr(Decl *D, const ParsedAttr &AL) {

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -999,6 +999,11 @@ Decl *TemplateDeclInstantiator::VisitHLSLBufferDecl(HLSLBufferDecl *Decl) {
   llvm_unreachable("HLSL buffer declarations cannot be instantiated");
 }
 
+Decl *TemplateDeclInstantiator::VisitHLSLRootSignatureDecl(
+    HLSLRootSignatureDecl *Decl) {
+  llvm_unreachable("HLSL root signature declarations cannot be instantiated");
+}
+
 Decl *
 TemplateDeclInstantiator::VisitPragmaCommentDecl(PragmaCommentDecl *D) {
   llvm_unreachable("pragma comment cannot be instantiated");

--- a/clang/lib/Serialization/ASTCommon.cpp
+++ b/clang/lib/Serialization/ASTCommon.cpp
@@ -458,6 +458,7 @@ bool serialization::isRedeclarableDeclKind(unsigned Kind) {
   case Decl::RequiresExprBody:
   case Decl::UnresolvedUsingIfExists:
   case Decl::HLSLBuffer:
+  case Decl::HLSLRootSignature:
   case Decl::OpenACCDeclare:
   case Decl::OpenACCRoutine:
     return false;

--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -15,7 +15,19 @@
   "), " \
   "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
 
-// CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[SAMPLE_RS_DECL:__hlsl_rootsig_decl_.*]]
+// CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[SAMPLE_RS_DECL:__hlsl_rootsig_decl_\d*]]
+// CHECK-SAME: RootElements{
+// CHECK-SAME:   CBV(b1, numDescriptors = 1, space = 0,
+// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = DataStaticWhileSetAtExecute),
+// CHECK-SAME:   SRV(t1, numDescriptors = 8, space = 0,
+// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile),
+// CHECK-SAME:   UAV(u1, numDescriptors = 0, space = 0,
+// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile),
+// CHECK-SAME:   DescriptorTable(numClauses = 3, visibility = All),
+// CHECK-SAME:   Sampler(s0, numDescriptors = 4, space = 1,
+// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = None),
+// CHECK-SAME:   DescriptorTable(numClauses = 1, visibility = All)
+// CHECK-SAME: }
 
 // CHECK: -RootSignatureAttr 0x{{.*}} {{.*}} [[SAMPLE_RS_DECL]]
 [RootSignature(SampleRS)]
@@ -51,7 +63,12 @@ void same_rs_string_main() {}
 // Ensure that when we define a different type root signature that it creates
 // a seperate decl and identifier to reference
 
-// CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[DIFF_RS_DECL:__hlsl_rootsig_decl_.*]]
+// CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[DIFF_RS_DECL:__hlsl_rootsig_decl_\d*]]
+// CHECK-SAME: RootElements{
+// CHECK-SAME:   Sampler(s0, numDescriptors = 4, space = 1,
+// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = None),
+// CHECK-SAME:   DescriptorTable(numClauses = 1, visibility = All)
+// CHECK-SAME: }
 
 // CHECK: -RootSignatureAttr 0x{{.*}} {{.*}} [[DIFF_RS_DECL]]
 [RootSignature(SampleDifferentRS)]

--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -1,0 +1,58 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
+// RUN:  -disable-llvm-passes -o - %s | FileCheck %s
+
+// This test ensures that the sample root signature is parsed without error and
+// the Attr AST Node is created succesfully. If an invalid root signature was
+// passed in then we would exit out of Sema before the Attr is created.
+
+#define SampleRS \
+  "DescriptorTable( " \
+  "  CBV(b1), " \
+  "  SRV(t1, numDescriptors = 8, " \
+  "          flags = DESCRIPTORS_VOLATILE), " \
+  "  UAV(u1, numDescriptors = 0, " \
+  "          flags = DESCRIPTORS_VOLATILE) " \
+  "), " \
+  "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
+
+// CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[SAMPLE_RS_DECL:__hlsl_rootsig_decl_.*]]
+
+// CHECK: -RootSignatureAttr 0x{{.*}} {{.*}} [[SAMPLE_RS_DECL]]
+[RootSignature(SampleRS)]
+void rs_main() {}
+
+// Ensure that if multiple root signatures are specified at different entry
+// points that we point to the correct root signature
+
+// CHECK: -RootSignatureAttr 0x{{.*}} {{.*}} [[SAMPLE_RS_DECL]]
+[RootSignature(SampleRS)]
+void same_rs_main() {}
+
+// Define the same root signature to ensure that the entry point will still
+// link to the same root signature declaration
+
+#define SampleSameRS \
+  "DescriptorTable( " \
+  "  CBV(b1), " \
+  "  SRV(t1, numDescriptors = 8, " \
+  "          flags = DESCRIPTORS_VOLATILE), " \
+  "  UAV(u1, numDescriptors = 0, " \
+  "          flags = DESCRIPTORS_VOLATILE) " \
+  "), " \
+  "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
+
+// CHECK: -RootSignatureAttr 0x{{.*}} {{.*}} [[SAMPLE_RS_DECL]]
+[RootSignature(SampleSameRS)]
+void same_rs_string_main() {}
+
+#define SampleDifferentRS \
+  "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
+
+// Ensure that when we define a different type root signature that it creates
+// a seperate decl and identifier to reference
+
+// CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[DIFF_RS_DECL:__hlsl_rootsig_decl_.*]]
+
+// CHECK: -RootSignatureAttr 0x{{.*}} {{.*}} [[DIFF_RS_DECL]]
+[RootSignature(SampleDifferentRS)]
+void different_rs_string_main() {}

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -o - %s -verify
+
+// Attr test
+
+[RootSignature()] // expected-error {{expected string literal as argument of 'RootSignature' attribute}}
+void bad_root_signature_0() {}
+
+// expected-error@+2 {{expected ')'}}
+// expected-note@+1 {{to match this '('}}
+[RootSignature("", "")]
+void bad_root_signature_1() {}

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -9,3 +9,9 @@ void bad_root_signature_0() {}
 // expected-note@+1 {{to match this '('}}
 [RootSignature("", "")]
 void bad_root_signature_1() {}
+
+[RootSignature(""), RootSignature("DescriptorTable()")] // expected-error {{attribute 'RootSignature' cannot appear more than once on a declaration}}
+void bad_root_signature_2() {}
+
+[RootSignature(""), RootSignature("")] // expected-warning {{attribute 'RootSignature' is already applied}}
+void bad_root_signature_3() {}

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -15,3 +15,6 @@ void bad_root_signature_2() {}
 
 [RootSignature(""), RootSignature("")] // expected-warning {{attribute 'RootSignature' is already applied}}
 void bad_root_signature_3() {}
+
+[RootSignature("DescriptorTable(), invalid")] // expected-error {{expected end of stream to denote end of parameters, or, another valid parameter of RootSignature}}
+void bad_root_signature_4() {}

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -7230,6 +7230,7 @@ CXCursor clang_getCursorDefinition(CXCursor C) {
   case Decl::MSProperty:
   case Decl::MSGuid:
   case Decl::HLSLBuffer:
+  case Decl::HLSLRootSignature:
   case Decl::UnnamedGlobalConstant:
   case Decl::TemplateParamObject:
   case Decl::IndirectField:

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_FRONTEND_HLSL_HLSLROOTSIGNATURE_H
 #define LLVM_FRONTEND_HLSL_HLSLROOTSIGNATURE_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/DXILABI.h"
 #include "llvm/Support/raw_ostream.h"
 #include <variant>
@@ -121,6 +122,8 @@ struct DescriptorTableClause {
 // Models RootElement : RootConstants | DescriptorTable | DescriptorTableClause
 using RootElement = std::variant<RootFlags, RootConstants, DescriptorTable,
                                  DescriptorTableClause>;
+
+void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements);
 
 } // namespace rootsig
 } // namespace hlsl

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -160,13 +160,9 @@ void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
     OS << " ";
     First = false;
     std::visit(OverloadMethods{
-      [&OS](DescriptorTable Table) {
-        Table.dump(OS);
-      },
-      [&OS](DescriptorTableClause Clause) {
-        Clause.dump(OS);
-      }
-    }, Element);
+                   [&OS](DescriptorTable Table) { Table.dump(OS); },
+                   [&OS](DescriptorTableClause Clause) { Clause.dump(OS); }},
+               Element);
   }
   OS << "}";
 }

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -154,7 +154,7 @@ template <class... Ts> OverloadMethods(Ts...) -> OverloadMethods<Ts...>;
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
   OS << "RootElements{";
   bool First = true;
-  for (auto Element : Elements) {
+  for (const RootElement &Element : Elements) {
     if (!First)
       OS << ",";
     OS << " ";

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -144,6 +144,33 @@ void DescriptorTableClause::dump(raw_ostream &OS) const {
   OS << ", flags = " << Flags << ")";
 }
 
+// Helper struct so that we can use the overloaded notation of std::visit
+template <class... Ts> struct OverloadMethods : Ts... {
+  using Ts::operator()...;
+};
+
+template <class... Ts> OverloadMethods(Ts...) -> OverloadMethods<Ts...>;
+
+void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
+  OS << "RootElements{";
+  bool First = true;
+  for (auto Element : Elements) {
+    if (!First)
+      OS << ",";
+    OS << " ";
+    First = false;
+    std::visit(OverloadMethods{
+      [&OS](DescriptorTable Table) {
+        Table.dump(OS);
+      },
+      [&OS](DescriptorTableClause Clause) {
+        Clause.dump(OS);
+      }
+    }, Element);
+  }
+  OS << "}";
+}
+
 } // namespace rootsig
 } // namespace hlsl
 } // namespace llvm

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -144,18 +144,7 @@ void DescriptorTableClause::dump(raw_ostream &OS) const {
   OS << ", flags = " << Flags << ")";
 }
 
-// Helper callable so that we can use the overloaded notation of std::visit
-namespace {
-struct ElementDumper {
-  raw_ostream &OS;
-  template <typename T> void operator()(const T &Element) const {
-    Element.dump(OS);
-  }
-};
-} // namespace
-
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
-  ElementDumper Dumper{OS};
   OS << "RootElements{";
   bool First = true;
   for (const RootElement &Element : Elements) {
@@ -163,7 +152,10 @@ void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
       OS << ",";
     OS << " ";
     First = false;
-    std::visit(Dumper, Element);
+    if (const auto &Clause = std::get_if<DescriptorTableClause>(&Element))
+      Clause->dump(OS);
+    if (const auto &Table = std::get_if<DescriptorTable>(&Element))
+      Table->dump(OS);
   }
   OS << "}";
 }


### PR DESCRIPTION
- Defines a new declaration node `HLSLRootSignature` in `DeclNodes.td` that will consist of a `TrailingObjects` of the in-memory construction of the root signature, namely an array of `hlsl::rootsig::RootElement`s

- Defines a new clang attr `RootSignature` which simply holds an identifier to a corresponding root signature declration as above

- Integrate the `HLSLRootSignatureParser` to construct the decl node in `ParseMicrosoftAttributes` and then attach the parsed attr with an identifier to the entry point function declaration.

- Defines the various required declaration methods

- Add testing that the declaration and reference attr are created correctly, and some syntactical error tests.

It was previously proposed that we could have the root elements reference be stored directly as an additional member of the attribute and to not have a seperate root signature decl. In contrast, by defining them seperately as this change proposes, we will allow a unique root signature to have its own declaration in the AST tree. This allows us to only construct a single root signature for all duplicate rootsignature attributes. Having it located directly as a declaration might also prove advantageous when we consider root signature libraries.

Resolves https://github.com/llvm/llvm-project/issues/119011