### PR TITLE
fix zstd_shared detection on mingw

### DIFF
--- a/llvm/cmake/modules/Findzstd.cmake
+++ b/llvm/cmake/modules/Findzstd.cmake
@@ -29,11 +29,11 @@ find_package_handle_standard_args(
 )
 
 if(zstd_FOUND)
-  if(zstd_LIBRARY MATCHES "${zstd_STATIC_LIBRARY_SUFFIX}$")
+  if(zstd_LIBRARY MATCHES "${zstd_STATIC_LIBRARY_SUFFIX}$" AND NOT zstd_LIBRARY MATCHES "\\.dll\\.a$")
     set(zstd_STATIC_LIBRARY "${zstd_LIBRARY}")
   elseif (NOT TARGET zstd::libzstd_shared)
     add_library(zstd::libzstd_shared SHARED IMPORTED)
-    if(MSVC OR "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+    if(WIN32 OR CYGWIN)
       include(GNUInstallDirs) # For CMAKE_INSTALL_LIBDIR and friends.
       # IMPORTED_LOCATION is the path to the DLL and IMPORTED_IMPLIB is the "library".
       get_filename_component(zstd_DIRNAME "${zstd_LIBRARY}" DIRECTORY)


### PR DESCRIPTION
The zstd_shared autodetection was broken for non-MSVC (mingw) compiled LLVM, since it assumed that `*.a` uniquely identifies a file as being a static library, but typically this is actually an import lib formed as the longer name `*.dll.a` from the binary. This leads to confusing output elsewhere, in cmake and llvm-config, when they report this is a static library at an absolute path instead of a shared library named `-lzstd`.