### PR TITLE
[RISCV] Fix generation of DWARF info for vector segmented types

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -850,6 +850,7 @@ llvm::DIType *CGDebugInfo::CreateType(const BuiltinType *BT) {
 
       bool Fractional = false;
       unsigned LMUL;
+      unsigned NFIELDS = Info.NumVectors;
       unsigned FixedSize = ElementCount * SEW;
       if (Info.ElementType == CGM.getContext().BoolTy) {
         // Mask type only occupies one vector register.
@@ -862,7 +863,7 @@ llvm::DIType *CGDebugInfo::CreateType(const BuiltinType *BT) {
         LMUL = FixedSize / 64;
       }
 
-      // Element count = (VLENB / SEW) x LMUL
+      // Element count = (VLENB / SEW) x LMUL x NFIELDS
       SmallVector<uint64_t, 12> Expr(
           // The DW_OP_bregx operation has two operands: a register which is
           // specified by an unsigned LEB128 number, followed by a signed LEB128
@@ -877,6 +878,9 @@ llvm::DIType *CGDebugInfo::CreateType(const BuiltinType *BT) {
         Expr.push_back(llvm::dwarf::DW_OP_div);
       else
         Expr.push_back(llvm::dwarf::DW_OP_mul);
+      // NFIELDS multiplier
+      if (NFIELDS > 1)
+        Expr.append({llvm::dwarf::DW_OP_constu, NFIELDS, llvm::dwarf::DW_OP_mul});
       // Element max index = count - 1
       Expr.append({llvm::dwarf::DW_OP_constu, 1, llvm::dwarf::DW_OP_minus});
 

--- a/clang/test/CodeGen/RISCV/riscv-v-debuginfo.c
+++ b/clang/test/CodeGen/RISCV/riscv-v-debuginfo.c
@@ -8,21 +8,77 @@ __rvv_int16m2_t f1(__rvv_int16m2_t arg_0, __rvv_int16m2_t arg_1, int64_t arg_2) 
   return ret;
 }
 
-// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_con
-// DEBUGINFO: stu, 2, DW_OP_div, DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 2, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
 
 __rvv_int16mf2_t f2(__rvv_int16mf2_t arg_0, __rvv_int16mf2_t arg_1, int64_t arg_2) {
   __rvv_int16mf2_t ret;
   return ret;
 }
 
-// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_con
-// DEBUGINFO: stu, 2, DW_OP_div, DW_OP_constu, 2, DW_OP_div, DW_OP_constu, 1, DW_OP_minus))
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 2, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_div, DW_OP_constu, 1, DW_OP_minus))
 
 __rvv_int32mf2_t f3(__rvv_int32mf2_t arg_0, __rvv_int32mf2_t arg_1, int64_t arg_2) {
   __rvv_int32mf2_t ret;
   return ret;
 }
 
-// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_con
-// DEBUGINFO: stu, 4, DW_OP_div, DW_OP_constu, 2, DW_OP_div, DW_OP_constu, 1, DW_OP_minus))
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 4, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_div, DW_OP_constu, 1, DW_OP_minus))
+
+__rvv_int16m2x2_t f4 (__rvv_int16m2x2_t arg_0, __rvv_int16m2x2_t arg_1, int64_t arg_2){
+  __rvv_int16m2x2_t ret;
+  return ret;
+}
+
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 2, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+
+__rvv_int16m2x4_t f5 (__rvv_int16m2x4_t arg_0, __rvv_int16m2x4_t arg_1, int64_t arg_2){
+   __rvv_int16m2x4_t ret;
+  return ret;
+}
+
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 2, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 4, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+
+__rvv_int32m2x2_t f6(__rvv_int32m2x2_t arg_0, __rvv_int32m2x2_t arg_1, int64_t arg_2) {
+  __rvv_int32m2x2_t ret;
+  return ret;
+}
+
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 4, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+
+__rvv_int32m2x4_t f7(__rvv_int32m2x4_t arg_0, __rvv_int32m2x4_t arg_1, int64_t arg_2) {
+  __rvv_int32m2x4_t ret;
+  return ret;
+}
+
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 4, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 4, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+
+__rvv_int32mf2x2_t f8(__rvv_int32mf2x2_t arg_0, __rvv_int32mf2x2_t arg_1, int64_t arg_2) {
+  __rvv_int32mf2x2_t ret;
+  return ret;
+}
+
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 4, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_div, DW_OP_constu, 2, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+
+__rvv_int32mf2x4_t f9(__rvv_int32mf2x4_t arg_0, __rvv_int32mf2x4_t arg_1, int64_t   arg_2) {
+  __rvv_int32mf2x4_t ret;
+  return ret;
+}
+
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 4, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_div, DW_OP_constu, 4, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))
+
+__rvv_int32mf2x8_t f10(__rvv_int32mf2x8_t arg_0, __rvv_int32mf2x8_t arg_1, int64_t   arg_2) {
+  __rvv_int32mf2x8_t ret;
+  return ret;
+}
+
+// !DISubrange(lowerBound: 0, upperBound: !DIExpression(DW_OP_bregx, 7202, 0, DW_OP_constu, 4, DW_OP_div,
+// DEBUGINFO: DW_OP_constu, 2, DW_OP_div, DW_OP_constu, 8, DW_OP_mul, DW_OP_constu, 1, DW_OP_minus))


### PR DESCRIPTION
In DWARF info RISC-V Vector types are presented as DW_TAG_array_type with tags DW_AT_type (what elements does this array consist of) and DW_TAG_subrange_type. DW_TAG_subrange_type have DW_AT_upper_bound tag which contain upper bound value for this array.

For now, it's generate same DWARF info about length of segmented types and their corresponding non-tuple types.

For example, vint32m4x2_t and vint32m4_t have DW_TAG_array_type with same DW_AT_type and DW_TAG_subrange_type, it means that this types have same length, which is not correct
(vint32m4x2_t length is twice as big as vint32m4_t)