### PR TITLE
[lldb] Merge/unify ABI-provided AArch64 unwind plans

### DIFF
--- a/lldb/source/Plugins/ABI/AArch64/ABIAArch64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABIAArch64.cpp
@@ -19,6 +19,7 @@
 #include <optional>
 
 using namespace lldb;
+using namespace lldb_private;
 
 LLDB_PLUGIN_DEFINE(ABIAArch64)
 
@@ -199,4 +200,45 @@ void ABIAArch64::AugmentRegisterInfo(
     addPartialRegisters(regs, z_regs, *z_byte_size, "d{0}", 8,
                         lldb::eEncodingIEEE754, lldb::eFormatFloat);
   }
+}
+
+UnwindPlanSP ABIAArch64::CreateFunctionEntryUnwindPlan() {
+  UnwindPlan::Row row;
+
+  // Our previous Call Frame Address is the stack pointer
+  row.GetCFAValue().SetIsRegisterPlusOffset(LLDB_REGNUM_GENERIC_SP, 0);
+
+  // Our previous PC is in the LR, all other registers are the same.
+  row.SetRegisterLocationToRegister(LLDB_REGNUM_GENERIC_PC,
+                                    LLDB_REGNUM_GENERIC_RA, true);
+
+  auto plan_sp = std::make_shared<UnwindPlan>(eRegisterKindGeneric);
+  plan_sp->AppendRow(std::move(row));
+  plan_sp->SetSourceName("arm64 at-func-entry default");
+  plan_sp->SetSourcedFromCompiler(eLazyBoolNo);
+  plan_sp->SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
+  plan_sp->SetUnwindPlanForSignalTrap(eLazyBoolNo);
+  return plan_sp;
+}
+
+UnwindPlanSP ABIAArch64::CreateDefaultUnwindPlan() {
+  UnwindPlan::Row row;
+  const int32_t ptr_size = 8;
+
+  row.GetCFAValue().SetIsRegisterPlusOffset(LLDB_REGNUM_GENERIC_FP,
+                                            2 * ptr_size);
+  row.SetUnspecifiedRegistersAreUndefined(true);
+
+  row.SetRegisterLocationToAtCFAPlusOffset(LLDB_REGNUM_GENERIC_FP,
+                                           ptr_size * -2, true);
+  row.SetRegisterLocationToAtCFAPlusOffset(LLDB_REGNUM_GENERIC_PC,
+                                           ptr_size * -1, true);
+
+  auto plan_sp = std::make_shared<UnwindPlan>(eRegisterKindGeneric);
+  plan_sp->AppendRow(std::move(row));
+  plan_sp->SetSourceName("arm64 default unwind plan");
+  plan_sp->SetSourcedFromCompiler(eLazyBoolNo);
+  plan_sp->SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
+  plan_sp->SetUnwindPlanForSignalTrap(eLazyBoolNo);
+  return plan_sp;
 }

--- a/lldb/source/Plugins/ABI/AArch64/ABIAArch64.h
+++ b/lldb/source/Plugins/ABI/AArch64/ABIAArch64.h
@@ -19,6 +19,9 @@ public:
   lldb::addr_t FixCodeAddress(lldb::addr_t pc) override;
   lldb::addr_t FixDataAddress(lldb::addr_t pc) override;
 
+  lldb::UnwindPlanSP CreateFunctionEntryUnwindPlan() override;
+  lldb::UnwindPlanSP CreateDefaultUnwindPlan() override;
+
 protected:
   virtual lldb::addr_t FixAddress(lldb::addr_t pc, lldb::addr_t mask) {
     return pc;

--- a/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
@@ -17,7 +17,6 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Value.h"
-#include "lldb/Symbol/UnwindPlan.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/Target.h"
@@ -29,8 +28,6 @@
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/ValueObject/ValueObjectConstResult.h"
-
-#include "Utility/ARM64_DWARF_Registers.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -342,48 +339,6 @@ ABIMacOSX_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   }
 
   return error;
-}
-
-UnwindPlanSP ABIMacOSX_arm64::CreateFunctionEntryUnwindPlan() {
-  uint32_t lr_reg_num = arm64_dwarf::lr;
-  uint32_t sp_reg_num = arm64_dwarf::sp;
-  uint32_t pc_reg_num = arm64_dwarf::pc;
-
-  UnwindPlan::Row row;
-
-  // Our previous Call Frame Address is the stack pointer
-  row.GetCFAValue().SetIsRegisterPlusOffset(sp_reg_num, 0);
-
-  // Our previous PC is in the LR, all other registers are the same.
-  row.SetRegisterLocationToRegister(pc_reg_num, lr_reg_num, true);
-
-  auto plan_sp = std::make_shared<UnwindPlan>(eRegisterKindDWARF);
-  plan_sp->AppendRow(std::move(row));
-  plan_sp->SetSourceName("arm64 at-func-entry default");
-  plan_sp->SetSourcedFromCompiler(eLazyBoolNo);
-  return plan_sp;
-}
-
-UnwindPlanSP ABIMacOSX_arm64::CreateDefaultUnwindPlan() {
-  uint32_t fp_reg_num = arm64_dwarf::fp;
-  uint32_t pc_reg_num = arm64_dwarf::pc;
-
-  UnwindPlan::Row row;
-  const int32_t ptr_size = 8;
-
-  row.GetCFAValue().SetIsRegisterPlusOffset(fp_reg_num, 2 * ptr_size);
-  row.SetUnspecifiedRegistersAreUndefined(true);
-
-  row.SetRegisterLocationToAtCFAPlusOffset(fp_reg_num, ptr_size * -2, true);
-  row.SetRegisterLocationToAtCFAPlusOffset(pc_reg_num, ptr_size * -1, true);
-
-  auto plan_sp = std::make_shared<UnwindPlan>(eRegisterKindDWARF);
-  plan_sp->AppendRow(std::move(row));
-  plan_sp->SetSourceName("arm64-apple-darwin default unwind plan");
-  plan_sp->SetSourcedFromCompiler(eLazyBoolNo);
-  plan_sp->SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
-  plan_sp->SetUnwindPlanForSignalTrap(eLazyBoolNo);
-  return plan_sp;
 }
 
 // AAPCS64 (Procedure Call Standard for the ARM 64-bit Architecture) says

