### PR TITLE
[HLSL][RootSignature] Implement serialized dump of Descriptor Tables

### DIFF
--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -53,8 +53,6 @@ enum class RegisterType { BReg, TReg, UReg, SReg };
 struct Register {
   RegisterType ViewType;
   uint32_t Number;
-
-  void dump(raw_ostream &OS) const;
 };
 
 // Models the end of a descriptor table and stores its visibility

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -53,6 +53,8 @@ enum class RegisterType { BReg, TReg, UReg, SReg };
 struct Register {
   RegisterType ViewType;
   uint32_t Number;
+
+  void dump(raw_ostream &OS) const;
 };
 
 // Models the end of a descriptor table and stores its visibility

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -61,6 +61,8 @@ struct Register {
 struct DescriptorTable {
   ShaderVisibility Visibility = ShaderVisibility::All;
   uint32_t NumClauses = 0; // The number of clauses in the table
+
+  void dump(raw_ostream &OS) const;
 };
 
 static const uint32_t NumDescriptorsUnbounded = 0xffffffff;

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -15,6 +15,7 @@
 #define LLVM_FRONTEND_HLSL_HLSLROOTSIGNATURE_H
 
 #include "llvm/Support/DXILABI.h"
+#include "llvm/Support/raw_ostream.h"
 #include <variant>
 
 namespace llvm {
@@ -86,6 +87,8 @@ struct DescriptorTableClause {
       break;
     }
   }
+
+  void dump(raw_ostream &OS) const;
 };
 
 // Models RootElement : DescriptorTable | DescriptorTableClause

