### PR TITLE
[KeyInstr] Fix DILocation AtomGroup/Rank bitfield packing for MSVC

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -2237,7 +2237,7 @@ class DILocation : public MDNode {
   friend class MDNode;
 #ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
   uint64_t AtomGroup : 61;
-  uint8_t AtomRank : 3;
+  uint64_t AtomRank : 3;
 #endif
 
   DILocation(LLVMContext &C, StorageType Storage, unsigned Line,

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -316,7 +316,7 @@ template <> struct MDNodeKeyImpl<DILocation> {
   Metadata *InlinedAt;
   bool ImplicitCode;
   uint64_t AtomGroup : 61;
-  uint8_t AtomRank : 3;
+  uint64_t AtomRank : 3;
 
   MDNodeKeyImpl(unsigned Line, unsigned Column, Metadata *Scope,
                 Metadata *InlinedAt, bool ImplicitCode, uint64_t AtomGroup,
@@ -338,7 +338,7 @@ template <> struct MDNodeKeyImpl<DILocation> {
 
   unsigned getHashValue() const {
     return hash_combine(Line, Column, Scope, InlinedAt, ImplicitCode, AtomGroup,
-                        AtomRank);
+                        (uint8_t)AtomRank);
   }
 };
 


### PR DESCRIPTION
Follow up to #133477.

As nikic pointed out: We need to use uint64_t for both fields to get actual bit packing with msvc (https://c.godbolt.org/z/1f556c1zb).

The cast to u8 in hash_combine prevents an increase in compile time (+0.16% for stage1-O0-g on compile-time-tracker).