### PR TITLE
[ArrayRef] Add constructor from iterator_range<U*> (NFC).

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -152,7 +152,8 @@ namespace llvm {
     /// Construct an ArrayRef<T> from iterator_range<U*>. This uses SFINAE
     /// to ensure that this is only used for iterator ranges over plain pointer
     /// iterators.
-    template <typename U, typename = std::enable_if_t<std::is_same_v<U *, T *>>>
+    template <typename U,
+              typename = std::enable_if_t<std::is_convertible_v<U *, T *>>>
     ArrayRef(const iterator_range<U *> &Range)
         : Data(Range.begin()), Length(llvm::size(Range)) {}
 

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -152,14 +152,15 @@ namespace llvm {
     /// Construct an ArrayRef<T> from iterator_range<U*>. This uses SFINAE
     /// to ensure that this is only used for iterator ranges of random access
     /// iterators that can be converted.
-    template <typename U>
-    ArrayRef(const iterator_range<U *> &Range,
-             std::enable_if_t<std::is_base_of<std::random_access_iterator_tag,
-                                              typename std::iterator_traits<
-                                                  decltype(Range.begin())>::
-                                                  iterator_category>::value &&
-                                  std::is_convertible<U *, T const *>::value,
-                              void> * = nullptr)
+    template <typename U,
+              typename = std::enable_if_t<
+                  std::is_base_of<
+                      std::random_access_iterator_tag,
+                      typename std::iterator_traits<
+                          decltype(std::declval<const iterator_range<U *> &>()
+                                       .begin())>::iterator_category>::value &&
+                  std::is_convertible_v<U *, T const *>>>
+    ArrayRef(const iterator_range<U *> &Range)
         : Data(Range.begin()), Length(llvm::size(Range)) {}
 
     /// @}

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -152,8 +152,8 @@ namespace llvm {
     /// Construct an ArrayRef<T> from iterator_range<U*>. This uses SFINAE
     /// to ensure that this is only used for iterator ranges over plain pointer
     /// iterators.
-    template <typename U,
-              typename = std::enable_if_t<std::is_convertible_v<U *, T *>>>
+    template <typename U, typename = std::enable_if_t<
+                              std::is_convertible_v<U *const *, T *const *>>>
     ArrayRef(const iterator_range<U *> &Range)
         : Data(Range.begin()), Length(llvm::size(Range)) {}
 

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -150,16 +150,9 @@ namespace llvm {
         : Data(Vec.data()), Length(Vec.size()) {}
 
     /// Construct an ArrayRef<T> from iterator_range<U*>. This uses SFINAE
-    /// to ensure that this is only used for iterator ranges of random access
-    /// iterators that can be converted.
-    template <typename U,
-              typename = std::enable_if<
-                  std::is_base_of<
-                      std::random_access_iterator_tag,
-                      typename std::iterator_traits<
-                          decltype(std::declval<const iterator_range<U *> &>()
-                                       .begin())>::iterator_category>::value &&
-                  std::is_convertible_v<U *, T const *>>>
+    /// to ensure that this is only used for iterator ranges over plain pointer
+    /// iterators.
+    template <typename U, typename = std::enable_if_t<std::is_same_v<U *, T *>>>
     ArrayRef(const iterator_range<U *> &Range)
         : Data(Range.begin()), Length(llvm::size(Range)) {}
 

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -153,7 +153,7 @@ namespace llvm {
     /// to ensure that this is only used for iterator ranges of random access
     /// iterators that can be converted.
     template <typename U,
-              typename = std::enable_if_t<
+              typename = std::enable_if<
                   std::is_base_of<
                       std::random_access_iterator_tag,
                       typename std::iterator_traits<

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -149,6 +149,19 @@ namespace llvm {
                  * = nullptr)
         : Data(Vec.data()), Length(Vec.size()) {}
 
+    /// Construct an ArrayRef<T> from iterator_range<U*>. This uses SFINAE
+    /// to ensure that this is only used for iterator ranges of random access
+    /// iterators that can be converted.
+    template <typename U>
+    ArrayRef(const iterator_range<U *> &Range,
+             std::enable_if_t<std::is_base_of<std::random_access_iterator_tag,
+                                              typename std::iterator_traits<
+                                                  decltype(Range.begin())>::
+                                                  iterator_category>::value &&
+                                  std::is_convertible<U *, T const *>::value,
+                              void> * = nullptr)
+        : Data(Range.begin()), Length(llvm::size(Range)) {}
+
     /// @}
     /// @name Simple Operations
     /// @{

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -260,9 +260,8 @@ TEST(ArrayRefTest, ArrayRefFromIteratorRange) {
   ArrayRef<int> A2 = make_range(A1.begin(), A1.end());
 
   EXPECT_EQ(A1.size(), A2.size());
-  for (std::size_t i = 0; i < A1.size(); ++i) {
+  for (std::size_t i = 0; i < A1.size(); ++i)
     EXPECT_EQ(A1[i], A2[i]);
-  }
 }
 
 TEST(ArrayRefTest, ArrayRefFromIteratorConstRange) {
@@ -270,9 +269,8 @@ TEST(ArrayRefTest, ArrayRefFromIteratorConstRange) {
   ArrayRef<const int> A2 = make_range(A1.begin(), A1.end());
 
   EXPECT_EQ(A1.size(), A2.size());
-  for (std::size_t i = 0; i < A1.size(); ++i) {
+  for (std::size_t i = 0; i < A1.size(); ++i)
     EXPECT_EQ(A1[i], A2[i]);
-  }
 }
 
 static_assert(std::is_trivially_copyable_v<ArrayRef<int>>,

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -264,13 +264,30 @@ static_assert(!std::is_constructible_v<
               "cannot construct from iterator range with non-pointer iterator");
 static_assert(!std::is_constructible_v<ArrayRef<int>, iterator_range<int>>,
               "cannot construct from iterator range with non-pointer iterator");
+
+class TestBase {};
+
+class TestDerived : public TestBase {};
+
+static_assert(
+    !std::is_constructible_v<ArrayRef<TestDerived>, iterator_range<TestBase *>>,
+    "cannot construct ArrayRef with derived type");
+static_assert(
+    !std::is_constructible_v<ArrayRef<TestBase>, iterator_range<TestDerived *>>,
+    "cannot construct ArrayRef base type");
+static_assert(!std::is_constructible_v<ArrayRef<TestBase *>,
+                                       iterator_range<TestDerived **>>,
+              "cannot construct ArrayRef pointer of base type");
+
 static_assert(
     !std::is_constructible_v<ArrayRef<int>, iterator_range<const int *>>,
     "cannot construct ArrayRef with non-const elements from const iterator "
     "range");
-
 static_assert(
     std::is_constructible_v<ArrayRef<char *>, iterator_range<char **>>,
+    "should be able to construct ArrayRef from iterator_range over pointers");
+static_assert(
+    !std::is_constructible_v<ArrayRef<char *>, iterator_range<char *const *>>,
     "should be able to construct ArrayRef from iterator_range over pointers");
 
 TEST(ArrayRefTest, ArrayRefFromIteratorRange) {

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -255,6 +255,26 @@ TEST(ArrayRefTest, ArrayRefFromStdArray) {
   }
 }
 
+TEST(ArrayRefTest, ArrayRefFromIteratorRange) {
+  std::array<int, 5> A1{{42, -5, 0, 1000000, -1000000}};
+  ArrayRef<int> A2 = make_range(A1.begin(), A1.end());
+
+  EXPECT_EQ(A1.size(), A2.size());
+  for (std::size_t i = 0; i < A1.size(); ++i) {
+    EXPECT_EQ(A1[i], A2[i]);
+  }
+}
+
+TEST(ArrayRefTest, ArrayRefFromIteratorConstRange) {
+  std::array<const int, 5> A1{{42, -5, 0, 1000000, -1000000}};
+  ArrayRef<const int> A2 = make_range(A1.begin(), A1.end());
+
+  EXPECT_EQ(A1.size(), A2.size());
+  for (std::size_t i = 0; i < A1.size(); ++i) {
+    EXPECT_EQ(A1[i], A2[i]);
+  }
+}
+
 static_assert(std::is_trivially_copyable_v<ArrayRef<int>>,
               "trivially copyable");
 

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -265,6 +265,11 @@ static_assert(!std::is_constructible_v<
 static_assert(!std::is_constructible_v<ArrayRef<int>, iterator_range<int>>,
               "cannot construct from iterator range with non-pointer iterator");
 static_assert(
+    !std::is_constructible_v<ArrayRef<int>, iterator_range<const int *>>,
+    "cannot construct ArrayRef with non-const elements from const iterator "
+    "range");
+
+static_assert(
     std::is_constructible_v<ArrayRef<char *>, iterator_range<char **>>,
     "should be able to construct ArrayRef from iterator_range over pointers");
 

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -259,14 +259,13 @@ struct TestRandomAccessIterator {
   using iterator_category = std::random_access_iterator_tag;
 };
 
-static_assert(
-    !std::is_constructible<ArrayRef<int>,
-                           iterator_range<TestRandomAccessIterator>>::value,
-    "cannot construct from iterator range with non-pointer iterator");
-static_assert(!std::is_constructible<ArrayRef<int>, iterator_range<int>>::value,
+static_assert(!std::is_constructible_v<
+                  ArrayRef<int>, iterator_range<TestRandomAccessIterator>>,
+              "cannot construct from iterator range with non-pointer iterator");
+static_assert(!std::is_constructible_v<ArrayRef<int>, iterator_range<int>>,
               "cannot construct from iterator range with non-pointer iterator");
 static_assert(
-    std::is_constructible<ArrayRef<char *>, iterator_range<char **>>::value,
+    std::is_constructible_v<ArrayRef<char *>, iterator_range<char **>>,
     "should be able to construct ArrayRef from iterator_range over pointers");
 
 TEST(ArrayRefTest, ArrayRefFromIteratorRange) {
@@ -276,6 +275,11 @@ TEST(ArrayRefTest, ArrayRefFromIteratorRange) {
   EXPECT_EQ(A1.size(), A2.size());
   for (std::size_t i = 0; i < A1.size(); ++i)
     EXPECT_EQ(A1[i], A2[i]);
+
+  ArrayRef<const int> A3 = make_range(A1.begin(), A1.end());
+  EXPECT_EQ(A1.size(), A3.size());
+  for (std::size_t i = 0; i < A1.size(); ++i)
+    EXPECT_EQ(A1[i], A3[i]);
 }
 
 TEST(ArrayRefTest, ArrayRefFromIteratorConstRange) {

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -255,6 +255,20 @@ TEST(ArrayRefTest, ArrayRefFromStdArray) {
   }
 }
 
+struct TestRandomAccessIterator {
+  using iterator_category = std::random_access_iterator_tag;
+};
+
+static_assert(
+    !std::is_constructible<ArrayRef<int>,
+                           iterator_range<TestRandomAccessIterator>>::value,
+    "cannot construct from iterator range with non-pointer iterator");
+static_assert(!std::is_constructible<ArrayRef<int>, iterator_range<int>>::value,
+              "cannot construct from iterator range with non-pointer iterator");
+static_assert(
+    std::is_constructible<ArrayRef<char *>, iterator_range<char **>>::value,
+    "should be able to construct ArrayRef from iterator_range over pointers");
+
 TEST(ArrayRefTest, ArrayRefFromIteratorRange) {
   std::array<int, 5> A1{{42, -5, 0, 1000000, -1000000}};
   ArrayRef<int> A2 = make_range(A1.begin(), A1.end());


### PR DESCRIPTION
Add a new constructor to ArrayRef that takes an iterator_range with a random access iterator that can be converted.

This can help to avoid creating unnecessary iterator_ranges for types where an ArrayRef can already be constructed. I will share a follow-up soon.