### PR TITLE
[RISCV] Fix Defs/Uses for SiFive CLIC Support

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -293,7 +293,7 @@ static void emitSiFiveCLICPreemptibleSaves(MachineFunction &MF,
 
   // Enable interrupts.
   BuildMI(MBB, MBBI, DL, TII->get(RISCV::CSRRSI))
-      .addReg(RISCV::X0)
+      .addReg(RISCV::X0, RegState::Define)
       .addImm(RISCVSysReg::mstatus)
       .addImm(8)
       .setMIFlag(MachineInstr::FrameSetup);
@@ -315,7 +315,7 @@ static void emitSiFiveCLICPreemptibleRestores(MachineFunction &MF,
 
   // Disable interrupts.
   BuildMI(MBB, MBBI, DL, TII->get(RISCV::CSRRCI))
-      .addReg(RISCV::X0)
+      .addReg(RISCV::X0, RegState::Define)
       .addImm(RISCVSysReg::mstatus)
       .addImm(8)
       .setMIFlag(MachineInstr::FrameSetup);
@@ -324,12 +324,12 @@ static void emitSiFiveCLICPreemptibleRestores(MachineFunction &MF,
   // in the function, they have already been restored once, so now have the
   // value stored in `emitSiFiveCLICPreemptibleSaves`.
   BuildMI(MBB, MBBI, DL, TII->get(RISCV::CSRRW))
-      .addReg(RISCV::X0)
+      .addReg(RISCV::X0, RegState::Define)
       .addImm(RISCVSysReg::mepc)
       .addReg(RISCV::X9, RegState::Kill)
       .setMIFlag(MachineInstr::FrameSetup);
   BuildMI(MBB, MBBI, DL, TII->get(RISCV::CSRRW))
-      .addReg(RISCV::X0)
+      .addReg(RISCV::X0, RegState::Define)
       .addImm(RISCVSysReg::mcause)
       .addReg(RISCV::X8, RegState::Kill)
       .setMIFlag(MachineInstr::FrameSetup);

--- a/llvm/test/CodeGen/RISCV/sifive-interrupt-attr.ll
+++ b/llvm/test/CodeGen/RISCV/sifive-interrupt-attr.ll
@@ -4,9 +4,6 @@
 ; RUN: llc -mtriple riscv64-unknown-elf -mattr=+experimental-xsfmclic -o - %s \
 ; RUN:   -verify-machineinstrs | FileCheck %s --check-prefix=RV64
 
-;; These are failing to verify.
-; XFAIL: *
-
 ; Test Handling of the SiFive-CLIC interrupt attributes.
 ;
 ; "stack-swap" means that sp should be swapped into `sf.mscratchcsw`


### PR DESCRIPTION
The expensive checks bots found issues with #132481, due to not setting defs/uses correctly. In 31bd7a507152 I added verify flags, so that the failure is reproduced without requiring expensive checks, and xfailed the test.

This change:
- Ensures that registers are correctly marked as defs/uses.
- Removes the xfail.
- Leaves the tests with `-verify-machineinstrs` which should have been present originally.