### PR TITLE
[OpenMP] Fix crash with invalid size expression

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -14551,7 +14551,10 @@ StmtResult SemaOpenMP::ActOnOpenMPStripeDirective(ArrayRef<OMPClause *> Clauses,
 
   const auto *SizesClause =
       OMPExecutableDirective::getSingleClause<OMPSizesClause>(Clauses);
-  if (!SizesClause || llvm::is_contained(SizesClause->getSizesRefs(), nullptr))
+  if (!SizesClause ||
+      llvm::any_of(SizesClause->getSizesRefs(), [](const Expr *SizeExpr) {
+        return !SizeExpr || SizeExpr->containsErrors();
+      }))
     return StmtError();
   unsigned NumLoops = SizesClause->getNumSizes();
 

--- a/clang/test/OpenMP/stripe_messages.cpp
+++ b/clang/test/OpenMP/stripe_messages.cpp
@@ -161,3 +161,11 @@ void template_inst() {
   // expected-note@+1 {{in instantiation of function template specialization 'templated_func_type_dependent<int>' requested here}}
   templated_func_type_dependent<int>();
 }
+
+namespace GH139433 {
+void f() {
+#pragma omp stripe sizes(a)
+  for (int i = 0; i < 10; i++)
+    ;
+}
+} // namespace GH139433

--- a/clang/test/OpenMP/stripe_messages.cpp
+++ b/clang/test/OpenMP/stripe_messages.cpp
@@ -164,7 +164,7 @@ void template_inst() {
 
 namespace GH139433 {
 void f() {
-#pragma omp stripe sizes(a)
+#pragma omp stripe sizes(a)    // expected-error {{use of undeclared identifier 'a'}}
   for (int i = 0; i < 10; i++)
     ;
 }


### PR DESCRIPTION
We weren't correctly handling size expressions with errors before trying to get the type of the size expression.

No release note needed because support for 'stripe' was added to the current release.

Fixes #139433