### PR TITLE
[llvm] Add extra tests for atomicrmw fmaximum/fminimum

### DIFF
--- a/llvm/bindings/ocaml/llvm/llvm.ml
+++ b/llvm/bindings/ocaml/llvm/llvm.ml
@@ -302,6 +302,8 @@ module AtomicRMWBinOp = struct
   | UDec_Wrap
   | USub_Cond
   | USub_Sat
+  | FMaximum
+  | FMinimum
 end
 
 module ValueKind = struct

--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -337,6 +337,8 @@ module AtomicRMWBinOp : sig
   | UDec_Wrap
   | USub_Cond
   | USub_Sat
+  | FMaximum
+  | FMinimum
 end
 
 (** The kind of an [llvalue], the result of [classify_value v].

--- a/llvm/test/Bindings/llvm-c/atomics.ll
+++ b/llvm/test/Bindings/llvm-c/atomics.ll
@@ -54,6 +54,8 @@ define void @atomic_rmw_ops(ptr %p, i32 %i, float %f) {
   %a.fsub      = atomicrmw fsub      ptr %p, float %f acq_rel, align 8
   %a.fmax      = atomicrmw fmax      ptr %p, float %f acq_rel, align 8
   %a.fmin      = atomicrmw fmin      ptr %p, float %f acq_rel, align 8
+  %a.fmaximum  = atomicrmw fmaximum  ptr %p, float %f acq_rel, align 8
+  %a.fminimum  = atomicrmw fminimum  ptr %p, float %f acq_rel, align 8
 
   %a.uinc_wrap = atomicrmw uinc_wrap ptr %p, i32 %i acq_rel, align 8
   %a.udec_wrap = atomicrmw udec_wrap ptr %p, i32 %i acq_rel, align 8


### PR DESCRIPTION
Add extra tests for `atomicrmw fmaximum/fminimum`, that I missed in my original PR #137701, and also `fmaximum`/`fminimum` should be defined in the ocaml bindings.