### PR TITLE
[PowerPC] catch v2i64 shift left by 1 is add case

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -18458,16 +18458,17 @@ static SDValue stripModuloOnShift(const TargetLowering &TLI, SDNode *N,
 
 SDValue PPCTargetLowering::combineVectorSHL(SDNode *N,
                                             DAGCombinerInfo &DCI) const {
-  assert(N->getValueType(0).isVector() && "Vector type expected.");
+  EVT VT = N->getValueType(0);
+  assert(VT.isVector() && "Vector type expected.");
 
   SDValue N1 = N->getOperand(1);
   if (!Subtarget.hasP8Altivec() || N1.getOpcode() != ISD::BUILD_VECTOR ||
-      !isOperationLegal(ISD::ADD, N->getValueType(0)))
+      !isOperationLegal(ISD::ADD, VT))
     return SDValue();
 
   // For 64-bit there is no splat immediate so we want to catch shift by 1 here
   // before the BUILD_VECTOR is replaced by a load.
-  EVT EltTy = N->getValueType(0).getScalarType();
+  EVT EltTy = VT.getScalarType();
   if (EltTy != MVT::i64)
     return SDValue();
 
@@ -18484,8 +18485,8 @@ SDValue PPCTargetLowering::combineVectorSHL(SDNode *N,
   if (SplatBits != 1)
     return SDValue();
 
-  return DCI.DAG.getNode(ISD::ADD, SDLoc(N), N->getValueType(0),
-                         N->getOperand(0), N->getOperand(0));
+  SDValue N0 = N->getOperand(0);
+  return DCI.DAG.getNode(ISD::ADD, SDLoc(N), VT, N0, N0);
 }
 
 SDValue PPCTargetLowering::combineSHL(SDNode *N, DAGCombinerInfo &DCI) const {

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.h
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.h
@@ -1441,6 +1441,7 @@ namespace llvm {
     SDValue combineStoreFPToInt(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineFPToIntToFP(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineSHL(SDNode *N, DAGCombinerInfo &DCI) const;
+    SDValue combineVectorSHL(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineSRA(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineSRL(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineMUL(SDNode *N, DAGCombinerInfo &DCI) const;

--- a/llvm/test/CodeGen/PowerPC/optimize-vector.ll
+++ b/llvm/test/CodeGen/PowerPC/optimize-vector.ll
@@ -36,10 +36,7 @@ entry:
 define dso_local <2 x i64> @x2d(<2 x i64> noundef %x) {
 ; CHECK-LABEL: x2d:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addis r3, r2, .LCPI3_0@toc@ha
-; CHECK-NEXT:    addi r3, r3, .LCPI3_0@toc@l
-; CHECK-NEXT:    lxvd2x v3, 0, r3
-; CHECK-NEXT:    vsld v2, v2, v3
+; CHECK-NEXT:    vaddudm v2, v2, v2
 ; CHECK-NEXT:    blr
 entry:
   %add = shl <2 x i64> %x, <i64 1, i64 1>

--- a/llvm/test/CodeGen/PowerPC/pr47891.ll
+++ b/llvm/test/CodeGen/PowerPC/pr47891.ll
@@ -7,26 +7,17 @@
 define dso_local void @poly2_lshift1(ptr nocapture %p) local_unnamed_addr #0 {
 ; CHECK-LABEL: poly2_lshift1:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    li r4, 72
-; CHECK-NEXT:    addis r6, r2, .LCPI0_1@toc@ha
-; CHECK-NEXT:    ld r5, 64(r3)
-; CHECK-NEXT:    lxvd2x vs0, r3, r4
-; CHECK-NEXT:    addi r6, r6, .LCPI0_1@toc@l
-; CHECK-NEXT:    lxvd2x v4, 0, r6
 ; CHECK-NEXT:    addis r6, r2, .LCPI0_0@toc@ha
+; CHECK-NEXT:    li r4, 72
+; CHECK-NEXT:    ld r5, 64(r3)
 ; CHECK-NEXT:    addi r6, r6, .LCPI0_0@toc@l
-; CHECK-NEXT:    xxswapd v2, vs0
-; CHECK-NEXT:    mtfprd f0, r5
-; CHECK-NEXT:    xxpermdi v3, v2, vs0, 2
-; CHECK-NEXT:    vsld v2, v2, v4
+; CHECK-NEXT:    lxvd2x vs0, r3, r4
 ; CHECK-NEXT:    lxvd2x v4, 0, r6
 ; CHECK-NEXT:    ld r6, 0(r3)
 ; CHECK-NEXT:    sldi r7, r6, 1
 ; CHECK-NEXT:    rotldi r6, r6, 1
 ; CHECK-NEXT:    std r7, 0(r3)
 ; CHECK-NEXT:    ld r7, 8(r3)
-; CHECK-NEXT:    vsrd v3, v3, v4
-; CHECK-NEXT:    xxlor vs0, v2, v3
 ; CHECK-NEXT:    rldimi r6, r7, 1, 0
 ; CHECK-NEXT:    rotldi r7, r7, 1
 ; CHECK-NEXT:    std r6, 8(r3)
@@ -44,6 +35,8 @@ define dso_local void @poly2_lshift1(ptr nocapture %p) local_unnamed_addr #0 {
 ; CHECK-NEXT:    std r7, 32(r3)
 ; CHECK-NEXT:    ld r7, 40(r3)
 ; CHECK-NEXT:    rldimi r6, r7, 1, 0
+; CHECK-NEXT:    xxswapd v2, vs0
+; CHECK-NEXT:    mtfprd f0, r5
 ; CHECK-NEXT:    rotldi r7, r7, 1
 ; CHECK-NEXT:    std r6, 40(r3)
 ; CHECK-NEXT:    ld r6, 48(r3)
@@ -54,10 +47,14 @@ define dso_local void @poly2_lshift1(ptr nocapture %p) local_unnamed_addr #0 {
 ; CHECK-NEXT:    rldimi r6, r7, 1, 0
 ; CHECK-NEXT:    std r6, 56(r3)
 ; CHECK-NEXT:    rotldi r6, r7, 1
-; CHECK-NEXT:    xxswapd vs0, vs0
-; CHECK-NEXT:    stxvd2x vs0, r3, r4
 ; CHECK-NEXT:    rldimi r6, r5, 1, 0
 ; CHECK-NEXT:    std r6, 64(r3)
+; CHECK-NEXT:    xxpermdi v3, v2, vs0, 2
+; CHECK-NEXT:    vsrd v3, v3, v4
+; CHECK-NEXT:    vaddudm v2, v2, v2
+; CHECK-NEXT:    xxlor vs0, v2, v3
+; CHECK-NEXT:    xxswapd vs0, vs0
+; CHECK-NEXT:    stxvd2x vs0, r3, r4
 ; CHECK-NEXT:    blr
 entry:
   %0 = load i64, ptr %p, align 8


### PR DESCRIPTION
For vector element sizes i8 - i32 the PPC BE catches the case of x << 1 at selection and generates x + x. This patch gets the v2i64 case.