### PR TITLE
[GlobalISel] Put legalizer rule debug behind a verbose option.

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerInfo.cpp
@@ -217,24 +217,28 @@ LegalizeActionStep LegalizeRuleSet::apply(const LegalityQuery &Query) const {
 bool LegalizeRuleSet::verifyTypeIdxsCoverage(unsigned NumTypeIdxs) const {
 #ifndef NDEBUG
   if (Rules.empty()) {
-    if (VerboseVerifyLegalizerInfo)
-      LLVM_DEBUG(
-          dbgs() << ".. type index coverage check SKIPPED: no rules defined\n");
+    if (VerboseVerifyLegalizerInfo) {
+      LLVM_DEBUG(dbgs() << ".. type index coverage check SKIPPED: "
+                        << "no rules defined\n");
+    }
     return true;
   }
   const int64_t FirstUncovered = TypeIdxsCovered.find_first_unset();
   if (FirstUncovered < 0) {
-    if (VerboseVerifyLegalizerInfo)
+    if (VerboseVerifyLegalizerInfo) {
       LLVM_DEBUG(dbgs() << ".. type index coverage check SKIPPED:"
                            " user-defined predicate detected\n");
+    }
     return true;
   }
   const bool AllCovered = (FirstUncovered >= NumTypeIdxs);
-  if (NumTypeIdxs > 0)
-    if (VerboseVerifyLegalizerInfo)
+  if (NumTypeIdxs > 0) {
+    if (VerboseVerifyLegalizerInfo) {
       LLVM_DEBUG(dbgs() << ".. the first uncovered type index: "
                         << FirstUncovered << ", "
                         << (AllCovered ? "OK" : "FAIL") << "\n");
+    }
+  }
   return AllCovered;
 #else
   return true;
@@ -244,22 +248,25 @@ bool LegalizeRuleSet::verifyTypeIdxsCoverage(unsigned NumTypeIdxs) const {
 bool LegalizeRuleSet::verifyImmIdxsCoverage(unsigned NumImmIdxs) const {
 #ifndef NDEBUG
   if (Rules.empty()) {
-    if (VerboseVerifyLegalizerInfo)
-      LLVM_DEBUG(
-          dbgs() << ".. imm index coverage check SKIPPED: no rules defined\n");
+    if (VerboseVerifyLegalizerInfo) {
+      LLVM_DEBUG(dbgs() << ".. imm index coverage check SKIPPED: "
+                        << "no rules defined\n");
+    }
     return true;
   }
   const int64_t FirstUncovered = ImmIdxsCovered.find_first_unset();
   if (FirstUncovered < 0) {
-    if (VerboseVerifyLegalizerInfo)
+    if (VerboseVerifyLegalizerInfo) {
       LLVM_DEBUG(dbgs() << ".. imm index coverage check SKIPPED:"
                            " user-defined predicate detected\n");
+    }
     return true;
   }
   const bool AllCovered = (FirstUncovered >= NumImmIdxs);
-  if (VerboseVerifyLegalizerInfo)
+  if (VerboseVerifyLegalizerInfo) {
     LLVM_DEBUG(dbgs() << ".. the first uncovered imm index: " << FirstUncovered
                       << ", " << (AllCovered ? "OK" : "FAIL") << "\n");
+  }
   return AllCovered;
 #else
   return true;
@@ -287,9 +294,10 @@ unsigned LegalizerInfo::getOpcodeIdxForOpcode(unsigned Opcode) const {
 unsigned LegalizerInfo::getActionDefinitionsIdx(unsigned Opcode) const {
   unsigned OpcodeIdx = getOpcodeIdxForOpcode(Opcode);
   if (unsigned Alias = RulesForOpcode[OpcodeIdx].getAlias()) {
-    if (VerboseVerifyLegalizerInfo)
+    if (VerboseVerifyLegalizerInfo) {
       LLVM_DEBUG(dbgs() << ".. opcode " << Opcode << " is aliased to " << Alias
                         << "\n");
+    }
     OpcodeIdx = getOpcodeIdxForOpcode(Alias);
     assert(RulesForOpcode[OpcodeIdx].getAlias() == 0 && "Cannot chain aliases");
   }
@@ -410,12 +418,13 @@ void LegalizerInfo::verify(const MCInstrInfo &MII) const {
                      ? std::max(OpInfo.getGenericImmIndex() + 1U, Acc)
                      : Acc;
         });
-    if (VerboseVerifyLegalizerInfo)
+    if (VerboseVerifyLegalizerInfo) {
       LLVM_DEBUG(dbgs() << MII.getName(Opcode) << " (opcode " << Opcode
                         << "): " << NumTypeIdxs << " type ind"
                         << (NumTypeIdxs == 1 ? "ex" : "ices") << ", "
                         << NumImmIdxs << " imm ind"
                         << (NumImmIdxs == 1 ? "ex" : "ices") << "\n");
+    }
     const LegalizeRuleSet &RuleSet = getActionDefinitions(Opcode);
     if (!RuleSet.verifyTypeIdxsCoverage(NumTypeIdxs))
       FailedOpcodes.push_back(Opcode);
@@ -428,8 +437,9 @@ void LegalizerInfo::verify(const MCInstrInfo &MII) const {
       errs() << " " << MII.getName(Opcode);
     errs() << "\n";
 
-    report_fatal_error("ill-defined LegalizerInfo"
-                       ", try -debug-only=legalizer-info for details");
+    report_fatal_error("ill-defined LegalizerInfo, try "
+                       "-debug-only=legalizer-info and "
+                       "-verbose-gisel-verify-legalizer-info for details");
   }
 #endif
 }

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerInfo.cpp
@@ -34,6 +34,12 @@ cl::opt<bool> llvm::DisableGISelLegalityCheck(
     cl::desc("Don't verify that MIR is fully legal between GlobalISel passes"),
     cl::Hidden);
 
+cl::opt<bool> VerboseVerifyLegalizerInfo(
+    "verbose-gisel-verify-legalizer-info",
+    cl::desc("Print more information to dbgs about GlobalISel legalizer rules "
+             "being verified"),
+    cl::Hidden);
+
 raw_ostream &llvm::operator<<(raw_ostream &OS, LegalizeAction Action) {
   switch (Action) {
   case Legal:
@@ -211,20 +217,24 @@ LegalizeActionStep LegalizeRuleSet::apply(const LegalityQuery &Query) const {
 bool LegalizeRuleSet::verifyTypeIdxsCoverage(unsigned NumTypeIdxs) const {
 #ifndef NDEBUG
   if (Rules.empty()) {
-    LLVM_DEBUG(
-        dbgs() << ".. type index coverage check SKIPPED: no rules defined\n");
+    if (VerboseVerifyLegalizerInfo)
+      LLVM_DEBUG(
+          dbgs() << ".. type index coverage check SKIPPED: no rules defined\n");
     return true;
   }
   const int64_t FirstUncovered = TypeIdxsCovered.find_first_unset();
   if (FirstUncovered < 0) {
-    LLVM_DEBUG(dbgs() << ".. type index coverage check SKIPPED:"
-                         " user-defined predicate detected\n");
+    if (VerboseVerifyLegalizerInfo)
+      LLVM_DEBUG(dbgs() << ".. type index coverage check SKIPPED:"
+                           " user-defined predicate detected\n");
     return true;
   }
   const bool AllCovered = (FirstUncovered >= NumTypeIdxs);
   if (NumTypeIdxs > 0)
-    LLVM_DEBUG(dbgs() << ".. the first uncovered type index: " << FirstUncovered
-                      << ", " << (AllCovered ? "OK" : "FAIL") << "\n");
+    if (VerboseVerifyLegalizerInfo)
+      LLVM_DEBUG(dbgs() << ".. the first uncovered type index: "
+                        << FirstUncovered << ", "
+                        << (AllCovered ? "OK" : "FAIL") << "\n");
   return AllCovered;
 #else
   return true;
@@ -234,19 +244,22 @@ bool LegalizeRuleSet::verifyTypeIdxsCoverage(unsigned NumTypeIdxs) const {
 bool LegalizeRuleSet::verifyImmIdxsCoverage(unsigned NumImmIdxs) const {
 #ifndef NDEBUG
   if (Rules.empty()) {
-    LLVM_DEBUG(
-        dbgs() << ".. imm index coverage check SKIPPED: no rules defined\n");
+    if (VerboseVerifyLegalizerInfo)
+      LLVM_DEBUG(
+          dbgs() << ".. imm index coverage check SKIPPED: no rules defined\n");
     return true;
   }
   const int64_t FirstUncovered = ImmIdxsCovered.find_first_unset();
   if (FirstUncovered < 0) {
-    LLVM_DEBUG(dbgs() << ".. imm index coverage check SKIPPED:"
-                         " user-defined predicate detected\n");
+    if (VerboseVerifyLegalizerInfo)
+      LLVM_DEBUG(dbgs() << ".. imm index coverage check SKIPPED:"
+                           " user-defined predicate detected\n");
     return true;
   }
   const bool AllCovered = (FirstUncovered >= NumImmIdxs);
-  LLVM_DEBUG(dbgs() << ".. the first uncovered imm index: " << FirstUncovered
-                    << ", " << (AllCovered ? "OK" : "FAIL") << "\n");
+  if (VerboseVerifyLegalizerInfo)
+    LLVM_DEBUG(dbgs() << ".. the first uncovered imm index: " << FirstUncovered
+                      << ", " << (AllCovered ? "OK" : "FAIL") << "\n");
   return AllCovered;
 #else
   return true;
@@ -274,8 +287,9 @@ unsigned LegalizerInfo::getOpcodeIdxForOpcode(unsigned Opcode) const {
 unsigned LegalizerInfo::getActionDefinitionsIdx(unsigned Opcode) const {
   unsigned OpcodeIdx = getOpcodeIdxForOpcode(Opcode);
   if (unsigned Alias = RulesForOpcode[OpcodeIdx].getAlias()) {
-    LLVM_DEBUG(dbgs() << ".. opcode " << Opcode << " is aliased to " << Alias
-                      << "\n");
+    if (VerboseVerifyLegalizerInfo)
+      LLVM_DEBUG(dbgs() << ".. opcode " << Opcode << " is aliased to " << Alias
+                        << "\n");
     OpcodeIdx = getOpcodeIdxForOpcode(Alias);
     assert(RulesForOpcode[OpcodeIdx].getAlias() == 0 && "Cannot chain aliases");
   }
@@ -396,11 +410,12 @@ void LegalizerInfo::verify(const MCInstrInfo &MII) const {
                      ? std::max(OpInfo.getGenericImmIndex() + 1U, Acc)
                      : Acc;
         });
-    LLVM_DEBUG(dbgs() << MII.getName(Opcode) << " (opcode " << Opcode
-                      << "): " << NumTypeIdxs << " type ind"
-                      << (NumTypeIdxs == 1 ? "ex" : "ices") << ", "
-                      << NumImmIdxs << " imm ind"
-                      << (NumImmIdxs == 1 ? "ex" : "ices") << "\n");
+    if (VerboseVerifyLegalizerInfo)
+      LLVM_DEBUG(dbgs() << MII.getName(Opcode) << " (opcode " << Opcode
+                        << "): " << NumTypeIdxs << " type ind"
+                        << (NumTypeIdxs == 1 ? "ex" : "ices") << ", "
+                        << NumImmIdxs << " imm ind"
+                        << (NumImmIdxs == 1 ? "ex" : "ices") << "\n");
     const LegalizeRuleSet &RuleSet = getActionDefinitions(Opcode);
     if (!RuleSet.verifyTypeIdxsCoverage(NumTypeIdxs))
       FailedOpcodes.push_back(Opcode);

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalizer-info-validation.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalizer-info-validation.mir
@@ -2,7 +2,7 @@
 # RUN: llc -mtriple=aarch64-- -run-pass=legalizer %s \
 # RUN:     -mcpu=cortex-a75 -o - 2>&1 | FileCheck %s --check-prefixes=CHECK
 
-# RUN: llc -mtriple=aarch64-- -run-pass=legalizer %s -debug-only=legalizer-info \
+# RUN: llc -mtriple=aarch64-- -run-pass=legalizer %s -debug-only=legalizer-info -verbose-gisel-verify-legalizer-info \
 # RUN:     -mcpu=cortex-a75 -o - 2>&1 | FileCheck %s --check-prefixes=CHECK,DEBUG
 
 # REQUIRES: asserts

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer-info-validation.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer-info-validation.mir
@@ -4,9 +4,9 @@
 # RUN: llc -mtriple=riscv64-- -run-pass=legalizer %s \
 # RUN:     -mattr=+m,+zbb,+zfh,+v -o - 2>&1 | FileCheck %s --check-prefixes=CHECK
 
-# RUN: llc -mtriple=riscv32-- -run-pass=legalizer %s -debug-only=legalizer-info \
+# RUN: llc -mtriple=riscv32-- -run-pass=legalizer %s -debug-only=legalizer-info -verbose-gisel-verify-legalizer-info \
 # RUN:     -mattr=+m,+zbb,+zfh,+v -o - 2>&1 | FileCheck %s --check-prefixes=CHECK,DEBUG,DEBUG-RV32
-# RUN: llc -mtriple=riscv64-- -run-pass=legalizer %s -debug-only=legalizer-info \
+# RUN: llc -mtriple=riscv64-- -run-pass=legalizer %s -debug-only=legalizer-info -verbose-gisel-verify-legalizer-info \
 # RUN:     -mattr=+m,+zbb,+zfh,+v -o - 2>&1 | FileCheck %s --check-prefixes=CHECK,DEBUG,DEBUG-RV64
 
 # REQUIRES: asserts


### PR DESCRIPTION
With the large number of G_ opcodes now present, this debug information emitted for checking the global isel legalizer rules are valid is quite verbose and runs even when gisel is not being used. This makes it especially verbose when running a single pass with -debug.

This patch puts it behind a verbose debug option so that most people don't need to worry about it.