### PR TITLE
[lldb-dap] While handling events, grab the APIMutex for consistency.

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1504,6 +1504,11 @@ void DAP::EventThread() {
   bool done = false;
   while (!done) {
     if (listener.WaitForEvent(1, event)) {
+      // Once we get an event, make sure we finish handling it before the main
+      // thread handles the next DAP request.
+      lldb::SBMutex lock = GetAPIMutex();
+      std::lock_guard<lldb::SBMutex> guard(lock);
+
       const auto event_mask = event.GetType();
       if (lldb::SBProcess::EventIsProcessEvent(event)) {
         lldb::SBProcess process = lldb::SBProcess::GetProcessFromEvent(event);


### PR DESCRIPTION
A number of unit tests are unstable at the moment and I believe this is due to event handling between the event thread and the DAP::Loop.

One way this manifests is the 'disconnect' request terminating the SBTarget while the event handler is still handling module events. This is causing a SIGPIPE between the debugserver and the lldb-dap process.

I have some additional follow up patches to address test event synchronization, since many tests seem to be under specified in terms of their expected state that I think is contributing to these kinds of races.