### PR TITLE
[flang-rt] Fix flang-rt unit test linking with LLVM_ENABLE_LIBCXX

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -285,6 +285,7 @@ function(runtime_default_target)
                                                 CUDA CMAKE_CUDA # For runtimes that may look for the CUDA compiler and/or SDK (libc, offload, flang-rt)
                                                 FFI # offload uses libffi
                                                 FLANG_RUNTIME # Shared between Flang and Flang-RT
+                                                LLVM_ENABLE_LIBCXX # Needed for C++ unit tests to link correctly
                                                 ${ARG_PREFIXES}
                            EXTRA_TARGETS ${extra_targets}
                                          ${test_targets}


### PR DESCRIPTION
This patch fixes and issue where the flang-rt unit tests fail to link 
when using LLVM_ENALBE_LIBCXX for the LLVM build (and not using 
CLANG_DEFAULT_CXX_STDLIB=libc++) because the -DLLVM_ENABLE_LIBCXX is
not passed on to the flang-rt cmake command.
By adding it to the PASSTHROUGH flags it gets used when building the
runtime tests as well.

Note: this will also cause the runtimes themselves to be built with
libc++, but this is also most likely what the user wanted when passing
-DLLVM_ENABLE_LIBCXX, and was the behaviour before the runtimes were
split into flang-rt. It won't affect linkage for the runtimes as they
only use the header only parts of the C++ library.
