### PR TITLE
[CoroEarly] Hide promise alloca for later passes

### DIFF
--- a/llvm/docs/Coroutines.rst
+++ b/llvm/docs/Coroutines.rst
@@ -2121,10 +2121,11 @@ Coroutine Transformation Passes
 ===============================
 CoroEarly
 ---------
-The pass CoroEarly lowers coroutine intrinsics that hide the details of the
-structure of the coroutine frame, but, otherwise not needed to be preserved to
-help later coroutine passes. This pass lowers `coro.frame`_, `coro.done`_,
-and `coro.promise`_ intrinsics.
+The CoroEarly pass ensures later middle end passes correctly interpret coroutine 
+semantics and lowers coroutine intrinsics that not needed to be preserved to 
+help later coroutine passes. This pass lowers `coro.promise`_ that outside the 
+coroutine body, `coro.frame`_ and `coro.done`_ intrinsics. It replace uses of 
+promise alloca with `coro.promise`_ intrinsic.
 
 .. _CoroSplit:
 

--- a/llvm/docs/Coroutines.rst
+++ b/llvm/docs/Coroutines.rst
@@ -2123,9 +2123,9 @@ CoroEarly
 ---------
 The CoroEarly pass ensures later middle end passes correctly interpret coroutine 
 semantics and lowers coroutine intrinsics that not needed to be preserved to 
-help later coroutine passes. This pass lowers `coro.promise`_ that outside the 
-coroutine body, `coro.frame`_ and `coro.done`_ intrinsics. It replace uses of 
-promise alloca with `coro.promise`_ intrinsic.
+help later coroutine passes. This pass lowers `coro.promise`_, `coro.frame`_ and 
+`coro.done`_ intrinsics. Afterwards, it replace uses of promise alloca with 
+`coro.promise`_ intrinsic.
 
 .. _CoroSplit:
 

--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -79,7 +79,8 @@ struct Shape {
 
   // Scan the function and collect the above intrinsics for later processing
   void analyze(Function &F, SmallVectorImpl<CoroFrameInst *> &CoroFrames,
-               SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves);
+               SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves,
+               SmallVectorImpl<CoroPromiseInst *> &CoroPromises);
   // If for some reason, we were not able to find coro.begin, bailout.
   void invalidateCoroutine(Function &F,
                            SmallVectorImpl<CoroFrameInst *> &CoroFrames);
