### PR TITLE
Revert "[Clang] Deprecate `__is_trivially_relocatable`"

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -1859,18 +1859,12 @@ The following type trait primitives are supported by Clang. Those traits marked
 * ``__is_trivially_constructible`` (C++, GNU, Microsoft)
 * ``__is_trivially_copyable`` (C++, GNU, Microsoft)
 * ``__is_trivially_destructible`` (C++, MSVC 2013)
-* ``__is_trivially_relocatable`` (Clang) (Deprecated,
-  use ``__builtin_is_cpp_trivially_relocatable`` instead).
-  Returns true if moving an object
+* ``__is_trivially_relocatable`` (Clang): Returns true if moving an object
   of the given type, and then destroying the source object, is known to be
   functionally equivalent to copying the underlying bytes and then dropping the
   source object on the floor. This is true of trivial types,
   C++26 relocatable types, and types which
   were made trivially relocatable via the ``clang::trivial_abi`` attribute.
-  This trait is deprecated and should be replaced by
-  ``__builtin_is_cpp_trivially_relocatable``. Note however that it is generally
-  unsafe to relocate a C++-relocatable type with ``memcpy`` or ``memmove``;
-  use ``__builtin_trivially_relocate``.
 * ``__builtin_is_cpp_trivially_relocatable`` (C++): Returns true if an object
   is trivially relocatable, as defined by the C++26 standard [meta.unary.prop].
   Note that when relocating the caller code should ensure that if the object is polymorphic,

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -579,15 +579,6 @@ Bug Fixes to Compiler Builtins
 - ``__has_unique_object_representations(Incomplete[])`` is no longer accepted, per
   `LWG4113 <https://cplusplus.github.io/LWG/issue4113>`_.
 
