### PR TITLE
[BOLT][test] Add pseudo-probe-split-func.test

### DIFF
--- a/bolt/test/X86/Inputs/pseudo-probe-split-func.c
+++ b/bolt/test/X86/Inputs/pseudo-probe-split-func.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+int bar(int x, int y) {
+  if (x % 3) {
+    return x - y;
+  }
+  return x + y;
+}
+
+void foo() {
+  int s, i = 0;
+  while (i++ < 4000 * 4000)
+    if (i % 91) s = bar(i, s); else s += 30;
+  printf("sum is %d\n", s);
+}
+
+int main() {
+  foo();
+  return 0;
+}

--- a/bolt/test/X86/pseudo-probe-split-func.test
+++ b/bolt/test/X86/pseudo-probe-split-func.test
@@ -1,0 +1,18 @@
+## This test checks if pseudo probes are present in split fragments
+RUN: %clang %cflags %p/Inputs/pseudo-probe-split-func.c -o %t \
+RUN:   -O3 -fuse-ld=lld -fpseudo-probe-for-profiling -fno-omit-frame-pointer \
+RUN:   -mno-omit-leaf-frame-pointer -g -Wl,-q
+## Test pseudo probe encoding when hot fragments are emitted before cold
+RUN: llvm-bolt %t -o %t.out -split-functions --split-strategy=all -lite=0
+RUN: llvm-profgen --binary=%t.out --perfscript=1 --output=%t.null \
+RUN:   --show-disassembly-only --show-pseudo-probe | FileCheck %s
+## Test pseudo probe encoding when cold fragments are emitted before hot
+RUN: llvm-bolt %t -o %t.cold -split-functions --split-strategy=all -lite=0 \
+RUN:   --hot-functions-at-end
+RUN: llvm-profgen --binary=%t.cold --perfscript=1 --output=%t.null \
+RUN:   --show-disassembly-only --show-pseudo-probe | FileCheck %s
+CHECK: Disassembly of section .text.cold.3
+CHECK: <foo.cold.3>:
+CHECK: [Probe]:       FUNC: foo Index: 8  Type: Block
+CHECK: <main.cold.3>:
+CHECK: [Probe]:       FUNC: foo Index: 8  Type: Block  Inlined: @ main:2


### PR DESCRIPTION
Add a test checking if pseudo probes can be encoded and decoded with
function splitting in BOLT.

Test Plan: bin/llvm-lit -a tools/bolt/test/X86/pseudo-probe-split-func.test
