### PR TITLE
[lldb-dap] Move registration of requests into DAP (NFC)

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -126,6 +126,7 @@ DAP::DAP(Log *log, const ReplMode default_repl_mode,
           [&](const ProgressEvent &event) { SendJSON(event.ToJSON()); }),
       reverse_request_seq(0), repl_mode(default_repl_mode) {
   configuration.preInitCommands = std::move(pre_init_commands);
+  RegisterRequests();
 }
 
 DAP::~DAP() = default;
@@ -1650,6 +1651,48 @@ void DAP::EventThread() {
       }
     }
   }
+}
+
+void DAP::RegisterRequests() {
+  RegisterRequest<AttachRequestHandler>();
+  RegisterRequest<BreakpointLocationsRequestHandler>();
+  RegisterRequest<CancelRequestHandler>();
+  RegisterRequest<CompletionsRequestHandler>();
+  RegisterRequest<ConfigurationDoneRequestHandler>();
+  RegisterRequest<ContinueRequestHandler>();
+  RegisterRequest<DataBreakpointInfoRequestHandler>();
+  RegisterRequest<DisassembleRequestHandler>();
+  RegisterRequest<DisconnectRequestHandler>();
+  RegisterRequest<EvaluateRequestHandler>();
+  RegisterRequest<ExceptionInfoRequestHandler>();
+  RegisterRequest<InitializeRequestHandler>();
+  RegisterRequest<LaunchRequestHandler>();
+  RegisterRequest<LocationsRequestHandler>();
+  RegisterRequest<NextRequestHandler>();
+  RegisterRequest<PauseRequestHandler>();
+  RegisterRequest<ReadMemoryRequestHandler>();
+  RegisterRequest<RestartRequestHandler>();
+  RegisterRequest<ScopesRequestHandler>();
+  RegisterRequest<SetBreakpointsRequestHandler>();
+  RegisterRequest<SetDataBreakpointsRequestHandler>();
+  RegisterRequest<SetExceptionBreakpointsRequestHandler>();
+  RegisterRequest<SetFunctionBreakpointsRequestHandler>();
+  RegisterRequest<SetInstructionBreakpointsRequestHandler>();
+  RegisterRequest<SetVariableRequestHandler>();
+  RegisterRequest<SourceRequestHandler>();
+  RegisterRequest<StackTraceRequestHandler>();
+  RegisterRequest<StepInRequestHandler>();
+  RegisterRequest<StepInTargetsRequestHandler>();
+  RegisterRequest<StepOutRequestHandler>();
+  RegisterRequest<ThreadsRequestHandler>();
+  RegisterRequest<VariablesRequestHandler>();
+
+  // Custom requests
+  RegisterRequest<CompileUnitsRequestHandler>();
+  RegisterRequest<ModulesRequestHandler>();
+
+  // Testing requests
+  RegisterRequest<TestGetTargetBreakpointsRequestHandler>();
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -188,7 +188,6 @@ struct DAP {
   // the old process here so we can detect this case and keep running.
   lldb::pid_t restarting_process_id;
   bool configuration_done;
-  llvm::StringMap<std::unique_ptr<BaseRequestHandler>> request_handlers;
   bool waiting_for_run_in_terminal;
   ProgressEventReporter progress_event_reporter;
   // Keep track of the last stop thread index IDs as threads won't go away
@@ -377,11 +376,6 @@ struct DAP {
     });
   }
 
-  /// Registers a request handler.
-  template <typename Handler> void RegisterRequest() {
-    request_handlers[Handler::GetCommand()] = std::make_unique<Handler>(*this);
-  }
-
   /// The set of capablities supported by this adapter.
   protocol::Capabilities GetCapabilities();
 
