### PR TITLE
Reduce llvm-gsymutil memory usage

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -103,6 +103,7 @@ public:
     std::unique_ptr<DWARFDebugMacro>
     parseMacroOrMacinfo(MacroSecType SectionType);
 
+    virtual Error doWorkThreadSafely(function_ref<Error()> Work) = 0;
   };
   friend class DWARFContextState;
 
@@ -490,6 +491,10 @@ public:
   /// Sets whether CU/TU should be populated manually. TU Index populated
   /// manually only for DWARF5.
   void setParseCUTUIndexManually(bool PCUTU) { ParseCUTUIndexManually = PCUTU; }
+
+  Error doWorkThreadSafely(function_ref<Error()> Work) {
+    return State->doWorkThreadSafely(Work);
+  }
 
 private:
   void addLocalsForDie(DWARFCompileUnit *CU, DWARFDie Subprogram, DWARFDie Die,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -566,6 +566,9 @@ public:
 
   Error tryExtractDIEsIfNeeded(bool CUDieOnly);
 
+  /// clearDIEs - Clear parsed DIEs to keep memory usage low.
+  void clearDIEs(bool KeepCUDie, bool KeepDWODies = false);
+
 private:
   /// Size in bytes of the .debug_info data associated with this compile unit.
   size_t getDebugInfoSize() const {
@@ -580,9 +583,6 @@ private:
   /// extractDIEsToVector - Appends all parsed DIEs to a vector.
   void extractDIEsToVector(bool AppendCUDie, bool AppendNonCUDIEs,
                            std::vector<DWARFDebugInfoEntry> &DIEs) const;
-
-  /// clearDIEs - Clear parsed DIEs to keep memory usage low.
-  void clearDIEs(bool KeepCUDie);
 
   /// parseDWO - Parses .dwo file for current compile unit. Returns true if
   /// it was actually constructed.

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -622,7 +622,9 @@ public:
       return getNormalTypeUnitMap();
   }
 
-
+  Error doWorkThreadSafely(function_ref<Error()> Work) override {
+    return Work();
+  }
 };
 
 class ThreadSafeState : public ThreadUnsafeDWARFContextState {
@@ -737,6 +739,11 @@ public:
   getTypeUnitMap(bool IsDWO) override {
     std::unique_lock<std::recursive_mutex> LockGuard(Mutex);
     return ThreadUnsafeDWARFContextState::getTypeUnitMap(IsDWO);
+  }
+
+  Error doWorkThreadSafely(function_ref<Error()> Work) override {
+    std::unique_lock<std::recursive_mutex> LockGuard(Mutex);
+    return ThreadUnsafeDWARFContextState::doWorkThreadSafely(Work);
   }
 };
 } // namespace

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -496,108 +496,111 @@ void DWARFUnit::extractDIEsIfNeeded(bool CUDieOnly) {
 }
 
 Error DWARFUnit::tryExtractDIEsIfNeeded(bool CUDieOnly) {
-  if ((CUDieOnly && !DieArray.empty()) ||
-      DieArray.size() > 1)
-    return Error::success(); // Already parsed.
+  return Context.doWorkThreadSafely([&]() -> Error {
+    if ((CUDieOnly && !DieArray.empty()) || DieArray.size() > 1)
+      return Error::success(); // Already parsed.
 
-  bool HasCUDie = !DieArray.empty();
-  extractDIEsToVector(!HasCUDie, !CUDieOnly, DieArray);
+    bool HasCUDie = !DieArray.empty();
+    extractDIEsToVector(!HasCUDie, !CUDieOnly, DieArray);
 
-  if (DieArray.empty())
-    return Error::success();
+    if (DieArray.empty())
+      return Error::success();
 
-  // If CU DIE was just parsed, copy several attribute values from it.
-  if (HasCUDie)
-    return Error::success();
+    // If CU DIE was just parsed, copy several attribute values from it.
+    if (HasCUDie)
+      return Error::success();
 
-  DWARFDie UnitDie(this, &DieArray[0]);
-  if (std::optional<uint64_t> DWOId =
-          toUnsigned(UnitDie.find(DW_AT_GNU_dwo_id)))
-    Header.setDWOId(*DWOId);
-  if (!IsDWO) {
-    assert(AddrOffsetSectionBase == std::nullopt);
-    assert(RangeSectionBase == 0);
-    assert(LocSectionBase == 0);
-    AddrOffsetSectionBase = toSectionOffset(UnitDie.find(DW_AT_addr_base));
-    if (!AddrOffsetSectionBase)
-      AddrOffsetSectionBase =
-          toSectionOffset(UnitDie.find(DW_AT_GNU_addr_base));
-    RangeSectionBase = toSectionOffset(UnitDie.find(DW_AT_rnglists_base), 0);
-    LocSectionBase = toSectionOffset(UnitDie.find(DW_AT_loclists_base), 0);
-  }
+    DWARFDie UnitDie(this, &DieArray[0]);
+    if (std::optional<uint64_t> DWOId =
+            toUnsigned(UnitDie.find(DW_AT_GNU_dwo_id)))
+      Header.setDWOId(*DWOId);
+    if (!IsDWO) {
+      assert(AddrOffsetSectionBase == std::nullopt);
+      assert(RangeSectionBase == 0);
+      assert(LocSectionBase == 0);
+      AddrOffsetSectionBase = toSectionOffset(UnitDie.find(DW_AT_addr_base));
+      if (!AddrOffsetSectionBase)
+        AddrOffsetSectionBase =
+            toSectionOffset(UnitDie.find(DW_AT_GNU_addr_base));
+      RangeSectionBase = toSectionOffset(UnitDie.find(DW_AT_rnglists_base), 0);
+      LocSectionBase = toSectionOffset(UnitDie.find(DW_AT_loclists_base), 0);
+    }
 
-  // In general, in DWARF v5 and beyond we derive the start of the unit's
-  // contribution to the string offsets table from the unit DIE's
-  // DW_AT_str_offsets_base attribute. Split DWARF units do not use this
-  // attribute, so we assume that there is a contribution to the string
-  // offsets table starting at offset 0 of the debug_str_offsets.dwo section.
-  // In both cases we need to determine the format of the contribution,
-  // which may differ from the unit's format.
-  DWARFDataExtractor DA(Context.getDWARFObj(), StringOffsetSection,
-                        IsLittleEndian, 0);
-  if (IsDWO || getVersion() >= 5) {
-    auto StringOffsetOrError =
-        IsDWO ? determineStringOffsetsTableContributionDWO(DA)
-              : determineStringOffsetsTableContribution(DA);
-    if (!StringOffsetOrError)
-      return createStringError(errc::invalid_argument,
-                               "invalid reference to or invalid content in "
-                               ".debug_str_offsets[.dwo]: " +
-                                   toString(StringOffsetOrError.takeError()));
+    // In general, in DWARF v5 and beyond we derive the start of the unit's
+    // contribution to the string offsets table from the unit DIE's
+    // DW_AT_str_offsets_base attribute. Split DWARF units do not use this
+    // attribute, so we assume that there is a contribution to the string
+    // offsets table starting at offset 0 of the debug_str_offsets.dwo section.
+    // In both cases we need to determine the format of the contribution,
+    // which may differ from the unit's format.
+    DWARFDataExtractor DA(Context.getDWARFObj(), StringOffsetSection,
+                          IsLittleEndian, 0);
+    if (IsDWO || getVersion() >= 5) {
+      auto StringOffsetOrError =
+          IsDWO ? determineStringOffsetsTableContributionDWO(DA)
+                : determineStringOffsetsTableContribution(DA);
+      if (!StringOffsetOrError) {
+        return createStringError(errc::invalid_argument,
+                                 "invalid reference to or invalid content in "
+                                 ".debug_str_offsets[.dwo]: " +
+                                     toString(StringOffsetOrError.takeError()));
+      }
 
-    StringOffsetsTableContribution = *StringOffsetOrError;
-  }
+      StringOffsetsTableContribution = *StringOffsetOrError;
+    }
 
-  // DWARF v5 uses the .debug_rnglists and .debug_rnglists.dwo sections to
-  // describe address ranges.
-  if (getVersion() >= 5) {
-    // In case of DWP, the base offset from the index has to be added.
+    // DWARF v5 uses the .debug_rnglists and .debug_rnglists.dwo sections to
+    // describe address ranges.
+    if (getVersion() >= 5) {
+      // In case of DWP, the base offset from the index has to be added.
+      if (IsDWO) {
+        uint64_t ContributionBaseOffset = 0;
+        if (auto *IndexEntry = Header.getIndexEntry())
+          if (auto *Contrib = IndexEntry->getContribution(DW_SECT_RNGLISTS))
+            ContributionBaseOffset = Contrib->getOffset();
+        setRangesSection(
+            &Context.getDWARFObj().getRnglistsDWOSection(),
+            ContributionBaseOffset +
+                DWARFListTableHeader::getHeaderSize(Header.getFormat()));
+      } else
+        setRangesSection(&Context.getDWARFObj().getRnglistsSection(),
+                         toSectionOffset(UnitDie.find(DW_AT_rnglists_base),
+                                         DWARFListTableHeader::getHeaderSize(
+                                             Header.getFormat())));
+    }
+
     if (IsDWO) {
-      uint64_t ContributionBaseOffset = 0;
+      // If we are reading a package file, we need to adjust the location list
+      // data based on the index entries.
+      StringRef Data = Header.getVersion() >= 5
+                           ? Context.getDWARFObj().getLoclistsDWOSection().Data
+                           : Context.getDWARFObj().getLocDWOSection().Data;
       if (auto *IndexEntry = Header.getIndexEntry())
-        if (auto *Contrib = IndexEntry->getContribution(DW_SECT_RNGLISTS))
-          ContributionBaseOffset = Contrib->getOffset();
-      setRangesSection(
-          &Context.getDWARFObj().getRnglistsDWOSection(),
-          ContributionBaseOffset +
-              DWARFListTableHeader::getHeaderSize(Header.getFormat()));
-    } else
-      setRangesSection(&Context.getDWARFObj().getRnglistsSection(),
-                       toSectionOffset(UnitDie.find(DW_AT_rnglists_base),
-                                       DWARFListTableHeader::getHeaderSize(
-                                           Header.getFormat())));
-  }
+        if (const auto *C = IndexEntry->getContribution(
+                Header.getVersion() >= 5 ? DW_SECT_LOCLISTS : DW_SECT_EXT_LOC))
+          Data = Data.substr(C->getOffset(), C->getLength());
 
-  if (IsDWO) {
-    // If we are reading a package file, we need to adjust the location list
-    // data based on the index entries.
-    StringRef Data = Header.getVersion() >= 5
-                         ? Context.getDWARFObj().getLoclistsDWOSection().Data
-                         : Context.getDWARFObj().getLocDWOSection().Data;
-    if (auto *IndexEntry = Header.getIndexEntry())
-      if (const auto *C = IndexEntry->getContribution(
-              Header.getVersion() >= 5 ? DW_SECT_LOCLISTS : DW_SECT_EXT_LOC))
-        Data = Data.substr(C->getOffset(), C->getLength());
+      DWARFDataExtractor DWARFData(Data, IsLittleEndian, getAddressByteSize());
+      LocTable =
+          std::make_unique<DWARFDebugLoclists>(DWARFData, Header.getVersion());
+      LocSectionBase = DWARFListTableHeader::getHeaderSize(Header.getFormat());
+    } else if (getVersion() >= 5) {
+      LocTable = std::make_unique<DWARFDebugLoclists>(
+          DWARFDataExtractor(Context.getDWARFObj(),
+                             Context.getDWARFObj().getLoclistsSection(),
+                             IsLittleEndian, getAddressByteSize()),
+          getVersion());
+    } else {
+      LocTable = std::make_unique<DWARFDebugLoc>(DWARFDataExtractor(
+          Context.getDWARFObj(), Context.getDWARFObj().getLocSection(),
+          IsLittleEndian, getAddressByteSize()));
+    }
 
-    DWARFDataExtractor DWARFData(Data, IsLittleEndian, getAddressByteSize());
-    LocTable =
-        std::make_unique<DWARFDebugLoclists>(DWARFData, Header.getVersion());
-    LocSectionBase = DWARFListTableHeader::getHeaderSize(Header.getFormat());
-  } else if (getVersion() >= 5) {
-    LocTable = std::make_unique<DWARFDebugLoclists>(
-        DWARFDataExtractor(Context.getDWARFObj(),
-                           Context.getDWARFObj().getLoclistsSection(),
-                           IsLittleEndian, getAddressByteSize()),
-        getVersion());
-  } else {
-    LocTable = std::make_unique<DWARFDebugLoc>(DWARFDataExtractor(
-        Context.getDWARFObj(), Context.getDWARFObj().getLocSection(),
-        IsLittleEndian, getAddressByteSize()));
-  }
+    // Don't fall back to DW_AT_GNU_ranges_base: it should be ignored for
+    // skeleton CU DIE, so that DWARF users not aware of it are not broken.
 
-  // Don't fall back to DW_AT_GNU_ranges_base: it should be ignored for
-  // skeleton CU DIE, so that DWARF users not aware of it are not broken.
-  return Error::success();
+    return Error::success();
+  });
 }
 
 bool DWARFUnit::parseDWO(StringRef DWOAlternativeLocation) {
@@ -652,15 +655,21 @@ bool DWARFUnit::parseDWO(StringRef DWOAlternativeLocation) {
   return true;
 }
 
-void DWARFUnit::clearDIEs(bool KeepCUDie) {
-  // Do not use resize() + shrink_to_fit() to free memory occupied by dies.
-  // shrink_to_fit() is a *non-binding* request to reduce capacity() to size().
-  // It depends on the implementation whether the request is fulfilled.
-  // Create a new vector with a small capacity and assign it to the DieArray to
-  // have previous contents freed.
-  DieArray = (KeepCUDie && !DieArray.empty())
-                 ? std::vector<DWARFDebugInfoEntry>({DieArray[0]})
-                 : std::vector<DWARFDebugInfoEntry>();
+void DWARFUnit::clearDIEs(bool KeepCUDie, bool KeepDWODies) {
+  assert(!Context.doWorkThreadSafely([&] {
+    if (!KeepDWODies && DWO) {
+      DWO->clearDIEs(KeepCUDie, KeepDWODies);
+    }
+    // Do not use resize() + shrink_to_fit() to free memory occupied by dies.
+    // shrink_to_fit() is a *non-binding* request to reduce capacity() to
+    // size(). It depends on the implementation whether the request is
+    // fulfilled. Create a new vector with a small capacity and assign it to the
+    // DieArray to have previous contents freed.
+    DieArray = (KeepCUDie && !DieArray.empty())
+                   ? std::vector<DWARFDebugInfoEntry>({DieArray[0]})
+                   : std::vector<DWARFDebugInfoEntry>();
+    return Error::success();
+  }));
 }
 
 Expected<DWARFAddressRangesVector>


### PR DESCRIPTION
For large binaries gsymutil ends up using too much memory. This diff adds DIE tree cleanup per compile unit to reduce memory usage.

P. S. Not sure about formatting. Maybe it hasn't been run in a while, or I have misconfigured something. 

`$ git clang-format HEAD~1
clang-format did not modify any files
$ clang-format --version
clang-format version 21.0.0git (git@github.com:peremyach/llvm-project.git 8d945c8357e1bd9872a34f92620d4916bfd27482)
`