### PR TITLE
[HLSL][RootSignature] Add metadata generation for descriptor tables

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4739,7 +4739,8 @@ def Error : InheritableAttr {
 def RootSignature : Attr {
   /// [RootSignature(Signature)]
   let Spellings = [Microsoft<"RootSignature">];
-  let Args = [IdentifierArgument<"Signature">];
+  let Args = [IdentifierArgument<"SignatureIdent">,
+              DeclArgument<HLSLRootSignature, "SignatureDecl", 0, /*fake=*/1>];
   let Subjects = SubjectList<[Function],
                              ErrorDiag, "'function'">;
   let LangOpts = [HLSL];

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -439,8 +439,7 @@ void CGHLSLRuntime::emitEntryFunction(const FunctionDecl *FD,
   B.CreateRetVoid();
 
   // Add and identify root signature to function, if applicable
-  const AttrVec &Attrs = FD->getAttrs();
-  for (const Attr *Attr : Attrs) {
+  for (const Attr *Attr : FD->getAttrs()) {
     if (const auto *RSAttr = dyn_cast<RootSignatureAttr>(Attr))
       addRootSignature(RSAttr->getSignatureDecl()->getRootElements(), EntryFn,
                        M);

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -68,15 +68,14 @@ void addDxilValVersion(StringRef ValVersionStr, llvm::Module &M) {
   DXILValMD->addOperand(Val);
 }
 
-void addRootSignature(
-    ArrayRef<llvm::hlsl::rootsig::RootElement> Elements,
-    llvm::Function *Fn, llvm::Module &M) {
+void addRootSignature(ArrayRef<llvm::hlsl::rootsig::RootElement> Elements,
+                      llvm::Function *Fn, llvm::Module &M) {
   auto &Ctx = M.getContext();
 
   llvm::hlsl::rootsig::MetadataBuilder Builder(Ctx, Elements);
   MDNode *RootSignature = Builder.BuildRootSignature();
-  MDNode *FnPairing = MDNode::get(Ctx, {ValueAsMetadata::get(Fn),
-                                        RootSignature});
+  MDNode *FnPairing =
+      MDNode::get(Ctx, {ValueAsMetadata::get(Fn), RootSignature});
 
   StringRef RootSignatureValKey = "dx.rootsignatures";
   auto *RootSignatureValMD = M.getOrInsertNamedMetadata(RootSignatureValKey);
@@ -443,7 +442,8 @@ void CGHLSLRuntime::emitEntryFunction(const FunctionDecl *FD,
   const AttrVec &Attrs = FD->getAttrs();
   for (const Attr *Attr : Attrs) {
     if (const auto *RSAttr = dyn_cast<RootSignatureAttr>(Attr))
-      addRootSignature(RSAttr->getSignatureDecl()->getRootElements(), EntryFn, M);
+      addRootSignature(RSAttr->getSignatureDecl()->getRootElements(), EntryFn,
+                       M);
   }
 }
 

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -73,20 +73,14 @@ void addRootSignature(
     llvm::Function *Fn, llvm::Module &M) {
   auto &Ctx = M.getContext();
 
-  SmallVector<Metadata *> GeneratedMetadata;
-  for (auto Element : Elements) {
-    MDNode *ExampleRootElement = MDNode::get(Ctx, {});
-    GeneratedMetadata.push_back(ExampleRootElement);
-  }
-
-  MDNode *ExampleRootSignature = MDNode::get(Ctx, GeneratedMetadata);
-
-  MDNode *ExamplePairing = MDNode::get(Ctx, {ValueAsMetadata::get(Fn),
-                                             ExampleRootSignature});
+  llvm::hlsl::rootsig::MetadataBuilder Builder(Ctx, Elements);
+  MDNode *RootSignature = Builder.BuildRootSignature();
+  MDNode *FnPairing = MDNode::get(Ctx, {ValueAsMetadata::get(Fn),
+                                        RootSignature});
 
   StringRef RootSignatureValKey = "dx.rootsignatures";
   auto *RootSignatureValMD = M.getOrInsertNamedMetadata(RootSignatureValKey);
-  RootSignatureValMD->addOperand(ExamplePairing);
+  RootSignatureValMD->addOperand(FnPairing);
 }
 
 } // namespace

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -959,7 +959,7 @@ void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
 
   IdentifierInfo *Ident = AL.getArgAsIdent(0)->getIdentifierInfo();
   if (auto *RS = D->getAttr<RootSignatureAttr>()) {
-    if (RS->getSignature() != Ident) {
+    if (RS->getSignatureIdent() != Ident) {
       Diag(AL.getLoc(), diag::err_disallowed_duplicate_attribute) << RS;
       return;
     }
@@ -970,10 +970,11 @@ void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
 
   LookupResult R(SemaRef, Ident, SourceLocation(), Sema::LookupOrdinaryName);
   if (SemaRef.LookupQualifiedName(R, D->getDeclContext()))
-    if (isa<HLSLRootSignatureDecl>(R.getFoundDecl())) {
+    if (auto *SignatureDecl =
+            dyn_cast<HLSLRootSignatureDecl>(R.getFoundDecl())) {
       // Perform validation of constructs here
-      D->addAttr(::new (getASTContext())
-                     RootSignatureAttr(getASTContext(), AL, Ident));
+      D->addAttr(::new (getASTContext()) RootSignatureAttr(
+          getASTContext(), AL, Ident, SignatureDecl));
     }
 }
 

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -19,7 +19,7 @@ void FirstEntry() {}
 [numthreads(1,1,1)]
 void SecondEntry() {}
 
-// Sanity test to ensure to root is added for this function
+// Sanity test to ensure no root is added for this function
 [shader("compute")]
 [numthreads(1,1,1)]
 void ThirdEntry() {}

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
+
+// CHECK: !dx.rootsignatures = !{![[#FIRST_ENTRY:]], ![[#SECOND_ENTRY:]]}
+// CHECK-DAG: ![[#FIRST_ENTRY]] = !{ptr @FirstEntry, ![[#RS:]]}
+// CHECK-DAG: ![[#SECOND_ENTRY]] = !{ptr @SecondEntry, ![[#RS:]]}
+// CHECK-DAG: ![[#RS]] = !{}
+
+[shader("compute"), RootSignature("")]
+[numthreads(1,1,1)]
+void FirstEntry() {}
+
+[shader("compute"), RootSignature("DescriptorTable()")]
+[numthreads(1,1,1)]
+void SecondEntry() {}
+
+// Sanity test to ensure to root is added for this function
+[shader("compute")]
+[numthreads(1,1,1)]
+void ThirdEntry() {}

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,9 +1,10 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
 
-// CHECK: !dx.rootsignatures = !{![[#FIRST_ENTRY:]], ![[#SECOND_ENTRY:]]}
-// CHECK-DAG: ![[#FIRST_ENTRY]] = !{ptr @FirstEntry, ![[#RS:]]}
-// CHECK-DAG: ![[#SECOND_ENTRY]] = !{ptr @SecondEntry, ![[#RS:]]}
-// CHECK-DAG: ![[#RS]] = !{}
+// CHECK-DAG: ![[#EMPTY:]] = !{}
+// CHECK-DAG: ![[#SECOND_RS:]] = !{![[#EMPTY]]}
+// CHECK-DAG: ![[#SECOND_ENTRY:]] = !{ptr @SecondEntry, ![[#SECOND_RS]]}
+// CHECK-DAG: ![[#FIRST_ENTRY:]] = !{ptr @FirstEntry, ![[#EMPTY]]}
+// CHECK-DAG: !dx.rootsignatures = !{![[#FIRST_ENTRY]], ![[#SECOND_ENTRY]]}
 
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -5,11 +5,13 @@
 [numthreads(1,1,1)]
 void FirstEntry() {}
 
+// CHECK-DAG: ![[#CBV:]] = !{!"CBV", i32 1, i32 0, i32 0, i32 -1, i32 4}
 // CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable"}
 // CHECK-DAG: ![[#SECOND_RS:]] = !{![[#TABLE]]}
 
 #define SampleDescriptorTable \
   "DescriptorTable( " \
+  "  CBV(b0) " \
   ")"
 [shader("compute"), RootSignature(SampleDescriptorTable)]
 [numthreads(1,1,1)]

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -6,12 +6,14 @@
 void FirstEntry() {}
 
 // CHECK-DAG: ![[#CBV:]] = !{!"CBV", i32 1, i32 0, i32 0, i32 -1, i32 4}
-// CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable"}
+// CHECK-DAG: ![[#SRV:]] = !{!"SRV", i32 4, i32 42, i32 3, i32 32, i32 0}
+// CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable", i32 0, ![[#CBV]], ![[#SRV]]}
 // CHECK-DAG: ![[#SECOND_RS:]] = !{![[#TABLE]]}
 
 #define SampleDescriptorTable \
   "DescriptorTable( " \
-  "  CBV(b0) " \
+  "  CBV(b0), " \
+  "  SRV(t42, space = 3, offset = 32, numDescriptors = 4, flags = 0) " \
   ")"
 [shader("compute"), RootSignature(SampleDescriptorTable)]
 [numthreads(1,1,1)]

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,16 +1,17 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
 
 // CHECK-DAG: ![[#EMPTY:]] = !{}
-// CHECK-DAG: ![[#SECOND_RS:]] = !{![[#EMPTY]]}
-// CHECK-DAG: ![[#SECOND_ENTRY:]] = !{ptr @SecondEntry, ![[#SECOND_RS]]}
-// CHECK-DAG: ![[#FIRST_ENTRY:]] = !{ptr @FirstEntry, ![[#EMPTY]]}
-// CHECK-DAG: !dx.rootsignatures = !{![[#FIRST_ENTRY]], ![[#SECOND_ENTRY]]}
-
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]
 void FirstEntry() {}
 
-[shader("compute"), RootSignature("DescriptorTable()")]
+// CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable"}
+// CHECK-DAG: ![[#SECOND_RS:]] = !{![[#TABLE]]}
+
+#define SampleDescriptorTable \
+  "DescriptorTable( " \
+  ")"
+[shader("compute"), RootSignature(SampleDescriptorTable)]
 [numthreads(1,1,1)]
 void SecondEntry() {}
 
@@ -18,3 +19,7 @@ void SecondEntry() {}
 [shader("compute")]
 [numthreads(1,1,1)]
 void ThirdEntry() {}
+
+// CHECK-DAG: ![[#FIRST_ENTRY:]] = !{ptr @FirstEntry, ![[#EMPTY]]}
+// CHECK-DAG: ![[#SECOND_ENTRY:]] = !{ptr @SecondEntry, ![[#SECOND_RS]]}
+// CHECK-DAG: !dx.rootsignatures = !{![[#FIRST_ENTRY]], ![[#SECOND_ENTRY]]}

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,14 +1,19 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
 
-// CHECK-DAG: ![[#EMPTY:]] = !{}
+// CHECK: !dx.rootsignatures = !{![[#FIRST_ENTRY:]], ![[#SECOND_ENTRY:]]}
+
+// CHECK: ![[#FIRST_ENTRY]] = !{ptr @FirstEntry, ![[#EMPTY:]]}
+// CHECK: ![[#EMPTY]] = !{}
+
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]
 void FirstEntry() {}
 
-// CHECK-DAG: ![[#CBV:]] = !{!"CBV", i32 1, i32 0, i32 0, i32 -1, i32 4}
-// CHECK-DAG: ![[#SRV:]] = !{!"SRV", i32 4, i32 42, i32 3, i32 32, i32 0}
-// CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable", i32 0, ![[#CBV]], ![[#SRV]]}
-// CHECK-DAG: ![[#SECOND_RS:]] = !{![[#TABLE]]}
+// CHECK: ![[#SECOND_ENTRY]] = !{ptr @SecondEntry, ![[#SECOND_RS:]]}
+// CHECK: ![[#SECOND_RS]] = !{![[#TABLE:]]}
+// CHECK: ![[#TABLE]] = !{!"DescriptorTable", i32 0, ![[#CBV:]], ![[#SRV:]]}
+// CHECK: ![[#CBV]] = !{!"CBV", i32 1, i32 0, i32 0, i32 -1, i32 4}
+// CHECK: ![[#SRV]] = !{!"SRV", i32 4, i32 42, i32 3, i32 32, i32 0}
 
 #define SampleDescriptorTable \
   "DescriptorTable( " \
@@ -19,11 +24,8 @@ void FirstEntry() {}
 [numthreads(1,1,1)]
 void SecondEntry() {}
 
-// Sanity test to ensure no root is added for this function
+// Sanity test to ensure no root is added for this function as there is only
+// two entries in !dx.roosignatures
 [shader("compute")]
 [numthreads(1,1,1)]
 void ThirdEntry() {}
-
-// CHECK-DAG: ![[#FIRST_ENTRY:]] = !{ptr @FirstEntry, ![[#EMPTY]]}
-// CHECK-DAG: ![[#SECOND_ENTRY:]] = !{ptr @SecondEntry, ![[#SECOND_RS]]}
-// CHECK-DAG: !dx.rootsignatures = !{![[#FIRST_ENTRY]], ![[#SECOND_ENTRY]]}

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -88,7 +88,9 @@ struct RootConstants {
 // Models the end of a descriptor table and stores its visibility
 struct DescriptorTable {
   ShaderVisibility Visibility = ShaderVisibility::All;
-  uint32_t NumClauses = 0; // The number of clauses in the table
+  // Denotes that the previous NumClauses in the RootElement array
+  // are the clauses in the table.
+  uint32_t NumClauses = 0;
 
   void dump(raw_ostream &OS) const;
 };
@@ -123,7 +125,21 @@ struct DescriptorTableClause {
   void dump(raw_ostream &OS) const;
 };
 
-// Models RootElement : RootConstants | DescriptorTable | DescriptorTableClause
+/// Models RootElement : RootFlags | RootConstants | DescriptorTable
+///  | DescriptorTableClause
+///
+/// A Root Signature is modeled in-memory by an array of RootElements. These
+/// aim to map closely to their DSL grammar reprsentation defined in the spec.
+///
+/// Each optional parameter has its default value defined in the struct, and,
+/// each mandatory parameter does not have a default initialization.
+///
+/// For the variants RootFlags, RootConstants and DescriptorTableClause: each
+/// data member maps directly to a parameter in the grammar.
+///
+/// The DescriptorTable is modelled by having its Clauses as the previous
+/// RootElements in the array, and it holds a data member for the Visibility
+/// parameter.
 using RootElement = std::variant<RootFlags, RootConstants, DescriptorTable,
                                  DescriptorTableClause>;
 

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -15,11 +15,16 @@
 #define LLVM_FRONTEND_HLSL_HLSLROOTSIGNATURE_H
 
 #include "llvm/ADT/ArrayRef.h"
+// #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/Support/DXILABI.h"
 #include "llvm/Support/raw_ostream.h"
 #include <variant>
 
 namespace llvm {
+class LLVMContext;
+class MDNode;
+class Metadata;
+
 namespace hlsl {
 namespace rootsig {
 
@@ -124,6 +129,24 @@ using RootElement = std::variant<RootFlags, RootConstants, DescriptorTable,
                                  DescriptorTableClause>;
 
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements);
+
+class MetadataBuilder {
+ public:
+  MetadataBuilder(llvm::LLVMContext &Ctx, ArrayRef<RootElement> Elements)
+   : Ctx(Ctx), Elements(Elements) {}
+
+  // Iterates through the elements and builds the respective nodes
+  MDNode *BuildRootSignature();
+
+ private:
+  // Define the various builders for the different metadata types
+  MDNode *BuildDescriptorTable(const DescriptorTable &Table);
+  MDNode *BuildDescriptorTableClause(const DescriptorTableClause &Clause);
+
+  llvm::LLVMContext &Ctx;
+  ArrayRef<RootElement> Elements;
+  SmallVector<Metadata *> GeneratedMetadata;
+};
 
 } // namespace rootsig
 } // namespace hlsl

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -15,7 +15,6 @@
 #define LLVM_FRONTEND_HLSL_HLSLROOTSIGNATURE_H
 
 #include "llvm/ADT/ArrayRef.h"
-// #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/Support/DXILABI.h"
 #include "llvm/Support/raw_ostream.h"
 #include <variant>

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -131,15 +131,18 @@ using RootElement = std::variant<RootFlags, RootConstants, DescriptorTable,
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements);
 
 class MetadataBuilder {
- public:
+public:
   MetadataBuilder(llvm::LLVMContext &Ctx, ArrayRef<RootElement> Elements)
-   : Ctx(Ctx), Elements(Elements) {}
+      : Ctx(Ctx), Elements(Elements) {}
 
-  // Iterates through the elements and builds the respective nodes
+  /// Iterates through the elements and dispatches onto the correct Build method
+  ///
+  /// Accumulates the root signature and returns the Metadata node that is just
+  /// a list of all the elements
   MDNode *BuildRootSignature();
 
- private:
-  // Define the various builders for the different metadata types
+private:
+  /// Define the various builders for the different metadata types
   MDNode *BuildDescriptorTable(const DescriptorTable &Table);
   MDNode *BuildDescriptorTableClause(const DescriptorTableClause &Clause);
 

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -163,25 +163,6 @@ void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
   OS << "}";
 }
 
-static MDString *ClauseTypeToName(LLVMContext &Ctx, ClauseType Type) {
-  StringRef Name;
-  switch (Type) {
-  case ClauseType::CBuffer:
-    Name = "CBV";
-    break;
-  case ClauseType::SRV:
-    Name = "SRV";
-    break;
-  case ClauseType::UAV:
-    Name = "UAV";
-    break;
-  case ClauseType::Sampler:
-    Name = "Sampler";
-    break;
-  }
-  return MDString::get(Ctx, Name);
-}
-
 MDNode *MetadataBuilder::BuildRootSignature() {
   for (const RootElement &Element : Elements) {
     MDNode *ElementMD = nullptr;
@@ -220,9 +201,12 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 MDNode *MetadataBuilder::BuildDescriptorTableClause(
     const DescriptorTableClause &Clause) {
   IRBuilder<> B(Ctx);
+  std::string Name;
+  llvm::raw_string_ostream OS(Name);
+  OS << Clause.Type;
   return MDNode::get(
       Ctx, {
-               ClauseTypeToName(Ctx, Clause.Type),
+               MDString::get(Ctx, OS.str()),
                ConstantAsMetadata::get(B.getInt32(Clause.NumDescriptors)),
                ConstantAsMetadata::get(B.getInt32(Clause.Reg.Number)),
                ConstantAsMetadata::get(B.getInt32(Clause.Space)),

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -183,12 +183,12 @@ MDNode *MetadataBuilder::BuildRootSignature() {
 }
 
 MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
-  IRBuilder<> B(Ctx);
+  IRBuilder<> Builder(Ctx);
   SmallVector<Metadata *> TableOperands;
   // Set the mandatory arguments
   TableOperands.push_back(MDString::get(Ctx, "DescriptorTable"));
   TableOperands.push_back(ConstantAsMetadata::get(
-      B.getInt32(llvm::to_underlying(Table.Visibility))));
+      Builder.getInt32(llvm::to_underlying(Table.Visibility))));
 
   // Remaining operands are references to the table's clauses. The in-memory
   // representation of the Root Elements created from parsing will ensure that
@@ -206,19 +206,19 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 
 MDNode *MetadataBuilder::BuildDescriptorTableClause(
     const DescriptorTableClause &Clause) {
-  IRBuilder<> B(Ctx);
+  IRBuilder<> Builder(Ctx);
   std::string Name;
   llvm::raw_string_ostream OS(Name);
   OS << Clause.Type;
   return MDNode::get(
       Ctx, {
                MDString::get(Ctx, OS.str()),
-               ConstantAsMetadata::get(B.getInt32(Clause.NumDescriptors)),
-               ConstantAsMetadata::get(B.getInt32(Clause.Reg.Number)),
-               ConstantAsMetadata::get(B.getInt32(Clause.Space)),
-               ConstantAsMetadata::get(B.getInt32(Clause.Offset)),
+               ConstantAsMetadata::get(Builder.getInt32(Clause.NumDescriptors)),
+               ConstantAsMetadata::get(Builder.getInt32(Clause.Reg.Number)),
+               ConstantAsMetadata::get(Builder.getInt32(Clause.Space)),
+               ConstantAsMetadata::get(Builder.getInt32(Clause.Offset)),
                ConstantAsMetadata::get(
-                   B.getInt32(llvm::to_underlying(Clause.Flags))),
+                   Builder.getInt32(llvm::to_underlying(Clause.Flags))),
            });
 }
 

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -170,6 +170,12 @@ MDNode *MetadataBuilder::BuildRootSignature() {
       ElementMD = BuildDescriptorTableClause(*Clause);
     if (const auto &Table = std::get_if<DescriptorTable>(&Element))
       ElementMD = BuildDescriptorTable(*Table);
+
+    // FIXME(#126586): remove once all RootElemnt variants are handled in a
+    // visit or otherwise
+    assert(ElementMD != nullptr &&
+           "Constructed an unhandled root element type.");
+
     GeneratedMetadata.push_back(ElementMD);
   }
 

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -220,15 +220,16 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 MDNode *MetadataBuilder::BuildDescriptorTableClause(
     const DescriptorTableClause &Clause) {
   IRBuilder<> B(Ctx);
-  return MDNode::get(Ctx, {
-    ClauseTypeToName(Ctx, Clause.Type),
-    ConstantAsMetadata::get(B.getInt32(Clause.NumDescriptors)),
-    ConstantAsMetadata::get(B.getInt32(Clause.Reg.Number)),
-    ConstantAsMetadata::get(B.getInt32(Clause.Space)),
-    ConstantAsMetadata::get(B.getInt32(Clause.Offset)),
-    ConstantAsMetadata::get(
-      B.getInt32(llvm::to_underlying(Clause.Flags))),
-  });
+  return MDNode::get(
+      Ctx, {
+               ClauseTypeToName(Ctx, Clause.Type),
+               ConstantAsMetadata::get(B.getInt32(Clause.NumDescriptors)),
+               ConstantAsMetadata::get(B.getInt32(Clause.Reg.Number)),
+               ConstantAsMetadata::get(B.getInt32(Clause.Space)),
+               ConstantAsMetadata::get(B.getInt32(Clause.Offset)),
+               ConstantAsMetadata::get(
+                   B.getInt32(llvm::to_underlying(Clause.Flags))),
+           });
 }
 
 } // namespace rootsig

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -196,7 +196,16 @@ MDNode *MetadataBuilder::BuildRootSignature() {
 }
 
 MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
-  return MDNode::get(Ctx, {MDString::get(Ctx, "DescriptorTable")});
+  IRBuilder<> B(Ctx);
+  SmallVector<Metadata *> TableOperands;
+  TableOperands.push_back(MDString::get(Ctx, "DescriptorTable"));
+  TableOperands.push_back(ConstantAsMetadata::get(B.getInt32(llvm::to_underlying(Table.Visibility))));
+
+  assert(Table.NumClauses <= GeneratedMetadata.size() && "Table expected all owned clauses to be generated already");
+  TableOperands.append(GeneratedMetadata.end() - Table.NumClauses, GeneratedMetadata.end());
+  GeneratedMetadata.pop_back_n(Table.NumClauses);
+
+  return MDNode::get(Ctx, TableOperands);
 }
 
 MDNode *MetadataBuilder::BuildDescriptorTableClause(const DescriptorTableClause &Clause) {

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -200,7 +200,16 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 }
 
 MDNode *MetadataBuilder::BuildDescriptorTableClause(const DescriptorTableClause &Clause) {
-  return MDNode::get(Ctx, {ClauseTypeToName(Ctx, Clause.Type)});
+  IRBuilder<> B(Ctx);
+  return MDNode::get(Ctx, {
+    ClauseTypeToName(Ctx, Clause.Type),
+    ConstantAsMetadata::get(B.getInt32(Clause.NumDescriptors)),
+    ConstantAsMetadata::get(B.getInt32(Clause.Reg.Number)),
+    ConstantAsMetadata::get(B.getInt32(Clause.Space)),
+    ConstantAsMetadata::get(B.getInt32(Clause.Offset)),
+    ConstantAsMetadata::get(
+      B.getInt32(llvm::to_underlying(Clause.Flags))),
+  });
 }
 
 } // namespace rootsig


### PR DESCRIPTION
- prereq: Modify `RootSignatureAttr` to hold a reference to the owned declaration
- Define and implement `MetadataBuilder` in `HLSLRootSignature`
- Integrate and invoke the builder in `CGHLSLRuntime.cpp` to generate the Root Signature for any associated entry functions
- Add tests to demonstrate functionality in `RootSignature.hlsl`

Resolves https://github.com/llvm/llvm-project/issues/126584

Note: this is essentially just https://github.com/llvm/llvm-project/pull/125131 rebased onto the new approach of constructing a root signature decl, instead of holding the elements in `AdditionalMembers`.