### PR TITLE
[Clang] Don't ditch typo-corrected lookup result

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -519,7 +519,7 @@ Improvements to Clang's diagnostics
   The warning message for non-overlapping cases has also been improved (#GH13473).
 
 - Fixed a duplicate diagnostic when performing typo correction on function template
-  calls with explicit template arguments. Fixes #GH139226.
+  calls with explicit template arguments. (#GH139226)
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -517,7 +517,10 @@ Improvements to Clang's diagnostics
 
 - Improved the ``-Wtautological-overlap-compare`` diagnostics to warn about overlapping and non-overlapping ranges involving character literals and floating-point literals. 
   The warning message for non-overlapping cases has also been improved (#GH13473).
-  
+
+- Fixed a duplicate diagnostic when performing typo correction on function template
+  calls with explicit template arguments. Fixes #GH139226.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -523,6 +523,9 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
       if (Found.isAmbiguous()) {
         Found.clear();
       } else if (!Found.empty()) {
+        // Do not erase the typo-corrected result to avoid duplicating the typo
+        // correction in future.
+        AllowFunctionTemplatesInLookup = true;
         Found.setLookupName(Corrected.getCorrection());
         if (LookupCtx) {
           std::string CorrectedStr(Corrected.getAsString(getLangOpts()));

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -523,8 +523,8 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
       if (Found.isAmbiguous()) {
         Found.clear();
       } else if (!Found.empty()) {
-        // Do not erase the typo-corrected result to avoid duplicating the typo
-        // correction in future.
+        // Do not erase the typo-corrected result to avoid duplicated
+        // diagnostics.
         AllowFunctionTemplatesInLookup = true;
         Found.setLookupName(Corrected.getCorrection());
         if (LookupCtx) {

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1.cpp
@@ -98,3 +98,16 @@ namespace PR11856 {
     }
   }
 }
+
+namespace GH139226 {
+
+struct Foo {
+  template <class T> void LookupWithID(); // expected-note {{declared here}}
+};
+
+void test(Foo &f) {
+  f.LookupWithId<int>();
+  // expected-error@-1 {{did you mean 'LookupWithID'}}
+}
+
+}


### PR DESCRIPTION
For a member function call like 'foo.bar<int>()', there are two typo-correction points after parsing the dot. The first occurs in ParseOptionalCXXScopeSpecifier, which tries to annotate the template name following any scope specifiers.

If the template name bar is not found within 'foo', the parser was previously instructed to drop any function templates found outside of the scope. This was intended to prevent ambiguity in expressions like 'foo->bar < 7', as explained in commit 50a3cddd. However, it's unnecessary to discard typo-corrected results that were strictly resolved within the scope 'foo'.

We won't perform a second typo-correction in ParseUnqualifiedId after the name being annotated.

Fixes https://github.com/llvm/llvm-project/issues/139226