### PR TITLE
[NFC] Replace report_fatal_error with reportFatalUsageError in DXILIntrinsicExpansion.cpp

### DIFF
--- a/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
+++ b/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
@@ -320,8 +320,7 @@ static Value *expandIsFPClass(CallInst *Orig) {
     return RetVal;
   }
   default:
-    report_fatal_error(Twine("Unsupported FPClassTest"),
-                       /* gen_crash_diag=*/false);
+    reportFatalUsageError("Unsupported FPClassTest");
   }
 }
 


### PR DESCRIPTION
Replaces the deprecated `report_fatal_error` function with `reportFatalUsageError`