### PR TITLE
[lldb][DataFormatters] Change ExtractIndexFromString to return std::optional

### DIFF
--- a/lldb/include/lldb/DataFormatters/FormattersHelpers.h
+++ b/lldb/include/lldb/DataFormatters/FormattersHelpers.h
@@ -53,7 +53,7 @@ void AddFilter(TypeCategoryImpl::SharedPointer category_sp,
                llvm::StringRef type_name,
                ScriptedSyntheticChildren::Flags flags, bool regex = false);
 
-size_t ExtractIndexFromString(const char *item_name);
+llvm::Expected<size_t> ExtractIndexFromString(const char *item_name);
 
 Address GetArrayAddressOrPointerValue(ValueObject &valobj);
 

--- a/lldb/include/lldb/DataFormatters/FormattersHelpers.h
+++ b/lldb/include/lldb/DataFormatters/FormattersHelpers.h
@@ -53,7 +53,7 @@ void AddFilter(TypeCategoryImpl::SharedPointer category_sp,
                llvm::StringRef type_name,
                ScriptedSyntheticChildren::Flags flags, bool regex = false);
 
-llvm::Expected<size_t> ExtractIndexFromString(const char *item_name);
+std::optional<size_t> ExtractIndexFromString(const char *item_name);
 
 Address GetArrayAddressOrPointerValue(ValueObject &valobj);
 

--- a/lldb/source/DataFormatters/FormattersHelpers.cpp
+++ b/lldb/source/DataFormatters/FormattersHelpers.cpp
@@ -106,9 +106,7 @@ lldb_private::formatters::ExtractIndexFromString(const char *item_name) {
   item_name++;
   char *endptr = nullptr;
   unsigned long int idx = ::strtoul(item_name, &endptr, 0);
-  if (idx == 0 && endptr == item_name)
-    return std::nullopt;
-  if (idx == ULONG_MAX)
+  if ((idx == 0 && endptr == item_name) || idx == ULONG_MAX)
     return std::nullopt;
   return idx;
 }

--- a/lldb/source/DataFormatters/FormattersHelpers.cpp
+++ b/lldb/source/DataFormatters/FormattersHelpers.cpp
@@ -97,19 +97,19 @@ void lldb_private::formatters::AddFilter(
   category_sp->AddTypeFilter(type_name, match_type, filter_sp);
 }
 
-llvm::Expected<size_t>
+std::optional<size_t>
 lldb_private::formatters::ExtractIndexFromString(const char *item_name) {
   if (!item_name || !*item_name)
-    return llvm::createStringError("String has no item named '%s'", item_name);
+    return std::nullopt;
   if (*item_name != '[')
-    return llvm::createStringError("String has no item named '%s'", item_name);
+    return std::nullopt;
   item_name++;
   char *endptr = nullptr;
   unsigned long int idx = ::strtoul(item_name, &endptr, 0);
   if (idx == 0 && endptr == item_name)
-    return llvm::createStringError("String has no item named '%s'", item_name);
+    return std::nullopt;
   if (idx == ULONG_MAX)
-    return llvm::createStringError("String has no item named '%s'", item_name);
+    return std::nullopt;
   return idx;
 }
 

--- a/lldb/source/DataFormatters/FormattersHelpers.cpp
+++ b/lldb/source/DataFormatters/FormattersHelpers.cpp
@@ -97,18 +97,19 @@ void lldb_private::formatters::AddFilter(
   category_sp->AddTypeFilter(type_name, match_type, filter_sp);
 }
 
