### PR TITLE
[analyzer] Improve cache locality by using separate allocators

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -138,7 +138,8 @@ public:
   /// Construct a CoreEngine object to analyze the provided CFG.
   CoreEngine(ExprEngine &exprengine,
              FunctionSummariesTy *FS,
-             AnalyzerOptions &Opts);
+             AnalyzerOptions &Opts,
+             llvm::BumpPtrAllocator &BlockCounterFactoryAllocator);
 
   CoreEngine(const CoreEngine &) = delete;
   CoreEngine &operator=(const CoreEngine &) = delete;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -136,8 +136,7 @@ private:
 
 public:
   /// Construct a CoreEngine object to analyze the provided CFG.
-  CoreEngine(ExprEngine &exprengine,
-             FunctionSummariesTy *FS,
+  CoreEngine(ExprEngine &exprengine, FunctionSummariesTy *FS,
              AnalyzerOptions &Opts,
              llvm::BumpPtrAllocator &BlockCounterFactoryAllocator);
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -181,7 +181,9 @@ private:
 public:
   ExprEngine(cross_tu::CrossTranslationUnitContext &CTU, AnalysisManager &mgr,
              SetOfConstDecls *VisitedCalleesIn,
-             FunctionSummariesTy *FS, InliningModes HowToInlineIn);
+             FunctionSummariesTy *FS, InliningModes HowToInlineIn,
+             std::array<llvm::BumpPtrAllocator, 7> &ProgramStateAllocators,
+             llvm::BumpPtrAllocator &BlockCounterFactoryAllocator);
 
   virtual ~ExprEngine() = default;
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -180,8 +180,8 @@ private:
 
 public:
   ExprEngine(cross_tu::CrossTranslationUnitContext &CTU, AnalysisManager &mgr,
-             SetOfConstDecls *VisitedCalleesIn,
-             FunctionSummariesTy *FS, InliningModes HowToInlineIn,
+             SetOfConstDecls *VisitedCalleesIn, FunctionSummariesTy *FS,
+             InliningModes HowToInlineIn,
              std::array<llvm::BumpPtrAllocator, 7> &ProgramStateAllocators,
              llvm::BumpPtrAllocator &BlockCounterFactoryAllocator);
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -527,11 +527,10 @@ private:
   std::vector<ProgramState *> freeStates;
 
 public:
-  ProgramStateManager(ASTContext &Ctx,
-                 StoreManagerCreator CreateStoreManager,
-                 ConstraintManagerCreator CreateConstraintManager,
-                 std::array<llvm::BumpPtrAllocator, 7> &Allocators,
-                 ExprEngine *expreng);
+  ProgramStateManager(ASTContext &Ctx, StoreManagerCreator CreateStoreManager,
+                      ConstraintManagerCreator CreateConstraintManager,
+                      std::array<llvm::BumpPtrAllocator, 7> &Allocators,
+                      ExprEngine *expreng);
 
   ~ProgramStateManager();
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -530,7 +530,7 @@ public:
   ProgramStateManager(ASTContext &Ctx,
                  StoreManagerCreator CreateStoreManager,
                  ConstraintManagerCreator CreateConstraintManager,
-                 llvm::BumpPtrAllocator& alloc,
+                 std::array<llvm::BumpPtrAllocator, 7> &Allocators,
                  ExprEngine *expreng);
 
   ~ProgramStateManager();

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -411,10 +411,11 @@ public:
                                const StackFrameContext *SFC);
 };
 
-SValBuilder* createSimpleSValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
-                                     llvm::BumpPtrAllocator &SymbolManagerAllocator,
-                                     llvm::BumpPtrAllocator &MemRegionManagerAllocator,
-                                     ASTContext &context, ProgramStateManager &stateMgr);
+SValBuilder *
+createSimpleSValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
+                        llvm::BumpPtrAllocator &SymbolManagerAllocator,
+                        llvm::BumpPtrAllocator &MemRegionManagerAllocator,
+                        ASTContext &context, ProgramStateManager &stateMgr);
 
 } // namespace ento
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -76,8 +76,10 @@ protected:
   const unsigned ArrayIndexWidth;
 
 public:
-  SValBuilder(llvm::BumpPtrAllocator &alloc, ASTContext &context,
-              ProgramStateManager &stateMgr);
+  SValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
+              llvm::BumpPtrAllocator &SymbolManagerAllocator,
+              llvm::BumpPtrAllocator &MemRegionManagerAllocator,
+              ASTContext &context, ProgramStateManager &stateMgr);
 
   virtual ~SValBuilder() = default;
 
