### PR TITLE
[AMDGPU] Refine GCNHazardRecognizer hasHazard()

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -474,11 +474,11 @@ hasHazard(StateT InitialState,
       StateIdx = StateHash2Idx[StateHash];
       if (LLVM_UNLIKELY(!StateT::isEqual(State, States[StateIdx]))) {
         // Hash collision
-        auto *Collision = llvm::find_if(Collisions, [&](auto &C) {
+        auto Collision = llvm::find_if(Collisions, [&](auto &C) {
           return C.first == StateHash &&
                  StateT::isEqual(State, States[C.second]);
         });
-        if (Collision) {
+        if (Collision != Collisions.end()) {
           StateIdx = Collision->second;
         } else {
           StateIdx = States.size();


### PR DESCRIPTION
Remove recursion to avoid stack overflow on large CFGs.
Avoid worklist for hazard search within single MachineBasicBlock.
Ensure predecessors are visited for all state combinations.