### PR TITLE
[NFC][Clang] Simplify getTrailingObjects for OpenACC/OpenMP Clause

### DIFF
--- a/clang/include/clang/AST/OpenACCClause.h
+++ b/clang/include/clang/AST/OpenACCClause.h
@@ -293,7 +293,7 @@ class OpenACCDeviceTypeClause final
            "Only a single asterisk version is permitted, and must be the "
            "only one");
 
-    llvm::uninitialized_copy(Archs, getTrailingObjects<DeviceTypeArgument>());
+    llvm::uninitialized_copy(Archs, getTrailingObjects());
   }
 
 public:
@@ -307,8 +307,7 @@ public:
   }
 
   ArrayRef<DeviceTypeArgument> getArchitectures() const {
-    return ArrayRef<DeviceTypeArgument>(
-        getTrailingObjects<DeviceTypeArgument>(), NumArchs);
+    return getTrailingObjects<DeviceTypeArgument>(NumArchs);
   }
 
   static OpenACCDeviceTypeClause *
@@ -421,9 +420,7 @@ class OpenACCSelfClause final
 
   // Intentionally internal, meant to be an implementation detail of everything
   // else. All non-internal uses should go through getConditionExpr/getVarList.
-  llvm::ArrayRef<Expr *> getExprs() const {
-    return {getTrailingObjects<Expr *>(), NumExprs};
-  }
+  ArrayRef<Expr *> getExprs() const { return getTrailingObjects(NumExprs); }
 
 public:
   static bool classof(const OpenACCClause *C) {
@@ -472,8 +469,8 @@ public:
 
   child_range children() {
     return child_range(
-        reinterpret_cast<Stmt **>(getTrailingObjects<Expr *>()),
-        reinterpret_cast<Stmt **>(getTrailingObjects<Expr *>() + NumExprs));
+        reinterpret_cast<Stmt **>(getTrailingObjects()),
+        reinterpret_cast<Stmt **>(getTrailingObjects() + NumExprs));
   }
 
   const_child_range children() const {
@@ -546,10 +543,10 @@ class OpenACCWaitClause final
         QueuesLoc(QueuesLoc) {
     // The first element of the trailing storage is always the devnum expr,
     // whether it is used or not.
-    auto *Exprs = getTrailingObjects<Expr *>();
+    auto *Exprs = getTrailingObjects();
     llvm::uninitialized_copy(ArrayRef(DevNumExpr), Exprs);
     llvm::uninitialized_copy(QueueIdExprs, Exprs + 1);
-    setExprs(getTrailingObjects<Expr *>(QueueIdExprs.size() + 1));
+    setExprs(getTrailingObjects(QueueIdExprs.size() + 1));
   }
 
 public:
@@ -586,7 +583,7 @@ class OpenACCNumGangsClause final
                         ArrayRef<Expr *> IntExprs, SourceLocation EndLoc)
       : OpenACCClauseWithExprs(OpenACCClauseKind::NumGangs, BeginLoc, LParenLoc,
                                EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(IntExprs.size()), IntExprs);
+    setExprs(getTrailingObjects(IntExprs.size()), IntExprs);
   }
 
 public:
@@ -614,7 +611,7 @@ class OpenACCTileClause final
                     ArrayRef<Expr *> SizeExprs, SourceLocation EndLoc)
       : OpenACCClauseWithExprs(OpenACCClauseKind::Tile, BeginLoc, LParenLoc,
                                EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(SizeExprs.size()), SizeExprs);
+    setExprs(getTrailingObjects(SizeExprs.size()), SizeExprs);
   }
 
 public:
@@ -851,7 +848,7 @@ class OpenACCPrivateClause final
                        ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::Private, BeginLoc,
                                  LParenLoc, EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -872,7 +869,7 @@ class OpenACCFirstPrivateClause final
                             ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::FirstPrivate, BeginLoc,
                                  LParenLoc, EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -893,7 +890,7 @@ class OpenACCDevicePtrClause final
                          ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::DevicePtr, BeginLoc,
                                  LParenLoc, EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -914,7 +911,7 @@ class OpenACCAttachClause final
                       ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::Attach, BeginLoc, LParenLoc,
                                  EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -935,7 +932,7 @@ class OpenACCDetachClause final
                       ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::Detach, BeginLoc, LParenLoc,
                                  EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -956,7 +953,7 @@ class OpenACCDeleteClause final
                       ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::Delete, BeginLoc, LParenLoc,
                                  EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -977,7 +974,7 @@ class OpenACCUseDeviceClause final
                          ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::UseDevice, BeginLoc,
                                  LParenLoc, EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -998,7 +995,7 @@ class OpenACCNoCreateClause final
                         ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::NoCreate, BeginLoc,
                                  LParenLoc, EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1019,7 +1016,7 @@ class OpenACCPresentClause final
                        ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::Present, BeginLoc,
                                  LParenLoc, EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1039,7 +1036,7 @@ class OpenACCHostClause final
                     ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::Host, BeginLoc, LParenLoc,
                                  EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1061,7 +1058,7 @@ class OpenACCDeviceClause final
                       ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::Device, BeginLoc, LParenLoc,
                                  EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1088,7 +1085,7 @@ class OpenACCCopyClause final
             Spelling == OpenACCClauseKind::PCopy ||
             Spelling == OpenACCClauseKind::PresentOrCopy) &&
            "Invalid clause kind for copy-clause");
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1121,7 +1118,7 @@ class OpenACCCopyInClause final
             Spelling == OpenACCClauseKind::PCopyIn ||
             Spelling == OpenACCClauseKind::PresentOrCopyIn) &&
            "Invalid clause kind for copyin-clause");
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1153,7 +1150,7 @@ class OpenACCCopyOutClause final
             Spelling == OpenACCClauseKind::PCopyOut ||
             Spelling == OpenACCClauseKind::PresentOrCopyOut) &&
            "Invalid clause kind for copyout-clause");
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1185,7 +1182,7 @@ class OpenACCCreateClause final
             Spelling == OpenACCClauseKind::PCreate ||
             Spelling == OpenACCClauseKind::PresentOrCreate) &&
            "Invalid clause kind for create-clause");
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1214,7 +1211,7 @@ class OpenACCReductionClause final
       : OpenACCClauseWithVarList(OpenACCClauseKind::Reduction, BeginLoc,
                                  LParenLoc, EndLoc),
         Op(Operator) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1239,7 +1236,7 @@ class OpenACCLinkClause final
                     ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::Link, BeginLoc, LParenLoc,
                                  EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:
