### PR TITLE
[DenseMap] Fix constness issues with lookup_or

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -220,8 +220,7 @@ public:
   // Return the entry with the specified key, or \p Default. This variant is
   // useful, because `lookup` cannot be used with non-default-constructible
   // values.
-  ValueT lookup_or(const_arg_type_t<KeyT> Val,
-                   const_arg_type_t<ValueT> Default) const {
+  ValueT lookup_or(const_arg_type_t<KeyT> Val, ValueT &&Default) const {
     if (const BucketT *Bucket = doFind(Val))
       return Bucket->getSecond();
     return Default;

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -15904,10 +15904,7 @@ const SCEV *ScalarEvolution::LoopGuards::rewrite(const SCEV *Expr) const {
     const SCEV *visitAddRecExpr(const SCEVAddRecExpr *Expr) { return Expr; }
 
     const SCEV *visitUnknown(const SCEVUnknown *Expr) {
-      auto I = Map.find(Expr);
-      if (I == Map.end())
-        return Expr;
-      return I->second;
+      return Map.lookup_or(Expr, Expr);
     }
 
     const SCEV *visitZeroExtendExpr(const SCEVZeroExtendExpr *Expr) {

--- a/llvm/unittests/ADT/DenseMapTest.cpp
+++ b/llvm/unittests/ADT/DenseMapTest.cpp
@@ -668,9 +668,14 @@ TEST(DenseMapCustomTest, LookupOr) {
 
   EXPECT_EQ(M.lookup_or(0, 4u), 3u);
   EXPECT_EQ(M.lookup_or(1, 4u), 0u);
+  EXPECT_EQ(M.lookup_or(2, 4u), 4u);
+}
 
-  NonDefaultConstructible DefaultV = M.lookup_or(2, 4u);
-  EXPECT_EQ(DefaultV, 4u);
+TEST(DenseMapCustomTest, LookupOrConstness) {
+  DenseMap<int, unsigned *> M;
+  unsigned Default = 3u;
+  unsigned *Ret = M.lookup_or(0, &Default);
+  EXPECT_EQ(Ret, &Default);
 }
 
 // Key traits that allows lookup with either an unsigned or char* key;

--- a/llvm/unittests/ADT/DenseMapTest.cpp
+++ b/llvm/unittests/ADT/DenseMapTest.cpp
@@ -668,7 +668,9 @@ TEST(DenseMapCustomTest, LookupOr) {
 
   EXPECT_EQ(M.lookup_or(0, 4u), 3u);
   EXPECT_EQ(M.lookup_or(1, 4u), 0u);
-  EXPECT_EQ(M.lookup_or(2, 4u), 4u);
+
+  NonDefaultConstructible DefaultV = M.lookup_or(2, 4u);
+  EXPECT_EQ(DefaultV, 4u);
 }
 
 // Key traits that allows lookup with either an unsigned or char* key;


### PR DESCRIPTION
Also demonstrate its use in ScalarEvolution.