### PR TITLE
[lldb] Move lldb_enable_attach from test_common to a separate header

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/attach.h
+++ b/lldb/packages/Python/lldbsuite/test/make/attach.h
@@ -1,0 +1,34 @@
+#ifndef LLDB_TEST_ATTACH_H
+#define LLDB_TEST_ATTACH_H
+
+// On some systems (e.g., some versions of linux) it is not possible to attach
+// to a process without it giving us special permissions. This defines the
+// lldb_enable_attach macro, which should perform any such actions, if needed by
+// the platform.
+#if defined(__linux__)
+#include <sys/prctl.h>
+
+// Android API <= 16 does not have these defined.
+#ifndef PR_SET_PTRACER
+#define PR_SET_PTRACER 0x59616d61
+#endif
+#ifndef PR_SET_PTRACER_ANY
+#define PR_SET_PTRACER_ANY ((unsigned long)-1)
+#endif
+
+// For now we execute on best effort basis.  If this fails for some reason, so
+// be it.
+#define lldb_enable_attach()                                                   \
+  do {                                                                         \
+    const int prctl_result =                                                   \
+        prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0);                    \
+    (void)prctl_result;                                                        \
+  } while (0)
+
+#else // not linux
+
+#define lldb_enable_attach()
+
+#endif // defined(__linux__)
+
+#endif // LLDB_TEST_ATTACH_H

--- a/lldb/packages/Python/lldbsuite/test/make/test_common.h
+++ b/lldb/packages/Python/lldbsuite/test/make/test_common.h
@@ -20,33 +20,3 @@
 #else
 #define LLVM_PRETTY_FUNCTION LLVM_PRETTY_FUNCTION
 #endif
-
-
-// On some systems (e.g., some versions of linux) it is not possible to attach to a process
-// without it giving us special permissions. This defines the lldb_enable_attach macro, which
-// should perform any such actions, if needed by the platform. This is a macro instead of a
-// function to avoid the need for complex linking of the test programs.
-#if defined(__linux__)
-#include <sys/prctl.h>
-
-// Android API <= 16 does not have these defined.
-#ifndef PR_SET_PTRACER
-#define PR_SET_PTRACER 0x59616d61
-#endif
-#ifndef PR_SET_PTRACER_ANY
-#define PR_SET_PTRACER_ANY ((unsigned long)-1)
-#endif
-
-// For now we execute on best effort basis.  If this fails for some reason, so be it.
-#define lldb_enable_attach()                                                          \
-    do                                                                                \
-    {                                                                                 \
-        const int prctl_result = prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0);  \
-        (void)prctl_result;                                                           \
-    } while (0)
-
-#else // not linux
-
-#define lldb_enable_attach()
-
-#endif

--- a/lldb/test/API/commands/process/attach-resume/main.cpp
+++ b/lldb/test/API/commands/process/attach-resume/main.cpp
@@ -1,7 +1,7 @@
-#include <stdio.h>
-#include <fcntl.h>
-
+#include "attach.h"
 #include <chrono>
+#include <cstdio>
+#include <fcntl.h>
 #include <thread>
 
 volatile bool debugger_flag = true; // The debugger will flip this to false

--- a/lldb/test/API/commands/process/attach/main.cpp
+++ b/lldb/test/API/commands/process/attach/main.cpp
@@ -1,6 +1,6 @@
-#include <stdio.h>
-
+#include "attach.h"
 #include <chrono>
+#include <cstdio>
 #include <thread>
 
 volatile int g_val = 12345;

--- a/lldb/test/API/commands/process/detach-resumes/main.cpp
+++ b/lldb/test/API/commands/process/detach-resumes/main.cpp
@@ -1,8 +1,9 @@
+#include "attach.h"
 #include "pseudo_barrier.h"
 #include <chrono>
+#include <cstdio>
 #include <fcntl.h>
 #include <fstream>
-#include <stdio.h>
 #include <thread>
 #include <vector>
 

