### PR TITLE
[Clang][Cygwin] don't use -Bsymbolic-functions

### DIFF
--- a/clang/tools/clang-shlib/CMakeLists.txt
+++ b/clang/tools/clang-shlib/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 
 # Optimize function calls for default visibility definitions to avoid PLT and
 # reduce dynamic relocations.
-if (NOT APPLE AND NOT MINGW AND NOT LLVM_LINKER_IS_SOLARISLD_ILLUMOS)
+if (NOT APPLE AND NOT MINGW AND NOT CYGWIN AND NOT LLVM_LINKER_IS_SOLARISLD_ILLUMOS)
   target_link_options(clang-cpp PRIVATE LINKER:-Bsymbolic-functions)
 endif()
 if (MINGW OR CYGWIN)


### PR DESCRIPTION
GNU ld seems to ignore this option, but LLD treats the presence of this unknown option as an error.