### PR TITLE
[lldb] Extend information for failed connection for gdb server

### DIFF
--- a/lldb/source/Host/common/TCPSocket.cpp
+++ b/lldb/source/Host/common/TCPSocket.cpp
@@ -169,7 +169,8 @@ Status TCPSocket::Connect(llvm::StringRef name) {
     return error;
   }
 
-  error = Status::FromErrorString("Failed to connect port");
+  error = Status::FromErrorStringWithFormatv(
+      "Failed to connect to {0}:{1}", host_port->hostname, host_port->port);
   return error;
 }
 


### PR DESCRIPTION
Before:
```
(lldb) r
error: connect remote failed (Failed to connect port)
error: Failed to connect port
```

After the patch:
```
(lldb) r
error: connect remote failed (Failed to connect localhost:47140)
error: Failed to connect localhost:47140
```