### PR TITLE
[libclc] Clean up unnecessary #undef __CLC_BODYs

### DIFF
--- a/libclc/clc/include/clc/common/clc_degrees.h
+++ b/libclc/clc/include/clc/common/clc_degrees.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_COMMON_CLC_DEGREES_H__

--- a/libclc/clc/include/clc/common/clc_radians.h
+++ b/libclc/clc/include/clc/common/clc_radians.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_COMMON_CLC_RADIANS_H__

--- a/libclc/clc/include/clc/common/clc_sign.h
+++ b/libclc/clc/include/clc/common/clc_sign.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_COMMON_CLC_SIGN_H__

--- a/libclc/clc/include/clc/common/clc_smoothstep.h
+++ b/libclc/clc/include/clc/common/clc_smoothstep.h
@@ -14,6 +14,5 @@
 
 #define __CLC_BODY <clc/common/clc_smoothstep.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 
 #endif // __CLC_COMMON_CLC_SMOOTHSTEP_H__

--- a/libclc/clc/include/clc/integer/clc_add_sat.h
+++ b/libclc/clc/include/clc/integer/clc_add_sat.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_ADD_SAT_H__

--- a/libclc/clc/include/clc/integer/clc_clz.h
+++ b/libclc/clc/include/clc/integer/clc_clz.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_CLZ_H__

--- a/libclc/clc/include/clc/integer/clc_ctz.h
+++ b/libclc/clc/include/clc/integer/clc_ctz.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_CTZ_H__

--- a/libclc/clc/include/clc/integer/clc_hadd.h
+++ b/libclc/clc/include/clc/integer/clc_hadd.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_HADD_H__

--- a/libclc/clc/include/clc/integer/clc_mad24.h
+++ b/libclc/clc/include/clc/integer/clc_mad24.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype24.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_MAD24_H__

--- a/libclc/clc/include/clc/integer/clc_mad_sat.h
+++ b/libclc/clc/include/clc/integer/clc_mad_sat.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_MAD_SAT_H__

--- a/libclc/clc/include/clc/integer/clc_mul24.h
+++ b/libclc/clc/include/clc/integer/clc_mul24.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype24.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_MUL24_H__

--- a/libclc/clc/include/clc/integer/clc_mul_hi.h
+++ b/libclc/clc/include/clc/integer/clc_mul_hi.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_MUL_HI_H__

--- a/libclc/clc/include/clc/integer/clc_rhadd.h
+++ b/libclc/clc/include/clc/integer/clc_rhadd.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_RHADD_H__

--- a/libclc/clc/include/clc/integer/clc_rotate.h
+++ b/libclc/clc/include/clc/integer/clc_rotate.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_ROTATE_H__

--- a/libclc/clc/include/clc/integer/clc_sub_sat.h
+++ b/libclc/clc/include/clc/integer/clc_sub_sat.h
@@ -14,7 +14,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTEGER_CLC_SUB_SAT_H__

--- a/libclc/clc/include/clc/internal/math/clc_sw_fma.h
+++ b/libclc/clc/include/clc/internal/math/clc_sw_fma.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_INTERNAL_MATH_CLC_SW_FMA_H__

--- a/libclc/clc/include/clc/math/clc_acos.h
+++ b/libclc/clc/include/clc/math/clc_acos.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ACOS_H__

--- a/libclc/clc/include/clc/math/clc_acosh.h
+++ b/libclc/clc/include/clc/math/clc_acosh.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ACOSH_H__

--- a/libclc/clc/include/clc/math/clc_acospi.h
+++ b/libclc/clc/include/clc/math/clc_acospi.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ACOSPI_H__

--- a/libclc/clc/include/clc/math/clc_asin.h
+++ b/libclc/clc/include/clc/math/clc_asin.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ASIN_H__

--- a/libclc/clc/include/clc/math/clc_asinh.h
+++ b/libclc/clc/include/clc/math/clc_asinh.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ASINH_H__

--- a/libclc/clc/include/clc/math/clc_asinpi.h
+++ b/libclc/clc/include/clc/math/clc_asinpi.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ASINPI_H__

--- a/libclc/clc/include/clc/math/clc_atan.h
+++ b/libclc/clc/include/clc/math/clc_atan.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ATAN_H__

--- a/libclc/clc/include/clc/math/clc_atan2.h
+++ b/libclc/clc/include/clc/math/clc_atan2.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ATAN2_H__

