### PR TITLE
[OpenMP][test] Properly check for NULL

### DIFF
--- a/openmp/tools/multiplex/tests/custom_data_storage/custom_data_storage.c
+++ b/openmp/tools/multiplex/tests/custom_data_storage/custom_data_storage.c
@@ -54,7 +54,7 @@ int main() {
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_parallel_begin:
 // CHECK-SAME: parent_task_id=[[_FIRST_INITIAL_TASK_ID]],
-// CHECK-SAME: parent_task_frame.exit=(nil),
+// CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID:[0-9]+]], requested_team_size=2,
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, invoker
@@ -100,7 +100,7 @@ int main() {
 // CHECK-SAME: prior_task_status=ompt_task_switch=7
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_control_tool:
-// CHECK-SAME: command=5, modifier=1, arg=(nil),
+// CHECK-SAME: command=5, modifier=1, arg=[[NULL]],
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: task level 0:
@@ -130,12 +130,12 @@ int main() {
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0,
-// CHECK-SAME: task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0,
-// CHECK-SAME: task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_implicit_task_end:
 // CHECK-SAME: parallel_id=0, task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]],
@@ -160,7 +160,7 @@ int main() {
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_parallel_begin:
 // CHECK-SAME: parent_task_id=[[SECOND_INITIAL_TASK_ID]],
-// CHECK-SAME: parent_task_frame.exit=(nil),
+// CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID:[0-9]+]], requested_team_size=2,
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, invoker
@@ -206,7 +206,7 @@ int main() {
 // CHECK-SAME: prior_task_status=ompt_task_switch=7
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_control_tool:
-// CHECK-SAME: command=5, modifier=1, arg=(nil),
+// CHECK-SAME: command=5, modifier=1, arg=[[NULL]],
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: task level 0:
@@ -236,12 +236,12 @@ int main() {
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0,
-// CHECK-SAME: task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0,
-// CHECK-SAME: task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_implicit_task_end:
 // CHECK-SAME: parallel_id=0,
@@ -268,22 +268,22 @@ int main() {
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_begin:
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_begin:
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0,
-// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0,
-// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool: ompt_event_implicit_task_end:
 // CHECK-SAME: parallel_id=0,
@@ -305,22 +305,22 @@ int main() {
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_begin:
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_begin:
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0,
-// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0,
-// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool: ompt_event_implicit_task_end:
 // CHECK-SAME: parallel_id=0,

--- a/openmp/tools/multiplex/tests/print/print.c
+++ b/openmp/tools/multiplex/tests/print/print.c
@@ -55,7 +55,7 @@ int main() {
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_parallel_begin:
 // CHECK-SAME: parent_task_id=[[_FIRST_INITIAL_TASK_ID]],
-// CHECK-SAME: parent_task_frame.exit=(nil),
+// CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID:[0-9]+]],
 // CHECK-SAME: requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker
@@ -101,7 +101,7 @@ int main() {
 // CHECK-SAME: prior_task_status=ompt_task_switch=7
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_control_tool:
-// CHECK-SAME: command=5, modifier=1, arg=(nil), codeptr_ra={{(0x)?[0-f]+}}
+// CHECK-SAME: command=5, modifier=1, arg=[[NULL]], codeptr_ra={{(0x)?[0-f]+}}
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: task level 0:
 // CHECK-SAME: task_id=[[_FIRST_EXPLICIT_TASK_ID]]
@@ -129,12 +129,12 @@ int main() {
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0, task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]],
-// CHECK-SAME: codeptr_ra=(nil)
+// CHECK-SAME: codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0, task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]],
-// CHECK-SAME: codeptr_ra=(nil)
+// CHECK-SAME: codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_implicit_task_end:
 // CHECK-SAME: parallel_id=0, task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]],
@@ -157,7 +157,7 @@ int main() {
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_parallel_begin:
 // CHECK-SAME: parent_task_id=[[SECOND_INITIAL_TASK_ID]],
-// CHECK-SAME: parent_task_frame.exit=(nil),
+// CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID:[0-9]+]],
 // CHECK-SAME: requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker
@@ -203,7 +203,7 @@ int main() {
 // CHECK-SAME: prior_task_status=ompt_task_switch=7
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_control_tool:
-// CHECK-SAME: command=5, modifier=1, arg=(nil), codeptr_ra={{(0x)?[0-f]+}}
+// CHECK-SAME: command=5, modifier=1, arg=[[NULL]], codeptr_ra={{(0x)?[0-f]+}}
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: task level 0:
 // CHECK-SAME: task_id=[[SECOND_EXPLICIT_TASK_ID]]
@@ -231,12 +231,12 @@ int main() {
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0, task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]],
-// CHECK-SAME: codeptr_ra=(nil)
+// CHECK-SAME: codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0, task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]],
-// CHECK-SAME: codeptr_ra=(nil)
+// CHECK-SAME: codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_implicit_task_end:
 // CHECK-SAME: parallel_id=0, task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]],
@@ -261,22 +261,22 @@ int main() {
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_begin:
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_begin:
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0, task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]],
-// CHECK-SAME: codeptr_ra=(nil)
+// CHECK-SAME: codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0, task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]],
-// CHECK-SAME: codeptr_ra=(nil)
+// CHECK-SAME: codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool: ompt_event_implicit_task_end:
 // CHECK-SAME: parallel_id=0, task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID]],
@@ -297,22 +297,22 @@ int main() {
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_begin:
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_begin:
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=(nil)
+// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]], codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_wait_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0, task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]],
-// CHECK-SAME: codeptr_ra=(nil)
+// CHECK-SAME: codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:
 // CHECK-SAME: ompt_event_barrier_implicit_parallel_end:
 // CHECK-SAME: parallel_id=0, task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]],
-// CHECK-SAME: codeptr_ra=(nil)
+// CHECK-SAME: codeptr_ra=[[NULL]]
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool: ompt_event_implicit_task_end:
 // CHECK-SAME: parallel_id=0, task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID]],


### PR DESCRIPTION
Only 2 `openmp` testsuite failures remain on Solaris/amd64.  They are due the same issue: the tests in question assume `NULL` pointers to be printed as `(nil)` while the rest of the testsuite uses `[[NULL]]` for that.

This patch changes them to follow suit.

Tested on `amd64-pc-solaris2.11` and `x86_64-pc-linux-gnu`.