### PR TITLE
[llvm] Use StringRef::{starts_with,find} (NFC)

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -780,7 +780,7 @@ llvm::Error DwarfTransformer::verify(StringRef GsymPath,
           const auto &dii = DwarfInlineInfos.getFrame(Idx);
           gsymFilename = LR->getSourceFile(Idx);
           // Verify function name
-          if (dii.FunctionName.find(gii.Name.str()) != 0)
+          if (!StringRef(dii.FunctionName).starts_with(gii.Name))
             Out << "error: address " << HEX64(Addr) << " DWARF function \""
                 << dii.FunctionName.c_str()
                 << "\" doesn't match GSYM function \"" << gii.Name << "\"\n";

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1796,11 +1796,11 @@ const Init *TernOpInit::Fold(const Record *CurRec) const {
     if (LHSs && MHSs && RHSs) {
       std::string Val = RHSs->getValue().str();
 
-      std::string::size_type found;
-      std::string::size_type idx = 0;
+      StringRef::size_type found;
+      StringRef::size_type idx = 0;
       while (true) {
-        found = Val.find(LHSs->getValue().str(), idx);
-        if (found == std::string::npos)
+        found = StringRef(Val).find(LHSs->getValue(), idx);
+        if (found == StringRef::npos)
           break;
         Val.replace(found, LHSs->getValue().size(), MHSs->getValue().str());
         idx = found + MHSs->getValue().size();


### PR DESCRIPTION
Calling find/contains in the StringRef domain allows us to avoid
creating temporary instances of std::string.
