### PR TITLE
[X86][NFC] Remove duplicate feature from Znver5 processor definition

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -1591,8 +1591,7 @@ def ProcessorFeatures {
     !listconcat(ZN3Features, ZN4AdditionalFeatures);
 
   list<SubtargetFeature> ZN5Tuning = ZN4Tuning;
-  list<SubtargetFeature> ZN5AdditionalFeatures = [FeatureVNNI,
-                                                  FeatureMOVDIRI,
+  list<SubtargetFeature> ZN5AdditionalFeatures = [FeatureMOVDIRI,
                                                   FeatureMOVDIR64B,
                                                   FeatureVP2INTERSECT,
                                                   FeaturePREFETCHI,


### PR DESCRIPTION
`FeatureVNNI` is already in Znver4AdditionalFeature.

Found by the new TableGen warning introduced in 951292be2c21bc903e63729338d872a878d2d49c