### PR TITLE
[lldb-dap] Don't error out when the process is in eStateUnloaded

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -968,6 +968,7 @@ lldb::SBError DAP::WaitForProcessToStop(std::chrono::seconds seconds) {
   while (std::chrono::steady_clock::now() < timeout_time) {
     const auto state = process.GetState();
     switch (state) {
+    case lldb::eStateUnloaded:
     case lldb::eStateAttaching:
     case lldb::eStateConnected:
     case lldb::eStateInvalid:
@@ -981,9 +982,6 @@ lldb::SBError DAP::WaitForProcessToStop(std::chrono::seconds seconds) {
       return error;
     case lldb::eStateExited:
       error.SetErrorString("process exited during launch or attach");
-      return error;
-    case lldb::eStateUnloaded:
-      error.SetErrorString("process unloaded during launch or attach");
       return error;
     case lldb::eStateCrashed:
     case lldb::eStateStopped:


### PR DESCRIPTION
DAP::WaitForProcessToStop treats the process in eStateUnloaded as an error. The process is in this state when it has just been created (before an attach or launch) or when it's restarted. Neither should be treated as errors.

The current implementation can trigger this error (and a corresponding test failure) when we call WaitForProcessToStop after attaching  in asynchronous mode (for example when using ConnectRemote which is always asynchronous (due to a bug).