### PR TITLE
[RISCV] Introduce add_vl combine for identity operand

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -16619,6 +16619,25 @@ NodeExtensionHelper::getSupportedFoldings(const SDNode *Root) {
 }
 } // End anonymous namespace.
 
+static SDValue simplifyOp_VL(SDNode *N) {
+  // TODO: Extend this to other binops using generic identity logic
+  assert(N->getOpcode() == RISCVISD::ADD_VL);
+  SDValue A = N->getOperand(0);
+  SDValue B = N->getOperand(1);
+  SDValue Passthru = N->getOperand(2);
+  if (!Passthru.isUndef())
+    // TODO:This could be a vmerge instead
+    return SDValue();
+  ;
+  if (ISD::isConstantSplatVectorAllZeros(B.getNode()))
+    return A;
+  // Peek through fixed to scalable
+  if (B.getOpcode() == ISD::INSERT_SUBVECTOR && B.getOperand(0).isUndef() &&
+      ISD::isConstantSplatVectorAllZeros(B.getOperand(1).getNode()))
+    return A;
+  return SDValue();
+}
+
 /// Combine a binary or FMA operation to its equivalent VW or VW_W form.
 /// The supported combines are:
 /// add | add_vl | or disjoint | or_vl disjoint -> vwadd(u) | vwadd(u)_w
@@ -18515,20 +18534,10 @@ static SDValue combineVqdotAccum(SDNode *N, SelectionDAG &DAG,
     return SDValue();
 
   SDValue AccumOp = DotOp.getOperand(2);
-  bool IsNullAdd = ISD::isConstantSplatVectorAllZeros(AccumOp.getNode());
-  // Peek through fixed to scalable
-  if (!IsNullAdd && AccumOp.getOpcode() == ISD::INSERT_SUBVECTOR &&
-      AccumOp.getOperand(0).isUndef())
-    IsNullAdd =
-        ISD::isConstantSplatVectorAllZeros(AccumOp.getOperand(1).getNode());
-
   SDLoc DL(N);
   EVT VT = N->getValueType(0);
-  // The manual constant folding is required, this case is not constant folded
-  // or combined.
-  if (!IsNullAdd)
-    Addend = DAG.getNode(RISCVISD::ADD_VL, DL, VT, AccumOp, Addend,
-                         DAG.getUNDEF(VT), AddMask, AddVL);
+  Addend = DAG.getNode(RISCVISD::ADD_VL, DL, VT, Addend, AccumOp,
+                       DAG.getUNDEF(VT), AddMask, AddVL);
 
   SDValue Ops[] = {DotOp.getOperand(0), DotOp.getOperand(1), Addend,
                    DotOp.getOperand(3), DotOp->getOperand(4)};
@@ -19657,6 +19666,8 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
     break;
   }
   case RISCVISD::ADD_VL:
+    if (SDValue V = simplifyOp_VL(N))
+      return V;
     if (SDValue V = combineOp_VLToVWOp_VL(N, DCI, Subtarget))
       return V;
     if (SDValue V = combineVqdotAccum(N, DAG, Subtarget))


### PR DESCRIPTION
This is mostly a refactor of the recently added zvqdotq accumulation path so that I can try merging that with the vwmacc codepaths.