### PR TITLE
[LLDB] Add IsCoreDumping to ProcessInstanceInfo

### DIFF
--- a/lldb/include/lldb/Utility/ProcessInfo.h
+++ b/lldb/include/lldb/Utility/ProcessInfo.h
@@ -247,6 +247,11 @@ public:
 
   std::optional<bool> IsZombie() const { return m_zombie; }
 
+  // proc/../status specifies CoreDumping as the field
+  // so we match the case here.
+  void SetIsCoreDumping(bool is_coredumping) { m_coredumping = is_coredumping; }
+  std::optional<bool> IsCoreDumping() const { return m_coredumping; }
+
   void Dump(Stream &s, UserIDResolver &resolver) const;
 
   static void DumpTableHeader(Stream &s, bool show_args, bool verbose);
@@ -266,6 +271,7 @@ protected:
   struct timespec m_cumulative_system_time;
   std::optional<int8_t> m_priority_value = std::nullopt;
   std::optional<bool> m_zombie = std::nullopt;
+  std::optional<bool> m_coredumping = std::nullopt;
 };
 
 typedef std::vector<ProcessInstanceInfo> ProcessInstanceInfoList;

--- a/lldb/source/Host/linux/Host.cpp
+++ b/lldb/source/Host/linux/Host.cpp
@@ -213,6 +213,11 @@ static bool GetStatusInfo(::pid_t Pid, ProcessInstanceInfo &ProcessInfo,
     } else if (Line.consume_front("Tgid:")) {
       Line = Line.ltrim();
       Line.consumeInteger(10, Tgid);
+    } else if (Line.consume_front("CoreDumping:")) {
+      uint32_t coredumping;
+      Line = Line.ltrim();
+      Line.consumeInteger(1, coredumping);
+      ProcessInfo.SetIsCoredumping(coredumping);
     }
   }
   return true;

--- a/lldb/source/Host/linux/Host.cpp
+++ b/lldb/source/Host/linux/Host.cpp
@@ -216,8 +216,8 @@ static bool GetStatusInfo(::pid_t Pid, ProcessInstanceInfo &ProcessInfo,
     } else if (Line.consume_front("CoreDumping:")) {
       uint32_t coredumping;
       Line = Line.ltrim();
-      Line.consumeInteger(1, coredumping);
-      ProcessInfo.SetIsCoreDumping(coredumping);
+      if (!Line.consumeInteger(2, coredumping))
+        ProcessInfo.SetIsCoreDumping(coredumping);
     }
   }
   return true;

--- a/lldb/source/Host/linux/Host.cpp
+++ b/lldb/source/Host/linux/Host.cpp
@@ -217,7 +217,7 @@ static bool GetStatusInfo(::pid_t Pid, ProcessInstanceInfo &ProcessInfo,
       uint32_t coredumping;
       Line = Line.ltrim();
       Line.consumeInteger(1, coredumping);
-      ProcessInfo.SetIsCoredumping(coredumping);
+      ProcessInfo.SetIsCoreDumping(coredumping);
     }
   }
   return true;

--- a/lldb/unittests/Host/posix/HostTest.cpp
+++ b/lldb/unittests/Host/posix/HostTest.cpp
@@ -115,5 +115,8 @@ TEST_F(HostTest, GetProcessInfoSetsPriority) {
   }
   ASSERT_TRUE(Info.IsZombie().has_value());
   ASSERT_FALSE(Info.IsZombie().value());
+
+  ASSERT_TRUE(Info.IsCoreDumping().has_value());
+  ASSERT_FALSE(Info.IsCoreDumping().value());
 }
 #endif


### PR DESCRIPTION
This is the first useful patch in the series related to enabling `PTRACE_SEIZE` for processes Coredumping. In order to make the decision if we want to seize or attach, we need to expose that in processinfo. Which we acquire by reading it from `/proc/pid/status`

Note that in status it is `CoreDumping` not `Coredumping`, so I kept with that, even if I prefer `Coredumping`