### PR TITLE
[VPlan] Speed up VPSlotTracker by using ModuleSlotTracker

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1508,11 +1508,11 @@ void VPSlotTracker::assignName(const VPValue *V) {
   // Use the name of the underlying Value, wrapped in "ir<>", and versioned by
   // appending ".Number" to the name if there are multiple uses.
   std::string Name;
-  if (UV) {
+  if (UV)
     Name = getName(UV);
-  } else {
+  else
     Name = VPI->getName();
-  }
+
   assert(!Name.empty() && "Name cannot be empty.");
   StringRef Prefix = UV ? "ir<" : "vp<%";
   std::string BaseName = (Twine(Prefix) + Name + Twine(">")).str();
@@ -1567,7 +1567,7 @@ std::string VPSlotTracker::getName(const Value *V) {
 
   if (!MST) {
     // Lazily create the ModuleSlotTracker when we first hit an unnamed
-    // instruction
+    // instruction.
     auto *I = cast<Instruction>(V);
     // This check is required to support unit tests with incomplete IR.
     if (I->getParent()) {

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1510,7 +1510,10 @@ void VPSlotTracker::assignName(const VPValue *V) {
   std::string Name;
   if (UV) {
     raw_string_ostream S(Name);
-    UV->printAsOperand(S, false);
+    if (MST)
+      UV->printAsOperand(S, false, *MST);
+    else
+      UV->printAsOperand(S, false);
   } else
     Name = VPI->getName();
 

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -396,6 +396,7 @@ class VPSlotTracker {
   void assignName(const VPValue *V);
   void assignNames(const VPlan &Plan);
   void assignNames(const VPBasicBlock *VPBB);
+  std::string getName(const VPValue *V);
 
 public:
   VPSlotTracker(const VPlan *Plan = nullptr) {

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -23,7 +23,6 @@
 #include "llvm/Analysis/DomTreeUpdater.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/DebugLoc.h"
-#include "llvm/IR/ModuleSlotTracker.h"
 #include "llvm/Support/InstructionCost.h"
 
 namespace llvm {
@@ -34,6 +33,7 @@ class DominatorTree;
 class InnerLoopVectorizer;
 class IRBuilderBase;
 class LoopInfo;
+class ModuleSlotTracker;
 class SCEV;
 class Type;
 class VPBasicBlock;
@@ -396,7 +396,7 @@ class VPSlotTracker {
   void assignName(const VPValue *V);
   void assignNames(const VPlan &Plan);
   void assignNames(const VPBasicBlock *VPBB);
-  std::string getName(const VPValue *V);
+  std::string getName(const Value *V);
 
 public:
   VPSlotTracker(const VPlan *Plan = nullptr) {

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -23,6 +23,7 @@
 #include "llvm/Analysis/DomTreeUpdater.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/DebugLoc.h"
+#include "llvm/IR/ModuleSlotTracker.h"
 #include "llvm/Support/InstructionCost.h"
 
 namespace llvm {
@@ -33,7 +34,6 @@ class DominatorTree;
 class InnerLoopVectorizer;
 class IRBuilderBase;
 class LoopInfo;
-class ModuleSlotTracker;
 class SCEV;
 class Type;
 class VPBasicBlock;


### PR DESCRIPTION
Currently, when VPSlotTracker is initialized with a VPlan, its assignName method calls printAsOperand on each underlying instruction. Each such call recomputes slot numbers for the entire function, leading to O(N × M) complexity, where M is the number of instructions in the loop and N is the number of instructions in the function.

This results in slow debug output for large loops. For example, printing costs of all instructions becomes O(M² × N), which is especially painful when enabling verbose dumps.

This patch improves debugging performance by caching slot numbers using ModuleSlotTracker. It avoids redundant recomputation and makes debug output significantly faster.