### PR TITLE
[HIP] fix bundle ID for amdgcnspirv

### DIFF
--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -145,11 +145,11 @@ bool OffloadTargetInfo::operator==(const OffloadTargetInfo &Target) const {
 
 std::string OffloadTargetInfo::str() const {
   std::string NormalizedTriple;
-  // Unfortunately we need some special sauce for AMDGPU because all the runtime
-  // assumes the triple to be "amdgcn-amd-amdhsa-" (empty environment) instead
-  // of "amdgcn-amd-amdhsa-unknown". It's gonna be very tricky to patch
-  // different layers of runtime.
-  if (Triple.isAMDGPU()) {
+  // Unfortunately we need some special sauce for AMDHSA because all the runtime
+  // assumes the triple to be "amdgcn/spirv64-amd-amdhsa-" (empty environment)
+  // instead of "amdgcn/spirv64-amd-amdhsa-unknown". It's gonna be very tricky
+  // to patch different layers of runtime.
+  if (Triple.getOS() == Triple::OSType::AMDHSA) {
     NormalizedTriple = Triple.normalize(Triple::CanonicalForm::THREE_IDENT);
     NormalizedTriple.push_back('-');
   } else {

--- a/clang/test/Driver/clang-offload-bundler-standardize.c
+++ b/clang/test/Driver/clang-offload-bundler-standardize.c
@@ -11,16 +11,17 @@
 //
 // RUN: echo 'Content of device file 1' > %t.tgt1
 // RUN: echo 'Content of device file 2' > %t.tgt2
-
+// RUN: echo 'Content of device file 3' > %t.tgt3
 //
 // Check code object compatibility for archive unbundling
 //
 // Create an object bundle
-// RUN: clang-offload-bundler -type=o -targets=host-%itanium_abi_triple,hip-amdgcn-amd-amdhsa--gfx906,hip-amdgcn-amd-amdhsa--gfx908 -input=%t.o -input=%t.tgt1 -input=%t.tgt2 -output=%t.bundle
+// RUN: clang-offload-bundler -type=o -targets=host-%itanium_abi_triple,hip-amdgcn-amd-amdhsa--gfx906,hip-amdgcn-amd-amdhsa--gfx908,hip-spirv64-amd-amdhsa--amdgcnspirv -input=%t.o -input=%t.tgt1 -input=%t.tgt2 -input=%t.tgt3 -output=%t.bundle
 
-// RUN: clang-offload-bundler -unbundle -type=o -targets=hip-amdgcn-amd-amdhsa--gfx906,hip-amdgcn-amd-amdhsa--gfx908 -input=%t.bundle -output=%t-hip-amdgcn-amd-amdhsa--gfx906.bc -output=%t-hip-amdgcn-amd-amdhsa--gfx908.bc -debug-only=CodeObjectCompatibility 2>&1 | FileCheck %s -check-prefix=BUNDLE
+// RUN: clang-offload-bundler -unbundle -type=o -targets=hip-amdgcn-amd-amdhsa--gfx906,hip-amdgcn-amd-amdhsa--gfx908,hip-spirv64-amd-amdhsa--amdgcnspirv -input=%t.bundle -output=%t-hip-amdgcn-amd-amdhsa--gfx906.bc -output=%t-hip-amdgcn-amd-amdhsa--gfx908.bc -output=%t-hip-spirv64-amd-amdhsa--amdgcnspirv.bc -debug-only=CodeObjectCompatibility 2>&1 | FileCheck %s -check-prefix=BUNDLE
 // BUNDLE: Compatible: Exact match: [CodeObject: hip-amdgcn-amd-amdhsa--gfx906] : [Target: hip-amdgcn-amd-amdhsa--gfx906]
 // BUNDLE: Compatible: Exact match: [CodeObject: hip-amdgcn-amd-amdhsa--gfx908] : [Target: hip-amdgcn-amd-amdhsa--gfx908]
+// BUNDLE: Compatible: Exact match: [CodeObject: hip-spirv64-amd-amdhsa--amdgcnspirv] : [Target: hip-spirv64-amd-amdhsa--amdgcnspirv]
 
 // Some code so that we can create a binary out of this file.
 int A = 0;


### PR DESCRIPTION
Currently ROCm 6.4.0 only recognize spirv64-amd-amdhsa- in bundle ID. spirv64-amd-amdhsa-unknown causes all HIP apps compiled for amdgcnspirv to fail.

Previously we fixed a similar issue for
amdgcn-amd-amdhsa-unknown. This patch extends that to spirv64-amd-amdhsa-unknown.