### PR TITLE
[llvm][Coro] Lower coro.frame in CoroEarly instead of CoroSplit

### DIFF
--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -78,17 +78,14 @@ struct Shape {
   }
 
   // Scan the function and collect the above intrinsics for later processing
-  void analyze(Function &F, SmallVectorImpl<CoroFrameInst *> &CoroFrames,
-               SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves,
+  void analyze(Function &F, SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves,
                CoroPromiseInst *&CoroPromise);
   // If for some reason, we were not able to find coro.begin, bailout.
-  void invalidateCoroutine(Function &F,
-                           SmallVectorImpl<CoroFrameInst *> &CoroFrames);
+  void invalidateCoroutine(Function &F);
   // Perform ABI related initial transformation
   void initABI();
   // Remove orphaned and unnecessary intrinsics
-  void cleanCoroutine(SmallVectorImpl<CoroFrameInst *> &CoroFrames,
-                      SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves,
+  void cleanCoroutine(SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves,
                       CoroPromiseInst *CoroPromise);
 
   // Field indexes for special fields in the switch lowering.
@@ -265,16 +262,15 @@ struct Shape {
 
   Shape() = default;
   explicit Shape(Function &F) {
-    SmallVector<CoroFrameInst *, 8> CoroFrames;
     SmallVector<CoroSaveInst *, 2> UnusedCoroSaves;
     CoroPromiseInst *CoroPromise = nullptr;
 
-    analyze(F, CoroFrames, UnusedCoroSaves, CoroPromise);
+    analyze(F, UnusedCoroSaves, CoroPromise);
     if (!CoroBegin) {
-      invalidateCoroutine(F, CoroFrames);
+      invalidateCoroutine(F);
       return;
     }
-    cleanCoroutine(CoroFrames, UnusedCoroSaves, CoroPromise);
+    cleanCoroutine(UnusedCoroSaves, CoroPromise);
   }
 };
 


### PR DESCRIPTION
Documentation of CoroEarly states:

> This pass lowers coro.frame, coro.done, and coro.promise intrinsics.

However, currently coro.frame lowering is handled by CoroSplit. This commit moves this operation to CoroEarly.
