### PR TITLE
[Timers] Add a flag to set a minimum timer value for printing

### DIFF
--- a/llvm/lib/Support/Timer.cpp
+++ b/llvm/lib/Support/Timer.cpp
@@ -381,9 +381,10 @@ void TimerGroup::PrintQueuedTimers(raw_ostream &OS) {
 
   // Loop through all of the timing data, printing it out.
   for (const PrintRecord &Record : llvm::reverse(TimersToPrint)) {
-    if (const TimeRecord &TR = Record.Time; TR.getUserTime() >= minPrintTime() ||
-                                            TR.getSystemTime() >= minPrintTime() ||
-                                            TR.getWallTime() >= minPrintTime()) {
+    if (const TimeRecord &TR = Record.Time;
+        TR.getUserTime() >= minPrintTime() ||
+        TR.getSystemTime() >= minPrintTime() ||
+        TR.getWallTime() >= minPrintTime()) {
       Record.Time.print(Total, OS);
       OS << Record.Description << '\n';
     }
@@ -531,7 +532,8 @@ public:
       cl::init(true), cl::Hidden};
   cl::opt<unsigned> MinPrintTime{
       "min-print-time",
-      cl::desc("Minimum time in seconds for a timer to be printed"), cl::init(0)};
+      cl::desc("Minimum time in seconds for a timer to be printed"),
+      cl::init(0)};
 
   sys::SmartMutex<true> TimerLock;
   TimerGroup DefaultTimerGroup{"misc", "Miscellaneous Ungrouped Timers",

--- a/llvm/lib/Support/Timer.cpp
+++ b/llvm/lib/Support/Timer.cpp
@@ -531,7 +531,7 @@ public:
                " time order"),
       cl::init(true), cl::Hidden};
   cl::opt<unsigned> MinPrintTime{
-      "min-print-time",
+      "timer-min-print-time",
       cl::desc("Minimum time in seconds for a timer to be printed"),
       cl::init(0)};
 

--- a/llvm/unittests/Support/TimerTest.cpp
+++ b/llvm/unittests/Support/TimerTest.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/Timer.h"
+#include "llvm/Support/CommandLine.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #if _WIN32
@@ -17,18 +19,20 @@
 
 using namespace llvm;
 
+cl::opt<unsigned> &minPrintTime();
+
 namespace {
 
 // FIXME: Put this somewhere in Support, it's also used in LockFileManager.
-void SleepMS() {
+void SleepMS(int ms = 1) {
 #if _WIN32
-  Sleep(1);
+  Sleep(ms);
 #else
   struct timespec Interval;
-  Interval.tv_sec = 0;
-  Interval.tv_nsec = 1000000;
+  Interval.tv_sec = ms / 1000;
+  Interval.tv_nsec = 1000000 * (ms % 1000);
 #if defined(__MVS__)
-  long Microseconds = (Interval.tv_nsec + 999) / 1000;
+  long Microseconds = (Interval.tv_nsec + Interval.tv_sec * 1000 + 999) / 1000;
   usleep(Microseconds);
 #else
   nanosleep(&Interval, nullptr);
@@ -80,6 +84,36 @@ TEST(Timer, TimerGroupTimerDestructed) {
     testing::internal::CaptureStderr();
   }
   EXPECT_FALSE(testing::internal::GetCapturedStderr().empty());
+}
+
+TEST(Timer, MinTimerFlag) {
+  testing::internal::CaptureStderr();
+
+  Timer T1("T1", "T1");
+  Timer T2("T2", "T2");
+
+  minPrintTime().setValue(2);
+
+  T1.startTimer();
+  T2.startTimer();
+
+  SleepMS(1000);
+  T1.stopTimer();
+
+  SleepMS(2000);
+  T2.stopTimer();
+
+  TimerGroup::printAll(llvm::errs());
+  std::string stderr = testing::internal::GetCapturedStderr();
+  EXPECT_THAT(stderr, testing::HasSubstr("T2"));
+  EXPECT_THAT(stderr, testing::Not(testing::HasSubstr("T1")));
+
+  testing::internal::CaptureStderr();
+
+  TimerGroup::printAllJSONValues(llvm::errs(), "");
+  stderr = testing::internal::GetCapturedStderr();
+  EXPECT_THAT(stderr, testing::HasSubstr("T2.wall"));
+  EXPECT_THAT(stderr, testing::Not(testing::HasSubstr("T1.wall")));
 }
 
 } // namespace

--- a/llvm/unittests/Support/TimerTest.cpp
+++ b/llvm/unittests/Support/TimerTest.cpp
@@ -92,15 +92,15 @@ TEST(Timer, MinTimerFlag) {
   Timer T1("T1", "T1");
   Timer T2("T2", "T2");
 
-  minPrintTime().setValue(2);
+  minPrintTime().setValue(1);
 
   T1.startTimer();
   T2.startTimer();
 
-  SleepMS(1000);
+  SleepMS(500);
   T1.stopTimer();
 
-  SleepMS(2000);
+  SleepMS(600);
   T2.stopTimer();
 
   TimerGroup::printAll(llvm::errs());


### PR DESCRIPTION
The new LLVM flag `-timer-min-print-time` is the number of seconds a timer must have in order for its value to be printed in either JSON or human readable formatting. This may be used, for example, with Clang's `-ftime-report` to reduce its output size by not printing insignificant values.

The default value of this flag is 0 which retains the current behavior of printing all timer values.