### PR TITLE
[clang] Complete the revert of 1a14ef1

### DIFF
--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -76,8 +76,6 @@ public:
   using RoundingMode = llvm::RoundingMode;
   using CFBranchLabelSchemeKind = clang::CFBranchLabelSchemeKind;
 
-  LangOptionsBase() = default;
-
   enum GCMode { NonGC, GCOnly, HybridGC };
   enum StackProtectorMode { SSPOff, SSPOn, SSPStrong, SSPReq };
 


### PR DESCRIPTION
When merging the fix for FEM_Indeterminate I reverted the follow on warning fixes, but misread this diff and retained the explicitly defaulted constructor.