### PR TITLE
[CIR][NFC] Fix an unused variable warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -519,7 +519,7 @@ LValue CIRGenFunction::emitLValue(const Expr *e) {
     return emitBinaryOperatorLValue(cast<BinaryOperator>(e));
   case Expr::CompoundAssignOperatorClass: {
     QualType ty = e->getType();
-    if (const AtomicType *at = ty->getAs<AtomicType>()) {
+    if (ty->getAs<AtomicType>()) {
       cgm.errorNYI(e->getSourceRange(),
                    "CompoundAssignOperator with AtomicType");
       return LValue();


### PR DESCRIPTION
This fixes a warning where a variable assigned in 'if' statement wasn't referenced again.