### PR TITLE
[HIP][HIPSTDPAR] Re-work allocation interposition for `hipstdpar`

### DIFF
--- a/clang/docs/HIPSupport.rst
+++ b/clang/docs/HIPSupport.rst
@@ -518,7 +518,7 @@ Predefined Macros
    * - ``__HIPSTDPAR__``
      - Defined when Clang is compiling code in algorithm offload mode, enabled
        with the ``--hipstdpar`` compiler option.
-   * - ``__HIPSTDPAR_INTERPOSE_ALLOC__``
+   * - ``__HIPSTDPAR_INTERPOSE_ALLOC__`` / ``__HIPSTDPAR_INTERPOSE_ALLOC_V1__``
      - Defined only when compiling in algorithm offload mode, when the user
        enables interposition mode with the ``--hipstdpar-interpose-alloc``
        compiler option, indicating that all dynamic memory allocation /

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -618,8 +618,10 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
     Builder.defineMacro("__HIP_MEMORY_SCOPE_SYSTEM", "5");
     if (LangOpts.HIPStdPar) {
       Builder.defineMacro("__HIPSTDPAR__");
-      if (LangOpts.HIPStdParInterposeAlloc)
+      if (LangOpts.HIPStdParInterposeAlloc) {
         Builder.defineMacro("__HIPSTDPAR_INTERPOSE_ALLOC__");
+        Builder.defineMacro("__HIPSTDPAR_INTERPOSE_ALLOC_V1__");
+      }
     }
     if (LangOpts.CUDAIsDevice) {
       Builder.defineMacro("__HIP_DEVICE_COMPILE__");

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -304,11 +304,13 @@
 // RUN: %clang_cc1 %s -E -dM -o - -x hip --hipstdpar -triple x86_64-unknown-linux-gnu \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-HIPSTDPAR
 // CHECK-HIPSTDPAR: #define __HIPSTDPAR__ 1
+// CHECK-HIPSTDPAR-NOT: #define __HIPSTDPAR_INTERPOSE_ALLOC_V1__ 1
 // CHECK-HIPSTDPAR-NOT: #define __HIPSTDPAR_INTERPOSE_ALLOC__ 1
 
 // RUN: %clang_cc1 %s -E -dM -o - -x hip --hipstdpar --hipstdpar-interpose-alloc \
 // RUN:  -triple x86_64-unknown-linux-gnu | FileCheck -match-full-lines %s \
 // RUN:  --check-prefix=CHECK-HIPSTDPAR-INTERPOSE
+// CHECK-HIPSTDPAR-INTERPOSE: #define __HIPSTDPAR_INTERPOSE_ALLOC_V1__ 1
 // CHECK-HIPSTDPAR-INTERPOSE: #define __HIPSTDPAR_INTERPOSE_ALLOC__ 1
 // CHECK-HIPSTDPAR-INTERPOSE: #define __HIPSTDPAR__ 1
 
@@ -316,4 +318,5 @@
 // RUN:  -triple amdgcn-amd-amdhsa -fcuda-is-device | FileCheck -match-full-lines \
 // RUN:  %s --check-prefix=CHECK-HIPSTDPAR-INTERPOSE-DEV-NEG
 // CHECK-HIPSTDPAR-INTERPOSE-DEV-NEG: #define __HIPSTDPAR__ 1
+// CHECK-HIPSTDPAR-INTERPOSE-DEV-NEG-NOT: #define __HIPSTDPAR_INTERPOSE_ALLOC_V1__ 1
 // CHECK-HIPSTDPAR-INTERPOSE-DEV-NEG-NOT: #define __HIPSTDPAR_INTERPOSE_ALLOC__ 1

--- a/llvm/lib/Transforms/HipStdPar/HipStdPar.cpp
+++ b/llvm/lib/Transforms/HipStdPar/HipStdPar.cpp
@@ -231,57 +231,55 @@ PreservedAnalyses
 }
 
 static constexpr std::pair<StringLiteral, StringLiteral> ReplaceMap[]{
-  {"aligned_alloc",             "__hipstdpar_aligned_alloc"},
-  {"calloc",                    "__hipstdpar_calloc"},
-  {"free",                      "__hipstdpar_free"},
-  {"malloc",                    "__hipstdpar_malloc"},
-  {"memalign",                  "__hipstdpar_aligned_alloc"},
-  {"mmap",                      "__hipstdpar_mmap"},
-  {"munmap",                    "__hipstdpar_munmap"},
-  {"posix_memalign",            "__hipstdpar_posix_aligned_alloc"},
-  {"realloc",                   "__hipstdpar_realloc"},
-  {"reallocarray",              "__hipstdpar_realloc_array"},
-  {"_ZdaPv",                    "__hipstdpar_operator_delete"},
-  {"_ZdaPvm",                   "__hipstdpar_operator_delete_sized"},
-  {"_ZdaPvSt11align_val_t",     "__hipstdpar_operator_delete_aligned"},
-  {"_ZdaPvmSt11align_val_t",    "__hipstdpar_operator_delete_aligned_sized"},
-  {"_ZdlPv",                    "__hipstdpar_operator_delete"},
-  {"_ZdlPvm",                   "__hipstdpar_operator_delete_sized"},
-  {"_ZdlPvSt11align_val_t",     "__hipstdpar_operator_delete_aligned"},
-  {"_ZdlPvmSt11align_val_t",    "__hipstdpar_operator_delete_aligned_sized"},
-  {"_Znam",                     "__hipstdpar_operator_new"},
-  {"_ZnamRKSt9nothrow_t",       "__hipstdpar_operator_new_nothrow"},
-  {"_ZnamSt11align_val_t",      "__hipstdpar_operator_new_aligned"},
-  {"_ZnamSt11align_val_tRKSt9nothrow_t",
-                                "__hipstdpar_operator_new_aligned_nothrow"},
+    {"aligned_alloc", "__hipstdpar_aligned_alloc"},
+    {"calloc", "__hipstdpar_calloc"},
+    {"free", "__hipstdpar_free"},
+    {"malloc", "__hipstdpar_malloc"},
+    {"memalign", "__hipstdpar_aligned_alloc"},
+    {"mmap", "__hipstdpar_mmap"},
+    {"munmap", "__hipstdpar_munmap"},
+    {"posix_memalign", "__hipstdpar_posix_aligned_alloc"},
+    {"realloc", "__hipstdpar_realloc"},
+    {"reallocarray", "__hipstdpar_realloc_array"},
+    {"_ZdaPv", "__hipstdpar_operator_delete"},
+    {"_ZdaPvm", "__hipstdpar_operator_delete_sized"},
+    {"_ZdaPvSt11align_val_t", "__hipstdpar_operator_delete_aligned"},
+    {"_ZdaPvmSt11align_val_t", "__hipstdpar_operator_delete_aligned_sized"},
+    {"_ZdlPv", "__hipstdpar_operator_delete"},
+    {"_ZdlPvm", "__hipstdpar_operator_delete_sized"},
+    {"_ZdlPvSt11align_val_t", "__hipstdpar_operator_delete_aligned"},
+    {"_ZdlPvmSt11align_val_t", "__hipstdpar_operator_delete_aligned_sized"},
+    {"_Znam", "__hipstdpar_operator_new"},
+    {"_ZnamRKSt9nothrow_t", "__hipstdpar_operator_new_nothrow"},
+    {"_ZnamSt11align_val_t", "__hipstdpar_operator_new_aligned"},
+    {"_ZnamSt11align_val_tRKSt9nothrow_t",
+     "__hipstdpar_operator_new_aligned_nothrow"},
 
-  {"_Znwm",                     "__hipstdpar_operator_new"},
-  {"_ZnwmRKSt9nothrow_t",       "__hipstdpar_operator_new_nothrow"},
-  {"_ZnwmSt11align_val_t",      "__hipstdpar_operator_new_aligned"},
-  {"_ZnwmSt11align_val_tRKSt9nothrow_t",
-                                "__hipstdpar_operator_new_aligned_nothrow"},
-  {"__builtin_calloc",          "__hipstdpar_calloc"},
-  {"__builtin_free",            "__hipstdpar_free"},
-  {"__builtin_malloc",          "__hipstdpar_malloc"},
-  {"__builtin_operator_delete", "__hipstdpar_operator_delete"},
-  {"__builtin_operator_new",    "__hipstdpar_operator_new"},
-  {"__builtin_realloc",         "__hipstdpar_realloc"},
-  {"__libc_calloc",             "__hipstdpar_calloc"},
-  {"__libc_free",               "__hipstdpar_free"},
-  {"__libc_malloc",             "__hipstdpar_malloc"},
-  {"__libc_memalign",           "__hipstdpar_aligned_alloc"},
-  {"__libc_realloc",            "__hipstdpar_realloc"}
-};
+    {"_Znwm", "__hipstdpar_operator_new"},
+    {"_ZnwmRKSt9nothrow_t", "__hipstdpar_operator_new_nothrow"},
+    {"_ZnwmSt11align_val_t", "__hipstdpar_operator_new_aligned"},
+    {"_ZnwmSt11align_val_tRKSt9nothrow_t",
+     "__hipstdpar_operator_new_aligned_nothrow"},
+    {"__builtin_calloc", "__hipstdpar_calloc"},
+    {"__builtin_free", "__hipstdpar_free"},
+    {"__builtin_malloc", "__hipstdpar_malloc"},
+    {"__builtin_operator_delete", "__hipstdpar_operator_delete"},
+    {"__builtin_operator_new", "__hipstdpar_operator_new"},
+    {"__builtin_realloc", "__hipstdpar_realloc"},
+    {"__libc_calloc", "__hipstdpar_calloc"},
+    {"__libc_free", "__hipstdpar_free"},
+    {"__libc_malloc", "__hipstdpar_malloc"},
+    {"__libc_memalign", "__hipstdpar_aligned_alloc"},
+    {"__libc_realloc", "__hipstdpar_realloc"}};
 
 static constexpr std::pair<StringLiteral, StringLiteral> HiddenMap[]{
-  // hidden_malloc and hidden_free are only kept for backwards compatibility /
-  // legacy purposes, and we should remove them in the future
-  {"__hipstdpar_hidden_malloc",   "__libc_malloc"},
-  {"__hipstdpar_hidden_free",     "__libc_free"},
-  {"__hipstdpar_hidden_memalign", "__libc_memalign"},
-  {"__hipstdpar_hidden_mmap",     "mmap"},
-  {"__hipstdpar_hidden_munmap",   "munmap"}
-};
+    // hidden_malloc and hidden_free are only kept for backwards compatibility /
+    // legacy purposes, and we should remove them in the future
+    {"__hipstdpar_hidden_malloc", "__libc_malloc"},
+    {"__hipstdpar_hidden_free", "__libc_free"},
+    {"__hipstdpar_hidden_memalign", "__libc_memalign"},
+    {"__hipstdpar_hidden_mmap", "mmap"},
+    {"__hipstdpar_hidden_munmap", "munmap"}};
 
 PreservedAnalyses
 HipStdParAllocationInterpositionPass::run(Module &M, ModuleAnalysisManager&) {


### PR DESCRIPTION
The allocation interposition mode had a number of issues, which are primarily addressed in the library component via <https://github.com/ROCm/rocThrust/pull/543>. However, it is necessary to interpose some additional symbols, which this patch does. Furthermore, to implement this in a compatible way, we guard the new implementation under a V1 macro, which is defined in addition to the existing `__HIPSTDPAR_INTERPOSE_ALLOC__` one.