### PR TITLE
[llvm] properly guard dump methods in Support lib classes

### DIFF
--- a/llvm/include/llvm/ADT/APFixedPoint.h
+++ b/llvm/include/llvm/ADT/APFixedPoint.h
@@ -249,7 +249,10 @@ public:
   }
 
   void print(raw_ostream &) const;
-  void dump() const;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
   // If LHS > RHS, return 1. If LHS == RHS, return 0. If LHS < RHS, return -1.
   int compare(const APFixedPoint &Other) const;

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1483,7 +1483,10 @@ public:
   }
 
   void print(raw_ostream &) const;
-  void dump() const;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
   bool getExactInverse(APFloat *inv) const {
     APFLOAT_DISPATCH_ON_SEMANTICS(getExactInverse(inv));

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1896,8 +1896,10 @@ public:
   ///  FoldingSets.
   void Profile(FoldingSetNodeID &id) const;
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// debug method
-  void dump() const;
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
   /// Returns whether this instance allocated memory.
   bool needsCleanup() const { return !isSingleWord(); }

--- a/llvm/include/llvm/ADT/DynamicAPInt.h
+++ b/llvm/include/llvm/ADT/DynamicAPInt.h
@@ -216,7 +216,9 @@ public:
   void static_assert_layout(); // NOLINT
 
   raw_ostream &print(raw_ostream &OS) const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
+#endif
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const DynamicAPInt &X) {

--- a/llvm/include/llvm/ADT/SlowDynamicAPInt.h
+++ b/llvm/include/llvm/ADT/SlowDynamicAPInt.h
@@ -79,7 +79,10 @@ public:
   unsigned getBitWidth() const { return Val.getBitWidth(); }
 
   void print(raw_ostream &OS) const;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
+#endif
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const SlowDynamicAPInt &X) {

--- a/llvm/include/llvm/ADT/TrieRawHashMap.h
+++ b/llvm/include/llvm/ADT/TrieRawHashMap.h
@@ -90,7 +90,10 @@ public:
   static void *operator new(size_t Size) { return ::operator new(Size); }
   void operator delete(void *Ptr) { ::operator delete(Ptr); }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
+#endif
+
   void print(raw_ostream &OS) const;
 
 protected:
@@ -214,7 +217,10 @@ public:
   using ThreadSafeTrieRawHashMapBase::operator delete;
   using HashType = HashT;
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   using ThreadSafeTrieRawHashMapBase::dump;
+#endif
+
   using ThreadSafeTrieRawHashMapBase::print;
 
 private:

--- a/llvm/include/llvm/ADT/Twine.h
+++ b/llvm/include/llvm/ADT/Twine.h
@@ -507,14 +507,16 @@ namespace llvm {
     /// stream \p OS.
     void print(raw_ostream &OS) const;
 
-    /// Dump the concatenated string represented by this twine to stderr.
-    void dump() const;
-
     /// Write the representation of this twine to the stream \p OS.
     void printRepr(raw_ostream &OS) const;
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+    /// Dump the concatenated string represented by this twine to stderr.
+    LLVM_DUMP_METHOD void dump() const;
+
     /// Dump the representation of this twine to stderr.
-    void dumpRepr() const;
+    LLVM_DUMP_METHOD void dumpRepr() const;
+#endif
 
     /// @}
   };

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -68,7 +68,9 @@ public:
   /// The ID of this node
   IDT Id;
 
-  LLVM_ABI void dump(raw_ostream &OS) const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump(raw_ostream &OS) const;
+#endif
 
 protected:
   /// The list of utility nodes associated with this node

--- a/llvm/include/llvm/Support/BranchProbability.h
+++ b/llvm/include/llvm/Support/BranchProbability.h
@@ -77,7 +77,9 @@ public:
 
   LLVM_ABI raw_ostream &print(raw_ostream &OS) const;
 
-  LLVM_ABI void dump() const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
   /// Scale a large integer.
   ///

--- a/llvm/include/llvm/Support/DebugCounter.h
+++ b/llvm/include/llvm/Support/DebugCounter.h
@@ -119,8 +119,10 @@ public:
     Counter.CurrChunkIdx = State.ChunkIdx;
   }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   // Dump or print the current counter set into llvm::dbgs().
