### PR TITLE
[compiler-rt][cmake] Add option to control shared library builds

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -91,6 +91,9 @@ mark_as_advanced(COMPILER_RT_SCUDO_STANDALONE_BUILD_SHARED)
 option(COMPILER_RT_BUILD_SCUDO_STANDALONE_WITH_LLVM_LIBC "Build SCUDO standalone with LLVM's libc headers" OFF)
 mark_as_advanced(COMPILER_RT_BUILD_SCUDO_STANDALONE_WITH_LLVM_LIBC)
 
+option(COMPILER_RT_BUILD_SHARED_LIBS "Build all libraries as shared libraries in addition to static libraries" ON)
+mark_as_advanced(COMPILER_RT_BUILD_SHARED_LIBS)
+
 if(FUCHSIA)
   set(COMPILER_RT_HWASAN_WITH_INTERCEPTORS_DEFAULT OFF)
 else()

--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -169,6 +169,10 @@ function(add_compiler_rt_runtime name type)
             "type argument must be OBJECT, STATIC, SHARED or MODULE")
     return()
   endif()
+  if(type STREQUAL "SHARED" AND NOT COMPILER_RT_BUILD_SHARED_LIBS)
+    message(STATUS "Skipping shared library ${name} because COMPILER_RT_BUILD_SHARED_LIBS is OFF")
+    return()
+  endif()
   cmake_parse_arguments(LIB
     ""
     "PARENT_TARGET"


### PR DESCRIPTION
This patch introduces a new option `COMPILER_RT_BUILD_SHARED_LIBS` to control whether shared libraries should be built for runtime libraries in compiler-rt. By default, this option is set to ON, allowing shared libraries to be built. If set to OFF, shared libraries will not be built, which can be useful for projects that do not require them or when building for environments where shared libraries are still not yet matured, such as WebAssembly/WASI.