### PR TITLE
[NFC] Fix c++ style comment in c file

### DIFF
--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -1224,7 +1224,7 @@ static CXString createCXString(const char *CS) {
 static CXString duplicateCXString(const char *CS) {
   CXString Str;
   Str.data = strdup(CS);
-  Str.private_flags = 1; // CXS_Malloc
+  Str.private_flags = 1; /* CXS_Malloc */
   return Str;
 }
 

--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -55,14 +55,16 @@ std::error_code restorezOSStdHandleAutoConversion(int FD);
 /** \brief Set the tag information for a file descriptor. */
 std::error_code setzOSFileTag(int FD, int CCSID, bool Text);
 
-// Get the the tag ccsid for a file name or a file descriptor.
+/** \brief Get the the tag ccsid for a file name or a file descriptor. */
 ErrorOr<__ccsid_t> getzOSFileTag(const char *FileName, const int FD = -1);
 
-// Query the file tag to determine if it needs conversion to UTF-8 codepage.
+/** \brief Query the file tag to determine if it needs conversion to UTF-8
+ *  codepage.
+ */
 ErrorOr<bool> needzOSConversion(const char *FileName, const int FD = -1);
 
-} // namespace llvm
-#endif // __cplusplus
+} /* namespace llvm */
+#endif /* __cplusplus */
 
 #endif /* __MVS__ */
 


### PR DESCRIPTION
Fix "C++ style comments are not allowed in ISO C90" warnings in some C files.