### PR TITLE
[lldb-dap] Refactor lldb-dap event handling.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -146,7 +146,9 @@ class DAPTestCaseBase(TestBase):
                     found = True
                     break
             self.assertTrue(
-                found, "verify '%s' found in console output for '%s'" % (cmd, flavor)
+                found,
+                "verify '%s' found in console output for '%s' in %s"
+                % (cmd, flavor, output),
             )
 
     def get_dict_value(self, d, key_path):

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -139,7 +139,9 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
             exitCommands=exitCommands,
             terminateCommands=terminateCommands,
             postRunCommands=postRunCommands,
+            disconnectAutomatically=False,
         )
+        self.dap_server.wait_for_stopped()
         # Get output from the console. This should contain both the
         # "initCommands" and the "preRunCommands".
         output = self.get_console()
@@ -169,6 +171,9 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
 
         # Continue until the program exits
         self.continue_to_exit()
+
+        self.dap_server.request_disconnect(terminateDebuggee=True)
+
         # Get output from the console. This should contain both the
         # "exitCommands" that were run after the second breakpoint was hit
         # and the "terminateCommands" due to the debugging session ending

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -45,7 +45,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
-        self.continue_to_next_stop()
+        self.dap_server.wait_for_stopped()
 
         # Use a relatively short timeout since this is only to ensure the
         # following request is queued.
@@ -78,7 +78,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
-        self.continue_to_next_stop()
+        self.dap_server.wait_for_stopped()
 
         blocking_seq = self.async_blocking_request(duration=self.timeoutval / 2)
         # Wait for the sleep to start to cancel the inflight request.

--- a/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
+++ b/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
@@ -169,6 +169,7 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
     def test_diagnositcs(self):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
+        self.dap_server.wait_for_stopped()
 
         core = self.getBuildArtifact("minidump.core")
         self.yaml2obj("minidump.yaml", core)
@@ -176,7 +177,9 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
             f"target create --core  {core}", context="repl"
         )
 
