### PR TITLE
[Test][Darwin] Mark zero_page_pc test as unsupported

### DIFF
--- a/compiler-rt/test/asan/TestCases/zero_page_pc.cpp
+++ b/compiler-rt/test/asan/TestCases/zero_page_pc.cpp
@@ -1,6 +1,9 @@
 // Check that ASan correctly detects SEGV on the zero page.
 // RUN: %clangxx_asan %s -o %t && not %run %t 2>&1 | FileCheck %s
 
+// Handled as a codesigning violation and exits with SIGKILL not SEGV
+// UNSUPPORTED: arm64e && ios
+
 #if defined(_MSC_VER) && !defined(__CLANG__)
 #  define __has_feature(x) 0
 #endif


### PR DESCRIPTION
This is handled as a SIGKILL and can't be intercepted by ASan's signal handler.

rdar://127512190