### PR TITLE
[BOLT][NFC] Add keep-nops option to non-empty-debug-line.test

### DIFF
--- a/bolt/test/non-empty-debug-line.test
+++ b/bolt/test/non-empty-debug-line.test
@@ -4,7 +4,7 @@
 REQUIRES: system-linux
 
 RUN: %clang %cflags %S/Inputs/hello.c -g -o %t
-RUN: llvm-bolt %t -o %t1 --update-debug-sections --funcs=_start
+RUN: llvm-bolt %t -o %t1 --update-debug-sections --funcs=_start --keep-nops
 RUN: llvm-readobj -S %t > %t2
 RUN: llvm-readobj -S %t1 >> %t2
 RUN: FileCheck %s --input-file %t2


### PR DESCRIPTION
On openSUSE distribution test is failing due to different .debug_line size without the keep-nops option