### PR TITLE
[lldb][SymbolFileDWARF] Don't search for DWP files on macOS

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -4211,6 +4211,9 @@ SymbolFileDWARFDebugMap *SymbolFileDWARF::GetDebugMapSymfile() {
 
 const std::shared_ptr<SymbolFileDWARFDwo> &SymbolFileDWARF::GetDwpSymbolFile() {
   llvm::call_once(m_dwp_symfile_once_flag, [this]() {
+    if (m_objfile_sp->GetArchitecture().GetTriple().isAppleMachO())
+      return;
+
     // Create a list of files to try and append .dwp to.
     FileSpecList symfiles;
     // Append the module's object file path.


### PR DESCRIPTION
A contrived performance measurement on my local machine:
1. Attach LLDB to LLDB
2. Measure how much time it takes to run `b operator[]`

Without this patch, we would spend a total of 400ms (which was ~4-5% of total execution) looking for DWP files (and failing to find them because they are not a concept on macOS).

We call into `GetDwpSymbolFile` via `DebugNamesDWARFIndex::GetFunctions -> ManualDWARFIndex::GetFunctions -> ManualDWARFIndex::Index`.

rdar://148212738