### PR TITLE
[flang][OpenMP] Set the default schedule modifier

### DIFF
--- a/flang/test/Lower/OpenMP/distribute-parallel-do.f90
+++ b/flang/test/Lower/OpenMP/distribute-parallel-do.f90
@@ -42,7 +42,7 @@ subroutine distribute_parallel_do_schedule()
 
   ! CHECK:      omp.parallel private({{.*}}) {
   ! CHECK:      omp.distribute {
-  ! CHECK-NEXT: omp.wsloop schedule(runtime) {
+  ! CHECK-NEXT: omp.wsloop schedule(runtime, nonmonotonic) {
   ! CHECK-NEXT: omp.loop_nest
   !$omp distribute parallel do schedule(runtime)
   do index_ = 1, 10

--- a/flang/test/Lower/OpenMP/parallel-wsloop.f90
+++ b/flang/test/Lower/OpenMP/parallel-wsloop.f90
@@ -64,7 +64,7 @@ subroutine parallel_do_with_clauses(nt)
   ! CHECK:      %[[WS_LB:.*]] = arith.constant 1 : i32
   ! CHECK:      %[[WS_UB:.*]] = arith.constant 9 : i32
   ! CHECK:      %[[WS_STEP:.*]] = arith.constant 1 : i32
-  ! CHECK:      omp.wsloop schedule(dynamic) private({{.*}}) {
+  ! CHECK:      omp.wsloop schedule(dynamic, nonmonotonic) private({{.*}}) {
   ! CHECK-NEXT: omp.loop_nest (%[[I:.*]]) : i32 = (%[[WS_LB]]) to (%[[WS_UB]]) inclusive step (%[[WS_STEP]]) {
   !$OMP PARALLEL DO NUM_THREADS(nt) SCHEDULE(dynamic)
   do i=1, 9

--- a/flang/test/Lower/OpenMP/wsloop-chunks.f90
+++ b/flang/test/Lower/OpenMP/wsloop-chunks.f90
@@ -20,7 +20,7 @@ do i=1, 9
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : i32
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 9 : i32
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 1 : i32
-! CHECK:         omp.wsloop nowait schedule(static = %[[VAL_2]] : i32) private({{.*}}) {
+! CHECK:         omp.wsloop nowait schedule(static = %[[VAL_2]] : i32, monotonic) private({{.*}}) {
 ! CHECK-NEXT:      omp.loop_nest (%[[ARG0:.*]]) : i32 = (%[[VAL_3]]) to (%[[VAL_4]]) inclusive step (%[[VAL_5]]) {
 ! CHECK:             hlfir.assign %[[ARG0]] to %[[STORE_IV:.*]]#0 : i32, !fir.ref<i32>
 ! CHECK:             %[[LOAD_IV:.*]] = fir.load %[[STORE_IV]]#0 : !fir.ref<i32>
@@ -40,7 +40,7 @@ do i=1, 9
 ! CHECK:         %[[VAL_15:.*]] = arith.constant 1 : i32
 ! CHECK:         %[[VAL_16:.*]] = arith.constant 9 : i32
 ! CHECK:         %[[VAL_17:.*]] = arith.constant 1 : i32
-! CHECK:         omp.wsloop nowait schedule(static = %[[VAL_14]] : i32) private({{.*}}) {
+! CHECK:         omp.wsloop nowait schedule(static = %[[VAL_14]] : i32, monotonic) private({{.*}}) {
 ! CHECK-NEXT:      omp.loop_nest (%[[ARG1:.*]]) : i32 = (%[[VAL_15]]) to (%[[VAL_16]]) inclusive step (%[[VAL_17]]) {
 ! CHECK:             hlfir.assign %[[ARG1]] to %[[STORE_IV1:.*]]#0 : i32, !fir.ref<i32>
 ! CHECK:             %[[VAL_24:.*]] = arith.constant 2 : i32
@@ -66,7 +66,7 @@ end do
 ! CHECK:         %[[VAL_30:.*]] = arith.constant 1 : i32
 ! CHECK:         %[[VAL_31:.*]] = arith.constant 9 : i32
 ! CHECK:         %[[VAL_32:.*]] = arith.constant 1 : i32
-! CHECK:         omp.wsloop nowait schedule(static = %[[VAL_29]] : i32) private({{.*}}) {
+! CHECK:         omp.wsloop nowait schedule(static = %[[VAL_29]] : i32, monotonic) private({{.*}}) {
 ! CHECK-NEXT:      omp.loop_nest (%[[ARG2:.*]]) : i32 = (%[[VAL_30]]) to (%[[VAL_31]]) inclusive step (%[[VAL_32]]) {
 ! CHECK:             hlfir.assign %[[ARG2]] to %[[STORE_IV2:.*]]#0 : i32, !fir.ref<i32>
 ! CHECK:             %[[VAL_39:.*]] = arith.constant 3 : i32

--- a/flang/test/Lower/OpenMP/wsloop.f90
+++ b/flang/test/Lower/OpenMP/wsloop.f90
@@ -58,7 +58,7 @@ subroutine loop_with_schedule_nowait
   ! CHECK:      %[[WS_LB:.*]] = arith.constant 1 : i32
   ! CHECK:      %[[WS_UB:.*]] = arith.constant 9 : i32
   ! CHECK:      %[[WS_STEP:.*]] = arith.constant 1 : i32
-  ! CHECK:      omp.wsloop nowait schedule(runtime) private(@{{.*}} %{{.*}}#0 -> %[[ALLOCA_IV:.*]] : !fir.ref<i32>) {
+  ! CHECK:      omp.wsloop nowait schedule(runtime, nonmonotonic) private(@{{.*}} %{{.*}}#0 -> %[[ALLOCA_IV:.*]] : !fir.ref<i32>) {
   ! CHECK-NEXT:   omp.loop_nest (%[[I:.*]]) : i32 = (%[[WS_LB]]) to (%[[WS_UB]]) inclusive step (%[[WS_STEP]]) {
   !$OMP DO SCHEDULE(runtime)
   do i=1, 9


### PR DESCRIPTION
This is fixing "Default loop schedule modifier for worksharing-loop constructs without static schedule and ordered clause is nonmonotonic since OpenMP 5.0" in the to-do list for removing the OpenMP experimental status warning. I quote the relevant part of OpenMP 6.0 in the patch.

So far as I can tell, in OpenMP 4.5 the default schedule modifier was the `def-sched-var` ICV. The initial value of this ICV is implementation defined (table 2.1). So I believe we don't need to check the version for this.

It wasn't obvious to me whether this should be done in Semantics, Lowering, or LLVMIR codegen. I didn't do it in semantics so that we didn't add modifiers which could be seen in the unparse. It was more convenient to implement in lowering than in codegen.