### PR TITLE
[CIR][NFC] Use arrangeFunctionDeclaration to build function types

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -81,7 +81,8 @@ static void appendParameterTypes(const CIRGenTypes &cgt,
 static const CIRGenFunctionInfo &
 arrangeCIRFunctionInfo(CIRGenTypes &cgt, SmallVectorImpl<CanQualType> &prefix,
                        CanQual<FunctionProtoType> ftp) {
-  RequiredArgs required = RequiredArgs::forPrototypePlus(ftp, prefix.size());
+  RequiredArgs required =
+      RequiredArgs::getFromProtoWithExtraSlots(ftp, prefix.size());
   assert(!cir::MissingFeatures::opCallExtParameterInfo());
   appendParameterTypes(cgt, prefix, ftp);
   CanQualType resultType = ftp->getReturnType().getUnqualifiedType();

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -44,14 +44,11 @@ CIRGenFunctionInfo::create(CanQualType resultType,
 
 cir::FuncType CIRGenTypes::getFunctionType(const CIRGenFunctionInfo &fi) {
   mlir::Type resultType = convertType(fi.getReturnType());
+  SmallVector<mlir::Type, 8> argTypes;
+  argTypes.reserve(fi.getNumRequiredArgs());
 
-  SmallVector<mlir::Type, 8> argTypes(fi.getNumRequiredArgs());
-
-  unsigned argNo = 0;
-  llvm::ArrayRef<CIRGenFunctionInfoArgInfo> argInfos(fi.argInfoBegin(),
-                                                     fi.getNumRequiredArgs());
-  for (const auto &argInfo : argInfos)
-    argTypes[argNo++] = convertType(argInfo.type);
+  for (const CIRGenFunctionInfoArgInfo &argInfo : fi.requiredArguments())
+    argTypes.push_back(convertType(argInfo.type));
 
   return cir::FuncType::get(argTypes,
                             (resultType ? resultType : builder.getVoidTy()),
@@ -61,6 +58,34 @@ cir::FuncType CIRGenTypes::getFunctionType(const CIRGenFunctionInfo &fi) {
 CIRGenCallee CIRGenCallee::prepareConcreteCallee(CIRGenFunction &cgf) const {
   assert(!cir::MissingFeatures::opCallVirtual());
   return *this;
+}
+
+/// Adds the formal parameters in FPT to the given prefix. If any parameter in
+/// FPT has pass_object_size_attrs, then we'll add parameters for those, too.
+/// TODO(cir): this should be shared with LLVM codegen
+static void appendParameterTypes(const CIRGenTypes &cgt,
+                                 SmallVectorImpl<CanQualType> &prefix,
+                                 CanQual<FunctionProtoType> fpt) {
+  assert(!cir::MissingFeatures::opCallExtParameterInfo());
+  // Fast path: don't touch param info if we don't need to.
+  if (!fpt->hasExtParameterInfos()) {
+    prefix.append(fpt->param_type_begin(), fpt->param_type_end());
+    return;
+  }
+
+  cgt.getCGModule().errorNYI("appendParameterTypes: hasExtParameterInfos");
+}
+
+/// Arrange the CIR function layout for a value of the given function type, on
+/// top of any implicit parameters already stored.
+static const CIRGenFunctionInfo &
+arrangeCIRFunctionInfo(CIRGenTypes &cgt, SmallVectorImpl<CanQualType> &prefix,
+                       CanQual<FunctionProtoType> ftp) {
+  RequiredArgs required = RequiredArgs::forPrototypePlus(ftp, prefix.size());
+  assert(!cir::MissingFeatures::opCallExtParameterInfo());
+  appendParameterTypes(cgt, prefix, ftp);
+  CanQualType resultType = ftp->getReturnType().getUnqualifiedType();
+  return cgt.arrangeCIRFunctionInfo(resultType, prefix, required);
 }
 
 static const CIRGenFunctionInfo &
@@ -95,6 +120,34 @@ CIRGenTypes::arrangeFreeFunctionCall(const CallArgList &args,
   return arrangeFreeFunctionLikeCall(*this, cgm, args, fnType);
 }
 
+/// Arrange the argument and result information for the declaration or
+/// definition of the given function.
+const CIRGenFunctionInfo &
+CIRGenTypes::arrangeFunctionDeclaration(const FunctionDecl *fd) {
+  if (const auto *md = dyn_cast<CXXMethodDecl>(fd)) {
+    if (md->isInstance()) {
+      cgm.errorNYI("arrangeFunctionDeclaration: instance method");
+    }
+  }
+
+  CanQualType funcTy = fd->getType()->getCanonicalTypeUnqualified();
+
+  assert(isa<FunctionType>(funcTy));
+  // TODO: setCUDAKernelCallingConvention
+  assert(!cir::MissingFeatures::cudaSupport());
+
+  // When declaring a function without a prototype, always use a non-variadic
+  // type.
+  if (CanQual<FunctionNoProtoType> noProto =
+          funcTy.getAs<FunctionNoProtoType>()) {
+    assert(!cir::MissingFeatures::opCallCIRGenFuncInfoExtParamInfo());
+    return arrangeCIRFunctionInfo(noProto->getReturnType(), std::nullopt,
+                                  RequiredArgs::All);
+  }
+
+  return arrangeFreeFunctionType(funcTy.castAs<FunctionProtoType>());
+}
+
 static cir::CIRCallOpInterface
 emitCallLikeOp(CIRGenFunction &cgf, mlir::Location callLoc,
                cir::FuncOp directFuncOp,
@@ -112,13 +165,8 @@ emitCallLikeOp(CIRGenFunction &cgf, mlir::Location callLoc,
 
 const CIRGenFunctionInfo &
 CIRGenTypes::arrangeFreeFunctionType(CanQual<FunctionProtoType> fpt) {
-  SmallVector<CanQualType, 8> argTypes;
-  for (unsigned i = 0, e = fpt->getNumParams(); i != e; ++i)
-    argTypes.push_back(fpt->getParamType(i));
-  RequiredArgs required = RequiredArgs::forPrototypePlus(fpt);
-
-  CanQualType resultType = fpt->getReturnType().getUnqualifiedType();
-  return arrangeCIRFunctionInfo(resultType, argTypes, required);
+  SmallVector<CanQualType, 16> argTypes;
+  return ::arrangeCIRFunctionInfo(*this, argTypes, fpt);
 }
 
 const CIRGenFunctionInfo &

--- a/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
@@ -47,21 +47,21 @@ public:
   ///
   /// If FD is not null, this will consider pass_object_size params in FD.
   static RequiredArgs
-  forPrototypePlus(const clang::FunctionProtoType *prototype,
-                   unsigned additional) {
+  getFromProtoWithExtraSlots(const clang::FunctionProtoType *prototype,
+                             unsigned additional) {
     if (!prototype->isVariadic())
       return All;
 
     if (prototype->hasExtParameterInfos())
       llvm_unreachable("NYI");
 
-    return RequiredArgs(prototype->getNumParams());
+    return RequiredArgs(prototype->getNumParams() + additional);
   }
 
   static RequiredArgs
-  forPrototypePlus(clang::CanQual<clang::FunctionProtoType> prototype,
-                   unsigned additional) {
-    return forPrototypePlus(prototype.getTypePtr(), additional);
+  getFromProtoWithExtraSlots(clang::CanQual<clang::FunctionProtoType> prototype,
+                             unsigned additional) {
+    return getFromProtoWithExtraSlots(prototype.getTypePtr(), additional);
   }
 
   unsigned getNumRequiredArgs() const {

--- a/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
@@ -47,7 +47,8 @@ public:
   ///
   /// If FD is not null, this will consider pass_object_size params in FD.
   static RequiredArgs
-  forPrototypePlus(const clang::FunctionProtoType *prototype) {
+  forPrototypePlus(const clang::FunctionProtoType *prototype,
+                   unsigned additional) {
     if (!prototype->isVariadic())
       return All;
 
@@ -58,8 +59,9 @@ public:
   }
 
   static RequiredArgs
-  forPrototypePlus(clang::CanQual<clang::FunctionProtoType> prototype) {
-    return forPrototypePlus(prototype.getTypePtr());
+  forPrototypePlus(clang::CanQual<clang::FunctionProtoType> prototype,
+                   unsigned additional) {
+    return forPrototypePlus(prototype.getTypePtr(), additional);
   }
 
   unsigned getNumRequiredArgs() const {
@@ -112,6 +114,14 @@ public:
   void Profile(llvm::FoldingSetNodeID &id) {
     id.AddBoolean(required.getOpaqueData());
     getReturnType().Profile(id);
+  }
+
+  llvm::ArrayRef<ArgInfo> arguments() const {
+    return llvm::ArrayRef<ArgInfo>(argInfoBegin(), numArgs);
+  }
+
+  llvm::ArrayRef<ArgInfo> requiredArguments() const {
+    return llvm::ArrayRef<ArgInfo>(argInfoBegin(), getNumRequiredArgs());
   }
 
   CanQualType getReturnType() const { return getArgsBuffer()[0].type; }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -249,21 +249,8 @@ void CIRGenModule::emitGlobalFunctionDefinition(clang::GlobalDecl gd,
     return;
   }
 
-  cir::FuncType funcType;
-  // TODO: Move this to arrangeFunctionDeclaration when it is
-  // implemented.
-  // When declaring a function without a prototype, always use a
-  // non-variadic type.
-  if (CanQual<FunctionNoProtoType> noProto =
-          funcDecl->getType()
-              ->getCanonicalTypeUnqualified()
-              .getAs<FunctionNoProtoType>()) {
-    const CIRGenFunctionInfo &fi = getTypes().arrangeCIRFunctionInfo(
-        noProto->getReturnType(), {}, RequiredArgs::All);
-    funcType = getTypes().getFunctionType(fi);
-  } else {
-    funcType = cast<cir::FuncType>(convertType(funcDecl->getType()));
-  }
+  const CIRGenFunctionInfo &fi = getTypes().arrangeGlobalDeclaration(gd);
+  cir::FuncType funcType = getTypes().getFunctionType(fi);
 
   cir::FuncOp funcOp = dyn_cast_if_present<cir::FuncOp>(op);
   if (!funcOp || funcOp.getFunctionType() != funcType) {

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -553,3 +553,17 @@ CIRGenTypes::arrangeCIRFunctionInfo(CanQualType returnType,
 
   return *fi;
 }
+
+const CIRGenFunctionInfo &CIRGenTypes::arrangeGlobalDeclaration(GlobalDecl gd) {
+  assert(!dyn_cast<ObjCMethodDecl>(gd.getDecl()) &&
+         "This is reported as a FIXME in LLVM codegen");
+  const auto *fd = cast<FunctionDecl>(gd.getDecl());
+
+  if (isa<CXXConstructorDecl>(gd.getDecl()) ||
+      isa<CXXDestructorDecl>(gd.getDecl())) {
+    cgm.errorNYI(SourceLocation(),
+                 "arrangeGlobalDeclaration for C++ constructor or destructor");
+  }
+
+  return arrangeFunctionDeclaration(fd);
+}


### PR DESCRIPTION
This change replaces the simplified call that we were previously using to convert the function type provided by a global declaration to the CIR function type. We now go through 'arrangeGlobalDeclaration' which builds the function type in a more complicated manner. This change has no observable differences for the currently upstreamed CIR support, but it is necessary to prepare for C++ member function calls, which require the extra handling.