### PR TITLE
[WebAssembly] Remove an unused using decl (NFC)

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
@@ -401,7 +401,6 @@ using WebAssembly::WasmEnableEH;
 using WebAssembly::WasmEnableEmEH;
 using WebAssembly::WasmEnableEmSjLj;
 using WebAssembly::WasmEnableSjLj;
-using WebAssembly::WasmUseLegacyEH;
 
 static void basicCheckForEHAndSjLj(TargetMachine *TM) {
 


### PR DESCRIPTION
The "using" decl seems to be unused since it was first introduced in:

  commit a8e1135baa9074f7c088c8e1999561f88699b56e
  Author: Heejin Ahn <aheejin@gmail.com>
  Date:   Thu Jan 9 22:36:10 2025 -0800
