### PR TITLE
[libc++] Reject abilist if it contains an ABI tag

### DIFF
--- a/libcxx/utils/sym_diff.py
+++ b/libcxx/utils/sym_diff.py
@@ -80,6 +80,11 @@ def main():
         old_syms_list, _ = util.filter_stdlib_symbols(old_syms_list)
         new_syms_list, _ = util.filter_stdlib_symbols(new_syms_list)
 
+    for symbol in new_syms_list:
+        if symbol["is_defined"] and 'B' in symbol["name"]:
+            print(f"Symbol {symbol['name']} contains an ABI tag!")
+            sys.exit(1)
+
     added, removed, changed = diff.diff(old_syms_list, new_syms_list)
     if args.removed_only:
         added = {}


### PR DESCRIPTION
We currently don't have any ABI tags in our dylib symbols, and this is unlikely to change in the future. By diagnosing this we avoid accidentally adding one through e.g. having `_LIBCPP_HIDE_FROM_ABI` on an exported symbol.
