### PR TITLE
[analyzer] Fix crashing __builtin_bit_cast

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -314,10 +314,9 @@ void ExprEngine::VisitCast(const CastExpr *CastE, const Expr *Ex,
       // Although `Ex` is an lvalue, it could have `Loc::ConcreteInt` kind
       // (e.g., `(int *)123456`).  In such cases, there is no MemRegion
       // available and we can't get the value to be casted.
-      const MemRegion *MR = State->getSVal(Ex, LCtx).getAsRegion();
       SVal CastedV = UnknownVal();
 
-      if (MR) {
+      if (const MemRegion *MR = State->getSVal(Ex, LCtx).getAsRegion()) {
         SVal OrigV = State->getSVal(MR);
         CastedV = svalBuilder.evalCast(svalBuilder.simplifySVal(State, OrigV),
                                        CastE->getType(), Ex->getType());

--- a/clang/test/Analysis/builtin_bitcast.cpp
+++ b/clang/test/Analysis/builtin_bitcast.cpp
@@ -39,7 +39,7 @@ struct A {
   }
 };
 void gh_69922(size_t p) {
-  // expected-warning-re@+1 {{(reg_${{[0-9]+}}<size_t p>) & 1U}}
+  // expected-warning@+1 {{Unknown}}
   clang_analyzer_dump(__builtin_bit_cast(A*, p & 1));
 
   __builtin_bit_cast(A*, p & 1)->set(2); // no-crash
@@ -49,5 +49,15 @@ void gh_69922(size_t p) {
   // store to the member variable `n`.
 
   clang_analyzer_dump(__builtin_bit_cast(A*, p & 1)->n); // Ideally, this should print "2".
-  // expected-warning-re@-1 {{(reg_${{[0-9]+}}<size_t p>) & 1U}}
+  // expected-warning@-1 {{Unknown}}
+}
+
+namespace {
+  typedef unsigned long uintptr_t;
+  
+  bool previously_crash(const void *& ptr) {
+    clang_analyzer_dump(__builtin_bit_cast(void*, static_cast<uintptr_t>(-1)));
+    // expected-warning-re@-1 {{{{[0-9]+}} (Loc)}}
+    return ptr == __builtin_bit_cast(void*, static_cast<uintptr_t>(-1));
+  }
 }

--- a/clang/test/Analysis/builtin_bitcast.cpp
+++ b/clang/test/Analysis/builtin_bitcast.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -triple x86_64-unknown-unknown -verify %s \
-// RUN:   -analyzer-checker=core,debug.ExprInspection
+// RUN:   -analyzer-checker=debug.ExprInspection -analyzer-disable-checker=core
 
 template <typename T> void clang_analyzer_dump(T);
 using size_t = decltype(sizeof(int));
@@ -59,5 +59,10 @@ namespace {
     clang_analyzer_dump(__builtin_bit_cast(void*, static_cast<uintptr_t>(-1)));
     // expected-warning-re@-1 {{{{[0-9]+}} (Loc)}}
     return ptr == __builtin_bit_cast(void*, static_cast<uintptr_t>(-1));
+  }
+
+  void check_loc_concreteInt() {
+    clang_analyzer_dump(__builtin_bit_cast(unsigned, *(reinterpret_cast<int*>(0xdeadbeef))));
+    // expected-warning@-1 {{Unknown}}
   }
 }

--- a/clang/test/Analysis/builtin_bitcast.cpp
+++ b/clang/test/Analysis/builtin_bitcast.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -triple x86_64-unknown-unknown -verify %s \
-// RUN:   -analyzer-checker=debug.ExprInspection -analyzer-disable-checker=core
+// RUN:   -analyzer-checker=core,debug.ExprInspection -analyzer-disable-checker=core.FixedAddressDereference
 
 template <typename T> void clang_analyzer_dump(T);
 using size_t = decltype(sizeof(int));

--- a/clang/test/Analysis/exercise-ps.c
+++ b/clang/test/Analysis/exercise-ps.c
@@ -41,7 +41,7 @@ void f4(char *array) {
 
   _Static_assert(sizeof(int) == 4, "Wrong triple for the test");
 
-  clang_analyzer_dump_int(__builtin_bit_cast(int, b)); // expected-warning {{lazyCompoundVal}}
+  clang_analyzer_dump_int(__builtin_bit_cast(int, b)); // expected-warning {{Unknown}}
   clang_analyzer_dump_int(array[__builtin_bit_cast(int, b)]); // expected-warning {{Unknown}}
 
   array[__builtin_bit_cast(int, b)] = 0x10; // no crash


### PR DESCRIPTION
I am investigating a CSA crash: https://godbolt.org/z/fEExYqoWM.  If one changes the `__builtin_bit_cast` to a C-style cast, the test will be fine.  So the problem is specific to `__builtin_bit_cast`.

Looking at the piece of code below, it seems that CSA handles `__builtin_bit_cast` just as an `LValueToRValue` cast.  The actual operation of cast-to-target-type is missing. 
```
void ExprEngine::VisitCast(const CastExpr *CastE, const Expr *Ex,
                           ExplodedNode *Pred, ExplodedNodeSet &Dst) {

  ExplodedNodeSet dstPreStmt;
  getCheckerManager().runCheckersForPreStmt(dstPreStmt, Pred, CastE, *this);

  if (CastE->getCastKind() == CK_LValueToRValue ||
      CastE->getCastKind() == CK_LValueToRValueBitCast) {
    for (ExplodedNode *subExprNode : dstPreStmt) {
      ProgramStateRef state = subExprNode->getState();
      const LocationContext *LCtx = subExprNode->getLocationContext();
      evalLoad(Dst, CastE, CastE, subExprNode, state, state->getSVal(Ex, LCtx));
    }
    return;
  }
```

The `BuiltinBitCastExpr` node always have the kind `LValueToRValueBitCast`.  I suppose it is just associated to the second argument of a `__builtin_bit_cast` call.  
```
-BuiltinBitCastExpr <col:17, col:45> 'void *' <LValueToRValueBitCast>
```

I'm trying to add the missing part.

Fixes #137417