### PR TITLE
[NFC] Address bit-field storage sizes to ensure ideal packing

### DIFF
--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -1859,7 +1859,8 @@ class ClassTemplateSpecializationDecl : public CXXRecordDecl,
   /// This needs to be cached as deduction is performed during declaration,
   /// and we need the information to be preserved so that it is consistent
   /// during instantiation.
-  bool StrictPackMatch : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned StrictPackMatch : 1;
 
 protected:
   ClassTemplateSpecializationDecl(ASTContext &Context, Kind DK, TagKind TK,

--- a/clang/include/clang/Analysis/Analyses/ThreadSafetyTIL.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafetyTIL.h
@@ -52,6 +52,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
@@ -1664,7 +1665,8 @@ private:
   unsigned BlockID : 31;
 
   // Bit to determine if a block has been visited during a traversal.
-  bool Visited : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned Visited : 1;
 
   // Predecessor blocks in the CFG.
   BlockArray Predecessors;

--- a/clang/include/clang/Basic/DiagnosticCategories.h
+++ b/clang/include/clang/Basic/DiagnosticCategories.h
@@ -11,7 +11,7 @@
 
 namespace clang {
   namespace diag {
-    enum {
+    enum DiagCategory {
 #define GET_CATEGORY_TABLE
 #define CATEGORY(X, ENUM) ENUM,
 #include "clang/Basic/DiagnosticGroups.inc"

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -980,7 +980,8 @@ class Sema;
     /// Have we matched any packs on the parameter side, versus any non-packs on
     /// the argument side, in a context where the opposite matching is also
     /// allowed?
-    bool StrictPackMatch : 1;
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned StrictPackMatch : 1;
 
     /// True if the candidate was found using ADL.
     LLVM_PREFERRED_TYPE(CallExpr::ADLCallKind)
@@ -996,7 +997,8 @@ class Sema;
 
     /// FailureKind - The reason why this candidate is not viable.
     /// Actually an OverloadFailureKind.
-    unsigned char FailureKind;
+    LLVM_PREFERRED_TYPE(OverloadFailureKind)
+    unsigned FailureKind : 8;
 
     /// The number of call arguments that were explicitly provided,
     /// to be used while performing partial ordering of function templates.

--- a/clang/include/clang/Sema/ScopeInfo.h
+++ b/clang/include/clang/Sema/ScopeInfo.h
@@ -103,7 +103,7 @@ enum class FirstCoroutineStmtKind { CoReturn, CoAwait, CoYield };
 /// currently being parsed.
 class FunctionScopeInfo {
 protected:
-  enum ScopeKind {
+  enum ScopeKind : uint8_t {
     SK_Function,
     SK_Block,
     SK_Lambda,

--- a/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+++ b/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <string>
 #include <utility>
 #include <vector>
@@ -269,7 +270,8 @@ public:
   unsigned NoRetryExhausted : 1;
 
   /// Emit analyzer warnings as errors.
-  bool AnalyzerWerror : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned AnalyzerWerror : 1;
 
   /// The inlining stack depth limit.
   unsigned InlineMaxStackDepth;

--- a/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+++ b/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
@@ -412,7 +412,7 @@ public:
             // an alias to the new verbose filename option because this
             // closely mimics the behavior under the old option.
             ShouldWriteStableReportFilename || ShouldWriteVerboseReportFilename,
-            AnalyzerWerror,
+            static_cast<bool>(AnalyzerWerror),
             ShouldApplyFixIts,
             ShouldDisplayCheckerNameForText};
   }

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -74,18 +74,18 @@ enum DiagnosticClass {
 struct StaticDiagInfoRec {
   uint16_t DiagID;
   LLVM_PREFERRED_TYPE(diag::Severity)
-  uint8_t DefaultSeverity : 3;
+  uint16_t DefaultSeverity : 3;
   LLVM_PREFERRED_TYPE(DiagnosticClass)
-  uint8_t Class : 3;
+  uint16_t Class : 3;
   LLVM_PREFERRED_TYPE(DiagnosticIDs::SFINAEResponse)
-  uint8_t SFINAE : 2;
-  uint8_t Category : 6;
+  uint16_t SFINAE : 2;
+  uint16_t Category : 6;
   LLVM_PREFERRED_TYPE(bool)
-  uint8_t WarnNoWerror : 1;
+  uint16_t WarnNoWerror : 1;
   LLVM_PREFERRED_TYPE(bool)
-  uint8_t WarnShowInSystemHeader : 1;
+  uint16_t WarnShowInSystemHeader : 1;
   LLVM_PREFERRED_TYPE(bool)
-  uint8_t WarnShowInSystemMacro : 1;
+  uint16_t WarnShowInSystemMacro : 1;
 
   uint16_t OptionGroupIndex : 15;
   LLVM_PREFERRED_TYPE(bool)

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -91,7 +91,6 @@ struct StaticDiagInfoRec {
 
   LLVM_PREFERRED_TYPE(diag::Group)
   uint16_t OptionGroupIndex : 15;
-
   LLVM_PREFERRED_TYPE(bool)
   uint16_t Deferrable : 1;
 

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringTable.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
 #include <map>
@@ -79,6 +80,7 @@ struct StaticDiagInfoRec {
   uint16_t Class : 3;
   LLVM_PREFERRED_TYPE(DiagnosticIDs::SFINAEResponse)
   uint16_t SFINAE : 2;
+  LLVM_PREFERRED_TYPE(diag::DiagCategory)
   uint16_t Category : 6;
   LLVM_PREFERRED_TYPE(bool)
   uint16_t WarnNoWerror : 1;
@@ -87,7 +89,9 @@ struct StaticDiagInfoRec {
   LLVM_PREFERRED_TYPE(bool)
   uint16_t WarnShowInSystemMacro : 1;
 
+  LLVM_PREFERRED_TYPE(diag::Group)
   uint16_t OptionGroupIndex : 15;
+
   LLVM_PREFERRED_TYPE(bool)
   uint16_t Deferrable : 1;
 

--- a/llvm/include/llvm/ADT/ImmutableSet.h
+++ b/llvm/include/llvm/ADT/ImmutableSet.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <cstdint>
@@ -213,9 +214,12 @@ private:
   ImutAVLTree *next = nullptr;
 
   unsigned height : 28;
-  bool IsMutable : 1;
-  bool IsDigestCached : 1;
-  bool IsCanonicalized : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IsMutable : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IsDigestCached : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IsCanonicalized : 1;
 
   value_type value;
   uint32_t digest = 0;

--- a/llvm/include/llvm/Bitstream/BitCodes.h
+++ b/llvm/include/llvm/Bitstream/BitCodes.h
@@ -32,10 +32,6 @@ namespace llvm {
 ///   2. It could be an encoding specification ("this operand encoded like so").
 ///
 class BitCodeAbbrevOp {
-  uint64_t Val;           // A literal value or data for an encoding.
-  LLVM_PREFERRED_TYPE(bool)
-  uint64_t IsLiteral : 1; // Indicate whether this is a literal value or not.
-  uint64_t Enc : 3;       // The encoding to use.
 public:
   enum Encoding {
     Fixed = 1,  // A fixed width field, Val specifies number of bits.
@@ -45,6 +41,14 @@ public:
     Blob  = 5   // 32-bit aligned array of 8-bit characters.
   };
 
+protected:
+  uint64_t Val;           // A literal value or data for an encoding.
+  LLVM_PREFERRED_TYPE(bool)
+  uint64_t IsLiteral : 1; // Indicate whether this is a literal value or not.
+  LLVM_PREFERRED_TYPE(Encoding)
+  uint64_t Enc : 3;       // The encoding to use.
+
+public:
   static bool isValidEncoding(uint64_t E) {
     return E >= 1 && E <= 5;
   }

--- a/llvm/include/llvm/Bitstream/BitCodes.h
+++ b/llvm/include/llvm/Bitstream/BitCodes.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Bitstream/BitCodeEnums.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
@@ -32,8 +33,9 @@ namespace llvm {
 ///
 class BitCodeAbbrevOp {
   uint64_t Val;           // A literal value or data for an encoding.
-  bool IsLiteral : 1;     // Indicate whether this is a literal value or not.
-  unsigned Enc   : 3;     // The encoding to use.
+  LLVM_PREFERRED_TYPE(bool)
+  uint64_t IsLiteral : 1; // Indicate whether this is a literal value or not.
+  uint64_t Enc : 3;       // The encoding to use.
 public:
   enum Encoding {
     Fixed = 1,  // A fixed width field, Val specifies number of bits.

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -149,7 +149,7 @@ private:
   /// Various bits of information used by the AsmPrinter to emit helpful
   /// comments.  This is *not* semantic information.  Do not use this for
   /// anything other than to convey comment information to AsmPrinter.
-  uint8_t AsmPrinterFlags : LLVM_MI_ASMPRINTERFLAGS_BITS;
+  uint32_t AsmPrinterFlags : LLVM_MI_ASMPRINTERFLAGS_BITS;
 
   /// Internal implementation detail class that provides out-of-line storage for
   /// extra info used by the machine instruction when this info cannot be stored

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -2996,7 +2996,7 @@ template <typename Derived, typename Alloc> struct AbstractManglingParser {
     };
     char Enc[2];      // Encoding
     OIKind Kind;      // Kind of operator
-    bool Flag : 1;   // Entry-specific flag
+    bool Flag : 1;    // Entry-specific flag
     Node::Prec Prec : 7; // Precedence
     const char *Name; // Spelling
 

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -165,18 +165,18 @@ class NodeArray;
 // traversed by the printLeft/Right functions to produce a demangled string.
 class Node {
 public:
-  enum Kind : unsigned {
+  enum Kind : uint8_t {
 #define NODE(NodeKind) K##NodeKind,
 #include "ItaniumNodes.def"
   };
 
   /// Three-way bool to track a cached value. Unknown is possible if this node
   /// has an unexpanded parameter pack below it that may affect this cache.
-  enum class Cache : unsigned { Yes, No, Unknown, };
+  enum class Cache : uint8_t { Yes, No, Unknown, };
 
   /// Operator precedence for expression nodes. Used to determine required
   /// parens in expression emission.
-  enum class Prec : unsigned {
+  enum class Prec : uint8_t {
     Primary,
     Postfix,
     Unary,
@@ -2996,8 +2996,7 @@ template <typename Derived, typename Alloc> struct AbstractManglingParser {
     };
     char Enc[2];      // Encoding
     OIKind Kind;      // Kind of operator
-    LLVM_PREFERRED_TYPE(bool)
-    unsigned Flag : 1;   // Entry-specific flag
+    bool Flag : 1;   // Entry-specific flag
     Node::Prec Prec : 7; // Precedence
     const char *Name; // Spelling
 

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -19,6 +19,7 @@
 #include "DemangleConfig.h"
 #include "StringViewExtras.h"
 #include "Utility.h"
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
@@ -164,18 +165,18 @@ class NodeArray;
 // traversed by the printLeft/Right functions to produce a demangled string.
 class Node {
 public:
-  enum Kind : unsigned char {
+  enum Kind : unsigned {
 #define NODE(NodeKind) K##NodeKind,
 #include "ItaniumNodes.def"
   };
 
   /// Three-way bool to track a cached value. Unknown is possible if this node
   /// has an unexpanded parameter pack below it that may affect this cache.
-  enum class Cache : unsigned char { Yes, No, Unknown, };
+  enum class Cache : unsigned { Yes, No, Unknown, };
 
   /// Operator precedence for expression nodes. Used to determine required
   /// parens in expression emission.
-  enum class Prec {
+  enum class Prec : unsigned {
     Primary,
     Postfix,
     Unary,
@@ -2995,7 +2996,8 @@ template <typename Derived, typename Alloc> struct AbstractManglingParser {
     };
     char Enc[2];      // Encoding
     OIKind Kind;      // Kind of operator
-    bool Flag : 1;    // Entry-specific flag
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned Flag : 1;   // Entry-specific flag
     Node::Prec Prec : 7; // Precedence
     const char *Name; // Spelling
 

--- a/llvm/include/llvm/IR/Metadata.h
+++ b/llvm/include/llvm/IR/Metadata.h
@@ -1076,8 +1076,8 @@ class MDNode : public Metadata {
   /// Explicity set alignment because bitfields by default have an
   /// alignment of 1 on z/OS.
   struct alignas(alignof(size_t)) Header {
-    bool IsResizable : 1;
-    bool IsLarge : 1;
+    size_t IsResizable : 1;
+    size_t IsLarge : 1;
     size_t SmallSize : 4;
     size_t SmallNumOps : 4;
     size_t : sizeof(size_t) * CHAR_BIT - 10;

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -28,6 +28,7 @@
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/ScaledNumber.h"
@@ -72,7 +73,8 @@ struct CalleeInfo {
   uint32_t Hotness : 3;
 
   // True if at least one of the calls to the callee is a tail call.
-  bool HasTailCall : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  uint32_t HasTailCall : 1;
 
   /// The value stored in RelBlockFreq has to be interpreted as the digits of
   /// a scaled number with a scale of \p -ScaleShift.

--- a/llvm/include/llvm/IR/User.h
+++ b/llvm/include/llvm/IR/User.h
@@ -79,7 +79,9 @@ protected:
   struct AllocInfo {
   public:
     const unsigned NumOps : NumUserOperandsBits;
+    LLVM_PREFERRED_TYPE(bool)
     const unsigned HasHungOffUses : 1;
+    LLVM_PREFERRED_TYPE(bool)
     const unsigned HasDescriptor : 1;
 
     AllocInfo() = delete;

--- a/llvm/include/llvm/IR/User.h
+++ b/llvm/include/llvm/IR/User.h
@@ -79,8 +79,8 @@ protected:
   struct AllocInfo {
   public:
     const unsigned NumOps : NumUserOperandsBits;
-    const bool HasHungOffUses : 1;
-    const bool HasDescriptor : 1;
+    const unsigned HasHungOffUses : 1;
+    const unsigned HasDescriptor : 1;
 
     AllocInfo() = delete;
 

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -40,9 +40,6 @@ template <typename T, typename U, typename = enableif_int<T, U>>
 using common_sint =
     std::common_type_t<std::make_signed_t<T>, std::make_signed_t<U>>;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wc++17-extensions"
-
 /// Mathematical constants.
 namespace numbers {
 // TODO: Track C++20 std::numbers.
@@ -79,8 +76,6 @@ constexpr float ef          = 0x1.5bf0a8P+1F, // (2.71828183) https://oeis.org/A
                 phif        = 0x1.9e377aP+0F; // (1.61803399) https://oeis.org/A001622
 // clang-format on
 } // namespace numbers
-
-#pragma GCC diagnostic pop
 
 /// Create a bitmask with the N right-most bits set to 1, and all other
 /// bits set to 0.  Only unsigned types are allowed.

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -40,6 +40,9 @@ template <typename T, typename U, typename = enableif_int<T, U>>
 using common_sint =
     std::common_type_t<std::make_signed_t<T>, std::make_signed_t<U>>;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wc++17-extensions"
+
 /// Mathematical constants.
 namespace numbers {
 // TODO: Track C++20 std::numbers.
@@ -76,6 +79,8 @@ constexpr float ef          = 0x1.5bf0a8P+1F, // (2.71828183) https://oeis.org/A
                 phif        = 0x1.9e377aP+0F; // (1.61803399) https://oeis.org/A001622
 // clang-format on
 } // namespace numbers
+
+#pragma GCC diagnostic pop
 
 /// Create a bitmask with the N right-most bits set to 1, and all other
 /// bits set to 0.  Only unsigned types are allowed.

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
@@ -63,10 +63,10 @@ public:
     int DataOffset : 31;
 
     /// Non-zero if this is a piece of an aggregate.
-    uint16_t IsSubfield : 1;
+    uint32_t IsSubfield : 1;
 
     /// Offset into aggregate.
-    uint16_t StructOffset : 15;
+    uint32_t StructOffset : 15;
 
     /// Register containing the data or the register base of the memory
     /// location containing the data.

--- a/llvm/lib/Target/AArch64/AArch64CollectLOH.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CollectLOH.cpp
@@ -272,9 +272,12 @@ static int mapRegToGPRIndex(MCRegister Reg) {
 /// datastructure for each tracked general purpose register.
 struct LOHInfo {
   MCLOHType Type : 8;           ///< "Best" type of LOH possible.
-  bool IsCandidate : 1;         ///< Possible LOH candidate.
-  bool OneUser : 1;             ///< Found exactly one user (yet).
-  bool MultiUsers : 1;          ///< Found multiple users.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IsCandidate : 1;     ///< Possible LOH candidate.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned OneUser : 1;         ///< Found exactly one user (yet).
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned MultiUsers : 1;      ///< Found multiple users.
   const MachineInstr *MI0;      ///< First instruction involved in the LOH.
   const MachineInstr *MI1;      ///< Second instruction involved in the LOH
                                 ///  (if any).

--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -193,7 +193,8 @@ namespace {
     struct ImmBranch {
       MachineInstr *MI;
       unsigned MaxDisp : 31;
-      bool isCond : 1;
+      LLVM_PREFERRED_TYPE(bool)
+      unsigned isCond : 1;
       unsigned UncondBr;
 
       ImmBranch(MachineInstr *mi, unsigned maxdisp, bool cond, unsigned ubr)

--- a/llvm/lib/Target/CSKY/CSKYConstantIslandPass.cpp
+++ b/llvm/lib/Target/CSKY/CSKYConstantIslandPass.cpp
@@ -184,7 +184,8 @@ class CSKYConstantIslands : public MachineFunctionPass {
   struct ImmBranch {
     MachineInstr *MI;
     unsigned MaxDisp : 31;
-    bool IsCond : 1;
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned IsCond : 1;
     int UncondBr;
 
     ImmBranch(MachineInstr *Mi, unsigned Maxdisp, bool Cond, int Ubr)

--- a/llvm/lib/Target/Mips/MipsConstantIslandPass.cpp
+++ b/llvm/lib/Target/Mips/MipsConstantIslandPass.cpp
@@ -321,7 +321,8 @@ namespace {
   struct ImmBranch {
     MachineInstr *MI;
     unsigned MaxDisp : 31;
-    bool isCond : 1;
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned isCond : 1;
     int UncondBr;
 
     ImmBranch(MachineInstr *mi, unsigned maxdisp, bool cond, int ubr)


### PR DESCRIPTION
The MS bit-field packing ABI depends on the storage size of the type of being placed in the bit-field. This PR addresses a number of cases in llvm where the storage type has lead to suboptimal packing.