### PR TITLE
[LLVM][OpenMP] Add older versions to llvm::omp::getOpenMPVersions

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMP.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMP.cpp
@@ -190,7 +190,7 @@ bool isCombinedConstruct(Directive D) {
 }
 
 ArrayRef<unsigned> getOpenMPVersions() {
-  static unsigned Versions[]{45, 50, 51, 52, 60};
+  static unsigned Versions[]{31, 40, 45, 50, 51, 52, 60};
   return Versions;
 }
 


### PR DESCRIPTION
Add 3.1 and 4.0 as versions. This will make flang's default OpenMP version (3.1) be included in the list.