### PR TITLE
[MISched] Add statistics to quantify scheduling

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -1196,6 +1196,9 @@ protected:
   const MachineSchedContext *Context;
   const TargetSchedModel *SchedModel = nullptr;
   const TargetRegisterInfo *TRI = nullptr;
+  unsigned TopIdx = 0;
+  unsigned BotIdx = 0;
+  unsigned NumRegionInstrs = 0;
 
   MachineSchedPolicy RegionPolicy;
 

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -3514,7 +3514,7 @@ void GenericScheduler::initPolicy(MachineBasicBlock::iterator Begin,
     RegionPolicy.OnlyTopDown = false;
   }
 
-  this->BotIdx = NumRegionInstrs - 1;
+  BotIdx = NumRegionInstrs - 1;
   this->NumRegionInstrs = NumRegionInstrs;
 }
 
@@ -3997,6 +3997,7 @@ SUnit *GenericScheduler::pickNode(bool &IsTopNode) {
     if (SU->NodeNum == TopIdx++)
       ++NumInstrsInSourceOrderPreRA;
   } else {
+    assert(BotIdx < NumRegionInstrs && "out of bounds");
     if (SU->NodeNum == BotIdx--)
       ++NumInstrsInSourceOrderPreRA;
   }
@@ -4350,6 +4351,7 @@ SUnit *PostGenericScheduler::pickNode(bool &IsTopNode) {
     if (SU->NodeNum == TopIdx++)
       ++NumInstrsInSourceOrderPostRA;
   } else {
+    assert(BotIdx < NumRegionInstrs && "out of bounds");
     if (SU->NodeNum == BotIdx--)
       ++NumInstrsInSourceOrderPostRA;
   }

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -4127,6 +4127,9 @@ void PostGenericScheduler::initPolicy(MachineBasicBlock::iterator Begin,
     RegionPolicy.OnlyBottomUp = false;
     RegionPolicy.OnlyTopDown = false;
   }
+
+  BotIdx = NumRegionInstrs - 1;
+  this->NumRegionInstrs = NumRegionInstrs;
 }
 
 void PostGenericScheduler::registerRoots() {


### PR DESCRIPTION
When diagnosing scheduler issues it can be useful to know how scheduling changes the order of instructions, particularly for large functions when it's not trivial to figure out from the debug output by looking at the scheduling unit (SU) IDs.

This adds pre-RA and post-RA statistics to track 1) the number of instructions that remain in source order after scheduling and 2) the total number of instructions scheduled, to compare 1) against.