### PR TITLE
[flang] Add missing copy constructor

### DIFF
--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -600,6 +600,7 @@ class TypeParamDetails {
 public:
   TypeParamDetails() = default;
   TypeParamDetails(const TypeParamDetails &) = default;
+  TypeParamDetails &operator=(const TypeParamDetails &) = default;
   std::optional<common::TypeParamAttr> attr() const { return attr_; }
   TypeParamDetails &set_attr(common::TypeParamAttr);
   MaybeIntExpr &init() { return init_; }


### PR DESCRIPTION
On some compilers the implicit copy ~constructor~ assignment operator was issuing a warning.