### PR TITLE
[OpenMP][Archer] Allow stop-start via omp_control_tool

### DIFF
--- a/openmp/tools/archer/README.md
+++ b/openmp/tools/archer/README.md
@@ -230,6 +230,35 @@ the report will look as follow:
 
 <a id="orgcc38a36"></a>
 
+## Pausing Analysis
+
+Archer's analysis may be paused, restarted or ended using OpenMP's
+omp_control_tool functionality with omp_control_tool_[pause|start|end].
+
+Suppose a parallel for loop shall not be considered by Archer:
+
+     1  #include <stdio.h>
+     2  #include <omp.h>
+     3
+     4  #define N 1000
+     5
+     6  int main (int argc, char **argv)
+     7  {
+     8    int a[N];
+     9
+    10  #pragma omp parallel
+    11  {
+    12    omp_control_tool(omp_control_tool_pause, 0, NULL);
+    13  #pragma omp for
+    14    for (int i = 0; i < N - 1; i++) {
+    15      a[i] = a[i + 1];
+    16    }
+    17    omp_control_tool(omp_control_tool_start, 0, NULL);
+    18  }
+    19  }
+
+For more information on the usage of omp_control_tool, see the OpenMP specification.
+
 # Contacts and Support
 
 -   [Google group](https://groups.google.com/forum/#!forum/archer-pruner)

--- a/openmp/tools/archer/ompt-tsan.cpp
+++ b/openmp/tools/archer/ompt-tsan.cpp
@@ -175,18 +175,18 @@ DECLARE_TSAN_FUNCTION(__tsan_func_exit)
 // This marker is used to define a happens-before arc. The race detector will
 // infer an arc from the begin to the end when they share the same pointer
 // argument.
-#define TsanHappensBefore(cv) \
-do { \ 
-  if (archer_state ==ACTIVE) \
-      AnnotateHappensBefore(__FILE__, __LINE__, cv); \
-} while(0)
+#define TsanHappensBefore(cv)                                                  \
+  do {                                                                         \
+    if (archer_state == ACTIVE)                                                \
+      AnnotateHappensBefore(__FILE__, __LINE__, cv);                           \
+  } while (0)
 
 // This marker defines the destination of a happens-before arc.
-#define TsanHappensAfter(cv) \
-do { \ 
-  if (archer_state ==ACTIVE) \
-      AnnotateHappensAfter(__FILE__, __LINE__, cv); \
-} while(0)
+#define TsanHappensAfter(cv)                                                   \
+  do {                                                                         \
+    if (archer_state == ACTIVE)                                                \
+      AnnotateHappensAfter(__FILE__, __LINE__, cv);                            \
+  } while (0)
 
 // Ignore any races on writes between here and the next TsanIgnoreWritesEnd.
 #define TsanIgnoreWritesBegin() AnnotateIgnoreWritesBegin(__FILE__, __LINE__)
@@ -1272,8 +1272,6 @@ static int ompt_tsan_initialize(ompt_function_lookup_t lookup, int device_num,
 static void ompt_tsan_finalize(ompt_data_t *tool_data) {
   if (archer_flags->ignore_serial)
     TsanIgnoreWritesEnd();
-//  if (archer_state == PAUSED || archer_state == ENDED)
-//    TsanIgnoreWritesEnd();
   if (archer_flags->print_max_rss) {
     struct rusage end;
     getrusage(RUSAGE_SELF, &end);

--- a/openmp/tools/archer/ompt-tsan.cpp
+++ b/openmp/tools/archer/ompt-tsan.cpp
@@ -603,7 +603,7 @@ static std::unordered_map<ompt_wait_id_t, std::mutex> Locks;
 static std::mutex LocksMutex;
 
 enum ArcherState { ACTIVE = 0, PAUSED, ENDED };
-static ArcherState archer_state{ACTIVE};
+static thread_local ArcherState archer_state{ACTIVE};
 
 static int ompt_tsan_control_tool(uint64_t command, uint64_t modifier,
                                   void *arg, const void *codeptr_ra) {

--- a/openmp/tools/archer/tests/control-tool/ended.c
+++ b/openmp/tools/archer/tests/control-tool/ended.c
@@ -1,5 +1,5 @@
 /*
- * skipped-access.c -- Archer testcase
+ * ended.c -- Archer testcase
  */
 
 //===----------------------------------------------------------------------===//
@@ -19,6 +19,9 @@
 int main(int argc, char *argv[]) {
   int var = 0;
 
+#pragma omp parallel
+  { omp_control_tool(omp_control_tool_end, 0, NULL); }
+
 #pragma omp parallel num_threads(2) shared(var)
   {
     if (omp_get_thread_num() == 0) {
@@ -26,11 +29,9 @@ int main(int argc, char *argv[]) {
     }
 
     /* We miss the race due to Archer being paused */
-    omp_control_tool(omp_control_tool_pause, 0, NULL);
     if (omp_get_thread_num() == 1) {
       var++;
     }
-    omp_control_tool(omp_control_tool_start, 0, NULL);
   }
 
   fprintf(stderr, "DONE\n");

--- a/openmp/tools/archer/tests/control-tool/skipped-access.c
+++ b/openmp/tools/archer/tests/control-tool/skipped-access.c
@@ -1,0 +1,42 @@
+/*
+ * barrier.c -- Archer testcase
+ */
+
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile-and-run-verbose | FileCheck %s
+// REQUIRES: tsan
+#include <omp.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+  int var = 0;
+
+#pragma omp parallel num_threads(2) shared(var)
+  {
+    if (omp_get_thread_num() == 0) {
+      var++;
+    }
+
+    /* We miss the race due to Archer being paused */
+    omp_control_tool(omp_control_tool_pause, 0, NULL);
+    if (omp_get_thread_num() == 1) {
+      var++;
+    }
+    omp_control_tool(omp_control_tool_start, 0, NULL);
+  }
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: DONE

--- a/openmp/tools/archer/tests/control-tool/skipped-barrier.c
+++ b/openmp/tools/archer/tests/control-tool/skipped-barrier.c
@@ -1,5 +1,5 @@
 /*
- * barrier.c -- Archer testcase
+ * skipped-barrier.c -- Archer testcase
  */
 
 //===----------------------------------------------------------------------===//
@@ -25,6 +25,7 @@ int main(int argc, char *argv[]) {
       var++;
     }
 
+    /* TSan detects a race as Archer does not see the barrier */
     omp_control_tool(omp_control_tool_pause, 0, NULL);
 #pragma omp barrier
     omp_control_tool(omp_control_tool_start, 0, NULL);

--- a/openmp/tools/archer/tests/control-tool/skipped-barrier.c
+++ b/openmp/tools/archer/tests/control-tool/skipped-barrier.c
@@ -1,0 +1,44 @@
+/*
+ * barrier.c -- Archer testcase
+ */
+
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile-and-run-race-verbose | FileCheck %s
+// REQUIRES: tsan
+#include <omp.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+  int var = 0;
+
+#pragma omp parallel num_threads(2) shared(var)
+  {
+    if (omp_get_thread_num() == 0) {
+      var++;
+    }
+
+    omp_control_tool(omp_control_tool_pause, 0, NULL);
+#pragma omp barrier
+    omp_control_tool(omp_control_tool_start, 0, NULL);
+
+    if (omp_get_thread_num() == 1) {
+      var++;
+    }
+  }
+
+  fprintf(stderr, "DONE\n");
+  int error = (var != 2);
+  return error;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: DONE
+// CHECK: ThreadSanitizer: reported {{[1]}} warnings

--- a/openmp/tools/archer/tests/control-tool/skipped-barrier.c
+++ b/openmp/tools/archer/tests/control-tool/skipped-barrier.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
   }
 
   fprintf(stderr, "DONE\n");
-  int error = (var != 2);
+  int error = 1;
   return error;
 }
 

--- a/openmp/tools/archer/tests/control-tool/verbose-output.c
+++ b/openmp/tools/archer/tests/control-tool/verbose-output.c
@@ -1,0 +1,46 @@
+/*
+ * verbose-output.c -- Archer testcase
+ */
+
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+
+// RUN: %libarcher-compile-and-run-verbose | FileCheck %s
+// REQUIRES: tsan
+#include <omp.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+
+#pragma omp parallel num_threads(1)
+{
+    omp_control_tool(omp_control_tool_pause, 0, NULL);
+//    omp_control_tool(omp_control_tool_start, 0, NULL);
+//    omp_control_tool(omp_control_tool_end, 0, NULL);
+}
+
+//#pragma omp parallel num_threads(2)
+//{
+//    omp_control_tool(omp_control_tool_pause, 0, NULL);
+//    omp_control_tool(omp_control_tool_start, 0, NULL);
+//}
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: reported
+// CHECK-NOT: Warning: please export TSAN_OPTIONS
+// CHECK: DONE
+// CHECK: [Archer] Paused operation
+// CHECK: [Archer] Started operation
+// CHECK: [Archer] Ended operation
+

--- a/openmp/tools/archer/tests/control-tool/verbose-output.c
+++ b/openmp/tools/archer/tests/control-tool/verbose-output.c
@@ -11,7 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 // RUN: %libarcher-compile-and-run-verbose | FileCheck %s
 // REQUIRES: tsan
 #include <omp.h>
@@ -20,32 +19,30 @@
 int main(int argc, char *argv[]) {
 
 #pragma omp parallel num_threads(2)
-{
+  {
+    omp_control_tool(omp_control_tool_start, 0, NULL);
     omp_control_tool(omp_control_tool_pause, 0, NULL);
     omp_control_tool(omp_control_tool_start, 0, NULL);
-}
+  }
 
 #pragma omp parallel num_threads(2)
-{
-    omp_control_tool(omp_control_tool_pause, 0, NULL);
-}
+  { omp_control_tool(omp_control_tool_pause, 0, NULL); }
 
 #pragma omp parallel num_threads(1)
-{
-    omp_control_tool(omp_control_tool_pause, 0, NULL);
-}
+  { omp_control_tool(omp_control_tool_pause, 0, NULL); }
 
 #pragma omp parallel num_threads(2)
-{
+  {
     omp_control_tool(omp_control_tool_pause, 0, NULL);
     omp_control_tool(omp_control_tool_start, 0, NULL);
     omp_control_tool(omp_control_tool_end, 0, NULL);
-}
+  }
 
   fprintf(stderr, "DONE\n");
   return 0;
 }
 // CHECK-NOT: One of the following ignores was not ended
+// CHECK-NOT: finished with ignores enabled
 // CHECK-NOT: ThreadSanitizer: data race
 // CHECK-NOT: ThreadSanitizer: reported
 // CHECK-NOT: Warning: please export TSAN_OPTIONS
@@ -53,4 +50,3 @@ int main(int argc, char *argv[]) {
 // CHECK: [Archer] Paused operation
 // CHECK: [Archer] Started operation
 // CHECK: [Archer] Ended operation
-

--- a/openmp/tools/archer/tests/control-tool/verbose-output.c
+++ b/openmp/tools/archer/tests/control-tool/verbose-output.c
@@ -19,23 +19,33 @@
 
 int main(int argc, char *argv[]) {
 
+#pragma omp parallel num_threads(2)
+{
+    omp_control_tool(omp_control_tool_pause, 0, NULL);
+    omp_control_tool(omp_control_tool_start, 0, NULL);
+}
+
+#pragma omp parallel num_threads(2)
+{
+    omp_control_tool(omp_control_tool_pause, 0, NULL);
+}
+
 #pragma omp parallel num_threads(1)
 {
     omp_control_tool(omp_control_tool_pause, 0, NULL);
-//    omp_control_tool(omp_control_tool_start, 0, NULL);
-//    omp_control_tool(omp_control_tool_end, 0, NULL);
 }
 
-//#pragma omp parallel num_threads(2)
-//{
-//    omp_control_tool(omp_control_tool_pause, 0, NULL);
-//    omp_control_tool(omp_control_tool_start, 0, NULL);
-//}
+#pragma omp parallel num_threads(2)
+{
+    omp_control_tool(omp_control_tool_pause, 0, NULL);
+    omp_control_tool(omp_control_tool_start, 0, NULL);
+    omp_control_tool(omp_control_tool_end, 0, NULL);
+}
 
   fprintf(stderr, "DONE\n");
   return 0;
 }
-
+// CHECK-NOT: One of the following ignores was not ended
 // CHECK-NOT: ThreadSanitizer: data race
 // CHECK-NOT: ThreadSanitizer: reported
 // CHECK-NOT: Warning: please export TSAN_OPTIONS

--- a/openmp/tools/archer/tests/lit.cfg
+++ b/openmp/tools/archer/tests/lit.cfg
@@ -104,10 +104,16 @@ config.environment['ARCHER_OPTIONS'] = "report_data_leak=1"
 config.substitutions.append(("%libarcher-compile-and-run-race-noserial", \
     "%%libarcher-compile && env ARCHER_OPTIONS=\"ignore_serial=1 %s\" %%libarcher-run-race" \
     % config.environment['ARCHER_OPTIONS']))
+config.substitutions.append(("%libarcher-compile-and-run-race-verbose", \
+    "%%libarcher-compile && env ARCHER_OPTIONS=\"verbose=1 %s\" %%libarcher-run-race" \
+    % config.environment['ARCHER_OPTIONS']))
 config.substitutions.append(("%libarcher-compile-and-run-race", \
     "%libarcher-compile && %libarcher-run-race"))
 config.substitutions.append(("%libarcher-compile-and-run-nosuppression", \
                              "%libarcher-compile && %libarcher-run-nosuppression"))
+config.substitutions.append(("%libarcher-compile-and-run-verbose", \
+    "%%libarcher-compile && env ARCHER_OPTIONS=\"verbose=1 %s\" %%libarcher-run" \
+    % config.environment['ARCHER_OPTIONS']))
 config.substitutions.append(("%libarcher-compile-and-run", \
                              "%libarcher-compile && %libarcher-run"))
 config.substitutions.append(("%libarcher-cxx-compile-and-run", \


### PR DESCRIPTION
Allows Archer to be paused, restarted and completely ended via `omp_control_tool`. TSan will also ignore memory accesses (writes) when Archer is paused or ended.

Intended use case is to reduce the overhead for long executions where late parts of the execution are of interest.