### PR TITLE
[flang][OpenMP] Always set "openmp_flags"

### DIFF
--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -178,17 +178,15 @@ if result:
     config.environment["LIBPGMATH"] = True
 
 # Determine if OpenMP runtime was built (enable OpenMP tests via REQUIRES in test file)
+openmp_flags_substitution = "-fopenmp"
 if config.have_openmp_rtl:
     config.available_features.add("openmp_runtime")
     # For the enabled OpenMP tests, add a substitution that is needed in the tests to find
     # the omp_lib.{h,mod} files, depending on whether the OpenMP runtime was built as a
     # project or runtime.
     if config.openmp_module_dir:
-        config.substitutions.append(
-            ("%openmp_flags", f"-fopenmp -J {config.openmp_module_dir}")
-        )
-    else:
-        config.substitutions.append(("%openmp_flags", "-fopenmp"))
+        openmp_flags_substitution += f" -J {config.openmp_module_dir}"
+config.substitutions.append(("%openmp_flags", openmp_flags_substitution))
 
 # Add features and substitutions to test F128 math support.
 # %f128-lib substitution may be used to generate check prefixes


### PR DESCRIPTION
Many OpenMP tests use "%openmp_flags" in the RUN line. In many OpenMP lit tests this variable is expected to at least have "-fopenmp" in it. However, in the lit config this variable was only given a value when the OpenMP runtime build was enabled.

If the runtime build was not enabled, %openmp_flags would expand to an empty string, and unless a lit test specifically used -fopenmp in the RUN line, OpenMP would be disabled.

This patch sets %openmp_flags to start with "-fopenmp" regardless of the build configuration.