### PR TITLE
[CIR][NFC] Remove redundant pointer casts

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -269,7 +269,7 @@ def PtrStrideOp : CIR_Op<"ptr_stride",
   let extraClassDeclaration = [{
     // Get type pointed by the base pointer.
     mlir::Type getElementTy() {
-      return mlir::cast<cir::PointerType>(getBase().getType()).getPointee();
+      return getBase().getType().getPointee();
     }
   }];
 }
@@ -1710,7 +1710,7 @@ def GetMemberOp : CIR_Op<"get_member"> {
 
     /// Return the result type.
     cir::PointerType getResultTy() {
-      return mlir::cast<cir::PointerType>(getResult().getType());
+      return getResult().getType();
     }
   }];
 


### PR DESCRIPTION
This mirrors incubator changes from https://github.com/llvm/clangir/pull/1609