### PR TITLE
[Clang][NFC] Use const auto & to avoid copy

### DIFF
--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1959,7 +1959,7 @@ void ModuleMapLoader::handleExportDecl(const modulemap::ExportDecl &ED) {
 }
 
 void ModuleMapLoader::handleExportAsDecl(const modulemap::ExportAsDecl &EAD) {
-  auto ModName = EAD.Id.front();
+  const auto &ModName = EAD.Id.front();
 
   if (!ActiveModule->ExportAsModule.empty()) {
     if (ActiveModule->ExportAsModule == ModName.first) {


### PR DESCRIPTION
Static analysis flagged this code as causing a copy when we never modify ModName and therefore we can use const auto & and avoid copying.