@@ -409,9 +411,10 @@ public:
                                const StackFrameContext *SFC);
 };
 
-SValBuilder* createSimpleSValBuilder(llvm::BumpPtrAllocator &alloc,
-                                     ASTContext &context,
-                                     ProgramStateManager &stateMgr);
+SValBuilder* createSimpleSValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
+                                     llvm::BumpPtrAllocator &SymbolManagerAllocator,
+                                     llvm::BumpPtrAllocator &MemRegionManagerAllocator,
+                                     ASTContext &context, ProgramStateManager &stateMgr);
 
 } // namespace ento
 

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -75,7 +75,8 @@ static std::unique_ptr<WorkList> generateWorkList(AnalyzerOptions &Opts) {
 }
 
 CoreEngine::CoreEngine(ExprEngine &exprengine, FunctionSummariesTy *FS,
-                       AnalyzerOptions &Opts, llvm::BumpPtrAllocator &BlockCounterFactoryAllocator)
+                       AnalyzerOptions &Opts,
+                       llvm::BumpPtrAllocator &BlockCounterFactoryAllocator)
     : ExprEng(exprengine), WList(generateWorkList(Opts)),
       CTUWList(Opts.IsNaiveCTUEnabled ? generateWorkList(Opts) : nullptr),
       BCounterFactory(BlockCounterFactoryAllocator), FunctionSummaries(FS) {}

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -75,10 +75,10 @@ static std::unique_ptr<WorkList> generateWorkList(AnalyzerOptions &Opts) {
 }
 
 CoreEngine::CoreEngine(ExprEngine &exprengine, FunctionSummariesTy *FS,
-                       AnalyzerOptions &Opts)
+                       AnalyzerOptions &Opts, llvm::BumpPtrAllocator &BlockCounterFactoryAllocator)
     : ExprEng(exprengine), WList(generateWorkList(Opts)),
       CTUWList(Opts.IsNaiveCTUEnabled ? generateWorkList(Opts) : nullptr),
-      BCounterFactory(G.getAllocator()), FunctionSummaries(FS) {}
+      BCounterFactory(BlockCounterFactoryAllocator), FunctionSummaries(FS) {}
 
 void CoreEngine::setBlockCounter(BlockCounter C) {
   WList->setBlockCounter(C);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -221,12 +221,15 @@ static const char* TagProviderName = "ExprEngine";
 
 ExprEngine::ExprEngine(cross_tu::CrossTranslationUnitContext &CTU,
                        AnalysisManager &mgr, SetOfConstDecls *VisitedCalleesIn,
-                       FunctionSummariesTy *FS, InliningModes HowToInlineIn)
+                       FunctionSummariesTy *FS, InliningModes HowToInlineIn,
+                       std::array<llvm::BumpPtrAllocator, 7> &ProgramStateAllocators,
+                       llvm::BumpPtrAllocator& BlockCounterFactoryAllocator)
     : CTU(CTU), IsCTUEnabled(mgr.getAnalyzerOptions().IsNaiveCTUEnabled),
       AMgr(mgr), AnalysisDeclContexts(mgr.getAnalysisDeclContextManager()),
