### PR TITLE
[LLDB][SBSaveCoreOptions] Add new API to expose the expected core size in bytes

### DIFF
--- a/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
+++ b/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
@@ -64,8 +64,8 @@ Note that currently ELF Core files are not supported."
 ) lldb::SBSaveCoreOptions::GetThreadsToSave;
 
 %feature("docstring", "
-    Get the current total number of bytes the core is expectd to have, excluding the overhead of the core file format.
-    Requires both a Process and a Style to be specified."
+    Get the current total number of bytes the core is expected to have, excluding the overhead of the core file format.
+    Requires both a Process and a Style to be specified. An error will be returned if the provided options would result in no data being saved."
 ) lldb::SBSaveCoreOptions::GetCurrentSizeInBytes;
 
 %feature("docstring", "

--- a/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
+++ b/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
@@ -64,5 +64,10 @@ Note that currently ELF Core files are not supported."
 ) lldb::SBSaveCoreOptions::GetThreadsToSave;
 
 %feature("docstring", "
+    Get the current total number of bytes the core is expectd to have, excluding the overhead of the core file format.
+    Requires both a Process and a Style to be specified."
+) lldb::SBSaveCoreOptions::GetCurrentSizeInBytes;
+
+%feature("docstring", "
     Unset all options."
 ) lldb::SBSaveCoreOptions::Clear;

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -119,8 +119,8 @@ public:
   ///   an empty collection will be returned.
   SBThreadCollection GetThreadsToSave() const;
 
-  /// Get the current total number of bytes the core is expected to be but not
-  /// including the overhead of the core file format. Requires a Process and
+  /// Get the current total number of bytes the core is expected to have
+  /// excluding the overhead of the core file format. Requires a Process and
   /// Style to be specified.
   ///
   /// \note

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -119,6 +119,19 @@ public:
   ///   an empty collection will be returned.
   SBThreadCollection GetThreadsToSave() const;
 
+  /// Get the current total number of bytes the core is expected to be but not
+  /// including the overhead of the core file format. Requires a Process and 
+  /// Style to be specified.
+  /// 
+  /// \note
+  ///   This can cause some modification of the underlying data store 
+  ///   as regions with no permissions, or invalid permissions will be removed
+  ///   and stacks will be minified up to their stack pointer + the redzone.
+  ///
+  /// \returns
+  ///   The expected size of the data contained in the core in bytes.
+  uint64_t GetCurrentSizeInBytes(SBError &error);
+
   /// Reset all options.
   void Clear();
 

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -120,11 +120,11 @@ public:
   SBThreadCollection GetThreadsToSave() const;
 
   /// Get the current total number of bytes the core is expected to be but not
-  /// including the overhead of the core file format. Requires a Process and 
+  /// including the overhead of the core file format. Requires a Process and
   /// Style to be specified.
-  /// 
+  ///
   /// \note
-  ///   This can cause some modification of the underlying data store 
+  ///   This can cause some modification of the underlying data store
   ///   as regions with no permissions, or invalid permissions will be removed
   ///   and stacks will be minified up to their stack pointer + the redzone.
   ///

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -49,6 +49,8 @@ public:
 
   lldb_private::ThreadCollection::collection GetThreadsToSave() const;
 
+  uint64_t GetCurrentSizeInBytes(Status &error);
+
   void Clear();
 
 private:

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -49,7 +49,7 @@ public:
 
   lldb_private::ThreadCollection::collection GetThreadsToSave() const;
 
