### PR TITLE
[flang][Evaluate] Fix AsGenericExpr for Relational

### DIFF
--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -125,9 +125,16 @@ template <typename A> bool IsCoarray(const A &x) { return GetCorank(x) > 0; }
 
 // Generalizing packagers: these take operations and expressions of more
 // specific types and wrap them in Expr<> containers of more abstract types.
-
 template <typename A> common::IfNoLvalue<Expr<ResultType<A>>, A> AsExpr(A &&x) {
   return Expr<ResultType<A>>{std::move(x)};
+}
+
+template <typename T, typename U = typename Relational<T>::Result>
+Expr<U> AsExpr(Relational<T> &&x) {
+  // The variant in Expr<Type<TypeCategory::Logical, KIND>> only contains
+  // Relational<SomeType>, not other Relational<T>s. Wrap the Relational<T>
+  // in Relational<SomeType> before creating Expr<>.
+  return Expr<U>(Relational<SomeType>{std::move(x)});
 }
 
 template <typename T> Expr<T> AsExpr(Expr<T> &&x) {

--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -125,6 +125,7 @@ template <typename A> bool IsCoarray(const A &x) { return GetCorank(x) > 0; }
 
 // Generalizing packagers: these take operations and expressions of more
 // specific types and wrap them in Expr<> containers of more abstract types.
+
 template <typename A> common::IfNoLvalue<Expr<ResultType<A>>, A> AsExpr(A &&x) {
   return Expr<ResultType<A>>{std::move(x)};
 }


### PR DESCRIPTION
The variant in Expr<Type<TypeCategory::Logical, KIND>> only contains Relational<SomeType>, not other, more specific Relational<T> types.

When calling AsGenericExpr for a value of type Relational<T>, the AsExpr function will attempt to create Expr<> directly for Relational<T>, which won't work for the above reason.

Implement an overload of AsExpr for Relational<T>, which will wrap the Relational<T> in Relational<SomeType> before creating Expr<>.