### PR TITLE
[MLIR][LLVM] Print LLVMStructType name using printEscapedString

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypeSyntax.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypeSyntax.cpp
@@ -11,6 +11,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
@@ -58,7 +59,9 @@ void LLVMStructType::print(AsmPrinter &printer) const {
   if (isIdentified()) {
     cyclicPrint = printer.tryStartCyclicPrint(*this);
 
-    printer << '"' << getName() << '"';
+    printer << '"';
+    llvm::printEscapedString(getName(), printer.getStream());
+    printer << '"';
     // If we are printing a reference to one of the enclosing structs, just
     // print the name and stop to avoid infinitely long output.
     if (failed(cyclicPrint)) {

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -1045,3 +1045,11 @@ llvm.func @llvm.aarch64.neon.st3.v8i8.p0(vector<8xi8>, vector<8xi8>, vector<8xi8
 
 llvm.mlir.global internal thread_local unnamed_addr @myglobal(-1 : i32) {addr_space = 0 : i32, alignment = 4 : i64, dso_local} : i32
 // CHECK: llvm.mlir.global internal thread_local unnamed_addr @myglobal(-1 : i32) {addr_space = 0 : i32, alignment = 4 : i64, dso_local} : i32
+
+// CHECK-LABEL: llvm.func @escapedtypename
+llvm.func @escapedtypename() {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK: llvm.alloca %0 x !llvm.struct<"bucket<string, double, '\\b'>::Iterator", (ptr, i64, i64)>
+  %1 = llvm.alloca %0 x !llvm.struct<"bucket<string, double, '\\b'>::Iterator", (ptr, i64, i64)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/Import/struct.ll
+++ b/mlir/test/Target/LLVMIR/Import/struct.ll
@@ -1,0 +1,11 @@
+
+; RUN: mlir-translate -import-llvm -split-input-file %s | FileCheck %s
+
+%"bucket<string, double, '\\b'>::Iterator" = type { ptr, i64, i64 }
+
+; CHECK-LABEL: llvm.func @g
+define void @g() {
+  %item.i = alloca %"bucket<string, double, '\\b'>::Iterator", align 8
+  ; CHECK: llvm.alloca %0 x !llvm.struct<"bucket<string, double, '\\b'>::Iterator", (ptr, i64, i64)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  ret void
+}

--- a/mlir/test/Target/LLVMIR/Import/struct.ll
+++ b/mlir/test/Target/LLVMIR/Import/struct.ll
@@ -1,4 +1,3 @@
-
 ; RUN: mlir-translate -import-llvm -split-input-file %s | FileCheck %s
 
 %"bucket<string, double, '\\b'>::Iterator" = type { ptr, i64, i64 }


### PR DESCRIPTION
LLVM struct type names need to be escaped when printed in order to allow interesting name choices.