-- ``__builtin_is_cpp_trivially_relocatable``, ``__builtin_is_replaceable`` and
-  ``__builtin_trivially_relocate`` have been added to support standard C++26 relocation.
-
-- ``__is_trivially_relocatable`` has been deprecated, and uses should be replaced by
-  ``__builtin_is_cpp_trivially_relocatable``.
-  Note that, it is generally unsafe to ``memcpy`` non-trivially copyable types that
-  are ``__builtin_is_cpp_trivially_relocatable``. It is recommended to use
-  ``__builtin_trivially_relocate`` instead.
-
 Bug Fixes to Attribute Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  - Fixed crash when a parameter to the ``clang::annotate`` attribute evaluates to ``void``. See #GH119125

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -544,6 +544,7 @@ TYPE_TRAIT_2(__is_pointer_interconvertible_base_of, IsPointerInterconvertibleBas
 #include "clang/Basic/TransformTypeTraits.def"
 
 // Clang-only C++ Type Traits
+TYPE_TRAIT_1(__is_trivially_relocatable, IsTriviallyRelocatable, KEYCXX)
 TYPE_TRAIT_1(__is_trivially_equality_comparable, IsTriviallyEqualityComparable, KEYCXX)
 TYPE_TRAIT_1(__is_bounded_array, IsBoundedArray, KEYCXX)
 TYPE_TRAIT_1(__is_unbounded_array, IsUnboundedArray, KEYCXX)
@@ -555,11 +556,8 @@ TYPE_TRAIT_2(__reference_converts_from_temporary, ReferenceConvertsFromTemporary
 // IsDeducible is only used internally by clang for CTAD implementation and
 // is not exposed to users.
 TYPE_TRAIT_2(/*EmptySpellingName*/, IsDeducible, KEYCXX)
-
-// __is_trivially_relocatable is deprecated
-TYPE_TRAIT_1(__builtin_is_cpp_trivially_relocatable, IsCppTriviallyRelocatable, KEYCXX)
-TYPE_TRAIT_1(__is_trivially_relocatable, IsTriviallyRelocatable, KEYCXX)
 TYPE_TRAIT_1(__is_bitwise_cloneable, IsBitwiseCloneable, KEYALL)
+TYPE_TRAIT_1(__builtin_is_cpp_trivially_relocatable, IsCppTriviallyRelocatable, KEYCXX)
 TYPE_TRAIT_1(__builtin_is_replaceable, IsReplaceable, KEYCXX)
 TYPE_TRAIT_1(__builtin_structured_binding_size, StructuredBindingSize, KEYCXX)
 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -6449,9 +6449,6 @@ void DiagnoseBuiltinDeprecation(Sema& S, TypeTrait Kind,
     case UTT_HasTrivialDestructor:
       Replacement = UTT_IsTriviallyDestructible;
       break;
-    case UTT_IsTriviallyRelocatable:
-      Replacement = clang::UTT_IsCppTriviallyRelocatable;
-      break;
     default:
       return;
   }

--- a/clang/test/SemaCXX/attr-trivial-abi.cpp
+++ b/clang/test/SemaCXX/attr-trivial-abi.cpp
@@ -1,6 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++11
-// RUN: %clang_cc1 -fsyntax-only -verify %s -triple x86_64-windows-msvc -std=c++11
-
 
 void __attribute__((trivial_abi)) foo(); // expected-warning {{'trivial_abi' attribute only applies to classes}}
 
@@ -12,38 +10,30 @@ class __attribute__((trivial_abi)) a { a(a &&); };
 // (And it is only trivially relocatable, currently, if it is trivial for calls.)
 // In this case, it is suppressed by an explicitly defined move constructor.
 // Similar concerns apply to later tests that have #if defined(_WIN64) && !defined(__MINGW32__)
-static_assert(!__is_trivially_relocatable(a<int>), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(a<int>), "");
+static_assert(!__is_trivially_relocatable(a<int>), "");
 #else
-static_assert(__is_trivially_relocatable(a<int>), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(a<int>), "");
+static_assert(__is_trivially_relocatable(a<int>), "");
 #endif
 
 struct [[clang::trivial_abi]] S0 {
   int a;
 };
-static_assert(__is_trivially_relocatable(S0), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S0), "");
+static_assert(__is_trivially_relocatable(S0), "");
 
 struct __attribute__((trivial_abi)) S1 {
   int a;
 };
-static_assert(__is_trivially_relocatable(S1), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S1), "");
-
+static_assert(__is_trivially_relocatable(S1), "");
 
 struct __attribute__((trivial_abi)) S3 { // expected-warning {{'trivial_abi' cannot be applied to 'S3'}} expected-note {{is polymorphic}}
   virtual void m();
 };
-static_assert(!__is_trivially_relocatable(S3), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S3), "");
-
+static_assert(!__is_trivially_relocatable(S3), "");
 
 struct S3_2 {
   virtual void m();
 } __attribute__((trivial_abi)); // expected-warning {{'trivial_abi' cannot be applied to 'S3_2'}} expected-note {{is polymorphic}}
-static_assert(!__is_trivially_relocatable(S3_2), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S3_2), "");
+static_assert(!__is_trivially_relocatable(S3_2), "");
 
 struct __attribute__((trivial_abi)) S3_3 { // expected-warning {{'trivial_abi' cannot be applied to 'S3_3'}} expected-note {{has a field of a non-trivial class type}}
   S3_3(S3_3 &&);
@@ -53,13 +43,9 @@ struct __attribute__((trivial_abi)) S3_3 { // expected-warning {{'trivial_abi' c
 // The ClangABI4OrPS4 calling convention kind passes classes in registers if the
 // copy constructor is trivial for calls *or deleted*, while other platforms do
 // not accept deleted constructors.
-static_assert(__is_trivially_relocatable(S3_3), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S3_3), "");
-
+static_assert(__is_trivially_relocatable(S3_3), "");
 #else
-static_assert(!__is_trivially_relocatable(S3_3), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(S3_3), "");
-
+static_assert(!__is_trivially_relocatable(S3_3), "");
 #endif
 
 // Diagnose invalid trivial_abi even when the type is templated because it has a non-trivial field.
@@ -68,28 +54,20 @@ struct __attribute__((trivial_abi)) S3_4 { // expected-warning {{'trivial_abi' c
   S3_4(S3_4 &&);
   S3_2 s32;
 };
-static_assert(!__is_trivially_relocatable(S3_4<int>), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(S3_4<int>), "");
-
+static_assert(!__is_trivially_relocatable(S3_4<int>), "");
 
 struct S4 {
   int a;
 };
-static_assert(__is_trivially_relocatable(S4), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S4), "");
-
+static_assert(__is_trivially_relocatable(S4), "");
 
 struct __attribute__((trivial_abi)) S5 : public virtual S4 { // expected-warning {{'trivial_abi' cannot be applied to 'S5'}} expected-note {{has a virtual base}}
 };
