### PR TITLE
[lldb][lldb-dap] Disable more tests on Windows

### DIFF
--- a/lldb/test/API/tools/lldb-dap/memory/TestDAP_memory.py
+++ b/lldb/test/API/tools/lldb-dap/memory/TestDAP_memory.py
@@ -12,6 +12,7 @@ import os
 
 
 class TestDAP_memory(lldbdap_testcase.DAPTestCaseBase):
+    @skipIfWindows
     def test_memory_refs_variables(self):
         """
         Tests memory references for evaluate
@@ -33,6 +34,7 @@ class TestDAP_memory(lldbdap_testcase.DAPTestCaseBase):
         # Non-pointers should also have memory-references
         self.assertIn("memoryReference", locals["not_a_ptr"].keys())
 
+    @skipIfWindows
     def test_memory_refs_evaluate(self):
         """
         Tests memory references for evaluate
@@ -52,6 +54,7 @@ class TestDAP_memory(lldbdap_testcase.DAPTestCaseBase):
             self.dap_server.request_evaluate("rawptr")["body"].keys(),
         )
 
+    @skipIfWindows
     def test_memory_refs_set_variable(self):
         """
         Tests memory references for `setVariable`
@@ -74,6 +77,7 @@ class TestDAP_memory(lldbdap_testcase.DAPTestCaseBase):
             ].keys(),
         )
 
+    @skipIfWindows
     def test_readMemory(self):
         """
         Tests the 'readMemory' request

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -411,16 +411,19 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
 
         self.verify_variables(verify_locals, locals)
 
+    @skipIfWindows
     def test_scopes_variables_setVariable_evaluate(self):
         self.do_test_scopes_variables_setVariable_evaluate(
             enableAutoVariableSummaries=False
         )
 
+    @skipIfWindows
     def test_scopes_variables_setVariable_evaluate_with_descriptive_summaries(self):
         self.do_test_scopes_variables_setVariable_evaluate(
             enableAutoVariableSummaries=True
         )
 
+    @skipIfWindows
     def do_test_scopes_and_evaluate_expansion(self, enableAutoVariableSummaries: bool):
         """
         Tests the evaluated expression expands successfully after "scopes" packets
@@ -673,6 +676,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
         ]["variables"]
         self.verify_variables(verify_children, children)
 
+    @skipIfWindows
     def test_return_variables(self):
         """
         Test the stepping out of a function with return value show the variable correctly.


### PR DESCRIPTION
These are currently failing on Windows on Arm:
https://lab.llvm.org/buildbot/#/builders/141/builds/8556

```
********************
Unresolved Tests (1):
  lldb-api :: tools/lldb-dap/memory/TestDAP_memory.py
********************
Failed Tests (1):
  lldb-api :: tools/lldb-dap/variables/TestDAP_variables.py
```