### PR TITLE
[OpenMP] Fix crash when diagnosing dist_schedule

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -903,6 +903,8 @@ OpenMP Support
 - Added support for 'omp stripe' directive.
 - Fixed a crashing bug with ``omp tile sizes`` if the argument to ``sizes`` was
   an invalid expression. (#GH139073)
+- Fixed a crashing bug with ``omp distribute dist_schedule`` if the argument to
+  ``dist_schedule`` was not strictly positive. (#GH139266)
 
 Improvements
 ^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -22753,7 +22753,8 @@ OMPClause *SemaOpenMP::ActOnOpenMPDistScheduleClause(
               ValExpr->getIntegerConstantExpr(getASTContext())) {
         if (Result->isSigned() && !Result->isStrictlyPositive()) {
           Diag(ChunkSizeLoc, diag::err_omp_negative_expression_in_clause)
-              << "dist_schedule" << ChunkSize->getSourceRange();
+              << "dist_schedule" << /*strictly positive*/ 1
+              << ChunkSize->getSourceRange();
           return nullptr;
         }
       } else if (getOpenMPCaptureRegionForClause(

--- a/clang/test/OpenMP/teams_distribute_dist_schedule_messages.cpp
+++ b/clang/test/OpenMP/teams_distribute_dist_schedule_messages.cpp
@@ -105,3 +105,11 @@ int main(int argc, char **argv) {
 
   return (tmain<int, 5>(argc) + tmain<char, 1>(argv[0][0])); // expected-note {{in instantiation of function template specialization 'tmain<int, 5>' requested here}} expected-note {{in instantiation of function template specialization 'tmain<char, 1>' requested here}}
 }
+
+namespace GH139266 {
+void f(void) {
+#pragma omp distribute dist_schedule(static, 0) // expected-error {[argument to 'dist_schedule' clause must be a strictly positive integer value}}
+  for (int i = 0; i < 10; i++)
+    ;
+}
+} // namespace GH139266


### PR DESCRIPTION
We were failing to pass a required argument when emitting the diagnostic, so the source range was being used in place of an index. This caused a failed assertion due to the incorrect index.

Fixes #139266