### PR TITLE
[lldb-dap] Give attach test binaries unique names

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -1,6 +1,6 @@
 import os
 import time
-import subprocess
+import uuid
 
 import dap_server
 from lldbsuite.test.lldbtest import *
@@ -28,9 +28,16 @@ class DAPTestCaseBase(TestBase):
             env=lldbDAPEnv,
         )
 
-    def build_and_create_debug_adapter(self, lldbDAPEnv=None):
-        self.build()
+    def build_and_create_debug_adapter(self, lldbDAPEnv=None, dictionary=None):
+        self.build(dictionary=dictionary)
         self.create_debug_adapter(lldbDAPEnv)
+
+    def build_and_create_debug_adapter_for_attach(self):
+        """Variant of build_and_create_debug_adapter that builds a uniquely
+        named binary."""
+        unique_name = str(uuid.uuid4())
+        self.build_and_create_debug_adapter(dictionary={"EXE": unique_name})
+        return self.getBuildArtifact(unique_name)
 
     def set_source_breakpoints(self, source_path, lines, data=None):
         """Sets source breakpoints and returns an array of strings containing

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -2,7 +2,6 @@
 Test lldb-dap attach request
 """
 
-
 import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -25,7 +24,7 @@ def spawn_and_wait(program, delay):
     process.wait()
 
 
-@skipIf
+@skip
 class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
     def set_and_hit_breakpoint(self, continueToExit=True):
         source = "main.c"
@@ -45,8 +44,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by process ID.
         """
-        self.build_and_create_debug_adapter()
-        program = self.getBuildArtifact("a.out")
+        program = self.build_and_create_debug_adapter_for_attach()
         self.process = subprocess.Popen(
             [program],
             stdin=subprocess.PIPE,
@@ -61,34 +59,15 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by process name.
         """
-        self.build_and_create_debug_adapter()
-        orig_program = self.getBuildArtifact("a.out")
-        # Since we are going to attach by process name, we need a unique
-        # process name that has minimal chance to match a process that is
-        # already running. To do this we use tempfile.mktemp() to give us a
-        # full path to a location where we can copy our executable. We then
-        # run this copy to ensure we don't get the error "more that one
-        # process matches 'a.out'".
-        program = tempfile.mktemp()
-        shutil.copyfile(orig_program, program)
-        shutil.copymode(orig_program, program)
+        program = self.build_and_create_debug_adapter_for_attach()
 
         # Use a file as a synchronization point between test and inferior.
         pid_file_path = lldbutil.append_to_process_working_directory(
             self, "pid_file_%d" % (int(time.time()))
         )
 
-        def cleanup():
-            if os.path.exists(program):
-                os.unlink(program)
-            self.run_platform_command("rm %s" % (pid_file_path))
-
-        # Execute the cleanup function during test case tear down.
-        self.addTearDownHook(cleanup)
-
         popen = self.spawnSubprocess(program, [pid_file_path])
-
-        pid = lldbutil.wait_for_file_on_target(self, pid_file_path)
+        lldbutil.wait_for_file_on_target(self, pid_file_path)
 
         self.attach(program=program)
         self.set_and_hit_breakpoint(continueToExit=True)
@@ -101,8 +80,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         next instance of a process to be launched, ingoring all current
         ones.
         """
-        self.build_and_create_debug_adapter()
-        program = self.getBuildArtifact("a.out")
+        program = self.build_and_create_debug_adapter_for_attach()
         self.spawn_thread = threading.Thread(
             target=spawn_and_wait,
             args=(
@@ -136,8 +114,8 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         "terminateCommands" are a list of LLDB commands that get executed when
         the debugger session terminates.
         """
-        self.build_and_create_debug_adapter()
-        program = self.getBuildArtifact("a.out")
+        program = self.build_and_create_debug_adapter_for_attach()
+
         # Here we just create a target and launch the process as a way to test
         # if we are able to use attach commands to create any kind of a target
         # and use it for debugging
@@ -209,8 +187,8 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         Tests that the "terminateCommands", that can be passed during
         attach, are run when the debugger is disconnected.
         """
-        self.build_and_create_debug_adapter()
-        program = self.getBuildArtifact("a.out")
+        program = self.build_and_create_debug_adapter_for_attach()
+
         # Here we just create a target and launch the process as a way to test
         # if we are able to use attach commands to create any kind of a target
         # and use it for debugging

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
@@ -2,7 +2,6 @@
 Test lldb-dap "port" configuration to "attach" request
 """
 
-
 import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -59,8 +58,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by port.
         """
-        self.build_and_create_debug_adapter()
-        program = self.getBuildArtifact("a.out")
+        program = self.build_and_create_debug_adapter_for_attach()
 
         debug_server_tool = self.getBuiltinDebugServerTool()
 
@@ -91,8 +89,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by process ID and port number.
         """
-        self.build_and_create_debug_adapter()
-        program = self.getBuildArtifact("a.out")
+        program = self.build_and_create_debug_adapter_for_attach()
 
         # It is not necessary to launch "lldb-server" to obtain the actual port and pid for attaching.
         # However, when providing the port number and pid directly, "lldb-dap" throws an error message, which is expected.
@@ -119,8 +116,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by invalid port number 0.
         """
-        self.build_and_create_debug_adapter()
-        program = self.getBuildArtifact("a.out")
+        program = self.build_and_create_debug_adapter_for_attach()
 
         port = 0
         response = self.attach(
@@ -138,8 +134,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by illegal/greater port number 65536
         """
-        self.build_and_create_debug_adapter()
-        program = self.getBuildArtifact("a.out")
+        program = self.build_and_create_debug_adapter_for_attach()
 
         port = 65536
         args = [program]

--- a/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
+++ b/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
@@ -5,6 +5,7 @@ import lldbdap_testcase
 from lldbsuite.test import lldbtest, lldbutil
 from lldbsuite.test.decorators import *
 
+
 # DAP tests are flakey, see https://github.com/llvm/llvm-project/issues/137660.
 @skip
 class TestDAP_commands(lldbdap_testcase.DAPTestCaseBase):
@@ -71,12 +72,11 @@ class TestDAP_commands(lldbdap_testcase.DAPTestCaseBase):
         self.do_test_abort_on_error(use_post_run_commands=True)
 
     def test_command_directive_abort_on_error_attach_commands(self):
-        program = self.getBuildArtifact("a.out")
         command_quiet = (
             "settings set target.show-hex-variable-values-with-leading-zeroes false"
         )
         command_abort_on_error = "settings set foo bar"
-        self.build_and_create_debug_adapter()
+        program = self.build_and_create_debug_adapter_for_attach()
         self.attach(
             program,
             attachCommands=["?!" + command_quiet, "!" + command_abort_on_error],


### PR DESCRIPTION
Give the test binaries used for attaching unique names to avoid accidentally attaching to the wrong binary.

Fixes #138197