### PR TITLE
[clang][modules] Timestamp-less validation API

### DIFF
--- a/clang-tools-extra/clangd/ModulesBuilder.cpp
+++ b/clang-tools-extra/clangd/ModulesBuilder.cpp
@@ -207,7 +207,8 @@ bool IsModuleFileUpToDate(PathRef ModuleFilePath,
   Preprocessor PP(PPOpts, *Diags, LangOpts, SourceMgr, HeaderInfo,
                   ModuleLoader);
 
-  IntrusiveRefCntPtr<ModuleCache> ModCache = createCrossProcessModuleCache();
+  IntrusiveRefCntPtr<ModuleCache> ModCache =
+      createCrossProcessModuleCache(HSOpts.BuildSessionTimestamp);
   PCHContainerOperations PCHOperations;
   ASTReader Reader(PP, *ModCache, /*ASTContext=*/nullptr,
                    PCHOperations.getRawReader(), {});

--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -33,17 +33,14 @@ public:
   virtual std::unique_ptr<llvm::AdvisoryLock>
   getLock(StringRef ModuleFilename) = 0;
 
-  // TODO: Abstract away timestamps with isUpToDate() and markUpToDate().
   // TODO: Consider exposing a "validation lock" API to prevent multiple clients
   // concurrently noticing an out-of-date module file and validating its inputs.
 
-  /// Returns the timestamp denoting the last time inputs of the module file
-  /// were validated.
-  virtual std::time_t getModuleTimestamp(StringRef ModuleFilename) = 0;
+  /// Checks whether the inputs of the module file were marked as validated.
+  virtual bool isMarkedUpToDate(StringRef ModuleFilename) = 0;
 
-  /// Updates the timestamp denoting the last time inputs of the module file
-  /// were validated.
-  virtual void updateModuleTimestamp(StringRef ModuleFilename) = 0;
+  /// Marks the inputs of the module file as validated.
+  virtual void markUpToDate(StringRef ModuleFilename) = 0;
 
   /// Returns this process's view of the module cache.
   virtual InMemoryModuleCache &getInMemoryModuleCache() = 0;
@@ -58,7 +55,8 @@ public:
 /// operated on by multiple processes. This instance must be used across all
 /// \c CompilerInstance instances participating in building modules for single
 /// translation unit in order to share the same \c InMemoryModuleCache.
-IntrusiveRefCntPtr<ModuleCache> createCrossProcessModuleCache();
+IntrusiveRefCntPtr<ModuleCache>
+createCrossProcessModuleCache(std::time_t BuildSessionTimestamp);
 } // namespace clang
 
 #endif

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -270,11 +270,9 @@ public:
   // system input files reside at [NumUserInputFiles, InputFilesLoaded.size()).
   unsigned NumUserInputFiles = 0;
 
-  /// If non-zero, specifies the time when we last validated input
-  /// files.  Zero means we never validated them.
-  ///
-  /// The time is specified in seconds since the start of the Epoch.
-  uint64_t InputFilesValidationTimestamp = 0;
+  /// Specifies whether the input files have been validated (i.e. checked
+  /// whether they are up-to-date).
+  bool InputFilesValidated = false;
 
   // === Source Locations ===
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -12,7 +12,6 @@
 #include "clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h"
 #include "clang/Tooling/DependencyScanning/InProcessModuleCache.h"
 #include "llvm/ADT/BitmaskEnum.h"
-#include "llvm/Support/Chrono.h"
 
 namespace clang {
 namespace tooling {
@@ -85,9 +84,7 @@ public:
   DependencyScanningService(
       ScanningMode Mode, ScanningOutputFormat Format,
       ScanningOptimizations OptimizeArgs = ScanningOptimizations::Default,
-      bool EagerLoadModules = false, bool TraceVFS = false,
-      std::time_t BuildSessionTimestamp =
-          llvm::sys::toTimeT(std::chrono::system_clock::now()));
+      bool EagerLoadModules = false, bool TraceVFS = false);
 
   ScanningMode getMode() const { return Mode; }
 
@@ -105,8 +102,6 @@ public:
 
   ModuleCacheEntries &getModuleCacheEntries() { return ModCacheEntries; }
 
-  std::time_t getBuildSessionTimestamp() const { return BuildSessionTimestamp; }
-
 private:
   const ScanningMode Mode;
   const ScanningOutputFormat Format;
@@ -120,8 +115,6 @@ private:
   DependencyScanningFilesystemSharedCache SharedCache;
   /// The global module cache entries.
   ModuleCacheEntries ModCacheEntries;
-  /// The build session timestamp.
-  std::time_t BuildSessionTimestamp;
 };
 
 } // end namespace dependencies

