### PR TITLE
[LLDB][NFC] Remove unneeded conditional

### DIFF
--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -1231,77 +1231,74 @@ protected:
     }
 
     if (platform_sp) {
-      Status error;
-      if (platform_sp) {
-        Stream &ostrm = result.GetOutputStream();
+      Stream &ostrm = result.GetOutputStream();
 
-        lldb::pid_t pid = m_options.match_info.GetProcessInfo().GetProcessID();
-        if (pid != LLDB_INVALID_PROCESS_ID) {
-          ProcessInstanceInfo proc_info;
-          if (platform_sp->GetProcessInfo(pid, proc_info)) {
-            ProcessInstanceInfo::DumpTableHeader(ostrm, m_options.show_args,
-                                                 m_options.verbose);
-            proc_info.DumpAsTableRow(ostrm, platform_sp->GetUserIDResolver(),
-                                     m_options.show_args, m_options.verbose);
-            result.SetStatus(eReturnStatusSuccessFinishResult);
-          } else {
-            result.AppendErrorWithFormat(
-                "no process found with pid = %" PRIu64 "\n", pid);
-          }
+      lldb::pid_t pid = m_options.match_info.GetProcessInfo().GetProcessID();
+      if (pid != LLDB_INVALID_PROCESS_ID) {
+        ProcessInstanceInfo proc_info;
+        if (platform_sp->GetProcessInfo(pid, proc_info)) {
+          ProcessInstanceInfo::DumpTableHeader(ostrm, m_options.show_args,
+                                               m_options.verbose);
+          proc_info.DumpAsTableRow(ostrm, platform_sp->GetUserIDResolver(),
+                                   m_options.show_args, m_options.verbose);
+          result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          ProcessInstanceInfoList proc_infos;
-          const uint32_t matches =
-              platform_sp->FindProcesses(m_options.match_info, proc_infos);
-          const char *match_desc = nullptr;
-          const char *match_name =
-              m_options.match_info.GetProcessInfo().GetName();
-          if (match_name && match_name[0]) {
-            switch (m_options.match_info.GetNameMatchType()) {
-            case NameMatch::Ignore:
-              break;
-            case NameMatch::Equals:
-              match_desc = "matched";
-              break;
-            case NameMatch::Contains:
-              match_desc = "contained";
-              break;
-            case NameMatch::StartsWith:
-              match_desc = "started with";
-              break;
-            case NameMatch::EndsWith:
-              match_desc = "ended with";
-              break;
-            case NameMatch::RegularExpression:
-              match_desc = "matched the regular expression";
-              break;
-            }
+          result.AppendErrorWithFormat(
+              "no process found with pid = %" PRIu64 "\n", pid);
+        }
+      } else {
+        ProcessInstanceInfoList proc_infos;
+        const uint32_t matches =
+            platform_sp->FindProcesses(m_options.match_info, proc_infos);
+        const char *match_desc = nullptr;
+        const char *match_name =
+            m_options.match_info.GetProcessInfo().GetName();
+        if (match_name && match_name[0]) {
+          switch (m_options.match_info.GetNameMatchType()) {
+          case NameMatch::Ignore:
+            break;
+          case NameMatch::Equals:
+            match_desc = "matched";
+            break;
+          case NameMatch::Contains:
+            match_desc = "contained";
+            break;
+          case NameMatch::StartsWith:
+            match_desc = "started with";
+            break;
+          case NameMatch::EndsWith:
+            match_desc = "ended with";
+            break;
+          case NameMatch::RegularExpression:
+            match_desc = "matched the regular expression";
+            break;
           }
+        }
 
-          if (matches == 0) {
-            if (match_desc)
-              result.AppendErrorWithFormatv(
-                  "no processes were found that {0} \"{1}\" on the \"{2}\" "
-                  "platform\n",
-                  match_desc, match_name, platform_sp->GetName());
-            else
-              result.AppendErrorWithFormatv(
-                  "no processes were found on the \"{0}\" platform\n",
-                  platform_sp->GetName());
-          } else {
-            result.AppendMessageWithFormatv(
-                "{0} matching process{1} found on \"{2}\"", matches,
-                matches > 1 ? "es were" : " was", platform_sp->GetName());
-            if (match_desc)
-              result.AppendMessageWithFormat(" whose name %s \"%s\"",
-                                             match_desc, match_name);
-            result.AppendMessageWithFormat("\n");
-            ProcessInstanceInfo::DumpTableHeader(ostrm, m_options.show_args,
-                                                 m_options.verbose);
-            for (uint32_t i = 0; i < matches; ++i) {
-              proc_infos[i].DumpAsTableRow(
-                  ostrm, platform_sp->GetUserIDResolver(), m_options.show_args,
-                  m_options.verbose);
-            }
+        if (matches == 0) {
+          if (match_desc)
+            result.AppendErrorWithFormatv(
+                "no processes were found that {0} \"{1}\" on the \"{2}\" "
+                "platform\n",
+                match_desc, match_name, platform_sp->GetName());
+          else
+            result.AppendErrorWithFormatv(
+                "no processes were found on the \"{0}\" platform\n",
+                platform_sp->GetName());
+        } else {
+          result.AppendMessageWithFormatv(
+              "{0} matching process{1} found on \"{2}\"", matches,
+              matches > 1 ? "es were" : " was", platform_sp->GetName());
+          if (match_desc)
+            result.AppendMessageWithFormat(" whose name %s \"%s\"", match_desc,
+                                           match_name);
+          result.AppendMessageWithFormat("\n");
+          ProcessInstanceInfo::DumpTableHeader(ostrm, m_options.show_args,
+                                               m_options.verbose);
+          for (uint32_t i = 0; i < matches; ++i) {
+            proc_infos[i].DumpAsTableRow(
+                ostrm, platform_sp->GetUserIDResolver(), m_options.show_args,
+                m_options.verbose);
           }
         }
       }


### PR DESCRIPTION
we already check for `platform_sp` not null in one line below. 

existing code
```
if (platform_sp) {
      Status error;
      if (platform_sp) {
...
...
     }
}
```

`platform_sp` null check is redundant and error variable is unused. 

### TEST PLAN 
manual test 

```
satyajanga@devvm21837:toolchain $ ./bin/lldb
LLDB logging initialized. Logs stored in: /tmp
(lldb) platform select host
  Platform: host
    Triple: x86_64-*-linux-gnu
OS Version: 6.9.0 (6.9.0-0_fbk5_hardened_1_gf368ae920c1a)
  Hostname: 127.0.0.1
WorkingDir: /home/satyajanga/llvm-sand/build/Debug/fbcode-x86_64/toolchain
    Kernel: #1 SMP Tue Feb 11 07:24:41 PST 2025
    Kernel: Linux
   Release: 6.9.0-0_fbk5_hardened_1_gf368ae920c1a
   Version: #1 SMP Tue Feb 11 07:24:41 PST 2025
(lldb) platform process list
144 matching processes were found on "host"

PID    PARENT USER       TRIPLE                         NAME
====== ====== ========== ============================== ============================
130461 874915 satyajanga x86_64-*-linux-gnu             sushd
135505 874915 satyajanga x86_64-*-linux-gnu             hg.real
817146 874915 satyajanga x86_64-*-linux-gnu             vscode-thrift
874915 1      satyajanga                                
874947 874915 satyajanga                                
```

and running the existing tests
```
satyajanga@devvm21837:toolchain $ ./bin/llvm-lit -v  ~/llvm-sand/external/llvm-project/lldb/test/API/commands/platform/
-- Testing: 9 tests, 9 workers --
PASS: lldb-api :: commands/platform/file/read/TestPlatformFileRead.py (1 of 9)
PASS: lldb-api :: commands/platform/file/close/TestPlatformFileClose.py (2 of 9)
UNSUPPORTED: lldb-api :: commands/platform/sdk/TestPlatformSDK.py (3 of 9)
PASS: lldb-api :: commands/platform/basic/TestPlatformPython.py (4 of 9)
PASS: lldb-api :: commands/platform/basic/TestPlatformCommand.py (5 of 9)
PASS: lldb-api :: commands/platform/connect/TestPlatformConnect.py (6 of 9)
PASS: lldb-api :: commands/platform/process/launch/TestPlatformProcessLaunch.py (7 of 9)
PASS: lldb-api :: commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py (8 of 9)
PASS: lldb-api :: commands/platform/process/list/TestProcessList.py (9 of 9)

Testing Time: 13.48s

Total Discovered Tests: 9
  Unsupported: 1 (11.11%)
  Passed     : 8 (88.89%)
satyajanga@devvm21837:toolchain $ 
```