### PR TITLE
[flang] Catch deferred type parameters in ALLOCATE(type-spec::)

### DIFF
--- a/flang/lib/Semantics/check-allocate.cpp
+++ b/flang/lib/Semantics/check-allocate.cpp
@@ -116,11 +116,17 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
       // C937
       if (auto it{FindCoarrayUltimateComponent(*derived)}) {
         context
-            .Say("Type-spec in ALLOCATE must not specify a type with a coarray"
-                 " ultimate component"_err_en_US)
+            .Say(
+                "Type-spec in ALLOCATE must not specify a type with a coarray ultimate component"_err_en_US)
             .Attach(it->name(),
                 "Type '%s' has coarray ultimate component '%s' declared here"_en_US,
                 info.typeSpec->AsFortran(), it.BuildResultDesignatorName());
+      }
+    }
+    if (auto dyType{evaluate::DynamicType::From(*info.typeSpec)}) {
+      if (dyType->HasDeferredTypeParameter()) {
+        context.Say(
+            "Type-spec in ALLOCATE must not have a deferred type parameter"_err_en_US);
       }
     }
   }

--- a/flang/test/Semantics/allocate01.f90
+++ b/flang/test/Semantics/allocate01.f90
@@ -62,6 +62,7 @@ subroutine C932(ed1, ed5, ed7, edc9, edc10, okad1, okpd1, okacd5)
   real, pointer, save :: okp3
   real, allocatable, save :: oka3, okac4[:,:]
   real, allocatable :: okacd5(:, :)[:]
+  character(:), allocatable :: chvar
 
   !ERROR: Name in ALLOCATE statement must be a variable name
   allocate(foo)
@@ -102,6 +103,8 @@ subroutine C932(ed1, ed5, ed7, edc9, edc10, okad1, okpd1, okacd5)
   allocate(edc9%nok)
   !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(edc10)
+  !ERROR: Type-spec in ALLOCATE must not have a deferred type parameter
+  allocate(character(:) :: chvar)
 
   ! No errors expected below:
   allocate(a_var)
@@ -117,4 +120,5 @@ subroutine C932(ed1, ed5, ed7, edc9, edc10, okad1, okpd1, okacd5)
   allocate(edc9%ok(4))
   allocate(edc10%ok)
   allocate(rp)
+  allocate(character(123) :: chvar)
 end subroutine


### PR DESCRIPTION
The type-spec in ALLOCATE may not have any deferred type parameters.

Fixes https://github.com/llvm/llvm-project/issues/138979.