### PR TITLE
[clang][bytecode] Only print ptr/reference types via toAPValue()

### DIFF
--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -107,7 +107,18 @@ void InterpFrame::destroy(unsigned Idx) {
 template <typename T>
 static void print(llvm::raw_ostream &OS, const T &V, ASTContext &ASTCtx,
                   QualType Ty) {
-  V.toAPValue(ASTCtx).printPretty(OS, ASTCtx, Ty);
+  if constexpr (std::is_same_v<Pointer, T>) {
+    if (Ty->isPointerOrReferenceType())
+      V.toAPValue(ASTCtx).printPretty(OS, ASTCtx, Ty);
+    else {
+      if (std::optional<APValue> RValue = V.toRValue(ASTCtx, Ty))
+        RValue->printPretty(OS, ASTCtx, Ty);
+      else
+        OS << "...";
+    }
+  } else {
+    V.toAPValue(ASTCtx).printPretty(OS, ASTCtx, Ty);
+  }
 }
 
 static bool shouldSkipInBacktrace(const Function *F) {

--- a/clang/test/AST/ByteCode/constexpr-frame-describe.cpp
+++ b/clang/test/AST/ByteCode/constexpr-frame-describe.cpp
@@ -79,8 +79,7 @@ static_assert(bar.fail1<int>()); // both-error {{constant expression}} \
 static_assert(bar.fail2<int*, 42>()); // both-error {{constant expression}} \
                                       // both-note {{in call to 'bar.fail2<int *, 42>()'}}
 static_assert(bar.fail3(3, 4UL, bar, &bar)); // both-error {{constant expression}} \
-                                             // expected-note {{in call to 'bar.fail3<int, unsigned long, Bar<int>, const Bar<int> *>(3, 4, &bar, &bar)'}} \
-                                             // ref-note {{in call to 'bar.fail3<int, unsigned long, Bar<int>, const Bar<int> *>(3, 4, {}, &bar)'}}
+                                             // both-note {{in call to 'bar.fail3<int, unsigned long, Bar<int>, const Bar<int> *>(3, 4, {}, &bar)'}}
 
 
 


### PR DESCRIPTION
Otherwise, convert them to an RValue to print them. This fixes the printing of e.g. complex values.