### PR TITLE
[compiler-rt][sanitizer_common] Alter sanitizer_set_report_path_test to not assume a fixed file path

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
@@ -18,8 +18,10 @@ int main(int argc, char **argv) {
   // Try setting again with an invalid/inaccessible directory.
   char buff_bad[1000];
   sprintf(buff_bad, "%s/report", argv[0]);
+  fprintf(stderr, "Expected bad report path: %s\n", buff_bad);
+  // CHECK: Expected bad report path: [[BADPATH:.*]]/report
   __sanitizer_set_report_path(buff_bad);
   assert(strncmp(buff, __sanitizer_get_report_path(), strlen(buff)) == 0);
 }
 
-// CHECK: ERROR: Can't create directory: {{.*}}Posix/Output/sanitizer_set_report_path_test.cpp.tmp
+// CHECK: ERROR: Can't create directory: [[BADPATH]]


### PR DESCRIPTION
Currently, `Posix/sanitizer_set_report_path_test.cpp` contains the following check: `// CHECK: ERROR: Can't create directory: {{.*}}Posix/Output/sanitizer_set_report_path_test.cpp.tmp`. This makes an assumption that the test file resides in `Posix/Output`, however when testing on a remote device, an alternative temporary directory path is used. This patch instead checks that the path in the error message matches the requested path dynamically.