### PR TITLE
[bazel] Fix layering check violation

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -837,6 +837,7 @@ cc_binary(
     deps = [
         ":APIHeaders",
         ":HostHeaders",
+        ":UtilityHeaders",
         ":liblldb.wrapper",
         ":lldb_options_inc_gen",
         "//llvm:Option",


### PR DESCRIPTION
I broke this in 2ce6333a41a68c89866d4075527bd43ce8fd3b6c since I only
tested with a toolchain that doesn't support layering checks