-size_t lldb_private::formatters::ExtractIndexFromString(const char *item_name) {
+llvm::Expected<size_t>
+lldb_private::formatters::ExtractIndexFromString(const char *item_name) {
   if (!item_name || !*item_name)
-    return UINT32_MAX;
+    return llvm::createStringError("String has no item named '%s'", item_name);
   if (*item_name != '[')
-    return UINT32_MAX;
+    return llvm::createStringError("String has no item named '%s'", item_name);
   item_name++;
   char *endptr = nullptr;
   unsigned long int idx = ::strtoul(item_name, &endptr, 0);
   if (idx == 0 && endptr == item_name)
-    return UINT32_MAX;
+    return llvm::createStringError("String has no item named '%s'", item_name);
   if (idx == ULONG_MAX)
-    return UINT32_MAX;
+    return llvm::createStringError("String has no item named '%s'", item_name);
   return idx;
 }
 

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -270,13 +270,12 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto idx_or_err = ExtractIndexFromString(name.AsCString());
-    if (!idx_or_err) {
-      llvm::consumeError(idx_or_err.takeError());
+    auto optional_idx = ExtractIndexFromString(name.AsCString());
+    if (!optional_idx) {
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     }
-    uint32_t idx = *idx_or_err;
+    uint32_t idx = *optional_idx;
     if (idx >= CalculateNumChildrenIgnoringErrors())
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -270,10 +270,14 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    const char *item_name = name.GetCString();
-    uint32_t idx = ExtractIndexFromString(item_name);
-    if (idx == UINT32_MAX ||
-        (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+    auto idx_or_err = ExtractIndexFromString(name.AsCString());
+    if (!idx_or_err) {
+      llvm::consumeError(idx_or_err.takeError());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
+    }
+    uint32_t idx = *idx_or_err;
+    if (idx >= CalculateNumChildrenIgnoringErrors())
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     return idx;

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -29,13 +29,12 @@ public:
   GenericBitsetFrontEnd(ValueObject &valobj, StdLib stdlib);
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-    if (!idx_or_err) {
-      llvm::consumeError(idx_or_err.takeError());
+    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+    if (!optional_idx) {
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     }
-    return *idx_or_err;
+    return *optional_idx;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -29,11 +29,13 @@ public:
   GenericBitsetFrontEnd(ValueObject &valobj, StdLib stdlib);
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    size_t idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (idx == UINT32_MAX)
+    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+    if (!idx_or_err) {
+      llvm::consumeError(idx_or_err.takeError());
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
-    return idx;
+    }
+    return *idx_or_err;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -39,11 +39,13 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (name == "$$dereference$$")
       return 0;
-    size_t idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (idx == UINT32_MAX)
+    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+    if (!idx_or_err) {
+      llvm::consumeError(idx_or_err.takeError());
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
-    return idx;
+    }
+    return *idx_or_err;
   }
 
   llvm::Expected<uint32_t> CalculateNumChildren() override {

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -39,13 +39,12 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (name == "$$dereference$$")
       return 0;
-    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-    if (!idx_or_err) {
-      llvm::consumeError(idx_or_err.takeError());
+    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+    if (!optional_idx) {
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     }
-    return *idx_or_err;
+    return *optional_idx;
   }
 
   llvm::Expected<uint32_t> CalculateNumChildren() override {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -108,12 +108,13 @@ lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  size_t idx = ExtractIndexFromString(name.GetCString());
-  if (idx == UINT32_MAX) {
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return idx;
+  return *idx_or_err;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -108,13 +108,12 @@ lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -107,11 +107,13 @@ private:
 class AbstractListFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    size_t idx = ExtractIndexFromString(name.GetCString());
-    if (idx == UINT32_MAX)
+    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+    if (!idx_or_err) {
+      llvm::consumeError(idx_or_err.takeError());
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
-    return idx;
+    }
+    return *idx_or_err;
   }
   lldb::ChildCacheState Update() override;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -107,13 +107,12 @@ private:
 class AbstractListFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-    if (!idx_or_err) {
-      llvm::consumeError(idx_or_err.takeError());
+    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+    if (!optional_idx) {
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     }
-    return *idx_or_err;
+    return *optional_idx;
   }
   lldb::ChildCacheState Update() override;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -395,13 +395,12 @@ lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::Update() {
 
 llvm::Expected<size_t> lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -395,12 +395,13 @@ lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::Update() {
 
 llvm::Expected<size_t> lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  size_t idx = ExtractIndexFromString(name.GetCString());
-  if (idx == UINT32_MAX) {
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return idx;
+  return *idx_or_err;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -179,12 +179,13 @@ lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
   if (!m_base)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  size_t idx = ExtractIndexFromString(name.GetCString());
-  if (idx == UINT32_MAX) {
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return idx;
+  return *idx_or_err;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -179,13 +179,12 @@ lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::
   if (!m_base)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -150,13 +150,12 @@ lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
   if (!m_start)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -150,11 +150,13 @@ lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::
   if (!m_start)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  size_t idx = ExtractIndexFromString(name.GetCString());
-  if (idx == UINT32_MAX)
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  return idx;
+  }
+  return *idx_or_err;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -133,12 +133,13 @@ llvm::Expected<size_t> lldb_private::formatters::
   if (!m_start)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  size_t idx = ExtractIndexFromString(name.GetCString());
-  if (idx == UINT32_MAX) {
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return idx;
+  return *idx_or_err;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -133,13 +133,12 @@ llvm::Expected<size_t> lldb_private::formatters::
   if (!m_start)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -21,13 +21,12 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-    if (!idx_or_err) {
-      llvm::consumeError(idx_or_err.takeError());
+    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+    if (!optional_idx) {
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     }
-    return *idx_or_err;
+    return *optional_idx;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -21,11 +21,13 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    size_t idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (idx == UINT32_MAX)
+    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+    if (!idx_or_err) {
+      llvm::consumeError(idx_or_err.takeError());
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
-    return idx;
+    }
+    return *idx_or_err;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -294,13 +294,12 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::Update() {
 llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -294,12 +294,13 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::Update() {
 llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  size_t idx = ExtractIndexFromString(name.GetCString());
-  if (idx == UINT32_MAX) {
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return idx;
+  return *idx_or_err;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -129,12 +129,13 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  size_t idx = ExtractIndexFromString(name.GetCString());
-  if (idx == UINT32_MAX) {
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return idx;
+  return *idx_or_err;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -129,13 +129,12 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 lldb_private::SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -203,11 +203,13 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    size_t index = formatters::ExtractIndexFromString(name.GetCString());
-    if (index == UINT32_MAX)
+    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+    if (!idx_or_err) {
+      llvm::consumeError(idx_or_err.takeError());
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
-    return index;
+    }
+    return *idx_or_err;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -203,13 +203,12 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-    if (!idx_or_err) {
-      llvm::consumeError(idx_or_err.takeError());
+    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+    if (!optional_idx) {
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     }
-    return *idx_or_err;
+    return *optional_idx;
   }
 
   lldb::ChildCacheState Update() override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -170,12 +170,13 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  size_t index = formatters::ExtractIndexFromString(name.GetCString());
-  if (index == UINT32_MAX) {
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return index;
+  return *idx_or_err;
 }
 
 lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
@@ -273,10 +274,14 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
   if (!m_count || !m_base_data_address)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  const char *item_name = name.GetCString();
-  uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -170,13 +170,12 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
   if (!m_start || !m_finish)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
@@ -274,13 +273,12 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
   if (!m_count || !m_base_data_address)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
@@ -98,12 +98,13 @@ LibStdcppTupleSyntheticFrontEnd::CalculateNumChildren() {
 
 llvm::Expected<size_t>
 LibStdcppTupleSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  size_t index = formatters::ExtractIndexFromString(name.GetCString());
-  if (index == UINT32_MAX) {
+  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return index;
+  return *idx_or_err;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
@@ -98,13 +98,12 @@ LibStdcppTupleSyntheticFrontEnd::CalculateNumChildren() {
 
 llvm::Expected<size_t>
 LibStdcppTupleSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = formatters::ExtractIndexFromString(name.GetCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  return *idx_or_err;
+  return *optional_idx;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -528,13 +528,12 @@ lldb_private::formatters::GenericNSArrayMSyntheticFrontEnd<D32, D64>::Update() {
 
 llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
     GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
@@ -620,13 +619,12 @@ template <typename D32, typename D64, bool Inline>
 llvm::Expected<size_t>
 lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<
     D32, D64, Inline>::GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -587,13 +587,12 @@ lldb_private::formatters::NSDictionaryISyntheticFrontEnd::
 
 llvm::Expected<size_t> lldb_private::formatters::
     NSDictionaryISyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
@@ -726,13 +725,12 @@ lldb_private::formatters::NSCFDictionarySyntheticFrontEnd::
 
 llvm::Expected<size_t> lldb_private::formatters::
     NSCFDictionarySyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
@@ -864,13 +862,12 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
 llvm::Expected<size_t>
 lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
@@ -1070,13 +1067,12 @@ template <typename D32, typename D64>
 llvm::Expected<size_t>
 lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
     D32, D64>::GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
@@ -1233,13 +1229,12 @@ lldb_private::formatters::Foundation1100::
 
 llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
     NSDictionaryMSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -587,10 +587,14 @@ lldb_private::formatters::NSDictionaryISyntheticFrontEnd::
 
 llvm::Expected<size_t> lldb_private::formatters::
     NSDictionaryISyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  const char *item_name = name.GetCString();
-  uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -722,12 +726,16 @@ lldb_private::formatters::NSCFDictionarySyntheticFrontEnd::
 
 llvm::Expected<size_t> lldb_private::formatters::
     NSCFDictionarySyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  const char *item_name = name.GetCString();
-  const uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
     return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString(), idx);
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 
@@ -856,10 +864,14 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
 llvm::Expected<size_t>
 lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  const char *item_name = name.GetCString();
-  uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -1058,10 +1070,14 @@ template <typename D32, typename D64>
 llvm::Expected<size_t>
 lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
     D32, D64>::GetIndexOfChildWithName(ConstString name) {
-  const char *item_name = name.GetCString();
-  uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -1217,10 +1233,14 @@ lldb_private::formatters::Foundation1100::
 
 llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
     NSDictionaryMSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  const char *item_name = name.GetCString();
-  uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -127,13 +127,12 @@ public:
   bool MightHaveChildren() override { return m_impl.m_mode != Mode::Invalid; }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto idx_or_err = ExtractIndexFromString(name.AsCString());
-    if (!idx_or_err) {
-      llvm::consumeError(idx_or_err.takeError());
+    auto optional_idx = ExtractIndexFromString(name.AsCString());
+    if (!optional_idx) {
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     }
-    uint32_t idx = *idx_or_err;
+    uint32_t idx = *optional_idx;
     if (idx >= CalculateNumChildrenIgnoringErrors())
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -389,13 +389,12 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::~NSSetISyntheticFrontEnd() {
 llvm::Expected<size_t>
 lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
@@ -528,13 +527,12 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::NSCFSetSyntheticFrontEnd(
 llvm::Expected<size_t>
 lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
@@ -668,13 +666,12 @@ lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<D32, D64>::
 template <typename D32, typename D64>
 llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
     D32, D64>::GetIndexOfChildWithName(ConstString name) {
-  auto idx_or_err = ExtractIndexFromString(name.AsCString());
-  if (!idx_or_err) {
-    llvm::consumeError(idx_or_err.takeError());
+  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  if (!optional_idx) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   }
-  uint32_t idx = *idx_or_err;
+  uint32_t idx = *optional_idx;
   if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -389,10 +389,14 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::~NSSetISyntheticFrontEnd() {
 llvm::Expected<size_t>
 lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
-  const char *item_name = name.GetCString();
-  uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -524,10 +528,14 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::NSCFSetSyntheticFrontEnd(
 llvm::Expected<size_t>
 lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
-  const char *item_name = name.GetCString();
-  const uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -660,10 +668,14 @@ lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<D32, D64>::
 template <typename D32, typename D64>
 llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
     D32, D64>::GetIndexOfChildWithName(ConstString name) {
-  const char *item_name = name.GetCString();
-  uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx == UINT32_MAX ||
-      (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors()))
+  auto idx_or_err = ExtractIndexFromString(name.AsCString());
+  if (!idx_or_err) {
+    llvm::consumeError(idx_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  uint32_t idx = *idx_or_err;
+  if (idx >= CalculateNumChildrenIgnoringErrors())
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;


### PR DESCRIPTION
This PR is in continuation of https://github.com/llvm/llvm-project/pull/136693.

It upgrades `ExtractIndexFromString` to use `llvm::Expected`.