### PR TITLE
[OpenMP] Fix __builtin_return_address calls for SPARC

### DIFF
--- a/openmp/runtime/src/ompt-internal.h
+++ b/openmp/runtime/src/ompt-internal.h
@@ -109,7 +109,8 @@ void ompt_pre_init(void);
 void ompt_post_init(void);
 void ompt_fini(void);
 
-#define OMPT_GET_RETURN_ADDRESS(level) __builtin_return_address(level)
+#define OMPT_GET_RETURN_ADDRESS(level)                                         \
+  __builtin_extract_return_addr(__builtin_return_address(level))
 #define OMPT_GET_FRAME_ADDRESS(level) __builtin_frame_address(level)
 #define OMPT_FRAME_FLAGS_APP (ompt_frame_application | ompt_frame_cfa)
 #define OMPT_FRAME_FLAGS_RUNTIME (ompt_frame_runtime | ompt_frame_cfa)

--- a/openmp/runtime/src/ompt-specific.h
+++ b/openmp/runtime/src/ompt-specific.h
@@ -102,15 +102,16 @@ inline void *__ompt_load_return_address(int gtid) {
   if (ompt_enabled.enabled && gtid >= 0 && __kmp_threads[gtid] &&              \
       !__kmp_threads[gtid]->th.ompt_thread_info.return_address)                \
   __kmp_threads[gtid]->th.ompt_thread_info.return_address =                    \
-      __builtin_return_address(0)*/
+      __builtin_extract_return_addr(__builtin_return_address(0))*/
 #define OMPT_STORE_RETURN_ADDRESS(gtid)                                        \
-  OmptReturnAddressGuard ReturnAddressGuard{gtid, __builtin_return_address(0)};
+  OmptReturnAddressGuard ReturnAddressGuard{                                   \
+      gtid, __builtin_extract_return_addr(__builtin_return_address(0))};
 #define OMPT_LOAD_RETURN_ADDRESS(gtid) __ompt_load_return_address(gtid)
 #define OMPT_LOAD_OR_GET_RETURN_ADDRESS(gtid)                                  \
   ((ompt_enabled.enabled && gtid >= 0 && __kmp_threads[gtid] &&                \
     __kmp_threads[gtid]->th.ompt_thread_info.return_address)                   \
        ? __ompt_load_return_address(gtid)                                      \
-       : __builtin_return_address(0))
+       : __builtin_extract_return_addr(__builtin_return_address(0)))
 
 #define OMPT_GET_DISPATCH_CHUNK(chunk, lb, ub, incr)                           \
   do {                                                                         \


### PR DESCRIPTION
`libomp` uses `__builtin_return_address` in two places.  However, on some targets those calls need to wrapped in `___builtin_extract_return_addr` to get at the actual return address.  SPARC is among those targets and the only one where `clang` actually implements this, cf. [[clang][Sparc] Fix __builtin_extract_return_addr etc.](https://reviews.llvm.org/D91607). `compiler-rt` needed the same adjustment, cf. [[sanitizer_common][test] Enable tests on SPARC](https://reviews.llvm.org/D91608). On other targets, this is a no-op.  However, there are more targets that have the same issue and `gcc`, unlike `clang`, correctly implements it, so there might be issues when building `libomp` with `gcc`.

This patch adds the necessary calls.

Tested on `sparcv9-sun-solaris2.11`, `sparc64-unknown-linux-gnu`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.