### PR TITLE
[clang-format] Handle C# where clause in SeparateDefinitionBlocks

### DIFF
--- a/clang/lib/Format/DefinitionBlockSeparator.cpp
+++ b/clang/lib/Format/DefinitionBlockSeparator.cpp
@@ -138,10 +138,8 @@ void DefinitionBlockSeparator::separateBlocks(
       assert(Direction >= -1);
       assert(Direction <= 1);
 
-      if (Style.isCSharp() &&
-          Lines[OpeningLineIndex]->First->is(TT_CSharpGenericTypeConstraint)) {
+      if (Lines[OpeningLineIndex]->First->is(TT_CSharpGenericTypeConstraint))
         return true;
-      }
 
       const size_t OperateIndex = OpeningLineIndex + Direction;
       assert(OperateIndex < Lines.size());

--- a/clang/lib/Format/DefinitionBlockSeparator.cpp
+++ b/clang/lib/Format/DefinitionBlockSeparator.cpp
@@ -137,6 +137,12 @@ void DefinitionBlockSeparator::separateBlocks(
     const auto MayPrecedeDefinition = [&](const int Direction = -1) {
       assert(Direction >= -1);
       assert(Direction <= 1);
+
+      if (Style.isCSharp() &&
+          Lines[OpeningLineIndex]->First->is(TT_CSharpGenericTypeConstraint)) {
+        return true;
+      }
+
       const size_t OperateIndex = OpeningLineIndex + Direction;
       assert(OperateIndex < Lines.size());
       const auto &OperateLine = Lines[OperateIndex];

--- a/clang/unittests/Format/DefinitionBlockSeparatorTest.cpp
+++ b/clang/unittests/Format/DefinitionBlockSeparatorTest.cpp
@@ -574,6 +574,11 @@ TEST_F(DefinitionBlockSeparatorTest, CSharp) {
                "\r\n"
                "public class FoobarClass {\r\n"
                "  int foobar;\r\n"
+               "}\r\n"
+               "\r\n"
+               "public class LogFactory<TLogger>\r\n"
+               "    where TLogger : class, new() {\r\n"
+               "  int i;\r\n"
                "}",
                Style);
 }


### PR DESCRIPTION
Fix #61956