### PR TITLE
RFC: [TTI] Assume casts between aliasing addrspaces are valid. NFCI.

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -136,7 +136,7 @@ public:
   virtual bool isAlwaysUniform(const Value *V) const { return false; }
 
   virtual bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
-    return false;
+    return addrspacesMayAlias(FromAS, ToAS);
   }
 
   virtual bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const {

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -387,10 +387,6 @@ public:
 
   bool isAlwaysUniform(const Value *V) const override { return false; }
 
-  bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const override {
-    return false;
-  }
-
   bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const override {
     return true;
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
@@ -177,27 +177,6 @@ public:
   bool isSourceOfDivergence(const Value *V) const override;
   bool isAlwaysUniform(const Value *V) const override;
 
-  bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const override {
-    // Address space casts must cast between different address spaces.
-    if (FromAS == ToAS)
-      return false;
-
-    if (FromAS == AMDGPUAS::FLAT_ADDRESS)
-      return AMDGPU::isExtendedGlobalAddrSpace(ToAS) ||
-             ToAS == AMDGPUAS::LOCAL_ADDRESS ||
-             ToAS == AMDGPUAS::PRIVATE_ADDRESS;
-
-    if (AMDGPU::isExtendedGlobalAddrSpace(FromAS))
-      return AMDGPU::isFlatGlobalAddrSpace(ToAS) ||
-             ToAS == AMDGPUAS::CONSTANT_ADDRESS_32BIT;
-
-    if (FromAS == AMDGPUAS::LOCAL_ADDRESS ||
-        FromAS == AMDGPUAS::PRIVATE_ADDRESS)
-      return ToAS == AMDGPUAS::FLAT_ADDRESS;
-
-    return false;
-  }
-
   bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const override {
     return AMDGPU::addrspacesMayAlias(AS0, AS1);
   }


### PR DESCRIPTION
Change the default implementation of isValidAddrSpaceCast to assume that
casts between any address spaces satisfying addrspacesMayAlias are
valid. This seems like a reasonable default assumption and targets can
still override it if they need something different.

This simplifies away the AMDGPU implementation.
