### PR TITLE
[llvm][test] Change an XFAIL into a more correct REQUIRES

### DIFF
--- a/llvm/test/ExecutionEngine/RuntimeDyld/X86/coff-alignment.ll
+++ b/llvm/test/ExecutionEngine/RuntimeDyld/X86/coff-alignment.ll
@@ -1,5 +1,4 @@
-; XFAIL: target=aarch64-pc-windows-{{.*}}
-; REQUIRES: system-windows
+; REQUIRES: system-windows, target=x86_64-{{.*}}-windows-{{.*}}
 ; RUN: opt -mtriple=x86_64-pc-win32-coff %s -o - | lli
 
 @o = common global i32 0, align 4


### PR DESCRIPTION
As this test is about executing x86_64 code with "lli", we should only try to do it if we actually execute on an x86_64 target. So instead of XFAILing individual architectures that can't execute it, instead change this into requiring an x86_64 target.

Also generalize the target triple form used; don't assume that the vendor field is set to "pc" - many mingw toolchains use the vendor field set to "w64".