### PR TITLE
[ARM][Driver] Fix i8mm feature string

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -795,7 +795,7 @@ fp16_fml_fallthrough:
     HasSimd = ItSimd->starts_with("+");
   if (!HasSimd && FPUSupportsNeon)
     Features.insert(Features.end(),
-                    {"-sha2", "-aes", "-crypto", "-dotprod", "-bf16", "-imm8"});
+                    {"-sha2", "-aes", "-crypto", "-dotprod", "-bf16", "-i8mm"});
 
   // For Arch >= ARMv8.0 && A or R profile:  crypto = sha2 + aes
   // Rather than replace within the feature vector, determine whether each

--- a/clang/test/Driver/arm-features.c
+++ b/clang/test/Driver/arm-features.c
@@ -105,3 +105,13 @@
 // RUN: %clang -target arm-none-none-eabi -march=armv8-r+bf16 -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-NEON-ENABLED-WITH-FEATURE %s
 // RUN: %clang -target arm-none-none-eabi -march=armv8-r+i8mm -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-NEON-ENABLED-WITH-FEATURE %s
 // CHECK-NEON-ENABLED-WITH-FEATURE: "-target-feature" "+neon"
+
+// Check that disabling NEON disables all features associated with this
+// RUN: %clang -target arm-none-none-eabi -march=armv8-a+nosimd -### -c %s 2>&1 | FileCheck -check-prefix=CHECK-NEON-DISABLED-DISABLES-ALL-DEPENDENCIES %s
+// CHECK-NEON-DISABLED-DISABLES-ALL-DEPENDENCIES: "-target-feature" "-neon"
+// CHECK-NEON-DISABLED-DISABLES-ALL-DEPENDENCIES: "-target-feature" "-dotprod"
+// CHECK-NEON-DISABLED-DISABLES-ALL-DEPENDENCIES: "-target-feature" "-bf16"
+// CHECK-NEON-DISABLED-DISABLES-ALL-DEPENDENCIES: "-target-feature" "-i8mm"
+// CHECK-NEON-DISABLED-DISABLES-ALL-DEPENDENCIES: "-target-feature" "-crypto"
+// CHECK-NEON-DISABLED-DISABLES-ALL-DEPENDENCIES: "-target-feature" "-sha2"
+// CHECK-NEON-DISABLED-DISABLES-ALL-DEPENDENCIES: "-target-feature" "-aes"


### PR DESCRIPTION
#137595 changed the behaviour for SIMD on ARM to ensure it is enabled and disabled correctly depending on the options used by the user. In this, the functionality to disable all features that depend on SIMD was added. However, there was a spelling error for the i8mm feature, which caused the `+nosimd` command to fail.

This fixes the error, and allows the command to work again.