### PR TITLE
[NFC][asan] Try to deflake asan_lsan_deadlock test

### DIFF
--- a/compiler-rt/test/asan/TestCases/asan_lsan_deadlock.cpp
+++ b/compiler-rt/test/asan/TestCases/asan_lsan_deadlock.cpp
@@ -36,11 +36,8 @@
 
 void Watchdog() {
   // Safety mechanism: Turn infinite deadlock into finite test failure
-  usleep(10000000);
-  // CHECK-NOT: Timeout! Deadlock detected.
-  puts("Timeout! Deadlock detected.");
-  fflush(stdout);
-  _exit(1);
+  sleep(60);
+  _exit(0);
 }
 
 int main(int argc, char **argv) {

--- a/compiler-rt/test/asan/TestCases/asan_lsan_deadlock.cpp
+++ b/compiler-rt/test/asan/TestCases/asan_lsan_deadlock.cpp
@@ -24,9 +24,8 @@
  * [Worker Thread] ASan: lock B -> requests lock A
  * 
  * Success Criteria: 
- * With proper lock ordering enforcement, watchdog should NOT trigger - test exits normally.
- * If deadlock occurs, watchdog terminates via _exit(1) after 10s timeout.
- */
+ * With proper lock ordering enforcement, watchdog should NOT trigger - test exits with Asan report.
+  */
 
 #include <mutex>
 #include <sanitizer/lsan_interface.h>
@@ -37,6 +36,7 @@
 void Watchdog() {
   // Safety mechanism: Turn infinite deadlock into finite test failure
   sleep(60);
+  // Unexpected. "not" in RUN will fail if we reached here.
   _exit(0);
 }
 


### PR DESCRIPTION
10s looks not enough. With highly parallel test
execution on VMs it's very possible that Asan
report will have no enough time to produce output.

I can reproduce locally 1s is not always enough,
but likely my workstation is faster then buildbot.

Additionally, don't use puts/CHECK to validate
timeout. We can exit with 0 and it should violate
"not" expectation.

Follow up to #131756.