### PR TITLE
[IR] Don't allow label arguments

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -64,6 +64,7 @@ Changes to the LLVM IR
 
 * Updated semantics of `llvm.type.checked.load.relative` to match that of
   `llvm.load.relative`.
+* Inline asm calls no longer accept ``label`` arguments. Use ``callbr`` instead.
 
 Changes to LLVM infrastructure
 ------------------------------

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -3072,6 +3072,8 @@ bool LLParser::parseParameterList(SmallVectorImpl<ParamInfo> &ArgList,
     Value *V;
     if (parseType(ArgTy, ArgLoc))
       return true;
+    if (!FunctionType::isValidArgumentType(ArgTy))
+      return error(ArgLoc, "invalid type for function argument");
 
     AttrBuilder ArgAttrs(M->getContext());
 
@@ -3381,7 +3383,7 @@ bool LLParser::parseArgumentList(SmallVectorImpl<ArgInfo> &ArgList,
         CurValID = ArgID + 1;
       }
 
-      if (!ArgTy->isFirstClassType())
+      if (!FunctionType::isValidArgumentType(ArgTy))
         return error(TypeLoc, "invalid type for function argument");
 
       ArgList.emplace_back(TypeLoc, ArgTy,

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -3488,13 +3488,8 @@ void ModuleBitcodeWriter::writeInstruction(const Instruction &I,
     pushValueAndType(CI.getCalledOperand(), InstID, Vals); // Callee
 
     // Emit value #'s for the fixed parameters.
-    for (unsigned i = 0, e = FTy->getNumParams(); i != e; ++i) {
-      // Check for labels (can happen with asm labels).
-      if (FTy->getParamType(i)->isLabelTy())
-        Vals.push_back(VE.getValueID(CI.getArgOperand(i)));
-      else
-        pushValue(CI.getArgOperand(i), InstID, Vals); // fixed param.
-    }
+    for (unsigned i = 0, e = FTy->getNumParams(); i != e; ++i)
+      pushValue(CI.getArgOperand(i), InstID, Vals); // fixed param.
 
     // Emit type/value pairs for varargs params.
     if (FTy->isVarArg()) {

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -390,7 +390,7 @@ bool FunctionType::isValidReturnType(Type *RetTy) {
 }
 
 bool FunctionType::isValidArgumentType(Type *ArgTy) {
-  return ArgTy->isFirstClassType();
+  return ArgTy->isFirstClassType() && !ArgTy->isLabelTy();
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2934,8 +2934,6 @@ void Verifier::visitFunction(const Function &F) {
           FT->getParamType(i));
     Check(Arg.getType()->isFirstClassType(),
           "Function arguments must have first-class types!", &Arg);
-    Check(!Arg.getType()->isLabelTy(),
-          "Function argument cannot be of label type!", &Arg, &F);
     if (!IsIntrinsic) {
       Check(!Arg.getType()->isMetadataTy(),
             "Function takes metadata but isn't an intrinsic", &Arg, &F);

--- a/llvm/test/Assembler/invalid-label-call-arg.ll
+++ b/llvm/test/Assembler/invalid-label-call-arg.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+
+; CHECK: invalid type for function argument
+define void @test() {
+bb:
+  call void asm "", ""(label %bb)
+  ret void
+}
+

--- a/llvm/test/Assembler/invalid-label.ll
+++ b/llvm/test/Assembler/invalid-label.ll
@@ -2,7 +2,7 @@
 ; RUN: FileCheck %s < %t
 ; Test the case where an invalid label name is used
 
-; CHECK: unable to create block named 'bb'
+; CHECK: invalid type for function argument
 
 define void @test(label %bb) {
 bb:

--- a/llvm/test/CodeGen/X86/asm-block-labels.ll
+++ b/llvm/test/CodeGen/X86/asm-block-labels.ll
@@ -13,7 +13,7 @@ entry:
 	call void asm sideeffect "int $$1", "~{dirflag},~{fpsr},~{flags},~{memory}"( )
 	call void asm sideeffect ".file \22block12.c\22", "~{dirflag},~{fpsr},~{flags}"( )
 	call void asm sideeffect ".line 2", "~{dirflag},~{fpsr},~{flags}"( )
-	call void asm sideeffect "brl ${0:l}", "X,~{dirflag},~{fpsr},~{flags},~{memory}"( label %"LASM$foo" )
+	call void asm sideeffect "brl ${0:l}", "X,~{dirflag},~{fpsr},~{flags},~{memory}"(ptr blockaddress(@bar, %"LASM$foo"))
 	br label %return
 
 return:		; preds = %"LASM$foo"
@@ -24,7 +24,7 @@ define void @baz() {
 entry:
 	call void asm sideeffect ".file \22block12.c\22", "~{dirflag},~{fpsr},~{flags}"( )
 	call void asm sideeffect ".line 3", "~{dirflag},~{fpsr},~{flags}"( )
-	call void asm sideeffect "brl ${0:l}", "X,~{dirflag},~{fpsr},~{flags},~{memory}"( label %"LASM$foo" )
+	call void asm sideeffect "brl ${0:l}", "X,~{dirflag},~{fpsr},~{flags},~{memory}"(ptr blockaddress(@baz, %"LASM$foo"))
 	call void asm sideeffect ".file \22block12.c\22", "~{dirflag},~{fpsr},~{flags}"( )
 	call void asm sideeffect ".line 4", "~{dirflag},~{fpsr},~{flags}"( )
 	call void asm sideeffect "int $$1", "~{dirflag},~{fpsr},~{flags},~{memory}"( )
@@ -42,7 +42,7 @@ return:		; preds = %"LASM$foo"
 
 define void @quux() {
 entry:
-	call void asm sideeffect inteldialect "brl ${0:l}", "X,~{dirflag},~{fpsr},~{flags},~{memory}"( label %"LASM$foo" )
+	call void asm sideeffect inteldialect "brl ${0:l}", "X,~{dirflag},~{fpsr},~{flags},~{memory}"(ptr blockaddress(@quux, %"LASM$foo"))
 	br label %"LASM$foo"
 
 "LASM$foo":		; preds = %entry

--- a/llvm/test/Verifier/invalid-label-param.ll
+++ b/llvm/test/Verifier/invalid-label-param.ll
@@ -7,8 +7,4 @@ define void @invalid_arg_type(i32 %0) {
 }
 
 declare void @foo(label)
-; CHECK: Function argument cannot be of label type!
-; CHECK-NEXT: label %0
-; CHECK-NEXT: ptr @foo
-
-
+; CHECK: invalid type for function argument


### PR DESCRIPTION
We currently accept label arguments to inline asm calls. This support predates both blockaddresses and callbr and is only covered by one X86 test. Remove it in favor of callbr (or at least blockaddress, though that cannot guarantee correct codegen, just like using block labels directly can't).

I didn't bother implementing bitcode upgrade support for this, but I can add it if desired.