### PR TITLE
VirtRegRewriter: Remove unused ID

### DIFF
--- a/llvm/lib/CodeGen/VirtRegMap.cpp
+++ b/llvm/lib/CodeGen/VirtRegMap.cpp
@@ -222,7 +222,6 @@ class VirtRegRewriter {
       MCRegister PhysReg, const MachineInstr &MI) const;
 
 public:
-  static char ID;
   VirtRegRewriter(bool ClearVirtRegs, SlotIndexes *Indexes, LiveIntervals *LIS,
                   LiveRegMatrix *LRM, VirtRegMap *VRM,
                   LiveDebugVariables *DebugVars)

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1505,7 +1505,7 @@ Expected<bool> parseMachineBlockPlacementPassOptions(StringRef Params) {
           inconvertibleErrorCode());
   }
   return AllowTailMerge;
-};
+}
 
 Expected<bool> parseVirtRegRewriterPassOptions(StringRef Params) {
   bool ClearVirtRegs = true;


### PR DESCRIPTION
Build failure caused by e91cbd4f299fd3f42928aff63f5d95f07be3f7fc

PR: #130564