### PR TITLE
[lldb] Provide an unconditional @skip annotation for API tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -397,6 +397,10 @@ def skipIf(
     )
 
 
+def skip(bugnumber=None):
+    return _decorateTest(DecorateMode.Skip, bugnumber=bugnumber)
+
+
 def _skip_fn_for_android(reason, api_levels, archs):
     def impl():
         result = lldbplatformutil.match_android_device(

--- a/lldb/test/API/commands/expression/import-std-module/pair/TestPairFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/pair/TestPairFromStdModule.py
@@ -13,7 +13,7 @@ class TestCase(TestBase):
     # FIXME: This regressed in 69d5a6662115499198ebfa07a081e98a6ce4b915
     # but needs further investigation for what underlying Clang/LLDB bug can't
     # handle that code change.
-    @skipIf
+    @skip
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/watchpoints/variable_out_of_scope/TestWatchedVarHitWhenInScope.py
+++ b/lldb/test/API/commands/watchpoints/variable_out_of_scope/TestWatchedVarHitWhenInScope.py
@@ -28,7 +28,7 @@ class WatchedVariableHitWhenInScopeTestCase(TestBase):
 
     # Test hangs due to a kernel bug, see fdfeff0f in the linux kernel for details
     @skipIfTargetAndroid(api_levels=list(range(25 + 1)), archs=["aarch64", "arm"])
-    @skipIf
+    @skip
     def test_watched_var_should_only_hit_when_in_scope(self):
         """Test that a variable watchpoint should only hit when in scope."""
         self.build(dictionary=self.d)

--- a/lldb/test/API/lang/objc/bitfield_ivars/TestBitfieldIvars.py
+++ b/lldb/test/API/lang/objc/bitfield_ivars/TestBitfieldIvars.py
@@ -42,7 +42,7 @@ class TestBitfieldIvars(TestBase):
 
     # This test is meant to be xfailed, but running the test triggers an ASan
     # issue, so it must be skipped for now.
-    @skipIf
+    @skip
     def testExprWholeObject(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
@@ -19,7 +19,7 @@ import sys
 import socket
 
 
-@skipIf
+@skip
 class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
     default_timeout = 20
 


### PR DESCRIPTION
The correct way of doing this today is to use `@skipIf` with no arguments, which reads like it expects a condition.

Fixes #137710