### PR TITLE
[libclc] Avoid casting NANs & literals to 'gentype'

### DIFF
--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -73,8 +73,8 @@
 #if (!defined(__HALF_ONLY) && !defined(__DOUBLE_ONLY))
 #define __CLC_SCALAR_GENTYPE float
 #define __CLC_FPSIZE 32
-#define __CLC_FP_LIT(x) x##F
-#define __CLC_GENTYPE_NAN FLT_NAN
+#define __CLC_FP_LIT(x) (__CLC_GENTYPE) x##F
+#define __CLC_GENTYPE_NAN (__CLC_GENTYPE) FLT_NAN
 
 #define __CLC_S_GENTYPE __CLC_XCONCAT(int, __CLC_VECSIZE)
 #define __CLC_U_GENTYPE __CLC_XCONCAT(uint, __CLC_VECSIZE)
@@ -149,8 +149,8 @@
 
 #define __CLC_SCALAR_GENTYPE double
 #define __CLC_FPSIZE 64
-#define __CLC_FP_LIT(x) (x)
-#define __CLC_GENTYPE_NAN DBL_NAN
+#define __CLC_FP_LIT(x) (__CLC_GENTYPE)(x)
+#define __CLC_GENTYPE_NAN (__CLC_GENTYPE) DBL_NAN
 
 #define __CLC_S_GENTYPE __CLC_XCONCAT(long, __CLC_VECSIZE)
 #define __CLC_U_GENTYPE __CLC_XCONCAT(ulong, __CLC_VECSIZE)
@@ -225,8 +225,8 @@
 
 #define __CLC_SCALAR_GENTYPE half
 #define __CLC_FPSIZE 16
-#define __CLC_FP_LIT(x) x##H
-#define __CLC_GENTYPE_NAN HALF_NAN
+#define __CLC_FP_LIT(x) (__CLC_GENTYPE) x##H
+#define __CLC_GENTYPE_NAN (__CLC_GENTYPE) HALF_NAN
 
 #define __CLC_S_GENTYPE __CLC_XCONCAT(short, __CLC_VECSIZE)
 #define __CLC_U_GENTYPE __CLC_XCONCAT(ushort, __CLC_VECSIZE)

--- a/libclc/clc/lib/generic/common/clc_sign.inc
+++ b/libclc/clc/lib/generic/common/clc_sign.inc
@@ -9,7 +9,6 @@
 _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_sign(__CLC_GENTYPE x) {
   __CLC_BIT_INTN ret_zero = __clc_isnan(x) || x == __CLC_FP_LIT(0.0);
   __CLC_GENTYPE ret_val =
-      __clc_select((__CLC_GENTYPE)__CLC_FP_LIT(1.0),
-                   (__CLC_GENTYPE)__CLC_FP_LIT(0.0), ret_zero);
+      __clc_select(__CLC_FP_LIT(1.0), __CLC_FP_LIT(0.0), ret_zero);
   return __clc_copysign(ret_val, x);
 }

