### PR TITLE
[lldb/docs] Fix/improve the gdb command map for dynamic types

### DIFF
--- a/lldb/docs/use/map.rst
+++ b/lldb/docs/use/map.rst
@@ -800,16 +800,24 @@ Print the dynamic type of the result of an expression
   (gdb) p someCPPObjectPtrOrReference
   (Only works for C++ objects)
 
-.. code-block:: shell
-
-  (lldb) expr -d 1 -- [SomeClass returnAnObject]
-  (lldb) expr -d 1 -- someCPPObjectPtrOrReference
-
-or set dynamic type printing to be the default:
+LLDB does this automatically if determining the dynamic type does not require
+running the target (in C++, running the target is never needed). This default is
+controlled by the `target.prefer-dynamic-value` setting. If that is disabled, it
+can be re-enabled on a per-command basis:
 
 .. code-block:: shell
 
-  (lldb) settings set target.prefer-dynamic run-target
+  (lldb) settings set target.prefer-dynamic-value no-dynamic-values
+  (lldb) frame variable -d no-run-target someCPPObjectPtrOrReference
+  (lldb) expr -d no-run-target -- someCPPObjectPtr
+
+Note that printing of the dynamic type of references is not possible with the
+`expr` command. The workaround is to take the address of the reference and
+instruct lldb to print the children of the resulting pointer.
+
+.. code-block:: shell
+
+  (lldb) expr -P1 -d no-run-target -- &someCPPObjectReference
 
 Call a function so you can stop at a breakpoint in it
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The setting and option value names were wrong. I'm assuming this changed over time, but I haven't tried to figure out when.