### PR TITLE
[OpenMP] Use pthread_self for __kmp_gettid on Solaris

### DIFF
--- a/openmp/runtime/src/kmp_wrapper_getpid.h
+++ b/openmp/runtime/src/kmp_wrapper_getpid.h
@@ -33,7 +33,7 @@
 #define __kmp_gettid() _lwp_self()
 #elif KMP_OS_OPENBSD
 #define __kmp_gettid() getthrid()
-#elif KMP_OS_AIX
+#elif KMP_OS_AIX || KMP_OS_SOLARIS
 #include <pthread.h>
 #define __kmp_gettid() pthread_self()
 #elif KMP_OS_HAIKU


### PR DESCRIPTION
Building `openmp` on Solaris/amd64, I get

```
In file included from openmp/runtime/src/kmp_utility.cpp:16:
openmp/runtime/src/kmp_wrapper_getpid.h:47:2: warning: No gettid found, use getpid instead [-W#warnings]
   47 | #warning No gettid found, use getpid instead
      |  ^

```

There's no reason to do this: Solaris can use `pthread_self` just as AIX does.

Tested on `amd64-pc-solaris2.11` and `x86_64-pc-linux-gnu`.