### PR TITLE
Fix TestEvents.py after: 4fdb8cb

### DIFF
--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -413,7 +413,7 @@ class EventAPITestCase(TestBase):
 
         # Add our stop hook here, don't report on the initial attach:
         self.runCmd(
-            f"target stop-hook add -P stop_hook.StopHook -k instance -v {self.instance} -F false"
+            f"target stop-hook add -P stop_hook.StopHook -k instance -v {self.instance} -I false"
         )
         self.stop_counter = 0
 


### PR DESCRIPTION
I changed the option name from at-first-stop (-F) to at-initial-stop (-I) but missed one place in the testsuite.