### PR TITLE
[IR] Convert check to assertion in PredIterator (NFC)

### DIFF
--- a/llvm/include/llvm/IR/CFG.h
+++ b/llvm/include/llvm/IR/CFG.h
@@ -54,9 +54,10 @@ protected:
   inline void advancePastNonTerminators() {
     // Loop to ignore non-terminator uses (for example BlockAddresses).
     while (!It.atEnd()) {
-      if (auto *Inst = dyn_cast<Instruction>(*It))
-        if (Inst->isTerminator())
-          break;
+      if (auto *Inst = dyn_cast<Instruction>(*It)) {
+        assert(Inst->isTerminator() && "BasicBlock used in non-terminator");
+        break;
+      }
 
       ++It;
     }


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/137799 and https://github.com/llvm/llvm-project/pull/137816, instruction uses of BasicBlocks are always terminators, so assert that instead of checking it.

This is a small compile-time improvement: https://llvm-compile-time-tracker.com/compare.php?from=a618ae2c729152133440315f7b2f23e4612b39f8&to=5a60dadb74fa0c5f68642a184ed3d592c185c421&stat=instructions:u