### PR TITLE
[Inline] Only consider provenance captures for scoped alias metadata

### DIFF
--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1313,7 +1313,9 @@ static void AddAliasScopeMetadata(CallBase &CB, ValueToValueMapTy &VMap,
         // nocapture only guarantees that no copies outlive the function, not
         // that the value cannot be locally captured.
         if (!RequiresNoCaptureBefore ||
-            !PointerMayBeCapturedBefore(A, /* ReturnCaptures */ false, I, &DT))
+            !capturesAnything(PointerMayBeCapturedBefore(
+                A, /*ReturnCaptures=*/false, I, &DT, /*IncludeI=*/false,
+                CaptureComponents::Provenance)))
           NoAliases.push_back(NewScopes[A]);
       }
 

--- a/llvm/test/Transforms/Inline/noalias-escape-source.ll
+++ b/llvm/test/Transforms/Inline/noalias-escape-source.ll
@@ -82,9 +82,9 @@ define void @test_addr_only_capture(ptr %p) {
 ; CHECK-SAME: ptr [[P:%.*]]) {
 ; CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META6:![0-9]+]])
 ; CHECK-NEXT:    call void @capture(ptr captures(address) [[P]])
-; CHECK-NEXT:    [[P2_I:%.*]] = call ptr @get_ptr()
+; CHECK-NEXT:    [[P2_I:%.*]] = call ptr @get_ptr(), !noalias [[META6]]
 ; CHECK-NEXT:    [[V_I:%.*]] = load i32, ptr [[P]], align 4, !alias.scope [[META6]]
-; CHECK-NEXT:    store i32 [[V_I]], ptr [[P2_I]], align 4
+; CHECK-NEXT:    store i32 [[V_I]], ptr [[P2_I]], align 4, !noalias [[META6]]
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_addr_only_capture(ptr %p)


### PR DESCRIPTION
When determining whether an escape source may alias with a noalias argument, only take provenance captures into account. If only the address of the argument was captured, an access through the escape source is not legal.