### PR TITLE
[MLIR][Presburger] removeTrivialRedundancy: skip unnecessary redundancy check

### DIFF
--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -21,7 +21,6 @@
 #include "mlir/Analysis/Presburger/Simplex.h"
 #include "mlir/Analysis/Presburger/Utils.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallBitVector.h"
@@ -45,7 +44,6 @@ using namespace mlir;
 using namespace presburger;
 
 using llvm::SmallDenseMap;
-using llvm::SmallDenseSet;
 
 std::unique_ptr<IntegerRelation> IntegerRelation::clone() const {
   return std::make_unique<IntegerRelation>(*this);
@@ -1824,8 +1822,6 @@ void IntegerRelation::removeTrivialRedundancy() {
   // for a given row.
   SmallDenseMap<ArrayRef<DynamicAPInt>, std::pair<unsigned, DynamicAPInt>>
       rowsWithoutConstTerm;
-  // To unique rows.
-  SmallDenseSet<ArrayRef<DynamicAPInt>, 8> rowSet;
 
   // Check if constraint is of the form <non-negative-constant> >= 0.
   auto isTriviallyValid = [&](unsigned r) -> bool {
@@ -1840,8 +1836,7 @@ void IntegerRelation::removeTrivialRedundancy() {
   SmallVector<bool, 256> redunIneq(getNumInequalities(), false);
   for (unsigned r = 0, e = getNumInequalities(); r < e; r++) {
     DynamicAPInt *rowStart = &inequalities(r, 0);
-    auto row = ArrayRef<DynamicAPInt>(rowStart, getNumCols());
-    if (isTriviallyValid(r) || !rowSet.insert(row).second) {
+    if (isTriviallyValid(r)) {
       redunIneq[r] = true;
       continue;
     }


### PR DESCRIPTION
`removeTrivialRedundancy` first marks duplicate rows redundant, then when multiple rows differ only by a constant term, it removes all but one of them. Since the latter removes all but one duplicate row as well, it is unnecessary (redundant!) to mark duplicate rows redundant. So we remove this step.