### PR TITLE
[NFC][Clang] Adopt `TrailingObjects` API to build ArrayRef

### DIFF
--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -3882,7 +3882,7 @@ public:
   /// Get the set of using declarations that this pack expanded into. Note that
   /// some of these may still be unresolved.
   ArrayRef<NamedDecl *> expansions() const {
-    return llvm::ArrayRef(getTrailingObjects<NamedDecl *>(), NumExpansions);
+    return getTrailingObjects<NamedDecl *>(NumExpansions);
   }
 
   static UsingPackDecl *Create(ASTContext &C, DeclContext *DC,

--- a/clang/include/clang/AST/DeclOpenACC.h
+++ b/clang/include/clang/AST/DeclOpenACC.h
@@ -76,8 +76,7 @@ class OpenACCDeclareDecl final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
 
   OpenACCDeclareDecl(DeclContext *DC, SourceLocation StartLoc,
@@ -89,8 +88,7 @@ class OpenACCDeclareDecl final
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
 
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
 public:
@@ -122,8 +120,7 @@ class OpenACCRoutineDecl final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
 
   OpenACCRoutineDecl(DeclContext *DC, SourceLocation StartLoc,
@@ -139,8 +136,7 @@ class OpenACCRoutineDecl final
     // Initialize the trailing storage.
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
 public:

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -2945,7 +2945,7 @@ public:
 
   /// Retrieve the argument types.
   ArrayRef<TypeSourceInfo *> getArgs() const {
-    return llvm::ArrayRef(getTrailingObjects<TypeSourceInfo *>(), getNumArgs());
+    return getTrailingObjects<TypeSourceInfo *>(getNumArgs());
   }
 
   SourceLocation getBeginLoc() const LLVM_READONLY { return Loc; }
@@ -3619,7 +3619,7 @@ public:
                                   ArrayRef<CleanupObject> objects);
 
   ArrayRef<CleanupObject> getObjects() const {
-    return llvm::ArrayRef(getTrailingObjects<CleanupObject>(), getNumObjects());
+    return getTrailingObjects<CleanupObject>(getNumObjects());
   }
 
   unsigned getNumObjects() const { return ExprWithCleanupsBits.NumObjects; }
@@ -5126,19 +5126,19 @@ public:
   void updateDependence() { setDependence(computeDependence(this)); }
 
   MutableArrayRef<Expr *> getInitExprs() {
-    return MutableArrayRef(getTrailingObjects<Expr *>(), NumExprs);
+    return getTrailingObjects<Expr *>(NumExprs);
   }
 
   const ArrayRef<Expr *> getInitExprs() const {
-    return ArrayRef(getTrailingObjects<Expr *>(), NumExprs);
+    return getTrailingObjects<Expr *>(NumExprs);
   }
 
   ArrayRef<Expr *> getUserSpecifiedInitExprs() {
-    return ArrayRef(getTrailingObjects<Expr *>(), NumUserSpecifiedExprs);
+    return getTrailingObjects<Expr *>(NumUserSpecifiedExprs);
   }
 
   const ArrayRef<Expr *> getUserSpecifiedInitExprs() const {
-    return ArrayRef(getTrailingObjects<Expr *>(), NumUserSpecifiedExprs);
+    return getTrailingObjects<Expr *>(NumUserSpecifiedExprs);
   }
 
   SourceLocation getBeginLoc() const LLVM_READONLY { return LParenLoc; }

--- a/clang/include/clang/AST/ExprOpenMP.h
+++ b/clang/include/clang/AST/ExprOpenMP.h
@@ -78,12 +78,12 @@ public:
 
   /// Fetches the dimensions for array shaping expression.
   ArrayRef<Expr *> getDimensions() const {
-    return llvm::ArrayRef(getTrailingObjects<Expr *>(), NumDims);
+    return getTrailingObjects<Expr *>(NumDims);
   }
 
   /// Fetches source ranges for the brackets os the array shaping expression.
   ArrayRef<SourceRange> getBracketsRanges() const {
-    return llvm::ArrayRef(getTrailingObjects<SourceRange>(), NumDims);
+    return getTrailingObjects<SourceRange>(NumDims);
   }
 
   /// Fetches base expression of array shaping expression.

--- a/clang/include/clang/AST/OpenACCClause.h
+++ b/clang/include/clang/AST/OpenACCClause.h
@@ -541,8 +541,7 @@ class OpenACCWaitClause final
     auto *Exprs = getTrailingObjects<Expr *>();
     llvm::uninitialized_copy(ArrayRef(DevNumExpr), Exprs);
     llvm::uninitialized_copy(QueueIdExprs, Exprs + 1);
-    setExprs(
-        MutableArrayRef(getTrailingObjects<Expr *>(), QueueIdExprs.size() + 1));
+    setExprs(getTrailingObjects<Expr *>(QueueIdExprs.size() + 1));
   }
 
 public:
@@ -580,7 +579,7 @@ class OpenACCNumGangsClause final
       : OpenACCClauseWithExprs(OpenACCClauseKind::NumGangs, BeginLoc, LParenLoc,
                                EndLoc) {
     llvm::uninitialized_copy(IntExprs, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), IntExprs.size()));
