### PR TITLE
[llvm-exegesis][AArch64] Adding missing PR_PAC_ macro defintions

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp
@@ -21,6 +21,15 @@
 #ifndef PR_PAC_APIAKEY
 #define PR_PAC_APIAKEY (1UL << 0)
 #endif
+#ifndef PR_PAC_APIBKEY
+#define PR_PAC_APIBKEY (1UL << 1)
+#endif
+#ifndef PR_PAC_APDAKEY
+#define PR_PAC_APDAKEY (1UL << 2)
+#endif
+#ifndef PR_PAC_APDBKEY
+#define PR_PAC_APDBKEY (1UL << 3)
+#endif
 #endif
 
 #define GET_AVAILABLE_OPCODE_CHECKER


### PR DESCRIPTION
This is a follow up of 3beacfa022da2a9c94e012e25bed89e8e4867ac2, which adds PR_PAC_APIAKEY macro to resolve the build failures on older Linux distros. However, it missed a few other definitions. This patch fixed this issue.

The defined values matches the linux header: https://github.com/torvalds/linux/blob/8bac8898fe398ffa3e09075ecea2be511725fb0b/include/uapi/linux/prctl.h#L227