### PR TITLE
[tsan][NFCI] Add note that GPU libraries may cause shadow mapping incompatibility

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
@@ -292,8 +292,12 @@ static void ReExecIfNeeded(bool ignore_heap) {
     } else {
       Printf(
           "FATAL: ThreadSanitizer: memory layout is incompatible, "
-          "even though ASLR is disabled.\n"
-          "Please file a bug.\n");
+          "even though ASLR is disabled.\n");
+      Printf(
+          "FATAL: This error may occur for programs that use GPU libraries.");
+      Printf(
+          "FATAL: If your program does not use GPU libraries, please file a "
+          "TSan bug.\n");
       DumpProcessMap();
       Die();
     }


### PR DESCRIPTION
GPU libraries may map a significant chunk of host memory that overlaps with the expected shadow mappings