### PR TITLE
[Support] FIx a warning

### DIFF
--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -735,8 +735,8 @@ private:
 #endif
 };
 
-/// @deprecated Use reportFatalInternalError() or reportFatalUsageError()
-/// instead.
+/// report_fatal_error below has been soft deprecated.
+/// Use reportFatalInternalError() or reportFatalUsageError() instead.
 [[noreturn]] void report_fatal_error(Error Err, bool gen_crash_diag = true);
 
 /// Report a fatal error that indicates a bug in LLVM.

--- a/llvm/include/llvm/Support/ErrorHandling.h
+++ b/llvm/include/llvm/Support/ErrorHandling.h
@@ -59,8 +59,8 @@ namespace llvm {
     ~ScopedFatalErrorHandler() { remove_fatal_error_handler(); }
   };
 
-/// @deprecated Use reportFatalInternalError() or reportFatalUsageError()
-/// instead.
+/// report_fatal_error below has been soft deprecated.
+/// Use reportFatalInternalError() or reportFatalUsageError() instead.
 [[noreturn]] void report_fatal_error(const char *reason,
                                      bool gen_crash_diag = true);
 [[noreturn]] void report_fatal_error(StringRef reason,


### PR DESCRIPTION
This patch fixes:

  llvm/include/llvm/Support/ErrorHandling.h:62:6: error: declaration
  is marked with '@deprecated' command but does not have a deprecation
  attribute [-Werror,-Wdocumentation-deprecated-sync]