--- a/libclc/clc/include/clc/math/clc_atan2pi.h
+++ b/libclc/clc/include/clc/math/clc_atan2pi.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ATAN2PI_H__

--- a/libclc/clc/include/clc/math/clc_atanh.h
+++ b/libclc/clc/include/clc/math/clc_atanh.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ATANH_H__

--- a/libclc/clc/include/clc/math/clc_atanpi.h
+++ b/libclc/clc/include/clc/math/clc_atanpi.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ATANPI_H__

--- a/libclc/clc/include/clc/math/clc_cbrt.inc
+++ b/libclc/clc/include/clc/math/clc_cbrt.inc
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_CBRT_H__

--- a/libclc/clc/include/clc/math/clc_ceil.h
+++ b/libclc/clc/include/clc/math/clc_ceil.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_CEIL_H__

--- a/libclc/clc/include/clc/math/clc_copysign.h
+++ b/libclc/clc/include/clc/math/clc_copysign.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_COPYSIGN_H__

--- a/libclc/clc/include/clc/math/clc_cosh.h
+++ b/libclc/clc/include/clc/math/clc_cosh.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_COSH_H__

--- a/libclc/clc/include/clc/math/clc_cospi.h
+++ b/libclc/clc/include/clc/math/clc_cospi.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_COSPI_H__

--- a/libclc/clc/include/clc/math/clc_exp.h
+++ b/libclc/clc/include/clc/math/clc_exp.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_EXP_H__

--- a/libclc/clc/include/clc/math/clc_exp10.h
+++ b/libclc/clc/include/clc/math/clc_exp10.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_EXP10_H__

--- a/libclc/clc/include/clc/math/clc_exp2.h
+++ b/libclc/clc/include/clc/math/clc_exp2.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_EXP2_H__

--- a/libclc/clc/include/clc/math/clc_exp_helper.h
+++ b/libclc/clc/include/clc/math/clc_exp_helper.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __DOUBLE_ONLY
 
 #endif // __CLC_MATH_CLC_EXP_HELPER

--- a/libclc/clc/include/clc/math/clc_expm1.h
+++ b/libclc/clc/include/clc/math/clc_expm1.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_EXPM1_H__

--- a/libclc/clc/include/clc/math/clc_fabs.h
+++ b/libclc/clc/include/clc/math/clc_fabs.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FABS_H__

--- a/libclc/clc/include/clc/math/clc_fdim.h
+++ b/libclc/clc/include/clc/math/clc_fdim.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FDIM_H__

--- a/libclc/clc/include/clc/math/clc_floor.h
+++ b/libclc/clc/include/clc/math/clc_floor.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FLOOR_H__

--- a/libclc/clc/include/clc/math/clc_fma.h
+++ b/libclc/clc/include/clc/math/clc_fma.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FMA_H__

--- a/libclc/clc/include/clc/math/clc_fmax.h
+++ b/libclc/clc/include/clc/math/clc_fmax.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FMAX_H__

--- a/libclc/clc/include/clc/math/clc_fmin.h
+++ b/libclc/clc/include/clc/math/clc_fmin.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FMIN_H__

--- a/libclc/clc/include/clc/math/clc_fmod.h
+++ b/libclc/clc/include/clc/math/clc_fmod.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FMOD_H__

--- a/libclc/clc/include/clc/math/clc_fract.h
+++ b/libclc/clc/include/clc/math/clc_fract.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FRACT_H__

--- a/libclc/clc/include/clc/math/clc_frexp.h
+++ b/libclc/clc/include/clc/math/clc_frexp.h
@@ -13,7 +13,6 @@
 #define __CLC_BODY <clc/math/unary_decl_with_int_ptr.inc>
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_FREXP_H__

--- a/libclc/clc/include/clc/math/clc_hypot.h
+++ b/libclc/clc/include/clc/math/clc_hypot.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_HYPOT_H__

--- a/libclc/clc/include/clc/math/clc_lgamma.h
+++ b/libclc/clc/include/clc/math/clc_lgamma.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_LGAMMA_H__

--- a/libclc/clc/include/clc/math/clc_lgamma_r.h
+++ b/libclc/clc/include/clc/math/clc_lgamma_r.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_LGAMMA_R_H__

