### PR TITLE
[compiler-rt] Use mangled function names on ARM64EC

### DIFF
--- a/compiler-rt/lib/builtins/aarch64/sme-abi.S
+++ b/compiler-rt/lib/builtins/aarch64/sme-abi.S
@@ -32,7 +32,7 @@
 // because the function does not return.
 DEFINE_COMPILERRT_PRIVATE_FUNCTION(do_abort)
   .cfi_startproc
-  .variant_pcs SYMBOL_NAME(do_abort)
+  .variant_pcs FUNC_SYMBOL(SYMBOL_NAME(do_abort))
   BTI_C
   stp  x29, x30, [sp, #-32]!
   cntd x0
@@ -42,14 +42,14 @@ DEFINE_COMPILERRT_PRIVATE_FUNCTION(do_abort)
   .cfi_offset w30, -24
   .cfi_offset w29, -32
   .cfi_offset 46, -16
-  bl  SYMBOL_NAME(__arm_sme_state)
+  bl  FUNC_SYMBOL(SYMBOL_NAME(__arm_sme_state))
   tbz  x0, #0, 2f
 1:
   smstop sm
 2:
   // We can't make this into a tail-call because the unwinder would
   // need to restore the value of VG.
-  bl  SYMBOL_NAME(abort)
+  bl  FUNC_SYMBOL(SYMBOL_NAME(abort))
   .cfi_endproc
 END_COMPILERRT_FUNCTION(do_abort)
 
@@ -107,7 +107,7 @@ DEFINE_COMPILERRT_FUNCTION(__arm_tpidr2_restore)
 1:
   ret
 2:
-  b  SYMBOL_NAME(do_abort)
+  b  FUNC_SYMBOL(SYMBOL_NAME(do_abort))
 END_COMPILERRT_FUNCTION(__arm_tpidr2_restore)
 
 DEFINE_COMPILERRT_FUNCTION(__arm_tpidr2_save)
@@ -148,7 +148,7 @@ DEFINE_COMPILERRT_FUNCTION(__arm_tpidr2_save)
 1:
   ret
 2:
-  b  SYMBOL_NAME(do_abort)
+  b  FUNC_SYMBOL(SYMBOL_NAME(do_abort))
 END_COMPILERRT_FUNCTION(__arm_tpidr2_save)
 
 DEFINE_COMPILERRT_FUNCTION(__arm_za_disable)
@@ -169,7 +169,7 @@ DEFINE_COMPILERRT_FUNCTION(__arm_za_disable)
   .cfi_def_cfa w29, 16
   .cfi_offset w30, -8
   .cfi_offset w29, -16
-  bl  SYMBOL_NAME(__arm_tpidr2_save)
+  bl  FUNC_SYMBOL(SYMBOL_NAME(__arm_tpidr2_save))
 
   // * Set TPIDR2_EL0 to null.
   msr TPIDR2_EL0, xzr
@@ -301,7 +301,7 @@ DEFINE_COMPILERRT_FUNCTION(__arm_sme_save)
   ret
 
 3:
-  b       SYMBOL_NAME(do_abort)
+  b       FUNC_SYMBOL(SYMBOL_NAME(do_abort))
 END_COMPILERRT_FUNCTION(__arm_sme_save)
 
 DEFINE_COMPILERRT_FUNCTION(__arm_sme_restore)
@@ -365,7 +365,7 @@ DEFINE_COMPILERRT_FUNCTION(__arm_sme_restore)
   ret
 
 3:
-  b       SYMBOL_NAME(do_abort)
+  b       FUNC_SYMBOL(SYMBOL_NAME(do_abort))
   .cfi_endproc
 END_COMPILERRT_FUNCTION(__arm_sme_restore)
 

--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -61,7 +61,7 @@
 #define LOCAL_LABEL(name) .L ## name
 #define FILE_LEVEL_DIRECTIVE
 #define SYMBOL_IS_FUNC(name)                                                   \
-  .def name SEPARATOR                                                          \
+  .def FUNC_SYMBOL(name) SEPARATOR                                             \
     .scl 2 SEPARATOR                                                           \
     .type 32 SEPARATOR                                                         \
   .endef
@@ -71,7 +71,7 @@
 
 #endif
 
-#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__) || defined(__arm64ec__)
 #define FUNC_ALIGN                                                             \
   .text SEPARATOR                                                              \
   .balign 16 SEPARATOR
@@ -208,6 +208,16 @@
 #define GLUE4(a, b, c, d) GLUE4_(a, b, c, d)
 
 #define SYMBOL_NAME(name) GLUE(__USER_LABEL_PREFIX__, name)
+#ifndef __arm64ec__
+#define FUNC_SYMBOL(name) name
+#else
+// On ARM64EC, function names and calls (but not address-taking or data symbol
+// references) use symbols prefixed with "#".
+#define QUOTE(a) #a
+#define STR(a) QUOTE(a)
+#define HASH #
+#define FUNC_SYMBOL(name) STR(GLUE2(HASH, name))
+#endif
 
 #ifdef VISIBILITY_HIDDEN
 #define DECLARE_SYMBOL_VISIBILITY(name)                                        \
@@ -222,54 +232,54 @@
 #define DEFINE_COMPILERRT_FUNCTION(name)                                       \
   DEFINE_CODE_STATE                                                            \
   FILE_LEVEL_DIRECTIVE SEPARATOR                                               \
-  .globl SYMBOL_NAME(name) SEPARATOR                                           \
+  .globl FUNC_SYMBOL(SYMBOL_NAME(name)) SEPARATOR                              \
   SYMBOL_IS_FUNC(SYMBOL_NAME(name)) SEPARATOR                                  \
   DECLARE_SYMBOL_VISIBILITY(name)                                              \
   DECLARE_FUNC_ENCODING                                                        \
-  SYMBOL_NAME(name):
+  FUNC_SYMBOL(SYMBOL_NAME(name)):
 
 #define DEFINE_COMPILERRT_THUMB_FUNCTION(name)                                 \
   DEFINE_CODE_STATE                                                            \
   FILE_LEVEL_DIRECTIVE SEPARATOR                                               \
-  .globl SYMBOL_NAME(name) SEPARATOR                                           \
+  .globl FUNC_SYMBOL(SYMBOL_NAME(name)) SEPARATOR                              \
   SYMBOL_IS_FUNC(SYMBOL_NAME(name)) SEPARATOR                                  \
   DECLARE_SYMBOL_VISIBILITY(name) SEPARATOR                                    \
   .thumb_func SEPARATOR                                                        \
-  SYMBOL_NAME(name):
+  FUNC_SYMBOL(SYMBOL_NAME(name)):
 
 #define DEFINE_COMPILERRT_PRIVATE_FUNCTION(name)                               \
   DEFINE_CODE_STATE                                                            \
   FILE_LEVEL_DIRECTIVE SEPARATOR                                               \
-  .globl SYMBOL_NAME(name) SEPARATOR                                           \
+  .globl FUNC_SYMBOL(SYMBOL_NAME(name)) SEPARATOR                              \
   SYMBOL_IS_FUNC(SYMBOL_NAME(name)) SEPARATOR                                  \
   HIDDEN(SYMBOL_NAME(name)) SEPARATOR                                          \
   DECLARE_FUNC_ENCODING                                                        \
-  SYMBOL_NAME(name):
+  FUNC_SYMBOL(SYMBOL_NAME(name)):
 
 #define DEFINE_COMPILERRT_PRIVATE_FUNCTION_UNMANGLED(name)                     \
   DEFINE_CODE_STATE                                                            \
-  .globl name SEPARATOR                                                        \
+  .globl FUNC_SYMBOL(name) SEPARATOR                                           \
   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
   HIDDEN(name) SEPARATOR                                                       \
   DECLARE_FUNC_ENCODING                                                        \
-  name:
+  FUNC_SYMBOL(name):
 
 #define DEFINE_COMPILERRT_OUTLINE_FUNCTION_UNMANGLED(name)                     \
   DEFINE_CODE_STATE                                                            \
   FUNC_ALIGN                                                                   \
-  .globl name SEPARATOR                                                        \
+  .globl FUNC_SYMBOL(name) SEPARATOR                                           \
   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
-  DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
+  DECLARE_SYMBOL_VISIBILITY_UNMANGLED(FUNC_SYMBOL(name)) SEPARATOR             \
   DECLARE_FUNC_ENCODING                                                        \
-  name:                                                                        \
+  FUNC_SYMBOL(name):                                                           \
   SEPARATOR CFI_START                                                          \
   SEPARATOR BTI_C
 
 #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
-  .globl SYMBOL_NAME(name) SEPARATOR                                           \
+  .globl FUNC_SYMBOL(SYMBOL_NAME(name)) SEPARATOR                              \
   SYMBOL_IS_FUNC(SYMBOL_NAME(name)) SEPARATOR                                  \
   DECLARE_SYMBOL_VISIBILITY(name) SEPARATOR                                    \
-  .set SYMBOL_NAME(name), SYMBOL_NAME(target) SEPARATOR
+  .set FUNC_SYMBOL(SYMBOL_NAME(name)), FUNC_SYMBOL(target) SEPARATOR
 
 #if defined(__ARM_EABI__)
 #define DEFINE_AEABI_FUNCTION_ALIAS(aeabi_name, name)                          \


### PR DESCRIPTION
On ARM64EC, function names and calls (but not address-taking or data symbol references) use symbols prefixed with "#". Since it's an unique behavior, introduce a new `FUNC_SYMBOL` macro instead of reusing something like `SYMBOL_NAME`, which is also used for data symbols.

Based on patch by Billy Laws.