### PR TITLE
Branch island no dsym

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -1038,6 +1038,15 @@ DynamicLoaderDarwin::GetStepThroughTrampolinePlan(Thread &thread,
     static RegularExpression g_branch_island_regex(g_branch_island_pattern);
 
     bool is_branch_island = g_branch_island_regex.Execute(current_name);
+    // FIXME: this is extra logging so I can figure out why this test is failing
+    // on the bot but not locally with all the same tools, etc...
+    if (thread_plan_sp && is_branch_island) {
+      if (log) {
+        StreamString s;
+        thread_plan_sp->GetDescription(&s, eDescriptionLevelVerbose);
+        LLDB_LOGF(log, "Am at a branch island, but already had plan: \n\t%s", s.GetData());
+      }
+    }
     if (!thread_plan_sp && is_branch_island) {
       thread_plan_sp = std::make_shared<ThreadPlanStepInstruction>(
           thread,

--- a/lldb/test/API/macosx/branch-islands/Makefile
+++ b/lldb/test/API/macosx/branch-islands/Makefile
@@ -4,7 +4,7 @@ CFLAGS_EXTRAS := -std=c99
 include Makefile.rules
 
 a.out: main.o padding1.o padding2.o padding3.o padding4.o foo.o
-	${CC} ${LDFLAGS} -fuse-ld=/usr/bin/ld foo.o padding1.o padding2.o padding3.o padding4.o main.o -o a.out
+	${CC} ${LDFLAGS} foo.o padding1.o padding2.o padding3.o padding4.o main.o -o a.out
 
 %.o: $(SRCDIR)/%.s
 	${CC} -c $<

--- a/lldb/test/API/macosx/branch-islands/Makefile
+++ b/lldb/test/API/macosx/branch-islands/Makefile
@@ -4,7 +4,7 @@ CFLAGS_EXTRAS := -std=c99
 include Makefile.rules
 
 a.out: main.o padding1.o padding2.o padding3.o padding4.o foo.o
-	${CC} ${LDFLAGS} foo.o padding1.o padding2.o padding3.o padding4.o main.o -o a.out
+	${CC} ${LDFLAGS} -fuse-ld=/usr/bin/ld foo.o padding1.o padding2.o padding3.o padding4.o main.o -o a.out
 
 %.o: $(SRCDIR)/%.s
 	${CC} -c $<

--- a/lldb/test/API/macosx/branch-islands/TestBranchIslands.py
+++ b/lldb/test/API/macosx/branch-islands/TestBranchIslands.py
@@ -15,7 +15,7 @@ class TestBranchIslandStepping(TestBase):
     @skipUnlessAppleSilicon
     def test_step_in_branch_island(self):
         """Make sure we can step in across a branch island"""
-        self.build()
+        self.build(debug_info="dwarf")
         self.main_source_file = lldb.SBFileSpec("main.c")
         self.do_test()
 

--- a/lldb/test/API/macosx/branch-islands/TestBranchIslands.py
+++ b/lldb/test/API/macosx/branch-islands/TestBranchIslands.py
@@ -2,7 +2,7 @@
 Make sure that we can step in across an arm64 branch island
 """
 
-
+import os
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
@@ -32,6 +32,9 @@ class TestBranchIslandStepping(TestBase):
         trace_before = lldbutil.print_stacktrace(thread, True)
         func_before = thread.frames[0].function
 
+        log_file_path = os.path.join(self.getBuildDir(), "step-log.txt")
+        self.runCmd(f"log enable -f {log_file_path} lldb step")
+        
         thread.StepInto()
         stop_frame = thread.frames[0]
         # This is failing on the bot, but I can't reproduce the failure
@@ -59,6 +62,10 @@ class TestBranchIslandStepping(TestBase):
             print(
                 f"\nStop disassembly:\n {lldbutil.disassemble(target, stop_frame.function)}"
             )
+            with open(log_file_path, "r") as f:
+                data = f.read()
+                print("Step Log:")
+                print(data)
 
         self.assertIn("foo", stop_frame.name, "Stepped into foo")
         var = stop_frame.FindVariable("a_variable_in_foo")


### PR DESCRIPTION
    When we get to the branch island, we don't see the symbol for
    it.
    
    The only other thing I can think of that would be a dsymutil bug?
    Let's try this just with dwarf, and then I'll have to revert all this
    and see if I can reproduce this locally somehow.
