### PR TITLE
[libc] Enable poll function for riscv

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -33,8 +33,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.fcntl.openat
 
     # poll.h entrypoints
-    # TODO: https://github.com/llvm/llvm-project/issues/125940
-    # libc.src.poll.poll
+    libc.src.poll.poll
 
     # sched.h entrypoints
     libc.src.sched.sched_get_priority_max

--- a/libc/include/sys/syscall.h.def
+++ b/libc/include/sys/syscall.h.def
@@ -1517,6 +1517,10 @@
 #define SYS_ppoll __NR_ppoll
 #endif
 
+#ifdef __NR_ppoll_time64
+#define SYS_ppoll_time64 __NR_ppoll_time64
+#endif
+
 #ifdef __NR_prctl
 #define SYS_prctl __NR_prctl
 #endif

--- a/libc/src/poll/linux/poll.cpp
+++ b/libc/src/poll/linux/poll.cpp
@@ -18,7 +18,7 @@
 
 #include <sys/syscall.h> // SYS_poll, SYS_ppoll
 
-#if SYS_poll
+#ifdef SYS_poll
 constexpr auto POLL_SYSCALL_ID = SYS_poll;
 #elif defined(SYS_ppoll)
 constexpr auto POLL_SYSCALL_ID = SYS_ppoll;


### PR DESCRIPTION
RV32 uses SYS_ppoll_time64 instead of SYS_ppoll, but the call is the same.