### PR TITLE
[clang][OpenMP] Add error for large expr in collapse clause

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -521,6 +521,8 @@ Improvements to Clang's diagnostics
 - Fixed a duplicate diagnostic when performing typo correction on function template
   calls with explicit template arguments. (#GH139226)
 
+- An error is now emitted when OpenMP ``collapse`` and ``ordered`` clauses has expression larger than 64 bit.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -521,7 +521,8 @@ Improvements to Clang's diagnostics
 - Fixed a duplicate diagnostic when performing typo correction on function template
   calls with explicit template arguments. (#GH139226)
 
-- An error is now emitted when OpenMP ``collapse`` and ``ordered`` clauses has expression larger than 64 bit.
+- An error is now emitted when OpenMP ``collapse`` and ``ordered`` clauses have an
+  argument larger than what can fit within a 64-bit integer.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11527,7 +11527,7 @@ def note_omp_collapse_ordered_expr : Note<
 def err_omp_negative_expression_in_clause : Error<
   "argument to '%0' clause must be a %select{non-negative|strictly positive}1 integer value">;
 def err_omp_large_expression_in_clause : Error<
-  "argument to '%0' clause cannot have more than 64 bits size">;
+  "argument to '%0' clause cannot have more than 64 bits">;
 def err_omp_not_integral : Error<
   "expression must have integral or unscoped enumeration "
   "type, not %0">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11526,6 +11526,8 @@ def note_omp_collapse_ordered_expr : Note<
   "as specified in %select{'collapse'|'ordered'|'collapse' and 'ordered'}0 clause%select{||s}0">;
 def err_omp_negative_expression_in_clause : Error<
   "argument to '%0' clause must be a %select{non-negative|strictly positive}1 integer value">;
+def err_omp_large_expression_in_clause : Error<
+  "argument to '%0' clause cannot have more than 64 bits size">;
 def err_omp_not_integral : Error<
   "expression must have integral or unscoped enumeration "
   "type, not %0">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11527,7 +11527,7 @@ def note_omp_collapse_ordered_expr : Note<
 def err_omp_negative_expression_in_clause : Error<
   "argument to '%0' clause must be a %select{non-negative|strictly positive}1 integer value">;
 def err_omp_large_expression_in_clause : Error<
-  "argument to '%0' clause cannot have more than 64 bits">;
+  "argument to '%0' clause requires a value that can be represented by a 64-bit">;
 def err_omp_not_integral : Error<
   "expression must have integral or unscoped enumeration "
   "type, not %0">;

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -15937,6 +15937,13 @@ ExprResult SemaOpenMP::VerifyPositiveIntegerConstantInClause(
         << E->getSourceRange();
     return ExprError();
   }
+
+  if (!Result.isRepresentableByInt64()) {
+    Diag(E->getExprLoc(), diag::err_omp_large_expression_in_clause)
+        << getOpenMPClauseNameForDiag(CKind) << E->getSourceRange();
+    return ExprError();
+  }
+
   if (CKind == OMPC_collapse && DSAStack->getAssociatedLoops() == 1)
     DSAStack->setAssociatedLoops(Result.getExtValue());
   else if (CKind == OMPC_ordered)

--- a/clang/test/OpenMP/for_collapse_messages.cpp
+++ b/clang/test/OpenMP/for_collapse_messages.cpp
@@ -49,7 +49,7 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp for collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp for collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
+  #pragma omp for collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}

--- a/clang/test/OpenMP/for_collapse_messages.cpp
+++ b/clang/test/OpenMP/for_collapse_messages.cpp
@@ -49,6 +49,8 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp for collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
+  #pragma omp for collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
+  for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}
 #else

--- a/clang/test/OpenMP/for_collapse_messages.cpp
+++ b/clang/test/OpenMP/for_collapse_messages.cpp
@@ -49,7 +49,7 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp for collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp for collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
+  #pragma omp for collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause requires a value that can be represented by a 64-bit}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}

--- a/clang/test/OpenMP/for_ordered_clause.cpp
+++ b/clang/test/OpenMP/for_ordered_clause.cpp
@@ -53,7 +53,7 @@ T tmain(T argc, S **argv) {
 #pragma omp for ordered(S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++)
     argv[0][i] = argv[0][i] - argv[0][i - ST];
-#pragma omp for ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause cannot have more than 64 bits size}}
+#pragma omp for ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause cannot have more than 64 bits}}
   for (int i = ST; i < N; i++)
     argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L

--- a/clang/test/OpenMP/for_ordered_clause.cpp
+++ b/clang/test/OpenMP/for_ordered_clause.cpp
@@ -53,6 +53,9 @@ T tmain(T argc, S **argv) {
 #pragma omp for ordered(S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++)
     argv[0][i] = argv[0][i] - argv[0][i - ST];
+#pragma omp for ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause cannot have more than 64 bits size}}
+  for (int i = ST; i < N; i++)
+    argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
 // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}
 #else

--- a/clang/test/OpenMP/for_ordered_clause.cpp
+++ b/clang/test/OpenMP/for_ordered_clause.cpp
@@ -53,7 +53,7 @@ T tmain(T argc, S **argv) {
 #pragma omp for ordered(S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++)
     argv[0][i] = argv[0][i] - argv[0][i - ST];
-#pragma omp for ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause cannot have more than 64 bits}}
+#pragma omp for ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause requires a value that can be represented by a 64-bit}}
   for (int i = ST; i < N; i++)
     argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L

--- a/clang/test/OpenMP/for_simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/for_simd_collapse_messages.cpp
@@ -43,6 +43,8 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp for simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
+  #pragma omp for simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
+  for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}
 #else

--- a/clang/test/OpenMP/for_simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/for_simd_collapse_messages.cpp
@@ -43,7 +43,7 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp for simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp for simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
+  #pragma omp for simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}

--- a/clang/test/OpenMP/for_simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/for_simd_collapse_messages.cpp
@@ -43,7 +43,7 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp for simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp for simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
+  #pragma omp for simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause requires a value that can be represented by a 64-bit}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}

--- a/clang/test/OpenMP/for_simd_loop_messages.cpp
+++ b/clang/test/OpenMP/for_simd_loop_messages.cpp
@@ -735,6 +735,9 @@ void test_ordered() {
 #pragma omp for simd ordered(1)
   for (int i = 0; i < 16; ++i)
     ;
+#pragma omp for simd ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause cannot have more than 64 bits size}}
+  for (int i = 0; i < 10; i++)
+    ;
 }
 
 void test_nowait() {

--- a/clang/test/OpenMP/for_simd_loop_messages.cpp
+++ b/clang/test/OpenMP/for_simd_loop_messages.cpp
@@ -735,7 +735,7 @@ void test_ordered() {
 #pragma omp for simd ordered(1)
   for (int i = 0; i < 16; ++i)
     ;
-#pragma omp for simd ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause cannot have more than 64 bits size}}
+#pragma omp for simd ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause cannot have more than 64 bits}}
   for (int i = 0; i < 10; i++)
     ;
 }

--- a/clang/test/OpenMP/for_simd_loop_messages.cpp
+++ b/clang/test/OpenMP/for_simd_loop_messages.cpp
@@ -735,7 +735,7 @@ void test_ordered() {
 #pragma omp for simd ordered(1)
   for (int i = 0; i < 16; ++i)
     ;
-#pragma omp for simd ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause cannot have more than 64 bits}}
+#pragma omp for simd ordered (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'ordered' clause requires a value that can be represented by a 64-bit}}
   for (int i = 0; i < 10; i++)
     ;
 }

--- a/clang/test/OpenMP/masked_taskloop_collapse_messages.cpp
+++ b/clang/test/OpenMP/masked_taskloop_collapse_messages.cpp
@@ -43,6 +43,8 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp masked taskloop collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
+  #pragma omp masked taskloop collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
+  for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}
 #else

--- a/clang/test/OpenMP/masked_taskloop_collapse_messages.cpp
+++ b/clang/test/OpenMP/masked_taskloop_collapse_messages.cpp
@@ -43,7 +43,7 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp masked taskloop collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp masked taskloop collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
+  #pragma omp masked taskloop collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause requires a value that can be represented by a 64-bit}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}

--- a/clang/test/OpenMP/masked_taskloop_simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/masked_taskloop_simd_collapse_messages.cpp
@@ -43,6 +43,8 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp masked taskloop simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
+  #pragma omp masked taskloop simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
+  for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}
 #else

--- a/clang/test/OpenMP/masked_taskloop_simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/masked_taskloop_simd_collapse_messages.cpp
@@ -43,7 +43,7 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp masked taskloop simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp masked taskloop simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
+  #pragma omp masked taskloop simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause requires a value that can be represented by a 64-bit}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}

--- a/clang/test/OpenMP/simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/simd_collapse_messages.cpp
@@ -43,6 +43,10 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
+  #pragma omp for collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
+  for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
+  #pragma omp simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
+  for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}
 #else

--- a/clang/test/OpenMP/simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/simd_collapse_messages.cpp
@@ -43,7 +43,7 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
+  #pragma omp simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}

--- a/clang/test/OpenMP/simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/simd_collapse_messages.cpp
@@ -43,8 +43,6 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp for collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
-  for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits size}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L

--- a/clang/test/OpenMP/simd_collapse_messages.cpp
+++ b/clang/test/OpenMP/simd_collapse_messages.cpp
@@ -43,7 +43,7 @@ T tmain(T argc, S **argv) {
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
   #pragma omp simd collapse (S) // expected-error {{'S' does not refer to a value}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
-  #pragma omp simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause cannot have more than 64 bits}}
+  #pragma omp simd collapse (0xFFFFFFFFFFFFFFFF) // expected-error {{argument to 'collapse' clause requires a value that can be represented by a 64-bit}}
   for (int i = ST; i < N; i++) argv[0][i] = argv[0][i] - argv[0][i-ST];
 #if __cplusplus <= 199711L
   // expected-error@+4 2 {{integral constant expression}} expected-note@+4 0+{{constant expression}}


### PR DESCRIPTION
Report error when OpenMP collapse clause has an expression that can't be represented in 64-bit

Issue #138445