### PR TITLE
[BOLT] Introduce BinaryFunction::canClone()

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1375,6 +1375,11 @@ public:
   /// Return true if the function should not have associated symbol table entry.
   bool isAnonymous() const { return IsAnonymous; }
 
+  /// Return true if we can allow the execution of the original body of the
+  /// function together with its rewritten copy. This means, e.g., that metadata
+  /// associated with the function can be duplicated/cloned.
+  bool canClone() const;
+
   /// If this function was folded, return the function it was folded into.
   BinaryFunction *getFoldedIntoFunction() const { return FoldedIntoFunction; }
 

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -3744,6 +3744,16 @@ void BinaryFunction::postProcessBranches() {
   assert(validateCFG() && "invalid CFG");
 }
 
+bool BinaryFunction::canClone() const {
+  // For instrumentation, we need to restrict the execution to the rewritten
+  // version of the function.
+  if (opts::Instrument)
+    return false;
+
+  // Check for the presence of metadata that cannot be duplicated.
+  return !hasEHRanges() && !hasSDTMarker() && !hasPseudoProbe() && !hasORC();
+}
+
 MCSymbol *BinaryFunction::addEntryPointAtOffset(uint64_t Offset) {
   assert(Offset && "cannot add primary entry point");
   assert(CurrentState == State::Empty || CurrentState == State::Disassembled);

--- a/bolt/lib/Passes/PatchEntries.cpp
+++ b/bolt/lib/Passes/PatchEntries.cpp
@@ -65,7 +65,7 @@ Error PatchEntries::runOnFunctions(BinaryContext &BC) {
       continue;
 
     // Check if we can skip patching the function.
-    if (!opts::ForcePatch && !Function.hasEHRanges() &&
+    if (!opts::ForcePatch && Function.canClone() &&
         Function.getSize() < PatchThreshold)
       continue;
 


### PR DESCRIPTION
In some scenarios, we want to allow execution of the original function code together with its rewritten (optimized) copy. We used to limit such capability when the function uses C++ exceptions, since we cannot duplicate exception tables. There's more metadata that cannot be duplicated, and this PR adds more checks via the introduction of canClone() function that checks all such limitations.