### PR TITLE
[HLSL][NFC] Simplify resource constructors codegen tests

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/ByteAddressBuffers-constructors.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ByteAddressBuffers-constructors.hlsl
@@ -35,25 +35,8 @@ export void foo() {
 // Buf1 initialization part 2 - body of ByteAddressBuffer C1 constructor with explicit binding that calls the C2 constructor
 // CHECK: define linkonce_odr void @_ZN4hlsl17ByteAddressBufferC1Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this,
 // CHECK-SAME: i32 noundef %registerNo, i32 noundef %spaceNo, i32 noundef %range, i32 noundef %index)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: %registerNo.addr = alloca i32, align 4
-// CHECK-NEXT: %spaceNo.addr = alloca i32, align 4
-// CHECK-NEXT: %range.addr = alloca i32, align 4
-// CHECK-NEXT: %index.addr = alloca i32, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: store i32 %registerNo, ptr %registerNo.addr, align 4
-// CHECK-NEXT: store i32 %spaceNo, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: store i32 %range, ptr %range.addr, align 4
-// CHECK-NEXT: store i32 %index, ptr %index.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK-NEXT: %0 = load i32, ptr %registerNo.addr, align 4
-// CHECK-NEXT: %1 = load i32, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: %2 = load i32, ptr %range.addr, align 4
-// CHECK-NEXT: %3 = load i32, ptr %index.addr, align 4
-// CHECK: call void @_ZN4hlsl17ByteAddressBufferC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this1, 
-// CHECK-SAME: i32 noundef %0, i32 noundef %1, i32 noundef %2, i32 noundef %3)
-// CHECK-NEXT: ret void
+// CHECK: call void @_ZN4hlsl17ByteAddressBufferC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4)
+// CHECK-SAME:  %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}})
 
 // Buf2 initialization part 1 - FIXME: constructor with implicit binding does not exist yet; 
 // the global init function currently calls the default RWByteAddressBuffer C1 constructor
@@ -71,43 +54,23 @@ export void foo() {
 // Buf3 initialization part 2 - body of RasterizerOrderedByteAddressBuffer default C1 constructor that
 // calls the default C2 constructor
 // CHECK: define linkonce_odr void @_ZN4hlsl34RasterizerOrderedByteAddressBufferC1Ev(ptr noundef nonnull align 4 dereferenceable(4) %this)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK: call void @_ZN4hlsl34RasterizerOrderedByteAddressBufferC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %this1)
+// CHECK: call void @_ZN4hlsl34RasterizerOrderedByteAddressBufferC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %{{.*}})
 // CHECK-NEXT: ret void
 
 // Buf1 initialization part 3 - ByteAddressBuffer C2 constructor with explicit binding that initializes
 // handle with @llvm.dx.resource.handlefrombinding
 // CHECK: define linkonce_odr void @_ZN4hlsl17ByteAddressBufferC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this,
 // CHECK-SAME: i32 noundef %registerNo, i32 noundef %spaceNo, i32 noundef %range, i32 noundef %index)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: %registerNo.addr = alloca i32, align 4
-// CHECK-NEXT: %spaceNo.addr = alloca i32, align 4
-// CHECK-NEXT: %range.addr = alloca i32, align 4
-// CHECK-NEXT: %index.addr = alloca i32, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: store i32 %registerNo, ptr %registerNo.addr, align 4
-// CHECK-NEXT: store i32 %spaceNo, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: store i32 %range, ptr %range.addr, align 4
-// CHECK-NEXT: store i32 %index, ptr %index.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK-NEXT: %0 = load i32, ptr %registerNo.addr, align 4
-// CHECK-NEXT: %1 = load i32, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: %2 = load i32, ptr %range.addr, align 4
-// CHECK-NEXT: %3 = load i32, ptr %index.addr, align 4
-// CHECK-DXIL-NEXT: %4 = call target("dx.RawBuffer", i8, 0, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i8_0_0t(
-// CHECK-DXIL-SAME: i32 %1, i32 %0, i32 %2, i32 %3, i1 false)
-// CHECK-NEXT: %__handle = getelementptr inbounds nuw %"class.hlsl::ByteAddressBuffer", ptr %this1, i32 0, i32 0
-// CHECK-DXIL-NEXT: store target("dx.RawBuffer", i8, 0, 0) %4, ptr %__handle, align 4
+// CHECK-DXIL: %[[HANDLE:.*]] = call target("dx.RawBuffer", i8, 0, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i8_0_0t(
+// CHECK-DXIL-SAME: i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i1 false)
+// CHECK-NEXT: %__handle = getelementptr inbounds nuw %"class.hlsl::ByteAddressBuffer", ptr %{{.*}}, i32 0, i32 0
+// CHECK-DXIL-NEXT: store target("dx.RawBuffer", i8, 0, 0) %[[HANDLE]], ptr %__handle, align 4
 // CHECK-NEXT: ret void
 
 // Buf3 initialization part 3 - body of RasterizerOrderedByteAddressBuffer default C2 constructor that
 // initializes handle to poison
 // CHECK: define linkonce_odr void @_ZN4hlsl34RasterizerOrderedByteAddressBufferC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %this)
-// CHECK: %__handle = getelementptr inbounds nuw %"class.hlsl::RasterizerOrderedByteAddressBuffer", ptr %this1, i32 0, i32 0
+// CHECK: %__handle = getelementptr inbounds nuw %"class.hlsl::RasterizerOrderedByteAddressBuffer", ptr %{{.*}}, i32 0, i32 0
 // CHECK: store target("dx.RawBuffer", i8, 1, 1) poison, ptr %__handle, align 4
 
 // Module initialization

--- a/clang/test/CodeGenHLSL/builtins/RWBuffer-constructor.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWBuffer-constructor.hlsl
@@ -35,25 +35,8 @@ export void foo() {
 // Buf1 initialization part 2 - body of RWBuffer<float> C1 constructor with explicit binding that calls the C2 constructor
 // CHECK: define linkonce_odr void @_ZN4hlsl8RWBufferIfEC1Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this,
 // CHECK-SAME: i32 noundef %registerNo, i32 noundef %spaceNo, i32 noundef %range, i32 noundef %index)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: %registerNo.addr = alloca i32, align 4
-// CHECK-NEXT: %spaceNo.addr = alloca i32, align 4
-// CHECK-NEXT: %range.addr = alloca i32, align 4
-// CHECK-NEXT: %index.addr = alloca i32, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: store i32 %registerNo, ptr %registerNo.addr, align 4
-// CHECK-NEXT: store i32 %spaceNo, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: store i32 %range, ptr %range.addr, align 4
-// CHECK-NEXT: store i32 %index, ptr %index.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK-NEXT: %0 = load i32, ptr %registerNo.addr, align 4
-// CHECK-NEXT: %1 = load i32, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: %2 = load i32, ptr %range.addr, align 4
-// CHECK-NEXT: %3 = load i32, ptr %index.addr, align 4
-// CHECK-NEXT: call void @_ZN4hlsl8RWBufferIfEC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this1,
-// CHECK-SAME: i32 noundef %0, i32 noundef %1, i32 noundef %2, i32 noundef %3)
-// CHECK-NEXT: ret void
+// CHECK: call void @_ZN4hlsl8RWBufferIfEC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4)
+// CHECK-SAME: %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}})
 
 // Buf2 initialization part 1 - FIXME: constructor with implicit binding does not exist yet; 
 // the global init function currently calls the default RWBufer<double> C1 constructor
@@ -69,48 +52,22 @@ export void foo() {
 
 // Buf3 initialization part 2 - body of RWBuffer<int> default C1 constructor that calls the default C2 constructor
 // CHECK: define linkonce_odr void @_ZN4hlsl8RWBufferIiEC1Ev(ptr noundef nonnull align 4 dereferenceable(4) %this)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK-NEXT: call void @_ZN4hlsl8RWBufferIiEC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %this1)
-// CHECK-NEXT: ret void
+// CHECK: call void @_ZN4hlsl8RWBufferIiEC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %{{.*}})
 
 // Buf1 initialization part 3 - body of RWBuffer<float> C2 constructor with explicit binding that initializes
 // handle with @llvm.dx.resource.handlefrombinding
 // CHECK: define linkonce_odr void @_ZN4hlsl8RWBufferIfEC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this,
 // CHECK-SAME: i32 noundef %registerNo, i32 noundef %spaceNo, i32 noundef %range, i32 noundef %index)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: %registerNo.addr = alloca i32, align 4
-// CHECK-NEXT: %spaceNo.addr = alloca i32, align 4
-// CHECK-NEXT: %range.addr = alloca i32, align 4
-// CHECK-NEXT: %index.addr = alloca i32, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: store i32 %registerNo, ptr %registerNo.addr, align 4
-// CHECK-NEXT: store i32 %spaceNo, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: store i32 %range, ptr %range.addr, align 4
-// CHECK-NEXT: store i32 %index, ptr %index.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK-NEXT: %0 = load i32, ptr %registerNo.addr, align 4
-// CHECK-NEXT: %1 = load i32, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: %2 = load i32, ptr %range.addr, align 4
-// CHECK-NEXT: %3 = load i32, ptr %index.addr, align 4
-// CHECK-DXIL-NEXT: %4 = call target("dx.TypedBuffer", float, 1, 0, 0) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f32_1_0_0t(
-// CHECK-DXIL-SAME: i32 %1, i32 %0, i32 %2, i32 %3, i1 false)
-// CHECK-NEXT: %__handle = getelementptr inbounds nuw %"class.hlsl::RWBuffer", ptr %this1, i32 0, i32 0
-// CHECK-DXIL-NEXT: store target("dx.TypedBuffer", float, 1, 0, 0) %4, ptr %__handle, align 4
+// CHECK-DXIL: %[[HANDLE:.*]] = call target("dx.TypedBuffer", float, 1, 0, 0) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f32_1_0_0t(
+// CHECK-DXIL-SAME: i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i1 false)
+// CHECK-NEXT: %__handle = getelementptr inbounds nuw %"class.hlsl::RWBuffer", ptr %{{.*}}, i32 0, i32 0
+// CHECK-DXIL-NEXT: store target("dx.TypedBuffer", float, 1, 0, 0) %[[HANDLE]], ptr %__handle, align 4
 // CHECK-NEXT: ret void
 
 // Buf3 initialization part 3 - body of RWBuffer<int> default C2 constructor that initializes handle to poison
 // CHECK: define linkonce_odr void @_ZN4hlsl8RWBufferIiEC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %this)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK-NEXT: %__handle = getelementptr inbounds nuw %"class.hlsl::RWBuffer.1", ptr %this1, i32 0, i32 0
+// CHECK: %__handle = getelementptr inbounds nuw %"class.hlsl::RWBuffer.1", ptr %{{.*}}, i32 0, i32 0
 // CHECK-NEXT: store target("dx.TypedBuffer", i32, 1, 0, 1) poison, ptr %__handle, align 4
-// CHECK-NEXT: ret void
 
 // Module initialization
 // CHECK: define internal void @_GLOBAL__sub_I_RWBuffer_constructor.hlsl()

--- a/clang/test/CodeGenHLSL/builtins/StructuredBuffers-constructors.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/StructuredBuffers-constructors.hlsl
@@ -36,25 +36,8 @@ export void foo() {
 // that calls the C2 constructor
 // CHECK: define linkonce_odr void @_ZN4hlsl16StructuredBufferIfEC1Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this, 
 // CHECK-SAME: i32 noundef %registerNo, i32 noundef %spaceNo, i32 noundef %range, i32 noundef %index)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: %registerNo.addr = alloca i32, align 4
-// CHECK-NEXT: %spaceNo.addr = alloca i32, align 4
-// CHECK-NEXT: %range.addr = alloca i32, align 4
-// CHECK-NEXT: %index.addr = alloca i32, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: store i32 %registerNo, ptr %registerNo.addr, align 4
-// CHECK-NEXT: store i32 %spaceNo, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: store i32 %range, ptr %range.addr, align 4
-// CHECK-NEXT: store i32 %index, ptr %index.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK-NEXT: %0 = load i32, ptr %registerNo.addr, align 4
-// CHECK-NEXT: %1 = load i32, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: %2 = load i32, ptr %range.addr, align 4
-// CHECK-NEXT: %3 = load i32, ptr %index.addr, align 4
-// CHECK: call void @_ZN4hlsl16StructuredBufferIfEC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this1, 
-// CHECK-SAME: i32 noundef %0, i32 noundef %1, i32 noundef %2, i32 noundef %3)
-// CHECK-NEXT: ret void
+// CHECK: call void @_ZN4hlsl16StructuredBufferIfEC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4)
+// CHECK-SAME: %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}}, i32 noundef %{{.*}})
 
 // Buf2 initialization part 1 - FIXME: constructor with implicit binding does not exist yet; 
 // the global init function currently calls the default RWStructuredBufer<double> C1 constructor
@@ -72,47 +55,23 @@ export void foo() {
 // Buf3 initialization part 2 - body of AppendStructuredBuffer<float> default C1 constructor that calls
 // the default C2 constructor
 // CHECK: define linkonce_odr void @_ZN4hlsl22AppendStructuredBufferIfEC1Ev(ptr noundef nonnull align 4 dereferenceable(4) %this)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK: call void @_ZN4hlsl22AppendStructuredBufferIfEC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %this1)
+// CHECK: call void @_ZN4hlsl22AppendStructuredBufferIfEC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %{{.*}})
 // CHECK-NEXT: ret void
 
 // Buf1 initialization part 3 - body of AppendStructuredBuffer<float> C2 constructor with explicit binding 
 // that initializes handle with @llvm.dx.resource.handlefrombinding
 // CHECK: define linkonce_odr void @_ZN4hlsl16StructuredBufferIfEC2Ejjij(ptr noundef nonnull align 4 dereferenceable(4) %this,
 // CHECK-SAME: i32 noundef %registerNo, i32 noundef %spaceNo, i32 noundef %range, i32 noundef %index)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: %registerNo.addr = alloca i32, align 4
-// CHECK-NEXT: %spaceNo.addr = alloca i32, align 4
-// CHECK-NEXT: %range.addr = alloca i32, align 4
-// CHECK-NEXT: %index.addr = alloca i32, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: store i32 %registerNo, ptr %registerNo.addr, align 4
-// CHECK-NEXT: store i32 %spaceNo, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: store i32 %range, ptr %range.addr, align 4
-// CHECK-NEXT: store i32 %index, ptr %index.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK-NEXT: %0 = load i32, ptr %registerNo.addr, align 4
-// CHECK-NEXT: %1 = load i32, ptr %spaceNo.addr, align 4
-// CHECK-NEXT: %2 = load i32, ptr %range.addr, align 4
-// CHECK-NEXT: %3 = load i32, ptr %index.addr, align 4
-// CHECK-DXIL-NEXT: %4 = call target("dx.RawBuffer", float, 0, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_f32_0_0t(
-// CHECK-DXIL-SAME: i32 %1, i32 %0, i32 %2, i32 %3, i1 false)
-// CHECK-NEXT: %__handle = getelementptr inbounds nuw %"class.hlsl::StructuredBuffer", ptr %this1, i32 0, i32 0
-// CHECK-DXIL-NEXT: store target("dx.RawBuffer", float, 0, 0) %4, ptr %__handle, align 4
+// CHECK-DXIL: %[[HANDLE:.*]] = call target("dx.RawBuffer", float, 0, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_f32_0_0t(
+// CHECK-SAME: i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i1 false)
+// CHECK-NEXT: %__handle = getelementptr inbounds nuw %"class.hlsl::StructuredBuffer", ptr %{{.*}}, i32 0, i32 0
+// CHECK-DXIL-NEXT: store target("dx.RawBuffer", float, 0, 0) %[[HANDLE]], ptr %__handle, align 4
 // CHECK-NEXT: ret void
 
 // Buf3 initialization part 3 - body of AppendStructuredBuffer<float> default C2 constructor that
 // initializes handle to poison
 // CHECK: define linkonce_odr void @_ZN4hlsl22AppendStructuredBufferIfEC2Ev(ptr noundef nonnull align 4 dereferenceable(4) %this)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: %this.addr = alloca ptr, align 4
-// CHECK-NEXT: store ptr %this, ptr %this.addr, align 4
-// CHECK-NEXT: %this1 = load ptr, ptr %this.addr, align 4
-// CHECK: %__handle = getelementptr inbounds nuw %"class.hlsl::AppendStructuredBuffer", ptr %this1, i32 0, i32 0
+// CHECK: %__handle = getelementptr inbounds nuw %"class.hlsl::AppendStructuredBuffer", ptr %{{.*}}, i32 0, i32 0
 // CHECK: store target("dx.RawBuffer", float, 1, 0) poison, ptr %__handle, align 4
 
 // Module initialization


### PR DESCRIPTION
Verification of the local allocas and load/store is not that useful and it makes the test fragile.