### PR TITLE
[SystemZ] Fix a bug introduced by #135767

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
@@ -13,6 +13,7 @@
 #include "SystemZRegisterInfo.h"
 #include "SystemZSubtarget.h"
 #include "llvm/CodeGen/LivePhysRegs.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/RegisterScavenging.h"
@@ -584,7 +585,7 @@ void SystemZELFFrameLowering::emitPrologue(MachineFunction &MF,
 
     // Reload return address from 8 bytes above stack pointer.
     BuildMI(MBB, MBBI, DL, ZII->get(SystemZ::LG))
-        .addReg(SystemZ::R14D)
+        .addReg(SystemZ::R14D, RegState::Define)
         .addReg(SystemZ::R15D)
         .addImm(8)
         .addReg(0);

--- a/llvm/test/CodeGen/SystemZ/mcount.ll
+++ b/llvm/test/CodeGen/SystemZ/mcount.ll
@@ -1,6 +1,6 @@
 ; Test proper insertion of mcount instrumentation
 ;
-; RUN: llc < %s -mtriple=s390x-linux-gnu -o - | FileCheck %s
+; RUN: llc < %s -mtriple=s390x-linux-gnu -verify-machineinstrs -o - | FileCheck %s
 ;
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: stg %r14, 8(%r15)


### PR DESCRIPTION
Commit `083b4a3d66` introduced a store-and-load pair around the `BRASL` call to mcount. That load instruction did not properly declare its target register as defined, leading to a bad machine instruction.

This commit fixes this by explicitly labeling `%r14` on the load as `def`.