### PR TITLE
Fix tests of lookup table generator

### DIFF
--- a/clang/tools/include-mapping/test.py
+++ b/clang/tools/include-mapping/test.py
@@ -52,7 +52,7 @@ class TestStdGen(unittest.TestCase):
   </tr>
 </tbody></table>
 """
-        self.assertEqual(_ParseSymbolPage(html, "foo"), set(["<cmath>"]))
+        self.assertEqual(_ParseSymbolPage(html, "foo", "foo"), set(["<cmath>"]))
 
     def testParseSymbolPage_MulHeaders(self):
         #  Defined in header <cstddef>
@@ -92,7 +92,9 @@ class TestStdGen(unittest.TestCase):
   </tr>
 </tbody></table>
 """
-        self.assertEqual(_ParseSymbolPage(html, "foo"), set(["<cstdio>", "<cstdlib>"]))
+        self.assertEqual(
+            _ParseSymbolPage(html, "foo", "foo"), set(["<cstdio>", "<cstdlib>"])
+        )
 
     def testParseSymbolPage_MulHeadersInSameDiv(self):
         # Multile <code> blocks in a Div.
@@ -118,7 +120,7 @@ class TestStdGen(unittest.TestCase):
 </tbody></table>
 """
         self.assertEqual(
-            _ParseSymbolPage(html, "foo"), set(["<algorithm>", "<utility>"])
+            _ParseSymbolPage(html, "foo", "foo"), set(["<algorithm>", "<utility>"])
         )
 
     def testParseSymbolPage_MulSymbolsInSameTd(self):
@@ -142,8 +144,10 @@ class TestStdGen(unittest.TestCase):
 </tr>
 </tbody></table>
 """
-        self.assertEqual(_ParseSymbolPage(html, "int8_t"), set(["<cstdint>"]))
-        self.assertEqual(_ParseSymbolPage(html, "int16_t"), set(["<cstdint>"]))
+        self.assertEqual(_ParseSymbolPage(html, "int8_t", "int8_t"), set(["<cstdint>"]))
+        self.assertEqual(
+            _ParseSymbolPage(html, "int16_t", "int16_t"), set(["<cstdint>"])
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
In https://github.com/llvm/llvm-project/pull/113612/files#diff-ada12e18f3e902b41b6989b46455c4e32656276e59907026e2464cf57d10d583, the parameter `qual_name` was introduced. However, the tests have not been adopted accordingly and hence cannot be executed.

## What
Fix the execution of tests by providing the missing argument.