### PR TITLE
[llvm][release] On release page, explain package types and verification

### DIFF
--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -53,7 +53,7 @@ LLVM {release} Release
 
 Each platform has one binary release package. The file name starts with either `LLVM-` or `clang+llvm-` and ends with the platform's name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
 
-Except for Windows. Where `LLVM-` is an installer intended for using LLVM as a toolchain and `clang+llvm-` contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the `LLVM-` installer, unless you are developing software which itself uses LLVM, in which case choose `clang+llvm-`.
+Except for Windows. Where `LLVM-*.exe` is an installer intended for using LLVM as a toolchain and `clang+llvm-` contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the `LLVM-` installer, unless you are developing software which itself uses LLVM, in which case choose `clang+llvm-`.
 
 If you do not find a release package for your platform, you may be able to find a community built package on the LLVM Discourse forum thread for this release. Remember that these are built by volunteers and may not always be available.
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -51,12 +51,9 @@ LLVM {release} Release
 
 # Package Types
 
-* If the file name starts with `LLVM-` then it is a binary release of LLVM for the platform at the end of the file name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
-* If the file name starts with `clang+llvm-` then it is a binary release of LLVM for the platform at the end of the filename. For example, `clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz` contains LLVM binaries for Armv7-a Linux.
+Each platform has one binary release package. The file name starts with either `LLVM-` or `clang+llvm-` and ends with the platform's name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
 
-Most of the time, you will want one of the files described above. Each platform will have either an `LLVM-` package or a `clang+llvm-` package.
-
-Except for Windows. Where the `LLVM-` file is an installer intended for using LLVM as a toolchain and the `clang+llvm-` archive contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the `LLLVM-` installer, unless you are developing software which itself uses LLVM, in which case choose the `clang+llvm-` archive.
+Except for Windows. Where `LLVM-` is an installer intended for using LLVM as a toolchain and `clang+llvm-` contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the `LLVM-` installer, unless you are developing software which itself uses LLVM, in which case choose `clang+llvm-`.
 
 If you do not find a release package for your platform, you may be able to find a community built package on the LLVM Discourse forum thread for this release. Remember that these are built by volunteers and may not always be available.
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -51,20 +51,20 @@ LLVM {} Release
 
 # Package Types
 
-* If the file name starts with `LLVM-` then it is a binary release of all of LLVM for the platform at the end of the file name. For example, `LLVM-20.1.1-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
-* If the file name starts with `clang+llvm-` then it is a binary release for the platform at the end of the filename. For example, `clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz` contains LLVM binaries for Armv7-a Linux.
+* If the file name starts with `LLVM-` then it is a binary release of LLVM for the platform at the end of the file name. For example, `LLVM-20.1.1-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
+* If the file name starts with `clang+llvm-` then it is a binary release of LLVM for the platform at the end of the filename. For example, `clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz` contains LLVM binaries for Armv7-a Linux.
 
-Most of the time, you will want one of the files described above.
+Most of the time, you will want one of the files described above. Each platform will have either an `LLVM-` package or a `clang+llvm-` package.
 
-Each platform will have either an `LLVM-` package or a `clang+llvm-` package. Except for Windows which has both. For Windows, the `LLVM-` file is an installer intended for using LLVM as a toolchain. The `clang+llvm-` file contains the contents of the installer, plus libraries and tools not normally used in a toolchain.
+Except for Windows which has both. For Windows, the `LLVM-` file is an installer intended for using LLVM as a toolchain. The `clang+llvm-` file contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the installer, unless you are developing software which itself uses LLVM.
 
 If you do not find a release package for your platform, you may be able to find a community built package on the LLVM Discourse forum thread for this release. Remember that these are built by volunteers and may not always be available.
 
 If you rely on a platform or configuration that is not one of the defaults, we suggest you use the binaries that your platform provides, or build your own release packages.
 
