### PR TITLE
[BOLT][test] Disable callcont-fallthru.s on AArch64

### DIFF
--- a/bolt/test/X86/callcont-fallthru.s
+++ b/bolt/test/X86/callcont-fallthru.s
@@ -1,6 +1,7 @@
 ## Ensures that a call continuation fallthrough count is set when using
 ## pre-aggregated perf data.
 
+# TODO: Remove once llvm-nm supports --synthetic (#138232)
 # REQUIRES: x86_64-linux
 
 # RUN: %clang %cflags -fpic -shared -xc /dev/null -o %t.so

--- a/bolt/test/X86/callcont-fallthru.s
+++ b/bolt/test/X86/callcont-fallthru.s
@@ -1,6 +1,8 @@
 ## Ensures that a call continuation fallthrough count is set when using
 ## pre-aggregated perf data.
 
+# REQUIRES: x86_64-linux
+
 # RUN: %clang %cflags -fpic -shared -xc /dev/null -o %t.so
 ## Link against a DSO to ensure PLT entries.
 # RUN: %clangxx %cxxflags %s %t.so -o %t -Wl,-q -nostdlib


### PR DESCRIPTION
Disabling this test on AArch64, until a consistent workaround is in place. See [this comment](https://github.com/llvm/llvm-project/pull/135867#issuecomment-2821084711) of:
- #135867

This would help unblock our buildbot (currently internal, but with plans of adding it to LLVM).