-static_assert(!__is_trivially_relocatable(S5), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(S5), "");
-
+static_assert(!__is_trivially_relocatable(S5), "");
 
 struct __attribute__((trivial_abi)) S9 : public S4 {
 };
-static_assert(__is_trivially_relocatable(S9), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S9), "");
-
+static_assert(__is_trivially_relocatable(S9), "");
 
 struct __attribute__((trivial_abi(1))) S8 { // expected-error {{'trivial_abi' attribute takes no arguments}}
   int a;
@@ -102,12 +80,8 @@ struct __attribute__((trivial_abi)) S10 {
 };
 
 S10<int *> p1;
-static_assert(__is_trivially_relocatable(S10<int>), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S10<int>), "");
-
-static_assert(__is_trivially_relocatable(S10<S3>), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S10<S3>), "");
-
+static_assert(__is_trivially_relocatable(S10<int>), "");
+static_assert(__is_trivially_relocatable(S10<S3>), "");
 
 template <class T>
 struct S14 {
@@ -119,21 +93,15 @@ struct __attribute__((trivial_abi)) S15 : S14<T> {
 };
 
 S15<int> s15;
-static_assert(__is_trivially_relocatable(S15<int>), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S15<int>), "");
-
-static_assert(__is_trivially_relocatable(S15<S3>), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S15<S3>), "");
+static_assert(__is_trivially_relocatable(S15<int>), "");
+static_assert(__is_trivially_relocatable(S15<S3>), "");
 
 template <class T>
 struct __attribute__((trivial_abi)) S16 {
   S14<T> a;
 };
-static_assert(__is_trivially_relocatable(S16<int>), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S16<int>), "");
-
-static_assert(__is_trivially_relocatable(S16<S3>), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S16<S3>), "");
+static_assert(__is_trivially_relocatable(S16<int>), "");
+static_assert(__is_trivially_relocatable(S16<S3>), "");
 
 S16<int> s16;
 
@@ -142,12 +110,8 @@ struct __attribute__((trivial_abi)) S17 {
 };
 
 S17<int> s17;
