### PR TITLE
[MLGO][Docs] Add initial skeleton of MLGO docs

### DIFF
--- a/llvm/docs/MLGO.rst
+++ b/llvm/docs/MLGO.rst
@@ -1,0 +1,28 @@
+====
+MLGO
+====
+
+Introduction
+============
+
+MLGO is a framework for integrating ML techniques systematically in LLVM. It is
+designed primarily to replace heuristics within LLVM with machine learned
+models. Currently there is upstream infrastructure for the following
+heuristics:
+
+* Inlining for size
+* Register allocation (LLVM greedy eviction heuristic) for performance
+
+This document is an outline of the tooling that composes MLGO.
+
+Corpus Tooling
+==============
+
+..
+    TODO(boomanaiden154): Write this section.
+
+Model Runner Interfaces
+=======================
+
+..
+    TODO(mtrofin): Write this section.

--- a/llvm/docs/Reference.rst
+++ b/llvm/docs/Reference.rst
@@ -41,6 +41,7 @@ LLVM and API reference documentation.
    PDB/index
    PointerAuth
    ScudoHardenedAllocator
+   MLGO
    MemoryModelRelaxationAnnotations
    MemTagSanitizer
    Security


### PR DESCRIPTION
This adds an initial skeleton of the MLGO docs. This is intended to be
fleshed out over the next couple days as we work on filling out the
relevant sections on the tooling/features that are available in upstream
LLVM.