--- a/llvm/lib/Frontend/HLSL/CMakeLists.txt
+++ b/llvm/lib/Frontend/HLSL/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_component_library(LLVMFrontendHLSL
   CBuffer.cpp
   HLSLResource.cpp
+  HLSLRootSignature.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Frontend

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -69,8 +69,8 @@ static raw_ostream &operator<<(raw_ostream &OS,
 }
 
 void DescriptorTable::dump(raw_ostream &OS) const {
-  OS << "DescriptorTable(numClauses = " << NumClauses;
-  OS << ", visibility = " << Visibility << ")";
+  OS << "DescriptorTable(numClauses = " << NumClauses
+     << ", visibility = " << Visibility << ")";
 }
 
 static raw_ostream &operator<<(raw_ostream &OS, const ClauseType &Type) {
@@ -135,10 +135,8 @@ static raw_ostream &operator<<(raw_ostream &OS,
 }
 
 void DescriptorTableClause::dump(raw_ostream &OS) const {
-  OS << Type << "(" << Reg;
-  OS << ", numDescriptors = " << NumDescriptors;
-  OS << ", space = " << Space;
-  OS << ", offset = ";
+  OS << Type << "(" << Reg << ", numDescriptors = " << NumDescriptors
+     << ", space = " << Space << ", offset = ";
   if (Offset == DescriptorTableOffsetAppend)
     OS << "DescriptorTableOffsetAppend";
   else

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -39,6 +39,42 @@ void Register::dump(raw_ostream &OS) const {
   OS << Number;
 }
 
+static void dumpVisibility(raw_ostream &OS, ShaderVisibility Visibility) {
+  switch (Visibility) {
+    case ShaderVisibility::All:
+      OS << "All";
+      break;
+    case ShaderVisibility::Vertex:
+      OS << "Vertex";
+      break;
+    case ShaderVisibility::Hull:
+      OS << "Hull";
+      break;
+    case ShaderVisibility::Domain:
+      OS << "Domain";
+      break;
+    case ShaderVisibility::Geometry:
+      OS << "Geometry";
+      break;
+    case ShaderVisibility::Pixel:
+      OS << "Pixel";
+      break;
+    case ShaderVisibility::Amplification:
+      OS << "Amplification";
+      break;
+    case ShaderVisibility::Mesh:
+      OS << "Mesh";
+      break;
+  }
+}
+
+void DescriptorTable::dump(raw_ostream &OS) const {
+  OS << "DescriptorTable(numClauses = " << NumClauses;
+  OS << ", visibility = ";
+  dumpVisibility(OS, Visibility);
+  OS << ")";
+}
+
 static void dumpClauseType(raw_ostream& OS, ClauseType Type) {
   switch (Type) {
   case ClauseType::CBuffer:

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -11,13 +11,105 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Frontend/HLSL/HLSLRootSignature.h"
+#include "llvm/ADT/bit.h"
 
 namespace llvm {
 namespace hlsl {
 namespace rootsig {
 
+static void dumpRegType(raw_ostream& OS, RegisterType Type) {
+  switch (Type) {
+  case RegisterType::BReg:
+    OS << "b";
+    break;
+  case RegisterType::TReg:
+    OS << "t";
+    break;
+  case RegisterType::UReg:
+    OS << "u";
+    break;
+  case RegisterType::SReg:
+    OS << "s";
+    break;
+  }
+}
+
+void Register::dump(raw_ostream &OS) const {
+  dumpRegType(OS, ViewType);
+  OS << Number;
+}
+
+static void dumpClauseType(raw_ostream& OS, ClauseType Type) {
+  switch (Type) {
+  case ClauseType::CBuffer:
+    OS << "CBV";
+    break;
+  case ClauseType::SRV:
+    OS << "SRV";
+    break;
+  case ClauseType::UAV:
+    OS << "UAV";
+    break;
+  case ClauseType::Sampler:
+    OS << "Sampler";
+    break;
+  }
+}
+
+static void dumpDescriptorRangeFlag(raw_ostream &OS, unsigned Bit) {
+  switch (static_cast<DescriptorRangeFlags>(Bit)) {
+    case DescriptorRangeFlags::DescriptorsVolatile:
+      OS << "DescriptorsVolatile";
+      break;
+    case DescriptorRangeFlags::DataVolatile:
+      OS << "DataVolatile";
+      break;
+    case DescriptorRangeFlags::DataStaticWhileSetAtExecute:
+      OS << "DataStaticWhileSetAtExecute";
+      break;
+    case DescriptorRangeFlags::DataStatic:
+      OS << "DataStatic";
+      break;
+    case DescriptorRangeFlags::DescriptorsStaticKeepingBufferBoundsChecks:
+      OS << "DescriptorsStaticKeepingBufferBoundsChecks";
+      break;
+    default:
+      OS << "invalid: " << Bit;
+      break;
+  }
+}
+
+static void dumpDescriptorRangeFlags(raw_ostream &OS, DescriptorRangeFlags Flags) {
+  bool FlagSet = false;
+  unsigned Remaining = llvm::to_underlying(Flags);
+  while (Remaining) {
+    unsigned Bit = 1u << llvm::countr_zero(Remaining);
+    if (Remaining & Bit) {
+      if (FlagSet)
+        OS << " | ";
+      dumpDescriptorRangeFlag(OS, Bit);
+      FlagSet = true;
+    }
+    Remaining &= ~Bit;
+  }
+  if (!FlagSet)
+    OS << "None";
+}
+
 void DescriptorTableClause::dump(raw_ostream &OS) const {
-  OS << "Clause!";
+  dumpClauseType(OS, Type);
+  OS << "(";
+  Reg.dump(OS);
+  OS << ", numDescriptors = " << NumDescriptors;
+  OS << ", space = " << Space;
+  OS << ", offset = ";
+  if (Offset == DescriptorTableOffsetAppend)
+    OS << "DESCRIPTOR_TABLE_OFFSET_APPEND";
+  else
+    OS << Offset;
+  OS << ", flags = ";
+  dumpDescriptorRangeFlags(OS, Flags);
+  OS << ")";
 }
 
 } // namespace rootsig

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -140,7 +140,7 @@ void DescriptorTableClause::dump(raw_ostream &OS) const {
   OS << ", space = " << Space;
   OS << ", offset = ";
   if (Offset == DescriptorTableOffsetAppend)
-    OS << "DESCRIPTOR_TABLE_OFFSET_APPEND";
+    OS << "DescriptorTableOffsetAppend";
   else
     OS << Offset;
   OS << ", flags = ";

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -17,7 +17,7 @@ namespace llvm {
 namespace hlsl {
 namespace rootsig {
 
-static void dumpRegType(raw_ostream& OS, RegisterType Type) {
+static void dumpRegType(raw_ostream &OS, RegisterType Type) {
   switch (Type) {
   case RegisterType::BReg:
     OS << "b";
@@ -41,30 +41,30 @@ void Register::dump(raw_ostream &OS) const {
 
 static void dumpVisibility(raw_ostream &OS, ShaderVisibility Visibility) {
   switch (Visibility) {
-    case ShaderVisibility::All:
-      OS << "All";
-      break;
-    case ShaderVisibility::Vertex:
-      OS << "Vertex";
-      break;
-    case ShaderVisibility::Hull:
-      OS << "Hull";
-      break;
-    case ShaderVisibility::Domain:
-      OS << "Domain";
-      break;
-    case ShaderVisibility::Geometry:
-      OS << "Geometry";
-      break;
-    case ShaderVisibility::Pixel:
-      OS << "Pixel";
-      break;
-    case ShaderVisibility::Amplification:
-      OS << "Amplification";
-      break;
-    case ShaderVisibility::Mesh:
-      OS << "Mesh";
-      break;
+  case ShaderVisibility::All:
+    OS << "All";
+    break;
+  case ShaderVisibility::Vertex:
+    OS << "Vertex";
+    break;
+  case ShaderVisibility::Hull:
+    OS << "Hull";
+    break;
+  case ShaderVisibility::Domain:
+    OS << "Domain";
+    break;
+  case ShaderVisibility::Geometry:
+    OS << "Geometry";
+    break;
+  case ShaderVisibility::Pixel:
+    OS << "Pixel";
+    break;
+  case ShaderVisibility::Amplification:
+    OS << "Amplification";
+    break;
+  case ShaderVisibility::Mesh:
+    OS << "Mesh";
+    break;
   }
 }
 
@@ -75,7 +75,7 @@ void DescriptorTable::dump(raw_ostream &OS) const {
   OS << ")";
 }
 
-static void dumpClauseType(raw_ostream& OS, ClauseType Type) {
+static void dumpClauseType(raw_ostream &OS, ClauseType Type) {
   switch (Type) {
   case ClauseType::CBuffer:
     OS << "CBV";
@@ -94,28 +94,29 @@ static void dumpClauseType(raw_ostream& OS, ClauseType Type) {
 
 static void dumpDescriptorRangeFlag(raw_ostream &OS, unsigned Bit) {
   switch (static_cast<DescriptorRangeFlags>(Bit)) {
-    case DescriptorRangeFlags::DescriptorsVolatile:
-      OS << "DescriptorsVolatile";
-      break;
-    case DescriptorRangeFlags::DataVolatile:
-      OS << "DataVolatile";
-      break;
-    case DescriptorRangeFlags::DataStaticWhileSetAtExecute:
-      OS << "DataStaticWhileSetAtExecute";
-      break;
-    case DescriptorRangeFlags::DataStatic:
-      OS << "DataStatic";
-      break;
-    case DescriptorRangeFlags::DescriptorsStaticKeepingBufferBoundsChecks:
-      OS << "DescriptorsStaticKeepingBufferBoundsChecks";
-      break;
-    default:
-      OS << "invalid: " << Bit;
-      break;
+  case DescriptorRangeFlags::DescriptorsVolatile:
+    OS << "DescriptorsVolatile";
+    break;
+  case DescriptorRangeFlags::DataVolatile:
+    OS << "DataVolatile";
+    break;
+  case DescriptorRangeFlags::DataStaticWhileSetAtExecute:
+    OS << "DataStaticWhileSetAtExecute";
+    break;
+  case DescriptorRangeFlags::DataStatic:
+    OS << "DataStatic";
+    break;
+  case DescriptorRangeFlags::DescriptorsStaticKeepingBufferBoundsChecks:
+    OS << "DescriptorsStaticKeepingBufferBoundsChecks";
+    break;
+  default:
+    OS << "invalid: " << Bit;
+    break;
   }
 }
 
-static void dumpDescriptorRangeFlags(raw_ostream &OS, DescriptorRangeFlags Flags) {
+static void dumpDescriptorRangeFlags(raw_ostream &OS,
+                                     DescriptorRangeFlags Flags) {
   bool FlagSet = false;
   unsigned Remaining = llvm::to_underlying(Flags);
   while (Remaining) {

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -1,0 +1,25 @@
+//===- HLSLRootSignature.cpp - HLSL Root Signature helper objects ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file This file contains helpers for working with HLSL Root Signatures.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Frontend/HLSL/HLSLRootSignature.h"
+
+namespace llvm {
+namespace hlsl {
+namespace rootsig {
+
+void DescriptorTableClause::dump(raw_ostream &OS) const {
+  OS << "Clause!";
+}
+
+} // namespace rootsig
+} // namespace hlsl
+} // namespace llvm

--- a/llvm/unittests/Frontend/CMakeLists.txt
+++ b/llvm/unittests/Frontend/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   Analysis
   Core
+  FrontendHLSL
   FrontendOpenACC
   FrontendOpenMP
   Passes
@@ -10,6 +11,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_unittest(LLVMFrontendTests
+  HLSLRootSignatureDumpTest.cpp
   OpenACCTest.cpp
   OpenMPContextTest.cpp
   OpenMPIRBuilderTest.cpp

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -95,4 +95,19 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
   EXPECT_EQ(Out, Expected);
 }
 
+TEST(HLSLRootSignatureTest, DescriptorTableDump) {
+  DescriptorTable Table;
+  Table.NumClauses = 4;
+  Table.Visibility = ShaderVisibility::Geometry;
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  Table.dump(OS);
+  OS.flush();
+
+  std::string Expected =
+    "DescriptorTable(numClauses = 4, visibility = Geometry)";
+  EXPECT_EQ(Out, Expected);
+}
+
 } // namespace

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -16,7 +16,7 @@ namespace {
 TEST(HLSLRootSignatureTest, DescriptorCBVClauseDump) {
   DescriptorTableClause Clause;
   Clause.Type = ClauseType::CBuffer;
-  Clause.Reg = { RegisterType::BReg, 0 };
+  Clause.Reg = {RegisterType::BReg, 0};
   Clause.setDefaultFlags();
 
   std::string Out;
@@ -24,17 +24,16 @@ TEST(HLSLRootSignatureTest, DescriptorCBVClauseDump) {
   Clause.dump(OS);
   OS.flush();
 
-  std::string Expected =
-    "CBV(b0, numDescriptors = 1, space = 0, "
-    "offset = DescriptorTableOffsetAppend, "
-    "flags = DataStaticWhileSetAtExecute)";
+  std::string Expected = "CBV(b0, numDescriptors = 1, space = 0, "
+                         "offset = DescriptorTableOffsetAppend, "
+                         "flags = DataStaticWhileSetAtExecute)";
   EXPECT_EQ(Out, Expected);
 }
 
 TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
   DescriptorTableClause Clause;
   Clause.Type = ClauseType::SRV;
-  Clause.Reg = { RegisterType::TReg, 0 };
+  Clause.Reg = {RegisterType::TReg, 0};
   Clause.NumDescriptors = 2;
   Clause.Space = 42;
   Clause.Offset = 3;
@@ -46,15 +45,14 @@ TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
   OS.flush();
 
   std::string Expected =
-    "SRV(t0, numDescriptors = 2, space = 42, offset = 3, flags = None)";
+      "SRV(t0, numDescriptors = 2, space = 42, offset = 3, flags = None)";
   EXPECT_EQ(Out, Expected);
 }
-
 
 TEST(HLSLRootSignatureTest, DescriptorUAVClauseDump) {
   DescriptorTableClause Clause;
   Clause.Type = ClauseType::UAV;
-  Clause.Reg = { RegisterType::UReg, 92374 };
+  Clause.Reg = {RegisterType::UReg, 92374};
   Clause.NumDescriptors = 3298;
   Clause.Space = 932847;
   Clause.Offset = 1;
@@ -66,19 +64,19 @@ TEST(HLSLRootSignatureTest, DescriptorUAVClauseDump) {
   OS.flush();
 
   std::string Expected =
-    "UAV(u92374, numDescriptors = 3298, space = 932847, offset = 1, flags = "
-    "DescriptorsVolatile | "
-    "DataVolatile | "
-    "DataStaticWhileSetAtExecute | "
-    "DataStatic | "
-    "DescriptorsStaticKeepingBufferBoundsChecks)";
+      "UAV(u92374, numDescriptors = 3298, space = 932847, offset = 1, flags = "
+      "DescriptorsVolatile | "
+      "DataVolatile | "
+      "DataStaticWhileSetAtExecute | "
+      "DataStatic | "
+      "DescriptorsStaticKeepingBufferBoundsChecks)";
   EXPECT_EQ(Out, Expected);
 }
 
 TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
   DescriptorTableClause Clause;
   Clause.Type = ClauseType::Sampler;
-  Clause.Reg = { RegisterType::SReg, 0 };
+  Clause.Reg = {RegisterType::SReg, 0};
   Clause.NumDescriptors = 2;
   Clause.Space = 42;
   Clause.Offset = DescriptorTableOffsetAppend;
@@ -89,9 +87,9 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
   Clause.dump(OS);
   OS.flush();
 
-  std::string Expected =
-    "Sampler(s0, numDescriptors = 2, space = 42, offset = DescriptorTableOffsetAppend, "
-    "flags = DescriptorsVolatile)";
+  std::string Expected = "Sampler(s0, numDescriptors = 2, space = 42, offset = "
+                         "DescriptorTableOffsetAppend, "
+                         "flags = DescriptorsVolatile)";
   EXPECT_EQ(Out, Expected);
 }
 
@@ -106,7 +104,7 @@ TEST(HLSLRootSignatureTest, DescriptorTableDump) {
   OS.flush();
 
   std::string Expected =
-    "DescriptorTable(numClauses = 4, visibility = Geometry)";
+      "DescriptorTable(numClauses = 4, visibility = Geometry)";
   EXPECT_EQ(Out, Expected);
 }
 

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -13,18 +13,86 @@ using namespace llvm::hlsl::rootsig;
 
 namespace {
 
-TEST(HLSLRootSignatureTest, DescriptorTablesDump) {
-  // Default clause
+TEST(HLSLRootSignatureTest, DescriptorCBVClauseDump) {
   DescriptorTableClause Clause;
   Clause.Type = ClauseType::CBuffer;
   Clause.Reg = { RegisterType::BReg, 0 };
+  Clause.setDefaultFlags();
 
   std::string Out;
   llvm::raw_string_ostream OS(Out);
   Clause.dump(OS);
   OS.flush();
 
-  EXPECT_EQ(Out, "Clause!");
+  std::string Expected =
+    "CBV(b0, numDescriptors = 1, space = 0, "
+    "offset = DESCRIPTOR_TABLE_OFFSET_APPEND, "
+    "flags = DataStaticWhileSetAtExecute)";
+  EXPECT_EQ(Out, Expected);
+}
+
+TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
+  DescriptorTableClause Clause;
+  Clause.Type = ClauseType::SRV;
+  Clause.Reg = { RegisterType::TReg, 0 };
+  Clause.NumDescriptors = 2;
+  Clause.Space = 42;
+  Clause.Offset = 3;
+  Clause.Flags = DescriptorRangeFlags::None;
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  Clause.dump(OS);
+  OS.flush();
+
+  std::string Expected =
+    "SRV(t0, numDescriptors = 2, space = 42, offset = 3, flags = None)";
+  EXPECT_EQ(Out, Expected);
+}
+
+
+TEST(HLSLRootSignatureTest, DescriptorUAVClauseDump) {
+  DescriptorTableClause Clause;
+  Clause.Type = ClauseType::UAV;
+  Clause.Reg = { RegisterType::UReg, 0 };
+  Clause.NumDescriptors = 2;
+  Clause.Space = 42;
+  Clause.Offset = 3;
+  Clause.Flags = DescriptorRangeFlags::ValidFlags;
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  Clause.dump(OS);
+  OS.flush();
+
+  std::string Expected =
+    "UAV(u0, numDescriptors = 2, space = 42, offset = 3, flags = "
+    "DescriptorsVolatile | "
+    "DataVolatile | "
+    "DataStaticWhileSetAtExecute | "
+    "DataStatic | "
+    "DescriptorsStaticKeepingBufferBoundsChecks)";
+  EXPECT_EQ(Out, Expected);
+}
+
+TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
+  DescriptorTableClause Clause;
+  Clause.Type = ClauseType::Sampler;
+  Clause.Reg = { RegisterType::SReg, 0 };
+  Clause.NumDescriptors = 2;
+  Clause.Space = 42;
+  Clause.Offset = 3;
+  Clause.Flags = DescriptorRangeFlags::ValidSamplerFlags;
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  Clause.dump(OS);
+  OS.flush();
+
+  std::string Expected =
+    "Sampler(s0, numDescriptors = 2, space = 42, offset = 3, "
+    "flags = DescriptorsVolatile)";
+  EXPECT_EQ(Out, Expected);
 }
 
 } // namespace

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -26,7 +26,7 @@ TEST(HLSLRootSignatureTest, DescriptorCBVClauseDump) {
 
   std::string Expected =
     "CBV(b0, numDescriptors = 1, space = 0, "
-    "offset = DESCRIPTOR_TABLE_OFFSET_APPEND, "
+    "offset = DescriptorTableOffsetAppend, "
     "flags = DataStaticWhileSetAtExecute)";
   EXPECT_EQ(Out, Expected);
 }
@@ -54,10 +54,10 @@ TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
 TEST(HLSLRootSignatureTest, DescriptorUAVClauseDump) {
   DescriptorTableClause Clause;
   Clause.Type = ClauseType::UAV;
-  Clause.Reg = { RegisterType::UReg, 0 };
-  Clause.NumDescriptors = 2;
-  Clause.Space = 42;
-  Clause.Offset = 3;
+  Clause.Reg = { RegisterType::UReg, 92374 };
+  Clause.NumDescriptors = 3298;
+  Clause.Space = 932847;
+  Clause.Offset = 1;
   Clause.Flags = DescriptorRangeFlags::ValidFlags;
 
   std::string Out;
@@ -66,7 +66,7 @@ TEST(HLSLRootSignatureTest, DescriptorUAVClauseDump) {
   OS.flush();
 
   std::string Expected =
-    "UAV(u0, numDescriptors = 2, space = 42, offset = 3, flags = "
+    "UAV(u92374, numDescriptors = 3298, space = 932847, offset = 1, flags = "
     "DescriptorsVolatile | "
     "DataVolatile | "
     "DataStaticWhileSetAtExecute | "
@@ -81,7 +81,7 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
   Clause.Reg = { RegisterType::SReg, 0 };
   Clause.NumDescriptors = 2;
   Clause.Space = 42;
-  Clause.Offset = 3;
+  Clause.Offset = DescriptorTableOffsetAppend;
   Clause.Flags = DescriptorRangeFlags::ValidSamplerFlags;
 
   std::string Out;
@@ -90,7 +90,7 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
   OS.flush();
 
   std::string Expected =
-    "Sampler(s0, numDescriptors = 2, space = 42, offset = 3, "
+    "Sampler(s0, numDescriptors = 2, space = 42, offset = DescriptorTableOffsetAppend, "
     "flags = DescriptorsVolatile)";
   EXPECT_EQ(Out, Expected);
 }

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -1,0 +1,30 @@
+//===-------- HLSLRootSignatureDumpTest.cpp - RootSignature dump tests ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Frontend/HLSL/HLSLRootSignature.h"
+#include "gtest/gtest.h"
+
+using namespace llvm::hlsl::rootsig;
+
+namespace {
+
+TEST(HLSLRootSignatureTest, DescriptorTablesDump) {
+  // Default clause
+  DescriptorTableClause Clause;
+  Clause.Type = ClauseType::CBuffer;
+  Clause.Reg = { RegisterType::BReg, 0 };
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  Clause.dump(OS);
+  OS.flush();
+
+  EXPECT_EQ(Out, "Clause!");
+}
+
+} // namespace


### PR DESCRIPTION
- defines the `dump` method for in-memory descriptor table data structs in `Frontend/HLSLRootSignature`
- creates unit test infrastructure to support unit tests of the dump methods

Resolves https://github.com/llvm/llvm-project/issues/138189