### PR TITLE
[SPIR-V] Fix LIT tests, improve ICmpInst's type inference

### DIFF
--- a/llvm/test/CodeGen/SPIRV/pointers/resource-addrspacecast-2.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/resource-addrspacecast-2.ll
@@ -1,9 +1,6 @@
 ; RUN: llc -verify-machineinstrs -O3 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s --match-full-lines
 ; RUN: %if spirv-tools %{ llc -O3 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
 
-; FIXME(134119): enable-this once Offset decoration are added.
-; XFAIL: spirv-tools
-
 %S2 = type { { [10 x { i32, i32 } ] }, i32 }
 
 ; CHECK-DAG:                     %[[#uint:]] = OpTypeInt 32 0

--- a/llvm/test/CodeGen/SPIRV/pointers/resource-addrspacecast.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/resource-addrspacecast.ll
@@ -1,9 +1,6 @@
 ; RUN: llc -verify-machineinstrs -O3 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O3 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
 
-; FIXME(134119): enable-this once Offset decoration are added.
-; XFAIL: spirv-tools
-
 %struct.S = type { i32 }
 
 ; CHECK-DAG:                     %[[#uint:]] = OpTypeInt 32 0


### PR DESCRIPTION
1. There are failed LIT tests at the moment due to type inference errors.
```
Failed Tests (3):
  LLVM :: CodeGen/SPIRV/pointers/ptr-eq-types.ll
  LLVM :: CodeGen/SPIRV/validate/sycl-hier-par-basic.ll
  LLVM :: CodeGen/SPIRV/validate/sycl-tangle-group-algorithms.ll
```
This PR improves type inference to fix the errors.

2. The following tests start passing:
```
Unexpectedly Passed Tests (2):
  LLVM :: CodeGen/SPIRV/pointers/resource-addrspacecast-2.ll
  LLVM :: CodeGen/SPIRV/pointers/resource-addrspacecast.ll
```
This PR removes XFAILS in those two test cases.