### PR TITLE
Added Memory Effect to assume_alignment

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -142,7 +142,7 @@ class AllocLikeOp<string mnemonic,
 // AssumeAlignmentOp
 //===----------------------------------------------------------------------===//
 
-def AssumeAlignmentOp : MemRef_Op<"assume_alignment"> {
+def AssumeAlignmentOp : MemRef_Op<"assume_alignment",[DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary =
       "assertion that gives alignment information to the input memref";
   let description = [{

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -526,6 +526,11 @@ LogicalResult AssumeAlignmentOp::verify() {
     return emitOpError("alignment must be power of 2");
   return success();
 }
+void AssumeAlignmentOp::getEffects(
+  SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+      &effects) {
+effects.emplace_back(MemoryEffects::Write::get());
+}
 
 //===----------------------------------------------------------------------===//
 // CastOp


### PR DESCRIPTION
Assume_alignment has no trait which specifies how it interacts with memory, this causes an issue in OwnershipBasedBufferDeallocation, which require all operations which operate on buffers to have explicit traits defining how the operation interacts with memory.

From my understanding, technically the operation is pure, however to make sure the operation doesn't get optimized away it has to have some side effect. I defined it to have similar side effects to CF AssertOp as both are asserts and assume_alignment gets lowered to it in RuntimeOpVerification. I'm not sure if this is correct and would appreciate the opinion of someone more experienced.