### PR TITLE
[clang] Compound Literal Statement Constant Expression Assertion Fix

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -589,6 +589,7 @@ Bug Fixes in This Version
 - Fixed a crash with an invalid member function parameter list with a default
   argument which contains a pragma. (#GH113722)
 - Fixed assertion failures when generating name lookup table in modules. (#GH61065, #GH134739)
+- Fixed an assertion failure in constant compound literal statements. (#GH139160)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -7248,8 +7248,7 @@ Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc, TypeSourceInfo *TInfo,
     if (auto ILE = dyn_cast<InitListExpr>(LiteralExpr))
       for (unsigned i = 0, j = ILE->getNumInits(); i != j; i++) {
         Expr *Init = ILE->getInit(i);
-        if (!Init->isTypeDependent() && !Init->isValueDependent() &&
-            !Init->getType()->isDependentType())
+        if (!Init->isTypeDependent() && !Init->isValueDependent())
           if (!Init->isConstantInitializer(Context, /*IsForRef=*/false)) {
             Diag(Init->getExprLoc(), diag::err_init_element_not_constant)
                 << Init->getSourceBitField();

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -7248,12 +7248,12 @@ Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc, TypeSourceInfo *TInfo,
     if (auto ILE = dyn_cast<InitListExpr>(LiteralExpr))
       for (unsigned i = 0, j = ILE->getNumInits(); i != j; i++) {
         Expr *Init = ILE->getInit(i);
-        if (!Init->isTypeDependent() && !Init->isValueDependent())
-          if (!Init->isConstantInitializer(Context, /*IsForRef=*/false)) {
-            Diag(Init->getExprLoc(), diag::err_init_element_not_constant)
-                << Init->getSourceBitField();
-            return ExprError();
-          }
+        if (!Init->isTypeDependent() && !Init->isValueDependent() &&
+            !Init->isConstantInitializer(Context, /*IsForRef=*/false)) {
+          Diag(Init->getExprLoc(), diag::err_init_element_not_constant)
+              << Init->getSourceBitField();
+          return ExprError();
+        }
 
         ILE->setInit(i, ConstantExpr::Create(Context, Init));
       }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -7241,16 +7241,16 @@ Sema::BuildCompoundLiteralExpr(SourceLocation LParenLoc, TypeSourceInfo *TInfo,
           ? VK_PRValue
           : VK_LValue;
 
+  // C99 6.5.2.5
+  //  "If the compound literal occurs outside the body of a function, the
+  //  initializer list shall consist of constant expressions."
   if (IsFileScope)
     if (auto ILE = dyn_cast<InitListExpr>(LiteralExpr))
       for (unsigned i = 0, j = ILE->getNumInits(); i != j; i++) {
         Expr *Init = ILE->getInit(i);
-        // C99 6.5.2.5
-        //  "If the compound literal occurs outside the body of a function, the
-        //  initializer list shall consist of constant expressions."
         if (!Init->isTypeDependent() && !Init->isValueDependent() &&
             !Init->getType()->isDependentType())
-          if (!Init->isConstantInitializer(Context, false)) {
+          if (!Init->isConstantInitializer(Context, /*IsForRef=*/false)) {
             Diag(Init->getExprLoc(), diag::err_init_element_not_constant)
                 << Init->getSourceBitField();
             return ExprError();

--- a/clang/test/SemaCXX/cxx2a-consteval.cpp
+++ b/clang/test/SemaCXX/cxx2a-consteval.cpp
@@ -1300,3 +1300,25 @@ void foo() {
 }
 
 }
+
+// https://github.com/llvm/llvm-project/issues/139160
+namespace GH139160{
+  // original test case taken from Github
+  struct A {int x[1]; }; 
+  A f(); // expected-note {{declared here}}
+  typedef int *t[];
+  consteval int* f(int* x) { return x; }
+
+  int ** x = (t){f(f().x)}; // expected-error    {{call to consteval function 'GH139160::f' is not a constant expression}}
+                            // expected-note@-1  {{non-constexpr function 'f' cannot be used in a constant expression}}
+                            // expected-error@-2 {{initializer element is not a compile-time constant}} 
+
+  struct B {int value, value_two;};
+  B make_struct() {return {10, 20};} // expected-note {{declared here}}
+  consteval int get_value(B container) {return container.value;}
+  B result = (B){10, get_value(make_struct())}; // expected-error {{initializer element is not a compile-time constant}} 
+                                                // expected-error@-1 {{call to consteval function 'GH139160::get_value' is not a constant expression}}
+                                                // expected-note@-2  {{non-constexpr function 'make_struct' cannot be used in a constant expression}}
+};
+
+


### PR DESCRIPTION
Compound literals initializer-list should be a constant expression if it is defined outside the body of a function.

Emit error instead of falling through tripping assertion error.

fixes #139160