### PR TITLE
[lldb] Support alternatives for scope format entries

### DIFF
--- a/lldb/include/lldb/Core/FormatEntity.h
+++ b/lldb/include/lldb/Core/FormatEntity.h
@@ -11,10 +11,10 @@
 
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-types.h"
+#include "llvm/ADT/SmallVector.h"
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-
 #include <string>
 #include <vector>
 
@@ -158,9 +158,7 @@ struct Entry {
   }
 
   Entry(Type t = Type::Invalid, const char *s = nullptr,
-        const char *f = nullptr)
-      : string(s ? s : ""), printf_format(f ? f : ""), type(t) {}
-
+        const char *f = nullptr);
   Entry(llvm::StringRef s);
   Entry(char ch);
 
@@ -170,15 +168,19 @@ struct Entry {
 
   void AppendText(const char *cstr);
 
-  void AppendEntry(const Entry &&entry) { children.push_back(entry); }
+  void AppendEntry(const Entry &&entry);
+
+  void StartAlternative();
 
   void Clear() {
     string.clear();
     printf_format.clear();
-    children.clear();
+    children_stack.clear();
+    children_stack.emplace_back();
     type = Type::Invalid;
     fmt = lldb::eFormatDefault;
     number = 0;
+    level = 0;
     deref = false;
   }
 
@@ -191,7 +193,7 @@ struct Entry {
       return false;
     if (printf_format != rhs.printf_format)
       return false;
-    if (children != rhs.children)
+    if (children_stack != rhs.children_stack)
       return false;
     if (type != rhs.type)
       return false;
@@ -202,9 +204,18 @@ struct Entry {
     return true;
   }
 
+  std::vector<Entry> &GetChildren();
+
   std::string string;
   std::string printf_format;
-  std::vector<Entry> children;
+
+  /// A stack of children entries, used by Scope entries to provide alterantive
+  /// children. All other entries have a stack of size 1.
+  /// @{
+  llvm::SmallVector<std::vector<Entry>, 1> children_stack;
+  size_t level = 0;
+  /// @}
+
   Type type;
   lldb::Format fmt = lldb::eFormatDefault;
   lldb::addr_t number = 0;

--- a/lldb/unittests/Core/FormatEntityTest.cpp
+++ b/lldb/unittests/Core/FormatEntityTest.cpp
@@ -20,24 +20,19 @@ using namespace llvm;
 using Definition = FormatEntity::Entry::Definition;
 using Entry = FormatEntity::Entry;
 
-namespace {
-class FormatEntityTest : public ::testing::Test {
-public:
-  Expected<std::string> Format(StringRef format_str) {
-    StreamString stream;
-    FormatEntity::Entry format;
-    Status status = FormatEntity::Parse(format_str, format);
-    if (status.Fail())
-      return status.ToError();
+static Expected<std::string> Format(StringRef format_str) {
+  StreamString stream;
+  FormatEntity::Entry format;
+  Status status = FormatEntity::Parse(format_str, format);
+  if (status.Fail())
+    return status.ToError();
 
-    FormatEntity::Format(format, stream, nullptr, nullptr, nullptr, nullptr,
-                         false, false);
-    return stream.GetString().str();
-  }
-};
-} // namespace
+  FormatEntity::Format(format, stream, nullptr, nullptr, nullptr, nullptr,
+                       false, false);
+  return stream.GetString().str();
+}
 
-TEST_F(FormatEntityTest, DefinitionConstructionNameAndType) {
+TEST(FormatEntityTest, DefinitionConstructionNameAndType) {
   Definition d("foo", FormatEntity::Entry::Type::Invalid);
 
   EXPECT_STREQ(d.name, "foo");
@@ -49,7 +44,7 @@ TEST_F(FormatEntityTest, DefinitionConstructionNameAndType) {
   EXPECT_FALSE(d.keep_separator);
 }
 
-TEST_F(FormatEntityTest, DefinitionConstructionNameAndString) {
+TEST(FormatEntityTest, DefinitionConstructionNameAndString) {
   Definition d("foo", "string");
 
   EXPECT_STREQ(d.name, "foo");
@@ -61,7 +56,7 @@ TEST_F(FormatEntityTest, DefinitionConstructionNameAndString) {
   EXPECT_FALSE(d.keep_separator);
 }
 
-TEST_F(FormatEntityTest, DefinitionConstructionNameTypeData) {
+TEST(FormatEntityTest, DefinitionConstructionNameTypeData) {
   Definition d("foo", FormatEntity::Entry::Type::Invalid, 33);
 
   EXPECT_STREQ(d.name, "foo");
@@ -73,7 +68,7 @@ TEST_F(FormatEntityTest, DefinitionConstructionNameTypeData) {
   EXPECT_FALSE(d.keep_separator);
 }
 
-TEST_F(FormatEntityTest, DefinitionConstructionNameTypeChildren) {
+TEST(FormatEntityTest, DefinitionConstructionNameTypeChildren) {
   Definition d("foo", FormatEntity::Entry::Type::Invalid, 33);
   Definition parent("parent", FormatEntity::Entry::Type::Invalid, 1, &d);
   EXPECT_STREQ(parent.name, "parent");
@@ -173,7 +168,7 @@ constexpr llvm::StringRef lookupStrings[] = {
     "${target.file.fullpath}",
     "${var.dummy-var-to-test-wildcard}"};
 
-TEST_F(FormatEntityTest, LookupAllEntriesInTree) {
+TEST(FormatEntityTest, LookupAllEntriesInTree) {
   for (const llvm::StringRef testString : lookupStrings) {
     Entry e;
     EXPECT_TRUE(FormatEntity::Parse(testString, e).Success())
@@ -181,7 +176,7 @@ TEST_F(FormatEntityTest, LookupAllEntriesInTree) {
   }
 }
 
-TEST_F(FormatEntityTest, Scope) {
+TEST(FormatEntityTest, Scope) {
   // Scope with  one alternative.
   EXPECT_THAT_EXPECTED(Format("{${frame.pc}|foo}"), HasValue("foo"));
 

--- a/lldb/unittests/Core/FormatEntityTest.cpp
+++ b/lldb/unittests/Core/FormatEntityTest.cpp
@@ -8,16 +8,36 @@
 
 #include "lldb/Core/FormatEntity.h"
 #include "lldb/Utility/Status.h"
-
+#include "lldb/Utility/StreamString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
 using namespace lldb_private;
+using namespace llvm;
 
 using Definition = FormatEntity::Entry::Definition;
 using Entry = FormatEntity::Entry;
 
-TEST(FormatEntityTest, DefinitionConstructionNameAndType) {
+namespace {
+class FormatEntityTest : public ::testing::Test {
+public:
+  Expected<std::string> Format(StringRef format_str) {
+    StreamString stream;
+    FormatEntity::Entry format;
+    Status status = FormatEntity::Parse(format_str, format);
+    if (status.Fail())
+      return status.ToError();
+
+    FormatEntity::Format(format, stream, nullptr, nullptr, nullptr, nullptr,
+                         false, false);
+    return stream.GetString().str();
+  }
+};
+} // namespace
+
+TEST_F(FormatEntityTest, DefinitionConstructionNameAndType) {
   Definition d("foo", FormatEntity::Entry::Type::Invalid);
 
   EXPECT_STREQ(d.name, "foo");
@@ -29,7 +49,7 @@ TEST(FormatEntityTest, DefinitionConstructionNameAndType) {
   EXPECT_FALSE(d.keep_separator);
 }
 
-TEST(FormatEntityTest, DefinitionConstructionNameAndString) {
+TEST_F(FormatEntityTest, DefinitionConstructionNameAndString) {
   Definition d("foo", "string");
 
   EXPECT_STREQ(d.name, "foo");
@@ -41,7 +61,7 @@ TEST(FormatEntityTest, DefinitionConstructionNameAndString) {
   EXPECT_FALSE(d.keep_separator);
 }
 
-TEST(FormatEntityTest, DefinitionConstructionNameTypeData) {
+TEST_F(FormatEntityTest, DefinitionConstructionNameTypeData) {
   Definition d("foo", FormatEntity::Entry::Type::Invalid, 33);
 
   EXPECT_STREQ(d.name, "foo");
@@ -53,7 +73,7 @@ TEST(FormatEntityTest, DefinitionConstructionNameTypeData) {
   EXPECT_FALSE(d.keep_separator);
 }
 
-TEST(FormatEntityTest, DefinitionConstructionNameTypeChildren) {
+TEST_F(FormatEntityTest, DefinitionConstructionNameTypeChildren) {
   Definition d("foo", FormatEntity::Entry::Type::Invalid, 33);
   Definition parent("parent", FormatEntity::Entry::Type::Invalid, 1, &d);
   EXPECT_STREQ(parent.name, "parent");
@@ -153,10 +173,37 @@ constexpr llvm::StringRef lookupStrings[] = {
     "${target.file.fullpath}",
     "${var.dummy-var-to-test-wildcard}"};
 
-TEST(FormatEntity, LookupAllEntriesInTree) {
+TEST_F(FormatEntityTest, LookupAllEntriesInTree) {
   for (const llvm::StringRef testString : lookupStrings) {
     Entry e;
     EXPECT_TRUE(FormatEntity::Parse(testString, e).Success())
         << "Formatting " << testString << " did not succeed";
   }
+}
+
+TEST_F(FormatEntityTest, Scope) {
+  // Scope with  one alternative.
+  EXPECT_THAT_EXPECTED(Format("{${frame.pc}|foo}"), HasValue("foo"));
+
+  // Scope with multiple alternatives.
+  EXPECT_THAT_EXPECTED(Format("{${frame.pc}|${function.name}|foo}"),
+                       HasValue("foo"));
+
+  // Escaped pipe inside a scope.
+  EXPECT_THAT_EXPECTED(Format("{foo\\|bar}"), HasValue("foo|bar"));
+
+  // Unescaped pipe outside a scope.
+  EXPECT_THAT_EXPECTED(Format("foo|bar"), HasValue("foo|bar"));
+
+  // Nested scopes. Note that scopes always resolve.
+  EXPECT_THAT_EXPECTED(Format("{{${frame.pc}|foo}|{bar}}"), HasValue("foo"));
+  EXPECT_THAT_EXPECTED(Format("{{${frame.pc}}|{bar}}"), HasValue(""));
+
+  // Pipe between scopes.
+  EXPECT_THAT_EXPECTED(Format("{foo}|{bar}"), HasValue("foo|bar"));
+  EXPECT_THAT_EXPECTED(Format("{foo}||{bar}"), HasValue("foo||bar"));
+
+  // Empty space between pipes.
+  EXPECT_THAT_EXPECTED(Format("{{foo}||{bar}}"), HasValue("foo"));
+  EXPECT_THAT_EXPECTED(Format("{${frame.pc}||{bar}}"), HasValue(""));
 }


### PR DESCRIPTION
This PR implements support for specifying multiple alternatives for scope format entries. Scopes are used to enclose things that should only be printed when everything in the scope resolves.

For example, the following scope only resolves if both `${line.file.basename}` and `${line.number}` resolve. `

```
{ at ${line.file.basename}:${line.number}}
```

However, the current implementation doesn't let you specify what to print when they don't resolve. This PR adds support for specifying multiple alternative scopes, which are evaluated left-to-right.

For example:

```
{ at ${line.file.basename}:${line.number}| in ${function.name}| <unknown location>}
```

This will resolve to:

 - ` at ${line.file.basename}:${line.number}` if the corresponding variables resolve.
 - Otherwise, this resolves to ` in ${function.name}` if `${function.name}` resolves.
 - Otherwise, this resolves to ` <unknown location>` which always resolves.

This PR makes the `|` character a special character within a scope, but allows it to be escaped.

I ended up with this approach because it fit quite nicely in the existing architecture of the format entries and by limiting the functionality to scopes, it sidesteps some complexity, like dealing with recursion.