--- a/clang/include/clang/Tooling/DependencyScanning/InProcessModuleCache.h
+++ b/clang/include/clang/Tooling/DependencyScanning/InProcessModuleCache.h
@@ -20,7 +20,7 @@ namespace tooling {
 namespace dependencies {
 struct ModuleCacheEntry {
   std::shared_mutex CompilationMutex;
-  std::atomic<std::time_t> Timestamp = 0;
+  std::atomic<bool> UpToDate = false;
 };
 
 struct ModuleCacheEntries {

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -72,7 +72,9 @@ CompilerInstance::CompilerInstance(
     ModuleCache *ModCache)
     : ModuleLoader(/*BuildingModule=*/ModCache),
       Invocation(std::move(Invocation)),
-      ModCache(ModCache ? ModCache : createCrossProcessModuleCache()),
+      ModCache(ModCache ? ModCache
+                        : createCrossProcessModuleCache(
+                              getHeaderSearchOpts().BuildSessionTimestamp)),
       ThePCHContainerOperations(std::move(PCHContainerOps)) {
   assert(this->Invocation && "Invocation must not be null");
 }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -3103,8 +3103,7 @@ ASTReader::ReadControlBlock(ModuleFile &F,
 
         unsigned N = ValidateSystemInputs ? NumInputs : NumUserInputs;
         if (HSOpts.ModulesValidateOncePerBuildSession &&
-            F.InputFilesValidationTimestamp > HSOpts.BuildSessionTimestamp &&
-            F.Kind == MK_ImplicitModule)
+            F.InputFilesValidated && F.Kind == MK_ImplicitModule)
           N = ForceValidateUserInputs ? NumUserInputs : 0;
 
         for (unsigned I = 0; I < N; ++I) {
@@ -4950,10 +4949,8 @@ ASTReader::ASTReadResult ASTReader::ReadAST(StringRef FileName, ModuleKind Type,
     // timestamp files are up-to-date in this build session.
     for (unsigned I = 0, N = Loaded.size(); I != N; ++I) {
       ImportedModule &M = Loaded[I];
-      if (M.Mod->Kind == MK_ImplicitModule &&
-          M.Mod->InputFilesValidationTimestamp < HSOpts.BuildSessionTimestamp)
-        getModuleManager().getModuleCache().updateModuleTimestamp(
-            M.Mod->FileName);
+      if (M.Mod->Kind == MK_ImplicitModule && !M.Mod->InputFilesValidated)
+        getModuleManager().getModuleCache().markUpToDate(M.Mod->FileName);
     }
   }
 

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -5394,7 +5394,7 @@ ASTWriter::WriteAST(llvm::PointerUnion<Sema *, Preprocessor *> Subject,
   if (WritingModule && PPRef.getHeaderSearchInfo()
                            .getHeaderSearchOpts()
                            .ModulesValidateOncePerBuildSession)
-    ModCache.updateModuleTimestamp(OutputFile);
+    ModCache.markUpToDate(OutputFile);
 
   if (ShouldCacheASTInMemory) {
     // Construct MemoryBuffer and update buffer manager.

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -174,11 +174,11 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
   NewModule->Index = Chain.size();
   NewModule->FileName = FileName.str();
   NewModule->ImportLoc = ImportLoc;
-  NewModule->InputFilesValidationTimestamp = 0;
+  NewModule->InputFilesValidated = false;
 
   if (NewModule->Kind == MK_ImplicitModule)
-    NewModule->InputFilesValidationTimestamp =
-        ModCache->getModuleTimestamp(NewModule->FileName);
+    NewModule->InputFilesValidated =
+        ModCache->isMarkedUpToDate(NewModule->FileName);
 
   // Load the contents of the module
   if (std::unique_ptr<llvm::MemoryBuffer> Buffer = lookupBuffer(FileName)) {

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -14,8 +14,6 @@ using namespace dependencies;
 
 DependencyScanningService::DependencyScanningService(
     ScanningMode Mode, ScanningOutputFormat Format,
-    ScanningOptimizations OptimizeArgs, bool EagerLoadModules, bool TraceVFS,
-    std::time_t BuildSessionTimestamp)
+    ScanningOptimizations OptimizeArgs, bool EagerLoadModules, bool TraceVFS)
     : Mode(Mode), Format(Format), OptimizeArgs(OptimizeArgs),
-      EagerLoadModules(EagerLoadModules), TraceVFS(TraceVFS),
-      BuildSessionTimestamp(BuildSessionTimestamp) {}
+      EagerLoadModules(EagerLoadModules), TraceVFS(TraceVFS) {}

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -428,10 +428,6 @@ public:
     ScanInstance.getPreprocessorOpts().AllowPCHWithDifferentModulesCachePath =
         true;
 
-    if (ScanInstance.getHeaderSearchOpts().ModulesValidateOncePerBuildSession)
-      ScanInstance.getHeaderSearchOpts().BuildSessionTimestamp =
-          Service.getBuildSessionTimestamp();
-
     ScanInstance.getFrontendOpts().GenerateGlobalModuleIndex = false;
     ScanInstance.getFrontendOpts().UseGlobalModuleIndex = false;
     // This will prevent us compiling individual modules asynchronously since


### PR DESCRIPTION
Timestamps are an implementation detail of the cross-process module cache implementation. This PR hides it from the `ModuleCache` API, which simplifies the in-process implementation.