### PR TITLE
[ADT]Add helper function to return a ArrayRef of MapVector's underlying vector

### DIFF
--- a/llvm/include/llvm/ADT/MapVector.h
+++ b/llvm/include/llvm/ADT/MapVector.h
@@ -57,6 +57,9 @@ public:
     return std::move(Vector);
   }
 
+  /// Returns an array reference of the underlying vector.
+  ArrayRef<value_type> getArrayRef() const { return Vector; }
+
   size_type size() const { return Vector.size(); }
 
   /// Grow the MapVector so that it can contain at least \p NumEntries items


### PR DESCRIPTION
SetVector currently has a [similar method](https://github.com/llvm/llvm-project/blob/c956ed06dc1c1b340d0c589c472c438b9220b36d/llvm/include/llvm/ADT/SetVector.h#L90), and https://github.com/llvm/llvm-project/pull/138170 has a use case to get an ArrayRef of MapVector's underlying vector.