### PR TITLE
[NFC][AArch64] Final Cleanup Pass Initialization

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CleanupLocalDynamicTLSPass.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CleanupLocalDynamicTLSPass.cpp
@@ -35,9 +35,7 @@ using namespace llvm;
 namespace {
 struct LDTLSCleanup : public MachineFunctionPass {
   static char ID;
-  LDTLSCleanup() : MachineFunctionPass(ID) {
-    initializeLDTLSCleanupPass(*PassRegistry::getPassRegistry());
-  }
+  LDTLSCleanup() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override {
     if (skipFunction(MF.getFunction()))

--- a/llvm/lib/Target/AArch64/AArch64FalkorHWPFFix.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FalkorHWPFFix.cpp
@@ -81,10 +81,7 @@ class FalkorMarkStridedAccessesLegacy : public FunctionPass {
 public:
   static char ID; // Pass ID, replacement for typeid
 
-  FalkorMarkStridedAccessesLegacy() : FunctionPass(ID) {
-    initializeFalkorMarkStridedAccessesLegacyPass(
-        *PassRegistry::getPassRegistry());
-  }
+  FalkorMarkStridedAccessesLegacy() : FunctionPass(ID) {}
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<TargetPassConfig>();
@@ -180,9 +177,7 @@ class FalkorHWPFFix : public MachineFunctionPass {
 public:
   static char ID;
 
-  FalkorHWPFFix() : MachineFunctionPass(ID) {
-    initializeFalkorHWPFFixPass(*PassRegistry::getPassRegistry());
-  }
+  FalkorHWPFFix() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &Fn) override;
 

--- a/llvm/lib/Target/AArch64/SMEABIPass.cpp
+++ b/llvm/lib/Target/AArch64/SMEABIPass.cpp
@@ -30,9 +30,7 @@ using namespace llvm;
 namespace {
 struct SMEABI : public FunctionPass {
   static char ID; // Pass identification, replacement for typeid
-  SMEABI() : FunctionPass(ID) {
-    initializeSMEABIPass(*PassRegistry::getPassRegistry());
-  }
+  SMEABI() : FunctionPass(ID) {}
 
   bool runOnFunction(Function &F) override;
 

--- a/llvm/lib/Target/AArch64/SMEPeepholeOpt.cpp
+++ b/llvm/lib/Target/AArch64/SMEPeepholeOpt.cpp
@@ -28,9 +28,7 @@ namespace {
 struct SMEPeepholeOpt : public MachineFunctionPass {
   static char ID;
 
-  SMEPeepholeOpt() : MachineFunctionPass(ID) {
-    initializeSMEPeepholeOptPass(*PassRegistry::getPassRegistry());
-  }
+  SMEPeepholeOpt() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 

--- a/llvm/lib/Target/AArch64/SVEIntrinsicOpts.cpp
+++ b/llvm/lib/Target/AArch64/SVEIntrinsicOpts.cpp
@@ -44,9 +44,7 @@ using namespace llvm::PatternMatch;
 namespace {
 struct SVEIntrinsicOpts : public ModulePass {
   static char ID; // Pass identification, replacement for typeid
-  SVEIntrinsicOpts() : ModulePass(ID) {
-    initializeSVEIntrinsicOptsPass(*PassRegistry::getPassRegistry());
-  }
+  SVEIntrinsicOpts() : ModulePass(ID) {}
 
   bool runOnModule(Module &M) override;
   void getAnalysisUsage(AnalysisUsage &AU) const override;


### PR DESCRIPTION
This finishes the work from 23c27f3efcdda730b365698ade5fd0c1c283f2e7 to cleanup where pass initializers are called from, as noted in #111767.

This patch addresses passes where the initializer does not start with `initializeAArch64`, which seemed to be missed in the previous commit.