### PR TITLE
[Clang][NFC] Capture by ref to avoid copying std::string

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/CheckerContext.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerContext.cpp
@@ -67,10 +67,10 @@ bool CheckerContext::isCLibraryFunction(const FunctionDecl *FD,
       //   _xxxxx_
       //   ^     ^ lookbehind and lookahead characters
 
-      const auto MatchPredecessor = [=]() -> bool {
+      const auto MatchPredecessor = [&]() -> bool {
         return start <= 0 || !llvm::isAlpha(BName[start - 1]);
       };
-      const auto MatchSuccessor = [=]() -> bool {
+      const auto MatchSuccessor = [&]() -> bool {
         std::size_t LookbehindPlace = start + Name.size();
         return LookbehindPlace >= BName.size() ||
                !llvm::isAlpha(BName[LookbehindPlace]);


### PR DESCRIPTION
Static analysis flagged capturing BName by value as opposed to by reference. Updated capture to be by reference.