### PR TITLE
[Github][CI] Rename New Premerge Jobs

### DIFF
--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -21,7 +21,7 @@ SCRAPE_INTERVAL_SECONDS = 5 * 60
 # Lists the Github workflows we want to track. Maps the Github job name to
 # the metric name prefix in grafana.
 # This metric name is also used as a key in the job->name map.
-GITHUB_WORKFLOW_TO_TRACK = {"LLVM Premerge Checks": "github_llvm_premerge_checks"}
+GITHUB_WORKFLOW_TO_TRACK = {"LLVM CI Checks": "github_llvm_premerge_checks"}
 
 # Lists the Github jobs to track for a given workflow. The key is the stable
 # name (metric name) of the workflow (see GITHUB_WORKFLOW_TO_TRACK).

--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -21,7 +21,7 @@ SCRAPE_INTERVAL_SECONDS = 5 * 60
 # Lists the Github workflows we want to track. Maps the Github job name to
 # the metric name prefix in grafana.
 # This metric name is also used as a key in the job->name map.
-GITHUB_WORKFLOW_TO_TRACK = {"LLVM CI Checks": "github_llvm_premerge_checks"}
+GITHUB_WORKFLOW_TO_TRACK = {"CI Checks": "github_llvm_premerge_checks"}
 
 # Lists the Github jobs to track for a given workflow. The key is the stable
 # name (metric name) of the workflow (see GITHUB_WORKFLOW_TO_TRACK).

--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -29,8 +29,8 @@ GITHUB_WORKFLOW_TO_TRACK = {"LLVM Premerge Checks": "github_llvm_premerge_checks
 # name.
 GITHUB_JOB_TO_TRACK = {
     "github_llvm_premerge_checks": {
-        "Linux Premerge Checks (Test Only - Please Ignore Results)": "premerge_linux",
-        "Windows Premerge Checks (Test Only - Please Ignore Results)": "premerge_windows",
+        "Build and Test Linux (Test Only - Please Ignore Results)": "premerge_linux",
+        "Build and Test Windows (Test Only - Please Ignore Results)": "premerge_windows",
     }
 }
 

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -1,4 +1,4 @@
-name: LLVM Premerge Checks
+name: LLVM CI Checks
 
 permissions:
   contents: read
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   premerge-checks-linux:
-    name: Linux Premerge Checks (Test Only - Please Ignore Results)
+    name: Build and Test Linux (Test Only - Please Ignore Results)
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
@@ -74,7 +74,7 @@ jobs:
           include-hidden-files: 'true'
 
   premerge-checks-windows:
-    name: Windows Premerge Checks (Test Only - Please Ignore Results)
+    name: Build and Test Windows (Test Only - Please Ignore Results)
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -1,4 +1,4 @@
-name: LLVM CI Checks
+name: CI Checks
 
 permissions:
   contents: read


### PR DESCRIPTION
This patch renames the new premerge job as suggested in https://discourse.llvm.org/t/github-ci-notifications-and-main-branch/85868/10. This uses more industry standard terms (like CI vs premerge checks which might be somewhat of a LLVM CI idiom?) and makes it more generic if we end up doing postcommit testing through Github.