### PR TITLE
[flang][Evaluate] Restrict ConstantBase constructor overload

### DIFF
--- a/flang/include/flang/Evaluate/constant.h
+++ b/flang/include/flang/Evaluate/constant.h
@@ -110,8 +110,12 @@ public:
   using Result = RESULT;
   using Element = ELEMENT;
 
-  template <typename A>
+  // Constructor for creating ConstantBase from an actual value (i.e.
+  // literals, etc.)
+  template <typename A,
+      typename = std::enable_if_t<std::is_convertible_v<A, Element>>>
   ConstantBase(const A &x, Result res = Result{}) : result_{res}, values_{x} {}
+
   ConstantBase(ELEMENT &&x, Result res = Result{})
       : result_{res}, values_{std::move(x)} {}
   ConstantBase(


### PR DESCRIPTION
ConstantBase has a constructor that takes a value of any type as an input: template <typename T> ConstantBase(const T &). A derived type Constant<T> is a member of many Expr<T> classes (as an alternative in the member variant).

When trying (erroneously) to create Expr<T> from a wrong input, if the specific instance of Expr<T> contains Constant<T>, it's that constructor that will be instantiated, leading to cryptic and unexpected errors.

Eliminate the constructor from overload for invalid input values to help produce more meaningful diagnostics.