### PR TITLE
[clang][bytecode][NFC] Delete DynamicAllocator copy/move ctors

### DIFF
--- a/clang/lib/AST/ByteCode/DynamicAllocator.h
+++ b/clang/lib/AST/ByteCode/DynamicAllocator.h
@@ -59,6 +59,8 @@ private:
 
 public:
   DynamicAllocator() = default;
+  DynamicAllocator(DynamicAllocator &) = delete;
+  DynamicAllocator(DynamicAllocator &&) = delete;
   ~DynamicAllocator();
 
   void cleanup();


### PR DESCRIPTION
They should never be needed.