### PR TITLE
[Cygwin] Emit COMDAT name correctly for Cygwin

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1830,7 +1830,7 @@ MCSection *TargetLoweringObjectFileCOFF::SelectSectionForGlobal(
       // Append "$symbol" to the section name *before* IR-level mangling is
       // applied when targetting mingw. This is what GCC does, and the ld.bfd
       // COFF linker will not properly handle comdats otherwise.
-      if (getContext().getTargetTriple().isWindowsGNUEnvironment())
+      if (getContext().getTargetTriple().isOSCygMing())
         raw_svector_ostream(Name) << '$' << ComdatGV->getName();
 
       return getContext().getCOFFSection(Name, Characteristics, COMDATSymName,

--- a/llvm/test/CodeGen/X86/mingw-comdats-xdata.ll
+++ b/llvm/test/CodeGen/X86/mingw-comdats-xdata.ll
@@ -1,5 +1,7 @@
 ; RUN: llc -mtriple=x86_64-w64-windows-gnu < %s | FileCheck %s --check-prefix=GNU
+; RUN: llc -mtriple=x86_64-pc-cygwin < %s | FileCheck %s --check-prefix=GNU
 ; RUN: llc -mtriple=x86_64-w64-windows-gnu < %s -filetype=obj | llvm-objdump - --headers | FileCheck %s --check-prefix=GNUOBJ
+; RUN: llc -mtriple=x86_64-pc-cygwin < %s -filetype=obj | llvm-objdump - --headers | FileCheck %s --check-prefix=GNUOBJ
 
 ; When doing GCC style comdats for MinGW, the .xdata sections don't have a normal comdat
 ; symbol attached, which requires a bit of adjustments for the assembler output.

--- a/llvm/test/CodeGen/X86/mingw-comdats.ll
+++ b/llvm/test/CodeGen/X86/mingw-comdats.ll
@@ -3,6 +3,7 @@
 ; RUN: llc -function-sections -mtriple=x86_64-w64-windows-gnu < %s | FileCheck %s --check-prefix=GNU
 ; RUN: llc -function-sections -mtriple=x86_64-pc-cygwin < %s | FileCheck %s --check-prefix=GNU
 ; RUN: llc -function-sections -mtriple=i686-w64-windows-gnu < %s | FileCheck %s --check-prefix=GNU32
+; RUN: llc -function-sections -mtriple=i686-pc-cygwin < %s | FileCheck %s --check-prefix=GNU32
 ; RUN: llc -function-sections -mtriple=x86_64-w64-windows-gnu < %s -filetype=obj | llvm-objdump - --headers | FileCheck %s --check-prefix=GNUOBJ
 ; RUN: llc -function-sections -mtriple=x86_64-pc-cygwin < %s -filetype=obj | llvm-objdump - --headers | FileCheck %s --check-prefix=GNUOBJ
 

--- a/llvm/test/CodeGen/X86/mingw-comdats.ll
+++ b/llvm/test/CodeGen/X86/mingw-comdats.ll
@@ -1,8 +1,10 @@
 ; RUN: llc -function-sections -mtriple=x86_64-windows-itanium < %s | FileCheck %s
 ; RUN: llc -function-sections -mtriple=x86_64-windows-msvc < %s | FileCheck %s
 ; RUN: llc -function-sections -mtriple=x86_64-w64-windows-gnu < %s | FileCheck %s --check-prefix=GNU
+; RUN: llc -function-sections -mtriple=x86_64-pc-cygwin < %s | FileCheck %s --check-prefix=GNU
 ; RUN: llc -function-sections -mtriple=i686-w64-windows-gnu < %s | FileCheck %s --check-prefix=GNU32
 ; RUN: llc -function-sections -mtriple=x86_64-w64-windows-gnu < %s -filetype=obj | llvm-objdump - --headers | FileCheck %s --check-prefix=GNUOBJ
+; RUN: llc -function-sections -mtriple=x86_64-pc-cygwin < %s -filetype=obj | llvm-objdump - --headers | FileCheck %s --check-prefix=GNUOBJ
 
 ; GCC and MSVC handle comdats completely differently. Make sure we do the right
 ; thing for each.


### PR DESCRIPTION
Cygwin-gcc emits COMDAT in the same format as MinGW-gcc.

Checking for the behavior of gcc:
```
$ cat test.cc
int bar(int);
__declspec(selectany) int gv = 42;
inline int foo(int x) { try { return bar(x) + gv; } catch (...) { return 0; } }
int main() { return foo(1); }

$ x86_64-pc-cygwin-gcc -c test.cc -o test.cygwin.o

$ x86_64-w64-mingw32-gcc -c test.cc -o test.mingw.o

$ objdump -h test.mingw.o

test.mingw.o:     ファイル形式 pe-x86-64

セクション:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .text         00000020  0000000000000000  0000000000000000  000001a4  2**4
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, CODE
  1 .data         00000000  0000000000000000  0000000000000000  00000000  2**4
                  ALLOC, LOAD, DATA
  2 .bss          00000000  0000000000000000  0000000000000000  00000000  2**4
                  ALLOC
  3 .data$gv      00000010  0000000000000000  0000000000000000  000001c4  2**4
                  CONTENTS, ALLOC, LOAD, DATA, LINK_ONCE_SAME_SIZE (COMDAT gv 25)
  4 .text$_Z3fooi 00000040  0000000000000000  0000000000000000  000001d4  2**4
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, CODE, LINK_ONCE_DISCARD (COMDAT _Z3fooi 6)
  5 .xdata$_Z3fooi 00000024  0000000000000000  0000000000000000  00000214  2**2
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, DATA, LINK_ONCE_DISCARD
  6 .pdata$_Z3fooi 0000000c  0000000000000000  0000000000000000  00000238  2**2
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, DATA, LINK_ONCE_DISCARD
  7 .xdata        0000000c  0000000000000000  0000000000000000  00000244  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  8 .pdata        0000000c  0000000000000000  0000000000000000  00000250  2**2
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, DATA
  9 .rdata$zzz    00000020  0000000000000000  0000000000000000  0000025c  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, DATA

$ diff -u <(objdump -h test.cygwin.o) <(objdump -h test.mingw.o)
--- /dev/fd/63  2025-05-06 10:20:13.000000000 +0900
+++ /dev/fd/62  2025-05-06 10:20:13.000000000 +0900
@@ -1,5 +1,5 @@

-test.cygwin.o:     ファイル形式 pe-x86-64
+test.mingw.o:     ファイル形式 pe-x86-64

 セクション:
 Idx Name          Size      VMA               LMA               File off  Algn
@@ -21,5 +21,5 @@
                   CONTENTS, ALLOC, LOAD, READONLY, DATA
   8 .pdata        0000000c  0000000000000000  0000000000000000  00000250  2**2
                   CONTENTS, ALLOC, LOAD, RELOC, READONLY, DATA
-  9 .rdata$zzz    00000030  0000000000000000  0000000000000000  0000025c  2**4
+  9 .rdata$zzz    00000020  0000000000000000  0000000000000000  0000025c  2**4
                   CONTENTS, ALLOC, LOAD, READONLY, DATA

```
Generated COMDAT names are identical.


> `-  9 .rdata$zzz    00000030  0000000000000000  0000000000000000  0000025c  2**4`
> `+  9 .rdata$zzz    00000020  0000000000000000  0000000000000000  0000025c  2**4`

This difference comes from size of .rdata section, It's not point of this PR.
