### PR TITLE
[msan][NFCI] Add note that GPU libraries may cause shadow mapping incompatibility

### DIFF
--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -483,6 +483,9 @@ void __msan_init() {
     Printf("FATAL: Disabling ASLR is known to cause this error.\n");
     Printf("FATAL: If running under GDB, try "
            "'set disable-randomization off'.\n");
+    Printf(
+        "FATAL: This error may also occur for programs that use GPU "
+        "libraries.\n");
     DumpProcessMap();
     Die();
   }


### PR DESCRIPTION
GPU libraries may map a significant chunk of host memory that overlaps with the expected shadow mappings