### PR TITLE
[lldb] Fix term settings completion tests

### DIFF
--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -334,22 +334,22 @@ class CommandLineCompletionTestCase(TestBase):
             "settings replace target.ru", "settings replace target.run-args"
         )
 
-    def test_settings_show_term(self):
+    def test_settings_show_term_width(self):
         self.complete_from_to("settings show term-w", "settings show term-width")
 
-    def test_settings_list_term(self):
+    def test_settings_list_term_width(self):
         self.complete_from_to("settings list term-w", "settings list term-width")
 
-    def test_settings_show_term(self):
+    def test_settings_show_term_height(self):
         self.complete_from_to("settings show term-h", "settings show term-height")
 
-    def test_settings_list_term(self):
+    def test_settings_list_term_height(self):
         self.complete_from_to("settings list term-h", "settings list term-height")
 
-    def test_settings_remove_term(self):
+    def test_settings_remove_term_width(self):
         self.complete_from_to("settings remove term-w", "settings remove term-width")
 
-    def test_settings_remove_term(self):
+    def test_settings_remove_term_height(self):
         self.complete_from_to("settings remove term-h", "settings remove term-height")
 
     def test_settings_s(self):


### PR DESCRIPTION
# PR Summary
Small PR - Several test functions for `term-width/height` completions had identical names, causing silent overriding. This gives them distinct _width/_height suffixes to ensure all tests run.