### PR TITLE
[MLIR] Remove extra 'any' from CompositePass inner pipeline string

### DIFF
--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -35,7 +35,9 @@ struct CompositeFixedPointPass final
     populateFunc(dynamicPM);
 
     llvm::raw_string_ostream os(pipelineStr);
-    dynamicPM.printAsTextualPipeline(os);
+    llvm::interleave(
+        dynamicPM, [&](mlir::Pass &pass) { pass.printAsTextualPipeline(os); },
+        [&]() { os << ","; });
   }
 
   LogicalResult initializeOptions(

--- a/mlir/test/Transforms/composite-pass.mlir
+++ b/mlir/test/Transforms/composite-pass.mlir
@@ -1,5 +1,9 @@
-// RUN: mlir-opt %s --log-actions-to=- --test-composite-fixed-point-pass -split-input-file | FileCheck %s
+// RUN: mlir-opt %s --log-actions-to=- --test-composite-fixed-point-pass -split-input-file --dump-pass-pipeline 2>&1 | FileCheck %s --check-prefixes=CHECK,PIPELINE
 // RUN: mlir-opt %s --log-actions-to=- --composite-fixed-point-pass='name=TestCompositePass pipeline=any(canonicalize,cse)' -split-input-file | FileCheck %s
+
+// Ensure the composite pass correctly prints its options.
+// PIPELINE:      builtin.module(composite-fixed-point-pass{max-iterations=10 name=TestCompositePass
+// PIPELINE-SAME: pipeline=canonicalize{ max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true},cse})
 
 // CHECK-LABEL: running `TestCompositePass`
 //       CHECK: running `Canonicalizer`


### PR DESCRIPTION
When a `CompositePass` is created programmatically, it incorrectly prepends an extra `any` to the inner pipeline string. For example:
```c++
passManager.nestAny().addPass(createCompositeFixedPointPass(
  "Pass1AndPass2",
  [](OpPassManager &nestedPassManger) {
    nestedPassManger.addPass(createPass1());
    nestedPassManger.addPass(createPass2());
  },
```
This would result in the following pipeline string:
```
any(composite-fixed-point-pass{max-iterations=3 name=Pass1AndPass2
pipeline=any(pass1,pass2)})
```

This commit fixes this issue, resulting in the pipeline string:
```
any(composite-fixed-point-pass{max-iterations=3 name=Pass1AndPass2
pipeline=pass1,pass2})
```