### PR TITLE
AArch64: Clean up relocation error messages.

### DIFF
--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
@@ -52,9 +52,6 @@ AArch64ELFObjectWriter::AArch64ELFObjectWriter(uint8_t OSABI, bool IsILP32)
 
 #define R_CLS(rtype)                                                           \
   IsILP32 ? ELF::R_AARCH64_P32_##rtype : ELF::R_AARCH64_##rtype
-#define BAD_ILP32_MOV(lp64rtype)                                               \
-  "ILP32 absolute MOV relocation not "                                         \
-  "supported (LP64 eqv: " #lp64rtype ")"
 
 // assumes IsILP32 is true
 static bool isNonILP32reloc(const MCFixup &Fixup,
@@ -63,40 +60,19 @@ static bool isNonILP32reloc(const MCFixup &Fixup,
     return false;
   switch (RefKind) {
   case AArch64MCExpr::VK_ABS_G3:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(MOVW_UABS_G3));
-    return true;
   case AArch64MCExpr::VK_ABS_G2:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(MOVW_UABS_G2));
-    return true;
   case AArch64MCExpr::VK_ABS_G2_S:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(MOVW_SABS_G2));
-    return true;
   case AArch64MCExpr::VK_ABS_G2_NC:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(MOVW_UABS_G2_NC));
-    return true;
   case AArch64MCExpr::VK_ABS_G1_S:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(MOVW_SABS_G1));
-    return true;
   case AArch64MCExpr::VK_ABS_G1_NC:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(MOVW_UABS_G1_NC));
-    return true;
   case AArch64MCExpr::VK_DTPREL_G2:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(TLSLD_MOVW_DTPREL_G2));
-    return true;
   case AArch64MCExpr::VK_DTPREL_G1_NC:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(TLSLD_MOVW_DTPREL_G1_NC));
-    return true;
   case AArch64MCExpr::VK_TPREL_G2:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(TLSLE_MOVW_TPREL_G2));
-    return true;
   case AArch64MCExpr::VK_TPREL_G1_NC:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(TLSLE_MOVW_TPREL_G1_NC));
-    return true;
   case AArch64MCExpr::VK_GOTTPREL_G1:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(TLSIE_MOVW_GOTTPREL_G1));
-    return true;
   case AArch64MCExpr::VK_GOTTPREL_G0_NC:
-    Ctx.reportError(Fixup.getLoc(), BAD_ILP32_MOV(TLSIE_MOVW_GOTTPREL_G0_NC));
+    Ctx.reportError(Fixup.getLoc(),
+                    "absolute MOV relocation is not supported in ILP32");
     return true;
   default:
     return false;
@@ -147,9 +123,8 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
     }
     case FK_Data_8:
       if (IsILP32) {
-        Ctx.reportError(Fixup.getLoc(),
-                        "ILP32 8 byte PC relative data "
-                        "relocation not supported (LP64 eqv: PREL64)");
+        Ctx.reportError(Fixup.getLoc(), "8 byte PC relative data "
+                                        "relocation is not supported in ILP32");
         return ELF::R_AARCH64_NONE;
       }
       return ELF::R_AARCH64_PREL64;
@@ -157,8 +132,7 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       if (SymLoc == AArch64MCExpr::VK_GOT_AUTH) {
         if (IsILP32) {
           Ctx.reportError(Fixup.getLoc(),
-                          "ILP32 ADR AUTH relocation not supported "
-                          "(LP64 eqv: AUTH_GOT_ADR_PREL_LO21)");
+                          "ADR AUTH relocation is not supported in ILP32");
           return ELF::R_AARCH64_NONE;
         }
         return ELF::R_AARCH64_AUTH_GOT_ADR_PREL_LO21;
