### PR TITLE
[OpenMP] Fix tentative parsing crash with metadirective

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -931,6 +931,10 @@ OpenMP Support
 - Fixed a crashing bug with a malformed ``cancel`` directive. (#GH139360)
 - Fixed a crashing bug with ``omp distribute dist_schedule`` if the argument to
   ``dist_schedule`` was not strictly positive. (#GH139266)
+- Fixed two crashing bugs with a malformed ``metadirective`` directive. One was
+  a crash if the next token after ``metadirective`` was a paren, bracket, or
+  brace. The other was if the next token after the meta directive was not an
+  open parenthesis. (#GH139665)
 
 Improvements
 ^^^^^^^^^^^^

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2786,8 +2786,12 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
                                    ? OMPC_unknown
                                    : getOpenMPClauseKind(PP.getSpelling(Tok));
       // Check if the clause is unrecognized.
-      if (CKind == OMPC_unknown)
+      if (CKind == OMPC_unknown) {
         Diag(Tok, diag::err_omp_expected_clause) << "metadirective";
+        TPA.Revert();
+        SkipUntil(tok::annot_pragma_openmp_end);
+        return Directive;
+      }
       if (getLangOpts().OpenMP < 52 && CKind == OMPC_otherwise)
         Diag(Tok, diag::err_omp_unexpected_clause)
             << getOpenMPClauseName(CKind) << "metadirective";
@@ -2798,8 +2802,11 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
 
       // Parse '('.
       if (T.expectAndConsume(diag::err_expected_lparen_after,
-                             getOpenMPClauseName(CKind).data()))
+                             getOpenMPClauseName(CKind).data())) {
+        TPA.Revert();
+        SkipUntil(tok::annot_pragma_openmp_end);
         return Directive;
+      }
 
       OMPTraitInfo &TI = Actions.getASTContext().getNewOMPTraitInfo();
       if (CKind == OMPC_when) {

--- a/clang/test/OpenMP/metadirective_messages.cpp
+++ b/clang/test/OpenMP/metadirective_messages.cpp
@@ -49,3 +49,13 @@ void foo() {
       ;
   #endif
   }
+
+namespace GH139665 {
+void f(){
+#pragma omp metadirective( // expected-error {{expected at least one clause on '#pragma omp metadirective' directive}}
+}
+
+void g() {
+#pragma omp metadirective align // expected-error {{expected '(' after 'align'}}
+}
+} // namespace GH139665


### PR DESCRIPTION
There were two crashes that have the same root cause: not correctly handling unexpected tokens. In one case, we were failing to return early which caused us to parse a paren as a regular token instead of a special token, causing an assertion. The other case was failing to commit or revert the tentative parse action when not getting a paren when one was expected.

Fixes #139665