### PR TITLE
[www][docs] Remove last mentions of IRC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,8 @@ describes how to get involved, raise issues and submit patches.
 
 ## Getting in touch
 
-Join the [LLVM Discourse forums](https://discourse.llvm.org/), [Discord
-chat](https://discord.gg/xS7Z362), or #llvm IRC channel on
-[OFTC](https://oftc.net/).
+Join the [LLVM Discourse forums](https://discourse.llvm.org/) or [Discord
+chat](https://discord.gg/xS7Z362).
 
 The LLVM project has adopted a [code of conduct](https://llvm.org/docs/CodeOfConduct.html) for
 participants to all modes of communication within the project.

--- a/bolt/Maintainers.txt
+++ b/bolt/Maintainers.txt
@@ -5,9 +5,8 @@ what goes in or not.
 
 The list is sorted by surname and formatted to allow easy grepping and
 beautification by scripts. The fields are: name (N), email (E), web-address
-(W), PGP key ID and fingerprint (P), description (D), snail-mail address
-(S) and (I) IRC handle. Each entry should contain at least the (N), (E) and
-(D) fields.
+(W), PGP key ID and fingerprint (P), and description (D). Each entry should
+contain at least the (N), (E) and (D) fields.
 
 N: Maksim Panchenko, Rafael Auler
 E: maks@fb.com, rafaelauler@fb.com

--- a/clang-tools-extra/Maintainers.txt
+++ b/clang-tools-extra/Maintainers.txt
@@ -15,7 +15,7 @@ assistance.
 Lead Maintainer
 ---------------
 | Aaron Ballman
-| aaron@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord), AaronBallman (IRC)
+| aaron@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord)
 
 
 clang-tidy
@@ -33,7 +33,7 @@ clang-tidy
 clang-query
 -----------
 | Aaron Ballman
-| aaron@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord), AaronBallman (IRC)
+| aaron@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord)
 
 
 clang-doc

--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -20,7 +20,7 @@ assistance.
 Lead Maintainer
 ---------------
 | Aaron Ballman
-| aaron\@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord), AaronBallman (IRC)
+| aaron\@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord)
 
 
 Contained Components
@@ -31,7 +31,7 @@ Clang that are typically contained to one area of the compiler.
 AST matchers
 ~~~~~~~~~~~~
 | Aaron Ballman
-| aaron\@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord), AaronBallman (IRC)
+| aaron\@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord)
 
 
 AST Visitors
@@ -300,7 +300,7 @@ standard, when fixing standards bugs, or when implementing a new standard featur
 C conformance
 ~~~~~~~~~~~~~
 | Aaron Ballman
-| aaron\@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord), AaronBallman (IRC)
+| aaron\@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord)
 
 
 C++ conformance

--- a/clang/www/menu.html.incl
+++ b/clang/www/menu.html.incl
@@ -36,7 +36,7 @@
     <a href="https://discourse.llvm.org/c/clang">Clang Forum</a>
     <a href="http://lists.llvm.org/mailman/listinfo/cfe-commits">cfe-commits List</a>
     <a href="https://github.com/llvm/llvm-project/issues">Bug Reports</a>
-    <a href="irc://irc.oftc.net/llvm">IRC: irc.oftc.net#llvm</a>
+    <a href="https://discord.gg/2kQU7PCuys">Discord</a>
   </div>
 
   <div class="submenu">

--- a/flang-rt/CODE_OWNERS.TXT
+++ b/flang-rt/CODE_OWNERS.TXT
@@ -5,9 +5,8 @@ what goes in or not.
 
 The list is sorted by surname and formatted to allow easy grepping and
 beautification by scripts. The fields are: name (N), email (E), web-address
-(W), PGP key ID and fingerprint (P), description (D), snail-mail address
-(S) and (I) IRC handle. Each entry should contain at least the (N), (E) and
-(D) fields.
+(W), PGP key ID and fingerprint (P), and description (D). Each entry should
+contain at least the (N), (E) and (D) fields.
 
 N: Steve Scalpone
 E: sscalpone@nvidia.com

--- a/libcxx/utils/ci/BOT_OWNERS.txt
+++ b/libcxx/utils/ci/BOT_OWNERS.txt
@@ -5,7 +5,7 @@ cannot be figured out by the community alone.
 The list is sorted by surname and formatted to allow easy grepping and
 beautification by scripts. The fields are: name (N), email (E), web-address
 (W), PGP key ID and fingerprint (P), description (D), snail-mail address
-(S), Phabricator handle (H), IRC handle (I) and GitHub username(s) (G).
+(S), Phabricator handle (H), and GitHub username(s) (G).
 Each entry should contain at least the (N), (E) and (D) fields.
 
 N: Linaro Toolchain Working Group

--- a/llvm/CREDITS.TXT
+++ b/llvm/CREDITS.TXT
@@ -5,8 +5,7 @@ done!
 
 The list is sorted by surname and formatted to allow easy grepping and
 beautification by scripts.  The fields are: name (N), email (E), web-address
-(W), PGP key ID and fingerprint (P), description (D), snail-mail address
-(S), and (I) IRC handle.
+(W), PGP key ID and fingerprint (P), and description (D).
 
 N: Vikram Adve
 E: vadve@cs.uiuc.edu
@@ -24,12 +23,10 @@ D: MingW Win32 API portability layer
 N: Aaron Ballman
 E: aaron@aaronballman.com
 D: Clang frontend, frontend attributes, Windows support, general bug fixing
-I: AaronBallman
 
 N: Alexey Bataev
 E: a.bataev@outlook.com
 D: Clang frontend, OpenMP in clang, SLP vectorizer, Loop vectorizer, InstCombine
