### PR TITLE
[WIP][analyzer] Refactor `ExplodedGraph::trim()`

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporter.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporter.h
@@ -294,8 +294,9 @@ public:
 
 protected:
   /// The ExplodedGraph node against which the report was thrown. It corresponds
-  /// to the end of the execution path that demonstrates the bug.
-  const ExplodedNode *ErrorNode = nullptr;
+  /// to the end of the execution path that demonstrates the bug. This is never
+  /// a nullpointer.
+  const ExplodedNode *ErrorNode;
 
   /// The range that corresponds to ErrorNode's program point. It is usually
   /// highlighted in the report.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -413,15 +413,12 @@ public:
   ///
   /// \param Nodes The nodes which must appear in the final graph. Presumably
   ///              these are end-of-path nodes (i.e. they have no successors).
-  /// \param[out] ForwardMap An optional map from nodes in this graph to nodes
+  /// \param[out] NodeMap An optional map from nodes in this graph to nodes
   ///                        in the returned graph.
-  /// \param[out] InverseMap An optional map from nodes in the returned graph to
-  ///                        nodes in this graph.
   /// \returns The trimmed graph
   std::unique_ptr<ExplodedGraph>
   trim(ArrayRef<const NodeTy *> Nodes,
-       InterExplodedGraphMap *ForwardMap = nullptr,
-       InterExplodedGraphMap *InverseMap = nullptr) const;
+       InterExplodedGraphMap *NodeMap = nullptr) const;
 
   /// Enable tracking of recently allocated nodes for potential reclamation
   /// when calling reclaimRecentlyAllocatedNodes().

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -300,6 +300,9 @@ private:
 using InterExplodedGraphMap =
     llvm::DenseMap<const ExplodedNode *, ExplodedNode *>;
 
