### PR TITLE
[Clang][Cygwin] Fix symbol visibility definition

### DIFF
--- a/clang/include/clang/Support/Compiler.h
+++ b/clang/include/clang/Support/Compiler.h
@@ -50,7 +50,7 @@
 #define CLANG_EXPORT_TEMPLATE
 #endif
 #elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||             \
-    defined(__MVS__)
+    defined(__MVS__) || defined(__CYGWIN__)
 #define CLANG_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define CLANG_TEMPLATE_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define CLANG_EXPORT_TEMPLATE


### PR DESCRIPTION
Currently building for Cygwin hits this error:
```
In file included from /h/projects/llvm-project/clang/lib/Basic/Attributes.cpp:17:
/h/projects/llvm-project/clang/include/clang/Basic/ParsedAttrInfo.h:180:73: error: invalid declarator before ‘;’ token
  180 | extern template class CLANG_TEMPLATE_ABI Registry<clang::ParsedAttrInfo>;
```
That's because `CLANG_TEMPLATE_ABI` ends up not being defined. The solution here is to follow MinGW case.

Split out from https://github.com/llvm/llvm-project/pull/134494