### PR TITLE
[DebugInfo] Simplify a string comparison (NFC)

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
@@ -913,7 +913,7 @@ Error LVDWARFReader::createScopes() {
           LT->getFileNameByIndex(
               1, None, DILineInfoSpecifier::FileLineInfoKind::RawValue,
               FileOne);
-          return FileZero.compare(FileOne);
+          return FileZero != FileOne;
         }
       }
 


### PR DESCRIPTION
Note that the lambda function we are in returns bool, so
FileZero.compare(FileOne) is equivalent to FileZero != FileOne in this
context.
