### PR TITLE
[DirectX] Disable all libcalls for DXIL in TargetLibraryInfo.cpp

### DIFF
--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -205,6 +205,11 @@ static void initializeLibCalls(TargetLibraryInfoImpl &TLI, const Triple &T,
     return;
   }
 
+  if (T.isDXIL()) {
+    TLI.disableAllFunctions();
+    return;
+  }
+
   // memset_pattern{4,8,16} is only available on iOS 3.0 and Mac OS X 10.5 and
   // later. All versions of watchOS support it.
   if (T.isMacOSX()) {

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -205,6 +205,9 @@ static void initializeLibCalls(TargetLibraryInfoImpl &TLI, const Triple &T,
     return;
   }
 
+  // DXIL does not support libcalls, and disabling them here prevents a number
+  // of passes from introducing libcalls into DXIL which would otherwise
+  // complicate lowering/legalization
   if (T.isDXIL()) {
     TLI.disableAllFunctions();
     return;


### PR DESCRIPTION
Fixes #138787

To the best of my knowledge, DXIL does not (and should not) support any of the libcalls in [`TargetLibraryInfo.def`](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/Analysis/TargetLibraryInfo.def).
Math libcalls are not used in HLSL and also do not have lowerings to DXIL. (The current implementation of math functions are done via intrinsics.)
If there is a mistake with disabling all libcalls, then the libcalls we need can be re-enabled in a follow-up PR.

Locally, the codegen tests for Clang HLSL and the DirectX backend appear to pass without any issues.
The offload test suite's clang-d3d12 tests are also passing locally (Unsupported: 31 (62.00%),  Passed: 19 (38.00%))
The change this PR introduces also eliminates the problematic memcpy intrinsics operating with a non-constant length argument and addrspace(3) ptrs showing up when compiling DML shaders. The number of DML shaders compiling successfully is greater with this PR than without.
