### PR TITLE
Avoid emitting a linker options section in the compiler if it is empty.

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3274,9 +3274,11 @@ void CodeGenModule::EmitModuleLinkOptions() {
   LinkerOptionsMetadata.append(MetadataArgs.begin(), MetadataArgs.end());
 
   // Add the linker options metadata flag.
-  auto *NMD = getModule().getOrInsertNamedMetadata("llvm.linker.options");
-  for (auto *MD : LinkerOptionsMetadata)
-    NMD->addOperand(MD);
+  if (!LinkerOptionsMetadata.empty()) {
+    auto *NMD = getModule().getOrInsertNamedMetadata("llvm.linker.options");
+    for (auto *MD : LinkerOptionsMetadata)
+      NMD->addOperand(MD);
+  }
 }
 
 void CodeGenModule::EmitDeferred() {

--- a/clang/test/Modules/module-impl-with-link.c
+++ b/clang/test/Modules/module-impl-with-link.c
@@ -3,4 +3,4 @@
 #include "foo.h"
 // Make sure we don't generate linker option for module Clib since this TU is
 // an implementation of Clib.
-// CHECK: !llvm.linker.options = !{}
+// CHECK-NOT: !llvm.linker.options =


### PR DESCRIPTION
Recently in some of our internal testing, we noticed that the compiler was sometimes generating an empty linker.options section which seems unnecessary. This proposed change causes the compiler to simply omit emitting the linker.options section if it is empty.