### PR TITLE
[lldb] Fix compilation errors from #138896

### DIFF
--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -99,7 +99,7 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   if (startupinfo.hStdOutput)
     inherited_handles.push_back(startupinfo.hStdOutput);
 
-  size_t attributelist_size = 0;
+  SIZE_T attributelist_size = 0;
   InitializeProcThreadAttributeList(/*lpAttributeList=*/nullptr,
                                     /*dwAttributeCount=*/1, /*dwFlags=*/0,
                                     &attributelist_size);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -924,7 +924,8 @@ Status GDBRemoteCommunication::StartDebugserverProcess(
     debugserver_args.AppendArgument(fd_arg.GetString());
     // Send "pass_comm_fd" down to the inferior so it can use it to
     // communicate back with this process. Ignored on Windows.
-    launch_info.AppendDuplicateFileAction((int)pass_comm_fd, (int)pass_comm_fd);
+    launch_info.AppendDuplicateFileAction((int64_t)pass_comm_fd,
+                                          (int64_t)pass_comm_fd);
   }
 
   // use native registers, not the GDB registers

--- a/lldb/tools/lldb-server/lldb-platform.cpp
+++ b/lldb/tools/lldb-server/lldb-platform.cpp
@@ -274,8 +274,8 @@ static Status spawn_process(const char *progname, const FileSpec &prog,
   self_args.AppendArgument(llvm::StringRef("platform"));
   self_args.AppendArgument(llvm::StringRef("--child-platform-fd"));
   self_args.AppendArgument(llvm::to_string(shared_socket.GetSendableFD()));
-  launch_info.AppendDuplicateFileAction((int)shared_socket.GetSendableFD(),
-                                        (int)shared_socket.GetSendableFD());
+  launch_info.AppendDuplicateFileAction((int64_t)shared_socket.GetSendableFD(),
+                                        (int64_t)shared_socket.GetSendableFD());
   if (gdb_port) {
     self_args.AppendArgument(llvm::StringRef("--gdbserver-port"));
     self_args.AppendArgument(llvm::to_string(gdb_port));


### PR DESCRIPTION
- s/size_t/SIZE_T to match the windows API
- case HANDLE to int64_t to avoid cast-to-int-of-different-size errors/warnings