### PR TITLE
[PPC][NFC] Remove duplicate processor feature from pwr9/10/11 and future

### DIFF
--- a/llvm/lib/Target/PowerPC/PPC.td
+++ b/llvm/lib/Target/PowerPC/PPC.td
@@ -435,8 +435,7 @@ def ProcessorFeatures {
      FeatureP9Vector,
      FeaturePPCPreRASched,
      FeaturePPCPostRASched,
-     FeatureISA3_0,
-     FeaturePredictableSelectIsExpensive
+     FeatureISA3_0
     ];
 
   // Some features are unique to Power9 and there is no reason to assume


### PR DESCRIPTION
The new TableGen warning introduced in https://github.com/llvm/llvm-project/commit/951292be2c21bc903e63729338d872a878d2d49c shows the following warnings:

```
warning: Processor future contains duplicate feature 'predictable-select-expensive'
warning: Processor pwr10 contains duplicate feature 'predictable-select-expensive'
warning: Processor pwr11 contains duplicate feature 'predictable-select-expensive'
warning: Processor pwr9 contains duplicate feature 'predictable-select-expensive'
```