-static_assert(__is_trivially_relocatable(S17<int>), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S17<int>), "");
-
-static_assert(__is_trivially_relocatable(S17<S3>), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S17<S3>), "");
-
+static_assert(__is_trivially_relocatable(S17<int>), "");
+static_assert(__is_trivially_relocatable(S17<S3>), "");
 
 namespace deletedCopyMoveConstructor {
 struct __attribute__((trivial_abi)) CopyMoveDeleted { // expected-warning {{'trivial_abi' cannot be applied to 'CopyMoveDeleted'}} expected-note {{copy constructors and move constructors are all deleted}}
@@ -155,24 +119,18 @@ struct __attribute__((trivial_abi)) CopyMoveDeleted { // expected-warning {{'tri
   CopyMoveDeleted(CopyMoveDeleted &&) = delete;
 };
 #ifdef __ORBIS__
-static_assert(__is_trivially_relocatable(CopyMoveDeleted), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(CopyMoveDeleted), "");
-
+static_assert(__is_trivially_relocatable(CopyMoveDeleted), "");
 #else
-static_assert(!__is_trivially_relocatable(CopyMoveDeleted), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(CopyMoveDeleted), "");
-
+static_assert(!__is_trivially_relocatable(CopyMoveDeleted), "");
 #endif
 
 struct __attribute__((trivial_abi)) S18 { // expected-warning {{'trivial_abi' cannot be applied to 'S18'}} expected-note {{copy constructors and move constructors are all deleted}}
   CopyMoveDeleted a;
 };
 #ifdef __ORBIS__
-static_assert(__is_trivially_relocatable(S18), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S18), "");
+static_assert(__is_trivially_relocatable(S18), "");
 #else
-static_assert(!__is_trivially_relocatable(S18), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(S18), "");
+static_assert(!__is_trivially_relocatable(S18), "");
 #endif
 
 struct __attribute__((trivial_abi)) CopyDeleted {
@@ -180,29 +138,25 @@ struct __attribute__((trivial_abi)) CopyDeleted {
   CopyDeleted(CopyDeleted &&) = default;
 };
 #if defined(_WIN64) && !defined(__MINGW32__)
-static_assert(!__is_trivially_relocatable(CopyDeleted), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(CopyDeleted), "");
-
+static_assert(!__is_trivially_relocatable(CopyDeleted), "");
 #else
-static_assert(__is_trivially_relocatable(CopyDeleted), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(CopyDeleted), "");
+static_assert(__is_trivially_relocatable(CopyDeleted), "");
 #endif
 
 struct __attribute__((trivial_abi)) MoveDeleted {
   MoveDeleted(const MoveDeleted &) = default;
   MoveDeleted(MoveDeleted &&) = delete;
 };
-static_assert(__is_trivially_relocatable(MoveDeleted), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(MoveDeleted), "");
+static_assert(__is_trivially_relocatable(MoveDeleted), "");
+
 struct __attribute__((trivial_abi)) S19 { // expected-warning {{'trivial_abi' cannot be applied to 'S19'}} expected-note {{copy constructors and move constructors are all deleted}}
   CopyDeleted a;
   MoveDeleted b;
 };
 #ifdef __ORBIS__
-static_assert(__is_trivially_relocatable(S19), ""); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S19), "");
-static_assert(!__is_trivially_relocatable(S19), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(S19), "");
+static_assert(__is_trivially_relocatable(S19), "");
+#else
+static_assert(!__is_trivially_relocatable(S19), "");
 #endif
 
 // This is fine since the move constructor isn't deleted.
@@ -210,12 +164,8 @@ struct __attribute__((trivial_abi)) S20 {
   int &&a; // a member of rvalue reference type deletes the copy constructor.
 };
 #if defined(_WIN64) && !defined(__MINGW32__)
-static_assert(!__is_trivially_relocatable(S20), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(S20), "");
-
+static_assert(!__is_trivially_relocatable(S20), "");
 #else
-static_assert(__is_trivially_relocatable(S20), ""); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(S20), "");
-
+static_assert(__is_trivially_relocatable(S20), "");
 #endif
 } // namespace deletedCopyMoveConstructor

--- a/clang/test/SemaCXX/ptrauth-triviality.cpp
+++ b/clang/test/SemaCXX/ptrauth-triviality.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -triple arm64-apple-ios -std=c++20 -fptrauth-calls -fptrauth-intrinsics -verify -fsyntax-only %s
 // RUN: %clang_cc1 -triple aarch64-linux-gnu -std=c++20 -fptrauth-calls -fptrauth-intrinsics -verify -fsyntax-only %s
+// expected-no-diagnostics
 
 #define AQ __ptrauth(1,1,50)
 #define IQ __ptrauth(1,0,50)
@@ -23,8 +24,7 @@ static_assert(!__is_trivially_constructible(S1, const S1&));
 static_assert(!__is_trivially_assignable(S1, const S1&));
 static_assert(__is_trivially_destructible(S1));
 static_assert(!__is_trivially_copyable(S1));
