### PR TITLE
[clang] Shard out some small gtest binaries

### DIFF
--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_clang_unittest(BasicTests
+add_distinct_clang_unittest(BasicTests
   CharInfoTest.cpp
   DarwinSDKInfoTest.cpp
   DiagnosticTest.cpp

--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Basic tests have few LLVM and Clang dependencies, so linking it as a
+# distinct target enables faster iteration times at low cost.
 add_distinct_clang_unittest(BasicTests
   CharInfoTest.cpp
   DarwinSDKInfoTest.cpp

--- a/clang/unittests/Format/CMakeLists.txt
+++ b/clang/unittests/Format/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Format tests have few LLVM and Clang dependencies, so linking it as a
+# distinct target enables faster iteration times at low cost.
 add_distinct_clang_unittest(FormatTests
   BracesInserterTest.cpp
   BracesRemoverTest.cpp

--- a/clang/unittests/Format/CMakeLists.txt
+++ b/clang/unittests/Format/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_clang_unittest(FormatTests
+add_distinct_clang_unittest(FormatTests
   BracesInserterTest.cpp
   BracesRemoverTest.cpp
   CleanupTest.cpp

--- a/clang/unittests/libclang/CrashTests/CMakeLists.txt
+++ b/clang/unittests/libclang/CrashTests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_clang_unittest(libclangCrashTests
+add_distinct_clang_unittest(libclangCrashTests
   LibclangCrashTest.cpp
   LINK_LIBS
   libclang

--- a/clang/unittests/libclang/CrashTests/CMakeLists.txt
+++ b/clang/unittests/libclang/CrashTests/CMakeLists.txt
@@ -1,3 +1,5 @@
+# FIXME(#137855): Ideally we'd fold this into AllClangUnitTests, but it fails
+# for unknown reasons. Until that is fixed, link it as a distinct gtest binary.
 add_distinct_clang_unittest(libclangCrashTests
   LibclangCrashTest.cpp
   LINK_LIBS

--- a/clang/unittests/libclang/CrashTests/LibclangCrashTest.cpp
+++ b/clang/unittests/libclang/CrashTests/LibclangCrashTest.cpp
@@ -23,8 +23,7 @@ TEST_F(LibclangParseTest, InstallAbortingLLVMFatalErrorHandler) {
                "");
 }
 
-// FIXME: Re-enable after Mac-AArch64 signpost crash issues are debugged.
-TEST_F(LibclangParseTest, DISABLED_UninstallAbortingLLVMFatalErrorHandler) {
+TEST_F(LibclangParseTest, UninstallAbortingLLVMFatalErrorHandler) {
   clang_toggleCrashRecovery(0);
   clang_install_aborting_llvm_fatal_error_handler();
   clang_uninstall_llvm_fatal_error_handler();


### PR DESCRIPTION
@nico mentioned that FormatTests and BasicTests are small binaries with
few dependencies, so keeping them separate is nice. I broke them out as
distinct test binaries, and they are still pretty small:

$ find tools/clang/unittests/ -type f -name '*Tests' | xargs du -cksh | sort -nr
708M    total
276M    tools/clang/unittests/AllClangUnitTests
244M    tools/clang/unittests/Interpreter/ClangReplInterpreterTests
167M    tools/clang/unittests/Interpreter/ExceptionTests/ClangReplInterpreterExceptionTests
 13M    tools/clang/unittests/Format/FormatTests
6.9M    tools/clang/unittests/Basic/BasicTests
1.1M    tools/clang/unittests/libclang/CrashTests/libclangCrashTests

I also broke out libclangCrashTests and re-enabled the failing test to
resolve llvm#137855.
