### PR TITLE
[LTO] Use llvm-lto2 instead of lld in the test

### DIFF
--- a/llvm/test/ThinLTO/X86/cache-emit-asm.ll
+++ b/llvm/test/ThinLTO/X86/cache-emit-asm.ll
@@ -2,9 +2,9 @@
 ;; as crashes or sanitizer errors. MCAsmStreamer has specific assumptions about
 ;; the lifetime of the output stream that are easy to overlook (see #138194).
 
-; RUN: rm -rf %t.cache
+; RUN: rm -rf %t && mkdir -p %t
 ; RUN: opt -module-hash -module-summary -thinlto-bc %s -o %t1.bc
-; RUN: ld.lld --thinlto-cache-dir=%t.cache --lto-emit-asm %t1.bc
+; RUN: llvm-lto2 run -cache-dir %t/cache --filetype=asm -o %t.o %t1.bc -r=%t1.bc,globalfunc
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
This is a follow-up to #138203. The added test used lld but lld is not always available, which breaks builds. Make the test use llvm-lto2. Also make the test a bit more similar to other tests in the same directory.