### PR TITLE
[clang-tidy] fix false negatives with type aliases in `cppcoreguidlines-pro-bounds-pointer-arithmetic` check

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsPointerArithmeticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsPointerArithmeticCheck.cpp
@@ -15,16 +15,13 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::cppcoreguidelines {
 
 void ProBoundsPointerArithmeticCheck::registerMatchers(MatchFinder *Finder) {
-  if (!getLangOpts().CPlusPlus)
-    return;
-
   const auto AllPointerTypes =
-      anyOf(hasType(pointerType()),
+      anyOf(hasType(hasUnqualifiedDesugaredType(pointerType())),
             hasType(autoType(
                 hasDeducedType(hasUnqualifiedDesugaredType(pointerType())))),
             hasType(decltypeType(hasUnderlyingType(pointerType()))));
 
-  // Flag all operators +, -, +=, -=, ++, -- that result in a pointer
+  // Flag all operators +, -, +=, -= that result in a pointer
   Finder->addMatcher(
       binaryOperator(
           hasAnyOperatorName("+", "-", "+=", "-="), AllPointerTypes,
@@ -32,8 +29,12 @@ void ProBoundsPointerArithmeticCheck::registerMatchers(MatchFinder *Finder) {
           .bind("expr"),
       this);
 
+  // Flag all operators ++, -- that result in a pointer
   Finder->addMatcher(
-      unaryOperator(hasAnyOperatorName("++", "--"), hasType(pointerType()))
+      unaryOperator(hasAnyOperatorName("++", "--"),
+                    hasType(hasUnqualifiedDesugaredType(pointerType())),
+                    unless(hasUnaryOperand(
+                        ignoringImpCasts(declRefExpr(to(isImplicit()))))))
           .bind("expr"),
       this);
 

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsPointerArithmeticCheck.h
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsPointerArithmeticCheck.h
@@ -23,6 +23,9 @@ class ProBoundsPointerArithmeticCheck : public ClangTidyCheck {
 public:
   ProBoundsPointerArithmeticCheck(StringRef Name, ClangTidyContext *Context)
       : ClangTidyCheck(Name, Context) {}
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 };

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -219,7 +219,8 @@ Changes in existing checks
 - Improved :doc:`cppcoreguidelines-pro-bounds-pointer-arithmetic
   <clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic>` check by
   fixing false positives when calling indexing operators that do not perform
-  pointer arithmetic in template, for example ``std::map::operator[]``.
+  pointer arithmetic in template, for example ``std::map::operator[]`` and
+  when pointer arithmetic was used through type aliases.
 
 - Improved :doc:`cppcoreguidelines-rvalue-reference-param-not-moved
   <clang-tidy/checks/cppcoreguidelines/rvalue-reference-param-not-moved>` check

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-pointer-arithmetic-pr36489.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-pointer-arithmetic-pr36489.cpp
@@ -1,11 +1,14 @@
 // RUN: %check_clang_tidy -std=c++14-or-later %s cppcoreguidelines-pro-bounds-pointer-arithmetic %t
 
 // Fix PR36489 and detect auto-deduced value correctly.
+typedef char* charPtr;
+
 char *getPtr();
 auto getPtrAuto() { return getPtr(); }
 decltype(getPtr()) getPtrDeclType();
 decltype(auto) getPtrDeclTypeAuto() { return getPtr(); }
 auto getPtrWithTrailingReturnType() -> char *;
+charPtr getCharPtr() { return getPtr(); }
 
 void auto_deduction_binary() {
   auto p1 = getPtr() + 1;
@@ -28,6 +31,10 @@ void auto_deduction_binary() {
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: do not use pointer arithmetic
   auto *p9 = getPtrDeclTypeAuto() + 1;
   // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: do not use pointer arithmetic
+  auto p10 = getCharPtr() + 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: do not use pointer 
+  auto* p11 = getCharPtr() + 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: do not use pointer arithmetic
 }
 
 void auto_deduction_subscript() {
@@ -49,5 +56,7 @@ void auto_deduction_subscript() {
   auto p7 = getPtrDeclType()[8];
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: do not use pointer arithmetic
   auto p8 = getPtrDeclTypeAuto()[9];
+  // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: do not use pointer arithmetic
+  auto p9 = getCharPtr()[10];
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: do not use pointer arithmetic
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-pointer-arithmetic.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-pointer-arithmetic.cpp
@@ -4,10 +4,13 @@ enum E {
   ENUM_LITERAL = 1
 };
 
+typedef int* IntPtr;
+
 int i = 4;
 int j = 1;
 int *p = 0;
 int *q = 0;
+IntPtr ip = 0;
 
 void fail() {
   q = p + 4;
@@ -50,6 +53,32 @@ void fail() {
 
   i = p[1];
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: do not use pointer arithmetic
+
+  p = ip + 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: do not use pointer arithmetic
+  ip++;
+  // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: do not use pointer arithmetic
+  i = ip[1];
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: do not use pointer arithmetic
+}
+
+template <typename T>
+void template_fail() {
+  T* p;
+  T* q;
+
+  p = q + 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: do not use pointer arithmetic
+  q = p - 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: do not use pointer arithmetic
+  p++;
+  // CHECK-MESSAGES: :[[@LINE-1]]:4: warning: do not use pointer arithmetic
+  i = p[1];
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: do not use pointer arithmetic
+}
+
+void instantiate() {
+  template_fail<int>();
 }
 
 struct S {


### PR DESCRIPTION
Fixed false negatives with type aliases in `cppcoreguidlines-pro-bounds-pointer-arithmetic` check.
Added tests with pointer arithmetic in template functions to make test cases more robust.

Closes https://github.com/llvm/llvm-project/issues/139241.