### PR TITLE
[Clang][Sema] Disable checking invalid template id in primary variable template initializer

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -4382,6 +4382,8 @@ Sema::CheckVarTemplateId(VarTemplateDecl *Template, SourceLocation TemplateLoc,
       return Context.isSameTemplateArgument(Arg1, Arg2);
     };
 
+// Workaround for GH139067 / https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120190
+#if 0
     if (VarDecl *Var = Template->getTemplatedDecl();
         ParsingInitForAutoVars.count(Var) &&
         llvm::equal(
@@ -4393,6 +4395,7 @@ Sema::CheckVarTemplateId(VarTemplateDecl *Template, SourceLocation TemplateLoc,
           << diag::ParsingInitFor::VarTemplate << Var << Var->getType();
       return true;
     }
+#endif
 
     SmallVector<VarTemplatePartialSpecializationDecl *, 4> PartialSpecs;
     Template->getPartialSpecializations(PartialSpecs);

--- a/clang/test/SemaCXX/cxx1y-variable-templates_top_level.cpp
+++ b/clang/test/SemaCXX/cxx1y-variable-templates_top_level.cpp
@@ -495,12 +495,12 @@ static_assert(C<int, 0,1,2,3,4>::VALUEARRAY[0] == 0, "");
 
 namespace appear_in_its_own_init {
 template <class T>
-auto GH51347 = GH51347<T>; // expected-error {{variable template 'GH51347' declared with deduced type 'auto' cannot appear in its own initializer}}
+auto GH51347 = GH51347<T>;
 
 template <class T, class... Ts>
 auto a = [] {
   using U = T;
-  a<U, Ts...>; // expected-error {{variable template 'a' declared with deduced type 'auto' cannot appear in its own initializer}}
+  a<U, Ts...>;
 };
 
 template <int...> int b;


### PR DESCRIPTION
Workaround for #139067