### PR TITLE
[OpenMP] Provide __NR_sched_[gs]etaffinity on Linux/sparc64

### DIFF
--- a/openmp/runtime/src/kmp_affinity.h
+++ b/openmp/runtime/src/kmp_affinity.h
@@ -311,6 +311,17 @@ public:
 #elif __NR_sched_getaffinity != 240
 #error Wrong code for getaffinity system call.
 #endif /* __NR_sched_getaffinity */
+#elif KMP_ARCH_SPARC
+#ifndef __NR_sched_setaffinity
+#define __NR_sched_setaffinity 261
+#elif __NR_sched_setaffinity != 261
+#error Wrong code for setaffinity system call.
+#endif /* __NR_sched_setaffinity */
+#ifndef __NR_sched_getaffinity
+#define __NR_sched_getaffinity 260
+#elif __NR_sched_getaffinity != 260
+#error Wrong code for getaffinity system call.
+#endif /* __NR_sched_getaffinity */
 #else
 #error Unknown or unsupported architecture
 #endif /* KMP_ARCH_* */


### PR DESCRIPTION
`libomp` doesn't currently build on Linux/sparc64 due to lack of `__NR_sched_setaffinity` and `__NR_sched_getaffinity` definitions.

This patch provides those.

Tested on `sparcv9-sun-solaris2.11`, `sparc64-unknown-linux-gnu`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.