@@ -184,8 +158,7 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       if (SymLoc == AArch64MCExpr::VK_GOT_AUTH && !IsNC) {
         if (IsILP32) {
           Ctx.reportError(Fixup.getLoc(),
-                          "ILP32 ADRP AUTH relocation not supported "
-                          "(LP64 eqv: AUTH_ADR_GOT_PAGE)");
+                          "ADRP AUTH relocation is not supported in ILP32");
           return ELF::R_AARCH64_NONE;
         }
         return ELF::R_AARCH64_AUTH_ADR_GOT_PAGE;
@@ -197,8 +170,7 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       if (SymLoc == AArch64MCExpr::VK_TLSDESC_AUTH && !IsNC) {
         if (IsILP32) {
           Ctx.reportError(Fixup.getLoc(),
-                          "ILP32 ADRP AUTH relocation not supported "
-                          "(LP64 eqv: AUTH_TLSDESC_ADR_PAGE21)");
+                          "ADRP AUTH relocation is not supported in ILP32");
           return ELF::R_AARCH64_NONE;
         }
         return ELF::R_AARCH64_AUTH_TLSDESC_ADR_PAGE21;
@@ -218,8 +190,7 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       if (SymLoc == AArch64MCExpr::VK_GOT_AUTH) {
         if (IsILP32) {
           Ctx.reportError(Fixup.getLoc(),
-                          "ILP32 LDR AUTH relocation not supported "
-                          "(LP64 eqv: AUTH_GOT_LD_PREL19)");
+                          "LDR AUTH relocation is not supported in ILP32");
           return ELF::R_AARCH64_NONE;
         }
         return ELF::R_AARCH64_AUTH_GOT_LD_PREL19;
@@ -260,10 +231,9 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       bool IsAuth = (RefKind == AArch64MCExpr::VK_AUTH ||
                      RefKind == AArch64MCExpr::VK_AUTHADDR);
       if (IsILP32) {
-        Ctx.reportError(Fixup.getLoc(),
-                        Twine("ILP32 8 byte absolute data "
-                              "relocation not supported (LP64 eqv: ") +
-                            (IsAuth ? "AUTH_ABS64" : "ABS64") + Twine(')'));
+        Ctx.reportError(
+            Fixup.getLoc(),
+            "8 byte absolute data relocation is not supported in ILP32");
         return ELF::R_AARCH64_NONE;
       }
       return (IsAuth ? ELF::R_AARCH64_AUTH_ABS64 : ELF::R_AARCH64_ABS64);
@@ -286,8 +256,7 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       if (RefKind == AArch64MCExpr::VK_TLSDESC_AUTH_LO12) {
         if (IsILP32) {
           Ctx.reportError(Fixup.getLoc(),
-                          "ILP32 ADD AUTH relocation not supported "
-                          "(LP64 eqv: AUTH_TLSDESC_ADD_LO12)");
+                          "ADD AUTH relocation is not supported in ILP32");
           return ELF::R_AARCH64_NONE;
         }
         return ELF::R_AARCH64_AUTH_TLSDESC_ADD_LO12;
@@ -295,8 +264,7 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       if (RefKind == AArch64MCExpr::VK_GOT_AUTH_LO12 && IsNC) {
         if (IsILP32) {
           Ctx.reportError(Fixup.getLoc(),
-                          "ILP32 ADD AUTH relocation not supported "
-                          "(LP64 eqv: AUTH_GOT_ADD_LO12_NC)");
+                          "ADD AUTH relocation is not supported in ILP32");
           return ELF::R_AARCH64_NONE;
         }
         return ELF::R_AARCH64_AUTH_GOT_ADD_LO12_NC;
