### PR TITLE
[CIR] Upstream support for switch statements case kinds

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -161,7 +161,6 @@ struct MissingFeatures {
   static bool targetSpecificCXXABI() { return false; }
   static bool moduleNameHash() { return false; }
   static bool setDSOLocal() { return false; }
-  static bool foldCaseStmt() { return false; }
   static bool constantFoldSwitchStatement() { return false; }
 
   // Missing types

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -97,6 +97,9 @@ struct MissingFeatures {
   // Unary operator handling
   static bool opUnaryPromotionType() { return false; }
 
+  // SwitchOp handling
+  static bool foldRangeCase() { return false; }
+
   // Clang early optimizations or things defered to LLVM lowering.
   static bool mayHaveIntegerOverflow() { return false; }
   static bool shouldReverseUnaryCondOnBoolExpr() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -98,6 +98,7 @@ struct MissingFeatures {
   static bool opUnaryPromotionType() { return false; }
 
   // SwitchOp handling
+  static bool foldCascadingCases() { return false; }
   static bool foldRangeCase() { return false; }
 
   // Clang early optimizations or things defered to LLVM lowering.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -278,6 +278,9 @@ public:
   /// addressed later.
   RValue getUndefRValue(clang::QualType ty);
 
+  const CaseStmt *foldCaseStmt(const clang::CaseStmt &s, mlir::Type condType,
+                               mlir::ArrayAttr &value, cir::CaseOpKind &kind);
+
   cir::FuncOp generateCode(clang::GlobalDecl gd, cir::FuncOp fn,
                            cir::FuncType funcType);
 
@@ -531,6 +534,11 @@ public:
   void emitDecl(const clang::Decl &d);
   mlir::LogicalResult emitDeclStmt(const clang::DeclStmt &s);
   LValue emitDeclRefLValue(const clang::DeclRefExpr *e);
+
+
+  mlir::LogicalResult emitDefaultStmt(const clang::DefaultStmt &s,
+                                      mlir::Type condType,
+                                      bool buildingTopLevelCase);
 
   /// Emit an `if` on a boolean condition to the specified blocks.
   /// FIXME: Based on the condition, this might try to simplify the codegen of

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -535,7 +535,6 @@ public:
   mlir::LogicalResult emitDeclStmt(const clang::DeclStmt &s);
   LValue emitDeclRefLValue(const clang::DeclRefExpr *e);
 
-
   mlir::LogicalResult emitDefaultStmt(const clang::DefaultStmt &s,
                                       mlir::Type condType,
                                       bool buildingTopLevelCase);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -278,9 +278,6 @@ public:
   /// addressed later.
   RValue getUndefRValue(clang::QualType ty);
 
-  const CaseStmt *foldCaseStmt(const clang::CaseStmt &s, mlir::Type condType,
-                               mlir::ArrayAttr &value, cir::CaseOpKind &kind);
-
   cir::FuncOp generateCode(clang::GlobalDecl gd, cir::FuncOp fn,
                            cir::FuncType funcType);
 

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -565,7 +565,6 @@ mlir::LogicalResult CIRGenFunction::emitCaseStmt(const CaseStmt &s,
                                                  bool buildingTopLevelCase) {
   cir::CaseOpKind kind;
   mlir::ArrayAttr value;
-  assert(!cir::MissingFeatures::foldCaseStmt());
   const CaseStmt *caseStmt = foldCaseStmt(s, condType, value, kind);
   return emitCaseDefaultCascade(caseStmt, condType, value, kind,
                                 buildingTopLevelCase);

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -456,8 +456,7 @@ CIRGenFunction::emitCaseDefaultCascade(const T *stmt, mlir::Type condType,
     if (isa<DefaultStmt>(sub) && isa<CaseStmt>(stmt)) {
       subStmtKind = SubStmtKind::Default;
       builder.createYield(loc);
-    } else if ((isa<CaseStmt>(sub) && isa<DefaultStmt>(stmt)) ||
-               (isa<CaseStmt>(sub) && isa<CaseStmt>(stmt))) {
+    } else if (isa<CaseStmt>(sub) && isa<DefaultStmt, CaseStmt>(stmt)) {
       subStmtKind = SubStmtKind::Case;
       builder.createYield(loc);
     } else {
@@ -536,8 +535,10 @@ mlir::LogicalResult CIRGenFunction::emitCaseStmt(const CaseStmt &s,
     kind = cir::CaseOpKind::Range;
 
     // We don't currently fold case range statements with other case statements.
-    // TODO(cir): Add this capability.
+    // TODO(cir): Add this capability. Folding these cases is going to be
+    // implemented in CIRSimplify when it is upstreamed.
     assert(!cir::MissingFeatures::foldRangeCase());
+    assert(!cir::MissingFeatures::foldCascadingCases());
   } else {
     caseEltValueListAttr.push_back(cir::IntAttr::get(condType, intVal));
     value = builder.getArrayAttr(caseEltValueListAttr);

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -429,7 +429,6 @@ mlir::LogicalResult CIRGenFunction::emitBreakStmt(const clang::BreakStmt &s) {
   return mlir::success();
 }
 
-
 const CaseStmt *CIRGenFunction::foldCaseStmt(const clang::CaseStmt &s,
                                              mlir::Type condType,
                                              mlir::ArrayAttr &value,
@@ -570,10 +569,9 @@ mlir::LogicalResult CIRGenFunction::emitCaseStmt(const CaseStmt &s,
                                 buildingTopLevelCase);
 }
 
-
-  mlir::LogicalResult CIRGenFunction::emitDefaultStmt(const clang::DefaultStmt &s,
-                                      mlir::Type condType,
-                                      bool buildingTopLevelCase) {
+mlir::LogicalResult CIRGenFunction::emitDefaultStmt(const clang::DefaultStmt &s,
+                                                    mlir::Type condType,
+                                                    bool buildingTopLevelCase) {
   return emitCaseDefaultCascade(&s, condType, builder.getArrayAttr({}),
                                 cir::CaseOpKind::Default, buildingTopLevelCase);
 }

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -518,20 +518,15 @@ mlir::LogicalResult CIRGenFunction::emitCaseStmt(const CaseStmt &s,
                                                  bool buildingTopLevelCase) {
   cir::CaseOpKind kind;
   mlir::ArrayAttr value;
-
-  SmallVector<mlir::Attribute, 1> caseEltValueListAttr;
   llvm::APSInt intVal = s.getLHS()->EvaluateKnownConstInt(getContext());
 
   // If the case statement has an RHS value, it is representing a GNU
   // case range statement, where LHS is the beginning of the range
   // and RHS is the end of the range.
   if (const Expr *rhs = s.getRHS()) {
-
     llvm::APSInt endVal = rhs->EvaluateKnownConstInt(getContext());
-    SmallVector<mlir::Attribute, 4> rangeCaseAttr = {
-        cir::IntAttr::get(condType, intVal),
-        cir::IntAttr::get(condType, endVal)};
-    value = builder.getArrayAttr(rangeCaseAttr);
+    value = builder.getArrayAttr({cir::IntAttr::get(condType, intVal),
+                                  cir::IntAttr::get(condType, endVal)});
     kind = cir::CaseOpKind::Range;
 
     // We don't currently fold case range statements with other case statements.
@@ -540,8 +535,7 @@ mlir::LogicalResult CIRGenFunction::emitCaseStmt(const CaseStmt &s,
     assert(!cir::MissingFeatures::foldRangeCase());
     assert(!cir::MissingFeatures::foldCascadingCases());
   } else {
-    caseEltValueListAttr.push_back(cir::IntAttr::get(condType, intVal));
-    value = builder.getArrayAttr(caseEltValueListAttr);
+    value = builder.getArrayAttr({cir::IntAttr::get(condType, intVal)});
     kind = cir::CaseOpKind::Equal;
   }
 

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -18,7 +18,7 @@ void sw1(int a) {
 }
 
 // CIR: cir.func @_Z3sw1i
-// CIR: cir.switch (%3 : !s32i) {
+// CIR: cir.switch (%[[COND:.*]] : !s32i) {
 // CIR-NEXT: cir.case(equal, [#cir.int<0> : !s32i]) {
 // CIR: cir.break
 // CIR: cir.case(equal, [#cir.int<1> : !s32i]) {
@@ -67,12 +67,12 @@ void sw2(int a) {
 
 // CIR: cir.func @_Z3sw2i
 // CIR: cir.scope {
-// CIR-NEXT:   %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init]
-// CIR-NEXT:   %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["fomo", init]
-// CIR:        cir.switch (%4 : !s32i) {
+// CIR-NEXT:   %[[YOLO:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init]
+// CIR-NEXT:   %[[FOMO:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["fomo", init]
+// CIR:        cir.switch (%[[COND:.*]] : !s32i) {
 // CIR-NEXT:   cir.case(equal, [#cir.int<3> : !s32i]) {
-// CIR-NEXT:     %5 = cir.const #cir.int<0> : !s32i
-// CIR-NEXT:     cir.store %5, %2 : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:     %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR-NEXT:     cir.store %[[ZERO]], %[[FOMO]] : !s32i, !cir.ptr<!s32i>
 
 // OGCG: define dso_local void @_Z3sw2i
 // OGCG: entry:
@@ -101,8 +101,8 @@ void sw3(int a) {
 
 // CIR: cir.func @_Z3sw3i
 // CIR: cir.scope {
-// CIR-NEXT:   %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT:   cir.switch (%1 : !s32i) {
+// CIR-NEXT:   %[[COND:.*]] = cir.load %[[A:.*]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   cir.switch (%[[COND]] : !s32i) {
 // CIR-NEXT:   cir.case(default, []) {
 // CIR-NEXT:     cir.break
 // CIR-NEXT:   }
@@ -131,24 +131,24 @@ int sw4(int a) {
 }
 
 // CIR: cir.func @_Z3sw4i
-// CIR:       cir.switch (%4 : !s32i) {
+// CIR:       cir.switch (%[[COND:.*]] : !s32i) {
 // CIR-NEXT:       cir.case(equal, [#cir.int<42> : !s32i]) {
 // CIR-NEXT:         cir.scope {
-// CIR-NEXT:           %5 = cir.const #cir.int<3> : !s32i
-// CIR-NEXT:           cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
-// CIR-NEXT:           %6 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT:           cir.return %6 : !s32i
+// CIR-NEXT:           %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR-NEXT:           cir.store %[[THREE]], %[[RETVAL:.*]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:           %[[RET3:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:           cir.return %[[RET3]] : !s32i
 // CIR-NEXT:         }
 // CIR-NEXT:         cir.yield
 // CIR-NEXT:       }
 // CIR-NEXT:       cir.case(default, []) {
-// CIR-NEXT:         %5 = cir.const #cir.int<2> : !s32i
-// CIR-NEXT:         cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
-// CIR-NEXT:         %6 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT:         cir.return %6 : !s32i
+// CIR-NEXT:         %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+// CIR-NEXT:         cir.store %[[TWO]], %[[RETVAL]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:         %[[RET2:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:         cir.return %[[RET2]] : !s32i
 // CIR-NEXT:       }
 // CIR-NEXT:       cir.yield
-// CIR-NEXT:       }
+// CIR-NEXT:  }
 
 // OGCG: define dso_local noundef i32 @_Z3sw4i
 // OGCG: entry:
@@ -173,7 +173,7 @@ void sw5(int a) {
 }
 
 // CIR: cir.func @_Z3sw5i
-// CIR: cir.switch (%1 : !s32i) {
+// CIR: cir.switch (%[[A:.*]] : !s32i) {
 // CIR-NEXT:   cir.case(equal, [#cir.int<1> : !s32i]) {
 // CIR-NEXT:     cir.yield
 // CIR-NEXT:   }
@@ -206,7 +206,7 @@ void sw6(int a) {
 }
 
 // CIR: cir.func @_Z3sw6i
-// CIR: cir.switch (%1 : !s32i) {
+// CIR: cir.switch (%[[A:.*]] : !s32i) {
 // CIR-NEXT: cir.case(equal, [#cir.int<0> : !s32i]) {
 // CIR-NEXT:     cir.yield
 // CIR-NEXT: }
@@ -261,7 +261,9 @@ void sw7(int a) {
 }
 
 // CIR: cir.func @_Z3sw7i
-// CIR: cir.case(equal, [#cir.int<0> : !s32i]) {
+// CIR: %[[X:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x"]
+// CIR: cir.switch (%[[A:.*]] : !s32i)
+// CIR-NEXT: cir.case(equal, [#cir.int<0> : !s32i]) {
 // CIR-NEXT:     cir.yield
 // CIR-NEXT: }
 // CIR-NEXT: cir.case(equal, [#cir.int<1> : !s32i]) {
@@ -279,6 +281,8 @@ void sw7(int a) {
 // CIR-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
 // CIR-NEXT:     cir.break
 // CIR-NEXT: }
+// CIR-NEXT: cir.yield
+// CIR: }
 
 // OGCG: define dso_local void @_Z3sw7i
 // OGCG: entry:
@@ -312,7 +316,8 @@ void sw8(int a) {
 }
 
 // CIR:    cir.func @_Z3sw8i
-// CIR:      cir.case(equal, [#cir.int<3> : !s32i]) {
+// CIR:    cir.switch (%[[A:.*]] : !s32i)
+// CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
 // CIR-NEXT:   cir.break
 // CIR-NEXT: }
 // CIR-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
@@ -352,7 +357,8 @@ void sw9(int a) {
 }
 
 // CIR:    cir.func @_Z3sw9i
-// CIR:      cir.case(equal, [#cir.int<3> : !s32i]) {
+// CIR:    cir.switch (%[[A:.*]] : !s32i)
+// CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
 // CIR-NEXT:   cir.break
 // CIR-NEXT: }
 // CIR-NEXT: cir.case(default, []) {
@@ -391,19 +397,20 @@ void sw10(int a) {
   }
 }
 
-//CIR:    cir.func @_Z4sw10i
-//CIR:      cir.case(equal, [#cir.int<3> : !s32i]) {
-//CIR-NEXT:   cir.break
-//CIR-NEXT: }
-//CIR-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
-//CIR-NEXT:   cir.yield
-//CIR-NEXT: }
-//CIR-NEXT: cir.case(default, []) {
-//CIR-NEXT:   cir.yield
-//CIR-NEXT: }
-//CIR-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
-//CIR-NEXT:   cir.break
-//CIR-NEXT: }
+// CIR:    cir.func @_Z4sw10i
+// CIR:    cir.switch (%[[A:.*]] : !s32i)
+// CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
+// CIR-NEXT:   cir.break
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(default, []) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
+// CIR-NEXT:   cir.break
+// CIR-NEXT: }
 
 // OGCG: define dso_local void @_Z4sw10i
 // OGCG: entry:
@@ -439,25 +446,26 @@ void sw11(int a) {
   }
 }
 
-//CIR:    cir.func @_Z4sw11i
-//CIR:      cir.case(equal, [#cir.int<3> : !s32i]) {
-//CIR-NEXT:   cir.break
-//CIR-NEXT: }
-//CIR-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
-//CIR-NEXT:   cir.yield
-//CIR-NEXT: }
-//CIR-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
-//CIR-NEXT:   cir.yield
-//CIR-NEXT: }
-//CIR-NEXT: cir.case(default, []) {
-//CIR-NEXT:   cir.yield
-//CIR-NEXT: }
-//CIR-NEXT: cir.case(equal, [#cir.int<6> : !s32i]) {
-//CIR-NEXT:   cir.yield
-//CIR-NEXT: }
-//CIR-NEXT: cir.case(equal, [#cir.int<7> : !s32i]) {
-//CIR-NEXT:   cir.break
-//CIR-NEXT: }
+// CIR:    cir.func @_Z4sw11i
+// CIR:    cir.switch (%[[A:.*]] : !s32i)
+// CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
+// CIR-NEXT:   cir.break
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(default, []) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<6> : !s32i]) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<7> : !s32i]) {
+// CIR-NEXT:   cir.break
+// CIR-NEXT: }
 
 // OGCG: define dso_local void @_Z4sw11i
 // OGCG: entry:
@@ -533,7 +541,7 @@ void sw13(int a, int b) {
 // CIR-NEXT:          cir.yield
 // CIR-NEXT:        }
 // CIR-NEXT:      }
-// CIR:         cir.yield
+//      CIR:    cir.yield
 //      CIR:    }
 //      CIR:    cir.return
 
@@ -688,7 +696,7 @@ int nested_switch(int a) {
   return 0;
 }
 
-// CIR: cir.switch (%6 : !s32i) {
+// CIR: cir.switch (%[[COND:.*]] : !s32i) {
 // CIR:   cir.case(equal, [#cir.int<0> : !s32i]) {
 // CIR:     cir.yield
 // CIR:   }

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -207,12 +207,25 @@ void sw6(int a) {
 
 // CIR: cir.func @_Z3sw6i
 // CIR: cir.switch (%1 : !s32i) {
-// CIR-NEXT: cir.case(anyof, [#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
-// CIR-NEXT:   cir.break
+// CIR-NEXT: cir.case(equal, [#cir.int<0> : !s32i]) {
+// CIR-NEXT:     cir.yield
 // CIR-NEXT: }
-// CIR-NEXT: cir.case(anyof, [#cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i]) {
-// CIR-NEXT:   cir.break
+// CIR-NEXT: cir.case(equal, [#cir.int<1> : !s32i]) {
+// CIR-NEXT:     cir.yield
 // CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<2> : !s32i]) {
+// CIR-NEXT:     cir.break
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
+// CIR-NEXT:     cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
+// CIR-NEXT:     cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
+// CIR-NEXT:     cir.break
+// CIR-NEXT: }
+
 
 // OGCG: define dso_local void @_Z3sw6i
 // OGCG: entry:
@@ -248,13 +261,24 @@ void sw7(int a) {
 }
 
 // CIR: cir.func @_Z3sw7i
-// CIR: cir.case(anyof, [#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
-// CIR-NEXT:   cir.yield
+// CIR: cir.case(equal, [#cir.int<0> : !s32i]) {
+// CIR-NEXT:     cir.yield
 // CIR-NEXT: }
-// CIR-NEXT: cir.case(anyof, [#cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i]) {
-// CIR-NEXT:   cir.break
+// CIR-NEXT: cir.case(equal, [#cir.int<1> : !s32i]) {
+// CIR-NEXT:     cir.yield
 // CIR-NEXT: }
-
+// CIR-NEXT: cir.case(equal, [#cir.int<2> : !s32i]) {
+// CIR-NEXT:     cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
+// CIR-NEXT:     cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
+// CIR-NEXT:     cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
+// CIR-NEXT:     cir.break
+// CIR-NEXT: }
 
 // OGCG: define dso_local void @_Z3sw7i
 // OGCG: entry:
@@ -419,13 +443,19 @@ void sw11(int a) {
 //CIR:      cir.case(equal, [#cir.int<3> : !s32i]) {
 //CIR-NEXT:   cir.break
 //CIR-NEXT: }
-//CIR-NEXT: cir.case(anyof, [#cir.int<4> : !s32i, #cir.int<5> : !s32i]) {
+//CIR-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
+//CIR-NEXT:   cir.yield
+//CIR-NEXT: }
+//CIR-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
 //CIR-NEXT:   cir.yield
 //CIR-NEXT: }
 //CIR-NEXT: cir.case(default, []) {
 //CIR-NEXT:   cir.yield
 //CIR-NEXT: }
-//CIR-NEXT: cir.case(anyof, [#cir.int<6> : !s32i, #cir.int<7> : !s32i]) {
+//CIR-NEXT: cir.case(equal, [#cir.int<6> : !s32i]) {
+//CIR-NEXT:   cir.yield
+//CIR-NEXT: }
+//CIR-NEXT: cir.case(equal, [#cir.int<7> : !s32i]) {
 //CIR-NEXT:   cir.break
 //CIR-NEXT: }
 
@@ -525,6 +555,114 @@ void sw13(int a, int b) {
 // OGCG: [[EPILOG]]:
 // OGCG:   br label %[[EPILOG2]]
 // OGCG: [[EPILOG2]]:
+// OGCG:   ret void
+
+void sw14(int x) {
+  switch (x) {
+    case 1:
+    case 2:
+    case 3 ... 6:
+    case 7:
+      break;
+    default:
+      break;
+  }
+}
+
+// CIR:      cir.func @_Z4sw14i
+// CIR:      cir.switch
+// CIR-NEXT: cir.case(equal, [#cir.int<1> : !s32i]) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<2> : !s32i]) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(range, [#cir.int<3> : !s32i, #cir.int<6> : !s32i]) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<7> : !s32i]) {
+// CIR-NEXT:   cir.break
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(default, []) {
+// CIR-NEXT:   cir.break
+// CIR-NEXT: }
+
+// OGCG: define dso_local void @_Z4sw14i
+// OGCG: entry:
+// OGCG:   %[[X_ADDR:.*]] = alloca i32, align 4
+// OGCG:   store i32 %x, ptr %[[X_ADDR]], align 4
+// OGCG:   %[[X_VAL:.*]] = load i32, ptr %[[X_ADDR]], align 4
+
+// OGCG:   switch i32 %[[X_VAL]], label %[[DEFAULT:.*]] [
+// OGCG-DAG:     i32 1, label %[[BB1:.*]]
+// OGCG-DAG:     i32 2, label %[[BB1]]
+// OGCG-DAG:     i32 3, label %[[BB2:.*]]
+// OGCG-DAG:     i32 4, label %[[BB2]]
+// OGCG-DAG:     i32 5, label %[[BB2]]
+// OGCG-DAG:     i32 6, label %[[BB2]]
+// OGCG-DAG:     i32 7, label %[[BB3:.*]]
+// OGCG:   ]
+// OGCG: [[BB1]]:
+// OGCG:   br label %[[BB2]]
+// OGCG: [[BB2]]:
+// OGCG:   br label %[[BB3]]
+// OGCG: [[BB3]]:
+// OGCG:   br label %[[EPILOG:.*]]
+// OGCG: [[DEFAULT]]:
+// OGCG:   br label %[[EPILOG]]
+// OGCG: [[EPILOG]]:
+// OGCG:   ret void
+
+void sw15(int x) {
+  int y;
+  switch (x) {
+    case 1:
+    case 2:
+      y = 0;
+    case 3:
+      break;
+    default:
+      break;
+  }
+}
+
+// CIR:      cir.func @_Z4sw15i
+// CIR:      %[[Y:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["y"]
+// CIR:      cir.switch
+// CIR-NEXT: cir.case(equal, [#cir.int<1> : !s32i]) {
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<2> : !s32i]) {
+// CIR-NEXT:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR-NEXT:   cir.store %[[ZERO]], %[[Y]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   cir.yield
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
+// CIR-NEXT:   cir.break
+// CIR-NEXT: }
+// CIR-NEXT: cir.case(default, []) {
+// CIR-NEXT:   cir.break
+// CIR-NEXT: }
+
+// OGCG: define dso_local void @_Z4sw15i
+// OGCG: entry:
+// OGCG:   %[[X_ADDR:.*]] = alloca i32, align 4
+// OGCG:   %[[Y:.*]] = alloca i32, align 4
+// OGCG:   store i32 %x, ptr %[[X_ADDR]], align 4
+// OGCG:   %[[X_VAL:.*]] = load i32, ptr %[[X_ADDR]], align 4
+// OGCG:   switch i32 %[[X_VAL]], label %[[DEFAULT:.*]] [
+// OGCG-DAG:     i32 1, label %[[BB0:.*]]
+// OGCG-DAG:     i32 2, label %[[BB0]]
+// OGCG-DAG:     i32 3, label %[[BB1:.*]]
+// OGCG:   ]
+// OGCG: [[BB0]]:
+// OGCG:   store i32 0, ptr %[[Y]], align 4
+// OGCG:   br label %[[BB1]]
+// OGCG: [[BB1]]:
+// OGCG:   br label %[[EPILOG:.*]]
+// OGCG: [[DEFAULT]]:
+// OGCG:   br label %[[EPILOG]]
+// OGCG: [[EPILOG]]:
 // OGCG:   ret void
 
 int nested_switch(int a) {


### PR DESCRIPTION
This introduces support for the following cir::case kinds:
- `Equal`
- `AnyOf`
- `Range`
