### PR TITLE
[mlir][EmitC] Add Bazel rules for conversions

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -3801,6 +3801,7 @@ cc_library(
         ":ControlFlowToSCF",
         ":ControlFlowToSPIRV",
         ":ConversionPassIncGen",
+        ":ConvertToEmitC",
         ":ConvertToLLVM",
         ":FuncToEmitC",
         ":FuncToLLVM",
@@ -3919,6 +3920,7 @@ cc_library(
         ":BufferizationInterfaces",
         ":ControlFlowDialect",
         ":ControlFlowInterfaces",
+        ":ConvertToEmitCInterface",
         ":DestinationStyleOpInterface",
         ":FunctionInterfaces",
         ":IR",
@@ -4332,6 +4334,7 @@ cc_library(
         ":BytecodeOpInterface",
         ":CallOpInterfaces",
         ":ControlFlowInterfaces",
+        ":ConvertToEmitCInterface",
         ":ConvertToLLVMInterface",
         ":FuncIncGen",
         ":FunctionInterfaces",
@@ -6755,6 +6758,7 @@ cc_library(
     ],
     deps = [
         ":ConversionPassIncGen",
+        ":ConvertToEmitCInterface",
         ":EmitCDialect",
         ":FuncDialect",
         ":Pass",
@@ -7506,6 +7510,7 @@ cc_library(
     deps = [
         ":ArithDialect",
         ":ConversionPassIncGen",
+        ":ConvertToEmitCInterface",
         ":EmitCDialect",
         ":EmitCTransforms",
         ":IR",
@@ -7658,6 +7663,34 @@ cc_library(
 )
 
 cc_library(
+    name = "ConvertToEmitCInterface",
+    hdrs = ["include/mlir/Conversion/ConvertToEmitC/ToEmitCInterface.h"],
+    includes = ["include"],
+    deps = [
+        ":ConversionPassIncGen",
+        ":IR",
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "ConvertToEmitC",
+    srcs = ["lib/Conversion/ConvertToEmitC/ConvertToEmitCPass.cpp"],
+    hdrs = ["include/mlir/Conversion/ConvertToEmitC/ConvertToEmitCPass.h"],
+    includes = ["include"],
+    deps = [
+        ":ConversionPassIncGen",
+        ":ConvertToEmitCInterface",
+        ":EmitCDialect",
+        ":IR",
+        ":LLVMCommonConversion",
+        ":Pass",
+        ":TransformUtils",
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "FuncToLLVM",
     srcs = [
         "lib/Conversion/FuncToLLVM/FuncToLLVM.cpp",
@@ -7789,6 +7822,7 @@ cc_library(
     ],
     deps = [
         ":ConversionPassIncGen",
+        ":ConvertToEmitCInterface",
         ":EmitCDialect",
         ":IR",
         ":MemRefDialect",
@@ -7908,6 +7942,7 @@ cc_library(
     deps = [
         ":ArithDialect",
         ":ConversionPassIncGen",
+        ":ConvertToEmitCInterface",
         ":EmitCDialect",
         ":EmitCTransforms",
         ":IR",
@@ -8764,6 +8799,7 @@ cc_library(
         ":ControlFlowDialect",
         ":ControlFlowTransforms",
         ":ConversionPasses",
+        ":ConvertToEmitC",
         ":ConvertToLLVM",
         ":DLTIDialect",
         ":EmitCDialect",
@@ -11768,6 +11804,7 @@ cc_library(
         ":CastInterfaces",
         ":CommonFolders",
         ":ControlFlowInterfaces",
+        ":ConvertToEmitCInterface",
         ":ConvertToLLVMInterface",
         ":DestinationStyleOpInterface",
         ":IR",
@@ -12044,6 +12081,7 @@ cc_library(
         ":CallOpInterfaces",
         ":CastInterfaces",
         ":ControlFlowInterfaces",
+        ":ConvertToEmitCInterface",
         ":ConvertToLLVMInterface",
         ":CopyOpInterface",
         ":DialectUtils",


### PR DESCRIPTION
Follow-up from #117549

tested by:

```
cd utils/bazel
bazelisk build --config=generic_clang @llvm-project//mlir:all
bazelisk test --config=generic_clang @llvm-project//mlir/test:all
```