@@ -429,6 +423,15 @@ struct DAP {
   void StartProgressEventThread();
 
 private:
+  /// Registration of request handler.
+  /// @{
+  void RegisterRequests();
+  template <typename Handler> void RegisterRequest() {
+    request_handlers[Handler::GetCommand()] = std::make_unique<Handler>(*this);
+  }
+  llvm::StringMap<std::unique_ptr<BaseRequestHandler>> request_handlers;
+  /// @}
+
   /// Event threads.
   /// @{
   void EventThread();

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -115,48 +115,6 @@ public:
 };
 } // anonymous namespace
 
-static void RegisterRequestCallbacks(DAP &dap) {
-  dap.RegisterRequest<AttachRequestHandler>();
-  dap.RegisterRequest<BreakpointLocationsRequestHandler>();
-  dap.RegisterRequest<CancelRequestHandler>();
-  dap.RegisterRequest<CompletionsRequestHandler>();
-  dap.RegisterRequest<ConfigurationDoneRequestHandler>();
-  dap.RegisterRequest<ContinueRequestHandler>();
-  dap.RegisterRequest<DataBreakpointInfoRequestHandler>();
-  dap.RegisterRequest<DisassembleRequestHandler>();
-  dap.RegisterRequest<DisconnectRequestHandler>();
-  dap.RegisterRequest<EvaluateRequestHandler>();
-  dap.RegisterRequest<ExceptionInfoRequestHandler>();
-  dap.RegisterRequest<InitializeRequestHandler>();
-  dap.RegisterRequest<LaunchRequestHandler>();
-  dap.RegisterRequest<LocationsRequestHandler>();
-  dap.RegisterRequest<NextRequestHandler>();
-  dap.RegisterRequest<PauseRequestHandler>();
-  dap.RegisterRequest<ReadMemoryRequestHandler>();
-  dap.RegisterRequest<RestartRequestHandler>();
-  dap.RegisterRequest<ScopesRequestHandler>();
-  dap.RegisterRequest<SetBreakpointsRequestHandler>();
-  dap.RegisterRequest<SetDataBreakpointsRequestHandler>();
-  dap.RegisterRequest<SetExceptionBreakpointsRequestHandler>();
-  dap.RegisterRequest<SetFunctionBreakpointsRequestHandler>();
-  dap.RegisterRequest<SetInstructionBreakpointsRequestHandler>();
-  dap.RegisterRequest<SetVariableRequestHandler>();
-  dap.RegisterRequest<SourceRequestHandler>();
-  dap.RegisterRequest<StackTraceRequestHandler>();
-  dap.RegisterRequest<StepInRequestHandler>();
-  dap.RegisterRequest<StepInTargetsRequestHandler>();
-  dap.RegisterRequest<StepOutRequestHandler>();
-  dap.RegisterRequest<ThreadsRequestHandler>();
-  dap.RegisterRequest<VariablesRequestHandler>();
-
-  // Custom requests
-  dap.RegisterRequest<CompileUnitsRequestHandler>();
-  dap.RegisterRequest<ModulesRequestHandler>();
-
-  // Testing requests
-  dap.RegisterRequest<TestGetTargetBreakpointsRequestHandler>();
-}
-
 static void PrintHelp(LLDBDAPOptTable &table, llvm::StringRef tool_name) {
   std::string usage_str = tool_name.str() + " options";
   table.printHelp(llvm::outs(), usage_str.c_str(), "LLDB DAP", false);
@@ -341,8 +299,6 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
                                     "Failed to configure stdout redirect: ");
         return;
       }
-
-      RegisterRequestCallbacks(dap);
 
       {
         std::scoped_lock<std::mutex> lock(dap_sessions_mutex);
@@ -596,8 +552,6 @@ int main(int argc, char *argv[]) {
                                 "Failed to configure stdout redirect: ");
     return EXIT_FAILURE;
   }
-
-  RegisterRequestCallbacks(dap);
 
   // used only by TestVSCode_redirection_to_console.py
   if (getenv("LLDB_DAP_TEST_STDOUT_STDERR_REDIRECTION") != nullptr)


### PR DESCRIPTION
Make the registration of request handlers a private implementation detail of the DAP class.