### PR TITLE
[clang][NFC] rename FPOptions.def's macro to FP_OPTION

### DIFF
--- a/clang/include/clang/Basic/FPOptions.def
+++ b/clang/include/clang/Basic/FPOptions.def
@@ -7,26 +7,26 @@
 //===----------------------------------------------------------------------===//
 
 // This file defines the Floating Point language options. Users of this file
-//  must define the OPTION macro to make use of this information.
-#ifndef OPTION
-#  error Define the OPTION macro to handle floating point language options
+//  must define the FP_OPTION macro to make use of this information.
+#ifndef FP_OPTION
+#  error Define the FP_OPTION macro to handle floating point language options
 #endif
 
-// OPTION(name, type, width, previousName)
-OPTION(FPContractMode, LangOptions::FPModeKind, 2, First)
-OPTION(RoundingMath, bool, 1, FPContractMode)
-OPTION(ConstRoundingMode, LangOptions::RoundingMode, 3, RoundingMath)
-OPTION(SpecifiedExceptionMode, LangOptions::FPExceptionModeKind, 2, ConstRoundingMode)
-OPTION(AllowFEnvAccess, bool, 1, SpecifiedExceptionMode)
-OPTION(AllowFPReassociate, bool, 1, AllowFEnvAccess)
-OPTION(NoHonorNaNs, bool, 1, AllowFPReassociate)
-OPTION(NoHonorInfs, bool, 1, NoHonorNaNs)
-OPTION(NoSignedZero, bool, 1, NoHonorInfs)
-OPTION(AllowReciprocal, bool, 1, NoSignedZero)
-OPTION(AllowApproxFunc, bool, 1, AllowReciprocal)
-OPTION(FPEvalMethod, LangOptions::FPEvalMethodKind, 2, AllowApproxFunc)
-OPTION(Float16ExcessPrecision, LangOptions::ExcessPrecisionKind, 2, FPEvalMethod)
-OPTION(BFloat16ExcessPrecision, LangOptions::ExcessPrecisionKind, 2, Float16ExcessPrecision)
-OPTION(MathErrno, bool, 1, BFloat16ExcessPrecision)
-OPTION(ComplexRange, LangOptions::ComplexRangeKind, 3, MathErrno)
-#undef OPTION
+// FP_OPTION(name, type, width, previousName)
+FP_OPTION(FPContractMode, LangOptions::FPModeKind, 2, First)
+FP_OPTION(RoundingMath, bool, 1, FPContractMode)
+FP_OPTION(ConstRoundingMode, LangOptions::RoundingMode, 3, RoundingMath)
+FP_OPTION(SpecifiedExceptionMode, LangOptions::FPExceptionModeKind, 2, ConstRoundingMode)
+FP_OPTION(AllowFEnvAccess, bool, 1, SpecifiedExceptionMode)
+FP_OPTION(AllowFPReassociate, bool, 1, AllowFEnvAccess)
+FP_OPTION(NoHonorNaNs, bool, 1, AllowFPReassociate)
+FP_OPTION(NoHonorInfs, bool, 1, NoHonorNaNs)
+FP_OPTION(NoSignedZero, bool, 1, NoHonorInfs)
+FP_OPTION(AllowReciprocal, bool, 1, NoSignedZero)
+FP_OPTION(AllowApproxFunc, bool, 1, AllowReciprocal)
+FP_OPTION(FPEvalMethod, LangOptions::FPEvalMethodKind, 2, AllowApproxFunc)
+FP_OPTION(Float16ExcessPrecision, LangOptions::ExcessPrecisionKind, 2, FPEvalMethod)
+FP_OPTION(BFloat16ExcessPrecision, LangOptions::ExcessPrecisionKind, 2, Float16ExcessPrecision)
+FP_OPTION(MathErrno, bool, 1, BFloat16ExcessPrecision)
+FP_OPTION(ComplexRange, LangOptions::ComplexRangeKind, 3, MathErrno)
+#undef FP_OPTION

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -856,7 +856,7 @@ public:
   // Define a fake option named "First" so that we have a PREVIOUS even for the
   // real first option.
   static constexpr storage_type FirstShift = 0, FirstWidth = 0;
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                    \
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                 \
   static constexpr storage_type NAME##Shift =                                  \
       PREVIOUS##Shift + PREVIOUS##Width;                                       \
   static constexpr storage_type NAME##Width = WIDTH;                           \
