### PR TITLE
[Clang][NFC] Use std::move for Detail in timeTraceMetadata

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -199,14 +199,15 @@ static llvm::TimeTraceMetadata timeTraceMetadata(const ExplodedNode *Pred,
   }
   auto SLoc = Loc.getSourceLocation();
   if (!SLoc)
-    return llvm::TimeTraceMetadata{Detail, ""};
+    return llvm::TimeTraceMetadata{std::move(Detail), ""};
   const auto &SM = Pred->getLocationContext()
                        ->getAnalysisDeclContext()
                        ->getASTContext()
                        .getSourceManager();
   auto Line = SM.getPresumedLineNumber(*SLoc);
   auto Fname = SM.getFilename(*SLoc);
-  return llvm::TimeTraceMetadata{Detail, Fname.str(), static_cast<int>(Line)};
+  return llvm::TimeTraceMetadata{std::move(Detail), Fname.str(),
+                                 static_cast<int>(Line)};
 }
 
 void CoreEngine::dispatchWorkItem(ExplodedNode *Pred, ProgramPoint Loc,


### PR DESCRIPTION
Static analysis flagged the use of Detail because we were not using std::move when returning values. Modified the returns to use std::move.