### PR TITLE
[sanitizer_common][asan] Disable enable_unmalloced_free_check flag on AIX

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -798,9 +798,9 @@ struct Allocator {
     if (chunk_state == CHUNK_QUARANTINE)
       ReportDoubleFree((uptr)ptr, stack);
     else {
-       if (common_flags()->enable_unmalloced_free_check)
-         ReportFreeNotMalloced((uptr)ptr, stack);
-     }
+      if (common_flags()->enable_unmalloced_free_check)
+        ReportFreeNotMalloced((uptr)ptr, stack);
+    }
   }
 
   void CommitBack(AsanThreadLocalMallocStorage *ms, BufferedStackTrace *stack) {

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -797,8 +797,10 @@ struct Allocator {
   void ReportInvalidFree(void *ptr, u8 chunk_state, BufferedStackTrace *stack) {
     if (chunk_state == CHUNK_QUARANTINE)
       ReportDoubleFree((uptr)ptr, stack);
-    else
-      ReportFreeNotMalloced((uptr)ptr, stack);
+    else {
+       if (common_flags()->enable_unmalloced_free_check)
+         ReportFreeNotMalloced((uptr)ptr, stack);
+     }
   }
 
   void CommitBack(AsanThreadLocalMallocStorage *ms, BufferedStackTrace *stack) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
@@ -283,5 +283,5 @@ COMMON_FLAG(bool, enable_symbolizer_markup, SANITIZER_FUCHSIA,
 COMMON_FLAG(bool, detect_invalid_join, true,
             "If set, check invalid joins of threads.")
 COMMON_FLAG(bool, enable_unmalloced_free_check, !SANITIZER_AIX,
-             "if true, FreeNotMalloced error will be reported. Only disable "
-             "this error detecting on AIX by default for now.")
+            "if true, FreeNotMalloced error will be reported. Only disable "
+            "this error detecting on AIX by default for now.")

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
@@ -282,3 +282,6 @@ COMMON_FLAG(bool, enable_symbolizer_markup, SANITIZER_FUCHSIA,
 
 COMMON_FLAG(bool, detect_invalid_join, true,
             "If set, check invalid joins of threads.")
+COMMON_FLAG(bool, enable_unmalloced_free_check, !SANITIZER_AIX,
+             "if true, FreeNotMalloced error will be reported. Only disable "
+             "this error detecting on AIX by default for now.")


### PR DESCRIPTION
There is currently a risk of false positives (from inconsistent interception of malloc), so disable on AIX for now. 

Issue: https://github.com/llvm/llvm-project/issues/138916