### PR TITLE
[RISCV] Rename XCValu intrinsic name *_slet(u) to *_sle(u))

### DIFF
--- a/clang/include/clang/Basic/BuiltinsRISCVXCV.td
+++ b/clang/include/clang/Basic/BuiltinsRISCVXCV.td
@@ -21,8 +21,8 @@ let Attributes = [NoThrow, Const] in {
 //===----------------------------------------------------------------------===//
 // XCValu extension.
 //===----------------------------------------------------------------------===//
-def alu_slet  : RISCVXCVBuiltin<"int(int, int)", "xcvalu">;
-def alu_sletu : RISCVXCVBuiltin<"int(unsigned int, unsigned int)", "xcvalu">;
+def alu_sle   : RISCVXCVBuiltin<"int(int, int)", "xcvalu">;
+def alu_sleu  : RISCVXCVBuiltin<"int(unsigned int, unsigned int)", "xcvalu">;
 def alu_exths : RISCVXCVBuiltin<"int(int)", "xcvalu">;
 def alu_exthz : RISCVXCVBuiltin<"unsigned int(unsigned int)", "xcvalu">;
 def alu_extbs : RISCVXCVBuiltin<"int(int)", "xcvalu">;

--- a/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
@@ -388,10 +388,10 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__builtin_riscv_cv_alu_exthz:
     return Builder.CreateZExt(Builder.CreateTrunc(Ops[0], Int16Ty), Int32Ty,
                               "exthz");
-  case RISCV::BI__builtin_riscv_cv_alu_slet:
+  case RISCV::BI__builtin_riscv_cv_alu_sle:
     return Builder.CreateZExt(Builder.CreateICmpSLE(Ops[0], Ops[1]), Int32Ty,
                               "sle");
-  case RISCV::BI__builtin_riscv_cv_alu_sletu:
+  case RISCV::BI__builtin_riscv_cv_alu_sleu:
     return Builder.CreateZExt(Builder.CreateICmpULE(Ops[0], Ops[1]), Int32Ty,
                               "sleu");
   case RISCV::BI__builtin_riscv_cv_alu_subN:

--- a/clang/lib/Headers/riscv_corev_alu.h
+++ b/clang/lib/Headers/riscv_corev_alu.h
@@ -24,13 +24,13 @@ static __inline__ long __DEFAULT_FN_ATTRS __riscv_cv_abs(long a) {
   return __builtin_abs(a);
 }
 
-static __inline__ long __DEFAULT_FN_ATTRS __riscv_cv_alu_slet(long a, long b) {
-  return __builtin_riscv_cv_alu_slet(a, b);
+static __inline__ long __DEFAULT_FN_ATTRS __riscv_cv_alu_sle(long a, long b) {
+  return __builtin_riscv_cv_alu_sle(a, b);
 }
 
 static __inline__ long __DEFAULT_FN_ATTRS
-__riscv_cv_alu_sletu(unsigned long a, unsigned long b) {
-  return __builtin_riscv_cv_alu_sletu(a, b);
+__riscv_cv_alu_sleu(unsigned long a, unsigned long b) {
+  return __builtin_riscv_cv_alu_sleu(a, b);
 }
 
 static __inline__ long __DEFAULT_FN_ATTRS __riscv_cv_alu_min(long a, long b) {

--- a/clang/test/CodeGen/RISCV/riscv-xcvalu-c-api.c
+++ b/clang/test/CodeGen/RISCV/riscv-xcvalu-c-api.c
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <riscv_corev_alu.h>
 
-// CHECK-LABEL: @test_alu_slet(
+// CHECK-LABEL: @test_alu_sle(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_ADDR_I:%.*]] = alloca i32, align 4
 // CHECK-NEXT:    [[B_ADDR_I:%.*]] = alloca i32, align 4
@@ -23,11 +23,11 @@
 // CHECK-NEXT:    [[SLE_I:%.*]] = zext i1 [[TMP4]] to i32
 // CHECK-NEXT:    ret i32 [[SLE_I]]
 //
-int test_alu_slet(int32_t a, int32_t b) {
-  return __riscv_cv_alu_slet(a, b);
+int test_alu_sle(int32_t a, int32_t b) {
+  return __riscv_cv_alu_sle(a, b);
 }
 
-// CHECK-LABEL: @test_alu_sletu(
+// CHECK-LABEL: @test_alu_sleu(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_ADDR_I:%.*]] = alloca i32, align 4
 // CHECK-NEXT:    [[B_ADDR_I:%.*]] = alloca i32, align 4
@@ -45,8 +45,8 @@ int test_alu_slet(int32_t a, int32_t b) {
 // CHECK-NEXT:    [[SLEU_I:%.*]] = zext i1 [[TMP4]] to i32
 // CHECK-NEXT:    ret i32 [[SLEU_I]]
 //
-int test_alu_sletu(uint32_t a, uint32_t b) {
-  return __riscv_cv_alu_sletu(a, b);
+int test_alu_sleu(uint32_t a, uint32_t b) {
+  return __riscv_cv_alu_sleu(a, b);
 }
 
 // CHECK-LABEL: @test_alu_min(

--- a/clang/test/CodeGen/RISCV/riscv-xcvalu.c
+++ b/clang/test/CodeGen/RISCV/riscv-xcvalu.c
@@ -16,7 +16,7 @@ int test_abs(int a) {
   return __builtin_abs(a);
 }
 
-// CHECK-LABEL: @test_alu_slet(
+// CHECK-LABEL: @test_alu_sle(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_ADDR:%.*]] = alloca i32, align 4
 // CHECK-NEXT:    [[B_ADDR:%.*]] = alloca i32, align 4
@@ -28,11 +28,11 @@ int test_abs(int a) {
 // CHECK-NEXT:    [[SLE:%.*]] = zext i1 [[TMP2]] to i32
 // CHECK-NEXT:    ret i32 [[SLE]]
 //
-int test_alu_slet(int32_t a, int32_t b) {
-  return __builtin_riscv_cv_alu_slet(a, b);
+int test_alu_sle(int32_t a, int32_t b) {
+  return __builtin_riscv_cv_alu_sle(a, b);
 }
 
-// CHECK-LABEL: @test_alu_sletu(
+// CHECK-LABEL: @test_alu_sleu(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_ADDR:%.*]] = alloca i32, align 4
 // CHECK-NEXT:    [[B_ADDR:%.*]] = alloca i32, align 4
@@ -44,8 +44,8 @@ int test_alu_slet(int32_t a, int32_t b) {
 // CHECK-NEXT:    [[SLEU:%.*]] = zext i1 [[TMP2]] to i32
 // CHECK-NEXT:    ret i32 [[SLEU]]
 //
-int test_alu_sletu(uint32_t a, uint32_t b) {
-  return __builtin_riscv_cv_alu_sletu(a, b);
+int test_alu_sleu(uint32_t a, uint32_t b) {
+  return __builtin_riscv_cv_alu_sleu(a, b);
 }
 
 // CHECK-LABEL: @test_alu_exths(

--- a/llvm/test/CodeGen/RISCV/xcvalu.ll
+++ b/llvm/test/CodeGen/RISCV/xcvalu.ll
@@ -17,8 +17,8 @@ define i32 @abs(i32 %a) {
   ret i32 %1
 }
 
-define i1 @slet(i32 %a, i32 %b) {
-; CHECK-LABEL: slet:
+define i1 @sle(i32 %a, i32 %b) {
+; CHECK-LABEL: sle:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    cv.sle a0, a0, a1
 ; CHECK-NEXT:    ret
@@ -26,8 +26,8 @@ define i1 @slet(i32 %a, i32 %b) {
   ret i1 %1
 }
 
-define i1 @sletu(i32 %a, i32 %b) {
-; CHECK-LABEL: sletu:
+define i1 @sleu(i32 %a, i32 %b) {
+; CHECK-LABEL: sleu:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    cv.sleu a0, a0, a1
 ; CHECK-NEXT:    ret


### PR DESCRIPTION
The instruction name and intrinsic name have been renamed to sle(u). The `t` was removed. Please refer to
https://github.com/openhwgroup/core-v-sw/blob/master/specifications/corev-builtin-spec.md.