@@ -87,7 +88,8 @@ struct Shape {
   void initABI();
   // Remove orphaned and unnecessary intrinsics
   void cleanCoroutine(SmallVectorImpl<CoroFrameInst *> &CoroFrames,
-                      SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves);
+                      SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves,
+                      SmallVectorImpl<CoroPromiseInst *> &CoroPromises);
 
   // Field indexes for special fields in the switch lowering.
   struct SwitchFieldIndex {
@@ -265,13 +267,14 @@ struct Shape {
   explicit Shape(Function &F) {
     SmallVector<CoroFrameInst *, 8> CoroFrames;
     SmallVector<CoroSaveInst *, 2> UnusedCoroSaves;
+    SmallVector<CoroPromiseInst *, 2> CoroPromises;
 
-    analyze(F, CoroFrames, UnusedCoroSaves);
+    analyze(F, CoroFrames, UnusedCoroSaves, CoroPromises);
     if (!CoroBegin) {
       invalidateCoroutine(F, CoroFrames);
       return;
     }
-    cleanCoroutine(CoroFrames, UnusedCoroSaves);
+    cleanCoroutine(CoroFrames, UnusedCoroSaves, CoroPromises);
   }
 };
 

--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -80,7 +80,7 @@ struct Shape {
   // Scan the function and collect the above intrinsics for later processing
   void analyze(Function &F, SmallVectorImpl<CoroFrameInst *> &CoroFrames,
                SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves,
-               SmallVectorImpl<CoroPromiseInst *> &CoroPromises);
+               CoroPromiseInst *&CoroPromise);
   // If for some reason, we were not able to find coro.begin, bailout.
   void invalidateCoroutine(Function &F,
                            SmallVectorImpl<CoroFrameInst *> &CoroFrames);
@@ -89,7 +89,7 @@ struct Shape {
   // Remove orphaned and unnecessary intrinsics
   void cleanCoroutine(SmallVectorImpl<CoroFrameInst *> &CoroFrames,
                       SmallVectorImpl<CoroSaveInst *> &UnusedCoroSaves,
-                      SmallVectorImpl<CoroPromiseInst *> &CoroPromises);
+                      CoroPromiseInst *CoroPromise);
 
   // Field indexes for special fields in the switch lowering.
   struct SwitchFieldIndex {
@@ -267,14 +267,14 @@ struct Shape {
   explicit Shape(Function &F) {
     SmallVector<CoroFrameInst *, 8> CoroFrames;
     SmallVector<CoroSaveInst *, 2> UnusedCoroSaves;
-    SmallVector<CoroPromiseInst *, 2> CoroPromises;
+    CoroPromiseInst * CoroPromise = nullptr;
 
-    analyze(F, CoroFrames, UnusedCoroSaves, CoroPromises);
+    analyze(F, CoroFrames, UnusedCoroSaves, CoroPromise);
     if (!CoroBegin) {
       invalidateCoroutine(F, CoroFrames);
       return;
     }
-    cleanCoroutine(CoroFrames, UnusedCoroSaves, CoroPromises);
+    cleanCoroutine(CoroFrames, UnusedCoroSaves, CoroPromise);
   }
 };
 

--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -267,7 +267,7 @@ struct Shape {
   explicit Shape(Function &F) {
     SmallVector<CoroFrameInst *, 8> CoroFrames;
     SmallVector<CoroSaveInst *, 2> UnusedCoroSaves;
-    CoroPromiseInst * CoroPromise = nullptr;
+    CoroPromiseInst *CoroPromise = nullptr;
 
     analyze(F, CoroFrames, UnusedCoroSaves, CoroPromise);
     if (!CoroBegin) {

--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -200,22 +200,12 @@ void Lowerer::lowerEarlyIntrinsics(Function &F) {
       default:
         continue;
       case Intrinsic::coro_begin:
-      case Intrinsic::coro_begin_custom_abi: {
-        auto CBI = cast<CoroBeginInst>(&I);
-
-        // Ignore coro id's that aren't pre-split.
-        auto Id = dyn_cast<CoroIdInst>(CBI->getId());
-        if (Id && !Id->getInfo().isPreSplit())
-          break;
-
+      case Intrinsic::coro_begin_custom_abi:
         if (CoroBegin)
           report_fatal_error(
               "coroutine should have exactly one defining @llvm.coro.begin");
-        CBI->addRetAttr(Attribute::NonNull);
-        CBI->addRetAttr(Attribute::NoAlias);
-        CoroBegin = CBI;
+        CoroBegin = cast<CoroBeginInst>(&I);
         break;
-      }
       case Intrinsic::coro_free:
         CoroFrees.push_back(cast<CoroFreeInst>(&I));
         break;

--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -168,6 +168,7 @@ void Lowerer::hidePromiseAlloca(CoroIdInst *CoroId, CoroBeginInst *CoroBegin) {
   SmallVector<Value *, 3> Arg{CoroBegin, Alignment, FromPromise};
   auto *PI = Builder.CreateIntrinsic(
       Builder.getPtrTy(), Intrinsic::coro_promise, Arg, {}, "promise.addr");
+  PI->setCannotDuplicate();
   PA->replaceUsesWithIf(PI, [CoroId](Use &U) {
     bool IsBitcast = U == U.getUser()->stripPointerCasts();
     bool IsCoroId = U.getUser() == CoroId;

--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -9,7 +9,6 @@
 #include "llvm/Transforms/Coroutines/CoroEarly.h"
 #include "CoroInternal.h"
 #include "llvm/IR/DIBuilder.h"
-#include "llvm/IR/Dominators.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
@@ -264,9 +263,8 @@ void Lowerer::lowerEarlyIntrinsics(Function &F) {
       auto *Alignment = Builder.getInt32(PA->getAlign().value());
       auto *FromPromise = Builder.getInt1(false);
       SmallVector<Value *, 3> Arg{CoroBegin, Alignment, FromPromise};
-      auto *PI =
-          Builder.CreateIntrinsic(Builder.getPtrTy(), Intrinsic::coro_promise,
-                                  Arg, {}, "promise.addr");
+      auto *PI = Builder.CreateIntrinsic(
+          Builder.getPtrTy(), Intrinsic::coro_promise, Arg, {}, "promise.addr");
       PA->replaceUsesWithIf(PI, [CoroId](Use &U) {
         bool IsBitcast = U == U.getUser()->stripPointerCasts();
         bool IsCoroId = U.getUser() == CoroId;

--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -237,9 +237,7 @@ void Lowerer::lowerEarlyIntrinsics(Function &F) {
         lowerResumeOrDestroy(*CB, CoroSubFnInst::DestroyIndex);
         break;
       case Intrinsic::coro_promise: {
-        bool OutsideCoro = CoroBegin == nullptr;
-        if (OutsideCoro)
-          lowerCoroPromise(cast<CoroPromiseInst>(&I));
+        lowerCoroPromise(cast<CoroPromiseInst>(&I));
         break;
       }
       case Intrinsic::coro_done:

--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -236,10 +236,9 @@ void Lowerer::lowerEarlyIntrinsics(Function &F) {
       case Intrinsic::coro_destroy:
         lowerResumeOrDestroy(*CB, CoroSubFnInst::DestroyIndex);
         break;
-      case Intrinsic::coro_promise: {
+      case Intrinsic::coro_promise:
         lowerCoroPromise(cast<CoroPromiseInst>(&I));
         break;
-      }
       case Intrinsic::coro_done:
         lowerCoroDone(cast<IntrinsicInst>(&I));
         break;
@@ -253,9 +252,9 @@ void Lowerer::lowerEarlyIntrinsics(Function &F) {
     for (CoroFreeInst *CF : CoroFrees)
       CF->setArgOperand(0, CoroId);
 
-    if (auto *PA = CoroId->getPromise()) {
-      assert(CoroBegin && "Use Switch-Resumed ABI but missing coro.begin");
-
+    auto *PA = CoroId->getPromise();
+    if (PA && CoroBegin) {
+      assert(isa<AllocaInst>(PA) && "Must pass alloca to coro.id");
       Builder.SetInsertPoint(*CoroBegin->getInsertionPointAfterDef());
 
       auto *Alignment = Builder.getInt32(PA->getAlign().value());

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -288,6 +288,8 @@ void coro::Shape::analyze(Function &F,
         }
         break;
       case Intrinsic::coro_promise:
+        assert(CoroPromise == nullptr &&
+               "CoroEarly must ensure coro.promise unique");
         CoroPromise = cast<CoroPromiseInst>(II);
         break;
       }

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -495,8 +495,10 @@ void coro::Shape::cleanCoroutine(
     CoroSave->eraseFromParent();
   UnusedCoroSaves.clear();
 
+  auto *AI = getPromiseAlloca();
   for (auto *PI : CoroPromises) {
-    PI->replaceAllUsesWith(getPromiseAlloca());
+    PI->replaceAllUsesWith(PI->isFromPromise() ? cast<Value>(CoroBegin)
+                                               : cast<Value>(AI));
     PI->eraseFromParent();
   }
 }

--- a/llvm/test/Instrumentation/AddressSanitizer/skip-coro.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/skip-coro.ll
@@ -15,8 +15,9 @@ define ptr @foo() #0 {
 entry:
   %__promise = alloca %struct.Promise, align 8
   %0 = call token @llvm.coro.id(i32 16, ptr nonnull %__promise, ptr null, ptr null)
-  %1 = call ptr @llvm.coro.noop()
-  ret ptr %1
+  %1 = call ptr @llvm.coro.begin(token %0, ptr null)
+  %2 = call ptr @llvm.coro.noop()
+  ret ptr %2
 }
 
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr)

--- a/llvm/test/Instrumentation/AddressSanitizer/skip-coro.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/skip-coro.ll
@@ -15,9 +15,8 @@ define ptr @foo() #0 {
 entry:
   %__promise = alloca %struct.Promise, align 8
   %0 = call token @llvm.coro.id(i32 16, ptr nonnull %__promise, ptr null, ptr null)
-  %1 = call ptr @llvm.coro.begin(token %0, ptr null)
-  %2 = call ptr @llvm.coro.noop()
-  ret ptr %2
+  %1 = call ptr @llvm.coro.noop()
+  ret ptr %1
 }
 
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr)

--- a/llvm/test/Transforms/Coroutines/gh105595.ll
+++ b/llvm/test/Transforms/Coroutines/gh105595.ll
@@ -1,0 +1,32 @@
+; Test that store-load operation that crosses suspension point will not be eliminated by DSE
+; Coro result conversion function that attempts to modify promise shall produce this pattern
+; RUN: opt < %s -passes='coro-early,dse' -S | FileCheck %s
+
+define void @fn() presplitcoroutine {
+  %__promise = alloca ptr, align 8
+  %id = call token @llvm.coro.id(i32 16, ptr %__promise, ptr @fn, ptr null)
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr null)
+; CHECK: %promise.addr = call ptr @llvm.coro.promise(ptr %hdl, i32 8, i1 false)
+  %save = call token @llvm.coro.save(ptr null)
+  %sp = call i8 @llvm.coro.suspend(token %save, i1 false)
+  %flag = icmp ule i8 %sp, 1
+  br i1 %flag, label %resume, label %suspend
+
+resume:
+; CHECK: call void @use_value(ptr %promise.addr)
+  call void @use_value(ptr %__promise)
+  br label %suspend
+
+suspend:
+  call i1 @llvm.coro.end(ptr null, i1 false, token none)
+; load value when resume
+; CHECK: %null = load ptr, ptr %promise.addr, align 8
+  %null = load ptr, ptr %__promise, align 8
+  call void @use_value(ptr %null)
+; store value when suspend
+; CHECK: store ptr null, ptr %promise.addr, align 8
+  store ptr null, ptr %__promise, align 8
+  ret void
+}
+
+declare void @use_value(ptr)

--- a/llvm/test/Transforms/Coroutines/gh105595.ll
+++ b/llvm/test/Transforms/Coroutines/gh105595.ll
@@ -18,7 +18,6 @@ resume:
   br label %suspend
 
 suspend:
-  call i1 @llvm.coro.end(ptr null, i1 false, token none)
 ; load value when resume
 ; CHECK: %null = load ptr, ptr %promise.addr, align 8
   %null = load ptr, ptr %__promise, align 8


### PR DESCRIPTION
Currently coroutine promises are modeled as allocas. This is problematic because other middle-end passes will assume promise dead after coroutine suspend, leading to misoptimizations.

I propose the front ends remain free to emit and use allocas to model coro promise. At CoroEarly, we will replace all uses of promise alloca with `coro.promise`. Non coroutine passes should only access promise through `coro.promise`. Then at CoroSplit, we will lower `coro.promise` back to promise alloca again. So that it will be correctly collected into coro frame. Note that we do not have to bother maintainers of other middle-end passes.

Fix #105595 