### PR TITLE
[Clang][NFC] Use std::move to avoid copy

### DIFF
--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -2010,7 +2010,8 @@ void ModuleMapLoader::handleConflict(const modulemap::ConflictDecl &CD) {
   Conflict.Id = CD.Id;
   Conflict.Message = CD.Message;
 
-  ActiveModule->UnresolvedConflicts.push_back(Conflict);
+  // FIXME: when we move to C++20 we should consider using emplace_back
+  ActiveModule->UnresolvedConflicts.push_back(std::move(Conflict));
 }
 
 void ModuleMapLoader::handleInferredModuleDecl(


### PR DESCRIPTION
Static analysis flagged this code for using copy when we could use std::move.

Worth noting that CD.Message is a StringRef but Conflict.Message is std::string. Otherwise I would have used a temporary in place and avoid a local variable.