### PR TITLE
compiler-rt: Exclude sync_fetch_and_* for any pre-ARMv6 targets

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -892,6 +892,18 @@ else ()
         ${TARGET_${arch}_CFLAGS})
       list(JOIN CMAKE_REQUIRED_FLAGS " " CMAKE_REQUIRED_FLAGS)
       message(STATUS "Performing additional configure checks with target flags: ${CMAKE_REQUIRED_FLAGS}")
+      # For ARM archs, exclude any sync builtins if dmb or mcr p15, #0, r0, c7, c10, #5
+      # is not supported
+      if (${arch} MATCHES "^(arm|armhf)$")
+        try_compile_only(COMPILER_RT_HAS_${arch}_SYNC
+                         SOURCE  "#if __ARM_ARCH < 6
+                                  #error DMB is only supported on ARMv6+ !
+                                  #endif
+                                  int main(void) { return 0; }")
+        if(NOT COMPILER_RT_HAS_${arch}_SYNC)
+          list(REMOVE_ITEM ${arch}_SOURCES ${arm_sync_SOURCES})
+        endif()
+      endif()
       # For ARM archs, exclude any VFP builtins if VFP is not supported
       if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em|armv8m.main|armv8.1m.main)$")
         check_compile_definition(__ARM_FP "${CMAKE_C_FLAGS}" COMPILER_RT_HAS_${arch}_VFP)


### PR DESCRIPTION
Sometimes builds may happen where ABI is not indidated by host_triple e.g. on Yocto the compiler used is called arm-poky-linux-gnueabi-clang for all arm32 cross compilers, it passed the ABI flags on cmdline in addition. e.g.

-march=armv5te -mfloat-abi=soft
or
-march=armv7-a -mfloat-abi=hard

compiler-rt's makery tries to add arm to COMPILER_RT_SUPPORTED_ARCH deducing it from triple name.

which ends up choosing `arm` as one of compiler-rt arch to build for. This arch is however using armv7+ defaults and then tried to build sync builtins using

arm-poky-linux-gnueabi-clang -march=armv5te -mfloat-abi=soft ...

Which does not compile correctly, in such cases it should simply remove the sync builtins from list of things to build similar to what is done when we use armv4t or armv5t

set(armv4t_SOURCES ${arm_min_SOURCES})
set(armv5te_SOURCES ${arm_min_SOURCES})

This lets compiler-rt build for arm architectures without depending upong compiler triple, but instead of poking the compiler for what it is building for