### PR TITLE
[AA] Change RunEarly to be a Boolean Flag in ExternalAAWrapper

### DIFF
--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -1013,10 +1013,15 @@ struct ExternalAAWrapperPass : ImmutablePass {
 
   explicit ExternalAAWrapperPass(CallbackT CB);
 
-  /// Returns whether this external AA should run before Basic AA.
+  /// Flag indicating whether this external AA should run before Basic AA.
   ///
-  /// By default, external AA passes are run after Basic AA. If this returns
-  /// true, the external AA will be run before Basic AA during alias analysis.
+  /// This flag is for LegacyPassManager only. To run an external AA early
+  /// with the NewPassManager, override the registerEarlyDefaultAliasAnalyses
+  /// method on the target machine.
+  ///
+  /// By default, external AA passes are run after Basic AA. If this flag is
+  /// set to true, the external AA will be run before Basic AA during alias
+  /// analysis.
   ///
   /// For some targets, we prefer to run the external AA early to improve
   /// compile time as it has more target-specific information. This is

--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -1011,7 +1011,7 @@ struct ExternalAAWrapperPass : ImmutablePass {
 
   ExternalAAWrapperPass();
 
-  explicit ExternalAAWrapperPass(CallbackT CB);
+  explicit ExternalAAWrapperPass(CallbackT CB, bool RunEarly = false);
 
   /// Flag indicating whether this external AA should run before Basic AA.
   ///

--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -1023,7 +1023,7 @@ struct ExternalAAWrapperPass : ImmutablePass {
   /// particularly useful when the external AA can provide more precise results
   /// than Basic AA so that Basic AA does not need to spend time recomputing
   /// them.
-  virtual bool runEarly() { return false; }
+  bool RunEarly = false;
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesAll();

--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -741,7 +741,7 @@ bool AAResultsWrapperPass::runOnFunction(Function &F) {
 
   // Add any target-specific alias analyses that should be run early.
   auto *ExtWrapperPass = getAnalysisIfAvailable<ExternalAAWrapperPass>();
-  if (ExtWrapperPass && ExtWrapperPass->runEarly() && ExtWrapperPass->CB) {
+  if (ExtWrapperPass && ExtWrapperPass->RunEarly && ExtWrapperPass->CB) {
     LLVM_DEBUG(dbgs() << "AAResults register Early ExternalAA: "
                       << ExtWrapperPass->getPassName() << "\n");
     ExtWrapperPass->CB(*this, F, *AAR);
@@ -777,7 +777,7 @@ bool AAResultsWrapperPass::runOnFunction(Function &F) {
 
   // If available, run an external AA providing callback over the results as
   // well.
-  if (ExtWrapperPass && !ExtWrapperPass->runEarly() && ExtWrapperPass->CB) {
+  if (ExtWrapperPass && !ExtWrapperPass->RunEarly && ExtWrapperPass->CB) {
     LLVM_DEBUG(dbgs() << "AAResults register Late ExternalAA: "
                       << ExtWrapperPass->getPassName() << "\n");
     ExtWrapperPass->CB(*this, F, *AAR);

--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -693,8 +693,8 @@ AnalysisKey AAManager::Key;
 
 ExternalAAWrapperPass::ExternalAAWrapperPass() : ImmutablePass(ID) {}
 
-ExternalAAWrapperPass::ExternalAAWrapperPass(CallbackT CB)
-    : ImmutablePass(ID), CB(std::move(CB)) {}
+ExternalAAWrapperPass::ExternalAAWrapperPass(CallbackT CB, bool RunEarly)
+    : ImmutablePass(ID), CB(std::move(CB)), RunEarly(RunEarly) {}
 
 char ExternalAAWrapperPass::ID = 0;
 

--- a/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.h
+++ b/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.h
@@ -90,14 +90,14 @@ class NVPTXExternalAAWrapper : public ExternalAAWrapperPass {
 public:
   static char ID;
 
-  bool runEarly() override { return true; }
-
   NVPTXExternalAAWrapper()
       : ExternalAAWrapperPass([](Pass &P, Function &, AAResults &AAR) {
           if (auto *WrapperPass =
                   P.getAnalysisIfAvailable<NVPTXAAWrapperPass>())
             AAR.addAAResult(WrapperPass->getResult());
-        }) {}
+        }) {
+    RunEarly = true;
+  }
 
   StringRef getPassName() const override {
     return "NVPTX Address space based Alias Analysis Wrapper";

--- a/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.h
+++ b/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.h
@@ -91,13 +91,13 @@ public:
   static char ID;
 
   NVPTXExternalAAWrapper()
-      : ExternalAAWrapperPass([](Pass &P, Function &, AAResults &AAR) {
-          if (auto *WrapperPass =
-                  P.getAnalysisIfAvailable<NVPTXAAWrapperPass>())
-            AAR.addAAResult(WrapperPass->getResult());
-        }) {
-    RunEarly = true;
-  }
+      : ExternalAAWrapperPass(
+            [](Pass &P, Function &, AAResults &AAR) {
+              if (auto *WrapperPass =
+                      P.getAnalysisIfAvailable<NVPTXAAWrapperPass>())
+                AAR.addAAResult(WrapperPass->getResult());
+            },
+            /*RunEarly=*/true) {}
 
   StringRef getPassName() const override {
     return "NVPTX Address space based Alias Analysis Wrapper";


### PR DESCRIPTION
Change the previous runEarly virtual function in ExternalAAWrapper to be a boolean flag.