@@ -1262,7 +1259,7 @@ class OpenACCDeviceResidentClause final
                               ArrayRef<Expr *> VarList, SourceLocation EndLoc)
       : OpenACCClauseWithVarList(OpenACCClauseKind::DeviceResident, BeginLoc,
                                  LParenLoc, EndLoc) {
-    setExprs(getTrailingObjects<Expr *>(VarList.size()), VarList);
+    setExprs(getTrailingObjects(VarList.size()), VarList);
   }
 
 public:

--- a/clang/include/clang/AST/OpenMPClause.h
+++ b/clang/include/clang/AST/OpenMPClause.h
@@ -295,8 +295,7 @@ protected:
 
   /// Fetches list of variables associated with this clause.
   MutableArrayRef<Expr *> getVarRefs() {
-    return MutableArrayRef<Expr *>(
-        static_cast<T *>(this)->template getTrailingObjects<Expr *>(), NumVars);
+    return static_cast<T *>(this)->template getTrailingObjects<Expr *>(NumVars);
   }
 
   /// Sets the list of variables for this clause.
@@ -336,8 +335,7 @@ public:
 
   /// Fetches list of all variables in the clause.
   ArrayRef<const Expr *> getVarRefs() const {
-    return llvm::ArrayRef(
-        static_cast<const T *>(this)->template getTrailingObjects<Expr *>(),
+    return static_cast<const T *>(this)->template getTrailingObjects<Expr *>(
         NumVars);
   }
 };
@@ -382,10 +380,8 @@ public:
   }
 
   MutableArrayRef<OpenMPDirectiveKind> getDirectiveKinds() {
-    return MutableArrayRef<OpenMPDirectiveKind>(
-        static_cast<T *>(this)
-            ->template getTrailingObjects<OpenMPDirectiveKind>(),
-        NumKinds);
+    return static_cast<T *>(this)
+        ->template getTrailingObjects<OpenMPDirectiveKind>(NumKinds);
   }
 
   void setDirectiveKinds(ArrayRef<OpenMPDirectiveKind> DK) {
@@ -984,14 +980,12 @@ public:
 
   /// Returns the tile size expressions.
   MutableArrayRef<Expr *> getSizesRefs() {
-    return MutableArrayRef<Expr *>(static_cast<OMPSizesClause *>(this)
-                                       ->template getTrailingObjects<Expr *>(),
-                                   NumSizes);
+    return static_cast<OMPSizesClause *>(this)
+        ->template getTrailingObjects<Expr *>(NumSizes);
   }
   ArrayRef<Expr *> getSizesRefs() const {
-    return ArrayRef<Expr *>(static_cast<const OMPSizesClause *>(this)
-                                ->template getTrailingObjects<Expr *>(),
-                            NumSizes);
+    return static_cast<const OMPSizesClause *>(this)
+        ->template getTrailingObjects<Expr *>(NumSizes);
   }
 
   /// Sets the tile size expressions.
@@ -1090,14 +1084,12 @@ public:
   /// Returns the permutation index expressions.
   ///@{
   MutableArrayRef<Expr *> getArgsRefs() {
-    return MutableArrayRef<Expr *>(static_cast<OMPPermutationClause *>(this)
-                                       ->template getTrailingObjects<Expr *>(),
-                                   NumLoops);
+    return static_cast<OMPPermutationClause *>(this)
+        ->template getTrailingObjects<Expr *>(NumLoops);
   }
   ArrayRef<Expr *> getArgsRefs() const {
-    return ArrayRef<Expr *>(static_cast<const OMPPermutationClause *>(this)
-                                ->template getTrailingObjects<Expr *>(),
-                            NumLoops);
+    return static_cast<const OMPPermutationClause *>(this)
+        ->template getTrailingObjects<Expr *>(NumLoops);
   }
   ///@}
 
@@ -3841,7 +3833,7 @@ class OMPReductionClause final
     return MutableArrayRef<Expr *>(getLHSExprs().end(), varlist_size());
   }
   ArrayRef<const Expr *> getRHSExprs() const {
-    return llvm::ArrayRef(getLHSExprs().end(), varlist_size());
+    return ArrayRef(getLHSExprs().end(), varlist_size());
   }
 
   /// Set list of helper reduction expressions, required for proper
