### PR TITLE
[flang] Propagate contiguous attribute through HLFIR.

### DIFF
--- a/flang/include/flang/Optimizer/Builder/HLFIRTools.h
+++ b/flang/include/flang/Optimizer/Builder/HLFIRTools.h
@@ -17,6 +17,7 @@
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FortranVariableInterface.h"
 #include "flang/Optimizer/HLFIR/HLFIRDialect.h"
+#include "flang/Optimizer/HLFIR/HLFIROps.h"
 #include <optional>
 
 namespace fir {
@@ -533,6 +534,12 @@ Entity gen1DSection(mlir::Location loc, fir::FirOpBuilder &builder,
                     mlir::ArrayRef<mlir::Value> extents,
                     mlir::ValueRange oneBasedIndices,
                     mlir::ArrayRef<mlir::Value> typeParams);
+
+/// Return true iff the given hlfir.designate produces
+/// a contiguous part of the memref object given that it is
+/// contiguous.
+bool designatePreservesContinuity(hlfir::DesignateOp op);
+
 } // namespace hlfir
 
 #endif // FORTRAN_OPTIMIZER_BUILDER_HLFIRTOOLS_H

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -221,6 +221,13 @@ inline bool hasBindcAttr(mlir::Operation *op) {
   return hasProcedureAttr<fir::FortranProcedureFlagsEnum::bind_c>(op);
 }
 
+/// Return true, if \p rebox operation keeps the input array
+/// continuous if it is initially continuous.
+/// When \p checkWhole is false, then the checking is only done
+/// for continuity in the innermost dimension, otherwise,
+/// the checking is done for continuity of the whole result of rebox.
+bool reboxPreservesContinuity(fir::ReboxOp rebox, bool checkWhole = true);
+
 } // namespace fir
 
 #endif // FORTRAN_OPTIMIZER_DIALECT_FIROPSSUPPORT_H

