### PR TITLE
[StackSlotColoring] Fix issue where colors for a StackID are dropped    

### DIFF
--- a/llvm/lib/CodeGen/StackSlotColoring.cpp
+++ b/llvm/lib/CodeGen/StackSlotColoring.cpp
@@ -287,8 +287,10 @@ void StackSlotColoring::InitializeSlots() {
 
     auto StackID = MFI->getStackID(FI);
     if (StackID != 0) {
-      AllColors.resize(StackID + 1);
-      UsedColors.resize(StackID + 1);
+      if (StackID >= AllColors.size()) {
+        AllColors.resize(StackID + 1);
+        UsedColors.resize(StackID + 1);
+      }
       AllColors[StackID].resize(LastFI);
       UsedColors[StackID].resize(LastFI);
     }


### PR DESCRIPTION
In InitializeSlots, if an interval with a non-zero StackID (A) is encountered we set All/UsedColors to a size of A + 1. If after this we process another interval with a non-zero StackID (B), where B < A, then we resize All/UsedColors to size < A + 1, and lose the BitVector associated with A.

AFAIK this is a latent bug upstream, but when adding a new TargetStackID locally I hit a `NextColors[StackID] != -1 && "No more spill slots?"` assertion due to this issue.