### PR TITLE
[mlir] Declare explicit typeid to fix dylib build

### DIFF
--- a/mlir/include/mlir/Pass/Pass.h
+++ b/mlir/include/mlir/Pass/Pass.h
@@ -493,8 +493,6 @@ class PassExecutionAction : public tracing::ActionImpl<PassExecutionAction> {
   using Base = tracing::ActionImpl<PassExecutionAction>;
 
 public:
-  /// Define a TypeID for this PassExecutionAction.
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PassExecutionAction)
   /// Construct a PassExecutionAction. This is called by the OpToOpPassAdaptor
   /// when it calls `executeAction`.
   PassExecutionAction(ArrayRef<IRUnit> irUnits, const Pass &pass);
@@ -525,5 +523,8 @@ public:
 };
 
 } // namespace mlir
+
+/// Define a TypeID for this PassExecutionAction.
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::PassExecutionAction)
 
 #endif // MLIR_PASS_PASS_H

--- a/mlir/lib/Pass/Pass.cpp
+++ b/mlir/lib/Pass/Pass.cpp
@@ -51,6 +51,8 @@ Operation *PassExecutionAction::getOp() const {
                          : llvm::dyn_cast_if_present<Operation *>(irUnits[0]);
 }
 
+MLIR_DEFINE_EXPLICIT_TYPE_ID(::mlir::PassExecutionAction)
+
 //===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This makes the dyn_cast<PassExecutionAction> work outside the dylib,
i.e. from the unit test binary, when the CMake setting
MLIR_LINK_MLIR_DYLIB is ON.

Fixes #138202
