### PR TITLE
[MIPS]Fix QNaNs in the MIPS legacy NaN encodings

### DIFF
--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -520,6 +520,9 @@ MipsTargetLowering::MipsTargetLowering(const MipsTargetMachine &TM,
 
   setOperationAction(ISD::TRAP, MVT::Other, Legal);
 
+  setOperationAction(ISD::ConstantFP, MVT::f32, Custom);
+  setOperationAction(ISD::ConstantFP, MVT::f64, Custom);
+
   setTargetDAGCombine({ISD::SDIVREM, ISD::UDIVREM, ISD::SELECT, ISD::AND,
                        ISD::OR, ISD::ADD, ISD::SUB, ISD::AssertZext, ISD::SHL,
                        ISD::SIGN_EXTEND});
@@ -1355,6 +1358,8 @@ LowerOperation(SDValue Op, SelectionDAG &DAG) const
   case ISD::FP_TO_SINT:         return lowerFP_TO_SINT(Op, DAG);
   case ISD::READCYCLECOUNTER:
     return lowerREADCYCLECOUNTER(Op, DAG);
+  case ISD::ConstantFP:
+    return lowerConstantFP(Op, DAG);
   }
   return SDValue();
 }
@@ -3013,6 +3018,30 @@ SDValue MipsTargetLowering::lowerFP_TO_SINT(SDValue Op,
   SDValue Trunc = DAG.getNode(MipsISD::TruncIntFP, SDLoc(Op), FPTy,
                               Op.getOperand(0));
   return DAG.getNode(ISD::BITCAST, SDLoc(Op), Op.getValueType(), Trunc);
+}
+
+SDValue MipsTargetLowering::lowerConstantFP(SDValue Op,
+                                            SelectionDAG &DAG) const {
+  SDLoc DL(Op);
+  EVT VT = Op.getSimpleValueType();
+  SDNode *N = Op.getNode();
+  ConstantFPSDNode *CFP = cast<ConstantFPSDNode>(N);
+
+  if (!CFP->isNaN() || Subtarget.isNaN2008()) {
+    return SDValue();
+  }
+
+  APFloat NaNValue = CFP->getValueAPF();
+  auto &Sem = NaNValue.getSemantics();
+
+  // The MSB of the mantissa should be zero for QNaNs in the MIPS legacy NaN
+  // encodings, and one for sNaNs. Check every NaN constants and make sure
+  // they are correctly encoded for legacy encodings.
+  if (!NaNValue.isSignaling()) {
+    APFloat RealQNaN = NaNValue.getSNaN(Sem);
+    return DAG.getConstantFP(RealQNaN, DL, VT);
+  }
+  return SDValue();
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Mips/MipsISelLowering.h
+++ b/llvm/lib/Target/Mips/MipsISelLowering.h
@@ -592,6 +592,7 @@ class TargetRegisterClass;
     SDValue lowerEH_DWARF_CFA(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerFP_TO_SINT(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerREADCYCLECOUNTER(SDValue Op, SelectionDAG &DAG) const;
+    SDValue lowerConstantFP(SDValue Op, SelectionDAG &DAG) const;
 
     /// isEligibleForTailCallOptimization - Check whether the call is eligible
     /// for tail call optimization.

--- a/llvm/test/CodeGen/Mips/qnan.ll
+++ b/llvm/test/CodeGen/Mips/qnan.ll
@@ -1,0 +1,14 @@
+; RUN: llc -O3 -mcpu=mips32r2 -mtriple=mips-linux-gnu < %s -o - | FileCheck %s -check-prefixes=MIPS_Legacy
+; RUN: llc -O3 -mcpu=mips32r2 -mtriple=mips-linux-gnu -mattr=+nan2008 < %s -o - | FileCheck %s -check-prefixes=MIPS_NaN2008
+
+define dso_local float @nan(float noundef %a, float noundef %b) local_unnamed_addr #0 {
+; MIPS_Legacy: $CPI0_0:
+; MIPS_Legacy-NEXT: .4byte  0x7fa00000 # float NaN
+
+; MIPS_NaN2008: $CPI0_0:
+; MIPS_NaN2008-NEXT: .4byte  0x7fc00000 # float NaN
+
+entry:
+  %0 = tail call float @llvm.minimum.f32(float %a, float %b)
+  ret float %0
+}


### PR DESCRIPTION
The MSB of the mantissa should be zero for QNaNs in the MIPS legacy NaN encodings, and one for sNaNs.

Fix #100495