### PR TITLE
[C++20] Fix a crash with spaceship and vector types

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -118,6 +118,9 @@ C++23 Feature Support
 
 C++20 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
+- Fixed a crash with a defaulted spaceship (``<=>``) operator when the class
+  contains a member declaration of vector type. Vector types cannot yet be
+  compared directly, so this causes the operator to be deleted. (#GH137452)
 
 C++17 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10176,6 +10176,9 @@ def note_defaulted_comparison_no_viable_function_synthesized : Note<
 def note_defaulted_comparison_not_rewritten_callee : Note<
   "defaulted %0 is implicitly deleted because this non-rewritten comparison "
   "function would be the best match for the comparison">;
+def note_defaulted_comparison_vector_types : Note<
+  "defaulted %0 is implicitly deleted because defaulted comparison of vector "
+  "types is not supported">;
 def note_defaulted_comparison_not_rewritten_conversion : Note<
   "defaulted %0 is implicitly deleted because a builtin comparison function "
   "using this conversion would be the best match for the comparison">;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -8653,8 +8653,15 @@ private:
 
         // FIXME: If the type we deduced is a vector type, we mark the
         // comparison as deleted because we don't yet support this.
-        if (isa<VectorType>(T))
+        if (isa<VectorType>(T)) {
+          if (Diagnose == ExplainDeleted) {
+            S.Diag(FD->getLocation(),
+                   diag::note_defaulted_comparison_vector_types)
+                << FD;
+            S.Diag(Subobj.Decl->getLocation(), diag::note_declared_at);
+          }
           return Result::deleted();
+        }
 
         if (NeedsDeducing) {
           std::optional<ComparisonCategoryType> Cat =

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -8651,6 +8651,11 @@ private:
         assert(Best->BuiltinParamTypes[2].isNull() &&
                "invalid builtin comparison");
 
+        // FIXME: If the type we deduced is a vector type, we mark the
+        // comparison as deleted because we don't yet support this.
+        if (isa<VectorType>(T))
+          return Result::deleted();
+
         if (NeedsDeducing) {
           std::optional<ComparisonCategoryType> Cat =
               getComparisonCategoryForBuiltinCmp(T);

--- a/clang/test/SemaCXX/cxx2a-three-way-comparison.cpp
+++ b/clang/test/SemaCXX/cxx2a-three-way-comparison.cpp
@@ -61,8 +61,9 @@ namespace PR44325 {
 
 namespace GH137452 {
 struct comparable_t {
-    __attribute__((vector_size(32))) double numbers;
+    __attribute__((vector_size(32))) double numbers;           // expected-note {{declared here}}
     auto operator<=>(const comparable_t& rhs) const = default; // expected-warning {{explicitly defaulted three-way comparison operator is implicitly deleted}} \
-                                                                  expected-note {{replace 'default' with 'delete'}}
+                                                                  expected-note {{replace 'default' with 'delete'}} \
+                                                                  expected-note {{defaulted 'operator<=>' is implicitly deleted because defaulted comparison of vector types is not supported}}
 };
 } // namespace GH137452

--- a/clang/test/SemaCXX/cxx2a-three-way-comparison.cpp
+++ b/clang/test/SemaCXX/cxx2a-three-way-comparison.cpp
@@ -58,3 +58,11 @@ namespace PR44325 {
   // implicit rewrite rules, not for explicit use by programs.
   bool c = cmp_cat() < 0; // expected-warning {{zero as null pointer constant}}
 }
+
+namespace GH137452 {
+struct comparable_t {
+    __attribute__((vector_size(32))) double numbers;
+    auto operator<=>(const comparable_t& rhs) const = default; // expected-warning {{explicitly defaulted three-way comparison operator is implicitly deleted}} \
+                                                                  expected-note {{replace 'default' with 'delete'}}
+};
+} // namespace GH137452


### PR DESCRIPTION
Vector types cannot be directly compared, you get an error when you try to do so. This patch causes the explicitly defaulted spaceship operator to be implicitly deleted.

Fixes #137452