### PR TITLE
Print source filename when invalid debug info is found in LTO.

### DIFF
--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -548,6 +548,7 @@ void LTOCodeGenerator::verifyMergedModuleOnce() {
     report_fatal_error("Broken module found, compilation aborted!");
   if (BrokenDebugInfo) {
     emitWarning("Invalid debug info found, debug info will be stripped");
+    emitWarning("Source FileName: " + MergedModule->getSourceFileName());
     StripDebugInfo(*MergedModule);
   }
 }

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -182,6 +182,8 @@ static void verifyLoadedModule(Module &TheModule) {
   if (BrokenDebugInfo) {
     TheModule.getContext().diagnose(ThinLTODiagnosticInfo(
         "Invalid debug info found, debug info will be stripped", DS_Warning));
+    TheModule.getContext().diagnose(ThinLTODiagnosticInfo(
+        "Source File Name: " + TheModule.getSourceFileName(), DS_Warning));
     StripDebugInfo(TheModule);
   }
 }


### PR DESCRIPTION
When invalid debug info is found in a module during LTO, the debug info from that module is stripped. However, we do not print the source filename, which makes it impossible to figure out where the invalid debug info is coming from.

This patch prints the source file name.