-I: ABataev
 
 N: Nate Begeman
 E: natebegeman@mac.com
@@ -180,7 +177,6 @@ D: Loop Vectorizer improvements
 D: Regression and Test Suite improvements
 D: Linux compatibility (GNU, musl, etc)
 D: Initial Linux kernel / Android support effort
-I: rengolin
 
 N: David Goodwin
 E: david@goodwinz.net
@@ -197,7 +193,6 @@ D: Improvements for space efficiency
 
 N: James Grosbach
 E: grosbach@apple.com
-I: grosbach
 D: SjLj exception handling support
 D: General fixes and improvements for the ARM back-end
 D: MCJIT
@@ -250,7 +245,6 @@ D: Author of LLVM Ada bindings
 N: Erich Keane
 E: erich.keane@intel.com
 D: A variety of Clang contributions including function multiversioning, regcall/vectorcall.
-I: ErichKeane
 
 N: Eric Kidd
 W: http://randomhacks.net/
@@ -326,7 +320,6 @@ D: Backend for Qualcomm's Hexagon VLIW processor.
 
 N: Bruno Cardoso Lopes
 E: bruno.cardoso@gmail.com
-I: bruno
 W: http://brunocardoso.cc
 D: Mips backend
 D: Random ARM integrated assembler and assembly parser improvements
@@ -367,7 +360,6 @@ D: Support for implicit TLS model used with MS VC runtime
 D: Dumping of Win64 EH structures
 
 N: Takumi Nakamura
-I: chapuni
 E: geek4civic@gmail.com
 E: chapuni@hf.rim.or.jp
 D: Maintaining the Git monorepo
@@ -442,12 +434,10 @@ D: Cmake dependency chain and various bug fixes
 
 N: Alex Rosenberg
 E: alexr@leftfield.org
-I: arosenberg
 D: ARM calling conventions rewrite, hard float support
 
 N: Chad Rosier
 E: mcrosier@codeaurora.org
-I: mcrosier
 D: AArch64 fast instruction selection pass
 D: Fixes and improvements to the ARM fast-isel pass
 D: Fixes and improvements to the AArch64 backend
@@ -462,7 +452,6 @@ D: MSIL backend
 
 N: Duncan Sands
 E: baldrick@free.fr
-I: baldrick
 D: Ada support in llvm-gcc
 D: Dragonegg plugin
 D: Exception handling improvements
@@ -533,7 +522,6 @@ E: phoebe.wang@intel.com
 D: X86 bug fixes and new instruction support.
 
 N: Bill Wendling
-I: wendling
 E: isanbard@gmail.com
 D: Release manager, IR Linker, LTO.
 D: Bunches of stuff.

--- a/llvm/docs/CodeOfConduct.rst
+++ b/llvm/docs/CodeOfConduct.rst
@@ -24,12 +24,12 @@ the spirit in which it's intended - a guide to make it easier to communicate
 and participate in the community.
 
 This code of conduct applies to all spaces managed by the LLVM project or The
-LLVM Foundation. This includes IRC and Discord channels, mailing lists, bug
-trackers, LLVM events such as the developer meetings and socials, and any other
-forums created by the project that the community uses for communication. It
-applies to all of your communication and conduct in these spaces, including
-emails, chats, things you say, slides, videos, posters, signs, or even t-shirts
-you display in these spaces.
+LLVM Foundation. This includes Discord channels, mailing lists, bug trackers,
+LLVM events such as the developer meetings and socials, and any other forums
+created by the project that the community uses for communication. It applies to
+all of your communication and conduct in these spaces, including emails, chats,
+things you say, slides, videos, posters, signs, or even t-shirts you display in
+these spaces.
 
 In rare cases, violations of this code outside of these spaces may affect a 
 person’s ability to participate within these spaces. Important examples 

--- a/llvm/docs/DiscourseMigrationGuide.md
+++ b/llvm/docs/DiscourseMigrationGuide.md
@@ -88,7 +88,6 @@ Use these email addresses to create a topic by email in the specific discourse c
 <tr><td>Project Infrastructure - Code Review</td><td>infra-codereview@discourse.llvm.org</td></tr>
 <tr><td>Project Infrastructure - Discord</td><td>infra-discord@discourse.llvm.org</td></tr>
 <tr><td>Project Infrastructure - Mailing Lists and Forums</td><td>infra-mailinglists@discourse.llvm.org</td></tr>
-<tr><td>Project Infrastructure - IRC</td><td> infra-irc@discourse.llvm.org</td></tr>
 <tr><td>Project Infrastructure - Infrastructure Working Group</td><td>infra-iwg@discourse.llvm.org</td></tr>
 <tr><td>Community</td><td>community@discourse.llvm.org</td></tr>
 <tr><td>Community - Women in Compilers and Tools</td><td>wict@discourse.llvm.org</td></tr>


### PR DESCRIPTION
It's the end of an era. The IRC channel was previously where the community gathered to discuss technical topics but is now a ghost town where the primary activity is moderators (me) kickbanning the same individual dozens of times a day for CoC violations and the secondary activity is telling the occasional person to come to Discord for help. The number of people engaging on IRC for the community's intended purposes seems to be roughly one person a month.

So this removes all remaining mentions of IRC from our documentation so that it no longer appears to be an "official" channel for communicating with the community. It also removes IRC handles from the various maintainers lists, since those would stand out as confusing anachronisms.

The IRC channel topic already recommends people come to the Discord server. There is no way to "shut down" an IRC channel such that it no longer exists, so the channel will continue to exist on OFTC, but will be unmoderated.

(This was previously discussed in https://discourse.llvm.org/c/llvm/5 but some mentions persisted.)