### PR TITLE
[Clang][PGO][UserManual] Specify usage of -b flag

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -2792,6 +2792,9 @@ usual build cycle when using sample profilers for optimization:
 
      $ llvm-profgen --binary=./code --output=code.prof --perfdata=perf.data
 
+   Please note, ``perf.data`` must be collected with ``-b`` flag to Linux ``perf``
+   for the above step to work.
+
    When using SEP the output is in the textual format corresponding to
    ``llvm-profgen --perfscript``. For example:
 


### PR DESCRIPTION
llvm-profgen cannot accept the perf profiles collected without `-b` and errors out with a message `"Invalid perf script input!"`.

This can also be validated from the code in function `checkPerfScriptType()` in `tools/llvm-profgen/PerfReader.cpp.`