### PR TITLE
[LLDB] Fix GetIndexOfChildMemberWithName to handle anonymous structs.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6743,8 +6743,6 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
           if (field_name.empty()) {
             CompilerType field_type = GetType(field->getType());
             std::vector<uint32_t> save_indices = child_indexes;
-            // We have to add on the number of non-empty base classes to this
-            // index!
             child_indexes.push_back(
                 child_idx + TypeSystemClang::GetNumBaseClasses(
                                 cxx_record_decl, omit_empty_base_classes));

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6743,14 +6743,11 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
           if (field_name.empty()) {
             CompilerType field_type = GetType(field->getType());
             std::vector<uint32_t> save_indices = child_indexes;
-            if (field_type.IsAnonymousType())
-              // We have to add on the number of non-empty base classes to this
-              // index!
-              child_indexes.push_back(
-                  child_idx +
-                  TypeSystemClang::GetNumBaseClasses(cxx_record_decl, true));
-            else
-              child_indexes.push_back(child_idx);
+            // We have to add on the number of non-empty base classes to this
+            // index!
+            child_indexes.push_back(
+                child_idx + TypeSystemClang::GetNumBaseClasses(
+                                cxx_record_decl, omit_empty_base_classes));
             if (field_type.GetIndexOfChildMemberWithName(
                     name, omit_empty_base_classes, child_indexes))
               return child_indexes.size();

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6743,7 +6743,14 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
           if (field_name.empty()) {
             CompilerType field_type = GetType(field->getType());
             std::vector<uint32_t> save_indices = child_indexes;
-            child_indexes.push_back(child_idx);
+            if (field_type.IsAnonymousType())
+              // We have to add on the number of non-empty base classes to this
+              // index!
+              child_indexes.push_back(
+                  child_idx +
+                  TypeSystemClang::GetNumBaseClasses(cxx_record_decl, true));
+            else
+              child_indexes.push_back(child_idx);
             if (field_type.GetIndexOfChildMemberWithName(
                     name, omit_empty_base_classes, child_indexes))
               return child_indexes.size();

--- a/lldb/test/API/lang/cpp/type_lookup_anon_struct/Makefile
+++ b/lldb/test/API/lang/cpp/type_lookup_anon_struct/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/type_lookup_anon_struct/TestCppTypeLookupAnonStruct.py
+++ b/lldb/test/API/lang/cpp/type_lookup_anon_struct/TestCppTypeLookupAnonStruct.py
@@ -12,16 +12,32 @@ class TestTypeLookupAnonStruct(TestBase):
     def test_lookup_anon_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
-            self, '// Set breakpoint here', lldb.SBFileSpec('main.cpp')
+            self, "// Set breakpoint here", lldb.SBFileSpec("main.cpp")
         )
 
-        self.expect_var_path('unnamed_derived.y', value='2')
-        self.expect_var_path('unnamed_derived.z', value='13')
-        self.expect('frame variable "derb.x"', error=True,
-                    substrs=['"x" is not a member of "(DerivedB) derb"'])
-        self.expect('frame variable "derb.y"', error=True,
-                    substrs=['"y" is not a member of "(DerivedB) derb"'])
-        self.expect_var_path('derb.w', value='14')
-        self.expect_var_path('derb.k', value='15')
-        self.expect_var_path('derb.a.x', value='1')
-        self.expect_var_path('derb.a.y', value='2')
+        self.expect_var_path("unnamed_derived.y", value="2")
+        self.expect_var_path("unnamed_derived.z", value="13")
+        self.expect(
+            'frame variable "derb.x"',
+            error=True,
+            substrs=['"x" is not a member of "(DerivedB) derb"']
+        )
+        self.expect(
+            'frame variable "derb.y"',
+            error=True,
+            substrs=['"y" is not a member of "(DerivedB) derb"']
+        )
+        self.expect_var_path("derb.w", value="14")
+        self.expect_var_path("derb.k", value="15")
+        self.expect_var_path("derb.a.x", value="1")
+        self.expect_var_path("derb.a.y", value="2")
+
+        self.expect_var_path("multi1.m", value="16")
+        self.expect_var_path("multi1.y", value="30")
+
+        self.expect_var_path("multi2.i", value="42")
+        self.expect_var_path("multi2.w", value="23")
+        self.expect_var_path("multi2.a.x", value="1")
+        self.expect_var_path("multi2.a.y", value="2")
+        self.expect_var_path("multi2.y", value="2")
+        self.expect_var_path("multi2.n", value="7")

--- a/lldb/test/API/lang/cpp/type_lookup_anon_struct/TestCppTypeLookupAnonStruct.py
+++ b/lldb/test/API/lang/cpp/type_lookup_anon_struct/TestCppTypeLookupAnonStruct.py
@@ -1,0 +1,27 @@
+"""
+Test that we properly print multiple types.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import decorators
+
+
+class TestTypeLookupAnonStruct(TestBase):
+    def test_lookup_anon_struct(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, '// Set breakpoint here', lldb.SBFileSpec('main.cpp')
+        )
+
+        self.expect_var_path('unnamed_derived.y', value='2')
+        self.expect_var_path('unnamed_derived.z', value='13')
+        self.expect('frame variable "derb.x"', error=True,
+                    substrs=['"x" is not a member of "(DerivedB) derb"'])
+        self.expect('frame variable "derb.y"', error=True,
+                    substrs=['"y" is not a member of "(DerivedB) derb"'])
+        self.expect_var_path('derb.w', value='14')
+        self.expect_var_path('derb.k', value='15')
+        self.expect_var_path('derb.a.x', value='1')
+        self.expect_var_path('derb.a.y', value='2')

--- a/lldb/test/API/lang/cpp/type_lookup_anon_struct/main.cpp
+++ b/lldb/test/API/lang/cpp/type_lookup_anon_struct/main.cpp
@@ -1,4 +1,4 @@
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   struct A {
     struct {
       int x = 1;
@@ -6,7 +6,7 @@ int main(int argc, char** argv) {
     int y = 2;
   } a;
 
-   struct B {
+  struct B {
     // Anonymous struct inherits another struct.
     struct : public A {
       int z = 3;
@@ -15,19 +15,38 @@ int main(int argc, char** argv) {
     A a;
   } b;
 
-   struct : public A {
-     struct {
-       int z = 13;
-     };
-   } unnamed_derived;
 
-   struct DerivedB : public B {
-     struct {
-       // `w` in anonymous struct overrides `w` from `B`.
-       int w = 14;
-       int k = 15;
-     };
-   } derb;
+  struct EmptyBase {
+  };
 
-   return 0; // Set breakpoint here
+  struct : public A {
+    struct {
+      int z = 13;
+    };
+  } unnamed_derived;
+
+  struct DerivedB : public B {
+    struct {
+      // `w` in anonymous struct shadows `w` from `B`.
+      int w = 14;
+      int k = 15;
+    };
+  } derb;
+
+  struct MultiBase : public EmptyBase, public A {
+    struct {
+      int m = 16;
+      int y = 30;
+    };
+  } multi1;
+
+  struct MB2 : public B, EmptyBase, public A {
+    int i = 42;
+    struct {
+      int w = 23;
+      int n = 7;
+    };
+  } multi2;
+
+  return 0; // Set breakpoint here
 }

--- a/lldb/test/API/lang/cpp/type_lookup_anon_struct/main.cpp
+++ b/lldb/test/API/lang/cpp/type_lookup_anon_struct/main.cpp
@@ -1,0 +1,33 @@
+int main(int argc, char** argv) {
+  struct A {
+    struct {
+      int x = 1;
+    };
+    int y = 2;
+  } a;
+
+   struct B {
+    // Anonymous struct inherits another struct.
+    struct : public A {
+      int z = 3;
+    };
+    int w = 4;
+    A a;
+  } b;
+
+   struct : public A {
+     struct {
+       int z = 13;
+     };
+   } unnamed_derived;
+
+   struct DerivedB : public B {
+     struct {
+       // `w` in anonymous struct overrides `w` from `B`.
+       int w = 14;
+       int k = 15;
+     };
+   } derb;
+
+   return 0; // Set breakpoint here
+}


### PR DESCRIPTION
When handling anonymous structs, GetIndexOfChildMemberWithName needs to add the number of non-empty base classes to the child index, to get the actual correct index. It was not doing so. This fixes that.