### PR TITLE
[clang][lex] Fix lexing malformed pragma within include directive

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -535,7 +535,9 @@ Bug Fixes in This Version
 - Fixed visibility calculation for template functions. (#GH103477)
 - Fixed a bug where an attribute before a ``pragma clang attribute`` or
   ``pragma clang __debug`` would cause an assertion. Instead, this now diagnoses
-  the invalid attribute location appropriately.  (#GH137861)
+  the invalid attribute location appropriately. (#GH137861)
+- Fixed a crash when a malformed ``_Pragma`` directive appears as part of an 
+  ``#include`` directive. (#GH138094)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Lex/Pragma.cpp
+++ b/clang/lib/Lex/Pragma.cpp
@@ -220,11 +220,11 @@ void Preprocessor::Handle_Pragma(Token &Tok) {
   if (!tok::isStringLiteral(Tok.getKind())) {
     Diag(PragmaLoc, diag::err__Pragma_malformed);
     // Skip bad tokens, and the ')', if present.
-    if (Tok.isNot(tok::r_paren) && Tok.isNot(tok::eof))
+    if (Tok.isNot(tok::r_paren) && Tok.isNot(tok::eof) && Tok.isNot(tok::eod))
       Lex(Tok);
     while (Tok.isNot(tok::r_paren) &&
            !Tok.isAtStartOfLine() &&
-           Tok.isNot(tok::eof))
+           Tok.isNot(tok::eof) && Tok.isNot(tok::eod))
       Lex(Tok);
     if (Tok.is(tok::r_paren))
       Lex(Tok);

--- a/clang/test/Preprocessor/_Pragma-in-include.c
+++ b/clang/test/Preprocessor/_Pragma-in-include.c
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -E %s -verify
+
+// Don't crash, verify that diagnostics are preserved
+#include _Pragma( // expected-error {{_Pragma takes a parenthesized string literal}} expected-error {{expected "FILENAME"}} 


### PR DESCRIPTION
fixes: https://github.com/llvm/llvm-project/issues/138094
this patch fixes a crash triggered by lexing past eof when emitting a diagnostic for a malformed `_Pragma` directive within an `include` directive.
Fixed by by preventing the lexer from eating a `tok::eod`.