### PR TITLE
[compiler-rt][NFC] Apply -nostdinc++ only to C++ source in profile runtime

### DIFF
--- a/compiler-rt/lib/profile/CMakeLists.txt
+++ b/compiler-rt/lib/profile/CMakeLists.txt
@@ -142,7 +142,10 @@ if(MSVC)
 endif()
 
 # We don't use the C++ Standard Library here, so avoid including it by mistake.
-append_list_if(COMPILER_RT_HAS_NOSTDINCXX_FLAG -nostdinc++ EXTRA_FLAGS)
+if(COMPILER_RT_HAS_NOSTDINCXX_FLAG)
+set_property(SOURCE InstrProfilingRuntime.cpp APPEND_STRING
+  PROPERTY COMPILE_FLAGS " -nostdinc++")
+endif()
 # XRay uses C++ standard library headers.
 string(REGEX REPLACE "-stdlib=[a-zA-Z+]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 


### PR DESCRIPTION
 Avoid passing the C++-specific `-nostdinc++` flag to C source files in the profile runtime library, which triggers warnings when building with GCC:
    
      cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
    
We only need `-nostdinc++` for `InstrProfilingRuntime.cpp` to prevent accidental inclusion of the C++ standard library headers. This patch scopes the flag to that file using `set_property()` and removes the flag from the global `EXTRA_FLAGS`.
```
[4875/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingInternal.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4876/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfiling.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4877/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingBuffer.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4878/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/GCDAProfiling.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4879/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingValue.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4881/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingNameVar.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4882/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingMergeFile.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4883/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingVersionVar.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4884/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingMerge.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4885/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingPlatformAIX.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4886/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingPlatformFuchsia.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4887/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingPlatformDarwin.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4888/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingPlatformOther.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4890/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingPlatformWindows.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4892/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingPlatformLinux.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4893/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingWriter.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4894/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingFile.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
[4895/15653] Building C object projects/compiler-rt/lib/profile/CMakeFiles/clang_rt.profile-x86_64.dir/InstrProfilingUtil.c.o
cc1: warning: command-line option ‘-nostdinc++’ is valid for C++/ObjC++ but not for C
```