### PR TITLE
[clang][analyzer] Fix a nullptr dereference when `-ftime-trace` is used

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -103,9 +103,10 @@ public:
   const Stmt *getStmt() const {
     switch (Elem->getKind()) {
     case CFGElement::Initializer:
-      if (Elem->castAs<CFGInitializer>().getInitializer() == nullptr)
-        return nullptr;
-      return Elem->castAs<CFGInitializer>().getInitializer()->getInit();
+      if (const auto *Init = Elem->castAs<CFGInitializer>().getInitializer()) {
+        return Init->getInit();
+      }
+      return nullptr;
     case CFGElement::ScopeBegin:
       return Elem->castAs<CFGScopeBegin>().getTriggerStmt();
     case CFGElement::ScopeEnd:

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -103,6 +103,8 @@ public:
   const Stmt *getStmt() const {
     switch (Elem->getKind()) {
     case CFGElement::Initializer:
+      if (Elem->castAs<CFGInitializer>().getInitializer() == nullptr)
+        return nullptr;
       return Elem->castAs<CFGInitializer>().getInitializer()->getInit();
     case CFGElement::ScopeBegin:
       return Elem->castAs<CFGScopeBegin>().getTriggerStmt();

--- a/clang/test/Analysis/ftime-trace-no-init.cpp
+++ b/clang/test/Analysis/ftime-trace-no-init.cpp
@@ -1,0 +1,5 @@
+// RUN: %clang --analyze %s -ftime-trace -Xclang -verify
+// expected-no-diagnostics
+
+// GitHub issue 139779
+struct {} a; // no-crash

--- a/clang/test/Analysis/ftime-trace-no-init.cpp
+++ b/clang/test/Analysis/ftime-trace-no-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang --analyze %s -ftime-trace -Xclang -verify
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,apiModeling %s -ftime-trace=%t.raw.json -verify
 // expected-no-diagnostics
 
 // GitHub issue 139779


### PR DESCRIPTION
Fixes #139779.

The bug was introduced in #137355 in `SymbolConjured::getStmt`, when trying to obtain a statement for a CFG initializer without an initializer.  This commit adds a null check before access.