### PR TITLE
[NFC] Fix potential nullptr dereference.

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantFunctionPtrDereferenceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantFunctionPtrDereferenceCheck.cpp
@@ -25,6 +25,7 @@ void RedundantFunctionPtrDereferenceCheck::registerMatchers(MatchFinder *Finder)
 
 void RedundantFunctionPtrDereferenceCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *Operator = Result.Nodes.getNodeAs<UnaryOperator>("op");
+  assert(Operator && "Operator is null");
   diag(Operator->getOperatorLoc(),
        "redundant repeated dereference of function pointer")
       << FixItHint::CreateRemoval(Operator->getOperatorLoc());


### PR DESCRIPTION
A `nullptr` dereference is detected by the code sanitizer. Adding an assert to make sure it's caught.