### PR TITLE
[NFC][Clang] Adopt `TrailingObjects` convenience API in MacroArgs

### DIFF
--- a/clang/lib/Lex/MacroArgs.cpp
+++ b/clang/lib/Lex/MacroArgs.cpp
@@ -66,7 +66,7 @@ MacroArgs *MacroArgs::create(const MacroInfo *MI,
                   "uninitialized array (as opposed to reusing a cached "
                   "MacroArgs)");
     std::copy(UnexpArgTokens.begin(), UnexpArgTokens.end(),
-              Result->getTrailingObjects<Token>());
+              Result->getTrailingObjects());
   }
 
   return Result;
@@ -119,7 +119,7 @@ const Token *MacroArgs::getUnexpArgument(unsigned Arg) const {
   assert(Arg < getNumMacroArguments() && "Invalid arg #");
   // The unexpanded argument tokens start immediately after the MacroArgs object
   // in memory.
-  const Token *Start = getTrailingObjects<Token>();
+  const Token *Start = getTrailingObjects();
   const Token *Result = Start;
 
   // Scan to find Arg.


### PR DESCRIPTION
Adopt convenience API for single trailing type added in https://github.com/llvm/llvm-project/pull/138970.