### PR TITLE
[lldb-dap] Remove the lldb-vscode symlink (NFC)

### DIFF
--- a/lldb/tools/lldb-vscode
+++ b/lldb/tools/lldb-vscode
@@ -1,1 +1,0 @@
-lldb-dap


### PR DESCRIPTION
Remove the `lldb-vscode` -> `lldb-dap` symlink in the `tools` directory. I initially created the symlink when we renamed the tool to make migration easier. I think enough time has passed that  we don't need it anymore.

My personal motivation is that the symlink causes every file in the `lldb-dap` directory to show up twice (once under `lldb-dap` and once under `lldb-vscode`) in Quick Open in VS Code.