+    setExprs(getTrailingObjects<Expr *>(IntExprs.size()));
   }
 
 public:
@@ -609,7 +608,7 @@ class OpenACCTileClause final
       : OpenACCClauseWithExprs(OpenACCClauseKind::Tile, BeginLoc, LParenLoc,
                                EndLoc) {
     llvm::uninitialized_copy(SizeExprs, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), SizeExprs.size()));
+    setExprs(getTrailingObjects<Expr *>(SizeExprs.size()));
   }
 
 public:
@@ -847,7 +846,7 @@ class OpenACCPrivateClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Private, BeginLoc,
                                  LParenLoc, EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -869,7 +868,7 @@ class OpenACCFirstPrivateClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::FirstPrivate, BeginLoc,
                                  LParenLoc, EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -891,7 +890,7 @@ class OpenACCDevicePtrClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::DevicePtr, BeginLoc,
                                  LParenLoc, EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -913,7 +912,7 @@ class OpenACCAttachClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Attach, BeginLoc, LParenLoc,
                                  EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -935,7 +934,7 @@ class OpenACCDetachClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Detach, BeginLoc, LParenLoc,
                                  EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -957,7 +956,7 @@ class OpenACCDeleteClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Delete, BeginLoc, LParenLoc,
                                  EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -979,7 +978,7 @@ class OpenACCUseDeviceClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::UseDevice, BeginLoc,
                                  LParenLoc, EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1001,7 +1000,7 @@ class OpenACCNoCreateClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::NoCreate, BeginLoc,
                                  LParenLoc, EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1023,7 +1022,7 @@ class OpenACCPresentClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Present, BeginLoc,
                                  LParenLoc, EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1044,7 +1043,7 @@ class OpenACCHostClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Host, BeginLoc, LParenLoc,
                                  EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1067,7 +1066,7 @@ class OpenACCDeviceClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Device, BeginLoc, LParenLoc,
                                  EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1095,7 +1094,7 @@ class OpenACCCopyClause final
             Spelling == OpenACCClauseKind::PresentOrCopy) &&
            "Invalid clause kind for copy-clause");
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1129,7 +1128,7 @@ class OpenACCCopyInClause final
             Spelling == OpenACCClauseKind::PresentOrCopyIn) &&
            "Invalid clause kind for copyin-clause");
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1162,7 +1161,7 @@ class OpenACCCopyOutClause final
             Spelling == OpenACCClauseKind::PresentOrCopyOut) &&
            "Invalid clause kind for copyout-clause");
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1195,7 +1194,7 @@ class OpenACCCreateClause final
             Spelling == OpenACCClauseKind::PresentOrCreate) &&
            "Invalid clause kind for create-clause");
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1225,7 +1224,7 @@ class OpenACCReductionClause final
                                  LParenLoc, EndLoc),
         Op(Operator) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1251,7 +1250,7 @@ class OpenACCLinkClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Link, BeginLoc, LParenLoc,
                                  EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:
@@ -1275,7 +1274,7 @@ class OpenACCDeviceResidentClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::DeviceResident, BeginLoc,
                                  LParenLoc, EndLoc) {
     llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
-    setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), VarList.size()));
+    setExprs(getTrailingObjects<Expr *>(VarList.size()));
   }
 
 public:

