### PR TITLE
[lldb] Use llvm::unique (NFC)

### DIFF
--- a/lldb/source/Target/DynamicRegisterInfo.cpp
+++ b/lldb/source/Target/DynamicRegisterInfo.cpp
@@ -497,10 +497,7 @@ void DynamicRegisterInfo::Finalize(const ArchSpec &arch) {
        pos != end; ++pos) {
     if (pos->second.size() > 1) {
       llvm::sort(pos->second);
-      reg_num_collection::iterator unique_end =
-          std::unique(pos->second.begin(), pos->second.end());
-      if (unique_end != pos->second.end())
-        pos->second.erase(unique_end, pos->second.end());
+      pos->second.erase(llvm::unique(pos->second), pos->second.end());
     }
     assert(!pos->second.empty());
     if (pos->second.back() != LLDB_INVALID_REGNUM)


### PR DESCRIPTION
While I am at it, this patch removes the "if" statement.
std::vector::erase(first, last) doesn't do anything when
first == last.
