### PR TITLE
[StructurizeCFG] Stop setting DebugLocs in flow blocks

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/si-annotate-dbg-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-annotate-dbg-info.ll
@@ -11,10 +11,10 @@ define amdgpu_ps i32 @if_else(i32 %0) !dbg !5 {
 ; OPT-NEXT:    [[TMP4:%.*]] = extractvalue { i1, i64 } [[TMP2]], 1, !dbg [[DBG14]]
 ; OPT-NEXT:    br i1 [[TMP3]], label [[FALSE:%.*]], label [[FLOW:%.*]], !dbg [[DBG14]]
 ; OPT:       Flow:
-; OPT-NEXT:    [[TMP5:%.*]] = call { i1, i64 } @llvm.amdgcn.else.i64.i64(i64 [[TMP4]]), !dbg [[DBG14]]
-; OPT-NEXT:    [[TMP6:%.*]] = extractvalue { i1, i64 } [[TMP5]], 0, !dbg [[DBG14]]
-; OPT-NEXT:    [[TMP8:%.*]] = extractvalue { i1, i64 } [[TMP5]], 1, !dbg [[DBG14]]
-; OPT-NEXT:    br i1 [[TMP6]], label [[TRUE:%.*]], label [[EXIT:%.*]], !dbg [[DBG14]]
+; OPT-NEXT:    [[TMP5:%.*]] = call { i1, i64 } @llvm.amdgcn.else.i64.i64(i64 [[TMP4]])
+; OPT-NEXT:    [[TMP6:%.*]] = extractvalue { i1, i64 } [[TMP5]], 0
+; OPT-NEXT:    [[TMP8:%.*]] = extractvalue { i1, i64 } [[TMP5]], 1
+; OPT-NEXT:    br i1 [[TMP6]], label [[TRUE:%.*]], label [[EXIT:%.*]]
 ; OPT:       true:
 ; OPT-NEXT:    br label [[EXIT]], !dbg [[DBG15:![0-9]+]]
 ; OPT:       false:
@@ -64,9 +64,9 @@ define amdgpu_ps void @loop_if_break(i32 %n) !dbg !19 {
 ; OPT-NEXT:    [[TMP3]] = phi i32 [ [[I_NEXT]], [[LOOP_BODY]] ], [ poison, [[LOOP]] ]
 ; OPT-NEXT:    [[TMP4:%.*]] = phi i1 [ false, [[LOOP_BODY]] ], [ true, [[LOOP]] ]
 ; OPT-NEXT:    call void @llvm.amdgcn.end.cf.i64(i64 [[TMP2]])
-; OPT-NEXT:    [[TMP5]] = call i64 @llvm.amdgcn.if.break.i64(i1 [[TMP4]], i64 [[PHI_BROKEN]]), !dbg [[DBG27]]
-; OPT-NEXT:    [[TMP6:%.*]] = call i1 @llvm.amdgcn.loop.i64(i64 [[TMP5]]), !dbg [[DBG27]]
-; OPT-NEXT:    br i1 [[TMP6]], label [[EXIT:%.*]], label [[LOOP]], !dbg [[DBG27]]
+; OPT-NEXT:    [[TMP5]] = call i64 @llvm.amdgcn.if.break.i64(i1 [[TMP4]], i64 [[PHI_BROKEN]])
+; OPT-NEXT:    [[TMP6:%.*]] = call i1 @llvm.amdgcn.loop.i64(i64 [[TMP5]])
+; OPT-NEXT:    br i1 [[TMP6]], label [[EXIT:%.*]], label [[LOOP]]
 ; OPT:       exit:
 ; OPT-NEXT:    call void @llvm.amdgcn.end.cf.i64(i64 [[TMP5]])
 ; OPT-NEXT:    ret void, !dbg [[DBG30:![0-9]+]]
@@ -132,7 +132,7 @@ attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !30 = !DILocation(line: 13, column: 1, scope: !19)
 ;.
 ; OPT: [[META0:![0-9]+]] = distinct !DICompileUnit(language: DW_LANG_C, file: [[META1:![0-9]+]], producer: "debugify", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
-; OPT: [[META1]] = !DIFile(filename: "../../../test/CodeGen/AMDGPU/si-annotate-dbg-info.ll", directory: {{.*}})
+; OPT: [[META1]] = !DIFile(filename: "{{.*}}si-annotate-dbg-info.ll", directory: {{.*}})
 ; OPT: [[DBG5]] = distinct !DISubprogram(name: "if_else", linkageName: "if_else", scope: null, file: [[META1]], line: 1, type: [[META6:![0-9]+]], scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: [[META0]], retainedNodes: [[META8:![0-9]+]])
 ; OPT: [[META6]] = !DISubroutineType(types: [[META7:![0-9]+]])
 ; OPT: [[META7]] = !{}

--- a/llvm/test/Transforms/StructurizeCFG/structurizecfg-debug-loc.ll
+++ b/llvm/test/Transforms/StructurizeCFG/structurizecfg-debug-loc.ll
@@ -5,7 +5,7 @@ define void @if_then_else(ptr addrspace(1) %out, i1 %arg) !dbg !7 {
 ; CHECK:  entry:
 ; CHECK:    br i1 {{.*}}, label %if.else, label %Flow, !dbg [[ITE_ENTRY_DL:![0-9]+]]
 ; CHECK:  Flow:
-; CHECK:    br i1 {{.*}}, label %if.then, label %exit, !dbg [[ITE_ENTRY_DL]]
+; CHECK:    br i1 {{.*}}, label %if.then, label %exit
 ; CHECK:  if.then:
 ; CHECK:    br label %exit, !dbg [[ITE_IFTHEN_DL:![0-9]+]]
 ; CHECK:  if.else:
@@ -36,7 +36,7 @@ define void @while_loop(ptr addrspace(1) %out) !dbg !14 {
 ; CHECK:  while.body:
 ; CHECK:    br label %Flow, !dbg [[WHILE_BODY_DL:![0-9]+]]
 ; CHECK:  Flow:
-; CHECK:    br i1 {{.*}}, label %exit, label %while.header, !dbg [[WHILE_HEADER_DL]]
+; CHECK:    br i1 {{.*}}, label %exit, label %while.header
 ; CHECK:  exit:
 ;
 entry:
@@ -63,7 +63,7 @@ define void @while_multiple_exits(ptr addrspace(1) %out) !dbg !21 {
 ; CHECK:  while.exiting:
 ; CHECK:    br label %Flow, !dbg [[WHILEME_EXITING_DL:![0-9]+]]
 ; CHECK:  Flow:
-; CHECK:    br i1 {{.*}}, label %exit, label %while.header, !dbg [[WHILEME_HEADER_DL]] 
+; CHECK:    br i1 {{.*}}, label %exit, label %while.header
 ; CHECK:  exit:
 ;
 entry:
@@ -86,11 +86,11 @@ define void @nested_if_then_else(ptr addrspace(1) %out, i1 %a, i1 %b) !dbg !28 {
 ; CHECK:  entry:
 ; CHECK:    br i1 {{.*}}, label %if.else, label %Flow4, !dbg [[NESTED_ENTRY_DL:![0-9]+]]
 ; CHECK:  Flow4:
-; CHECK:    br i1 {{.*}}, label %if.then, label %exit, !dbg [[NESTED_ENTRY_DL]]
+; CHECK:    br i1 {{.*}}, label %if.then, label %exit
 ; CHECK:  if.then:
 ; CHECK:    br i1 {{.*}}, label %if.then.else, label %Flow2, !dbg [[NESTED_IFTHEN_DL:![0-9]+]]
 ; CHECK:  Flow2:
-; CHECK:    br i1 {{.*}}, label %if.then.then, label %Flow3, !dbg [[NESTED_IFTHEN_DL]]
+; CHECK:    br i1 {{.*}}, label %if.then.then, label %Flow3
 ; CHECK:  if.then.then:
 ; CHECK:    br label %Flow3, !dbg [[NESTED_IFTHENTHEN_DL:![0-9]+]]
 ; CHECK:  if.then.else:
@@ -98,15 +98,15 @@ define void @nested_if_then_else(ptr addrspace(1) %out, i1 %a, i1 %b) !dbg !28 {
 ; CHECK:  if.else:
 ; CHECK:    br i1 {{.*}}, label %if.else.else, label %Flow, !dbg [[NESTED_IFELSE_DL:![0-9]+]]
 ; CHECK:  Flow:
-; CHECK:    br i1 {{.*}}, label %if.else.then, label %Flow1, !dbg [[NESTED_IFELSE_DL]]
+; CHECK:    br i1 {{.*}}, label %if.else.then, label %Flow1
 ; CHECK:  if.else.then:
 ; CHECK:    br label %Flow1, !dbg [[NESTED_IFELSETHEN_DL:![0-9]+]]
 ; CHECK:  if.else.else:
 ; CHECK:    br label %Flow, !dbg [[NESTED_IFELSEELSE_DL:![0-9]+]]
 ; CHECK:  Flow1:
-; CHECK:    br label %Flow4, !dbg [[NESTED_IFELSE_DL]]
+; CHECK:    br label %Flow4
 ; CHECK:  Flow3:
-; CHECK:    br label %exit, !dbg [[NESTED_IFTHEN_DL]]
+; CHECK:    br label %exit
 ; CHECK:  exit:
 ;
 entry:


### PR DESCRIPTION
Flow blocks are generated code that don't really correspond to any location in the source, so principly they should have empty DebugLocs. Practically, setting these debug locs leads to redundant is_stmts being generated after #108251, causing stepping test failures in the ROCm GDB test suite.

Fixes SWDEV-502134