### PR TITLE
[DWARFLinkerParallel] Change more cases of compare_exchange_weak to compare_exchange_strong

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/ArrayList.h
+++ b/llvm/lib/DWARFLinker/Parallel/ArrayList.h
@@ -49,7 +49,7 @@ public:
       if (!CurGroup->Next)
         allocateNewGroup(CurGroup->Next);
 
-      LastGroup.compare_exchange_strong(CurGroup, CurGroup->Next);
+      LastGroup.compare_exchange_weak(CurGroup, CurGroup->Next);
     } while (true);
 
     // Store item into the current group.
@@ -145,7 +145,7 @@ protected:
       ItemsGroup *NextGroup = CurGroup->Next;
 
       if (!NextGroup) {
-        if (CurGroup->Next.compare_exchange_strong(NextGroup, NewGroup))
+        if (CurGroup->Next.compare_exchange_weak(NextGroup, NewGroup))
           break;
       }
 

--- a/llvm/lib/DWARFLinker/Parallel/ArrayList.h
+++ b/llvm/lib/DWARFLinker/Parallel/ArrayList.h
@@ -49,7 +49,7 @@ public:
       if (!CurGroup->Next)
         allocateNewGroup(CurGroup->Next);
 
-      LastGroup.compare_exchange_weak(CurGroup, CurGroup->Next);
+      LastGroup.compare_exchange_strong(CurGroup, CurGroup->Next);
     } while (true);
 
     // Store item into the current group.
@@ -137,7 +137,7 @@ protected:
     NewGroup->Next = nullptr;
 
     // Try to replace current group with allocated one.
-    if (AtomicGroup.compare_exchange_weak(CurGroup, NewGroup))
+    if (AtomicGroup.compare_exchange_strong(CurGroup, NewGroup))
       return true;
 
     // Put allocated group as last group.
@@ -145,7 +145,7 @@ protected:
       ItemsGroup *NextGroup = CurGroup->Next;
 
       if (!NextGroup) {
-        if (CurGroup->Next.compare_exchange_weak(NextGroup, NewGroup))
+        if (CurGroup->Next.compare_exchange_strong(NextGroup, NewGroup))
           break;
       }
 


### PR DESCRIPTION
This is a follow-up to 07bc54bf4554398b199f4dc849e5193b98422f23; this seems to perhaps fix occasional crashes in dsymutil on Windows on aarch64.

While these are used in loops, which could be tolerant to concurrent accesses, the overall logic seems to assume that they don't have spurious failures; I've observed one case in a debugger, where LastGroup == nullptr within the loop in ArrayList::add().

The remaining uses of compare_exchange_weak() in
DWARFLinkerCompileUnit.h also seem very suspicious; if there would be a true concurrent write, leading to compare_exchange_weak() returning false, it seems like we would get stuck in an endless loop - but changing them to compare_exchange_strong() wouldn't make any difference with respect to that.