### PR TITLE
Revert "[clang][analyzer] Fix a nullptr dereference when `-ftime-trace` is used"

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -103,10 +103,7 @@ public:
   const Stmt *getStmt() const {
     switch (Elem->getKind()) {
     case CFGElement::Initializer:
-      if (const auto *Init = Elem->castAs<CFGInitializer>().getInitializer()) {
-        return Init->getInit();
-      }
-      return nullptr;
+      return Elem->castAs<CFGInitializer>().getInitializer()->getInit();
     case CFGElement::ScopeBegin:
       return Elem->castAs<CFGScopeBegin>().getTriggerStmt();
     case CFGElement::ScopeEnd:

--- a/clang/test/Analysis/ftime-trace-no-init.cpp
+++ b/clang/test/Analysis/ftime-trace-no-init.cpp
@@ -1,5 +1,0 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,apiModeling %s -ftime-trace=%t.raw.json -verify
-// expected-no-diagnostics
-
-// GitHub issue 139779
-struct {} a; // no-crash


### PR DESCRIPTION
Reverts llvm/llvm-project#139820

Reverting due to buildbot failures in asan