### PR TITLE
[MC][AArch64][ARM][X86] Push target-dependent assembler flags into targets

### DIFF
--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -213,9 +213,6 @@ public:
   /// Give backend an opportunity to finish layout after relaxation
   virtual void finishLayout(MCAssembler const &Asm) const {}
 
-  /// Handle any target-specific assembler flags. By default, do nothing.
-  virtual void handleAssemblerFlag(MCAssemblerFlag Flag) {}
-
   /// Generate the compact unwind encoding for the CFI instructions.
   virtual uint64_t generateCompactUnwindEncoding(const MCDwarfFrameInfo *FI,
                                                  const MCContext *Ctxt) const {

--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -166,13 +166,6 @@ protected:
   const char *InlineAsmStart;
   const char *InlineAsmEnd;
 
-  /// These are assembly directives that tells the assembler to interpret the
-  /// following instructions differently.  Defaults to ".code16", ".code32",
-  /// ".code64".
-  const char *Code16Directive;
-  const char *Code32Directive;
-  const char *Code64Directive;
-
   /// Which dialect of an assembler variant to use.  Defaults to 0
   unsigned AssemblerDialect = 0;
 
@@ -544,9 +537,6 @@ public:
 
   const char *getInlineAsmStart() const { return InlineAsmStart; }
   const char *getInlineAsmEnd() const { return InlineAsmEnd; }
-  const char *getCode16Directive() const { return Code16Directive; }
-  const char *getCode32Directive() const { return Code32Directive; }
-  const char *getCode64Directive() const { return Code64Directive; }
   unsigned getAssemblerDialect() const { return AssemblerDialect; }
   bool doesAllowAtInName() const { return AllowAtInName; }
   void setAllowAtInName(bool V) { AllowAtInName = V; }

--- a/llvm/include/llvm/MC/MCDirectives.h
+++ b/llvm/include/llvm/MC/MCDirectives.h
@@ -50,14 +50,6 @@ enum MCSymbolAttr {
   MCSA_Memtag,                  ///< .memtag (ELF)
 };
 
-enum MCAssemblerFlag {
-  MCAF_SyntaxUnified,         ///< .syntax (ARM/ELF)
-  MCAF_SubsectionsViaSymbols, ///< .subsections_via_symbols (MachO)
-  MCAF_Code16,                ///< .code16 (X86) / .code 16 (ARM)
-  MCAF_Code32,                ///< .code32 (X86) / .code 32 (ARM)
-  MCAF_Code64                 ///< .code64 (X86)
-};
-
 enum MCDataRegionType {
   MCDR_DataRegion,            ///< .data_region
   MCDR_DataRegionJT8,         ///< .data_region jt8

--- a/llvm/include/llvm/MC/MCELFStreamer.h
+++ b/llvm/include/llvm/MC/MCELFStreamer.h
@@ -53,7 +53,6 @@ public:
   void emitLabel(MCSymbol *Symbol, SMLoc Loc = SMLoc()) override;
   void emitLabelAtPos(MCSymbol *Symbol, SMLoc Loc, MCDataFragment &F,
                       uint64_t Offset) override;
-  void emitAssemblerFlag(MCAssemblerFlag Flag) override;
   void emitWeakReference(MCSymbol *Alias, const MCSymbol *Symbol) override;
   bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override;
   void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -169,6 +169,11 @@ public:
 
   virtual void annotateTLSDescriptorSequence(const MCSymbolRefExpr *SRE);
 
+  virtual void emitSyntaxUnified();
+
+  virtual void emitCode16();
+  virtual void emitCode32();
+
   // Note in the output that the specified \p Symbol is a Thumb mode function.
   virtual void emitThumbFunc(MCSymbol *Symbol);
   virtual void emitThumbSet(MCSymbol *Symbol, const MCExpr *Value);
@@ -471,8 +476,8 @@ public:
 
   virtual void emitEHSymAttributes(const MCSymbol *Symbol, MCSymbol *EHSymbol);
 
-  /// Note in the output the specified \p Flag.
-  virtual void emitAssemblerFlag(MCAssemblerFlag Flag);
+  /// Emit a .subsection_via_symbols directive.
+  virtual void emitSubsectionsViaSymbols();
 
   /// Emit the given list \p Options of strings as linker
   /// options into the output.

--- a/llvm/include/llvm/MC/MCWasmStreamer.h
+++ b/llvm/include/llvm/MC/MCWasmStreamer.h
@@ -44,7 +44,6 @@ public:
   void emitLabel(MCSymbol *Symbol, SMLoc Loc = SMLoc()) override;
   void emitLabelAtPos(MCSymbol *Symbol, SMLoc Loc, MCDataFragment &F,
                       uint64_t Offset) override;
-  void emitAssemblerFlag(MCAssemblerFlag Flag) override;
   void emitWeakReference(MCSymbol *Alias, const MCSymbol *Symbol) override;
   bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override;
   void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,

--- a/llvm/include/llvm/MC/MCWinCOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCWinCOFFStreamer.h
@@ -45,7 +45,6 @@ public:
   void initSections(bool NoExecStack, const MCSubtargetInfo &STI) override;
   void changeSection(MCSection *Section, uint32_t Subsection = 0) override;
   void emitLabel(MCSymbol *Symbol, SMLoc Loc = SMLoc()) override;
-  void emitAssemblerFlag(MCAssemblerFlag Flag) override;
   bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override;
   void emitSymbolDesc(MCSymbol *Symbol, unsigned DescValue) override;
   void beginCOFFSymbolDef(MCSymbol const *Symbol) override;

--- a/llvm/lib/MC/MCAsmInfo.cpp
+++ b/llvm/lib/MC/MCAsmInfo.cpp
@@ -48,9 +48,6 @@ MCAsmInfo::MCAsmInfo() {
   LinkerPrivateGlobalPrefix = "";
   InlineAsmStart = "APP";
   InlineAsmEnd = "NO_APP";
-  Code16Directive = ".code16";
-  Code32Directive = ".code32";
-  Code64Directive = ".code64";
   ZeroDirective = "\t.zero\t";
   AsciiDirective = "\t.ascii\t";
   AscizDirective = "\t.asciz\t";

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -182,7 +182,7 @@ public:
 
   void emitLabel(MCSymbol *Symbol, SMLoc Loc = SMLoc()) override;
 
-  void emitAssemblerFlag(MCAssemblerFlag Flag) override;
+  void emitSubsectionsViaSymbols() override;
   void emitLinkerOptions(ArrayRef<std::string> Options) override;
   void emitDataRegion(MCDataRegionType Kind) override;
   void emitVersionMin(MCVersionMinType Kind, unsigned Major, unsigned Minor,
@@ -597,15 +597,8 @@ void MCAsmStreamer::emitGNUAttribute(unsigned Tag, unsigned Value) {
   OS << "\t.gnu_attribute " << Tag << ", " << Value << "\n";
 }
 
-void MCAsmStreamer::emitAssemblerFlag(MCAssemblerFlag Flag) {
-  switch (Flag) {
-  case MCAF_SyntaxUnified:         OS << "\t.syntax unified"; break;
-  case MCAF_SubsectionsViaSymbols: OS << ".subsections_via_symbols"; break;
-  case MCAF_Code16:                OS << '\t'<< MAI->getCode16Directive();break;
-  case MCAF_Code32:                OS << '\t'<< MAI->getCode32Directive();break;
-  case MCAF_Code64:                OS << '\t'<< MAI->getCode64Directive();break;
-  }
-  EmitEOL();
+void MCAsmStreamer::emitSubsectionsViaSymbols() {
+  OS << ".subsections_via_symbols\n";
 }
 
 void MCAsmStreamer::emitLinkerOptions(ArrayRef<std::string> Options) {

--- a/llvm/lib/MC/MCELFStreamer.cpp
+++ b/llvm/lib/MC/MCELFStreamer.cpp
@@ -84,11 +84,6 @@ void MCELFStreamer::emitLabelAtPos(MCSymbol *S, SMLoc Loc, MCDataFragment &F,
     Symbol->setType(ELF::STT_TLS);
 }
 
-void MCELFStreamer::emitAssemblerFlag(MCAssemblerFlag Flag) {
-  // Let the target do whatever target specific stuff it needs to do.
-  getAssembler().getBackend().handleAssemblerFlag(Flag);
-}
-
 // If bundle alignment is used and there are any instructions in the section, it
 // needs to be aligned to at least the bundle size.
 static void setSectionAlignmentForBundling(const MCAssembler &Assembler,

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -89,7 +89,7 @@ public:
   void emitLabel(MCSymbol *Symbol, SMLoc Loc = SMLoc()) override;
   void emitAssignment(MCSymbol *Symbol, const MCExpr *Value) override;
   void emitEHSymAttributes(const MCSymbol *Symbol, MCSymbol *EHSymbol) override;
-  void emitAssemblerFlag(MCAssemblerFlag Flag) override;
+  void emitSubsectionsViaSymbols() override;
   void emitLinkerOptions(ArrayRef<std::string> Options) override;
   void emitDataRegion(MCDataRegionType Kind) override;
   void emitVersionMin(MCVersionMinType Kind, unsigned Major, unsigned Minor,
@@ -209,19 +209,8 @@ void MCMachOStreamer::emitDataRegionEnd() {
   emitLabel(Data.End);
 }
 
-void MCMachOStreamer::emitAssemblerFlag(MCAssemblerFlag Flag) {
-  // Let the target do whatever target specific stuff it needs to do.
-  getAssembler().getBackend().handleAssemblerFlag(Flag);
-  // Do any generic stuff we need to do.
-  switch (Flag) {
-  case MCAF_SyntaxUnified: return; // no-op here.
-  case MCAF_Code16: return; // Change parsing mode; no-op here.
-  case MCAF_Code32: return; // Change parsing mode; no-op here.
-  case MCAF_Code64: return; // Change parsing mode; no-op here.
-  case MCAF_SubsectionsViaSymbols:
-    getWriter().setSubsectionsViaSymbols(true);
-    return;
-  }
+void MCMachOStreamer::emitSubsectionsViaSymbols() {
+  getWriter().setSubsectionsViaSymbols(true);
 }
 
 void MCMachOStreamer::emitLinkerOptions(ArrayRef<std::string> Options) {

--- a/llvm/lib/MC/MCNullStreamer.cpp
+++ b/llvm/lib/MC/MCNullStreamer.cpp
@@ -38,6 +38,7 @@ namespace {
 
     void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
                           Align ByteAlignment) override {}
+    void emitSubsectionsViaSymbols() override {};
     void beginCOFFSymbolDef(const MCSymbol *Symbol) override {}
     void emitCOFFSymbolStorageClass(int StorageClass) override {}
     void emitCOFFSymbolType(int Type) override {}

--- a/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
@@ -817,7 +817,7 @@ bool DarwinAsmParser::parseDirectiveSubsectionsViaSymbols(StringRef, SMLoc) {
 
   Lex();
 
-  getStreamer().emitAssemblerFlag(MCAF_SubsectionsViaSymbols);
+  getStreamer().emitSubsectionsViaSymbols();
 
   return false;
 }

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -1245,7 +1245,10 @@ void MCStreamer::emitAbsoluteSymbolDiffAsULEB128(const MCSymbol *Hi,
   emitULEB128Value(Diff);
 }
 
-void MCStreamer::emitAssemblerFlag(MCAssemblerFlag Flag) {}
+void MCStreamer::emitSubsectionsViaSymbols() {
+  llvm_unreachable(
+      "emitSubsectionsViaSymbols only supported on Mach-O targets");
+}
 void MCStreamer::emitSymbolDesc(MCSymbol *Symbol, unsigned DescValue) {}
 void MCStreamer::beginCOFFSymbolDef(const MCSymbol *Symbol) {
   llvm_unreachable("this directive only supported on COFF targets");

--- a/llvm/lib/MC/MCWasmStreamer.cpp
+++ b/llvm/lib/MC/MCWasmStreamer.cpp
@@ -59,14 +59,6 @@ void MCWasmStreamer::emitLabelAtPos(MCSymbol *S, SMLoc Loc, MCDataFragment &F,
     Symbol->setTLS();
 }
 
-void MCWasmStreamer::emitAssemblerFlag(MCAssemblerFlag Flag) {
-  // Let the target do whatever target specific stuff it needs to do.
-  getAssembler().getBackend().handleAssemblerFlag(Flag);
-
-  // Do any generic stuff we need to do.
-  llvm_unreachable("invalid assembler flag!");
-}
-
 void MCWasmStreamer::changeSection(MCSection *Section, uint32_t Subsection) {
   MCAssembler &Asm = getAssembler();
   auto *SectionWasm = cast<MCSectionWasm>(Section);

--- a/llvm/lib/MC/MCWinCOFFStreamer.cpp
+++ b/llvm/lib/MC/MCWinCOFFStreamer.cpp
@@ -184,22 +184,6 @@ void MCWinCOFFStreamer::emitLabel(MCSymbol *S, SMLoc Loc) {
   MCObjectStreamer::emitLabel(Symbol, Loc);
 }
 
-void MCWinCOFFStreamer::emitAssemblerFlag(MCAssemblerFlag Flag) {
-  // Let the target do whatever target specific stuff it needs to do.
-  getAssembler().getBackend().handleAssemblerFlag(Flag);
-
-  switch (Flag) {
-  // None of these require COFF specific handling.
-  case MCAF_SyntaxUnified:
-  case MCAF_Code16:
-  case MCAF_Code32:
-  case MCAF_Code64:
-    break;
-  case MCAF_SubsectionsViaSymbols:
-    llvm_unreachable("COFF doesn't support .subsections_via_symbols");
-  }
-}
-
 bool MCWinCOFFStreamer::emitSymbolAttribute(MCSymbol *S,
                                             MCSymbolAttr Attribute) {
   auto *Symbol = cast<MCSymbolCOFF>(S);

--- a/llvm/lib/Object/RecordStreamer.h
+++ b/llvm/lib/Object/RecordStreamer.h
@@ -54,9 +54,10 @@ public:
   void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
                         Align ByteAlignment) override;
 
-  // Ignore COFF-specific directives; we do not need any information from them,
-  // but the default implementation of these methods crashes, so we override
-  // them with versions that do nothing.
+  // Ignore format-specific directives; we do not need any information from
+  // them, but the default implementation of these methods crashes, so we
+  // override them with versions that do nothing.
+  void emitSubsectionsViaSymbols() override {};
   void beginCOFFSymbolDef(const MCSymbol *Symbol) override {}
   void emitCOFFSymbolStorageClass(int StorageClass) override {}
   void emitCOFFSymbolType(int Type) override {}

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -961,7 +961,7 @@ void AArch64AsmPrinter::emitEndOfAsmFile(Module &M) {
     // implementation of multiple entry points).  If this doesn't occur, the
     // linker can safely perform dead code stripping.  Since LLVM never
     // generates code that does this, it is always safe to set.
-    OutStreamer->emitAssemblerFlag(MCAF_SubsectionsViaSymbols);
+    OutStreamer->emitSubsectionsViaSymbols();
   }
 
   if (TT.isOSBinFormatELF()) {

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
@@ -108,7 +108,6 @@ AArch64MCAsmInfoELF::AArch64MCAsmInfoELF(const Triple &T) {
   CommentString = "//";
   PrivateGlobalPrefix = ".L";
   PrivateLabelPrefix = ".L";
-  Code32Directive = ".code\t32";
 
   Data16bitsDirective = "\t.hword\t";
   Data32bitsDirective = "\t.word\t";

--- a/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -66,10 +66,10 @@ void ARMAsmPrinter::emitFunctionEntryLabel() {
   auto &TS =
       static_cast<ARMTargetStreamer &>(*OutStreamer->getTargetStreamer());
   if (AFI->isThumbFunction()) {
-    OutStreamer->emitAssemblerFlag(MCAF_Code16);
+    TS.emitCode16();
     TS.emitThumbFunc(CurrentFnSym);
   } else {
-    OutStreamer->emitAssemblerFlag(MCAF_Code32);
+    TS.emitCode32();
   }
 
   // Emit symbol for CMSE non-secure entry point
@@ -171,7 +171,9 @@ bool ARMAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
   // These are created per function, rather than per TU, since it's
   // relatively easy to exceed the thumb branch range within a TU.
   if (! ThumbIndirectPads.empty()) {
-    OutStreamer->emitAssemblerFlag(MCAF_Code16);
+    auto &TS =
+        static_cast<ARMTargetStreamer &>(*OutStreamer->getTargetStreamer());
+    TS.emitCode16();
     emitAlignment(Align(2));
     for (std::pair<unsigned, MCSymbol *> &TIP : ThumbIndirectPads) {
       OutStreamer->emitLabel(TIP.second);
@@ -489,24 +491,30 @@ void ARMAsmPrinter::emitInlineAsmEnd(const MCSubtargetInfo &StartInfo,
   // the start mode, then restore the start mode.
   const bool WasThumb = isThumb(StartInfo);
   if (!EndInfo || WasThumb != isThumb(*EndInfo)) {
-    OutStreamer->emitAssemblerFlag(WasThumb ? MCAF_Code16 : MCAF_Code32);
+    auto &TS =
+        static_cast<ARMTargetStreamer &>(*OutStreamer->getTargetStreamer());
+    if (WasThumb)
+      TS.emitCode16();
+    else
+      TS.emitCode32();
   }
 }
 
 void ARMAsmPrinter::emitStartOfAsmFile(Module &M) {
   const Triple &TT = TM.getTargetTriple();
+  auto &TS =
+      static_cast<ARMTargetStreamer &>(*OutStreamer->getTargetStreamer());
   // Use unified assembler syntax.
-  OutStreamer->emitAssemblerFlag(MCAF_SyntaxUnified);
+  TS.emitSyntaxUnified();
 
   // Emit ARM Build Attributes
   if (TT.isOSBinFormatELF())
     emitAttributes();
 
   // Use the triple's architecture and subarchitecture to determine
-  // if we're thumb for the purposes of the top level code16 assembler
-  // flag.
+  // if we're thumb for the purposes of the top level code16 state.
   if (!M.getModuleInlineAsm().empty() && TT.isThumb())
-    OutStreamer->emitAssemblerFlag(MCAF_Code16);
+    TS.emitCode16();
 }
 
 static void
@@ -575,7 +583,7 @@ void ARMAsmPrinter::emitEndOfAsmFile(Module &M) {
     // implementation of multiple entry points).  If this doesn't occur, the
     // linker can safely perform dead code stripping.  Since LLVM never
     // generates code that does this, it is always safe to set.
-    OutStreamer->emitAssemblerFlag(MCAF_SubsectionsViaSymbols);
+    OutStreamer->emitSubsectionsViaSymbols();
   }
 
   // The last attribute to be emitted is ABI_optimization_goals

--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -11654,7 +11654,7 @@ bool ARMAsmParser::parseDirectiveThumb(SMLoc L) {
   if (!isThumb())
     SwitchMode();
 
-  getParser().getStreamer().emitAssemblerFlag(MCAF_Code16);
+  getTargetStreamer().emitCode16();
   getParser().getStreamer().emitCodeAlignment(Align(2), &getSTI(), 0);
   return false;
 }
@@ -11667,7 +11667,7 @@ bool ARMAsmParser::parseDirectiveARM(SMLoc L) {
 
   if (isThumb())
     SwitchMode();
-  getParser().getStreamer().emitAssemblerFlag(MCAF_Code32);
+  getTargetStreamer().emitCode32();
   getParser().getStreamer().emitCodeAlignment(Align(4), &getSTI(), 0);
   return false;
 }
@@ -11715,7 +11715,7 @@ bool ARMAsmParser::parseDirectiveThumbFunc(SMLoc L) {
   if (!isThumb())
     SwitchMode();
 
-  getParser().getStreamer().emitAssemblerFlag(MCAF_Code16);
+  getTargetStreamer().emitCode16();
 
   NextSymbolIsThumb = true;
   return false;
@@ -11768,14 +11768,14 @@ bool ARMAsmParser::parseDirectiveCode(SMLoc L) {
 
     if (!isThumb())
       SwitchMode();
-    getParser().getStreamer().emitAssemblerFlag(MCAF_Code16);
+    getTargetStreamer().emitCode16();
   } else {
     if (!hasARM())
       return Error(L, "target does not support ARM mode");
 
     if (isThumb())
       SwitchMode();
-    getParser().getStreamer().emitAssemblerFlag(MCAF_Code32);
+    getTargetStreamer().emitCode32();
   }
 
   return false;
@@ -11824,8 +11824,10 @@ void ARMAsmParser::FixModeAfterArchChange(bool WasThumb, SMLoc Loc) {
       SwitchMode();
     } else {
       // Mode switch forced, because the new arch doesn't support the old mode.
-      getParser().getStreamer().emitAssemblerFlag(isThumb() ? MCAF_Code16
-                                                            : MCAF_Code32);
+      if (isThumb())
+        getTargetStreamer().emitCode16();
+      else
+        getTargetStreamer().emitCode32();
       // Warn about the implcit mode switch. GAS does not switch modes here,
       // but instead stays in the old mode, reporting an error on any following
       // instructions as the mode does not exist on the target.

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
@@ -18,11 +18,9 @@
 namespace llvm {
 
 class ARMAsmBackend : public MCAsmBackend {
-  bool isThumbMode;    // Currently emitting Thumb code.
 public:
-  ARMAsmBackend(const Target &T, bool isThumb, llvm::endianness Endian)
-      : MCAsmBackend(Endian), isThumbMode(isThumb) {}
-
+  ARMAsmBackend(const Target &T, llvm::endianness Endian)
+      : MCAsmBackend(Endian) {}
 
   bool hasNOP(const MCSubtargetInfo *STI) const {
     return STI->hasFeature(ARM::HasV6T2Ops);
@@ -64,11 +62,7 @@ public:
   bool writeNopData(raw_ostream &OS, uint64_t Count,
                     const MCSubtargetInfo *STI) const override;
 
-  void handleAssemblerFlag(MCAssemblerFlag Flag) override;
-
   unsigned getPointerSize() const { return 4; }
-  bool isThumb() const { return isThumbMode; }
-  void setIsThumb(bool it) { isThumbMode = it; }
 };
 } // end namespace llvm
 

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendDarwin.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendDarwin.h
@@ -22,9 +22,8 @@ public:
   const MachO::CPUSubTypeARM Subtype;
   ARMAsmBackendDarwin(const Target &T, const MCSubtargetInfo &STI,
                       const MCRegisterInfo &MRI)
-      : ARMAsmBackend(T, STI.getTargetTriple().isThumb(),
-                      llvm::endianness::little),
-        MRI(MRI), TT(STI.getTargetTriple()),
+      : ARMAsmBackend(T, llvm::endianness::little), MRI(MRI),
+        TT(STI.getTargetTriple()),
         Subtype((MachO::CPUSubTypeARM)cantFail(
             MachO::getCPUSubType(STI.getTargetTriple()))) {}
 

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendELF.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendELF.h
@@ -17,9 +17,8 @@ namespace llvm {
 class ARMAsmBackendELF : public ARMAsmBackend {
 public:
   uint8_t OSABI;
-  ARMAsmBackendELF(const Target &T, bool isThumb, uint8_t OSABI,
-                   llvm::endianness Endian)
-      : ARMAsmBackend(T, isThumb, Endian), OSABI(OSABI) {}
+  ARMAsmBackendELF(const Target &T, uint8_t OSABI, llvm::endianness Endian)
+      : ARMAsmBackend(T, Endian), OSABI(OSABI) {}
 
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override {

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendWinCOFF.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendWinCOFF.h
@@ -15,8 +15,8 @@
 namespace llvm {
 class ARMAsmBackendWinCOFF : public ARMAsmBackend {
 public:
-  ARMAsmBackendWinCOFF(const Target &T, bool isThumb)
-      : ARMAsmBackend(T, isThumb, llvm::endianness::little) {}
+  ARMAsmBackendWinCOFF(const Target &T)
+      : ARMAsmBackend(T, llvm::endianness::little) {}
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override {
     return createARMWinCOFFObjectWriter();

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
@@ -53,8 +53,6 @@ ARMMCAsmInfoDarwin::ARMMCAsmInfoDarwin(const Triple &TheTriple) {
 
   Data64bitsDirective = nullptr;
   CommentString = "@";
-  Code16Directive = ".code\t16";
-  Code32Directive = ".code\t32";
   UseDataRegionDirectives = true;
 
   SupportsDebugInformation = true;
@@ -82,8 +80,6 @@ ARMELFMCAsmInfo::ARMELFMCAsmInfo(const Triple &TheTriple) {
 
   Data64bitsDirective = nullptr;
   CommentString = "@";
-  Code16Directive = ".code\t16";
-  Code32Directive = ".code\t32";
 
   SupportsDebugInformation = true;
 
@@ -141,8 +137,6 @@ ARMCOFFMCAsmInfoGNU::ARMCOFFMCAsmInfoGNU() {
   HasSingleParameterDotFile = true;
 
   CommentString = "@";
-  Code16Directive = ".code\t16";
-  Code32Directive = ".code\t32";
   PrivateGlobalPrefix = ".L";
   PrivateLabelPrefix = ".L";
 

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMTargetStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMTargetStreamer.cpp
@@ -115,6 +115,9 @@ void ARMTargetStreamer::emitFPU(ARM::FPUKind FPU) {}
 void ARMTargetStreamer::finishAttributeSection() {}
 void ARMTargetStreamer::annotateTLSDescriptorSequence(
     const MCSymbolRefExpr *SRE) {}
+void ARMTargetStreamer::emitSyntaxUnified() {}
+void ARMTargetStreamer::emitCode16() {}
+void ARMTargetStreamer::emitCode32() {}
 void ARMTargetStreamer::emitThumbFunc(MCSymbol *Symbol) {}
 void ARMTargetStreamer::emitThumbSet(MCSymbol *Symbol, const MCExpr *Value) {}
 

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -4791,7 +4791,7 @@ bool X86AsmParser::ParseDirectiveCode(StringRef IDVal, SMLoc L) {
     Parser.Lex();
     if (!is16BitMode()) {
       SwitchMode(X86::Is16Bit);
-      getParser().getStreamer().emitAssemblerFlag(MCAF_Code16);
+      getTargetStreamer().emitCode16();
     }
   } else if (IDVal == ".code16gcc") {
     // .code16gcc parses as if in 32-bit mode, but emits code in 16-bit mode.
@@ -4799,19 +4799,19 @@ bool X86AsmParser::ParseDirectiveCode(StringRef IDVal, SMLoc L) {
     Code16GCC = true;
     if (!is16BitMode()) {
       SwitchMode(X86::Is16Bit);
-      getParser().getStreamer().emitAssemblerFlag(MCAF_Code16);
+      getTargetStreamer().emitCode16();
     }
   } else if (IDVal == ".code32") {
     Parser.Lex();
     if (!is32BitMode()) {
       SwitchMode(X86::Is32Bit);
-      getParser().getStreamer().emitAssemblerFlag(MCAF_Code32);
+      getTargetStreamer().emitCode32();
     }
   } else if (IDVal == ".code64") {
     Parser.Lex();
     if (!is64BitMode()) {
       SwitchMode(X86::Is64Bit);
-      getParser().getStreamer().emitAssemblerFlag(MCAF_Code64);
+      getTargetStreamer().emitCode64();
     }
   } else {
     Error(L, "unknown directive " + IDVal);

--- a/llvm/lib/Target/X86/MCTargetDesc/X86TargetStreamer.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86TargetStreamer.h
@@ -18,6 +18,10 @@ class X86TargetStreamer : public MCTargetStreamer {
 public:
   X86TargetStreamer(MCStreamer &S) : MCTargetStreamer(S) {}
 
+  virtual void emitCode16() {}
+  virtual void emitCode32() {}
+  virtual void emitCode64() {}
+
   virtual bool emitFPOProc(const MCSymbol *ProcSym, unsigned ParamsSize,
                            SMLoc L = {}) {
     return false;

--- a/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFTargetStreamer.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFTargetStreamer.cpp
@@ -32,6 +32,10 @@ public:
                               MCInstPrinter &InstPrinter)
       : X86TargetStreamer(S), OS(OS), InstPrinter(InstPrinter) {}
 
+  void emitCode16() override;
+  void emitCode32() override;
+  void emitCode64() override;
+
   bool emitFPOProc(const MCSymbol *ProcSym, unsigned ParamsSize,
                    SMLoc L) override;
   bool emitFPOEndPrologue(SMLoc L) override;
@@ -95,6 +99,12 @@ public:
   bool emitFPOSetFrame(MCRegister Reg, SMLoc L) override;
 };
 } // end namespace
+
+void X86WinCOFFAsmTargetStreamer::emitCode16() { OS << "\t.code16\n"; }
+
+void X86WinCOFFAsmTargetStreamer::emitCode32() { OS << "\t.code32\n"; }
+
+void X86WinCOFFAsmTargetStreamer::emitCode64() { OS << "\t.code64\n"; }
 
 bool X86WinCOFFAsmTargetStreamer::emitFPOProc(const MCSymbol *ProcSym,
                                               unsigned ParamsSize, SMLoc L) {
@@ -452,9 +462,9 @@ MCTargetStreamer *llvm::createX86AsmTargetStreamer(MCStreamer &S,
 
 MCTargetStreamer *
 llvm::createX86ObjectTargetStreamer(MCStreamer &S, const MCSubtargetInfo &STI) {
-  // No need to register a target streamer.
+  // No need for a special target streamer.
   if (!STI.getTargetTriple().isOSBinFormatCOFF())
-    return nullptr;
+    return new X86TargetStreamer(S);
   // Registers itself to the MCStreamer.
   return new X86WinCOFFTargetStreamer(S);
 }

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -918,8 +918,11 @@ void X86AsmPrinter::emitStartOfAsmFile(Module &M) {
   // If this is not inline asm and we're in 16-bit
   // mode prefix assembly with .code16.
   bool is16 = TT.getEnvironment() == Triple::CODE16;
-  if (M.getModuleInlineAsm().empty() && is16)
-    OutStreamer->emitAssemblerFlag(MCAF_Code16);
+  if (M.getModuleInlineAsm().empty() && is16) {
+    auto *XTS =
+        static_cast<X86TargetStreamer *>(OutStreamer->getTargetStreamer());
+    XTS->emitCode16();
+  }
 }
 
 static void
@@ -1011,7 +1014,7 @@ void X86AsmPrinter::emitEndOfAsmFile(Module &M) {
     // points). If this doesn't occur, the linker can safely perform dead code
     // stripping. Since LLVM never generates code that does this, it is always
     // safe to set.
-    OutStreamer->emitAssemblerFlag(MCAF_SubsectionsViaSymbols);
+    OutStreamer->emitSubsectionsViaSymbols();
   } else if (TT.isOSBinFormatCOFF()) {
     if (usesMSVCFloatingPoint(TT, M)) {
       // In Windows' libcmt.lib, there is a file which is linked in only if the

--- a/llvm/test/CodeGen/ARM/ldrd.ll
+++ b/llvm/test/CodeGen/ARM/ldrd.ll
@@ -16,7 +16,7 @@ declare ptr @get_ptr()
 declare void @use_i64(i64 %v)
 
 define void @test_ldrd(i64 %a) nounwind readonly "frame-pointer"="all" {
-; CHECK-LABEL: test_ldrd:
+; CHECK-LABEL: test_ldrd:{{.*$}}
 ; NORMAL: bl{{x?}} _get_ptr
 ; A8: ldrd r0, r1, [r0]
 ; Cortex-M3 errata 602117: LDRD with base in list may result in incorrect base
@@ -138,7 +138,7 @@ define void @strd_spill_ldrd_reload(i32 %v0, i32 %v1) "frame-pointer"="all" {
 
 declare void @extfunc2(ptr, i32, i32)
 
-; CHECK-LABEL: ldrd_postupdate_dec:
+; CHECK-LABEL: ldrd_postupdate_dec:{{.*$}}
 ; NORMAL: ldrd r1, r2, [r0], #-8
 ; CONSERVATIVE-NOT: ldrd
 ; CHECK: bl{{x?}} _extfunc
@@ -151,7 +151,7 @@ define void @ldrd_postupdate_dec(ptr %p0) "frame-pointer"="all" {
   ret void
 }
 
-; CHECK-LABEL: ldrd_postupdate_inc:
+; CHECK-LABEL: ldrd_postupdate_inc:{{.*$}}
 ; NORMAL: ldrd r1, r2, [r0], #8
 ; CONSERVATIVE-NOT: ldrd
 ; CHECK: bl{{x?}} _extfunc
@@ -164,7 +164,7 @@ define void @ldrd_postupdate_inc(ptr %p0) "frame-pointer"="all" {
   ret void
 }
 
-; CHECK-LABEL: strd_postupdate_dec:
+; CHECK-LABEL: strd_postupdate_dec:{{.*$}}
 ; NORMAL: strd r1, r2, [r0], #-8
 ; CONSERVATIVE-NOT: strd
 ; CHECK: bx lr
@@ -176,7 +176,7 @@ define ptr @strd_postupdate_dec(ptr %p0, i32 %v0, i32 %v1) "frame-pointer"="none
   ret ptr %p1
 }
 
-; CHECK-LABEL: strd_postupdate_inc:
+; CHECK-LABEL: strd_postupdate_inc:{{.*$}}
 ; NORMAL: strd r1, r2, [r0], #8
 ; CONSERVATIVE-NOT: strd
 ; CHECK: bx lr
@@ -188,7 +188,7 @@ define ptr @strd_postupdate_inc(ptr %p0, i32 %v0, i32 %v1) "frame-pointer"="none
   ret ptr %p1
 }
 
-; CHECK-LABEL: ldrd_strd_aa:
+; CHECK-LABEL: ldrd_strd_aa:{{.*$}}
 ; NORMAL: ldrd [[TMP1:r[0-9]]], [[TMP2:r[0-9]]],
 ; NORMAL: strd [[TMP1]], [[TMP2]],
 ; CONSERVATIVE-NOT: ldrd

--- a/llvm/test/CodeGen/ARM/thumb-function-section-reloc.ll
+++ b/llvm/test/CodeGen/ARM/thumb-function-section-reloc.ll
@@ -46,9 +46,9 @@ define dso_local void @_ZdlPv(ptr %ptr) local_unnamed_addr nounwind "target-feat
 ; CHECK-NEXT: 	.globl	_ZdlPv                          @ -- Begin function _ZdlPv
 ; CHECK-NEXT: 	.p2align	1
 ; CHECK-NEXT: 	.type	_ZdlPv,%function
-; CHECK-NEXT: 	.code	16                              @ @_ZdlPv
+; CHECK-NEXT: 	.code	16
 ; CHECK-NEXT: 	.thumb_func
-; CHECK-NEXT: _ZdlPv:
+; CHECK-NEXT: _ZdlPv:                                   @ @_ZdlPv
 ; CHECK-NEXT: .L_ZdlPv$local:
 ; CHECK-NEXT: .type .L_ZdlPv$local,%function
 ; CHECK-NEXT: 	.fnstart

--- a/llvm/test/CodeGen/Thumb/thumb-shrink-wrapping.ll
+++ b/llvm/test/CodeGen/Thumb/thumb-shrink-wrapping.ll
@@ -750,9 +750,9 @@ define i32 @loopInfoRestoreOutsideLoop(i32 %cond, i32 %N) nounwind {
 ; ENABLE-V4T-NEXT:    @ -- End function
 ; ENABLE-V4T-NEXT:    .globl _emptyFrame @ -- Begin function emptyFrame
 ; ENABLE-V4T-NEXT:    .p2align 1
-; ENABLE-V4T-NEXT:    .code 16 @ @emptyFrame
+; ENABLE-V4T-NEXT:    .code 16
 ; ENABLE-V4T-NEXT:    .thumb_func _emptyFrame
-; ENABLE-V4T-NEXT:  _emptyFrame:
+; ENABLE-V4T-NEXT:  _emptyFrame: @ @emptyFrame
 ; ENABLE-V4T-NEXT:    .cfi_startproc
 ; ENABLE-V4T-NEXT:  @ %bb.0: @ %entry
 ; ENABLE-V4T-NEXT:    movs r0, #0
@@ -787,9 +787,9 @@ define i32 @loopInfoRestoreOutsideLoop(i32 %cond, i32 %N) nounwind {
 ; ENABLE-V5T-NEXT:    @ -- End function
 ; ENABLE-V5T-NEXT:    .globl _emptyFrame @ -- Begin function emptyFrame
 ; ENABLE-V5T-NEXT:    .p2align 1
-; ENABLE-V5T-NEXT:    .code 16 @ @emptyFrame
+; ENABLE-V5T-NEXT:    .code 16
 ; ENABLE-V5T-NEXT:    .thumb_func _emptyFrame
-; ENABLE-V5T-NEXT:  _emptyFrame:
+; ENABLE-V5T-NEXT:  _emptyFrame: @ @emptyFrame
 ; ENABLE-V5T-NEXT:    .cfi_startproc
 ; ENABLE-V5T-NEXT:  @ %bb.0: @ %entry
 ; ENABLE-V5T-NEXT:    movs r0, #0
@@ -826,9 +826,9 @@ define i32 @loopInfoRestoreOutsideLoop(i32 %cond, i32 %N) nounwind {
 ; DISABLE-V4T-NEXT:    @ -- End function
 ; DISABLE-V4T-NEXT:    .globl _emptyFrame @ -- Begin function emptyFrame
 ; DISABLE-V4T-NEXT:    .p2align 1
-; DISABLE-V4T-NEXT:    .code 16 @ @emptyFrame
+; DISABLE-V4T-NEXT:    .code 16
 ; DISABLE-V4T-NEXT:    .thumb_func _emptyFrame
-; DISABLE-V4T-NEXT:  _emptyFrame:
+; DISABLE-V4T-NEXT:  _emptyFrame: @ @emptyFrame
 ; DISABLE-V4T-NEXT:    .cfi_startproc
 ; DISABLE-V4T-NEXT:  @ %bb.0: @ %entry
 ; DISABLE-V4T-NEXT:    movs r0, #0
@@ -862,9 +862,9 @@ define i32 @loopInfoRestoreOutsideLoop(i32 %cond, i32 %N) nounwind {
 ; DISABLE-V5T-NEXT:    @ -- End function
 ; DISABLE-V5T-NEXT:    .globl _emptyFrame @ -- Begin function emptyFrame
 ; DISABLE-V5T-NEXT:    .p2align 1
-; DISABLE-V5T-NEXT:    .code 16 @ @emptyFrame
+; DISABLE-V5T-NEXT:    .code 16
 ; DISABLE-V5T-NEXT:    .thumb_func _emptyFrame
-; DISABLE-V5T-NEXT:  _emptyFrame:
+; DISABLE-V5T-NEXT:  _emptyFrame: @ @emptyFrame
 ; DISABLE-V5T-NEXT:    .cfi_startproc
 ; DISABLE-V5T-NEXT:  @ %bb.0: @ %entry
 ; DISABLE-V5T-NEXT:    movs r0, #0

--- a/llvm/test/DebugInfo/ARM/header.ll
+++ b/llvm/test/DebugInfo/ARM/header.ll
@@ -8,8 +8,8 @@
 ; CHECK-NEXT: .section        __TEXT,__text,regular,pure_instructions
 ; CHECK-NEXT: .globl  _f
 ; CHECK-NEXT: .p2align  2
-; CHECK-NEXT: .code 32                    @ @f
-; CHECK-NEXT: _f:
+; CHECK-NEXT: .code 32
+; CHECK-NEXT: _f:                         @ @f
 
 ; CHECK:  .section        __DWARF,__debug_str,regular,debug
 

--- a/llvm/utils/UpdateTestChecks/asm.py
+++ b/llvm/utils/UpdateTestChecks/asm.py
@@ -32,7 +32,7 @@ ASM_FUNCTION_X86_RE = re.compile(
 )
 
 ASM_FUNCTION_ARM_RE = re.compile(
-    r"^(?P<func>[0-9a-zA-Z_$]+):\n"  # f: (name of function)
+    r'^(?P<func>[0-9a-zA-Z_$]+):[ \t]*@+[ \t]*@"?(?P=func)"?\n'  # f: (name of function)
     r"(?:\.L(?P=func)\$local:\n)?"  # drop .L<func>$local:
     r"(?:\s*\.type\s+\.L(?P=func)\$local,@function\n)?"  # drop .type .L<func>$local
     r"\s+\.fnstart\n"  # .fnstart
@@ -175,7 +175,7 @@ ASM_FUNCTION_ARM_DARWIN_RE = re.compile(
 )
 
 ASM_FUNCTION_ARM_MACHO_RE = re.compile(
-    r"^_(?P<func>[^:]+):[ \t]*\n"
+    r'^_(?P<func>[^:]+):[ \t]*@[ \t]@"?(?P=func)"?\n'
     r"([ \t]*.cfi_startproc\n[ \t]*)?"
     r"(?P<body>.*?)\n"
     r"[ \t]*\.cfi_endproc\n",
@@ -183,17 +183,23 @@ ASM_FUNCTION_ARM_MACHO_RE = re.compile(
 )
 
 ASM_FUNCTION_THUMBS_DARWIN_RE = re.compile(
-    r"^_(?P<func>[^:]+):\n" r"(?P<body>.*?)\n" r"[ \t]*\.data_region\n",
+    r'^_(?P<func>[^:]+):[ \t]*@[ \t]@"?(?P=func)"?\n'
+    r"(?P<body>.*?)\n"
+    r"[ \t]*\.data_region\n",
     flags=(re.M | re.S),
 )
 
 ASM_FUNCTION_THUMB_DARWIN_RE = re.compile(
-    r"^_(?P<func>[^:]+):\n" r"(?P<body>.*?)\n" r"^[ \t]*@[ \t]--[ \t]End[ \t]function",
+    r'^_(?P<func>[^:]+):[ \t]*@[ \t]@"?(?P=func)"?\n'
+    r"(?P<body>.*?)\n"
+    r"^[ \t]*@[ \t]--[ \t]End[ \t]function",
     flags=(re.M | re.S),
 )
 
 ASM_FUNCTION_ARM_IOS_RE = re.compile(
-    r"^_(?P<func>[^:]+):\n" r"(?P<body>.*?)" r"^[ \t]*@[ \t]--[ \t]End[ \t]function",
+    r'^_(?P<func>[^:]+):[ \t]*@[ \t]@"?(?P=func)"?\n'
+    r"(?P<body>.*?)"
+    r"^[ \t]*@[ \t]--[ \t]End[ \t]function",
     flags=(re.M | re.S),
 )
 


### PR DESCRIPTION
The .syntax unified directive and .codeX/.code X directives are, other
than some simple common printing code, exclusively implemented in the
targets themselves. Thus, remove the corresponding MCAF_* flags and
reimplement the directives solely within the targets. This avoids
exposing all targets to all other targets' flags.

Since MCAF_SubsectionsViaSymbols is all that remains, convert it to its
own function like other directives, simplifying its implementation.

Note that, on X86, we now always need a target streamer when parsing
assembly, as it's now used for directives that aren't COFF-specific. It
still does not however need to do anything when producing a non-COFF
object file, so this commit does not introduce any new target streamers.

There is some churn in test output, and corresponding UTC regex changes,
due to comments no longer being flushed by these various directives (and
EmitEOL is not exposed outside MCAsmStreamer.cpp so we couldn't do so
even if we wanted to), but that was a bit odd to be doing anyway.

This is motivated by Morello LLVM, which adds yet another assembler flag
to distinguish A64 and C64 instruction sets, but did not update every
switch and so emits warnings during the build. Rather than fix those
warnings it seems better to instead make the problem not exist in the
first place via this change.
