### PR TITLE
[LLVM][SelectionDAG] Simplify SplitVecOp_VSETCC.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -4343,9 +4343,10 @@ SDValue DAGTypeLegalizer::SplitVecOp_VSETCC(SDNode *N) {
 
   auto PartEltCnt = Lo0.getValueType().getVectorElementCount();
 
-  LLVMContext &Context = *DAG.getContext();
-  EVT PartResVT = EVT::getVectorVT(Context, MVT::i1, PartEltCnt);
-  EVT WideResVT = EVT::getVectorVT(Context, MVT::i1, PartEltCnt*2);
+  EVT VT = N->getValueType(0);
+  EVT PartResVT = VT.getHalfNumVectorElementsVT(*DAG.getContext());
+  assert(PartResVT.getVectorElementCount() == PartEltCnt &&
+         "Expected an equal split!");
 
   if (Opc == ISD::SETCC) {
     LoRes = DAG.getNode(ISD::SETCC, DL, PartResVT, Lo0, Lo1, N->getOperand(2));
@@ -4369,12 +4370,8 @@ SDValue DAGTypeLegalizer::SplitVecOp_VSETCC(SDNode *N) {
     HiRes = DAG.getNode(ISD::VP_SETCC, DL, PartResVT, Hi0, Hi1,
                         N->getOperand(2), MaskHi, EVLHi);
   }
-  SDValue Con = DAG.getNode(ISD::CONCAT_VECTORS, DL, WideResVT, LoRes, HiRes);
 
-  EVT OpVT = N->getOperand(0).getValueType();
-  ISD::NodeType ExtendCode =
-      TargetLowering::getExtendForContent(TLI.getBooleanContents(OpVT));
-  return DAG.getNode(ExtendCode, DL, N->getValueType(0), Con);
+  return DAG.getNode(ISD::CONCAT_VECTORS, DL, VT, LoRes, HiRes);
 }
 
 

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -4341,12 +4341,8 @@ SDValue DAGTypeLegalizer::SplitVecOp_VSETCC(SDNode *N) {
   GetSplitVector(N->getOperand(isStrict ? 1 : 0), Lo0, Hi0);
   GetSplitVector(N->getOperand(isStrict ? 2 : 1), Lo1, Hi1);
 
-  auto PartEltCnt = Lo0.getValueType().getVectorElementCount();
-
   EVT VT = N->getValueType(0);
-  EVT PartResVT = VT.getHalfNumVectorElementsVT(*DAG.getContext());
-  assert(PartResVT.getVectorElementCount() == PartEltCnt &&
-         "Expected an equal split!");
+  EVT PartResVT = Lo0.getValueType().changeElementType(VT.getScalarType());
 
   if (Opc == ISD::SETCC) {
     LoRes = DAG.getNode(ISD::SETCC, DL, PartResVT, Lo0, Lo1, N->getOperand(2));

--- a/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
@@ -890,8 +890,6 @@ define <8 x i1> @test_fcmp_une(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmeq v0.4s, v0.4s, v1.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-NEXT:    mvn v0.16b, v0.16b
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp une <8 x bfloat> %a, %b
@@ -913,8 +911,6 @@ define <8 x i1> @test_fcmp_ueq(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
 ; CHECK-NEXT:    mvn v0.16b, v0.16b
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp ueq <8 x bfloat> %a, %b
@@ -932,8 +928,6 @@ define <8 x i1> @test_fcmp_ugt(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmge v0.4s, v1.4s, v0.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-NEXT:    mvn v0.16b, v0.16b
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp ugt <8 x bfloat> %a, %b
@@ -951,8 +945,6 @@ define <8 x i1> @test_fcmp_uge(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-NEXT:    mvn v0.16b, v0.16b
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp uge <8 x bfloat> %a, %b
@@ -970,8 +962,6 @@ define <8 x i1> @test_fcmp_ult(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmge v0.4s, v0.4s, v1.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-NEXT:    mvn v0.16b, v0.16b
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp ult <8 x bfloat> %a, %b
@@ -989,8 +979,6 @@ define <8 x i1> @test_fcmp_ule(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmgt v0.4s, v0.4s, v1.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-NEXT:    mvn v0.16b, v0.16b
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp ule <8 x bfloat> %a, %b
@@ -1012,8 +1000,6 @@ define <8 x i1> @test_fcmp_uno(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
 ; CHECK-NEXT:    mvn v0.16b, v0.16b
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp uno <8 x bfloat> %a, %b
@@ -1034,8 +1020,6 @@ define <8 x i1> @test_fcmp_one(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    orr v1.16b, v2.16b, v4.16b
 ; CHECK-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp one <8 x bfloat> %a, %b
@@ -1052,8 +1036,6 @@ define <8 x i1> @test_fcmp_oeq(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmeq v2.4s, v3.4s, v2.4s
 ; CHECK-NEXT:    fcmeq v0.4s, v0.4s, v1.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp oeq <8 x bfloat> %a, %b
@@ -1070,8 +1052,6 @@ define <8 x i1> @test_fcmp_ogt(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmgt v2.4s, v3.4s, v2.4s
 ; CHECK-NEXT:    fcmgt v0.4s, v0.4s, v1.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp ogt <8 x bfloat> %a, %b
@@ -1088,8 +1068,6 @@ define <8 x i1> @test_fcmp_oge(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmge v2.4s, v3.4s, v2.4s
 ; CHECK-NEXT:    fcmge v0.4s, v0.4s, v1.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp oge <8 x bfloat> %a, %b
@@ -1106,8 +1084,6 @@ define <8 x i1> @test_fcmp_olt(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmgt v2.4s, v3.4s, v2.4s
 ; CHECK-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp olt <8 x bfloat> %a, %b
@@ -1124,8 +1100,6 @@ define <8 x i1> @test_fcmp_ole(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    fcmge v2.4s, v3.4s, v2.4s
 ; CHECK-NEXT:    fcmge v0.4s, v1.4s, v0.4s
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp ole <8 x bfloat> %a, %b
@@ -1146,8 +1120,6 @@ define <8 x i1> @test_fcmp_ord(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 ; CHECK-NEXT:    orr v1.16b, v2.16b, v4.16b
 ; CHECK-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-NEXT:    ret
   %1 = fcmp ord <8 x bfloat> %a, %b

--- a/llvm/test/CodeGen/AArch64/fcmp.ll
+++ b/llvm/test/CodeGen/AArch64/fcmp.ll
@@ -1145,8 +1145,6 @@ define <7 x half> @v7f16_half(<7 x half> %a, <7 x half> %b, <7 x half> %d, <7 x 
 ; CHECK-SD-NOFP16-NEXT:    fcmgt v4.4s, v5.4s, v4.4s
 ; CHECK-SD-NOFP16-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-SD-NOFP16-NEXT:    uzp1 v0.8h, v0.8h, v4.8h
-; CHECK-SD-NOFP16-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-SD-NOFP16-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-SD-NOFP16-NEXT:    bsl v0.16b, v2.16b, v3.16b
 ; CHECK-SD-NOFP16-NEXT:    ret
 ;
@@ -1275,8 +1273,6 @@ define <8 x half> @v8f16_half(<8 x half> %a, <8 x half> %b, <8 x half> %d, <8 x 
 ; CHECK-SD-NOFP16-NEXT:    fcmgt v4.4s, v5.4s, v4.4s
 ; CHECK-SD-NOFP16-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-SD-NOFP16-NEXT:    uzp1 v0.8h, v0.8h, v4.8h
-; CHECK-SD-NOFP16-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-SD-NOFP16-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-SD-NOFP16-NEXT:    bsl v0.16b, v2.16b, v3.16b
 ; CHECK-SD-NOFP16-NEXT:    ret
 ;
@@ -1328,10 +1324,6 @@ define <16 x half> @v16f16_half(<16 x half> %a, <16 x half> %b, <16 x half> %d, 
 ; CHECK-SD-NOFP16-NEXT:    fcmgt v0.4s, v2.4s, v0.4s
 ; CHECK-SD-NOFP16-NEXT:    uzp1 v1.8h, v1.8h, v16.8h
 ; CHECK-SD-NOFP16-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
-; CHECK-SD-NOFP16-NEXT:    shl v1.8h, v1.8h, #15
-; CHECK-SD-NOFP16-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-SD-NOFP16-NEXT:    cmlt v1.8h, v1.8h, #0
-; CHECK-SD-NOFP16-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-SD-NOFP16-NEXT:    bsl v1.16b, v5.16b, v7.16b
 ; CHECK-SD-NOFP16-NEXT:    bsl v0.16b, v4.16b, v6.16b
 ; CHECK-SD-NOFP16-NEXT:    ret
@@ -1384,45 +1376,41 @@ entry:
 define <7 x i32> @v7f16_i32(<7 x half> %a, <7 x half> %b, <7 x i32> %d, <7 x i32> %e) {
 ; CHECK-SD-NOFP16-LABEL: v7f16_i32:
 ; CHECK-SD-NOFP16:       // %bb.0: // %entry
-; CHECK-SD-NOFP16-NEXT:    fcvtl2 v2.4s, v0.8h
-; CHECK-SD-NOFP16-NEXT:    fcvtl2 v3.4s, v1.8h
+; CHECK-SD-NOFP16-NEXT:    fmov s2, w0
+; CHECK-SD-NOFP16-NEXT:    fmov s4, w7
 ; CHECK-SD-NOFP16-NEXT:    mov x8, sp
-; CHECK-SD-NOFP16-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-SD-NOFP16-NEXT:    fcvtl v1.4s, v1.4h
-; CHECK-SD-NOFP16-NEXT:    ldr s4, [sp, #24]
-; CHECK-SD-NOFP16-NEXT:    add x9, sp, #32
-; CHECK-SD-NOFP16-NEXT:    ld1 { v4.s }[1], [x9]
-; CHECK-SD-NOFP16-NEXT:    add x9, sp, #16
-; CHECK-SD-NOFP16-NEXT:    fcmgt v2.4s, v3.4s, v2.4s
-; CHECK-SD-NOFP16-NEXT:    fmov s3, w4
+; CHECK-SD-NOFP16-NEXT:    fmov s5, w4
+; CHECK-SD-NOFP16-NEXT:    fcvtl v6.4s, v0.4h
+; CHECK-SD-NOFP16-NEXT:    ldr s3, [sp, #24]
+; CHECK-SD-NOFP16-NEXT:    fcvtl v7.4s, v1.4h
+; CHECK-SD-NOFP16-NEXT:    fcvtl2 v0.4s, v0.8h
+; CHECK-SD-NOFP16-NEXT:    add x9, sp, #8
+; CHECK-SD-NOFP16-NEXT:    mov v2.s[1], w1
+; CHECK-SD-NOFP16-NEXT:    ld1 { v4.s }[1], [x8]
+; CHECK-SD-NOFP16-NEXT:    fcvtl2 v1.4s, v1.8h
+; CHECK-SD-NOFP16-NEXT:    mov v5.s[1], w5
+; CHECK-SD-NOFP16-NEXT:    add x8, sp, #32
+; CHECK-SD-NOFP16-NEXT:    ld1 { v3.s }[1], [x8]
+; CHECK-SD-NOFP16-NEXT:    add x8, sp, #16
+; CHECK-SD-NOFP16-NEXT:    fcmgt v6.4s, v7.4s, v6.4s
+; CHECK-SD-NOFP16-NEXT:    ld1 { v4.s }[2], [x9]
+; CHECK-SD-NOFP16-NEXT:    add x9, sp, #40
+; CHECK-SD-NOFP16-NEXT:    mov v2.s[2], w2
 ; CHECK-SD-NOFP16-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-SD-NOFP16-NEXT:    fmov s1, w0
-; CHECK-SD-NOFP16-NEXT:    mov v3.s[1], w5
-; CHECK-SD-NOFP16-NEXT:    mov v1.s[1], w1
-; CHECK-SD-NOFP16-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-SD-NOFP16-NEXT:    fmov s2, w7
-; CHECK-SD-NOFP16-NEXT:    mov v3.s[2], w6
-; CHECK-SD-NOFP16-NEXT:    ld1 { v2.s }[1], [x8]
-; CHECK-SD-NOFP16-NEXT:    mov v1.s[2], w2
-; CHECK-SD-NOFP16-NEXT:    add x8, sp, #8
-; CHECK-SD-NOFP16-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-SD-NOFP16-NEXT:    ld1 { v2.s }[2], [x8]
-; CHECK-SD-NOFP16-NEXT:    add x8, sp, #40
-; CHECK-SD-NOFP16-NEXT:    cmlt v0.8h, v0.8h, #0
-; CHECK-SD-NOFP16-NEXT:    mov v1.s[3], w3
-; CHECK-SD-NOFP16-NEXT:    ld1 { v4.s }[2], [x8]
-; CHECK-SD-NOFP16-NEXT:    ld1 { v2.s }[3], [x9]
-; CHECK-SD-NOFP16-NEXT:    sshll v5.4s, v0.4h, #0
-; CHECK-SD-NOFP16-NEXT:    sshll2 v0.4s, v0.8h, #0
-; CHECK-SD-NOFP16-NEXT:    bif v1.16b, v2.16b, v5.16b
-; CHECK-SD-NOFP16-NEXT:    bsl v0.16b, v3.16b, v4.16b
+; CHECK-SD-NOFP16-NEXT:    mov v5.s[2], w6
+; CHECK-SD-NOFP16-NEXT:    ld1 { v3.s }[2], [x9]
+; CHECK-SD-NOFP16-NEXT:    ld1 { v4.s }[3], [x8]
+; CHECK-SD-NOFP16-NEXT:    mov v1.16b, v6.16b
+; CHECK-SD-NOFP16-NEXT:    mov v2.s[3], w3
+; CHECK-SD-NOFP16-NEXT:    bsl v0.16b, v5.16b, v3.16b
+; CHECK-SD-NOFP16-NEXT:    bsl v1.16b, v2.16b, v4.16b
+; CHECK-SD-NOFP16-NEXT:    mov w5, v0.s[1]
+; CHECK-SD-NOFP16-NEXT:    mov w6, v0.s[2]
+; CHECK-SD-NOFP16-NEXT:    fmov w4, s0
 ; CHECK-SD-NOFP16-NEXT:    mov w1, v1.s[1]
 ; CHECK-SD-NOFP16-NEXT:    mov w2, v1.s[2]
 ; CHECK-SD-NOFP16-NEXT:    mov w3, v1.s[3]
-; CHECK-SD-NOFP16-NEXT:    mov w5, v0.s[1]
-; CHECK-SD-NOFP16-NEXT:    mov w6, v0.s[2]
 ; CHECK-SD-NOFP16-NEXT:    fmov w0, s1
-; CHECK-SD-NOFP16-NEXT:    fmov w4, s0
 ; CHECK-SD-NOFP16-NEXT:    ret
 ;
 ; CHECK-SD-FP16-LABEL: v7f16_i32:
@@ -1630,17 +1618,12 @@ entry:
 define <8 x i32> @v8f16_i32(<8 x half> %a, <8 x half> %b, <8 x i32> %d, <8 x i32> %e) {
 ; CHECK-SD-NOFP16-LABEL: v8f16_i32:
 ; CHECK-SD-NOFP16:       // %bb.0: // %entry
-; CHECK-SD-NOFP16-NEXT:    fcvtl2 v6.4s, v0.8h
-; CHECK-SD-NOFP16-NEXT:    fcvtl2 v7.4s, v1.8h
-; CHECK-SD-NOFP16-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-SD-NOFP16-NEXT:    fcvtl v1.4s, v1.4h
+; CHECK-SD-NOFP16-NEXT:    fcvtl v6.4s, v0.4h
+; CHECK-SD-NOFP16-NEXT:    fcvtl v7.4s, v1.4h
+; CHECK-SD-NOFP16-NEXT:    fcvtl2 v0.4s, v0.8h
+; CHECK-SD-NOFP16-NEXT:    fcvtl2 v1.4s, v1.8h
 ; CHECK-SD-NOFP16-NEXT:    fcmgt v6.4s, v7.4s, v6.4s
 ; CHECK-SD-NOFP16-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-SD-NOFP16-NEXT:    uzp1 v0.8h, v0.8h, v6.8h
-; CHECK-SD-NOFP16-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-SD-NOFP16-NEXT:    cmlt v0.8h, v0.8h, #0
-; CHECK-SD-NOFP16-NEXT:    sshll v6.4s, v0.4h, #0
-; CHECK-SD-NOFP16-NEXT:    sshll2 v0.4s, v0.8h, #0
 ; CHECK-SD-NOFP16-NEXT:    mov v1.16b, v0.16b
 ; CHECK-SD-NOFP16-NEXT:    mov v0.16b, v6.16b
 ; CHECK-SD-NOFP16-NEXT:    bsl v1.16b, v3.16b, v5.16b
@@ -1694,37 +1677,24 @@ entry:
 define <16 x i32> @v16f16_i32(<16 x half> %a, <16 x half> %b, <16 x i32> %d, <16 x i32> %e) {
 ; CHECK-SD-NOFP16-LABEL: v16f16_i32:
 ; CHECK-SD-NOFP16:       // %bb.0: // %entry
-; CHECK-SD-NOFP16-NEXT:    fcvtl2 v17.4s, v0.8h
-; CHECK-SD-NOFP16-NEXT:    fcvtl2 v18.4s, v2.8h
-; CHECK-SD-NOFP16-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-SD-NOFP16-NEXT:    fcvtl v2.4s, v2.4h
-; CHECK-SD-NOFP16-NEXT:    fcvtl2 v16.4s, v1.8h
-; CHECK-SD-NOFP16-NEXT:    fcvtl2 v19.4s, v3.8h
-; CHECK-SD-NOFP16-NEXT:    fcvtl v1.4s, v1.4h
-; CHECK-SD-NOFP16-NEXT:    fcvtl v3.4s, v3.4h
-; CHECK-SD-NOFP16-NEXT:    fcmgt v17.4s, v18.4s, v17.4s
-; CHECK-SD-NOFP16-NEXT:    fcmgt v0.4s, v2.4s, v0.4s
-; CHECK-SD-NOFP16-NEXT:    fcmgt v2.4s, v19.4s, v16.4s
-; CHECK-SD-NOFP16-NEXT:    fcmgt v1.4s, v3.4s, v1.4s
-; CHECK-SD-NOFP16-NEXT:    ldp q18, q19, [sp, #32]
-; CHECK-SD-NOFP16-NEXT:    uzp1 v0.8h, v0.8h, v17.8h
-; CHECK-SD-NOFP16-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
-; CHECK-SD-NOFP16-NEXT:    ldp q2, q20, [sp]
-; CHECK-SD-NOFP16-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-SD-NOFP16-NEXT:    shl v1.8h, v1.8h, #15
-; CHECK-SD-NOFP16-NEXT:    cmlt v0.8h, v0.8h, #0
-; CHECK-SD-NOFP16-NEXT:    cmlt v1.8h, v1.8h, #0
-; CHECK-SD-NOFP16-NEXT:    sshll v3.4s, v0.4h, #0
-; CHECK-SD-NOFP16-NEXT:    sshll v16.4s, v1.4h, #0
-; CHECK-SD-NOFP16-NEXT:    sshll2 v17.4s, v1.8h, #0
-; CHECK-SD-NOFP16-NEXT:    sshll2 v1.4s, v0.8h, #0
-; CHECK-SD-NOFP16-NEXT:    mov v0.16b, v3.16b
-; CHECK-SD-NOFP16-NEXT:    mov v3.16b, v17.16b
-; CHECK-SD-NOFP16-NEXT:    bsl v1.16b, v5.16b, v20.16b
-; CHECK-SD-NOFP16-NEXT:    bsl v0.16b, v4.16b, v2.16b
-; CHECK-SD-NOFP16-NEXT:    mov v2.16b, v16.16b
-; CHECK-SD-NOFP16-NEXT:    bsl v3.16b, v7.16b, v19.16b
-; CHECK-SD-NOFP16-NEXT:    bsl v2.16b, v6.16b, v18.16b
+; CHECK-SD-NOFP16-NEXT:    fcvtl v16.4s, v1.4h
+; CHECK-SD-NOFP16-NEXT:    fcvtl v17.4s, v3.4h
+; CHECK-SD-NOFP16-NEXT:    fcvtl v18.4s, v0.4h
+; CHECK-SD-NOFP16-NEXT:    fcvtl v19.4s, v2.4h
+; CHECK-SD-NOFP16-NEXT:    fcvtl2 v1.4s, v1.8h
+; CHECK-SD-NOFP16-NEXT:    fcvtl2 v3.4s, v3.8h
+; CHECK-SD-NOFP16-NEXT:    fcvtl2 v0.4s, v0.8h
+; CHECK-SD-NOFP16-NEXT:    fcvtl2 v2.4s, v2.8h
+; CHECK-SD-NOFP16-NEXT:    fcmgt v16.4s, v17.4s, v16.4s
+; CHECK-SD-NOFP16-NEXT:    fcmgt v18.4s, v19.4s, v18.4s
+; CHECK-SD-NOFP16-NEXT:    fcmgt v3.4s, v3.4s, v1.4s
+; CHECK-SD-NOFP16-NEXT:    fcmgt v1.4s, v2.4s, v0.4s
+; CHECK-SD-NOFP16-NEXT:    ldp q0, q19, [sp]
+; CHECK-SD-NOFP16-NEXT:    ldp q2, q17, [sp, #32]
+; CHECK-SD-NOFP16-NEXT:    bit v0.16b, v4.16b, v18.16b
+; CHECK-SD-NOFP16-NEXT:    bsl v1.16b, v5.16b, v19.16b
+; CHECK-SD-NOFP16-NEXT:    bsl v3.16b, v7.16b, v17.16b
+; CHECK-SD-NOFP16-NEXT:    bit v2.16b, v6.16b, v16.16b
 ; CHECK-SD-NOFP16-NEXT:    ret
 ;
 ; CHECK-SD-FP16-LABEL: v16f16_i32:

--- a/llvm/test/CodeGen/AArch64/fp16-v8-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/fp16-v8-instructions.ll
@@ -522,8 +522,6 @@ define <8 x i1> @test_fcmp_une(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmeq v0.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -552,8 +550,6 @@ define <8 x i1> @test_fcmp_ueq(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
 ; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -580,8 +576,6 @@ define <8 x i1> @test_fcmp_ugt(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmge v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -606,8 +600,6 @@ define <8 x i1> @test_fcmp_uge(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -632,8 +624,6 @@ define <8 x i1> @test_fcmp_ult(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmge v0.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -658,8 +648,6 @@ define <8 x i1> @test_fcmp_ule(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmgt v0.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -688,8 +676,6 @@ define <8 x i1> @test_fcmp_uno(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
 ; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -719,8 +705,6 @@ define <8 x i1> @test_fcmp_one(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    orr v1.16b, v2.16b, v4.16b
 ; CHECK-CVT-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -745,8 +729,6 @@ define <8 x i1> @test_fcmp_oeq(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmeq v2.4s, v3.4s, v2.4s
 ; CHECK-CVT-NEXT:    fcmeq v0.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -769,8 +751,6 @@ define <8 x i1> @test_fcmp_ogt(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmgt v2.4s, v3.4s, v2.4s
 ; CHECK-CVT-NEXT:    fcmgt v0.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -793,8 +773,6 @@ define <8 x i1> @test_fcmp_oge(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmge v2.4s, v3.4s, v2.4s
 ; CHECK-CVT-NEXT:    fcmge v0.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -817,8 +795,6 @@ define <8 x i1> @test_fcmp_olt(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmgt v2.4s, v3.4s, v2.4s
 ; CHECK-CVT-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -841,8 +817,6 @@ define <8 x i1> @test_fcmp_ole(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    fcmge v2.4s, v3.4s, v2.4s
 ; CHECK-CVT-NEXT:    fcmge v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;
@@ -869,8 +843,6 @@ define <8 x i1> @test_fcmp_ord(<8 x half> %a, <8 x half> %b) #0 {
 ; CHECK-CVT-NEXT:    orr v1.16b, v2.16b, v4.16b
 ; CHECK-CVT-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-CVT-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-CVT-NEXT:    shl v0.8h, v0.8h, #15
-; CHECK-CVT-NEXT:    cmlt v0.8h, v0.8h, #0
 ; CHECK-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-CVT-NEXT:    ret
 ;


### PR DESCRIPTION
Preserving the original result element type when splitting vector setcc operations removes redundant extensions that are awkward to optimise after the fact.

Whilst the result type might not be legal, the current decision to force an i1 vector result is almost certainly not going to be legal either. Given by this point we've already gone through the process of identifying a better element result type, I figure we may as well use it.