### PR TITLE
[mlir][SCF][TilingInterface] Add support for divisibility hints to tiling options

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/Transforms/TileUsingInterface.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/TileUsingInterface.h
@@ -124,6 +124,17 @@ struct SCFTilingOptions {
     mappingVector = llvm::to_vector(mapping);
     return *this;
   }
+
+  /// Gives hints for whether the tile sizes divide the iteration space evenly.
+  /// For static sizes, this is trivially verifiable (and the helpers here take
+  /// advantage of that), however for dynamic sizes we are always forced to be
+  /// pessimistic. This allows external analysis to check for divisibility and
+  /// pass on the info to tiling.
+  SmallVector<bool> divisibilityHint = {};
+  SCFTilingOptions &setDivisibilityHint(ArrayRef<bool> hint) {
+    divisibilityHint.assign(hint.begin(), hint.end());
+    return *this;
+  }
 };
 
 /// Transformation information returned after tiling.

--- a/mlir/test/lib/Interfaces/TilingInterface/TestTilingInterfaceTransformOps.cpp
+++ b/mlir/test/lib/Interfaces/TilingInterface/TestTilingInterfaceTransformOps.cpp
@@ -21,6 +21,7 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/TilingInterface.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 
 #define GET_OP_CLASSES
 #include "TestTilingInterfaceTransformOps.h.inc"
