### PR TITLE
[libc] Enable setitimer and getitimer functions on riscv

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -371,8 +371,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.uio.readv
 
     # sys/time.h entrypoints
-    # libc.src.sys.time.setitimer
-    # libc.src.sys.time.getitimer
+    libc.src.sys.time.setitimer
+    libc.src.sys.time.getitimer
 )
 
 if(LLVM_LIBC_INCLUDE_SCUDO)

--- a/libc/src/sys/time/linux/getitimer.cpp
+++ b/libc/src/sys/time/linux/getitimer.cpp
@@ -16,8 +16,22 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, getitimer, (int which, struct itimerval *curr_value)) {
-  long ret =
-      LIBC_NAMESPACE::syscall_impl<long>(SYS_getitimer, which, curr_value);
+  long ret = 0;
+  if constexpr (sizeof(time_t) > sizeof(long)) {
+    // There is no SYS_getitimer_time64 call, so we can't use time_t directly.
+    long curr_value32[4];
+    ret = LIBC_NAMESPACE::syscall_impl<long>(SYS_getitimer, which, curr_value32);
+    if (!ret) {
+      curr_value->it_interval.tv_sec = curr_value32[0];
+      curr_value->it_interval.tv_usec = curr_value32[1];
+      curr_value->it_value.tv_sec = curr_value32[2];
+      curr_value->it_value.tv_usec = curr_value32[3];
+    }
+  } else {
+    ret =
+        LIBC_NAMESPACE::syscall_impl<long>(SYS_getitimer, which, curr_value);
+  }
+
   // On failure, return -1 and set errno.
   if (ret < 0) {
     libc_errno = static_cast<int>(-ret);

--- a/libc/src/sys/time/linux/getitimer.cpp
+++ b/libc/src/sys/time/linux/getitimer.cpp
@@ -20,7 +20,8 @@ LLVM_LIBC_FUNCTION(int, getitimer, (int which, struct itimerval *curr_value)) {
   if constexpr (sizeof(time_t) > sizeof(long)) {
     // There is no SYS_getitimer_time64 call, so we can't use time_t directly.
     long curr_value32[4];
-    ret = LIBC_NAMESPACE::syscall_impl<long>(SYS_getitimer, which, curr_value32);
+    ret =
+        LIBC_NAMESPACE::syscall_impl<long>(SYS_getitimer, which, curr_value32);
     if (!ret) {
       curr_value->it_interval.tv_sec = curr_value32[0];
       curr_value->it_interval.tv_usec = curr_value32[1];
@@ -28,8 +29,7 @@ LLVM_LIBC_FUNCTION(int, getitimer, (int which, struct itimerval *curr_value)) {
       curr_value->it_value.tv_usec = curr_value32[3];
     }
   } else {
-    ret =
-        LIBC_NAMESPACE::syscall_impl<long>(SYS_getitimer, which, curr_value);
+    ret = LIBC_NAMESPACE::syscall_impl<long>(SYS_getitimer, which, curr_value);
   }
 
   // On failure, return -1 and set errno.

--- a/libc/src/sys/time/linux/setitimer.cpp
+++ b/libc/src/sys/time/linux/setitimer.cpp
@@ -17,8 +17,30 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(int, setitimer,
                    (int which, const struct itimerval *new_value,
                     struct itimerval *old_value)) {
-  long ret = LIBC_NAMESPACE::syscall_impl<long>(SYS_setitimer, which, new_value,
-                                                old_value);
+  long ret = 0;
+  if constexpr (sizeof(time_t) > sizeof(long)) {
+    // There is no SYS_setitimer_time64 call, so we can't use time_t directly,
+    // and need to convert it to long first.
+    long new_value32[4] = {static_cast<long>(new_value->it_interval.tv_sec),
+                           new_value->it_interval.tv_usec,
+                           static_cast<long>(new_value->it_value.tv_sec),
+                           new_value->it_value.tv_usec};
+    long old_value32[4];
+
+    ret = LIBC_NAMESPACE::syscall_impl<long>(SYS_setitimer, which, new_value32,
+                                             old_value32);
+
+    if (!ret && old_value) {
+      old_value->it_interval.tv_sec = old_value32[0];
+      old_value->it_interval.tv_usec = old_value32[1];
+      old_value->it_value.tv_sec = old_value32[2];
+      old_value->it_value.tv_usec = old_value32[3];
+    }
+  } else {
+    ret = LIBC_NAMESPACE::syscall_impl<long>(SYS_setitimer, which, new_value,
+                                             old_value);
+  }
+
   // On failure, return -1 and set errno.
   if (ret < 0) {
     libc_errno = static_cast<int>(-ret);


### PR DESCRIPTION
These functions don't have a _time64 variant, so we can't use time_t directly (since our time_t is an uint64_t). The workaround is to use longs when doing the syscall and write back when necessary.