### PR TITLE
[lldb] Disable statusline on Windows

### DIFF
--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -177,7 +177,7 @@ let Definition = "debugger" in {
   def ShowStatusline: Property<"show-statusline", "Boolean">,
     Global,
     DefaultTrue,
-    Desc<"Whether to show a statusline at the bottom of the terminal.">;
+    Desc<"Whether to show a statusline at the bottom of the terminal (not supported on Windows).">;
   def Separator : Property<"separator", "String">,
                   Global,
                   DefaultStringValue<"│ ">,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2031,6 +2031,9 @@ void Debugger::CancelForwardEvents(const ListenerSP &listener_sp) {
 }
 
 bool Debugger::StatuslineSupported() {
+// We have trouble with the contol codes on Windows, see
+// https://github.com/llvm/llvm-project/issues/134846.
+#ifndef _WIN32
   if (GetShowStatusline()) {
     if (lldb::LockableStreamFileSP stream_sp = GetOutputStreamSP()) {
       File &file = stream_sp->GetUnlockedFile();
@@ -2038,6 +2041,7 @@ bool Debugger::StatuslineSupported() {
              file.GetIsTerminalWithColors();
     }
   }
+#endif
   return false;
 }
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -249,7 +249,8 @@ Changes to LLDB
 * A statusline was added to command-line LLDB to show progress events and
   information about the current state of the debugger at the bottom of the
   terminal. This is on by default and can be configured using the
-  `show-statusline` and `statusline-format` settings.
+  `show-statusline` and `statusline-format` settings. It is not currently
+  supported on Windows.
 * The `min-gdbserver-port` and `max-gdbserver-port` options have been removed
   from `lldb-server`'s platform mode. Since the changes to `lldb-server`'s port
   handling in LLDB 20, these options have had no effect.


### PR DESCRIPTION
Something to do with control code handling in Windows terminals breaks the statusline in various ways. It makes LLDB unusable and even if you set the setting to disable statusline, it's too late, and the terminal session is now in a weird state.

See https://github.com/llvm/llvm-project/issues/134846 for more details.

Until we figure this out, don't allow it to be used on Windows.