### PR TITLE
[lld][WebAssembly] Don't mark `--start-lib`/`--end-lib` files as live

### DIFF
--- a/lld/test/wasm/Inputs/start-lib1.s
+++ b/lld/test/wasm/Inputs/start-lib1.s
@@ -5,3 +5,10 @@ foo:
   .functype foo () -> ()
   call bar
   end_function
+
+# Static constructor inserted here to ensure the object file is not
+# being processed as "live".  Live object files have their static constructors
+# preserved even if no symbol within is used.
+.section .init_array,"",@
+  .p2align 2
+  .int32 foo

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -317,10 +317,6 @@ void LinkerDriver::addFile(StringRef path) {
     if (inWholeArchive) {
       for (const auto &[m, offset] : members) {
         auto *object = createObjectFile(m, path, offset);
-        // Mark object as live; object members are normally not
-        // live by default but -whole-archive is designed to treat
-        // them as such.
-        object->markLive();
         files.push_back(object);
       }
 

--- a/lld/wasm/InputFiles.cpp
+++ b/lld/wasm/InputFiles.cpp
@@ -423,8 +423,10 @@ ObjFile::ObjFile(MemoryBufferRef m, StringRef archiveName, bool lazy)
   // https://github.com/llvm/llvm-project/issues/98778
   checkArch(wasmObj->getArch());
 
-  // If this isn't part of an archive, it's eagerly linked, so mark it live.
-  if (archiveName.empty())
+  // Unless we are processing this as a lazy object file (e.g. part of an
+  // archive file or within `--start-lib`/`--end-lib`, it's eagerly linked, so
+  // mark it live.
+  if (!lazy)
     markLive();
 }
 


### PR DESCRIPTION
Without this change files in `--start-lib`/`--end-lib` groups were being marked as live, which means there static constructors were being included in the link.