### PR TITLE
[Sema] Warn about omitting deprecated enumerator in switch

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -497,6 +497,33 @@ Improvements to Clang's diagnostics
 - ``-Wreserved-identifier`` now fires on reserved parameter names in a function
   declaration which is not a definition.
 
+- ``-Wswitch`` will now diagnose unhandled enumerators in switches also when
+  the enumerator is deprecated. Warnings about using deprecated enumerators in
+  switch cases have moved behind a new ``-Wdeprecated-switch-case`` flag.
+
+  For example:
+
+  .. code-block:: c
+
+    enum E {
+      Red,
+      Green,
+      Blue [[deprecated]]
+    };
+    void example(enum E e) {
+      switch (e) {
+      case Red:   // stuff...
+      case Green: // stuff...
+      }
+    }
+
+  will result in a warning about ``Blue`` not being handled in the switch.
+
+  The warning can be fixed either by adding a ``default:``, or by adding
+  ``case Blue:``. Since the enumerator is deprecated, the latter approach will
+  trigger a ``'Blue' is deprecated`` warning, which can be turned off with
+  ``-Wno-deprecated-switch-case``.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -233,7 +233,8 @@ def DeprecatedCopyWithDtor : DiagGroup<"deprecated-copy-with-dtor", [DeprecatedC
 def DeprecatedLiteralOperator : DiagGroup<"deprecated-literal-operator">;
 // For compatibility with GCC.
 def : DiagGroup<"deprecated-copy-dtor", [DeprecatedCopyWithDtor]>;
-def DeprecatedDeclarations : DiagGroup<"deprecated-declarations">;
+def DeprecatedSwitchCase : DiagGroup<"deprecated-switch-case">;
+def DeprecatedDeclarations : DiagGroup<"deprecated-declarations", [DeprecatedSwitchCase]>;
 def DeprecatedRedundantConstexprStaticDef : DiagGroup<"deprecated-redundant-constexpr-static-def">;
 def UnavailableDeclarations : DiagGroup<"unavailable-declarations">;
 def UnguardedAvailabilityNew : DiagGroup<"unguarded-availability-new">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6009,6 +6009,8 @@ def note_not_found_by_two_phase_lookup : Note<"%0 should be declared prior to th
 def err_undeclared_use : Error<"use of undeclared %0">;
 def warn_deprecated : Warning<"%0 is deprecated">,
     InGroup<DeprecatedDeclarations>;
+def warn_deprecated_switch_case : Warning<"%0 is deprecated">,
+    InGroup<DeprecatedSwitchCase>;
 def note_from_diagnose_if : Note<"from 'diagnose_if' attribute on %0:">;
 def warn_property_method_deprecated :
     Warning<"property access is using %0 method which is deprecated">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6009,7 +6009,7 @@ def note_not_found_by_two_phase_lookup : Note<"%0 should be declared prior to th
 def err_undeclared_use : Error<"use of undeclared %0">;
 def warn_deprecated : Warning<"%0 is deprecated">,
     InGroup<DeprecatedDeclarations>;
-def warn_deprecated_switch_case : Warning<"%0 is deprecated">,
+def warn_deprecated_switch_case : Warning<warn_deprecated.Summary>,
     InGroup<DeprecatedSwitchCase>;
 def note_from_diagnose_if : Note<"from 'diagnose_if' attribute on %0:">;
 def warn_property_method_deprecated :

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -6767,6 +6767,9 @@ public:
     };
     std::optional<InitializationContext> DelayedDefaultInitializationContext;
 
+    /// Whether evaluating an expression for a switch case label.
+    bool IsCaseExpr = false;
+
     ExpressionEvaluationContextRecord(ExpressionEvaluationContext Context,
                                       unsigned NumCleanupObjects,
                                       CleanupInfo ParentCleanup,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -6747,6 +6747,9 @@ public:
     /// example, in a for-range initializer).
     bool InLifetimeExtendingContext = false;
 
+    /// Whether evaluating an expression for a switch case label.
+    bool IsCaseExpr = false;
+
     /// Whether we should rebuild CXXDefaultArgExpr and CXXDefaultInitExpr.
     bool RebuildDefaultArgOrDefaultInit = false;
 
@@ -6766,9 +6769,6 @@ public:
       DeclContext *Context = nullptr;
     };
     std::optional<InitializationContext> DelayedDefaultInitializationContext;
