### PR TITLE
[clang] Remove "unknown" from availability diags

### DIFF
--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -698,17 +698,17 @@ static AvailabilityResult CheckAvailability(ASTContext &Context,
     auto &Triple = Context.getTargetInfo().getTriple();
     StringRef TargetEnv = Triple.getEnvironmentName();
     StringRef EnvName =
-        Triple.hasEnvironment()
-            ? llvm::Triple::getEnvironmentTypeName(Triple.getEnvironment())
-            : "";
+        llvm::Triple::getEnvironmentTypeName(Triple.getEnvironment());
     // Matching environment or no environment on attribute.
-    if (!IIEnv || (!TargetEnv.empty() && IIEnv->getName() == TargetEnv)) {
+    if (!IIEnv || (Triple.hasEnvironment() && IIEnv->getName() == TargetEnv)) {
       if (Message) {
         Message->clear();
         llvm::raw_string_ostream Out(*Message);
         VersionTuple VTI(A->getIntroduced());
-        Out << "introduced in " << PrettyPlatformName << " " << VTI << " "
-            << EnvName << HintMessage;
+        Out << "introduced in " << PrettyPlatformName << " " << VTI;
+        if (Triple.hasEnvironment())
+          Out << " " << EnvName;
+        Out << HintMessage;
       }
     }
     // Non-matching environment or no environment on target.
@@ -716,8 +716,10 @@ static AvailabilityResult CheckAvailability(ASTContext &Context,
       if (Message) {
         Message->clear();
         llvm::raw_string_ostream Out(*Message);
-        Out << "not available on " << PrettyPlatformName << " " << EnvName
-            << HintMessage;
+        Out << "not available on " << PrettyPlatformName;
+        if (Triple.hasEnvironment())
+          Out << " " << EnvName;
+        Out << HintMessage;
       }
     }
 

--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -695,11 +695,13 @@ static AvailabilityResult CheckAvailability(ASTContext &Context,
   if (!A->getIntroduced().empty() &&
       EnclosingVersion < A->getIntroduced()) {
     IdentifierInfo *IIEnv = A->getEnvironment();
-    StringRef TargetEnv =
-        Context.getTargetInfo().getTriple().getEnvironmentName();
-    StringRef EnvName = llvm::Triple::getEnvironmentTypeName(
-        Context.getTargetInfo().getTriple().getEnvironment());
-    // Matching environment or no environment on attribute
+    auto &Triple = Context.getTargetInfo().getTriple();
+    StringRef TargetEnv = Triple.getEnvironmentName();
+    StringRef EnvName =
+        Triple.hasEnvironment()
+            ? llvm::Triple::getEnvironmentTypeName(Triple.getEnvironment())
+            : "";
+    // Matching environment or no environment on attribute.
     if (!IIEnv || (!TargetEnv.empty() && IIEnv->getName() == TargetEnv)) {
       if (Message) {
         Message->clear();
@@ -709,7 +711,7 @@ static AvailabilityResult CheckAvailability(ASTContext &Context,
             << EnvName << HintMessage;
       }
     }
-    // Non-matching environment or no environment on target
+    // Non-matching environment or no environment on target.
     else {
       if (Message) {
         Message->clear();

--- a/clang/test/Driver/attr-availability-erroneous-diags.c
+++ b/clang/test/Driver/attr-availability-erroneous-diags.c
@@ -1,0 +1,10 @@
+// RUN: not %clang -target x86_64-apple-darwin9 -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK: error:
+// CHECK-SAME: 'f0' is unavailable: introduced in macOS 11
+// CHECK-NOT: unknown 
+
+void f0(void) __attribute__((availability(macosx,strict,introduced=11)));
+
+void client(void) {
+f0(); }


### PR DESCRIPTION
Previously, diagnostics like `error: 'fNew' is unavailable: introduced in macOS 11 unknown` were getting emitted when the active target triple didn't have an environment tied to it. Instead, add a guard against this to avoid the `unknown`.