### PR TITLE
[lld][WebAssembly] Fix reported names of LTO output files

### DIFF
--- a/lld/test/wasm/lto/signature-mismatch.ll
+++ b/lld/test/wasm/lto/signature-mismatch.ll
@@ -17,4 +17,4 @@ define void @_start() {
 
 ; CHECK: error: function signature mismatch: f
 ; CHECK: >>> defined as (i32) -> void in {{.*}}signature-mismatch.ll.tmp1.o
-; CHECK: >>> defined as () -> void in lto.tmp
+; CHECK: >>> defined as () -> void in {{.*}}signature-mismatch.ll.tmp.wasm.lto.o

--- a/lld/wasm/LTO.cpp
+++ b/lld/wasm/LTO.cpp
@@ -183,10 +183,11 @@ static void thinLTOCreateEmptyIndexFiles() {
 
 // Merge all the bitcode files we have seen, codegen the result
 // and return the resulting objects.
-std::vector<StringRef> BitcodeCompiler::compile() {
+SmallVector<InputFile *, 0> BitcodeCompiler::compile() {
   unsigned maxTasks = ltoObj->getMaxTasks();
   buf.resize(maxTasks);
   files.resize(maxTasks);
+  filenames.resize(maxTasks);
 
   // The --thinlto-cache-dir option specifies the path to a directory in which
   // to cache native object files for ThinLTO incremental builds. If a path was
@@ -233,14 +234,20 @@ std::vector<StringRef> BitcodeCompiler::compile() {
   if (!ctx.arg.thinLTOCacheDir.empty())
     pruneCache(ctx.arg.thinLTOCacheDir, ctx.arg.thinLTOCachePolicy, files);
 
-  std::vector<StringRef> ret;
+  SmallVector<InputFile *, 0> ret;
   for (unsigned i = 0; i != maxTasks; ++i) {
     StringRef objBuf = buf[i].second;
     StringRef bitcodeFilePath = buf[i].first;
+    if (files[i]) {
+      // When files[i] is not null, we get the native relocatable file from the
+      // cache. filenames[i] contains the original BitcodeFile's identifier.
+      objBuf = files[i]->getBuffer();
+      bitcodeFilePath = filenames[i];
+    } else {
+      objBuf = buf[i].second;
+      bitcodeFilePath = buf[i].first;
+    }
     if (objBuf.empty())
-      continue;
-    ret.emplace_back(objBuf.data(), objBuf.size());
-    if (!ctx.arg.saveTemps)
       continue;
 
     // If the input bitcode file is path/to/x.o and -o specifies a.out, the
@@ -266,7 +273,9 @@ std::vector<StringRef> BitcodeCompiler::compile() {
       sys::path::remove_dots(path, true);
       ltoObjName = saver().save(path.str());
     }
-    saveBuffer(objBuf, ltoObjName);
+    if (ctx.arg.saveTemps)
+      saveBuffer(objBuf, ltoObjName);
+    ret.emplace_back(createObjectFile(MemoryBufferRef(objBuf, ltoObjName)));
   }
 
   if (!ctx.arg.ltoObjPath.empty()) {
@@ -274,10 +283,6 @@ std::vector<StringRef> BitcodeCompiler::compile() {
     for (unsigned i = 1; i != maxTasks; ++i)
       saveBuffer(buf[i].second, ctx.arg.ltoObjPath + Twine(i));
   }
-
-  for (std::unique_ptr<MemoryBuffer> &file : files)
-    if (file)
-      ret.push_back(file->getBuffer());
 
   return ret;
 }

--- a/lld/wasm/LTO.h
+++ b/lld/wasm/LTO.h
@@ -45,13 +45,14 @@ public:
   ~BitcodeCompiler();
 
   void add(BitcodeFile &f);
-  std::vector<StringRef> compile();
+  SmallVector<InputFile *, 0> compile();
 
 private:
   std::unique_ptr<llvm::lto::LTO> ltoObj;
   // An array of (module name, native relocatable file content) pairs.
   SmallVector<std::pair<std::string, SmallString<0>>, 0> buf;
   std::vector<std::unique_ptr<MemoryBuffer>> files;
+  SmallVector<std::string, 0> filenames;
   std::unique_ptr<llvm::raw_fd_ostream> indexFile;
   llvm::DenseSet<StringRef> thinIndices;
 };

--- a/lld/wasm/SymbolTable.cpp
+++ b/lld/wasm/SymbolTable.cpp
@@ -87,8 +87,8 @@ void SymbolTable::compileBitcodeFiles() {
   for (BitcodeFile *f : ctx.bitcodeFiles)
     lto->add(*f);
 
-  for (StringRef filename : lto->compile()) {
-    auto *obj = make<ObjFile>(MemoryBufferRef(filename, "lto.tmp"), "");
+  for (auto &file : lto->compile()) {
+    auto *obj = cast<ObjFile>(file);
     obj->parse(true);
     ctx.objectFiles.push_back(obj);
   }


### PR DESCRIPTION
This change was made in the ELF linker in #78835 but somehow never made it over the wasm port.