--- a/flang/include/flang/Optimizer/Dialect/FortranVariableInterface.td
+++ b/flang/include/flang/Optimizer/Dialect/FortranVariableInterface.td
@@ -22,51 +22,57 @@ def fir_FortranVariableOpInterface : OpInterface<"FortranVariableOpInterface"> {
     query about all their Fortran properties.
   }];
 
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/"Get the address produced by the definition",
-      /*retTy=*/"mlir::Value",
-      /*methodName=*/"getBase",
-      /*args=*/(ins),
-      /*methodBody=*/[{}],
-      /*defaultImplementation=*/[{
+  let methods =
+      [InterfaceMethod<
+           /*desc=*/"Get the address produced by the definition",
+           /*retTy=*/"mlir::Value",
+           /*methodName=*/"getBase",
+           /*args=*/(ins),
+           /*methodBody=*/[{}],
+           /*defaultImplementation=*/[{
         ConcreteOp op = mlir::cast<ConcreteOp>(this->getOperation());
         return op.getResult();
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Get Fortran attributes",
-      /*retTy=*/"std::optional<fir::FortranVariableFlagsEnum>",
-      /*methodName=*/"getFortranAttrs",
-      /*args=*/(ins),
-      /*methodBody=*/[{}],
-      /*defaultImplementation=*/[{
+      }]>,
+       InterfaceMethod<
+           /*desc=*/"Get Fortran attributes",
+           /*retTy=*/"std::optional<fir::FortranVariableFlagsEnum>",
+           /*methodName=*/"getFortranAttrs",
+           /*args=*/(ins),
+           /*methodBody=*/[{}],
+           /*defaultImplementation=*/[{
         ConcreteOp op = mlir::cast<ConcreteOp>(this->getOperation());
         return op.getFortran_attrs();
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Get the shape of the variable. May be a null value.",
-      /*retTy=*/"mlir::Value",
-      /*methodName=*/"getShape",
-      /*args=*/(ins),
-      /*methodBody=*/[{}],
-      /*defaultImplementation=*/[{
+      }]>,
+       InterfaceMethod<
+           /*desc=*/"Get the shape of the variable. May be a null value.",
+           /*retTy=*/"mlir::Value",
+           /*methodName=*/"getShape",
+           /*args=*/(ins),
+           /*methodBody=*/[{}],
+           /*defaultImplementation=*/[{
         ConcreteOp op = mlir::cast<ConcreteOp>(this->getOperation());
         return op.getShape();
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Get explicit type parameters of the variable",
-      /*retTy=*/"mlir::OperandRange",
-      /*methodName=*/"getExplicitTypeParams",
-      /*args=*/(ins),
-      /*methodBody=*/[{}],
-      /*defaultImplementation=*/[{
+      }]>,
+       InterfaceMethod<
+           /*desc=*/"Get explicit type parameters of the variable",
+           /*retTy=*/"mlir::OperandRange",
+           /*methodName=*/"getExplicitTypeParams",
+           /*args=*/(ins),
+           /*methodBody=*/[{}],
+           /*defaultImplementation=*/[{
         ConcreteOp op = mlir::cast<ConcreteOp>(this->getOperation());
         return op.getTypeparams();
-      }]
-    >,
+      }]>,
+       InterfaceMethod<
+           /*desc=*/"Set Fortran attributes",
+           /*retTy=*/"void",
+           /*methodName=*/"setFortranAttrs",
+           /*args=*/(ins "fir::FortranVariableFlagsEnum":$flags),
+           /*methodBody=*/[{}],
+           /*defaultImplementation=*/[{
+        ConcreteOp op = mlir::cast<ConcreteOp>(this->getOperation());
+        op.setFortran_attrs(fir::FortranVariableFlagsAttr::get(op->getContext(), flags));
+      }]>,
   ];
 
   let extraClassDeclaration = [{

--- a/flang/include/flang/Optimizer/HLFIR/HLFIROps.td
+++ b/flang/include/flang/Optimizer/HLFIR/HLFIROps.td
@@ -313,6 +313,7 @@ def hlfir_ParentComponentOp : hlfir_Op<"parent_comp", [AttrSizedOperandSegments,
     std::optional<fir::FortranVariableFlagsEnum> getFortranAttrs() const {
       return std::nullopt;
     }
+    void setFortranAttrs(fir::FortranVariableFlagsEnum flags) {}
   }];
 
   let results = (outs AnyFortranVariable);
@@ -1078,6 +1079,7 @@ def hlfir_NullOp : hlfir_Op<"null", [NoMemoryEffect, fir_FortranVariableOpInterf
     std::optional<fir::FortranVariableFlagsEnum> getFortranAttrs() const {
       return std::nullopt;
     }
+    void setFortranAttrs(fir::FortranVariableFlagsEnum flags) {}
     mlir::Value getShape() const {return mlir::Value{};}
     mlir::OperandRange getExplicitTypeParams() const {
       // Return an empty range.
@@ -1766,6 +1768,7 @@ def hlfir_ForallIndexOp : hlfir_Op<"forall_index", [fir_FortranVariableOpInterfa
     std::optional<fir::FortranVariableFlagsEnum> getFortranAttrs() const {
       return std::nullopt;
     }
+    void setFortranAttrs(fir::FortranVariableFlagsEnum flags) {}
     mlir::Value getShape() const {return mlir::Value{};}
     mlir::OperandRange getExplicitTypeParams() const {
       // Return an empty range.

--- a/flang/include/flang/Optimizer/HLFIR/Passes.td
+++ b/flang/include/flang/Optimizer/HLFIR/Passes.td
@@ -69,4 +69,8 @@ def InlineHLFIRAssign : Pass<"inline-hlfir-assign"> {
   let summary = "Inline hlfir.assign operations";
 }
 
+def PropagateFortranVariableAttributes : Pass<"propagate-fortran-attrs"> {
+  let summary = "Propagate FortranVariableFlagsAttr attributes through HLFIR";
+}
+
 #endif //FORTRAN_DIALECT_HLFIR_PASSES

--- a/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_flang_library(HLFIRTransforms
   ScheduleOrderedAssignments.cpp
   SimplifyHLFIRIntrinsics.cpp
   OptimizedBufferization.cpp
+  PropagateFortranVariableAttributes.cpp
 
   DEPENDS
   CUFAttrsIncGen

--- a/flang/lib/Optimizer/HLFIR/Transforms/PropagateFortranVariableAttributes.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/PropagateFortranVariableAttributes.cpp
@@ -1,0 +1,123 @@
+//===- PropagateFortranVariableAttributes.cpp -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file defines a pass that propagates FortranVariableFlagsAttr
+/// attributes through HLFIR. For example, it can set contiguous attribute
+/// on hlfir.designate that produces a contiguous slice of a contiguous
+/// Fortran array. This pass can be applied multiple times to expose
+/// more Fortran attributes, e.g. after inlining and constant propagation.
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/HLFIRTools.h"
+#include "flang/Optimizer/Dialect/FIROpsSupport.h"
+#include "flang/Optimizer/HLFIR/HLFIRDialect.h"
+#include "flang/Optimizer/HLFIR/HLFIROps.h"
+#include "flang/Optimizer/HLFIR/Passes.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace hlfir {
+#define GEN_PASS_DEF_PROPAGATEFORTRANVARIABLEATTRIBUTES
+#include "flang/Optimizer/HLFIR/Passes.h.inc"
+} // namespace hlfir
+
+#define DEBUG_TYPE "propagate-fortran-attrs"
+
+namespace {
+class PropagateFortranVariableAttributes
+    : public hlfir::impl::PropagateFortranVariableAttributesBase<
+          PropagateFortranVariableAttributes> {
+public:
+  using PropagateFortranVariableAttributesBase<
+      PropagateFortranVariableAttributes>::
+      PropagateFortranVariableAttributesBase;
+  void runOnOperation() override;
+};
+
+class Propagator {
+public:
+  Propagator() {}
+
+  void process(mlir::Operation *op);
+
+private:
+  static bool isContiguous(mlir::Operation *op) {
+    if (mlir::isa<fir::AllocaOp, fir::AllocMemOp>(op))
+      return true;
+    auto varOp = mlir::dyn_cast<fir::FortranVariableOpInterface>(op);
+    if (!varOp)
+      return false;
+    return hlfir::Entity{varOp}.isSimplyContiguous();
+  }
+
+  static void setContiguousAttr(fir::FortranVariableOpInterface op);
+};
+} // namespace
+
+void Propagator::setContiguousAttr(fir::FortranVariableOpInterface op) {
+  LLVM_DEBUG(llvm::dbgs() << "Setting continuity for:\n" << op << "\n");
+  fir::FortranVariableFlagsEnum attrs =
+      op.getFortranAttrs().value_or(fir::FortranVariableFlagsEnum::None);
+  attrs = attrs | fir::FortranVariableFlagsEnum::contiguous;
+  op.setFortranAttrs(attrs);
+}
+
+void Propagator::process(mlir::Operation *op) {
+  if (!isContiguous(op))
+    return;
+  llvm::SmallVector<mlir::Operation *> workList{op};
+  while (!workList.empty()) {
+    mlir::Operation *current = workList.pop_back_val();
+    LLVM_DEBUG(llvm::dbgs() << "Propagating continuity from operation:\n"
+                            << *current << "\n");
+
+    for (mlir::OpOperand &use : current->getUses()) {
+      mlir::Operation *useOp = use.getOwner();
+      if (auto varOp = mlir::dyn_cast<fir::FortranVariableOpInterface>(useOp)) {
+        // If the user is not currently contiguous, set the contiguous
+        // attribute and skip it. The propagation will pick it up later.
+        mlir::Value memref;
+        mlir::TypeSwitch<mlir::Operation *, void>(useOp)
+            .Case<hlfir::DeclareOp, hlfir::DesignateOp>(
+                [&](auto op) { memref = op.getMemref(); })
+            .Default([&](auto op) {});
+
+        if (memref == use.get() && !isContiguous(varOp)) {
+          // Make additional checks for hlfir.designate.
+          if (auto designateOp = mlir::dyn_cast<hlfir::DesignateOp>(useOp))
+            if (!hlfir::designatePreservesContinuity(designateOp))
+              continue;
+
+          setContiguousAttr(varOp);
+        }
+        continue;
+      }
+      mlir::TypeSwitch<mlir::Operation *, void>(useOp)
+          .Case(
+              [&](fir::ConvertOp op) { workList.push_back(op.getOperation()); })
+          .Case([&](fir::EmboxOp op) {
+            if (op.getMemref() == use.get())
+              workList.push_back(op.getOperation());
+          })
+          .Case([&](fir::ReboxOp op) {
+            if (op.getBox() == use.get() && fir::reboxPreservesContinuity(op))
+              workList.push_back(op.getOperation());
+          });
+    }
+  }
+}
+
+void PropagateFortranVariableAttributes::runOnOperation() {
+  mlir::Operation *rootOp = getOperation();
+  mlir::MLIRContext *context = &getContext();
+  mlir::RewritePatternSet patterns(context);
+  Propagator propagator;
+  rootOp->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+    propagator.process(op);
+    return mlir::WalkResult::advance();
+  });
+}

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -250,6 +250,8 @@ void createHLFIRToFIRPassPipeline(mlir::PassManager &pm, bool enableOpenMP,
           {/*allowNewSideEffects=*/true});
     });
     addNestedPassToAllTopLevelOperations<PassConstructor>(
+        pm, hlfir::createPropagateFortranVariableAttributes);
+    addNestedPassToAllTopLevelOperations<PassConstructor>(
         pm, hlfir::createOptimizedBufferization);
     addNestedPassToAllTopLevelOperations<PassConstructor>(
         pm, hlfir::createInlineHLFIRAssign);

--- a/flang/lib/Optimizer/Transforms/LoopVersioning.cpp
+++ b/flang/lib/Optimizer/Transforms/LoopVersioning.cpp
@@ -209,46 +209,15 @@ static mlir::Value unwrapPassThroughOps(mlir::Value val) {
   return val;
 }
 
-/// Return true, if \p rebox operation keeps the input array
-/// continuous in the innermost dimension, if it is initially continuous
-/// in the innermost dimension.
-static bool reboxPreservesContinuity(fir::ReboxOp rebox) {
-  // If slicing is not involved, then the rebox does not affect
-  // the continuity of the array.
-  auto sliceArg = rebox.getSlice();
-  if (!sliceArg)
-    return true;
-
-  // A slice with step=1 in the innermost dimension preserves
-  // the continuity of the array in the innermost dimension.
-  if (auto sliceOp =
-          mlir::dyn_cast_or_null<fir::SliceOp>(sliceArg.getDefiningOp())) {
-    if (sliceOp.getFields().empty() && sliceOp.getSubstr().empty()) {
-      auto triples = sliceOp.getTriples();
-      if (triples.size() > 2)
-        if (auto innermostStep = fir::getIntIfConstant(triples[2]))
-          if (*innermostStep == 1)
-            return true;
-    }
-
-    LLVM_DEBUG(llvm::dbgs()
-               << "REBOX with slicing may produce non-contiguous array: "
-               << sliceOp << '\n'
-               << rebox << '\n');
-    return false;
-  }
-
-  LLVM_DEBUG(llvm::dbgs() << "REBOX with unknown slice" << sliceArg << '\n'
-                          << rebox << '\n');
-  return false;
-}
-
 /// if a value comes from a fir.rebox, follow the rebox to the original source,
 /// of the value, otherwise return the value
 static mlir::Value unwrapReboxOp(mlir::Value val) {
   while (fir::ReboxOp rebox = val.getDefiningOp<fir::ReboxOp>()) {
-    if (!reboxPreservesContinuity(rebox))
+    if (!fir::reboxPreservesContinuity(rebox, /*checkWhole=*/false)) {
+      LLVM_DEBUG(llvm::dbgs() << "REBOX may produce non-contiguous array: "
+                              << rebox << '\n');
       break;
+    }
     val = rebox.getBox();
   }
   return val;

--- a/flang/test/Driver/mlir-pass-pipeline.f90
+++ b/flang/test/Driver/mlir-pass-pipeline.f90
@@ -36,18 +36,22 @@ end program
 ! O2-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
 ! O2-NEXT: 'fir.global' Pipeline
 ! O2-NEXT:   SimplifyHLFIRIntrinsics
+! O2-NEXT:   PropagateFortranVariableAttributes
 ! O2-NEXT:   OptimizedBufferization
 ! O2-NEXT:   InlineHLFIRAssign
 ! O2-NEXT: 'func.func' Pipeline
 ! O2-NEXT:   SimplifyHLFIRIntrinsics
+! O2-NEXT:   PropagateFortranVariableAttributes
 ! O2-NEXT:   OptimizedBufferization
 ! O2-NEXT:   InlineHLFIRAssign
 ! O2-NEXT: 'omp.declare_reduction' Pipeline
 ! O2-NEXT:   SimplifyHLFIRIntrinsics
+! O2-NEXT:   PropagateFortranVariableAttributes
 ! O2-NEXT:   OptimizedBufferization
 ! O2-NEXT:   InlineHLFIRAssign
 ! O2-NEXT: 'omp.private' Pipeline
 ! O2-NEXT:   SimplifyHLFIRIntrinsics
+! O2-NEXT:   PropagateFortranVariableAttributes
 ! O2-NEXT:   OptimizedBufferization
 ! O2-NEXT:   InlineHLFIRAssign
 ! ALL: LowerHLFIROrderedAssignments

--- a/flang/test/Fir/basic-program.fir
+++ b/flang/test/Fir/basic-program.fir
@@ -37,18 +37,22 @@ func.func @_QQmain() {
 // PASSES-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']
 // PASSES-NEXT: 'fir.global' Pipeline
 // PASSES-NEXT:    SimplifyHLFIRIntrinsics
+// PASSES-NEXT:    PropagateFortranVariableAttributes
 // PASSES-NEXT:    OptimizedBufferization
 // PASSES-NEXT:    InlineHLFIRAssign
 // PASSES-NEXT: 'func.func' Pipeline
 // PASSES-NEXT:    SimplifyHLFIRIntrinsics
+// PASSES-NEXT:    PropagateFortranVariableAttributes
 // PASSES-NEXT:    OptimizedBufferization
 // PASSES-NEXT:    InlineHLFIRAssign
 // PASSES-NEXT: 'omp.declare_reduction' Pipeline
 // PASSES-NEXT:    SimplifyHLFIRIntrinsics
+// PASSES-NEXT:    PropagateFortranVariableAttributes
 // PASSES-NEXT:    OptimizedBufferization
 // PASSES-NEXT:    InlineHLFIRAssign
 // PASSES-NEXT: 'omp.private' Pipeline
 // PASSES-NEXT:    SimplifyHLFIRIntrinsics
+// PASSES-NEXT:    PropagateFortranVariableAttributes
 // PASSES-NEXT:    OptimizedBufferization
 // PASSES-NEXT:    InlineHLFIRAssign
 // PASSES-NEXT:   LowerHLFIROrderedAssignments

--- a/flang/test/HLFIR/propagate-contiguous-attribute.fir
+++ b/flang/test/HLFIR/propagate-contiguous-attribute.fir
@@ -252,3 +252,24 @@ func.func @_QPtest6(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fi
   hlfir.assign %103 to %104 : !fir.box<!fir.array<11xf32>>, !fir.box<!fir.array<11xf32>>
   return
 }
+
+// -----
+
+// Make sure contiguous attribute is not set on hlfir.declare:
+//subroutine test7()
+//  real, pointer :: x(:)
+//end subroutine test7
+
+func.func @_QPtest7() {
+  %c0 = arith.constant 0 : index
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.alloca !fir.box<!fir.ptr<!fir.array<?xf32>>> {bindc_name = "x", uniq_name = "_QFtest7Ex"}
+  %2 = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  %3 = fir.shape %c0 : (index) -> !fir.shape<1>
+  %4 = fir.embox %2(%3) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  fir.store %4 to %1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  %5:2 = hlfir.declare %1 {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest7Ex"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+  return
+}
+// CHECK-LABEL:   func.func @_QPtest7(
+// CHECK-NOT: contiguous

--- a/flang/test/HLFIR/propagate-contiguous-attribute.fir
+++ b/flang/test/HLFIR/propagate-contiguous-attribute.fir
@@ -1,0 +1,254 @@
+// RUN: fir-opt --propagate-fortran-attrs --split-input-file %s | FileCheck %s
+
+//subroutine test1(x, n, k1, k2)
+//  real :: x(n)
+//  x(1:k1) = x(k1+1:k2)
+//end subroutine test1
+
+// CHECK-LABEL:   func.func @_QPtest1(
+func.func @_QPtest1(%arg0: !fir.ref<!fir.array<?xf32>> {fir.bindc_name = "x"}, %arg1: !fir.ref<i32> {fir.bindc_name = "n"}, %arg2: !fir.ref<i32> {fir.bindc_name = "k1"}, %arg3: !fir.ref<i32> {fir.bindc_name = "k2"}) {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  %c0 = arith.constant 0 : index
+  %0 = fir.dummy_scope : !fir.dscope
+  %1:2 = hlfir.declare %arg2 dummy_scope %0 {uniq_name = "_QFtest1Ek1"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+  %2:2 = hlfir.declare %arg3 dummy_scope %0 {uniq_name = "_QFtest1Ek2"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+  %3:2 = hlfir.declare %arg1 dummy_scope %0 {uniq_name = "_QFtest1En"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+  %4 = fir.load %3#0 : !fir.ref<i32>
+  %5 = fir.convert %4 : (i32) -> index
+  %6 = arith.cmpi sgt, %5, %c0 : index
+  %7 = arith.select %6, %5, %c0 : index
+  %8 = fir.shape %7 : (index) -> !fir.shape<1>
+  %9:2 = hlfir.declare %arg0(%8) dummy_scope %0 {uniq_name = "_QFtest1Ex"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
+  %10 = fir.load %1#0 : !fir.ref<i32>
+  %11 = arith.addi %10, %c1_i32 overflow<nsw> : i32
+  %12 = fir.load %2#0 : !fir.ref<i32>
+  %13 = fir.convert %11 : (i32) -> index
+  %14 = fir.convert %12 : (i32) -> index
+  %15 = arith.subi %14, %13 : index
+  %16 = arith.addi %15, %c1 : index
+  %17 = arith.cmpi sgt, %16, %c0 : index
+  %18 = arith.select %17, %16, %c0 : index
+  %19 = fir.shape %18 : (index) -> !fir.shape<1>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  %20 = hlfir.designate %9#0 (%13:%14:%c1)  shape %19 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  %21 = fir.convert %10 : (i32) -> index
+  %22 = arith.cmpi sgt, %21, %c0 : index
+  %23 = arith.select %22, %21, %c0 : index
+  %24 = fir.shape %23 : (index) -> !fir.shape<1>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  %25 = hlfir.designate %9#0 (%c1:%21:%c1)  shape %24 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  hlfir.assign %20 to %25 : !fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+//subroutine test2(x, n, k1, k2)
+//  real, contiguous :: x(:)
+//  x(1:k1) = x(k1+1:k2)
+//end subroutine test2
+
+// CHECK-LABEL:   func.func @_QPtest2(
+func.func @_QPtest2(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous}, %arg1: !fir.ref<i32> {fir.bindc_name = "n"}, %arg2: !fir.ref<i32> {fir.bindc_name = "k1"}, %arg3: !fir.ref<i32> {fir.bindc_name = "k2"}) {
+  %c1_i32 = arith.constant 1 : i32
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = fir.dummy_scope : !fir.dscope
+  %1:2 = hlfir.declare %arg2 dummy_scope %0 {uniq_name = "_QFtest2Ek1"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+  %2:2 = hlfir.declare %arg3 dummy_scope %0 {uniq_name = "_QFtest2Ek2"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+  %3:2 = hlfir.declare %arg1 dummy_scope %0 {uniq_name = "_QFtest2En"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+  %4 = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  %5:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
+  %6 = fir.shape_shift %c1, %5#1 : (index, index) -> !fir.shapeshift<1>
+  %7:2 = hlfir.declare %4(%6) dummy_scope %0 {fortran_attrs = #fir.var_attrs<contiguous>, uniq_name = "_QFtest2Ex"} : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
+  %8 = fir.load %1#0 : !fir.ref<i32>
+  %9 = arith.addi %8, %c1_i32 overflow<nsw> : i32
+  %10 = fir.load %2#0 : !fir.ref<i32>
+  %11 = fir.convert %9 : (i32) -> index
+  %12 = fir.convert %10 : (i32) -> index
+  %13 = arith.subi %12, %11 : index
+  %14 = arith.addi %13, %c1 : index
+  %15 = arith.cmpi sgt, %14, %c0 : index
+  %16 = arith.select %15, %14, %c0 : index
+  %17 = fir.shape %16 : (index) -> !fir.shape<1>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  %18 = hlfir.designate %7#0 (%11:%12:%c1)  shape %17 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  %19 = fir.convert %8 : (i32) -> index
+  %20 = arith.cmpi sgt, %19, %c0 : index
+  %21 = arith.select %20, %19, %c0 : index
+  %22 = fir.shape %21 : (index) -> !fir.shape<1>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  %23 = hlfir.designate %7#0 (%c1:%19:%c1)  shape %22 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  hlfir.assign %18 to %23 : !fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+//subroutine test3
+//  real :: x(10:100)
+//  call inner(x)
+//contains
+//  subroutine inner(x) ! manually inlined
+//    real :: x(:)
+//    x(10:20) = x(21:31)
+//  end subroutine inner
+//end subroutine test3
+
+// CHECK-LABEL:   func.func @_QPtest3() {
+func.func @_QPtest3() {
+  %c91 = arith.constant 91 : index
+  %c10 = arith.constant 10 : index
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.alloca !fir.array<91xf32> {bindc_name = "x", uniq_name = "_QFtest3Ex"}
+  %2 = fir.shape_shift %c10, %c91 : (index, index) -> !fir.shapeshift<1>
+  %3:2 = hlfir.declare %1(%2) {uniq_name = "_QFtest3Ex"} : (!fir.ref<!fir.array<91xf32>>, !fir.shapeshift<1>) -> (!fir.box<!fir.array<91xf32>>, !fir.ref<!fir.array<91xf32>>)
+  %4 = fir.convert %3#0 : (!fir.box<!fir.array<91xf32>>) -> !fir.box<!fir.array<?xf32>>
+  // inner() code:
+  %c20 = arith.constant 20 : index
+  %c11 = arith.constant 11 : index
+  %c1 = arith.constant 1 : index
+  %c31 = arith.constant 31 : index
+  %c21 = arith.constant 21 : index
+  %100 = fir.dummy_scope : !fir.dscope
+  %101:2 = hlfir.declare %4 dummy_scope %100 {uniq_name = "_QFtest3FinnerEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  %102 = fir.shape %c11 : (index) -> !fir.shape<1>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  %103 = hlfir.designate %101#0 (%c21:%c31:%c1)  shape %102 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  %104 = hlfir.designate %101#0 (%c10:%c20:%c1)  shape %102 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  hlfir.assign %103 to %104 : !fir.box<!fir.array<11xf32>>, !fir.box<!fir.array<11xf32>>
+  return
+}
+
+// -----
+
+//subroutine test4
+//  real :: x(100)
+//  call inner(x)
+//contains
+//  subroutine inner(x) ! manually inlined
+//    real :: x(:)
+//    x(10:20) = x(21:31)
+//  end subroutine inner
+//end subroutine test4
+
+// CHECK-LABEL:   func.func @_QPtest4() {
+func.func @_QPtest4() {
+  %c100 = arith.constant 100 : index
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.alloca !fir.array<100xf32> {bindc_name = "x", uniq_name = "_QFtest4Ex"}
+  %2 = fir.shape %c100 : (index) -> !fir.shape<1>
+  %3:2 = hlfir.declare %1(%2) {uniq_name = "_QFtest4Ex"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
+  %4 = fir.embox %3#0(%2) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<100xf32>>
+  %5 = fir.convert %4 : (!fir.box<!fir.array<100xf32>>) -> !fir.box<!fir.array<?xf32>>
+  // inner() code:
+  %c20 = arith.constant 20 : index
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
+  %c1 = arith.constant 1 : index
+  %c31 = arith.constant 31 : index
+  %c21 = arith.constant 21 : index
+  %100 = fir.dummy_scope : !fir.dscope
+// CHECK: hlfir.declare{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>, uniq_name = "_QFtest4FinnerEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  %101:2 = hlfir.declare %5 dummy_scope %100 {uniq_name = "_QFtest4FinnerEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  %102 = fir.shape %c11 : (index) -> !fir.shape<1>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  %103 = hlfir.designate %101#0 (%c21:%c31:%c1)  shape %102 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  %104 = hlfir.designate %101#0 (%c10:%c20:%c1)  shape %102 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  hlfir.assign %103 to %104 : !fir.box<!fir.array<11xf32>>, !fir.box<!fir.array<11xf32>>
+  return
+}
+
+// -----
+
+//subroutine test5
+//  real :: x(100)
+//  call inner(x(1:50))
+//contains
+//  subroutine inner(x) ! manually inlined
+//    real :: x(:)
+//    x(10:20) = x(21:31)
+//  end subroutine inner
+//end subroutine test5
+
+// CHECK-LABEL:   func.func @_QPtest5() {
+func.func @_QPtest5() {
+  %c50 = arith.constant 50 : index
+  %c1 = arith.constant 1 : index
+  %c100 = arith.constant 100 : index
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.alloca !fir.array<100xf32> {bindc_name = "x", uniq_name = "_QFtest5Ex"}
+  %2 = fir.shape %c100 : (index) -> !fir.shape<1>
+  %3:2 = hlfir.declare %1(%2) {uniq_name = "_QFtest5Ex"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
+  %4 = fir.shape %c50 : (index) -> !fir.shape<1>
+  %5 = hlfir.designate %3#0 (%c1:%c50:%c1)  shape %4 : (!fir.ref<!fir.array<100xf32>>, index, index, index, !fir.shape<1>) -> !fir.ref<!fir.array<50xf32>>
+  %6 = fir.embox %5(%4) : (!fir.ref<!fir.array<50xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<50xf32>>
+  %7 = fir.convert %6 : (!fir.box<!fir.array<50xf32>>) -> !fir.box<!fir.array<?xf32>>
+  // inner() code:
+  %c20 = arith.constant 20 : index
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
+  %c31 = arith.constant 31 : index
+  %c21 = arith.constant 21 : index
+  %100 = fir.dummy_scope : !fir.dscope
+// CHECK: hlfir.declare{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>, uniq_name = "_QFtest5FinnerEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  %101:2 = hlfir.declare %7 dummy_scope %100 {uniq_name = "_QFtest5FinnerEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  %102 = fir.shape %c11 : (index) -> !fir.shape<1>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  %103 = hlfir.designate %101#0 (%c21:%c31:%c1)  shape %102 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  %104 = hlfir.designate %101#0 (%c10:%c20:%c1)  shape %102 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  hlfir.assign %103 to %104 : !fir.box<!fir.array<11xf32>>, !fir.box<!fir.array<11xf32>>
+  return
+}
+
+// -----
+
+//subroutine test6(x,k)
+//  real, contiguous :: x(:)
+//  call inner(x(1:k))
+//contains
+//  subroutine inner(x) ! manually inlined
+//    real :: x(:)
+//    x(10:20) = x(21:31)
+//  end subroutine inner
+//end subroutine test6
+
+// CHECK-LABEL:   func.func @_QPtest6(
+func.func @_QPtest6(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous}, %arg1: !fir.ref<i32> {fir.bindc_name = "k"}) {
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = fir.dummy_scope : !fir.dscope
+  %1:2 = hlfir.declare %arg1 dummy_scope %0 {uniq_name = "_QFtest6Ek"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+  %2 = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  %3:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
+  %4 = fir.shape_shift %c1, %3#1 : (index, index) -> !fir.shapeshift<1>
+  %5:2 = hlfir.declare %2(%4) dummy_scope %0 {fortran_attrs = #fir.var_attrs<contiguous>, uniq_name = "_QFtest6Ex"} : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
+  %6 = fir.load %1#0 : !fir.ref<i32>
+  %7 = fir.convert %6 : (i32) -> index
+  %8 = arith.cmpi sgt, %7, %c0 : index
+  %9 = arith.select %8, %7, %c0 : index
+  %10 = fir.shape %9 : (index) -> !fir.shape<1>
+  // hlfir.designate manually replaced with fir.rebox:
+  %slice = fir.slice %c1, %7, %c1 : (index, index, index) -> !fir.slice<1>
+  %11 = fir.rebox %5#0 [%slice] : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  // inner() code:
+  %c20 = arith.constant 20 : index
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
+  %c31 = arith.constant 31 : index
+  %c21 = arith.constant 21 : index
+  %100 = fir.dummy_scope : !fir.dscope
+// CHECK: hlfir.declare{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>, uniq_name = "_QFtest6FinnerEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  %101:2 = hlfir.declare %11 dummy_scope %100 {uniq_name = "_QFtest6FinnerEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  %102 = fir.shape %c11 : (index) -> !fir.shape<1>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  %103 = hlfir.designate %101#0 (%c21:%c31:%c1)  shape %102 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+// CHECK: hlfir.designate{{.*}}{fortran_attrs = #fir.var_attrs<contiguous>} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  %104 = hlfir.designate %101#0 (%c10:%c20:%c1)  shape %102 : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<11xf32>>
+  hlfir.assign %103 to %104 : !fir.box<!fir.array<11xf32>>, !fir.box<!fir.array<11xf32>>
+  return
+}


### PR DESCRIPTION
This change allows marking more designators producing an opaque
box with 'contiguous' attribute, e.g. like in test1 case
in flang/test/HLFIR/propagate-contiguous-attribute.fir.
This would make isSimplyContiguous() return true for such
designators allowing merging hlfir.eval_in_mem with hlfir.assign
where the LHS is a contiguous array section.

Depends on #139003