### PR TITLE
[lldb-dap] Add runInTerminal support for Windows

### DIFF
--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -43,7 +43,6 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
         except:
             return False
 
-    @skipIfWindows
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
     def test_runInTerminal(self):
         if not self.isTestSupported():
@@ -113,7 +112,6 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
         self.assertIn("FOO", request_envs)
         self.assertEqual("BAR", request_envs["FOO"])
 
-    @skipIfWindows
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
     def test_runInTerminalInvalidTarget(self):
         if not self.isTestSupported():
@@ -132,7 +130,6 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
             response["message"],
         )
 
-    @skipIfWindows
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
     def test_missingArgInRunInTerminalLauncher(self):
         if not self.isTestSupported():

--- a/lldb/tools/lldb-dap/FifoFiles.cpp
+++ b/lldb/tools/lldb-dap/FifoFiles.cpp
@@ -24,26 +24,53 @@ using namespace llvm;
 
 namespace lldb_dap {
 
-FifoFile::FifoFile(StringRef path) : m_path(path) {}
+#if defined(_WIN32)
+FifoFile::FifoFile(StringRef path, HANDLE handle, bool is_server)
+    : m_path(path), m_is_server(is_server), m_pipe_fd(handle) {}
+#else
+FifoFile::FifoFile(StringRef path, bool is_server)
+    : m_path(path), m_is_server(is_server) {}
+#endif
 
 FifoFile::~FifoFile() {
-#if !defined(_WIN32)
-  unlink(m_path.c_str());
+#if defined(_WIN32)
+  if (m_pipe_fd == INVALID_HANDLE_VALUE)
+    return;
+  if (m_is_server)
+    DisconnectNamedPipe(m_pipe_fd);
+  CloseHandle(m_pipe_fd);
+#else
+  if (m_is_server)
+    unlink(m_path.c_str());
 #endif
 }
 
-Expected<std::shared_ptr<FifoFile>> CreateFifoFile(StringRef path) {
+Expected<std::shared_ptr<FifoFile>> CreateFifoFile(StringRef path,
+                                                   bool is_server) {
 #if defined(_WIN32)
-  return createStringError(inconvertibleErrorCode(), "Unimplemented");
+  if (!is_server)
+    return std::make_shared<FifoFile>(path, INVALID_HANDLE_VALUE, is_server);
+  HANDLE handle =
+      CreateNamedPipeA(path.data(), PIPE_ACCESS_DUPLEX,
+                       PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT, 1,
+                       1024 * 16, 1024 * 16, 0, NULL);
+  if (handle == INVALID_HANDLE_VALUE)
+    return createStringError(
+        std::error_code(GetLastError(), std::generic_category()),
+        "Couldn't create fifo file: %s", path.data());
+  return std::make_shared<FifoFile>(path, handle, is_server);
 #else
+  if (!is_server)
+    return std::make_shared<FifoFile>(path, is_server);
   if (int err = mkfifo(path.data(), 0600))
     return createStringError(std::error_code(err, std::generic_category()),
                              "Couldn't create fifo file: %s", path.data());
-  return std::make_shared<FifoFile>(path);
+  return std::make_shared<FifoFile>(path, is_server);
 #endif
 }
 
-FifoFileIO::FifoFileIO(StringRef fifo_file, StringRef other_endpoint_name)
+FifoFileIO::FifoFileIO(std::shared_ptr<FifoFile> fifo_file,
+                       StringRef other_endpoint_name)
     : m_fifo_file(fifo_file), m_other_endpoint_name(other_endpoint_name) {}
 
 Expected<json::Value> FifoFileIO::ReadJSON(std::chrono::milliseconds timeout) {
@@ -52,11 +79,27 @@ Expected<json::Value> FifoFileIO::ReadJSON(std::chrono::milliseconds timeout) {
   std::optional<std::string> line;
   std::future<void> *future =
       new std::future<void>(std::async(std::launch::async, [&]() {
-        std::ifstream reader(m_fifo_file, std::ifstream::in);
+#if defined(_WIN32)
+        std::string buffer;
+        buffer.reserve(4096);
+        char ch;
+        DWORD bytes_read = 0;
+        while (ReadFile(m_fifo_file->m_pipe_fd, &ch, 1, &bytes_read, NULL) &&
+               (bytes_read == 1)) {
+          buffer.push_back(ch);
+          if (ch == '\n') {
+            break;
+          }
+        }
+        if (!buffer.empty())
+          line = std::move(buffer);
+#else
+        std::ifstream reader(m_fifo_file->m_path, std::ifstream::in);
         std::string buffer;
         std::getline(reader, buffer);
         if (!buffer.empty())
           line = buffer;
+#endif
       }));
   if (future->wait_for(timeout) == std::future_status::timeout || !line)
     // Indeed this is a leak, but it's intentional. "future" obj destructor
@@ -78,9 +121,18 @@ Error FifoFileIO::SendJSON(const json::Value &json,
   bool done = false;
   std::future<void> *future =
       new std::future<void>(std::async(std::launch::async, [&]() {
-        std::ofstream writer(m_fifo_file, std::ofstream::out);
+#if defined(_WIN32)
+        std::string buffer = JSONToString(json);
+        buffer.append("\n");
+        DWORD bytes_write = 0;
+        WriteFile(m_fifo_file->m_pipe_fd, buffer.c_str(), buffer.size(),
+                  &bytes_write, NULL);
+        done = bytes_write == buffer.size();
+#else
+        std::ofstream writer(m_fifo_file->m_path, std::ofstream::out);
         writer << JSONToString(json) << std::endl;
         done = true;
+#endif
       }));
   if (future->wait_for(timeout) == std::future_status::timeout || !done) {
     // Indeed this is a leak, but it's intentional. "future" obj destructor will
@@ -97,5 +149,21 @@ Error FifoFileIO::SendJSON(const json::Value &json,
   delete future;
   return Error::success();
 }
+
+#if defined(_WIN32)
+bool FifoFileIO::Connect() {
+  if (m_fifo_file->m_is_server) {
+    return ConnectNamedPipe(m_fifo_file->m_pipe_fd, NULL);
+  }
+  if (!WaitNamedPipeA(m_fifo_file->m_path.c_str(), NMPWAIT_WAIT_FOREVER))
+    return false;
+  m_fifo_file->m_pipe_fd =
+      CreateFileA(m_fifo_file->m_path.c_str(), GENERIC_READ | GENERIC_WRITE, 0,
+                  NULL, OPEN_EXISTING, 0, NULL);
+  if (m_fifo_file->m_pipe_fd == INVALID_HANDLE_VALUE)
+    return false;
+  return true;
+}
+#endif
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -1463,7 +1463,7 @@ llvm::json::Object CreateRunInTerminalReverseRequest(
   req_args.push_back("--launch-target");
   req_args.push_back(program.str());
   req_args.insert(req_args.end(), args.begin(), args.end());
-  run_in_terminal_args.try_emplace("args", args);
+  run_in_terminal_args.try_emplace("args", req_args);
 
   if (!cwd.empty())
     run_in_terminal_args.try_emplace("cwd", cwd);


### PR DESCRIPTION
Added `runInTerminal` support for Windows based on Windows Named Pipes. Adapted existed `FifoFile` class to Windows client-server pipes model. When server side owns the assosieted filesystem handle and client side only provide read-write acces to it. Also, fixed small typo in `JSONUtill.cpp` related to `runInTerminal` functionality.