### PR TITLE
[RISCV][MC] Add aliases for beq/bne with x0 as the first argument => beqz/bnez

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -965,8 +965,12 @@ def : InstAlias<"sgtu $rd, $rs, $rt", (SLTU GPR:$rd, GPR:$rt, GPR:$rs), 0>;
 
 def : InstAlias<"beqz $rs, $offset",
                 (BEQ GPR:$rs,      X0, bare_simm13_lsb0:$offset)>;
+def : InstAlias<"beqz $rs, $offset",
+                (BEQ      X0, GPR:$rs, bare_simm13_lsb0:$offset)>;
 def : InstAlias<"bnez $rs, $offset",
                 (BNE GPR:$rs,      X0, bare_simm13_lsb0:$offset)>;
+def : InstAlias<"bnez $rs, $offset",
+                (BNE      X0, GPR:$rs, bare_simm13_lsb0:$offset)>;
 def : InstAlias<"blez $rs, $offset",
                 (BGE      X0, GPR:$rs, bare_simm13_lsb0:$offset)>;
 def : InstAlias<"bgez $rs, $offset",

--- a/llvm/test/MC/RISCV/rvi-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rvi-aliases-valid.s
@@ -122,10 +122,22 @@ bgtu x17, x18, 28
 # CHECK-OBJ: bgeu s3, s2, 0x70
 bleu x18, x19, 32
 
+# beqz/bnez where operands are reversed to the canonical form.
+# CHECK-S-NOALIAS: beq zero, a0, 512
+# CHECK-S: beq zero, a0, 512
+# CHECK-OBJ-NOALIAS: beq zero, a0, 0x254
+# CHECK-OBJ: beq zero, a0, 0x254
+beq zero, x10, 512
+# CHECK-S-NOALIAS: bne zero, a1, 1024
+# CHECK-S: bne zero, a1, 1024
+# CHECK-OBJ-NOALIAS: bne zero, a1, 0x458
+# CHECK-OBJ: bne zero, a1, 0x458
+bne zero, x11, 1024
+
 # CHECK-S-NOALIAS: jal zero, 2044
 # CHECK-S: j 2044
-# CHECK-OBJ-NOALIAS: jal zero, 0x850
-# CHECK-OBJ: j 0x850
+# CHECK-OBJ-NOALIAS: jal zero, 0x858
+# CHECK-OBJ: j 0x858
 j 2044
 # CHECK-S-NOALIAS: jal zero, foo
 # CHECK-S: j foo
@@ -148,8 +160,8 @@ j a0
 j .
 # CHECK-S-NOALIAS: jal ra, 2040
 # CHECK-S: jal 2040
-# CHECK-OBJ-NOALIAS: jal ra, 0x85c
-# CHECK-OBJ: jal 0x85c
+# CHECK-OBJ-NOALIAS: jal ra, 0x864
+# CHECK-OBJ: jal 0x864
 jal 2040
 # CHECK-S-NOALIAS: jal ra, foo
 # CHECK-S: jal foo

--- a/llvm/test/MC/RISCV/rvi-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rvi-aliases-valid.s
@@ -122,16 +122,16 @@ bgtu x17, x18, 28
 # CHECK-OBJ: bgeu s3, s2, 0x70
 bleu x18, x19, 32
 
-# beqz/bnez where operands are reversed to the canonical form.
+# Emit beqz/bnez alias even when operands are reversed to the canonical form.
 # CHECK-S-NOALIAS: beq zero, a0, 512
-# CHECK-S: beq zero, a0, 512
+# CHECK-S: beqz a0, 512
 # CHECK-OBJ-NOALIAS: beq zero, a0, 0x254
-# CHECK-OBJ: beq zero, a0, 0x254
+# CHECK-OBJ: beqz a0, 0x254
 beq zero, x10, 512
 # CHECK-S-NOALIAS: bne zero, a1, 1024
-# CHECK-S: bne zero, a1, 1024
+# CHECK-S: bnez a1, 1024
 # CHECK-OBJ-NOALIAS: bne zero, a1, 0x458
-# CHECK-OBJ: bne zero, a1, 0x458
+# CHECK-OBJ: bnez a1, 0x458
 bne zero, x11, 1024
 
 # CHECK-S-NOALIAS: jal zero, 2044


### PR DESCRIPTION
I don't see a good reason not to use the alias for this form as well. We have CompressPat for both ways round, so the difference isn't meaningful from that perspective. Because we're mostly compiling with RVC enabled, you mostly see the beq/bne forms with x0 as the first operand in disassembly in the case of the second operand being a register that isn't compressible. I think this just makes assembly harder to read and sticks out for no good reason in such cases.