### PR TITLE
[BOLT] Use StringRef::contains (NFC)

### DIFF
--- a/bolt/lib/Profile/YAMLProfileReader.cpp
+++ b/bolt/lib/Profile/YAMLProfileReader.cpp
@@ -887,7 +887,7 @@ Error YAMLProfileReader::readProfile(BinaryContext &BC) {
 }
 
 bool YAMLProfileReader::usesEvent(StringRef Name) const {
-  return YamlBP.Header.EventNames.find(std::string(Name)) != StringRef::npos;
+  return StringRef(YamlBP.Header.EventNames).contains(Name);
 }
 
 } // end namespace bolt


### PR DESCRIPTION
Once we convert EventNames to StringRef, which is cheap, we can call
StringRef::contains without creating a temporary instance of
std::string.
