### PR TITLE
[clang-tidy][NFC][doc] fix typos in docs.

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/boost/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/boost/use-ranges.rst
@@ -64,7 +64,7 @@ Calls to the following std library algorithms are checked:
 ``std::mismatch``,
 ``std::next_permutation``,
 ``std::none_of``,
-``std::parital_sum``,
+``std::partial_sum``,
 ``std::partial_sort_copy``,
 ``std::partition_copy``,
 ``std::partition_point``,

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/casting-through-void.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/casting-through-void.rst
@@ -26,7 +26,7 @@ Note: it is expected that, after applying the suggested fix and using
 <../cppcoreguidelines/pro-type-reinterpret-cast>` will emit a warning.
 This is intentional: ``reinterpret_cast`` is a dangerous operation that can
 easily break the strict aliasing rules when dereferencing the casted pointer,
-invoking Undefined Behavior. The warning is there to prompt users to carefuly
+invoking Undefined Behavior. The warning is there to prompt users to carefully
 analyze whether the usage of ``reinterpret_cast`` is safe, in which case the
 warning may be suppressed.
 


### PR DESCRIPTION
Fixed typos in docs of `clang-tidy` checks.