### PR TITLE
[bazel] Fix lldb ODR issue

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -9,6 +9,7 @@ load("@build_bazel_apple_support//rules:apple_genrule.bzl", "apple_genrule")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//:vars.bzl", "LLVM_VERSION_MAJOR", "LLVM_VERSION_MINOR", "LLVM_VERSION_PATCH", "LLVM_VERSION_SUFFIX", "PACKAGE_VERSION")
 load("//lldb/source/Plugins:plugin_config.bzl", "DEFAULT_PLUGINS", "DEFAULT_SCRIPT_PLUGINS", "OBJCPP_COPTS")
+load("//mlir:build_defs.bzl", "cc_headers_only")
 load("//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(
@@ -572,6 +573,11 @@ cc_library(
     }),
 )
 
+cc_headers_only(
+    name = "HostHeaders",
+    src = ":Host",
+)
+
 td_library(
     name = "CoreTdFiles",
     srcs = glob([
@@ -830,8 +836,7 @@ cc_binary(
     ]),
     deps = [
         ":APIHeaders",
-        ":Host",
-        ":Utility",
+        ":HostHeaders",
         ":liblldb.wrapper",
         ":lldb_options_inc_gen",
         "//llvm:Option",


### PR DESCRIPTION
In 42622c79592b98b899d787c89db11cea1b540b96, depending on the entire
utility library resulted in the lldb binary having more symbols that it
needs, duplicating those in liblldb, leading to odr violations. Now
instead we just expose the Host library's headers, which happens to be
enough for this to compile and link, referencing the symbols from
liblldb
