### PR TITLE
[clang-format] Don't annotate enum colon as InheritanceColon

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1423,7 +1423,7 @@ private:
         Tok->setType(TT_BitFieldColon);
       } else if (Contexts.size() == 1 &&
                  !Line.First->isOneOf(tok::kw_enum, tok::kw_case,
-                                      tok::kw_default)) {
+                                      tok::kw_default, tok::kw_typedef)) {
         FormatToken *Prev = Tok->getPreviousNonComment();
         if (!Prev)
           break;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1422,8 +1422,9 @@ private:
       } else if (CurrentToken && CurrentToken->is(tok::numeric_constant)) {
         Tok->setType(TT_BitFieldColon);
       } else if (Contexts.size() == 1 &&
-                 !Line.First->isOneOf(tok::kw_enum, tok::kw_case,
-                                      tok::kw_default)) {
+                 !Line.getFirstNonComment()->isOneOf(tok::kw_enum, tok::kw_case,
+                                                     tok::kw_default) &&
+                 !Line.startsWith(tok::kw_typedef, tok::kw_enum)) {
         FormatToken *Prev = Tok->getPreviousNonComment();
         if (!Prev)
           break;
@@ -1437,7 +1438,7 @@ private:
             break;
           if (PrevPrev && PrevPrev->isOneOf(tok::r_paren, tok::kw_noexcept))
             Tok->setType(TT_CtorInitializerColon);
-        } else if (!Prev->endsSequence(tok::kw_enum, tok::kw_typedef)) {
+        } else {
           Tok->setType(TT_InheritanceColon);
           if (Prev->isAccessSpecifierKeyword())
             Line.Type = LT_AccessModifier;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1423,7 +1423,7 @@ private:
         Tok->setType(TT_BitFieldColon);
       } else if (Contexts.size() == 1 &&
                  !Line.First->isOneOf(tok::kw_enum, tok::kw_case,
-                                      tok::kw_default, tok::kw_typedef)) {
+                                      tok::kw_default)) {
         FormatToken *Prev = Tok->getPreviousNonComment();
         if (!Prev)
           break;
@@ -1437,7 +1437,7 @@ private:
             break;
           if (PrevPrev && PrevPrev->isOneOf(tok::r_paren, tok::kw_noexcept))
             Tok->setType(TT_CtorInitializerColon);
-        } else {
+        } else if (!Prev->endsSequence(tok::kw_enum, tok::kw_typedef)) {
           Tok->setType(TT_InheritanceColon);
           if (Prev->isAccessSpecifierKeyword())
             Line.Type = LT_AccessModifier;

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -3666,7 +3666,7 @@ TEST_F(TokenAnnotatorTest, BraceKind) {
                     getGoogleStyle(FormatStyle::LK_JavaScript));
   ASSERT_EQ(Tokens.size(), 12u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::identifier, TT_ClassHeadName);
-  EXPECT_TOKEN(Tokens[4], tok::identifier, TT_Unknown); // Not TT_StartOfName
+  EXPECT_TOKEN(Tokens[4], tok::identifier, TT_Unknown); // Not TT_StartOfName.
   EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_ClassLBrace);
   EXPECT_BRACE_KIND(Tokens[8], BK_Block);
   EXPECT_TOKEN(Tokens[9], tok::r_brace, TT_ClassRBrace);
@@ -3833,7 +3833,7 @@ TEST_F(TokenAnnotatorTest, CppOnlyKeywordInC) {
   ASSERT_EQ(Tokens.size(), 8u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown); // Not tok::kw_new
   EXPECT_TOKEN(Tokens[4], tok::amp, TT_BinaryOperator);
-  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown); // Not TT_StartOfName
+  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown); // Not TT_StartOfName.
 }
 
 TEST_F(TokenAnnotatorTest, FunctionTryBlock) {
@@ -3947,7 +3947,7 @@ TEST_F(TokenAnnotatorTest, VariableTemplate) {
   EXPECT_TOKEN(Tokens[4], tok::identifier, TT_VariableTemplate);
   EXPECT_TOKEN(Tokens[5], tok::less, TT_TemplateOpener);
   EXPECT_TOKEN(Tokens[7], tok::greater, TT_TemplateCloser);
-  EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_Unknown); // Not TT_CastRParen
+  EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_Unknown); // Not TT_CastRParen.
   EXPECT_TOKEN(Tokens[9], tok::plus, TT_BinaryOperator);
 }
 
@@ -4031,6 +4031,12 @@ TEST_F(TokenAnnotatorTest, UserDefinedLiteral) {
   auto Tokens = annotate("auto dollars = 2_$;");
   ASSERT_EQ(Tokens.size(), 6u) << Tokens;
   EXPECT_EQ(Tokens[3]->TokenText, "2_$");
+}
+
+TEST_F(TokenAnnotatorTest, EnumColonInTypedef) {
+  auto Tokens = annotate("typedef enum : int {} foo;");
+  ASSERT_EQ(Tokens.size(), 9u) << Tokens;
+  EXPECT_TOKEN(Tokens[2], tok::colon, TT_Unknown); // Not TT_InheritanceColon.
 }
 
 } // namespace

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -3666,7 +3666,7 @@ TEST_F(TokenAnnotatorTest, BraceKind) {
                     getGoogleStyle(FormatStyle::LK_JavaScript));
   ASSERT_EQ(Tokens.size(), 12u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::identifier, TT_ClassHeadName);
-  EXPECT_TOKEN(Tokens[4], tok::identifier, TT_Unknown); // Not TT_StartOfName.
+  EXPECT_TOKEN(Tokens[4], tok::identifier, TT_Unknown); // Not TT_StartOfName
   EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_ClassLBrace);
   EXPECT_BRACE_KIND(Tokens[8], BK_Block);
   EXPECT_TOKEN(Tokens[9], tok::r_brace, TT_ClassRBrace);
@@ -3833,7 +3833,7 @@ TEST_F(TokenAnnotatorTest, CppOnlyKeywordInC) {
   ASSERT_EQ(Tokens.size(), 8u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown); // Not tok::kw_new
   EXPECT_TOKEN(Tokens[4], tok::amp, TT_BinaryOperator);
-  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown); // Not TT_StartOfName.
+  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown); // Not TT_StartOfName
 }
 
 TEST_F(TokenAnnotatorTest, FunctionTryBlock) {
@@ -3947,7 +3947,7 @@ TEST_F(TokenAnnotatorTest, VariableTemplate) {
   EXPECT_TOKEN(Tokens[4], tok::identifier, TT_VariableTemplate);
   EXPECT_TOKEN(Tokens[5], tok::less, TT_TemplateOpener);
   EXPECT_TOKEN(Tokens[7], tok::greater, TT_TemplateCloser);
-  EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_Unknown); // Not TT_CastRParen.
+  EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_Unknown); // Not TT_CastRParen
   EXPECT_TOKEN(Tokens[9], tok::plus, TT_BinaryOperator);
 }
 


### PR DESCRIPTION
Fix #61156