--- a/libclc/clc/include/clc/math/clc_log.h
+++ b/libclc/clc/include/clc/math/clc_log.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_LOG_H__

--- a/libclc/clc/include/clc/math/clc_log10.h
+++ b/libclc/clc/include/clc/math/clc_log10.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_LOG10_H__

--- a/libclc/clc/include/clc/math/clc_log1p.h
+++ b/libclc/clc/include/clc/math/clc_log1p.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_LOG1P_H__

--- a/libclc/clc/include/clc/math/clc_log2.h
+++ b/libclc/clc/include/clc/math/clc_log2.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_LOG2_H__

--- a/libclc/clc/include/clc/math/clc_mad.h
+++ b/libclc/clc/include/clc/math/clc_mad.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_MAD_H__

--- a/libclc/clc/include/clc/math/clc_modf.h
+++ b/libclc/clc/include/clc/math/clc_modf.h
@@ -13,7 +13,6 @@
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_MODF_H__

--- a/libclc/clc/include/clc/math/clc_nan.h
+++ b/libclc/clc/include/clc/math/clc_nan.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_NAN_H__

--- a/libclc/clc/include/clc/math/clc_native_cos.h
+++ b/libclc/clc/include/clc/math/clc_native_cos.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_divide.h
+++ b/libclc/clc/include/clc/math/clc_native_divide.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_exp.h
+++ b/libclc/clc/include/clc/math/clc_native_exp.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_exp10.h
+++ b/libclc/clc/include/clc/math/clc_native_exp10.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_exp2.h
+++ b/libclc/clc/include/clc/math/clc_native_exp2.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_log.h
+++ b/libclc/clc/include/clc/math/clc_native_log.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_log10.h
+++ b/libclc/clc/include/clc/math/clc_native_log10.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_log2.h
+++ b/libclc/clc/include/clc/math/clc_native_log2.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_powr.h
+++ b/libclc/clc/include/clc/math/clc_native_powr.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_recip.h
+++ b/libclc/clc/include/clc/math/clc_native_recip.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_rsqrt.h
+++ b/libclc/clc/include/clc/math/clc_native_rsqrt.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_sin.h
+++ b/libclc/clc/include/clc/math/clc_native_sin.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_sqrt.h
+++ b/libclc/clc/include/clc/math/clc_native_sqrt.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_native_tan.h
+++ b/libclc/clc/include/clc/math/clc_native_tan.h
@@ -15,7 +15,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 #undef __FLOAT_ONLY
 

--- a/libclc/clc/include/clc/math/clc_nextafter.h
+++ b/libclc/clc/include/clc/math/clc_nextafter.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_NEXTAFTER_H__

--- a/libclc/clc/include/clc/math/clc_pow.h
+++ b/libclc/clc/include/clc/math/clc_pow.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_POW_H__

--- a/libclc/clc/include/clc/math/clc_pown.h
+++ b/libclc/clc/include/clc/math/clc_pown.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_POWN_H__

--- a/libclc/clc/include/clc/math/clc_powr.h
+++ b/libclc/clc/include/clc/math/clc_powr.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_POWR_H__

--- a/libclc/clc/include/clc/math/clc_remainder.h
+++ b/libclc/clc/include/clc/math/clc_remainder.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_REMAINDER_H__

--- a/libclc/clc/include/clc/math/clc_remquo.h
+++ b/libclc/clc/include/clc/math/clc_remquo.h
@@ -16,7 +16,6 @@
 #include <clc/math/gentype.inc>
 
 #undef __CLC_ADDRESS_SPACE
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_REMQUO_H__

--- a/libclc/clc/include/clc/math/clc_rint.h
+++ b/libclc/clc/include/clc/math/clc_rint.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_RINT_H__

--- a/libclc/clc/include/clc/math/clc_rootn.h
+++ b/libclc/clc/include/clc/math/clc_rootn.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ROOTN_H__

--- a/libclc/clc/include/clc/math/clc_round.h
+++ b/libclc/clc/include/clc/math/clc_round.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_ROUND_H__

--- a/libclc/clc/include/clc/math/clc_rsqrt.h
+++ b/libclc/clc/include/clc/math/clc_rsqrt.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_RSQRT_H__

--- a/libclc/clc/include/clc/math/clc_sincos_helpers.h
+++ b/libclc/clc/include/clc/math/clc_sincos_helpers.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __FLOAT_ONLY
 
 #endif // __CLC_MATH_CLC_SINCOS_HELPERS_H__