--- a/clang/include/clang/AST/OpenMPClause.h
+++ b/clang/include/clang/AST/OpenMPClause.h
@@ -3820,10 +3820,10 @@ class OMPReductionClause final
 
   /// Get the list of help private variable reduction flags
   MutableArrayRef<bool> getPrivateVariableReductionFlags() {
-    return MutableArrayRef(getTrailingObjects<bool>(), varlist_size());
+    return getTrailingObjects<bool>(varlist_size());
   }
   ArrayRef<bool> getPrivateVariableReductionFlags() const {
-    return ArrayRef(getTrailingObjects<bool>(), varlist_size());
+    return getTrailingObjects<bool>(varlist_size());
   }
 
   /// Returns the number of Expr* objects in trailing storage
@@ -9660,8 +9660,7 @@ public:
 
   /// Get the clauses storage.
   MutableArrayRef<OMPClause *> getClauses() {
-    return llvm::MutableArrayRef(getTrailingObjects<OMPClause *>(),
-                                     NumClauses);
+    return getTrailingObjects<OMPClause *>(NumClauses);
   }
   ArrayRef<OMPClause *> getClauses() const {
     return const_cast<OMPChildren *>(this)->getClauses();

--- a/clang/include/clang/AST/StmtOpenACC.h
+++ b/clang/include/clang/AST/StmtOpenACC.h
@@ -145,8 +145,7 @@ class OpenACCComputeConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
 
   OpenACCComputeConstruct(OpenACCDirectiveKind K, SourceLocation Start,
@@ -163,8 +162,7 @@ class OpenACCComputeConstruct final
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
 
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
   void setStructuredBlock(Stmt *S) { setAssociatedStmt(S); }
@@ -259,8 +257,7 @@ class OpenACCCombinedConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
 
   OpenACCCombinedConstruct(OpenACCDirectiveKind K, SourceLocation Start,
@@ -275,8 +272,7 @@ class OpenACCCombinedConstruct final
 
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
   void setStructuredBlock(Stmt *S) { setAssociatedStmt(S); }
 
@@ -312,8 +308,7 @@ class OpenACCDataConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
 
   OpenACCDataConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
@@ -325,8 +320,7 @@ class OpenACCDataConstruct final
                                        DirectiveLoc, End, StructuredBlock) {
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
   void setStructuredBlock(Stmt *S) { setAssociatedStmt(S); }
 
@@ -360,8 +354,7 @@ class OpenACCEnterDataConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
   OpenACCEnterDataConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
                             SourceLocation End,
@@ -371,8 +364,7 @@ class OpenACCEnterDataConstruct final
                              DirectiveLoc, End) {
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
 public:
@@ -398,8 +390,7 @@ class OpenACCExitDataConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
   OpenACCExitDataConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
                            SourceLocation End,
@@ -409,8 +400,7 @@ class OpenACCExitDataConstruct final
                              DirectiveLoc, End) {
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
 public:
@@ -438,8 +428,7 @@ class OpenACCHostDataConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
   OpenACCHostDataConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
                            SourceLocation End,
@@ -450,8 +439,7 @@ class OpenACCHostDataConstruct final
                                        DirectiveLoc, End, StructuredBlock) {
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
   void setStructuredBlock(Stmt *S) { setAssociatedStmt(S); }
 
@@ -679,8 +667,7 @@ class OpenACCInitConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
   OpenACCInitConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
                        SourceLocation End,
@@ -690,8 +677,7 @@ class OpenACCInitConstruct final
                              End) {
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
 public:
@@ -719,8 +705,7 @@ class OpenACCShutdownConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
   OpenACCShutdownConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
                            SourceLocation End,
@@ -730,8 +715,7 @@ class OpenACCShutdownConstruct final
                              DirectiveLoc, End) {
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
 public:
@@ -758,8 +742,7 @@ class OpenACCSetConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
 
   OpenACCSetConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
@@ -770,8 +753,7 @@ class OpenACCSetConstruct final
                              End) {
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
 public:
@@ -798,8 +780,7 @@ class OpenACCUpdateConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
 
   OpenACCUpdateConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
@@ -810,8 +791,7 @@ class OpenACCUpdateConstruct final
                              End) {
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
 public:
@@ -844,8 +824,7 @@ class OpenACCAtomicConstruct final
     std::uninitialized_value_construct(
         getTrailingObjects<const OpenACCClause *>(),
         getTrailingObjects<const OpenACCClause *>() + NumClauses);
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  NumClauses));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
   }
 
   OpenACCAtomicConstruct(SourceLocation Start, SourceLocation DirectiveLoc,
@@ -860,8 +839,7 @@ class OpenACCAtomicConstruct final
     llvm::uninitialized_copy(Clauses,
                              getTrailingObjects<const OpenACCClause *>());
 
-    setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                  Clauses.size()));
+    setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
   }
 
   void setAssociatedStmt(Stmt *S) {

--- a/clang/lib/AST/OpenACCClause.cpp
+++ b/clang/lib/AST/OpenACCClause.cpp
@@ -167,7 +167,7 @@ OpenACCGangClause::OpenACCGangClause(SourceLocation BeginLoc,
                              EndLoc) {
   assert(GangKinds.size() == IntExprs.size() && "Mismatch exprs/kind?");
   llvm::uninitialized_copy(IntExprs, getTrailingObjects<Expr *>());
-  setExprs(MutableArrayRef(getTrailingObjects<Expr *>(), IntExprs.size()));
+  setExprs(getTrailingObjects<Expr *>(IntExprs.size()));
   llvm::uninitialized_copy(GangKinds, getTrailingObjects<OpenACCGangKind>());
 }
 

--- a/clang/lib/AST/OpenMPClause.cpp
+++ b/clang/lib/AST/OpenMPClause.cpp
@@ -374,7 +374,7 @@ void OMPOrderedClause::setLoopNumIterations(unsigned NumLoop,
 }
 
 ArrayRef<Expr *> OMPOrderedClause::getLoopNumIterations() const {
-  return llvm::ArrayRef(getTrailingObjects<Expr *>(), NumberOfLoops);
+  return getTrailingObjects<Expr *>(NumberOfLoops);
 }
 
 void OMPOrderedClause::setLoopCounter(unsigned NumLoop, Expr *Counter) {

--- a/clang/lib/AST/StmtOpenACC.cpp
+++ b/clang/lib/AST/StmtOpenACC.cpp
@@ -44,8 +44,7 @@ OpenACCLoopConstruct::OpenACCLoopConstruct(unsigned NumClauses)
   std::uninitialized_value_construct(
       getTrailingObjects<const OpenACCClause *>(),
       getTrailingObjects<const OpenACCClause *>() + NumClauses);
-  setClauseList(
-      MutableArrayRef(getTrailingObjects<const OpenACCClause *>(), NumClauses));
+  setClauseList(getTrailingObjects<const OpenACCClause *>(NumClauses));
 }
 
 OpenACCLoopConstruct::OpenACCLoopConstruct(
@@ -64,8 +63,7 @@ OpenACCLoopConstruct::OpenACCLoopConstruct(
   llvm::uninitialized_copy(Clauses,
                            getTrailingObjects<const OpenACCClause *>());
 
-  setClauseList(MutableArrayRef(getTrailingObjects<const OpenACCClause *>(),
-                                Clauses.size()));
+  setClauseList(getTrailingObjects<const OpenACCClause *>(Clauses.size()));
 }
 
 OpenACCLoopConstruct *OpenACCLoopConstruct::CreateEmpty(const ASTContext &C,

--- a/clang/lib/AST/StmtOpenMP.cpp
+++ b/clang/lib/AST/StmtOpenMP.cpp
@@ -31,7 +31,7 @@ void OMPChildren::setClauses(ArrayRef<OMPClause *> Clauses) {
 }
 
 MutableArrayRef<Stmt *> OMPChildren::getChildren() {
-  return llvm::MutableArrayRef(getTrailingObjects<Stmt *>(), NumChildren);
+  return getTrailingObjects<Stmt *>(NumChildren);
 }
 
 OMPChildren *OMPChildren::Create(void *Mem, ArrayRef<OMPClause *> Clauses) {


### PR DESCRIPTION
Adopt `getTrailingObjects()` overload that returns an ArrayRef that was added in https://github.com/llvm/llvm-project/pull/138970.