+using TrimGraphWorklist =
+    SmallVector<const ExplodedNode*, 32>;
+
 class ExplodedGraph {
 protected:
   friend class CoreEngine;
@@ -411,13 +414,17 @@ public:
   /// Creates a trimmed version of the graph that only contains paths leading
   /// to the given nodes.
   ///
-  /// \param Nodes The nodes which must appear in the final graph. Presumably
-  ///              these are end-of-path nodes (i.e. they have no successors).
-  /// \param[out] NodeMap An optional map from nodes in this graph to nodes
-  ///                        in the returned graph.
+  /// \param[in,out] Worklist Vector of nodes which must appear in the final
+  ///                         graph. Presumably these are end-of-path nodes
+  ///                         (i.e. they have no successors). This argument is
+  ///                         consumed and emptied by the trimming algorithm.
+  ///
+  /// \param[out] NodeMap If specified, this will be filled to map nodes from
+  ///                     this map to nodes in the returned graph.
+  ///
   /// \returns The trimmed graph
   std::unique_ptr<ExplodedGraph>
-  trim(ArrayRef<const NodeTy *> Nodes,
+  trim(TrimGraphWorklist &Worklist,
        InterExplodedGraphMap *NodeMap = nullptr) const;
 
   /// Enable tracking of recently allocated nodes for potential reclamation

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -300,8 +300,7 @@ private:
 using InterExplodedGraphMap =
     llvm::DenseMap<const ExplodedNode *, ExplodedNode *>;
 
-using TrimGraphWorklist =
-    SmallVector<const ExplodedNode*, 32>;
+using TrimGraphWorklist = SmallVector<const ExplodedNode *, 32>;
 
 class ExplodedGraph {
 protected:

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -298,7 +298,7 @@ private:
 };
 
 using InterExplodedGraphMap =
-    llvm::DenseMap<const ExplodedNode *, const ExplodedNode *>;
+    llvm::DenseMap<const ExplodedNode *, ExplodedNode *>;
 
 class ExplodedGraph {
 protected:

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -409,8 +409,6 @@ public:
   llvm::BumpPtrAllocator & getAllocator() { return BVC.getAllocator(); }
   BumpVectorContext &getNodeAllocator() { return BVC; }
 
-  using NodeMap = llvm::DenseMap<const ExplodedNode *, ExplodedNode *>;
-
   /// Creates a trimmed version of the graph that only contains paths leading
   /// to the given nodes.
   ///

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -424,6 +424,13 @@ public:
   trim(TrimGraphWorklist &Worklist,
        InterExplodedGraphMap *NodeMap = nullptr) const;
 
+  std::unique_ptr<ExplodedGraph>
+  trim(ArrayRef<const ExplodedNode *> Nodes,
+       InterExplodedGraphMap *NodeMap = nullptr) const {
+    TrimGraphWorklist Worklist{Nodes};
+    return trim(Worklist, NodeMap);
+  }
+
   /// Enable tracking of recently allocated nodes for potential reclamation
   /// when calling reclaimRecentlyAllocatedNodes().
   void enableNodeReclamation(unsigned Interval) {

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2633,7 +2633,8 @@ BugPathGetter::BugPathGetter(const ExplodedGraph *OriginalGraph,
     assert(I->isValid() &&
            "We only allow BugReporterVisitors and BugReporter itself to "
            "invalidate reports!");
-    Nodes.emplace_back(I->getErrorNode());
+    if (const ExplodedNode *ErrNode = I->getErrorNode())
+      Nodes.emplace_back(ErrNode);
   }
 
   // The trimmed graph is created in the body of the constructor to ensure

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2171,6 +2171,7 @@ PathSensitiveBugReport::PathSensitiveBugReport(
     : BugReport(Kind::PathSensitive, bt, shortDesc, desc), ErrorNode(errorNode),
       ErrorNodeRange(getStmt() ? getStmt()->getSourceRange() : SourceRange()),
       UniqueingLocation(LocationToUnique), UniqueingDecl(DeclToUnique) {
+  assert(ErrorNode && "The error node must not be null!");
   assert(!isDependency(ErrorNode->getState()
                            ->getAnalysisManager()
                            .getCheckerManager()
@@ -2633,8 +2634,7 @@ BugPathGetter::BugPathGetter(const ExplodedGraph *OriginalGraph,
     assert(I->isValid() &&
            "We only allow BugReporterVisitors and BugReporter itself to "
            "invalidate reports!");
-    if (const ExplodedNode *ErrNode = I->getErrorNode())
-      Worklist.emplace_back(ErrNode);
+    Worklist.emplace_back(I->getErrorNode());
   }
 
   // The trimmed graph is created in the body of the constructor to ensure

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2627,9 +2627,9 @@ public:
 } // namespace
 
 BugPathGetter::BugPathGetter(const ExplodedGraph *OriginalGraph,
-                             ArrayRef<PathSensitiveBugReport *> &bugReports) {
+                             ArrayRef<PathSensitiveBugReport *> &BugReports) {
   TrimGraphWorklist Worklist;
-  for (const auto I : bugReports) {
+  for (const auto I : BugReports) {
     assert(I->isValid() &&
            "We only allow BugReporterVisitors and BugReporter itself to "
            "invalidate reports!");
@@ -2647,7 +2647,7 @@ BugPathGetter::BugPathGetter(const ExplodedGraph *OriginalGraph,
   // in the new graph.
   llvm::SmallPtrSet<const ExplodedNode *, 32> RemainingNodes;
 
-  for (PathSensitiveBugReport *Report : bugReports) {
+  for (PathSensitiveBugReport *Report : BugReports) {
     const ExplodedNode *NewNode = NodeMap.lookup(Report->getErrorNode());
     assert(NewNode &&
            "Failed to construct a trimmed graph that contains this error "

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2630,11 +2630,11 @@ public:
 BugPathGetter::BugPathGetter(const ExplodedGraph *OriginalGraph,
                              ArrayRef<PathSensitiveBugReport *> &BugReports) {
   TrimGraphWorklist Worklist;
-  for (const auto I : BugReports) {
-    assert(I->isValid() &&
+  for (PathSensitiveBugReport *BR : BugReports) {
+    assert(BR->isValid() &&
            "We only allow BugReporterVisitors and BugReporter itself to "
            "invalidate reports!");
-    Worklist.emplace_back(I->getErrorNode());
+    Worklist.emplace_back(BR->getErrorNode());
   }
 
   // The trimmed graph is created in the body of the constructor to ensure

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2639,8 +2639,8 @@ BugPathGetter::BugPathGetter(const ExplodedGraph *OriginalGraph,
 
   // The trimmed graph is created in the body of the constructor to ensure
   // that the DenseMaps have been initialized already.
-  InterExplodedGraphMap ForwardMap;
-  TrimmedGraph = OriginalGraph->trim(Nodes, &ForwardMap);
+  InterExplodedGraphMap NodeMap;
+  TrimmedGraph = OriginalGraph->trim(Nodes, &NodeMap);
 
   // Find the (first) error node in the trimmed graph.  We just need to consult
   // the node map which maps from nodes in the original graph to nodes
@@ -2648,7 +2648,7 @@ BugPathGetter::BugPathGetter(const ExplodedGraph *OriginalGraph,
   llvm::SmallPtrSet<const ExplodedNode *, 32> RemainingNodes;
 
   for (PathSensitiveBugReport *Report : bugReports) {
-    const ExplodedNode *NewNode = ForwardMap.lookup(Report->getErrorNode());
+    const ExplodedNode *NewNode = NodeMap.lookup(Report->getErrorNode());
     assert(NewNode &&
            "Failed to construct a trimmed graph that contains this error "
            "node!");

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2628,19 +2628,19 @@ public:
 
 BugPathGetter::BugPathGetter(const ExplodedGraph *OriginalGraph,
                              ArrayRef<PathSensitiveBugReport *> &bugReports) {
-  SmallVector<const ExplodedNode *, 32> Nodes;
+  TrimGraphWorklist Worklist;
   for (const auto I : bugReports) {
     assert(I->isValid() &&
            "We only allow BugReporterVisitors and BugReporter itself to "
            "invalidate reports!");
     if (const ExplodedNode *ErrNode = I->getErrorNode())
-      Nodes.emplace_back(ErrNode);
+      Worklist.emplace_back(ErrNode);
   }
 
   // The trimmed graph is created in the body of the constructor to ensure
   // that the DenseMaps have been initialized already.
   InterExplodedGraphMap NodeMap;
-  TrimmedGraph = OriginalGraph->trim(Nodes, &NodeMap);
+  TrimmedGraph = OriginalGraph->trim(Worklist, &NodeMap);
 
   // Find the (first) error node in the trimmed graph.  We just need to consult
   // the node map which maps from nodes in the original graph to nodes

--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -475,8 +475,8 @@ ExplodedGraph::trim(ArrayRef<const NodeTy *> Sinks,
     // in the trimmed graph, then add the corresponding edges with
     // `addPredecessor()`, otherwise add them to the worklist.
     for (const ExplodedNode *Pred : N->Preds) {
-      if (const ExplodedNode *Mapped = NodeMap->lookup(Pred))
-        NewN->addPredecessor(const_cast<ExplodedNode *>(Mapped), *Trimmed);
+      if (ExplodedNode *Mapped = NodeMap->lookup(Pred))
+        NewN->addPredecessor(Mapped, *Trimmed);
       else
         Worklist.push_back(Pred);
     }
@@ -487,8 +487,8 @@ ExplodedGraph::trim(ArrayRef<const NodeTy *> Sinks,
     // worklist. Maybe we'll reach them through a different direction, maybe
     // they will be omitted from the trimmed graph.)
     for (const ExplodedNode *Succ : N->Succs)
-      if (const ExplodedNode *Mapped = NodeMap->lookup(Succ))
-        const_cast<ExplodedNode *>(Mapped)->addPredecessor(NewN, *Trimmed);
+      if (ExplodedNode *Mapped = NodeMap->lookup(Succ))
+        Mapped->addPredecessor(NewN, *Trimmed);
   }
 
   assert(Trimmed->getRoot() && "The root must be reachable from any nonempty set of sinks!");

--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -439,14 +439,12 @@ ExplodedNode *ExplodedGraph::createUncachedNode(const ProgramPoint &L,
 }
 
 std::unique_ptr<ExplodedGraph>
-ExplodedGraph::trim(ArrayRef<const NodeTy *> Sinks,
+ExplodedGraph::trim(TrimGraphWorklist &Worklist,
                     InterExplodedGraphMap *NodeMap) const {
-  if (Sinks.empty())
+  if (Worklist.empty())
     return nullptr;
 
   std::unique_ptr<ExplodedGraph> Trimmed = std::make_unique<ExplodedGraph>();
-
-  SmallVector<const ExplodedNode*, 32> Worklist{Sinks};
 
   InterExplodedGraphMap Scratch;
   if (!NodeMap)

--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -462,10 +462,11 @@ ExplodedGraph::trim(TrimGraphWorklist &Worklist,
     // Create the corresponding node in the new graph and record the mapping
     // from the old node to the new node.
     ExplodedNode *NewN = Trimmed->createUncachedNode(N->getLocation(), N->State,
-                                               N->getID(), N->isSink());
+                                                     N->getID(), N->isSink());
     Place->second = NewN;
 
-    // If this is the root node, designate is as the root in the trimmed graph as well.
+    // If this is the root node, designate is as the root in the trimmed graph
+    // as well.
     if (N == getRoot())
       Trimmed->designateAsRoot(NewN);
 
@@ -489,7 +490,8 @@ ExplodedGraph::trim(TrimGraphWorklist &Worklist,
         Mapped->addPredecessor(NewN, *Trimmed);
   }
 
-  assert(Trimmed->getRoot() && "The root must be reachable from any nonempty set of sinks!");
+  assert(Trimmed->getRoot() &&
+         "The root must be reachable from any nonempty set of sinks!");
 
   return Trimmed;
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -4096,7 +4096,8 @@ std::string ExprEngine::DumpGraph(bool trim, StringRef Filename) {
 
 std::string ExprEngine::DumpGraph(ArrayRef<const ExplodedNode *> Nodes,
                                   StringRef Filename) {
-  std::unique_ptr<ExplodedGraph> TrimmedG(G.trim(Nodes));
+  TrimGraphWorklist Worklist{Nodes};
+  std::unique_ptr<ExplodedGraph> TrimmedG(G.trim(Worklist));
 
   if (!TrimmedG) {
     llvm::errs() << "warning: Trimmed ExplodedGraph is empty.\n";

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -4096,8 +4096,7 @@ std::string ExprEngine::DumpGraph(bool trim, StringRef Filename) {
 
 std::string ExprEngine::DumpGraph(ArrayRef<const ExplodedNode *> Nodes,
                                   StringRef Filename) {
-  TrimGraphWorklist Worklist{Nodes};
-  std::unique_ptr<ExplodedGraph> TrimmedG(G.trim(Worklist));
+  std::unique_ptr<ExplodedGraph> TrimmedG(G.trim(Nodes));
 
   if (!TrimmedG) {
     llvm::errs() << "warning: Trimmed ExplodedGraph is empty.\n";


### PR DESCRIPTION
...because its implementation was using a complicated two-pass graph traversal while in fact one pass is sufficient for performing that trimming operation.

Note that this commit changes the interface of `trim`: it no longer accepts nullpointers within the array `Sinks` and `BugReporter.cpp` (the single non-debug caller) was modified accordingly. This also affects the interface of `DumpGraph` (which calls `trim` under the hood), but that's a debug helper which is only called if some developer compiles a tweaked version of the analyzer for local debugging and it is unlikely that a developer would pass nullpointers to it.

WORK IN PROGRESS -- DO NOT MERGE!

After this commit the analyzer will pick different representatives from the bug report equivalence classes (because some iteration order changes), which breaks lots of testcases.