### PR TITLE
Fix buildbot failure due to triple normalization issues

### DIFF
--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -674,7 +674,11 @@ class LLVMConfig(object):
                 (
                     "%itanium_abi_triple",
                     self.normalize_triple(
-                        self.make_itanium_abi_triple(self.config.target_triple)
+                        self.make_itanium_abi_triple(
+                            self.get_process_output(
+                                [self.config.clang, "--print-target-triple"]
+                            )[0].split("\n")[0]
+                        )
                     ),
                 )
             )


### PR DESCRIPTION
We have been seeing buildbot failures due to https://github.com/llvm/llvm-project/pull/122629. I posted https://github.com/llvm/llvm-project/pull/135571 to update the triple normalization logic, but that patch hasn't gotten any traction.

So in this patch I am updating the lit config to use triple from clang's output for `%itanium_abi_triple` substitution, instead of relying on `self.config.target_triple` which might not be in a canonical form.

Buildbot failure example: https://lab.llvm.org/buildbot/#/builders/40

Change-Id: Ib9c3425fddac45d7468fad20929fd29358a55e1b