### PR TITLE
Revert "MC: Support quoted symbol names"

### DIFF
--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -212,27 +212,6 @@ MCDataFragment *MCContext::allocInitialFragment(MCSection &Sec) {
 MCSymbol *MCContext::getOrCreateSymbol(const Twine &Name) {
   SmallString<128> NameSV;
   StringRef NameRef = Name.toStringRef(NameSV);
-  if (NameRef.contains('\\')) {
-    NameSV = NameRef;
-    size_t S = 0;
-    // Support escaped \\ and \" as in GNU Assembler. GAS issues a warning for
-    // other characters following \\, which we do not implement due to code
-    // structure.
-    for (size_t I = 0, E = NameSV.size(); I < E; ++I) {
-      char C = NameSV[I];
-      if (C == '\\') {
-        switch (NameSV[I + 1]) {
-        case '"':
-        case '\\':
-          C = NameSV[++I];
-          break;
-        }
-      }
-      NameSV[S++] = C;
-    }
-    NameSV.resize(S);
-    NameRef = NameSV;
-  }
 
   assert(!NameRef.empty() && "Normal symbols cannot be unnamed!");
 

--- a/llvm/lib/MC/MCSymbol.cpp
+++ b/llvm/lib/MC/MCSymbol.cpp
@@ -74,8 +74,6 @@ void MCSymbol::print(raw_ostream &OS, const MCAsmInfo *MAI) const {
       OS << "\\n";
     else if (C == '"')
       OS << "\\\"";
-    else if (C == '\\')
-      OS << "\\\\";
     else
       OS << C;
   }

--- a/llvm/test/MC/AsmParser/quoted.s
+++ b/llvm/test/MC/AsmParser/quoted.s
@@ -9,9 +9,6 @@
 "a b":
   call "a b"
 
-# CHECK: "a b\\":
-"a b\\":
-
 #--- err.s
  "a\":
 # ERR: 1:2: error: unterminated string constant

--- a/llvm/test/MC/COFF/safeseh.s
+++ b/llvm/test/MC/COFF/safeseh.s
@@ -2,5 +2,5 @@
 
 // check that we quote the output of .safeseh
 
-.safeseh "\\foo"
-// CHECK: .safeseh "\\foo"
+.safeseh "\01foo"
+// CHECK: .safeseh "\01foo"

--- a/llvm/test/MC/ELF/symbol-names.s
+++ b/llvm/test/MC/ELF/symbol-names.s
@@ -1,13 +1,6 @@
-// RUN: llvm-mc -triple=x86_64 -filetype=obj %s | llvm-objdump -tdr - | FileCheck %s
+// RUN: llvm-mc -triple i686-pc-linux -filetype=obj %s -o - | llvm-readobj --symbols - | FileCheck %s
 
 // MC allows ?'s in symbol names as an extension.
-
-// CHECK-LABEL:SYMBOL TABLE:
-// CHECK-NEXT: 0000000000000001 l     F .text  0000000000000000 a"b\{{$}}
-// CHECK-NEXT: 0000000000000006 l       .text  0000000000000000 a\{{$}}
-// CHECK-NEXT: 0000000000000000 g     F .text  0000000000000000 foo?bar
-// CHECK-NEXT: 0000000000000000 *UND*          0000000000000000 a"b\q{{$}}
-// CHECK-EMPTY:
 
 .text
 .globl foo?bar
@@ -15,14 +8,5 @@
 foo?bar:
 ret
 
-// CHECK-LABEL:<a"b\>:
-// CHECK-NEXT:   callq  {{.*}} <a"b\>
-// CHECK-LABEL:<a\>:
-// CHECK-NEXT:   callq  {{.*}}
-// CHECK-NEXT:     R_X86_64_PLT32 a"b\q-0x4
-.type "a\"b\\", @function
-"a\"b\\":
-  call "a\"b\\"
-"a\\":
-/// GAS emits a warning for \q
-  call "a\"b\q"
+// CHECK: Symbol
+// CHECK: Name: foo?bar


### PR DESCRIPTION
Reverts llvm/llvm-project#138817

The BOLT testing is failing after this change.