### PR TITLE
[mlir][vector] Standardize `base` Naming Across Vector Ops (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1263,20 +1263,23 @@ def Vector_ExtractStridedSliceOp :
 
 // TODO: Tighten semantics so that masks and inbounds can't be used
 // simultaneously within the same transfer op.
-def Vector_TransferReadOp
-    : Vector_Op<"transfer_read",
-                [DeclareOpInterfaceMethods<VectorTransferOpInterface>,
-                 DeclareOpInterfaceMethods<
-                     VectorUnrollOpInterface, ["getShapeForUnroll"]>,
-                 DeclareOpInterfaceMethods<MaskableOpInterface>,
-                 DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                 DeclareOpInterfaceMethods<ConditionallySpeculatable>,
-                 AttrSizedOperandSegments, DestinationStyleOpInterface]>,
-      Arguments<(ins AnyShaped:$base, Variadic<Index>:$indices,
-          AffineMapAttr:$permutation_map, AnyType:$padding,
-          Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
-          BoolArrayAttr:$in_bounds)>,
-      Results<(outs AnyVectorOfAnyRank:$vector)> {
+def Vector_TransferReadOp :
+  Vector_Op<"transfer_read", [
+      DeclareOpInterfaceMethods<VectorTransferOpInterface>,
+      DeclareOpInterfaceMethods<VectorUnrollOpInterface, ["getShapeForUnroll"]>,
+      DeclareOpInterfaceMethods<MaskableOpInterface>,
+      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+      DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+      AttrSizedOperandSegments,
+      DestinationStyleOpInterface
+    ]>,
+    Arguments<(ins AnyShaped:$base,
+                   Variadic<Index>:$indices,
+                   AffineMapAttr:$permutation_map,
+                   AnyType:$padding,
+                   Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
+                   BoolArrayAttr:$in_bounds)>,
+    Results<(outs AnyVectorOfAnyRank:$vector)> {
 
   let summary = "Reads a supervector from memory into an SSA vector value.";
 
@@ -1465,25 +1468,30 @@ def Vector_TransferReadOp
   }];
 
   let builders = [
-      /// 1. Builder that sets padding to zero and an empty mask (variant with
-      /// attrs).
-      OpBuilder<(ins "VectorType":$vectorType, "Value":$base,
-          "ValueRange":$indices, "AffineMapAttr":$permutationMapAttr,
-          "ArrayAttr":$inBoundsAttr)>,
-      /// 2. Builder that sets padding to zero and an empty mask (variant
-      /// without attrs).
-      OpBuilder<(ins "VectorType":$vectorType, "Value":$base,
-          "ValueRange":$indices, "AffineMap":$permutationMap,
-          CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
-      /// 3. Builder that sets permutation map to 'getMinorIdentityMap'.
-      OpBuilder<(ins "VectorType":$vectorType, "Value":$base,
-          "ValueRange":$indices, "Value":$padding,
-          CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
-      /// 4. Builder that sets padding to zero and permutation map to
-      /// 'getMinorIdentityMap'.
-      OpBuilder<(ins "VectorType":$vectorType, "Value":$base,
-          "ValueRange":$indices,
-          CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
+    /// 1. Builder that sets padding to zero and an empty mask (variant with attrs).
+    OpBuilder<(ins "VectorType":$vectorType,
+                   "Value":$source,
+                   "ValueRange":$indices,
+                   "AffineMapAttr":$permutationMapAttr,
+                   "ArrayAttr":$inBoundsAttr)>,
+    /// 2. Builder that sets padding to zero and an empty mask (variant without attrs).
+    OpBuilder<(ins "VectorType":$vectorType,
+                   "Value":$source,
+                   "ValueRange":$indices,
+                   "AffineMap":$permutationMap,
+                   CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
+    /// 3. Builder that sets permutation map to 'getMinorIdentityMap'.
+    OpBuilder<(ins "VectorType":$vectorType,
+                   "Value":$source,
+                   "ValueRange":$indices,
+                   "Value":$padding,
+                   CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
+    /// 4. Builder that sets padding to zero and permutation map to
+    /// 'getMinorIdentityMap'.
+    OpBuilder<(ins "VectorType":$vectorType,
+                   "Value":$source,
+                   "ValueRange":$indices,
+                   CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
   ];
 
   let extraClassDeclaration = [{
@@ -1503,20 +1511,23 @@ def Vector_TransferReadOp
 
 // TODO: Tighten semantics so that masks and inbounds can't be used
 // simultaneously within the same transfer op.
-def Vector_TransferWriteOp
-    : Vector_Op<"transfer_write",
-                [DeclareOpInterfaceMethods<VectorTransferOpInterface>,
-                 DeclareOpInterfaceMethods<
-                     VectorUnrollOpInterface, ["getShapeForUnroll"]>,
-                 DeclareOpInterfaceMethods<MaskableOpInterface>,
-                 DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                 DeclareOpInterfaceMethods<ConditionallySpeculatable>,
-                 AttrSizedOperandSegments, DestinationStyleOpInterface]>,
-      Arguments<(ins AnyVectorOfAnyRank:$valueToStore, AnyShaped:$base,
-          Variadic<Index>:$indices, AffineMapAttr:$permutation_map,
-          Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
-          BoolArrayAttr:$in_bounds)>,
-      Results<(outs Optional<AnyRankedTensor>:$result)> {
+def Vector_TransferWriteOp :
+  Vector_Op<"transfer_write", [
+      DeclareOpInterfaceMethods<VectorTransferOpInterface>,
+      DeclareOpInterfaceMethods<VectorUnrollOpInterface, ["getShapeForUnroll"]>,
+      DeclareOpInterfaceMethods<MaskableOpInterface>,
+      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+      DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+      AttrSizedOperandSegments,
+      DestinationStyleOpInterface
+  ]>,
+    Arguments<(ins AnyVectorOfAnyRank:$valueToStore,
+                   AnyShaped:$base,
+                   Variadic<Index>:$indices,
+                   AffineMapAttr:$permutation_map,
+                   Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
+                   BoolArrayAttr:$in_bounds)>,
+    Results<(outs Optional<AnyRankedTensor>:$result)> {
 
   let summary = "The vector.transfer_write op writes a supervector to memory.";
 

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1263,23 +1263,20 @@ def Vector_ExtractStridedSliceOp :
 
 // TODO: Tighten semantics so that masks and inbounds can't be used
 // simultaneously within the same transfer op.
-def Vector_TransferReadOp :
-  Vector_Op<"transfer_read", [
-      DeclareOpInterfaceMethods<VectorTransferOpInterface>,
-      DeclareOpInterfaceMethods<VectorUnrollOpInterface, ["getShapeForUnroll"]>,
-      DeclareOpInterfaceMethods<MaskableOpInterface>,
-      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-      DeclareOpInterfaceMethods<ConditionallySpeculatable>,
-      AttrSizedOperandSegments,
-      DestinationStyleOpInterface
-    ]>,
-    Arguments<(ins AnyShaped:$source,
-                   Variadic<Index>:$indices,
-                   AffineMapAttr:$permutation_map,
-                   AnyType:$padding,
-                   Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
-                   BoolArrayAttr:$in_bounds)>,
-    Results<(outs AnyVectorOfAnyRank:$vector)> {
+def Vector_TransferReadOp
+    : Vector_Op<"transfer_read",
+                [DeclareOpInterfaceMethods<VectorTransferOpInterface>,
+                 DeclareOpInterfaceMethods<
+                     VectorUnrollOpInterface, ["getShapeForUnroll"]>,
+                 DeclareOpInterfaceMethods<MaskableOpInterface>,
+                 DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                 DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+                 AttrSizedOperandSegments, DestinationStyleOpInterface]>,
+      Arguments<(ins AnyShaped:$base, Variadic<Index>:$indices,
+          AffineMapAttr:$permutation_map, AnyType:$padding,
+          Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
+          BoolArrayAttr:$in_bounds)>,
+      Results<(outs AnyVectorOfAnyRank:$vector)> {
 
   let summary = "Reads a supervector from memory into an SSA vector value.";
 
@@ -1468,30 +1465,25 @@ def Vector_TransferReadOp :
   }];
 
   let builders = [
-    /// 1. Builder that sets padding to zero and an empty mask (variant with attrs).
-    OpBuilder<(ins "VectorType":$vectorType,
-                   "Value":$source,
-                   "ValueRange":$indices,
-                   "AffineMapAttr":$permutationMapAttr,
-                   "ArrayAttr":$inBoundsAttr)>,
-    /// 2. Builder that sets padding to zero and an empty mask (variant without attrs).
-    OpBuilder<(ins "VectorType":$vectorType,
-                   "Value":$source,
-                   "ValueRange":$indices,
-                   "AffineMap":$permutationMap,
-                   CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
-    /// 3. Builder that sets permutation map to 'getMinorIdentityMap'.
-    OpBuilder<(ins "VectorType":$vectorType,
-                   "Value":$source,
-                   "ValueRange":$indices,
-                   "Value":$padding,
-                   CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
-    /// 4. Builder that sets padding to zero and permutation map to
-    /// 'getMinorIdentityMap'.
-    OpBuilder<(ins "VectorType":$vectorType,
-                   "Value":$source,
-                   "ValueRange":$indices,
-                   CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
+      /// 1. Builder that sets padding to zero and an empty mask (variant with
+      /// attrs).
+      OpBuilder<(ins "VectorType":$vectorType, "Value":$base,
+          "ValueRange":$indices, "AffineMapAttr":$permutationMapAttr,
+          "ArrayAttr":$inBoundsAttr)>,
+      /// 2. Builder that sets padding to zero and an empty mask (variant
+      /// without attrs).
+      OpBuilder<(ins "VectorType":$vectorType, "Value":$base,
+          "ValueRange":$indices, "AffineMap":$permutationMap,
+          CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
+      /// 3. Builder that sets permutation map to 'getMinorIdentityMap'.
+      OpBuilder<(ins "VectorType":$vectorType, "Value":$base,
+          "ValueRange":$indices, "Value":$padding,
+          CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
+      /// 4. Builder that sets padding to zero and permutation map to
+      /// 'getMinorIdentityMap'.
+      OpBuilder<(ins "VectorType":$vectorType, "Value":$base,
+          "ValueRange":$indices,
+          CArg<"std::optional<ArrayRef<bool>>", "::std::nullopt">:$inBounds)>,
   ];
 
   let extraClassDeclaration = [{
@@ -1511,23 +1503,20 @@ def Vector_TransferReadOp :
 
 // TODO: Tighten semantics so that masks and inbounds can't be used
 // simultaneously within the same transfer op.
-def Vector_TransferWriteOp :
-  Vector_Op<"transfer_write", [
-      DeclareOpInterfaceMethods<VectorTransferOpInterface>,
-      DeclareOpInterfaceMethods<VectorUnrollOpInterface, ["getShapeForUnroll"]>,
-      DeclareOpInterfaceMethods<MaskableOpInterface>,
-      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-      DeclareOpInterfaceMethods<ConditionallySpeculatable>,
-      AttrSizedOperandSegments,
-      DestinationStyleOpInterface
-  ]>,
-    Arguments<(ins AnyVectorOfAnyRank:$valueToStore,
-                   AnyShaped:$source,
-                   Variadic<Index>:$indices,
-                   AffineMapAttr:$permutation_map,
-                   Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
-                   BoolArrayAttr:$in_bounds)>,
-    Results<(outs Optional<AnyRankedTensor>:$result)> {
+def Vector_TransferWriteOp
+    : Vector_Op<"transfer_write",
+                [DeclareOpInterfaceMethods<VectorTransferOpInterface>,
+                 DeclareOpInterfaceMethods<
+                     VectorUnrollOpInterface, ["getShapeForUnroll"]>,
+                 DeclareOpInterfaceMethods<MaskableOpInterface>,
+                 DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                 DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+                 AttrSizedOperandSegments, DestinationStyleOpInterface]>,
+      Arguments<(ins AnyVectorOfAnyRank:$valueToStore, AnyShaped:$base,
+          Variadic<Index>:$indices, AffineMapAttr:$permutation_map,
+          Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
+          BoolArrayAttr:$in_bounds)>,
+      Results<(outs Optional<AnyRankedTensor>:$result)> {
 
   let summary = "The vector.transfer_write op writes a supervector to memory.";
 
@@ -1663,7 +1652,7 @@ def Vector_TransferWriteOp :
     ///  ops of other dialects.
     Value getValue() { return getVector(); }
 
-    MutableOperandRange getDpsInitsMutable() { return getSourceMutable(); }
+    MutableOperandRange getDpsInitsMutable() { return getBaseMutable(); }
   }];
 
   let hasFolder = 1;

--- a/mlir/include/mlir/Interfaces/VectorInterfaces.td
+++ b/mlir/include/mlir/Interfaces/VectorInterfaces.td
@@ -75,66 +75,75 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
   }];
   let cppNamespace = "::mlir";
 
-  let methods = [InterfaceMethod<
-                     /*desc=*/[{
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
         Return the `in_bounds` attribute name.
       }],
-                     /*retTy=*/"::mlir::StringRef",
-                     /*methodName=*/"getInBoundsAttrName",
-                     /*args=*/(ins)>,
-                 InterfaceMethod<
-                     /*desc=*/[{
+      /*retTy=*/"::mlir::StringRef",
+      /*methodName=*/"getInBoundsAttrName",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Return the `permutation_map` attribute name.
       }],
-                     /*retTy=*/"::mlir::StringRef",
-                     /*methodName=*/"getPermutationMapAttrName",
-                     /*args=*/(ins)>,
-                 InterfaceMethod<
-                     /*desc=*/[{
+      /*retTy=*/"::mlir::StringRef",
+      /*methodName=*/"getPermutationMapAttrName",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Return the optional in_bounds attribute that specifies for each vector
         dimension whether it is in-bounds or not. (Broadcast dimensions are
         always in-bounds).
       }],
-                     /*retTy=*/"::mlir::ArrayAttr",
-                     /*methodName=*/"getInBounds",
-                     /*args=*/(ins)>,
-                 InterfaceMethod<
-                     /*desc=*/[{
+      /*retTy=*/"::mlir::ArrayAttr",
+      /*methodName=*/"getInBounds",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Return the memref or ranked tensor operand that this operation operates
         on. In case of a "read" operation, that's the source from which the
         operation reads. In case of a "write" operation, that's the destination
         into which the operation writes.
+        TODO: Change name of operand, which is not accurate for xfer_write.
       }],
-                     /*retTy=*/"::mlir::Value",
-                     /*methodName=*/"getBase",
-                     /*args=*/(ins)>,
-                 InterfaceMethod<
-                     /*desc=*/[{
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"getBase",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Return the vector that this operation operates on. In case of a "read",
         that's the vector OpResult. In case of a "write", that's the vector
         operand value that is written by the op.
       }],
-                     /*retTy=*/"::mlir::Value",
-                     /*methodName=*/"getVector",
-                     /*args=*/(ins)>,
-                 InterfaceMethod<
-                     /*desc=*/[{
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"getVector",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Return the type of the vector that this operation operates on.
       }],
-                     /*retTy=*/"::mlir::VectorType",
-                     /*methodName=*/"getVectorType",
-                     /*args=*/(ins)>,
-                 InterfaceMethod<
-                     /*desc=*/[{
+      /*retTy=*/"::mlir::VectorType",
+      /*methodName=*/"getVectorType",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Return the indices that specify the starting offsets into the source
         operand. The starting offsets are guaranteed to be in-bounds.
       }],
-                     /*retTy=*/"::mlir::OperandRange",
-                     /*methodName=*/"getIndices",
-                     /*args=*/(ins)>,
+      /*retTy=*/"::mlir::OperandRange",
+      /*methodName=*/"getIndices",
+      /*args=*/(ins)
+    >,
 
-                 InterfaceMethod<
-                     /*desc=*/[{
+    InterfaceMethod<
+      /*desc=*/[{
         Return the permutation map that describes the mapping of vector
         dimensions to source dimensions, as well as broadcast dimensions.
 
@@ -153,17 +162,20 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
             : memref<?x?xvector<4x3xf32>>, vector<1x1x4x3xf32>
         ```
       }],
-                     /*retTy=*/"::mlir::AffineMap",
-                     /*methodName=*/"getPermutationMap",
-                     /*args=*/(ins)>,
-                 InterfaceMethod<
-                     /*desc=*/[{
+      /*retTy=*/"::mlir::AffineMap",
+      /*methodName=*/"getPermutationMap",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Return the mask operand if the op has a mask. Otherwise, return an
         empty value.
       }],
-                     /*retTy=*/"Value",
-                     /*methodName=*/"getMask",
-                     /*args=*/(ins)>];
+      /*retTy=*/"Value",
+      /*methodName=*/"getMask",
+      /*args=*/(ins)
+    >
+  ];
 
   let extraSharedClassDeclaration = [{
     /// Return a vector of all in_bounds values as booleans (one per vector
@@ -173,6 +185,12 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
       for (int64_t i = 0, e = $_op.getTransferRank(); i < e; ++i)
         inBounds.push_back($_op.isDimInBounds(i));
       return inBounds;
+    }
+
+    /// Wrapper for getBase, which replaced getSource.
+    [[deprecated("Use getBase instead!")]]
+    ::mlir::Value getSource() {
+        return $_op.getBase();
     }
 
     /// Return the number of leading shaped dimensions (of the "source" operand)

--- a/mlir/include/mlir/Interfaces/VectorInterfaces.td
+++ b/mlir/include/mlir/Interfaces/VectorInterfaces.td
@@ -75,75 +75,66 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
   }];
   let cppNamespace = "::mlir";
 
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/[{
+  let methods = [InterfaceMethod<
+                     /*desc=*/[{
         Return the `in_bounds` attribute name.
       }],
-      /*retTy=*/"::mlir::StringRef",
-      /*methodName=*/"getInBoundsAttrName",
-      /*args=*/(ins)
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
+                     /*retTy=*/"::mlir::StringRef",
+                     /*methodName=*/"getInBoundsAttrName",
+                     /*args=*/(ins)>,
+                 InterfaceMethod<
+                     /*desc=*/[{
         Return the `permutation_map` attribute name.
       }],
-      /*retTy=*/"::mlir::StringRef",
-      /*methodName=*/"getPermutationMapAttrName",
-      /*args=*/(ins)
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
+                     /*retTy=*/"::mlir::StringRef",
+                     /*methodName=*/"getPermutationMapAttrName",
+                     /*args=*/(ins)>,
+                 InterfaceMethod<
+                     /*desc=*/[{
         Return the optional in_bounds attribute that specifies for each vector
         dimension whether it is in-bounds or not. (Broadcast dimensions are
         always in-bounds).
       }],
-      /*retTy=*/"::mlir::ArrayAttr",
-      /*methodName=*/"getInBounds",
-      /*args=*/(ins)
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
+                     /*retTy=*/"::mlir::ArrayAttr",
+                     /*methodName=*/"getInBounds",
+                     /*args=*/(ins)>,
+                 InterfaceMethod<
+                     /*desc=*/[{
         Return the memref or ranked tensor operand that this operation operates
         on. In case of a "read" operation, that's the source from which the
         operation reads. In case of a "write" operation, that's the destination
         into which the operation writes.
-        TODO: Change name of operand, which is not accurate for xfer_write.
       }],
-      /*retTy=*/"::mlir::Value",
-      /*methodName=*/"getSource",
-      /*args=*/(ins)
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
+                     /*retTy=*/"::mlir::Value",
+                     /*methodName=*/"getBase",
+                     /*args=*/(ins)>,
+                 InterfaceMethod<
+                     /*desc=*/[{
         Return the vector that this operation operates on. In case of a "read",
         that's the vector OpResult. In case of a "write", that's the vector
         operand value that is written by the op.
       }],
-      /*retTy=*/"::mlir::Value",
-      /*methodName=*/"getVector",
-      /*args=*/(ins)
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
+                     /*retTy=*/"::mlir::Value",
+                     /*methodName=*/"getVector",
+                     /*args=*/(ins)>,
+                 InterfaceMethod<
+                     /*desc=*/[{
         Return the type of the vector that this operation operates on.
       }],
-      /*retTy=*/"::mlir::VectorType",
-      /*methodName=*/"getVectorType",
-      /*args=*/(ins)
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
+                     /*retTy=*/"::mlir::VectorType",
+                     /*methodName=*/"getVectorType",
+                     /*args=*/(ins)>,
+                 InterfaceMethod<
+                     /*desc=*/[{
         Return the indices that specify the starting offsets into the source
         operand. The starting offsets are guaranteed to be in-bounds.
       }],
-      /*retTy=*/"::mlir::OperandRange",
-      /*methodName=*/"getIndices",
-      /*args=*/(ins)
-    >,
+                     /*retTy=*/"::mlir::OperandRange",
+                     /*methodName=*/"getIndices",
+                     /*args=*/(ins)>,
 
-    InterfaceMethod<
-      /*desc=*/[{
+                 InterfaceMethod<
+                     /*desc=*/[{
         Return the permutation map that describes the mapping of vector
         dimensions to source dimensions, as well as broadcast dimensions.
 
@@ -162,20 +153,17 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
             : memref<?x?xvector<4x3xf32>>, vector<1x1x4x3xf32>
         ```
       }],
-      /*retTy=*/"::mlir::AffineMap",
-      /*methodName=*/"getPermutationMap",
-      /*args=*/(ins)
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
+                     /*retTy=*/"::mlir::AffineMap",
+                     /*methodName=*/"getPermutationMap",
+                     /*args=*/(ins)>,
+                 InterfaceMethod<
+                     /*desc=*/[{
         Return the mask operand if the op has a mask. Otherwise, return an
         empty value.
       }],
-      /*retTy=*/"Value",
-      /*methodName=*/"getMask",
-      /*args=*/(ins)
-    >
-  ];
+                     /*retTy=*/"Value",
+                     /*methodName=*/"getMask",
+                     /*args=*/(ins)>];
 
   let extraSharedClassDeclaration = [{
     /// Return a vector of all in_bounds values as booleans (one per vector
@@ -203,7 +191,7 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
 
     /// Return the shaped type of the "source" operand value.
     ::mlir::ShapedType getShapedType() {
-      return ::llvm::cast<::mlir::ShapedType>($_op.getSource().getType());
+      return ::llvm::cast<::mlir::ShapedType>($_op.getBase().getType());
     }
 
     /// Return the number of dimensions that participate in the permutation map.

--- a/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
+++ b/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
@@ -486,7 +486,7 @@ struct CombineTransferReadOpTranspose final
     Value result =
         rewriter
             .create<vector::TransferReadOp>(
-                loc, resultType, transferReadOp.getSource(),
+                loc, resultType, transferReadOp.getBase(),
                 transferReadOp.getIndices(), AffineMapAttr::get(newMap),
                 transferReadOp.getPadding(), transferReadOp.getMask(),
                 transferReadOp.getInBoundsAttr())
@@ -581,7 +581,7 @@ convertTransferReadOp(RewriterBase &rewriter, vector::TransferReadOp op,
   gpu::MMAMatrixType type =
       gpu::MMAMatrixType::get(op.getVectorType().getShape(), elType, fragType);
   Value load = rewriter.create<gpu::SubgroupMmaLoadMatrixOp>(
-      op.getLoc(), type, op.getSource(), op.getIndices(),
+      op.getLoc(), type, op.getBase(), op.getIndices(),
       rewriter.getIndexAttr(*stride),
       isTranspose ? rewriter.getUnitAttr() : UnitAttr());
   valueMapping[mappingResult] = load;
@@ -612,7 +612,7 @@ convertTransferWriteOp(RewriterBase &rewriter, vector::TransferWriteOp op,
 
   Value matrix = it->second;
   auto store = rewriter.create<gpu::SubgroupMmaStoreMatrixOp>(
-      op.getLoc(), matrix, op.getSource(), op.getIndices(),
+      op.getLoc(), matrix, op.getBase(), op.getIndices(),
       rewriter.getIndexAttr(*stride), /*transpose=*/UnitAttr());
   (void)store;
 
@@ -759,7 +759,7 @@ creatLdMatrixCompatibleLoads(RewriterBase &rewriter, vector::TransferReadOp op,
                                          indices);
 
   nvgpu::LdMatrixOp newOp = rewriter.create<nvgpu::LdMatrixOp>(
-      loc, vectorType, op.getSource(), indices, *transpose, params->numTiles);
+      loc, vectorType, op.getBase(), indices, *transpose, params->numTiles);
   valueMapping[op] = newOp->getResult(0);
   return success();
 }
@@ -819,7 +819,7 @@ createNonLdMatrixLoads(RewriterBase &rewriter, vector::TransferReadOp op,
           rewriter, op, *coords, {laneId, logicalValueId}, newIndices);
 
       Value el = rewriter.create<vector::LoadOp>(loc, loadedElType,
-                                                 op.getSource(), newIndices);
+                                                 op.getBase(), newIndices);
       result = rewriter.create<vector::InsertOp>(loc, el, result, i);
     }
   } else {
@@ -842,7 +842,7 @@ createNonLdMatrixLoads(RewriterBase &rewriter, vector::TransferReadOp op,
         getXferIndices<vector::TransferReadOp>(
             rewriter, op, *coords, {laneId, logicalValueId}, newIndices);
         Value el = rewriter.create<memref::LoadOp>(op.getLoc(), loadedElType,
-                                                   op.getSource(), newIndices);
+                                                   op.getBase(), newIndices);
         result = rewriter.create<vector::InsertOp>(
             op.getLoc(), el, result, ArrayRef<int64_t>{i, innerIdx});
       }
@@ -876,7 +876,7 @@ convertTransferReadToLoads(RewriterBase &rewriter, vector::TransferReadOp op,
     return rewriter.notifyMatchFailure(op, "no warpMatrixInfo");
 
   bool isLdMatrixCompatible =
-      isSharedMemory(cast<MemRefType>(op.getSource().getType())) &&
+      isSharedMemory(cast<MemRefType>(op.getBase().getType())) &&
       nvgpu::inferTileWidthInBits(*warpMatrixInfo) == 128;
 
   VectorType vecTy = op.getVectorType();
@@ -934,7 +934,7 @@ convertTransferWriteToStores(RewriterBase &rewriter, vector::TransferWriteOp op,
     SmallVector<Value, 4> newIndices;
     getXferIndices<vector::TransferWriteOp>(
         rewriter, op, *coords, {laneId, logicalValueId}, newIndices);
-    rewriter.create<vector::StoreOp>(loc, el, op.getSource(), newIndices);
+    rewriter.create<vector::StoreOp>(loc, el, op.getBase(), newIndices);
   }
 
   LLVM_DEBUG(DBGS() << "erase: " << op << "\n");

--- a/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
+++ b/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
@@ -192,7 +192,7 @@ struct TransferReadLowering : public OpRewritePattern<vector::TransferReadOp> {
 
     xegpu::CreateNdDescOp ndDesc =
         createNdDescriptor(rewriter, loc, descType,
-                           dyn_cast<TypedValue<MemRefType>>(readOp.getSource()),
+                           dyn_cast<TypedValue<MemRefType>>(readOp.getBase()),
                            readOp.getIndices());
 
     DenseI64ArrayAttr transposeAttr =
@@ -231,10 +231,10 @@ struct TransferWriteLowering
         vecTy.getShape(), vecTy.getElementType(),
         /*array_length=*/1, /*boundary_check=*/writeOp.hasOutOfBoundsDim(),
         xegpu::MemorySpace::Global);
-    xegpu::CreateNdDescOp ndDesc = createNdDescriptor(
-        rewriter, loc, descType,
-        dyn_cast<TypedValue<MemRefType>>(writeOp.getSource()),
-        writeOp.getIndices());
+    xegpu::CreateNdDescOp ndDesc =
+        createNdDescriptor(rewriter, loc, descType,
+                           dyn_cast<TypedValue<MemRefType>>(writeOp.getBase()),
+                           writeOp.getIndices());
 
     // By default, no specific caching policy is assigned.
     xegpu::CachePolicyAttr hint = nullptr;

--- a/mlir/lib/Dialect/AMDGPU/Transforms/TransferReadToLoad.cpp
+++ b/mlir/lib/Dialect/AMDGPU/Transforms/TransferReadToLoad.cpp
@@ -118,7 +118,7 @@ static Value createVectorLoadForMaskedLoad(OpBuilder &builder, Location loc,
   Value fill = builder.create<vector::SplatOp>(loc, unbroadcastedVectorType,
                                                readOp.getPadding());
   Value load = builder.create<vector::LoadOp>(
-      loc, unbroadcastedVectorType, readOp.getSource(), readOp.getIndices());
+      loc, unbroadcastedVectorType, readOp.getBase(), readOp.getIndices());
   Value res = builder.create<arith::SelectOp>(loc, unbroadcastedVectorType,
                                               readOp.getMask(), load, fill);
   // Insert a broadcasting op if required.
@@ -149,7 +149,7 @@ struct TransferReadLowering final : OpRewritePattern<vector::TransferReadOp> {
     }
 
     Location loc = readOp.getLoc();
-    Value src = readOp.getSource();
+    Value src = readOp.getBase();
 
     VectorType vectorType = readOp.getVectorType();
     int64_t vectorSize = vectorType.getNumElements();

--- a/mlir/lib/Dialect/ArmSME/Transforms/VectorLegalization.cpp
+++ b/mlir/lib/Dialect/ArmSME/Transforms/VectorLegalization.cpp
@@ -315,7 +315,7 @@ struct LegalizeTransferReadOpsByDecomposition
          decomposeToSMETiles(rewriter, vectorType, smeTileType, transposed)) {
       auto smeMask = extractSMEMask(rewriter, loc, mask, smeTile);
       auto smeRead = rewriter.create<vector::TransferReadOp>(
-          loc, smeTileType, readOp.getSource(),
+          loc, smeTileType, readOp.getBase(),
           getSMESubTileIndices(rewriter, loc, readOp.getIndices(), smeTile),
           readOp.getPermutationMapAttr(), readOp.getPadding(), smeMask,
           readOp.getInBoundsAttr());
@@ -359,7 +359,7 @@ struct LegalizeTransferWriteOpsByDecomposition
     auto smeTileType = getSMETileTypeForElement(vectorType.getElementType());
     auto inputSMETiles = adaptor.getValueToStore();
 
-    Value destTensorOrMemref = writeOp.getSource();
+    Value destTensorOrMemref = writeOp.getBase();
     for (auto [index, smeTile] : llvm::enumerate(decomposeToSMETiles(
              rewriter, vectorType, smeTileType, transposed))) {
       auto smeMask = extractSMEMask(rewriter, loc, mask, smeTile);
@@ -497,7 +497,7 @@ struct LegalizeMultiTileTransferWriteAsStoreLoop
       auto slice =
           rewriter.create<vector::ExtractOp>(loc, tile, tileSliceIndex);
       rewriter.create<vector::TransferWriteOp>(
-          loc, slice, writeOp.getSource(), ValueRange{storeRow, storeCol},
+          loc, slice, writeOp.getBase(), ValueRange{storeRow, storeCol},
           AffineMapAttr::get(writeOp.getPermutationMap().dropResult(0)),
           sliceMask,
           rewriter.getBoolArrayAttr(
@@ -677,7 +677,7 @@ struct LiftIllegalVectorTransposeToMemory
         });
     SmallVector<Value> strides(readType.getRank(), Value(one));
     auto readSubview = rewriter.create<memref::SubViewOp>(
-        loc, illegalRead.getSource(), illegalRead.getIndices(), readSizes,
+        loc, illegalRead.getBase(), illegalRead.getIndices(), readSizes,
         strides);
 
     // Apply the transpose to all values/attributes of the transfer_read:
@@ -851,7 +851,7 @@ struct LowerIllegalTransposeStoreViaZA
 
     // Note: We need to use `get_tile` as there's no vector-level `undef`.
     Value undefTile = rewriter.create<arm_sme::GetTileOp>(loc, smeTileType);
-    Value destTensorOrMemref = writeOp.getSource();
+    Value destTensorOrMemref = writeOp.getBase();
     auto numSlicesPerTile =
         std::min(sourceType.getDimSize(0), smeTileType.getDimSize(0));
     auto numSlices =

--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -2627,7 +2627,7 @@ struct PadOpVectorizationWithTransferReadPattern
       SmallVector<bool> inBounds(xferOp.getVectorType().getRank(), false);
       xferOp->setAttr(xferOp.getInBoundsAttrName(),
                       rewriter.getBoolArrayAttr(inBounds));
-      xferOp.getSourceMutable().assign(padOp.getSource());
+      xferOp.getBaseMutable().assign(padOp.getSource());
       xferOp.getPaddingMutable().assign(padValue);
     });
 
@@ -3114,7 +3114,7 @@ LogicalResult LinalgCopyVTRForwardingPattern::matchAndRewrite(
     return rewriter.notifyMatchFailure(xferOp, "unsupported mask");
 
   // Transfer into `view`.
-  Value viewOrAlloc = xferOp.getSource();
+  Value viewOrAlloc = xferOp.getBase();
   if (!viewOrAlloc.getDefiningOp<memref::ViewOp>() &&
       !viewOrAlloc.getDefiningOp<memref::AllocOp>())
     return rewriter.notifyMatchFailure(xferOp, "source not a view or alloc");
@@ -3191,7 +3191,7 @@ LogicalResult LinalgCopyVTWForwardingPattern::matchAndRewrite(
     return rewriter.notifyMatchFailure(xferOp, "unsupported mask");
 
   // Transfer into `viewOrAlloc`.
-  Value viewOrAlloc = xferOp.getSource();
+  Value viewOrAlloc = xferOp.getBase();
   if (!viewOrAlloc.getDefiningOp<memref::ViewOp>() &&
       !viewOrAlloc.getDefiningOp<memref::AllocOp>())
     return rewriter.notifyMatchFailure(xferOp, "source not a view or alloc");

--- a/mlir/lib/Dialect/MemRef/Transforms/ExtractAddressComputations.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ExtractAddressComputations.cpp
@@ -119,7 +119,7 @@ static nvgpu::LdMatrixOp rebuildLdMatrixOp(RewriterBase &rewriter,
 template <typename TransferLikeOp>
 static FailureOr<Value>
 getTransferLikeOpSrcMemRef(TransferLikeOp transferLikeOp) {
-  Value src = transferLikeOp.getSource();
+  Value src = transferLikeOp.getBase();
   if (isa<MemRefType>(src.getType()))
     return src;
   return failure();

--- a/mlir/lib/Dialect/MemRef/Transforms/FoldMemRefAliasOps.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/FoldMemRefAliasOps.cpp
@@ -225,7 +225,7 @@ static Value getMemRefOperand(LoadOrStoreOpTy op) {
 }
 
 static Value getMemRefOperand(vector::TransferReadOp op) {
-  return op.getSource();
+  return op.getBase();
 }
 
 static Value getMemRefOperand(nvgpu::LdMatrixOp op) {
@@ -241,7 +241,7 @@ static Value getMemRefOperand(vector::MaskedLoadOp op) { return op.getBase(); }
 static Value getMemRefOperand(vector::MaskedStoreOp op) { return op.getBase(); }
 
 static Value getMemRefOperand(vector::TransferWriteOp op) {
-  return op.getSource();
+  return op.getBase();
 }
 
 static Value getMemRefOperand(gpu::SubgroupMmaLoadMatrixOp op) {

--- a/mlir/lib/Dialect/NVGPU/TransformOps/NVGPUTransformOps.cpp
+++ b/mlir/lib/Dialect/NVGPU/TransformOps/NVGPUTransformOps.cpp
@@ -172,7 +172,7 @@ static Value getValueLoadedFromGlobal(Operation *op) {
   if (!load)
     return nullptr;
 
-  auto loadType = dyn_cast<MemRefType>(load.getSource().getType());
+  auto loadType = dyn_cast<MemRefType>(load.getBase().getType());
   if (!loadType || !hasDefaultMemorySpace(loadType))
     return nullptr;
   return load;
@@ -185,7 +185,7 @@ static bool isStoreToShared(Operation *op, Value v) {
   if (!store || store.getVector() != v)
     return false;
 
-  auto storeType = dyn_cast<MemRefType>(store.getSource().getType());
+  auto storeType = dyn_cast<MemRefType>(store.getBase().getType());
   return storeType || hasSharedMemorySpace(storeType);
 }
 

--- a/mlir/lib/Dialect/NVGPU/Transforms/Utils.cpp
+++ b/mlir/lib/Dialect/NVGPU/Transforms/Utils.cpp
@@ -71,9 +71,9 @@ Value nvgpu::getMemrefOperand(Operation *op) {
   if (auto storeOp = dyn_cast<memref::StoreOp>(op))
     return storeOp.getMemref();
   if (auto transferWrite = dyn_cast<vector::TransferWriteOp>(op))
-    return transferWrite.getSource();
+    return transferWrite.getBase();
   if (auto transferRead = dyn_cast<vector::TransferReadOp>(op))
-    return transferRead.getSource();
+    return transferRead.getBase();
   if (auto storeOp = dyn_cast<vector::StoreOp>(op))
     return storeOp.getBase();
   if (auto loadOp = dyn_cast<vector::LoadOp>(op))

--- a/mlir/lib/Dialect/NVGPU/Utils/MMAUtils.cpp
+++ b/mlir/lib/Dialect/NVGPU/Utils/MMAUtils.cpp
@@ -285,7 +285,7 @@ bool nvgpu::canLowerToWarpMatrixOperation(vector::TransferReadOp op) {
   // information to ensure correctness of downstream assumptions. It is possible
   // to enable this if caller can assert that tensor will be lowered in a
   // particular manner.
-  auto sourceType = dyn_cast<MemRefType>(op.getSource().getType());
+  auto sourceType = dyn_cast<MemRefType>(op.getBase().getType());
   if (!sourceType)
     return false;
 
@@ -309,7 +309,7 @@ bool nvgpu::canLowerToWarpMatrixOperation(vector::TransferWriteOp op) {
     return false;
   // Currently we can't support reads on tensor types because we need stride
   // information to ensure correctness of downstream assumptions.
-  auto sourceType = dyn_cast<MemRefType>(op.getSource().getType());
+  auto sourceType = dyn_cast<MemRefType>(op.getBase().getType());
   if (!sourceType)
     return false;
 

--- a/mlir/lib/Dialect/Tensor/Transforms/FoldTensorSubsetOps.cpp
+++ b/mlir/lib/Dialect/Tensor/Transforms/FoldTensorSubsetOps.cpp
@@ -36,7 +36,7 @@ namespace tensor {
 using namespace mlir;
 
 static Value getTensorOperand(vector::TransferReadOp op) {
-  return op.getSource();
+  return op.getBase();
 }
 
 static Value getTensorOperand(tensor::InsertSliceOp op) {

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -314,7 +314,7 @@ bool mlir::vector::isDisjointTransferIndices(
 bool mlir::vector::isDisjointTransferSet(VectorTransferOpInterface transferA,
                                          VectorTransferOpInterface transferB,
                                          bool testDynamicValueUsingBounds) {
-  if (transferA.getSource() != transferB.getSource())
+  if (transferA.getBase() != transferB.getBase())
     return false;
   return isDisjointTransferIndices(transferA, transferB,
                                    testDynamicValueUsingBounds);
@@ -4206,7 +4206,7 @@ static void printTransferAttrs(OpAsmPrinter &p, VectorTransferOpInterface op) {
 }
 
 void TransferReadOp::print(OpAsmPrinter &p) {
-  p << " " << getSource() << "[" << getIndices() << "], " << getPadding();
+  p << " " << getBase() << "[" << getIndices() << "], " << getPadding();
   if (getMask())
     p << ", " << getMask();
   printTransferAttrs(p, *this);
@@ -4465,7 +4465,7 @@ static LogicalResult foldTransferFullMask(TransferOp op) {
 static Value foldRAW(TransferReadOp readOp) {
   if (!llvm::isa<RankedTensorType>(readOp.getShapedType()))
     return {};
-  auto defWrite = readOp.getSource().getDefiningOp<vector::TransferWriteOp>();
+  auto defWrite = readOp.getBase().getDefiningOp<vector::TransferWriteOp>();
   while (defWrite) {
     if (checkSameValueRAW(defWrite, readOp))
       return defWrite.getVector();
@@ -4473,7 +4473,7 @@ static Value foldRAW(TransferReadOp readOp) {
             cast<VectorTransferOpInterface>(defWrite.getOperation()),
             cast<VectorTransferOpInterface>(readOp.getOperation())))
       break;
-    defWrite = defWrite.getSource().getDefiningOp<vector::TransferWriteOp>();
+    defWrite = defWrite.getBase().getDefiningOp<vector::TransferWriteOp>();
   }
   return {};
 }
@@ -4501,7 +4501,7 @@ void TransferReadOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   if (llvm::isa<MemRefType>(getShapedType()))
-    effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable(),
+    effects.emplace_back(MemoryEffects::Read::get(), &getBaseMutable(),
                          SideEffects::DefaultResource::get());
 }
 
@@ -4543,7 +4543,7 @@ struct TransferReadAfterWriteToBroadcast
     if (readOp.hasOutOfBoundsDim() ||
         !llvm::isa<RankedTensorType>(readOp.getShapedType()))
       return failure();
-    auto defWrite = readOp.getSource().getDefiningOp<vector::TransferWriteOp>();
+    auto defWrite = readOp.getBase().getDefiningOp<vector::TransferWriteOp>();
     if (!defWrite)
       return failure();
     // TODO: If the written transfer chunk is a superset of the read transfer
@@ -4728,7 +4728,7 @@ ParseResult TransferWriteOp::parse(OpAsmParser &parser,
 }
 
 void TransferWriteOp::print(OpAsmPrinter &p) {
-  p << " " << getVector() << ", " << getSource() << "[" << getIndices() << "]";
+  p << " " << getVector() << ", " << getBase() << "[" << getIndices() << "]";
   if (getMask())
     p << ", " << getMask();
   printTransferAttrs(p, *this);
@@ -4807,7 +4807,7 @@ static LogicalResult foldReadInitWrite(TransferWriteOp write,
   if (write.getTransferRank() == 0)
     return failure();
   auto rankedTensorType =
-      llvm::dyn_cast<RankedTensorType>(write.getSource().getType());
+      llvm::dyn_cast<RankedTensorType>(write.getBase().getType());
   // If not operating on tensors, bail.
   if (!rankedTensorType)
     return failure();
@@ -4829,7 +4829,7 @@ static LogicalResult foldReadInitWrite(TransferWriteOp write,
   if (read.hasOutOfBoundsDim() || write.hasOutOfBoundsDim())
     return failure();
   // Tensor types must be the same.
-  if (read.getSource().getType() != rankedTensorType)
+  if (read.getBase().getType() != rankedTensorType)
     return failure();
   // Vector types must be the same.
   if (read.getVectorType() != write.getVectorType())
@@ -4846,13 +4846,13 @@ static LogicalResult foldReadInitWrite(TransferWriteOp write,
       llvm::any_of(write.getIndices(), isNotConstantZero))
     return failure();
   // Success.
-  results.push_back(read.getSource());
+  results.push_back(read.getBase());
   return success();
 }
 
 static bool checkSameValueWAR(vector::TransferReadOp read,
                               vector::TransferWriteOp write) {
-  return read.getSource() == write.getSource() &&
+  return read.getBase() == write.getBase() &&
          read.getIndices() == write.getIndices() &&
          read.getPermutationMap() == write.getPermutationMap() &&
          read.getVectorType() == write.getVectorType() && !read.getMask() &&
@@ -4874,7 +4874,7 @@ static bool checkSameValueWAR(vector::TransferReadOp read,
 /// ```
 static LogicalResult foldWAR(TransferWriteOp write,
                              SmallVectorImpl<OpFoldResult> &results) {
-  if (!llvm::isa<RankedTensorType>(write.getSource().getType()))
+  if (!llvm::isa<RankedTensorType>(write.getBase().getType()))
     return failure();
   auto read = write.getVector().getDefiningOp<vector::TransferReadOp>();
   if (!read)
@@ -4882,7 +4882,7 @@ static LogicalResult foldWAR(TransferWriteOp write,
 
   if (!checkSameValueWAR(read, write))
     return failure();
-  results.push_back(read.getSource());
+  results.push_back(read.getBase());
   return success();
 }
 
@@ -4954,12 +4954,11 @@ public:
       return failure();
     vector::TransferWriteOp writeToModify = writeOp;
 
-    auto defWrite =
-        writeOp.getSource().getDefiningOp<vector::TransferWriteOp>();
+    auto defWrite = writeOp.getBase().getDefiningOp<vector::TransferWriteOp>();
     while (defWrite) {
       if (checkSameValueWAW(writeOp, defWrite)) {
         rewriter.modifyOpInPlace(writeToModify, [&]() {
-          writeToModify.getSourceMutable().assign(defWrite.getSource());
+          writeToModify.getBaseMutable().assign(defWrite.getBase());
         });
         return success();
       }
@@ -4972,7 +4971,7 @@ public:
       if (!defWrite->hasOneUse())
         break;
       writeToModify = defWrite;
-      defWrite = defWrite.getSource().getDefiningOp<vector::TransferWriteOp>();
+      defWrite = defWrite.getBase().getDefiningOp<vector::TransferWriteOp>();
     }
     return failure();
   }

--- a/mlir/lib/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -52,7 +52,7 @@ struct TransferReadOpInterface
     auto readOp = cast<vector::TransferReadOp>(op);
     assert(isa<TensorType>(readOp.getShapedType()) &&
            "only tensor types expected");
-    FailureOr<Value> buffer = getBuffer(rewriter, readOp.getSource(), options);
+    FailureOr<Value> buffer = getBuffer(rewriter, readOp.getBase(), options);
     if (failed(buffer))
       return failure();
     replaceOpWithNewBufferizedOp<vector::TransferReadOp>(
@@ -110,7 +110,7 @@ struct TransferWriteOpInterface
 
     // Create a new transfer_write on buffer that doesn't have a return value.
     FailureOr<Value> resultBuffer =
-        getBuffer(rewriter, writeOp.getSource(), options);
+        getBuffer(rewriter, writeOp.getBase(), options);
     if (failed(resultBuffer))
       return failure();
     rewriter.create<vector::TransferWriteOp>(

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMask.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMask.cpp
@@ -222,7 +222,7 @@ public:
 
     // Replace the `vector.mask` operation.
     rewriter.replaceOpWithNewOp<TransferReadOp>(
-        maskingOp.getOperation(), readOp.getVectorType(), readOp.getSource(),
+        maskingOp.getOperation(), readOp.getVectorType(), readOp.getBase(),
         readOp.getIndices(), readOp.getPermutationMap(), readOp.getPadding(),
         maskingOp.getMask(), readOp.getInBounds());
     return success();
@@ -245,7 +245,7 @@ public:
     // Replace the `vector.mask` operation.
     rewriter.replaceOpWithNewOp<TransferWriteOp>(
         maskingOp.getOperation(), resultType, writeOp.getVector(),
-        writeOp.getSource(), writeOp.getIndices(), writeOp.getPermutationMap(),
+        writeOp.getBase(), writeOp.getIndices(), writeOp.getPermutationMap(),
         maskingOp.getMask(), writeOp.getInBounds());
     return success();
   }

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
@@ -139,7 +139,7 @@ struct TransferReadPermutationLowering
     VectorType newReadType = VectorType::get(
         newVectorShape, op.getVectorType().getElementType(), newScalableDims);
     Value newRead = rewriter.create<vector::TransferReadOp>(
-        op.getLoc(), newReadType, op.getSource(), op.getIndices(),
+        op.getLoc(), newReadType, op.getBase(), op.getIndices(),
         AffineMapAttr::get(newMap), op.getPadding(), op.getMask(),
         newInBoundsAttr);
 
@@ -214,7 +214,7 @@ struct TransferWritePermutationLowering
     auto newMap = AffineMap::getMinorIdentityMap(
         map.getNumDims(), map.getNumResults(), rewriter.getContext());
     auto newWrite = rewriter.create<vector::TransferWriteOp>(
-        op.getLoc(), newVec, op.getSource(), op.getIndices(),
+        op.getLoc(), newVec, op.getBase(), op.getIndices(),
         AffineMapAttr::get(newMap), op.getMask(), newInBoundsAttr);
     if (newWrite.hasPureTensorSemantics())
       return newWrite.getResult();
@@ -300,7 +300,7 @@ struct TransferWriteNonPermutationLowering
     }
     ArrayAttr newInBoundsAttr = rewriter.getBoolArrayAttr(newInBoundsValues);
     auto newWrite = rewriter.create<vector::TransferWriteOp>(
-        op.getLoc(), newVec, op.getSource(), op.getIndices(),
+        op.getLoc(), newVec, op.getBase(), op.getIndices(),
         AffineMapAttr::get(newMap), newMask, newInBoundsAttr);
     if (newWrite.hasPureTensorSemantics())
       return newWrite.getResult();
@@ -371,7 +371,7 @@ struct TransferOpReduceRank
                   op.getInBoundsAttr().getValue().take_back(reducedShapeRank))
             : ArrayAttr();
     Value newRead = rewriter.create<vector::TransferReadOp>(
-        op.getLoc(), newReadType, op.getSource(), op.getIndices(),
+        op.getLoc(), newReadType, op.getBase(), op.getIndices(),
         AffineMapAttr::get(newMap), op.getPadding(), op.getMask(),
         newInBoundsAttr);
     return rewriter
@@ -474,12 +474,12 @@ struct TransferReadToVectorLoadLowering
       Value fill = rewriter.create<vector::SplatOp>(
           read.getLoc(), unbroadcastedVectorType, read.getPadding());
       res = rewriter.create<vector::MaskedLoadOp>(
-          read.getLoc(), unbroadcastedVectorType, read.getSource(),
+          read.getLoc(), unbroadcastedVectorType, read.getBase(),
           read.getIndices(), read.getMask(), fill);
     } else {
-      res = rewriter.create<vector::LoadOp>(
-          read.getLoc(), unbroadcastedVectorType, read.getSource(),
-          read.getIndices());
+      res = rewriter.create<vector::LoadOp>(read.getLoc(),
+                                            unbroadcastedVectorType,
+                                            read.getBase(), read.getIndices());
     }
 
     // Insert a broadcasting op if required.
@@ -570,11 +570,11 @@ struct TransferWriteToVectorStoreLowering
             });
 
       rewriter.create<vector::MaskedStoreOp>(
-          write.getLoc(), write.getSource(), write.getIndices(),
-          write.getMask(), write.getVector());
+          write.getLoc(), write.getBase(), write.getIndices(), write.getMask(),
+          write.getVector());
     } else {
       rewriter.create<vector::StoreOp>(write.getLoc(), write.getVector(),
-                                       write.getSource(), write.getIndices());
+                                       write.getBase(), write.getIndices());
     }
     // There's no return value for StoreOps. Use Value() to signal success to
     // matchAndRewrite.

--- a/mlir/lib/Dialect/Vector/Transforms/SubsetOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/SubsetOpInterfaceImpl.cpp
@@ -37,7 +37,7 @@ struct TransferReadOpSubsetExtractionOpInterface
     : public SubsetExtractionOpInterface::ExternalModel<
           TransferReadOpSubsetExtractionOpInterface, vector::TransferReadOp> {
   OpOperand &getSourceOperand(Operation *op) const {
-    return cast<vector::TransferReadOp>(op).getSourceMutable();
+    return cast<vector::TransferReadOp>(op).getBaseMutable();
   }
 };
 
@@ -49,7 +49,7 @@ struct TransferWriteOpSubsetInsertionOpInterface
   }
 
   OpOperand &getDestinationOperand(Operation *op) const {
-    return cast<vector::TransferWriteOp>(op).getSourceMutable();
+    return cast<vector::TransferWriteOp>(op).getBaseMutable();
   }
 
   Value buildSubsetExtraction(Operation *op, OpBuilder &builder,

--- a/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
@@ -718,7 +718,7 @@ struct WarpOpTransferRead : public WarpDistributionPattern {
     auto read = operand->get().getDefiningOp<vector::TransferReadOp>();
 
     // Source must be defined outside of the region.
-    if (!warpOp.isDefinedOutsideOfRegion(read.getSource()))
+    if (!warpOp.isDefinedOutsideOfRegion(read.getBase()))
       return rewriter.notifyMatchFailure(
           read, "source must be defined outside of the region");
 
@@ -802,7 +802,7 @@ struct WarpOpTransferRead : public WarpDistributionPattern {
         hasMask ? newWarpOp.getResult(newRetIndices[newRetIndices.size() - 1])
                 : Value();
     auto newRead = rewriter.create<vector::TransferReadOp>(
-        read.getLoc(), distributedVal.getType(), read.getSource(), newIndices,
+        read.getLoc(), distributedVal.getType(), read.getBase(), newIndices,
         read.getPermutationMapAttr(), newPadding, newMask,
         read.getInBoundsAttr());
 

--- a/mlir/lib/Dialect/Vector/Transforms/VectorDropLeadUnitDim.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDropLeadUnitDim.cpp
@@ -230,7 +230,7 @@ struct CastAwayTransferReadLeadingOneDim
     if (read.getTransferRank() == 0)
       return failure();
 
-    auto shapedType = cast<ShapedType>(read.getSource().getType());
+    auto shapedType = cast<ShapedType>(read.getBase().getType());
     if (shapedType.getElementType() != read.getVectorType().getElementType())
       return failure();
 
@@ -260,7 +260,7 @@ struct CastAwayTransferReadLeadingOneDim
     }
 
     auto newRead = rewriter.create<vector::TransferReadOp>(
-        read.getLoc(), newType, read.getSource(), read.getIndices(),
+        read.getLoc(), newType, read.getBase(), read.getIndices(),
         AffineMapAttr::get(newMap), read.getPadding(), mask, inBoundsAttr);
     rewriter.replaceOpWithNewOp<vector::BroadcastOp>(read, oldType, newRead);
 
@@ -284,7 +284,7 @@ struct CastAwayTransferWriteLeadingOneDim
     if (write.getTransferRank() == 0)
       return failure();
 
-    auto shapedType = dyn_cast<ShapedType>(write.getSource().getType());
+    auto shapedType = dyn_cast<ShapedType>(write.getBase().getType());
     if (shapedType.getElementType() != write.getVectorType().getElementType())
       return failure();
 
@@ -314,13 +314,13 @@ struct CastAwayTransferWriteLeadingOneDim
       Value newMask = dropUnitDimsFromMask(
           rewriter, write.getLoc(), write.getMask(), newType, newMap, maskType);
       rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
-          write, newVector, write.getSource(), write.getIndices(),
+          write, newVector, write.getBase(), write.getIndices(),
           AffineMapAttr::get(newMap), newMask, inBoundsAttr);
       return success();
     }
 
     rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
-        write, newVector, write.getSource(), write.getIndices(),
+        write, newVector, write.getBase(), write.getIndices(),
         AffineMapAttr::get(newMap), inBoundsAttr);
     return success();
   }

--- a/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
@@ -1249,7 +1249,7 @@ struct ConvertVectorTransferRead final
 
     auto loc = op.getLoc();
     auto containerElemTy =
-        cast<MemRefType>(adaptor.getSource().getType()).getElementType();
+        cast<MemRefType>(adaptor.getBase().getType()).getElementType();
     Type emulatedElemTy = op.getType().getElementType();
     int emulatedBits = emulatedElemTy.getIntOrFloatBitWidth();
     int containerBits = containerElemTy.getIntOrFloatBitWidth();
@@ -1272,7 +1272,7 @@ struct ConvertVectorTransferRead final
                                                       adaptor.getPadding());
 
     auto stridedMetadata =
-        rewriter.create<memref::ExtractStridedMetadataOp>(loc, op.getSource());
+        rewriter.create<memref::ExtractStridedMetadataOp>(loc, op.getBase());
 
     OpFoldResult linearizedIndices;
     memref::LinearizedMemRefInfo linearizedInfo;
@@ -1294,7 +1294,7 @@ struct ConvertVectorTransferRead final
                                         emulatedPerContainerElem);
 
     auto newRead = rewriter.create<vector::TransferReadOp>(
-        loc, VectorType::get(numElements, containerElemTy), adaptor.getSource(),
+        loc, VectorType::get(numElements, containerElemTy), adaptor.getBase(),
         getValueOrCreateConstantIndexOp(rewriter, loc, linearizedIndices),
         newPadding);
 

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
@@ -92,7 +92,7 @@ void TransferOptimization::deadStoreOp(vector::TransferWriteOp write) {
                     << "\n");
   llvm::SmallVector<Operation *, 8> blockingAccesses;
   Operation *firstOverwriteCandidate = nullptr;
-  Value source = memref::skipViewLikeOps(cast<MemrefValue>(write.getSource()));
+  Value source = memref::skipViewLikeOps(cast<MemrefValue>(write.getBase()));
   llvm::SmallVector<Operation *, 32> users(source.getUsers().begin(),
                                            source.getUsers().end());
   llvm::SmallDenseSet<Operation *, 32> processed;
@@ -112,8 +112,8 @@ void TransferOptimization::deadStoreOp(vector::TransferWriteOp write) {
     if (auto nextWrite = dyn_cast<vector::TransferWriteOp>(user)) {
       // Check candidate that can override the store.
       if (memref::isSameViewOrTrivialAlias(
-              cast<MemrefValue>(nextWrite.getSource()),
-              cast<MemrefValue>(write.getSource())) &&
+              cast<MemrefValue>(nextWrite.getBase()),
+              cast<MemrefValue>(write.getBase())) &&
           checkSameValueWAW(nextWrite, write) &&
           postDominators.postDominates(nextWrite, write)) {
         if (firstOverwriteCandidate == nullptr ||
@@ -178,7 +178,7 @@ void TransferOptimization::storeToLoadForwarding(vector::TransferReadOp read) {
                     << "\n");
   SmallVector<Operation *, 8> blockingWrites;
   vector::TransferWriteOp lastwrite = nullptr;
-  Value source = memref::skipViewLikeOps(cast<MemrefValue>(read.getSource()));
+  Value source = memref::skipViewLikeOps(cast<MemrefValue>(read.getBase()));
   llvm::SmallVector<Operation *, 32> users(source.getUsers().begin(),
                                            source.getUsers().end());
   llvm::SmallDenseSet<Operation *, 32> processed;
@@ -202,8 +202,8 @@ void TransferOptimization::storeToLoadForwarding(vector::TransferReadOp read) {
               /*testDynamicValueUsingBounds=*/true))
         continue;
       if (memref::isSameViewOrTrivialAlias(
-              cast<MemrefValue>(read.getSource()),
-              cast<MemrefValue>(write.getSource())) &&
+              cast<MemrefValue>(read.getBase()),
+              cast<MemrefValue>(write.getBase())) &&
           dominators.dominates(write, read) && checkSameValueRAW(write, read)) {
         if (lastwrite == nullptr || dominators.dominates(lastwrite, write))
           lastwrite = write;
@@ -351,7 +351,7 @@ class TransferReadDropUnitDimsPattern
     auto loc = transferReadOp.getLoc();
     Value vector = transferReadOp.getVector();
     VectorType vectorType = cast<VectorType>(vector.getType());
-    Value source = transferReadOp.getSource();
+    Value source = transferReadOp.getBase();
     MemRefType sourceType = dyn_cast<MemRefType>(source.getType());
     // TODO: support tensor types.
     if (!sourceType)
@@ -433,7 +433,7 @@ class TransferWriteDropUnitDimsPattern
     auto loc = transferWriteOp.getLoc();
     Value vector = transferWriteOp.getVector();
     VectorType vectorType = cast<VectorType>(vector.getType());
-    Value source = transferWriteOp.getSource();
+    Value source = transferWriteOp.getBase();
     MemRefType sourceType = dyn_cast<MemRefType>(source.getType());
     // TODO: support tensor type.
     if (!sourceType)
@@ -604,7 +604,7 @@ public:
     auto loc = transferReadOp.getLoc();
     Value vector = transferReadOp.getVector();
     VectorType vectorType = cast<VectorType>(vector.getType());
-    auto source = transferReadOp.getSource();
+    auto source = transferReadOp.getBase();
     MemRefType sourceType = dyn_cast<MemRefType>(source.getType());
 
     // 0. Check pre-conditions
@@ -695,7 +695,7 @@ public:
     auto loc = transferWriteOp.getLoc();
     Value vector = transferWriteOp.getVector();
     VectorType vectorType = cast<VectorType>(vector.getType());
-    Value source = transferWriteOp.getSource();
+    Value source = transferWriteOp.getBase();
     MemRefType sourceType = dyn_cast<MemRefType>(source.getType());
 
     // 0. Check pre-conditions
@@ -851,12 +851,12 @@ class RewriteScalarExtractElementOfTransferRead
                                                     *getConstantIntValue(ofr));
       }
     }
-    if (isa<MemRefType>(xferOp.getSource().getType())) {
-      rewriter.replaceOpWithNewOp<memref::LoadOp>(extractOp, xferOp.getSource(),
+    if (isa<MemRefType>(xferOp.getBase().getType())) {
+      rewriter.replaceOpWithNewOp<memref::LoadOp>(extractOp, xferOp.getBase(),
                                                   newIndices);
     } else {
       rewriter.replaceOpWithNewOp<tensor::ExtractOp>(
-          extractOp, xferOp.getSource(), newIndices);
+          extractOp, xferOp.getBase(), newIndices);
     }
 
     return success();
@@ -899,12 +899,12 @@ class RewriteScalarExtractOfTransferRead
             extractOp.getLoc(), *getConstantIntValue(ofr));
       }
     }
-    if (isa<MemRefType>(xferOp.getSource().getType())) {
-      rewriter.replaceOpWithNewOp<memref::LoadOp>(extractOp, xferOp.getSource(),
+    if (isa<MemRefType>(xferOp.getBase().getType())) {
+      rewriter.replaceOpWithNewOp<memref::LoadOp>(extractOp, xferOp.getBase(),
                                                   newIndices);
     } else {
       rewriter.replaceOpWithNewOp<tensor::ExtractOp>(
-          extractOp, xferOp.getSource(), newIndices);
+          extractOp, xferOp.getBase(), newIndices);
     }
 
     return success();
@@ -932,12 +932,12 @@ class RewriteScalarWrite : public OpRewritePattern<vector::TransferWriteOp> {
     Value scalar =
         rewriter.create<vector::ExtractOp>(xferOp.getLoc(), xferOp.getVector());
     // Construct a scalar store.
-    if (isa<MemRefType>(xferOp.getSource().getType())) {
+    if (isa<MemRefType>(xferOp.getBase().getType())) {
       rewriter.replaceOpWithNewOp<memref::StoreOp>(
-          xferOp, scalar, xferOp.getSource(), xferOp.getIndices());
+          xferOp, scalar, xferOp.getBase(), xferOp.getIndices());
     } else {
       rewriter.replaceOpWithNewOp<tensor::InsertOp>(
-          xferOp, scalar, xferOp.getSource(), xferOp.getIndices());
+          xferOp, scalar, xferOp.getBase(), xferOp.getIndices());
     }
     return success();
   }

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransferSplitRewritePatterns.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransferSplitRewritePatterns.cpp
@@ -58,7 +58,7 @@ static Value createInBoundsCond(RewriterBase &b,
         b, loc, b.getAffineDimExpr(0) + b.getAffineConstantExpr(vectorSize),
         {xferOp.getIndices()[indicesIdx]});
     OpFoldResult dimSz =
-        memref::getMixedSize(b, loc, xferOp.getSource(), indicesIdx);
+        memref::getMixedSize(b, loc, xferOp.getBase(), indicesIdx);
     auto maybeCstSum = getConstantIntValue(sum);
     auto maybeCstDimSz = getConstantIntValue(dimSz);
     if (maybeCstSum && maybeCstDimSz && *maybeCstSum <= *maybeCstDimSz)
@@ -185,7 +185,7 @@ static Value castToCompatibleMemRefType(OpBuilder &b, Value memref,
 }
 
 /// Operates under a scoped context to build the intersection between the
-/// view `xferOp.getSource()` @ `xferOp.getIndices()` and the view `alloc`.
+/// view `xferOp.getbase()` @ `xferOp.getIndices()` and the view `alloc`.
 // TODO: view intersection/union/differences should be a proper std op.
 static std::pair<Value, Value>
 createSubViewIntersection(RewriterBase &b, VectorTransferOpInterface xferOp,
@@ -202,8 +202,8 @@ createSubViewIntersection(RewriterBase &b, VectorTransferOpInterface xferOp,
   auto isaWrite = isa<vector::TransferWriteOp>(xferOp);
   xferOp.zipResultAndIndexing([&](int64_t resultIdx, int64_t indicesIdx) {
     using MapList = ArrayRef<ArrayRef<AffineExpr>>;
-    Value dimMemRef = b.create<memref::DimOp>(xferOp.getLoc(),
-                                              xferOp.getSource(), indicesIdx);
+    Value dimMemRef =
+        b.create<memref::DimOp>(xferOp.getLoc(), xferOp.getBase(), indicesIdx);
     Value dimAlloc = b.create<memref::DimOp>(loc, alloc, resultIdx);
     Value index = xferOp.getIndices()[indicesIdx];
     AffineExpr i, j, k;
@@ -221,9 +221,9 @@ createSubViewIntersection(RewriterBase &b, VectorTransferOpInterface xferOp,
   SmallVector<OpFoldResult> destIndices(memrefRank, b.getIndexAttr(0));
   SmallVector<OpFoldResult> strides(memrefRank, b.getIndexAttr(1));
   auto copySrc = b.create<memref::SubViewOp>(
-      loc, isaWrite ? alloc : xferOp.getSource(), srcIndices, sizes, strides);
+      loc, isaWrite ? alloc : xferOp.getBase(), srcIndices, sizes, strides);
   auto copyDest = b.create<memref::SubViewOp>(
-      loc, isaWrite ? xferOp.getSource() : alloc, destIndices, sizes, strides);
+      loc, isaWrite ? xferOp.getBase() : alloc, destIndices, sizes, strides);
   return std::make_pair(copySrc, copyDest);
 }
 
@@ -252,7 +252,7 @@ createFullPartialLinalgCopy(RewriterBase &b, vector::TransferReadOp xferOp,
                             MemRefType compatibleMemRefType, Value alloc) {
   Location loc = xferOp.getLoc();
   Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
-  Value memref = xferOp.getSource();
+  Value memref = xferOp.getBase();
   return b.create<scf::IfOp>(
       loc, inBoundsCond,
       [&](OpBuilder &b, Location loc) {
@@ -305,7 +305,7 @@ static scf::IfOp createFullPartialVectorTransferRead(
   Location loc = xferOp.getLoc();
   scf::IfOp fullPartialIfOp;
   Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
-  Value memref = xferOp.getSource();
+  Value memref = xferOp.getBase();
   return b.create<scf::IfOp>(
       loc, inBoundsCond,
       [&](OpBuilder &b, Location loc) {
@@ -352,7 +352,7 @@ getLocationToWriteFullVec(RewriterBase &b, vector::TransferWriteOp xferOp,
                           MemRefType compatibleMemRefType, Value alloc) {
   Location loc = xferOp.getLoc();
   Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
-  Value memref = xferOp.getSource();
+  Value memref = xferOp.getBase();
   return b
       .create<scf::IfOp>(
           loc, inBoundsCond,
@@ -509,7 +509,7 @@ static Operation *getAutomaticAllocationScope(Operation *op) {
 ///
 /// Preconditions:
 ///  1. `xferOp.getPermutationMap()` must be a minor identity map
-///  2. the rank of the `xferOp.getSource()` and the rank of the
+///  2. the rank of the `xferOp.getBase()` and the rank of the
 ///     `xferOp.getVector()` must be equal. This will be relaxed in the future
 ///     but requires rank-reducing subviews.
 LogicalResult mlir::vector::splitFullAndPartialTransfer(
@@ -611,7 +611,7 @@ LogicalResult mlir::vector::splitFullAndPartialTransfer(
   // The operation is cloned to prevent deleting information needed for the
   // later IR creation.
   IRMapping mapping;
-  mapping.map(xferWriteOp.getSource(), memrefAndIndices.front());
+  mapping.map(xferWriteOp.getBase(), memrefAndIndices.front());
   mapping.map(xferWriteOp.getIndices(), memrefAndIndices.drop_front());
   auto *clone = b.clone(*xferWriteOp, mapping);
   clone->setAttr(xferWriteOp.getInBoundsAttrName(), inBoundsAttr);

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1265,7 +1265,7 @@ public:
     unsigned lastIndex = llvm::size(xferOp.getIndices()) - 1;
     Value off = xferOp.getIndices()[lastIndex];
     Value dim =
-        vector::createOrFoldDimOp(rewriter, loc, xferOp.getSource(), lastIndex);
+        vector::createOrFoldDimOp(rewriter, loc, xferOp.getBase(), lastIndex);
     Value b = rewriter.create<arith::SubIOp>(loc, dim.getType(), dim, off);
     Value mask = rewriter.create<vector::CreateMaskOp>(
         loc,
@@ -1437,7 +1437,7 @@ class DropInnerMostUnitDimsTransferRead
     if (readOp.getMask())
       return failure();
 
-    auto srcType = dyn_cast<MemRefType>(readOp.getSource().getType());
+    auto srcType = dyn_cast<MemRefType>(readOp.getBase().getType());
     if (!srcType)
       return failure();
 
@@ -1469,7 +1469,7 @@ class DropInnerMostUnitDimsTransferRead
 
     auto loc = readOp.getLoc();
     SmallVector<OpFoldResult> sizes =
-        memref::getMixedSizes(rewriter, loc, readOp.getSource());
+        memref::getMixedSizes(rewriter, loc, readOp.getBase());
     SmallVector<OpFoldResult> offsets(srcType.getRank(),
                                       rewriter.getIndexAttr(0));
     SmallVector<OpFoldResult> strides(srcType.getRank(),
@@ -1480,7 +1480,7 @@ class DropInnerMostUnitDimsTransferRead
     ArrayAttr inBoundsAttr = rewriter.getArrayAttr(
         readOp.getInBoundsAttr().getValue().drop_back(dimsToDrop));
     Value rankedReducedView = rewriter.create<memref::SubViewOp>(
-        loc, resultMemrefType, readOp.getSource(), offsets, sizes, strides);
+        loc, resultMemrefType, readOp.getBase(), offsets, sizes, strides);
     auto permMap = getTransferMinorIdentityMap(
         cast<ShapedType>(rankedReducedView.getType()), resultTargetVecType);
     Value result = rewriter.create<vector::TransferReadOp>(
@@ -1527,7 +1527,7 @@ class DropInnerMostUnitDimsTransferWrite
     if (writeOp.getMask())
       return failure();
 
-    auto srcType = dyn_cast<MemRefType>(writeOp.getSource().getType());
+    auto srcType = dyn_cast<MemRefType>(writeOp.getBase().getType());
     if (!srcType)
       return failure();
 
@@ -1559,7 +1559,7 @@ class DropInnerMostUnitDimsTransferWrite
 
     Location loc = writeOp.getLoc();
     SmallVector<OpFoldResult> sizes =
-        memref::getMixedSizes(rewriter, loc, writeOp.getSource());
+        memref::getMixedSizes(rewriter, loc, writeOp.getBase());
     SmallVector<OpFoldResult> offsets(srcType.getRank(),
                                       rewriter.getIndexAttr(0));
     SmallVector<OpFoldResult> strides(srcType.getRank(),
@@ -1571,7 +1571,7 @@ class DropInnerMostUnitDimsTransferWrite
         writeOp.getInBoundsAttr().getValue().drop_back(dimsToDrop));
 
     Value rankedReducedView = rewriter.create<memref::SubViewOp>(
-        loc, resultMemrefType, writeOp.getSource(), offsets, sizes, strides);
+        loc, resultMemrefType, writeOp.getBase(), offsets, sizes, strides);
     auto permMap = getTransferMinorIdentityMap(
         cast<ShapedType>(rankedReducedView.getType()), resultTargetVecType);
 

--- a/mlir/lib/Dialect/Vector/Transforms/VectorUnroll.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorUnroll.cpp
@@ -164,7 +164,7 @@ struct UnrollTransferReadPattern
           sliceTransferIndices(elementOffsets, originalIndices,
                                readOp.getPermutationMap(), loc, rewriter);
       auto slicedRead = rewriter.create<vector::TransferReadOp>(
-          loc, targetType, readOp.getSource(), indices,
+          loc, targetType, readOp.getBase(), indices,
           readOp.getPermutationMapAttr(), readOp.getPadding(), readOp.getMask(),
           readOp.getInBoundsAttr());
 
@@ -215,7 +215,7 @@ struct UnrollTransferWritePattern
           sliceTransferIndices(elementOffsets, originalIndices,
                                writeOp.getPermutationMap(), loc, rewriter);
       Operation *slicedWrite = rewriter.create<vector::TransferWriteOp>(
-          loc, slicedVector, resultTensor ? resultTensor : writeOp.getSource(),
+          loc, slicedVector, resultTensor ? resultTensor : writeOp.getBase(),
           indices, writeOp.getPermutationMapAttr(), writeOp.getInBoundsAttr());
       // For the tensor case update the destination for the next transfer write.
       if (!slicedWrite->getResults().empty())

--- a/mlir/lib/Dialect/Vector/Utils/VectorUtils.cpp
+++ b/mlir/lib/Dialect/Vector/Utils/VectorUtils.cpp
@@ -312,7 +312,7 @@ SmallVector<OpFoldResult> vector::getMixedSizesXfer(bool hasTensorSemantics,
 
   Value base = TypeSwitch<Operation *, Value>(xfer)
                    .Case<vector::TransferReadOp>(
-                       [&](auto readOp) { return readOp.getSource(); })
+                       [&](auto readOp) { return readOp.getBase(); })
                    .Case<vector::TransferWriteOp>(
                        [&](auto writeOp) { return writeOp.getOperand(1); });
 


### PR DESCRIPTION
[mlir][vector] Standardize base Naming Across Vector Ops (NFC)

This change standardizes the naming convention for the argument
representing the value to read from or write to in Vector ops that
interface with Tensors or MemRefs. Specifically, it ensures that all
such ops use the name `base` (i.e., the base address or location to
which offsets are applied).

Updated operations:

* `vector.transfer_read`,
* `vector.transfer_write`.

For reference, these ops already use `base`:

* `vector.load`, `vector.store`, `vector.scatter`, `vector.gather`,
  `vector.expandload`, `vector.compressstore`, `vector.maskedstore`,
  `vector.maskedload`.

This is a non-functional change (NFC) and does not alter the semantics of these
operations.  However, it does require users of the XFer ops to switch from
`op.getSource()` to `op.getBase()`.

To ease the transition, this PR temporarily adds a `getSource()` interface
method for compatibility. This is intended for downstream use only and should
not be relied on upstream. The method will be removed prior to the LLVM 21
release.

Implements #131602
