### PR TITLE
[TableGen] Print a warning when a Processor contains duplicate Features / TuneFeatures

### DIFF
--- a/llvm/test/TableGen/DuplicateProcessorFeatures.td
+++ b/llvm/test/TableGen/DuplicateProcessorFeatures.td
@@ -8,9 +8,10 @@ def FeatureA : SubtargetFeature<"NameA", "", "", "">;
 def FeatureB : SubtargetFeature<"NameB", "", "", "">;
 def FeatureC : SubtargetFeature<"NameC", "", "", "">;
 
-// CHECK: warning: Processor CPU0 has duplicate Features: NameA
+// CHECK: warning: Processor CPU0 contains duplicate feature 'NameA'
 def P0 : ProcessorModel<"CPU0", NoSchedModel, [FeatureA, FeatureB, FeatureA]>;
-// CHECK: warning: Processor CPU1 has duplicate TuneFeatures: NameB
+// CHECK: warning: Processor CPU1 contains duplicate tune feature 'NameB'
+// CHECK: warning: Processor CPU1 has 'NameC' in both feature and tune feature sets
 def P1 : ProcessorModel<"CPU1", NoSchedModel,
-                        /*Features=*/[FeatureA, FeatureB, FeatureC],
-                        /*TuneFeatures=*/[FeatureB, FeatureC, FeatureB]>;
+                        /*Features=*/[FeatureC],
+                        /*TuneFeatures=*/[FeatureB, FeatureB, FeatureC]>;

--- a/llvm/test/TableGen/DuplicateProcessorFeatures.td
+++ b/llvm/test/TableGen/DuplicateProcessorFeatures.td
@@ -1,0 +1,16 @@
+// RUN: llvm-tblgen -gen-subtarget -I %p/../../include %s 2>&1 | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+def MyTarget : Target;
+
+def FeatureA : SubtargetFeature<"NameA", "", "", "">;
+def FeatureB : SubtargetFeature<"NameB", "", "", "">;
+def FeatureC : SubtargetFeature<"NameC", "", "", "">;
+
+// CHECK: warning: Processor CPU0 has duplicate Features: NameA
+def P0 : ProcessorModel<"CPU0", NoSchedModel, [FeatureA, FeatureB, FeatureA]>;
+// CHECK: warning: Processor CPU1 has duplicate TuneFeatures: NameB
+def P1 : ProcessorModel<"CPU1", NoSchedModel,
+                        /*Features=*/[FeatureA, FeatureB, FeatureC],
+                        /*TuneFeatures=*/[FeatureB, FeatureC, FeatureB]>;

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -336,7 +336,7 @@ unsigned SubtargetEmitter::cpuNames(raw_ostream &OS) {
 static void checkDuplicateCPUFeatures(StringRef CPUName,
                                       ArrayRef<const Record *> Features,
                                       ArrayRef<const Record *> TuneFeatures) {
-  // We had made sure each SubtargetFeature Record has a unique name, so we can
+  // We have made sure each SubtargetFeature Record has a unique name, so we can
   // simply use pointer sets here.
   SmallPtrSet<const Record *, 8> FeatureSet, TuneFeatureSet;
   for (const auto *FeatureRec : Features) {
@@ -350,7 +350,7 @@ static void checkDuplicateCPUFeatures(StringRef CPUName,
       PrintWarning("Processor " + CPUName +
                    " contains duplicate tune feature '" +
                    TuneFeatureRec->getValueAsString("Name") + "'");
-    if (FeatureSet.count(TuneFeatureRec))
+    if (FeatureSet.contains(TuneFeatureRec))
       PrintWarning("Processor " + CPUName + " has '" +
                    TuneFeatureRec->getValueAsString("Name") +
                    "' in both feature and tune feature sets");


### PR DESCRIPTION
I don't think a processor should normally contains duplicate features. I'm open to make this an error rather than a warning.