-
-    /// Whether evaluating an expression for a switch case label.
-    bool IsCaseExpr = false;
 
     ExpressionEvaluationContextRecord(ExpressionEvaluationContext Context,
                                       unsigned NumCleanupObjects,

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -273,7 +273,6 @@ ExprResult Parser::ParseArrayBoundExpression() {
 }
 
 ExprResult Parser::ParseCaseExpression(SourceLocation CaseLoc) {
-
   EnterExpressionEvaluationContext ConstantEvaluated(
       Actions, Sema::ExpressionEvaluationContext::ConstantEvaluated);
   Actions.currentEvaluationContext().IsCaseExpr = true;

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -273,8 +273,11 @@ ExprResult Parser::ParseArrayBoundExpression() {
 }
 
 ExprResult Parser::ParseCaseExpression(SourceLocation CaseLoc) {
+
   EnterExpressionEvaluationContext ConstantEvaluated(
       Actions, Sema::ExpressionEvaluationContext::ConstantEvaluated);
+  Actions.currentEvaluationContext().IsCaseExpr = true;
+
   ExprResult LHS(ParseCastExpression(CastParseKind::AnyCastExpr, false,
                                      TypeCastState::NotTypeCast));
   ExprResult Res(ParseRHSOfBinaryExpression(LHS, prec::Conditional));

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -549,6 +549,11 @@ static void DoEmitAvailabilityWarning(Sema &S, AvailabilityResult K,
     return;
   }
   case AR_Deprecated:
+    // Don't diagnose deprecated values in case expressions: they still need to
+    // be handled for the switch to be considered covered.
+    if (S.currentEvaluationContext().IsCaseExpr)
+      return;
+
     diag = !ObjCPropertyAccess ? diag::warn_deprecated
                                : diag::warn_property_method_deprecated;
     diag_message = diag::warn_deprecated_message;

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -549,13 +549,13 @@ static void DoEmitAvailabilityWarning(Sema &S, AvailabilityResult K,
     return;
   }
   case AR_Deprecated:
-    // Don't diagnose deprecated values in case expressions: they still need to
-    // be handled for the switch to be considered covered.
-    if (S.currentEvaluationContext().IsCaseExpr)
-      return;
+    if (ObjCPropertyAccess)
+      diag = diag::warn_property_method_deprecated;
+    else if (S.currentEvaluationContext().IsCaseExpr)
+      diag = diag::warn_deprecated_switch_case;
+    else
+      diag = diag::warn_deprecated;
 
-    diag = !ObjCPropertyAccess ? diag::warn_deprecated
-                               : diag::warn_property_method_deprecated;
     diag_message = diag::warn_deprecated_message;
     diag_fwdclass_message = diag::warn_deprecated_fwdclass_message;
     property_note_select = /* deprecated */ 0;

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -1667,8 +1667,12 @@ Sema::ActOnFinishSwitchStmt(SourceLocation SwitchLoc, Stmt *Switch,
         // Don't warn about omitted unavailable EnumConstantDecls.
         switch (EI->second->getAvailability()) {
         case AR_Deprecated:
-          // Omitting a deprecated constant is ok; it should never materialize.
+          // Deprecated enumerators still need to be handled: they may be
+          // deprecated, but can still occur.
+          break;
+
         case AR_Unavailable:
+          // Omitting an unavailable enumerator is ok; it should never occur.
           continue;
 
         case AR_NotYetIntroduced:

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -1667,8 +1667,8 @@ Sema::ActOnFinishSwitchStmt(SourceLocation SwitchLoc, Stmt *Switch,
         // Don't warn about omitted unavailable EnumConstantDecls.
         switch (EI->second->getAvailability()) {
         case AR_Deprecated:
-          // Deprecated enumerators still need to be handled: they may be
-          // deprecated, but can still occur.
+          // Deprecated enumerators need to be handled: they may be deprecated,
+          // but can still occur.
           break;
 
         case AR_Unavailable:

--- a/clang/test/Sema/switch-availability.c
+++ b/clang/test/Sema/switch-availability.c
@@ -15,7 +15,7 @@ enum SwitchTwo {
 };
 
 void testSwitchTwo(enum SwitchTwo st) {
-  switch (st) {} // expected-warning{{enumeration values 'Vim' and 'Emacs' not handled in switch}}
+  switch (st) {} // expected-warning{{enumeration values 'Ed', 'Vim' and 'Emacs' not handled in switch}}
 }
 
 enum SwitchThree {

--- a/clang/test/Sema/switch-availability.c
+++ b/clang/test/Sema/switch-availability.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -verify -Wswitch -triple x86_64-apple-macosx10.12 %s
+// RUN: %clang_cc1 -verify -Wswitch -Wreturn-type -triple x86_64-apple-macosx10.12 %s
 
 enum SwitchOne {
   Unavail __attribute__((availability(macos, unavailable))),
@@ -25,3 +25,16 @@ enum SwitchThree {
 void testSwitchThree(enum SwitchThree st) {
   switch (st) {} // expected-warning{{enumeration value 'New' not handled in switch}}
 }
+
+enum SwitchFour {
+  Red,
+  Green,
+  Blue [[deprecated]]
+};
+
+int testSwitchFour(enum SwitchFour e) {
+  switch (e) { // expected-warning{{enumeration value 'Blue' not handled in switch}}
+  case Red:   return 1;
+  case Green: return 2;
+  }
+} // expected-warning{{non-void function does not return a value in all control paths}}

--- a/clang/test/Sema/switch-availability.c
+++ b/clang/test/Sema/switch-availability.c
@@ -15,7 +15,7 @@ enum SwitchTwo {
 };
 
 void testSwitchTwo(enum SwitchTwo st) {
-  switch (st) {} // expected-warning{{enumeration values 'Ed', 'Vim' and 'Emacs' not handled in switch}}
+  switch (st) {} // expected-warning{{enumeration values 'Ed', 'Vim', and 'Emacs' not handled in switch}}
 }
 
 enum SwitchThree {

--- a/clang/test/Sema/switch-availability.c
+++ b/clang/test/Sema/switch-availability.c
@@ -38,3 +38,11 @@ int testSwitchFour(enum SwitchFour e) {
   case Green: return 2;
   }
 } // expected-warning{{non-void function does not return a value in all control paths}}
+
+int testSwitchFourCovered(enum SwitchFour e) {
+  switch (e) {
+  case Red:   return 1;
+  case Green: return 2;
+  case Blue:  return 3; // no warning
+  }
+}

--- a/clang/test/Sema/switch-availability.c
+++ b/clang/test/Sema/switch-availability.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -verify -Wswitch -Wreturn-type -triple x86_64-apple-macosx10.12 %s
+// RUN: %clang_cc1 -verify -Wswitch -Wreturn-type -Wno-deprecated-switch-case -DNO_DEPRECATED_CASE -triple x86_64-apple-macosx10.12 %s
 
 enum SwitchOne {
   Unavail __attribute__((availability(macos, unavailable))),
@@ -29,6 +30,9 @@ void testSwitchThree(enum SwitchThree st) {
 enum SwitchFour {
   Red,
   Green,
+#ifndef NO_DEPRECATED_CASE
+// expected-note@+2{{'Blue' has been explicitly marked deprecated here}}
+#endif
   Blue [[deprecated]]
 };
 
@@ -43,6 +47,9 @@ int testSwitchFourCovered(enum SwitchFour e) {
   switch (e) {
   case Red:   return 1;
   case Green: return 2;
-  case Blue:  return 3; // no warning
-  }
+#ifndef NO_DEPRECATED_CASE
+// expected-warning@+2{{'Blue' is deprecated}}
+#endif
+  case Blue:  return 3;
+  } // no warning
 }

--- a/clang/test/SemaObjC/unguarded-availability.m
+++ b/clang/test/SemaObjC/unguarded-availability.m
@@ -343,21 +343,21 @@ AVAILABLE_10_12
 @end
 
 typedef enum {
-  AK_Dodo __attribute__((availability(macos, deprecated=10.3))), // expected-note 3 {{marked deprecated here}}
+  AK_Dodo __attribute__((availability(macos, deprecated=10.3))), // expected-note 1 {{marked deprecated here}}
   AK_Cat __attribute__((availability(macos, introduced=10.4))),
   AK_CyborgCat __attribute__((availability(macos, introduced=10.12))), // expected-note {{'AK_CyborgCat' has been marked as being introduced in macOS 10.12 here, but the deployment target is macOS 10.9}}
 } Animals;
 
 void switchAnimals(Animals a) {
   switch (a) {
-  case AK_Dodo: break; // expected-warning{{'AK_Dodo' is deprecated}}
+  case AK_Dodo: break; // no warn
   case AK_Cat: break;
   case AK_Cat|AK_CyborgCat: break; // expected-warning{{case value not in enum}}
   case AK_CyborgCat: break; // no warn
   }
 
   switch (a) {
-  case AK_Dodo...AK_CyborgCat: // expected-warning {{'AK_Dodo' is depr}}
+  case AK_Dodo...AK_CyborgCat: // no warn
     break;
   }
 

--- a/clang/test/SemaObjC/unguarded-availability.m
+++ b/clang/test/SemaObjC/unguarded-availability.m
@@ -343,21 +343,21 @@ AVAILABLE_10_12
 @end
 
 typedef enum {
-  AK_Dodo __attribute__((availability(macos, deprecated=10.3))), // expected-note 1 {{marked deprecated here}}
+  AK_Dodo __attribute__((availability(macos, deprecated=10.3))), // expected-note 3 {{marked deprecated here}}
   AK_Cat __attribute__((availability(macos, introduced=10.4))),
   AK_CyborgCat __attribute__((availability(macos, introduced=10.12))), // expected-note {{'AK_CyborgCat' has been marked as being introduced in macOS 10.12 here, but the deployment target is macOS 10.9}}
 } Animals;
 
 void switchAnimals(Animals a) {
   switch (a) {
-  case AK_Dodo: break; // no warn
+  case AK_Dodo: break; // expected-warning{{'AK_Dodo' is deprecated}}
   case AK_Cat: break;
   case AK_Cat|AK_CyborgCat: break; // expected-warning{{case value not in enum}}
   case AK_CyborgCat: break; // no warn
   }
 
   switch (a) {
-  case AK_Dodo...AK_CyborgCat: // no warn
+  case AK_Dodo...AK_CyborgCat: // expected-warning {{'AK_Dodo' is depr}}
     break;
   }
 


### PR DESCRIPTION
This undoes part of 3e4e3b17c14c15c23c0ed18ca9165b42b1b13ae3 which added the "Omitting a deprecated constant is ok; it should never materialize." logic.

That seems wrong: deprecated means the enumerator is likely to be removed in future versions, not that it cannot materialize.