### PR TITLE
[Clang] Never consider conversion from single-element braced-init-list perfect

### DIFF
--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -360,6 +360,13 @@ class Sema;
     LLVM_PREFERRED_TYPE(bool)
     unsigned ObjCLifetimeConversionBinding : 1;
 
+    /// Whether the source expression was originally a single element
+    /// braced-init-list. Such a conversion is not a perfect match,
+    /// as we prefer a std::list_initializer constructor over an exact match
+    /// constructor.
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned FromBracedInitList : 1;
+
     /// FromType - The type that this conversion is converting
     /// from. This is an opaque pointer that can be translated into a
     /// QualType.
@@ -412,6 +419,12 @@ class Sema;
     bool isPerfect(const ASTContext &C) const {
       if (!isIdentityConversion())
         return false;
+
+      // We might prefer a std::initializer constructor,
+      // so this sequence cannot be perfect
+      if (FromBracedInitList)
+        return false;
+
       // If we are not performing a reference binding, we can skip comparing
       // the types, which has a noticeable performance impact.
       if (!ReferenceBinding) {

--- a/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
+++ b/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
@@ -2,6 +2,20 @@
 // RUN: %clang_cc1 -triple=x86_64-unknown-unknown -fsyntax-only -verify -std=c++20 %s
 // RUN: %clang_cc1 -triple=x86_64-unknown-unknown -fsyntax-only -verify -std=c++2c %s
 
+namespace std {
+  typedef decltype(sizeof(int)) size_t;
+  template <class _E> class initializer_list {
+    const _E *__begin_;
+    size_t __size_;
+
+    constexpr initializer_list(const _E *__b, size_t __s)
+        : __begin_(__b), __size_(__s) {}
+
+  public:
+    constexpr initializer_list() : __begin_(nullptr), __size_(0) {}
+  };
+} // namespace std
+
 template <typename T>
 struct Invalid { static_assert(false, "instantiated Invalid"); }; // #err-invalid
 
@@ -204,3 +218,17 @@ using a = void(int &);
 template <typename c> void d(c &);
 void f(a);
 template <class> void f(bool j) { f(&d<int>); }
+
+struct InitListAreNotPerfect {
+  InitListAreNotPerfect(int) = delete;
+  template<class T>
+  InitListAreNotPerfect(std::initializer_list<T>);
+};
+InitListAreNotPerfect InitListAreNotPerfect_test({0});
+struct InitListAreNotPerfectCpy {
+  InitListAreNotPerfectCpy();
+  InitListAreNotPerfectCpy(const InitListAreNotPerfectCpy&);
+  template <typename T> InitListAreNotPerfectCpy(std::initializer_list<T>);
+};
+
+InitListAreNotPerfectCpy InitListAreNotPerfectCpy_test({InitListAreNotPerfectCpy{}});


### PR DESCRIPTION
We might prefer a template std::initializer list constructor.

Fix a regression introduced by #136203
https://github.com/llvm/llvm-project/pull/136203#issuecomment-2843498895

GCC had a similar issue and a similar fix
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100963