### PR TITLE
[Offload] Add 'Maintainers.md' file for offload

### DIFF
--- a/offload/Maintainers.md
+++ b/offload/Maintainers.md
@@ -1,0 +1,13 @@
+# LLVM Offload Library Maintainers
+
+This file is a list of the
+[maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for
+the LLVM Offloading library.
+
+# Current Maintainers
+
+Johannes Doerfert \
+jdoerfert@llnl.gov (email), [jdoerfert](https://github.com/jdoerfert) (GitHub)
+
+Joseph Huber \
+joseph.huber@amd.com (email), [jhuber6](https://github.com/jhuber6) (Github)


### PR DESCRIPTION
Summary:
The offload project lacks a maintainers file. Adding it with myself and
Johannes as the still active maintainers.