--- a/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.h
+++ b/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.h
@@ -27,10 +27,6 @@ public:
   bool GetArgumentValues(lldb_private::Thread &thread,
                          lldb_private::ValueList &values) const override;
 
-  lldb::UnwindPlanSP CreateFunctionEntryUnwindPlan() override;
-
-  lldb::UnwindPlanSP CreateDefaultUnwindPlan() override;
-
   bool RegisterIsVolatile(const lldb_private::RegisterInfo *reg_info) override;
 
   // The arm64 ABI requires that stack frames be 16 byte aligned.

--- a/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.cpp
@@ -30,8 +30,6 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/ValueObject/ValueObjectConstResult.h"
 
-#include "Utility/ARM64_DWARF_Registers.h"
-
 using namespace lldb;
 using namespace lldb_private;
 
@@ -383,48 +381,6 @@ Status ABISysV_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   }
 
   return error;
-}
-
-UnwindPlanSP ABISysV_arm64::CreateFunctionEntryUnwindPlan() {
-  uint32_t lr_reg_num = arm64_dwarf::lr;
-  uint32_t sp_reg_num = arm64_dwarf::sp;
-
-  UnwindPlan::Row row;
-
-  // Our previous Call Frame Address is the stack pointer, all other registers
-  // are the same.
-  row.GetCFAValue().SetIsRegisterPlusOffset(sp_reg_num, 0);
-
-  auto plan_sp = std::make_shared<UnwindPlan>(eRegisterKindDWARF);
-  plan_sp->AppendRow(std::move(row));
-  plan_sp->SetReturnAddressRegister(lr_reg_num);
-  plan_sp->SetSourceName("arm64 at-func-entry default");
-  plan_sp->SetSourcedFromCompiler(eLazyBoolNo);
-  plan_sp->SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
-  plan_sp->SetUnwindPlanForSignalTrap(eLazyBoolNo);
-  return plan_sp;
-}
-
-UnwindPlanSP ABISysV_arm64::CreateDefaultUnwindPlan() {
-  uint32_t fp_reg_num = arm64_dwarf::fp;
-  uint32_t pc_reg_num = arm64_dwarf::pc;
-
-  UnwindPlan::Row row;
-  const int32_t ptr_size = 8;
-
-  row.GetCFAValue().SetIsRegisterPlusOffset(fp_reg_num, 2 * ptr_size);
-  row.SetUnspecifiedRegistersAreUndefined(true);
-
-  row.SetRegisterLocationToAtCFAPlusOffset(fp_reg_num, ptr_size * -2, true);
-  row.SetRegisterLocationToAtCFAPlusOffset(pc_reg_num, ptr_size * -1, true);
-
-  auto plan_sp = std::make_shared<UnwindPlan>(eRegisterKindDWARF);
-  plan_sp->AppendRow(std::move(row));
-  plan_sp->SetSourceName("arm64 default unwind plan");
-  plan_sp->SetSourcedFromCompiler(eLazyBoolNo);
-  plan_sp->SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
-  plan_sp->SetUnwindPlanForSignalTrap(eLazyBoolNo);
-  return plan_sp;
 }
 
 // AAPCS64 (Procedure Call Standard for the ARM 64-bit Architecture) says

--- a/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.h
+++ b/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.h
@@ -30,10 +30,6 @@ public:
   SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                        lldb::ValueObjectSP &new_value) override;
 
-  lldb::UnwindPlanSP CreateFunctionEntryUnwindPlan() override;
-
-  lldb::UnwindPlanSP CreateDefaultUnwindPlan() override;
-
   bool RegisterIsVolatile(const lldb_private::RegisterInfo *reg_info) override;
 
   // The arm64 ABI requires that stack frames be 16 byte aligned.


### PR DESCRIPTION
The macos and sysv ABIs return functionally equivalent unwind plans, so they can be implemented in the base AArch64 class. The only difference between them was that the macos plan provided a "pc=lr" rule whereas the sysv plan called SetReturnAddressRegister (which causes the unwind machinery to act as if that rule was present). This difference was enough to cause `CompareUnwindPlansForIdenticalInitialPCLocation` to return a different value and break the (temporarily reverted) TestUnwindFramelessFaulted test.

While merging the two functions, I couldn't stop myself from simplifying them to use the generic register number schemes -- which exposed another bug in CompareUnwindPlansForIdenticalInitialPCLocation, namely that it was expecting all unwind plans to use the LLDB numbering scheme. This patch fixes that as well.