### PR TITLE
[lldb] fix tests with spaces in command path

### DIFF
--- a/llvm/utils/lit/lit/llvm/subst.py
+++ b/llvm/utils/lit/lit/llvm/subst.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shlex
 
 import lit.util
 
@@ -118,6 +119,8 @@ class ToolSubst(object):
             command_str = str(self.command)
 
         if command_str:
+            # A command path with spaces will fail to be parsed by ShParser if they are not quoted.
+            command_str = shlex.quote(command_str)
             if self.extra_args:
                 command_str = " ".join([command_str] + self.extra_args)
         else:


### PR DESCRIPTION
# Summary

LLDB tests will fail with the "command not found" error if there are spaces in the command path.

This PR fixes the issue by quoting the command.

# Description

The path of a command that was substituted in a test file (for instance `lld-link`) may contain spaces. On windows, it will start will `C:\Program Files\...`. This will cause the command to be parsed as `['C:\Program', 'Files\...', ...`.

This causes the tests to fail.

# Fix

During the parsing stage of the test file, we use `shlex.quote` to shell escape the command path. The command is test parsed correctly by `ShUtil.ShParser.parse` and the rest of the flow is executed as expected.