### PR TITLE
[clang-doc] Add HTMLMustacheGenerator methods

### DIFF
--- a/clang-tools-extra/unittests/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/unittests/clang-doc/CMakeLists.txt
@@ -34,6 +34,7 @@ clang_target_link_libraries(ClangDocTests
   clangTooling
   clangToolingCore
   )
+
 target_link_libraries(ClangDocTests
   PRIVATE
   clangDoc

--- a/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp
@@ -10,7 +10,9 @@
 #include "Generators.h"
 #include "Representation.h"
 #include "clang/Basic/Version.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Testing/Support/Error.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -40,13 +42,43 @@ getClangDocContext(std::vector<std::string> UserStylesheets = {},
   return CDCtx;
 }
 
+static void verifyFileContents(const Twine &Path, StringRef Contents) {
+  auto Buffer = MemoryBuffer::getFile(Path);
+  ASSERT_TRUE((bool)Buffer);
+  StringRef Data = Buffer.get()->getBuffer();
+  ASSERT_EQ(Data, Contents);
+}
+
 TEST(HTMLMustacheGeneratorTest, createResources) {
   auto G = getHTMLMustacheGenerator();
   ASSERT_THAT(G, NotNull()) << "Could not find HTMLMustacheGenerator";
   ClangDocContext CDCtx = getClangDocContext();
+  EXPECT_THAT_ERROR(G->createResources(CDCtx), Failed())
+      << "Empty UserStylesheets or JsScripts should fail!";
+
+  unittest::TempDir RootTestDirectory("createResourcesTest", /*Unique=*/true);
+  CDCtx.OutDirectory = RootTestDirectory.path();
+
+  unittest::TempFile CSS("clang-doc-mustache", "css", "CSS");
+  unittest::TempFile JS("mustache", "js", "JavaScript");
+
+  CDCtx.UserStylesheets[0] = CSS.path();
+  CDCtx.JsScripts[0] = JS.path();
 
   EXPECT_THAT_ERROR(G->createResources(CDCtx), Succeeded())
-      << "Failed to create resources.";
+      << "Failed to create resources with valid UserStylesheets and JsScripts";
+  {
+    SmallString<256> PathBuf;
+    llvm::sys::path::append(PathBuf, RootTestDirectory.path(),
+                            "clang-doc-mustache.css");
+    verifyFileContents(PathBuf, "CSS");
+  }
+
+  {
+    SmallString<256> PathBuf;
+    llvm::sys::path::append(PathBuf, RootTestDirectory.path(), "mustache.js");
+    verifyFileContents(PathBuf, "JavaScript");
+  }
 }
 
 TEST(HTMLMustacheGeneratorTest, generateDocs) {
@@ -79,8 +111,7 @@ TEST(HTMLMustacheGeneratorTest, generateDocsForInfo) {
   I.Children.Functions.back().Name = "OneFunction";
   I.Children.Enums.emplace_back();
 
-  EXPECT_THAT_ERROR(G->generateDocForInfo(&I, Actual, CDCtx), Succeeded())
-      << "Failed to generate docs.";
+  EXPECT_THAT_ERROR(G->generateDocForInfo(&I, Actual, CDCtx), Failed());
 
   std::string Expected = R"raw()raw";
   EXPECT_THAT(Actual.str(), Eq(Expected));


### PR DESCRIPTION
Split from #133161. This patch fills in the implementation for a number
of the MustacheHTMLGenerator methods. Many of these APIs are just
stubbed out, and will have their implementation filled in by later
patches.

Co-authored-by: Peter Chou <peter.chou@mail.utoronto.ca>