### PR TITLE
[RISCV] Add Andes XAndesVDot (Andes Vector Dot Product) extension.

### DIFF
--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -157,6 +157,7 @@
 // CHECK-NEXT:     svpbmt               1.0       'Svpbmt' (Page-Based Memory Types)
 // CHECK-NEXT:     svvptc               1.0       'Svvptc' (Obviating Memory-Management Instructions after Marking PTEs Valid)
 // CHECK-NEXT:     xandesperf           5.0       'XAndesPerf' (Andes Performance Extension)
+// CHECK-NEXT:     xandesvdot           5.0       'XAndesVDot' (Andes Vector Dot Product Extension)
 // CHECK-NEXT:     xandesvpackfph       5.0       'XAndesVPackFPH' (Andes Vector Packed FP16 Extension)
 // CHECK-NEXT:     xcvalu               1.0       'XCValu' (CORE-V ALU Operations)
 // CHECK-NEXT:     xcvbi                1.0       'XCVbi' (CORE-V Immediate Branching)

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -511,6 +511,9 @@ The current vendor extensions supported are:
 ``XAndesVPackFPH``
   LLVM implements `version 5.0.0 of the Andes Vector Packed FP16 Extension specification <https://github.com/andestech/andes-v5-isa/releases/download/ast-v5_4_0-release/AndeStar_V5_ISA_Spec_UM165-v1.5.08-20250317.pdf>`__ by Andes Technology. All instructions are prefixed with `nds.` as described in the specification.
 
+``XAndesVDot``
+  LLVM implements `version 5.0.0 of the Andes Vector Dot Product Extension specification <https://github.com/andestech/andes-v5-isa/releases/download/ast-v5_4_0-release/AndeStar_V5_ISA_Spec_UM165-v1.5.08-20250317.pdf>`__ by Andes Technology. All instructions are prefixed with `nds.` as described in the specification.
+
 Experimental C Intrinsics
 =========================
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -186,6 +186,7 @@ Changes to the RISC-V Backend
 * Adds assembler support for the Andes `XAndesperf` (Andes Performance extension).
 * `-mcpu=sifive-p870` was added.
 * Adds assembler support for the Andes `XAndesvpackfph` (Andes Vector Packed FP16 extension).
+* Adds assembler support for the Andes `XAndesvdot` (Andes Vector Dot Product extension).
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -728,7 +728,8 @@ static constexpr FeatureBitset XTHeadGroup = {
     RISCV::FeatureVendorXTHeadVdot};
 
 static constexpr FeatureBitset XAndesGroup = {
-    RISCV::FeatureVendorXAndesPerf, RISCV::FeatureVendorXAndesVPackFPH};
+    RISCV::FeatureVendorXAndesPerf, RISCV::FeatureVendorXAndesVPackFPH,
+    RISCV::FeatureVendorXAndesVDot};
 
 static constexpr DecoderListEntry DecoderList32[]{
     // Vendor Extensions

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1525,6 +1525,14 @@ def HasVendorXAndesVPackFPH
       AssemblerPredicate<(all_of FeatureVendorXAndesVPackFPH),
                          "'XAndesVPackFPH' (Andes Vector Packed FP16 Extension)">;
 
+def FeatureVendorXAndesVDot
+    : RISCVExtension<5, 0, "Andes Vector Dot Product Extension",
+                     [FeatureStdExtZve32x]>;
+def HasVendorXAndesVDot
+    : Predicate<"Subtarget->hasVendorXAndesVDot()">,
+      AssemblerPredicate<(all_of FeatureVendorXAndesVDot),
+                         "'XAndesVDot' (Andes Vector Dot Product Extension)">;
+
 //===----------------------------------------------------------------------===//
 // LLVM specific features and extensions
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
@@ -338,6 +338,29 @@ class NDSRVInstVFPMAD<bits<6> funct6, string opcodestr>
   let RVVConstraint = VMConstraint;
 }
 
+class NDSRVInstVD4DOT<bits<6> funct6, string opcodestr>
+    : RVInst<(outs VR:$vd), (ins VR:$vs1, VR:$vs2, VMaskOp:$vm),
+             opcodestr # "." # "vv", "$vd, $vs1, $vs2$vm", [], InstFormatR>,
+      SchedBinaryMC<"WriteVIMulAddV", "ReadVIMulAddV", "ReadVIMulAddV"> {
+  bits<5> vs2;
+  bits<5> vs1;
+  bits<5> vd;
+  bit vm;
+
+  let Inst{31-26} = funct6;
+  let Inst{25} = vm;
+  let Inst{24-20} = vs2;
+  let Inst{19-15} = vs1;
+  let Inst{14-12} = 0b100;
+  let Inst{11-7} = vd;
+  let Inst{6-0} = OPC_CUSTOM_2.Value;
+  let hasSideEffects = 0;
+  let mayLoad = 0;
+  let mayStore = 0;
+
+  let RVVConstraint = VMConstraint;
+}
+
 //===----------------------------------------------------------------------===//
 // XAndesPerf
 //===----------------------------------------------------------------------===//
