### PR TITLE
[sanitizer_common] Add default arch powerpc

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp
@@ -282,6 +282,9 @@ class LLVMSymbolizerProcess final : public SymbolizerProcess {
     const char *const kSymbolizerArch = "--default-arch=powerpc64";
 #  elif defined(__powerpc64__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     const char *const kSymbolizerArch = "--default-arch=powerpc64le";
+#  elif defined(__powerpc__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    // Must check __powerpc__ after __powerpc64__ because both can be set.
+    const char* const kSymbolizerArch = "--default-arch=powerpc";
 #  elif defined(__s390x__)
     const char *const kSymbolizerArch = "--default-arch=s390x";
 #  elif defined(__s390__)

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp
@@ -284,7 +284,7 @@ class LLVMSymbolizerProcess final : public SymbolizerProcess {
     const char *const kSymbolizerArch = "--default-arch=powerpc64le";
 #  elif defined(__powerpc__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     // Must check __powerpc__ after __powerpc64__ because both can be set.
-    const char* const kSymbolizerArch = "--default-arch=powerpc";
+    const char *const kSymbolizerArch = "--default-arch=powerpc";
 #  elif defined(__s390x__)
     const char *const kSymbolizerArch = "--default-arch=s390x";
 #  elif defined(__s390__)

--- a/compiler-rt/test/sanitizer_common/TestCases/Inputs/sanitizer_default_arch/llvm-symbolizer
+++ b/compiler-rt/test/sanitizer_common/TestCases/Inputs/sanitizer_default_arch/llvm-symbolizer
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+ # Assisted by watsonx Code Assistant
+ import json
+ import sys
+ print(json.dumps(sys.argv[1:]), file=sys.stderr)
+ print("main\n??:0:0\n")

--- a/compiler-rt/test/sanitizer_common/TestCases/Inputs/sanitizer_default_arch/llvm-symbolizer
+++ b/compiler-rt/test/sanitizer_common/TestCases/Inputs/sanitizer_default_arch/llvm-symbolizer
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
- # Assisted by watsonx Code Assistant
- import json
- import sys
- print(json.dumps(sys.argv[1:]), file=sys.stderr)
- print("main\n??:0:0\n")
+# Assisted by watsonx Code Assistant
+import json
+import sys
+print(json.dumps(sys.argv[1:]), file=sys.stderr)
+print("main\n??:0:0\n")

--- a/compiler-rt/test/sanitizer_common/TestCases/symbolizer_default_arch_ppc64.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/symbolizer_default_arch_ppc64.cpp
@@ -1,0 +1,18 @@
+// REQUIRES: powerpc64-target-arch
+
+ // RUN: %clangxx -O0 %s -o %t
+ // RUN: %env_tool_opts=external_symbolizer_path=%p/Inputs/sanitizer_default_arch/llvm-symbolizer \
+ // RUN:   %run %t 2>&1 | FileCheck %s
+
+ #include <sanitizer/common_interface_defs.h>
+
+ static void Symbolize() {
+   char buffer[100];
+   __sanitizer_symbolize_pc(__builtin_return_address(0), "%p %F %L", buffer,
+                            sizeof(buffer));
+ }
+
+ int main() {
+   // CHECK: "--default-arch=powerpc64"
+   Symbolize();
+ }

--- a/compiler-rt/test/sanitizer_common/TestCases/symbolizer_default_arch_ppc64.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/symbolizer_default_arch_ppc64.cpp
@@ -1,18 +1,18 @@
 // REQUIRES: powerpc64-target-arch
 
- // RUN: %clangxx -O0 %s -o %t
- // RUN: %env_tool_opts=external_symbolizer_path=%p/Inputs/sanitizer_default_arch/llvm-symbolizer \
+// RUN: %clangxx -O0 %s -o %t
+// RUN: %env_tool_opts=external_symbolizer_path=%p/Inputs/sanitizer_default_arch/llvm-symbolizer \
  // RUN:   %run %t 2>&1 | FileCheck %s
 
- #include <sanitizer/common_interface_defs.h>
+#include <sanitizer/common_interface_defs.h>
 
- static void Symbolize() {
-   char buffer[100];
-   __sanitizer_symbolize_pc(__builtin_return_address(0), "%p %F %L", buffer,
-                            sizeof(buffer));
- }
+static void Symbolize() {
+  char buffer[100];
+  __sanitizer_symbolize_pc(__builtin_return_address(0), "%p %F %L", buffer,
+                           sizeof(buffer));
+}
 
- int main() {
-   // CHECK: "--default-arch=powerpc64"
-   Symbolize();
- }
+int main() {
+  // CHECK: "--default-arch=powerpc64"
+  Symbolize();
+}


### PR DESCRIPTION
Ensure `__powerpc__` is checked after `__powerpc64__` because when `__powerpc64__` is set, `__powerpc__` is also set. 

Issue: https://github.com/llvm/llvm-project/issues/138916