### PR TITLE
[cmake] Pass LLVM_TABLEGEN_FLAGS to cross compile targets

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -100,7 +100,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
         -DLLVM_INCLUDE_BENCHMARKS=OFF
         -DLLVM_INCLUDE_TESTS=OFF
-        -DLLVM_TABLEGEN_FLAGS="{LLVM_TABLEGEN_FLAGS}"
+        -DLLVM_TABLEGEN_FLAGS="${LLVM_TABLEGEN_FLAGS}"
         ${build_type_flags} ${linker_flag} ${external_clang_dir} ${libc_flags}
         ${ARGN}
     WORKING_DIRECTORY ${${project_name}_${target_name}_BUILD}

--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -100,6 +100,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
         -DLLVM_INCLUDE_BENCHMARKS=OFF
         -DLLVM_INCLUDE_TESTS=OFF
+        -DLLVM_TABLEGEN_FLAGS="{LLVM_TABLEGEN_FLAGS}"
         ${build_type_flags} ${linker_flag} ${external_clang_dir} ${libc_flags}
         ${ARGN}
     WORKING_DIRECTORY ${${project_name}_${target_name}_BUILD}


### PR DESCRIPTION
If ValueTypes.td contains conditional directives enabled by defs in LLVM_TABLEGEN_FLAGS then native build tblgen and min-tblgen must be built with matching flags.
This ensures the embedded types in TableGen are consistent with those used for building tables.