@@ -397,6 +420,16 @@ let Predicates = [HasVendorXAndesVPackFPH],
     Uses = [FRM, VL, VTYPE], mayRaiseFPException = true in {
 def NDS_VFPMADT_VF : NDSRVInstVFPMAD<0b000010, "nds.vfpmadt">;
 def NDS_VFPMADB_VF : NDSRVInstVFPMAD<0b000011, "nds.vfpmadb">;
+}
+
+//===----------------------------------------------------------------------===//
+// XAndesVDot
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasVendorXAndesVDot], Uses = [VL, VTYPE] in {
+def NDS_VD4DOTS_VV  : NDSRVInstVD4DOT<0b000100, "nds.vd4dots">;
+def NDS_VD4DOTU_VV  : NDSRVInstVD4DOT<0b000111, "nds.vd4dotu">;
+def NDS_VD4DOTSU_VV : NDSRVInstVD4DOT<0b000101, "nds.vd4dotsu">;
 }
 } // DecoderNamespace = "XAndes"
 

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -104,6 +104,7 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-xqcisls %s -o - | FileCheck --check-prefix=RV32XQCISLS %s
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-xqcisync %s -o - | FileCheck --check-prefix=RV32XQCISYNC %s
 ; RUN: llc -mtriple=riscv32 -mattr=+xandesperf %s -o - | FileCheck --check-prefix=RV32XANDESPERF %s
+; RUN: llc -mtriple=riscv32 -mattr=+xandesvdot %s -o - | FileCheck --check-prefix=RV32XANDESVDOT %s
 ; RUN: llc -mtriple=riscv32 -mattr=+xandesvpackfph %s -o - | FileCheck --check-prefix=RV32XANDESVPACKFPH %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zaamo %s -o - | FileCheck --check-prefix=RV32ZAAMO %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zalrsc %s -o - | FileCheck --check-prefix=RV32ZALRSC %s
@@ -255,6 +256,7 @@
 ; RUN: llc -mtriple=riscv64 -mattr=+xtheadsync %s -o - | FileCheck --check-prefix=RV64XTHEADSYNC %s
 ; RUN: llc -mtriple=riscv64 -mattr=+xtheadvdot %s -o - | FileCheck --check-prefixes=CHECK,RV64XTHEADVDOT %s
 ; RUN: llc -mtriple=riscv64 -mattr=+xandesperf %s -o - | FileCheck --check-prefix=RV64XANDESPERF %s
+; RUN: llc -mtriple=riscv64 -mattr=+xandesvdot %s -o - | FileCheck --check-prefix=RV64XANDESVDOT %s
 ; RUN: llc -mtriple=riscv64 -mattr=+xandesvpackfph %s -o - | FileCheck --check-prefix=RV64XANDESVPACKFPH %s
 ; RUN: llc -mtriple=riscv64 -mattr=+za64rs %s -o - | FileCheck --check-prefixes=CHECK,RV64ZA64RS %s
 ; RUN: llc -mtriple=riscv64 -mattr=+za128rs %s -o - | FileCheck --check-prefixes=CHECK,RV64ZA128RS %s
@@ -449,6 +451,7 @@
 ; RV32XQCISLS: .attribute 5, "rv32i2p1_xqcisls0p2"
 ; RV32XQCISYNC: attribute 5, "rv32i2p1_zca1p0_xqcisync0p3"
 ; RV32XANDESPERF: .attribute 5, "rv32i2p1_xandesperf5p0"
+; RV32XANDESVDOT: .attribute 5, "rv32i2p1_zicsr2p0_zve32x1p0_zvl32b1p0_xandesvdot5p0"
 ; RV32XANDESVPACKFPH: .attribute 5, "rv32i2p1_f2p2_zicsr2p0_zve32f1p0_zve32x1p0_zvfhmin1p0_zvl32b1p0_xandesvpackfph5p0"
 ; RV32ZAAMO: .attribute 5, "rv32i2p1_zaamo1p0"
 ; RV32ZALRSC: .attribute 5, "rv32i2p1_zalrsc1p0"
@@ -601,6 +604,7 @@
 ; RV64XTHEADSYNC: .attribute 5, "rv64i2p1_xtheadsync1p0"
 ; RV64XTHEADVDOT: .attribute 5, "rv64i2p1_f2p2_d2p2_v1p0_zicsr2p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0_xtheadvdot1p0"
 ; RV64XANDESPERF: .attribute 5, "rv64i2p1_xandesperf5p0"
+; RV64XANDESVDOT: .attribute 5, "rv64i2p1_zicsr2p0_zve32x1p0_zvl32b1p0_xandesvdot5p0"
 ; RV64XANDESVPACKFPH: .attribute 5, "rv64i2p1_f2p2_zicsr2p0_zve32f1p0_zve32x1p0_zvfhmin1p0_zvl32b1p0_xandesvpackfph5p0"
 ; RV64ZTSO: .attribute 5, "rv64i2p1_ztso1p0"
 ; RV64ZAAMO: .attribute 5, "rv64i2p1_zaamo1p0"

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -171,6 +171,7 @@
 ; CHECK-NEXT:   ventana-veyron                   - Ventana Veyron-Series processors.
 ; CHECK-NEXT:   vxrm-pipeline-flush              - VXRM writes causes pipeline flush.
 ; CHECK-NEXT:   xandesperf                       - 'XAndesPerf' (Andes Performance Extension).
