### PR TITLE
[Clang] Detect bit copies that should be relocation.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -853,6 +853,13 @@ def warn_cxxstruct_memaccess : Warning<
   "first argument in call to "
   "%0 is a pointer to non-trivially copyable type %1">,
   InGroup<NonTrivialMemcall>;
+
+def warn_cxxstruct_memaccess_relocatable
+    : Warning<"calling %0 with a pointer to a type %1 which is trivially "
+              "relocatable "
+              "but not trivially copyable; did you mean to call %2?">,
+      InGroup<NonTrivialMemcall>;
+
 def note_nontrivial_field : Note<
   "field is non-trivial to %select{copy|default-initialize}0">;
 def err_non_trivial_c_union_in_invalid_context : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -855,9 +855,10 @@ def warn_cxxstruct_memaccess : Warning<
   InGroup<NonTrivialMemcall>;
 
 def warn_cxxstruct_memaccess_relocatable
-    : Warning<"calling %0 with a pointer to a type %1 which is trivially "
-              "relocatable "
-              "but not trivially copyable; did you mean to call %2?">,
+    : Warning<
+          "calling %0 with a pointer to a type %1 which is trivially "
+          "relocatable but not trivially copyable"
+          "%select{|; did you mean to call 'std::trivially_relocate'?}2">,
       InGroup<NonTrivialMemcall>;
 
 def note_nontrivial_field : Note<

--- a/clang/test/SemaCXX/warn-memaccess.cpp
+++ b/clang/test/SemaCXX/warn-memaccess.cpp
@@ -90,9 +90,12 @@ void test_memmove(TriviallyCopyable* tc0, TriviallyCopyable* tc1,
 
 
 void test_possible_relocation(Relocatable* r, const Relocatable* r2) {
-     // expected-warning@+1 {{calling 'memcpy' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable; did you mean to call __builtin_trivially_relocate?}}
+     // cxx26-warning@+2 {{calling 'memcpy' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable; did you mean to call 'std::trivially_relocate'?}}
+     // cxx11-warning@+1 {{calling 'memcpy' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable}}
      memcpy(r, r, sizeof(*r));
-     // expected-warning@+1 {{calling 'memmove' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable; did you mean to call __builtin_trivially_relocate?}}
+
+     // cxx26-warning@+2 {{calling 'memmove' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable; did you mean to call 'std::trivially_relocate'?}}
+     // cxx11-warning@+1 {{calling 'memmove' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable}}
      memmove(r, r, sizeof(*r));
 
      // expected-warning@+2{{destination for this 'memcpy' call is a pointer to dynamic class 'Relocatable'}}
@@ -102,19 +105,4 @@ void test_possible_relocation(Relocatable* r, const Relocatable* r2) {
      // expected-warning@+2{{destination for this 'memmove' call is a pointer to dynamic class 'Relocatable'}}
      // expected-note@+1{{explicitly cast the pointer to silence this warning}}
      memmove(r, r2, sizeof(*r));
-}
-
-namespace std {
-  using ::memcpy;
-  using ::memmove;
-};
-
-
-void test_possible_relocation_std(Relocatable* r, const Relocatable* r2) {
-     // cxx11-warning@+2 {{calling 'memcpy' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable; did you mean to call __builtin_trivially_relocate?}}
-     // cxx26-warning@+1 {{calling 'memcpy' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable; did you mean to call std::trivially_relocate?}}
-     std::memcpy(r, r, sizeof(*r));
-     // cxx11-warning@+2 {{calling 'memmove' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable; did you mean to call __builtin_trivially_relocate?}}
-     // cxx26-warning@+1 {{calling 'memmove' with a pointer to a type 'Relocatable' which is trivially relocatable but not trivially copyable; did you mean to call std::trivially_relocate?}}
-     std::memmove(r, r, sizeof(*r));
 }


### PR DESCRIPTION
We already warn when memcpy/memmove involves a non-trivially-copyable type. Although we only warn when the target (not the source) is not trivially copyable.

As we moved to deprecate the old is __is_trivially_relocatable trait, it's useful to help users migrating away from memcpy.

Note that currently __builtin_trivially_relocate and memmove have the same effect, but that will change as ptrauth learn to handle relocatable types, we add preconditions (ubsan), etc.