### PR TITLE
[MLIR][Arith] Add ValueBoundsOpInterface for FloorDivSI

### DIFF
--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -75,11 +75,12 @@ struct MulIOpInterface
   }
 };
 
-struct DivSIOpInterface
-    : public ValueBoundsOpInterface::ExternalModel<DivSIOpInterface, DivSIOp> {
+struct FloorDivSIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<FloorDivSIOpInterface,
+                                                   FloorDivSIOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
                                    ValueBoundsConstraintSet &cstr) const {
-    auto divSIOp = cast<DivSIOp>(op);
+    auto divSIOp = cast<FloorDivSIOp>(op);
     assert(value == divSIOp.getResult() && "invalid value");
 
     AffineExpr lhs = cstr.getExpr(divSIOp.getLhs());
@@ -170,7 +171,7 @@ void mlir::arith::registerValueBoundsOpInterfaceExternalModels(
     arith::ConstantOp::attachInterface<arith::ConstantOpInterface>(*ctx);
     arith::SubIOp::attachInterface<arith::SubIOpInterface>(*ctx);
     arith::MulIOp::attachInterface<arith::MulIOpInterface>(*ctx);
-    arith::DivSIOp::attachInterface<arith::DivSIOpInterface>(*ctx);
+    arith::FloorDivSIOp::attachInterface<arith::FloorDivSIOpInterface>(*ctx);
     arith::SelectOp::attachInterface<arith::SelectOpInterface>(*ctx);
   });
 }

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -75,6 +75,19 @@ struct MulIOpInterface
   }
 };
 
+struct DivSIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<DivSIOpInterface, DivSIOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto divSIOp = cast<DivSIOp>(op);
+    assert(value == divSIOp.getResult() && "invalid value");
+
+    AffineExpr lhs = cstr.getExpr(divSIOp.getLhs());
+    AffineExpr rhs = cstr.getExpr(divSIOp.getRhs());
+    cstr.bound(value) == lhs.floorDiv(rhs);
+  }
+};
+
 struct SelectOpInterface
     : public ValueBoundsOpInterface::ExternalModel<SelectOpInterface,
                                                    SelectOp> {
@@ -157,6 +170,7 @@ void mlir::arith::registerValueBoundsOpInterfaceExternalModels(
     arith::ConstantOp::attachInterface<arith::ConstantOpInterface>(*ctx);
     arith::SubIOp::attachInterface<arith::SubIOpInterface>(*ctx);
     arith::MulIOp::attachInterface<arith::MulIOpInterface>(*ctx);
+    arith::DivSIOp::attachInterface<arith::DivSIOpInterface>(*ctx);
     arith::SelectOp::attachInterface<arith::SelectOpInterface>(*ctx);
   });
 }

--- a/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
@@ -65,6 +65,30 @@ func.func @arith_muli_non_pure(%a: index, %b: index) -> index {
 
 // -----
 
+// CHECK: #[[$map:.*]] = affine_map<()[s0] -> (s0 floordiv 5)>
+// CHECK-LABEL: func @arith_divsi(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[apply:.*]] = affine.apply #[[$map]]()[%[[a]]]
+//       CHECK:   return %[[apply]]
+func.func @arith_divsi(%a: index) -> index {
+  %0 = arith.constant 5 : index
+  %1 = arith.divsi %a, %0 : index
+  %2 = "test.reify_bound"(%1) : (index) -> (index)
+  return %2 : index
+}
+
+// -----
+
+func.func @arith_divsi_non_pure(%a: index, %b: index) -> index {
+  %0 = arith.divsi %a, %b : index
+  // Semi-affine expressions (such as "symbol * symbol") are not supported.
+  // expected-error @below{{could not reify bound}}
+  %1 = "test.reify_bound"(%0) : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
 // CHECK-LABEL: func @arith_const()
 //       CHECK:   %[[c5:.*]] = arith.constant 5 : index
 //       CHECK:   %[[c5:.*]] = arith.constant 5 : index

--- a/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
@@ -66,21 +66,21 @@ func.func @arith_muli_non_pure(%a: index, %b: index) -> index {
 // -----
 
 // CHECK: #[[$map:.*]] = affine_map<()[s0] -> (s0 floordiv 5)>
-// CHECK-LABEL: func @arith_divsi(
+// CHECK-LABEL: func @arith_floordivsi(
 //  CHECK-SAME:     %[[a:.*]]: index
 //       CHECK:   %[[apply:.*]] = affine.apply #[[$map]]()[%[[a]]]
 //       CHECK:   return %[[apply]]
-func.func @arith_divsi(%a: index) -> index {
+func.func @arith_floordivsi(%a: index) -> index {
   %0 = arith.constant 5 : index
-  %1 = arith.divsi %a, %0 : index
+  %1 = arith.floordivsi %a, %0 : index
   %2 = "test.reify_bound"(%1) : (index) -> (index)
   return %2 : index
 }
 
 // -----
 
-func.func @arith_divsi_non_pure(%a: index, %b: index) -> index {
-  %0 = arith.divsi %a, %b : index
+func.func @arith_floordivsi_non_pure(%a: index, %b: index) -> index {
+  %0 = arith.floordivsi %a, %b : index
   // Semi-affine expressions (such as "symbol * symbol") are not supported.
   // expected-error @below{{could not reify bound}}
   %1 = "test.reify_bound"(%0) : (index) -> (index)


### PR DESCRIPTION
Enables value bounds inference through signed division operations.