### PR TITLE
[Cygwin] Enable TLS on Cygwin target

### DIFF
--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -965,7 +965,6 @@ public:
   CygwinX86_64TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
       : X86_64TargetInfo(Triple, Opts) {
     this->WCharType = TargetInfo::UnsignedShort;
-    TLSSupported = false;
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/test/Driver/emulated-tls.cpp
+++ b/clang/test/Driver/emulated-tls.cpp
@@ -8,6 +8,8 @@
 // RUN:   | FileCheck -check-prefix=NOEMU %s
 // RUN: %clang -### --target=i686-pc-cygwin %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=EMU %s
+// RUN: %clang -### --target=x86_64-pc-cygwin %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=EMU %s
 // RUN: %clang -### --target=i686-pc-openbsd %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=EMU %s
 
@@ -17,6 +19,8 @@
 // RUN: | FileCheck -check-prefix=EMU %s
 // RUN: %clang -### -target i686-pc-cygwin %s -fno-emulated-tls -femulated-tls 2>&1 \
 // RUN: | FileCheck -check-prefix=EMU %s
+// RUN: %clang -### -target x86_64-pc-cygwin %s -fno-emulated-tls -femulated-tls 2>&1 \
+// RUN: | FileCheck -check-prefix=EMU %s
 // RUN: %clang -### -target i686-pc-openbsd %s -fno-emulated-tls -femulated-tls 2>&1 \
 // RUN: | FileCheck -check-prefix=EMU %s
 
@@ -25,6 +29,8 @@
 // RUN: %clang -### -target arm-linux-gnu %s -femulated-tls -fno-emulated-tls 2>&1 \
 // RUN: | FileCheck -check-prefix=NOEMU %s
 // RUN: %clang -### -target i686-pc-cygwin %s -femulated-tls -fno-emulated-tls 2>&1 \
+// RUN: | FileCheck -check-prefix=NOEMU %s
+// RUN: %clang -### -target x86_64-pc-cygwin %s -femulated-tls -fno-emulated-tls 2>&1 \
 // RUN: | FileCheck -check-prefix=NOEMU %s
 // RUN: %clang -### -target i686-pc-openbsd %s -femulated-tls -fno-emulated-tls 2>&1 \
 // RUN: | FileCheck -check-prefix=NOEMU %s


### PR DESCRIPTION
Cygwin environment and toolchain supports EMUTLS.

From https://cygwin.com/git/?p=newlib-cygwin.git;a=blob;f=config/tls.m4;hb=HEAD#l118,

```
$ LANG=C gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-cygwin/15/lto-wrapper.exe Target: x86_64-pc-cygwin
Configured with: (snip)
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 15.0.1 20250406 (experimental) (GCC)

$ echo '__thread int a; int b; int main() { return a = b; }' | gcc -S -xc -o- - | grep __emutls_get_address
        call    __emutls_get_address
        .def    __emutls_get_address;   .scl    2;      .type   32;     .endef
```