### PR TITLE
[LoopInterchange] Skip legality check if surrounding loops already guarantee dependency (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -236,9 +236,9 @@ static void interChangeDependencies(CharMatrix &DepMatrix, unsigned FromIndx,
 // [Theorem] A permutation of the loops in a perfect nest is legal if and only
 // if the direction matrix, after the same permutation is applied to its
 // columns, has no ">" direction as the leftmost non-"=" direction in any row.
-static std::optional<bool>
-isLexicographicallyPositive(std::vector<char> &DV, unsigned Begin = 0,
-                            unsigned End = DV.size()) {
+static std::optional<bool> isLexicographicallyPositive(std::vector<char> &DV,
+                                                       unsigned Begin,
+                                                       unsigned End) {
   ArrayRef<char> DVRef(DV);
   for (unsigned char Direction : DVRef.slice(Begin, End - Begin)) {
     if (Direction == '<')
@@ -247,6 +247,10 @@ isLexicographicallyPositive(std::vector<char> &DV, unsigned Begin = 0,
       return false;
   }
   return std::nullopt;
+}
+
+static std::optional<bool> isLexicographicallyPositive(std::vector<char> &DV) {
+  return isLexicographicallyPositive(DV, 0, DV.size());
 }
 
 // Checks if it is legal to interchange 2 loops.
@@ -269,10 +273,10 @@ static bool isLegalToInterChangeLoops(CharMatrix &DepMatrix,
 
     // Check if the direction vector is lexicographically positive (or zero)
     // for both before/after exchanged.
-    if (isLexicographicallyPositive(Cur, 0, Cur.size()) == false)
+    if (isLexicographicallyPositive(Cur) == false)
       return false;
     std::swap(Cur[InnerLoopId], Cur[OuterLoopId]);
-    if (isLexicographicallyPositive(Cur, 0, Cur.size()) == false)
+    if (isLexicographicallyPositive(Cur) == false)
       return false;
   }
   return true;

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -232,13 +232,13 @@ static void interChangeDependencies(CharMatrix &DepMatrix, unsigned FromIndx,
 }
 
 // Check if a direction vector is lexicographically positive. Return true if it
-// is positive, nullopt if it is "zero", othrewise false.
+// is positive, nullopt if it is "zero", otherwise false.
 // [Theorem] A permutation of the loops in a perfect nest is legal if and only
 // if the direction matrix, after the same permutation is applied to its
 // columns, has no ">" direction as the leftmost non-"=" direction in any row.
 static std::optional<bool> isLexicographicallyPositive(std::vector<char> &DV,
-                                                       unsigned Begin,
-                                                       unsigned End) {
+                                                       unsigned Begin = 0,
+                                                       unsigned End = DV.size()) {
   ArrayRef<char> DVRef(DV);
   for (unsigned char Direction : DVRef.slice(Begin, End - Begin)) {
     if (Direction == '<')
@@ -261,9 +261,8 @@ static bool isLegalToInterChangeLoops(CharMatrix &DepMatrix,
     // before and after swapping OuterLoop vs InnerLoop
     Cur = DepMatrix[Row];
 
-    // If the direction vector is lexicographically positive due to an element
-    // to the left of OuterLoopId, it is still positive after exchanging the two
-    // loops. In such a case we can skip the subsequent check.
+    // If the surrounding loops already ensure that the direction vector is lexicographically positive, nothing within the loop will be able to break the dependence.
+    // In such a case we can skip the subsequent check.
     if (isLexicographicallyPositive(Cur, 0, OuterLoopId) == true)
       continue;
 

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -236,9 +236,9 @@ static void interChangeDependencies(CharMatrix &DepMatrix, unsigned FromIndx,
 // [Theorem] A permutation of the loops in a perfect nest is legal if and only
 // if the direction matrix, after the same permutation is applied to its
 // columns, has no ">" direction as the leftmost non-"=" direction in any row.
-static std::optional<bool> isLexicographicallyPositive(std::vector<char> &DV,
-                                                       unsigned Begin = 0,
-                                                       unsigned End = DV.size()) {
+static std::optional<bool>
+isLexicographicallyPositive(std::vector<char> &DV, unsigned Begin = 0,
+                            unsigned End = DV.size()) {
   ArrayRef<char> DVRef(DV);
   for (unsigned char Direction : DVRef.slice(Begin, End - Begin)) {
     if (Direction == '<')
@@ -261,8 +261,9 @@ static bool isLegalToInterChangeLoops(CharMatrix &DepMatrix,
     // before and after swapping OuterLoop vs InnerLoop
     Cur = DepMatrix[Row];
 
-    // If the surrounding loops already ensure that the direction vector is lexicographically positive, nothing within the loop will be able to break the dependence.
-    // In such a case we can skip the subsequent check.
+    // If the surrounding loops already ensure that the direction vector is
+    // lexicographically positive, nothing within the loop will be able to break
+    // the dependence. In such a case we can skip the subsequent check.
     if (isLexicographicallyPositive(Cur, 0, OuterLoopId) == true)
       continue;
 


### PR DESCRIPTION
The legality check in LoopInterchange allows two loops to be exchanged if all direction vectors are lexicographically positive (or zero) for both before and after the swap. The current implementation performs this routine naively.  However, if a direction vector is lexicographically positive due to an element corresponding to a loop that is outside the given two loops (i.e., if there is an element `<` before the loops we are trying to interchange), then obviously it is also positive after exchanging them. For example, for a direction vector `[< < >]`, swapping the last two elements doesn't make it lexicographically negative because the first element is `<`.
This patch adds a code to skip legality check if surrounding loops already guarantee that the direction vector is lexicographically positive. Note that this is only a small improvement on its own, but it's necessary to relax the legality check I'm working on.

Split off from #118267 