### PR TITLE
[LLVM][Cygwin] Fix Signals compatibility with Cygwin API

### DIFF
--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -847,7 +847,7 @@ void llvm::sys::PrintStackTrace(raw_ostream &OS, int Depth) {
 
     const char *name = strrchr(dlinfo.dli_fname, '/');
     if (!name)
-      OS << format(" %-*s", width, dlinfo.dli_fname);
+      OS << format(" %-*s", width, static_cast<const char *>(dlinfo.dli_fname));
     else
       OS << format(" %-*s", width, name + 1);
 


### PR DESCRIPTION
Cygwin types sometimes do not match Linux exactly. Like in this case:
```
In file included from /h/projects/llvm-project/llvm/include/llvm/Support/Error.h:23,
                 from /h/projects/llvm-project/llvm/include/llvm/Support/FileSystem.h:34,
                 from /h/projects/llvm-project/llvm/lib/Support/Signals.cpp:22:
/h/projects/llvm-project/llvm/include/llvm/Support/Format.h: In instantiation of ‘llvm::format_object<Ts>::format_object(const char*, const Ts& ...) [with Ts = {int, char [4096]}]’:
/h/projects/llvm-project/llvm/include/llvm/Support/Format.h:126:10:   required from ‘llvm::format_object<Ts ...> llvm::format(const char*, const Ts& ...) [with Ts = {int, char [4096]}]’
/h/projects/llvm-project/llvm/lib/Support/Unix/Signals.inc:850:19:   required from here
/h/projects/llvm-project/llvm/include/llvm/Support/Format.h:106:34: error: no matching function for call to ‘std::tuple<int, char [4096]>::tuple(const int&, const char [4096])’
  106 |       : format_object_base(fmt), Vals(vals...) {
      |                                  ^~~~~~~~~~~~~
```
Casting here is safe and solves the issue.

Split out from https://github.com/llvm/llvm-project/pull/134494