-static_assert(!__is_trivially_relocatable(S1)); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(S1));
+static_assert(!__is_trivially_relocatable(S1));
 static_assert(!__is_trivially_equality_comparable(S1));
 
 static_assert(__is_trivially_constructible(Holder<S1>));
@@ -32,8 +32,7 @@ static_assert(!__is_trivially_constructible(Holder<S1>, const Holder<S1>&));
 static_assert(!__is_trivially_assignable(Holder<S1>, const Holder<S1>&));
 static_assert(__is_trivially_destructible(Holder<S1>));
 static_assert(!__is_trivially_copyable(Holder<S1>));
-static_assert(!__is_trivially_relocatable(Holder<S1>)); // expected-warning{{deprecated}}
-static_assert(!__builtin_is_cpp_trivially_relocatable(Holder<S1>));
+static_assert(!__is_trivially_relocatable(Holder<S1>));
 static_assert(!__is_trivially_equality_comparable(Holder<S1>));
 
 struct S2 {
@@ -46,8 +45,7 @@ static_assert(__is_trivially_constructible(S2, const S2&));
 static_assert(__is_trivially_assignable(S2, const S2&));
 static_assert(__is_trivially_destructible(S2));
 static_assert(__is_trivially_copyable(S2));
-static_assert(__is_trivially_relocatable(S2)); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(S2));
+static_assert(__is_trivially_relocatable(S2));
 static_assert(__is_trivially_equality_comparable(S2));
 
 static_assert(__is_trivially_constructible(Holder<S2>));
@@ -55,8 +53,7 @@ static_assert(__is_trivially_constructible(Holder<S2>, const Holder<S2>&));
 static_assert(__is_trivially_assignable(Holder<S2>, const Holder<S2>&));
 static_assert(__is_trivially_destructible(Holder<S2>));
 static_assert(__is_trivially_copyable(Holder<S2>));
