### PR TITLE
[NFC][mlir][AsmPrinter] Don't compute resourceStr when --mlir-elide-resource-strings-if-larger=0

### DIFF
--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -3463,6 +3463,10 @@ void OperationPrinter::printResourceFileMetadata(
       std::optional<uint64_t> charLimit =
           printerFlags.getLargeResourceStringLimit();
       if (charLimit.has_value()) {
+        // Don't compute resourceStr when charLimit is 0.
+        if (charLimit.value() == 0)
+          return;
+
         llvm::raw_string_ostream ss(resourceStr);
         valueFn(ss);
 

--- a/mlir/test/IR/pretty-resources-print.mlir
+++ b/mlir/test/IR/pretty-resources-print.mlir
@@ -2,11 +2,16 @@
 
 // RUN: mlir-opt %s --mlir-elide-resource-strings-if-larger=20| FileCheck %s
 
+// RUN: mlir-opt %s --mlir-elide-resource-strings-if-larger=0| FileCheck %s --check-prefix=ZERO
+
+
 // To ensure we print the resource keys, have reference to them
 // CHECK: attr = dense_resource<blob1> : tensor<3xi64>
+// ZERO: attr = dense_resource<blob1> : tensor<3xi64>
 "test.blob1op"() {attr = dense_resource<blob1> : tensor<3xi64> } : () -> ()
 
 // CHECK-NEXT: attr = dense_resource<blob2> : tensor<3xi64>
+// ZERO-NEXT: attr = dense_resource<blob2> : tensor<3xi64>
 "test.blob2op"() {attr = dense_resource<blob2> : tensor<3xi64> } : () -> ()
 
 // CHECK:      {-#
@@ -20,6 +25,11 @@
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: #-}
+
+// Make sure no external_resources are printed when --mlir-elide-resource-strings-if-larger=0
+// ZERO:      {-#
+// ZERO-EMPTY:
+// ZERO-NEXT: #-}
 
 {-#
   dialect_resources: {


### PR DESCRIPTION
When skipping the printing of large DenseResourceElementsAttr with --mlir-elide-resource-strings-if-larger,
we need to compute resourceStr to check if the string is small enough to print.

With --mlir-elide-resource-strings-if-larger set to 0, nothing should be printed, but we still compute the size.

This change will allow an early return when --mlir-elide-resource-strings-if-larger=0, making the print process faster.