### PR TITLE
[ARM][Compiler-RT] Add optional exclusion of libc provided ARM AEABI builtins from compiler-rt.

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -453,43 +453,38 @@ set(thumb1_base_SOURCES
   ${GENERIC_SOURCES}
 )
 
+set(arm_EABI_RT_SOURCES
+  arm/aeabi_cdcmp.S
+  arm/aeabi_cdcmpeq_check_nan.c
+  arm/aeabi_cfcmp.S
+  arm/aeabi_cfcmpeq_check_nan.c
+  arm/aeabi_dcmp.S
+  arm/aeabi_div0.c
+  arm/aeabi_drsub.c
+  arm/aeabi_fcmp.S
+  arm/aeabi_frsub.c
+  arm/aeabi_idivmod.S
+  arm/aeabi_ldivmod.S
+  arm/aeabi_uidivmod.S
+  arm/aeabi_uldivmod.S
+)
+
+set(arm_EABI_CLIB_SOURCES
+  arm/aeabi_memcmp.S
+  arm/aeabi_memcpy.S
+  arm/aeabi_memmove.S
+  arm/aeabi_memset.S
+)
+
 if(NOT COMPILER_RT_EXCLUDE_LIBC_PROVIDED_ARM_AEABI_BUILTINS)
   set(arm_EABI_SOURCES
-     arm/aeabi_cdcmp.S
-     arm/aeabi_cdcmpeq_check_nan.c
-     arm/aeabi_cfcmp.S
-     arm/aeabi_cfcmpeq_check_nan.c
-     arm/aeabi_dcmp.S
-     arm/aeabi_div0.c
-     arm/aeabi_drsub.c
-     arm/aeabi_fcmp.S
-     arm/aeabi_frsub.c
-     arm/aeabi_idivmod.S
-     arm/aeabi_ldivmod.S
-     arm/aeabi_memcmp.S
-     arm/aeabi_memcpy.S
-     arm/aeabi_memmove.S
-     arm/aeabi_memset.S
-     arm/aeabi_uidivmod.S
-     arm/aeabi_uldivmod.S
+    ${arm_EABI_RT_SOURCES}
+    ${arm_EABI_CLIB_SOURCES}
   )
 else()
