### PR TITLE
[vectorization] More flexibility for VFxIC

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -516,6 +516,16 @@ public:
   unsigned selectInterleaveCount(VPlan &Plan, ElementCount VF,
                                  InstructionCost LoopCost);
 
+  /// Search in \p ProfitableVFs if the selected \p VF exists.
+  std::optional<VectorizationFactor> getProfitableVF(ElementCount VF) const {
+    if (!hasPlanWithVF(VF))
+      return std::nullopt;
+    for (const auto &P : ProfitableVFs)
+      if (P.Width == VF)
+        return P;
+    return std::nullopt;
+  }
+
   /// Generate the IR code for the vectorized loop captured in VPlan \p BestPlan
   /// according to the best selected \p VF and  \p UF.
   ///


### PR DESCRIPTION
Vectorization factor (VF) and Interleave count (IC) are key to obtain good performance.

As of today, controlling VF and IC can be done:
(1) At compilation unit though compilers, `-mllvm -force-vector-width=8 -mllvm -force-vector-interleave=2`
(2) At loop level though pragmas, `#pragma clang loop vectorize_width(2) interleave_count(2)`

Approach (1) is only used in a "test mode": if VF is not valid it can either crash or fall back to a scalar version.

Approach (2) is effective but can be only deployed at loop level based on user expertise. The exploration of the best combination of (VF x IC) for a given loop is architecture/machine dependent and must be done for every new architecture/machine. Thus, this is both error prone and time consuming. Also, developer only does this fine-tuning for hotspots, leaving room for improvement for other loops.

When applications are flat (e.g., weather forecast code), this approach is no longer viable since no real hotspot exists.

Based on that, we developed (see the just-accepted paper at ISC'25 [^1]) a new technique to ease the automation of testing various (VF x IC) at the compilation unit level. 

Two new compilation flags were proposed:
- `clang -mllvm -change-vectorize-to-custom-IC=X`: that set the custom Interleave Count
- `clang -mllvm -change-vectorize-to-custom-VF=Y`: that set the custom Vectorization Factor

For each loop in the compilation unit, the vectorizer uses these custom factors if vectorization is enabled, custom factors are valid and profitable. As a convention, we established that setting a coefficient to 0 uses the default value chosen by the LoopVectorizer.

This approach supposes that there exist a good (VF x IC) at the application level: this is a reasonable assumption for code that always manipulates same data-type (typical case of HPC applications).

In the paper, experiment has been reported with a subset of LORE [^2] and several mini-apps. This shows both the maturity of the approach and the potential gain with this exhaustive exploration. Table below depicts the potential gain on various benchmarks (with respect to `mcpu-generic-vf0-ic0`):

| Bench               | Neoverse-N1 | Neoverse-V1 | Neoverse-V2 |
| ------------------- | ----------- | ----------- | ----------- |
| LORE[^2]            | -6.17%      | -22.34%     | -15.97%     |
| MiniBUDE[^3]        | -4%         | -18%        | -16%        |
| CloverLeaf[^4]      | -0.4%       | -2%         | -3%         |
| Hydro[^5]           | -128%       | -2%         | -0.1%       |
| LULESH[^6]          | -15%        | -1%         | -5%         |
| Dwarf-p-cloudsc[^7] | -2%         | -11%        | -12%        |

Speed up of this table is computed using formula `speedup = 1 - ref_time/mut_time` with `ref_time` the time of the run `mcpu-generic-vf0-ic0` and `mut_time` the time of the best mutation.

[^1]: https://ieeexplore.ieee.org/document/11018308
[^2]: https://vectorization.computer/
[^3]: https://github.com/UoB-HPC/miniBUDE
[^4]: https://github.com/UK-MAC/CloverLeaf
[^5]: https://github.com/HydroBench/Hydro
[^6]: https://github.com/LLNL/LULESH
[^7]: https://github.com/ecmwf-ifs/dwarf-p-cloudsc