### PR TITLE
[lldb] Use std:::string::find with std::string_view (NFC)

### DIFF
--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -1076,7 +1076,7 @@ llvm::Expected<Args> Options::ParseAlias(const Args &args,
 
     if (!input_line.empty()) {
       llvm::StringRef tmp_arg = args_copy[idx].ref();
-      size_t pos = input_line.find(std::string(tmp_arg));
+      size_t pos = input_line.find(tmp_arg);
       if (pos != std::string::npos)
         input_line.erase(pos, tmp_arg.size());
     }


### PR DESCRIPTION
std::string::find accepts anything that can be converted to
std::string_view starting in C++17.  Since StringRef can be converted
to std::string_view, we do not need to create a temporary instance of
std::string here.
