### PR TITLE
[mlir] Use std::string::find with std::string_view (NFC)

### DIFF
--- a/mlir/lib/TableGen/Predicate.cpp
+++ b/mlir/lib/TableGen/Predicate.cpp
@@ -141,14 +141,14 @@ static void performSubstitutions(std::string &str,
                                  ArrayRef<Subst> substitutions) {
   // Apply all parent substitutions from innermost to outermost.
   for (const auto &subst : llvm::reverse(substitutions)) {
-    auto pos = str.find(std::string(subst.first));
+    auto pos = str.find(subst.first);
     while (pos != std::string::npos) {
       str.replace(pos, subst.first.size(), std::string(subst.second));
       // Skip the newly inserted substring, which itself may consider the
       // pattern to match.
       pos += subst.second.size();
       // Find the next possible match position.
-      pos = str.find(std::string(subst.first), pos);
+      pos = str.find(subst.first, pos);
     }
   }
 }


### PR DESCRIPTION
Starting with C++17, std::string::find accepts anything that can be
converted to std::string_view, including StringRef, allowing us to
avoid creating temporary instances of std::string.
