### PR TITLE
[LAA] Strip dead code in getStrideFromPointer (NFC)

### DIFF
--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -2862,23 +2862,6 @@ static const SCEV *getStrideFromPointer(Value *Ptr, ScalarEvolution *SE, Loop *L
 
   V = S->getStepRecurrence(*SE);
 
-  // Strip off the size of access multiplication if we are still analyzing the
-  // pointer.
-  if (OrigPtr == Ptr) {
-    if (auto *M = dyn_cast<SCEVMulExpr>(V)) {
-      auto *StepConst = dyn_cast<SCEVConstant>(M->getOperand(0));
-      if (!StepConst)
-        return nullptr;
-
-      auto StepVal = StepConst->getAPInt().trySExtValue();
-      // Bail out on a non-unit pointer access size.
-      if (!StepVal || StepVal != 1)
-        return nullptr;
-
-      V = M->getOperand(1);
-    }
-  }
-
   // Note that the restriction after this loop invariant check are only
   // profitability restrictions.
   if (!SE->isLoopInvariant(V, Lp))


### PR DESCRIPTION
The SCEV multiply by 1 doesn't make sense, because SCEV would fold it: therefore, the OrigPtr == Ptr branch effectively rejects a multiply. However, in this branch, we have a pointer SCEV that cannot be a multiply, and hence the code the code is dead. Strip it.