### PR TITLE
[ValueTracking][NFC] Drop outdated TODO in canCreateUndefOrPoison

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -7788,8 +7788,6 @@ static bool canCreateUndefOrPoison(const Operator *Op, UndefPoisonKind Kind,
   case Instruction::FRem:
     return false;
   case Instruction::GetElementPtr:
-    // inbounds is handled above
-    // TODO: what about inrange on constexpr?
     return false;
   default: {
     const auto *CE = dyn_cast<ConstantExpr>(Op);

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -7786,7 +7786,6 @@ static bool canCreateUndefOrPoison(const Operator *Op, UndefPoisonKind Kind,
   case Instruction::FMul:
   case Instruction::FDiv:
   case Instruction::FRem:
-    return false;
   case Instruction::GetElementPtr:
     return false;
   default: {


### PR DESCRIPTION
The inrange constexpr GEP case is handled since 425cbbc602c9.