### PR TITLE
[MC][TableGen] Expand ImplicitOffset field of MCInstrDesc

### DIFF
--- a/llvm/include/llvm/MC/MCInstrDesc.h
+++ b/llvm/include/llvm/MC/MCInstrDesc.h
@@ -209,8 +209,8 @@ public:
   unsigned short SchedClass;     // enum identifying instr sched class
   unsigned char NumImplicitUses; // Num of regs implicitly used
   unsigned char NumImplicitDefs; // Num of regs implicitly defined
-  unsigned short ImplicitOffset; // Offset to start of implicit op list
   unsigned short OpInfoOffset;   // Offset to info about operands
+  unsigned int ImplicitOffset;   // Offset to start of implicit op list
   uint64_t Flags;                // Flags identifying machine instr class
   uint64_t TSFlags;              // Target Specific Flag values
 

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -1106,12 +1106,14 @@ void InstrInfoEmitter::emitRecord(
   OS << Inst.ImplicitUses.size() << ",\t" << Inst.ImplicitDefs.size() << ",\t";
   std::vector<const Record *> ImplicitOps = Inst.ImplicitUses;
   llvm::append_range(ImplicitOps, Inst.ImplicitDefs);
-  OS << Target.getName() << "ImpOpBase + " << EmittedLists[ImplicitOps]
-     << ",\t";
 
   // Emit the operand info offset.
   OperandInfoTy OperandInfo = GetOperandInfo(Inst);
-  OS << OperandInfoMap.find(OperandInfo)->second << ",\t0";
+  OS << OperandInfoMap.find(OperandInfo)->second << ",\t";
+
+  // Emit implicit operand base.
+  OS << Target.getName() << "ImpOpBase + " << EmittedLists[ImplicitOps]
+     << ",\t0";
 
   // Emit all of the target independent flags...
   if (Inst.isPreISelOpcode)


### PR DESCRIPTION
Increase width of ImplicitOffset to `int` from `short` to allow more table capacity.
Reorder the elements to maintain natural alignment.