### PR TITLE
[MISched] Fix off-by-one error in debug output with -misched-cutoff=<n> flag

### DIFF
--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -965,7 +965,7 @@ void ScheduleDAGMI::moveInstruction(
 
 bool ScheduleDAGMI::checkSchedLimit() {
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS && !defined(NDEBUG)
-  if ((NumInstrsScheduled + 1) == MISchedCutoff && MISchedCutoff != ~0U) {
+  if (NumInstrsScheduled == MISchedCutoff && MISchedCutoff != ~0U) {
     CurrentTop = CurrentBottom;
     return false;
   }
@@ -1003,13 +1003,14 @@ void ScheduleDAGMI::schedule() {
 
   bool IsTopNode = false;
   while (true) {
+    if (!checkSchedLimit())
+      break;
+
     LLVM_DEBUG(dbgs() << "** ScheduleDAGMI::schedule picking next node\n");
     SUnit *SU = SchedImpl->pickNode(IsTopNode);
     if (!SU) break;
 
     assert(!SU->isScheduled && "Node already scheduled");
-    if (!checkSchedLimit())
-      break;
 
     MachineInstr *MI = SU->getInstr();
     if (IsTopNode) {
@@ -1637,13 +1638,14 @@ void ScheduleDAGMILive::schedule() {
 
   bool IsTopNode = false;
   while (true) {
+    if (!checkSchedLimit())
+      break;
+
     LLVM_DEBUG(dbgs() << "** ScheduleDAGMILive::schedule picking next node\n");
     SUnit *SU = SchedImpl->pickNode(IsTopNode);
     if (!SU) break;
 
     assert(!SU->isScheduled && "Node already scheduled");
-    if (!checkSchedLimit())
-      break;
 
     scheduleMI(SU, IsTopNode);
 

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -965,7 +965,7 @@ void ScheduleDAGMI::moveInstruction(
 
 bool ScheduleDAGMI::checkSchedLimit() {
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS && !defined(NDEBUG)
-  if (NumInstrsScheduled == MISchedCutoff && MISchedCutoff != ~0U) {
+  if ((NumInstrsScheduled + 1) == MISchedCutoff && MISchedCutoff != ~0U) {
     CurrentTop = CurrentBottom;
     return false;
   }

--- a/llvm/test/CodeGen/AArch64/misched-cutoff.mir
+++ b/llvm/test/CodeGen/AArch64/misched-cutoff.mir
@@ -4,7 +4,7 @@
 
 # REQUIRES: asserts
 
-# CHECK-CUTOFF-COUNT-2: Scheduling SU
+# CHECK-CUTOFF-COUNT-1: Scheduling SU
 
 # NOTE: copied from machine-scheduler.mir
 


### PR DESCRIPTION
This flag instructs the scheduler to stop scheduling after N instructions, but
in the debug output it appears as if it's scheduling N+1 instructions, e.g.

$ llc -misched-cutoff=10 -debug-only=machine-scheduler
example.ll 2>&1 | grep "^Scheduling SU" | wc -l
11

as it calls pickNode before calling checkSchedLimit.