### PR TITLE
[TableGen][CodeGen] Give every leaf register a unique regunit

### DIFF
--- a/llvm/test/TableGen/SubRegsAndAliases.td
+++ b/llvm/test/TableGen/SubRegsAndAliases.td
@@ -1,0 +1,80 @@
+// RUN: llvm-tblgen -gen-register-info -register-info-debug -I %p/../../include %s -o /dev/null 2>&1 | FileCheck %s
+include "llvm/Target/Target.td"
+def TestTarget : Target;
+
+def lo : SubRegIndex<32, 0>;
+def hi : SubRegIndex<32, 32>;
+
+// One superreg with two subregs.
+def Alo : Register<"">;
+def Ahi : Register<"">;
+def A : Register<""> {
+  let SubRegs = [Alo, Ahi];
+  let SubRegIndices = [lo, hi];
+}
+
+// Same but the subregs alias.
+def Blo : Register<"">;
+def Bhi : Register<""> {
+  let Aliases = [Blo];
+}
+def B : Register<""> {
+  let SubRegs = [Blo, Bhi];
+  let SubRegIndices = [lo, hi];
+}
+
+// Same but the superreg has an alias.
+def Clo : Register<"">;
+def Chi : Register<"">;
+def D : Register<"">;
+def C : Register<""> {
+  let SubRegs = [Clo, Chi];
+  let SubRegIndices = [lo, hi];
+  let Aliases = [D];
+}
+
+def TestRC : RegisterClass<"Test", [i64], 0, (add A, B)>;
+
+// CHECK-LABEL: Register A:
+// CHECK: SubReg hi = Ahi
+// CHECK: SubReg lo = Alo
+// CHECK: RegUnit 0
+// CHECK: RegUnit 1
+
+// CHECK-LABEL: Register Ahi:
+// CHECK: RegUnit 1
+
+// CHECK-LABEL: Register Alo:
+// CHECK: RegUnit 0
+
+// CHECK-LABEL: Register B:
+// CHECK: SubReg hi = Bhi
+// CHECK: SubReg lo = Blo
+// CHECK: RegUnit 2
+// CHECK: RegUnit 3
+// CHECK: RegUnit 4
+
+// CHECK-LABEL: Register Bhi:
+// CHECK: RegUnit 3
+// CHECK: RegUnit 4
+
+// CHECK-LABEL: Register Blo:
+// CHECK: RegUnit 2
+// CHECK: RegUnit 3
+
+// CHECK-LABEL: Register C:
+// CHECK: SubReg hi = Chi
+// CHECK: SubReg lo = Clo
+// CHECK: RegUnit 5
+// CHECK: RegUnit 6
+// CHECK: RegUnit 7
+
+// CHECK-LABEL: Register Chi:
+// CHECK: RegUnit 6
+
+// CHECK-LABEL: Register Clo:
+// CHECK: RegUnit 5
+
+// CHECK-LABEL: Register D:
+// CHECK: RegUnit 7
+// CHECK: RegUnit 8

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -1934,6 +1934,8 @@ void RegisterInfoEmitter::debugDump(raw_ostream &OS) {
       OS << "\tSubReg " << SubIdx->getName() << " = " << SubReg->getName()
          << '\n';
     }
+    for (unsigned U : R.getNativeRegUnits())
+      OS << "\tRegUnit " << U << '\n';
   }
 }
 


### PR DESCRIPTION
Give every leaf register a unique regunit, even if it has ad hoc
aliases.

Previously only leaf registers *without* ad hoc aliases would get a
unique regunit, but that caused situations where regunits could not be
used to distinguish a register from its subregs. For example:

- Registers A and B alias. They both get regunit 0 only.
- Register C has subregs A and B. It inherits regunits from its subregs,
  so it also gets regunit 0 only.

After this fix, registers A and B will get a unique regunit in addition
to the regunit representing the alias, for example:

- A will get regunits 0 and 1.
- B will get regunits 0 and 2.
- C will get regunits 0, 1 and 2.
