### PR TITLE
[mlir][Vector] Improve `vector.mask` verifier

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2482,8 +2482,13 @@ def Vector_MaskOp : Vector_Op<"mask", [
     masked. Values used within the region are captured from above. Only one
     *maskable* operation can be masked with a `vector.mask` operation at a time.
     An operation is *maskable* if it implements the `MaskableOpInterface`. The
-    terminator yields all results of the maskable operation to the result of
-    this operation.
+    terminator yields all results from the maskable operation to the result of
+    this operation. No other values are allowed to be yielded.
+
+    An empty `vector.mask` operation is considered ill-formed but legal to
+    facilitate optimizations across the `vector.mask` operation. It is considered
+    a no-op regardless of its returned values and will be removed by the
+    canonicalizer.
 
     The vector mask argument holds a bit for each vector lane and determines
     which vector lanes should execute the maskable operation and which ones

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2488,6 +2488,7 @@ def Vector_MaskOp : Vector_Op<"mask", [
     An empty `vector.mask` operation is currently legal to enable optimizations
     across the `vector.mask` region. However, this might change in the future
     once vector transformations gain better support for `vector.mask`.
+    TODO: Consider making empty `vector.mask` illegal.
 
     The vector mask argument holds a bit for each vector lane and determines
     which vector lanes should execute the maskable operation and which ones

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2485,10 +2485,9 @@ def Vector_MaskOp : Vector_Op<"mask", [
     terminator yields all results from the maskable operation to the result of
     this operation. No other values are allowed to be yielded.
 
-    An empty `vector.mask` operation is considered ill-formed but legal to
-    facilitate optimizations across the `vector.mask` operation. It is considered
-    a no-op regardless of its returned values and will be removed by the
-    canonicalizer.
+    An empty `vector.mask` operation is legal to facilitate optimizations across
+    the `vector.mask` operation. However, it is considered a no-op regardless of
+    its returned values and will be removed by the canonicalizer.
 
     The vector mask argument holds a bit for each vector lane and determines
     which vector lanes should execute the maskable operation and which ones

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2485,9 +2485,9 @@ def Vector_MaskOp : Vector_Op<"mask", [
     terminator yields all results from the maskable operation to the result of
     this operation. No other values are allowed to be yielded.
 
-    An empty `vector.mask` operation is legal to facilitate optimizations across
-    the `vector.mask` operation. However, it is considered a no-op regardless of
-    its returned values and will be removed by the canonicalizer.
+    An empty `vector.mask` operation is currently legal to enable optimizations
+    across the `vector.mask` region. However, this might change in the future
+    once vector transformations gain better support for `vector.mask`.
 
     The vector mask argument holds a bit for each vector lane and determines
     which vector lanes should execute the maskable operation and which ones

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -1756,12 +1756,12 @@ func.func @vector_mask_empty_passthru_no_return_type(%mask : vector<8xi1>,
 
 // -----
 
-func.func @vector_mask_non_empty_external_return(%t0: tensor<?xf32>, %idx: index,
-                                                 %m0: vector<16xi1>, %ext: vector<16xf32>) -> vector<16xf32> {
+func.func @vector_mask_non_empty_external_return(%t: tensor<?xf32>, %idx: index,
+                                                 %m: vector<16xi1>, %ext: vector<16xf32>) -> vector<16xf32> {
   %ft0 = arith.constant 0.0 : f32
-  // expected-error@+1 {{'vector.mask' op expects all the results from the MaskableOpInterface to be returned by the terminator}}
-  %0 = vector.mask %m0 {
-    %1 =vector.transfer_read %t0[%idx], %ft0 : tensor<?xf32>, vector<16xf32>
+  // expected-error@+1 {{'vector.mask' op expects all the results from the MaskableOpInterface to match all the values returned by the terminator}}
+  %0 = vector.mask %m {
+    %1 =vector.transfer_read %t[%idx], %ft0 : tensor<?xf32>, vector<16xf32>
     vector.yield %ext : vector<16xf32>
   } : vector<16xi1> -> vector<16xf32>
 
@@ -1779,12 +1779,12 @@ func.func @vector_mask_empty_passthru_empty_return_type(%mask : vector<8xi1>,
 
 // -----
 
-func.func @vector_mask_non_empty_mixed_return(%t0: tensor<?xf32>, %idx: index,
-                                              %m0: vector<16xi1>, %ext: vector<16xf32>) -> (vector<16xf32>, vector<16xf32>) {
+func.func @vector_mask_non_empty_mixed_return(%t: tensor<?xf32>, %idx: index,
+                                              %m: vector<16xi1>, %ext: vector<16xf32>) -> (vector<16xf32>, vector<16xf32>) {
   %ft0 = arith.constant 0.0 : f32
   // expected-error@+1 {{'vector.mask' op expects number of results to match maskable operation number of results}}
-  %0:2 = vector.mask %m0 {
-    %1 =vector.transfer_read %t0[%idx], %ft0 : tensor<?xf32>, vector<16xf32>
+  %0:2 = vector.mask %m {
+    %1 =vector.transfer_read %t[%idx], %ft0 : tensor<?xf32>, vector<16xf32>
     vector.yield %1, %ext : vector<16xf32>, vector<16xf32>
   } : vector<16xi1> -> (vector<16xf32>, vector<16xf32>)
 

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -1756,11 +1756,39 @@ func.func @vector_mask_empty_passthru_no_return_type(%mask : vector<8xi1>,
 
 // -----
 
+func.func @vector_mask_non_empty_external_return(%t0: tensor<?xf32>, %idx: index,
+                                                 %m0: vector<16xi1>, %ext: vector<16xf32>) -> vector<16xf32> {
+  %ft0 = arith.constant 0.0 : f32
+  // expected-error@+1 {{'vector.mask' op expects all the results from the MaskableOpInterface to be returned by the terminator}}
+  %0 = vector.mask %m0 {
+    %1 =vector.transfer_read %t0[%idx], %ft0 : tensor<?xf32>, vector<16xf32>
+    vector.yield %ext : vector<16xf32>
+  } : vector<16xi1> -> vector<16xf32>
+
+  return %0 : vector<16xf32>
+}
+
+// -----
+
 func.func @vector_mask_empty_passthru_empty_return_type(%mask : vector<8xi1>,
                                                         %passthru : vector<8xi32>) {
   // expected-error@+1 {{'vector.mask' expects a result if passthru operand is provided}}
   vector.mask %mask, %passthru { } : vector<8xi1> -> ()
   return
+}
+
+// -----
+
+func.func @vector_mask_non_empty_mixed_return(%t0: tensor<?xf32>, %idx: index,
+                                              %m0: vector<16xi1>, %ext: vector<16xf32>) -> (vector<16xf32>, vector<16xf32>) {
+  %ft0 = arith.constant 0.0 : f32
+  // expected-error@+1 {{'vector.mask' op expects number of results to match maskable operation number of results}}
+  %0:2 = vector.mask %m0 {
+    %1 =vector.transfer_read %t0[%idx], %ft0 : tensor<?xf32>, vector<16xf32>
+    vector.yield %1, %ext : vector<16xf32>, vector<16xf32>
+  } : vector<16xi1> -> (vector<16xf32>, vector<16xf32>)
+
+  return %0#0, %0#1 : vector<16xf32>, vector<16xf32>
 }
 
 // -----


### PR DESCRIPTION
This PR improves the `vector.mask` verifier to make sure it's not applying masking semantics to operations defined outside of the `vector.mask` region. Documentation is updated to emphasize that and make it clearer, even though it already stated that.

As part of this change, the logic that ensures that a terminator is present in the region mask has been simplified to make it less surprising to the user when a `vector.yield` is explicitly provided in the IR.