### PR TITLE
Revert "[lldb][Format] Make function name frame-format variables work without debug-info"

### DIFF
--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -1809,12 +1809,11 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
   case Entry::Type::FunctionReturnRight:
   case Entry::Type::FunctionReturnLeft:
   case Entry::Type::FunctionQualifiers: {
-    Language *language_plugin = nullptr;
-    if (sc->function)
-      language_plugin = Language::FindPlugin(sc->function->GetLanguage());
-    else if (sc->symbol)
-      language_plugin = Language::FindPlugin(sc->symbol->GetLanguage());
+    if (!sc->function)
+      return false;
 
+    Language *language_plugin =
+        Language::FindPlugin(sc->function->GetLanguage());
     if (!language_plugin)
       return false;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -381,34 +381,6 @@ GetDemangledScope(const SymbolContext &sc) {
   return demangled_name.slice(info->ScopeRange.first, info->ScopeRange.second);
 }
 
-static bool PrintDemangledArgumentList(Stream &s, const SymbolContext &sc) {
-  assert(sc.symbol);
-
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
-    return false;
-
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return false;
-
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return false;
-
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return false;
-
-  if (info->ArgumentsRange.second < info->ArgumentsRange.first)
-    return false;
-
-  s << demangled_name.slice(info->ArgumentsRange.first,
-                            info->ArgumentsRange.second);
-
-  return true;
-}
-
 bool CPlusPlusLanguage::CxxMethodName::TrySimplifiedParse() {
   // This method tries to parse simple method definitions which are presumably
   // most comman in user programs. Definitions that can be parsed by this
@@ -1918,6 +1890,8 @@ bool CPlusPlusLanguage::GetFunctionDisplayName(
 bool CPlusPlusLanguage::HandleFrameFormatVariable(
     const SymbolContext &sc, const ExecutionContext *exe_ctx,
     FormatEntity::Entry::Type type, Stream &s) {
+  assert(sc.function);
+
   switch (type) {
   case FormatEntity::Entry::Type::FunctionScope: {
     std::optional<llvm::StringRef> scope = GetDemangledScope(sc);
@@ -1951,14 +1925,6 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   }
 
   case FormatEntity::Entry::Type::FunctionFormattedArguments: {
-    // This ensures we print the arguments even when no debug-info is available.
-    //
-    // FIXME: we should have a Entry::Type::FunctionArguments and
-    // use it in the plugin.cplusplus.display.function-name-format
-    // once we have a "fallback operator" in the frame-format language.
-    if (!sc.function && sc.symbol)
-      return PrintDemangledArgumentList(s, sc);
-
     VariableList args;
     if (auto variable_list_sp = GetFunctionVariableList(sc))
       variable_list_sp->AppendVariablesWithScope(eValueTypeVariableArgument,

--- a/lldb/test/Shell/Settings/TestFrameFormatFunctionBasename.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatFunctionBasename.test
@@ -7,10 +7,6 @@
 # RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
 #
-# RUN: %clang_host -O0 %t/main.cpp -o %t-nodebug.out
-# RUN: %lldb -x -b -s %t/commands.input %t-nodebug.out -o exit 2>&1 \
-# RUN:       | FileCheck %s
-
 #--- main.cpp
 namespace ns {
 template<typename T>

--- a/lldb/test/Shell/Settings/TestFrameFormatFunctionFormattedArguments.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatFunctionFormattedArguments.test
@@ -6,10 +6,6 @@
 # RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.out
 # RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
-#
-# RUN: %clang_host -O0 %t/main.cpp -o %t-nodebug.out
-# RUN: %lldb -x -b -s %t/commands.input %t-nodebug.out -o exit 2>&1 \
-# RUN:       | FileCheck %s --check-prefix=CHECK-NODEBUG
 
 #--- main.cpp
 struct Foo {
@@ -46,8 +42,3 @@ bt
 # CHECK: custom-frame '({{.*}}=5, x=10)'
 # CHECK: custom-frame '(str="hello", fptr=({{.*}}.out`{{.*}}foo(int,{{.*}}int) at main.cpp:{{[0-9]+}}))'
 # CHECK: custom-frame '(argc=1, argv={{.*}})'
-
-# CHECK-NODEBUG: custom-frame '()'
-# CHECK-NODEBUG: custom-frame '()'
-# CHECK-NODEBUG: custom-frame '(int, int)'
-# CHECK-NODEBUG: custom-frame '(char const*, void (*)(int, int))'

--- a/lldb/test/Shell/Settings/TestFrameFormatFunctionQualifiers.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatFunctionQualifiers.test
@@ -6,10 +6,6 @@
 # RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.out
 # RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
-#
-# RUN: %clang_host -O0 %t/main.cpp -o %t-nodebug.out
-# RUN: %lldb -x -b -s %t/commands.input %t-nodebug.out -o exit 2>&1 \
-# RUN:       | FileCheck %s
 
 #--- main.cpp
 struct Foo {

--- a/lldb/test/Shell/Settings/TestFrameFormatFunctionReturn.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatFunctionReturn.test
@@ -7,10 +7,6 @@
 # RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.out
 # RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
-#
-# RUN: %clang_host -O0 %t/main.cpp -o %t-nodebug.out
-# RUN: %lldb -x -b -s %t/commands.input %t-nodebug.out -o exit 2>&1 \
-# RUN:       | FileCheck %s
 
 #--- main.cpp
 namespace ns::ns2 {

--- a/lldb/test/Shell/Settings/TestFrameFormatFunctionScope.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatFunctionScope.test
@@ -4,11 +4,8 @@
 
 # RUN: split-file %s %t
 # RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.out
-# RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
-# RUN:       | FileCheck %s
-#
-# RUN: %clang_host -O0 %t/main.cpp -o %t-nodebug.out
-# RUN: %lldb -x -b -s %t/commands.input %t-nodebug.out -o exit 2>&1 \
+# RUN: %lldb -o "settings set interpreter.stop-command-source-on-error false" \
+# RUN:       -x -b -s %t/commands.input %t.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
 
 #--- main.cpp

--- a/lldb/test/Shell/Settings/TestFrameFormatFunctionTemplateArguments.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatFunctionTemplateArguments.test
@@ -3,12 +3,8 @@
 # Test the ${function.template-arguments} frame-format variable.
 
 # RUN: split-file %s %t
-# RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.out
-# RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
-# RUN:       | FileCheck %s
-#
-# RUN: %clang_host -O0 %t/main.cpp -o %t-nodebug.out
-# RUN: %lldb -x -b -s %t/commands.input %t-nodebug.out -o exit 2>&1 \
+# RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.cxx.out
+# RUN: %lldb -x -b -s %t/commands.input %t.cxx.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
 
 #--- main.cpp


### PR DESCRIPTION
Reverts llvm/llvm-project#137408

This change broke `lldb/test/Shell/Unwind/split-machine-functions.test`.

The test binary has a symbol named `_Z3foov.cold` and the test expects the backtrace to print the name of the cold part of the function like this:

```
# SPLIT: frame #1: {{.*}}`foo() (.cold) +
```
but now it gets

```
frame #1: 0x000055555555514f split-machine-functions.test.tmp`foo() + 12
```