### PR TITLE
[MemProf] Fix summary bitcode record description (NFC)

### DIFF
--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -311,12 +311,12 @@ enum GlobalValueSummarySymtabCodes {
   // [nummib x (numcontext x total size)]?]
   FS_PERMODULE_ALLOC_INFO = 27,
   // Summary of combined index memprof callsite metadata.
-  // [valueid, context radix tree index, numver,
-  //  numver x version]
+  // [valueid, numstackindices, numver,
+  //  numstackindices x stackidindex, numver x version]
   FS_COMBINED_CALLSITE_INFO = 28,
   // Summary of combined index allocation memprof metadata.
   // [nummib, numver,
-  //  nummib x (alloc type, numstackids, numstackids x stackidindex),
+  //  nummib x (alloc type, context radix tree index),
   //  numver x version]
   FS_COMBINED_ALLOC_INFO = 29,
   // List of all stack ids referenced by index in the callsite and alloc infos.


### PR DESCRIPTION
Commit 776476c282bca71d5b856e80e0a88fbd6f3ccdd2 (PR117404), which
introduced the radix tree representation of allocation context summary
records, incorrectly changed the description of the
FS_COMBINED_CALLSITE_INFO record instead of the intended
FS_COMBINED_ALLOC_INFO record.