--- a/lldb/test/API/commands/register/register/register_command/main.cpp
+++ b/lldb/test/API/commands/register/register/register_command/main.cpp
@@ -1,6 +1,6 @@
-#include <stdio.h>
-
+#include "attach.h"
 #include <chrono>
+#include <cstdio>
 #include <thread>
 
 long double outermost_return_long_double (long double my_long_double);

--- a/lldb/test/API/driver/batch_mode/main.c
+++ b/lldb/test/API/driver/batch_mode/main.c
@@ -1,3 +1,4 @@
+#include "attach.h"
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/lldb/test/API/functionalities/deleted-executable/main.cpp
+++ b/lldb/test/API/functionalities/deleted-executable/main.cpp
@@ -1,3 +1,4 @@
+#include "attach.h"
 #include <chrono>
 #include <fstream>
 #include <thread>

--- a/lldb/test/API/functionalities/load_after_attach/main.cpp
+++ b/lldb/test/API/functionalities/load_after_attach/main.cpp
@@ -1,9 +1,10 @@
+#include "attach.h"
 #include "dylib.h"
 #include <cassert>
-#include <cstdio>
-#include <thread>
 #include <chrono>
+#include <cstdio>
 #include <fstream>
+#include <thread>
 
 int main(int argc, char* argv[]) {
   lldb_enable_attach();

--- a/lldb/test/API/functionalities/process_group/main.c
+++ b/lldb/test/API/functionalities/process_group/main.c
@@ -1,6 +1,7 @@
+#include "attach.h"
 #include <stdio.h>
-#include <unistd.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 volatile int release_child_flag = 0;
 

--- a/lldb/test/API/functionalities/thread/create_after_attach/main.cpp
+++ b/lldb/test/API/functionalities/thread/create_after_attach/main.cpp
@@ -1,5 +1,6 @@
-#include <stdio.h>
+#include "attach.h"
 #include <chrono>
+#include <cstdio>
 #include <thread>
 
 using std::chrono::microseconds;

--- a/lldb/test/API/iohandler/completion/main.c
+++ b/lldb/test/API/iohandler/completion/main.c
@@ -1,5 +1,4 @@
 int main(int argc, char **argv) {
-  lldb_enable_attach();
   int to_complete = 0;
   return to_complete;
 }

--- a/lldb/test/API/python_api/hello_world/main.c
+++ b/lldb/test/API/python_api/hello_world/main.c
@@ -1,3 +1,4 @@
+#include "attach.h"
 #include <stdio.h>
 #ifdef _MSC_VER
 #include <windows.h>

--- a/lldb/test/API/tools/lldb-dap/attach/main.c
+++ b/lldb/test/API/tools/lldb-dap/attach/main.c
@@ -1,3 +1,4 @@
+#include "attach.h"
 #include <stdio.h>
 #ifdef _WIN32
 #include <process.h>

--- a/lldb/test/API/tools/lldb-dap/disconnect/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/disconnect/main.cpp
@@ -1,3 +1,4 @@
+#include "attach.h"
 #include <chrono>
 #include <cstdio>
 #include <fstream>

--- a/lldb/test/API/tools/lldb-server/attach-wait/shim.cpp
+++ b/lldb/test/API/tools/lldb-server/attach-wait/shim.cpp
@@ -1,5 +1,6 @@
-#include <unistd.h>
+#include "attach.h"
 #include <cstdio>
+#include <unistd.h>
 
 int main(int argc, char *argv[]) {
   lldb_enable_attach();

--- a/lldb/test/API/tools/lldb-server/main.cpp
+++ b/lldb/test/API/tools/lldb-server/main.cpp
@@ -1,3 +1,4 @@
+#include "attach.h"
 #include <atomic>
 #include <cassert>
 #include <chrono>


### PR DESCRIPTION
test_common is force-included into every compilation, which causes problems when we're compiling assembly code, as we were in #138805.

This avoids that as we can include the header only when it's needed.