### PR TITLE
[flang][docs] Document technique for regenerating a module hermetically

### DIFF
--- a/flang/docs/ModFiles.md
+++ b/flang/docs/ModFiles.md
@@ -171,3 +171,14 @@ modules of dependent libraries need not also be packaged with the library.
 When the compiler reads a hermetic module file, the copies of the dependent
 modules are read into their own scope, and will not conflict with other modules
 of the same name that client code might `USE`.
+
+One can use the `-fhermetic-module-files` option when building the top-level
+module files of a library for which not all of the implementation modules
+will (or can) be shipped.
+
+It is also possible to convert a default module file to a hermetic one after
+the fact.
+Since module files are Fortran source, simply copy the module file to a new
+temporary free form Fortran source file and recompile it (`-fsyntax-only`)
+with the `-fhermetic-module-files` flag, and that will regenerate the module
+file in place with all of its dependent modules included.


### PR DESCRIPTION
A flang-new module file is Fortran source, so it can be recompiled with the `-fhermetic-module-files` option to convert it into a hermetic one.