### PR TITLE
[SLP] Simplify buildTree() (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -10068,17 +10068,17 @@ void BoUpSLP::buildTreeRec(ArrayRef<Value *> VLRef, unsigned Depth,
     return true;
   };
 
-  ScalarsVectorizationLegality SVL =
+  ScalarsVectorizationLegality Legality =
       getScalarsVectorizationLegality(VL, Depth, UserTreeIdx);
-  const InstructionsState &S = SVL.getInstructionsState();
-  if (!SVL.isLegal()) {
-    if (SVL.trySplitVectorize()) {
+  const InstructionsState &S = Legality.getInstructionsState();
+  if (!Legality.isLegal()) {
+    if (Legality.trySplitVectorize()) {
       auto [MainOp, AltOp] = getMainAltOpsNoStateVL(VL);
       // Last chance to try to vectorize alternate node.
       if (MainOp && AltOp && TrySplitNode(InstructionsState(MainOp, AltOp)))
         return;
     }
-    if (SVL.tryToFindDuplicates())
+    if (Legality.tryToFindDuplicates())
       tryToFindDuplicates(VL, ReuseShuffleIndices, *TTI, *TLI, S, UserTreeIdx);
 
     newGatherTreeEntry(VL, S, UserTreeIdx, ReuseShuffleIndices);


### PR DESCRIPTION
This NFC aims to simplify the interfaces used in `buildTree()` to make it easier to understand where decisions for legality are made.

In particular, there is now a single point of definition for legality decisions. This makes it clear where all those decisions are made. Previously, multiple variables with a large scope were passed by reference.