### PR TITLE
[libc] Fix implicit conversion error on rv32

### DIFF
--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -757,7 +757,7 @@ public:
       result.set_significand(number);
       result.set_biased_exponent(static_cast<StorageType>(ep + 1));
     } else {
-      result.set_significand(number >> -ep);
+      result.set_significand(number >> static_cast<unsigned>(-ep));
     }
     return RetT(result.uintval());
   }


### PR DESCRIPTION
This patch fixes the following error on rv32 (and possibly other 32-bit archs):

FPBits.h:760:40: error: implicit conversion loses integer precision: 'int' to 'size_t' (aka 'unsigned int') [-Werror,-Wimplicit-int-conversion]
  760 |       result.set_significand(number >> -ep);

Fixes #138425.