### PR TITLE
[mlir][vector] Additional transpose folding 

### DIFF
--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -450,28 +450,6 @@ func.func @extract_strided_fold_insert(%a: vector<2x8xf32>, %b: vector<1x4xf32>,
 
 // -----
 
-// CHECK-LABEL: transpose_1D_identity
-// CHECK-SAME: ([[ARG:%.*]]: vector<4xf32>)
-func.func @transpose_1D_identity(%arg : vector<4xf32>) -> vector<4xf32> {
-  // CHECK-NOT: transpose
-  %0 = vector.transpose %arg, [0] : vector<4xf32> to vector<4xf32>
-  // CHECK-NEXT: return [[ARG]]
-  return %0 : vector<4xf32>
-}
-
-// -----
-
-// CHECK-LABEL: transpose_2D_identity
-// CHECK-SAME: ([[ARG:%.*]]: vector<4x3xf32>)
-func.func @transpose_2D_identity(%arg : vector<4x3xf32>) -> vector<4x3xf32> {
-  // CHECK-NOT: transpose
-  %0 = vector.transpose %arg, [0, 1] : vector<4x3xf32> to vector<4x3xf32>
-  // CHECK-NEXT: return [[ARG]]
-  return %0 : vector<4x3xf32>
-}
-
-// -----
-
 // CHECK-LABEL: transpose_3D_identity
 // CHECK-SAME: ([[ARG:%.*]]: vector<4x3x2xf32>)
 func.func @transpose_3D_identity(%arg : vector<4x3x2xf32>) -> vector<4x3x2xf32> {

--- a/mlir/test/Dialect/Vector/canonicalize/vector-transpose.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize/vector-transpose.mlir
@@ -1,6 +1,10 @@
 // RUN: mlir-opt %s -canonicalize="test-convergence" -split-input-file -allow-unregistered-dialect | FileCheck %s
 
-// This file contains some canonicalizations tests involving vector.transpose.
+// This file contains some tests of canonicalizations and foldings involving vector.transpose.
+
+// +----------------------------------------
+//  Tests of FoldTransposeBroadcast
+// +----------------------------------------
 
 // CHECK-LABEL: func @transpose_scalar_broadcast1
 //  CHECK-SAME: (%[[ARG:.+]]: vector<1xf32>)
@@ -251,7 +255,10 @@ func.func @negative_transpose_of_shape_cast(%arg : vector<6xi8>) -> vector<2x3xi
 
 // -----
 
-// Test of transpose folding
+// +-----------------------------------
+//  Tests of transpose folding
+// +-----------------------------------
+
 //  CHECK-LABEL: transpose_1D_identity
 //   CHECK-SAME:   [[ARG:%.*]]: vector<4xf32>
 //   CHECK-NEXT:   return [[ARG]]
@@ -262,7 +269,6 @@ func.func @transpose_1D_identity(%arg : vector<4xf32>) -> vector<4xf32> {
 
 // -----
 
-// Test of transpose folding
 // CHECK-LABEL: transpose_2D_identity
 //  CHECK-SAME:    [[ARG:%.*]]: vector<4x3xf32>
 //  CHECK-NEXT:    return [[ARG]]
@@ -273,11 +279,20 @@ func.func @transpose_2D_identity(%arg : vector<4x3xf32>) -> vector<4x3xf32> {
 
 // -----
 
-// Test of transpose folding
 // CHECK-LABEL: transpose_shape_and_order_preserving
 //  CHECK-SAME:    [[ARG:%.*]]: vector<6x1x1x4xi8>
 //  CHECK-NEXT:    return [[ARG]]
 func.func @transpose_shape_and_order_preserving(%arg : vector<6x1x1x4xi8>) -> vector<6x1x1x4xi8> {
   %0 = vector.transpose %arg, [0, 2, 1, 3] : vector<6x1x1x4xi8> to vector<6x1x1x4xi8>
   return %0 : vector<6x1x1x4xi8>
+}
+
+// -----
+
+// CHECK-LABEL: negative_transpose_fold
+//       CHECK: [[TRANSP:%.*]] = vector.transpose
+//       CHECK: return [[TRANSP]]
+func.func @negative_transpose_fold(%arg : vector<2x2xi8>) -> vector<2x2xi8> {
+  %0 = vector.transpose %arg, [1, 0] : vector<2x2xi8> to vector<2x2xi8>
+  return %0 : vector<2x2xi8>
 }

--- a/mlir/test/Dialect/Vector/canonicalize/vector-transpose.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize/vector-transpose.mlir
@@ -2,9 +2,9 @@
 
 // This file contains some tests of canonicalizations and foldings involving vector.transpose.
 
-// +----------------------------------------
-//  Tests of FoldTransposeBroadcast
-// +----------------------------------------
+// +---------------------------------------------------------------------------
+//  Tests of FoldTransposeBroadcast: transpose(broadcast) -> broadcast
+// +---------------------------------------------------------------------------
 
 // CHECK-LABEL: func @transpose_scalar_broadcast1
 //  CHECK-SAME: (%[[ARG:.+]]: vector<1xf32>)
@@ -256,7 +256,7 @@ func.func @negative_transpose_of_shape_cast(%arg : vector<6xi8>) -> vector<2x3xi
 // -----
 
 // +-----------------------------------
-//  Tests of transpose folding
+//  Tests of TransposeOp::fold
 // +-----------------------------------
 
 //  CHECK-LABEL: transpose_1D_identity

--- a/mlir/test/Dialect/Vector/canonicalize/vector-transpose.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize/vector-transpose.mlir
@@ -248,3 +248,36 @@ func.func @negative_transpose_of_shape_cast(%arg : vector<6xi8>) -> vector<2x3xi
   %1 = vector.transpose %0, [1, 0] : vector<3x2xi8> to vector<2x3xi8>
   return %1 : vector<2x3xi8>
 }
+
+// -----
+
+// Test of transpose folding
+//  CHECK-LABEL: transpose_1D_identity
+//   CHECK-SAME:   [[ARG:%.*]]: vector<4xf32>
+//   CHECK-NEXT:   return [[ARG]]
+func.func @transpose_1D_identity(%arg : vector<4xf32>) -> vector<4xf32> {
+  %0 = vector.transpose %arg, [0] : vector<4xf32> to vector<4xf32>
+  return %0 : vector<4xf32>
+}
+
+// -----
+
+// Test of transpose folding
+// CHECK-LABEL: transpose_2D_identity
+//  CHECK-SAME:    [[ARG:%.*]]: vector<4x3xf32>
+//  CHECK-NEXT:    return [[ARG]]
+func.func @transpose_2D_identity(%arg : vector<4x3xf32>) -> vector<4x3xf32> {
+  %0 = vector.transpose %arg, [0, 1] : vector<4x3xf32> to vector<4x3xf32>
+  return %0 : vector<4x3xf32>
+}
+
+// -----
+
+// Test of transpose folding
+// CHECK-LABEL: transpose_shape_and_order_preserving
+//  CHECK-SAME:    [[ARG:%.*]]: vector<6x1x1x4xi8>
+//  CHECK-NEXT:    return [[ARG]]
+func.func @transpose_shape_and_order_preserving(%arg : vector<6x1x1x4xi8>) -> vector<6x1x1x4xi8> {
+  %0 = vector.transpose %arg, [0, 2, 1, 3] : vector<6x1x1x4xi8> to vector<6x1x1x4xi8>
+  return %0 : vector<6x1x1x4xi8>
+}

--- a/mlir/test/Dialect/Vector/vector-transpose-lowering.mlir
+++ b/mlir/test/Dialect/Vector/vector-transpose-lowering.mlir
@@ -65,13 +65,15 @@ func.func @transpose102_8x1x8xf32(%arg0: vector<8x1x8xf32>) -> vector<1x8x8xf32>
   return %0 : vector<1x8x8xf32>
 }
 
-// CHECK-LABEL:   func @transpose1023_1x1x8x8xf32(
-func.func @transpose1023_1x1x8x8xf32(%arg0: vector<1x1x8x8xf32>) -> vector<1x1x8x8xf32> {
-  // Note the single 2-D extract/insert pair since 2 and 3 are not transposed!
-  //      CHECK: vector.extract {{.*}}[0, 0] : vector<8x8xf32> from vector<1x1x8x8xf32>
-  // CHECK-NEXT: vector.insert {{.*}} [0, 0] : vector<8x8xf32> into vector<1x1x8x8xf32>
-  %0 = vector.transpose %arg0, [1, 0, 2, 3] : vector<1x1x8x8xf32> to vector<1x1x8x8xf32>
-  return %0 : vector<1x1x8x8xf32>
+// CHECK-LABEL:   func @transpose1023_2x1x8x4xf32(
+func.func @transpose1023_2x1x8x4xf32(%arg0: vector<2x1x8x4xf32>) -> vector<1x2x8x4xf32> {
+  // Note the 2-D extract/insert pair since dimensions 2 and 3 are not transposed!
+  //      CHECK: vector.extract {{.*}}[0, 0] : vector<8x4xf32> from vector<2x1x8x4xf32>
+  // CHECK-NEXT: vector.insert {{.*}} [0, 0] : vector<8x4xf32> into vector<1x2x8x4xf32>
+  // CHECK-NEXT: vector.extract {{.*}}[1, 0] : vector<8x4xf32> from vector<2x1x8x4xf32>
+  // CHECK-NEXT: vector.insert {{.*}} [0, 1] : vector<8x4xf32> into vector<1x2x8x4xf32>
+  %0 = vector.transpose %arg0, [1, 0, 2, 3] : vector<2x1x8x4xf32> to vector<1x2x8x4xf32>
+  return %0 : vector<1x2x8x4xf32>
 }
 
 /// Scalable dim should not be unrolled.


### PR DESCRIPTION
Fold transpose with unit-dimensions. Seen in the wild:
```
 %0 = vector.transpose %arg, [0, 2, 1, 3] : vector<6x1x1x4xi8> to vector<6x1x1x4xi8>
```

This transpose can be folded because (1) it preserves the shape and (2) the shuffled dims are unit extent. 

Also addresses comment about static vs anonymous namespace: https://github.com/llvm/llvm-project/pull/135841#discussion_r2071869067