### PR TITLE
[CSKY] Remove duplicate processor features in ck807e/ck807ef

### DIFF
--- a/llvm/lib/Target/CSKY/CSKY.td
+++ b/llvm/lib/Target/CSKY/CSKY.td
@@ -568,7 +568,7 @@ class CK807<string n, SchedMachineModel m, list<SubtargetFeature> f,
 def : CK807<"ck807", NoSchedModel, []>;
 def : CK807<"c807", NoSchedModel, []>;
 def : CK807<"r807", NoSchedModel, []>;
-def : CK807<"ck807e", NoSchedModel, [FeatureDSP, HasDSP1E2, HasDSPE60]>;
+def : CK807<"ck807e", NoSchedModel, []>;
 def : CK807<"ck807f", NoSchedModel,
             [FeatureFPUV2_SF, FeatureFPUV2_DF, FeatureFdivdu,
              HasFLOATE1, HasFLOAT1E2, HasFLOAT1E3, HasFLOAT3E4]>;
@@ -579,7 +579,7 @@ def : CK807<"r807f", NoSchedModel,
             [FeatureFPUV2_SF, FeatureFPUV2_DF, FeatureFdivdu,
              HasFLOATE1, HasFLOAT1E2, HasFLOAT1E3, HasFLOAT3E4]>;
 def : CK807<"ck807ef", NoSchedModel, [
-  FeatureDSP, HasDSP1E2, HasDSPE60, FeatureFPUV2_SF, FeatureFPUV2_DF,
+  FeatureFPUV2_SF, FeatureFPUV2_DF,
   FeatureFdivdu, HasFLOATE1, HasFLOAT1E2, HasFLOAT1E3, HasFLOAT3E4]>;
 
 // CK810 series


### PR DESCRIPTION
The new TableGen warning introduced in 951292b shows the following warnings:

```
warning: Processor ck807e contains duplicate feature 'edsp'
warning: Processor ck807e contains duplicate feature 'dsp1e2'
warning: Processor ck807e contains duplicate feature 'dspe60'
warning: Processor ck807ef contains duplicate feature 'edsp'
warning: Processor ck807ef contains duplicate feature 'dsp1e2'
warning: Processor ck807ef contains duplicate feature 'dspe60'
```