### PR TITLE
[JITLink][Cygwin] undef i386 in JITLink/i386.h

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/i386.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/i386.h
@@ -16,6 +16,8 @@
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/TableManager.h"
 
+#undef i386
+
 namespace llvm::jitlink::i386 {
 /// Represets i386 fixups
 enum EdgeKind_i386 : Edge::Kind {


### PR DESCRIPTION
i686 cygwin gcc has a default define of i386 to 1, which conflicts with a namespace named i386, so undef it.