### PR TITLE
update_test_checks: indent dbg records

### DIFF
--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.expected
@@ -47,11 +47,11 @@ define dso_local void @foo(ptr %A) #0 !dbg !7 {
 entry:
   %A.addr = alloca ptr, align 8, !DIAssignID !16
   %i = alloca i32, align 4
-  #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
+    #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
+    #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !22
-  #dbg_declare(ptr %i, !14, !DIExpression(), !23)
+    #dbg_declare(ptr %i, !14, !DIExpression(), !23)
   store i32 0, ptr %i, align 4, !dbg !23, !tbaa !24
   br label %for.cond, !dbg !22
 
@@ -130,9 +130,9 @@ entry:
   %A.addr = alloca ptr, align 8
   %i = alloca i32, align 4
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
+    #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !47
-  #dbg_declare(ptr %i, !44, !DIExpression(), !48)
+    #dbg_declare(ptr %i, !44, !DIExpression(), !48)
   store i32 0, ptr %i, align 4, !dbg !48, !tbaa !24
   br label %for.cond, !dbg !47
 

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.funcsig.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.funcsig.expected
@@ -48,11 +48,11 @@ define dso_local void @foo(ptr %A) #0 !dbg !7 {
 entry:
   %A.addr = alloca ptr, align 8, !DIAssignID !16
   %i = alloca i32, align 4
-  #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
+    #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
+    #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !22
-  #dbg_declare(ptr %i, !14, !DIExpression(), !23)
+    #dbg_declare(ptr %i, !14, !DIExpression(), !23)
   store i32 0, ptr %i, align 4, !dbg !23, !tbaa !24
   br label %for.cond, !dbg !22
 
@@ -132,9 +132,9 @@ entry:
   %A.addr = alloca ptr, align 8
   %i = alloca i32, align 4
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
+    #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !47
-  #dbg_declare(ptr %i, !44, !DIExpression(), !48)
+    #dbg_declare(ptr %i, !44, !DIExpression(), !48)
   store i32 0, ptr %i, align 4, !dbg !48, !tbaa !24
   br label %for.cond, !dbg !47
 

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.funcsig.globals.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.funcsig.globals.expected
@@ -48,11 +48,11 @@ define dso_local void @foo(ptr %A) #0 !dbg !7 {
 entry:
   %A.addr = alloca ptr, align 8, !DIAssignID !16
   %i = alloca i32, align 4
-  #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
+    #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
+    #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !22
-  #dbg_declare(ptr %i, !14, !DIExpression(), !23)
+    #dbg_declare(ptr %i, !14, !DIExpression(), !23)
   store i32 0, ptr %i, align 4, !dbg !23, !tbaa !24
   br label %for.cond, !dbg !22
 
@@ -132,9 +132,9 @@ entry:
   %A.addr = alloca ptr, align 8
   %i = alloca i32, align 4
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
+    #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !47
-  #dbg_declare(ptr %i, !44, !DIExpression(), !48)
+    #dbg_declare(ptr %i, !44, !DIExpression(), !48)
   store i32 0, ptr %i, align 4, !dbg !48, !tbaa !24
   br label %for.cond, !dbg !47
 

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.funcsig.noglobals.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.funcsig.noglobals.expected
@@ -47,11 +47,11 @@ define dso_local void @foo(ptr %A) #0 !dbg !7 {
 entry:
   %A.addr = alloca ptr, align 8, !DIAssignID !16
   %i = alloca i32, align 4
-  #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
+    #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
+    #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !22
-  #dbg_declare(ptr %i, !14, !DIExpression(), !23)
+    #dbg_declare(ptr %i, !14, !DIExpression(), !23)
   store i32 0, ptr %i, align 4, !dbg !23, !tbaa !24
   br label %for.cond, !dbg !22
 
