### PR TITLE
[HIP] change default offload archs

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -780,6 +780,10 @@ public:
   virtual Expected<SmallVector<std::string>>
   getSystemGPUArchs(const llvm::opt::ArgList &Args) const;
 
+  /// getHIPDefaultOffloadArchs - Get the default offload arch's for HIP.
+  virtual SmallVector<StringRef>
+  getHIPDefaultOffloadArchs(const llvm::opt::ArgList &Args) const;
+
   /// addProfileRTLibs - When -fprofile-instr-profile is specified, try to pass
   /// a suitable profile runtime library to the linker.
   virtual void addProfileRTLibs(const llvm::opt::ArgList &Args,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3503,6 +3503,9 @@ class OffloadingActionBuilder final {
             GpuArchList.push_back(OffloadArch::AMDGCNSPIRV);
           else
             GpuArchList.push_back(OffloadArch::Generic);
+        } else if (AssociatedOffloadKind == Action::OFK_HIP) {
+          for (auto A : ToolChains.front()->getHIPDefaultOffloadArchs(Args))
+            GpuArchList.push_back(A.data());
         } else {
           GpuArchList.push_back(DefaultOffloadArch);
         }
@@ -4825,7 +4828,8 @@ Driver::getOffloadArchs(Compilation &C, const llvm::opt::DerivedArgList &Args,
     if (Kind == Action::OFK_Cuda) {
       Archs.insert(OffloadArchToString(OffloadArch::CudaDefault));
     } else if (Kind == Action::OFK_HIP) {
-      Archs.insert(OffloadArchToString(OffloadArch::HIPDefault));
+      for (auto A : TC->getHIPDefaultOffloadArchs(Args))
+        Archs.insert(A);
     } else if (Kind == Action::OFK_SYCL) {
       Archs.insert(StringRef());
     } else if (Kind == Action::OFK_OpenMP) {

--- a/clang/test/Driver/hip-default-gpu-arch.hip
+++ b/clang/test/Driver/hip-default-gpu-arch.hip
@@ -1,3 +1,3 @@
 // RUN: %clang -### -nogpulib -nogpuinc -c %s 2>&1 | FileCheck %s
 
-// CHECK: {{.*}}clang{{.*}}"-target-cpu" "gfx906"
+// CHECK: {{.*}}clang{{.*}}"-triple" "{{amdgcn|spirv64}}-amd-amdhsa"{{.*}} "-target-cpu" "{{amdgcnspirv|gfx.*}}"


### PR DESCRIPTION
Currently, HIP uses gfx906 as the default offload
arch, which only works on systems with gfx906.

For non-interactive uses, this is less of a concern since they all set explicit offload arch's for supported GPU's. The only use of default offload arch is when the clang wrapper hipcc is used as a C++ compiler
during compiler detection of cmake, where the default offload arch is used to compile a C++ program as HIP program and executed. However since there is no
kernel, the default offload arch just works.

However, gfx906 as default offload arch is very
inconvenient for interactive users since in most cases they would like to compile for the GPU on the system.

With this patch, if AMD GPU's are detected on the system, they will be used as default offload arch's for HIP. Otherwise, if `amd-llvm-spirv` is found and executable, `amdgcnspirv` will be used as the default offload arch, since it works for all AMD GPU's supporting HIP.
Otherwise, the original default offload arch is used, which is gfx906.