### PR TITLE
[verify][swift] Allow passing swifterror to phi instructions

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3662,9 +3662,9 @@ void Verifier::visitCallBase(CallBase &Call) {
 
       while (!PHIWorkList.empty()) {
         const auto *PhiI = PHIWorkList.pop_back_val();
-        for (const auto &Op : PhiI->incoming_values()) {
-          const auto *NextPhiI = dyn_cast<PHINode>(Op.get());
-          if (Values.insert(Op.get()) && NextPhiI)
+        for (const Value *Op : PhiI->incoming_values()) {
+          const auto *NextPhiI = dyn_cast<PHINode>(Op);
+          if (Values.insert(Op) && NextPhiI)
             PHIWorkList.push_back(NextPhiI);
         }
       }

--- a/llvm/test/Verifier/swifterror.ll
+++ b/llvm/test/Verifier/swifterror.ll
@@ -1,4 +1,4 @@
-; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s --implicit-check-not=swifterror
 
 %swift_error = type {i64, i8}
 
@@ -7,6 +7,36 @@
 ; CHECK: %t = getelementptr inbounds ptr, ptr %error_ptr_ref, i64 1
 define float @foo(ptr swifterror %error_ptr_ref) {
   %t = getelementptr inbounds ptr, ptr %error_ptr_ref, i64 1
+  ret float 1.0
+}
+
+; CHECK: swifterror value can only be loaded and stored from, or as a swifterror argument!
+; CHECK: %ptr0 = alloca swifterror ptr, align 8
+; CHECK: %t = getelementptr inbounds ptr, ptr %err, i64 1
+; CHECK: swifterror value can only be loaded and stored from, or as a swifterror argument!
+; CHECK: %ptr1 = alloca swifterror ptr, align 8
+; CHECK: %t = getelementptr inbounds ptr, ptr %err, i64 1
+define float @phi(i1 %a) {
+entry:
+  %ptr0 = alloca swifterror ptr, align 8
+  %ptr1 = alloca swifterror ptr, align 8
+  %ptr2 = alloca ptr, align 8
+  br i1 %a, label %body, label %body2
+
+body:
+  %err = phi ptr [ %ptr0, %entry ], [ %ptr1, %body ]
+  %t = getelementptr inbounds ptr, ptr %err, i64 1
+  br label %body
+
+; CHECK: swifterror argument for call has mismatched alloca
+; CHECK: %ptr2 = alloca ptr, align 8
+; CHECK: %call = call float @foo(ptr swifterror %err_bad)
+body2:
+  %err_bad = phi ptr [ %ptr0, %entry ], [ %ptr2, %body2 ]
+  %call = call float @foo(ptr swifterror %err_bad)
+  br label %body2
+
+end:
   ret float 1.0
 }
 
@@ -22,12 +52,14 @@ entry:
 }
 
 ; CHECK: swifterror alloca must have pointer type
+; CHECK: %a = alloca swifterror i128, align 8
 define void @swifterror_alloca_invalid_type() {
   %a = alloca swifterror i128
   ret void
 }
 
 ; CHECK: swifterror alloca must not be array allocation
+; CHECK: %a = alloca swifterror ptr, i64 2, align 8
 define void @swifterror_alloca_array() {
   %a = alloca swifterror ptr, i64 2
   ret void


### PR DESCRIPTION
We encountered some code that failed swift verification because some swifterror values were passed to phi instructions. I believe this should be valid, so this PR adjusts the verification code to allow this.