### PR TITLE
[Clang][Cygwin] Remove erroneous _WIN32 define and clean up Cygwin code

### DIFF
--- a/clang/tools/libclang/CIndexer.cpp
+++ b/clang/tools/libclang/CIndexer.cpp
@@ -26,12 +26,6 @@
 #include <cstdio>
 #include <mutex>
 
-#ifdef __CYGWIN__
-#include <cygwin/version.h>
-#include <sys/cygwin.h>
-#define _WIN32 1
-#endif
-
 #ifdef _WIN32
 #include <windows.h>
 #elif defined(_AIX)
@@ -111,16 +105,6 @@ const std::string &CIndexer::getClangResourcesPath() {
   VirtualQuery((void *)(uintptr_t)clang_createTranslationUnit, &mbi,
                sizeof(mbi));
   GetModuleFileNameA((HINSTANCE)mbi.AllocationBase, path, MAX_PATH);
-
-#ifdef __CYGWIN__
-  char w32path[MAX_PATH];
-  strcpy(w32path, path);
-#if CYGWIN_VERSION_API_MAJOR > 0 || CYGWIN_VERSION_API_MINOR >= 181
-  cygwin_conv_path(CCP_WIN_A_TO_POSIX, w32path, path, MAX_PATH);
-#else
-  cygwin_conv_to_full_posix_path(w32path, path);
-#endif
-#endif
 
   LibClangPath += path;
 #elif defined(_AIX)


### PR DESCRIPTION
With this define present and building with Clang the build fails:
```
In file included from /h/projects/llvm-project/clang/tools/libclang/CIndexer.cpp:36:
In file included from /usr/include/w32api/windows.h:69:
In file included from /usr/include/w32api/windef.h:9:
In file included from /usr/include/w32api/minwindef.h:163:
In file included from /usr/include/w32api/winnt.h:1658:
In file included from /usr/lib/clang/20/include/x86intrin.h:15:
In file included from /usr/lib/clang/20/include/immintrin.h:24:
In file included from /usr/lib/clang/20/include/xmmintrin.h:31:
/usr/lib/clang/20/include/mm_malloc.h:45:22: error: use of undeclared identifier '_aligned_malloc'; did you mean 'aligned_alloc'?
   45 |   __mallocedMemory = _aligned_malloc(__size, __align);
      |                      ^
```
Removing it allows the build with Clang to succeed and doesn't break build with GCC.

The "#define _WIN32" was originally "#define LLVM_ON_WIN32", but this was changed into a plain "#define _WIN32" (which not necessarily is something that is supported to do) in 1865df49960e34cc90d0083b0e0cd4771c0feb35 as part of a larger refactoring.

This cygwin specific code isn't needed for converting paths anymore, as dladdr takes care of it. (dladdr was added to cygwin in 2017, according to the tags in version 2.8.0.)