### PR TITLE
[clang][bytecode] Save Immediate bit in Function

### DIFF
--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -26,6 +26,7 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
       HasRVO(HasRVO) {
   if (const auto *F = dyn_cast<const FunctionDecl *>(Source)) {
     Variadic = F->isVariadic();
+    Immediate = F->isImmediateFunction();
     if (const auto *CD = dyn_cast<CXXConstructorDecl>(F)) {
       Virtual = CD->isVirtual();
       Kind = FunctionKind::Ctor;

--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -22,8 +22,9 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
                    bool HasThisPointer, bool HasRVO, bool IsLambdaStaticInvoker)
     : P(P), Kind(FunctionKind::Normal), Source(Source), ArgSize(ArgSize),
       ParamTypes(std::move(ParamTypes)), Params(std::move(Params)),
-      ParamOffsets(std::move(ParamOffsets)), HasThisPointer(HasThisPointer),
-      HasRVO(HasRVO) {
+      ParamOffsets(std::move(ParamOffsets)), IsValid(false),
+      IsFullyCompiled(false), HasThisPointer(HasThisPointer), HasRVO(HasRVO),
+      Defined(false) {
   if (const auto *F = dyn_cast<const FunctionDecl *>(Source)) {
     Variadic = F->isVariadic();
     Immediate = F->isImmediateFunction();
@@ -41,7 +42,13 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
         Kind = FunctionKind::LambdaCallOperator;
       else if (MD->isCopyAssignmentOperator() || MD->isMoveAssignmentOperator())
         Kind = FunctionKind::CopyOrMoveOperator;
+    } else {
+      Virtual = false;
     }
+  } else {
+    Variadic = false;
+    Virtual = false;
+    Immediate = false;
   }
 }
 

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -277,23 +277,32 @@ private:
   /// List of parameter offsets.
   llvm::SmallVector<unsigned, 8> ParamOffsets;
   /// Flag to indicate if the function is valid.
-  bool IsValid = false;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IsValid : 1;
   /// Flag to indicate if the function is done being
   /// compiled to bytecode.
-  bool IsFullyCompiled = false;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IsFullyCompiled : 1;
   /// Flag indicating if this function takes the this pointer
   /// as the first implicit argument
-  bool HasThisPointer = false;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned HasThisPointer : 1;
   /// Whether this function has Return Value Optimization, i.e.
   /// the return value is constructed in the caller's stack frame.
   /// This is done for functions that return non-primive values.
-  bool HasRVO = false;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned HasRVO : 1;
   /// If we've already compiled the function's body.
-  bool HasBody = false;
-  bool Defined = false;
-  bool Variadic = false;
-  bool Virtual = false;
-  bool Immediate = false;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned HasBody : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned Defined : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned Variadic : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned Virtual : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned Immediate : 1;
 
 public:
   /// Dumps the disassembled bytecode to \c llvm::errs().

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -155,6 +155,7 @@ public:
 
   /// Checks if the function is virtual.
   bool isVirtual() const { return Virtual; };
+  bool isImmediate() const { return Immediate; }
 
   /// Checks if the function is a constructor.
   bool isConstructor() const { return Kind == FunctionKind::Ctor; }
@@ -292,6 +293,7 @@ private:
   bool Defined = false;
   bool Variadic = false;
   bool Virtual = false;
+  bool Immediate = false;
 
 public:
   /// Dumps the disassembled bytecode to \c llvm::errs().

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1502,7 +1502,7 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
   InterpFrame *FrameBefore = S.Current;
   S.Current = NewFrame.get();
 
-  InterpStateCCOverride CCOverride(S, Func->getDecl()->isImmediateFunction());
+  InterpStateCCOverride CCOverride(S, Func->isImmediate());
   // Note that we cannot assert(CallResult.hasValue()) here since
   // Ret() above only sets the APValue if the curent frame doesn't
   // have a caller set.


### PR DESCRIPTION
Otherwise, we have to look at the FunctionDecl at every function call.