### PR TITLE
[NVPTX] Support the OpenCL generic addrspace feature by default

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -170,6 +170,8 @@ public:
     Opts["cl_khr_global_int32_extended_atomics"] = true;
     Opts["cl_khr_local_int32_base_atomics"] = true;
     Opts["cl_khr_local_int32_extended_atomics"] = true;
+
+    Opts["__opencl_c_generic_address_space"] = true;
   }
 
   const llvm::omp::GV &getGridValue() const override {

--- a/clang/test/Misc/nvptx.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx.languageOptsOpenCL.cl
@@ -132,3 +132,11 @@
 #pragma OPENCL EXTENSION cl_khr_subgroups: enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_subgroups' - ignoring}}
 
+#if (__OPENCL_C_VERSION__ >= 300)
+#ifndef __opencl_c_generic_address_space
+#error "Missing __opencl_c_generic_address_space define"
+#else
+#error "Incorrect __opencl_c_generic_address_space define"
+#endif
+#pragma OPENCL EXTENSION __opencl_c_generic_address_space: enable
+#endif


### PR DESCRIPTION
As best as I can see, all NVPTX architectures support the generic address space.

I note there's a FIXME in the target's address space map about 'generic' still having to be added to the target but we haven't observed any issues with it downstream. The generic address space is mapped to the same target address space as default/private (0), but this isn't necessarily a problem for users.