### PR TITLE
[ADT] Remove `is_scoped_enum_v`

### DIFF
--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -73,7 +73,8 @@ struct from_range_t {
 };
 inline constexpr from_range_t from_range{};
 
-template <typename T, typename UnderlyingT = std::underlying_type_t<T>>
+template <typename T, typename UnderlyingT = typename std::enable_if_t<
+                          std::is_enum_v<T>, std::underlying_type<T>>::type>
 constexpr bool is_scoped_enum_v =
     std::is_enum_v<T> && !std::is_convertible_v<T, UnderlyingT>;
 

--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -72,12 +72,6 @@ struct from_range_t {
   explicit from_range_t() = default;
 };
 inline constexpr from_range_t from_range{};
-
-template <typename T, typename UnderlyingT = typename std::enable_if_t<
-                          std::is_enum_v<T>, std::underlying_type<T>>::type>
-constexpr bool is_scoped_enum_v =
-    std::is_enum_v<T> && !std::is_convertible_v<T, UnderlyingT>;
-
 } // namespace llvm
 
 #endif // LLVM_ADT_STLFORWARDCOMPAT_H


### PR DESCRIPTION
`std::underlying_type` is not SFINAE-friendly in Clang and GCC before 9, and it's too much of a hassle to make it work. Instead, I'm inlining the implementation in the only place it's needed. Fixes buildbot failure https://lab.llvm.org/buildbot/#/builders/134/builds/17904 caused by #138089. Demo: https://godbolt.org/z/9qo3csP98