### PR TITLE
[Test] Disable Linux perf test under WSL

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_perf.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_perf.s
@@ -1,5 +1,9 @@
 # REQUIRES: native && x86_64-linux
 
+# Linux perf not supported by Windows Kernel's Linux syscall emulation layer
+# https://github.com/microsoft/WSL/issues/4595
+# UNSUPPORTED: wsl1
+
 # FIXME: Investigate why broken with MSAN
 # UNSUPPORTED: msan
 

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -383,6 +383,13 @@ else:
     # Others/can-execute.txt
     config.available_features.add("can-execute")
 
+# Detect Windows Subsystem for Linux (WSL)
+uname_r = platform.uname().release
+if uname_r.endswith("-Microsoft"):
+    config.available_features.add("wsl1")
+elif uname_r.endswith("microsoft-standard-WSL2"):
+    config.available_features.add("wsl2")
+
 # Loadable module
 if config.has_plugins:
     config.available_features.add("plugins")


### PR DESCRIPTION
Linux perf_events is not implemented in WSL1, skip the test that requires it.

There is just a single test that requires perf_events. It fails under WSL1 with:
```sh
env JITDUMPDIR=/home/meinersbur/build/llvm-project/release/test/ExecutionEngine/JITLink/x86-64/Output/ELF_perf.s.tmp /home/meinersbur/build/llvm-project/release/bin/llvm-jitlink -perf-support /home/meinersbur/build/llvm-project/release/test/ExecutionEngine/JITLink/x86-64/Output/ELF_perf.s.tmp/ELF_x86-64_perf.o
llvm-jitlink error: PerfState not initialized
```

WSL environment detection logic follows https://github.com/scivision/detect-windows-subsystem-for-linux/blob/main/is_wsl.py

Also see WSL issue: https://github.com/microsoft/WSL/issues/4595