### PR TITLE
[VPlan] Add VPPhi subclass for VPInstruction with PHI opcodes.(NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -252,8 +252,7 @@ public:
 
   VPInstruction *createScalarPhi(ArrayRef<VPValue *> IncomingValues,
                                  DebugLoc DL, const Twine &Name = "") {
-    return tryInsertInstruction(
-        new VPPhi(Instruction::PHI, IncomingValues, DL, Name));
+    return tryInsertInstruction(new VPPhi(IncomingValues, DL, Name));
   }
 
   /// Convert the input value \p Current to the corresponding value of an

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -253,7 +253,7 @@ public:
   VPInstruction *createScalarPhi(ArrayRef<VPValue *> IncomingValues,
                                  DebugLoc DL, const Twine &Name = "") {
     return tryInsertInstruction(
-        new VPInstruction(Instruction::PHI, IncomingValues, DL, Name));
+        new VPPhi(Instruction::PHI, IncomingValues, DL, Name));
   }
 
   /// Convert the input value \p Current to the corresponding value of an

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1143,6 +1143,28 @@ public:
 #endif
 };
 
+struct VPPhi : public VPInstruction, public VPPhiAccessors {
+  VPPhi(unsigned Opcode, ArrayRef<VPValue *> Operands, DebugLoc DL,
+        const Twine &Name = "")
+      : VPInstruction(Opcode, Operands, DL, Name) {}
+
+  static inline bool classof(const VPRecipeBase *U) {
+    auto *R = dyn_cast<VPInstruction>(U);
+    return R && R->getOpcode() == Instruction::PHI;
+  }
+
+  void execute(VPTransformState &State) override;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  /// Print the recipe.
+  void print(raw_ostream &O, const Twine &Indent,
+             VPSlotTracker &SlotTracker) const override;
+#endif
+
+protected:
+  const VPRecipeBase *getAsRecipe() const override { return this; }
+};
+
 /// A recipe to wrap on original IR instruction not to be modified during
 /// execution, except for PHIs. PHIs are modeled via the VPIRPhi subclass.
 /// Expect PHIs, VPIRInstructions cannot have any operands.

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1144,9 +1144,8 @@ public:
 };
 
 struct VPPhi : public VPInstruction, public VPPhiAccessors {
-  VPPhi(unsigned Opcode, ArrayRef<VPValue *> Operands, DebugLoc DL,
-        const Twine &Name = "")
-      : VPInstruction(Opcode, Operands, DL, Name) {}
+  VPPhi(ArrayRef<VPValue *> Operands, DebugLoc DL, const Twine &Name = "")
+      : VPInstruction(Instruction::PHI, Operands, DL, Name) {}
 
   static inline bool classof(const VPRecipeBase *U) {
     auto *R = dyn_cast<VPInstruction>(U);

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1154,12 +1154,6 @@ struct VPPhi : public VPInstruction, public VPPhiAccessors {
 
   void execute(VPTransformState &State) override;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  /// Print the recipe.
-  void print(raw_ostream &O, const Twine &Indent,
-             VPSlotTracker &SlotTracker) const override;
-#endif
-
 protected:
   const VPRecipeBase *getAsRecipe() const override { return this; }
 };

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1135,17 +1135,6 @@ void VPPhi::execute(VPTransformState &State) {
   State.set(this, Phi, VPLane(0));
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-void VPPhi::print(raw_ostream &O, const Twine &Indent,
-                  VPSlotTracker &SlotTracker) const {
-  O << Indent << "EMIT ";
-  printAsOperand(O, SlotTracker);
-  O << " = phi ";
-
-  printPhiOperands(O, SlotTracker);
-}
-#endif
-
 VPIRInstruction *VPIRInstruction ::create(Instruction &I) {
   if (auto *Phi = dyn_cast<PHINode>(&I))
     return new VPIRPhi(*Phi);


### PR DESCRIPTION
Similarly to VPInstructionWithType and VPIRPhi, add VPPhi as a subclass for VPInstruction. This allows implementing the VPPhiAccessors trait, making available helpers for generic printing of incoming values / blocks and accessors for incoming blocks and values.

It will also allow properly verifying def-uses for values used by VPInstructions with PHI opcodes via
https://github.com/llvm/llvm-project/pull/124838.