--- a/libclc/clc/include/clc/math/clc_sinh.h
+++ b/libclc/clc/include/clc/math/clc_sinh.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_SINH_H__

--- a/libclc/clc/include/clc/math/clc_sinpi.h
+++ b/libclc/clc/include/clc/math/clc_sinpi.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_SINPI_H__

--- a/libclc/clc/include/clc/math/clc_sqrt.h
+++ b/libclc/clc/include/clc/math/clc_sqrt.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_SQRT_H__

--- a/libclc/clc/include/clc/math/clc_tanh.h
+++ b/libclc/clc/include/clc/math/clc_tanh.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_TANH_H__

--- a/libclc/clc/include/clc/math/clc_tanpi.h
+++ b/libclc/clc/include/clc/math/clc_tanpi.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_TANPI_H__

--- a/libclc/clc/include/clc/math/clc_tgamma.h
+++ b/libclc/clc/include/clc/math/clc_tgamma.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_TGAMMA_H__

--- a/libclc/clc/include/clc/math/clc_trunc.h
+++ b/libclc/clc/include/clc/math/clc_trunc.h
@@ -14,7 +14,6 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_MATH_CLC_TRUNC_H__

--- a/libclc/clc/include/clc/relational/clc_bitselect.h
+++ b/libclc/clc/include/clc/relational/clc_bitselect.h
@@ -14,6 +14,5 @@
 #define __CLC_BODY <clc/relational/clc_bitselect.inc>
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 
 #endif // __CLC_RELATIONAL_CLC_BITSELECT_H__

--- a/libclc/clc/include/clc/relational/clc_bitselect.h
+++ b/libclc/clc/include/clc/relational/clc_bitselect.h
@@ -14,5 +14,4 @@
 #define __CLC_BODY <clc/relational/clc_bitselect.inc>
 #include <clc/integer/gentype.inc>
 
-
 #endif // __CLC_RELATIONAL_CLC_BITSELECT_H__

--- a/libclc/clc/include/clc/relational/clc_isfinite.h
+++ b/libclc/clc/include/clc/relational/clc_isfinite.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISFINITE_H__

--- a/libclc/clc/include/clc/relational/clc_isgreater.h
+++ b/libclc/clc/include/clc/relational/clc_isgreater.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISGREATER_H__

--- a/libclc/clc/include/clc/relational/clc_isgreaterequal.h
+++ b/libclc/clc/include/clc/relational/clc_isgreaterequal.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISGREATEREQUAL_H__

--- a/libclc/clc/include/clc/relational/clc_isless.h
+++ b/libclc/clc/include/clc/relational/clc_isless.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISLESS_H__

--- a/libclc/clc/include/clc/relational/clc_islessequal.h
+++ b/libclc/clc/include/clc/relational/clc_islessequal.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISLESSEQUAL_H__

--- a/libclc/clc/include/clc/relational/clc_islessgreater.h
+++ b/libclc/clc/include/clc/relational/clc_islessgreater.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISLESSGREATER_H__

--- a/libclc/clc/include/clc/relational/clc_isnormal.h
+++ b/libclc/clc/include/clc/relational/clc_isnormal.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISNORMAL_H__

--- a/libclc/clc/include/clc/relational/clc_isnotequal.h
+++ b/libclc/clc/include/clc/relational/clc_isnotequal.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISNOTEQUAL_H__

--- a/libclc/clc/include/clc/relational/clc_isordered.h
+++ b/libclc/clc/include/clc/relational/clc_isordered.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISORDERED_H__

--- a/libclc/clc/include/clc/relational/clc_isunordered.h
+++ b/libclc/clc/include/clc/relational/clc_isunordered.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_ISUNORDERED_H__

--- a/libclc/clc/include/clc/relational/clc_signbit.h
+++ b/libclc/clc/include/clc/relational/clc_signbit.h
@@ -14,7 +14,6 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __CLC_RELATIONAL_CLC_SIGNBIT_H__

--- a/libclc/clc/lib/generic/math/clc_hypot.cl
+++ b/libclc/clc/lib/generic/math/clc_hypot.cl
@@ -20,4 +20,3 @@
 
 #define __CLC_BODY <clc_hypot.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/clc/lib/generic/relational/clc_bitselect.cl
