### PR TITLE
[NFCI][PGO]Re-purpose synthetic entry count to pseduo entry count for AFDO supplementary profiles

### DIFF
--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -296,11 +296,11 @@ public:
     }
   }
 
-  enum ProfileCountType { PCT_Real, PCT_Synthetic };
+  enum ProfileCountType { PCT_Real, PCT_Pseudo };
 
   /// Class to represent profile counts.
   ///
-  /// This class represents both real and synthetic profile counts.
+  /// This class represents both real and supplementary profile counts.
   class ProfileCount {
   private:
     uint64_t Count = 0;
@@ -311,7 +311,7 @@ public:
         : Count(Count), PCT(PCT) {}
     uint64_t getCount() const { return Count; }
     ProfileCountType getType() const { return PCT; }
-    bool isSynthetic() const { return PCT == PCT_Synthetic; }
+    bool isPseudo() const { return PCT == PCT_Pseudo; }
   };
 
   /// Set the entry count for this function.
@@ -330,16 +330,17 @@ public:
   /// Get the entry count for this function.
   ///
   /// Entry count is the number of times the function was executed.
-  /// When AllowSynthetic is false, only pgo_data will be returned.
-  std::optional<ProfileCount> getEntryCount(bool AllowSynthetic = false) const;
+  /// When \p AllowPseudo is false, supplementary AFDO profile counts in an
+  /// iFDO-optimized binary is not used.
+  std::optional<ProfileCount> getEntryCount(bool AllowPseudo = false) const;
 
   /// Return true if the function is annotated with profile data.
   ///
   /// Presence of entry counts from a profile run implies the function has
-  /// profile annotations. If IncludeSynthetic is false, only return true
-  /// when the profile data is real.
-  bool hasProfileData(bool IncludeSynthetic = false) const {
-    return getEntryCount(IncludeSynthetic).has_value();
+  /// profile annotations. If \p AllowPseudo is false, supplementary AFDO
+  /// profile counts in an iFDO-optimized binary is not used.
+  bool hasProfileData(bool AllowPseudo = false) const {
+    return getEntryCount(AllowPseudo).has_value();
   }
 
   /// Returns the set of GUIDs that needs to be imported to the function for

--- a/llvm/include/llvm/IR/MDBuilder.h
+++ b/llvm/include/llvm/IR/MDBuilder.h
@@ -83,10 +83,10 @@ public:
   MDNode *createUnpredictable();
 
   /// Return metadata containing the entry \p Count for a function, a boolean
-  /// \Synthetic indicating whether the counts were synthetized, and the
-  /// GUIDs stored in \p Imports that need to be imported for sample PGO, to
-  /// enable the same inlines as the profiled optimized binary
-  MDNode *createFunctionEntryCount(uint64_t Count, bool Synthetic,
+  /// \p Pseudo indicating whether the counts were from supplementary AFDO
+  /// profiles, and the GUIDs stored in \p Imports that need to be imported for
+  /// sample PGO, to enable the same inlines as the profiled optimized binary
+  MDNode *createFunctionEntryCount(uint64_t Count, bool Pseudo,
                                    const DenseSet<GlobalValue::GUID> *Imports);
 
   /// Return metadata containing the section prefix for a global object.

--- a/llvm/lib/IR/MDBuilder.cpp
+++ b/llvm/lib/IR/MDBuilder.cpp
@@ -69,12 +69,11 @@ MDNode *MDBuilder::createBranchWeights(ArrayRef<uint32_t> Weights,
 MDNode *MDBuilder::createUnpredictable() { return MDNode::get(Context, {}); }
 
 MDNode *MDBuilder::createFunctionEntryCount(
-    uint64_t Count, bool Synthetic,
-    const DenseSet<GlobalValue::GUID> *Imports) {
+    uint64_t Count, bool Pseudo, const DenseSet<GlobalValue::GUID> *Imports) {
   Type *Int64Ty = Type::getInt64Ty(Context);
   SmallVector<Metadata *, 8> Ops;
-  if (Synthetic)
-    Ops.push_back(createString("synthetic_function_entry_count"));
+  if (Pseudo)
+    Ops.push_back(createString("pseudo_function_entry_count"));
   else
     Ops.push_back(createString("function_entry_count"));
   Ops.push_back(createConstant(ConstantInt::get(Int64Ty, Count)));

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -2046,7 +2046,7 @@ static void updateCallProfile(Function *Callee, const ValueToValueMapTy &VMap,
                               const ProfileCount &CalleeEntryCount,
                               const CallBase &TheCall, ProfileSummaryInfo *PSI,
                               BlockFrequencyInfo *CallerBFI) {
-  if (CalleeEntryCount.isSynthetic() || CalleeEntryCount.getCount() < 1)
+  if (CalleeEntryCount.isPseudo() || CalleeEntryCount.getCount() < 1)
     return;
   auto CallSiteCount =
       PSI ? PSI->getProfileCount(TheCall, CallerBFI) : std::nullopt;

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -5190,14 +5190,14 @@ TEST_F(FunctionAttachmentTest, RealEntryCount) {
   EXPECT_EQ(Function::PCT_Real, Count->getType());
 }
 
-TEST_F(FunctionAttachmentTest, SyntheticEntryCount) {
+TEST_F(FunctionAttachmentTest, PseudoEntryCount) {
   Function *F = getFunction("bar");
   EXPECT_FALSE(F->getEntryCount().has_value());
-  F->setEntryCount(123, Function::PCT_Synthetic);
-  auto Count = F->getEntryCount(true /*allow synthetic*/);
+  F->setEntryCount(123, Function::PCT_Pseudo);
+  auto Count = F->getEntryCount(true /*allow pseudo*/);
   EXPECT_TRUE(Count.has_value());
   EXPECT_EQ(123u, Count->getCount());
-  EXPECT_EQ(Function::PCT_Synthetic, Count->getType());
+  EXPECT_EQ(Function::PCT_Pseudo, Count->getType());
 }
 
 TEST_F(FunctionAttachmentTest, SubprogramAttachment) {


### PR DESCRIPTION
From https://github.com/llvm/llvm-project/pull/107471 and on, there are no active user of setting a function's synthetic counts (except in unit tests). This patch proposes to repurpose the synthetic count concepts to record the fact that a function's entry count is generated from AFDO supplementary profiles. This patch doesn't include the change to 'set' pseudo count itself. A follow-up change will do it.

AFDO supplementary profiles are introduced to enhance instrumented FDO profiles for representativeness, by merging a binary's AFDO production sample into FDO profile. During the merge, a function's hot/cold attribute is _corrected_ by AFDO profiles, and the branch weights of the function's basic blocks are not accurate.

The goal of this re-purpose is for compiler passes to tell whether a function's branch weights are static or based on profiles.
