### PR TITLE
[cmake] Warn if LLVM_PROFDATA_FILE was specified but wasn't found

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -1240,6 +1240,8 @@ if(LLVM_PROFDATA_FILE AND EXISTS ${LLVM_PROFDATA_FILE})
   else()
     message(FATAL_ERROR "LLVM_PROFDATA_FILE can only be specified when compiling with clang")
   endif()
+elseif(LLVM_PROFDATA_FILE)
+  message(WARNING "LLVM_PROFDATA_FILE specified, but ${LLVM_PROFDATA_FILE} not found")
 endif()
 
 option(LLVM_BUILD_INSTRUMENTED_COVERAGE "Build LLVM and tools with Code Coverage instrumentation" Off)


### PR DESCRIPTION
Ideally we should perhaps even error out here; if the user requested building with profiling info, but that profile wasn't found, it seems like the build configuration is subtly broken, and I would expect the user to want to know about it. But that may be a too disruptive change, as users may very well rely on being able to build things in such a setup anyway thanks to Hyrum's Law.

To make things clearer, at least print a warning in this case.