### PR TITLE
[lldb] Use -Wno-documentation-deprecated-sync if available

### DIFF
--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -16,6 +16,15 @@ if (CXX_SUPPORTS_DOCUMENTATION)
     PRIVATE -Wdocumentation)
 endif()
 
+# Apply -Wno-documentation-deprecated-sync while we migrate away from
+# report_fatal_error in llvm/include/llvm/Support/ErrorHandling.h
+# and llvm/include/llvm/Support/Error.h.
+check_cxx_compiler_flag("-Wno-documentation-deprecated-sync"
+                        CXX_SUPPORTS_DOCUMENTATION_DEPRECATED_SYNC)
+if (CXX_SUPPORTS_DOCUMENTATION_DEPRECATED_SYNC)
+  target_compile_options(APITests
+    PRIVATE -Wno-documentation-deprecated-sync)
+endif()
 
 if(Python3_RPATH)
   set_property(TARGET APITests APPEND PROPERTY BUILD_RPATH "${Python3_RPATH}")

--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -19,9 +19,11 @@ endif()
 # Apply -Wno-documentation-deprecated-sync while we migrate away from
 # report_fatal_error in llvm/include/llvm/Support/ErrorHandling.h
 # and llvm/include/llvm/Support/Error.h.
+# Remove this block of code when the migration is complete.
+# See https://github.com/llvm/llvm-project/issues/138914.
 check_cxx_compiler_flag("-Wno-documentation-deprecated-sync"
-                        CXX_SUPPORTS_DOCUMENTATION_DEPRECATED_SYNC)
-if (CXX_SUPPORTS_DOCUMENTATION_DEPRECATED_SYNC)
+                        CXX_SUPPORTS_NO_DOCUMENTATION_DEPRECATED_SYNC)
+if (CXX_SUPPORTS_NO_DOCUMENTATION_DEPRECATED_SYNC)
   target_compile_options(APITests
     PRIVATE -Wno-documentation-deprecated-sync)
 endif()


### PR DESCRIPTION
report_fatal_error has been marked "@deprecated" in its comment, but
the function itself is not marked with [[deprecated]] yet.  This
causes warnings like:

  llvm/include/llvm/Support/ErrorHandling.h:61:6: error: declaration
  is marked with '@deprecated' command but does not have a deprecation
  attribute [-Werror,-Wdocumentation-deprecated-sync]

  llvm/include/llvm/Support/Error.h:738:6: error: declaration is
  marked with '@deprecated' command but does not have a deprecation
  attribute [-Werror,-Wdocumentation-deprecated-sync]

This patch disables the warning while we migrate away from
report_fatal_error.
