### PR TITLE
[lld][InstrProf] Skip BP ordering input sections with null data

### DIFF
--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -115,7 +115,7 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     for (auto *sec : file->sections) {
       for (auto &subsec : sec->subsections) {
         auto *isec = subsec.isec;
-        if (!isec || isec->data.empty())
+        if (!isec || isec->data.empty() || !isec->data.data())
           continue;
         // ConcatInputSections are entirely live or dead, so the offset is
         // irrelevant.

--- a/lld/test/MachO/bp-section-orderer.s
+++ b/lld/test/MachO/bp-section-orderer.s
@@ -106,6 +106,10 @@ r3:
 r4:
   .quad s2
 
+.bss
+bss0:
+  .zero 10
+
 .subsections_via_symbols
 
 #--- a.proftext


### PR DESCRIPTION
In MachO, `.bss` `isec`s have a length, but point to null. This causes Balanced Partitioning to crash on these inputs.

This code was in the original implementation, but was removed in https://github.com/llvm/llvm-project/pull/124482/files#diff-b2aac8833d29d297ae5ada1b36eb4e88f53691fd91df954c24e0c264f3131d4aL27