### PR TITLE
[WebAssembly,MC] Add ref.test_func handling to AsmParser

### DIFF
--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -669,7 +669,8 @@ public:
         return true;
       ExpectFuncType = true;
     } else if (Name == "ref.test") {
-      // When we get support for wasm-gc types, this should become ExpectRefType.
+      // When we get support for wasm-gc types, this should become
+      // ExpectRefType.
       ExpectFuncType = true;
     }
 

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -669,6 +669,7 @@ public:
         return true;
       ExpectFuncType = true;
     } else if (Name == "ref.test") {
+      // When we get support for wasm-gc types, this should become ExpectRefType.
       ExpectFuncType = true;
     }
 

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -668,6 +668,8 @@ public:
       if (parseFunctionTableOperand(&FunctionTable))
         return true;
       ExpectFuncType = true;
+    } else if (Name == "ref.test_func") {
+      ExpectFuncType = true;
     }
 
     // Returns true if the next tokens are a catch clause

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -668,7 +668,7 @@ public:
       if (parseFunctionTableOperand(&FunctionTable))
         return true;
       ExpectFuncType = true;
-    } else if (Name == "ref.test_func") {
+    } else if (Name == "ref.test") {
       ExpectFuncType = true;
     }
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrRef.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrRef.td
@@ -42,7 +42,7 @@ defm REF_TEST_FUNCREF :
     (outs),
     (ins TypeIndex:$type),
     [],
-    "ref.test_func\t$type, $ref", "ref.test_func $type", 0xfb14>;
+    "ref.test\t$type, $ref", "ref.test $type", 0xfb14>;
 
 defm "" : REF_I<FUNCREF, funcref, "func">;
 defm "" : REF_I<EXTERNREF, externref, "extern">;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrRef.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrRef.td
@@ -36,6 +36,14 @@ multiclass REF_I<WebAssemblyRegClass rc, ValueType vt, string ht> {
         Requires<[HasReferenceTypes]>;
 }
 
+defm REF_TEST_FUNCREF :
+  I<(outs I32: $res),
+    (ins TypeIndex:$type, FUNCREF: $ref),
+    (outs),
+    (ins TypeIndex:$type),
+    [],
+    "ref.test_func\t$type, $ref", "ref.test_func $type", 0xfb14>;
+
 defm "" : REF_I<FUNCREF, funcref, "func">;
 defm "" : REF_I<EXTERNREF, externref, "extern">;
 defm "" : REF_I<EXNREF, exnref, "exn">;

--- a/llvm/test/MC/WebAssembly/reference-types.s
+++ b/llvm/test/MC/WebAssembly/reference-types.s
@@ -37,9 +37,9 @@ ref_null_test:
 ref_test_test:
   .functype ref_test_test () -> (i32, i32)
   ref.null_func
-  ref.test_func () -> ()
+  ref.test () -> ()
   ref.null_func
-  ref.test_func () -> (i32)
+  ref.test () -> (i32)
   end_function
 
 # CHECK-LABEL: ref_sig_test_funcref:

--- a/llvm/test/MC/WebAssembly/reference-types.s
+++ b/llvm/test/MC/WebAssembly/reference-types.s
@@ -27,6 +27,21 @@ ref_null_test:
   drop
   end_function
 
+# CHECK-LABEL: ref_test_test:
+# CHECK: ref.null_func   # encoding: [0xd0,0x70]
+# CHECK: ref.test () -> () # encoding: [0xfb,0x14,0x80'A',0x80'A',0x80'A',0x80'A',A]
+# CHECK: # fixup A - offset: 2, value: .Ltypeindex0@TYPEINDEX, kind: fixup_uleb128_i32
+# CHECK: ref.null_func   # encoding: [0xd0,0x70]
+# CHECK: ref.test () -> (i32) # encoding: [0xfb,0x14,0x80'A',0x80'A',0x80'A',0x80'A',A]
+# CHECK: # fixup A - offset: 2, value: .Ltypeindex1@TYPEINDEX, kind: fixup_uleb128_i32
+ref_test_test:
+  .functype ref_test_test () -> (i32, i32)
+  ref.null_func
+  ref.test_func () -> ()
+  ref.null_func
+  ref.test_func () -> (i32)
+  end_function
+
 # CHECK-LABEL: ref_sig_test_funcref:
 # CHECK-NEXT: .functype ref_sig_test_funcref (funcref) -> (funcref)
 ref_sig_test_funcref:


### PR DESCRIPTION
This will allow us to eliminate the hand-coded webassembly here:
https://github.com/python/cpython/blob/main/Python/emscripten_trampoline.c#L138

cc @tlively @sbc100