@@ -351,38 +319,31 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       if (SymLoc == AArch64MCExpr::VK_GOT && IsNC) {
         if (IsILP32)
           return ELF::R_AARCH64_P32_LD32_GOT_LO12_NC;
-        Ctx.reportError(Fixup.getLoc(),
-                        "LP64 4 byte unchecked GOT load/store relocation "
-                        "not supported (ILP32 eqv: LD32_GOT_LO12_NC");
+        Ctx.reportError(Fixup.getLoc(), "4 byte unchecked GOT load/store "
+                                        "relocation is not supported in LP64");
         return ELF::R_AARCH64_NONE;
       }
       if (SymLoc == AArch64MCExpr::VK_GOT && !IsNC) {
         if (IsILP32) {
-          Ctx.reportError(Fixup.getLoc(),
-                          "ILP32 4 byte checked GOT load/store relocation "
-                          "not supported (unchecked eqv: LD32_GOT_LO12_NC)");
-        } else {
-          Ctx.reportError(Fixup.getLoc(),
-                          "LP64 4 byte checked GOT load/store relocation "
-                          "not supported (unchecked/ILP32 eqv: "
-                          "LD32_GOT_LO12_NC)");
+          Ctx.reportError(
+              Fixup.getLoc(),
+              "4 byte checked GOT load/store relocation is not supported");
         }
         return ELF::R_AARCH64_NONE;
       }
       if (SymLoc == AArch64MCExpr::VK_GOTTPREL && IsNC) {
         if (IsILP32)
           return ELF::R_AARCH64_P32_TLSIE_LD32_GOTTPREL_LO12_NC;
-        Ctx.reportError(Fixup.getLoc(), "LP64 32-bit load/store "
-                                        "relocation not supported (ILP32 eqv: "
-                                        "TLSIE_LD32_GOTTPREL_LO12_NC)");
+        Ctx.reportError(Fixup.getLoc(), "32-bit load/store "
+                                        "relocation is not supported in LP64");
         return ELF::R_AARCH64_NONE;
       }
       if (SymLoc == AArch64MCExpr::VK_TLSDESC && !IsNC) {
         if (IsILP32)
           return ELF::R_AARCH64_P32_TLSDESC_LD32_LO12;
-        Ctx.reportError(Fixup.getLoc(),
-                        "LP64 4 byte TLSDESC load/store relocation "
-                        "not supported (ILP32 eqv: TLSDESC_LD64_LO12)");
+        Ctx.reportError(
+            Fixup.getLoc(),
+            "4 byte TLSDESC load/store relocation is not supported in LP64");
         return ELF::R_AARCH64_NONE;
       }
 
@@ -405,11 +366,9 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
           return (IsAuth ? ELF::R_AARCH64_AUTH_LD64_GOT_LO12_NC
                          : ELF::R_AARCH64_LD64_GOT_LO12_NC);
         }
-        Ctx.reportError(Fixup.getLoc(),
-                        Twine("ILP32 64-bit load/store "
-                              "relocation not supported (LP64 eqv: ") +
-                            (IsAuth ? "AUTH_GOT_LO12_NC" : "LD64_GOT_LO12_NC") +
-                            Twine(')'));
+        Ctx.reportError(
+            Fixup.getLoc(),
+            "64-bit load/store relocation is not supported in ILP32");
         return ELF::R_AARCH64_NONE;
       }
       if (SymLoc == AArch64MCExpr::VK_DTPREL && !IsNC)
