### PR TITLE
[LLDB][Minidump] Add some buffer directories

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -75,6 +75,12 @@ Status MinidumpFileBuilder::AddHeaderAndCalculateDirectories() {
     }
   }
 
+  // Add a generous buffer of directories, these are quite small
+  // and forks may add new directories upstream LLDB hadn't accounted for
+  // when we started pre-calculating directory size, so this should account for
+  // that
+  m_expected_directories += 100;
+
   m_saved_data_size +=
       m_expected_directories * sizeof(llvm::minidump::Directory);
   Status error;


### PR DESCRIPTION
Add a generous amount of buffer directories. I found out some LLDB forks (internal and external) had custom ranges that could fail because we didn't pre-account for those. To prevent this from being a problem, I've added a large number of buffer directories at the cost of 240 bytes.