### PR TITLE
Fix use of std::errc() for C++ < 11

### DIFF
--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -1277,7 +1277,7 @@ _LIBCPP_HIDE_FROM_ABI inline _OutputIterator num_put<_CharT, _OutputIterator>::_
   }
 
   auto __res = std::__to_chars_integral(__buffer_ptr, __char_buffer + __buffer_size, __uval, __base);
-  _LIBCPP_ASSERT_INTERNAL(__res.__ec == std::errc(), "to_chars: invalid maximum buffer size computed?");
+  _LIBCPP_ASSERT_INTERNAL(__res.__ec == std::errc(0), "to_chars: invalid maximum buffer size computed?");
 
   // Make letters uppercase
   if (__flags & ios_base::hex && __flags & ios_base::uppercase) {


### PR DESCRIPTION
After 8fc2538f338088bd084d217a7569d72c3b630e8c "Reapply '[libc++] Optimize num_put integral functions' (#131613) (#133572)",

```
#include <locale>
```

started to fail with

> $ clang++ -stdlib=libc++ -std=c++03 -fsyntax-only test.cc
> In file included from test.cc:1:
> ~/llvm/inst/bin/../include/c++/v1/locale:1280:41: error: no matching constructor for initialization of 'std::errc'
>  1280 |   _LIBCPP_ASSERT_INTERNAL(__res.__ec == std::errc(), "to_chars: invalid maximum buffer size computed?");
>       |                                         ^
> ~/llvm/inst/bin/../include/c++/v1/__assert:94:86: note: expanded from macro '_LIBCPP_ASSERT_INTERNAL'
>    94 | #  define _LIBCPP_ASSERT_INTERNAL(expression, message)                _LIBCPP_ASSERT(expression, message)
>       |                                                                                      ^
> ~/llvm/inst/bin/../include/c++/v1/__assert:21:39: note: expanded from macro '_LIBCPP_ASSERT'
>    21 |   (__builtin_expect(static_cast<bool>(expression), 1)                                                                  \
>       |                                       ^
> ~/llvm/inst/bin/../include/c++/v1/__system_error/errc.h:262:36: note: candidate constructor not viable: requires single argument '__v', but no arguments were provided
>   262 | _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(errc)
>       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
> ~/llvm/inst/bin/../include/c++/v1/__config:618:29: note: expanded from macro '_LIBCPP_DECLARE_STRONG_ENUM_EPILOG'
>   618 |       _LIBCPP_HIDE_FROM_ABI x(__lx __v) : __v_(__v) {}                                                                 \
>       |                             ^ ~~~~~~~~
> ~/llvm/inst/bin/../include/c++/v1/__system_error/errc.h:262:36: note: candidate constructor not viable: requires single argument '__v', but no arguments were provided
>   262 | _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(errc)
>       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
> ~/llvm/inst/bin/../include/c++/v1/__config:619:38: note: expanded from macro '_LIBCPP_DECLARE_STRONG_ENUM_EPILOG'
>   619 |       _LIBCPP_HIDE_FROM_ABI explicit x(int __v) : __v_(static_cast<__lx>(__v)) {}                                      \
>       |                                      ^ ~~~~~~~
> ~/llvm/inst/bin/../include/c++/v1/__system_error/errc.h:143:29: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided
>   143 | _LIBCPP_DECLARE_STRONG_ENUM(errc){
>       |                             ^~~~
> 1 error generated.