### PR TITLE
[llvm] Fixed Demangle OutputBuffer

### DIFF
--- a/llvm/include/llvm/Demangle/Utility.h
+++ b/llvm/include/llvm/Demangle/Utility.h
@@ -136,6 +136,8 @@ public:
 
   OutputBuffer &prepend(std::string_view R) {
     size_t Size = R.size();
+    if (!Size)
+      return *this;
 
     grow(Size);
     std::memmove(Buffer + Size, Buffer, CurrentPosition);


### PR DESCRIPTION
The [llvm-clang-x86_64-expensive-checks-win](https://lab.llvm.org/buildbot/#/builders/14/builds/3075) buildbot has been broken by #133249. 
DemangleTests causes the exception 0x80000003 inside CRT in case of the debug build on Windows.