### PR TITLE
[NFC][clang-offload-bundler] Simplify main function

### DIFF
--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -426,12 +426,9 @@ int main(int argc, const char **argv) {
   OffloadBundler Bundler(BundlerConfig);
 
   return doWork([&]() {
-    if (Unbundle) {
-      if (BundlerConfig.FilesType == "a")
-        return Bundler.UnbundleArchive();
-      else
-        return Bundler.UnbundleFiles();
-    } else
-      return Bundler.BundleFiles();
+    if (Unbundle)
+      return (BundlerConfig.FilesType == "a") ? Bundler.UnbundleArchive()
+                                              : Bundler.UnbundleFiles();
+    return Bundler.BundleFiles();
   });
 }


### PR DESCRIPTION
Applied "no else after return" rule from the LLVM's Coding Standards https://llvm.org/docs/CodingStandards.html#don-t-use-else-after-a-return