### PR TITLE
[AsmParser] Replace starIsStartOfStatement with tokenIsStartOfStatement.

### DIFF
--- a/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
@@ -508,8 +508,10 @@ public:
   virtual bool equalIsAsmAssignment() { return true; };
   // Return whether this start of statement identifier is a label
   virtual bool isLabel(AsmToken &Token) { return true; };
-  // Return whether this parser accept star as start of statement
-  virtual bool starIsStartOfStatement() { return false; };
+  // Return whether this parser accepts the given token as start of statement.
+  virtual bool tokenIsStartOfStatement(AsmToken::TokenKind Token) {
+    return false;
+  }
 
   virtual const MCExpr *applySpecifier(const MCExpr *E, uint32_t,
                                        MCContext &Ctx) {

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -1769,11 +1769,9 @@ bool AsmParser::parseStatement(ParseStatementInfo &Info,
     // Treat '}' as a valid identifier in this context.
     Lex();
     IDVal = "}";
-  } else if (Lexer.is(AsmToken::Star) &&
-             getTargetParser().starIsStartOfStatement()) {
-    // Accept '*' as a valid start of statement.
+  } else if (getTargetParser().tokenIsStartOfStatement(ID.getKind())) {
     Lex();
-    IDVal = "*";
+    IDVal = ID.getString();
   } else if (parseIdentifier(IDVal)) {
     if (!TheCondState.Ignore) {
       Lex(); // always eat a token

--- a/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
+++ b/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
@@ -49,7 +49,9 @@ class BPFAsmParser : public MCTargetAsmParser {
   bool equalIsAsmAssignment() override { return false; }
   // "*" is used for dereferencing memory that it will be the start of
   // statement.
-  bool starIsStartOfStatement() override { return true; }
+  bool tokenIsStartOfStatement(AsmToken::TokenKind Token) override {
+    return Token == AsmToken::Star;
+  }
 
 #define GET_ASSEMBLER_HEADER
 #include "BPFGenAsmMatcher.inc"


### PR DESCRIPTION
Currently `MCTargetAsmParser::starIsStartOfStatement` checks for `*` at the start of the statement. There are other (currently) downstream back-ends that need the same treatment for other tokens. Instead of introducing bespoke APIs for each such token, we generalize (and rename) starIsStartOfStatement as tokenIsStartOfStatement which takes the token of interest as an argument.

Update the BPF AsmParser (the only upstream consumer today) to use the new version.