### PR TITLE
[lldb] Fix ForwardListFrontEnd::CalculateNumChildren

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -251,7 +251,7 @@ llvm::Expected<uint32_t> ForwardListFrontEnd::CalculateNumChildren() {
 
   ListEntry current(m_head);
   m_count = 0;
-  while (current && m_count < m_list_capping_size) {
+  while (current) {
     ++m_count;
     current = current.next();
   }

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/forward_list/TestDataFormatterGenericForwardList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/forward_list/TestDataFormatterGenericForwardList.py
@@ -53,13 +53,14 @@ class TestDataFormatterGenericForwardList(TestBase):
             substrs=["target.max-children-count (unsigned) = 256"],
         )
 
+        self.runCmd("settings set target.max-children-count 256", check=False)
         self.expect(
             "frame variable thousand_elts",
             matching=False,
-            substrs=["[256]", "[333]", "[444]", "[555]", "[666]", "..."],
+            substrs=["[256]", "[333]", "[444]", "[555]", "[666]"],
         )
-        self.runCmd("settings set target.max-children-count 3", check=False)
 
+        self.runCmd("settings set target.max-children-count 3", check=False)
         self.expect(
             "frame variable thousand_elts",
             matching=False,
@@ -73,7 +74,7 @@ class TestDataFormatterGenericForwardList(TestBase):
         self.expect(
             "frame variable thousand_elts",
             matching=True,
-            substrs=["size=256", "[0]", "[1]", "[2]", "..."],
+            substrs=["size=1000", "[0]", "[1]", "[2]", "..."],
         )
 
     def do_test_ptr_and_ref(self, stdlib_type):
@@ -138,7 +139,7 @@ class TestDataFormatterGenericForwardList(TestBase):
             "frame variable ref",
             matching=True,
             substrs=[
-                "size=256",
+                "size=1000",
                 "[0] = 999",
                 "[1] = 998",
                 "[2] = 997",
@@ -149,7 +150,7 @@ class TestDataFormatterGenericForwardList(TestBase):
             "frame variable *ptr",
             matching=True,
             substrs=[
-                "size=256",
+                "size=1000",
                 "[0] = 999",
                 "[1] = 998",
                 "[2] = 997",


### PR DESCRIPTION
Fixes the calculation of the number of children for `std::forward_list` to no longer be
capped. The calculation was capped by the value of `target.max-children-count`.

This resulted in at least the following problems:

1. The summary formatter would display the incorrect size when the size was greater than
   `max-child-count`.
2. The elision marker (`...`) would not be shown when the number of elements was greater
   than `max-child-count`.
