### PR TITLE
[flang][OpenMP][Semantics] resolve objects in the flush arg list

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -409,6 +409,19 @@ public:
   }
   void Post(const parser::OpenMPDepobjConstruct &) { PopContext(); }
 
+  bool Pre(const parser::OpenMPFlushConstruct &x) {
+    PushContext(x.source, llvm::omp::Directive::OMPD_flush);
+    for (auto &arg : x.v.Arguments().v) {
+      if (auto *locator{std::get_if<parser::OmpLocator>(&arg.u)}) {
+        if (auto *object{std::get_if<parser::OmpObject>(&locator->u)}) {
+          ResolveOmpObject(*object, Symbol::Flag::OmpDependObject);
+        }
+      }
+    }
+    return true;
+  }
+  void Post(const parser::OpenMPFlushConstruct &) { PopContext(); }
+
   bool Pre(const parser::OpenMPRequiresConstruct &x) {
     using Flags = WithOmpDeclarative::RequiresFlags;
     using Requires = WithOmpDeclarative::RequiresFlag;

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -414,7 +414,14 @@ public:
     for (auto &arg : x.v.Arguments().v) {
       if (auto *locator{std::get_if<parser::OmpLocator>(&arg.u)}) {
         if (auto *object{std::get_if<parser::OmpObject>(&locator->u)}) {
-          ResolveOmpObject(*object, Symbol::Flag::OmpDependObject);
+          if (auto *name{std::get_if<parser::Name>(&object->u)}) {
+            // ResolveOmpCommonBlockName resolves the symbol as a side effect
+            if (!ResolveOmpCommonBlockName(name)) {
+              context_.Say(name->source, // 2.15.3
+                  "COMMON block must be declared in the same scoping unit "
+                  "in which the OpenMP directive or clause appears"_err_en_US);
+            }
+          }
         }
       }
     }

--- a/flang/test/Semantics/OpenMP/flush04.f90
+++ b/flang/test/Semantics/OpenMP/flush04.f90
@@ -1,0 +1,11 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+
+! Regression test to ensure that the name /c/ in the flush argument list is
+! resolved to the common block symbol.
+
+  common /c/ x
+  real :: x
+!ERROR: FLUSH argument must be a variable list item
+  !$omp flush(/c/)
+end
+


### PR DESCRIPTION
Fixes #136583

Normally the flush argument list would contain a DataRef to some variable. All DataRefs are handled generically in resolve-names and so the problem wasn't observed. But when a common block name is specified, this is not parsed as a DataRef. There was already handling in resolve-directives for OmpObjectList but not for argument lists. I've added a visitor for FLUSH which ensures all of the arguments have been resolved.

The test is there to make sure the compiler doesn't crashed encountering the unresolved symbol. It shows that we currently deny flushing a common block. I'm not sure that it is right to restrict common blocks from flush argument lists, but fixing that can come in a different patch. This one is fixing an ICE.