### PR TITLE
[clang-doc] Track if a type is a template or builtin

### DIFF
--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -164,6 +164,9 @@ struct TypeInfo {
   bool operator==(const TypeInfo &Other) const { return Type == Other.Type; }
 
   Reference Type; // Referenced type in this info.
+
+  bool IsTemplate = false;
+  bool IsBuiltIn = false;
 };
 
 // Represents one template parameter.

--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -420,9 +420,12 @@ static RecordDecl *getRecordDeclForType(const QualType &T) {
 static TypeInfo getTypeInfoForType(const QualType &T,
                                    const PrintingPolicy &Policy) {
   const TagDecl *TD = getTagDeclForType(T);
-  if (!TD)
-    return TypeInfo(Reference(SymbolID(), T.getAsString(Policy)));
-
+  if (!TD) {
+    TypeInfo TI = TypeInfo(Reference(SymbolID(), T.getAsString(Policy)));
+    TI.IsBuiltIn = T->isBuiltinType();
+    TI.IsTemplate = T->isTemplateTypeParmType();
+    return TI;
+  }
   InfoType IT;
   if (isa<EnumDecl>(TD)) {
     IT = InfoType::IT_enum;
@@ -431,8 +434,12 @@ static TypeInfo getTypeInfoForType(const QualType &T,
   } else {
     IT = InfoType::IT_default;
   }
-  return TypeInfo(Reference(getUSRForDecl(TD), TD->getNameAsString(), IT,
-                            T.getAsString(Policy), getInfoRelativePath(TD)));
+  Reference R = Reference(getUSRForDecl(TD), TD->getNameAsString(), IT,
+                          T.getAsString(Policy), getInfoRelativePath(TD));
+  TypeInfo TI = TypeInfo(R);
+  TI.IsBuiltIn = T->isBuiltinType();
+  TI.IsTemplate = T->isTemplateTypeParmType();
+  return TI;
 }
 
 static bool isPublic(const clang::AccessSpecifier AS,


### PR DESCRIPTION
Originally part of #133161. This patch adds preliminary tracking
for of TypeInfo, by tracking if the type is a builtin or template.

The new functionality is not yet exercised.

Co-authored-by: Peter Chou <peter.chou@mail.utoronto.ca>