-static_assert(__is_trivially_relocatable(Holder<S2>)); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(Holder<S2>));
+static_assert(__is_trivially_relocatable(Holder<S2>));
 static_assert(__is_trivially_equality_comparable(Holder<S2>));
 
 struct AA S3 {
@@ -70,19 +67,15 @@ static_assert(!__is_trivially_constructible(S3, const S3&));
 static_assert(!__is_trivially_assignable(S3, const S3&));
 static_assert(__is_trivially_destructible(S3));
 static_assert(!__is_trivially_copyable(S3));
-static_assert(!__is_trivially_relocatable(S3)); // expected-warning{{deprecated}}
-//FIXME
-static_assert(__builtin_is_cpp_trivially_relocatable(S3));
+static_assert(!__is_trivially_relocatable(S3));
 static_assert(!__is_trivially_equality_comparable(S3));
-
 
 static_assert(!__is_trivially_constructible(Holder<S3>));
 static_assert(!__is_trivially_constructible(Holder<S3>, const Holder<S3>&));
 static_assert(!__is_trivially_assignable(Holder<S3>, const Holder<S3>&));
 static_assert(__is_trivially_destructible(Holder<S3>));
 static_assert(!__is_trivially_copyable(Holder<S3>));
-static_assert(__is_trivially_relocatable(Holder<S3>)); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(Holder<S3>));
+static_assert(__is_trivially_relocatable(Holder<S3>));
 static_assert(!__is_trivially_equality_comparable(Holder<S3>));
 
 struct IA S4 {
@@ -96,9 +89,7 @@ static_assert(!__is_trivially_constructible(S4, const S4&));
 static_assert(!__is_trivially_assignable(S4, const S4&));
 static_assert(__is_trivially_destructible(S4));
 static_assert(!__is_trivially_copyable(S4));
-static_assert(!__is_trivially_relocatable(S4)); // expected-warning{{deprecated}}
-//FIXME
-static_assert(__builtin_is_cpp_trivially_relocatable(S4));
+static_assert(!__is_trivially_relocatable(S4));
 static_assert(!__is_trivially_equality_comparable(S4));
 
 static_assert(!__is_trivially_constructible(Holder<S4>));
@@ -106,8 +97,7 @@ static_assert(!__is_trivially_constructible(Holder<S4>, const Holder<S4>&));
 static_assert(!__is_trivially_assignable(Holder<S4>, const Holder<S4>&));
 static_assert(__is_trivially_destructible(Holder<S4>));
 static_assert(!__is_trivially_copyable(Holder<S4>));
-static_assert(__is_trivially_relocatable(Holder<S4>)); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(Holder<S4>));
+static_assert(__is_trivially_relocatable(Holder<S4>));
 static_assert(!__is_trivially_equality_comparable(Holder<S4>));
 
 struct PA S5 {
@@ -121,9 +111,7 @@ static_assert(!__is_trivially_constructible(S5, const S5&));
 static_assert(!__is_trivially_assignable(S5, const S5&));
 static_assert(__is_trivially_destructible(S5));
 static_assert(!__is_trivially_copyable(S5));
-static_assert(!__is_trivially_relocatable(S5)); // expected-warning{{deprecated}}
-//FIXME
-static_assert(__builtin_is_cpp_trivially_relocatable(S5));
+static_assert(!__is_trivially_relocatable(S5));
 static_assert(!__is_trivially_equality_comparable(S5));
 
 static_assert(!__is_trivially_constructible(Holder<S5>));
@@ -131,6 +119,5 @@ static_assert(!__is_trivially_constructible(Holder<S5>, const Holder<S5>&));
 static_assert(!__is_trivially_assignable(Holder<S5>, const Holder<S5>&));
 static_assert(__is_trivially_destructible(Holder<S5>));
 static_assert(!__is_trivially_copyable(Holder<S5>));
-static_assert(__is_trivially_relocatable(Holder<S5>)); // expected-warning{{deprecated}}
-static_assert(__builtin_is_cpp_trivially_relocatable(Holder<S5>));
+static_assert(__is_trivially_relocatable(Holder<S5>));
 static_assert(!__is_trivially_equality_comparable(Holder<S5>));

--- a/clang/test/SemaCXX/type-traits-nonobject.cpp
+++ b/clang/test/SemaCXX/type-traits-nonobject.cpp
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
 
+// expected-no-diagnostics
+
 static_assert(!__is_pod(void), "");
 static_assert(!__is_pod(int&), "");
 static_assert(!__is_pod(int()), "");
@@ -11,13 +13,7 @@ static_assert(!__is_trivially_copyable(int&), "");
 static_assert(!__is_trivially_copyable(int()), "");
 static_assert(!__is_trivially_copyable(int()&), "");
 
-static_assert(!__is_trivially_relocatable(void), ""); // expected-warning{{deprecated}}
-static_assert(!__is_trivially_relocatable(int&), ""); // expected-warning{{deprecated}}
-static_assert(!__is_trivially_relocatable(int()), ""); // expected-warning{{deprecated}}
-static_assert(!__is_trivially_relocatable(int()&), ""); // expected-warning{{deprecated}}
-
-
-static_assert(!__builtin_is_cpp_trivially_relocatable(void), "");
-static_assert(!__builtin_is_cpp_trivially_relocatable(int&), "");
-static_assert(!__builtin_is_cpp_trivially_relocatable(int()), "");
-static_assert(!__builtin_is_cpp_trivially_relocatable(int()&), "");
+static_assert(!__is_trivially_relocatable(void), "");
+static_assert(!__is_trivially_relocatable(int&), "");
+static_assert(!__is_trivially_relocatable(int()), "");
+static_assert(!__is_trivially_relocatable(int()&), "");


### PR DESCRIPTION
Reverts llvm/llvm-project#138835

This is causing a test failure on a bot: https://lab.llvm.org/buildbot/#/builders/144/builds/24541