### PR TITLE
Loosen DWARF form check in discriminant-member.ll

### DIFF
--- a/llvm/test/DebugInfo/Generic/discriminant-member.ll
+++ b/llvm/test/DebugInfo/Generic/discriminant-member.ll
@@ -5,14 +5,14 @@
 ; of discriminants, and where both refer to a DIE that is not a child
 ; of the variant.
 
-; CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "Discr")
+; CHECK: DW_AT_name [DW_FORM_str{{[a-z]+}}]  ({{.*}} = "Discr")
 ; CHECK: DW_TAG_variant_part
 ;   CHECK-NOT: TAG
 ;     CHECK: DW_AT_discr [DW_FORM_ref4] (cu + {{0x[0-9a-fA-F]+}} => {[[OFFSET:0x[0-9a-fA-F]+]]})
 ;     CHECK: DW_TAG_variant
 ;       CHECK: DW_AT_discr_list [DW_FORM_block1] (<0x05> 00 17 01 61 6c )
 ;       CHECK: DW_TAG_member
-;         CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "var0")
+;         CHECK: DW_AT_name [DW_FORM_str{{[a-z]+}}]  ({{.*}} = "var0")
 ;         CHECK: DW_AT_type
 ;         CHECK: DW_AT_alignment
 ;         CHECK: DW_AT_data_member_location [DW_FORM_data1]	(0x00)

--- a/llvm/test/DebugInfo/Generic/discriminant-member.ll
+++ b/llvm/test/DebugInfo/Generic/discriminant-member.ll
@@ -5,14 +5,14 @@
 ; of discriminants, and where both refer to a DIE that is not a child
 ; of the variant.
 
-; CHECK: DW_AT_name [DW_FORM_str{{[a-z]+}}]  ({{.*}} = "Discr")
+; CHECK: DW_AT_name [DW_FORM_str{{[a-z]+}}]  ({{(.* = )?}}"Discr")
 ; CHECK: DW_TAG_variant_part
 ;   CHECK-NOT: TAG
 ;     CHECK: DW_AT_discr [DW_FORM_ref4] (cu + {{0x[0-9a-fA-F]+}} => {[[OFFSET:0x[0-9a-fA-F]+]]})
 ;     CHECK: DW_TAG_variant
 ;       CHECK: DW_AT_discr_list [DW_FORM_block1] (<0x05> 00 17 01 61 6c )
 ;       CHECK: DW_TAG_member
-;         CHECK: DW_AT_name [DW_FORM_str{{[a-z]+}}]  ({{.*}} = "var0")
+;         CHECK: DW_AT_name [DW_FORM_str{{[a-z]+}}]  ({{(.* = )?}}"var0")
 ;         CHECK: DW_AT_type
 ;         CHECK: DW_AT_alignment
 ;         CHECK: DW_AT_data_member_location [DW_FORM_data1]	(0x00)


### PR DESCRIPTION
The new test discriminant-member.ll (see #138953) failed on AIX. It seems that the string form is different in the DWARF. The log reads:

          50:  DW_AT_name [DW_FORM_string] ("Discr")

... but the test only looks for DW_FORM_strp. Since the precise form isn't important here, this patch changes the test to accept any string form.