### PR TITLE
[Clang] Don't retain template FoundDecl for conversion function calls

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -545,6 +545,7 @@ Bug Fixes to C++ Support
 - Clang no longer crashes when establishing subsumption between some constraint expressions. (#GH122581)
 - Clang now issues an error when placement new is used to modify a const-qualified variable
   in a ``constexpr`` function. (#GH131432)
+- Fixed an incorrect TreeTransform for calls to ``consteval`` functions if a conversion template is present. (#GH137885)
 - Clang now emits a warning when class template argument deduction for alias templates is used in C++17. (#GH133806)
 
 Bug Fixes to AST Handling

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -3977,7 +3977,7 @@ IsUserDefinedConversion(Sema &S, Expr *From, QualType ToType,
           //   phase of [over.match.list] when the initializer list has exactly
           //   one element that is itself an initializer list, [...] and the
           //   conversion is to X or reference to cv X, user-defined conversion
-          //   sequences are not cnosidered.
+          //   sequences are not considered.
           if (SuppressUserConversions && ListInitializing) {
             SuppressUserConversions =
                 NumArgs == 1 && isa<InitListExpr>(Args[0]) &&
@@ -14750,6 +14750,12 @@ ExprResult Sema::CreateUnresolvedLookupExpr(CXXRecordDecl *NamingClass,
 ExprResult Sema::BuildCXXMemberCallExpr(Expr *E, NamedDecl *FoundDecl,
                                         CXXConversionDecl *Method,
                                         bool HadMultipleCandidates) {
+  // FoundDecl can be the TemplateDecl of Method. Don't retain a template in
+  // the FoundDecl as it impedes TransformMemberExpr.
+  // We go a bit further here: if there's no difference in UnderlyingDecl,
+  // then using FoundDecl vs Method shouldn't make a difference either.
+  if (FoundDecl->getUnderlyingDecl() == FoundDecl)
+    FoundDecl = Method;
   // Convert the expression to match the conversion function's implicit object
   // parameter.
   ExprResult Exp;

--- a/clang/test/SemaCXX/cxx2a-consteval.cpp
+++ b/clang/test/SemaCXX/cxx2a-consteval.cpp
@@ -1272,3 +1272,31 @@ int main() {
 }
 
 } // namespace GH107175
+
+namespace GH137885 {
+
+template <typename... P> struct A {};
+
+template <int N>
+struct B {
+  consteval B() {}
+
+  template <typename... P> consteval operator A<P...>() const {
+    static_assert(sizeof...(P) == N);
+    return {};
+  }
+};
+
+template <typename T> struct type_identity {
+  using type = T;
+};
+
+template <typename... P>
+void foo(typename type_identity<A<P...>>::type a, P...) {}
+
+void foo() {
+  foo(B<0>());
+  foo(B<5>(), 1, 2, 3, 4, 5);
+}
+
+}


### PR DESCRIPTION
In consteval calls rewriting, we expect an instantiated AST to remain untouched. However, this was not true when rebuilding a MemberExpr in TreeTransform, as it relies on FoundDecl to build a resolved member call expression. This is due to the fact that the instantiated CXXMemberCallExpr still holds a template declaration as FoundDecl, leading to a non-dependent-to-dependent transform.

I don't think it makes much sense to preserve a template in FoundDecl. FoundDecl should primarily distinguish declarations whose getUnderlyingDecl() points elsewhere, like UsingShadowDecl.

Fixes https://github.com/llvm/llvm-project/issues/137885