### PR TITLE
[lldb] Change the statusline format to print "no target"

### DIFF
--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -186,7 +186,7 @@ let Definition = "debugger" in {
       : Property<"statusline-format", "FormatEntity">,
         Global,
         DefaultStringValue<
-            "${ansi.negative}{${target.file.basename}}{ "
+            "${ansi.negative}{${target.file.basename}|no target}{ "
             "${separator}${line.file.basename}:${line.number}:${line.column}}{ "
             "${separator}${thread.stop-reason}}{ "
             "${separator}{${progress.count} }${progress.message}}">,

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -6,7 +6,18 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.lldbpexpect import PExpectTest
 
 
+# PExpect uses many timeouts internally and doesn't play well
+# under ASAN on a loaded machine..
+@skipIfAsan
 class TestStatusline(PExpectTest):
+
+    # Change this value to something smaller to make debugging this test less
+    # tedious.
+    TIMEOUT = 60
+
+    TERMINAL_HEIGHT = 10
+    TERMINAL_WIDTH = 60
+
     def do_setup(self):
         # Create a target and run to a breakpoint.
         exe = self.getBuildArtifact("a.out")
@@ -15,20 +26,18 @@ class TestStatusline(PExpectTest):
         )
         self.expect('breakpoint set -p "Break here"', substrs=["Breakpoint 1"])
         self.expect("run", substrs=["stop reason"])
+        self.resize()
 
-    # PExpect uses many timeouts internally and doesn't play well
-    # under ASAN on a loaded machine..
-    @skipIfAsan
+    def resize(self):
+        # Change the terminal dimensions. When we launch the tests, we reset
+        # all the settings, leaving the terminal dimensions unset.
+        self.child.setwinsize(self.TERMINAL_HEIGHT, self.TERMINAL_WIDTH)
+
     def test(self):
         """Basic test for the statusline."""
         self.build()
-        self.launch()
+        self.launch(timeout=self.TIMEOUT)
         self.do_setup()
-
-        # Change the terminal dimensions.
-        terminal_height = 10
-        terminal_width = 60
-        self.child.setwinsize(terminal_height, terminal_width)
 
         # Enable the statusline and check for the control character and that we
         # can see the target, the location and the stop reason.
@@ -36,15 +45,15 @@ class TestStatusline(PExpectTest):
         self.expect(
             "set set show-statusline true",
             [
-                "\x1b[0;{}r".format(terminal_height - 1),
+                "\x1b[0;{}r".format(self.TERMINAL_HEIGHT - 1),
                 "a.out | main.c:2:11 | breakpoint 1.1                        ",
             ],
         )
 
         # Change the terminal dimensions and make sure it's reflected immediately.
-        self.child.setwinsize(terminal_height, 25)
+        self.child.setwinsize(self.TERMINAL_HEIGHT, 25)
         self.child.expect(re.escape("a.out | main.c:2:11 | bre"))
-        self.child.setwinsize(terminal_height, terminal_width)
+        self.child.setwinsize(self.TERMINAL_HEIGHT, self.TERMINAL_WIDTH)
 
         # Change the separator.
         self.expect('set set separator "S "', ["a.out S main.c:2:11"])
@@ -58,22 +67,14 @@ class TestStatusline(PExpectTest):
 
         # Hide the statusline and check or the control character.
         self.expect(
-            "set set show-statusline false", ["\x1b[0;{}r".format(terminal_height)]
+            "set set show-statusline false", ["\x1b[0;{}r".format(self.TERMINAL_HEIGHT)]
         )
 
-    # PExpect uses many timeouts internally and doesn't play well
-    # under ASAN on a loaded machine..
-    @skipIfAsan
     def test_no_color(self):
         """Basic test for the statusline with colors disabled."""
         self.build()
-        self.launch(use_colors=False)
+        self.launch(use_colors=False, timeout=self.TIMEOUT)
         self.do_setup()
-
-        # Change the terminal dimensions.
-        terminal_height = 10
-        terminal_width = 60
-        self.child.setwinsize(terminal_height, terminal_width)
 
         # Enable the statusline and check for the "reverse video" control character.
         self.expect(
@@ -87,15 +88,20 @@ class TestStatusline(PExpectTest):
         """Regression test for lock inversion between the statusline mutex and
         the output mutex."""
         self.build()
-        self.launch(extra_args=["-o", "settings set use-color false"])
+        self.launch(
+            extra_args=["-o", "settings set use-color false"], timeout=self.TIMEOUT
+        )
         self.child.expect("(lldb)")
-
-        # Change the terminal dimensions.
-        terminal_height = 10
-        terminal_width = 60
-        self.child.setwinsize(terminal_height, terminal_width)
+        self.resize()
 
         exe = self.getBuildArtifact("a.out")
 
         self.expect("file {}".format(exe), ["Current executable"])
         self.expect("help", ["Debugger commands"])
+
+    def test_no_target(self):
+        """Test that we print "no target" when launched without a target."""
+        self.launch(timeout=self.TIMEOUT)
+        self.resize()
+
+        self.expect("set set show-statusline true", ["no target"])

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -10,7 +10,6 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 # under ASAN on a loaded machine..
 @skipIfAsan
 class TestStatusline(PExpectTest):
-
     # Change this value to something smaller to make debugging this test less
     # tedious.
     TIMEOUT = 60


### PR DESCRIPTION
Change the default statusline format to print "no target" when lldb is launched without a target. Currently, the statusline is empty, which looks rather odd.