### PR TITLE
[Cygwin] RTTI and VTable should be dllexport-ed

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -3754,7 +3754,7 @@ static bool ShouldUseExternalRTTIDescriptor(CodeGenModule &CGM,
     bool IsDLLImport = RD->hasAttr<DLLImportAttr>();
 
     // Don't import the RTTI but emit it locally.
-    if (CGM.getTriple().isWindowsGNUEnvironment())
+    if (CGM.getTriple().isOSCygMing())
       return false;
 
     if (CGM.getVTables().isVTableExternal(RD)) {
@@ -4041,10 +4041,7 @@ static llvm::GlobalVariable::LinkageTypes getTypeInfoLinkage(CodeGenModule &CGM,
           return llvm::GlobalValue::ExternalLinkage;
       // MinGW always uses LinkOnceODRLinkage for type info.
       if (RD->isDynamicClass() &&
-          !CGM.getContext()
-               .getTargetInfo()
-               .getTriple()
-               .isWindowsGNUEnvironment())
+          !CGM.getContext().getTargetInfo().getTriple().isOSCygMing())
         return CGM.getVTableLinkage(RD);
     }
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6274,7 +6274,7 @@ static void ReferenceDllExportedMembers(Sema &S, CXXRecordDecl *Class) {
     }
   } MarkingDllexportedContext(S, Class, ClassAttr->getLocation());
 
-  if (S.Context.getTargetInfo().getTriple().isWindowsGNUEnvironment())
+  if (S.Context.getTargetInfo().getTriple().isOSCygMing())
     S.MarkVTableUsed(Class->getLocation(), Class, true);
 
   for (Decl *Member : Class->decls()) {

--- a/clang/test/CodeGenCXX/dllexport-missing-key.cpp
+++ b/clang/test/CodeGenCXX/dllexport-missing-key.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-windows-gnu -emit-llvm -std=c++11 -o - %s | FileCheck --check-prefix=GNU %s
+// RUN: %clang_cc1 -triple x86_64-pc-cygwin   -emit-llvm -std=c++11 -o - %s | FileCheck --check-prefix=GNU %s
 
 class __declspec(dllexport) QAbstractLayoutStyleInfo {
 public:

--- a/clang/test/CodeGenCXX/dllimport-missing-key.cpp
+++ b/clang/test/CodeGenCXX/dllimport-missing-key.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple i686-windows-gnu -emit-llvm -std=c++1y -O0 -o - %s -w | FileCheck --check-prefix=GNU %s
+// RUN: %clang_cc1 -triple i686-pc-cygwin   -emit-llvm -std=c++1y -O0 -o - %s -w | FileCheck --check-prefix=GNU %s
 
 class __declspec(dllimport) QObjectData {
 public:

--- a/clang/test/CodeGenCXX/dllimport-rtti.cpp
+++ b/clang/test/CodeGenCXX/dllimport-rtti.cpp
@@ -1,5 +1,8 @@
-// RUN: %clang_cc1 -triple i686-windows-msvc -emit-llvm -std=c++1y -fms-extensions -O1 -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=MSVC
-// RUN: %clang_cc1 -triple i686-windows-gnu  -emit-llvm -std=c++1y -fms-extensions -O1 -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=GNU
+// RUN: %clang_cc1 -triple i686-windows-msvc  -emit-llvm -std=c++1y -fms-extensions -O1 -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=MSVC
+// RUN: %clang_cc1 -triple i686-windows-gnu   -emit-llvm -std=c++1y -fms-extensions -O1 -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=GNU
+// RUN: %clang_cc1 -triple x86_64-windows-gnu -emit-llvm -std=c++1y -fms-extensions -O1 -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=GNU
+// RUN: %clang_cc1 -triple i686-pc-cygwin     -emit-llvm -std=c++1y -fms-extensions -O1 -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=GNU
+// RUN: %clang_cc1 -triple x86_64-pc-cygwin   -emit-llvm -std=c++1y -fms-extensions -O1 -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=GNU
 
 struct __declspec(dllimport) S {
   virtual void f() {}

--- a/clang/test/CodeGenCXX/rtti-mingw64.cpp
+++ b/clang/test/CodeGenCXX/rtti-mingw64.cpp
@@ -1,4 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-windows-gnu %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-pc-cygwin   %s -emit-llvm -o - | FileCheck %s
+
 struct A { int a; };
 struct B : virtual A { int b; };
 B b;

--- a/clang/test/CodeGenCXX/virt-dtor-key.cpp
+++ b/clang/test/CodeGenCXX/virt-dtor-key.cpp
@@ -1,5 +1,9 @@
-// RUN: %clang_cc1 -triple i386-linux -emit-llvm %s -o - | FileCheck %s
-// RUN: %clang_cc1 -triple i386-windows-gnu -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-MINGW
+// RUN: %clang_cc1 -triple i686-linux         -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple i686-windows-gnu   -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-MINGW
+// RUN: %clang_cc1 -triple x86_64-windows-gnu -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-MINGW
+// RUN: %clang_cc1 -triple i686-pc-cygwin     -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-MINGW
+// RUN: %clang_cc1 -triple x86_64-pc-cygwin   -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-MINGW
+
 // CHECK: @_ZTI3foo ={{.*}} constant
 // CHECK-MINGW: @_ZTI3foo = linkonce_odr
 class foo {

--- a/clang/test/CodeGenCXX/vtable-key-function-ios.cpp
+++ b/clang/test/CodeGenCXX/vtable-key-function-ios.cpp
@@ -3,6 +3,8 @@
 
 // RUN: %clang_cc1 %s -triple=x86_64-pc-windows-gnu -emit-llvm -o - | FileCheck -check-prefixes=CHECK,CHECK-MINGW %s
 // RUN: %clang_cc1 %s -triple=x86_64-pc-windows-gnu -emit-llvm -o - | FileCheck -check-prefix=CHECK-LATE %s
+// RUN: %clang_cc1 %s -triple=x86_64-pc-cygwin      -emit-llvm -o - | FileCheck -check-prefixes=CHECK,CHECK-MINGW %s
+// RUN: %clang_cc1 %s -triple=x86_64-pc-cygwin      -emit-llvm -o - | FileCheck -check-prefix=CHECK-LATE %s
 
 // The 'a' variants ask for the vtable first.
 // The 'b' variants ask for the vtable second.


### PR DESCRIPTION
Behaves as same as both of Clang and GCC targetting MinGW. Required for compatibility for Cygwin-GCC.

Divided from https://github.com/llvm/llvm-project/pull/138773
