### PR TITLE
[mlir][acc] Add LegalizeDataValues support for DeclareEnterOp

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
@@ -58,8 +58,7 @@
 #define ACC_COMPUTE_CONSTRUCT_AND_LOOP_OPS                                     \
   ACC_COMPUTE_CONSTRUCT_OPS, mlir::acc::LoopOp
 #define ACC_DATA_CONSTRUCT_STRUCTURED_OPS                                      \
-  mlir::acc::DataOp, mlir::acc::DeclareOp, mlir::acc::HostDataOp,              \
-      mlir::acc::DeclareEnterOp
+  mlir::acc::DataOp, mlir::acc::DeclareOp, mlir::acc::HostDataOp
 #define ACC_DATA_CONSTRUCT_UNSTRUCTURED_OPS                                    \
   mlir::acc::EnterDataOp, mlir::acc::ExitDataOp, mlir::acc::UpdateOp,          \
       mlir::acc::DeclareEnterOp, mlir::acc::DeclareExitOp

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
@@ -58,7 +58,8 @@
 #define ACC_COMPUTE_CONSTRUCT_AND_LOOP_OPS                                     \
   ACC_COMPUTE_CONSTRUCT_OPS, mlir::acc::LoopOp
 #define ACC_DATA_CONSTRUCT_STRUCTURED_OPS                                      \
-  mlir::acc::DataOp, mlir::acc::DeclareOp, mlir::acc::HostDataOp
+  mlir::acc::DataOp, mlir::acc::DeclareOp, mlir::acc::HostDataOp,              \
+      mlir::acc::DeclareEnterOp
 #define ACC_DATA_CONSTRUCT_UNSTRUCTURED_OPS                                    \
   mlir::acc::EnterDataOp, mlir::acc::ExitDataOp, mlir::acc::UpdateOp,          \
       mlir::acc::DeclareEnterOp, mlir::acc::DeclareExitOp

--- a/mlir/lib/Dialect/OpenACC/Transforms/LegalizeDataValues.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/LegalizeDataValues.cpp
@@ -165,8 +165,8 @@ public:
     bool replaceHostVsDevice = this->hostToDevice.getValue();
 
     // Initialize dominance info
-    DominanceInfo domInfo(funcOp);
-    PostDominanceInfo postDomInfo(funcOp);
+    DominanceInfo domInfo;
+    PostDominanceInfo postDomInfo;
     bool computedDomInfo = false;
 
     funcOp.walk([&](Operation *op) {

--- a/mlir/lib/Dialect/OpenACC/Transforms/LegalizeDataValues.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/LegalizeDataValues.cpp
@@ -140,8 +140,7 @@ collectAndReplaceInRegion(Op &op, bool hostToDevice,
     }
   }
 
-  if constexpr (std::is_same_v<Op, acc::DeclareEnterOp> ||
-                std::is_same_v<Op, acc::EnterDataOp>) {
+  if constexpr (std::is_same_v<Op, acc::DeclareEnterOp>) {
     assert(domInfo && postDomInfo &&
            "Dominance info required for DeclareEnterOp");
     replaceAllUsesInUnstructuredComputeRegionWith<Op>(op, values, *domInfo,

--- a/mlir/lib/Dialect/OpenACC/Transforms/LegalizeDataValues.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/LegalizeDataValues.cpp
@@ -84,8 +84,7 @@ static void replaceAllUsesInUnstructuredComputeRegionWith(
         exitOps.push_back(declareExit);
     }
     if (exitOps.empty())
-      op.emitError(
-          "declare enter token must be used by at least one declare exit op");
+      return;
   }
 
   for (auto p : values) {


### PR DESCRIPTION
The patch extends the existing LegalizeDataValues to support DeclareEnter and DeclareExit pair.
Since unlike other ops, DeclareEnter and DeclareExit don't have a region defined, we use dominance/post dominance information to ensure only the uses within the region dominated by DeclareEnter and post dominated by DeclareExit are updated with data on device.