### PR TITLE
[clang][Darwin] Minor args cleanup

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2582,8 +2582,7 @@ void DarwinClang::AddClangSystemIncludeArgs(
     llvm::opt::ArgStringList &CC1Args) const {
   AppleMachO::AddClangSystemIncludeArgs(DriverArgs, CC1Args);
 
-  if (DriverArgs.hasArg(options::OPT_nostdinc) ||
-      DriverArgs.hasArg(options::OPT_nostdlibinc))
+  if (DriverArgs.hasArg(options::OPT_nostdinc, options::OPT_nostdlibinc))
     return;
 
   llvm::SmallString<128> Sysroot = GetEffectiveSysroot(DriverArgs);


### PR DESCRIPTION
I just realized that ArgList.hasArg takes multiple arguments. Consolidate the two calls into one.