### PR TITLE
[HLSL][NFC] Rename isImplicit() to hasRegisterStot() on HLSLResourceBindingAttr

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4785,15 +4785,15 @@ def HLSLResourceBinding: InheritableAttr {
         SlotNumber = SlotNum;
         SpaceNumber = SpaceNum;
       }
-      bool isImplicit() const {
-        return !SlotNumber.has_value();
+      bool hasRegisterSlot() const {
+        return SlotNumber.has_value();
       }
       RegisterType getRegisterType() const {
-        assert(!isImplicit() && "binding does not have register slot");
+        assert(hasRegisterSlot() && "binding does not have register slot");
         return RegType;
       }
       unsigned getSlotNumber() const {
-        assert(!isImplicit() && "binding does not have register slot");
+        assert(hasRegisterSlot() && "binding does not have register slot");
         return SlotNumber.value();
       }
       unsigned getSpaceNumber() const {

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -261,7 +261,7 @@ void CGHLSLRuntime::addBuffer(const HLSLBufferDecl *BufDecl) {
       BufDecl->getAttr<HLSLResourceBindingAttr>();
   // FIXME: handle implicit binding if no binding attribute is found
   // (llvm/llvm-project#110722)
-  if (RBA && !RBA->isImplicit())
+  if (RBA && RBA->hasRegisterSlot())
     initializeBufferFromBinding(CGM, BufGV, RBA->getSlotNumber(),
                                 RBA->getSpaceNumber());
 }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1979,7 +1979,7 @@ void SemaHLSL::ActOnEndOfTranslationUnit(TranslationUnitDecl *TU) {
     for (const Decl *VD : DefaultCBufferDecls) {
       const HLSLResourceBindingAttr *RBA =
           VD->getAttr<HLSLResourceBindingAttr>();
-      if (RBA && !RBA->isImplicit() &&
+      if (RBA && RBA->hasRegisterSlot() &&
           RBA->getRegisterType() == HLSLResourceBindingAttr::RegisterType::C) {
         DefaultCBuffer->setHasValidPackoffset(true);
         break;
@@ -3271,7 +3271,7 @@ static bool initVarDeclWithCtor(Sema &S, VarDecl *VD,
 
 static bool initGlobalResourceDecl(Sema &S, VarDecl *VD) {
   HLSLResourceBindingAttr *RBA = VD->getAttr<HLSLResourceBindingAttr>();
-  if (!RBA || RBA->isImplicit())
+  if (!RBA || !RBA->hasRegisterSlot())
     // FIXME: add support for implicit binding (llvm/llvm-project#110722)
     return false;
 
@@ -3356,7 +3356,7 @@ void SemaHLSL::processExplicitBindingsOnDecl(VarDecl *VD) {
   bool HasBinding = false;
   for (Attr *A : VD->attrs()) {
     HLSLResourceBindingAttr *RBA = dyn_cast<HLSLResourceBindingAttr>(A);
-    if (!RBA || RBA->isImplicit())
+    if (!RBA || !RBA->hasRegisterSlot())
       continue;
     HasBinding = true;
 


### PR DESCRIPTION
Renaming because the name `isImplicit` is ambiguous. It can mean implicit attribute or implicit binding.