@@ -130,9 +130,9 @@ entry:
   %A.addr = alloca ptr, align 8
   %i = alloca i32, align 4
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
+    #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !47
-  #dbg_declare(ptr %i, !44, !DIExpression(), !48)
+    #dbg_declare(ptr %i, !44, !DIExpression(), !48)
   store i32 0, ptr %i, align 4, !dbg !48, !tbaa !24
   br label %for.cond, !dbg !47
 

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.funcsig.transitiveglobals.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/various_ir_values_dbgrecords.ll.funcsig.transitiveglobals.expected
@@ -47,11 +47,11 @@ define dso_local void @foo(ptr %A) #0 !dbg !7 {
 entry:
   %A.addr = alloca ptr, align 8, !DIAssignID !16
   %i = alloca i32, align 4
-  #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
+    #dbg_assign(i1 undef, !13, !DIExpression(), !16, ptr %A.addr, !DIExpression(), !17)
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
+    #dbg_declare(ptr %A.addr, !13, !DIExpression(), !17)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !22
-  #dbg_declare(ptr %i, !14, !DIExpression(), !23)
+    #dbg_declare(ptr %i, !14, !DIExpression(), !23)
   store i32 0, ptr %i, align 4, !dbg !23, !tbaa !24
   br label %for.cond, !dbg !22
 
@@ -130,9 +130,9 @@ entry:
   %A.addr = alloca ptr, align 8
   %i = alloca i32, align 4
   store ptr %A, ptr %A.addr, align 8, !tbaa !18
-  #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
+    #dbg_declare(ptr %A.addr, !43, !DIExpression(), !46)
   call void @llvm.lifetime.start.p0(i64 4, ptr %i) #2, !dbg !47
-  #dbg_declare(ptr %i, !44, !DIExpression(), !48)
+    #dbg_declare(ptr %i, !44, !DIExpression(), !48)
   store i32 0, ptr %i, align 4, !dbg !48, !tbaa !24
   br label %for.cond, !dbg !47
 

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -602,6 +602,8 @@ TRIPLE_ARG_RE = re.compile(r"-m?triple[= ]([^ ]+)")
 MARCH_ARG_RE = re.compile(r"-march[= ]([^ ]+)")
 DEBUG_ONLY_ARG_RE = re.compile(r"-debug-only[= ]([^ ]+)")
 
+IS_DEBUG_RECORD_RE = re.compile(r"^(\s+)#dbg_")
+
 SCRUB_LEADING_WHITESPACE_RE = re.compile(r"^(\s+)")
 SCRUB_WHITESPACE_RE = re.compile(r"(?!^(|  \w))[ \t]+", flags=re.M)
 SCRUB_PRESERVE_LEADING_WHITESPACE_RE = re.compile(r"((?!^)[ \t]*(\S))[ \t]+")

--- a/llvm/utils/update_test_checks.py
+++ b/llvm/utils/update_test_checks.py
@@ -252,7 +252,9 @@ def update_test(ti: common.TestInfo):
             ):
                 # This input line of the function body will go as-is into the output.
                 # Except make leading whitespace uniform: 2 spaces. 4 for debug records.
-                indent = "  " if not common.IS_DEBUG_RECORD_RE.match(input_line) else "    "
+                indent = (
+                    "  " if not common.IS_DEBUG_RECORD_RE.match(input_line) else "    "
+                )
                 input_line = common.SCRUB_LEADING_WHITESPACE_RE.sub(indent, input_line)
                 output_lines.append(input_line)
                 dropped_previous_line = False

--- a/llvm/utils/update_test_checks.py
+++ b/llvm/utils/update_test_checks.py
@@ -251,8 +251,9 @@ def update_test(ti: common.TestInfo):
                 skip_same_checks=dropped_previous_line,
             ):
                 # This input line of the function body will go as-is into the output.
-                # Except make leading whitespace uniform: 2 spaces.
-                input_line = common.SCRUB_LEADING_WHITESPACE_RE.sub(r"  ", input_line)
+                # Except make leading whitespace uniform: 2 spaces. 4 for debug records.
+                indent = "  " if not common.IS_DEBUG_RECORD_RE.match(input_line) else "    "
+                input_line = common.SCRUB_LEADING_WHITESPACE_RE.sub(indent, input_line)
                 output_lines.append(input_line)
                 dropped_previous_line = False
                 if input_line.strip() == "}":


### PR DESCRIPTION
LLVM prints debug records like `#dbg_value` indented 2 additional spaces.