### PR TITLE
[LAA] Fix implicit trunc from int64 to int and losing info

### DIFF
--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1585,6 +1585,8 @@ std::optional<int> llvm::getPointersDiff(Type *ElemTyA, Value *PtrA,
     OffsetB = OffsetB.sextOrTrunc(IdxWidth);
 
     OffsetB -= OffsetA;
+    if (OffsetB.getSignificantBits() > sizeof(int) * 8)
+      return std::nullopt;
     Val = OffsetB.getSExtValue();
   } else {
     // Otherwise compute the distance with SCEV between the base pointers.
@@ -1593,6 +1595,8 @@ std::optional<int> llvm::getPointersDiff(Type *ElemTyA, Value *PtrA,
     std::optional<APInt> Diff =
         SE.computeConstantDifference(PtrSCEVB, PtrSCEVA);
     if (!Diff)
+      return std::nullopt;
+    if (Diff->getSignificantBits() > sizeof(int) * 8)
       return std::nullopt;
     Val = Diff->getSExtValue();
   }

--- a/llvm/test/Transforms/SLPVectorizer/X86/long-pointer-distance.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/long-pointer-distance.ll
@@ -5,7 +5,13 @@ define void @test(ptr %this) {
 ; CHECK-LABEL: define void @test(
 ; CHECK-SAME: ptr [[THIS:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    store <4 x i64> <i64 1, i64 2, i64 3, i64 4>, ptr [[THIS]], align 8
+; CHECK-NEXT:    store i64 1, ptr [[THIS]], align 8
+; CHECK-NEXT:    [[B:%.*]] = getelementptr i8, ptr [[THIS]], i64 8
+; CHECK-NEXT:    store i64 2, ptr [[B]], align 8
+; CHECK-NEXT:    [[C:%.*]] = getelementptr i8, ptr [[THIS]], i64 4294967312
+; CHECK-NEXT:    store i64 3, ptr [[C]], align 8
+; CHECK-NEXT:    [[D:%.*]] = getelementptr i8, ptr [[THIS]], i64 4294967320
+; CHECK-NEXT:    store i64 4, ptr [[D]], align 8
 ; CHECK-NEXT:    ret void
 ;
 entry:


### PR DESCRIPTION
Need to check if the distance fits into int size before trying to get
int64_t difference and store it in int.

Fixes #139202
