### PR TITLE
[OpenMP] Fix crash on invalid with cancel directive

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -922,6 +922,7 @@ OpenMP Support
   an invalid expression. (#GH139073)
 - Fixed a crashing bug with ``omp simd collapse`` if the argument to
   ``collapse`` was an invalid expression. (#GH138493)
+- Fixed a crashing bug with a malformed ``cancel`` directive. (#GH139360)
 - Fixed a crashing bug with ``omp distribute dist_schedule`` if the argument to
   ``dist_schedule`` was not strictly positive. (#GH139266)
 

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2487,7 +2487,7 @@ StmtResult Parser::ParseOpenMPExecutableDirective(
   } else if (DKind == OMPD_cancellation_point || DKind == OMPD_cancel) {
     CancelRegion = parseOpenMPDirectiveKind(*this);
     if (Tok.isNot(tok::annot_pragma_openmp_end))
-      ConsumeToken();
+      ConsumeAnyToken();
   }
 
   if (isOpenMPLoopDirective(DKind))

--- a/clang/test/OpenMP/cancel_messages.cpp
+++ b/clang/test/OpenMP/cancel_messages.cpp
@@ -93,3 +93,8 @@ label1 : {
   return 0;
 }
 
+namespace GH139360 {
+void f(){
+#pragma omp cancel( // expected-error {{one of 'for', 'parallel', 'sections' or 'taskgroup' is expected}}
+}
+} // namesapce GH139360


### PR DESCRIPTION
If the next token after 'cancel' is a special token, we would trigger an assertion. We should be consuming any token, same as elsewhere in the function.

Note, we could check for an unknown directive and do different error recovery, but that caused too many behavioral changes for other tests in the form of "unexpected tokens ignored" diagnostics that didn't seem like an improvement for the test cases.

Fixes #139360