### PR TITLE
[clang] Include <stddef.h> for size_t

### DIFF
--- a/clang/lib/Headers/mm_malloc.h
+++ b/clang/lib/Headers/mm_malloc.h
@@ -15,6 +15,8 @@
 #ifdef _WIN32
 #include <malloc.h>
 #else
+#include <stddef.h>
+
 #ifndef __cplusplus
 extern int posix_memalign(void **__memptr, size_t __alignment, size_t __size);
 #else


### PR DESCRIPTION
This is to fix Clang module build in chromium.