### PR TITLE
Add flags check to createVariantMemberType

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -1253,7 +1253,8 @@ public:
   ///
   /// Class type for pointer-to-members, objective-c property node for ivars,
   /// global constant wrapper for static members, virtual base pointer offset
-  /// for inheritance, or a tuple of template parameters for template aliases.
+  /// for inheritance, a tuple of template parameters for template aliases,
+  /// discriminant for a variant, or storage offset for a bit field.
   ///
   /// TODO: Separate out types that need this extra operand: pointer-to-member
   /// types and member fields (static members and ivars).

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -438,6 +438,9 @@ DIDerivedType *DIBuilder::createVariantMemberType(
     DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
     uint64_t SizeInBits, uint32_t AlignInBits, uint64_t OffsetInBits,
     Constant *Discriminant, DINode::DIFlags Flags, DIType *Ty) {
+  // "ExtraData" is overloaded for bit fields and for variants, so
+  // make sure to disallow this.
+  assert((Flags & DINode::FlagBitField) == 0);
   return DIDerivedType::get(
       VMContext, dwarf::DW_TAG_member, Name, File, LineNumber,
       getNonCompileUnitScope(Scope), Ty, SizeInBits, AlignInBits, OffsetInBits,


### PR DESCRIPTION
I noticed that DIDerivedType overloads the "ExtraData" member depending on the precise type being implemented.  A variant part uses this to store the discriminant (a reference to another member), but a bit field uses it to store the storage offset.

This patch changes createVariantMemberType to ensure that the FlagBitField is not used when creating a variant part.  If this flag is used, the ExtraData field would be erroneously used in two different ways.

The patch also updates a comment in DIDerivedType to list a couple more cases.