### PR TITLE
[AIX] Opt in to per-target runtime dir

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -373,7 +373,12 @@ macro(construct_compiler_rt_default_triple)
     message(STATUS "cmake c compiler target: ${CMAKE_C_COMPILER_TARGET}")
     set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${CMAKE_C_COMPILER_TARGET})
   else()
-    set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${LLVM_TARGET_TRIPLE} CACHE STRING
+    set(target_triple ${LLVM_TARGET_TRIPLE})
+    # AIX triples can have OS version numbers we don't want for the compiler-rt target.
+    if (target_triple MATCHES "aix")
+      string(REGEX REPLACE "[0-9.]+$" "" target_triple "${target_triple}")
+    endif()
+    set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${target_triple} CACHE STRING
           "Default triple for which compiler-rt runtimes will be built.")
   endif()
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -976,7 +976,7 @@ endif()
 set(LLVM_TARGET_TRIPLE_ENV CACHE STRING "The name of environment variable to override default target. Disabled by blank.")
 mark_as_advanced(LLVM_TARGET_TRIPLE_ENV)
 
-if(CMAKE_SYSTEM_NAME MATCHES "BSD|Linux|OS390")
+if(CMAKE_SYSTEM_NAME MATCHES "BSD|Linux|OS390|AIX")
   set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR_default ON)
 else()
   set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR_default OFF)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -73,12 +73,7 @@ endfunction()
 macro(set_enable_per_target_runtime_dir)
   # May have been set by llvm/CMakeLists.txt.
   if (NOT DEFINED LLVM_ENABLE_PER_TARGET_RUNTIME_DIR)
-    # AIX should fold 32-bit & 64-bit arch libraries into a single archive.
-    if (LLVM_TARGET_TRIPLE MATCHES "aix")
-      set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR OFF)
-    else()
-      set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR ON)
-    endif()
+    set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR ON)
   endif()
 endmacro()
 


### PR DESCRIPTION
Many targets have already migrated to the per-target runtime directory layout, which is generally preferred. For AIX however, we are currently using per-target runtime directories by default for some runtimes (i.e. `flang-rt`) but not others. This change makes things consistent for other runtimes (most primarily `compiler-rt`) as well, adopting the layout uniformly for the AIX target.

This change also normalizes the triple used for building compiler-rt to remove any OS version number, as there is currently no need to version the runtimes this way and the driver code doesn't expect this anyhow.