### PR TITLE
[X86] Remove LLD command in LIT test

### DIFF
--- a/llvm/test/CodeGen/X86/apx/tls.ll
+++ b/llvm/test/CodeGen/X86/apx/tls.ll
@@ -5,14 +5,10 @@
 ; RUN: llc -mattr=+egpr %s -mtriple=x86_64 -filetype=obj -o %t.o -x86-enable-apx-for-relocation=true
 ; RUN: llvm-objdump --no-print-imm-hex -dr %t.o | FileCheck %s --check-prefix=GOTTPOFF_APXRELAX
 ; RUN: echo '.tbss; .globl b,c,d,e,f,g,h,i,j; b: .zero 4;c: .zero 4;d: .zero 4;e: .zero 4;f: .zero 4;g: .zero 4;h: .zero 4;i: .zero 4;j: .zero 4' | llvm-mc -filetype=obj -triple=x86_64 - -o %t1.o
-; RUN: ld.lld  %t.o %t1.o -o %t.so
-; RUN: llvm-objdump --no-print-imm-hex -dr %t.so | FileCheck %s --check-prefix=GOTTPOFF_LD_APXRELAX
 
 ; RUN: llc -mattr=+egpr %s -mtriple=x86_64 -filetype=obj -o %t.o
 ; RUN: llvm-objdump --no-print-imm-hex -dr %t.o | FileCheck %s --check-prefix=GOTTPOFF_NOAPXRELAX
 ; RUN: echo '.tbss; .globl b,c,d,e,f,g,h,i,j; b: .zero 4;c: .zero 4;d: .zero 4;e: .zero 4;f: .zero 4;g: .zero 4;h: .zero 4;i: .zero 4;j: .zero 4' | llvm-mc -filetype=obj -triple=x86_64 - -o %t1.o
-; RUN: ld.lld  %t.o %t1.o -o %t.so
-; RUN: llvm-objdump --no-print-imm-hex -dr %t.so | FileCheck %s --check-prefix=GOTTPOFF_LD_NOAPXRELAX
 
 
 ; TLSDESC: d5 18 89 c0       movq %rax, %r16
@@ -21,11 +17,9 @@
 
 ; GOTTPOFF_APXRELAX: d5 48 8b 05 00 00 00 00       movq (%rip), %r16
 ; GOTTPOFF_APXRELAX-NEXT: R_X86_64_CODE_4_GOTTPOFF j-0x4
-; GOTTPOFF_LD_APXRELAX: d5 18 c7 c0 fc ff ff ff       movq $-4, %r16
 
 ; GOTTPOFF_NOAPXRELAX: 48 8b 1d 00 00 00 00       movq (%rip), %rbx
 ; GOTTPOFF_NOAPXRELAX-NEXT: R_X86_64_GOTTPOFF j-0x4
-; GOTTPOFF_LD_NOAPXRELAX: 48 c7 c3 fc ff ff ff       movq $-4, %rbx
 
 @a = thread_local global i32 0, align 4
 @b = external thread_local global i32, align 4


### PR DESCRIPTION
The test introduced in #136660, may be failed as ld.lld command not found.