### PR TITLE
[clang] Make `-ftime-report` and `-ftime-report-json` honor `-info-output-file`

### DIFF
--- a/clang/test/Misc/time-passes.c
+++ b/clang/test/Misc/time-passes.c
@@ -3,6 +3,10 @@
 // RUN:     -ftime-report %s -o /dev/null 2>&1 | \
 // RUN:     FileCheck %s --check-prefixes=TIME,NPM
 // RUN: %clang_cc1 -emit-obj -O1 \
+// RUN:     -ftime-report %s -o /dev/null \
+// RUN:     -mllvm -info-output-file=%t
+// RUN: cat %t | FileCheck %s --check-prefixes=TIME,NPM
+// RUN: %clang_cc1 -emit-obj -O1 \
 // RUN:     -ftime-report=per-pass %s -o /dev/null 2>&1 | \
 // RUN:     FileCheck %s --check-prefixes=TIME,NPM
 // RUN: %clang_cc1 -emit-obj -O1 \
@@ -11,6 +15,10 @@
 // RUN: %clang_cc1 -emit-obj -O1 \
 // RUN:     -ftime-report-json %s -o /dev/null 2>&1 | \
 // RUN:     FileCheck %s --check-prefixes=JSON
+// RUN: %clang_cc1 -emit-obj -O1 \
+// RUN:     -ftime-report-json %s -o /dev/null \
+// RUN:     -mllvm -info-output-file=%t
+// RUN: cat %t | FileCheck %s --check-prefixes=JSON
 
 // TIME: Pass execution timing report
 // TIME: Total Execution Time:

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -296,12 +296,13 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
 
   // If any timers were active but haven't been destroyed yet, print their
   // results now.  This happens in -disable-free mode.
+  std::unique_ptr<raw_ostream> IOFile = llvm::CreateInfoOutputFile();
   if (Clang->getCodeGenOpts().TimePassesJson) {
-    llvm::errs() << "{\n";
-    llvm::TimerGroup::printAllJSONValues(llvm::errs(), "");
-    llvm::errs() << "\n}\n";
+    *IOFile << "{\n";
+    llvm::TimerGroup::printAllJSONValues(*IOFile, "");
+    *IOFile << "\n}\n";
   } else {
-    llvm::TimerGroup::printAll(llvm::errs());
+    llvm::TimerGroup::printAll(*IOFile);
   }
   llvm::TimerGroup::clearAll();
 


### PR DESCRIPTION
This way, the output of `-ftime-report` and `-ftime-report-json` can be redirected to a specific file rather than just stderr.