### PR TITLE
[mlir][docs] Add quant dialect pass doc into Passes.md (NFC)

### DIFF
--- a/mlir/docs/Passes.md
+++ b/mlir/docs/Passes.md
@@ -84,6 +84,10 @@ This document describes the available MLIR passes and their contracts.
 
 [include "NVGPUPasses.md"]
 
+## 'quant' Dialect Passes
+
+[include "QuantPasses.md"]
+
 ## Reducer Passes
 
 [include "ReducerPasses.md"]


### PR DESCRIPTION
This PR added documentation for the quant dialect passes to `Passes.md`, as it had not been included.