### PR TITLE
[HLSL] Make lerp overload tests stricter. NFC

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/lerp-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/lerp-overloads.hlsl
@@ -1,160 +1,162 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple  dxil-pc-shadermodel6.3-library %s -emit-llvm -O1 -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="noundef nofpclass(nan inf)" -DTARGET=dx
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s -emit-llvm -O1 -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="spir_func noundef nofpclass(nan inf)" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple  dxil-pc-shadermodel6.3-library %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="noundef nofpclass(nan inf)" -DTARGET=dx
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="spir_func noundef nofpclass(nan inf)" -DTARGET=spv
 
 // CHECK: define [[FNATTRS]] float @_Z16test_lerp_doubled(
-// CHECK-NEXT: [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = fptrunc {{.*}} double [[P0:%.*]] to float
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
-// CHECK-NEXT:    ret float [[LERP]]
+// CHECK:    [[CONV0:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
+// CHECK:    ret float [[LERP]]
 float test_lerp_double(double p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_lerp_double2Dv2_d(
-// CHECK-NEXT: [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = fptrunc {{.*}} <2 x double> [[P0:%.*]] to <2 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
-// CHECK-NEXT:    ret <2 x float> [[LERP]]
+// CHECK:    [[CONV0:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
+// CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_double2(double2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_lerp_double3Dv3_d(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = fptrunc {{.*}} <3 x double> [[P0:%.*]] to <3 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
-// CHECK-NEXT:    ret <3 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
+// CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_double3(double3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_lerp_double4Dv4_d(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = fptrunc {{.*}} <4 x double> [[P0:%.*]] to <4 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
-// CHECK-NEXT:    ret <4 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
+// CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_double4(double4 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_lerp_inti(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp i32 [[P0:%.*]] to float
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
-// CHECK-NEXT:    ret float [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
+// CHECK:    ret float [[LERP]]
 float test_lerp_int(int p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_lerp_int2Dv2_i(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp <2 x i32> [[P0:%.*]] to <2 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
-// CHECK-NEXT:    ret <2 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
+// CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_int2(int2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_lerp_int3Dv3_i(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp <3 x i32> [[P0:%.*]] to <3 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
-// CHECK-NEXT:    ret <3 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
+// CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_int3(int3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_lerp_int4Dv4_i(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp <4 x i32> [[P0:%.*]] to <4 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
-// CHECK-NEXT:    ret <4 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
+// CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_int4(int4 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_lerp_uintj(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp i32 [[P0:%.*]] to float
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
-// CHECK-NEXT:    ret float [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
+// CHECK:    ret float [[LERP]]
 float test_lerp_uint(uint p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_lerp_uint2Dv2_j(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp <2 x i32> [[P0:%.*]] to <2 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
-// CHECK-NEXT:    ret <2 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
+// CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_uint2(uint2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_lerp_uint3Dv3_j(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp <3 x i32> [[P0:%.*]] to <3 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
-// CHECK-NEXT:    ret <3 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
+// CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_uint3(uint3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_lerp_uint4Dv4_j(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp <4 x i32> [[P0:%.*]] to <4 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
-// CHECK-NEXT:    ret <4 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
+// CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_uint4(uint4 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_lerp_int64_tl(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp i64 [[P0:%.*]] to float
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
-// CHECK-NEXT:    ret float [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
+// CHECK:    ret float [[LERP]]
 float test_lerp_int64_t(int64_t p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_lerp_int64_t2Dv2_l(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp <2 x i64> [[P0:%.*]] to <2 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
-// CHECK-NEXT:    ret <2 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
+// CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_int64_t2(int64_t2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_lerp_int64_t3Dv3_l(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp <3 x i64> [[P0:%.*]] to <3 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
-// CHECK-NEXT:    ret <3 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
+// CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_int64_t3(int64_t3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_lerp_int64_t4Dv4_l(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp <4 x i64> [[P0:%.*]] to <4 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
-// CHECK-NEXT:    ret <4 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
+// CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_int64_t4(int64_t4 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_lerp_uint64_tm(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp i64 [[P0:%.*]] to float
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
-// CHECK-NEXT:    ret float [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
+// CHECK:    ret float [[LERP]]
 float test_lerp_uint64_t(uint64_t p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_lerp_uint64_t2Dv2_m(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp <2 x i64> [[P0:%.*]] to <2 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
-// CHECK-NEXT:    ret <2 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
+// CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_uint64_t2(uint64_t2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_lerp_uint64_t3Dv3_m(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp <3 x i64> [[P0:%.*]] to <3 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
-// CHECK-NEXT:    ret <3 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
+// CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_uint64_t3(uint64_t3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_lerp_uint64_t4Dv4_m(
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp <4 x i64> [[P0:%.*]] to <4 x float>
-// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
-// CHECK-NEXT:    ret <4 x float> [[LERP]]
-//
+// CHECK:    [[CONV0:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
+// CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_uint64_t4(uint64_t4 p0) { return lerp(p0, p0, p0); }

--- a/clang/test/CodeGenHLSL/builtins/lerp-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/lerp-overloads.hlsl
@@ -1,108 +1,160 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
-// RUN:   -DFNATTRS="noundef nofpclass(nan inf)" -DTARGET=dx
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
-// RUN:   -DFNATTRS="spir_func noundef nofpclass(nan inf)" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple  dxil-pc-shadermodel6.3-library %s -emit-llvm -O1 -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="noundef nofpclass(nan inf)" -DTARGET=dx
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s -emit-llvm -O1 -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="spir_func noundef nofpclass(nan inf)" -DTARGET=spv
 
-// CHECK-LABEL: test_lerp_double
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].lerp.f32(float %{{.*}}, float %{{.*}}, float %{{.*}})
-// CHECK: ret float %hlsl.lerp
+// CHECK: define [[FNATTRS]] float @_Z16test_lerp_doubled(
+// CHECK-NEXT: [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = fptrunc {{.*}} double [[P0:%.*]] to float
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
+// CHECK-NEXT:    ret float [[LERP]]
 float test_lerp_double(double p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_double2
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> %{{.*}}, <2 x float> %{{.*}}, <2 x float> %{{.*}})
-// CHECK: ret <2 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_lerp_double2Dv2_d(
+// CHECK-NEXT: [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = fptrunc {{.*}} <2 x double> [[P0:%.*]] to <2 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
+// CHECK-NEXT:    ret <2 x float> [[LERP]]
 float2 test_lerp_double2(double2 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_double3
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> %{{.*}}, <3 x float> %{{.*}}, <3 x float> %{{.*}})
-// CHECK: ret <3 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_lerp_double3Dv3_d(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = fptrunc {{.*}} <3 x double> [[P0:%.*]] to <3 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
+// CHECK-NEXT:    ret <3 x float> [[LERP]]
+//
 float3 test_lerp_double3(double3 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_double4
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> %{{.*}}, <4 x float> %{{.*}}, <4 x float> %{{.*}})
-// CHECK: ret <4 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_lerp_double4Dv4_d(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = fptrunc {{.*}} <4 x double> [[P0:%.*]] to <4 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
+// CHECK-NEXT:    ret <4 x float> [[LERP]]
+//
 float4 test_lerp_double4(double4 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_int
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].lerp.f32(float %{{.*}}, float %{{.*}}, float %{{.*}})
-// CHECK: ret float %hlsl.lerp
+// CHECK: define [[FNATTRS]] float @_Z13test_lerp_inti(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp i32 [[P0:%.*]] to float
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
+// CHECK-NEXT:    ret float [[LERP]]
+//
 float test_lerp_int(int p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_int2
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> %{{.*}}, <2 x float> %{{.*}}, <2 x float> %{{.*}})
-// CHECK: ret <2 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_lerp_int2Dv2_i(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp <2 x i32> [[P0:%.*]] to <2 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
+// CHECK-NEXT:    ret <2 x float> [[LERP]]
+//
 float2 test_lerp_int2(int2 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_int3
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> %{{.*}}, <3 x float> %{{.*}}, <3 x float> %{{.*}})
-// CHECK: ret <3 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_lerp_int3Dv3_i(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp <3 x i32> [[P0:%.*]] to <3 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
+// CHECK-NEXT:    ret <3 x float> [[LERP]]
+//
 float3 test_lerp_int3(int3 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_int4
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> %{{.*}}, <4 x float> %{{.*}}, <4 x float> %{{.*}})
-// CHECK: ret <4 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_lerp_int4Dv4_i(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp <4 x i32> [[P0:%.*]] to <4 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
+// CHECK-NEXT:    ret <4 x float> [[LERP]]
+//
 float4 test_lerp_int4(int4 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_uint
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].lerp.f32(float %{{.*}}, float %{{.*}}, float %{{.*}})
-// CHECK: ret float %hlsl.lerp
+// CHECK: define [[FNATTRS]] float @_Z14test_lerp_uintj(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp i32 [[P0:%.*]] to float
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
+// CHECK-NEXT:    ret float [[LERP]]
+//
 float test_lerp_uint(uint p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_uint2
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> %{{.*}}, <2 x float> %{{.*}}, <2 x float> %{{.*}})
-// CHECK: ret <2 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_lerp_uint2Dv2_j(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp <2 x i32> [[P0:%.*]] to <2 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
+// CHECK-NEXT:    ret <2 x float> [[LERP]]
+//
 float2 test_lerp_uint2(uint2 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_uint3
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> %{{.*}}, <3 x float> %{{.*}}, <3 x float> %{{.*}})
-// CHECK: ret <3 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_lerp_uint3Dv3_j(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp <3 x i32> [[P0:%.*]] to <3 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
+// CHECK-NEXT:    ret <3 x float> [[LERP]]
+//
 float3 test_lerp_uint3(uint3 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_uint4
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> %{{.*}}, <4 x float> %{{.*}}, <4 x float> %{{.*}})
-// CHECK: ret <4 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_lerp_uint4Dv4_j(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp <4 x i32> [[P0:%.*]] to <4 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
+// CHECK-NEXT:    ret <4 x float> [[LERP]]
+//
 float4 test_lerp_uint4(uint4 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_int64_t
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].lerp.f32(float %{{.*}}, float %{{.*}}, float %{{.*}})
-// CHECK: ret float %hlsl.lerp
+// CHECK: define [[FNATTRS]] float @_Z17test_lerp_int64_tl(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp i64 [[P0:%.*]] to float
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
+// CHECK-NEXT:    ret float [[LERP]]
+//
 float test_lerp_int64_t(int64_t p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_int64_t2
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> %{{.*}}, <2 x float> %{{.*}}, <2 x float> %{{.*}})
-// CHECK: ret <2 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_lerp_int64_t2Dv2_l(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp <2 x i64> [[P0:%.*]] to <2 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
+// CHECK-NEXT:    ret <2 x float> [[LERP]]
+//
 float2 test_lerp_int64_t2(int64_t2 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_int64_t3
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> %{{.*}}, <3 x float> %{{.*}}, <3 x float> %{{.*}})
-// CHECK: ret <3 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_lerp_int64_t3Dv3_l(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp <3 x i64> [[P0:%.*]] to <3 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
+// CHECK-NEXT:    ret <3 x float> [[LERP]]
+//
 float3 test_lerp_int64_t3(int64_t3 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_int64_t4
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> %{{.*}}, <4 x float> %{{.*}}, <4 x float> %{{.*}})
-// CHECK: ret <4 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_lerp_int64_t4Dv4_l(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp <4 x i64> [[P0:%.*]] to <4 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
+// CHECK-NEXT:    ret <4 x float> [[LERP]]
+//
 float4 test_lerp_int64_t4(int64_t4 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_uint64_t
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].lerp.f32(float %{{.*}}, float %{{.*}}, float %{{.*}})
-// CHECK: ret float %hlsl.lerp
+// CHECK: define [[FNATTRS]] float @_Z18test_lerp_uint64_tm(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp i64 [[P0:%.*]] to float
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV]], float [[CONV]], float [[CONV]])
+// CHECK-NEXT:    ret float [[LERP]]
+//
 float test_lerp_uint64_t(uint64_t p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_uint64_t2
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> %{{.*}}, <2 x float> %{{.*}}, <2 x float> %{{.*}})
-// CHECK: ret <2 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_lerp_uint64_t2Dv2_m(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp <2 x i64> [[P0:%.*]] to <2 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV]], <2 x float> [[CONV]], <2 x float> [[CONV]])
+// CHECK-NEXT:    ret <2 x float> [[LERP]]
+//
 float2 test_lerp_uint64_t2(uint64_t2 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_uint64_t3
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> %{{.*}}, <3 x float> %{{.*}}, <3 x float> %{{.*}})
-// CHECK: ret <3 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_lerp_uint64_t3Dv3_m(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp <3 x i64> [[P0:%.*]] to <3 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV]], <3 x float> [[CONV]], <3 x float> [[CONV]])
+// CHECK-NEXT:    ret <3 x float> [[LERP]]
+//
 float3 test_lerp_uint64_t3(uint64_t3 p0) { return lerp(p0, p0, p0); }
 
-// CHECK-LABEL: test_lerp_uint64_t4
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> %{{.*}}, <4 x float> %{{.*}}, <4 x float> %{{.*}})
-// CHECK: ret <4 x float> %hlsl.lerp
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_lerp_uint64_t4Dv4_m(
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp <4 x i64> [[P0:%.*]] to <4 x float>
+// CHECK-NEXT:    [[LERP:%.*]] = tail call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV]], <4 x float> [[CONV]], <4 x float> [[CONV]])
+// CHECK-NEXT:    ret <4 x float> [[LERP]]
+//
 float4 test_lerp_uint64_t4(uint64_t4 p0) { return lerp(p0, p0, p0); }


### PR DESCRIPTION
These tests had checks across multiple functions, because none of the hlsl header implementation functions were inlined. Switch the run lines to use -O1 instead of -disable-llvm-passes and rewrite the tests to actually look at the whole function.

Note - this would be simpler with update_cc_test_checks, but the differences between DX and SPIRV are difficult to account for with those scripts.