### PR TITLE
[MLIR][DRR] Fix inconsistent operand and arg index usage

### DIFF
--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -1872,6 +1872,11 @@ def TestEitherOpB : TEST_Op<"either_op_b"> {
   let results = (outs I32:$output);
 }
 
+def TestEitherOpC : TEST_Op<"either_op_c"> {
+  let arguments = (ins AnyI32Attr:$attr, AnyInteger:$arg0, AnyInteger:$arg1);
+  let results = (outs I32:$output);
+}
+
 def : Pat<(TestEitherOpA (either I32:$arg1, I16:$arg2), $x),
           (TestEitherOpB $arg2, $x)>;
 
@@ -1882,6 +1887,9 @@ def : Pat<(TestEitherOpA (either (TestEitherOpB I32:$arg1, $_),
                                  (TestEitherOpB I16:$arg2, $_)),
                           $x),
           (TestEitherOpB $arg2, $x)>;
+
+def : Pat<(TestEitherOpC ConstantAttr<I32Attr, "0">, (either $arg1, I32:$arg2)),
+          (TestEitherOpB $arg1, $arg2)>;
 
 def TestEitherHelperOpA : TEST_Op<"either_helper_op_a"> {
   let arguments = (ins I32:$arg0);

--- a/mlir/test/mlir-tblgen/pattern.mlir
+++ b/mlir/test/mlir-tblgen/pattern.mlir
@@ -609,8 +609,8 @@ func.func @redundantTest(%arg0: i32) -> i32 {
 // Test either directive
 //===----------------------------------------------------------------------===//
 
-// CHECK: @either_dag_leaf_only
-func.func @either_dag_leaf_only_1(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () {
+// CHECK-LABEL: @eitherDagLeafOnly
+func.func @eitherDagLeafOnly(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () {
   // CHECK: "test.either_op_b"(%arg1, %arg2) : (i16, i8) -> i32
   %0 = "test.either_op_a"(%arg0, %arg1, %arg2) : (i32, i16, i8) -> i32
   // CHECK: "test.either_op_b"(%arg1, %arg2) : (i16, i8) -> i32
@@ -618,8 +618,8 @@ func.func @either_dag_leaf_only_1(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () {
   return
 }
 
-// CHECK: @either_dag_leaf_dag_node
-func.func @either_dag_leaf_dag_node(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () {
+// CHECK-LABEL: @eitherDagLeafDagNode
+func.func @eitherDagLeafDagNode(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () {
   %0 = "test.either_op_b"(%arg0, %arg0) : (i32, i32) -> i32
   // CHECK: "test.either_op_b"(%arg1, %arg2) : (i16, i8) -> i32
   %1 = "test.either_op_a"(%0, %arg1, %arg2) : (i32, i16, i8) -> i32
@@ -628,8 +628,8 @@ func.func @either_dag_leaf_dag_node(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () 
   return
 }
 
-// CHECK: @either_dag_node_dag_node
-func.func @either_dag_node_dag_node(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () {
+// CHECK-LABEL: @eitherDagNodeDagNode
+func.func @eitherDagNodeDagNode(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () {
   %0 = "test.either_op_b"(%arg0, %arg0) : (i32, i32) -> i32
   %1 = "test.either_op_b"(%arg1, %arg1) : (i16, i16) -> i32
   // CHECK: "test.either_op_b"(%arg1, %arg2) : (i16, i8) -> i32
@@ -639,10 +639,22 @@ func.func @either_dag_node_dag_node(%arg0 : i32, %arg1 : i16, %arg2 : i8) -> () 
   return
 }
 
+// CHECK-LABEL: @testEitherOpWithAttr
+func.func @testEitherOpWithAttr(%arg0 : i32, %arg1 : i16) -> () {
+  // CHECK: "test.either_op_b"(%arg1, %arg0) : (i16, i32) -> i32
+  %0 = "test.either_op_c"(%arg0, %arg1) {attr = 0 : i32} : (i32, i16) -> i32
+  // CHECK: "test.either_op_b"(%arg1, %arg0) : (i16, i32) -> i32
+  %1 = "test.either_op_c"(%arg1, %arg0) {attr = 0 : i32} : (i16, i32) -> i32
+  // CHECK: "test.either_op_c"(%arg0, %arg1) <{attr = 1 : i32}> : (i32, i16) -> i32
+  %2 = "test.either_op_c"(%arg0, %arg1) {attr = 1 : i32} : (i32, i16) -> i32
+  return
+}
+
 //===----------------------------------------------------------------------===//
 // Test that ops without type deduction can be created with type builders.
 //===----------------------------------------------------------------------===//
 
+// CHECK-LABEL: @explicitReturnTypeTest
 func.func @explicitReturnTypeTest(%arg0 : i64) -> i8 {
   %0 = "test.source_op"(%arg0) {tag = 11 : i32} : (i64) -> i8
   // CHECK: "test.op_x"(%arg0) : (i64) -> i32
@@ -650,6 +662,7 @@ func.func @explicitReturnTypeTest(%arg0 : i64) -> i8 {
   return %0 : i8
 }
 
+// CHECK-LABEL: @returnTypeBuilderTest
 func.func @returnTypeBuilderTest(%arg0 : i1) -> i8 {
   %0 = "test.source_op"(%arg0) {tag = 22 : i32} : (i1) -> i8
   // CHECK: "test.op_x"(%arg0) : (i1) -> i1
@@ -657,6 +670,7 @@ func.func @returnTypeBuilderTest(%arg0 : i1) -> i8 {
   return %0 : i8
 }
 
+// CHECK-LABEL: @multipleReturnTypeBuildTest
 func.func @multipleReturnTypeBuildTest(%arg0 : i1) -> i1 {
   %0 = "test.source_op"(%arg0) {tag = 33 : i32} : (i1) -> i1
   // CHECK: "test.one_to_two"(%arg0) : (i1) -> (i64, i32)
@@ -666,6 +680,7 @@ func.func @multipleReturnTypeBuildTest(%arg0 : i1) -> i1 {
   return %0 : i1
 }
 
+// CHECK-LABEL: @copyValueType
 func.func @copyValueType(%arg0 : i8) -> i32 {
   %0 = "test.source_op"(%arg0) {tag = 44 : i32} : (i8) -> i32
   // CHECK: "test.op_x"(%arg0) : (i8) -> i8
@@ -673,6 +688,7 @@ func.func @copyValueType(%arg0 : i8) -> i32 {
   return %0 : i32
 }
 
+// CHECK-LABEL: @multipleReturnTypeDifferent
 func.func @multipleReturnTypeDifferent(%arg0 : i1) -> i64 {
   %0 = "test.source_op"(%arg0) {tag = 55 : i32} : (i1) -> i64
   // CHECK: "test.one_to_two"(%arg0) : (i1) -> (i1, i64)
@@ -684,6 +700,7 @@ func.func @multipleReturnTypeDifferent(%arg0 : i1) -> i64 {
 // Test that multiple trailing directives can be mixed in patterns.
 //===----------------------------------------------------------------------===//
 
+// CHECK-LABEL: @returnTypeAndLocation
 func.func @returnTypeAndLocation(%arg0 : i32) -> i1 {
   %0 = "test.source_op"(%arg0) {tag = 66 : i32} : (i32) -> i1
   // CHECK: "test.op_x"(%arg0) : (i32) -> i32 loc("loc1")
@@ -696,6 +713,7 @@ func.func @returnTypeAndLocation(%arg0 : i32) -> i1 {
 // Test that patterns can create ConstantStrAttr
 //===----------------------------------------------------------------------===//
 
+// CHECK-LABEL: @testConstantStrAttr
 func.func @testConstantStrAttr() -> () {
   // CHECK: test.has_str_value {value = "foo"}
   test.no_str_value {value = "bar"}
@@ -706,6 +724,7 @@ func.func @testConstantStrAttr() -> () {
 // Test that patterns with variadics propagate sizes
 //===----------------------------------------------------------------------===//
 
+// CHECK-LABEL: @testVariadic
 func.func @testVariadic(%arg_0: i32, %arg_1: i32, %brg: i64,
     %crg_0: f32, %crg_1: f32, %crg_2: f32, %crg_3: f32) -> () {
   // CHECK: "test.variadic_rewrite_dst_op"(%arg2, %arg3, %arg4, %arg5, %arg6, %arg0, %arg1) <{operandSegmentSizes = array<i32: 1, 4, 2>}> : (i64, f32, f32, f32, f32, i32, i32) -> ()


### PR DESCRIPTION
Background issue: #139813

In [emitEitherOperandMatch()](https://github.com/llvm/llvm-project/blob/e62fc14a5d214f801758b35bdcad0c8efc65e8b8/mlir/tools/mlir-tblgen/RewriterGen.cpp#L774) we check if `op.getArg(argIndex)` is a `NamedTypeConstraint`:

```cpp
} else if (isa<NamedTypeConstraint *>(op.getArg(argIndex))) {
      emitOperandMatch(tree, opName, /*operandName=*/formatv("v{0}", i).str(),
                       operandIndex,
                       /*operandMatcher=*/eitherArgTree.getArgAsLeaf(i),
                       /*argName=*/eitherArgTree.getArgName(i), argIndex,
                       /*variadicSubIndex=*/std::nullopt);
      ++operandIndex;
}
```

but in `emitOperandMatch()` we cast on `op.getArg(operandIndex)`, which is incorrect if the operation has attributes or other non-operand arguments before its operands.