### PR TITLE
[FuzzMutate] Prevent UB caused by parameter ABI attributes

### DIFF
--- a/llvm/include/llvm/FuzzMutate/IRMutator.h
+++ b/llvm/include/llvm/FuzzMutate/IRMutator.h
@@ -144,9 +144,6 @@ public:
 
   using IRMutationStrategy::mutate;
   void mutate(BasicBlock &BB, RandomIRBuilder &IB) override;
-
-private:
-  bool isUnsupportedFunction(Function *F);
 };
 
 /// Strategy to split a random block and insert a random CFG in between.

--- a/llvm/include/llvm/FuzzMutate/IRMutator.h
+++ b/llvm/include/llvm/FuzzMutate/IRMutator.h
@@ -144,6 +144,9 @@ public:
 
   using IRMutationStrategy::mutate;
   void mutate(BasicBlock &BB, RandomIRBuilder &IB) override;
+
+private:
+  bool isUnsupportedFunction(Function *F);
 };
 
 /// Strategy to split a random block and insert a random CFG in between.


### PR DESCRIPTION
This PR prevents the IRMutator from incorrectly calling functions that have ABI attributes, otherwise the mutations introduce UB.