### PR TITLE
[Clang][NFC] assert IFaceT in SemaObjC::HandleExprPropertyRefExpr

### DIFF
--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -1980,6 +1980,7 @@ ExprResult SemaObjC::HandleExprPropertyRefExpr(
     SourceLocation SuperLoc, QualType SuperType, bool Super) {
   ASTContext &Context = getASTContext();
   const ObjCInterfaceType *IFaceT = OPT->getInterfaceType();
+  assert(IFaceT && "Expected an Interface");
   ObjCInterfaceDecl *IFace = IFaceT->getDecl();
 
   if (!MemberName.isIdentifier()) {


### PR DESCRIPTION
Static analysis flagged that we use IFaceT in HandleExprPropertyRefExpr without checking even though getInterfaceType() can return nullptr. The comments make it clear the assumption is that we will always have an interface, so we will document this via an assert.

Fixes: https://github.com/llvm/llvm-project/issues/134954