### PR TITLE
[NFC][AMDGPU] Drop recursive types in LowerBufferFatPointers

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -267,7 +267,7 @@ namespace {
 class BufferFatPtrTypeLoweringBase : public ValueMapTypeRemapper {
   DenseMap<Type *, Type *> Map;
 
-  Type *remapTypeImpl(Type *Ty, SmallPtrSetImpl<StructType *> &Seen);
+  Type *remapTypeImpl(Type *Ty);
 
 protected:
   virtual Type *remapScalar(PointerType *PT) = 0;
@@ -305,8 +305,7 @@ protected:
 } // namespace
 
 // This code is adapted from the type remapper in lib/Linker/IRMover.cpp
-Type *BufferFatPtrTypeLoweringBase::remapTypeImpl(
-    Type *Ty, SmallPtrSetImpl<StructType *> &Seen) {
+Type *BufferFatPtrTypeLoweringBase::remapTypeImpl(Type *Ty) {
   Type **Entry = &Map[Ty];
   if (*Entry)
     return *Entry;
@@ -331,18 +330,11 @@ Type *BufferFatPtrTypeLoweringBase::remapTypeImpl(
   // require recursion.
   if (Ty->getNumContainedTypes() == 0 && IsUniqued)
     return *Entry = Ty;
-  if (!IsUniqued) {
-    // Create a dummy type for recursion purposes.
-    if (!Seen.insert(TyAsStruct).second) {
-      StructType *Placeholder = StructType::create(Ty->getContext());
-      return *Entry = Placeholder;
-    }
-  }
   bool Changed = false;
   SmallVector<Type *> ElementTypes(Ty->getNumContainedTypes(), nullptr);
   for (unsigned int I = 0, E = Ty->getNumContainedTypes(); I < E; ++I) {
     Type *OldElem = Ty->getContainedType(I);
-    Type *NewElem = remapTypeImpl(OldElem, Seen);
+    Type *NewElem = remapTypeImpl(OldElem);
     ElementTypes[I] = NewElem;
     Changed |= (OldElem != NewElem);
   }
@@ -366,13 +358,6 @@ Type *BufferFatPtrTypeLoweringBase::remapTypeImpl(
       return *Entry = StructType::get(Ty->getContext(), ElementTypes, IsPacked);
     SmallString<16> Name(STy->getName());
     STy->setName("");
-    Type **RecursionEntry = &Map[Ty];
-    if (*RecursionEntry) {
-      auto *Placeholder = cast<StructType>(*RecursionEntry);
-      Placeholder->setBody(ElementTypes, IsPacked);
-      Placeholder->setName(Name);
-      return *Entry = Placeholder;
-    }
     return *Entry = StructType::create(Ty->getContext(), ElementTypes, Name,
                                        IsPacked);
   }
@@ -380,8 +365,7 @@ Type *BufferFatPtrTypeLoweringBase::remapTypeImpl(
 }
 
 Type *BufferFatPtrTypeLoweringBase::remapType(Type *SrcTy) {
-  SmallPtrSet<StructType *, 2> Visited;
-  return remapTypeImpl(SrcTy, Visited);
+  return remapTypeImpl(SrcTy);
 }
 
 Type *BufferFatPtrToStructTypeMap::remapScalar(PointerType *PT) {


### PR DESCRIPTION
Now that IRMover and the rest of LLVM don't allow recursive types, drop support for them from the clone of the IRMover code used when lowering buffer fat pointer operations.