### PR TITLE
[X86][AVX10] Fix assertion with strict fcmp

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -24573,9 +24573,11 @@ SDValue X86TargetLowering::LowerSETCC(SDValue Op, SelectionDAG &DAG) const {
     if (CC == ISD::SETOEQ || CC == ISD::SETUNE) {
       auto NewCC = (CC == ISD::SETOEQ) ? X86::COND_E : (X86::COND_NE);
       assert(Op0.getSimpleValueType() != MVT::bf16 && "Unsupported Type");
-      if (Op0.getSimpleValueType() != MVT::f80)
-        return getSETCC(
+      if (Op0.getSimpleValueType() != MVT::f80) {
+        SDValue Res = getSETCC(
             NewCC, DAG.getNode(X86ISD::UCOMX, dl, MVT::i32, Op0, Op1), dl, DAG);
+        return IsStrict ? DAG.getMergeValues({Res, Chain}, dl) : Res;
+      }
     }
   }
   // Handle floating point.

--- a/llvm/test/CodeGen/X86/avx10_2-cmp.ll
+++ b/llvm/test/CodeGen/X86/avx10_2-cmp.ll
@@ -276,3 +276,24 @@ if.then66:                                        ; preds = %entry
 if.end70:                                         ; preds = %entry
   ret i32 0
 }
+
+define i1 @constrained_fcmp() {
+; X64-LABEL: constrained_fcmp:
+; X64:       # %bb.0: # %entry
+; X64-NEXT:    vxorpd %xmm0, %xmm0, %xmm0
+; X64-NEXT:    vucomxsd %xmm0, %xmm0
+; X64-NEXT:    setne %al
+; X64-NEXT:    retq
+;
+; X86-LABEL: constrained_fcmp:
+; X86:       # %bb.0: # %entry
+; X86-NEXT:    vxorpd %xmm0, %xmm0, %xmm0
+; X86-NEXT:    vucomxsd %xmm0, %xmm0
+; X86-NEXT:    setne %al
+; X86-NEXT:    retl
+entry:
+  %0 = tail call i1 @llvm.experimental.constrained.fcmps.f64(double 0.000000e+00, double 0.000000e+00, metadata !"une", metadata !"fpexcept.strict")
+  ret i1 %0
+}
+
+declare i1 @llvm.experimental.constrained.fcmps.f64(double, double, metadata, metadata)


### PR DESCRIPTION
Check the strict mode and return MERGE_VALUES to fix the assertion of invalid index for values defined in Res node.