### PR TITLE
[WebAssembly] Fix trunc in FastISel

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -992,7 +992,10 @@ bool WebAssemblyFastISel::selectTrunc(const Instruction *I) {
   if (Reg == 0)
     return false;
 
-  if (Trunc->getOperand(0)->getType()->isIntegerTy(64)) {
+  unsigned FromBitWidth = Trunc->getOperand(0)->getType()->getIntegerBitWidth();
+  unsigned ToBitWidth = Trunc->getType()->getIntegerBitWidth();
+
+  if (ToBitWidth <= 32 && (32 < FromBitWidth && FromBitWidth <= 64)) {
     Register Result = createResultReg(&WebAssembly::I32RegClass);
     BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD,
             TII.get(WebAssembly::I32_WRAP_I64), Result)

--- a/llvm/test/CodeGen/WebAssembly/fast-isel-pr138479.ll
+++ b/llvm/test/CodeGen/WebAssembly/fast-isel-pr138479.ll
@@ -1,0 +1,15 @@
+; RUN: llc < %s -asm-verbose=false -fast-isel -fast-isel-abort=1 -verify-machineinstrs | FileCheck %s
+
+target triple = "wasm32-unknown-unknown"
+
+declare void @extern48(i48)
+
+; CHECK-LABEL: call_trunc_i64_to_i48:
+; CHECK:       local.get 0
+; CHECK-NEXT:  call extern48
+; CHECK-NEXT:  end_function
+define void @call_trunc_i64_to_i48(i64 %x) {
+  %x48 = trunc i64 %x to i48
+  call void @extern48(i48 %x48)
+  ret void
+}


### PR DESCRIPTION
Previous logic did not handle the case where the result bit size was between 32 and 64 bits inclusive. I updated the if-statements for more precise handling.

An alternative solution would have been to abort FastISel in case the result type is not legal for FastISel.

Resolves: #64222.

This PR began as an investigation into the root cause of https://github.com/ziglang/zig/issues/20966.

Godbolt link showing incorrect codegen on 20.1.0: https://godbolt.org/z/cEr4vY7d4.
