### PR TITLE
[flang][volatile] Get volatility of designators from base instead of component symbol

### DIFF
--- a/flang/test/Semantics/assign02.f90
+++ b/flang/test/Semantics/assign02.f90
@@ -8,9 +8,11 @@ module m1
   type t2
     sequence
     real :: t2Field
+    real, pointer :: t2FieldPtr
   end type
   type t3
     type(t2) :: t3Field
+    type(t2), pointer :: t3FieldPtr
   end type
 contains
 
@@ -198,6 +200,14 @@ contains
     q2 => y%t3Field
     !OK:
     q3 => y
+    !ERROR: VOLATILE target associated with non-VOLATILE pointer
+    p3%t3FieldPtr => y%t3Field
+    !ERROR: VOLATILE target associated with non-VOLATILE pointer
+    p3%t3FieldPtr%t2FieldPtr => y%t3Field%t2Field
+    !OK
+    q3%t3FieldPtr => y%t3Field
+    !OK
+    q3%t3FieldPtr%t2FieldPtr => y%t3Field%t2Field
   end
 end
 


### PR DESCRIPTION
The standard says in [8.5.20 VOLATILE attribute]:
If an object has the VOLATILE attribute, then all of its sub-objects also have the VOLATILE attribute.

This code takes this into account and uses the volatility of the base of the designator instead of that of the component. In fact, fields in a structure are not allowed to have the volatile attribute. So given the code, `A%B => t`,  symbol `B` could never directly have the volatile attribute, and the volatility of `A` indicates the volatility of `B`.


This PR should address [the comments](https://github.com/llvm/llvm-project/pull/132486#issuecomment-2851313119) on this PR #132486