### PR TITLE
[lldb][NFC] Avoid an assertion failure in dwim-print

### DIFF
--- a/lldb/source/Utility/DiagnosticsRendering.cpp
+++ b/lldb/source/Utility/DiagnosticsRendering.cpp
@@ -186,7 +186,7 @@ void RenderDiagnosticDetails(Stream &stream,
   // Work through each detail in reverse order using the vector/stack.
   bool did_print = false;
   for (; !remaining_details.empty(); remaining_details.pop_back()) {
-   const  auto &detail = remaining_details.back();
+    const auto &detail = remaining_details.back();
     // Get the information to print this detail and remove it from the stack.
     // Print all the lines for all the other messages first.
     stream << std::string(padding, ' ');

--- a/lldb/source/Utility/DiagnosticsRendering.cpp
+++ b/lldb/source/Utility/DiagnosticsRendering.cpp
@@ -185,9 +185,8 @@ void RenderDiagnosticDetails(Stream &stream,
 
   // Work through each detail in reverse order using the vector/stack.
   bool did_print = false;
-  for (auto detail = remaining_details.rbegin();
-       detail != remaining_details.rend();
-       ++detail, remaining_details.pop_back()) {
+  for (; !remaining_details.empty(); remaining_details.pop_back()) {
+    auto &detail = remaining_details.back();
     // Get the information to print this detail and remove it from the stack.
     // Print all the lines for all the other messages first.
     stream << std::string(padding, ' ');
@@ -196,7 +195,7 @@ void RenderDiagnosticDetails(Stream &stream,
          llvm::ArrayRef(remaining_details).drop_back(1)) {
       uint16_t column = remaining_detail.source_location->column;
       // Is this a note with the same column as another diagnostic?
-      if (column == detail->source_location->column)
+      if (column == detail.source_location->column)
         continue;
 
       if (column >= x_pos) {
@@ -205,16 +204,16 @@ void RenderDiagnosticDetails(Stream &stream,
       }
     }
 
-    uint16_t column = detail->source_location->column;
+    uint16_t column = detail.source_location->column;
     // Print the line connecting the ^ with the error message.
     if (column >= x_pos)
       stream << std::string(column - x_pos, ' ') << joint << hbar << spacer;
 
     // Print a colorized string based on the message's severity type.
-    PrintSeverity(stream, detail->severity);
+    PrintSeverity(stream, detail.severity);
 
     // Finally, print the message and start a new line.
-    stream << detail->message << '\n';
+    stream << detail.message << '\n';
     did_print = true;
   }
 

--- a/lldb/source/Utility/DiagnosticsRendering.cpp
+++ b/lldb/source/Utility/DiagnosticsRendering.cpp
@@ -186,7 +186,7 @@ void RenderDiagnosticDetails(Stream &stream,
   // Work through each detail in reverse order using the vector/stack.
   bool did_print = false;
   for (; !remaining_details.empty(); remaining_details.pop_back()) {
-    auto &detail = remaining_details.back();
+   const  auto &detail = remaining_details.back();
     // Get the information to print this detail and remove it from the stack.
     // Print all the lines for all the other messages first.
     stream << std::string(padding, ' ');


### PR DESCRIPTION
In a Debug build on Windows, printing inline diagnostics resulted in an error, for example:

```
> cd llvm-project\lldb\test\API\functionalities\postmortem\elf-core
> lldb.exe -c altmain.core
> p dummy
LLDB diagnostics will be written to ...
Please include the directory content when filing a bug report
Exception Code: 0x80000003
0x00007FF8FD6633EC, C:\llvm\build\bin\liblldb.dll(0x00007FF8FC2C0000) + 0x13A33EC byte(s), std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<lldb_private::DiagnosticDetail> > >::_Compat() + 0x6C byte(s), C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.43.34808\include\vector, line 202 + 0x5D byte(s)
0x00007FF8FD662ABE, C:\llvm\build\bin\liblldb.dll(0x00007FF8FC2C0000) + 0x13A2ABE byte(s), std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<lldb_private::DiagnosticDetail> > >::operator==() + 0x1E byte(s), C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.43.34808\include\vector, line 166 + 0x0 byte(s)
0x00007FF8FD662B2E, C:\llvm\build\\bin\liblldb.dll(0x00007FF8FC2C0000) + 0x13A2B2E byte(s), std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<lldb_private::DiagnosticDetail> > >::operator!=() + 0x1E byte(s), C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.43.34808\include\vector, line 176 + 0xF byte(s)
0x00007FF8FD65EE1C, C:\llvm\build\\bin\liblldb.dll(0x00007FF8FC2C0000) + 0x139EE1C byte(s), std::operator!=<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<lldb_private::DiagnosticDetail> > >,std::_Vector_iterator<std::_Vector_val<std::_Simple_types<lldb_private::DiagnosticDetail> > > >() + 0x3C byte(s), C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.43.34808\include\xutility, line 1947 + 0x0 byte(s)
0x00007FF8FD65D4E5, C:\llvm\build\\bin\liblldb.dll(0x00007FF8FC2C0000) + 0x139D4E5 byte(s), lldb_private::RenderDiagnosticDetails() + 0x8F5 byte(s), C:\llvm\src\llvm-project\lldb\source\Utility\DiagnosticsRendering.cpp, line 189 + 0x25 byte(s)
...
```

The comparison operator of the iterators checks that they belong to the same container, but `remaining_details.pop_back()` invalidates `detail` making it incompatible with `remaining_details.rend()`.