-  uint64_t GetCurrentSizeInBytes(Status &error);
+  llvm::Expected<uint64_t> GetCurrentSizeInBytes();
 
   void Clear();
 

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -116,14 +116,16 @@ void SBSaveCoreOptions::Clear() {
 
 uint64_t SBSaveCoreOptions::GetCurrentSizeInBytes(SBError &error) {
   LLDB_INSTRUMENT_VA(this, error);
-  llvm::Expected<uint64_t> expected_bytes = m_opaque_up->GetCurrentSizeInBytes();
+  llvm::Expected<uint64_t> expected_bytes =
+      m_opaque_up->GetCurrentSizeInBytes();
   if (!expected_bytes) {
-    error = SBError(lldb_private::Status::FromError(expected_bytes.takeError()));
+    error =
+        SBError(lldb_private::Status::FromError(expected_bytes.takeError()));
     return 0;
   }
   // Clear the error, so if the clearer uses it we set it to success.
   error.Clear();
-  return *expected_bytes; 
+  return *expected_bytes;
 }
 
 lldb_private::SaveCoreOptions &SBSaveCoreOptions::ref() const {

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -114,6 +114,11 @@ void SBSaveCoreOptions::Clear() {
   m_opaque_up->Clear();
 }
 
+uint64_t SBSaveCoreOptions::GetCurrentSizeInBytes(SBError &error) {
+  LLDB_INSTRUMENT_VA(this, error);
+  return m_opaque_up->GetCurrentSizeInBytes(error.ref());
+}
+
 lldb_private::SaveCoreOptions &SBSaveCoreOptions::ref() const {
   return *m_opaque_up.get();
 }

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -116,7 +116,14 @@ void SBSaveCoreOptions::Clear() {
 
 uint64_t SBSaveCoreOptions::GetCurrentSizeInBytes(SBError &error) {
   LLDB_INSTRUMENT_VA(this, error);
-  return m_opaque_up->GetCurrentSizeInBytes(error.ref());
+  llvm::Expected<uint64_t> expected_bytes = m_opaque_up->GetCurrentSizeInBytes();
+  if (!expected_bytes) {
+    error = SBError(lldb_private::Status::FromError(expected_bytes.takeError()));
+    return 0;
+  }
+  // Clear the error, so if the clearer uses it we set it to success.
+  error.Clear();
+  return *expected_bytes; 
 }
 
 lldb_private::SaveCoreOptions &SBSaveCoreOptions::ref() const {

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -145,20 +145,20 @@ SaveCoreOptions::GetThreadsToSave() const {
   return thread_collection;
 }
 
-uint64_t SaveCoreOptions::GetCurrentSizeInBytes(Status &error) {
-  if (!m_process_sp) {
-    error = Status::FromErrorString("Requires a process to be set.");
-    return 0;
-  }
+llvm::Expected<uint64_t> SaveCoreOptions::GetCurrentSizeInBytes() {
+  Status error;
+  if (!m_process_sp)
+    return Status::FromErrorString("Requires a process to be set.").takeError();
+
 
   error = EnsureValidConfiguration(m_process_sp);
   if (error.Fail())
-    return 0;
+    return error.takeError();
 
   CoreFileMemoryRanges ranges;
   error = m_process_sp->CalculateCoreFileSaveRanges(*this, ranges);
   if (error.Fail())
-    return 0;
+    return error.takeError();
 
   uint64_t total_in_bytes = 0;
   for (auto &core_range : ranges)

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -151,13 +151,17 @@ uint64_t SaveCoreOptions::GetCurrentSizeInBytes(Status &error) {
     return 0;
   }
 
+  error = EnsureValidConfiguration(m_process_sp);
+  if (error.Fail())
+    return 0;
+
   CoreFileMemoryRanges ranges;
   error = m_process_sp->CalculateCoreFileSaveRanges(*this, ranges);
   if (error.Fail())
     return 0;
 
   uint64_t total_in_bytes = 0;
-  for (auto& core_range : ranges)
+  for (auto &core_range : ranges)
     total_in_bytes += core_range.data.range.size();
 
   return total_in_bytes;

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -145,6 +145,24 @@ SaveCoreOptions::GetThreadsToSave() const {
   return thread_collection;
 }
 
+uint64_t SaveCoreOptions::GetCurrentSizeInBytes(Status &error) {
+  if (!m_process_sp) {
+    error = Status::FromErrorString("Requires a process to be set.");
+    return 0;
+  }
+
+  CoreFileMemoryRanges ranges;
+  error = m_process_sp->CalculateCoreFileSaveRanges(*this, ranges);
+  if (error.Fail())
+    return 0;
+
+  uint64_t total_in_bytes = 0;
+  for (auto& core_range : ranges)
+    total_in_bytes += core_range.data.range.size();
+
+  return total_in_bytes;
+}
+
 void SaveCoreOptions::ClearProcessSpecificData() {
   // Deliberately not following the formatter style here to indicate that
   // this method will be expanded in the future.

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -150,7 +150,6 @@ llvm::Expected<uint64_t> SaveCoreOptions::GetCurrentSizeInBytes() {
   if (!m_process_sp)
     return Status::FromErrorString("Requires a process to be set.").takeError();
 
-
   error = EnsureValidConfiguration(m_process_sp);
   if (error.Fail())
     return error.takeError();

--- a/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
+++ b/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
@@ -105,9 +105,9 @@ class SBSaveCoreOptionsAPICase(TestBase):
         self.assertEqual(thread_collection.GetSize(), 3)
         self.assertIn(middle_thread, thread_collection)
 
-    def test_get_total_in_bytes(self):
+    def test_get_current_size_in_bytes(self):
         """
-        Tests that get total in bytes properly returns an error without a process,
+        Tests that ensures GetCurrentSizeInBytes properly returns an error without a process,
         and the readable regions with a process.
         """
 
@@ -115,13 +115,52 @@ class SBSaveCoreOptionsAPICase(TestBase):
         options.SetStyle(lldb.eSaveCoreCustomOnly)
         process = self.get_basic_process()
         memory_range = lldb.SBMemoryRegionInfo()
-        process.GetMemoryRegionInfo(0x7FFF12A84030, memory_range)
+        
+        # Add the memory range of 0x1000-0x1100
+        process.GetMemoryRegionInfo(0x1000, memory_range)
         options.AddMemoryRegionToSave(memory_range)
+
+        # Check that we fail when we have no process set
+        # even though we added a memory region.
         error = lldb.SBError()
         total = options.GetCurrentSizeInBytes(error)
         self.assertTrue(error.Fail(), error.GetCString())
+
+        # Check that we don't get an error now that we've added a process
         options.SetProcess(process)
         total = options.GetCurrentSizeInBytes(error)
         self.assertTrue(error.Success(), error.GetCString())
+
+        # Validate the size returned is the same size as the single region we added.
         expected_size = memory_range.GetRegionEnd() - memory_range.GetRegionBase()
         self.assertEqual(total, expected_size)
+
+    def test_get_total_in_bytes_missing_requirements(self):
+        """
+        Tests the matrix of error responses that GetCurrentSizeInBytes
+        """
+
+        options = lldb.SBSaveCoreOptions()
+
+        # No process, no style returns an error.
+        error = lldb.SBError()
+        total = options.GetCurrentSizeInBytes(error)
+        self.assertTrue(error.Fail(), error.GetCString())
+
+        # No process returns an error
+        options.SetStyle(lldb.eSaveCoreCustomOnly)
+        total = options.GetCurrentSizeInBytes(error)
+        self.assertTrue(error.Fail(), error.GetCString())
+
+        options.Clear()
+
+        # No style returns an error
+        process = self.get_basic_process()
+        options.SetProcess(process)
+        total = options.GetCurrentSizeInBytes(error)
+        self.assertTrue(error.Fail(), error.GetCString())
+
+        # Options that result in no valid data returns an error.
+        options.SetStyle(lldb.eSaveCoreCustomOnly)
+        total = options.GetCurrentSizeInBytes(error)
+        self.assertTrue(error.Fail(), error.GetCString())

--- a/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
+++ b/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
@@ -115,7 +115,7 @@ class SBSaveCoreOptionsAPICase(TestBase):
         options.SetStyle(lldb.eSaveCoreCustomOnly)
         process = self.get_basic_process()
         memory_range = lldb.SBMemoryRegionInfo()
-        
+
         # Add the memory range of 0x1000-0x1100
         process.GetMemoryRegionInfo(0x1000, memory_range)
         options.AddMemoryRegionToSave(memory_range)

--- a/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
+++ b/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
@@ -107,7 +107,7 @@ class SBSaveCoreOptionsAPICase(TestBase):
 
     def test_get_total_in_bytes(self):
         """
-        Tests that get total in bytes properly returns an error without a process, 
+        Tests that get total in bytes properly returns an error without a process,
         and the readable regions with a process.
         """
 

--- a/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
+++ b/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
@@ -104,3 +104,24 @@ class SBSaveCoreOptionsAPICase(TestBase):
         thread_collection = options.GetThreadsToSave()
         self.assertEqual(thread_collection.GetSize(), 3)
         self.assertIn(middle_thread, thread_collection)
+
+    def test_get_total_in_bytes(self):
+        """
+        Tests that get total in bytes properly returns an error without a process, 
+        and the readable regions with a process.
+        """
+
+        options = lldb.SBSaveCoreOptions()
+        options.SetStyle(lldb.eSaveCoreCustomOnly)
+        process = self.get_basic_process()
+        memory_range = lldb.SBMemoryRegionInfo()
+        process.GetMemoryRegionInfo(0x7FFF12A84030, memory_range)
+        options.AddMemoryRegionToSave(memory_range)
+        error = lldb.SBError()
+        total = options.GetCurrentSizeInBytes(error)
+        self.assertTrue(error.Fail(), error.GetCString())
+        options.SetProcess(process)
+        total = options.GetCurrentSizeInBytes(error)
+        self.assertTrue(error.Success(), error.GetCString())
+        expected_size = memory_range.GetRegionEnd() - memory_range.GetRegionBase()
+        self.assertEqual(total, expected_size)

--- a/lldb/test/API/python_api/sbsavecoreoptions/basic_minidump.yaml
+++ b/lldb/test/API/python_api/sbsavecoreoptions/basic_minidump.yaml
@@ -36,6 +36,9 @@ Streams:
           Content:               'BAADBEEF'
   - Type:            Memory64List
     Memory Ranges:
-      - Start of Memory Range: 0x7FFF12A84030
-        Data Size:       0x2FD0
+      - Start of Memory Range: 0x1000
+        Data Size:       0x100
+        Content :        ''
+      - Start of Memory Range: 0x2000
+        Data Size:       0x200
         Content :        ''

--- a/lldb/test/API/python_api/sbsavecoreoptions/basic_minidump.yaml
+++ b/lldb/test/API/python_api/sbsavecoreoptions/basic_minidump.yaml
@@ -34,3 +34,8 @@ Streams:
         Stack:
           Start of Memory Range: 0x00007FFFC8DFF000
           Content:               'BAADBEEF'
+  - Type:            Memory64List
+    Memory Ranges:
+      - Start of Memory Range: 0x7FFF12A84030
+        Data Size:       0x2FD0
+        Content :        ''


### PR DESCRIPTION
My current internal work requires some sensitivity to IO usage. I had a work around to calculate the expected size of a Minidump, but I've added this PR so an automated system could look at the expected size of an LLDB generated Minidump and then choose if it has the space or wants to generate it.

There are some prerequisites to calculating the correct size, so I have the API take a reference for an SBError, I originally tried to return an SBError and instead take a uint64_t reference, but this made the API very difficult to use in python.

Added a test case as well.