### PR TITLE
[Clang] Ignore -fchar8_t in C

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -317,7 +317,7 @@ Modified Compiler Flags
 
 - The ``-mexecute-only`` and ``-mpure-code`` flags are now accepted for AArch64 targets. (#GH125688)
 
-- The ``-fchar8_t`` flag is no longer consider in non-C++ languages modes. (#GH55373)
+- The ``-fchar8_t`` flag is no longer considered in non-C++ languages modes. (#GH55373)
 
 Removed Compiler Flags
 -------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -317,6 +317,8 @@ Modified Compiler Flags
 
 - The ``-mexecute-only`` and ``-mpure-code`` flags are now accepted for AArch64 targets. (#GH125688)
 
+- The ``-fchar8_t`` flag is no longer consider in non-C++ languages modes. (#GH55373)
+
 Removed Compiler Flags
 -------------------------
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3879,7 +3879,8 @@ defm char8__t : BoolFOption<"char8_t",
   LangOpts<"Char8">, Default<cpp20.KeyPath>,
   PosFlag<SetTrue, [], [ClangOption], "Enable">,
   NegFlag<SetFalse, [], [ClangOption], "Disable">,
-  BothFlags<[], [ClangOption, CC1Option], " C++ builtin type char8_t">>;
+  BothFlags<[], [ClangOption, CC1Option], " C++ builtin type char8_t">>,
+  ShouldParseIf<cplusplus.KeyPath>;
 def fshort_wchar : Flag<["-"], "fshort-wchar">, Group<f_Group>,
   HelpText<"Force wchar_t to be a short unsigned int">;
 def fno_short_wchar : Flag<["-"], "fno-short-wchar">, Group<f_Group>,

--- a/clang/test/Lexer/char8_t.cpp
+++ b/clang/test/Lexer/char8_t.cpp
@@ -5,6 +5,7 @@
 // RUN: %clang_cc1 -std=c++17 -verify %s
 // RUN: %clang_cc1 -std=c++17 -verify %s -fno-char8_t
 // RUN: %clang_cc1 -std=c++20 -verify %s -fno-char8_t
+// RUN: %clang_cc1 -x c -verify %s -fchar8_t
 
 #if defined(__cpp_char8_t) != defined(CHAR8_T)
 #error wrong setting for __cpp_char_t


### PR DESCRIPTION
In C, `char8_t` is an alias to unsigned char, and should never be a keyword.

Fixes #55373