-      Engine(*this, FS, mgr.getAnalyzerOptions()), G(Engine.getGraph()),
-      StateMgr(getContext(), mgr.getStoreManagerCreator(),
-               mgr.getConstraintManagerCreator(), G.getAllocator(), this),
+      Engine(*this, FS, mgr.getAnalyzerOptions(), BlockCounterFactoryAllocator),
+             G(Engine.getGraph()),
+      StateMgr(getContext(), mgr.getStoreManagerCreator(), mgr.getConstraintManagerCreator(),
+               ProgramStateAllocators, this),
       SymMgr(StateMgr.getSymbolManager()), MRMgr(StateMgr.getRegionManager()),
       svalBuilder(StateMgr.getSValBuilder()), ObjCNoRet(mgr.getASTContext()),
       BR(mgr, *this), VisitedCallees(VisitedCalleesIn),

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -219,17 +219,18 @@ REGISTER_TRAIT_WITH_PROGRAMSTATE(PendingArrayDestruction,
 
 static const char* TagProviderName = "ExprEngine";
 
-ExprEngine::ExprEngine(cross_tu::CrossTranslationUnitContext &CTU,
-                       AnalysisManager &mgr, SetOfConstDecls *VisitedCalleesIn,
-                       FunctionSummariesTy *FS, InliningModes HowToInlineIn,
-                       std::array<llvm::BumpPtrAllocator, 7> &ProgramStateAllocators,
-                       llvm::BumpPtrAllocator& BlockCounterFactoryAllocator)
+ExprEngine::ExprEngine(
+    cross_tu::CrossTranslationUnitContext &CTU, AnalysisManager &mgr,
+    SetOfConstDecls *VisitedCalleesIn, FunctionSummariesTy *FS,
+    InliningModes HowToInlineIn,
+    std::array<llvm::BumpPtrAllocator, 7> &ProgramStateAllocators,
+    llvm::BumpPtrAllocator &BlockCounterFactoryAllocator)
     : CTU(CTU), IsCTUEnabled(mgr.getAnalyzerOptions().IsNaiveCTUEnabled),
       AMgr(mgr), AnalysisDeclContexts(mgr.getAnalysisDeclContextManager()),
       Engine(*this, FS, mgr.getAnalyzerOptions(), BlockCounterFactoryAllocator),
-             G(Engine.getGraph()),
-      StateMgr(getContext(), mgr.getStoreManagerCreator(), mgr.getConstraintManagerCreator(),
-               ProgramStateAllocators, this),
+      G(Engine.getGraph()),
+      StateMgr(getContext(), mgr.getStoreManagerCreator(),
+               mgr.getConstraintManagerCreator(), ProgramStateAllocators, this),
       SymMgr(StateMgr.getSymbolManager()), MRMgr(StateMgr.getRegionManager()),
       svalBuilder(StateMgr.getSValBuilder()), ObjCNoRet(mgr.getASTContext()),
       BR(mgr, *this), VisitedCallees(VisitedCalleesIn),

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -69,18 +69,17 @@ int64_t ProgramState::getID() const {
   return getStateManager().Alloc.identifyKnownAlignedObject<ProgramState>(this);
 }
 
-ProgramStateManager::ProgramStateManager(ASTContext &Ctx,
-                                         StoreManagerCreator CreateSMgr,
-                                         ConstraintManagerCreator CreateCMgr,
-                                         std::array<llvm::BumpPtrAllocator, 7> &Allocators,
-                                         ExprEngine *ExprEng)
-  : Eng(ExprEng), EnvMgr(Allocators[0]), GDMFactory(Allocators[1]),
-    svalBuilder(createSimpleSValBuilder(Allocators[2], Allocators[3], Allocators[4], Ctx, *this)),
-    CallEventMgr(new CallEventManager(Allocators[5])), Alloc(Allocators[6]) {
+ProgramStateManager::ProgramStateManager(
+    ASTContext &Ctx, StoreManagerCreator CreateSMgr,
+    ConstraintManagerCreator CreateCMgr,
+    std::array<llvm::BumpPtrAllocator, 7> &Allocators, ExprEngine *ExprEng)
+    : Eng(ExprEng), EnvMgr(Allocators[0]), GDMFactory(Allocators[1]),
+      svalBuilder(createSimpleSValBuilder(Allocators[2], Allocators[3],
+                                          Allocators[4], Ctx, *this)),
+      CallEventMgr(new CallEventManager(Allocators[5])), Alloc(Allocators[6]) {
   StoreMgr = (*CreateSMgr)(*this);
   ConstraintMgr = (*CreateCMgr)(*this, ExprEng);
 }
-
 
 ProgramStateManager::~ProgramStateManager() {
   for (GDMContextsTy::iterator I=GDMContexts.begin(), E=GDMContexts.end();

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -72,11 +72,11 @@ int64_t ProgramState::getID() const {
 ProgramStateManager::ProgramStateManager(ASTContext &Ctx,
                                          StoreManagerCreator CreateSMgr,
                                          ConstraintManagerCreator CreateCMgr,
-                                         llvm::BumpPtrAllocator &alloc,
+                                         std::array<llvm::BumpPtrAllocator, 7> &Allocators,
                                          ExprEngine *ExprEng)
-  : Eng(ExprEng), EnvMgr(alloc), GDMFactory(alloc),
-    svalBuilder(createSimpleSValBuilder(alloc, Ctx, *this)),
-    CallEventMgr(new CallEventManager(alloc)), Alloc(alloc) {
+  : Eng(ExprEng), EnvMgr(Allocators[0]), GDMFactory(Allocators[1]),
+    svalBuilder(createSimpleSValBuilder(Allocators[2], Allocators[3], Allocators[4], Ctx, *this)),
+    CallEventMgr(new CallEventManager(Allocators[5])), Alloc(Allocators[6]) {
   StoreMgr = (*CreateSMgr)(*this);
   ConstraintMgr = (*CreateCMgr)(*this, ExprEng);
 }

--- a/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
@@ -52,13 +52,12 @@ void SValBuilder::anchor() {}
 SValBuilder::SValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
                          llvm::BumpPtrAllocator &SymbolManagerAllocator,
                          llvm::BumpPtrAllocator &MemRegionManagerAllocator,
-                         ASTContext &context,
-                         ProgramStateManager &stateMgr)
+                         ASTContext &context, ProgramStateManager &stateMgr)
     : Context(context), BasicVals(context, BasicValueFactoryAllocator),
       SymMgr(context, BasicVals, SymbolManagerAllocator),
-      MemMgr(context, MemRegionManagerAllocator),
-      StateMgr(stateMgr),
-      AnOpts(stateMgr.getOwningEngine().getAnalysisManager().getAnalyzerOptions()),
+      MemMgr(context, MemRegionManagerAllocator), StateMgr(stateMgr),
+      AnOpts(
+          stateMgr.getOwningEngine().getAnalysisManager().getAnalyzerOptions()),
       ArrayIndexTy(context.LongLongTy),
       ArrayIndexWidth(context.getTypeSize(ArrayIndexTy)) {}
 

--- a/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
@@ -49,13 +49,16 @@ using namespace ento;
 
 void SValBuilder::anchor() {}
 
-SValBuilder::SValBuilder(llvm::BumpPtrAllocator &alloc, ASTContext &context,
+SValBuilder::SValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
+                         llvm::BumpPtrAllocator &SymbolManagerAllocator,
+                         llvm::BumpPtrAllocator &MemRegionManagerAllocator,
+                         ASTContext &context,
                          ProgramStateManager &stateMgr)
-    : Context(context), BasicVals(context, alloc),
-      SymMgr(context, BasicVals, alloc), MemMgr(context, alloc),
+    : Context(context), BasicVals(context, BasicValueFactoryAllocator),
+      SymMgr(context, BasicVals, SymbolManagerAllocator),
+      MemMgr(context, MemRegionManagerAllocator),
       StateMgr(stateMgr),
-      AnOpts(
-          stateMgr.getOwningEngine().getAnalysisManager().getAnalyzerOptions()),
+      AnOpts(stateMgr.getOwningEngine().getAnalysisManager().getAnalyzerOptions()),
       ArrayIndexTy(context.LongLongTy),
       ArrayIndexWidth(context.getTypeSize(ArrayIndexTy)) {}
 

--- a/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
@@ -64,9 +64,14 @@ class SimpleSValBuilder : public SValBuilder {
   SVal simplifySValOnce(ProgramStateRef State, SVal V);
 
 public:
-  SimpleSValBuilder(llvm::BumpPtrAllocator &alloc, ASTContext &context,
-                    ProgramStateManager &stateMgr)
-      : SValBuilder(alloc, context, stateMgr) {}
+  SimpleSValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
+                    llvm::BumpPtrAllocator &SymbolManagerAllocator,
+                    llvm::BumpPtrAllocator &MemRegionManagerAllocator,
+                    ASTContext &context, ProgramStateManager &stateMgr)
+      : SValBuilder(BasicValueFactoryAllocator,
+                    SymbolManagerAllocator,
+                    MemRegionManagerAllocator,
+                    context, stateMgr) {}
   ~SimpleSValBuilder() override {}
 
   SVal evalBinOpNN(ProgramStateRef state, BinaryOperator::Opcode op,
@@ -98,10 +103,14 @@ public:
 };
 } // end anonymous namespace
 
-SValBuilder *ento::createSimpleSValBuilder(llvm::BumpPtrAllocator &alloc,
-                                           ASTContext &context,
-                                           ProgramStateManager &stateMgr) {
-  return new SimpleSValBuilder(alloc, context, stateMgr);
+SValBuilder *ento::createSimpleSValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
+                                           llvm::BumpPtrAllocator &SymbolManagerAllocator,
+                                           llvm::BumpPtrAllocator &MemRegionManagerAllocator,
+                                           ASTContext &context, ProgramStateManager &stateMgr) {
+  return new SimpleSValBuilder(BasicValueFactoryAllocator,
+                               SymbolManagerAllocator,
+                               MemRegionManagerAllocator,
+                               context, stateMgr);
 }
 
 // Checks if the negation the value and flipping sign preserve

--- a/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
@@ -68,10 +68,8 @@ public:
                     llvm::BumpPtrAllocator &SymbolManagerAllocator,
                     llvm::BumpPtrAllocator &MemRegionManagerAllocator,
                     ASTContext &context, ProgramStateManager &stateMgr)
-      : SValBuilder(BasicValueFactoryAllocator,
-                    SymbolManagerAllocator,
-                    MemRegionManagerAllocator,
-                    context, stateMgr) {}
+      : SValBuilder(BasicValueFactoryAllocator, SymbolManagerAllocator,
+                    MemRegionManagerAllocator, context, stateMgr) {}
   ~SimpleSValBuilder() override {}
 
   SVal evalBinOpNN(ProgramStateRef state, BinaryOperator::Opcode op,
@@ -103,14 +101,14 @@ public:
 };
 } // end anonymous namespace
 
-SValBuilder *ento::createSimpleSValBuilder(llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
-                                           llvm::BumpPtrAllocator &SymbolManagerAllocator,
-                                           llvm::BumpPtrAllocator &MemRegionManagerAllocator,
-                                           ASTContext &context, ProgramStateManager &stateMgr) {
+SValBuilder *ento::createSimpleSValBuilder(
+    llvm::BumpPtrAllocator &BasicValueFactoryAllocator,
+    llvm::BumpPtrAllocator &SymbolManagerAllocator,
+    llvm::BumpPtrAllocator &MemRegionManagerAllocator, ASTContext &context,
+    ProgramStateManager &stateMgr) {
   return new SimpleSValBuilder(BasicValueFactoryAllocator,
                                SymbolManagerAllocator,
-                               MemRegionManagerAllocator,
-                               context, stateMgr);
+                               MemRegionManagerAllocator, context, stateMgr);
 }
 
 // Checks if the negation the value and flipping sign preserve

--- a/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+++ b/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
@@ -752,7 +752,10 @@ void AnalysisConsumer::RunPathSensitiveChecks(Decl *D,
   if (!Mgr->getAnalysisDeclContext(D)->getAnalysis<RelaxedLiveVariables>())
     return;
 
-  ExprEngine Eng(CTU, *Mgr, VisitedCallees, &FunctionSummaries, IMode);
+  std::array<llvm::BumpPtrAllocator, 7> ProgramStateManagerAllocators;
+  llvm::BumpPtrAllocator BlockCounterFactoryAllocator;
+
+  ExprEngine Eng(CTU, *Mgr, VisitedCallees, &FunctionSummaries, IMode, ProgramStateManagerAllocators, BlockCounterFactoryAllocator);
 
   // Execute the worklist algorithm.
   llvm::TimeRecord ExprEngineStartTime;

--- a/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+++ b/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
@@ -755,7 +755,8 @@ void AnalysisConsumer::RunPathSensitiveChecks(Decl *D,
   std::array<llvm::BumpPtrAllocator, 7> ProgramStateManagerAllocators;
   llvm::BumpPtrAllocator BlockCounterFactoryAllocator;
 
-  ExprEngine Eng(CTU, *Mgr, VisitedCallees, &FunctionSummaries, IMode, ProgramStateManagerAllocators, BlockCounterFactoryAllocator);
+  ExprEngine Eng(CTU, *Mgr, VisitedCallees, &FunctionSummaries, IMode,
+                 ProgramStateManagerAllocators, BlockCounterFactoryAllocator);
 
   // Execute the worklist algorithm.
   llvm::TimeRecord ExprEngineStartTime;


### PR DESCRIPTION
This patch improves the performance of the Clang Static Analyzer by passing separate `BumpPtrAllocator` instances to its data structures instead of using the `BumpPtrAllocator` of the ExplodedGraph everywhere.

It greatly reduces the analysis time of [three example translation units](https://github.com/user-attachments/files/17232762/repros.tar.gz) that are particularly affected by disabling node reclamation, as mentioned in [issue #105512](https://github.com/llvm/llvm-project/issues/105512). It also brings a modest improvement in the general case as well, according to my testing on the [vim](https://github.com/vim/vim) repository with `scan-build`.

My measurements are in the [measurements.ods](https://github.com/user-attachments/files/20014809/measurements.ods) file.
