### PR TITLE
[TableGen] Use std::string::find (NFC)

### DIFF
--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1796,11 +1796,11 @@ const Init *TernOpInit::Fold(const Record *CurRec) const {
     if (LHSs && MHSs && RHSs) {
       std::string Val = RHSs->getValue().str();
 
-      StringRef::size_type found;
-      StringRef::size_type idx = 0;
+      std::string::size_type found;
+      std::string::size_type idx = 0;
       while (true) {
-        found = StringRef(Val).find(LHSs->getValue(), idx);
-        if (found == StringRef::npos)
+        found = Val.find(LHSs->getValue(), idx);
+        if (found == std::string::npos)
           break;
         Val.replace(found, LHSs->getValue().size(), MHSs->getValue().str());
         idx = found + MHSs->getValue().size();

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1796,14 +1796,13 @@ const Init *TernOpInit::Fold(const Record *CurRec) const {
     if (LHSs && MHSs && RHSs) {
       std::string Val = RHSs->getValue().str();
 
-      std::string::size_type found;
-      std::string::size_type idx = 0;
+      std::string::size_type Idx = 0;
       while (true) {
-        found = Val.find(LHSs->getValue(), idx);
-        if (found == std::string::npos)
+        std::string::size_type Found = Val.find(LHSs->getValue(), Idx);
+        if (Found == std::string::npos)
           break;
-        Val.replace(found, LHSs->getValue().size(), MHSs->getValue().str());
-        idx = found + MHSs->getValue().size();
+        Val.replace(Found, LHSs->getValue().size(), MHSs->getValue().str());
+        Idx = Found + MHSs->getValue().size();
       }
 
       return StringInit::get(RK, Val);


### PR DESCRIPTION
This patch partially reverts #139661 for a better solution.
Specifically, we can take advantage of the fact that std::string::find
accepts anything that can be converted to std::string_view, including
StringRef, starting with C++17.  This way, we do not need to cast Val
to StringRef or LHSs->getValue() to std::string.
