### PR TITLE
[analyzer] Make it a noop when initializing a field of empty record

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -717,7 +717,7 @@ void ExprEngine::handleConstructor(const Expr *E,
         // since it's then possible to be initializing one part of a multi-
         // dimensional array.
         const CXXRecordDecl *TargetHeldRecord =
-            dyn_cast_or_null<CXXRecordDecl>(CE->getType()->getAsRecordDecl());
+            cast<CXXRecordDecl>(CE->getType()->getAsRecordDecl());
 
         if (!TargetHeldRecord || !TargetHeldRecord->isEmpty())
           State = State->bindDefaultZero(Target, LCtx);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -701,7 +701,6 @@ void ExprEngine::handleConstructor(const Expr *E,
   if (CE) {
     // FIXME: Is it possible and/or useful to do this before PreStmt?
     StmtNodeBuilder Bldr(DstPreVisit, PreInitialized, *currBldrCtx);
-    ASTContext &Ctx = LCtx->getAnalysisDeclContext()->getASTContext();
     for (ExplodedNode *N : DstPreVisit) {
       ProgramStateRef State = N->getState();
       if (CE->requiresZeroInitialization()) {
@@ -718,7 +717,7 @@ void ExprEngine::handleConstructor(const Expr *E,
         // since it's then possible to be initializing one part of a multi-
         // dimensional array.
         const CXXRecordDecl *TargetHeldRecord =
-            Target.getType(Ctx)->getPointeeCXXRecordDecl();
+            dyn_cast_or_null<CXXRecordDecl>(CE->getType()->getAsRecordDecl());
 
         if (!TargetHeldRecord || !TargetHeldRecord->isEmpty())
           State = State->bindDefaultZero(Target, LCtx);

--- a/clang/test/Analysis/issue-137252.cpp
+++ b/clang/test/Analysis/issue-137252.cpp
@@ -4,7 +4,7 @@
 // expected-no-diagnostics
 
 // This test reproduces the issue that previously the static analyzer
-// initialized an [[__no_unique_address__]] empty field to zero,
+// initialized an [[no_unique_address]] empty field to zero,
 // over-writing a non-empty field with the same offset.
 
 namespace std {

--- a/clang/test/Analysis/issue-137252.cpp
+++ b/clang/test/Analysis/issue-137252.cpp
@@ -1,0 +1,45 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=cplusplus -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=cplusplus -verify %s -DEMPTY_CLASS
+
+// expected-no-diagnostics
+
+// This test reproduces the issue that previously the static analyzer
+// initialized an [[__no_unique_address__]] empty field to zero,
+// over-writing a non-empty field with the same offset.
+
+namespace std {
+#ifdef EMPTY_CLASS
+
+  template <typename T>
+  class default_delete {
+    T dump();
+    static T x;
+  };
+  template <class _Tp, class _Dp = default_delete<_Tp> >
+#else
+
+  struct default_delete {};
+  template <class _Tp, class _Dp = default_delete >
+#endif
+  class unique_ptr {
+    [[__no_unique_address__]]  _Tp * __ptr_;
+    [[__no_unique_address__]] _Dp __deleter_;
+
+  public:
+    explicit unique_ptr(_Tp* __p) noexcept
+      : __ptr_(__p),
+        __deleter_() {}
+
+    ~unique_ptr() {
+      delete __ptr_;
+    }
+  };
+}
+
+struct X {};
+
+int main()
+{
+    std::unique_ptr<X> a(new X());          // previously leak falsely reported
+    return 0;
+}

--- a/clang/test/Analysis/issue-137252.cpp
+++ b/clang/test/Analysis/issue-137252.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=cplusplus -verify %s
 // RUN: %clang_analyze_cc1 -analyzer-checker=cplusplus -verify %s -DEMPTY_CLASS
-
+// UNSUPPORTED: system-windows
 // expected-no-diagnostics
 
 // This test reproduces the issue that previously the static analyzer


### PR DESCRIPTION
Previously, Static Analyzer initializes empty type fields with zeroes. This can cause problems when those fields have no unique addresses. For example, https://github.com/llvm/llvm-project/issues/137252.

rdar://146753089