### PR TITLE
Fix the lldb-dap error when empty source map is specified

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -851,7 +851,7 @@ class DebugCommunication(object):
             args_dict["debuggerRoot"] = debuggerRoot
         if launchCommands:
             args_dict["launchCommands"] = launchCommands
-        if sourceMap:
+        if sourceMap is not None: # sourceMap can be empty array.
             args_dict["sourceMap"] = sourceMap
         if runInTerminal:
             args_dict["runInTerminal"] = runInTerminal

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -100,6 +100,24 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
                     )
 
     @skipIfWindows
+    def test_empty_sourceMap(self):
+        """
+        Tests the launch with empty source map should not issue source map command.
+        """
+        program = self.getBuildArtifact("a.out")
+        self.build_and_create_debug_adapter()
+        empty_source_map = []
+        self.launch(program, sourceMap=empty_source_map)
+        self.continue_to_exit()
+
+        # Now get the console output and verify no source map command was issued for empty source map.
+        console_output = self.get_console()
+        self.assertTrue(
+            console_output and len(console_output) > 0, "expect some console output"
+        )
+        self.assertNotIn("Setting source map:", console_output)
+
+    @skipIfWindows
     def test_cwd(self):
         """
         Tests the default launch of a simple program with a current working

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -57,9 +57,8 @@ void BaseRequestHandler::SetSourceMapFromArguments(
       "source must be be an array of two-element arrays, "
       "each containing a source and replacement path string.\n";
 
-  std::string sourceMapCommand;
-  llvm::raw_string_ostream strm(sourceMapCommand);
-  strm << "settings set target.source-map ";
+  std::string sourceMapCommandMappings;
+  llvm::raw_string_ostream strm(sourceMapCommandMappings);
   const auto sourcePath = GetString(arguments, "sourcePath").value_or("");
 
   // sourceMap is the new, more general form of sourcePath and overrides it.
@@ -94,7 +93,9 @@ void BaseRequestHandler::SetSourceMapFromArguments(
     // Do any source remapping needed before we create our targets
     strm << "\".\" \"" << sourcePath << "\"";
   }
-  if (!sourceMapCommand.empty()) {
+  if (!sourceMapCommandMappings.empty()) {
+    std::string sourceMapCommand = "settings set target.source-map ";
+    sourceMapCommand += sourceMapCommandMappings;
     dap.RunLLDBCommands("Setting source map:", {sourceMapCommand});
   }
 }


### PR DESCRIPTION
We have some lldb-dap clients that are specifying an empty source map during launching, we noticed that, even empty source map is specified, lldb-dap still tries to run it without any arguments which shows as following error in VSCode:
```
Setting source map:
(lldb) settings set target.source-map 
error: 'settings set' takes more arguments
```

This PR fixes the regression by detecting the mapping is empty and do not run the command. A test is added which fails before but passes with this PR.
