### PR TITLE
Fix spelling error crtp-constructor-accessibility.rst

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/crtp-constructor-accessibility.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/crtp-constructor-accessibility.rst
@@ -9,7 +9,7 @@ can be constructed outside itself and the derived class.
 The CRTP is an idiom, in which a class derives from a template class, where 
 itself is the template argument. It should be ensured that if a class is
 intended to be a base class in this idiom, it can only be instantiated if
-the derived class is it's template argument.
+the derived class is its template argument.
 
 Example:
 


### PR DESCRIPTION
it's = it has, which is not correct here.