### PR TITLE
[PPC] ROP protection won't be supported with the ELFV1 ABI.

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -685,6 +685,12 @@ bool PPCTargetInfo::initFeatureMap(
       return false;
     }
 
+    if (ABI == "elfv1") {
+      Diags.Report(diag::err_unsupported_abi_for_opt)
+          << "-mrop-protect" << "elfv2";
+      return false;
+    }
+
     if (!(ArchDefs & ArchDefinePwr8)) {
       // We can turn on ROP Protect on Power 8 and above.
       Diags.Report(diag::err_opt_not_valid_with_opt) << "-mrop-protect" << CPU;

--- a/clang/test/Driver/ppc-mrop-protection-support-check.c
+++ b/clang/test/Driver/ppc-mrop-protection-support-check.c
@@ -6,10 +6,22 @@
 // RUN: not %clang -target powerpc64le-unknown-linux-gnu -fsyntax-only \
 // RUN:   -mcpu=pwr7 -mrop-protect %s 2>&1 | FileCheck %s --check-prefix=NOROP
 
+// RUN: not %clang -target powerpc64-unknown-linux-gnu -fsyntax-only \
+// RUN:   -mcpu=power8 -mrop-protect %s 2>&1 | FileCheck %s --check-prefix=ELFV1
+// RUN: not %clang -target powerpc64le-unknown-linux-gnu -fsyntax-only \
+// RUN:   -mcpu=power8 -mrop-protect -mabi=elfv1 %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=ELFV1
+
 // RUN: not %clang -target powerpc-unknown-linux -fsyntax-only \
 // RUN: -mcpu=pwr8 -mrop-protect %s 2>&1 | FileCheck %s --check-prefix=32BIT
 // RUN: not %clang -target powerpc-unknown-aix -fsyntax-only \
 // RUN: -mcpu=pwr8 -mrop-protect %s 2>&1 | FileCheck %s --check-prefix=32BIT
+
+#ifdef __ROP_PROTECT__
+#if defined(__CALL_ELF) && __CALL_ELF == 1
+#error "ROP protection not supported with 64-bit elfv1 abi"
+#endif
+#endif
 
 #ifdef __ROP_PROTECT__
 static_assert(false, "ROP Protect enabled");
@@ -20,3 +32,4 @@ static_assert(false, "ROP Protect enabled");
 // NOROP: option '-mrop-protect' cannot be specified with
 
 // 32BIT: option '-mrop-protect' cannot be specified on this target
+// ELFV1: '-mrop-protect' can only be used with the 'elfv2' ABI

--- a/clang/test/Preprocessor/init-ppc64.c
+++ b/clang/test/Preprocessor/init-ppc64.c
@@ -697,9 +697,7 @@
 // RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64-none-none -target-feature +mma -target-cpu power10 -fno-signed-char < /dev/null | FileCheck -check-prefix PPC-MMA %s
 // PPC-MMA:#define __MMA__ 1
 //
-// RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64-none-none -target-feature +rop-protect -target-cpu power10 -fno-signed-char < /dev/null | FileCheck -check-prefix PPC-ROP %s
-// RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64-none-none -target-feature +rop-protect -target-cpu power9 -fno-signed-char < /dev/null | FileCheck -check-prefix PPC-ROP %s
-// RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64-none-none -target-feature +rop-protect -target-cpu power8 -fno-signed-char < /dev/null | FileCheck -check-prefix PPC-ROP %s
+// RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64-none-none -target-feature +rop-protect -target-abi elfv2 -target-cpu power8 -fno-signed-char < /dev/null | FileCheck -check-prefix PPC-ROP %s
 // PPC-ROP:#define __ROP_PROTECT__ 1
 //
 // RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64-none-none -target-feature +float128 -target-cpu power9 -fno-signed-char < /dev/null | FileCheck -check-prefix PPC-FLOAT128 %s


### PR DESCRIPTION
Disables -mrop-protect option for the elfv1 ABI. Tests both a target where this ABI is the default and a target where we explicitly have to set the ABI to elfv1.