### PR TITLE
[MLIR][LLVM] Debug info: fix DIDerivedTypeAttr relation to DIScopeAttr

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -90,8 +90,8 @@ bool DINodeAttr::classof(Attribute attr) {
 
 bool DIScopeAttr::classof(Attribute attr) {
   return llvm::isa<DICommonBlockAttr, DICompileUnitAttr, DICompositeTypeAttr,
-                   DIFileAttr, DILocalScopeAttr, DIModuleAttr, DINamespaceAttr>(
-      attr);
+                   DIDerivedTypeAttr, DIFileAttr, DILocalScopeAttr,
+                   DIModuleAttr, DINamespaceAttr>(attr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/LLVMIR/debuginfo.mlir
+++ b/mlir/test/Dialect/LLVMIR/debuginfo.mlir
@@ -131,6 +131,12 @@
   annotations = #llvm.di_annotation<name = "foo", value = "bar">
 >
 
+// CHECK-DAG: #[[SP3:.*]] = #llvm.di_subprogram<scope = #[[PTR2]], file = #[[FILE]], type = #[[SPTYPE1]]>
+#sp3 = #llvm.di_subprogram<
+  // Omit the optional parameters.
+  scope = #ptr2, file = #file, type = #spType1
+>
+
 // CHECK-DAG: #[[BLOCK0:.*]] = #llvm.di_lexical_block<scope = #[[SP0]], line = 1, column = 2>
 #block0 = #llvm.di_lexical_block<scope = #sp0, line = 1, column = 2>
 
@@ -139,6 +145,9 @@
 
 // CHECK-DAG: #[[BLOCK2:.*]] = #llvm.di_lexical_block<scope = #[[SP2]]>
 #block2 = #llvm.di_lexical_block<scope = #sp2>
+
+// CHECK-DAG: #[[BLOCK3:.*]] = #llvm.di_lexical_block<scope = #[[SP3]]>
+#block3 = #llvm.di_lexical_block<scope = #sp3>
 
 // CHECK-DAG: #[[VAR0:.*]] = #llvm.di_local_variable<scope = #[[BLOCK0]], name = "alloc", file = #[[FILE]], line = 6, arg = 1, alignInBits = 32, type = #[[INT0]]>
 #var0 = #llvm.di_local_variable<
@@ -156,6 +165,12 @@
 #var2 = #llvm.di_local_variable<
   // Omit the optional parameters.
   scope = #block2, name = "arg2"
+>
+
+// CHECK-DAG: #[[VAR3:.*]] = #llvm.di_local_variable<scope = #[[BLOCK3]], name = "arg3">
+#var3 = #llvm.di_local_variable<
+  // Omit the optional parameters.
+  scope = #block3, name = "arg3"
 >
 
 // CHECK-DAG: #[[LABEL1:.*]] =  #llvm.di_label<scope = #[[BLOCK1]], name = "label", file = #[[FILE]], line = 42>
@@ -194,12 +209,14 @@ llvm.func @addr(%arg: i64) {
   llvm.return
 }
 
-// CHECK: llvm.func @value(%[[ARG1:.*]]: i32, %[[ARG2:.*]]: i32)
-llvm.func @value(%arg1: i32, %arg2: i32) {
+// CHECK: llvm.func @value(%[[ARG1:.*]]: i32, %[[ARG2:.*]]: i32, %[[ARG3:.*]]: i32)
+llvm.func @value(%arg1: i32, %arg2: i32, %arg3 : i32) {
   // CHECK: llvm.intr.dbg.value #[[VAR1]] #llvm.di_expression<[DW_OP_LLVM_fragment(16, 8), DW_OP_plus_uconst(2), DW_OP_deref]> = %[[ARG1]]
   llvm.intr.dbg.value #var1 #llvm.di_expression<[DW_OP_LLVM_fragment(16, 8), DW_OP_plus_uconst(2), DW_OP_deref]> = %arg1 : i32
   // CHECK: llvm.intr.dbg.value #[[VAR2]] = %[[ARG2]]
   llvm.intr.dbg.value #var2 = %arg2 : i32
+  // CHECK: llvm.intr.dbg.value #[[VAR3]] = %[[ARG3]]
+  llvm.intr.dbg.value #var3 = %arg3 : i32
   // CHECK: llvm.intr.dbg.label #[[LABEL1]]
   llvm.intr.dbg.label #label1
   // CHECK: llvm.intr.dbg.label #[[LABEL2]]


### PR DESCRIPTION
Fix `di_subprogram` references to scopes composed of `di_derived_type`s, which currently fail to parse with:

```
error: failed to parse LLVM_DISubprogramAttr parameter 'scope' which is to be a `DIScopeAttr`
```