### PR TITLE
Revert "[Clang] Diagnose invalid function types in dependent contexts (#138731)"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -566,7 +566,7 @@ Bug Fixes in This Version
 - Fixed a bug where an attribute before a ``pragma clang attribute`` or
   ``pragma clang __debug`` would cause an assertion. Instead, this now diagnoses
   the invalid attribute location appropriately. (#GH137861)
-- Fixed a crash when a malformed ``_Pragma`` directive appears as part of an 
+- Fixed a crash when a malformed ``_Pragma`` directive appears as part of an
   ``#include`` directive. (#GH138094)
 - Fixed a crash during constant evaluation involving invalid lambda captures
   (#GH138832)
@@ -675,7 +675,6 @@ Bug Fixes to C++ Support
 - Fixed an assertion when trying to constant-fold various builtins when the argument
   referred to a reference to an incomplete type. (#GH129397)
 - Fixed a crash when a cast involved a parenthesized aggregate initialization in dependent context. (#GH72880)
-- Fixed a crash when forming an invalid function type in a dependent context. (#GH138657) (#GH115725) (#GH68852)
 - No longer crashes when instantiating invalid variable template specialization
   whose type depends on itself. (#GH51347), (#GH55872)
 - Improved parser recovery of invalid requirement expressions. In turn, this

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -6550,15 +6550,6 @@ ExprResult Sema::ActOnCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
   return Call;
 }
 
-// Any type that could be used to form a callable expression
-static bool MayBeFunctionType(const ASTContext &Context, QualType T) {
-  return T == Context.BoundMemberTy || T == Context.UnknownAnyTy ||
-         T == Context.BuiltinFnTy || T == Context.OverloadTy ||
-         T->isFunctionType() || T->isFunctionReferenceType() ||
-         T->isMemberFunctionPointerType() || T->isFunctionPointerType() ||
-         T->isBlockPointerType() || T->isRecordType();
-}
-
 ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
                                MultiExprArg ArgExprs, SourceLocation RParenLoc,
                                Expr *ExecConfig, bool IsExecConfig,
@@ -6611,15 +6602,6 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
         tryImplicitlyCaptureThisIfImplicitMemberFunctionAccessWithDependentArgs(
             *this, dyn_cast<UnresolvedMemberExpr>(Fn->IgnoreParens()),
             Fn->getBeginLoc());
-
-        // If the type of the function itself is not dependent
-        // check that it is a reasonable as a function, as type deduction
-        // later assume the CallExpr has a sensible TYPE.
-        if (!Fn->getType()->isDependentType() &&
-            !MayBeFunctionType(Context, Fn->getType()))
-          return ExprError(
-              Diag(LParenLoc, diag::err_typecheck_call_not_function)
-              << Fn->getType() << Fn->getSourceRange());
 
         return CallExpr::Create(Context, Fn, ArgExprs, Context.DependentTy,
                                 VK_PRValue, RParenLoc, CurFPFeatureOverrides());


### PR DESCRIPTION
This reverts commit cf9b4d1e7961214deabd99a9fc3b1d4c9e78a71f.

Causes breakages as reported here: https://github.com/llvm/llvm-project/pull/138731#issuecomment-2864298000