-* `<sub-project>*.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (aside from `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
-
-* To get all the `llvm-project` sources for this release, choose the one of the `Source Code`archives."""
+In addition, source archives are available:
+* `<sub-project>*.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (except for `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
+* To get all the `llvm-project` source code for this release, choose the one of the `Source Code`archives."""
         ).format(release)
 
     prerelease = True if "rc" in release else False

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -47,16 +47,16 @@ def create_release(repo, release, tag=None, name=None, message=None):
         # do the reflowing for us instead.
         message = dedent(
             """\
-LLVM {} Release
+LLVM {release} Release
 
 # Package Types
 
-* If the file name starts with `LLVM-` then it is a binary release of LLVM for the platform at the end of the file name. For example, `LLVM-20.1.1-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
-* If the file name starts with `clang+llvm-` then it is a binary release of LLVM for the platform at the end of the filename. For example, `clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz` contains LLVM binaries for Armv7-a Linux.
+* If the file name starts with `LLVM-` then it is a binary release of LLVM for the platform at the end of the file name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
+* If the file name starts with `clang+llvm-` then it is a binary release of LLVM for the platform at the end of the filename. For example, `clang+llvm-{release}-armv7a-linux-gnueabihf.tar.gz` contains LLVM binaries for Armv7-a Linux.
 
 Most of the time, you will want one of the files described above. Each platform will have either an `LLVM-` package or a `clang+llvm-` package.
 
-Except for Windows which has both. For Windows, the `LLVM-` file is an installer intended for using LLVM as a toolchain. The `clang+llvm-` file contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the installer, unless you are developing software which itself uses LLVM.
+Except for Windows. Where the `LLVM-` file is an installer intended for using LLVM as a toolchain and the `clang+llvm-` archive contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the `LLLVM-` installer, unless you are developing software which itself uses LLVM, in which case choose the `clang+llvm-` archive.
 
 If you do not find a release package for your platform, you may be able to find a community built package on the LLVM Discourse forum thread for this release. Remember that these are built by volunteers and may not always be available.
 
@@ -64,8 +64,8 @@ If you rely on a platform or configuration that is not one of the defaults, we s
 
 In addition, source archives are available:
 * `<sub-project>*.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (except for `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
-* To get all the `llvm-project` source code for this release, choose the one of the `Source Code`archives."""
-        ).format(release)
+* To get all the `llvm-project` source code for this release, choose the one of the `Source Code` archives."""
+        ).format(release=release)
 
     prerelease = True if "rc" in release else False
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -42,17 +42,28 @@ def create_release(repo, release, tag=None, name=None, message=None):
         name = "LLVM {}".format(release)
 
     if not message:
-        message = dedent(
-            """\
-            LLVM {} Release
+        # Note that these lines are not length limited because if we do so, GitHub
+        # assumes that should be how it is laid out on the page. We want GitHub to
+        # do the reflowing for us instead.
+        message = dedent("""\
+LLVM {} Release
 
-            # A note on binaries
+# Package Types
 
-            Volunteers make binaries for the LLVM project, which will be uploaded
-            when they have had time to test and build these binaries. They might
-            not be available directly or not at all for each release. We suggest
-            you use the binaries from your distribution or build your own if you
-            rely on a specific platform or configuration."""
+* If the file name starts with `LLVM-` then it is a binary release of all of LLVM for the platform at the end of the file name. For example, `LLVM-20.1.1-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
+* If the file name starts with `clang+llvm-` then it is a binary release for the platform at the end of the filename. For example, `clang+llvm-20.1.1-armv7a-linux-gnueabihf.tar.gz` contains LLVM binaries for Armv7-a Linux.
+
+Most of the time, you will want one of the files described above.
+
+Each platform will have either an `LLVM-` package or a `clang+llvm-` package. Except for Windows which has both. For Windows, the `LLVM-` file is an installer intended for using LLVM as a toolchain. The `clang+llvm-` file contains the contents of the installer, plus libraries and tools not normally used in a toolchain.
+
+If you do not find a release package for your platform, you may be able to find a community built package on the LLVM Discourse forum thread for this release. Remember that these are built by volunteers and may not always be available.
+
+If you rely on a platform or configuration that is not one of the defaults, we suggest you use the binaries that your platform provides, or build your own release packages.
+
+* `<sub-project>*.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (aside from `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
+
+* To get all the `llvm-project` sources for this release, choose the one of the `Source Code`archives."""
         ).format(release)
 
     prerelease = True if "rc" in release else False

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -45,7 +45,8 @@ def create_release(repo, release, tag=None, name=None, message=None):
         # Note that these lines are not length limited because if we do so, GitHub
         # assumes that should be how it is laid out on the page. We want GitHub to
         # do the reflowing for us instead.
-        message = dedent("""\
+        message = dedent(
+            """\
 LLVM {} Release
 
 # Package Types

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -67,7 +67,7 @@ In addition, source archives are available:
 
 All packages come with a matching `.sig` or `.jsonl` file. You should use these to verify the integrity of the packages.
 
-If it has a `.sig` file, it should have been signed by the release managers using GPG. Download the keys from the [LLVM website]((https://releases.llvm.org/release-keys.asc), import them into your keyring and use them to verify the file:
+If it has a `.sig` file, it should have been signed by the release managers using GPG. Download the keys from the [LLVM website](https://releases.llvm.org/release-keys.asc), import them into your keyring and use them to verify the file:
 ```
 $ gpg --import release-keys.asc
 $ gpg --verify <package file name>.sig <package file name>

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -49,7 +49,7 @@ def create_release(repo, release, tag=None, name=None, message=None):
             """\
 LLVM {release} Release
 
-# Package Types
+## Package Types
 
 Each platform has one binary release package. The file name starts with either `LLVM-` or `clang+llvm-` and ends with the platform's name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -61,7 +61,7 @@ If you rely on a platform or configuration that is not one of the defaults, we s
 
 In addition, source archives are available:
 * `<sub-project>*.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (except for `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
-* To get all the `llvm-project` source code for this release, choose the one of the `Source Code` archives.
+* To get all the `llvm-project` source code for this release, choose `llvm-project-{release}.src.tar.xz`.
 
 ## Verifying Packages
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -61,7 +61,20 @@ If you rely on a platform or configuration that is not one of the defaults, we s
 
 In addition, source archives are available:
 * `<sub-project>*.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (except for `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
-* To get all the `llvm-project` source code for this release, choose the one of the `Source Code` archives."""
+* To get all the `llvm-project` source code for this release, choose the one of the `Source Code` archives.
+
+## Verifying Packages
+
+All packages are signed by the release managers using GPG. To verify a package,
+first [download](https://releases.llvm.org/release-keys.asc) the keys from
+the LLVM website, then import them into your keyring:
+```
+$ gpg --import release-keys.asc
+```
+Then verify the package using the matching `.sig` file:
+```
+$ gpg --verify <package file name>.sig <package file name>
+```"""
         ).format(release=release)
 
     prerelease = True if "rc" in release else False

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -65,13 +65,20 @@ In addition, source archives are available:
 
 ## Verifying Packages
 
-All packages are signed by the release managers using GPG and should be verified before use. To verify a package, first [download](https://releases.llvm.org/release-keys.asc) the keys from the LLVM website, then import them into your keyring:
+All packages come with a matching `.sig` or `.jsonl` file. You should use these to verify the integrity of the packages.
+
+If it has a `.sig` file, it should have been signed by the release managers using GPG. Download the keys from the [LLVM website]((https://releases.llvm.org/release-keys.asc), import them into your keyring and use them to verify the file:
 ```
 $ gpg --import release-keys.asc
-```
-Then verify the package using the matching `.sig` file:
-```
 $ gpg --verify <package file name>.sig <package file name>
+```
+
+If it has a `.jsonl` file, use [gh](https://cli.github.com/manual/gh_attestation_verify) to verify the package:
+```
+gh attestation verify --repo llvm/llvm-project <package file name>
+(if you are able to connect to GitHub)
+gh attestation verify --repo llvm/llvm-project <package file name> --bundle <package file name>.jsonl
+(using attestation file on disk)
 ```"""
         ).format(release=release)
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -65,7 +65,7 @@ In addition, source archives are available:
 
 ## Verifying Packages
 
-All packages are signed by the release managers using GPG. To verify a package, first [download](https://releases.llvm.org/release-keys.asc) the keys from the LLVM website, then import them into your keyring:
+All packages are signed by the release managers using GPG and should be verified before use. To verify a package, first [download](https://releases.llvm.org/release-keys.asc) the keys from the LLVM website, then import them into your keyring:
 ```
 $ gpg --import release-keys.asc
 ```

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -60,7 +60,7 @@ If you do not find a release package for your platform, you may be able to find 
 If you rely on a platform or configuration that is not one of the defaults, we suggest you use the binaries that your platform provides, or build your own release packages.
 
 In addition, source archives are available:
-* `<sub-project>*.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (except for `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
+* `<sub-project>-{release}.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (except for `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
 * To get all the `llvm-project` source code for this release, choose `llvm-project-{release}.src.tar.xz`.
 
 ## Verifying Packages

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -65,9 +65,7 @@ In addition, source archives are available:
 
 ## Verifying Packages
 
-All packages are signed by the release managers using GPG. To verify a package,
-first [download](https://releases.llvm.org/release-keys.asc) the keys from
-the LLVM website, then import them into your keyring:
+All packages are signed by the release managers using GPG. To verify a package, first [download](https://releases.llvm.org/release-keys.asc) the keys from the LLVM website, then import them into your keyring:
 ```
 $ gpg --import release-keys.asc
 ```


### PR DESCRIPTION
Background: https://discourse.llvm.org/t/rfc-explaining-release-package-types-and-purposes/85985

So that users can understand which they should use, particularly for Windows. The original text about community builds is kept, after explaining the main release package formats.

In addition, explain how to use gpg or gh to verify the packages.