### PR TITLE
[OpenMP] Use TLS for gtid on Solaris

### DIFF
--- a/openmp/runtime/src/kmp_global.cpp
+++ b/openmp/runtime/src/kmp_global.cpp
@@ -172,7 +172,7 @@ int __kmp_ncores = 0;
 int __kmp_chunk = 0;
 int __kmp_force_monotonic = 0;
 int __kmp_abort_delay = 0;
-#if (KMP_OS_LINUX || KMP_OS_AIX) && defined(KMP_TDATA_GTID)
+#if (KMP_OS_LINUX || KMP_OS_AIX || KMP_OS_SOLARIS) && defined(KMP_TDATA_GTID)
 int __kmp_gtid_mode = 3; /* use __declspec(thread) TLS to store gtid */
 int __kmp_adjust_gtid_mode = FALSE;
 #elif KMP_OS_WINDOWS


### PR DESCRIPTION
When running the `openmp` testsuite on Solaris/amd64, many tests `FAIL` like

```
# | OMP: Error #11: Stack overflow detected for OpenMP thread #1
```

In a `Debug` build, I also get
```
# | Assertion failure at kmp_runtime.cpp(203): __kmp_gtid_get_specific() < 0 || __kmp_gtid_get_specific() == i.
```

Further investigation shows that just setting `__kmp_gtid_mode` to 3 massively reduces the number of failures.

Tested on `amd64-pc-solaris2.11` and `x86_64-pc-linux-gnu`.