### PR TITLE
[mlir] Call hash_combine_range with a range (NFC)

### DIFF
--- a/mlir/include/mlir/IR/Properties.td
+++ b/mlir/include/mlir/IR/Properties.td
@@ -554,7 +554,7 @@ class ArrayProp<Property elem = Property<>, string newSummary = ""> :
           return }] # !subst("$_storage", "propStorage", elem.hashProperty) # [{;
         };
         auto mapped = ::llvm::map_range($_storage, getElemHash);
-        return ::llvm::hash_combine_range(mapped.begin(), mapped.end());
+        return ::llvm::hash_combine_range(mapped);
       }()
     }]);
 }


### PR DESCRIPTION
With #136459, we can now invoke hash_combine_range with a range.
