### PR TITLE
[clang AST] move mangling API to namespace clang to allow calls from swift-frontend

### DIFF
--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -40,6 +40,13 @@ struct ThisAdjustment;
 struct ThunkInfo;
 class VarDecl;
 
+/// Extract mangling function name from MangleContext such that swift can call
+/// it to prepare for ObjCDirect in swift.
+void mangleObjCMethodName(raw_ostream &OS, bool includePrefixByte,
+  bool isInstanceMethod, StringRef ClassName,
+  std::optional<StringRef> CategoryName,
+  StringRef MethodName);
+
 /// MangleContext - Context for tracking state which persists across multiple
 /// calls to the C++ name mangler.
 class MangleContext {

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -43,9 +43,9 @@ class VarDecl;
 /// Extract mangling function name from MangleContext such that swift can call
 /// it to prepare for ObjCDirect in swift.
 void mangleObjCMethodName(raw_ostream &OS, bool includePrefixByte,
-  bool isInstanceMethod, StringRef ClassName,
-  std::optional<StringRef> CategoryName,
-  StringRef MethodName);
+                          bool isInstanceMethod, StringRef ClassName,
+                          std::optional<StringRef> CategoryName,
+                          StringRef MethodName);
 
 /// MangleContext - Context for tracking state which persists across multiple
 /// calls to the C++ name mangler.

--- a/clang/lib/AST/Mangle.cpp
+++ b/clang/lib/AST/Mangle.cpp
@@ -29,6 +29,23 @@
 
 using namespace clang;
 
+void clang::mangleObjCMethodName(raw_ostream &OS, bool includePrefixByte,
+                                 bool isInstanceMethod, StringRef ClassName,
+                                 std::optional<StringRef> CategoryName,
+                                 StringRef MethodName) {
+  // \01+[ContainerName(CategoryName) SelectorName]
+  if (includePrefixByte)
+    OS << "\01";
+  OS << (isInstanceMethod ? '-' : '+');
+  OS << '[';
+  OS << ClassName;
+  if (CategoryName)
+    OS << "(" << *CategoryName << ")";
+  OS << " ";
+  OS << MethodName;
+  OS << ']';
+}
+
 // FIXME: For blocks we currently mimic GCC's mangling scheme, which leaves
 // much to be desired. Come up with a better mangling scheme.
 
@@ -362,26 +379,26 @@ void MangleContext::mangleObjCMethodName(const ObjCMethodDecl *MD,
   }
 
   // \01+[ContainerName(CategoryName) SelectorName]
-  if (includePrefixByte) {
-    OS << '\01';
-  }
-  OS << (MD->isInstanceMethod() ? '-' : '+') << '[';
+  auto CategoryName = std::optional<StringRef>();
+  StringRef ClassName = "";
   if (const auto *CID = MD->getCategory()) {
     if (const auto *CI = CID->getClassInterface()) {
-      OS << CI->getName();
+      ClassName = CI->getName();
       if (includeCategoryNamespace) {
-        OS << '(' << *CID << ')';
+        CategoryName = CID->getName();
       }
     }
   } else if (const auto *CD =
                  dyn_cast<ObjCContainerDecl>(MD->getDeclContext())) {
-    OS << CD->getName();
+    ClassName = CD->getName();
   } else {
     llvm_unreachable("Unexpected ObjC method decl context");
   }
-  OS << ' ';
-  MD->getSelector().print(OS);
-  OS << ']';
+  std::string MethodName;
+  llvm::raw_string_ostream MethodNameOS(MethodName);
+  MD->getSelector().print(MethodNameOS);
+  clang::mangleObjCMethodName(OS, includePrefixByte, MD->isInstanceMethod(),
+                              ClassName, CategoryName, MethodName);
 }
 
 void MangleContext::mangleObjCMethodNameAsSourceName(const ObjCMethodDecl *MD,


### PR DESCRIPTION
When implementing `@objcDirect` in Swift, Swift needs to mangle a native `Decl` that is not a clang Node, which in turn don't have access to `clang::MangleContext`. Reimplementing mangling logic in Swift is redundant.

This patch moves mangling logic from `clang::MangleContext` to `clang` using only basic types (`StringRef`, `std::optional`, etc.), such that Swift can we can just call Clang API: Swift depends on Clang already.

We are separating this from #126639 so we can draft the proposal on the Swift side. #126639  will be worked to depend on this PR.

Tests: No new tests, old ones should pass with no problem.