### PR TITLE
[libc] Enable utimes function for riscv

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -290,7 +290,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.statvfs.statvfs
 
     # sys/utimes.h entrypoints
-    # libc.src.sys.time.utimes
+    libc.src.sys.time.utimes
 
     # sys/utsname.h entrypoints
     libc.src.sys.utsname.uname

--- a/libc/include/sys/syscall.h.def
+++ b/libc/include/sys/syscall.h.def
@@ -2301,6 +2301,10 @@
 #define SYS_utimes __NR_utimes
 #endif
 
+#ifdef __NR_utimensat_time64
+#define SYS_utimensat_time64 __NR_utimensat_time64
+#endif
+
 #ifdef __NR_utrap_install
 #define SYS_utrap_install __NR_utrap_install
 #endif

--- a/libc/src/sys/time/linux/utimes.cpp
+++ b/libc/src/sys/time/linux/utimes.cpp
@@ -9,8 +9,8 @@
 #include "src/sys/time/utimes.h"
 
 #include "hdr/fcntl_macros.h"
-#include "hdr/types/struct_timeval.h"
 #include "hdr/types/struct_timespec.h"
+#include "hdr/types/struct_timeval.h"
 
 #include "src/__support/OSUtil/syscall.h"
 #include "src/__support/common.h"

--- a/libc/src/sys/time/linux/utimes.cpp
+++ b/libc/src/sys/time/linux/utimes.cpp
@@ -21,7 +21,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-#if SYS_utimes
+#ifdef SYS_utimes
 constexpr auto UTIMES_SYSCALL_ID = SYS_utimes;
 #elif defined(SYS_utimensat)
 constexpr auto UTIMES_SYSCALL_ID = SYS_utimensat;


### PR DESCRIPTION
RV32 uses SYS_utimensat_time64 instead of SYS_utimensat but the call is the same.