### PR TITLE
langref updates for aarch64 trampoline

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -411,7 +411,7 @@ added in the future:
       be saved by the caller, but on Windows, xmm6-xmm15 are preserved.
 
     - On AArch64 the callee preserve all general purpose registers, except
-      X0-X8 and X16-X18. Not allowed with nest.
+      X0-X8 and X16-X18. Not allowed with ``nest``.
 
     The idea behind this convention is to support calls to runtime functions
     that have a hot path and a cold path. The hot path is usually a small piece
@@ -449,7 +449,7 @@ added in the future:
 
     - On AArch64 the callee preserve all general purpose registers, except
       X0-X8 and X16-X18. Furthermore it also preserves lower 128 bits of V8-V31
-      SIMD floating point registers. Not allowed with nest.
+      SIMD floating point registers. Not allowed with ``nest``.
 
     The idea behind this convention is to support calls to runtime functions
     that don't need to call out to any other functions.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -411,8 +411,7 @@ added in the future:
       be saved by the caller, but on Windows, xmm6-xmm15 are preserved.
 
     - On AArch64 the callee preserve all general purpose registers, except
-      X0-X8 and X16-X18. Using this calling convention with nest is forbidden
-      and may crash llvm.
+      X0-X8 and X16-X18. Not allowed with nest.
 
     The idea behind this convention is to support calls to runtime functions
     that have a hot path and a cold path. The hot path is usually a small piece
@@ -450,8 +449,7 @@ added in the future:
 
     - On AArch64 the callee preserve all general purpose registers, except
       X0-X8 and X16-X18. Furthermore it also preserves lower 128 bits of V8-V31
-      SIMD floating point registers. Using this calling convention with nest is
-      forbidden and may crash llvm.
+      SIMD floating point registers. Not allowed with nest.
 
     The idea behind this convention is to support calls to runtime functions
     that don't need to call out to any other functions.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -410,8 +410,9 @@ added in the future:
       calling convention: on most platforms, they are not preserved and need to
       be saved by the caller, but on Windows, xmm6-xmm15 are preserved.
 
-    - On AArch64 the callee preserve all general purpose registers, except X0-X8
-      and X16-X18.
+    - On AArch64 the callee preserve all general purpose registers, except
+      X0-X8 and X16-X18. Using this calling convention with nest is forbidden
+      and may crash llvm.
 
     The idea behind this convention is to support calls to runtime functions
     that have a hot path and a cold path. The hot path is usually a small piece
@@ -447,9 +448,10 @@ added in the future:
       R11. R11 can be used as a scratch register. Furthermore it also preserves
       all floating-point registers (XMMs/YMMs).
 
-    - On AArch64 the callee preserve all general purpose registers, except X0-X8
-      and X16-X18. Furthermore it also preserves lower 128 bits of V8-V31 SIMD -
-      floating point registers.
+    - On AArch64 the callee preserve all general purpose registers, except
+      X0-X8 and X16-X18. Furthermore it also preserves lower 128 bits of V8-V31
+      SIMD floating point registers. Using this calling convention with nest is
+      forbidden and may crash llvm.
 
     The idea behind this convention is to support calls to runtime functions
     that don't need to call out to any other functions.
@@ -21120,7 +21122,12 @@ sufficiently aligned block of memory; this memory is written to by the
 intrinsic. Note that the size and the alignment are target-specific -
 LLVM currently provides no portable way of determining them, so a
 front-end that generates this intrinsic needs to have some
-target-specific knowledge. The ``func`` argument must hold a function.
+target-specific knowledge.
+
+The ``func`` argument must be a constant (potentially bitcasted) pointer to a
+function declaration or definition, since the calling convention may affect the
+content of the trampoline that is created.
+
 
 Semantics:
 """"""""""


### PR DESCRIPTION
Add clarifying comments to the langref from the review of #126743 (split from the functional changes, to follow).

@efriedma-quic as discussed here https://github.com/llvm/llvm-project/pull/126743#discussion_r1975955490