### PR TITLE
[libc++] Use template variables in a bunch of places instead of class templates

### DIFF
--- a/libcxx/include/__algorithm/equal_range.h
+++ b/libcxx/include/__algorithm/equal_range.h
@@ -58,7 +58,7 @@ __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp
 template <class _ForwardIterator, class _Tp, class _Compare>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp) {
-  static_assert(__is_callable<_Compare&, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare&, decltype(*__first), const _Tp&>, "The comparator has to be callable");
   static_assert(is_copy_constructible<_ForwardIterator>::value, "Iterator has to be copy constructible");
   return std::__equal_range<_ClassicAlgPolicy>(
       std::move(__first),

--- a/libcxx/include/__algorithm/includes.h
+++ b/libcxx/include/__algorithm/includes.h
@@ -53,7 +53,7 @@ includes(_InputIterator1 __first1,
          _InputIterator2 __last2,
          _Compare __comp) {
   static_assert(
-      __is_callable<_Compare&, decltype(*__first1), decltype(*__first2)>::value, "The comparator has to be callable");
+      __is_callable_v<_Compare&, decltype(*__first1), decltype(*__first2)>, "The comparator has to be callable");
 
   return std::__includes(
       std::move(__first1),

--- a/libcxx/include/__algorithm/is_permutation.h
+++ b/libcxx/include/__algorithm/is_permutation.h
@@ -250,7 +250,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool is_permutation(
     _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __pred) {
-  static_assert(__is_callable<_BinaryPredicate&, decltype(*__first1), decltype(*__first2)>::value,
+  static_assert(__is_callable_v<_BinaryPredicate&, decltype(*__first1), decltype(*__first2)>,
                 "The comparator has to be callable");
 
   return std::__is_permutation<_ClassicAlgPolicy>(std::move(__first1), std::move(__last1), std::move(__first2), __pred);
@@ -287,7 +287,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
     _ForwardIterator2 __first2,
     _ForwardIterator2 __last2,
     _BinaryPredicate __pred) {
-  static_assert(__is_callable<_BinaryPredicate&, decltype(*__first1), decltype(*__first2)>::value,
+  static_assert(__is_callable_v<_BinaryPredicate&, decltype(*__first1), decltype(*__first2)>,
                 "The comparator has to be callable");
 
   return std::__is_permutation<_ClassicAlgPolicy>(

--- a/libcxx/include/__algorithm/lower_bound.h
+++ b/libcxx/include/__algorithm/lower_bound.h
@@ -92,7 +92,7 @@ __lower_bound(_ForwardIterator __first, _Sent __last, const _Type& __value, _Com
 template <class _ForwardIterator, class _Tp, class _Compare>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 lower_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp) {
-  static_assert(__is_callable<_Compare&, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare&, decltype(*__first), const _Tp&>, "The comparator has to be callable");
   auto __proj = std::__identity();
   return std::__lower_bound<_ClassicAlgPolicy>(__first, __last, __value, __comp, __proj);
 }

--- a/libcxx/include/__algorithm/max_element.h
+++ b/libcxx/include/__algorithm/max_element.h
@@ -39,7 +39,7 @@ template <class _ForwardIterator, class _Compare>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
   static_assert(
-      __is_callable<_Compare&, decltype(*__first), decltype(*__first)>::value, "The comparator has to be callable");
+      __is_callable_v<_Compare&, decltype(*__first), decltype(*__first)>, "The comparator has to be callable");
   return std::__max_element<__comp_ref_type<_Compare> >(__first, __last, __comp);
 }
 

--- a/libcxx/include/__algorithm/min_element.h
+++ b/libcxx/include/__algorithm/min_element.h
@@ -53,7 +53,7 @@ min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) 
   static_assert(
       __has_forward_iterator_category<_ForwardIterator>::value, "std::min_element requires a ForwardIterator");
   static_assert(
-      __is_callable<_Compare&, decltype(*__first), decltype(*__first)>::value, "The comparator has to be callable");
+      __is_callable_v<_Compare&, decltype(*__first), decltype(*__first)>, "The comparator has to be callable");
 
   return std::__min_element<__comp_ref_type<_Compare> >(std::move(__first), std::move(__last), __comp);
 }

--- a/libcxx/include/__algorithm/minmax.h
+++ b/libcxx/include/__algorithm/minmax.h
@@ -40,7 +40,7 @@ minmax(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __
 template <class _Tp, class _Compare>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Tp, _Tp>
 minmax(initializer_list<_Tp> __t, _Compare __comp) {
-  static_assert(__is_callable<_Compare&, _Tp, _Tp>::value, "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare&, _Tp, _Tp>, "The comparator has to be callable");
   __identity __proj;
   auto __ret = std::__minmax_element_impl(__t.begin(), __t.end(), __comp, __proj);
   return pair<_Tp, _Tp>(*__ret.first, *__ret.second);

--- a/libcxx/include/__algorithm/minmax_element.h
+++ b/libcxx/include/__algorithm/minmax_element.h
@@ -84,7 +84,7 @@ minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __com
   static_assert(
       __has_forward_iterator_category<_ForwardIterator>::value, "std::minmax_element requires a ForwardIterator");
   static_assert(
-      __is_callable<_Compare&, decltype(*__first), decltype(*__first)>::value, "The comparator has to be callable");
+      __is_callable_v<_Compare&, decltype(*__first), decltype(*__first)>, "The comparator has to be callable");
   auto __proj = __identity();
   return std::__minmax_element_impl(__first, __last, __comp, __proj);
 }

--- a/libcxx/include/__algorithm/partial_sort_copy.h
+++ b/libcxx/include/__algorithm/partial_sort_copy.h
@@ -76,8 +76,8 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
     _RandomAccessIterator __result_first,
     _RandomAccessIterator __result_last,
     _Compare __comp) {
-  static_assert(__is_callable<_Compare&, decltype(*__first), decltype(*__result_first)>::value,
-                "The comparator has to be callable");
+  static_assert(
+      __is_callable_v<_Compare&, decltype(*__first), decltype(*__result_first)>, "The comparator has to be callable");
 
   auto __result = std::__partial_sort_copy<_ClassicAlgPolicy>(
       __first,

--- a/libcxx/include/__algorithm/search.h
+++ b/libcxx/include/__algorithm/search.h
@@ -166,7 +166,7 @@ search(_ForwardIterator1 __first1,
        _ForwardIterator2 __first2,
        _ForwardIterator2 __last2,
        _BinaryPredicate __pred) {
-  static_assert(__is_callable<_BinaryPredicate&, decltype(*__first1), decltype(*__first2)>::value,
+  static_assert(__is_callable_v<_BinaryPredicate&, decltype(*__first1), decltype(*__first2)>,
                 "The comparator has to be callable");
   auto __proj = __identity();
   return std::__search_impl(__first1, __last1, __first2, __last2, __pred, __proj, __proj).first;

--- a/libcxx/include/__algorithm/search_n.h
+++ b/libcxx/include/__algorithm/search_n.h
@@ -152,7 +152,7 @@ template <class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator search_n(
     _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred) {
   static_assert(
-      __is_callable<_BinaryPredicate&, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
+      __is_callable_v<_BinaryPredicate&, decltype(*__first), const _Tp&>, "The comparator has to be callable");
   auto __proj = __identity();
   return std::__search_n_impl(__first, __last, std::__convert_to_integral(__count), __value, __pred, __proj).first;
 }

--- a/libcxx/include/__algorithm/upper_bound.h
+++ b/libcxx/include/__algorithm/upper_bound.h
@@ -52,7 +52,7 @@ __upper_bound(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp
 template <class _ForwardIterator, class _Tp, class _Compare>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp) {
-  static_assert(__is_callable<_Compare&, const _Tp&, decltype(*__first)>::value, "The comparator has to be callable");
+  static_assert(__is_callable_v<_Compare&, const _Tp&, decltype(*__first)>, "The comparator has to be callable");
   static_assert(is_copy_constructible<_ForwardIterator>::value, "Iterator has to be copy constructible");
   return std::__upper_bound<_ClassicAlgPolicy>(
       std::move(__first), std::move(__last), __value, std::move(__comp), std::__identity());

--- a/libcxx/include/__expected/unexpected.h
+++ b/libcxx/include/__expected/unexpected.h
@@ -17,6 +17,7 @@
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__type_traits/is_object.h>
 #include <__type_traits/is_same.h>
+#include <__type_traits/is_specialization.h>
 #include <__type_traits/is_swappable.h>
 #include <__type_traits/is_volatile.h>
 #include <__type_traits/negation.h>
@@ -42,16 +43,16 @@ template <class _Err>
 class unexpected;
 
 template <class _Tp>
-struct __is_std_unexpected : false_type {};
+inline constexpr bool __is_std_unexpected_v = false;
 
-template <class _Err>
-struct __is_std_unexpected<unexpected<_Err>> : true_type {};
+template <class _Tp>
+inline constexpr bool __is_std_unexpected_v<unexpected<_Tp>> = true;
 
 template <class _Tp>
 using __valid_std_unexpected _LIBCPP_NODEBUG = _BoolConstant< //
     is_object_v<_Tp> &&                                       //
     !is_array_v<_Tp> &&                                       //
-    !__is_std_unexpected<_Tp>::value &&                       //
+    !__is_std_unexpected_v<_Tp> &&                            //
     !is_const_v<_Tp> &&                                       //
     !is_volatile_v<_Tp>                                       //
     >;

--- a/libcxx/include/__functional/bind.h
+++ b/libcxx/include/__functional/bind.h
@@ -105,11 +105,11 @@ __mu(_Ti&, _Uj& __uj) {
   return std::forward<typename tuple_element<__indx, _Uj>::type>(std::get<__indx>(__uj));
 }
 
-template <class _Ti,
-          class _Uj,
-          __enable_if_t<!is_bind_expression<_Ti>::value && is_placeholder<_Ti>::value == 0 &&
-                            !__is_reference_wrapper<_Ti>::value,
-                        int> = 0>
+template <
+    class _Ti,
+    class _Uj,
+    __enable_if_t<!is_bind_expression<_Ti>::value && is_placeholder<_Ti>::value == 0 && !__is_reference_wrapper_v<_Ti>,
+                  int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Ti& __mu(_Ti& __ti, _Uj&) {
   return __ti;
 }
@@ -151,27 +151,23 @@ template <class _Ti, class _TupleUj>
 struct __mu_return
     : public __mu_return_impl<
           _Ti,
-          __is_reference_wrapper<_Ti>::value,
+          __is_reference_wrapper_v<_Ti>,
           is_bind_expression<_Ti>::value,
           0 < is_placeholder<_Ti>::value && is_placeholder<_Ti>::value <= tuple_size<_TupleUj>::value,
           _TupleUj> {};
 
 template <class _Fp, class _BoundArgs, class _TupleUj>
-struct __is_valid_bind_return {
-  static const bool value = false;
-};
+inline const bool __is_valid_bind_return_v = false;
 
 template <class _Fp, class... _BoundArgs, class _TupleUj>
-struct __is_valid_bind_return<_Fp, tuple<_BoundArgs...>, _TupleUj> {
-  static const bool value = __is_invocable_v<_Fp, typename __mu_return<_BoundArgs, _TupleUj>::type...>;
-};
+inline const bool __is_valid_bind_return_v<_Fp, tuple<_BoundArgs...>, _TupleUj> =
+    __is_invocable_v<_Fp, typename __mu_return<_BoundArgs, _TupleUj>::type...>;
 
 template <class _Fp, class... _BoundArgs, class _TupleUj>
-struct __is_valid_bind_return<_Fp, const tuple<_BoundArgs...>, _TupleUj> {
-  static const bool value = __is_invocable_v<_Fp, typename __mu_return<const _BoundArgs, _TupleUj>::type...>;
-};
+inline const bool __is_valid_bind_return_v<_Fp, const tuple<_BoundArgs...>, _TupleUj> =
+    __is_invocable_v<_Fp, typename __mu_return<const _BoundArgs, _TupleUj>::type...>;
 
-template <class _Fp, class _BoundArgs, class _TupleUj, bool = __is_valid_bind_return<_Fp, _BoundArgs, _TupleUj>::value>
+template <class _Fp, class _BoundArgs, class _TupleUj, bool = __is_valid_bind_return_v<_Fp, _BoundArgs, _TupleUj> >
 struct __bind_return;
 
 template <class _Fp, class... _BoundArgs, class _TupleUj>

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -38,6 +38,7 @@
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__type_traits/is_reference.h>
 #include <__type_traits/is_same.h>
+#include <__type_traits/is_specialization.h>
 #include <__type_traits/is_swappable.h>
 #include <__type_traits/remove_const.h>
 #include <__type_traits/remove_cvref.h>
@@ -61,17 +62,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Key, class _Tp>
 struct __hash_value_type;
 
-template <class _Tp>
-struct __is_hash_value_type_imp : false_type {};
-
-template <class _Key, class _Value>
-struct __is_hash_value_type_imp<__hash_value_type<_Key, _Value> > : true_type {};
-
 template <class... _Args>
-struct __is_hash_value_type : false_type {};
+inline const bool __is_hash_value_type_v = false;
 
 template <class _One>
-struct __is_hash_value_type<_One> : __is_hash_value_type_imp<__remove_cvref_t<_One> > {};
+inline const bool __is_hash_value_type_v<_One> = __is_specialization_v<__remove_cvref_t<_One>, __hash_value_type>;
 
 _LIBCPP_EXPORTED_FROM_ABI size_t __next_prime(size_t __n);
 
@@ -839,28 +834,28 @@ public:
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI iterator __emplace_hint_multi(const_iterator __p, _Args&&... __args);
 
-  template <class _ValueT = _Tp, __enable_if_t<__is_hash_value_type<_ValueT>::value, int> = 0>
+  template <class _ValueT = _Tp, __enable_if_t<__is_hash_value_type_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __insert_unique_from_orphaned_node(value_type&& __value) {
     __node_holder __h = __construct_node(const_cast<key_type&&>(__value.first), std::move(__value.second));
     __node_insert_unique(__h.get());
     __h.release();
   }
 
-  template <class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type<_ValueT>::value, int> = 0>
+  template <class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __insert_unique_from_orphaned_node(value_type&& __value) {
     __node_holder __h = __construct_node(std::move(__value));
     __node_insert_unique(__h.get());
     __h.release();
   }
 
-  template <class _ValueT = _Tp, __enable_if_t<__is_hash_value_type<_ValueT>::value, int> = 0>
+  template <class _ValueT = _Tp, __enable_if_t<__is_hash_value_type_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __insert_multi_from_orphaned_node(value_type&& __value) {
     __node_holder __h = __construct_node(const_cast<key_type&&>(__value.first), std::move(__value.second));
     __node_insert_multi(__h.get());
     __h.release();
   }
 
-  template <class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type<_ValueT>::value, int> = 0>
+  template <class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __insert_multi_from_orphaned_node(value_type&& __value) {
     __node_holder __h = __construct_node(std::move(__value));
     __node_insert_multi(__h.get());
@@ -1042,7 +1037,7 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI __next_pointer __detach() _NOEXCEPT;
 
-  template <class _From, class _ValueT = _Tp, __enable_if_t<__is_hash_value_type<_ValueT>::value, int> = 0>
+  template <class _From, class _ValueT = _Tp, __enable_if_t<__is_hash_value_type_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __assign_value(__get_hash_node_value_type_t<_Tp>& __lhs, _From&& __rhs) {
     // This is technically UB, since the object was constructed as `const`.
     // Clang doesn't optimize on this currently though.
@@ -1050,7 +1045,7 @@ private:
     __lhs.second                       = std::forward<_From>(__rhs).second;
   }
 
-  template <class _From, class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type<_ValueT>::value, int> = 0>
+  template <class _From, class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __assign_value(_Tp& __lhs, _From&& __rhs) {
     __lhs = std::forward<_From>(__rhs);
   }
@@ -1818,7 +1813,7 @@ template <class _Tp, class _Hash, class _Equal, class _Alloc>
 template <class... _Args>
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_holder
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__construct_node(_Args&&... __args) {
-  static_assert(!__is_hash_value_type<_Args...>::value, "Construct cannot be called with a hash value type");
+  static_assert(!__is_hash_value_type_v<_Args...>, "Construct cannot be called with a hash value type");
   __node_allocator& __na = __node_alloc();
   __node_holder __h(__node_traits::allocate(__na, 1), _Dp(__na));
 
@@ -1839,7 +1834,7 @@ template <class _Tp, class _Hash, class _Equal, class _Alloc>
 template <class... _Args>
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_holder
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__construct_node_hash(size_t __hash, _Args&&... __args) {
-  static_assert(!__is_hash_value_type<_Args...>::value, "Construct cannot be called with a hash value type");
+  static_assert(!__is_hash_value_type_v<_Args...>, "Construct cannot be called with a hash value type");
   __node_allocator& __na = __node_alloc();
   __node_holder __h(__node_traits::allocate(__na, 1), _Dp(__na));
   std::__construct_at(std::addressof(*__h), /* hash = */ __hash, __na, std::forward<_Args>(__args)...);

--- a/libcxx/include/__mdspan/extents.h
+++ b/libcxx/include/__mdspan/extents.h
@@ -479,13 +479,10 @@ namespace __mdspan_detail {
 
 // Helper type traits for identifying a class as extents.
 template <class _Tp>
-struct __is_extents : false_type {};
+inline constexpr bool __is_extents_v = false;
 
 template <class _IndexType, size_t... _ExtentsPack>
-struct __is_extents<extents<_IndexType, _ExtentsPack...>> : true_type {};
-
-template <class _Tp>
-inline constexpr bool __is_extents_v = __is_extents<_Tp>::value;
+inline constexpr bool __is_extents_v<extents<_IndexType, _ExtentsPack...>> = true;
 
 // Function to check whether a set of indices are a multidimensional
 // index into extents. This is a word of power in the C++ standard

--- a/libcxx/include/__mdspan/layout_left.h
+++ b/libcxx/include/__mdspan/layout_left.h
@@ -43,7 +43,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Extents>
 class layout_left::mapping {
 public:
-  static_assert(__mdspan_detail::__is_extents<_Extents>::value,
+  static_assert(__mdspan_detail::__is_extents_v<_Extents>,
                 "layout_left::mapping template argument must be a specialization of extents.");
 
   using extents_type = _Extents;

--- a/libcxx/include/__mdspan/layout_right.h
+++ b/libcxx/include/__mdspan/layout_right.h
@@ -43,7 +43,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Extents>
 class layout_right::mapping {
 public:
-  static_assert(__mdspan_detail::__is_extents<_Extents>::value,
+  static_assert(__mdspan_detail::__is_extents_v<_Extents>,
                 "layout_right::mapping template argument must be a specialization of extents.");
 
   using extents_type = _Extents;

--- a/libcxx/include/__mdspan/layout_stride.h
+++ b/libcxx/include/__mdspan/layout_stride.h
@@ -68,7 +68,7 @@ concept __layout_mapping_alike = requires {
 template <class _Extents>
 class layout_stride::mapping {
 public:
-  static_assert(__mdspan_detail::__is_extents<_Extents>::value,
+  static_assert(__mdspan_detail::__is_extents_v<_Extents>,
                 "layout_stride::mapping template argument must be a specialization of extents.");
 
   using extents_type = _Extents;

--- a/libcxx/include/__random/discard_block_engine.h
+++ b/libcxx/include/__random/discard_block_engine.h
@@ -64,10 +64,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit discard_block_engine(_Engine&& __e) : __e_(std::move(__e)), __n_(0) {}
 #endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI explicit discard_block_engine(result_type __sd) : __e_(__sd), __n_(0) {}
-  template <
-      class _Sseq,
-      __enable_if_t<__is_seed_sequence<_Sseq, discard_block_engine>::value && !is_convertible<_Sseq, _Engine>::value,
-                    int> = 0>
+  template <class _Sseq,
+            __enable_if_t<__is_seed_sequence_v<_Sseq, discard_block_engine> && !is_convertible<_Sseq, _Engine>::value,
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit discard_block_engine(_Sseq& __q) : __e_(__q), __n_(0) {}
   _LIBCPP_HIDE_FROM_ABI void seed() {
     __e_.seed();
@@ -77,7 +76,7 @@ public:
     __e_.seed(__sd);
     __n_ = 0;
   }
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, discard_block_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, discard_block_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void seed(_Sseq& __q) {
     __e_.seed(__q);
     __n_ = 0;

--- a/libcxx/include/__random/independent_bits_engine.h
+++ b/libcxx/include/__random/independent_bits_engine.h
@@ -94,12 +94,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit independent_bits_engine(result_type __sd) : __e_(__sd) {}
   template <
       class _Sseq,
-      __enable_if_t<__is_seed_sequence<_Sseq, independent_bits_engine>::value && !is_convertible<_Sseq, _Engine>::value,
+      __enable_if_t<__is_seed_sequence_v<_Sseq, independent_bits_engine> && !is_convertible<_Sseq, _Engine>::value,
                     int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit independent_bits_engine(_Sseq& __q) : __e_(__q) {}
   _LIBCPP_HIDE_FROM_ABI void seed() { __e_.seed(); }
   _LIBCPP_HIDE_FROM_ABI void seed(result_type __sd) { __e_.seed(__sd); }
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, independent_bits_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, independent_bits_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void seed(_Sseq& __q) {
     __e_.seed(__q);
   }

--- a/libcxx/include/__random/is_seed_sequence.h
+++ b/libcxx/include/__random/is_seed_sequence.h
@@ -21,10 +21,8 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Sseq, class _Engine>
-struct __is_seed_sequence {
-  static _LIBCPP_CONSTEXPR const bool value =
-      !is_convertible<_Sseq, typename _Engine::result_type>::value && !is_same<__remove_cv_t<_Sseq>, _Engine>::value;
-};
+inline const bool __is_seed_sequence_v =
+    !is_convertible<_Sseq, typename _Engine::result_type>::value && !is_same<__remove_cv_t<_Sseq>, _Engine>::value;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__random/linear_congruential_engine.h
+++ b/libcxx/include/__random/linear_congruential_engine.h
@@ -265,14 +265,14 @@ public:
 #else
   _LIBCPP_HIDE_FROM_ABI explicit linear_congruential_engine(result_type __s = default_seed) { seed(__s); }
 #endif
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, linear_congruential_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, linear_congruential_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit linear_congruential_engine(_Sseq& __q) {
     seed(__q);
   }
   _LIBCPP_HIDE_FROM_ABI void seed(result_type __s = default_seed) {
     seed(integral_constant<bool, __m == 0>(), integral_constant<bool, __c == 0>(), __s);
   }
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, linear_congruential_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, linear_congruential_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void seed(_Sseq& __q) {
     __seed(
         __q,

--- a/libcxx/include/__random/mersenne_twister_engine.h
+++ b/libcxx/include/__random/mersenne_twister_engine.h
@@ -172,7 +172,7 @@ public:
 #else
   _LIBCPP_HIDE_FROM_ABI explicit mersenne_twister_engine(result_type __sd = default_seed) { seed(__sd); }
 #endif
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, mersenne_twister_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, mersenne_twister_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit mersenne_twister_engine(_Sseq& __q) {
     seed(__q);
   }
@@ -182,7 +182,7 @@ public:
       __x_[__i] = (__f * (__x_[__i - 1] ^ __rshift<__w - 2>(__x_[__i - 1])) + __i) & _Max;
     __i_ = 0;
   }
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, mersenne_twister_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, mersenne_twister_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void seed(_Sseq& __q) {
     __seed(__q, integral_constant<unsigned, 1 + (__w - 1) / 32>());
   }

--- a/libcxx/include/__random/shuffle_order_engine.h
+++ b/libcxx/include/__random/shuffle_order_engine.h
@@ -88,10 +88,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit shuffle_order_engine(_Engine&& __e) : __e_(std::move(__e)) { __init(); }
 #endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI explicit shuffle_order_engine(result_type __sd) : __e_(__sd) { __init(); }
-  template <
-      class _Sseq,
-      __enable_if_t<__is_seed_sequence<_Sseq, shuffle_order_engine>::value && !is_convertible<_Sseq, _Engine>::value,
-                    int> = 0>
+  template <class _Sseq,
+            __enable_if_t<__is_seed_sequence_v<_Sseq, shuffle_order_engine> && !is_convertible<_Sseq, _Engine>::value,
+                          int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit shuffle_order_engine(_Sseq& __q) : __e_(__q) {
     __init();
   }
@@ -103,7 +102,7 @@ public:
     __e_.seed(__sd);
     __init();
   }
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, shuffle_order_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, shuffle_order_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void seed(_Sseq& __q) {
     __e_.seed(__q);
     __init();

--- a/libcxx/include/__random/subtract_with_carry_engine.h
+++ b/libcxx/include/__random/subtract_with_carry_engine.h
@@ -86,14 +86,14 @@ public:
 #else
   _LIBCPP_HIDE_FROM_ABI explicit subtract_with_carry_engine(result_type __sd = default_seed) { seed(__sd); }
 #endif
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, subtract_with_carry_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, subtract_with_carry_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit subtract_with_carry_engine(_Sseq& __q) {
     seed(__q);
   }
   _LIBCPP_HIDE_FROM_ABI void seed(result_type __sd = default_seed) {
     seed(__sd, integral_constant<unsigned, 1 + (__w - 1) / 32>());
   }
-  template <class _Sseq, __enable_if_t<__is_seed_sequence<_Sseq, subtract_with_carry_engine>::value, int> = 0>
+  template <class _Sseq, __enable_if_t<__is_seed_sequence_v<_Sseq, subtract_with_carry_engine>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void seed(_Sseq& __q) {
     __seed(__q, integral_constant<unsigned, 1 + (__w - 1) / 32>());
   }

--- a/libcxx/include/__type_traits/invoke.h
+++ b/libcxx/include/__type_traits/invoke.h
@@ -107,7 +107,7 @@ inline const bool __is_invocable_r_impl = false;
 
 template <class _Ret, class... _Args>
 inline const bool __is_invocable_r_impl<_Ret, true, _Args...> =
-    __is_core_convertible<__invoke_result_t<_Args...>, _Ret>::value || is_void<_Ret>::value;
+    __is_core_convertible_v<__invoke_result_t<_Args...>, _Ret> || is_void<_Ret>::value;
 
 template <class _Ret, class... _Args>
 inline const bool __is_invocable_r_v = __is_invocable_r_impl<_Ret, __is_invocable_v<_Args...>, _Args...>;
@@ -155,7 +155,7 @@ using __enable_if_bullet1 _LIBCPP_NODEBUG =
 
 template <class _Fp, class _A0, class _DecayFp = __decay_t<_Fp>, class _DecayA0 = __decay_t<_A0> >
 using __enable_if_bullet2 _LIBCPP_NODEBUG =
-    __enable_if_t<is_member_function_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
+    __enable_if_t<is_member_function_pointer<_DecayFp>::value && __is_reference_wrapper_v<_DecayA0> >;
 
 template <class _Fp,
           class _A0,
@@ -165,7 +165,7 @@ template <class _Fp,
 using __enable_if_bullet3 _LIBCPP_NODEBUG =
     __enable_if_t<is_member_function_pointer<_DecayFp>::value &&
                   !(is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value) &&
-                  !__is_reference_wrapper<_DecayA0>::value>;
+                  !__is_reference_wrapper_v<_DecayA0> >;
 
 template <class _Fp,
           class _A0,
@@ -178,7 +178,7 @@ using __enable_if_bullet4 _LIBCPP_NODEBUG =
 
 template <class _Fp, class _A0, class _DecayFp = __decay_t<_Fp>, class _DecayA0 = __decay_t<_A0> >
 using __enable_if_bullet5 _LIBCPP_NODEBUG =
-    __enable_if_t<is_member_object_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
+    __enable_if_t<is_member_object_pointer<_DecayFp>::value && __is_reference_wrapper_v<_DecayA0> >;
 
 template <class _Fp,
           class _A0,
@@ -188,7 +188,7 @@ template <class _Fp,
 using __enable_if_bullet6 _LIBCPP_NODEBUG =
     __enable_if_t<is_member_object_pointer<_DecayFp>::value &&
                   !(is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value) &&
-                  !__is_reference_wrapper<_DecayA0>::value>;
+                  !__is_reference_wrapper_v<_DecayA0> >;
 
 // __invoke forward declarations
 
@@ -267,7 +267,7 @@ struct __invokable_r {
   using _Result _LIBCPP_NODEBUG = decltype(__try_call<_Fp, _Args...>(0));
 
   using type              = __conditional_t<_IsNotSame<_Result, __nat>::value,
-                                            __conditional_t<is_void<_Ret>::value, true_type, __is_core_convertible<_Result, _Ret> >,
+                                            integral_constant<bool, is_void<_Ret>::value || __is_core_convertible_v<_Result, _Ret> >,
                                             false_type>;
   static const bool value = type::value;
 };

--- a/libcxx/include/__type_traits/is_callable.h
+++ b/libcxx/include/__type_traits/is_callable.h
@@ -25,7 +25,7 @@ template <class...>
 false_type __is_callable_helper(...);
 
 template <class _Func, class... _Args>
-struct __is_callable : decltype(std::__is_callable_helper<_Func, _Args...>(0)) {};
+inline const bool __is_callable_v = decltype(std::__is_callable_helper<_Func, _Args...>(0))::value;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/is_core_convertible.h
+++ b/libcxx/include/__type_traits/is_core_convertible.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_IS_CORE_CONVERTIBLE_H
 
 #include <__config>
-#include <__type_traits/integral_constant.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -29,9 +28,6 @@ inline const bool __is_core_convertible_v = false;
 template <class _Tp, class _Up>
 inline const bool
     __is_core_convertible_v<_Tp, _Up, decltype(static_cast<void (*)(_Up)>(0)(static_cast<_Tp (*)()>(0)()))> = true;
-
-template <class _Tp, class _Up>
-using __is_core_convertible _LIBCPP_NODEBUG = integral_constant<bool, __is_core_convertible_v<_Tp, _Up> >;
 
 #if _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__type_traits/is_equality_comparable.h
+++ b/libcxx/include/__type_traits/is_equality_comparable.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/enable_if.h>
-#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_integral.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_signed.h>

--- a/libcxx/include/__type_traits/is_reference_wrapper.h
+++ b/libcxx/include/__type_traits/is_reference_wrapper.h
@@ -11,7 +11,7 @@
 
 #include <__config>
 #include <__fwd/functional.h>
-#include <__type_traits/integral_constant.h>
+#include <__type_traits/is_specialization.h>
 #include <__type_traits/remove_cv.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -21,11 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __is_reference_wrapper_impl : false_type {};
-template <class _Tp>
-struct __is_reference_wrapper_impl<reference_wrapper<_Tp> > : true_type {};
-template <class _Tp>
-struct __is_reference_wrapper : __is_reference_wrapper_impl<__remove_cv_t<_Tp> > {};
+inline const bool __is_reference_wrapper_v = __is_specialization_v<__remove_cv_t<_Tp>, reference_wrapper>;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__utility/in_place.h
+++ b/libcxx/include/__utility/in_place.h
@@ -12,6 +12,7 @@
 #include <__config>
 #include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
+#include <__type_traits/is_specialization.h>
 #include <__type_traits/remove_cvref.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -42,20 +43,15 @@ template <size_t _Idx>
 inline constexpr in_place_index_t<_Idx> in_place_index{};
 
 template <class _Tp>
-struct __is_inplace_type_imp : false_type {};
-template <class _Tp>
-struct __is_inplace_type_imp<in_place_type_t<_Tp>> : true_type {};
+inline constexpr bool __is_in_place_type_v = __is_specialization_v<__remove_cvref_t<_Tp>, in_place_type_t>;
 
 template <class _Tp>
-using __is_inplace_type _LIBCPP_NODEBUG = __is_inplace_type_imp<__remove_cvref_t<_Tp>>;
-
-template <class _Tp>
-struct __is_inplace_index_imp : false_type {};
+inline constexpr bool __is_in_place_index_impl = false;
 template <size_t _Idx>
-struct __is_inplace_index_imp<in_place_index_t<_Idx>> : true_type {};
+inline constexpr bool __is_in_place_index_impl<in_place_index_t<_Idx>> = true;
 
 template <class _Tp>
-using __is_inplace_index _LIBCPP_NODEBUG = __is_inplace_index_imp<__remove_cvref_t<_Tp>>;
+inline constexpr bool __is_in_place_index_v = __is_in_place_index_impl<__remove_cvref_t<_Tp>>;
 
 #endif // _LIBCPP_STD_VER >= 17
 

--- a/libcxx/include/__utility/is_pointer_in_range.h
+++ b/libcxx/include/__utility/is_pointer_in_range.h
@@ -26,13 +26,13 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Up, class = void>
-struct __is_less_than_comparable : false_type {};
+inline const bool __is_less_than_comparable_v = false;
 
 template <class _Tp, class _Up>
-struct __is_less_than_comparable<_Tp, _Up, __void_t<decltype(std::declval<_Tp>() < std::declval<_Up>())> > : true_type {
-};
+inline const bool
+    __is_less_than_comparable_v<_Tp, _Up, __void_t<decltype(std::declval<_Tp>() < std::declval<_Up>())> > = true;
 
-template <class _Tp, class _Up, __enable_if_t<__is_less_than_comparable<const _Tp*, const _Up*>::value, int> = 0>
+template <class _Tp, class _Up, __enable_if_t<__is_less_than_comparable_v<const _Tp*, const _Up*>, int> = 0>
 _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool
 __is_pointer_in_range(const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
   _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__begin, __end), "[__begin, __end) is not a valid range");
@@ -47,7 +47,7 @@ __is_pointer_in_range(const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
   return !__less<>()(__ptr, __begin) && __less<>()(__ptr, __end);
 }
 
-template <class _Tp, class _Up, __enable_if_t<!__is_less_than_comparable<const _Tp*, const _Up*>::value, int> = 0>
+template <class _Tp, class _Up, __enable_if_t<!__is_less_than_comparable_v<const _Tp*, const _Up*>, int> = 0>
 _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool
 __is_pointer_in_range(const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
   if (__libcpp_is_constant_evaluated())

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -201,10 +201,10 @@ public:
       __other.__call(_Action::_Move, this);
   }
 
-  template <class _ValueType,
-            class _Tp        = decay_t<_ValueType>,
-            enable_if_t<!is_same_v<_Tp, any> && !__is_inplace_type<_ValueType>::value && is_copy_constructible_v<_Tp>,
-                        int> = 0>
+  template <
+      class _ValueType,
+      class _Tp = decay_t<_ValueType>,
+      enable_if_t<!is_same_v<_Tp, any> && !__is_in_place_type_v<_ValueType> && is_copy_constructible_v<_Tp>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI any(_ValueType&& __value) : __h_(nullptr) {
     __any_imp::_Handler<_Tp>::__create(*this, std::forward<_ValueType>(__value));
   }

--- a/libcxx/include/experimental/propagate_const
+++ b/libcxx/include/experimental/propagate_const
@@ -150,6 +150,12 @@ template <class _Tp>
 class propagate_const;
 
 template <class _Up>
+inline constexpr bool __is_propagate_const_v = false;
+
+template <class _Up>
+inline constexpr bool __is_propagate_const_v<propagate_const<_Up>> = true;
+
+template <class _Up>
 inline _LIBCPP_HIDE_FROM_ABI constexpr const _Up& get_underlying(const propagate_const<_Up>& __pu) _NOEXCEPT;
 
 template <class _Up>
@@ -188,12 +194,6 @@ private:
     return __get_pointer(__u.get());
   }
 
-  template <class _Up>
-  struct __is_propagate_const : false_type {};
-
-  template <class _Up>
-  struct __is_propagate_const<propagate_const<_Up>> : true_type {};
-
   _Tp __t_;
 
 public:
@@ -220,13 +220,13 @@ public:
 
   template <class _Up,
             enable_if_t<!is_convertible<_Up&&, _Tp>::value && is_constructible<_Tp, _Up&&>::value &&
-                            !__is_propagate_const<decay_t<_Up>>::value,
+                            !__is_propagate_const_v<decay_t<_Up>>,
                         bool> = true>
   explicit _LIBCPP_HIDE_FROM_ABI constexpr propagate_const(_Up&& __u) : __t_(std::forward<_Up>(__u)) {}
 
   template <class _Up,
             enable_if_t<is_convertible<_Up&&, _Tp>::value && is_constructible<_Tp, _Up&&>::value &&
-                            !__is_propagate_const<decay_t<_Up>>::value,
+                            !__is_propagate_const_v<decay_t<_Up>>,
                         bool> = false>
   _LIBCPP_HIDE_FROM_ABI constexpr propagate_const(_Up&& __u) : __t_(std::forward<_Up>(__u)) {}
 
@@ -240,7 +240,7 @@ public:
     return *this;
   }
 
-  template <class _Up, class _Vp = enable_if_t<!__is_propagate_const<decay_t<_Up>>::value>>
+  template <class _Up, class _Vp = enable_if_t<!__is_propagate_const_v<decay_t<_Up>>>>
   _LIBCPP_HIDE_FROM_ABI constexpr propagate_const& operator=(_Up&& __u) {
     __t_ = std::forward<_Up>(__u);
     return *this;

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -681,9 +681,9 @@ concept __is_derived_from_optional = requires(const _Tp& __t) { []<class _Up>(co
 #    endif // _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
-struct __is_std_optional : false_type {};
+inline constexpr bool __is_std_optional_v = false;
 template <class _Tp>
-struct __is_std_optional<optional<_Tp>> : true_type {};
+inline constexpr bool __is_std_optional_v<optional<_Tp>> = true;
 
 template <class _Tp, class... _Args>
 inline constexpr bool __is_constructible_for_optional_v = is_constructible_v<_Tp, _Args...>;
@@ -844,10 +844,10 @@ private:
   };
   template <class _Up>
   using _CheckOptionalArgsCtor _LIBCPP_NODEBUG =
-      _If< _IsNotSame<__remove_cvref_t<_Up>, in_place_t>::value && _IsNotSame<__remove_cvref_t<_Up>, optional>::value &&
-               (!is_same_v<remove_cv_t<_Tp>, bool> || !__is_std_optional<__remove_cvref_t<_Up>>::value),
-           _CheckOptionalArgsConstructor,
-           __check_tuple_constructor_fail >;
+      _If<_IsNotSame<__remove_cvref_t<_Up>, in_place_t>::value && _IsNotSame<__remove_cvref_t<_Up>, optional>::value &&
+              (!is_same_v<remove_cv_t<_Tp>, bool> || !__is_std_optional_v<__remove_cvref_t<_Up>>),
+          _CheckOptionalArgsConstructor,
+          __check_tuple_constructor_fail>;
   template <class _QualUp>
   struct _CheckOptionalLikeConstructor {
     template <class _Up, class _Opt = optional<_Up>>
@@ -1228,8 +1228,8 @@ public:
 #      endif
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto and_then(_Func&& __f) & {
     using _Up = invoke_result_t<_Func, _Tp&>;
-    static_assert(__is_std_optional<remove_cvref_t<_Up>>::value,
-                  "Result of f(value()) must be a specialization of std::optional");
+    static_assert(
+        __is_std_optional_v<remove_cvref_t<_Up>>, "Result of f(value()) must be a specialization of std::optional");
     if (*this)
       return std::invoke(std::forward<_Func>(__f), value());
     return remove_cvref_t<_Up>();
@@ -1241,8 +1241,8 @@ public:
 #      endif
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto and_then(_Func&& __f) const& {
     using _Up = invoke_result_t<_Func, const _Tp&>;
-    static_assert(__is_std_optional<remove_cvref_t<_Up>>::value,
-                  "Result of f(value()) must be a specialization of std::optional");
+    static_assert(
+        __is_std_optional_v<remove_cvref_t<_Up>>, "Result of f(value()) must be a specialization of std::optional");
     if (*this)
       return std::invoke(std::forward<_Func>(__f), value());
     return remove_cvref_t<_Up>();
@@ -1254,7 +1254,7 @@ public:
 #      endif
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto and_then(_Func&& __f) && {
     using _Up = invoke_result_t<_Func, _Tp&&>;
-    static_assert(__is_std_optional<remove_cvref_t<_Up>>::value,
+    static_assert(__is_std_optional_v<remove_cvref_t<_Up>>,
                   "Result of f(std::move(value())) must be a specialization of std::optional");
     if (*this)
       return std::invoke(std::forward<_Func>(__f), std::move(value()));
@@ -1267,7 +1267,7 @@ public:
 #      endif
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto and_then(_Func&& __f) const&& {
     using _Up = invoke_result_t<_Func, const _Tp&&>;
-    static_assert(__is_std_optional<remove_cvref_t<_Up>>::value,
+    static_assert(__is_std_optional_v<remove_cvref_t<_Up>>,
                   "Result of f(std::move(value())) must be a specialization of std::optional");
     if (*this)
       return std::invoke(std::forward<_Func>(__f), std::move(value()));

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -203,14 +203,14 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #  if _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
-struct __is_std_span : false_type {};
+inline constexpr bool __is_std_span_v = false;
 
 template <class _Tp, size_t _Sz>
-struct __is_std_span<span<_Tp, _Sz>> : true_type {};
+inline constexpr bool __is_std_span_v<span<_Tp, _Sz>> = true;
 
 template <class _Range, class _ElementType>
 concept __span_compatible_range =
-    !__is_std_span<remove_cvref_t<_Range>>::value &&                //
+    !__is_std_span_v<remove_cvref_t<_Range>> &&                     //
     ranges::contiguous_range<_Range> &&                             //
     ranges::sized_range<_Range> &&                                  //
     (ranges::borrowed_range<_Range> || is_const_v<_ElementType>) && //

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -728,25 +728,25 @@ template <class _ValExpr>
 class __val_expr;
 
 template <class _ValExpr>
-struct __is_val_expr : false_type {};
+inline const bool __is_val_expr_v = false;
 
 template <class _ValExpr>
-struct __is_val_expr<__val_expr<_ValExpr> > : true_type {};
+inline const bool __is_val_expr_v<__val_expr<_ValExpr> > = true;
 
 template <class _Tp>
-struct __is_val_expr<valarray<_Tp> > : true_type {};
+inline const bool __is_val_expr_v<valarray<_Tp> > = true;
 
 template <class _Tp>
-struct __is_val_expr<slice_array<_Tp> > : true_type {};
+inline const bool __is_val_expr_v<slice_array<_Tp> > = true;
 
 template <class _Tp>
-struct __is_val_expr<gslice_array<_Tp> > : true_type {};
+inline const bool __is_val_expr_v<gslice_array<_Tp> > = true;
 
 template <class _Tp>
-struct __is_val_expr<mask_array<_Tp> > : true_type {};
+inline const bool __is_val_expr_v<mask_array<_Tp> > = true;
 
 template <class _Tp>
-struct __is_val_expr<indirect_array<_Tp> > : true_type {};
+inline const bool __is_val_expr_v<indirect_array<_Tp> > = true;
 
 // The functions using a __val_expr access the elements by their index.
 // valarray and the libc++ lazy proxies have an operator[]. The
@@ -877,34 +877,34 @@ public:
   _LIBCPP_HIDE_FROM_ABI valarray& operator<<=(const value_type& __x);
   _LIBCPP_HIDE_FROM_ABI valarray& operator>>=(const value_type& __x);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator*=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator/=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator%=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator+=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator-=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator^=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator|=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator&=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator<<=(const _Expr& __v);
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI valarray& operator>>=(const _Expr& __v);
 
   // member functions:
@@ -961,14 +961,12 @@ template <class _Tp, size_t _Size>
 valarray(const _Tp (&)[_Size], size_t) -> valarray<_Tp>;
 #  endif
 
-template <class _Expr,
-          __enable_if_t<__is_val_expr<_Expr>::value && __val_expr_use_member_functions<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr> && __val_expr_use_member_functions<_Expr>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI typename _Expr::value_type __get(const _Expr& __v, size_t __i) {
   return __v.__get(__i);
 }
 
-template <class _Expr,
-          __enable_if_t<__is_val_expr<_Expr>::value && !__val_expr_use_member_functions<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr> && !__val_expr_use_member_functions<_Expr>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI typename _Expr::value_type __get(const _Expr& __v, size_t __i) {
   return __v[__i];
 }
@@ -1054,37 +1052,37 @@ private:
   size_t __stride_;
 
 public:
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator*=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator/=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator%=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator+=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator-=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator^=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator&=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator|=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator<<=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator>>=(const _Expr& __v) const;
 
   slice_array(slice_array const&) = default;
@@ -1119,7 +1117,7 @@ inline const slice_array<_Tp>& slice_array<_Tp>::operator=(const slice_array& __
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1134,7 +1132,7 @@ inline void slice_array<_Tp>::operator=(const valarray<value_type>& __va) const 
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator*=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1142,7 +1140,7 @@ inline void slice_array<_Tp>::operator*=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator/=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1150,7 +1148,7 @@ inline void slice_array<_Tp>::operator/=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator%=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1158,7 +1156,7 @@ inline void slice_array<_Tp>::operator%=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator+=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1166,7 +1164,7 @@ inline void slice_array<_Tp>::operator+=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator-=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1174,7 +1172,7 @@ inline void slice_array<_Tp>::operator-=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator^=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1182,7 +1180,7 @@ inline void slice_array<_Tp>::operator^=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator&=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1190,7 +1188,7 @@ inline void slice_array<_Tp>::operator&=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator|=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1198,7 +1196,7 @@ inline void slice_array<_Tp>::operator|=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator<<=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1206,7 +1204,7 @@ inline void slice_array<_Tp>::operator<<=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void slice_array<_Tp>::operator>>=(const _Expr& __v) const {
   value_type* __t = __vp_;
   for (size_t __i = 0; __i < __size_; ++__i, __t += __stride_)
@@ -1283,37 +1281,37 @@ private:
   valarray<size_t> __1d_;
 
 public:
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator*=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator/=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator%=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator+=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator-=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator^=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator&=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator|=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator<<=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator>>=(const _Expr& __v) const;
 
   _LIBCPP_HIDE_FROM_ABI const gslice_array& operator=(const gslice_array& __ga) const;
@@ -1342,7 +1340,7 @@ private:
 };
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1351,7 +1349,7 @@ inline void gslice_array<_Tp>::operator=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator*=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1360,7 +1358,7 @@ inline void gslice_array<_Tp>::operator*=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator/=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1369,7 +1367,7 @@ inline void gslice_array<_Tp>::operator/=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator%=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1378,7 +1376,7 @@ inline void gslice_array<_Tp>::operator%=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator+=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1387,7 +1385,7 @@ inline void gslice_array<_Tp>::operator+=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator-=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1396,7 +1394,7 @@ inline void gslice_array<_Tp>::operator-=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator^=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1405,7 +1403,7 @@ inline void gslice_array<_Tp>::operator^=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator&=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1414,7 +1412,7 @@ inline void gslice_array<_Tp>::operator&=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator|=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1423,7 +1421,7 @@ inline void gslice_array<_Tp>::operator|=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator<<=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1432,7 +1430,7 @@ inline void gslice_array<_Tp>::operator<<=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void gslice_array<_Tp>::operator>>=(const _Expr& __v) const {
   typedef const size_t* _Ip;
   size_t __j = 0;
@@ -1468,37 +1466,37 @@ private:
   valarray<size_t> __1d_;
 
 public:
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator*=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator/=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator%=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator+=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator-=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator^=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator&=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator|=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator<<=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator>>=(const _Expr& __v) const;
 
   mask_array(const mask_array&) = default;
@@ -1528,7 +1526,7 @@ private:
 };
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1536,7 +1534,7 @@ inline void mask_array<_Tp>::operator=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator*=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1544,7 +1542,7 @@ inline void mask_array<_Tp>::operator*=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator/=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1552,7 +1550,7 @@ inline void mask_array<_Tp>::operator/=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator%=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1560,7 +1558,7 @@ inline void mask_array<_Tp>::operator%=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator+=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1568,7 +1566,7 @@ inline void mask_array<_Tp>::operator+=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator-=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1576,7 +1574,7 @@ inline void mask_array<_Tp>::operator-=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator^=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1584,7 +1582,7 @@ inline void mask_array<_Tp>::operator^=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator&=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1592,7 +1590,7 @@ inline void mask_array<_Tp>::operator&=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator|=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1600,7 +1598,7 @@ inline void mask_array<_Tp>::operator|=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator<<=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1608,7 +1606,7 @@ inline void mask_array<_Tp>::operator<<=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void mask_array<_Tp>::operator>>=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1673,37 +1671,37 @@ private:
   valarray<size_t> __1d_;
 
 public:
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator*=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator/=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator%=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator+=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator-=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator^=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator&=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator|=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator<<=(const _Expr& __v) const;
 
-  template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+  template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI operator>>=(const _Expr& __v) const;
 
   indirect_array(const indirect_array&) = default;
@@ -1734,7 +1732,7 @@ private:
 };
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1742,7 +1740,7 @@ inline void indirect_array<_Tp>::operator=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator*=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1750,7 +1748,7 @@ inline void indirect_array<_Tp>::operator*=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator/=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1758,7 +1756,7 @@ inline void indirect_array<_Tp>::operator/=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator%=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1766,7 +1764,7 @@ inline void indirect_array<_Tp>::operator%=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator+=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1774,7 +1772,7 @@ inline void indirect_array<_Tp>::operator+=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator-=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1782,7 +1780,7 @@ inline void indirect_array<_Tp>::operator-=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator^=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1790,7 +1788,7 @@ inline void indirect_array<_Tp>::operator^=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator&=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1798,7 +1796,7 @@ inline void indirect_array<_Tp>::operator&=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator|=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1806,7 +1804,7 @@ inline void indirect_array<_Tp>::operator|=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator<<=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -1814,7 +1812,7 @@ inline void indirect_array<_Tp>::operator<<=(const _Expr& __v) const {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline void indirect_array<_Tp>::operator>>=(const _Expr& __v) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
@@ -2389,7 +2387,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator>>=(const value_type& __x) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator*=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2398,7 +2396,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator*=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator/=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2407,7 +2405,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator/=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator%=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2416,7 +2414,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator%=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator+=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2425,7 +2423,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator+=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator-=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2434,7 +2432,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator-=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator^=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2443,7 +2441,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator^=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator|=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2452,7 +2450,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator|=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator&=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2461,7 +2459,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator&=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator<<=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2470,7 +2468,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator<<=(const _Expr& __v) {
 }
 
 template <class _Tp>
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> >
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> >
 inline valarray<_Tp>& valarray<_Tp>::operator>>=(const _Expr& __v) {
   size_t __i = 0;
   for (value_type* __t = __begin_; __t != __end_; ++__t, ++__i)
@@ -2606,9 +2604,7 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(valarray<_Tp>& __x, valarray<_Tp>& __y) _
   __x.swap(__y);
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<multiplies<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator*(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2616,7 +2612,7 @@ operator*(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(multiplies<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<multiplies<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator*(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2625,7 +2621,7 @@ operator*(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(multiplies<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<multiplies<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator*(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2634,9 +2630,7 @@ operator*(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(multiplies<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<divides<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator/(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2644,7 +2638,7 @@ operator/(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(divides<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<divides<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator/(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2653,7 +2647,7 @@ operator/(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(divides<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<divides<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator/(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2662,9 +2656,7 @@ operator/(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(divides<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<modulus<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator%(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2672,7 +2664,7 @@ operator%(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(modulus<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<modulus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator%(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2681,7 +2673,7 @@ operator%(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(modulus<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<modulus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator%(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2690,9 +2682,7 @@ operator%(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(modulus<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<plus<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator+(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2700,7 +2690,7 @@ operator+(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(plus<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<plus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator+(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2709,7 +2699,7 @@ operator+(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(plus<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<plus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator+(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2718,9 +2708,7 @@ operator+(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(plus<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<minus<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator-(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2728,7 +2716,7 @@ operator-(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(minus<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<minus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator-(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2737,7 +2725,7 @@ operator-(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(minus<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<minus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator-(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2746,9 +2734,7 @@ operator-(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(minus<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<bit_xor<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator^(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2756,7 +2742,7 @@ operator^(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(bit_xor<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<bit_xor<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator^(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2765,7 +2751,7 @@ operator^(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(bit_xor<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<bit_xor<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator^(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2774,9 +2760,7 @@ operator^(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(bit_xor<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<bit_and<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator&(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2784,7 +2768,7 @@ operator&(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(bit_and<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<bit_and<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator&(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2793,7 +2777,7 @@ operator&(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(bit_and<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<bit_and<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator&(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2802,9 +2786,7 @@ operator&(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(bit_and<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<bit_or<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator|(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2812,7 +2794,7 @@ operator|(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(bit_or<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<bit_or<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator|(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2821,7 +2803,7 @@ operator|(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(bit_or<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<bit_or<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator|(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2830,9 +2812,7 @@ operator|(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(bit_or<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<__bit_shift_left<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator<<(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2840,7 +2820,7 @@ operator<<(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(__bit_shift_left<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr< _BinaryOp<__bit_shift_left<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator<<(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2849,7 +2829,7 @@ operator<<(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(__bit_shift_left<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr< _BinaryOp<__bit_shift_left<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator<<(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2858,9 +2838,7 @@ operator<<(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(__bit_shift_left<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<__bit_shift_right<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator>>(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2868,7 +2846,7 @@ operator>>(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(__bit_shift_right<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<
     _BinaryOp<__bit_shift_right<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator>>(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2877,7 +2855,7 @@ operator>>(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(__bit_shift_right<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr< _BinaryOp<__bit_shift_right<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator>>(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2886,9 +2864,7 @@ operator>>(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(__bit_shift_right<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<logical_and<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator&&(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2896,7 +2872,7 @@ operator&&(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(logical_and<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<logical_and<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator&&(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2905,7 +2881,7 @@ operator&&(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(logical_and<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<logical_and<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator&&(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2914,9 +2890,7 @@ operator&&(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(logical_and<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<logical_or<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator||(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2924,7 +2898,7 @@ operator||(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(logical_or<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<logical_or<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator||(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2933,7 +2907,7 @@ operator||(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(logical_or<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<logical_or<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator||(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2942,9 +2916,7 @@ operator||(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(logical_or<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<equal_to<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator==(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2952,7 +2924,7 @@ operator==(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(equal_to<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<equal_to<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator==(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2961,7 +2933,7 @@ operator==(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(equal_to<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<equal_to<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator==(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2970,9 +2942,7 @@ operator==(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(equal_to<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<not_equal_to<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator!=(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -2980,7 +2950,7 @@ operator!=(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(not_equal_to<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<not_equal_to<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator!=(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -2989,7 +2959,7 @@ operator!=(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(not_equal_to<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<not_equal_to<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator!=(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -2998,9 +2968,7 @@ operator!=(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(not_equal_to<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<less<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator<(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -3008,7 +2976,7 @@ operator<(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(less<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<less<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator<(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -3017,7 +2985,7 @@ operator<(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(less<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<less<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator<(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -3026,9 +2994,7 @@ operator<(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(less<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<greater<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator>(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -3036,7 +3002,7 @@ operator>(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(greater<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<greater<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator>(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -3045,7 +3011,7 @@ operator>(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(greater<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<greater<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator>(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -3054,9 +3020,7 @@ operator>(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(greater<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<less_equal<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator<=(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -3064,7 +3028,7 @@ operator<=(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(less_equal<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<less_equal<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator<=(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -3073,7 +3037,7 @@ operator<=(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(less_equal<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<less_equal<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator<=(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -3082,9 +3046,7 @@ operator<=(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(less_equal<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<greater_equal<typename _Expr1::value_type>, _Expr1, _Expr2> >
 operator>=(const _Expr1& __x, const _Expr2& __y) {
   typedef typename _Expr1::value_type value_type;
@@ -3092,7 +3054,7 @@ operator>=(const _Expr1& __x, const _Expr2& __y) {
   return __val_expr<_Op>(_Op(greater_equal<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<greater_equal<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator>=(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -3101,7 +3063,7 @@ operator>=(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(greater_equal<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<greater_equal<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator>=(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -3110,7 +3072,7 @@ operator>=(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(greater_equal<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__abs_expr<typename _Expr::value_type>, _Expr> >
 abs(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3118,7 +3080,7 @@ abs(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__abs_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__acos_expr<typename _Expr::value_type>, _Expr> >
 acos(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3126,7 +3088,7 @@ acos(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__acos_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__asin_expr<typename _Expr::value_type>, _Expr> >
 asin(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3134,7 +3096,7 @@ asin(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__asin_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__atan_expr<typename _Expr::value_type>, _Expr> >
 atan(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3142,9 +3104,7 @@ atan(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__atan_expr<value_type>(), __x));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 [[__nodiscard__]] inline
     _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<__atan2_expr<typename _Expr1::value_type>, _Expr1, _Expr2> >
     atan2(const _Expr1& __x, const _Expr2& __y) {
@@ -3153,7 +3113,7 @@ template <class _Expr1,
   return __val_expr<_Op>(_Op(__atan2_expr<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<__atan2_expr<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 atan2(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -3162,7 +3122,7 @@ atan2(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(__atan2_expr<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<__atan2_expr<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 atan2(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -3171,7 +3131,7 @@ atan2(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(__atan2_expr<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__cos_expr<typename _Expr::value_type>, _Expr> >
 cos(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3179,7 +3139,7 @@ cos(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__cos_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__cosh_expr<typename _Expr::value_type>, _Expr> >
 cosh(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3187,7 +3147,7 @@ cosh(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__cosh_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__exp_expr<typename _Expr::value_type>, _Expr> >
 exp(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3195,7 +3155,7 @@ exp(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__exp_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__log_expr<typename _Expr::value_type>, _Expr> >
 log(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3203,7 +3163,7 @@ log(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__log_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__log10_expr<typename _Expr::value_type>, _Expr> >
 log10(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3211,9 +3171,7 @@ log10(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__log10_expr<value_type>(), __x));
 }
 
-template <class _Expr1,
-          class _Expr2,
-          __enable_if_t<__is_val_expr<_Expr1>::value && __is_val_expr<_Expr2>::value, int> = 0>
+template <class _Expr1, class _Expr2, __enable_if_t<__is_val_expr_v<_Expr1> && __is_val_expr_v<_Expr2>, int> = 0>
 [[__nodiscard__]] inline
     _LIBCPP_HIDE_FROM_ABI __val_expr<_BinaryOp<__pow_expr<typename _Expr1::value_type>, _Expr1, _Expr2> >
     pow(const _Expr1& __x, const _Expr2& __y) {
@@ -3222,7 +3180,7 @@ template <class _Expr1,
   return __val_expr<_Op>(_Op(__pow_expr<value_type>(), __x, __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<__pow_expr<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 pow(const _Expr& __x, const typename _Expr::value_type& __y) {
@@ -3231,7 +3189,7 @@ pow(const _Expr& __x, const typename _Expr::value_type& __y) {
   return __val_expr<_Op>(_Op(__pow_expr<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
 __val_expr<_BinaryOp<__pow_expr<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 pow(const typename _Expr::value_type& __x, const _Expr& __y) {
@@ -3240,7 +3198,7 @@ pow(const typename _Expr::value_type& __x, const _Expr& __y) {
   return __val_expr<_Op>(_Op(__pow_expr<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__sin_expr<typename _Expr::value_type>, _Expr> >
 sin(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3248,7 +3206,7 @@ sin(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__sin_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__sinh_expr<typename _Expr::value_type>, _Expr> >
 sinh(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3256,7 +3214,7 @@ sinh(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__sinh_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__sqrt_expr<typename _Expr::value_type>, _Expr> >
 sqrt(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3264,7 +3222,7 @@ sqrt(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__sqrt_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__tan_expr<typename _Expr::value_type>, _Expr> >
 tan(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;
@@ -3272,7 +3230,7 @@ tan(const _Expr& __x) {
   return __val_expr<_Op>(_Op(__tan_expr<value_type>(), __x));
 }
 
-template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
+template <class _Expr, __enable_if_t<__is_val_expr_v<_Expr>, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__tanh_expr<typename _Expr::value_type>, _Expr> >
 tanh(const _Expr& __x) {
   typedef typename _Expr::value_type value_type;

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1173,9 +1173,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr variant(variant&&)      = default;
 
   template < class _Arg,
-             enable_if_t<!is_same_v<__remove_cvref_t<_Arg>, variant>, int>        = 0,
-             enable_if_t<!__is_inplace_type<__remove_cvref_t<_Arg>>::value, int>  = 0,
-             enable_if_t<!__is_inplace_index<__remove_cvref_t<_Arg>>::value, int> = 0,
+             enable_if_t<!is_same_v<__remove_cvref_t<_Arg>, variant>, int>    = 0,
+             enable_if_t<!__is_in_place_type_v<__remove_cvref_t<_Arg>>, int>  = 0,
+             enable_if_t<!__is_in_place_index_v<__remove_cvref_t<_Arg>>, int> = 0,
              class _Tp  = __variant_detail::__best_match_t<_Arg, _Types...>,
              size_t _Ip = __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
              enable_if_t<is_constructible_v<_Tp, _Arg>, int> = 0>

--- a/libcxx/test/libcxx-03/type_traits/is_callable.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/type_traits/is_callable.compile.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <__type_traits/is_callable.h>
+#include <__cxx03/__type_traits/is_callable.h>
 
 struct Functor {
   void operator()();

--- a/libcxx/test/libcxx/type_traits/is_callable.compile.pass.cpp
+++ b/libcxx/test/libcxx/type_traits/is_callable.compile.pass.cpp
@@ -22,10 +22,9 @@ struct ArgumentFunctor {
   bool operator()(int, int);
 };
 
-static_assert(std::__is_callable<Functor>::value, "");
-static_assert(std::__is_callable<decltype(func)>::value, "");
-static_assert(!std::__is_callable<NotFunctor>::value, "");
-static_assert(!std::__is_callable<NotFunctor,
-                                  decltype(&NotFunctor::compare)>::value, "");
-static_assert(std::__is_callable<ArgumentFunctor, int, int>::value, "");
-static_assert(!std::__is_callable<ArgumentFunctor, int>::value, "");
+static_assert(std::__is_callable_v<Functor>, "");
+static_assert(std::__is_callable_v<decltype(func)>, "");
+static_assert(!std::__is_callable_v<NotFunctor>, "");
+static_assert(!std::__is_callable_v<NotFunctor, decltype(&NotFunctor::compare)>, "");
+static_assert(std::__is_callable_v<ArgumentFunctor, int, int>, "");
+static_assert(!std::__is_callable_v<ArgumentFunctor, int>, "");

--- a/libcxx/test/libcxx/utilities/utility/__is_inplace_index.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/__is_inplace_index.pass.cpp
@@ -18,20 +18,20 @@ struct S {};
 
 int main(int, char**) {
   using I = std::in_place_index_t<0>;
-  static_assert( std::__is_inplace_index<I>::value, "");
-  static_assert( std::__is_inplace_index<const I>::value, "");
-  static_assert( std::__is_inplace_index<const volatile I>::value, "");
-  static_assert( std::__is_inplace_index<I&>::value, "");
-  static_assert( std::__is_inplace_index<const I&>::value, "");
-  static_assert( std::__is_inplace_index<const volatile I&>::value, "");
-  static_assert( std::__is_inplace_index<I&&>::value, "");
-  static_assert( std::__is_inplace_index<const I&&>::value, "");
-  static_assert( std::__is_inplace_index<const volatile I&&>::value, "");
-  static_assert(!std::__is_inplace_index<std::in_place_type_t<int>>::value, "");
-  static_assert(!std::__is_inplace_index<std::in_place_t>::value, "");
-  static_assert(!std::__is_inplace_index<void>::value, "");
-  static_assert(!std::__is_inplace_index<int>::value, "");
-  static_assert(!std::__is_inplace_index<S>::value, "");
+  static_assert(std::__is_in_place_index_v<I>, "");
+  static_assert(std::__is_in_place_index_v<const I>, "");
+  static_assert(std::__is_in_place_index_v<const volatile I>, "");
+  static_assert(std::__is_in_place_index_v<I&>, "");
+  static_assert(std::__is_in_place_index_v<const I&>, "");
+  static_assert(std::__is_in_place_index_v<const volatile I&>, "");
+  static_assert(std::__is_in_place_index_v<I&&>, "");
+  static_assert(std::__is_in_place_index_v<const I&&>, "");
+  static_assert(std::__is_in_place_index_v<const volatile I&&>, "");
+  static_assert(!std::__is_in_place_index_v<std::in_place_type_t<int>>, "");
+  static_assert(!std::__is_in_place_index_v<std::in_place_t>, "");
+  static_assert(!std::__is_in_place_index_v<void>, "");
+  static_assert(!std::__is_in_place_index_v<int>, "");
+  static_assert(!std::__is_in_place_index_v<S>, "");
 
   return 0;
 }

--- a/libcxx/test/libcxx/utilities/utility/__is_inplace_type.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/__is_inplace_type.pass.cpp
@@ -18,20 +18,20 @@ struct S {};
 
 int main(int, char**) {
   using T = std::in_place_type_t<int>;
-  static_assert( std::__is_inplace_type<T>::value, "");
-  static_assert( std::__is_inplace_type<const T>::value, "");
-  static_assert( std::__is_inplace_type<const volatile T>::value, "");
-  static_assert( std::__is_inplace_type<T&>::value, "");
-  static_assert( std::__is_inplace_type<const T&>::value, "");
-  static_assert( std::__is_inplace_type<const volatile T&>::value, "");
-  static_assert( std::__is_inplace_type<T&&>::value, "");
-  static_assert( std::__is_inplace_type<const T&&>::value, "");
-  static_assert( std::__is_inplace_type<const volatile T&&>::value, "");
-  static_assert(!std::__is_inplace_type<std::in_place_index_t<0>>::value, "");
-  static_assert(!std::__is_inplace_type<std::in_place_t>::value, "");
-  static_assert(!std::__is_inplace_type<void>::value, "");
-  static_assert(!std::__is_inplace_type<int>::value, "");
-  static_assert(!std::__is_inplace_type<S>::value, "");
+  static_assert(std::__is_in_place_type_v<T>, "");
+  static_assert(std::__is_in_place_type_v<const T>, "");
+  static_assert(std::__is_in_place_type_v<const volatile T>, "");
+  static_assert(std::__is_in_place_type_v<T&>, "");
+  static_assert(std::__is_in_place_type_v<const T&>, "");
+  static_assert(std::__is_in_place_type_v<const volatile T&>, "");
+  static_assert(std::__is_in_place_type_v<T&&>, "");
+  static_assert(std::__is_in_place_type_v<const T&&>, "");
+  static_assert(std::__is_in_place_type_v<const volatile T&&>, "");
+  static_assert(!std::__is_in_place_type_v<std::in_place_index_t<0>>, "");
+  static_assert(!std::__is_in_place_type_v<std::in_place_t>, "");
+  static_assert(!std::__is_in_place_type_v<void>, "");
+  static_assert(!std::__is_in_place_type_v<int>, "");
+  static_assert(!std::__is_in_place_type_v<S>, "");
 
   return 0;
 }


### PR DESCRIPTION
This reduces compile time and memory, since template variables are more efficient. NFC otherwise.
