### PR TITLE
allow implicit completion inside empty template argument list

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -2455,6 +2455,11 @@ bool isIncludeFile(llvm::StringRef Line) {
 }
 
 bool allowImplicitCompletion(llvm::StringRef Content, unsigned Offset) {
+  // Check if we're inside an empty template argument list
+  if (Content.size() > 2 && Content[Offset - 1] == '<' &&
+      Content[Offset] == '>')
+    return true;
+
   // Look at last line before completion point only.
   Content = Content.take_front(Offset);
   auto Pos = Content.rfind('\n');

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -3978,6 +3978,7 @@ TEST(AllowImplicitCompletion, All) {
       "foo.^bar",
       "foo->^bar",
       "foo::^bar",
+      "std::vector<std::vector<^>>",
       "  #  include <^foo.h>",
       "#import <foo/^bar.h>",
       "#include_next \"^",
@@ -3990,6 +3991,7 @@ TEST(AllowImplicitCompletion, All) {
       "#include \"foo.h\"^",
       "#error <^",
       "#<^",
+      "a <^b",
   };
   for (const char *Test : Yes) {
     llvm::Annotations A(Test);


### PR DESCRIPTION
I noticed that when triggering completion inside something like `std::vector<^>`  via the '<' trigger character, no results are returned. This PR adds a small heuristic to detect this case and offer completions