### PR TITLE
Fix crash when an attribute is applied to pragma attribute/pragma dump

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -471,6 +471,9 @@ Bug Fixes in This Version
   evaluation. The crashes were happening during diagnostics emission due to
   unimplemented statement printer. (#GH132641)
 - Fixed visibility calculation for template functions. (#GH103477)
+- Fixed a bug where an attribute before a ``pragma clang attribute`` or
+  ``pragma clang __debug`` would cause an assertion. Instead, this now diagnoses
+  the invalid attribute location appropriately.  (#GH137861)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -526,10 +526,14 @@ Retry:
     return ParsePragmaLoopHint(Stmts, StmtCtx, TrailingElseLoc, CXX11Attrs);
 
   case tok::annot_pragma_dump:
+    ProhibitAttributes(CXX11Attrs);
+    ProhibitAttributes(GNUAttrs);
     HandlePragmaDump();
     return StmtEmpty();
 
   case tok::annot_pragma_attribute:
+    ProhibitAttributes(CXX11Attrs);
+    ProhibitAttributes(GNUAttrs);
     HandlePragmaAttribute();
     return StmtEmpty();
   }

--- a/clang/test/Parser/gh137861.cpp
+++ b/clang/test/Parser/gh137861.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 %s -verify 
+
+void foo() {
+  // expected-error@+1{{an attribute list cannot appear here}}
+__attribute__((aligned(64)))
+#pragma clang attribute push(__attribute__((uninitialized)), apply_to = any(variable(is_local)))
+{
+  int f;
+}
+#pragma clang attribute pop
+}
+
+void foo2() {
+  // expected-error@+1{{an attribute list cannot appear here}}
+__attribute__((aligned(64)))
+#pragma clang __debug dump foo
+}
+
+void foo3() {
+  // expected-error@+1{{an attribute list cannot appear here}}
+  [[nodiscard]]
+#pragma clang attribute push(__attribute__((uninitialized)), apply_to = any(variable(is_local)))
+{
+  int f;
+}
+#pragma clang attribute pop
+}
+
+void foo4() {
+  // expected-error@+1{{an attribute list cannot appear here}}
+  [[nodiscard]]
+#pragma clang __debug dump foo
+}


### PR DESCRIPTION
These two don't result in a statement, so the attempt to apply the attributes to them was crashing.  This patch correctly prohibits the use of attributes on these clauses.

Fixes: #137861