### PR TITLE
[BasicAA] Gracefully handle large LocationSize

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1237,8 +1237,11 @@ AliasResult BasicAAResult::aliasGEP(
   if (V1Size.isScalable() || V2Size.isScalable())
     return AliasResult::MayAlias;
 
-  // We need to know both acess sizes for all the following heuristics.
-  if (!V1Size.hasValue() || !V2Size.hasValue())
+  // We need to know both access sizes for all the following heuristics. Don't
+  // try to reason about sizes larger than the index space.
+  unsigned BW = DecompGEP1.Offset.getBitWidth();
+  if (!V1Size.hasValue() || !V2Size.hasValue() ||
+      !isUIntN(BW, V1Size.getValue()) || !isUIntN(BW, V2Size.getValue()))
     return AliasResult::MayAlias;
 
   APInt GCD;
@@ -1293,7 +1296,6 @@ AliasResult BasicAAResult::aliasGEP(
 
   // Compute ranges of potentially accessed bytes for both accesses. If the
   // interseciton is empty, there can be no overlap.
-  unsigned BW = OffsetRange.getBitWidth();
   ConstantRange Range1 = OffsetRange.add(
       ConstantRange(APInt(BW, 0), APInt(BW, V1Size.getValue())));
   ConstantRange Range2 =

--- a/llvm/test/Analysis/BasicAA/size-overflow.ll
+++ b/llvm/test/Analysis/BasicAA/size-overflow.ll
@@ -1,11 +1,11 @@
-; RUN: opt -passes=aa-eval -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
+; RUN: opt -passes=aa-eval -print-all-alias-modref-info -disable-output < %s 2>&1 | FileCheck %s
 
 target datalayout = "p:32:32"
 
 ; Make sure that using a LocationSize larget than the index space does not
 ; assert.
 
-; Just Mod:  Ptr: i32* %gep	<->  call void @llvm.memset.p0.i64(ptr %p, i8 0, i64 68719476736, i1 false)
+; CHECK: Just Mod:  Ptr: i32* %gep	<->  call void @llvm.memset.p0.i64(ptr %p, i8 0, i64 4294967296, i1 false)
 define void @test(ptr %p, i32 %idx) {
   %gep = getelementptr i8, ptr %p, i32 %idx
   load i32, ptr %gep

--- a/llvm/test/Analysis/BasicAA/size-overflow.ll
+++ b/llvm/test/Analysis/BasicAA/size-overflow.ll
@@ -1,0 +1,14 @@
+; RUN: opt -passes=aa-eval -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
+
+target datalayout = "p:32:32"
+
+; Make sure that using a LocationSize larget than the index space does not
+; assert.
+
+; Just Mod:  Ptr: i32* %gep	<->  call void @llvm.memset.p0.i64(ptr %p, i8 0, i64 68719476736, i1 false)
+define void @test(ptr %p, i32 %idx) {
+  %gep = getelementptr i8, ptr %p, i32 %idx
+  load i32, ptr %gep
+  call void @llvm.memset.i64(ptr %p, i8 0, i64 u0x100000000, i1 false)
+  ret void
+}


### PR DESCRIPTION
If the LocationSize is larger than the index space of the pointer type, bail out instead of triggering an APInt assertion.

Fixes the issue reported at https://github.com/llvm/llvm-project/pull/119365#issuecomment-2849874894.