### PR TITLE
[KeyInstr] Hide new MDNodeKeyImpl<DILocation> fields

### DIFF
--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -315,30 +315,53 @@ template <> struct MDNodeKeyImpl<DILocation> {
   Metadata *Scope;
   Metadata *InlinedAt;
   bool ImplicitCode;
+#ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
   uint64_t AtomGroup : 61;
   uint64_t AtomRank : 3;
+#endif
 
   MDNodeKeyImpl(unsigned Line, unsigned Column, Metadata *Scope,
                 Metadata *InlinedAt, bool ImplicitCode, uint64_t AtomGroup,
                 uint8_t AtomRank)
       : Line(Line), Column(Column), Scope(Scope), InlinedAt(InlinedAt),
-        ImplicitCode(ImplicitCode), AtomGroup(AtomGroup), AtomRank(AtomRank) {}
+        ImplicitCode(ImplicitCode)
+#ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
+        ,
+        AtomGroup(AtomGroup), AtomRank(AtomRank)
+#endif
+  {
+  }
 
   MDNodeKeyImpl(const DILocation *L)
       : Line(L->getLine()), Column(L->getColumn()), Scope(L->getRawScope()),
-        InlinedAt(L->getRawInlinedAt()), ImplicitCode(L->isImplicitCode()),
-        AtomGroup(L->getAtomGroup()), AtomRank(L->getAtomRank()) {}
+        InlinedAt(L->getRawInlinedAt()), ImplicitCode(L->isImplicitCode())
+#ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
+        ,
+        AtomGroup(L->getAtomGroup()), AtomRank(L->getAtomRank())
+#endif
+  {
+  }
 
   bool isKeyOf(const DILocation *RHS) const {
     return Line == RHS->getLine() && Column == RHS->getColumn() &&
            Scope == RHS->getRawScope() && InlinedAt == RHS->getRawInlinedAt() &&
-           ImplicitCode == RHS->isImplicitCode() &&
-           AtomGroup == RHS->getAtomGroup() && AtomRank == RHS->getAtomRank();
+           ImplicitCode == RHS->isImplicitCode()
+#ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
+           && AtomGroup == RHS->getAtomGroup() &&
+           AtomRank == RHS->getAtomRank();
+#else
+        ;
+#endif
   }
 
   unsigned getHashValue() const {
-    return hash_combine(Line, Column, Scope, InlinedAt, ImplicitCode, AtomGroup,
-                        (uint8_t)AtomRank);
+    return hash_combine(Line, Column, Scope, InlinedAt, ImplicitCode
+#ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
+                        ,
+                        AtomGroup, (uint8_t)AtomRank);
+#else
+    );
+#endif
   }
 };
 


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/133477.

This prevents a compile time regression pointed out by nikic
https://llvm-compile-time-tracker.com/compare.php?from=d33c6764680ed78ffe824a83b6a33c0b609bafce&to=0c7c82af230bd525bb96a54ca9480797b5fa2a42&stat=instructions:u

The additional checks in the methods seem to cause most of the regression
(rather than being a consequence of increased size due to the fields
themselves).

The additional ifdefs are somewhat ugly - but I'm not sure if we can get around
that for now?