### PR TITLE
[NFC][Clang] Adopt simplified `getTrailingObjects` in ASTConcept

### DIFF
--- a/clang/include/clang/AST/ASTConcept.h
+++ b/clang/include/clang/AST/ASTConcept.h
@@ -93,11 +93,11 @@ struct ASTConstraintSatisfaction final :
   bool ContainsErrors : 1;
 
   const UnsatisfiedConstraintRecord *begin() const {
-    return getTrailingObjects<UnsatisfiedConstraintRecord>();
+    return getTrailingObjects();
   }
 
   const UnsatisfiedConstraintRecord *end() const {
-    return getTrailingObjects<UnsatisfiedConstraintRecord>() + NumRecords;
+    return getTrailingObjects() + NumRecords;
   }
 
   ASTConstraintSatisfaction(const ASTContext &C,

--- a/clang/lib/AST/ASTConcept.cpp
+++ b/clang/lib/AST/ASTConcept.cpp
@@ -40,9 +40,8 @@ ASTConstraintSatisfaction::ASTConstraintSatisfaction(
       IsSatisfied{Satisfaction.IsSatisfied}, ContainsErrors{
                                                  Satisfaction.ContainsErrors} {
   for (unsigned I = 0; I < NumRecords; ++I)
-    CreateUnsatisfiedConstraintRecord(
-        C, Satisfaction.Details[I],
-        getTrailingObjects<UnsatisfiedConstraintRecord>() + I);
+    CreateUnsatisfiedConstraintRecord(C, Satisfaction.Details[I],
+                                      getTrailingObjects() + I);
 }
 
 ASTConstraintSatisfaction::ASTConstraintSatisfaction(
@@ -51,9 +50,8 @@ ASTConstraintSatisfaction::ASTConstraintSatisfaction(
       IsSatisfied{Satisfaction.IsSatisfied},
       ContainsErrors{Satisfaction.ContainsErrors} {
   for (unsigned I = 0; I < NumRecords; ++I)
-    CreateUnsatisfiedConstraintRecord(
-        C, *(Satisfaction.begin() + I),
-        getTrailingObjects<UnsatisfiedConstraintRecord>() + I);
+    CreateUnsatisfiedConstraintRecord(C, *(Satisfaction.begin() + I),
+                                      getTrailingObjects() + I);
 }
 
 ASTConstraintSatisfaction *


### PR DESCRIPTION
Use non-templated form of `getTrailingObjects` when using a single trailing type in `TrailingObjects`.