### PR TITLE
[Clang] Fix handling of pack indexing types in constraints of redeclaration

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -667,6 +667,7 @@ Bug Fixes to C++ Support
   whose type depends on itself. (#GH51347), (#GH55872)
 - Improved parser recovery of invalid requirement expressions. In turn, this
   fixes crashes from follow-on processing of the invalid requirement. (#GH138820)
+- Fixed the handling of pack indexing types in the constraints of a member function redeclaration. (#GH138255)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -221,7 +221,8 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable llvm::ContextualFoldingSet<DependentDecltypeType, ASTContext &>
       DependentDecltypeTypes;
 
-  mutable llvm::FoldingSet<PackIndexingType> DependentPackIndexingTypes;
+  mutable llvm::ContextualFoldingSet<PackIndexingType, ASTContext &>
+      DependentPackIndexingTypes;
 
   mutable llvm::FoldingSet<TemplateTypeParmType> TemplateTypeParmTypes;
   mutable llvm::FoldingSet<ObjCTypeParamType> ObjCTypeParamTypes;

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -4549,6 +4549,10 @@ public:
 
   bool isFullySubstituted() const { return FullySubstituted; }
 
+  bool isPartiallySubstituted() const {
+    return isValueDependent() && TransformedExpressions;
+  };
+
   /// Determine if the expression was expanded to empty.
   bool expandsToEmptyPack() const {
     return isFullySubstituted() && TransformedExpressions == 0;
@@ -4591,10 +4595,6 @@ public:
   ArrayRef<Expr *> getExpressions() const {
     return {getTrailingObjects<Expr *>(), TransformedExpressions};
   }
-
-  bool isPartiallySubstituted() const {
-    return isValueDependent() && TransformedExpressions;
-  };
 
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == PackIndexingExprClass;

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -4592,6 +4592,10 @@ public:
     return {getTrailingObjects<Expr *>(), TransformedExpressions};
   }
 
+  bool isPartiallySubstituted() const {
+    return isValueDependent() && TransformedExpressions;
+  };
+
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == PackIndexingExprClass;
   }

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -5976,7 +5976,6 @@ class PackIndexingType final
       private llvm::TrailingObjects<PackIndexingType, QualType> {
   friend TrailingObjects;
 
-  const ASTContext &Context;
   QualType Pattern;
   Expr *IndexExpr;
 
@@ -5987,9 +5986,8 @@ class PackIndexingType final
 
 protected:
   friend class ASTContext; // ASTContext creates these.
-  PackIndexingType(const ASTContext &Context, QualType Canonical,
-                   QualType Pattern, Expr *IndexExpr, bool FullySubstituted,
-                   ArrayRef<QualType> Expansions = {});
+  PackIndexingType(QualType Canonical, QualType Pattern, Expr *IndexExpr,
+                   bool FullySubstituted, ArrayRef<QualType> Expansions = {});
 
 public:
   Expr *getIndexExpr() const { return IndexExpr; }
@@ -6024,12 +6022,7 @@ public:
     return T->getTypeClass() == PackIndexing;
   }
 
-  void Profile(llvm::FoldingSetNodeID &ID) {
-    if (hasSelectedType())
-      getSelectedType().Profile(ID);
-    else
-      Profile(ID, Context, getPattern(), getIndexExpr(), isFullySubstituted());
-  }
+  void Profile(llvm::FoldingSetNodeID &ID, const ASTContext &Context);
   static void Profile(llvm::FoldingSetNodeID &ID, const ASTContext &Context,
                       QualType Pattern, Expr *E, bool FullySubstituted);
 

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -2291,9 +2291,15 @@ void StmtProfiler::VisitSizeOfPackExpr(const SizeOfPackExpr *S) {
 }
 
 void StmtProfiler::VisitPackIndexingExpr(const PackIndexingExpr *E) {
-  VisitExpr(E);
-  VisitExpr(E->getPackIdExpression());
   VisitExpr(E->getIndexExpr());
+
+  if (E->isPartiallySubstituted()) {
+    ID.AddInteger(E->getExpressions().size());
+    for (const Expr *Sub : E->getExpressions())
+      Visit(Sub);
+  } else {
+    VisitExpr(E->getPackIdExpression());
+  }
 }
 
 void StmtProfiler::VisitSubstNonTypeTemplateParmPackExpr(

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1478,7 +1478,7 @@ namespace {
       }
     }
 
-    TemplateArgument getTemplateArgumentorUnsubstitutedExpansionPattern(
+    TemplateArgument getTemplateArgumentOrUnsubstitutedExpansionPattern(
         const TemplateArgument &TA) {
       if (TA.getKind() != TemplateArgument::Pack)
         return TA;
@@ -1905,7 +1905,7 @@ Decl *TemplateInstantiator::TransformDecl(SourceLocation Loc, Decl *D) {
       TemplateArgument Arg = TemplateArgs(TTP->getDepth(), TTP->getPosition());
 
       if (TemplateArgs.ArgumentsAreInjectedParameters(TTP->getDepth())) {
-        Arg = getTemplateArgumentorUnsubstitutedExpansionPattern(Arg);
+        Arg = getTemplateArgumentOrUnsubstitutedExpansionPattern(Arg);
       } else if (TTP->isParameterPack()) {
         assert(Arg.getKind() == TemplateArgument::Pack &&
                "Missing argument pack");
@@ -2058,7 +2058,7 @@ TemplateName TemplateInstantiator::TransformTemplateName(
       if (TemplateArgs.isRewrite()) {
         // We're rewriting the template parameter as a reference to another
         // template parameter.
-        Arg = getTemplateArgumentorUnsubstitutedExpansionPattern(Arg);
+        Arg = getTemplateArgumentOrUnsubstitutedExpansionPattern(Arg);
         assert(Arg.getKind() == TemplateArgument::Template &&
                "unexpected nontype template argument kind in template rewrite");
         return Arg.getAsTemplate();
@@ -2072,7 +2072,7 @@ TemplateName TemplateInstantiator::TransformTemplateName(
                "Missing argument pack");
 
         if (ArgumentsAreInjectedTemplateParams)
-          Arg = getTemplateArgumentorUnsubstitutedExpansionPattern(Arg);
+          Arg = getTemplateArgumentOrUnsubstitutedExpansionPattern(Arg);
 
         else if (!getSema().ArgPackSubstIndex) {
           // We have the template argument pack to substitute, but we're not
@@ -2138,7 +2138,7 @@ TemplateInstantiator::TransformTemplateParmRefExpr(DeclRefExpr *E,
   if (TemplateArgs.isRewrite()) {
     // We're rewriting the template parameter as a reference to another
     // template parameter.
-    Arg = getTemplateArgumentorUnsubstitutedExpansionPattern(Arg);
+    Arg = getTemplateArgumentOrUnsubstitutedExpansionPattern(Arg);
     assert(Arg.getKind() == TemplateArgument::Expression &&
            "unexpected nontype template argument kind in template rewrite");
     // FIXME: This can lead to the same subexpression appearing multiple times
@@ -2591,7 +2591,7 @@ TemplateInstantiator::TransformTemplateTypeParmType(TypeLocBuilder &TLB,
     if (TemplateArgs.isRewrite()) {
       // We're rewriting the template parameter as a reference to another
       // template parameter.
-      Arg = getTemplateArgumentorUnsubstitutedExpansionPattern(Arg);
+      Arg = getTemplateArgumentOrUnsubstitutedExpansionPattern(Arg);
       assert(Arg.getKind() == TemplateArgument::Type &&
              "unexpected nontype template argument kind in template rewrite");
       QualType NewT = Arg.getAsType();

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -823,6 +823,13 @@ bool Sema::CheckParameterPacksForExpansion(
         continue;
       }
 
+      // Template arguments that are injected template parameters
+      // Cannot be expanded, even if they constitute a pack expansion.
+      if (TemplateArgs.ArgumentsAreInjectedParameters(Depth)) {
+        ShouldExpand = false;
+        continue;
+      }
+
       // Determine the size of the argument pack.
       ArrayRef<TemplateArgument> Pack =
           TemplateArgs(Depth, Index).getPackAsArray();

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6884,7 +6884,7 @@ TreeTransform<Derived>::TransformPackIndexingType(TypeLocBuilder &TLB,
     assert(!Unexpanded.empty() && "Pack expansion without parameter packs?");
     // Determine whether the set of unexpanded parameter packs can and should
     // be expanded.
-    bool ShouldExpand = true;
+    bool ShouldExpand = false;
     bool RetainExpansion = false;
     UnsignedOrNone NumExpansions = std::nullopt;
     if (getDerived().TryExpandParameterPacks(TL.getEllipsisLoc(), SourceRange(),

--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -785,55 +785,71 @@ consteval void S::mfn() requires (bool(&fn)) {}
 
 namespace GH138255 {
 
-  template <typename... T>
-  concept C = true;
+template <typename... T>
+concept C = true;
 
-  struct Func {
-      template<typename... Ts>
-      requires C<Ts...[0]>
-      static auto buggy() -> void;
-
-      template<typename... Ts>
-      requires C<Ts...[0]>
-      friend auto fr() -> void;
-
-      template<typename... Ts>
-      requires C<Ts...[0]>
-      friend auto fr2() -> void{}; // expected-note{{previous definition is here}}
-  };
+struct Func {
+  template<typename... Ts>
+  requires C<Ts...[0]>
+  static auto buggy() -> void;
 
   template<typename... Ts>
   requires C<Ts...[0]>
-  auto Func::buggy() -> void {}
+  friend auto fr() -> void;
 
   template<typename... Ts>
   requires C<Ts...[0]>
-  auto fr() -> void {}
+  friend auto fr2() -> void{}; // expected-note{{previous definition is here}}
+};
 
+template<typename... Ts>
+requires C<Ts...[0]>
+auto Func::buggy() -> void {}
+
+template<typename... Ts>
+requires C<Ts...[0]>
+auto fr() -> void {}
+
+template<typename... Ts>
+requires C<Ts...[0]>
+auto fr2() -> void {} // expected-error{{redefinition of 'fr2'}}
+
+
+template <typename... Ts>
+requires C<Ts...[0]>
+struct Class;
+
+template <typename... Ts>
+requires C<Ts...[0]>
+struct Class;
+
+
+template <typename...>
+struct TplClass {
   template<typename... Ts>
   requires C<Ts...[0]>
-  auto fr2() -> void {} // expected-error{{redefinition of 'fr2'}}
+  static auto buggy() -> void;
+};
 
+template<>
+template<typename... Ts>
+requires C<Ts...[0]>
+auto TplClass<int>::buggy() -> void {}
 
-  template <typename... Ts>
+}
+
+namespace PackIndexExpr {
+template <int... T>
+concept C = true;
+
+template <typename...> struct TplClass {
+  template <int... Ts>
   requires C<Ts...[0]>
-  struct Class;
+  static auto buggy() -> void;
+};
 
-  template <typename... Ts>
-  requires C<Ts...[0]>
-  struct Class;
-
-
-  template <typename...>
-  struct TplClass {
-      template<typename... Ts>
-      requires C<Ts...[0]>
-      static auto buggy() -> void;
-  };
-
-  template<>
-  template<typename... Ts>
-  requires C<Ts...[0]>
-  auto TplClass<int>::buggy() -> void {}
-
-  }
+template <>
+template <int... Ts>
+requires C<Ts...[0]>
+auto TplClass<int>::buggy() -> void {}
+}

--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -1,4 +1,6 @@
-// RUN: %clang_cc1 -std=c++20 -verify %s
+// RUN: %clang_cc1 -std=c++20 -Wno-c++26-extensions -verify %s
+// RUN: %clang_cc1 -std=c++2c -Wno-c++26-extensions -verify %s
+
 
 static constexpr int PRIMARY = 0;
 static constexpr int SPECIALIZATION_CONCEPT = 1;
@@ -779,3 +781,59 @@ template <typename T>
 consteval void S::mfn() requires (bool(&fn)) {}
 
 }
+
+
+namespace GH138255 {
+
+  template <typename... T>
+  concept C = true;
+
+  struct Func {
+      template<typename... Ts>
+      requires C<Ts...[0]>
+      static auto buggy() -> void;
+
+      template<typename... Ts>
+      requires C<Ts...[0]>
+      friend auto fr() -> void;
+
+      template<typename... Ts>
+      requires C<Ts...[0]>
+      friend auto fr2() -> void{}; // expected-note{{previous definition is here}}
+  };
+
+  template<typename... Ts>
+  requires C<Ts...[0]>
+  auto Func::buggy() -> void {}
+
+  template<typename... Ts>
+  requires C<Ts...[0]>
+  auto fr() -> void {}
+
+  template<typename... Ts>
+  requires C<Ts...[0]>
+  auto fr2() -> void {} // expected-error{{redefinition of 'fr2'}}
+
+
+  template <typename... Ts>
+  requires C<Ts...[0]>
+  struct Class;
+
+  template <typename... Ts>
+  requires C<Ts...[0]>
+  struct Class;
+
+
+  template <typename...>
+  struct TplClass {
+      template<typename... Ts>
+      requires C<Ts...[0]>
+      static auto buggy() -> void;
+  };
+
+  template<>
+  template<typename... Ts>
+  requires C<Ts...[0]>
+  auto TplClass<int>::buggy() -> void {}
+
+  }


### PR DESCRIPTION


When checking the constraints of a potential redeclaration we inject the template parameter as template arguments to compare them.

This would make clang:
  - try to expand these injected parameters (which are treated as packs of size 1)
  - inject a SubstTemplateTypeParmPackType

Why expanding the pack indexing is wasteful, it's recoverable, as it was only partially expanded.

However, creating SubstTemplateTypeParmPackType nodes was problematic as, before we can establish that declarations are identical, these nodes won't canonicalize to the same types (at this point they have unrelated associated decl).

To avoid these issues, we track whether a set of template arguments are injected template parameters. And if they are, skip some substitutions/instantiations.

Cleanup pack indexing profiling as a drive-by.

Fixes #138255