### PR TITLE
[ItaniumDemangle] Fix libcxxabi OutputBuffer::prepend for empty inputs

### DIFF
--- a/libcxxabi/src/demangle/Utility.h
+++ b/libcxxabi/src/demangle/Utility.h
@@ -136,6 +136,8 @@ public:
 
   OutputBuffer &prepend(std::string_view R) {
     size_t Size = R.size();
+    if (!Size)
+      return *this;
 
     grow(Size);
     std::memmove(Buffer + Size, Buffer, CurrentPosition);


### PR DESCRIPTION
See #138564 for details.