### PR TITLE
[AMDGPU][NFC] Remove duplicate features in gfx908/909/90a

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -1534,8 +1534,7 @@ def FeatureISAVersion9_Generic : FeatureSet<
 
 def FeatureISAVersion9_0_MI_Common : FeatureSet<
   !listconcat(FeatureISAVersion9_0_Common.Features,
-    [FeatureAddressableLocalMemorySize65536,
-     FeatureFmaMixInsts,
+    [FeatureFmaMixInsts,
      FeatureDLInsts,
      FeatureDot1Insts,
      FeatureDot2Insts,
@@ -1585,8 +1584,7 @@ def FeatureISAVersion9_0_8 : FeatureSet<
 
 def FeatureISAVersion9_0_9 : FeatureSet<
   !listconcat(FeatureISAVersion9_0_Consumer_Common.Features,
-    [FeatureMadMixInsts,
-     FeatureImageInsts])>;
+    [FeatureMadMixInsts])>;
 
 def FeatureISAVersion9_0_A : FeatureSet<
   !listconcat(FeatureISAVersion9_0_MI_Common.Features,


### PR DESCRIPTION
The new TableGen warning introduced in https://github.com/llvm/llvm-project/commit/951292be2c21bc903e63729338d872a878d2d49c shows the following warnings:
```
warning: Processor gfx908 contains duplicate feature 'addressablelocalmemorysize65536'
warning: Processor gfx909 contains duplicate feature 'image-insts'
warning: Processor gfx90a contains duplicate feature 'addressablelocalmemorysize65536'
```