### PR TITLE
Propose new ClangIR Maintainers

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -57,7 +57,7 @@ Clang MLIR generation
 | akaylor\@nvidia.com (email), AndyKaylor (Discord), AndyKaylor (GitHub)
 
 | Bruno Cardoso Lopes
-| sonicsprawl (Discord), bcardosolopes (GitHub)
+| bruno.cardoso\@gmail.com (email), sonicsprawl (Discord), bcardosolopes (GitHub)
 
 
 Analysis & CFG

--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -51,6 +51,14 @@ Clang LLVM IR generation
 | Anton Korobeynikov
 | anton\@korobeynikov.info (email), asl (Phabricator), asl (GitHub)
 
+Clang MLIR generation
+~~~~~~~~~~~~~~~~~~~~~
+| Andy Kaylor
+| akaylor\@nvidia.com (email), AndyKaylor (Discord), AndyKaylor (GitHub)
+
+| Bruno Cardoso Lopes
+| sonicsprawl (Discord), bcardosolopes (GitHub)
+
 
 Analysis & CFG
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
While I don't propose any change to the process we've been using for ClangIR contributions, it is important that we have maintainers listed so that folks have a good point of contact for the project in the upstream.