### PR TITLE
[lldb-dap] Fix machine-overridable scope

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -73,9 +73,8 @@
       "title": "lldb-dap",
       "properties": {
         "lldb-dap.executable-path": {
-          "scope": "resource",
-          "type": "string",
           "scope": "machine-overridable",
+          "type": "string",
           "description": "The path to the lldb-dap binary, e.g. /usr/local/bin/lldb-dap"
         },
         "lldb-dap.arguments": {
@@ -88,7 +87,7 @@
           "description": "The list of additional arguments used to launch the debug adapter executable."
         },
         "lldb-dap.log-path": {
-          "scope": "resource",
+          "scope": "machine-overridable",
           "type": "string",
           "description": "The log path for lldb-dap (if any)"
         },


### PR DESCRIPTION
My previous commit was a bit sloppy, I didn't spot that `lldb-dap.executable-path` already had a scope and I didn't consider that `lldb-dap.log-path` should have the same scope.

This PR addresses both:

 - Fix duplicate scope for `lldb-dap.executable-path`.
 - Change scope of `lldb-dap.log-path` to `machine-overridable` too.