### PR TITLE
[MemRef] Added trait NoMemoryEffect to assume_alignment operation

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -142,7 +142,7 @@ class AllocLikeOp<string mnemonic,
 // AssumeAlignmentOp
 //===----------------------------------------------------------------------===//
 
-def AssumeAlignmentOp : MemRef_Op<"assume_alignment"> {
+def AssumeAlignmentOp : MemRef_Op<"assume_alignment", [NoMemoryEffect]> {
   let summary =
       "assertion that gives alignment information to the input memref";
   let description = [{


### PR DESCRIPTION
Assume_alignment has no trait which specifies how it interacts with memory, this causes an issue in OwnershipBasedBufferDeallocation, which require all operations which operate on buffers to have explicit traits defining how the operation interacts with memory.

To prevent this error, I changed assume_alignment to include the trait NoMemoryEffect. This is valid because assume_alignment is an assertion for optimization purposes only; it does not allocate, free, read, or write memory, nor does it change program semantics or memory state.