### PR TITLE
[clang] Add hasAnyNameInVector matcher

### DIFF
--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -3144,6 +3144,24 @@ extern const internal::VariadicFunction<internal::Matcher<NamedDecl>, StringRef,
                                         internal::hasAnyNameFunc>
     hasAnyName;
 
+/// Matches NamedDecl nodes that have any of the names in vector.
+///
+/// This is useful for matching a list of names that are only known at runtime,
+/// e.g. through a command line argument.
+///
+/// \code
+///     hasAnyName({a, b, c})
+/// \endcode
+///  is equivalent to
+/// \code
+///     anyOf(hasName(a), hasName(b), hasName(c))
+/// \endcode
+inline internal::Matcher<NamedDecl>
+hasAnyNameInVector(std::vector<std::string> Names) {
+  return internal::Matcher<NamedDecl>(
+      new internal::HasNameMatcher(std::move(Names)));
+}
+
 /// Matches NamedDecl nodes whose fully qualified names contain
 /// a substring matched by the given RegExp.
 ///


### PR DESCRIPTION
This is useful for matching functions whose name is given as a
parameter, e.g.
