### PR TITLE
[OpenMP] Fix KMP_OS_AIX handling

### DIFF
--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -821,7 +821,7 @@ private:
 typedef KMPAffinity::Mask kmp_affin_mask_t;
 extern KMPAffinity *__kmp_affinity_dispatch;
 
-#ifndef KMP_OS_AIX
+#if !KMP_OS_AIX
 class kmp_affinity_raii_t {
   kmp_affin_mask_t *mask;
   bool restored;

--- a/openmp/runtime/src/kmp_affinity.cpp
+++ b/openmp/runtime/src/kmp_affinity.cpp
@@ -5468,7 +5468,7 @@ void __kmp_affinity_bind_init_mask(int gtid) {
     __kmp_set_system_affinity(th->th.th_affin_mask, FALSE);
   } else
 #endif
-#ifndef KMP_OS_AIX
+#if !KMP_OS_AIX
     // Do not set the full mask as the init mask on AIX.
     __kmp_set_system_affinity(th->th.th_affin_mask, TRUE);
 #endif

--- a/openmp/runtime/src/kmp_platform.h
+++ b/openmp/runtime/src/kmp_platform.h
@@ -27,6 +27,7 @@
 #define KMP_OS_SOLARIS 0
 #define KMP_OS_WASI 0
 #define KMP_OS_EMSCRIPTEN 0
+#define KMP_OS_AIX 0
 #define KMP_OS_UNIX 0 /* disjunction of KMP_OS_LINUX, KMP_OS_DARWIN etc. */
 
 #ifdef _WIN32
@@ -163,11 +164,11 @@
 #undef KMP_ARCH_PPC64_ELFv1
 #define KMP_ARCH_PPC64_ELFv1 1
 #endif
-#elif defined KMP_OS_AIX
+#elif KMP_OS_AIX
 #undef KMP_ARCH_PPC64_XCOFF
 #define KMP_ARCH_PPC64_XCOFF 1
 #endif
-#elif defined(__powerpc__) && defined(KMP_OS_AIX)
+#elif defined(__powerpc__) && KMP_OS_AIX
 #undef KMP_ARCH_PPC_XCOFF
 #define KMP_ARCH_PPC_XCOFF 1
 #undef KMP_ARCH_PPC

--- a/openmp/runtime/src/kmp_wrapper_getpid.h
+++ b/openmp/runtime/src/kmp_wrapper_getpid.h
@@ -17,7 +17,7 @@
 
 // On Unix-like systems (Linux* OS and OS X*) getpid() is declared in standard
 // headers.
-#if !defined(KMP_OS_AIX) && !defined(KMP_OS_HAIKU)
+#if !KMP_OS_AIX && !KMP_OS_HAIKU
 #include <sys/syscall.h>
 #endif
 #include <sys/types.h>


### PR DESCRIPTION
When building `openmp` on Linux/sparc64, I get

```
In file included fromopenmp/runtime/src/kmp_utility.cpp:16:
openmp/runtime/src/kmp_wrapper_getpid.h:47:2: warning: No gettid found, use getpid instead [-W#warnings]
   47 | #warning No gettid found, use getpid instead
      |  ^
```

This is highly confusing since `<sys/syscall.h>` **does** define `SYS_gettid` and the header is supposed to be included:

```
#if !defined(KMP_OS_AIX) && !defined(KMP_OS_HAIKU)
#include <sys/syscall.h>
#endif
```

However, this actually is **not** the case for two reasons:

- `KMP_OS_HAIKU` is always defined, either as 1 on Haiku or as 0 otherwise.
- `KMP_OS_AIX` is even worse: it is only defined as 1 on on AIX, but undefined otherwise.

All those `KMP_OS_*` macros are supposed to always be defined as 1/0 as appropriate, and to be checked with `#if`, not `#ifdef`.  AIX is violating this, causing the problem above.

Other targets probably get `<sys/syscall.h>` indirectly otherwise, but Linux/sparc64 does not.

This patch fixes this by also defining `KMP_OS_AIX` as 0 on other OSes and changing the checks to `#if` as necessary.

Tested on `sparc64-unknown-linux-gnu`, `sparcv9-sun-solaris2.11`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.