@@ -423,25 +382,25 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       if (SymLoc == AArch64MCExpr::VK_GOTTPREL && IsNC) {
         if (!IsILP32)
           return ELF::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC;
-        Ctx.reportError(Fixup.getLoc(), "ILP32 64-bit load/store "
-                                        "relocation not supported (LP64 eqv: "
-                                        "TLSIE_LD64_GOTTPREL_LO12_NC)");
+        Ctx.reportError(
+            Fixup.getLoc(),
+            "64-bit load/store relocation is not supported in ILP32");
         return ELF::R_AARCH64_NONE;
       }
       if (SymLoc == AArch64MCExpr::VK_TLSDESC) {
         if (!IsILP32)
           return ELF::R_AARCH64_TLSDESC_LD64_LO12;
-        Ctx.reportError(Fixup.getLoc(), "ILP32 64-bit load/store "
-                                        "relocation not supported (LP64 eqv: "
-                                        "TLSDESC_LD64_LO12)");
+        Ctx.reportError(
+            Fixup.getLoc(),
+            "64-bit load/store relocation is not supported in ILP32");
         return ELF::R_AARCH64_NONE;
       }
       if (SymLoc == AArch64MCExpr::VK_TLSDESC_AUTH) {
         if (!IsILP32)
           return ELF::R_AARCH64_AUTH_TLSDESC_LD64_LO12;
-        Ctx.reportError(Fixup.getLoc(), "ILP32 64-bit load/store AUTH "
-                                        "relocation not supported (LP64 eqv: "
-                                        "AUTH_TLSDESC_LD64_LO12)");
+        Ctx.reportError(
+            Fixup.getLoc(),
+            "64-bit load/store AUTH relocation is not supported in ILP32");
         return ELF::R_AARCH64_NONE;
       }
       Ctx.reportError(Fixup.getLoc(),

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
@@ -228,15 +228,16 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
                  ? ELF::R_AARCH64_GOTPCREL32
                  : R_CLS(ABS32);
     case FK_Data_8: {
-      bool IsAuth = (RefKind == AArch64MCExpr::VK_AUTH ||
-                     RefKind == AArch64MCExpr::VK_AUTHADDR);
       if (IsILP32) {
         Ctx.reportError(
             Fixup.getLoc(),
             "8 byte absolute data relocation is not supported in ILP32");
         return ELF::R_AARCH64_NONE;
       }
-      return (IsAuth ? ELF::R_AARCH64_AUTH_ABS64 : ELF::R_AARCH64_ABS64);
+      if (RefKind == AArch64MCExpr::VK_AUTH ||
+          RefKind == AArch64MCExpr::VK_AUTHADDR)
+        return ELF::R_AARCH64_AUTH_ABS64;
+      return ELF::R_AARCH64_ABS64;
     }
     case AArch64::fixup_aarch64_add_imm12:
       if (RefKind == AArch64MCExpr::VK_DTPREL_HI12)

--- a/llvm/test/MC/AArch64/adrp-auth-relocation.s
+++ b/llvm/test/MC/AArch64/adrp-auth-relocation.s
@@ -9,4 +9,4 @@ adrp x0, :got_auth:sym
 sym:
 
 // CHECK: R_AARCH64_AUTH_ADR_GOT_PAGE sym
-// CHECK-ILP32: error: ILP32 ADRP AUTH relocation not supported (LP64 eqv: AUTH_ADR_GOT_PAGE)
+// CHECK-ILP32: error: ADRP AUTH relocation is not supported in ILP32

--- a/llvm/test/MC/AArch64/error-location.s
+++ b/llvm/test/MC/AArch64/error-location.s
@@ -31,7 +31,7 @@
 // CHECK: :[[@LINE+1]]:{{[0-9]+}}: error: invalid fixup for 16-bit load/store instruction
   ldrh w0, [x1, :gottprel_lo12:undef]
 
-// CHECK: :[[@LINE+1]]:{{[0-9]+}}: error: LP64 32-bit load/store relocation not supported (ILP32 eqv: TLSIE_LD32_GOTTPREL_LO12_NC)
+// CHECK: :[[@LINE+1]]:{{[0-9]+}}: error: 32-bit load/store relocation is not supported in LP64
   ldr w0, [x1, :gottprel_lo12:undef]
 
 

--- a/llvm/test/MC/AArch64/ilp32-diagnostics.s
+++ b/llvm/test/MC/AArch64/ilp32-diagnostics.s
@@ -3,102 +3,102 @@
 // RUN: FileCheck --check-prefix=ERROR %s --implicit-check-not=error: < %t2
 
 .xword sym-.
-// ERROR: [[#@LINE-1]]:8: error: ILP32 8 byte PC relative data relocation not supported (LP64 eqv: PREL64)
+// ERROR: [[#@LINE-1]]:8: error: 8 byte PC relative data relocation is not supported in ILP32
 
 .xword sym+16
-// ERROR: [[#@LINE-1]]:8: error: ILP32 8 byte absolute data relocation not supported (LP64 eqv: ABS64)
+// ERROR: [[#@LINE-1]]:8: error: 8 byte absolute data relocation is not supported in ILP32
 
 .xword sym@AUTH(da,42)
-// ERROR: [[#@LINE-1]]:8: error: ILP32 8 byte absolute data relocation not supported (LP64 eqv: AUTH_ABS64)
+// ERROR: [[#@LINE-1]]:8: error: 8 byte absolute data relocation is not supported in ILP32
 
 .xword sym@AUTH(da,42,addr)
-// ERROR: [[#@LINE-1]]:8: error: ILP32 8 byte absolute data relocation not supported (LP64 eqv: AUTH_ABS64)
+// ERROR: [[#@LINE-1]]:8: error: 8 byte absolute data relocation is not supported in ILP32
 
 movz x7, #:abs_g3:some_label
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: MOVW_UABS_G3)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR:        movz x7, #:abs_g3:some_label
 
 movz x3, #:abs_g2:some_label
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: MOVW_UABS_G2)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movz x3, #:abs_g2:some_label
 
 movz x19, #:abs_g2_s:some_label
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: MOVW_SABS_G2)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movz x19, #:abs_g2_s:some_label
 
 movk x5, #:abs_g2_nc:some_label
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: MOVW_UABS_G2_NC)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movk x5, #:abs_g2_nc:some_label
 
 movz x19, #:abs_g1_s:some_label
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: MOVW_SABS_G1)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movz x19, #:abs_g1_s:some_label
 
 movk x5, #:abs_g1_nc:some_label
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: MOVW_UABS_G1_NC)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movk x5, #:abs_g1_nc:some_label
 
 movz x3, #:dtprel_g2:var
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: TLSLD_MOVW_DTPREL_G2)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movz x3, #:dtprel_g2:var
 
 movk x9, #:dtprel_g1_nc:var
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: TLSLD_MOVW_DTPREL_G1_NC)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movk x9, #:dtprel_g1_nc:var
 
 movz x3, #:tprel_g2:var
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: TLSLE_MOVW_TPREL_G2)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movz x3, #:tprel_g2:var
 
 movk x9, #:tprel_g1_nc:var
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: TLSLE_MOVW_TPREL_G1_NC)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movk x9, #:tprel_g1_nc:var
 
 movz x15, #:gottprel_g1:var
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: TLSIE_MOVW_GOTTPREL_G1)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movz x15, #:gottprel_g1:var
 
 movk x13, #:gottprel_g0_nc:var
