### PR TITLE
[lldb][test] Test all libcxxabi demangler test-cases against TrackingOutputBuffer

### DIFF
--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -619,7 +619,7 @@ struct DemanglingInfoCorrectnessTestCase {
 };
 
 DemanglingInfoCorrectnessTestCase g_demangling_correctness_test_cases[] = {
-#include "DemanglingCorrectness.inc"
+#include "llvm/Testing/Demangle/DemangleTestCases.inc"
 };
 
 struct DemanglingInfoCorrectnessTestFixutre

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -638,9 +638,11 @@ TEST_P(DemanglingInfoCorrectnessTestFixutre, Correctness) {
   TrackingOutputBuffer OB;
   Root->print(OB);
 
-  // Filter out cases which would never show up in frames. We only care about function names.
-  if (Root->getKind() != llvm::itanium_demangle::Node::Kind::KFunctionEncoding
-      && Root->getKind() != llvm::itanium_demangle::Node::Kind::KDotSuffix)
+  // Filter out cases which would never show up in frames. We only care about
+  // function names.
+  if (Root->getKind() !=
+          llvm::itanium_demangle::Node::Kind::KFunctionEncoding &&
+      Root->getKind() != llvm::itanium_demangle::Node::Kind::KDotSuffix)
     return;
 
   ASSERT_TRUE(OB.NameInfo.hasBasename());

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -612,3 +612,59 @@ TEST_P(DemanglingPartsTestFixture, DemanglingParts) {
 
 INSTANTIATE_TEST_SUITE_P(DemanglingPartsTests, DemanglingPartsTestFixture,
                          ::testing::ValuesIn(g_demangling_parts_test_cases));
+
+struct DemanglingInfoCorrectnessTestCase {
+  const char *mangled;
+  const char *demangled;
+};
+
+DemanglingInfoCorrectnessTestCase g_demangling_correctness_test_cases[] = {
+#include "DemanglingCorrectness.inc"
+};
+
+struct DemanglingInfoCorrectnessTestFixutre
+    : public ::testing::TestWithParam<DemanglingInfoCorrectnessTestCase> {};
+
+TEST_P(DemanglingInfoCorrectnessTestFixutre, Correctness) {
+  auto [mangled, demangled] = GetParam();
+
+  llvm::itanium_demangle::ManglingParser<TestAllocator> Parser(
+      mangled, mangled + ::strlen(mangled));
+
+  const auto *Root = Parser.parse();
+
+  ASSERT_NE(nullptr, Root);
+
+  TrackingOutputBuffer OB;
+  Root->print(OB);
+  auto tracked_name = llvm::StringRef(OB);
+
+  auto return_left = tracked_name.slice(0, OB.NameInfo.ScopeRange.first);
+  auto scope = tracked_name.slice(OB.NameInfo.ScopeRange.first,
+                                  OB.NameInfo.ScopeRange.second);
+  auto basename = tracked_name.slice(OB.NameInfo.BasenameRange.first,
+                                     OB.NameInfo.BasenameRange.second);
+  auto template_args = tracked_name.slice(OB.NameInfo.BasenameRange.second,
+                                          OB.NameInfo.ArgumentsRange.first);
+  auto args = tracked_name.slice(OB.NameInfo.ArgumentsRange.first,
+                                 OB.NameInfo.ArgumentsRange.second);
+  auto return_right = tracked_name.slice(OB.NameInfo.ArgumentsRange.second,
+                                         OB.NameInfo.QualifiersRange.first);
+  auto qualifiers = tracked_name.slice(OB.NameInfo.QualifiersRange.first,
+                                       OB.NameInfo.QualifiersRange.second);
+  auto suffix = tracked_name.slice(OB.NameInfo.QualifiersRange.second,
+                                   llvm::StringRef::npos);
+
+  auto reconstructed_name =
+      llvm::join_items("", return_left, scope, basename, template_args, args,
+                       return_right, qualifiers, suffix);
+
+  // Special vtable names aren't tracked but won't show up in frames anyway.
+  if (Root->getKind() != llvm::itanium_demangle::Node::Kind::KSpecialName ||
+      !llvm::StringRef(mangled).starts_with("_ZTV"))
+    EXPECT_EQ(reconstructed_name, demangled);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DemanglingInfoCorrectnessTests, DemanglingInfoCorrectnessTestFixutre,
+    ::testing::ValuesIn(g_demangling_correctness_test_cases));


### PR DESCRIPTION
To test the infrastructure added in https://github.com/llvm/llvm-project/pull/131836 in would be nice to confirm that we can reconstruct all kinds of demangled names. The libcxxabi test-suite already has all those test-cases.

This patch copies those test-cases (taken from `libcxxabi/test/test_demangle.pass.cpp`), reconstructs the name like LLDB would when showing backtraces, and confirms that all demangled names can be fully reconstructed.

Two open questions:
1. Do we really want a copy of all those test-cases in LLDB? It's
   unlikely to be kept in sync with the demangler test-suite. It includes 30,000+ test-cases
2. Do we want to turn the `GetDemangledBasename`/`GetDemangledScope`/etc. into public APIs (e.g., on `TrackingOutputBuffer`) so that we can use the exact same method of extraction in the tests?