### PR TITLE
[Clang] Fix Sema::checkArgCount for 0-arg functions

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -168,7 +168,7 @@ bool Sema::checkArgCount(CallExpr *Call, unsigned DesiredArgCount) {
 
   return Diag(Range.getBegin(), diag::err_typecheck_call_too_many_args)
          << 0 /*function call*/ << DesiredArgCount << ArgCount
-         << /*is non object*/ 0 << Call->getArg(1)->getSourceRange();
+         << /*is non object*/ 0 << Range;
 }
 
 static bool checkBuiltinVerboseTrap(CallExpr *Call, Sema &S) {

--- a/clang/lib/Sema/SemaWasm.cpp
+++ b/clang/lib/Sema/SemaWasm.cpp
@@ -52,7 +52,7 @@ static bool CheckWasmBuiltinArgIsInteger(Sema &S, CallExpr *E,
 }
 
 bool SemaWasm::BuiltinWasmRefNullExtern(CallExpr *TheCall) {
-  if (SemaRef.checkArgCount(TheCall, 0))
+  if (SemaRef.checkArgCount(TheCall, /*DesiredArgCount=*/0))
     return true;
 
   TheCall->setType(getASTContext().getWebAssemblyExternrefType());
@@ -62,7 +62,7 @@ bool SemaWasm::BuiltinWasmRefNullExtern(CallExpr *TheCall) {
 
 bool SemaWasm::BuiltinWasmRefNullFunc(CallExpr *TheCall) {
   ASTContext &Context = getASTContext();
-  if (SemaRef.checkArgCount(TheCall, 0))
+  if (SemaRef.checkArgCount(TheCall, /*DesiredArgCount=*/0))
     return true;
 
   // This custom type checking code ensures that the nodes are as expected

--- a/clang/lib/Sema/SemaWasm.cpp
+++ b/clang/lib/Sema/SemaWasm.cpp
@@ -52,7 +52,7 @@ static bool CheckWasmBuiltinArgIsInteger(Sema &S, CallExpr *E,
 }
 
 bool SemaWasm::BuiltinWasmRefNullExtern(CallExpr *TheCall) {
-  if (TheCall->getNumArgs() != 0)
+  if (SemaRef.checkArgCount(TheCall, 0))
     return true;
 
   TheCall->setType(getASTContext().getWebAssemblyExternrefType());
@@ -62,12 +62,8 @@ bool SemaWasm::BuiltinWasmRefNullExtern(CallExpr *TheCall) {
 
 bool SemaWasm::BuiltinWasmRefNullFunc(CallExpr *TheCall) {
   ASTContext &Context = getASTContext();
-  if (TheCall->getNumArgs() != 0) {
-    Diag(TheCall->getBeginLoc(), diag::err_typecheck_call_too_many_args)
-        << 0 /*function call*/ << /*expected*/ 0 << TheCall->getNumArgs()
-        << /*is non object*/ 0;
+  if (SemaRef.checkArgCount(TheCall, 0))
     return true;
-  }
 
   // This custom type checking code ensures that the nodes are as expected
   // in order to later on generate the necessary builtin.

--- a/clang/test/Sema/builtins-wasm.c
+++ b/clang/test/Sema/builtins-wasm.c
@@ -7,6 +7,7 @@ static __externref_t table[0];
 typedef void (*__funcref funcref_t)();
 void test_ref_null() {
   funcref_t func = __builtin_wasm_ref_null_func(0); // expected-error {{too many arguments to function call, expected 0, have 1}}
+  __externref_t ref = __builtin_wasm_ref_null_extern(0); // expected-error {{too many arguments to function call, expected 0, have 1}}
 }
 
 void test_table_size(__externref_t ref, void *ptr, int arr[]) {

--- a/clang/test/Sema/builtins.c
+++ b/clang/test/Sema/builtins.c
@@ -75,7 +75,7 @@ void test10(void) __attribute__((noreturn));
 
 void test10(void) {
   __asm__("int3");
-  __builtin_unreachable();
+  __builtin_unreachable(1, 2, 3, 6, 7);
 
   // No warning about falling off the end of a noreturn function.
 }

--- a/clang/test/Sema/builtins.c
+++ b/clang/test/Sema/builtins.c
@@ -75,7 +75,7 @@ void test10(void) __attribute__((noreturn));
 
 void test10(void) {
   __asm__("int3");
-  __builtin_unreachable(1, 2, 3, 6, 7);
+  __builtin_unreachable();
 
   // No warning about falling off the end of a noreturn function.
 }


### PR DESCRIPTION
When calling a function that expects zero arguments with one argument, `Call->getArg(1)` will trap when trying to format the diagnostic. 

This also seems to improve the rendering of the diagnostic some of the time. Before:
```
$ ./bin/clang -c a.c
a.c:2:30: error: too many arguments to function call, expected 2, have 4
    2 |   __builtin_annotation(1, 2, 3, 4);
      |                           ~  ^
```
After:
```
$ ./bin/clang -c a.c
a.c:2:30: error: too many arguments to function call, expected 2, have 4
    2 |   __builtin_annotation(1, 2, 3, 4);
      |                              ^~~~
```

Split from #139580.