### PR TITLE
[libc++] Mark std::expected as nodiscard

### DIFF
--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -448,7 +448,7 @@ private:
 };
 
 template <class _Tp, class _Err>
-class expected : private __expected_base<_Tp, _Err> {
+class [[nodiscard]] expected : private __expected_base<_Tp, _Err> {
   static_assert(!is_reference_v<_Tp> && !is_function_v<_Tp> && !is_same_v<remove_cv_t<_Tp>, in_place_t> &&
                     !is_same_v<remove_cv_t<_Tp>, unexpect_t> && !__is_std_unexpected<remove_cv_t<_Tp>>::value &&
                     __valid_std_unexpected<_Err>::value,
@@ -1379,7 +1379,7 @@ private:
 
 template <class _Tp, class _Err>
   requires is_void_v<_Tp>
-class expected<_Tp, _Err> : private __expected_void_base<_Err> {
+class [[nodiscard]] expected<_Tp, _Err> : private __expected_void_base<_Err> {
   static_assert(__valid_std_unexpected<_Err>::value,
                 "[expected.void.general] A program that instantiates expected<T, E> with a E that is not a "
                 "valid argument for unexpected<E> is ill-formed");

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -447,7 +447,7 @@ private:
 };
 
 template <class _Tp, class _Err>
-class expected : private __expected_base<_Tp, _Err> {
+class [[nodiscard]] expected : private __expected_base<_Tp, _Err> {
   static_assert(!is_reference_v<_Tp> && !is_function_v<_Tp> && !is_same_v<remove_cv_t<_Tp>, in_place_t> &&
                     !is_same_v<remove_cv_t<_Tp>, unexpect_t> && !__is_std_unexpected<remove_cv_t<_Tp>>::value &&
                     __valid_std_unexpected<_Err>::value,
@@ -1375,7 +1375,7 @@ private:
 
 template <class _Tp, class _Err>
   requires is_void_v<_Tp>
-class expected<_Tp, _Err> : private __expected_void_base<_Err> {
+class [[nodiscard]] expected<_Tp, _Err> : private __expected_void_base<_Err> {
   static_assert(__valid_std_unexpected<_Err>::value,
                 "[expected.void.general] A program that instantiates expected<T, E> with a E that is not a "
                 "valid argument for unexpected<E> is ill-formed");

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/nodiscard.verify.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++23
+
+// <expected>
+
+// Test that ignoring std::expected generates [[nodiscard]] warnings.
+
+#include <expected>
+
+std::expected<int, int> returns_expected();
+std::expected<void, int> returns_expected_void();
+
+std::expected<int, int> and_then(int);
+std::expected<void, int> and_then_void();
+std::expected<int, int> or_else(int);
+std::expected<void, int> or_else_void(int);
+int transform(int);
+void transform_void();
+int transform_error(int);
+int transform_error_void(int);
+
+void test() {
+  returns_expected();      // expected-warning {{ignoring return value of type 'expected<int, int>'}}
+  returns_expected_void(); // expected-warning {{ignoring return value of type 'expected<void, int>'}}
+
+  returns_expected().and_then(and_then);
+      // expected-warning@-1 {{ignoring return value}}
+  returns_expected_void().and_then(and_then_void);
+      // expected-warning@-1 {{ignoring return value}}
+  returns_expected().or_else(or_else);
+      // expected-warning@-1 {{ignoring return value}}
+  returns_expected_void().or_else(or_else_void);
+      // expected-warning@-1 {{ignoring return value}}
+  returns_expected().transform(transform);
+      // expected-warning@-1 {{ignoring return value}}
+  returns_expected_void().transform(transform_void);
+      // expected-warning@-1 {{ignoring return value}}
+  returns_expected().transform_error(transform_error);
+      // expected-warning@-1 {{ignoring return value}}
+  returns_expected_void().transform_error(transform_error_void);
+      // expected-warning@-1 {{ignoring return value}}
+}

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/nodiscard.verify.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++23
+
+// <expected>
+
+// Test that ignoring std::expected generates [[nodiscard]] warnings.
+
+#include <expected>
+
+std::expected<int, int> returns_expected();
+std::expected<void, int> returns_expected_void();
+
+std::expected<int, int> and_then(int);
+std::expected<void, int> and_then_void();
+std::expected<int, int> or_else(int);
+std::expected<void, int> or_else_void(int);
+int transform(int);
+void transform_void();
+int transform_error(int);
+int transform_error_void(int);
+
+void test() {
+  returns_expected();      // expected-warning {{ignoring return value of type 'expected<int, int>'}}
+  returns_expected_void(); // expected-warning {{ignoring return value of type 'expected<void, int>'}}
+
+  returns_expected().and_then(and_then);
+  // expected-warning@-1 {{ignoring return value}}
+  returns_expected_void().and_then(and_then_void);
+  // expected-warning@-1 {{ignoring return value}}
+  returns_expected().or_else(or_else);
+  // expected-warning@-1 {{ignoring return value}}
+  returns_expected_void().or_else(or_else_void);
+  // expected-warning@-1 {{ignoring return value}}
+  returns_expected().transform(transform);
+  // expected-warning@-1 {{ignoring return value}}
+  returns_expected_void().transform(transform_void);
+  // expected-warning@-1 {{ignoring return value}}
+  returns_expected().transform_error(transform_error);
+  // expected-warning@-1 {{ignoring return value}}
+  returns_expected_void().transform_error(transform_error_void);
+  // expected-warning@-1 {{ignoring return value}}
+}

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/nodiscard.verify.cpp
@@ -31,19 +31,19 @@ void test() {
   returns_expected_void(); // expected-warning {{ignoring return value of type 'expected<void, int>'}}
 
   returns_expected().and_then(and_then);
-      // expected-warning@-1 {{ignoring return value}}
+  // expected-warning@-1 {{ignoring return value}}
   returns_expected_void().and_then(and_then_void);
-      // expected-warning@-1 {{ignoring return value}}
+  // expected-warning@-1 {{ignoring return value}}
   returns_expected().or_else(or_else);
-      // expected-warning@-1 {{ignoring return value}}
+  // expected-warning@-1 {{ignoring return value}}
   returns_expected_void().or_else(or_else_void);
-      // expected-warning@-1 {{ignoring return value}}
+  // expected-warning@-1 {{ignoring return value}}
   returns_expected().transform(transform);
-      // expected-warning@-1 {{ignoring return value}}
+  // expected-warning@-1 {{ignoring return value}}
   returns_expected_void().transform(transform_void);
-      // expected-warning@-1 {{ignoring return value}}
+  // expected-warning@-1 {{ignoring return value}}
   returns_expected().transform_error(transform_error);
-      // expected-warning@-1 {{ignoring return value}}
+  // expected-warning@-1 {{ignoring return value}}
   returns_expected_void().transform_error(transform_error_void);
-      // expected-warning@-1 {{ignoring return value}}
+  // expected-warning@-1 {{ignoring return value}}
 }


### PR DESCRIPTION
Fixes #130656

@hulxv seems no longer to be active, this patch version fixes the errors in the test suite from #130820.