-  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
   LLVM_ABI void print(raw_ostream &OS) const;
 

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -513,7 +513,10 @@ public:
   bool operator!=(const KnownBits &Other) const { return !(*this == Other); }
 
   LLVM_ABI void print(raw_ostream &OS) const;
-  LLVM_ABI void dump() const;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
 private:
   // Internal helper for getting the initial KnownBits for an `srem` or `urem`

--- a/llvm/include/llvm/Support/SMTAPI.h
+++ b/llvm/include/llvm/Support/SMTAPI.h
@@ -71,7 +71,9 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
 protected:
   /// Query the SMT solver and returns true if two sorts are equal (same kind
@@ -118,7 +120,9 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
 protected:
   /// Query the SMT solver and returns true if two sorts are equal (same kind
@@ -136,7 +140,9 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 };
 
 /// Shared pointer for SMTExprs, used by SMTSolver API.
@@ -152,7 +158,9 @@ public:
   SMTSolver() = default;
   virtual ~SMTSolver() = default;
 
-  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 
   // Returns an appropriate floating-point sort for the given bitwidth.
   SMTSortRef getFloatSort(unsigned BitWidth) {

--- a/llvm/include/llvm/Support/ScaledNumber.h
+++ b/llvm/include/llvm/Support/ScaledNumber.h
@@ -424,7 +424,10 @@ class ScaledNumberBase {
 public:
   static constexpr int DefaultPrecision = 10;
 
-  LLVM_ABI static void dump(uint64_t D, int16_t E, int Width);
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD static void dump(uint64_t D, int16_t E, int Width);
+#endif
+
   LLVM_ABI static raw_ostream &print(raw_ostream &OS, uint64_t D, int16_t E,
                                      int Width, unsigned Precision);
   LLVM_ABI static std::string toString(uint64_t D, int16_t E, int Width,
@@ -607,7 +610,12 @@ public:
                      unsigned Precision = DefaultPrecision) const {
     return ScaledNumberBase::print(OS, Digits, Scale, Width, Precision);
   }
-  void dump() const { return ScaledNumberBase::dump(Digits, Scale, Width); }
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const {
+    return ScaledNumberBase::dump(Digits, Scale, Width);
+  }
+#endif
 
   ScaledNumber &operator+=(const ScaledNumber &X) {
     std::tie(Digits, Scale) =

--- a/llvm/lib/Support/APFixedPoint.cpp
+++ b/llvm/lib/Support/APFixedPoint.cpp
@@ -439,7 +439,10 @@ void APFixedPoint::print(raw_ostream &OS) const {
   Sema.print(OS);
   OS << "})";
 }
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void APFixedPoint::dump() const { print(llvm::errs()); }
+#endif
 
 APFixedPoint APFixedPoint::negate(bool *Overflow) const {
   if (!isSaturated()) {

--- a/llvm/lib/Support/BalancedPartitioning.cpp
+++ b/llvm/lib/Support/BalancedPartitioning.cpp
@@ -21,10 +21,12 @@
 using namespace llvm;
 #define DEBUG_TYPE "balanced-partitioning"
 
-void BPFunctionNode::dump(raw_ostream &OS) const {
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void BPFunctionNode::dump(raw_ostream &OS) const {
   OS << formatv("{{ID={0} Utilities={{{1:$[,]}} Bucket={2}}", Id,
                 make_range(UtilityNodes.begin(), UtilityNodes.end()), Bucket);
 }
+#endif
 
 template <typename Func>
 void BalancedPartitioning::BPThreadPool::async(Func &&F) {

--- a/llvm/lib/Support/DebugCounter.cpp
+++ b/llvm/lib/Support/DebugCounter.cpp
@@ -248,6 +248,8 @@ bool DebugCounter::shouldExecuteImpl(unsigned CounterName) {
   return true;
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DebugCounter::dump() const {
   print(dbgs());
 }
+#endif

--- a/llvm/lib/Support/DynamicAPInt.cpp
+++ b/llvm/lib/Support/DynamicAPInt.cpp
@@ -32,4 +32,6 @@ raw_ostream &DynamicAPInt::print(raw_ostream &OS) const {
   return OS << ValLarge;
 }
 
-void DynamicAPInt::dump() const { print(dbgs()); }
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void DynamicAPInt::dump() const { print(dbgs()); }
+#endif

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -1152,7 +1152,10 @@ void KnownBits::print(raw_ostream &OS) const {
       OS << "?";
   }
 }
-void KnownBits::dump() const {
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void KnownBits::dump() const {
   print(dbgs());
   dbgs() << "\n";
 }
+#endif

--- a/llvm/lib/Support/ScaledNumber.cpp
+++ b/llvm/lib/Support/ScaledNumber.cpp
@@ -317,7 +317,9 @@ raw_ostream &ScaledNumberBase::print(raw_ostream &OS, uint64_t D, int16_t E,
   return OS << toString(D, E, Width, Precision);
 }
 
-void ScaledNumberBase::dump(uint64_t D, int16_t E, int Width) {
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void ScaledNumberBase::dump(uint64_t D, int16_t E, int Width) {
   print(dbgs(), D, E, Width, 0) << "[" << Width << ":" << D << "*2^" << E
                                 << "]";
 }
+#endif

--- a/llvm/lib/Support/SlowDynamicAPInt.cpp
+++ b/llvm/lib/Support/SlowDynamicAPInt.cpp
@@ -283,4 +283,6 @@ SlowDynamicAPInt &SlowDynamicAPInt::operator--() {
 /// ---------------------------------------------------------------------------
 void SlowDynamicAPInt::print(raw_ostream &OS) const { OS << Val; }
 
-void SlowDynamicAPInt::dump() const { print(dbgs()); }
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void SlowDynamicAPInt::dump() const { print(dbgs()); }
+#endif

--- a/llvm/lib/Support/Z3Solver.cpp
+++ b/llvm/lib/Support/Z3Solver.cpp
@@ -989,7 +989,9 @@ llvm::SMTSolverRef llvm::CreateZ3Solver() {
 #endif
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SMTSort::dump() const { print(llvm::errs()); }
 LLVM_DUMP_METHOD void SMTExpr::dump() const { print(llvm::errs()); }
 LLVM_DUMP_METHOD void SMTSolver::dump() const { print(llvm::errs()); }
 LLVM_DUMP_METHOD void SMTSolverStatistics::dump() const { print(llvm::errs()); }
+#endif


### PR DESCRIPTION
## Purpose
Add proper preprocessor guards for all `dump()` methods in the LLVM support library. This change ensures these methods are not part of the public ABI for release builds.

## Overview
* Annotates all `dump` methods in Support and ADT source with the `LLVM_DUMP_METHOD` macro. 
* Conditionally includes all `dump` method definitions in Support and ADT source so they are only present on debug/assert builds and when `LLVM_ENABLE_DUMP` is explicitly defined. 

NOTE: For many of these `dump` methods, the implementation was already properly guarded but the declaration in the header file was not.

## Background
This issue was raised in comments on #136629. I am addressing it as a separate change since it is independent from the changes being made in that PR.

According to [this documentation](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/Support/Compiler.h#L637), `dump` methods should be annotated with `LLVM_DUMP_METHOD` and conditionally included as follows:
```
#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
  LLVM_DUMP_METHOD void dump() const;
#endif
```

## Validation
* Local release build succeeds.
* CI