### PR TITLE
[llvm-exegesis][AArch64] Adding PR_PAC_APIAKEY macro definition

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp
@@ -18,6 +18,9 @@
 #ifndef PR_PAC_GET_ENABLED_KEYS
 #define PR_PAC_GET_ENABLED_KEYS 61
 #endif
+#ifndef PR_PAC_APIAKEY
+#define PR_PAC_APIAKEY (1UL << 0)
+#endif
 #endif
 
 #define GET_AVAILABLE_OPCODE_CHECKER


### PR DESCRIPTION
In older Linux distros, PR_PAC_APIAKEY is not defined and it causes build failures on linux arm64 platform. This patch adds the definition of this macro if it is not defined.