### PR TITLE
[WebAssembly] Add extended-const to the "generic" CPU.

### DIFF
--- a/clang/lib/Basic/Targets/WebAssembly.cpp
+++ b/clang/lib/Basic/Targets/WebAssembly.cpp
@@ -168,6 +168,7 @@ bool WebAssemblyTargetInfo::initFeatureMap(
     Features["bulk-memory"] = true;
     Features["bulk-memory-opt"] = true;
     Features["call-indirect-overlong"] = true;
+    Features["extended-const"] = true;
     Features["multivalue"] = true;
     Features["mutable-globals"] = true;
     Features["nontrapping-fptoint"] = true;
@@ -189,7 +190,6 @@ bool WebAssemblyTargetInfo::initFeatureMap(
     addGenericFeatures();
     Features["atomics"] = true;
     Features["exception-handling"] = true;
-    Features["extended-const"] = true;
     Features["fp16"] = true;
     Features["multimemory"] = true;
     Features["tail-call"] = true;

--- a/clang/test/Preprocessor/wasm-target-features.c
+++ b/clang/test/Preprocessor/wasm-target-features.c
@@ -35,13 +35,13 @@
 // EXCEPTION-HANDLING: #define __wasm_exception_handling__ 1{{$}}
 
 // RUN: %clang -E -dM %s -o - 2>&1 \
-// RUN:     -target wasm32-unknown-unknown -mextended-const \
-// RUN:   | FileCheck %s -check-prefix=EXTENDED-CONST
+// RUN:     -target wasm32-unknown-unknown -mno-extended-const \
+// RUN:   | FileCheck %s -check-prefix=NO-EXTENDED-CONST
 // RUN: %clang -E -dM %s -o - 2>&1 \
-// RUN:     -target wasm64-unknown-unknown -mextended-const \
-// RUN:   | FileCheck %s -check-prefix=EXTENDED-CONST
+// RUN:     -target wasm64-unknown-unknown -mno-extended-const \
+// RUN:   | FileCheck %s -check-prefix=NO-EXTENDED-CONST
 //
-// EXTENDED-CONST: #define __wasm_extended_const__ 1{{$}}
+// NO-EXTENDED-CONST-NOT: #define __wasm_extended_const__ 1{{$}}
 
 // RUN: %clang -E -dM %s -o - 2>&1 \
 // RUN:     -target wasm32-unknown-unknown -mfp16 \
@@ -164,6 +164,7 @@
 // RUN:   | FileCheck %s -check-prefix=GENERIC-INCLUDE
 //
 // GENERIC-INCLUDE-DAG: #define __wasm_bulk_memory__ 1{{$}}
+// GENERIC-INCLUDE-DAG: #define __wasm_extended_const__ 1{{$}}
 // GENERIC-INCLUDE-DAG: #define __wasm_multivalue__ 1{{$}}
 // GENERIC-INCLUDE-DAG: #define __wasm_mutable_globals__ 1{{$}}
 // GENERIC-INCLUDE-DAG: #define __wasm_nontrapping_fptoint__ 1{{$}}
@@ -179,7 +180,6 @@
 //
 // GENERIC-NOT: #define __wasm_atomics__ 1{{$}}
 // GENERIC-NOT: #define __wasm_exception_handling__ 1{{$}}
-// GENERIC-NOT: #define __wasm_extended_const__ 1{{$}}
 // GENERIC-NOT: #define __wasm__fp16__ 1{{$}}
 // GENERIC-NOT: #define __wasm_multimemory__ 1{{$}}
 // GENERIC-NOT: #define __wasm_relaxed_simd__ 1{{$}}


### PR DESCRIPTION
This enables -mextended-const in the default "generic" CPU for WebAssembly. extended-const is implemented in the latest versions of all the major browsers, though we should investigate what percentage of each browsers' users have updated to a version that has -mextended-const.

@sbc100 @dschuff 
