### PR TITLE
[lld] Use --no-warnings flag to suppress --noinhibit-exec warnings

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -86,7 +86,9 @@ ELFSyncStream elf::Log(Ctx &ctx) { return {ctx, DiagLevel::Log}; }
 ELFSyncStream elf::Msg(Ctx &ctx) { return {ctx, DiagLevel::Msg}; }
 ELFSyncStream elf::Warn(Ctx &ctx) { return {ctx, DiagLevel::Warn}; }
 ELFSyncStream elf::Err(Ctx &ctx) {
-  return {ctx, ctx.arg.noinhibitExec ? DiagLevel::Warn : DiagLevel::Err};
+  if (ctx.arg.noinhibitExec)
+    return {ctx, ctx.e.suppressWarnings ? DiagLevel::None : DiagLevel::Warn};
+  return {ctx, DiagLevel::Err};
 }
 ELFSyncStream elf::ErrAlways(Ctx &ctx) { return {ctx, DiagLevel::Err}; }
 ELFSyncStream elf::Fatal(Ctx &ctx) { return {ctx, DiagLevel::Fatal}; }

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -87,8 +87,10 @@ static void printLocation(ELFSyncStream &s, InputSectionBase &sec,
 
 void elf::reportRangeError(Ctx &ctx, uint8_t *loc, const Relocation &rel,
                            const Twine &v, int64_t min, uint64_t max) {
-  ErrorPlace errPlace = getErrorPlace(ctx, loc);
   auto diag = Err(ctx);
+  if (diag.getDiagLevel() == DiagLevel::None)
+    return;
+  ErrorPlace errPlace = getErrorPlace(ctx, loc);
   diag << errPlace.loc << "relocation " << rel.type
        << " out of range: " << v.str() << " is not in [" << min << ", " << max
        << ']';
@@ -119,6 +121,8 @@ void elf::reportRangeError(Ctx &ctx, uint8_t *loc, const Relocation &rel,
 void elf::reportRangeError(Ctx &ctx, uint8_t *loc, int64_t v, int n,
                            const Symbol &sym, const Twine &msg) {
   auto diag = Err(ctx);
+  if (diag.getDiagLevel() == DiagLevel::None)
+    return;
   diag << getErrorPlace(ctx, loc).loc << msg << " is out of range: " << v
        << " is not in [" << llvm::minIntN(n) << ", " << llvm::maxIntN(n) << "]";
   if (!sym.getName().empty()) {

--- a/lld/include/lld/Common/ErrorHandler.h
+++ b/lld/include/lld/Common/ErrorHandler.h
@@ -168,6 +168,7 @@ public:
   ~SyncStream();
   StringRef str() { return os.str(); }
   uint64_t tell() { return os.tell(); }
+  DiagLevel getDiagLevel() { return level; }
 };
 
 [[noreturn]] void exitLld(int val);


### PR DESCRIPTION
--noinhibit-exec is useful for debugging relocation errors for large binaries which usually emit tons and tons of linker warnings making the linking process prohibitively slow as it tries to construct useful messages by getting symbol and section names where error occurs. This is the main cause of linker slowdown that shows up in profiling such links using more than 90% of total link time.

These linker messages are not always needed. Use --no-warnings to speed up this linking process.