### PR TITLE
[X86] Asm modifier %a: add (%rip) for 64-bit static relocation model

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -5776,6 +5776,7 @@ and GCC likely indicates a bug in LLVM.
 
 Target-independent:
 
+- ``a``: Print a memory reference. Targets might customize the output.
 - ``c``: Print an immediate integer constant unadorned, without
   the target-specific immediate punctuation (e.g. no ``$`` prefix).
 - ``n``: Negate and print immediate integer constant unadorned, without the
@@ -5913,6 +5914,8 @@ target-independent modifiers.
 
 X86:
 
+- ``a``: Print a memory reference. This displays as ``sym(%rip)`` for x86-64.
+  i386 should only use this with the static relocation model.
 - ``c``: Print an unadorned integer or symbol name. (The latter is
   target-specific behavior for this typically target-independent modifier).
 - ``A``: Print a register name with a '``*``' before it.

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -744,7 +744,7 @@ bool X86AsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
         llvm_unreachable("unexpected operand type!");
       case MachineOperand::MO_GlobalAddress:
         PrintSymbolOperand(MO, O);
-        if (Subtarget->isPICStyleRIPRel())
+        if (Subtarget->is64Bit())
           O << "(%rip)";
         return false;
       case MachineOperand::MO_Register:

--- a/llvm/test/CodeGen/X86/asm-modifier.ll
+++ b/llvm/test/CodeGen/X86/asm-modifier.ll
@@ -6,12 +6,19 @@
 @var = internal global i32 0, align 4
 
 define dso_local void @test_a() nounwind {
-; CHECK-LABEL: test_a:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    #APP
-; CHECK-NEXT:    #TEST 42 var#
-; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    ret{{[l|q]}}
+; X86-LABEL: test_a:
+; X86:       # %bb.0:
+; X86-NEXT:    #APP
+; X86-NEXT:    #TEST 42 var#
+; X86-NEXT:    #NO_APP
+; X86-NEXT:    retl
+;
+; X64-LABEL: test_a:
+; X64:       # %bb.0:
+; X64-NEXT:    #APP
+; X64-NEXT:    #TEST 42 var(%rip)#
+; X64-NEXT:    #NO_APP
+; X64-NEXT:    retq
   tail call void asm sideeffect "#TEST ${0:a} ${1:a}#", "i,i"(i32 42, ptr @var)
   ret void
 }


### PR DESCRIPTION
In GCC,

```
static int a;
int foo() {
  asm("# %a0" : : "i"(&a));
}
```

lowers to `# a(%rip)` regardless of the PIC mode. This PR follow suits
for ELF -fno-pic, matching ELF -fpic (asm-modifier-pic.ll) and Mach-O
(which defaults to PIC).

Close https://github.com/llvm/llvm-project/issues/139001