@@ -54,12 +55,11 @@ static llvm::SmallDenseSet<Operation *> collectTiledAndFusedOps(Operation *op) {
 /// Apply a tile and fuse transformation to all payload ops and store both the
 /// tiled operation as well as the created tile loops.
 template <typename Range>
-static LogicalResult
-applyTileAndFuseToAll(RewriterBase &rewriter, Operation *transformOp,
-                      Range &&payloadOps, unsigned numLoops,
-                      ArrayRef<OpFoldResult> tileSizes,
-                      ArrayRef<int64_t> interchange, bool useForall,
-                      TransformResults &transformResults) {
+static LogicalResult applyTileAndFuseToAll(
+    RewriterBase &rewriter, Operation *transformOp, Range &&payloadOps,
+    unsigned numLoops, ArrayRef<OpFoldResult> tileSizes,
+    ArrayRef<int64_t> interchange, ArrayRef<bool> divisibilityHint,
+    bool useForall, TransformResults &transformResults) {
   SmallVector<Operation *> tiledOps;
   SmallVector<SmallVector<Operation *>> loopOps(numLoops);
 
@@ -85,6 +85,7 @@ applyTileAndFuseToAll(RewriterBase &rewriter, Operation *transformOp,
     if (useForall) {
       tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
     }
+    tilingOptions.setDivisibilityHint(divisibilityHint);
 
     scf::SCFTileAndFuseOptions tileAndFuseOptions;
     tileAndFuseOptions.setTilingOptions(tilingOptions);
@@ -151,13 +152,16 @@ transform::TestFuseAndYieldOp::apply(TransformRewriter &rewriter,
   SmallVector<int64_t> tileInterchange =
       extractFromIntegerArrayAttr<int64_t>(getTileInterchange());
 
+  SmallVector<bool> divisibilityHint(
+      getDivisibilityHint().getAsValueRange<BoolAttr>());
+
   SmallVector<OpFoldResult> tileSizesOfr =
       getAsIndexOpFoldResult(rewriter.getContext(), tileSizes);
 
   LogicalResult result = applyTileAndFuseToAll(
       rewriter, getOperation(), state.getPayloadOps(getTarget()),
       tileSizes.size() - llvm::count(tileSizes, 0), tileSizesOfr,
-      tileInterchange, getUseForall(), transformResults);
+      tileInterchange, divisibilityHint, getUseForall(), transformResults);
   return failed(result) ? DiagnosedSilenceableFailure::definiteFailure()
                         : DiagnosedSilenceableFailure::success();
 }
@@ -237,7 +241,8 @@ template <typename Range>
 static LogicalResult
 applyTileToAll(RewriterBase &rewriter, Operation *transformOp,
                Range &&payloadOps, ArrayRef<OpFoldResult> tileSizes,
-               ArrayRef<int64_t> interchange, std::optional<ArrayAttr> mapping,
+               ArrayRef<int64_t> interchange, ArrayRef<bool> divisibilityHint,
+               std::optional<ArrayAttr> mapping,
                TransformResults &transformResults) {
   SmallVector<Operation *> tiledOps;
   SmallVector<Operation *> loopOps;
@@ -251,6 +256,7 @@ applyTileToAll(RewriterBase &rewriter, Operation *transformOp,
     if (mapping) {
       tilingOptions.setMapping(mapping.value().getValue());
     }
+    tilingOptions.setDivisibilityHint(divisibilityHint);
     tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
 
     rewriter.setInsertionPoint(target);
@@ -287,9 +293,12 @@ transform::TestTileUsingForallOp::apply(TransformRewriter &rewriter,
   SmallVector<OpFoldResult> tileSizesOfr =
       getAsIndexOpFoldResult(rewriter.getContext(), tileSizes);
 
-  LogicalResult result =
-      applyTileToAll(rewriter, getOperation(), state.getPayloadOps(getTarget()),
-                     tileSizesOfr, interchange, getMapping(), transformResults);
+  SmallVector<bool> divisibilityHint(
+      getDivisibilityHint().getAsValueRange<BoolAttr>());
+
+  LogicalResult result = applyTileToAll(
+      rewriter, getOperation(), state.getPayloadOps(getTarget()), tileSizesOfr,
+      interchange, divisibilityHint, getMapping(), transformResults);
   return failed(result) ? DiagnosedSilenceableFailure::definiteFailure()
                         : DiagnosedSilenceableFailure::success();
 }
@@ -363,11 +372,15 @@ transform::TestFuseUsingForallOp::apply(TransformRewriter &rewriter,
   SmallVector<int64_t> tileInterchange =
       extractFromIntegerArrayAttr<int64_t>(getInterchange());
 
+  SmallVector<bool> divisibilityHint(
+      getDivisibilityHint().getAsValueRange<BoolAttr>());
+
   scf::SCFTilingOptions tilingOptions;
   tilingOptions.interchangeVector = tileInterchange;
   SmallVector<OpFoldResult> tileSizesOfr =
       getAsIndexOpFoldResult(rewriter.getContext(), tileSizes);
   tilingOptions = tilingOptions.setTileSizes(tileSizesOfr);
+  tilingOptions = tilingOptions.setDivisibilityHint(divisibilityHint);
   tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
   scf::SCFTileAndFuseOptions tileAndFuseOptions;
   tileAndFuseOptions.tilingOptions = tilingOptions;

--- a/mlir/test/lib/Interfaces/TilingInterface/TestTilingInterfaceTransformOps.td
+++ b/mlir/test/lib/Interfaces/TilingInterface/TestTilingInterfaceTransformOps.td
@@ -38,12 +38,14 @@ def TestFuseAndYieldOp : Op<Transform_Dialect, "test.fuse_and_yield",
     (ins TransformHandleTypeInterface:$target,
         DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_sizes,
         DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_interchange,
+        DefaultValuedOptionalAttr<BoolArrayAttr, "{}">:$divisibility_hint,
         DefaultValuedAttr<BoolAttr, "false">:$use_forall);
   let results = (outs TransformHandleTypeInterface:$transfomed,
       Variadic<TransformHandleTypeInterface>:$loops);
 
   let assemblyFormat = [{
     $target ($tile_sizes^)? (`interchange` $tile_interchange^)?
+    (`divisibility_hint` `=` $divisibility_hint^)?
     (`use_forall` $use_forall^)? attr-dict 
     `:` functional-type(operands, results)
   }];
@@ -91,12 +93,14 @@ def TestTileUsingForallOp : Op<Transform_Dialect, "test.tile_using_forall",
   let arguments = (ins TransformHandleTypeInterface:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_sizes,
                    DefaultValuedOptionalAttr<I64ArrayAttr, "{}">:$interchange,
+                   DefaultValuedOptionalAttr<BoolArrayAttr, "{}">:$divisibility_hint,
                    OptionalAttr<DeviceMappingArrayAttr>:$mapping);
   let results = (outs TransformHandleTypeInterface:$tiled_op,
                       Variadic<TransformHandleTypeInterface>:$loops);
 
   let assemblyFormat = [{
     $target ($tile_sizes^)? (`interchange` `=` $interchange^)?
+    (`divisibility_hint` `=` $divisibility_hint^)?
     (`mapping` `=` $mapping^)?
     attr-dict `:` functional-type(operands, results)
   }];
@@ -114,12 +118,14 @@ def TestFuseUsingForallOp : Op<Transform_Dialect, "test.fuse_using_forall",
   let arguments = (ins TransformHandleTypeInterface:$root_op,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_sizes,
                    DefaultValuedOptionalAttr<I64ArrayAttr, "{}">:$interchange,
+                   DefaultValuedOptionalAttr<BoolArrayAttr, "{}">:$divisibility_hint,
                    OptionalAttr<DeviceMappingArrayAttr>:$mapping);
   let results = (outs TransformHandleTypeInterface:$tiled_ops,
                       Variadic<TransformHandleTypeInterface>:$loops);
 
   let assemblyFormat = [{
     $root_op ($tile_sizes^)? (`interchange` $interchange^)?
+    (`divisibility_hint` `=` $divisibility_hint^)?
     (`mapping` `=` $mapping^)?
     attr-dict `:` functional-type(operands, results)
   }];


### PR DESCRIPTION
The tiling helpers in SCF have support for emitting residual tiles when the iteration space is indivisible by a tile size. For static iteration spaces, the helpers omit checks for residual tiles when it's obvious they aren't needed, however we are always pessimistic for dynamic sizes. Rather than requiring the helpers to analyze the IR for divisibility information, which can require an expensive analysis, it's better to do such analysis in advance and then tile.

This patch adds a tiling option called |divisibilityHint| that allows specifying which dimensions of the iteration space are statically known to be divisible by their respective tile sizes.