### PR TITLE
[OpenMP] No long crash on an invalid sizes argument

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -891,6 +891,8 @@ OpenMP Support
 - Added support 'no_openmp_constructs' assumption clause.
 - Added support for 'self_maps' in map and requirement clause.
 - Added support for 'omp stripe' directive.
+- Fixed a crashing bug with ``omp tile sizes`` if the argument to ``sizes`` was
+  an invalid expression. (#GH139073)
 
 Improvements
 ^^^^^^^^^^^^

--- a/clang/test/OpenMP/tile_messages.cpp
+++ b/clang/test/OpenMP/tile_messages.cpp
@@ -161,3 +161,12 @@ void template_inst() {
   // expected-note@+1 {{in instantiation of function template specialization 'templated_func_type_dependent<int>' requested here}}
   templated_func_type_dependent<int>();
 }
+
+namespace GH139073 {
+void f(void) {
+  // Clang would previously crash on this because of the invalid DeclRefExpr.
+#pragma omp tile sizes(a) // expected-error {{use of undeclared identifier 'a'}}
+  for (int i = 0; i < 10; i++)
+    ;
+}
+} // namespace GH139073


### PR DESCRIPTION
We were trying to get type information out of an expression node which contained errors. That causes the type of the expression to be dependent, which the code was not expecting. Now we handle error conditions with an early return.

Fixes #139073