### PR TITLE
[OpenMP][test] Define print_possible_return_addresses on SPARC

### DIFF
--- a/openmp/runtime/test/ompt/callback.h
+++ b/openmp/runtime/test/ompt/callback.h
@@ -311,6 +311,14 @@ ompt_label_##id:
   printf("%" PRIu64 ": current_address=%p or %p or %p\n",                      \
          ompt_get_thread_data()->value, ((char *)addr) - 2,                    \
          ((char *)addr) - 8, ((char *)addr) - 12)
+#elif KMP_ARCH_SPARC
+// FIXME: Need to distinguish between 32 and 64-bit SPARC?
+// On SPARC the NOP instruction is 4 bytes long.
+// FIXME: Explain.  Can use __builtin_frob_return_addr?
+#define print_possible_return_addresses(addr)                                  \
+  printf("%" PRIu64 ": current_address=%p or %p\n",                            \
+         ompt_get_thread_data()->value, ((char *)addr) - 12,                   \
+         (char *)addr - 20)
 #else
 #error Unsupported target architecture, cannot determine address offset!
 #endif


### PR DESCRIPTION
Parts of the `openmp` testsuite currently don't build on SPARC due to the lack of a `print_possible_return_addresses` definition.

This patch provides one.  With it, the vast majority of tests `PASS` on Solaris/sparcv9 and, with an additional patch, on Linux/sparc64.

The current definition was obtained empirically.

Tested on `sparcv9-sun-solaris2.11`, `sparc64-unknown-linux-gnu`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.