--- a/libclc/clc/lib/generic/math/clc_asinpi.inc
+++ b/libclc/clc/lib/generic/math/clc_asinpi.inc
@@ -38,7 +38,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_asinpi(__CLC_GENTYPE x) {
   __CLC_UINTN aux = ux & EXSIGNBIT_SP32;
   __CLC_UINTN xs = ux ^ aux;
   __CLC_GENTYPE shalf =
-      __CLC_AS_GENTYPE(xs | __CLC_AS_UINTN((__CLC_GENTYPE)__CLC_FP_LIT(0.5)));
+      __CLC_AS_GENTYPE(xs | __CLC_AS_UINTN(__CLC_FP_LIT(0.5)));
 
   __CLC_INTN xexp = __CLC_AS_INTN(aux >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
 

--- a/libclc/clc/lib/generic/math/clc_atanpi.inc
+++ b/libclc/clc/lib/generic/math/clc_atanpi.inc
@@ -17,7 +17,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
 
   __CLC_GENTYPE xbypi = MATH_DIVIDE(x, pi);
   __CLC_GENTYPE shalf =
-      __CLC_AS_GENTYPE(sx | __CLC_AS_UINTN((__CLC_GENTYPE)__CLC_FP_LIT(0.5)));
+      __CLC_AS_GENTYPE(sx | __CLC_AS_UINTN(__CLC_FP_LIT(0.5)));
 
   __CLC_GENTYPE v = __CLC_AS_GENTYPE(aux);
 

--- a/libclc/clc/lib/generic/math/clc_fdim.inc
+++ b/libclc/clc/lib/generic/math/clc_fdim.inc
@@ -8,8 +8,7 @@
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_fdim(__CLC_GENTYPE x,
                                                 __CLC_GENTYPE y) {
-  return __clc_select(
-      __builtin_elementwise_max(x - y, (__CLC_GENTYPE)__CLC_FP_LIT(0.0)),
-      __CLC_GENTYPE_NAN,
-      __CLC_CONVERT_BIT_INTN(__clc_isnan(x) || __clc_isnan(y)));
+  return __clc_select(__builtin_elementwise_max(x - y, __CLC_FP_LIT(0.0)),
+                      __CLC_GENTYPE_NAN,
+                      __CLC_CONVERT_BIT_INTN(__clc_isnan(x) || __clc_isnan(y)));
 }

--- a/libclc/clc/lib/generic/math/clc_rootn.inc
+++ b/libclc/clc/lib/generic/math/clc_rootn.inc
@@ -203,8 +203,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_rootn(__CLC_GENTYPE x,
   __CLC_BIT_INTN x_is_ninf = ix == (__CLC_INTN)NINFBITPATT_SP32;
   __CLC_BIT_INTN x_is_pinf = ix == (__CLC_INTN)PINFBITPATT_SP32;
 
-  ret = (!xpos & (inty == 2)) ? __CLC_AS_INTN((__CLC_GENTYPE)__CLC_GENTYPE_NAN)
-                              : ret;
+  ret = (!xpos & (inty == 2)) ? __CLC_AS_INTN(__CLC_GENTYPE_NAN) : ret;
   __CLC_INTN xinf =
       xpos ? (__CLC_INTN)PINFBITPATT_SP32 : (__CLC_INTN)NINFBITPATT_SP32;
   ret = ((ax == 0) & !ypos & (inty == 1)) ? xinf : ret;
@@ -217,7 +216,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_rootn(__CLC_GENTYPE x,
   ret = (x_is_pinf & !ypos) ? 0 : ret;
   ret = (x_is_pinf & ypos) ? PINFBITPATT_SP32 : ret;
   ret = ax > PINFBITPATT_SP32 ? ix : ret;
-  ret = ny == 0 ? __CLC_AS_INTN((__CLC_GENTYPE)__CLC_GENTYPE_NAN) : ret;
+  ret = ny == 0 ? __CLC_AS_INTN(__CLC_GENTYPE_NAN) : ret;
 
   return __CLC_AS_GENTYPE(ret);
 }
@@ -371,8 +370,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_rootn(__CLC_GENTYPE x,
   // Now all the edge cases
   __CLC_BIT_INTN x_is_ninf = ux == (__CLC_LONGN)NINFBITPATT_DP64;
   __CLC_BIT_INTN x_is_pinf = ux == (__CLC_LONGN)PINFBITPATT_DP64;
-  ret = (!xpos & (inty == 2)) ? __CLC_AS_LONGN((__CLC_GENTYPE)__CLC_GENTYPE_NAN)
-                              : ret;
+  ret = (!xpos & (inty == 2)) ? __CLC_AS_LONGN(__CLC_GENTYPE_NAN) : ret;
   __CLC_LONGN xinf =
       xpos ? (__CLC_LONGN)PINFBITPATT_DP64 : (__CLC_LONGN)NINFBITPATT_DP64;
   ret = ((ax == 0L) & !ypos & (inty == 1)) ? xinf : ret;
@@ -387,9 +385,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_rootn(__CLC_GENTYPE x,
   ret = (x_is_pinf & !ypos) ? 0L : ret;
   ret = (x_is_pinf & ypos) ? (__CLC_LONGN)PINFBITPATT_DP64 : ret;
   ret = ax > (__CLC_LONGN)PINFBITPATT_DP64 ? ux : ret;
-  ret = __CLC_CONVERT_LONGN(ny == 0)
-            ? __CLC_AS_LONGN((__CLC_GENTYPE)__CLC_GENTYPE_NAN)
-            : ret;
+  ret = __CLC_CONVERT_LONGN(ny == 0) ? __CLC_AS_LONGN(__CLC_GENTYPE_NAN) : ret;
   return __CLC_AS_GENTYPE(ret);
 }
 


### PR DESCRIPTION
By having these already defined as type 'gentype' we can avoid unnecessary casting.