### PR TITLE
[AMDGPU] Simplify GCNTTIImpl::isValidAddrSpaceCast. NFCI.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
@@ -182,20 +182,8 @@ public:
     if (FromAS == ToAS)
       return false;
 
-    if (FromAS == AMDGPUAS::FLAT_ADDRESS)
-      return AMDGPU::isExtendedGlobalAddrSpace(ToAS) ||
-             ToAS == AMDGPUAS::LOCAL_ADDRESS ||
-             ToAS == AMDGPUAS::PRIVATE_ADDRESS;
-
-    if (AMDGPU::isExtendedGlobalAddrSpace(FromAS))
-      return AMDGPU::isFlatGlobalAddrSpace(ToAS) ||
-             ToAS == AMDGPUAS::CONSTANT_ADDRESS_32BIT;
-
-    if (FromAS == AMDGPUAS::LOCAL_ADDRESS ||
-        FromAS == AMDGPUAS::PRIVATE_ADDRESS)
-      return ToAS == AMDGPUAS::FLAT_ADDRESS;
-
-    return false;
+    // Casts between any aliasing address spaces are valid.
+    return AMDGPU::addrspacesMayAlias(FromAS, ToAS);
   }
 
   bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const override {


### PR DESCRIPTION
This just removes some code that references specific address spaces.
