### PR TITLE
[lit] Add HOME to "safe" variables to pass through to tests

### DIFF
--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -66,6 +66,7 @@ class TestingConfig(object):
             "DFLTCC",
             "QEMU_LD_PREFIX",
             "QEMU_CPU",
+            "HOME",
         ]
 
         if sys.platform.startswith("aix"):


### PR DESCRIPTION
Incldue `HOME` among the variables that are passed through to tests when environment is cleaned. This is necessary for Gentoo build environments, where individual package builds are given temporary home directories that are exposed via `HOME` variable. By stripping the variable, `lit` made these tests attempt to access user's home directory, resulting in permission errors.