### PR TITLE
[flang][OpenMP]Replace assert with if-condition

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -3545,8 +3545,7 @@ void OmpStructureChecker::CheckReductionObjects(
   // names into the lists of their members.
   for (const parser::OmpObject &object : objects.v) {
     auto *symbol{GetObjectSymbol(object)};
-    assert(symbol && "Expecting a symbol for object");
-    if (IsCommonBlock(*symbol)) {
+    if (symbol && IsCommonBlock(*symbol)) {
       auto source{GetObjectSource(object)};
       context_.Say(source ? *source : GetContext().clauseSource,
           "Common block names are not allowed in %s clause"_err_en_US,

--- a/flang/test/Semantics/OpenMP/reduction-undefined.f90
+++ b/flang/test/Semantics/OpenMP/reduction-undefined.f90
@@ -1,0 +1,18 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+
+subroutine dont_crash(values)
+  implicit none
+  integer, parameter :: n = 100
+  real :: values(n)
+  integer :: i
+  !ERROR: No explicit type declared for 'sum'
+  sum = 0
+  !ERROR: No explicit type declared for 'sum'
+  !$omp parallel do reduction(+:sum)
+  do i = 1, n
+  !ERROR: No explicit type declared for 'sum'
+  !ERROR: No explicit type declared for 'sum'
+     sum = sum + values(i)
+  end do
+end subroutine dont_crash
+


### PR DESCRIPTION
If a symbol is not declared, check-omp-structure hits an assert. It should be safe to treat undeclared symbols as "not from a block", as they would have to be declared to be in a block...

Adding simple test to confirm it gives error messages, not crashing.

This should fix issue #131655 (there is already a check for symbol being not null in the code identified in the ticket).