### PR TITLE
[llvm][docs] Small improvements to llvm-test-suite doc

### DIFF
--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -86,10 +86,15 @@ MicroBenchmarks/XRay microbenchmarks, you need to add `compiler-rt` to your
    PASS: test-suite :: MultiSource/Applications/ALAC/encode/alacconvert-encode.test (2 of 474)
    ...
    ```
-**NOTE!** even in the case you only want to get the compile-time results
-(`-DTEST_SUITE_RUN_BENCHMARKS=OFF`, to get code size, llvm stats etc),
-you need to run the test with the above `llvm-lit` command. In that case,
-the *results.json* file will contain compile-time metrics only.
+
+```{note}
+  Even when you only want compile-time results you still need to run the test
+  with the above `llvm-lit` command. In this case, the `results.json` file will
+  contain compile time metrics only (code size, llvm stats and so on).
+
+  This mode is enabled by settting `-DTEST_SUITE_RUN_BENCHMARKS=OFF`,
+  more details [here](common_configuration_options).
+```
 
 6. Show and compare result files (optional):
 
@@ -204,6 +209,7 @@ benchmarks. CMake can print a list of them:
 % cmake -LAH
 ```
 
+(common_configuration_options)=
 ### Common Configuration Options
 
 - `CMAKE_C_FLAGS`

--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -45,8 +45,9 @@ Quickstart
    ```
 
 3. Create a build directory and use CMake to configure the suite. Use the
-   `CMAKE_C_COMPILER` option to specify the compiler to test. Use a cache file
-   to choose a typical build configuration:
+   `CMAKE_C_COMPILER` option to specify the compiler to test (the C++ compiler
+   will be inferred automatically from this). Use a cache file to choose a typical
+   build configuration:
 
    ```bash
    % mkdir test-suite-build
@@ -85,9 +86,10 @@ MicroBenchmarks/XRay microbenchmarks, you need to add `compiler-rt` to your
    PASS: test-suite :: MultiSource/Applications/ALAC/encode/alacconvert-encode.test (2 of 474)
    ...
    ```
-**NOTE!** even in the case you only want to get the compile-time results(code size, llvm stats etc),
-you need to run the test with the above `llvm-lit` command. In that case, the *results.json* file will
-contain compile-time metrics.
+**NOTE!** even in the case you only want to get the compile-time results
+(`-DTEST_SUITE_RUN_BENCHMARKS=OFF`, to get code size, llvm stats etc),
+you need to run the test with the above `llvm-lit` command. In that case,
+the *results.json* file will contain compile-time metrics only.
 
 6. Show and compare result files (optional):
 


### PR DESCRIPTION
* Mention earlier that the C++ compiler will be inferred from the C compiler setting. It does say this later, but a mention earlier will save people (aka me) from wondering why we don't set CMAKE_CXX_COMPILER.
* Mention earlier the compile only TEST_SUITE_RUN_BENCHMARKS=OFF setting, as it's a common use case. We already say the consequences of doing that, but not actually how to enable it until later in the doc.
* Reorder that text to make more sense.
* Make it into a proper Sphinx note block.