### PR TITLE
[flang][docs] Add note about Cray pointers and the TARGET attribute

### DIFF
--- a/flang/docs/Aliasing.md
+++ b/flang/docs/Aliasing.md
@@ -283,11 +283,11 @@ end
 
 Optimizations assume that Cray pointers do not alias any other variables.
 In the above example, it is assumed that `handle` and `target` do not alias,
-and optimizations will treat them as seperate entities.
+and optimizations will treat them as separate entities.
 
-You may add the TARGET attribute to variables aliasing with a Cray pointer (the
-`target` variable in this example), and this will disable some optimizations
-that would otherwise assume there is no aliasing.
+In order to disable optimizations that assume that there is no aliasing between
+Cray pointer targets and entities they alias with, add the TARGET attribute to
+variables aliasing with a Cray pointer (the `target` variable in this example).
 
 ## Type considerations
 

--- a/flang/docs/Aliasing.md
+++ b/flang/docs/Aliasing.md
@@ -264,11 +264,30 @@ Fortran also has no rule against associating read-only data with a pointer.
 Cray pointers are, or were, an extension that attempted to provide
 some of the capabilities of modern pointers and allocatables before those
 features were standardized.
-They had some aliasing restrictions; in particular, Cray pointers were
-not allowed to alias each other.
 
-They are now more or less obsolete and we have no plan in place to
-support them.
+They had some aliasing restrictions; in particular, Cray pointers were not
+allowed to alias each other.
+
+In this example, `handle` aliases with `target`.
+
+```
+integer(kind=8) :: target(10)
+integer(kind=8) :: ptr
+integer(kind=8) :: handle(10)
+pointer(ptr, handle)
+target = 1
+ptr = loc(target)
+print *, target
+end
+```
+
+Optimizations assume that Cray pointers do not alias any other variables.
+In the above example, it is assumed that `handle` and `target` do not alias,
+and optimizations will treat them as seperate entities.
+
+You may add the TARGET attribute to variables aliasing with a Cray pointer (the
+`target` variable in this example), and this will disable some optimizations
+that would otherwise assume there is no aliasing.
 
 ## Type considerations
 


### PR DESCRIPTION
We found some tests checking for loops assigning between Cray pointer handles and their pointees which produced "incorrect" results with optimizations enabled; this is because the compiler expects Cray pointers not to alias with any other entity.

[The HPE documentation for Cray Fortran extensions specifies:](https://support.hpe.com/hpesc/public/docDisplay?docId=a00113911en_us&docLocale=en_US&page=Types.html#cray-poiter-type)

> the compiler assumes that the storage of a pointee is
> never overlaid on the storage of another variable

Jean pointed out that if a user's code uses entities that alias via Cray pointers, they may add the TARGET attribute to inform Flang of this aliasing, but that Flang's behavior is in line with Cray's own documentation and we should not make any changes to our alias analysis to try and detect this case.

Updating documentation so that users that encounter this situation have a way to allow their code to compile as they intend.