### PR TITLE
[DirectX] Make DXILOpLowering responsible for cleaning up dead intrinsics

### DIFF
--- a/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
+++ b/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
@@ -36,14 +36,6 @@ static bool finalizeLinkage(Module &M) {
       M.getFunctionList().erase(F);
   }
 
-  // Do a pass over intrinsics that are no longer used and remove them.
-  Funcs.clear();
-  for (Function &F : M.functions())
-    if (F.isIntrinsic() && F.use_empty())
-      Funcs.push_back(&F);
-  for (Function *F : Funcs)
-    F->eraseFromParent();
-
   return false;
 }
 

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -756,14 +756,20 @@ public:
       case Intrinsic::lifetime_start:
       case Intrinsic::lifetime_end:
       case Intrinsic::not_intrinsic:
+        if (F.use_empty())
+          F.eraseFromParent();
         continue;
-      default: {
-        SmallString<128> Msg =
-            formatv("Unsupported intrinsic {0} for DXIL lowering", F.getName());
-        M.getContext().emitError(Msg);
-        HasErrors |= true;
+      default:
+        if (F.use_empty())
+          F.eraseFromParent();
+        else {
+          SmallString<128> Msg = formatv(
+              "Unsupported intrinsic {0} for DXIL lowering", F.getName());
+          M.getContext().emitError(Msg);
+          HasErrors |= true;
+        }
         break;
-      }
+
 #define DXIL_OP_INTRINSIC(OpCode, Intrin, ...)                                 \
   case Intrin:                                                                 \
     HasErrors |= replaceFunctionWithOp(                                        \

--- a/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
@@ -98,6 +98,7 @@ public:
 
   FunctionPass *createTargetRegisterAllocator(bool) override { return nullptr; }
   void addCodeGenPrepare() override {
+    addPass(createDXILFinalizeLinkageLegacyPass());
     addPass(createDXILIntrinsicExpansionLegacyPass());
     addPass(createDXILCBufferAccessLegacyPass());
     addPass(createDXILDataScalarizationLegacyPass());
@@ -108,7 +109,6 @@ public:
     addPass(createScalarizerPass(DxilScalarOptions));
     addPass(createDXILForwardHandleAccessesLegacyPass());
     addPass(createDXILLegalizeLegacyPass());
-    addPass(createDXILFinalizeLinkageLegacyPass());
     addPass(createDXILTranslateMetadataLegacyPass());
     addPass(createDXILOpLoweringLegacyPass());
     addPass(createDXILPrepareModulePass());

--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -13,6 +13,7 @@
 ; CHECK-OBJ-NEXT: Create Garbage Collector Module Metadata
 
 ; CHECK-NEXT: ModulePass Manager
+; CHECK-NEXT:   DXIL Finalize Linkage
 ; CHECK-NEXT:   DXIL Intrinsic Expansion
 ; CHECK-NEXT:   DXIL CBuffer Access
 ; CHECK-NEXT:   DXIL Data Scalarization
@@ -23,7 +24,6 @@
 ; CHECK-NEXT:     Scalarize vector operations
 ; CHECK-NEXT:     DXIL Forward Handle Accesses
 ; CHECK-NEXT:     DXIL Legalizer
-; CHECK-NEXT:   DXIL Finalize Linkage
 ; CHECK-NEXT:   DXIL Resources Analysis
 ; CHECK-NEXT:   DXIL Module Metadata analysis
 ; CHECK-NEXT:   DXIL Shader Flag Analysis


### PR DESCRIPTION
This moves the responsibility for cleaning up dead intrinsics from DXILFinalizeLinkage to DXILOpLowering, and moves DXILFinalizeLinkage back to it's pre-#136244 place in the pipeline. Doing this avoids issues with DXIL passes running on obviously dead code, and makes it more clear what DXILFinalizeLinkage is really doing.

This also helps with the story for #134260, as cleaning up dead intrinsics doesn't make sense if this becomes a more generic pass.

Note that test/CodeGen/DirectX/remove-dead-intriniscs.ll already covers most of the testing here. It'd be nice to have something that catches the regression from changing the pass ordering but I couldn't come up with anything that wouldn't be incredibly fragile.

Fixes #138180.