### PR TITLE
ELF: Switch to parallelSort for RELR relocations.

### DIFF
--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -2111,7 +2111,7 @@ template <class ELFT> bool RelrSection<ELFT>::updateAllocSize(Ctx &ctx) {
   std::unique_ptr<uint64_t[]> offsets(new uint64_t[relocs.size()]);
   for (auto [i, r] : llvm::enumerate(relocs))
     offsets[i] = r.getOffset();
-  llvm::sort(offsets.get(), offsets.get() + relocs.size());
+  llvm::parallelSort(offsets.get(), offsets.get() + relocs.size());
 
   // For each leading relocation, find following ones that can be folded
   // as a bitmap and fold them.


### PR DESCRIPTION
For firefox-x64 one of the more time consuming parts
of finalizeSections() was the call to llvm::sort in
RelrSection::updateAllocSize(). Switching that to use parallelSort
yielded the following improvement on firefox-x64 with ldflags -S on
an Apple M2 Ultra:

```
    N           Min           Max        Median           Avg        Stddev
x 512     1.1446024     1.2462944     1.1918706     1.1929871      0.016145
+ 512     1.1142867     1.2350058     1.1858642     1.1858839   0.016219708
Difference at 95.0% confidence
	-0.00710318 +/- 0.00198234
	-0.595412% +/- 0.166166%
	(Student's t, pooled s = 0.0161824)
```
