### PR TITLE
[Instrumentor] Allow printing a runtime stub

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/IPO/Instrumentor.h
@@ -118,6 +118,18 @@ struct IRTCallDescription {
                            InstrumentorIRBuilderTy &IIRB, const DataLayout &DL,
                            InstrumentationCaches &ICaches);
 
+  /// Create a string representation of the function declaration in C. Two
+  /// strings are returned: the function definition with direct arguments and
+  /// the function with any indirect argument.
+  std::pair<std::string, std::string>
+  createCSignature(const InstrumentationConfig &IConf) const;
+
+  /// Create a string representation of the function definition in C. The
+  /// function body implements a stub and only prints the passed arguments. Two
+  /// strings are returned: the function definition with direct arguments and
+  /// the function with any indirect argument.
+  std::pair<std::string, std::string> createCBodies() const;
+
   /// Return whether the \p IRTA argument can be replaced.
   bool isReplacable(IRTArg &IRTA) const {
     return (IRTA.Flags & (IRTArg::REPLACABLE | IRTArg::REPLACABLE_CUSTOM));
@@ -338,6 +350,9 @@ struct InstrumentationConfig {
   InstrumentationConfig() : SS(StringAllocator) {
     RuntimePrefix = BaseConfigurationOption::createStringOption(
         *this, "runtime_prefix", "The runtime API prefix.", "__instrumentor_");
+    RuntimeStubsFile = BaseConfigurationOption::createStringOption(
+        *this, "runtime_stubs_file",
+        "The file into which runtime stubs should be written.", "");
     TargetRegex = BaseConfigurationOption::createStringOption(
         *this, "target_regex",
         "Regular expression to be matched against the module target. "
@@ -384,6 +399,7 @@ struct InstrumentationConfig {
 
   /// The base configuration options.
   std::unique_ptr<BaseConfigurationOption> RuntimePrefix;
+  std::unique_ptr<BaseConfigurationOption> RuntimeStubsFile;
   std::unique_ptr<BaseConfigurationOption> TargetRegex;
   std::unique_ptr<BaseConfigurationOption> HostEnabled;
   std::unique_ptr<BaseConfigurationOption> GPUEnabled;

--- a/llvm/include/llvm/Transforms/IPO/InstrumentorStubPrinter.h
+++ b/llvm/include/llvm/Transforms/IPO/InstrumentorStubPrinter.h
@@ -1,0 +1,32 @@
+//===- Transforms/IPO/InstrumentorStubPrinter.h ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A generator of Instrumentor's runtime stubs.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORMS_IPO_INSTRUMENTOR_STUB_PRINTER_H
+#define LLVM_TRANSFORMS_IPO_INSTRUMENTOR_STUB_PRINTER_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Transforms/IPO/Instrumentor.h"
+
+namespace llvm {
+namespace instrumentor {
+
+/// Print a runtime stub file with the implementation of the instrumentation
+/// runtime functions corresponding to the instrumentation opportunities
+/// enabled.
+void printRuntimeStub(const InstrumentationConfig &IConf,
+                      StringRef StubRuntimeName, LLVMContext &Ctx);
+
+} // end namespace instrumentor
+} // end namespace llvm
+
+#endif // LLVM_TRANSFORMS_IPO_INSTRUMENTOR_STUB_PRINTER_H

--- a/llvm/lib/Transforms/IPO/CMakeLists.txt
+++ b/llvm/lib/Transforms/IPO/CMakeLists.txt
@@ -29,6 +29,7 @@ add_llvm_component_library(LLVMipo
   Inliner.cpp
   Instrumentor.cpp
   InstrumentorConfigFile.cpp
+  InstrumentorStubPrinter.cpp
   Internalize.cpp
   LoopExtractor.cpp
   LowerTypeTests.cpp

--- a/llvm/lib/Transforms/IPO/Instrumentor.cpp
+++ b/llvm/lib/Transforms/IPO/Instrumentor.cpp
@@ -13,6 +13,7 @@
 
 #include "llvm/Transforms/IPO/Instrumentor.h"
 #include "llvm/Transforms/IPO/InstrumentorConfigFile.h"
+#include "llvm/Transforms/IPO/InstrumentorStubPrinter.h"
 
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -264,6 +265,8 @@ PreservedAnalyses InstrumentorPass::run(Module &M, InstrumentationConfig &IConf,
     return PreservedAnalyses::all();
 
   writeConfigToJSON(IConf, WriteConfigFile, IIRB.Ctx);
+
+  printRuntimeStub(IConf, IConf.RuntimeStubsFile->getString(), IIRB.Ctx);
 
   bool Changed = Impl.instrument();
   if (!Changed)

--- a/llvm/lib/Transforms/IPO/InstrumentorStubPrinter.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorStubPrinter.cpp
@@ -1,0 +1,210 @@
+//===-- InstrumentorStubPrinter.cpp ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/IPO/Instrumentor.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <string>
+#include <system_error>
+
+namespace llvm {
+namespace instrumentor {
+
+/// Get the string representation of an argument with type \p Ty. Two strings
+/// are returned: one for direct arguments and another for indirect arguments.
+/// The flags in \p Flags describe the properties of the argument. See
+/// IRTArg::IRArgFlagTy.
+static std::pair<std::string, std::string> getAsCType(Type *Ty,
+                                                      unsigned Flags) {
+  if (Ty->isIntegerTy()) {
+    auto BW = Ty->getIntegerBitWidth();
+    if (BW == 1)
+      return {"bool ", "bool *"};
+    auto S = "int" + std::to_string(BW) + "_t ";
+    return {S, S + "*"};
+  }
+  if (Ty->isPointerTy())
+    return {Flags & IRTArg::STRING ? "char *" : "void *", "void **"};
+  if (Ty->isFloatTy())
+    return {"float ", "float *"};
+  if (Ty->isDoubleTy())
+    return {"double ", "double *"};
+  return {"<>", "<>"};
+}
+
+/// Get the string representation of the C printf format of an argument with
+/// type \p Ty. The flags in \p Flags describe the properties of the argument.
+/// See IRTArg::IRArgFlagTy.
+static std::string getPrintfFormatString(Type *Ty, unsigned Flags) {
+  if (Ty->isIntegerTy()) {
+    if (Ty->getIntegerBitWidth() > 32) {
+      assert(Ty->getIntegerBitWidth() == 64);
+      return "%lli";
+    }
+    return "%i";
+  }
+  if (Ty->isPointerTy())
+    return Flags & IRTArg::STRING ? "%s" : "%p";
+  if (Ty->isFloatTy())
+    return "%f";
+  if (Ty->isDoubleTy())
+    return "%lf";
+  return "<>";
+}
+
+std::pair<std::string, std::string> IRTCallDescription::createCBodies() const {
+  std::string DirectFormat = "printf(\"" + IO.getName().str() +
+                             (IO.IP.isPRE() ? " pre" : " post") + " -- ";
+  std::string IndirectFormat = DirectFormat;
+  std::string DirectArg, IndirectArg, DirectReturnValue, IndirectReturnValue;
+
+  auto AddToFormats = [&](Twine S) {
+    DirectFormat += S.str();
+    IndirectFormat += S.str();
+  };
+  auto AddToArgs = [&](Twine S) {
+    DirectArg += S.str();
+    IndirectArg += S.str();
+  };
+  bool First = true;
+  for (auto &IRArg : IO.IRTArgs) {
+    if (!IRArg.Enabled)
+      continue;
+    if (!First)
+      AddToFormats(", ");
+    First = false;
+    AddToArgs(", " + IRArg.Name);
+    AddToFormats(IRArg.Name + ": ");
+    if (NumReplaceableArgs == 1 && (IRArg.Flags & IRTArg::REPLACABLE)) {
+      DirectReturnValue = IRArg.Name;
+      if (!isPotentiallyIndirect(IRArg))
+        IndirectReturnValue = IRArg.Name;
+    }
+    if (!isPotentiallyIndirect(IRArg)) {
+      AddToFormats(getPrintfFormatString(IRArg.Ty, IRArg.Flags));
+    } else {
+      DirectFormat += getPrintfFormatString(IRArg.Ty, IRArg.Flags);
+      IndirectFormat += "%p";
+      IndirectArg += "_ptr";
+      // Add the indirect argument size
+      if (!(IRArg.Flags & IRTArg::INDIRECT_HAS_SIZE)) {
+        IndirectFormat += ", " + IRArg.Name.str() + "_size: %i";
+        IndirectArg += ", " + IRArg.Name.str() + "_size";
+      }
+    }
+  }
+
+  std::string DirectBody = DirectFormat + "\\n\"" + DirectArg + ");\n";
+  std::string IndirectBody = IndirectFormat + "\\n\"" + IndirectArg + ");\n";
+  if (RetTy)
+    IndirectReturnValue = DirectReturnValue = "0";
+  if (!DirectReturnValue.empty())
+    DirectBody += "  return " + DirectReturnValue + ";\n";
+  if (!IndirectReturnValue.empty())
+    IndirectBody += "  return " + IndirectReturnValue + ";\n";
+  return {DirectBody, IndirectBody};
+}
+
+std::pair<std::string, std::string>
+IRTCallDescription::createCSignature(const InstrumentationConfig &IConf) const {
+  SmallVector<std::string> DirectArgs, IndirectArgs;
+  std::string DirectRetTy = "void ", IndirectRetTy = "void ";
+  for (auto &IRArg : IO.IRTArgs) {
+    if (!IRArg.Enabled)
+      continue;
+    const auto &[DirectArgTy, IndirectArgTy] =
+        getAsCType(IRArg.Ty, IRArg.Flags);
+    std::string DirectArg = DirectArgTy + IRArg.Name.str();
+    std::string IndirectArg = IndirectArgTy + IRArg.Name.str() + "_ptr";
+    std::string IndirectArgSize = "int32_t " + IRArg.Name.str() + "_size";
+    DirectArgs.push_back(DirectArg);
+    if (NumReplaceableArgs == 1 && (IRArg.Flags & IRTArg::REPLACABLE)) {
+      DirectRetTy = DirectArgTy;
+      if (!isPotentiallyIndirect(IRArg))
+        IndirectRetTy = DirectArgTy;
+    }
+    if (!isPotentiallyIndirect(IRArg)) {
+      IndirectArgs.push_back(DirectArg);
+    } else {
+      IndirectArgs.push_back(IndirectArg);
+      if (!(IRArg.Flags & IRTArg::INDIRECT_HAS_SIZE))
+        IndirectArgs.push_back(IndirectArgSize);
+    }
+  }
+
+  auto DirectName =
+      IConf.getRTName(IO.IP.isPRE() ? "pre_" : "post_", IO.getName(), "");
+  auto IndirectName =
+      IConf.getRTName(IO.IP.isPRE() ? "pre_" : "post_", IO.getName(), "_ind");
+  auto MakeSignature = [&](std::string &RetTy, std::string &Name,
+                           SmallVectorImpl<std::string> &Args) {
+    return RetTy + Name + "(" + join(Args, ", ") + ")";
+  };
+
+  if (RetTy) {
+    auto UserRetTy = getAsCType(RetTy, 0).first;
+    assert((DirectRetTy == UserRetTy || DirectRetTy == "void ") &&
+           (IndirectRetTy == UserRetTy || IndirectRetTy == "void ") &&
+           "Explicit return type but also implicit one!");
+    IndirectRetTy = DirectRetTy = UserRetTy;
+  }
+  if (RequiresIndirection)
+    return {"", MakeSignature(IndirectRetTy, IndirectName, IndirectArgs)};
+  if (!MightRequireIndirection)
+    return {MakeSignature(DirectRetTy, DirectName, DirectArgs), ""};
+  return {MakeSignature(DirectRetTy, DirectName, DirectArgs),
+          MakeSignature(IndirectRetTy, IndirectName, IndirectArgs)};
+}
+
+void printRuntimeStub(const InstrumentationConfig &IConf,
+                      StringRef StubRuntimeName, LLVMContext &Ctx) {
+  if (StubRuntimeName.empty())
+    return;
+
+  std::error_code EC;
+  raw_fd_ostream OS(StubRuntimeName, EC);
+  if (EC) {
+    Ctx.emitError(
+        Twine("failed to open instrumentor stub runtime file for writing: ") +
+        EC.message());
+    return;
+  }
+
+  OS << "// LLVM Instrumentor stub runtime\n\n";
+  OS << "#include <stdint.h>\n";
+  OS << "#include <stdio.h>\n\n";
+
+  for (auto &ChoiceMap : IConf.IChoices) {
+    for (auto &[_, IO] : ChoiceMap) {
+      if (!IO->Enabled)
+        continue;
+      IRTCallDescription IRTCallDesc(*IO, IO->getRetTy(Ctx));
+      const auto Signatures = IRTCallDesc.createCSignature(IConf);
+      const auto Bodies = IRTCallDesc.createCBodies();
+      if (!Signatures.first.empty()) {
+        OS << Signatures.first << " {\n";
+        OS << "  " << Bodies.first << "}\n\n";
+      }
+      if (!Signatures.second.empty()) {
+        OS << Signatures.second << " {\n";
+        OS << "  " << Bodies.second << "}\n\n";
+      }
+    }
+  }
+}
+
+} // end namespace instrumentor
+} // end namespace llvm

--- a/llvm/lib/Transforms/IPO/InstrumentorStubPrinter.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorStubPrinter.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// The implementation of a generator of Instrumentor's runtime stubs.
+//
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/IPO/Instrumentor.h"

--- a/llvm/test/Instrumentation/Instrumentor/bad_rt_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/bad_rt_config.json
@@ -2,10 +2,8 @@
   "configuration": {
     "runtime_prefix": "__instrumentor_",
     "runtime_prefix.description": "The runtime API prefix.",
-    "runtime_stubs_file": "",
-    "runtime_stubs_file.description": "The file into which runtime stubs should be written.",
-    "demangle_function_names": true,
-    "demangle_function_names.description": "Demangle functions names passed to the runtime."
+    "runtime_stubs_file": ".",
+    "runtime_stubs_file.description": "The file into which runtime stubs should be written."
   },
   "instruction_pre": {
     "load": {
@@ -15,8 +13,6 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
-      "base_pointer_info": false,
-      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value_size": true,
       "value_size.description": "The size of the loaded value.",
       "alignment": true,
@@ -28,7 +24,9 @@
       "sync_scope_id": true,
       "sync_scope_id.description": "The sync scope id of the load.",
       "is_volatile": true,
-      "is_volatile.description": "Flag indicating a volatile load."
+      "is_volatile.description": "Flag indicating a volatile load.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
     },
     "store": {
       "enabled": true,
@@ -37,8 +35,6 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
-      "base_pointer_info": false,
-      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.description": "The stored value.",
       "value_size": true,
@@ -52,7 +48,9 @@
       "sync_scope_id": true,
       "sync_scope_id.description": "The sync scope id of the store.",
       "is_volatile": true,
-      "is_volatile.description": "Flag indicating a volatile store."
+      "is_volatile.description": "Flag indicating a volatile store.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
     }
   },
   "instruction_post": {
@@ -62,8 +60,6 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
-      "base_pointer_info": false,
-      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.replace": true,
       "value.description": "The loaded value.",
@@ -78,7 +74,9 @@
       "sync_scope_id": true,
       "sync_scope_id.description": "The sync scope id of the load.",
       "is_volatile": true,
-      "is_volatile.description": "Flag indicating a volatile load."
+      "is_volatile.description": "Flag indicating a volatile load.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
     },
     "store": {
       "enabled": true,
@@ -86,8 +84,6 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
-      "base_pointer_info": false,
-      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.description": "The stored value.",
       "value_size": true,
@@ -101,7 +97,9 @@
       "sync_scope_id": true,
       "sync_scope_id.description": "The sync scope id of the store.",
       "is_volatile": true,
-      "is_volatile.description": "Flag indicating a volatile store."
+      "is_volatile.description": "Flag indicating a volatile store.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
     }
   }
 }

--- a/llvm/test/Instrumentation/Instrumentor/default_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/default_config.json
@@ -2,6 +2,8 @@
   "configuration": {
     "runtime_prefix": "__instrumentor_",
     "runtime_prefix.description": "The runtime API prefix.",
+    "runtime_stubs_file": "",
+    "runtime_stubs_file.description": "The file into which runtime stubs should be written.",
     "target_regex": "",
     "target_regex.description": "Regular expression to be matched against the module target. Only targets that match this regex will be instrumented",
     "host_enabled": true,

--- a/llvm/test/Instrumentation/Instrumentor/default_rt
+++ b/llvm/test/Instrumentation/Instrumentor/default_rt
@@ -1,0 +1,37 @@
+// LLVM Instrumentor stub runtime
+
+#include <stdint.h>
+#include <stdio.h>
+
+void *__instrumentor_pre_load(void *pointer, int32_t pointer_as, int64_t value_size, int64_t alignment, int32_t value_type_id, int32_t atomicity_ordering, int8_t sync_scope_id, int8_t is_volatile, int32_t id) {
+  printf("load pre -- pointer: %p, pointer_as: %i, value_size: %lli, alignment: %lli, value_type_id: %i, atomicity_ordering: %i, sync_scope_id: %i, is_volatile: %i, id: %i\n", pointer, pointer_as, value_size, alignment, value_type_id, atomicity_ordering, sync_scope_id, is_volatile, id);
+  return pointer;
+}
+
+void *__instrumentor_pre_store(void *pointer, int32_t pointer_as, int64_t value, int64_t value_size, int64_t alignment, int32_t value_type_id, int32_t atomicity_ordering, int8_t sync_scope_id, int8_t is_volatile, int32_t id) {
+  printf("store pre -- pointer: %p, pointer_as: %i, value: %lli, value_size: %lli, alignment: %lli, value_type_id: %i, atomicity_ordering: %i, sync_scope_id: %i, is_volatile: %i, id: %i\n", pointer, pointer_as, value, value_size, alignment, value_type_id, atomicity_ordering, sync_scope_id, is_volatile, id);
+  return pointer;
+}
+
+void *__instrumentor_pre_store_ind(void *pointer, int32_t pointer_as, int64_t *value_ptr, int64_t value_size, int64_t alignment, int32_t value_type_id, int32_t atomicity_ordering, int8_t sync_scope_id, int8_t is_volatile, int32_t id) {
+  printf("store pre -- pointer: %p, pointer_as: %i, value: %p, value_size: %lli, alignment: %lli, value_type_id: %i, atomicity_ordering: %i, sync_scope_id: %i, is_volatile: %i, id: %i\n", pointer, pointer_as, value_ptr, value_size, alignment, value_type_id, atomicity_ordering, sync_scope_id, is_volatile, id);
+  return pointer;
+}
+
+int64_t __instrumentor_post_load(void *pointer, int32_t pointer_as, int64_t value, int64_t value_size, int64_t alignment, int32_t value_type_id, int32_t atomicity_ordering, int8_t sync_scope_id, int8_t is_volatile, int32_t id) {
+  printf("load post -- pointer: %p, pointer_as: %i, value: %lli, value_size: %lli, alignment: %lli, value_type_id: %i, atomicity_ordering: %i, sync_scope_id: %i, is_volatile: %i, id: %i\n", pointer, pointer_as, value, value_size, alignment, value_type_id, atomicity_ordering, sync_scope_id, is_volatile, id);
+  return value;
+}
+
+void __instrumentor_post_load_ind(void *pointer, int32_t pointer_as, int64_t *value_ptr, int64_t value_size, int64_t alignment, int32_t value_type_id, int32_t atomicity_ordering, int8_t sync_scope_id, int8_t is_volatile, int32_t id) {
+  printf("load post -- pointer: %p, pointer_as: %i, value: %p, value_size: %lli, alignment: %lli, value_type_id: %i, atomicity_ordering: %i, sync_scope_id: %i, is_volatile: %i, id: %i\n", pointer, pointer_as, value_ptr, value_size, alignment, value_type_id, atomicity_ordering, sync_scope_id, is_volatile, id);
+}
+
+void __instrumentor_post_store(void *pointer, int32_t pointer_as, int64_t value, int64_t value_size, int64_t alignment, int32_t value_type_id, int32_t atomicity_ordering, int8_t sync_scope_id, int8_t is_volatile, int32_t id) {
+  printf("store post -- pointer: %p, pointer_as: %i, value: %lli, value_size: %lli, alignment: %lli, value_type_id: %i, atomicity_ordering: %i, sync_scope_id: %i, is_volatile: %i, id: %i\n", pointer, pointer_as, value, value_size, alignment, value_type_id, atomicity_ordering, sync_scope_id, is_volatile, id);
+}
+
+void __instrumentor_post_store_ind(void *pointer, int32_t pointer_as, int64_t *value_ptr, int64_t value_size, int64_t alignment, int32_t value_type_id, int32_t atomicity_ordering, int8_t sync_scope_id, int8_t is_volatile, int32_t id) {
+  printf("store post -- pointer: %p, pointer_as: %i, value: %p, value_size: %lli, alignment: %lli, value_type_id: %i, atomicity_ordering: %i, sync_scope_id: %i, is_volatile: %i, id: %i\n", pointer, pointer_as, value_ptr, value_size, alignment, value_type_id, atomicity_ordering, sync_scope_id, is_volatile, id);
+}
+

--- a/llvm/test/Instrumentation/Instrumentor/generate_bad_rt.ll
+++ b/llvm/test/Instrumentation/Instrumentor/generate_bad_rt.ll
@@ -1,0 +1,3 @@
+; RUN: not opt < %s -passes=instrumentor -instrumentor-read-config-file=%S/bad_rt_config.json 2>&1 | FileCheck %s
+
+; CHECK: error: failed to open instrumentor stub runtime file for writing: Is a directory

--- a/llvm/test/Instrumentation/Instrumentor/generate_bad_rt.ll
+++ b/llvm/test/Instrumentation/Instrumentor/generate_bad_rt.ll
@@ -1,3 +1,3 @@
-; RUN: not opt < %s -passes=instrumentor -instrumentor-read-config-file=%S/bad_rt_config.json 2>&1 | FileCheck %s
+; RUN: not opt < %s -passes=instrumentor -instrumentor-read-config-file=%S/bad_rt_config.json 2>&1 | FileCheck %s --ignore-case
 
 ; CHECK: error: failed to open instrumentor stub runtime file for writing: Is a directory

--- a/llvm/test/Instrumentation/Instrumentor/generate_rt.ll
+++ b/llvm/test/Instrumentation/Instrumentor/generate_rt.ll
@@ -1,0 +1,2 @@
+; RUN: opt < %s -passes=instrumentor -instrumentor-read-config-file=%S/rt_config.json -S
+; RUN: diff rt.c %S/default_rt

--- a/llvm/test/Instrumentation/Instrumentor/generate_rt.ll
+++ b/llvm/test/Instrumentation/Instrumentor/generate_rt.ll
@@ -1,2 +1,2 @@
 ; RUN: opt < %s -passes=instrumentor -instrumentor-read-config-file=%S/rt_config.json -S
-; RUN: diff rt.c %S/default_rt
+; RUN: diff -b rt.c %S/default_rt

--- a/llvm/test/Instrumentation/Instrumentor/load_store_noreplace_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/load_store_noreplace_config.json
@@ -2,7 +2,7 @@
   "configuration": {
     "runtime_prefix": "__instrumentor_",
     "runtime_prefix.description": "The runtime API prefix.",
-    "runtime_stubs_file": "rt.c",
+    "runtime_stubs_file": "",
     "runtime_stubs_file.description": "The file into which runtime stubs should be written.",
     "demangle_function_names": true,
     "demangle_function_names.description": "Demangle functions names passed to the runtime."

--- a/llvm/test/Instrumentation/Instrumentor/rt_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/rt_config.json
@@ -2,10 +2,8 @@
   "configuration": {
     "runtime_prefix": "__instrumentor_",
     "runtime_prefix.description": "The runtime API prefix.",
-    "runtime_stubs_file": "",
-    "runtime_stubs_file.description": "The file into which runtime stubs should be written.",
-    "demangle_function_names": true,
-    "demangle_function_names.description": "Demangle functions names passed to the runtime."
+    "runtime_stubs_file": "rt.c",
+    "runtime_stubs_file.description": "The file into which runtime stubs should be written."
   },
   "instruction_pre": {
     "load": {
@@ -15,8 +13,6 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
-      "base_pointer_info": false,
-      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value_size": true,
       "value_size.description": "The size of the loaded value.",
       "alignment": true,
@@ -28,7 +24,9 @@
       "sync_scope_id": true,
       "sync_scope_id.description": "The sync scope id of the load.",
       "is_volatile": true,
-      "is_volatile.description": "Flag indicating a volatile load."
+      "is_volatile.description": "Flag indicating a volatile load.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
     },
     "store": {
       "enabled": true,
@@ -37,8 +35,6 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
-      "base_pointer_info": false,
-      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.description": "The stored value.",
       "value_size": true,
@@ -52,7 +48,9 @@
       "sync_scope_id": true,
       "sync_scope_id.description": "The sync scope id of the store.",
       "is_volatile": true,
-      "is_volatile.description": "Flag indicating a volatile store."
+      "is_volatile.description": "Flag indicating a volatile store.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
     }
   },
   "instruction_post": {
@@ -62,8 +60,6 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
-      "base_pointer_info": false,
-      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.replace": true,
       "value.description": "The loaded value.",
@@ -78,7 +74,9 @@
       "sync_scope_id": true,
       "sync_scope_id.description": "The sync scope id of the load.",
       "is_volatile": true,
-      "is_volatile.description": "Flag indicating a volatile load."
+      "is_volatile.description": "Flag indicating a volatile load.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
     },
     "store": {
       "enabled": true,
@@ -86,8 +84,6 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
-      "base_pointer_info": false,
-      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.description": "The stored value.",
       "value_size": true,
@@ -101,7 +97,9 @@
       "sync_scope_id": true,
       "sync_scope_id.description": "The sync scope id of the store.",
       "is_volatile": true,
-      "is_volatile.description": "Flag indicating a volatile store."
+      "is_volatile.description": "Flag indicating a volatile store.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
     }
   }
 }


### PR DESCRIPTION
This PR extends the Instrumentor the option `configuration.runtime_stubs_file` to generate a runtime stub file with the configured instrumentation. The stub prints all parameters passed to each enabled instrumentation function.