### PR TITLE
[Clang][Cygwin] attempt to fix building shared libclang.

### DIFF
--- a/clang/include/clang-c/Platform.h
+++ b/clang/include/clang-c/Platform.h
@@ -22,7 +22,7 @@ LLVM_CLANG_C_EXTERN_C_BEGIN
 #ifndef CINDEX_NO_EXPORTS
   #define CINDEX_EXPORTS
 #endif
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
   #ifdef CINDEX_EXPORTS
     #ifdef _CINDEX_LIB_
       #define CINDEX_LINKAGE __declspec(dllexport)

--- a/clang/tools/libclang/CMakeLists.txt
+++ b/clang/tools/libclang/CMakeLists.txt
@@ -158,7 +158,7 @@ if(ENABLE_STATIC)
 endif()
 
 if(ENABLE_SHARED)
-  if(WIN32)
+  if(WIN32 OR CYGWIN)
     set_target_properties(libclang
       PROPERTIES
       VERSION ${LIBCLANG_LIBRARY_VERSION}


### PR DESCRIPTION
@mstorsjo I don't understand why this isn't working.  We know it works for MinGW right?