+++ b/libclc/clc/lib/generic/relational/clc_bitselect.cl
@@ -11,7 +11,6 @@
 
 #define __CLC_BODY <clc_bitselect.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 
 #define FLOAT_BITSELECT(f_type, i_type, width)                                 \
   _CLC_OVERLOAD _CLC_DEF f_type##width __clc_bitselect(                        \

--- a/libclc/clspv/lib/shared/vstore_half.cl
+++ b/libclc/clspv/lib/shared/vstore_half.cl
@@ -137,7 +137,6 @@ _CLC_DEF _CLC_OVERLOAD float __clc_rte(float x) {
 
 #define __CLC_BODY "vstore_half.inc"
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef FUNC
 #undef __XFUNC
 #undef __FUNC

--- a/libclc/generic/include/clc/async/async_work_group_copy.h
+++ b/libclc/generic/include/clc/async/async_work_group_copy.h
@@ -10,10 +10,8 @@
 #define __CLC_SRC_ADDR_SPACE global
 #define __CLC_BODY <clc/async/async_work_group_copy.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 #define __CLC_BODY <clc/async/async_work_group_copy.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef __CLC_DST_ADDR_SPACE
 #undef __CLC_SRC_ADDR_SPACE
 
@@ -21,9 +19,7 @@
 #define __CLC_SRC_ADDR_SPACE local
 #define __CLC_BODY <clc/async/async_work_group_copy.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 #define __CLC_BODY <clc/async/async_work_group_copy.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef __CLC_DST_ADDR_SPACE
 #undef __CLC_SRC_ADDR_SPACE

--- a/libclc/generic/include/clc/async/async_work_group_strided_copy.h
+++ b/libclc/generic/include/clc/async/async_work_group_strided_copy.h
@@ -10,10 +10,8 @@
 #define __CLC_SRC_ADDR_SPACE global
 #define __CLC_BODY <clc/async/async_work_group_strided_copy.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 #define __CLC_BODY <clc/async/async_work_group_strided_copy.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef __CLC_DST_ADDR_SPACE
 #undef __CLC_SRC_ADDR_SPACE
 
@@ -21,9 +19,7 @@
 #define __CLC_SRC_ADDR_SPACE local
 #define __CLC_BODY <clc/async/async_work_group_strided_copy.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 #define __CLC_BODY <clc/async/async_work_group_strided_copy.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef __CLC_DST_ADDR_SPACE
 #undef __CLC_SRC_ADDR_SPACE

--- a/libclc/generic/include/clc/async/prefetch.h
+++ b/libclc/generic/include/clc/async/prefetch.h
@@ -8,8 +8,6 @@
 
 #define __CLC_BODY <clc/async/prefetch.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 
 #define __CLC_BODY <clc/async/prefetch.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/common/degrees.h
+++ b/libclc/generic/include/clc/common/degrees.h
@@ -8,4 +8,3 @@
 
 #define __CLC_BODY <clc/common/degrees.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/common/radians.h
+++ b/libclc/generic/include/clc/common/radians.h
@@ -8,4 +8,3 @@
 
 #define __CLC_BODY <clc/common/radians.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/common/sign.h
+++ b/libclc/generic/include/clc/common/sign.h
@@ -10,4 +10,3 @@
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #include <clc/math/gentype.inc>
 #undef __CLC_FUNCTION
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/common/smoothstep.h
+++ b/libclc/generic/include/clc/common/smoothstep.h
@@ -8,4 +8,3 @@
 
 #define __CLC_BODY <clc/common/smoothstep.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/common/step.h
+++ b/libclc/generic/include/clc/common/step.h
@@ -8,4 +8,3 @@
 
 #define __CLC_BODY <clc/common/step.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/integer/clz.h
+++ b/libclc/generic/include/clc/integer/clz.h
@@ -11,5 +11,4 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/integer/ctz.h
+++ b/libclc/generic/include/clc/integer/ctz.h
@@ -13,7 +13,6 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 
 #endif // __OPENCL_C_VERSION__ >= CL_VERSION_2_0

--- a/libclc/generic/include/clc/integer/hadd.h
+++ b/libclc/generic/include/clc/integer/hadd.h
@@ -11,5 +11,4 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/integer/mad_hi.h
+++ b/libclc/generic/include/clc/integer/mad_hi.h
@@ -12,4 +12,3 @@
 #include <clc/integer/gentype.inc>
 
 #undef __CLC_FUNCTION
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/integer/mad_sat.h
+++ b/libclc/generic/include/clc/integer/mad_sat.h
@@ -8,4 +8,3 @@
 
 #define __CLC_BODY <clc/integer/mad_sat.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/integer/mul24.h
+++ b/libclc/generic/include/clc/integer/mul24.h
@@ -11,5 +11,4 @@
 
 #include <clc/integer/gentype24.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/integer/mul_hi.h
+++ b/libclc/generic/include/clc/integer/mul_hi.h
@@ -11,5 +11,4 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/integer/popcount.h
+++ b/libclc/generic/include/clc/integer/popcount.h
@@ -11,5 +11,4 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/integer/rhadd.h
+++ b/libclc/generic/include/clc/integer/rhadd.h
@@ -11,5 +11,4 @@
 
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/acos.h
+++ b/libclc/generic/include/clc/math/acos.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/acosh.h
+++ b/libclc/generic/include/clc/math/acosh.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/acospi.h
+++ b/libclc/generic/include/clc/math/acospi.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/asin.h
+++ b/libclc/generic/include/clc/math/asin.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/asinh.h
+++ b/libclc/generic/include/clc/math/asinh.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/asinpi.h
+++ b/libclc/generic/include/clc/math/asinpi.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/atan.h
+++ b/libclc/generic/include/clc/math/atan.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/atan2.h
+++ b/libclc/generic/include/clc/math/atan2.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/atan2pi.h
+++ b/libclc/generic/include/clc/math/atan2pi.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/atanh.h
+++ b/libclc/generic/include/clc/math/atanh.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/atanpi.h
+++ b/libclc/generic/include/clc/math/atanpi.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/cbrt.h
+++ b/libclc/generic/include/clc/math/cbrt.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/ceil.h
+++ b/libclc/generic/include/clc/math/ceil.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/copysign.h
+++ b/libclc/generic/include/clc/math/copysign.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/cos.h
+++ b/libclc/generic/include/clc/math/cos.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/cosh.h
+++ b/libclc/generic/include/clc/math/cosh.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/cospi.h
+++ b/libclc/generic/include/clc/math/cospi.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/erf.h
+++ b/libclc/generic/include/clc/math/erf.h
@@ -13,5 +13,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/erfc.h
+++ b/libclc/generic/include/clc/math/erfc.h
@@ -13,5 +13,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/exp.h
+++ b/libclc/generic/include/clc/math/exp.h
@@ -13,5 +13,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/exp10.h
+++ b/libclc/generic/include/clc/math/exp10.h
@@ -13,5 +13,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/exp2.h
+++ b/libclc/generic/include/clc/math/exp2.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/expm1.h
+++ b/libclc/generic/include/clc/math/expm1.h
@@ -13,5 +13,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/fabs.h
+++ b/libclc/generic/include/clc/math/fabs.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/fdim.h
+++ b/libclc/generic/include/clc/math/fdim.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/floor.h
+++ b/libclc/generic/include/clc/math/floor.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/fma.h
+++ b/libclc/generic/include/clc/math/fma.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/fmax.h
+++ b/libclc/generic/include/clc/math/fmax.h
@@ -11,6 +11,5 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 

--- a/libclc/generic/include/clc/math/fmin.h
+++ b/libclc/generic/include/clc/math/fmin.h
@@ -11,6 +11,5 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION
 

--- a/libclc/generic/include/clc/math/half_cos.h
+++ b/libclc/generic/include/clc/math/half_cos.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_divide.h
+++ b/libclc/generic/include/clc/math/half_divide.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_exp.h
+++ b/libclc/generic/include/clc/math/half_exp.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_exp10.h
+++ b/libclc/generic/include/clc/math/half_exp10.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_exp2.h
+++ b/libclc/generic/include/clc/math/half_exp2.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_log.h
+++ b/libclc/generic/include/clc/math/half_log.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_log10.h
+++ b/libclc/generic/include/clc/math/half_log10.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_log2.h
+++ b/libclc/generic/include/clc/math/half_log2.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_powr.h
+++ b/libclc/generic/include/clc/math/half_powr.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_recip.h
+++ b/libclc/generic/include/clc/math/half_recip.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_rsqrt.h
+++ b/libclc/generic/include/clc/math/half_rsqrt.h
@@ -11,5 +11,4 @@
 #define __FLOAT_ONLY
 #include <clc/math/gentype.inc>
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_sin.h
+++ b/libclc/generic/include/clc/math/half_sin.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_sqrt.h
+++ b/libclc/generic/include/clc/math/half_sqrt.h
@@ -11,5 +11,4 @@
 #define __FLOAT_ONLY
 #include <clc/math/gentype.inc>
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/half_tan.h
+++ b/libclc/generic/include/clc/math/half_tan.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/hypot.h
+++ b/libclc/generic/include/clc/math/hypot.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/ilogb.h
+++ b/libclc/generic/include/clc/math/ilogb.h
@@ -9,4 +9,3 @@
 #define __CLC_BODY <clc/math/ilogb.inc>
 
 #include <clc/math/gentype.inc>
-

--- a/libclc/generic/include/clc/math/ilogb.h
+++ b/libclc/generic/include/clc/math/ilogb.h
@@ -10,4 +10,3 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/math/lgamma.h
+++ b/libclc/generic/include/clc/math/lgamma.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/lgamma_r.h
+++ b/libclc/generic/include/clc/math/lgamma_r.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/log.h
+++ b/libclc/generic/include/clc/math/log.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/log10.h
+++ b/libclc/generic/include/clc/math/log10.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/log1p.h
+++ b/libclc/generic/include/clc/math/log1p.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/log2.h
+++ b/libclc/generic/include/clc/math/log2.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/logb.h
+++ b/libclc/generic/include/clc/math/logb.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/mad.h
+++ b/libclc/generic/include/clc/math/mad.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/maxmag.h
+++ b/libclc/generic/include/clc/math/maxmag.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/minmag.h
+++ b/libclc/generic/include/clc/math/minmag.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_cos.h
+++ b/libclc/generic/include/clc/math/native_cos.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_divide.h
+++ b/libclc/generic/include/clc/math/native_divide.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_exp.h
+++ b/libclc/generic/include/clc/math/native_exp.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_exp10.h
+++ b/libclc/generic/include/clc/math/native_exp10.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_exp2.h
+++ b/libclc/generic/include/clc/math/native_exp2.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_log.h
+++ b/libclc/generic/include/clc/math/native_log.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_log10.h
+++ b/libclc/generic/include/clc/math/native_log10.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_log2.h
+++ b/libclc/generic/include/clc/math/native_log2.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_powr.h
+++ b/libclc/generic/include/clc/math/native_powr.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_recip.h
+++ b/libclc/generic/include/clc/math/native_recip.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_rsqrt.h
+++ b/libclc/generic/include/clc/math/native_rsqrt.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_sin.h
+++ b/libclc/generic/include/clc/math/native_sin.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_sqrt.h
+++ b/libclc/generic/include/clc/math/native_sqrt.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/native_tan.h
+++ b/libclc/generic/include/clc/math/native_tan.h
@@ -13,5 +13,4 @@
 #include <clc/math/gentype.inc>
 
 #undef __FLOAT_ONLY
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/nextafter.h
+++ b/libclc/generic/include/clc/math/nextafter.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/pow.h
+++ b/libclc/generic/include/clc/math/pow.h
@@ -9,5 +9,4 @@
 #define __CLC_FUNCTION pow
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/pown.h
+++ b/libclc/generic/include/clc/math/pown.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/powr.h
+++ b/libclc/generic/include/clc/math/powr.h
@@ -9,5 +9,4 @@
 #define __CLC_FUNCTION powr
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/rint.h
+++ b/libclc/generic/include/clc/math/rint.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/rootn.h
+++ b/libclc/generic/include/clc/math/rootn.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/round.h
+++ b/libclc/generic/include/clc/math/round.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/rsqrt.h
+++ b/libclc/generic/include/clc/math/rsqrt.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/sin.h
+++ b/libclc/generic/include/clc/math/sin.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/sinh.h
+++ b/libclc/generic/include/clc/math/sinh.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/sinpi.h
+++ b/libclc/generic/include/clc/math/sinpi.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/sqrt.h
+++ b/libclc/generic/include/clc/math/sqrt.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/tan.h
+++ b/libclc/generic/include/clc/math/tan.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/tanh.h
+++ b/libclc/generic/include/clc/math/tanh.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/tanpi.h
+++ b/libclc/generic/include/clc/math/tanpi.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/tgamma.h
+++ b/libclc/generic/include/clc/math/tgamma.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/math/trunc.h
+++ b/libclc/generic/include/clc/math/trunc.h
@@ -11,5 +11,4 @@
 
 #include <clc/math/gentype.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/bitselect.h
+++ b/libclc/generic/include/clc/relational/bitselect.h
@@ -10,4 +10,3 @@
 #include <clc/math/gentype.inc>
 #define __CLC_BODY <clc/relational/bitselect.inc>
 #include <clc/integer/gentype.inc>
-

--- a/libclc/generic/include/clc/relational/bitselect.h
+++ b/libclc/generic/include/clc/relational/bitselect.h
@@ -11,4 +11,3 @@
 #define __CLC_BODY <clc/relational/bitselect.inc>
 #include <clc/integer/gentype.inc>
 
-#undef __CLC_BODY

--- a/libclc/generic/include/clc/relational/isfinite.h
+++ b/libclc/generic/include/clc/relational/isfinite.h
@@ -13,5 +13,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/isgreater.h
+++ b/libclc/generic/include/clc/relational/isgreater.h
@@ -13,5 +13,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/isgreaterequal.h
+++ b/libclc/generic/include/clc/relational/isgreaterequal.h
@@ -13,5 +13,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/isless.h
+++ b/libclc/generic/include/clc/relational/isless.h
@@ -11,5 +11,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/islessequal.h
+++ b/libclc/generic/include/clc/relational/islessequal.h
@@ -11,5 +11,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/islessgreater.h
+++ b/libclc/generic/include/clc/relational/islessgreater.h
@@ -11,5 +11,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/isnormal.h
+++ b/libclc/generic/include/clc/relational/isnormal.h
@@ -13,5 +13,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/isnotequal.h
+++ b/libclc/generic/include/clc/relational/isnotequal.h
@@ -13,5 +13,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/isordered.h
+++ b/libclc/generic/include/clc/relational/isordered.h
@@ -13,5 +13,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/isunordered.h
+++ b/libclc/generic/include/clc/relational/isunordered.h
@@ -13,5 +13,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/clc/relational/signbit.h
+++ b/libclc/generic/include/clc/relational/signbit.h
@@ -13,5 +13,4 @@
 
 #include <clc/relational/floatn.inc>
 
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/include/math/clc_tan.h
+++ b/libclc/generic/include/math/clc_tan.h
@@ -9,5 +9,4 @@
 #define __CLC_FUNCTION __clc_tan
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef __CLC_FUNCTION

--- a/libclc/generic/lib/async/async_work_group_copy.cl
+++ b/libclc/generic/lib/async/async_work_group_copy.cl
@@ -10,8 +10,6 @@
 
 #define __CLC_BODY <async_work_group_copy.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 
 #define __CLC_BODY <async_work_group_copy.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/lib/async/async_work_group_strided_copy.cl
+++ b/libclc/generic/lib/async/async_work_group_strided_copy.cl
@@ -10,8 +10,6 @@
 
 #define __CLC_BODY <async_work_group_strided_copy.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 
 #define __CLC_BODY <async_work_group_strided_copy.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/lib/async/prefetch.cl
+++ b/libclc/generic/lib/async/prefetch.cl
@@ -10,8 +10,6 @@
 
 #define __CLC_BODY <prefetch.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 
 #define __CLC_BODY <prefetch.inc>
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY

--- a/libclc/generic/lib/shared/vload.cl
+++ b/libclc/generic/lib/shared/vload.cl
@@ -118,7 +118,6 @@ VLOAD_ADDR_SPACES(half)
 
 #define __CLC_BODY "vload_half.inc"
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef FUNC
 #undef __FUNC
 #undef VEC_LOAD16

--- a/libclc/generic/lib/shared/vstore.cl
+++ b/libclc/generic/lib/shared/vstore.cl
@@ -236,7 +236,6 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rte(double x) {
 
 #define __CLC_BODY "vstore_half.inc"
 #include <clc/math/gentype.inc>
-#undef __CLC_BODY
 #undef FUNC
 #undef __XFUNC
 #undef __FUNC


### PR DESCRIPTION
This macro is automatically undefined by the various gentype-like helpers.