-	message(STATUS "COMPILER_RT_EXCLUDE_LIBC_PROVIDED_ARM_AEABI_BUILTINS is ON, so skipping __aeabi_memcpy, __aeabi_memmove and __aeabi_memset Sources")
+  message(STATUS "COMPILER_RT_EXCLUDE_LIBC_PROVIDED_ARM_AEABI_BUILTINS is ON, so skipping __aeabi_memcmp, __aeabi_memcpy, __aeabi_memmove and __aeabi_memset Sources")
   set(arm_EABI_SOURCES
-     arm/aeabi_cdcmp.S
-     arm/aeabi_cdcmpeq_check_nan.c
-     arm/aeabi_cfcmp.S
-     arm/aeabi_cfcmpeq_check_nan.c
-     arm/aeabi_dcmp.S
-     arm/aeabi_div0.c
-     arm/aeabi_drsub.c
-     arm/aeabi_fcmp.S
-     arm/aeabi_frsub.c
-     arm/aeabi_idivmod.S
-     arm/aeabi_ldivmod.S
-     arm/aeabi_memcmp.S
-     arm/aeabi_uidivmod.S
-     arm/aeabi_uldivmod.S
+    ${arm_EABI_RT_SOURCES}
   )
 endif()
 

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -230,6 +230,9 @@ set(GENERIC_TF_SOURCES
 option(COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN
   "Skip the atomic builtin (these should normally be provided by a shared library)"
   On)
+option(COMPILER_RT_EXCLUDE_LIBC_PROVIDED_ARM_AEABI_BUILTINS
+  "Skip the standard C library provided arm aeabi builtins from compiler-rt)"
+  Off)
 
 if(NOT FUCHSIA AND NOT COMPILER_RT_BAREMETAL_BUILD AND NOT COMPILER_RT_GPU_BUILD)
   set(GENERIC_SOURCES
@@ -450,25 +453,45 @@ set(thumb1_base_SOURCES
   ${GENERIC_SOURCES}
 )
 
-set(arm_EABI_SOURCES
-  arm/aeabi_cdcmp.S
-  arm/aeabi_cdcmpeq_check_nan.c
-  arm/aeabi_cfcmp.S
-  arm/aeabi_cfcmpeq_check_nan.c
-  arm/aeabi_dcmp.S
-  arm/aeabi_div0.c
-  arm/aeabi_drsub.c
-  arm/aeabi_fcmp.S
-  arm/aeabi_frsub.c
-  arm/aeabi_idivmod.S
-  arm/aeabi_ldivmod.S
-  arm/aeabi_memcmp.S
-  arm/aeabi_memcpy.S
-  arm/aeabi_memmove.S
-  arm/aeabi_memset.S
-  arm/aeabi_uidivmod.S
-  arm/aeabi_uldivmod.S
-)
+if(NOT COMPILER_RT_EXCLUDE_LIBC_PROVIDED_ARM_AEABI_BUILTINS)
+  set(arm_EABI_SOURCES
+     arm/aeabi_cdcmp.S
+     arm/aeabi_cdcmpeq_check_nan.c
+     arm/aeabi_cfcmp.S
+     arm/aeabi_cfcmpeq_check_nan.c
+     arm/aeabi_dcmp.S
+     arm/aeabi_div0.c
+     arm/aeabi_drsub.c
+     arm/aeabi_fcmp.S
+     arm/aeabi_frsub.c
+     arm/aeabi_idivmod.S
+     arm/aeabi_ldivmod.S
+     arm/aeabi_memcmp.S
+     arm/aeabi_memcpy.S
+     arm/aeabi_memmove.S
+     arm/aeabi_memset.S
+     arm/aeabi_uidivmod.S
+     arm/aeabi_uldivmod.S
+  )
+else()
+	message(STATUS "COMPILER_RT_EXCLUDE_LIBC_PROVIDED_ARM_AEABI_BUILTINS is ON, so skipping __aeabi_memcpy, __aeabi_memmove and __aeabi_memset Sources")
+  set(arm_EABI_SOURCES
+     arm/aeabi_cdcmp.S
+     arm/aeabi_cdcmpeq_check_nan.c
+     arm/aeabi_cfcmp.S
+     arm/aeabi_cfcmpeq_check_nan.c
+     arm/aeabi_dcmp.S
+     arm/aeabi_div0.c
+     arm/aeabi_drsub.c
+     arm/aeabi_fcmp.S
+     arm/aeabi_frsub.c
+     arm/aeabi_idivmod.S
+     arm/aeabi_ldivmod.S
+     arm/aeabi_memcmp.S
+     arm/aeabi_uidivmod.S
+     arm/aeabi_uldivmod.S
+  )
+endif()
 
 set(arm_Thumb1_JT_SOURCES
   arm/switch16.S


### PR DESCRIPTION
This patch introduces a new optional CMake flag:
  COMPILER_RT_EXCLUDE_LIBC_PROVIDED_ARM_AEABI_BUILTINS

When enabled, this flag excludes the following ARM AEABI memory function implementations from the compiler-rt build:
        __aeabi_memcmp
	__aeabi_memset
	__aeabi_memcpy
	__aeabi_memmove

These functions are already provided by standard C libraries like glibc, newlib, and picolibc, so excluding them avoids duplicate symbol definitions and reduces unnecessary code duplication.

Note: 
-  libgcc does not define the __aeabi_* functions that overlap with those provided by the C library. Enabling this option makes compiler-rt behave consistently with libgcc.
-  This prevents duplicate symbol errors when linking, particularly in bare-metal configurations where compiler-rt is linked first. 
- This flag is OFF by default, meaning all AEABI memory builtins will still be built unless explicitly excluded.

This change is useful for environments where libc provides runtime routines, supporting more minimal, conflict free builds.