### PR TITLE
[mlir][IR] Allow !llvm.target as vector element and memref element type

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
@@ -293,7 +293,10 @@ def LLVMPointerType : LLVMType<"LLVMPointer", "ptr", [
 // LLVMTargetExtType
 //===----------------------------------------------------------------------===//
 
-def LLVMTargetExtType : LLVMType<"LLVMTargetExt", "target"> {
+def LLVMTargetExtType
+    : LLVMType<
+          "LLVMTargetExt",
+          "target", [VectorElementTypeInterface, MemRefElementTypeInterface]> {
   let summary = "LLVM target-specific extension type";
   let description = [{
     LLVM dialect target extension type, which are generally unintrospectable

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -819,7 +819,8 @@ bool mlir::LLVM::isCompatibleVectorType(Type type) {
     if (auto intType = llvm::dyn_cast<IntegerType>(elementType))
       return intType.isSignless();
     return llvm::isa<BFloat16Type, Float16Type, Float32Type, Float64Type,
-                     Float80Type, Float128Type, LLVMPointerType>(elementType);
+                     Float80Type, Float128Type, LLVMPointerType,
+                     LLVMTargetExtType>(elementType);
   }
   return false;
 }

--- a/mlir/test/Conversion/FuncToLLVM/func-memref.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/func-memref.mlir
@@ -123,3 +123,11 @@ func.func @loop_carried(%arg0 : index, %arg1 : index, %arg2 : index, %base0 : !b
   ^bb3:  // pred: ^bb1
     return %1, %2 : memref<64xi32, 201>, memref<64xi32, 201>
 }
+
+// -----
+
+func.func @memref_target_ext(%arg0: memref<4x!llvm.target<"spirv.Event">>) {
+  return
+}
+// CHECK-LABEL: func @memref_target_ext
+// CHECK-SAME: (%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: i64, %arg3: i64, %arg4: i64)

--- a/mlir/test/Dialect/LLVMIR/types-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/types-invalid.mlir
@@ -140,3 +140,11 @@ func.func private @target_ext_no_name() {
   // expected-error@below {{failed to parse LLVMTargetExtType parameter 'extTypeName' which is to be a `::llvm::StringRef`}}
   "some.op"() : () -> !llvm.target<i32, 42>
 }
+
+// -----
+
+func.func @invalid_nested_vector_target_ext() {
+  // expected-error@+1 {{vector elements must be int/index/float or be a vector element type}}
+  "some.op"() : () -> vector<2xvector<4x!llvm.target<"spirv.Event">>>
+  return
+}

--- a/mlir/test/Dialect/LLVMIR/types.mlir
+++ b/mlir/test/Dialect/LLVMIR/types.mlir
@@ -197,3 +197,41 @@ llvm.func @ext_target() {
     %4 = "some.op"() : () -> !llvm.target<"target5", i32, f64, 0, 5>
     llvm.return
 }
+
+// -----
+
+// CHECK-LABEL: @target_ext_in_vector
+func.func @target_ext_in_vector() {
+  // CHECK: vector<4x!llvm.target<"spirv.Event">>
+  "some.op"() : () -> vector<4x!llvm.target<"spirv.Event">>
+
+  // CHECK: vector<[8]x!llvm.target<"spirv.DeviceEvent">>
+  "some.op"() : () -> vector<[8]x!llvm.target<"spirv.DeviceEvent">>
+
+  // CHECK: vector<16x!llvm.target<"cuda.CUstream">>
+  "some.op"() : () -> vector<16x!llvm.target<"cuda.CUstream">>
+
+  // CHECK: vector<4x!llvm.target<"nvvm.Foo", i32, 5>>
+  "some.op"() : () -> vector<4x!llvm.target<"nvvm.Foo", i32, 5>>
+
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @target_ext_in_memref
+func.func @target_ext_in_memref() {
+  // CHECK: memref<4x!llvm.target<"spirv.Event">>
+  "some.op"() : () -> memref<4x!llvm.target<"spirv.Event">>
+
+  // CHECK: memref<8x!llvm.target<"spirv.DeviceEvent">>
+  "some.op"() : () -> memref<8x!llvm.target<"spirv.DeviceEvent">>
+
+  // CHECK: memref<?x!llvm.target<"cuda.CUstream">>
+  "some.op"() : () -> memref<?x!llvm.target<"cuda.CUstream">>
+
+  // CHECK: memref<4x8x!llvm.target<"nvvm.Foo", i32, 5>>
+  "some.op"() : () -> memref<4x8x!llvm.target<"nvvm.Foo", i32, 5>>
+
+  return
+}


### PR DESCRIPTION
This commit uses the `VectorTypeElementInterface` to extend support of MLIR vector types and memref types to `!llvm.target`. This gives users the option to make their LLVM target extension types compatible with MLIR vector types and read/load operations on those vectors use by implementing their own Data Layout Type Interface. 

RFC: https://discourse.llvm.org/t/rfc-support-llvm-target-as-element-types-of-vector-and-memref/86302