### PR TITLE
Fix build failure in DXILResource.h on newer versions of MSVC

### DIFF
--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -671,6 +671,8 @@ public:
     case dxil::ResourceClass::Sampler:
       return SamplerSpaces;
     }
+
+    llvm_unreachable("Invalid resource class");
   }
 
   friend class DXILResourceBindingAnalysis;


### PR DESCRIPTION
The change #137258 introduced a build break on newer versions of MSVC:

```
llvm\include\llvm\Analysis\DXILResource.h(674) : warning C4715: 'llvm::DXILResourceBindingInfo::getBindingSpaces': not all control paths return a value
```

Fix is to add a `default` case that will ICE.