### PR TITLE
Reset CodeGenOptions fields for clean module/PCH builds

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -209,7 +209,7 @@ void ModuleDepCollector::addOutputPaths(CowCompilerInvocation &CI,
 void dependencies::resetBenignCodeGenOptions(frontend::ActionKind ProgramAction,
                                              const LangOptions &LangOpts,
                                              CodeGenOptions &CGOpts) {
-  // Reset to default-constructed values (not necessarily empty) to avoid leaking build-specific data.
+  // Reset to default-constructed values to avoid leaking build-specific data.
   if (ProgramAction == frontend::GenerateModule) {
     CGOpts.MainFileName = {};
     CGOpts.DwarfDebugFlags = {};

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -209,20 +209,21 @@ void ModuleDepCollector::addOutputPaths(CowCompilerInvocation &CI,
 void dependencies::resetBenignCodeGenOptions(frontend::ActionKind ProgramAction,
                                              const LangOptions &LangOpts,
                                              CodeGenOptions &CGOpts) {
-  // TODO: Figure out better way to set options to their default value.
+  // For actions that produce modules or PCHs, reset options that could leak build-specific data.
   if (ProgramAction == frontend::GenerateModule) {
-    CGOpts.MainFileName.clear();
-    CGOpts.DwarfDebugFlags.clear();
+    CGOpts.MainFileName = {};
+    CGOpts.DwarfDebugFlags = {};
   }
+
   if (ProgramAction == frontend::GeneratePCH ||
       (ProgramAction == frontend::GenerateModule && !LangOpts.ModulesCodegen)) {
-    CGOpts.DebugCompilationDir.clear();
-    CGOpts.CoverageCompilationDir.clear();
-    CGOpts.CoverageDataFile.clear();
-    CGOpts.CoverageNotesFile.clear();
-    CGOpts.ProfileInstrumentUsePath.clear();
-    CGOpts.SampleProfileFile.clear();
-    CGOpts.ProfileRemappingFile.clear();
+    CGOpts.DebugCompilationDir = {};
+    CGOpts.CoverageCompilationDir = {};
+    CGOpts.CoverageDataFile = {};
+    CGOpts.CoverageNotesFile = {};
+    CGOpts.ProfileInstrumentUsePath = {};
+    CGOpts.SampleProfileFile = {};
+    CGOpts.ProfileRemappingFile = {};
   }
 }
 

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -209,7 +209,7 @@ void ModuleDepCollector::addOutputPaths(CowCompilerInvocation &CI,
 void dependencies::resetBenignCodeGenOptions(frontend::ActionKind ProgramAction,
                                              const LangOptions &LangOpts,
                                              CodeGenOptions &CGOpts) {
-  // For actions that produce modules or PCHs, reset options that could leak build-specific data.
+  // Reset to default-constructed values (not necessarily empty) to avoid leaking build-specific data.
   if (ProgramAction == frontend::GenerateModule) {
     CGOpts.MainFileName = {};
     CGOpts.DwarfDebugFlags = {};

--- a/clang/test/Modules/reset-codegen-options.c
+++ b/clang/test/Modules/reset-codegen-options.c
@@ -1,0 +1,21 @@
+// REQUIRES: modules
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fmodules -emit-module-interface -fmodule-name=TestModule -o - %s \
+// RUN:   -fmodule-file=module.pcm 2>&1 | FileCheck %s --implicit-check-not="MainFileName" --implicit-check-not="DebugCompilationDir"
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-pch -o - %s 2>&1 | FileCheck %s --implicit-check-not="DwarfDebugFlags"
+
+// CHECK-NOT: MainFileName
+// CHECK-NOT: DwarfDebugFlags
+// CHECK-NOT: DebugCompilationDir
+// CHECK-NOT: CoverageCompilationDir
+// CHECK-NOT: CoverageDataFile
+// CHECK-NOT: CoverageNotesFile
+// CHECK-NOT: ProfileInstrumentUsePath
+// CHECK-NOT: SampleProfileFile
+// CHECK-NOT: ProfileRemappingFile
+
+int foo() {
+    return 42;
+  }
+  


### PR DESCRIPTION
This change resets certain CodeGenOptions fields using = {} instead of .clear(), to clean up build-specific data when generating modules or PCH files. It helps make the output more consistent and easier to maintain