### PR TITLE
[TableGen] Avoid assignmentInAssert warning

### DIFF
--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -2608,9 +2608,9 @@ void GICombinerEmitter::emitTestSimplePredicate(raw_ostream &OS) {
     // That way we can just get the RuleID from the enum by subtracting
     // (GICXXPred_Invalid + 1).
     unsigned ExpectedID = 0;
-    (void)ExpectedID;
     for (const auto &ID : keys(AllCombineRules)) {
-      assert(ExpectedID++ == ID && "combine rules are not ordered!");
+      ++ExpectedID;
+      assert(ExpectedID == ID && "combine rules are not ordered!");
       OS << "  " << getIsEnabledPredicateEnumName(ID) << EnumeratorSeparator;
       EnumeratorSeparator = ",\n";
     }


### PR DESCRIPTION
ExpectedID should be optimized out anyway if built without assertions because nothing reads its value.

Fixes #90327