### PR TITLE
[HWASan] personality-thunk should inherit BTI/GCS/PAC flags via createWithDefaultAttr

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1843,16 +1843,10 @@ void HWAddressSanitizer::instrumentPersonalityFunctions() {
         Int32Ty, {Int32Ty, Int32Ty, Int64Ty, PtrTy, PtrTy}, false);
     bool IsLocal = P.first && (!isa<GlobalValue>(P.first) ||
                                cast<GlobalValue>(P.first)->hasLocalLinkage());
-    auto *ThunkFn = Function::Create(ThunkFnTy,
+    auto *ThunkFn = Function::createWithDefaultAttr(ThunkFnTy,
                                      IsLocal ? GlobalValue::InternalLinkage
                                              : GlobalValue::LinkOnceODRLinkage,
-                                     ThunkName, &M);
-    // TODO: think about other attributes as well.
-    if (any_of(P.second, [](const Function *F) {
-          return F->hasFnAttribute("branch-target-enforcement");
-        })) {
-      ThunkFn->addFnAttr("branch-target-enforcement");
-    }
+                                     /*AddrSpace=*/0, ThunkName, &M);
     if (!IsLocal) {
       ThunkFn->setVisibility(GlobalValue::HiddenVisibility);
       ThunkFn->setComdat(M.getOrInsertComdat(ThunkName));


### PR DESCRIPTION
Replace the Function::Create + manual BTI attribute logic(a76cf06) in instrumentPersonalityFunctions with Function::createWithDefaultAttr. This ensures that all module-level default attributes are automatically inherited by every __hwasan_personality_thunk.

Update personality-bti.ll to only verify that the branch protection flags are correctly propagated from module.flags into the thunk's attribute group.