### PR TITLE
[CIR][NFC] Fix an unused variable warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -90,9 +90,10 @@ public:
   }
 
   mlir::Attribute VisitCastExpr(CastExpr *e, QualType destType) {
-    if (const auto *ece = dyn_cast<ExplicitCastExpr>(e))
+    if (isa<ExplicitCastExpr>(e))
       cgm.errorNYI(e->getBeginLoc(),
                    "ConstExprEmitter::VisitCastExpr explicit cast");
+
     Expr *subExpr = e->getSubExpr();
 
     switch (e->getCastKind()) {


### PR DESCRIPTION
This fixes a warning where a variable assigned in 'if' statement wasn't referenced again.