@@ -5925,18 +5917,15 @@ protected:
   /// Get the unique declarations that are in the trailing objects of the
   /// class.
   MutableArrayRef<ValueDecl *> getUniqueDeclsRef() {
-    return MutableArrayRef<ValueDecl *>(
-        static_cast<T *>(this)->template getTrailingObjects<ValueDecl *>(),
+    return static_cast<T *>(this)->template getTrailingObjects<ValueDecl *>(
         NumUniqueDeclarations);
   }
 
   /// Get the unique declarations that are in the trailing objects of the
   /// class.
   ArrayRef<ValueDecl *> getUniqueDeclsRef() const {
-    return ArrayRef<ValueDecl *>(
-        static_cast<const T *>(this)
-            ->template getTrailingObjects<ValueDecl *>(),
-        NumUniqueDeclarations);
+    return static_cast<const T *>(this)
+        ->template getTrailingObjects<ValueDecl *>(NumUniqueDeclarations);
   }
 
   /// Set the unique declarations that are in the trailing objects of the
@@ -5950,16 +5939,14 @@ protected:
   /// Get the number of lists per declaration that are in the trailing
   /// objects of the class.
   MutableArrayRef<unsigned> getDeclNumListsRef() {
-    return MutableArrayRef<unsigned>(
-        static_cast<T *>(this)->template getTrailingObjects<unsigned>(),
+    return static_cast<T *>(this)->template getTrailingObjects<unsigned>(
         NumUniqueDeclarations);
   }
 
   /// Get the number of lists per declaration that are in the trailing
   /// objects of the class.
   ArrayRef<unsigned> getDeclNumListsRef() const {
-    return ArrayRef<unsigned>(
-        static_cast<const T *>(this)->template getTrailingObjects<unsigned>(),
+    return static_cast<const T *>(this)->template getTrailingObjects<unsigned>(
         NumUniqueDeclarations);
   }
 
@@ -5999,18 +5986,14 @@ protected:
 
   /// Get the components that are in the trailing objects of the class.
   MutableArrayRef<MappableComponent> getComponentsRef() {
-    return MutableArrayRef<MappableComponent>(
-        static_cast<T *>(this)
-            ->template getTrailingObjects<MappableComponent>(),
-        NumComponents);
+    return static_cast<T *>(this)
+        ->template getTrailingObjects<MappableComponent>(NumComponents);
   }
 
   /// Get the components that are in the trailing objects of the class.
   ArrayRef<MappableComponent> getComponentsRef() const {
-    return ArrayRef<MappableComponent>(
-        static_cast<const T *>(this)
-            ->template getTrailingObjects<MappableComponent>(),
-        NumComponents);
+    return static_cast<const T *>(this)
+        ->template getTrailingObjects<MappableComponent>(NumComponents);
   }
 
   /// Set the components that are in the trailing objects of the class.

--- a/clang/lib/AST/OpenACCClause.cpp
+++ b/clang/lib/AST/OpenACCClause.cpp
@@ -114,7 +114,7 @@ OpenACCSelfClause::OpenACCSelfClause(SourceLocation BeginLoc,
     : OpenACCClauseWithParams(OpenACCClauseKind::Self, BeginLoc, LParenLoc,
                               EndLoc),
       HasConditionExpr(std::nullopt), NumExprs(VarList.size()) {
-  llvm::uninitialized_copy(VarList, getTrailingObjects<Expr *>());
+  llvm::uninitialized_copy(VarList, getTrailingObjects());
 }
 
 OpenACCSelfClause::OpenACCSelfClause(SourceLocation BeginLoc,
@@ -126,8 +126,7 @@ OpenACCSelfClause::OpenACCSelfClause(SourceLocation BeginLoc,
   assert((!ConditionExpr || ConditionExpr->isInstantiationDependent() ||
           ConditionExpr->getType()->isScalarType()) &&
          "Condition expression type not scalar/dependent");
-  llvm::uninitialized_copy(ArrayRef(ConditionExpr),
-                           getTrailingObjects<Expr *>());
+  llvm::uninitialized_copy(ArrayRef(ConditionExpr), getTrailingObjects());
 }
 
 OpenACCClause::child_range OpenACCClause::children() {


### PR DESCRIPTION
Simplify usage of `getTrailingObjects` for OpenACC/OpenMP Clause by using either the non-templated form for single trailing types or using the single argument form that returns an ArrayRef/MutableArrayRef.