### PR TITLE
[BOLT][test] Disable PLT check in callcont-fallthru

### DIFF
--- a/bolt/test/X86/callcont-fallthru.s
+++ b/bolt/test/X86/callcont-fallthru.s
@@ -6,7 +6,7 @@
 # RUN: %clangxx %cxxflags %s %t.so -o %t -Wl,-q -nostdlib
 # RUN: link_fdata %s %t %t.pat PREAGGT1
 # RUN: link_fdata %s %t %t.pat2 PREAGGT2
-# RUN: link_fdata %s %t %t.patplt PREAGGPLT
+# DONTRUN: link_fdata %s %t %t.patplt PREAGGPLT
 
 # RUN: llvm-strip --strip-unneeded %t -o %t.strip
 # RUN: llvm-objcopy --remove-section=.eh_frame %t.strip %t.noeh
@@ -26,8 +26,8 @@
 
 ## Check pre-aggregated traces don't report zero-sized PLT fall-through as
 ## invalid trace
-# RUN: llvm-bolt %t.strip --pa -p %t.patplt -o %t.out | FileCheck %s \
-# RUN:   --check-prefix=CHECK-PLT
+# DONTRUN: llvm-bolt %t.strip --pa -p %t.patplt -o %t.out | FileCheck %s \
+# DONTRUN:   --check-prefix=CHECK-PLT
 # CHECK-PLT: traces mismatching disassembled function contents: 0
 
   .globl foo


### PR DESCRIPTION
Some testing configurations don't support `nm --synthetic` option (where
nm is a symlink to llvm-nm), which prevents us from resolving `puts@plt`
symbol address in profile generation inside the test.
Disable the check until llvm-nm support is landed (#138232).

Test Plan: bin/llvm-lit -a tools/bolt/test/X86/callcont-fallthru.s
