### PR TITLE
[SimplifyCFG][swifterror] Don't sink calls with swifterror params

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -4224,6 +4224,14 @@ bool llvm::canReplaceOperandWithVariable(const Instruction *I, unsigned OpIdx) {
   if (I->getOperand(OpIdx)->getType()->isMetadataTy())
     return false;
 
+  // swifterror pointers can only be used by a load, store, or as a swifterror
+  // argument; swifterror pointers are not allowed to be used in select or phi
+  // instructions.
+  if ((OpIdx == 1 && isa<StoreInst>(I)) || (OpIdx == 0 && isa<LoadInst>(I)) ||
+      (OpIdx < I->getNumOperands() && isa<CallBase>(I)))
+    if (I->getOperand(OpIdx)->isSwiftError())
+      return false;
+
   // Early exit.
   if (!isa<Constant, InlineAsm>(I->getOperand(OpIdx)))
     return true;

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -4227,8 +4227,7 @@ bool llvm::canReplaceOperandWithVariable(const Instruction *I, unsigned OpIdx) {
   // swifterror pointers can only be used by a load, store, or as a swifterror
   // argument; swifterror pointers are not allowed to be used in select or phi
   // instructions.
-  if ((OpIdx == 1 && isa<StoreInst>(I)) || (OpIdx == 0 && isa<LoadInst>(I)) ||
-      (OpIdx < I->getNumOperands() && isa<CallBase>(I)))
+  if (OpIdx < I->getNumOperands())
     if (I->getOperand(OpIdx)->isSwiftError())
       return false;
 

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -4220,19 +4220,19 @@ void llvm::maybeMarkSanitizerLibraryCallNoBuiltin(
 }
 
 bool llvm::canReplaceOperandWithVariable(const Instruction *I, unsigned OpIdx) {
+  const auto *Op = I->getOperand(OpIdx);
   // We can't have a PHI with a metadata type.
-  if (I->getOperand(OpIdx)->getType()->isMetadataTy())
+  if (Op->getType()->isMetadataTy())
     return false;
 
   // swifterror pointers can only be used by a load, store, or as a swifterror
   // argument; swifterror pointers are not allowed to be used in select or phi
   // instructions.
-  if (OpIdx < I->getNumOperands())
-    if (I->getOperand(OpIdx)->isSwiftError())
-      return false;
+  if (Op->isSwiftError())
+    return false;
 
   // Early exit.
-  if (!isa<Constant, InlineAsm>(I->getOperand(OpIdx)))
+  if (!isa<Constant, InlineAsm>(Op))
     return true;
 
   switch (I->getOpcode()) {

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -2208,19 +2208,6 @@ static bool canSinkInstructions(
     if (!I->isSameOperationAs(I0, Instruction::CompareUsingIntersectedAttrs))
       return false;
 
-    // swifterror pointers can only be used by a load, store, or as a swifterror
-    // argument; sinking a load, store, or call would require introducing a
-    // select for the pointer operand, which isn't allowed for swifterror
-    // pointers.
-    if (isa<StoreInst>(I) && I->getOperand(1)->isSwiftError())
-      return false;
-    if (isa<LoadInst>(I) && I->getOperand(0)->isSwiftError())
-      return false;
-    if (const auto *CB = dyn_cast<CallBase>(I))
-      for (const Use &Arg : CB->args())
-        if (Arg->isSwiftError())
-          return false;
-
     // Treat MMRAs conservatively. This pass can be quite aggressive and
     // could drop a lot of MMRAs otherwise.
     if (MMRAMetadata(*I) != I0MMRA)


### PR DESCRIPTION
We've encountered an LLVM verification failure when building Swift with the SimplifyCFG pass enabled. I found that https://reviews.llvm.org/D158083 fixed this pass by preventing sinking loads or stores of swifterror values, but it did not implement the same protection for call or invokes. 
In `Verifier.cpp` [here](https://github.com/ellishg/llvm-project/blob/c68535581135a1513c9c4c1c7672307d4b5e616e/llvm/lib/IR/Verifier.cpp#L4360-L4364) and [here](https://github.com/ellishg/llvm-project/blob/c68535581135a1513c9c4c1c7672307d4b5e616e/llvm/lib/IR/Verifier.cpp#L3661-L3662) we can see that swifterror values must also be used directly by call instructions.