-// ERROR: [[#@LINE-1]]:1: error: ILP32 absolute MOV relocation not supported (LP64 eqv: TLSIE_MOVW_GOTTPREL_G0_NC)
+// ERROR: [[#@LINE-1]]:1: error: absolute MOV relocation is not supported in ILP32
 // ERROR: movk x13, #:gottprel_g0_nc:var
 
 ldr x10, [x0, #:gottprel_lo12:var]
-// ERROR: [[#@LINE-1]]:1: error: ILP32 64-bit load/store relocation not supported (LP64 eqv: TLSIE_LD64_GOTTPREL_LO12_NC)
+// ERROR: [[#@LINE-1]]:1: error: 64-bit load/store relocation is not supported in ILP32
 // ERROR: ldr x10, [x0, #:gottprel_lo12:var]
 
 ldr x24, [x23, #:got_lo12:sym]
-// ERROR: [[#@LINE-1]]:1: error: ILP32 64-bit load/store relocation not supported (LP64 eqv: LD64_GOT_LO12_NC)
+// ERROR: [[#@LINE-1]]:1: error: 64-bit load/store relocation is not supported in ILP32
 
 ldr x24, [x23, #:got_auth_lo12:sym]
-// ERROR: [[#@LINE-1]]:1: error: ILP32 64-bit load/store relocation not supported (LP64 eqv: AUTH_GOT_LO12_NC)
+// ERROR: [[#@LINE-1]]:1: error: 64-bit load/store relocation is not supported in ILP32
 
 add x24, x23, #:got_auth_lo12:sym
-// ERROR: [[#@LINE-1]]:1: error: ILP32 ADD AUTH relocation not supported (LP64 eqv: AUTH_GOT_ADD_LO12_NC)
+// ERROR: [[#@LINE-1]]:1: error: ADD AUTH relocation is not supported in ILP32
 
 ldr x24, [x23, :gottprel_lo12:sym]
-// ERROR: [[#@LINE-1]]:1: error: ILP32 64-bit load/store relocation not supported (LP64 eqv: TLSIE_LD64_GOTTPREL_LO12_NC)
+// ERROR: [[#@LINE-1]]:1: error: 64-bit load/store relocation is not supported in ILP32
 
 ldr x10, [x0, #:gottprel_lo12:var]
-// ERROR: [[#@LINE-1]]:1: error: ILP32 64-bit load/store relocation not supported (LP64 eqv: TLSIE_LD64_GOTTPREL_LO12_NC)
+// ERROR: [[#@LINE-1]]:1: error: 64-bit load/store relocation is not supported in ILP32
 // ERROR: ldr x10, [x0, #:gottprel_lo12:var]
 
 ldr x24, [x23, #:got_lo12:sym]
-// ERROR: [[#@LINE-1]]:1: error: ILP32 64-bit load/store relocation not supported (LP64 eqv: LD64_GOT_LO12_NC)
+// ERROR: [[#@LINE-1]]:1: error: 64-bit load/store relocation is not supported in ILP32
 
 ldr x24, [x23, :gottprel_lo12:sym]
-// ERROR: [[#@LINE-1]]:1: error: ILP32 64-bit load/store relocation not supported (LP64 eqv: TLSIE_LD64_GOTTPREL_LO12_NC)
+// ERROR: [[#@LINE-1]]:1: error: 64-bit load/store relocation is not supported in ILP32
 
 ldr x24, :got_auth:sym
-// ERROR: [[#@LINE-1]]:1: error: ILP32 LDR AUTH relocation not supported (LP64 eqv: AUTH_GOT_LD_PREL19)
+// ERROR: [[#@LINE-1]]:1: error: LDR AUTH relocation is not supported in ILP32
 
 adr x24, :got_auth:sym
-// ERROR: [[#@LINE-1]]:1: error: ILP32 ADR AUTH relocation not supported (LP64 eqv: AUTH_GOT_ADR_PREL_LO21)
+// ERROR: [[#@LINE-1]]:1: error: ADR AUTH relocation is not supported in ILP32
 
 adrp x24, :tlsdesc_auth:sym
-// ERROR: [[#@LINE-1]]:1: error: ILP32 ADRP AUTH relocation not supported (LP64 eqv: AUTH_TLSDESC_ADR_PAGE21)
+// ERROR: [[#@LINE-1]]:1: error: ADRP AUTH relocation is not supported in ILP32
 
 ldr x24, [x23, :tlsdesc_auth_lo12:sym]
-// ERROR: [[#@LINE-1]]:1: error: ILP32 64-bit load/store AUTH relocation not supported (LP64 eqv: AUTH_TLSDESC_LD64_LO12)
+// ERROR: [[#@LINE-1]]:1: error: 64-bit load/store AUTH relocation is not supported in ILP32
 
 add x24, x23, :tlsdesc_auth_lo12:sym
-// ERROR: [[#@LINE-1]]:1: error: ILP32 ADD AUTH relocation not supported (LP64 eqv: AUTH_TLSDESC_ADD_LO12)
+// ERROR: [[#@LINE-1]]:1: error: ADD AUTH relocation is not supported in ILP32


### PR DESCRIPTION
"<foo> relocation is not supported in ILP32" is more accurate than
what we have now.

Also, remove "LP64 eqv:" annotations because they create a maintenance
burden and are unlikely to be helpful.
