### PR TITLE
[OpenMP][test] Adjust tool_available_search.c for Solaris

### DIFF
--- a/openmp/runtime/test/ompt/loadtool/tool_available_search/tool_available_search.c
+++ b/openmp/runtime/test/ompt/loadtool/tool_available_search/tool_available_search.c
@@ -26,12 +26,12 @@
 // CHECK-SAME: [[PARENTPATH]]/second_tool.so
 // CHECK-SAME: [[PARENTPATH]]/third_tool.so
 // CHECK-NEXT: Opening [[PARENTPATH]]/non_existing_file.so... Failed:
-// CHECK-SAME: [[PARENTPATH]]/non_existing_file.so: cannot open shared object
-// CHECK-SAME: file: No such file or directory
+// CHECK-SAME: [[PARENTPATH]]/non_existing_file.so: {{cannot open shared object file|open failed}}:
+// CHECK-SAME: No such file or directory
 // CHECK-NEXT: Opening [[PARENTPATH]]/first_tool.so... Success.
 // CHECK-NEXT: Searching for ompt_start_tool in
 // CHECK-SAME: [[PARENTPATH]]/first_tool.so... Failed:
-// CHECK-SAME: [[PARENTPATH]]/first_tool.so: undefined symbol: ompt_start_tool
+// CHECK-SAME: {{.*/first_tool.so: undefined symbol: ompt_start_tool|ld.so.1: .*: ompt_start_tool: can't find symbol}}
 // CHECK-NEXT: Opening [[PARENTPATH]]/second_tool.so... Success.
 // CHECK-NEXT: Searching for ompt_start_tool in
 // CHECK-SAME: [[PARENTPATH]]/second_tool.so... 0: Do not initialize tool


### PR DESCRIPTION
After PR #138514, only 3 testsuite failures remain on Solaris/amd64.  One of them is

```
libomp :: ompt/loadtool/tool_available_search/tool_available_search.c
```

The issue is that the expected message is that emitted by Linux/glibc, while the Solaris message differs:

On Linux/x86_64, I get
```
Opening projects/openmp/runtime/test/ompt/loadtool/tool_available_search/Output/non_existing_file.so... Failed: projects/openmp/runtime/test/ompt/loadtool/tool_available_search/Output/non_existing_file.so: cannot open shared object file: No such file or directory
```
while Solaris/amd64 emits
```
Opening projects/openmp/runtime/test/ompt/loadtool/tool_available_search/Output/non_existing_file.so... Failed: ld.so.1: tool_available_search.c.tmp: projects/openmp/runtime/test/ompt/loadtool/tool_available_search/Output/non_existing_file.so: open failed: No such file or directory
```

Since the exact wording is obviously an implementation detail, this patch allows for both forms.

Tested on `amd64-pc-solaris2.11` and `x86_64-pc-linux-gnu`.