@@ -865,7 +865,7 @@ public:
 #include "clang/Basic/FPOptions.def"
 
   static constexpr storage_type TotalWidth = 0
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS) +WIDTH
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS) +WIDTH
 #include "clang/Basic/FPOptions.def"
       ;
   static_assert(TotalWidth <= StorageBitSize, "Too short type for FPOptions");
@@ -974,7 +974,7 @@ public:
   // We can define most of the accessors automatically:
   // TODO: consider enforcing the assertion that value fits within bits
   // statically.
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                    \
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                 \
   TYPE get##NAME() const {                                                     \
     return static_cast<TYPE>((Value & NAME##Mask) >> NAME##Shift);             \
   }                                                                            \
@@ -1085,7 +1085,7 @@ public:
   }
   bool operator!=(FPOptionsOverride other) const { return !(*this == other); }
 
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                    \
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                 \
   bool has##NAME##Override() const {                                           \
     return OverrideMask & FPOptions::NAME##Mask;                               \
   }                                                                            \

--- a/clang/lib/AST/JSONNodeDumper.cpp
+++ b/clang/lib/AST/JSONNodeDumper.cpp
@@ -1864,7 +1864,7 @@ void JSONNodeDumper::visitVerbatimLineComment(
 
 llvm::json::Object JSONNodeDumper::createFPOptions(FPOptionsOverride FPO) {
   llvm::json::Object Ret;
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                    \
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                 \
   if (FPO.has##NAME##Override())                                               \
     Ret.try_emplace(#NAME, static_cast<unsigned>(FPO.get##NAME##Override()));
 #include "clang/Basic/FPOptions.def"

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -1114,7 +1114,7 @@ const char *TextNodeDumper::getCommandName(unsigned CommandID) {
 }
 
 void TextNodeDumper::printFPOptions(FPOptionsOverride FPO) {
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                    \
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                 \
   if (FPO.has##NAME##Override())                                               \
     OS << " " #NAME "=" << FPO.get##NAME##Override();
 #include "clang/Basic/FPOptions.def"

--- a/clang/lib/Basic/LangOptions.cpp
+++ b/clang/lib/Basic/LangOptions.cpp
@@ -219,7 +219,7 @@ FPOptions FPOptions::defaultWithoutTrailingStorage(const LangOptions &LO) {
 
 FPOptionsOverride FPOptions::getChangesSlow(const FPOptions &Base) const {
   FPOptions::storage_type OverrideMask = 0;
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                    \
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                 \
   if (get##NAME() != Base.get##NAME())                                         \
     OverrideMask |= NAME##Mask;
 #include "clang/Basic/FPOptions.def"
@@ -227,14 +227,14 @@ FPOptionsOverride FPOptions::getChangesSlow(const FPOptions &Base) const {
 }
 
 LLVM_DUMP_METHOD void FPOptions::dump() {
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                    \
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                 \
   llvm::errs() << "\n " #NAME " " << get##NAME();
 #include "clang/Basic/FPOptions.def"
   llvm::errs() << "\n";
 }
 
 LLVM_DUMP_METHOD void FPOptionsOverride::dump() {
-#define OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                    \
+#define FP_OPTION(NAME, TYPE, WIDTH, PREVIOUS)                                 \
   if (has##NAME##Override())                                                   \
     llvm::errs() << "\n " #NAME " Override is " << get##NAME##Override();
 #include "clang/Basic/FPOptions.def"


### PR DESCRIPTION
While investigating the recent warnings around FEM_Indeterminate I noticed that the macro name for FPOptions.def was given the very generic name `OPTION`.

This PR renames it to FP_OPTION instead.