### PR TITLE
[Clang][SYCL] Add initial set of Intel OffloadArch values

### DIFF
--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -101,9 +101,6 @@ enum class OffloadArch {
   AMDGCNSPIRV,
   Generic, // A processor model named 'generic' if the target backend defines a
            // public one.
-  // Note: this is an initial list of Intel GPU and GPU offloading
-  // architectures. The list will be expanded later as support for more
-  // architectures is added.
   // Intel CPUs
   GRANITERAPIDS,
   // Intel GPUs

--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -101,6 +101,13 @@ enum class OffloadArch {
   AMDGCNSPIRV,
   Generic, // A processor model named 'generic' if the target backend defines a
            // public one.
+  // Note: this is an initial list of Intel GPU and GPU offloading
+  // architectures. The list will be expanded later as support for more
+  // architectures is added.
+  // Intel CPUs
+  GRANITERAPIDS,
+  // Intel GPUs
+  BMG_G21,
   LAST,
 
   CudaDefault = OffloadArch::SM_52,
@@ -114,6 +121,18 @@ static inline bool IsNVIDIAOffloadArch(OffloadArch A) {
 static inline bool IsAMDOffloadArch(OffloadArch A) {
   // Generic processor model is for testing only.
   return A >= OffloadArch::GFX600 && A < OffloadArch::Generic;
+}
+
+static inline bool IsIntelCPUOffloadArch(OffloadArch Arch) {
+  return Arch >= OffloadArch::GRANITERAPIDS && Arch < OffloadArch::BMG_G21;
+}
+
+static inline bool IsIntelGPUOffloadArch(OffloadArch Arch) {
+  return Arch >= OffloadArch::BMG_G21 && Arch < OffloadArch::LAST;
+}
+
+static inline bool IsIntelOffloadArch(OffloadArch Arch) {
+  return IsIntelCPUOffloadArch(Arch) || IsIntelGPUOffloadArch(Arch);
 }
 
 const char *OffloadArchToString(OffloadArch A);

--- a/clang/lib/Basic/OffloadArch.cpp
+++ b/clang/lib/Basic/OffloadArch.cpp
@@ -87,6 +87,10 @@ static const OffloadArchToStringMap ArchNames[] = {
     GFX(1200), // gfx1200
     GFX(1201), // gfx1201
     {OffloadArch::AMDGCNSPIRV, "amdgcnspirv", "compute_amdgcn"},
+    // Intel CPUs
+    {OffloadArch::GRANITERAPIDS, "graniterapids", ""},
+    // Intel GPUS
+    {OffloadArch::BMG_G21, "bmg_g21", ""},
     {OffloadArch::Generic, "generic", ""},
     // clang-format on
 };

--- a/clang/lib/Basic/Targets/NVPTX.cpp
+++ b/clang/lib/Basic/Targets/NVPTX.cpp
@@ -241,6 +241,8 @@ void NVPTXTargetInfo::getTargetDefines(const LangOptions &Opts,
       case OffloadArch::GFX1201:
       case OffloadArch::AMDGCNSPIRV:
       case OffloadArch::Generic:
+      case OffloadArch::GRANITERAPIDS:
+      case OffloadArch::BMG_G21:
       case OffloadArch::LAST:
         break;
       case OffloadArch::UNKNOWN:

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -2334,6 +2334,8 @@ void CGOpenMPRuntimeGPU::processRequiresDirective(const OMPRequiresDecl *D) {
       case OffloadArch::GFX1201:
       case OffloadArch::AMDGCNSPIRV:
       case OffloadArch::Generic:
+      case OffloadArch::GRANITERAPIDS:
+      case OffloadArch::BMG_G21:
       case OffloadArch::UNUSED:
       case OffloadArch::UNKNOWN:
         break;

--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -7,6 +7,7 @@ add_distinct_clang_unittest(BasicTests
   FileEntryTest.cpp
   FileManagerTest.cpp
   LineOffsetMappingTest.cpp
+  OffloadArchTest.cpp
   SanitizersTest.cpp
   SarifTest.cpp
   SourceManagerTest.cpp

--- a/clang/unittests/Basic/OffloadArchTest.cpp
+++ b/clang/unittests/Basic/OffloadArchTest.cpp
@@ -1,0 +1,36 @@
+//===- unittests/Basic/OffloadArchTest.cpp - Test OffloadArch -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Basic/OffloadArch.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+
+TEST(OffloadArchTest, basic) {
+  EXPECT_TRUE(IsNVIDIAOffloadArch(OffloadArch::SM_20));
+  EXPECT_TRUE(IsNVIDIAOffloadArch(OffloadArch::SM_120a));
+  EXPECT_FALSE(IsNVIDIAOffloadArch(OffloadArch::GFX600));
+
+  EXPECT_FALSE(IsAMDOffloadArch(OffloadArch::SM_120a));
+  EXPECT_TRUE(IsAMDOffloadArch(OffloadArch::GFX600));
+  EXPECT_TRUE(IsAMDOffloadArch(OffloadArch::GFX1201));
+  EXPECT_TRUE(IsAMDOffloadArch(OffloadArch::GFX12_GENERIC));
+  EXPECT_TRUE(IsAMDOffloadArch(OffloadArch::AMDGCNSPIRV));
+  EXPECT_FALSE(IsAMDOffloadArch(OffloadArch::GRANITERAPIDS));
+
+  EXPECT_TRUE(IsIntelOffloadArch(OffloadArch::GRANITERAPIDS));
+  EXPECT_TRUE(IsIntelCPUOffloadArch(OffloadArch::GRANITERAPIDS));
+  EXPECT_FALSE(IsIntelGPUOffloadArch(OffloadArch::GRANITERAPIDS));
+  EXPECT_TRUE(IsIntelOffloadArch(OffloadArch::BMG_G21));
+  EXPECT_FALSE(IsIntelCPUOffloadArch(OffloadArch::BMG_G21));
+  EXPECT_TRUE(IsIntelGPUOffloadArch(OffloadArch::BMG_G21));
+
+  EXPECT_FALSE(IsNVIDIAOffloadArch(OffloadArch::Generic));
+  EXPECT_FALSE(IsAMDOffloadArch(OffloadArch::Generic));
+  EXPECT_FALSE(IsIntelOffloadArch(OffloadArch::Generic));
+}


### PR DESCRIPTION
Following #137070, this PR adds an initial set of Intel `OffloadArch` values with corresponding predicates that will be used in SYCL offloading. More Intel architectures will be added in a future PR.