### PR TITLE
llvm-jitlink: Fix bug in target address computation.

### DIFF
--- a/llvm/tools/llvm-jitlink/llvm-jitlink-elf.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-elf.cpp
@@ -194,7 +194,8 @@ Error registerELFGraphInfo(Session &S, LinkGraph &G) {
     else
       FileInfo.SectionInfos[Sec.getName()] = {
           ArrayRef<char>(FirstSym->getBlock().getContent().data(), SecSize),
-          (SecAddr - FirstSym->getOffset()).getValue(), FirstSym->getTargetFlags()};
+          (SecAddr - FirstSym->getOffset()).getValue(),
+          FirstSym->getTargetFlags()};
   }
 
   return Error::success();


### PR DESCRIPTION
llvm-jitlink has a bug revealed by my followup change where the
RuntimeDyldChecker::MemoryRegionInfo::TargetAddress field was
incorrectly being set to the address of the first symbol in the
section instead of the address of the section, which caused the
ExecutionEngine/JITLink/x86-64/ELF_small_pic_relocations.s test to
fail, so fix that for ELF. It looks like the same bug could exist for
the other object formats (but maybe not for Mach-O because of the atom
model?) but I'm not familiar with the JIT linker so I left them as is.

This change will be tested implicitly when my followup change lands.
