### PR TITLE
[CIR] Refactor floating point type constraints

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
@@ -110,4 +110,35 @@ def CIR_AnyFundamentalSIntType
     let cppFunctionName = "isFundamentalSIntType";
 }
 
+//===----------------------------------------------------------------------===//
+// Float Type predicates
+//===----------------------------------------------------------------------===//
+
+def CIR_AnySingleType : CIR_TypeBase<"::cir::SingleType", "single float type">;
+def CIR_AnyFP32Type : TypeAlias<CIR_AnySingleType>;
+
+def CIR_AnyDoubleType : CIR_TypeBase<"::cir::DoubleType", "double float type">;
+def CIR_AnyFP64Type : TypeAlias<CIR_AnyDoubleType>;
+
+def CIR_AnyFP16Type : CIR_TypeBase<"::cir::FP16Type", "f16 type">;
+def CIR_AnyBFloat16Type : CIR_TypeBase<"::cir::BF16Type", "bf16 type">;
+def CIR_AnyFP80Type : CIR_TypeBase<"::cir::FP80Type", "f80 type">;
+def CIR_AnyFP128Type : CIR_TypeBase<"::cir::FP128Type", "f128 type">;
+def CIR_AnyLongDoubleType : CIR_TypeBase<"::cir::LongDoubleType",
+    "long double type">;
+
+def CIR_AnyFloatType : AnyTypeOf<[
+    CIR_AnySingleType, CIR_AnyDoubleType, CIR_AnyFP16Type,
+    CIR_AnyBFloat16Type, CIR_AnyFP80Type, CIR_AnyFP128Type,
+    CIR_AnyLongDoubleType
+]> {
+    let cppFunctionName = "isAnyFloatingPointType";
+}
+
+def CIR_AnyIntOrFloatType : AnyTypeOf<[CIR_AnyFloatType, CIR_AnyIntType],
+    "integer or floating point type"
+> {
+    let cppFunctionName = "isAnyIntegerOrFloatingPointType";
+}
+
 #endif // CLANG_CIR_DIALECT_IR_CIRTYPECONSTRAINTS_TD

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -26,7 +26,6 @@ struct RecordTypeStorage;
 
 bool isValidFundamentalIntWidth(unsigned width);
 
-bool isAnyFloatingPointType(mlir::Type t);
 bool isFPOrFPVectorTy(mlir::Type);
 
 } // namespace cir

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -80,12 +80,10 @@ def CIR_IntType : CIR_Type<"Int", "int",
 // FloatType
 //===----------------------------------------------------------------------===//
 
-class CIR_FloatType<string name, string mnemonic>
-    : CIR_Type<name, mnemonic,
-          [
-            DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-            DeclareTypeInterfaceMethods<CIRFPTypeInterface>,
-          ]> {}
+class CIR_FloatType<string name, string mnemonic> : CIR_Type<name, mnemonic, [
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+  DeclareTypeInterfaceMethods<CIRFPTypeInterface>
+]>;
 
 def CIR_Single : CIR_FloatType<"Single", "float"> {
   let summary = "CIR single-precision 32-bit float type";
@@ -155,20 +153,13 @@ def CIR_LongDouble : CIR_FloatType<"LongDouble", "long_double"> {
     format are all in use.
   }];
 
-  let parameters = (ins "mlir::Type":$underlying);
+  let parameters = (ins AnyTypeOf<[CIR_Double, CIR_FP80, CIR_FP128],
+    "expects !cir.double, !cir.fp80 or !cir.fp128">:$underlying);
 
   let assemblyFormat = [{
     `<` $underlying `>`
   }];
-
-  let genVerifyDecl = 1;
 }
-
-// Constraints
-
-def CIR_AnyFloat: AnyTypeOf<[CIR_Single, CIR_Double, CIR_FP80, CIR_FP128,
-                             CIR_LongDouble, CIR_FP16, CIR_BFloat16]>;
-def CIR_AnyIntOrFloat: AnyTypeOf<[CIR_AnyFloat, CIR_IntType]>;
 
 //===----------------------------------------------------------------------===//
 // PointerType
@@ -518,7 +509,7 @@ def CIRRecordType : Type<
 
 def CIR_AnyType : AnyTypeOf<[
   CIR_VoidType, CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_IntType,
-  CIR_AnyFloat, CIR_PointerType, CIR_FuncType, CIR_RecordType
+  CIR_AnyFloatType, CIR_PointerType, CIR_FuncType, CIR_RecordType
 ]>;
 
 #endif // MLIR_CIR_DIALECT_CIR_TYPES

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -550,26 +550,6 @@ LongDoubleType::getABIAlignment(const mlir::DataLayout &dataLayout,
       .getABIAlignment(dataLayout, params);
 }
 
-LogicalResult
-LongDoubleType::verify(function_ref<InFlightDiagnostic()> emitError,
-                       mlir::Type underlying) {
-  if (!mlir::isa<DoubleType, FP80Type, FP128Type>(underlying)) {
-    emitError() << "invalid underlying type for long double";
-    return failure();
-  }
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// Floating-point type helpers
-//===----------------------------------------------------------------------===//
-
-bool cir::isAnyFloatingPointType(mlir::Type t) {
-  return isa<cir::SingleType, cir::DoubleType, cir::LongDoubleType,
-             cir::FP80Type, cir::BF16Type, cir::FP16Type, cir::FP128Type>(t);
-}
-
 //===----------------------------------------------------------------------===//
 // Floating-point and Float-point Vector type helpers
 //===----------------------------------------------------------------------===//

--- a/clang/test/CIR/IR/invalid-long-double.cir
+++ b/clang/test/CIR/IR/invalid-long-double.cir
@@ -1,0 +1,6 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+// expected-error@+1 {{failed to verify 'underlying': expects !cir.double, !cir.fp80 or !cir.fp128}}
+cir.func @bad_long_double(%arg0 : !cir.long_double<!cir.float>) -> () {
+  cir.return
+}


### PR DESCRIPTION
- This cleans up moves cir floating point type constraints to dedicated constraints file, and fixes long double verifier to use constraints directly.
- Renames `CIR_AnyFloat` to `CIR_AnyFloatType`.

This mirrors inbubator changes from https://github.com/llvm/clangir/pull/1594