### PR TITLE
[llvm] Fix cmake string expansion in CrossCompile.cmake

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -83,9 +83,9 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
 
   add_custom_command(OUTPUT ${${project_name}_${target_name}_BUILD}/CMakeCache.txt
     COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
-        -DCMAKE_MAKE_PROGRAM="${CMAKE_MAKE_PROGRAM}"
-        -DCMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER}"
-        -DCMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}"
+        "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
+        "-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}"
+        "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}"
         ${CROSS_TOOLCHAIN_FLAGS_${target_name}} ${CMAKE_CURRENT_SOURCE_DIR}
         ${CROSS_TOOLCHAIN_FLAGS_${project_name}_${target_name}}
         -DLLVM_TARGET_IS_CROSSCOMPILE_HOST=TRUE


### PR DESCRIPTION
This fixes an issue where builds on Windows with LLVM_OPTIMIZED_TABLEGEN
will fail if CMAKE_MAKE_PROGRAM, CMAKE_C_COMPILER_LAUNCHER or
CMAKE_CXX_COMPILER_LAUNCHER are lists rather than paths to a binary;
this occurs when one of these programs is passed with arguments instead
of just as a path.

On non-Windows this works regardless as the sub-cmake command runs in a
proper shell, but on Windows it runs differently and so these strings
need to be expanded correctly by cmake.
