### PR TITLE
[mlir][ROCDL] Remove unneeded bf16 expansion in LowerGPUToROCDL

### DIFF
--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -319,7 +319,6 @@ struct LowerGpuOpsToROCDLOpsPass final
     {
       RewritePatternSet patterns(ctx);
       populateGpuRewritePatterns(patterns);
-      arith::populateExpandBFloat16Patterns(patterns);
       (void)applyPatternsGreedily(m, std::move(patterns));
     }
 


### PR DESCRIPTION
The umbrella pass fol lowering GPU ops to ROCDL (aka  lowering to LLVM
+ the AMDGPU-specific setup) would call the arith patterns that manually implemented extf and truncf on bfloat because the LLVM AMDGPU backend used to not suppport those operaitons.

Since the backend does now support these operations and has for quite some time, remove these patterns from the default lowering flow.