### PR TITLE
[clang][OpenMP] Treat "workshare" as unknown OpenMP directive

### DIFF
--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2738,6 +2738,11 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
     Diag(Tok, diag::err_omp_unknown_directive);
     return StmtError();
   }
+  if (DKind == OMPD_workshare) {
+    // "workshare" is an executable, Fortran-only directive. Treat it
+    // as unknown.
+    DKind = OMPD_unknown;
+  }
 
   StmtResult Directive = StmtError();
 

--- a/clang/test/OpenMP/openmp_workshare.c
+++ b/clang/test/OpenMP/openmp_workshare.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -verify -fopenmp -ferror-limit 100 -o - %s
+
+// Workshare is a Fortran-only directive.
+
+void foo() {
+#pragma omp workshare // expected-error {{expected an OpenMP directive}}
+}
+


### PR DESCRIPTION
The "workshare" construct is only present in Fortran. The common OpenMP code does treat it as any other directive, but in clang we need to reject it, and do so gracefully before it encounters an internal assertion.

Fixes https://github.com/llvm/llvm-project/issues/139424