+; CHECK-NEXT:   xandesvdot                       - 'XAndesVDot' (Andes Vector Dot Product Extension).
 ; CHECK-NEXT:   xandesvpackfph                   - 'XAndesVPackFPH' (Andes Vector Packed FP16 Extension).
 ; CHECK-NEXT:   xcvalu                           - 'XCValu' (CORE-V ALU Operations).
 ; CHECK-NEXT:   xcvbi                            - 'XCVbi' (CORE-V Immediate Branching).

--- a/llvm/test/MC/RISCV/xandesvdot-valid.s
+++ b/llvm/test/MC/RISCV/xandesvdot-valid.s
@@ -1,0 +1,51 @@
+# XAndesVDot - Andes Vector Dot Product Extension
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+xandesvdot -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM %s
+# RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+xandesvdot < %s \
+# RUN:     | llvm-objdump --mattr=+xandesvdot -M no-aliases -d -r - \
+# RUN:     | FileCheck -check-prefixes=CHECK-OBJ %s
+# RUN: not llvm-mc -triple=riscv32 -show-encoding %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+xandesvdot -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM %s
+# RUN: llvm-mc -filetype=obj -triple riscv64 -mattr=+xandesvdot < %s \
+# RUN:     | llvm-objdump --mattr=+xandesvdot -M no-aliases -d -r - \
+# RUN:     | FileCheck -check-prefixes=CHECK-OBJ %s
+# RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+
+# CHECK-OBJ: nds.vd4dots.vv v8, v10, v12
+# CHECK-ASM: nds.vd4dots.vv v8, v10, v12
+# CHECK-ASM: encoding: [0x5b,0x44,0xc5,0x12]
+# CHECK-ERROR: instruction requires the following: 'XAndesVDot' (Andes Vector Dot Product Extension){{$}}
+nds.vd4dots.vv v8, v10, v12
+
+# CHECK-OBJ: nds.vd4dots.vv v8, v10, v12, v0.t
+# CHECK-ASM: nds.vd4dots.vv v8, v10, v12, v0.t
+# CHECK-ASM: encoding: [0x5b,0x44,0xc5,0x10]
+# CHECK-ERROR: instruction requires the following: 'XAndesVDot' (Andes Vector Dot Product Extension){{$}}
+nds.vd4dots.vv v8, v10, v12, v0.t
+
+# CHECK-OBJ: nds.vd4dotu.vv v8, v10, v12
+# CHECK-ASM: nds.vd4dotu.vv v8, v10, v12
+# CHECK-ASM: encoding: [0x5b,0x44,0xc5,0x1e]
+# CHECK-ERROR: instruction requires the following: 'XAndesVDot' (Andes Vector Dot Product Extension){{$}}
+nds.vd4dotu.vv v8, v10, v12
+
+# CHECK-OBJ: nds.vd4dotu.vv v8, v10, v12, v0.t
+# CHECK-ASM: nds.vd4dotu.vv v8, v10, v12, v0.t
+# CHECK-ASM: encoding: [0x5b,0x44,0xc5,0x1c]
+# CHECK-ERROR: instruction requires the following: 'XAndesVDot' (Andes Vector Dot Product Extension){{$}}
+nds.vd4dotu.vv v8, v10, v12, v0.t
+
+# CHECK-OBJ: nds.vd4dotsu.vv v8, v10, v12
+# CHECK-ASM: nds.vd4dotsu.vv v8, v10, v12
+# CHECK-ASM: encoding: [0x5b,0x44,0xc5,0x16]
+# CHECK-ERROR: instruction requires the following: 'XAndesVDot' (Andes Vector Dot Product Extension){{$}}
+nds.vd4dotsu.vv v8, v10, v12
+
+# CHECK-OBJ: nds.vd4dotsu.vv v8, v10, v12, v0.t
+# CHECK-ASM: nds.vd4dotsu.vv v8, v10, v12, v0.t
+# CHECK-ASM: encoding: [0x5b,0x44,0xc5,0x14]
+# CHECK-ERROR: instruction requires the following: 'XAndesVDot' (Andes Vector Dot Product Extension){{$}}
+nds.vd4dotsu.vv v8, v10, v12, v0.t

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1128,6 +1128,7 @@ R"(All available -march extensions for RISC-V
     svpbmt               1.0
     svvptc               1.0
     xandesperf           5.0
+    xandesvdot           5.0
     xandesvpackfph       5.0
     xcvalu               1.0
     xcvbi                1.0


### PR DESCRIPTION
The spec can be found at:
https://github.com/andestech/andes-v5-isa/releases/tag/ast-v5_4_0-release.

This patch only supports assembler.

Intrinsics support will be added in a later patch.