### PR TITLE
[lldb][test] Fix beginning/end of file test failed on Windows

### DIFF
--- a/lldb/test/Shell/Commands/Inputs/cross_platform.c
+++ b/lldb/test/Shell/Commands/Inputs/cross_platform.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+void doNothing() { printf("doNothing\n"); }
+
+void doSomethiing() {
+  doNothing();
+  doNothing();
+  doNothing();
+}
+
+int main() {
+  doSomethiing();
+  doNothing();
+  doSomethiing();
+  return 0;
+}

--- a/lldb/test/Shell/Commands/command-list-reach-beginning-of-file.test
+++ b/lldb/test/Shell/Commands/command-list-reach-beginning-of-file.test
@@ -1,6 +1,4 @@
-# Source uses unistd.h.
-# UNSUPPORTED: system-windows
-# RUN: %clang_host -g -O0 %S/Inputs/sigchld.c -o %t.out
+# RUN: %clang_host -g -O0 %S/Inputs/cross_platform.c -o %t.out
 # RUN: %lldb %t.out -b -s %s 2>&1 | FileCheck %s
 
 list
@@ -12,14 +10,8 @@ b main
 r
 # CHECK: int main()
 
-list
-# CHECK: if (child_pid == 0)
-
 list -
-# CHECK: int main()
-
-list -10
-# CHECK: #include <assert.h>
+# CHECK: #include <stdio.h>
 
 list -
 # CHECK: note: Reached beginning of the file, no more to page
@@ -28,4 +20,4 @@ list -
 # CHECK: note: Reached beginning of the file, no more to page
 
 list
-# CHECK: int main()
+# CHECK: doNothing();

--- a/lldb/test/Shell/Commands/command-list-reach-end-of-file.test
+++ b/lldb/test/Shell/Commands/command-list-reach-end-of-file.test
@@ -1,6 +1,4 @@
-# Source uses unistd.h.
-# UNSUPPORTED: system-windows
-# RUN: %clang_host -g -O0 %S/Inputs/sigchld.c -o %t.out
+# RUN: %clang_host -g -O0 %S/Inputs/cross_platform.c -o %t.out
 # RUN: %lldb %t.out -b -s %s 2>&1 | FileCheck %s
 
 list
@@ -11,12 +9,6 @@ b main
 
 r
 # CHECK: int main()
-
-list
-# CHECK: if (child_pid == 0)
-
-list
-# CHECK: printf("signo = %d\n", SIGCHLD);
 
 list
 # CHECK: return 0;


### PR DESCRIPTION
As @DavidSpickett mentioned, this change fixed the test failure introduced in [#137515](https://github.com/llvm/llvm-project/pull/137515#issuecomment-2866632780), which was caused by the use of platform-specific headers not available on Windows.

This PR does not modify any functional code; it only updates the test cases.