-        output = self.get_important()
+        output = self.collect_important(
+            self.timeoutval, pattern="process ID from minidump file"
+        )
         self.assertIn(
             "warning: unable to retrieve process ID from minidump file",
             output,

--- a/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
+++ b/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
@@ -22,12 +22,8 @@ class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
                 process.terminate()
                 process.wait()
             stdout_data = process.stdout.read().decode()
-            stderr_data = process.stderr.read().decode()
             print("========= STDOUT =========", file=sys.stderr)
             print(stdout_data, file=sys.stderr)
-            print("========= END =========", file=sys.stderr)
-            print("========= STDERR =========", file=sys.stderr)
-            print(stderr_data, file=sys.stderr)
             print("========= END =========", file=sys.stderr)
             print("========= DEBUG ADAPTER PROTOCOL LOGS =========", file=sys.stderr)
             with open(log_file_path, "r") as file:
@@ -52,13 +48,13 @@ class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
         lldb-dap handles invalid message headers.
         """
         process = self.launch()
-        process.stdin.write(b"not the corret message header")
+        process.stdin.write(b"not the correct message header")
         process.stdin.close()
         self.assertEqual(process.wait(timeout=5.0), 1)
 
     def test_partial_header(self):
         """
-        lldb-dap handles parital message headers.
+        lldb-dap handles partial message headers.
         """
         process = self.launch()
         process.stdin.write(b"Content-Length: ")

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -75,9 +75,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         self.dap_server.request_disconnect()
 
         # Wait until the underlying lldb-dap process dies.
-        self.dap_server.process.wait(
-            timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval
-        )
+        self.dap_server.process.wait(timeout=self.timeoutval)
 
         # Check the return code
         self.assertEqual(self.dap_server.process.poll(), 0)
@@ -536,12 +534,13 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
             terminateCommands=terminateCommands,
             disconnectAutomatically=False,
         )
+        self.dap_server.wait_for_stopped()
         self.get_console()
         # Once it's disconnected the console should contain the
         # "terminateCommands"
         self.dap_server.request_disconnect(terminateDebuggee=True)
         output = self.collect_console(
-            timeout_secs=1.0,
+            timeout_secs=self.timeoutval,
             pattern=terminateCommands[0],
         )
         self.verify_commands("terminateCommands", output, terminateCommands)
@@ -553,7 +552,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         as the one returned by "version" command.
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
+        self.build_and_launch(program, stopOnEntry=True)
 
         source = "main.c"
         breakpoint_line = line_number(source, "// breakpoint 1")

--- a/lldb/test/API/tools/lldb-dap/terminated-event/TestDAP_terminatedEvent.py
+++ b/lldb/test/API/tools/lldb-dap/terminated-event/TestDAP_terminatedEvent.py
@@ -32,7 +32,7 @@ class TestDAP_terminatedEvent(lldbdap_testcase.DAPTestCaseBase):
 
         program_basename = "a.out.stripped"
         program = self.getBuildArtifact(program_basename)
-        self.build_and_launch(program)
+        self.build_and_launch(program, stopOnEntry=True, disconnectAutomatically=False)
         # Set breakpoints
         functions = ["foo"]
         breakpoint_ids = self.set_function_breakpoints(functions)

--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -7,16 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "Breakpoint.h"
-#include "DAP.h"
 #include "JSONUtils.h"
 #include "lldb/API/SBAddress.h"
 #include "lldb/API/SBBreakpointLocation.h"
 #include "lldb/API/SBLineEntry.h"
-#include "lldb/API/SBMutex.h"
 #include "llvm/ADT/StringExtras.h"
 #include <cstddef>
 #include <cstdint>
-#include <mutex>
 #include <string>
 
 using namespace lldb_dap;
@@ -81,9 +78,6 @@ bool Breakpoint::MatchesName(const char *name) {
 }
 
 void Breakpoint::SetBreakpoint() {
-  lldb::SBMutex lock = m_dap.GetAPIMutex();
-  std::lock_guard<lldb::SBMutex> guard(lock);
-
   m_bp.AddName(kDAPBreakpointLabel);
   if (!m_condition.empty())
     SetCondition();

--- a/lldb/tools/lldb-dap/ExceptionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/ExceptionBreakpoint.cpp
@@ -9,16 +9,11 @@
 #include "ExceptionBreakpoint.h"
 #include "BreakpointBase.h"
 #include "DAP.h"
-#include "lldb/API/SBMutex.h"
 #include "lldb/API/SBTarget.h"
-#include <mutex>
 
 namespace lldb_dap {
 
 void ExceptionBreakpoint::SetBreakpoint() {
-  lldb::SBMutex lock = m_dap.GetAPIMutex();
-  std::lock_guard<lldb::SBMutex> guard(lock);
-
   if (m_bp.IsValid())
     return;
   bool catch_value = m_filter.find("_catch") != std::string::npos;

--- a/lldb/tools/lldb-dap/FunctionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/FunctionBreakpoint.cpp
@@ -8,8 +8,6 @@
 
 #include "FunctionBreakpoint.h"
 #include "DAP.h"
-#include "lldb/API/SBMutex.h"
-#include <mutex>
 
 namespace lldb_dap {
 
@@ -19,9 +17,6 @@ FunctionBreakpoint::FunctionBreakpoint(
       m_function_name(breakpoint.name) {}
 
 void FunctionBreakpoint::SetBreakpoint() {
-  lldb::SBMutex lock = m_dap.GetAPIMutex();
-  std::lock_guard<lldb::SBMutex> guard(lock);
-
   if (m_function_name.empty())
     return;
   m_bp = m_dap.target.BreakpointCreateByName(m_function_name.c_str());

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -18,7 +18,6 @@
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBEnvironment.h"
 #include "llvm/Support/Error.h"
-#include <mutex>
 
 #if !defined(_WIN32)
 #include <unistd.h>
@@ -137,9 +136,6 @@ void BaseRequestHandler::Run(const Request &request) {
     dap.Send(cancelled);
     return;
   }
-
-  lldb::SBMutex lock = dap.GetAPIMutex();
-  std::lock_guard<lldb::SBMutex> guard(lock);
 
   // FIXME: After all the requests have migrated from LegacyRequestHandler >
   // RequestHandler<> we should be able to move this into

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -13,7 +13,6 @@
 #include "lldb/API/SBBreakpoint.h"
 #include "lldb/API/SBFileSpecList.h"
 #include "lldb/API/SBFrame.h"
-#include "lldb/API/SBMutex.h"
 #include "lldb/API/SBTarget.h"
 #include "lldb/API/SBThread.h"
 #include "lldb/API/SBValue.h"
@@ -21,7 +20,6 @@
 #include <cassert>
 #include <cctype>
 #include <cstdlib>
-#include <mutex>
 #include <utility>
 
 namespace lldb_dap {
@@ -34,9 +32,6 @@ SourceBreakpoint::SourceBreakpoint(DAP &dap,
       m_column(breakpoint.column.value_or(LLDB_INVALID_COLUMN_NUMBER)) {}
 
 void SourceBreakpoint::SetBreakpoint(const llvm::StringRef source_path) {
-  lldb::SBMutex lock = m_dap.GetAPIMutex();
-  std::lock_guard<lldb::SBMutex> guard(lock);
-
   lldb::SBFileSpecList module_list;
   m_bp = m_dap.target.BreakpointCreateByLocation(
       source_path.str().c_str(), m_line, m_column, 0, module_list);

--- a/lldb/tools/lldb-dap/Transport.h
+++ b/lldb/tools/lldb-dap/Transport.h
@@ -66,14 +66,14 @@ public:
   void operator=(const Transport &rhs) = delete;
   /// @}
 
-  /// Writes a Debug Adater Protocol message to the output stream.
+  /// Writes a Debug Adapter Protocol message to the output stream.
   llvm::Error Write(const protocol::Message &M);
 
-  /// Reads the next Debug Adater Protocol message from the input stream.
+  /// Reads the next Debug Adapter Protocol message from the input stream.
   ///
   /// \param timeout[in]
   ///     A timeout to wait for reading the initial header. Once a message
-  ///     header is recieved, this will block until the full message is
+  ///     header is received, this will block until the full message is
   ///     read.
   ///
   /// \returns Returns the next protocol message.


### PR DESCRIPTION
Refactor lldp-dap to use a `lldb_private::MainLoop` to handle events and protocol messages.

This should ensure more uniform handling of debugger state by ensuring only one action is being performed at a time. The MainLoop handles both protocol messages and events. As a result, we can remove some API locks and mutex locks that are not needed.