### PR TITLE
[NVPTX] Fix NVPTXAA_before_BasicAA Test

### DIFF
--- a/llvm/test/Analysis/NVPTXAA/NVPTXAA_before_BasicAA.ll
+++ b/llvm/test/Analysis/NVPTXAA/NVPTXAA_before_BasicAA.ll
@@ -1,4 +1,4 @@
-; REQUIRES: asserts
+; REQUIRES: asserts, nvptx-registered-target
 ; RUN: opt -aa-pipeline=default -passes='require<aa>' -debug-pass-manager -disable-output -S < %s 2>&1 | FileCheck %s
 ; RUN: llc --debug-only='aa' -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=LEGACY
 

--- a/llvm/test/CodeGen/NVPTX/NVPTXAA_before_BasicAA.ll
+++ b/llvm/test/CodeGen/NVPTX/NVPTXAA_before_BasicAA.ll
@@ -1,4 +1,4 @@
-; REQUIRES: asserts, nvptx-registered-target
+; REQUIRES: asserts
 ; RUN: opt -aa-pipeline=default -passes='require<aa>' -debug-pass-manager -disable-output -S < %s 2>&1 | FileCheck %s
 ; RUN: llc --debug-only='aa' -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=LEGACY
 


### PR DESCRIPTION
Fix the failed test in the [PR](https://github.com/llvm/llvm-project/pull/125965) by moving the test to CodeGen/NVPTX.