### PR TITLE
[HIP] Fix return type in __clang_hip_cmath.h

### DIFF
--- a/clang/lib/Headers/__clang_hip_cmath.h
+++ b/clang/lib/Headers/__clang_hip_cmath.h
@@ -464,12 +464,13 @@ class __promote : public __promote_imp<_A1, _A2, _A3> {};
 #if __cplusplus >= 201103L
 #define __HIP_OVERLOAD2(__retty, __fn)                                         \
   template <typename __T1, typename __T2>                                      \
-  __DEVICE__ __CONSTEXPR__ typename __hip_enable_if<                           \
-      __hip::is_arithmetic<__T1>::value && __hip::is_arithmetic<__T2>::value,  \
-      typename __hip::__promote<__T1, __T2>::type>::type                       \
-  __fn(__T1 __x, __T2 __y) {                                                   \
-    typedef typename __hip::__promote<__T1, __T2>::type __result_type;         \
-    return __fn((__result_type)__x, (__result_type)__y);                       \
+  __DEVICE__ __CONSTEXPR__                                                     \
+      typename __hip_enable_if<__hip::is_arithmetic<__T1>::value &&            \
+                                   __hip::is_arithmetic<__T2>::value,          \
+                               __retty>::type                                  \
+      __fn(__T1 __x, __T2 __y) {                                               \
+    typedef typename __hip::__promote<__T1, __T2>::type __arg_type;            \
+    return __fn((__arg_type)__x, (__arg_type)__y);                             \
   }
 #else
 #define __HIP_OVERLOAD2(__retty, __fn)                                         \

--- a/clang/test/Headers/__clang_hip_cmath-return_types.hip
+++ b/clang/test/Headers/__clang_hip_cmath-return_types.hip
@@ -376,19 +376,19 @@ __device__ void test_isnormal()
 __device__ void test_isgreater()
 {
     static_assert(is_same<decltype(isgreater((float)0, (float)0)), bool>::value, "");
-    static_assert(is_same<decltype(isgreater((float)0, (double)0)), double>::value, "");
-    static_assert(is_same<decltype(isgreater((double)0, (float)0)), double>::value, "");
+    static_assert(is_same<decltype(isgreater((float)0, (double)0)), bool>::value, "");
+    static_assert(is_same<decltype(isgreater((double)0, (float)0)), bool>::value, "");
     static_assert(is_same<decltype(isgreater((double)0, (double)0)), bool>::value, "");
-    static_assert(is_same<decltype(isgreater(0, (double)0)), double>::value, "");
+    static_assert(is_same<decltype(isgreater(0, (double)0)), bool>::value, "");
 }
 
 __device__ void test_isgreaterequal()
 {
     static_assert(is_same<decltype(isgreaterequal((float)0, (float)0)), bool>::value, "");
-    static_assert(is_same<decltype(isgreaterequal((float)0, (double)0)), double>::value, "");
-    static_assert(is_same<decltype(isgreaterequal((double)0, (float)0)), double>::value, "");
+    static_assert(is_same<decltype(isgreaterequal((float)0, (double)0)), bool>::value, "");
+    static_assert(is_same<decltype(isgreaterequal((double)0, (float)0)), bool>::value, "");
     static_assert(is_same<decltype(isgreaterequal((double)0, (double)0)), bool>::value, "");
-    static_assert(is_same<decltype(isgreaterequal(0, (double)0)), double>::value, "");
+    static_assert(is_same<decltype(isgreaterequal(0, (double)0)), bool>::value, "");
 }
 
 __device__ void test_isinf()
@@ -400,28 +400,28 @@ __device__ void test_isinf()
 __device__ void test_isless()
 {
     static_assert(is_same<decltype(isless((float)0, (float)0)), bool>::value, "");
-    static_assert(is_same<decltype(isless((float)0, (double)0)), double>::value, "");
-    static_assert(is_same<decltype(isless((double)0, (float)0)), double>::value, "");
+    static_assert(is_same<decltype(isless((float)0, (double)0)), bool>::value, "");
+    static_assert(is_same<decltype(isless((double)0, (float)0)), bool>::value, "");
     static_assert(is_same<decltype(isless((double)0, (double)0)), bool>::value, "");
-    static_assert(is_same<decltype(isless(0, (double)0)), double>::value, "");
+    static_assert(is_same<decltype(isless(0, (double)0)), bool>::value, "");
 }
 
 __device__ void test_islessequal()
 {
     static_assert(is_same<decltype(islessequal((float)0, (float)0)), bool>::value, "");
-    static_assert(is_same<decltype(islessequal((float)0, (double)0)), double>::value, "");
-    static_assert(is_same<decltype(islessequal((double)0, (float)0)), double>::value, "");
+    static_assert(is_same<decltype(islessequal((float)0, (double)0)), bool>::value, "");
+    static_assert(is_same<decltype(islessequal((double)0, (float)0)), bool>::value, "");
     static_assert(is_same<decltype(islessequal((double)0, (double)0)), bool>::value, "");
-    static_assert(is_same<decltype(islessequal(0, (double)0)), double>::value, "");
+    static_assert(is_same<decltype(islessequal(0, (double)0)), bool>::value, "");
 }
 
 __device__ void test_islessgreater()
 {
     static_assert(is_same<decltype(islessgreater((float)0, (float)0)), bool>::value, "");
-    static_assert(is_same<decltype(islessgreater((float)0, (double)0)), double>::value, "");
-    static_assert(is_same<decltype(islessgreater((double)0, (float)0)), double>::value, "");
+    static_assert(is_same<decltype(islessgreater((float)0, (double)0)), bool>::value, "");
+    static_assert(is_same<decltype(islessgreater((double)0, (float)0)), bool>::value, "");
     static_assert(is_same<decltype(islessgreater((double)0, (double)0)), bool>::value, "");
-    static_assert(is_same<decltype(islessgreater(0, (double)0)), double>::value, "");
+    static_assert(is_same<decltype(islessgreater(0, (double)0)), bool>::value, "");
 }
 
 __device__ void test_isnan()
@@ -433,10 +433,10 @@ __device__ void test_isnan()
 __device__ void test_isunordered()
 {
     static_assert(is_same<decltype(isunordered((float)0, (float)0)), bool>::value, "");
-    static_assert(is_same<decltype(isunordered((float)0, (double)0)), double>::value, "");
-    static_assert(is_same<decltype(isunordered((double)0, (float)0)), double>::value, "");
+    static_assert(is_same<decltype(isunordered((float)0, (double)0)), bool>::value, "");
+    static_assert(is_same<decltype(isunordered((double)0, (float)0)), bool>::value, "");
     static_assert(is_same<decltype(isunordered((double)0, (double)0)), bool>::value, "");
-    static_assert(is_same<decltype(isunordered(0, (double)0)), double>::value, "");
+    static_assert(is_same<decltype(isunordered(0, (double)0)), bool>::value, "");
 }
 
 __device__ void test_acosh()


### PR DESCRIPTION
Before, some functions like `isgreater(float, double)` would return a `double` instead of a `bool`.

I've stumbled upon this bug while trying to adapt [`External/CUDA/cmath.cu`](https://github.com/llvm/llvm-test-suite/blob/main/External/CUDA/cmath.cu) to HIP.

```
/_llvm-test-suite/External/HIP/../CUDA/math_h.cu:617:20: error: static assertion failed due to requirement 'std::is_same<double, bool>::value':
617 |     static_assert((std::is_same<decltype(isgreater((float)0, (double)0)), bool>::value), "");
```