### PR TITLE
FEAT: 1 byte for "true" & "false"

### DIFF
--- a/clang/lib/Headers/stdbool.h
+++ b/clang/lib/Headers/stdbool.h
@@ -22,8 +22,8 @@
  */
 #elif !defined(__cplusplus)
 #define bool _Bool
-#define true 1
-#define false 0
+#define true ((bool)1)
+#define false ((bool)0)
 #elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
 /* Define _Bool as a GNU extension. */
 #define _Bool bool


### PR DESCRIPTION
# In C language,

- the size of "true" and "false" macro is 4 bytes (for x64 arch)

- but the size of "bool" (typedef _Bool) is 1 byte.

- In order to decrease the memory usage, we can set the size of "true" and "false" macros to 1 byte using explicit typecasting in macro definition.