### PR TITLE
[CodeGen][NPM] Account inserted passes for -start/stop options

### DIFF
--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -583,8 +583,10 @@ protected:
   void insertPass(InsertedPassT &&Pass) const {
     AfterCallbacks.emplace_back(
         [&](StringRef Name, MachineFunctionPassManager &MFPM) mutable {
-          if (Name == TargetPassT::name())
-            MFPM.addPass(std::forward<InsertedPassT>(Pass));
+          if (Name == TargetPassT::name()) {
+            if (runBeforeAdding(InsertedPassT::name()))
+              MFPM.addPass(std::forward<InsertedPassT>(Pass));
+          }
         });
   }
 

--- a/llvm/test/tools/llc/new-pm/start-stop-inserted.ll
+++ b/llvm/test/tools/llc/new-pm/start-stop-inserted.ll
@@ -1,0 +1,15 @@
+; REQUIRES: amdgpu-registered-target
+
+; AMDGPU inserts the fourth instance of dead-mi-elimination pass after detect-dead-lanes
+; This checks that the pipeline stops before that.
+
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -O3 -enable-new-pm -stop-before=dead-mi-elimination,4 --print-pipeline-passes -filetype=null %s | FileCheck %s
+
+; There is no way to -start-after an inserted pass right now.
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -O3 -enable-new-pm -start-after=dead-mi-elimination,4 --print-pipeline-passes -filetype=null %s
+
+
+; CHECK: dead-mi-elimination
+; CHECK: dead-mi-elimination
+; CHECK: dead-mi-elimination
+; CHECK-NOT: dead-mi-elimination


### PR DESCRIPTION
This partly solves the issue #138831 for `-enable-new-pm`.

* #137290 will not have this problem, but I am adding this till we migrate to the new pass builder structure.

Even with this, there is no way to `-start-after` an inserted pass right now.