### PR TITLE
Fix test pfalse-v4i1.ll added in #138712 to require asserts.

### DIFF
--- a/llvm/test/CodeGen/Hexagon/isel/pfalse-v4i1.ll
+++ b/llvm/test/CodeGen/Hexagon/isel/pfalse-v4i1.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -march=hexagon -debug-only=isel 2>&1 < %s - | FileCheck %s
+; REQUIRES: asserts
 
 ; CHECK: [[R0:%[0-9]+]]:intregs = A2_tfrsi 0
 ; CHECK-NEXT: predregs = C2_tfrrp killed [[R0]]:intregs


### PR DESCRIPTION
The main branch commit 57e88993fee30f4441e87df4df061393600b2ada was was cherry-picked to the release/20.x branch in ae97a56d363f95d382bac5eca5f9b5775b1919c2 and it did not include a follow-up fix that I made to the test which was failing when run in a configuration that did not include asserts. This cherry-pick should fix that as it did on main.

This test failure was seen on one of our internal bots that builds without asserts enabled.