### PR TITLE
[MLIR] Testing arith-to-emitc conversions using opaque types

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
@@ -46,6 +46,14 @@ bool isIntegerIndexOrOpaqueType(Type type);
 /// Determines whether \p type is a valid floating-point type in EmitC.
 bool isSupportedFloatType(mlir::Type type);
 
+/// Determines whether \p type is a valid floating-point or opaque type in
+/// EmitC.
+bool isFloatOrOpaqueType(mlir::Type type);
+
+/// Determines whether \p type is a valid integer or opaque type in
+/// EmitC.
+bool isIntegerOrOpaqueType(mlir::Type type);
+
 /// Determines whether \p type is a emitc.size_t/ssize_t type.
 bool isPointerWideType(mlir::Type type);
 

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitCPass.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitCPass.cpp
@@ -54,7 +54,7 @@ void ConvertArithToEmitC::populateOpaqueTypeConversions(
           if (floatAttr.getType().isF80()) {
             return emitc::OpaqueAttr::get(type.getContext(), "f80");
           }
-          return {};
+          return attrToConvert;
         }
         if (auto intAttr = llvm::dyn_cast<IntegerAttr>(attrToConvert)) {
           if (intAttr.getType().isInteger() &&
@@ -62,7 +62,7 @@ void ConvertArithToEmitC::populateOpaqueTypeConversions(
             return emitc::OpaqueAttr::get(type.getContext(), "i80");
           }
         }
-        return {};
+        return attrToConvert;
       });
 }
 

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -132,6 +132,14 @@ bool mlir::emitc::isSupportedFloatType(Type type) {
   return false;
 }
 
+bool mlir::emitc::isIntegerOrOpaqueType(Type type) {
+  return isa<emitc::OpaqueType>(type) || isSupportedIntegerType(type);
+}
+
+bool mlir::emitc::isFloatOrOpaqueType(Type type) {
+  return isa<emitc::OpaqueType>(type) || isSupportedFloatType(type);
+}
+
 bool mlir::emitc::isPointerWideType(Type type) {
   return isa<emitc::SignedSizeTType, emitc::SizeTType, emitc::PtrDiffTType>(
       type);

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-unsupported.mlir
@@ -15,27 +15,11 @@ func.func @arith_cast_vector(%arg0: vector<5xf32>) -> vector<5xi32> {
 }
 
 // -----
-func.func @arith_cast_f80(%arg0: f80) -> i32 {
-  // expected-error @+1 {{failed to legalize operation 'arith.fptosi'}}
-  %t = arith.fptosi %arg0 : f80 to i32
-  return %t: i32
-}
-
-// -----
 
 func.func @arith_cast_f128(%arg0: f128) -> i32 {
   // expected-error @+1 {{failed to legalize operation 'arith.fptosi'}}
   %t = arith.fptosi %arg0 : f128 to i32
   return %t: i32
-}
-
-
-// -----
-
-func.func @arith_cast_to_f80(%arg0: i32) -> f80 {
-  // expected-error @+1 {{failed to legalize operation 'arith.sitofp'}}
-  %t = arith.sitofp %arg0 : i32 to f80
-  return %t: f80
 }
 
 // -----

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-unsupported.mlir
@@ -64,14 +64,6 @@ func.func @arith_cmpf_tensor(%arg0: tensor<5xf32>, %arg1: tensor<5xf32>) -> tens
 
 // -----
 
-func.func @arith_negf_f80(%arg0: f80) -> f80 {
-  // expected-error @+1 {{failed to legalize operation 'arith.negf'}}
-  %n = arith.negf %arg0 : f80
-  return %n: f80
-}
-
-// -----
-
 func.func @arith_negf_tensor(%arg0: tensor<5xf32>) -> tensor<5xf32> {
   // expected-error @+1 {{failed to legalize operation 'arith.negf'}}
   %n = arith.negf %arg0 : tensor<5xf32>

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -824,9 +824,9 @@ func.func @int_opaque_conversion(%arg0: i80, %arg1: i80, %arg2: i1) {
   // CHECK: [[LT:[^ ]*]] = emitc.cmp lt, [[arg1_cast]], [[Bitwidth]] : (!emitc.opaque<"i80">, !emitc.opaque<"i80">) -> i1
   // CHECK: [[Poison:[^ ]*]] = "emitc.constant"() <{value = #emitc.opaque<"opaque_shift_poison">}> : () -> !emitc.opaque<"i80">
   // CHECK: [[Exp:[^ ]*]] = emitc.expression : !emitc.opaque<"i80"> {
-  // CHECK: [[LShift:[^ ]*]] = emitc.bitwise_left_shift [[arg0_cast]], [[arg1_cast]] : (!emitc.opaque<"i80">, !emitc.opaque<"i80">) -> !emitc.opaque<"i80">
-  // CHECK: emitc.conditional [[LT]], [[LShift]], [[Poison]] : !emitc.opaque<"i80">
-  // CHECK: emitc.yield {{.*}} : !emitc.opaque<"i80">
+  // CHECK: [[LShift:[^ ]*]] = bitwise_left_shift [[arg0_cast]], [[arg1_cast]] : (!emitc.opaque<"i80">, !emitc.opaque<"i80">) -> !emitc.opaque<"i80">
+  // CHECK: conditional [[LT]], [[LShift]], [[Poison]] : !emitc.opaque<"i80">
+  // CHECK: yield {{.*}} : !emitc.opaque<"i80">
   // CHECK: }
   %12 = arith.shli %arg0, %arg1 : i80
   // CHECK: emitc.cmp eq, [[arg0_cast]], [[arg1_cast]] : (!emitc.opaque<"i80">, !emitc.opaque<"i80">) -> i1


### PR DESCRIPTION
Currently, most of the type conversions in ArithToEmitC do not support emitc opaque types. This is problematic if someone uses opaque types, as the testing has to be done locally.
To fix this, opaque types are legalized for the conversions. Additionally, i80 and f80 types, both unsupported in emitc, are converted into opaque types in the arith-to-emitc pass. This way, the handling of opaque types can be properly tested in the added test cases for float and integer types.