### PR TITLE
Only emit -Wmicrosoft-goto in C++ mode

### DIFF
--- a/clang/lib/Sema/JumpDiagnostics.cpp
+++ b/clang/lib/Sema/JumpDiagnostics.cpp
@@ -998,7 +998,8 @@ void JumpScopeChecker::CheckJump(Stmt *From, Stmt *To, SourceLocation DiagLoc,
   SmallVector<unsigned, 10> ToScopesError;
   SmallVector<unsigned, 10> ToScopesWarning;
   for (unsigned I = ToScope; I != CommonScope; I = Scopes[I].ParentScope) {
-    if (S.getLangOpts().MSVCCompat && JumpDiagWarning != 0 &&
+    if (S.getLangOpts().MSVCCompat && S.getLangOpts().CPlusPlus &&
+        JumpDiagWarning != 0 &&
         IsMicrosoftJumpWarning(JumpDiagError, Scopes[I].InDiag))
       ToScopesWarning.push_back(I);
     else if (IsCXX98CompatWarning(S, Scopes[I].InDiag) ||

--- a/clang/test/Sema/warn-jump-bypasses-init.c
+++ b/clang/test/Sema/warn-jump-bypasses-init.c
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify=c,both -Wjump-bypasses-init %s
 // RUN: %clang_cc1 -fsyntax-only -verify=c,both -Wc++-compat %s
 // RUN: %clang_cc1 -fsyntax-only -verify=good %s
+// RUN: %clang_cc1 -fsyntax-only -verify=good -fms-compatibility %s
 // RUN: %clang_cc1 -fsyntax-only -verify=cxx,both -x c++ %s
 // good-no-diagnostics
 


### PR DESCRIPTION
Follow-up to #138009 which added diagnostics for "jump past initialization" in C mode, in which case they're not an MS extension.