### PR TITLE
[flang] Pad Hollerith actual arguments

### DIFF
--- a/flang/test/Semantics/pad-hollerith-arg.f
+++ b/flang/test/Semantics/pad-hollerith-arg.f
@@ -1,0 +1,5 @@
+! RUN: %flang_fc1 -fdebug-unparse %s | FileCheck %s
+! Ensure that Hollerith actual arguments are blank padded.
+! CHECK: CALL foo("abc     ")
+      call foo(3habc)
+      end


### PR DESCRIPTION
For more compatible legacy behavior on old tests, extend Hollerith actual arguments on the right with trailing blanks out to a multiple of 8 bytes.  Fixes Fujitsu test 0343_0069.