### PR TITLE
[Offload] Fix PowerPC builds that pass -mcpu

### DIFF
--- a/offload/DeviceRTL/CMakeLists.txt
+++ b/offload/DeviceRTL/CMakeLists.txt
@@ -132,9 +132,12 @@ function(compileDeviceRTLLibrary target_name target_triple)
     BUILD_RPATH ""
     INSTALL_RPATH ""
     RUNTIME_OUTPUT_NAME libomptarget-${target_name}.bc)
-  target_compile_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}" "-fuse-ld=lld" "-march=")
+  target_compile_options(libomptarget-${target_name} PRIVATE
+    "--target=${target_triple}" "-fuse-ld=lld" "-march=" "-mcpu="
+    "-Wno-unused-command-line-argument")
   target_link_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}"
-                      "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm" "-fuse-ld=lld" "-march=")
+                      "-mcpu=power8" "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm"
+                      "-fuse-ld=lld" "-march=" "-mcpu=")
   install(TARGETS libomptarget-${target_name}
           PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
           DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${target_triple}")
@@ -152,7 +155,8 @@ function(compileDeviceRTLLibrary target_name target_triple)
   )
   target_link_libraries(omptarget.${target_name} PRIVATE omptarget.${target_name}.all_objs)
   target_link_options(omptarget.${target_name} PRIVATE "--target=${target_triple}"
-                      "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm" "-fuse-ld=lld" "-march=")
+                      "-Wno-unused-command-line-argument""-r" "-nostdlib" "-flto"
+                       "-Wl,--lto-emit-llvm" "-fuse-ld=lld" "-march=" "-mcpu=")
 
   install(TARGETS omptarget.${target_name}
           ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${target_triple}")

--- a/offload/DeviceRTL/CMakeLists.txt
+++ b/offload/DeviceRTL/CMakeLists.txt
@@ -136,7 +136,7 @@ function(compileDeviceRTLLibrary target_name target_triple)
     "--target=${target_triple}" "-fuse-ld=lld" "-march=" "-mcpu="
     "-Wno-unused-command-line-argument")
   target_link_options(libomptarget-${target_name} PRIVATE "--target=${target_triple}"
-                      "-mcpu=power8" "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm"
+                      "-r" "-nostdlib" "-flto" "-Wl,--lto-emit-llvm"
                       "-fuse-ld=lld" "-march=" "-mcpu=")
   install(TARGETS libomptarget-${target_name}
           PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ


### PR DESCRIPTION
Summary:
Another hacky fix done until
https://github.com/llvm/llvm-project/pull/136729 lands. This time for
`-mcpu`.
