### PR TITLE
[libclc] Append file_specific_compile_options after ARG_COMPILE_FLAGS

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -284,8 +284,9 @@ function(add_libclc_builtin_set)
       TRIPLE ${ARG_TRIPLE}
       INPUT ${input_file}
       OUTPUT ${output_file}
-      EXTRA_OPTS -fno-builtin -nostdlib "${file_specific_compile_options}"
-        "${ARG_COMPILE_FLAGS}" -I${CMAKE_CURRENT_SOURCE_DIR}/${file_dir}
+      EXTRA_OPTS -fno-builtin -nostdlib "${ARG_COMPILE_FLAGS}"
+        "${file_specific_compile_options}"
+        -I${CMAKE_CURRENT_SOURCE_DIR}/${file_dir}
       DEPENDENCIES ${input_file_dep}
     )
     list( APPEND compile_tgts ${tgt} )


### PR DESCRIPTION
This enables file_specific_compile_options to take precedence over ARG_COMPILE_FLAGS. For example, if we add -fno-slp-vectorize to COMPILE_OPTIONS of a file, the behavior changes as follows:
* Before this PR: -fno-slp-vectorize is overwritten by -O3, resulting in SLP vectorizer remaining enabled.
* After this PR: -fno-slp-vectorize overwrites -O3, effectively disabling SLP vectorizer.