### PR TITLE
[libclang/python] Add tests for equality operators.

### DIFF
--- a/clang/bindings/python/tests/cindex/test_cursor.py
+++ b/clang/bindings/python/tests/cindex/test_cursor.py
@@ -1035,3 +1035,18 @@ struct B {};
         self.assertNotEqual(foos[0], foos[1])
         self.assertEqual(foos[0], prime_foo)
         self.assertIsNone(tu.cursor.specialized_template)
+
+    def test_equality(self):
+        tu = get_tu(CHILDREN_TEST, lang="cpp")
+        cursor1 = get_cursor(tu, "s0")
+        cursor1_2 = get_cursor(tu, "s0")
+        cursor2 = get_cursor(tu, "f0")
+
+        self.assertIsNotNone(cursor1)
+        self.assertIsNotNone(cursor1_2)
+        self.assertIsNotNone(cursor2)
+
+        self.assertEqual(cursor1, cursor1)
+        self.assertEqual(cursor1, cursor1_2)
+        self.assertNotEqual(cursor1, cursor2)
+        self.assertNotEqual(cursor1, "foo")

--- a/clang/bindings/python/tests/cindex/test_location.py
+++ b/clang/bindings/python/tests/cindex/test_location.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from clang.cindex import (
     Config,
@@ -16,7 +17,7 @@ import unittest
 
 from .util import get_cursor, get_tu
 
-INPUTS_DIR = os.path.join(os.path.dirname(__file__), "INPUTS")
+INPUTS_DIR = Path(__file__).parent / "INPUTS"
 
 BASE_INPUT = "int one;\nint two;\n"
 
@@ -155,8 +156,8 @@ int one;
         assert not l_t1_14 < l_t2_13
 
     def test_equality(self):
-        path = os.path.join(INPUTS_DIR, "testfile.c")
-        path_a = os.path.join(INPUTS_DIR, "a.inc")
+        path = INPUTS_DIR / "testfile.c"
+        path_a = INPUTS_DIR / "a.inc"
         tu = TranslationUnit.from_source(path)
         main_file = File.from_name(tu, path)
         a_file = File.from_name(tu, path_a)

--- a/clang/bindings/python/tests/cindex/test_location.py
+++ b/clang/bindings/python/tests/cindex/test_location.py
@@ -16,6 +16,8 @@ import unittest
 
 from .util import get_cursor, get_tu
 
+INPUTS_DIR = os.path.join(os.path.dirname(__file__), "INPUTS")
+
 BASE_INPUT = "int one;\nint two;\n"
 
 
@@ -151,3 +153,21 @@ int one;
         assert l_t1_12 < l_t2_13 < l_t1_14
         assert not l_t2_13 < l_t1_12
         assert not l_t1_14 < l_t2_13
+
+    def test_equality(self):
+        path = os.path.join(INPUTS_DIR, "testfile.c")
+        path_a = os.path.join(INPUTS_DIR, "a.inc")
+        tu = TranslationUnit.from_source(path)
+        main_file = File.from_name(tu, path)
+        a_file = File.from_name(tu, path_a)
+
+        location1 = SourceLocation.from_position(tu, main_file, 1, 3)
+        location2 = SourceLocation.from_position(tu, main_file, 2, 2)
+        location1_2 = SourceLocation.from_position(tu, main_file, 1, 3)
+        file2_location1 = SourceLocation.from_position(tu, a_file, 1, 3)
+
+        self.assertEqual(location1, location1)
+        self.assertEqual(location1, location1_2)
+        self.assertNotEqual(location1, location2)
+        self.assertNotEqual(location1, file2_location1)
+        self.assertNotEqual(location1, "foo")

--- a/clang/bindings/python/tests/cindex/test_source_range.py
+++ b/clang/bindings/python/tests/cindex/test_source_range.py
@@ -9,6 +9,8 @@ import unittest
 
 from .util import get_tu
 
+INPUTS_DIR = os.path.join(os.path.dirname(__file__), "INPUTS")
+
 
 def create_range(tu, line1, column1, line2, column2):
     return SourceRange.from_locations(
@@ -83,3 +85,16 @@ aaaaa"""
         r_curly = create_range(tu2, 1, 11, 3, 1)
         l_f2 = SourceLocation.from_position(tu2, tu2.get_file("./numbers.inc"), 4, 1)
         assert l_f2 in r_curly
+
+    def test_equality(self):
+        path = os.path.join(INPUTS_DIR, "testfile.c")
+        tu = TranslationUnit.from_source(path)
+
+        r1 = create_range(tu, 1, 1, 2, 2)
+        r2 = create_range(tu, 1, 2, 2, 2)
+        r1_2 = create_range(tu, 1, 1, 2, 2)
+
+        self.assertEqual(r1, r1)
+        self.assertEqual(r1, r1_2)
+        self.assertNotEqual(r1, r2)
+        self.assertNotEqual(r1, "foo")

--- a/clang/bindings/python/tests/cindex/test_source_range.py
+++ b/clang/bindings/python/tests/cindex/test_source_range.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from clang.cindex import Config, SourceLocation, SourceRange, TranslationUnit
 
@@ -9,7 +10,7 @@ import unittest
 
 from .util import get_tu
 
-INPUTS_DIR = os.path.join(os.path.dirname(__file__), "INPUTS")
+INPUTS_DIR = Path(__file__).parent / "INPUTS"
 
 
 def create_range(tu, line1, column1, line2, column2):
@@ -87,7 +88,7 @@ aaaaa"""
         assert l_f2 in r_curly
 
     def test_equality(self):
-        path = os.path.join(INPUTS_DIR, "testfile.c")
+        path = INPUTS_DIR / "testfile.c"
         tu = TranslationUnit.from_source(path)
 
         r1 = create_range(tu, 1, 1, 2, 2)


### PR DESCRIPTION
Adds tests for SourceRange, SourceLocation and Cursor.
This is a follow-up to #138074