### PR TITLE
[compiler-rt] Correctly detect cross-compiling for adding flags

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -297,8 +297,7 @@ macro(get_test_cc_for_arch arch cc_out cflags_out)
   if (NOT ${ARGC} EQUAL 3)
     message(FATAL_ERROR "got too many args. expected 3, got ${ARGC} (namely: ${ARGV})")
   endif()
-  if(ANDROID OR (NOT APPLE AND ${arch} MATCHES "arm|aarch64|riscv32|riscv64"))
-    # This is only true if we are cross-compiling.
+  if(CMAKE_CROSSCOMPILING)
     # Build all tests with host compiler and use host tools.
     set(${cc_out} ${COMPILER_RT_TEST_COMPILER})
     set(${cflags_out} ${COMPILER_RT_TEST_COMPILER_CFLAGS})


### PR DESCRIPTION
This started with "Android is always cross-compiled" in commit aa9d74cc5db8c2a16c2cd39bfb7e501ca1bb7c72, and continued with individual architectures like ARM in 6759fd9fdd3c9d49c8aaf64626d5a8c59648ed10. Later Apple was carved out in 8887c63e327fb726b502b3b2fad44e50de60d5aa. I think we should just use the variable provided by CMake instead.