### PR TITLE
[flang] fix Werror=dangling-reference

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -421,7 +421,8 @@ static void CheckSubscripts(
 
 static void CheckSubscripts(
     semantics::SemanticsContext &context, CoarrayRef &ref) {
-  const Symbol &coarraySymbol{ref.GetBase().GetLastSymbol()};
+  const auto &base = ref.GetBase();
+  const Symbol &coarraySymbol{base.GetLastSymbol()};
   Shape lb, ub;
   if (FoldSubscripts(context, coarraySymbol, ref.subscript(), lb, ub)) {
     ValidateSubscripts(context, coarraySymbol, ref.subscript(), lb, ub);

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -421,7 +421,7 @@ static void CheckSubscripts(
 
 static void CheckSubscripts(
     semantics::SemanticsContext &context, CoarrayRef &ref) {
-  const auto &base = ref.GetBase();
+  const auto &base{ref.GetBase()};
   const Symbol &coarraySymbol{base.GetLastSymbol()};
   Shape lb, ub;
   if (FoldSubscripts(context, coarraySymbol, ref.subscript(), lb, ub)) {


### PR DESCRIPTION
when compiling with g++ 13.3.0 flang build on arm64-linux ubuntu 24.04 machine fails with:

llvm-project/flang/lib/Semantics/expression.cpp:424:17: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
424 |   const Symbol &coarraySymbol{ref.GetBase().GetLastSymbol()};
    |                 ^~~~~~~~~~~~~
llvm-project/flang/lib/Semantics/expression.cpp:424:58: note: the temporary was destroyed at the end of the full expression ‘Fortran::evaluate::CoarrayRef::GetBase() const().Fortran::evaluate::NamedEntity::GetLastSymbol()’
424 |   const Symbol &coarraySymbol{ref.GetBase().GetLastSymbol()};
    |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~

Keep the base in a temporary variable to make sure it is not deleted.