### PR TITLE
[C2y] Correctly handle 0 in the preprocessor

### DIFF
--- a/clang/lib/Lex/LiteralSupport.cpp
+++ b/clang/lib/Lex/LiteralSupport.cpp
@@ -1420,7 +1420,7 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
   }
 
   // Parse a potential octal literal prefix.
-  bool SawOctalPrefix = false;
+  bool SawOctalPrefix = false, IsNakedZero = false;
   if ((c1 == 'O' || c1 == 'o') && (s[1] >= '0' && s[1] <= '7')) {
     unsigned DiagId;
     if (LangOpts.C2y)
@@ -1438,7 +1438,8 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
   auto _ = llvm::make_scope_exit([&] {
     // If we still have an octal value but we did not see an octal prefix,
     // diagnose as being an obsolescent feature starting in C2y.
-    if (radix == 8 && LangOpts.C2y && !SawOctalPrefix && !hadError)
+    if (radix == 8 && LangOpts.C2y && !SawOctalPrefix && !hadError &&
+        !IsNakedZero)
       Diags.Report(TokLoc, diag::warn_unprefixed_octal_deprecated);
   });
 
@@ -1453,6 +1454,8 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
   // anything, we leave the digit start where it was.
   if (s != PossibleNewDigitStart)
     DigitsBegin = PossibleNewDigitStart;
+  else
+    IsNakedZero = s == ThisTokEnd; // Is the only thing we've seen a 0?
 
   if (s == ThisTokEnd)
     return; // Done, simple octal number like 01234

--- a/clang/lib/Lex/LiteralSupport.cpp
+++ b/clang/lib/Lex/LiteralSupport.cpp
@@ -1420,7 +1420,7 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
   }
 
   // Parse a potential octal literal prefix.
-  bool SawOctalPrefix = false, IsNakedZero = false;
+  bool SawOctalPrefix = false, IsSingleZero = false;
   if ((c1 == 'O' || c1 == 'o') && (s[1] >= '0' && s[1] <= '7')) {
     unsigned DiagId;
     if (LangOpts.C2y)
@@ -1439,7 +1439,7 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
     // If we still have an octal value but we did not see an octal prefix,
     // diagnose as being an obsolescent feature starting in C2y.
     if (radix == 8 && LangOpts.C2y && !SawOctalPrefix && !hadError &&
-        !IsNakedZero)
+        !IsSingleZero)
       Diags.Report(TokLoc, diag::warn_unprefixed_octal_deprecated);
   });
 
@@ -1455,7 +1455,7 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
   if (s != PossibleNewDigitStart)
     DigitsBegin = PossibleNewDigitStart;
   else
-    IsNakedZero = s == ThisTokEnd; // Is the only thing we've seen a 0?
+    IsSingleZero = (s == ThisTokEnd); // Is the only thing we've seen a 0?
 
   if (s == ThisTokEnd)
     return; // Done, simple octal number like 01234

--- a/clang/test/C/C2y/n3353.c
+++ b/clang/test/C/C2y/n3353.c
@@ -46,6 +46,10 @@ static const void *ptr = 0o0;  /* ext-warning {{octal integer literals are a C2y
 // 0 by itself is not deprecated, of course.
 int k = 0;
 
+// Test a preprocessor use of 0 by itself, which is also not deprecated.
+#if 0
+#endif
+
 // Make sure there are no surprises with auto and type deduction. Promotion
 // turns this into an 'int', and 'constexpr' implies 'const'.
 constexpr auto l = 0o1234567; /* ext-warning {{octal integer literals are a C2y extension}}


### PR DESCRIPTION
We do not diagnose 0 as a deprecated octal literal outside of the preprocessor. This fixes a bug where we were accidentally diagnosing 0 from a preprocessor conditional, however.

No release note because this is fixing an issue with a new change.