### PR TITLE
[perf-training][merge-fdata] Clean up input fdata files

### DIFF
--- a/clang/utils/perf-training/perf-helper.py
+++ b/clang/utils/perf-training/perf-helper.py
@@ -65,9 +65,11 @@ def merge_fdata(args):
             + "\tMerges all fdata files from path into output."
         )
         return 1
-    cmd = [args[0], "-o", args[1]]
-    cmd.extend(findFilesWithExtension(args[2], "fdata"))
-    subprocess.check_call(cmd)
+    inputs = findFilesWithExtension(args[2], "fdata")
+    subprocess.check_call([args[0], inputs, "-o", args[1]])
+    # Remove input fdata files to save space.
+    for filename in inputs:
+        os.remove(filename)
     return 0
 
 


### PR DESCRIPTION
BOLT AArch64 worker has been running out of disk space due to excessive
fdata files being produced from clang-bolt builder. Delete merged fdata
files to counter disk space waste.

Test Plan: TBD
