### PR TITLE
[clang][analyzer] Fix a nullptr dereference when -ftime-trace is used (Reland)

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -103,7 +103,10 @@ public:
   const Stmt *getStmt() const {
     switch (Elem->getKind()) {
     case CFGElement::Initializer:
-      return Elem->castAs<CFGInitializer>().getInitializer()->getInit();
+      if (const auto *Init = Elem->castAs<CFGInitializer>().getInitializer()) {
+        return Init->getInit();
+      }
+      return nullptr;
     case CFGElement::ScopeBegin:
       return Elem->castAs<CFGScopeBegin>().getTriggerStmt();
     case CFGElement::ScopeEnd:

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -101,6 +101,11 @@ public:
 
   // It might return null.
   const Stmt *getStmt() const {
+    if (const auto *Parent = Elem.getParent()) {
+      // Sometimes the CFG element is invalid, avoid dereferencing it.
+      if (Elem.getIndexInBlock() >= Parent->size())
+        return nullptr;
+    }
     switch (Elem->getKind()) {
     case CFGElement::Initializer:
       if (const auto *Init = Elem->castAs<CFGInitializer>().getInitializer()) {

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -100,48 +100,7 @@ public:
   ConstCFGElementRef getCFGElementRef() const { return Elem; }
 
   // It might return null.
-  const Stmt *getStmt() const {
-    // Sometimes the CFG element is invalid, avoid dereferencing it.
-    if (Elem.getParent() == nullptr ||
-        Elem.getIndexInBlock() >= Elem.getParent()->size())
-      return nullptr;
-    switch (Elem->getKind()) {
-    case CFGElement::Initializer:
-      if (const auto *Init = Elem->castAs<CFGInitializer>().getInitializer()) {
-        return Init->getInit();
-      }
-      return nullptr;
-    case CFGElement::ScopeBegin:
-      return Elem->castAs<CFGScopeBegin>().getTriggerStmt();
-    case CFGElement::ScopeEnd:
-      return Elem->castAs<CFGScopeEnd>().getTriggerStmt();
-    case CFGElement::NewAllocator:
-      return Elem->castAs<CFGNewAllocator>().getAllocatorExpr();
-    case CFGElement::LifetimeEnds:
-      return Elem->castAs<CFGLifetimeEnds>().getTriggerStmt();
-    case CFGElement::LoopExit:
-      return Elem->castAs<CFGLoopExit>().getLoopStmt();
-    case CFGElement::Statement:
-      return Elem->castAs<CFGStmt>().getStmt();
-    case CFGElement::Constructor:
-      return Elem->castAs<CFGConstructor>().getStmt();
-    case CFGElement::CXXRecordTypedCall:
-      return Elem->castAs<CFGCXXRecordTypedCall>().getStmt();
-    case CFGElement::AutomaticObjectDtor:
-      return Elem->castAs<CFGAutomaticObjDtor>().getTriggerStmt();
-    case CFGElement::DeleteDtor:
-      return Elem->castAs<CFGDeleteDtor>().getDeleteExpr();
-    case CFGElement::BaseDtor:
-      return nullptr;
-    case CFGElement::MemberDtor:
-      return nullptr;
-    case CFGElement::TemporaryDtor:
-      return Elem->castAs<CFGTemporaryDtor>().getBindTemporaryExpr();
-    case CFGElement::CleanupFunction:
-      return nullptr;
-    }
-    return nullptr;
-  }
+  const Stmt *getStmt() const;
 
   unsigned getCount() const { return Count; }
   /// It might return null.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -101,11 +101,10 @@ public:
 
   // It might return null.
   const Stmt *getStmt() const {
-    if (const auto *Parent = Elem.getParent()) {
-      // Sometimes the CFG element is invalid, avoid dereferencing it.
-      if (Elem.getIndexInBlock() >= Parent->size())
-        return nullptr;
-    }
+    // Sometimes the CFG element is invalid, avoid dereferencing it.
+    if (Elem.getParent() == nullptr ||
+        Elem.getIndexInBlock() >= Elem.getParent()->size())
+      return nullptr;
     switch (Elem->getKind()) {
     case CFGElement::Initializer:
       if (const auto *Init = Elem->castAs<CFGInitializer>().getInitializer()) {

--- a/clang/lib/StaticAnalyzer/Core/SymbolManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SymbolManager.cpp
@@ -80,6 +80,49 @@ void UnarySymExpr::dumpToStream(raw_ostream &os) const {
     os << ')';
 }
 
+const Stmt *SymbolConjured::getStmt() const {
+  // Sometimes the CFG element is invalid, avoid dereferencing it.
+  if (Elem.getParent() == nullptr ||
+      Elem.getIndexInBlock() >= Elem.getParent()->size())
+    return nullptr;
+  switch (Elem->getKind()) {
+  case CFGElement::Initializer:
+    if (const auto *Init = Elem->castAs<CFGInitializer>().getInitializer()) {
+      return Init->getInit();
+    }
+    return nullptr;
+  case CFGElement::ScopeBegin:
+    return Elem->castAs<CFGScopeBegin>().getTriggerStmt();
+  case CFGElement::ScopeEnd:
+    return Elem->castAs<CFGScopeEnd>().getTriggerStmt();
+  case CFGElement::NewAllocator:
+    return Elem->castAs<CFGNewAllocator>().getAllocatorExpr();
+  case CFGElement::LifetimeEnds:
+    return Elem->castAs<CFGLifetimeEnds>().getTriggerStmt();
+  case CFGElement::LoopExit:
+    return Elem->castAs<CFGLoopExit>().getLoopStmt();
+  case CFGElement::Statement:
+    return Elem->castAs<CFGStmt>().getStmt();
+  case CFGElement::Constructor:
+    return Elem->castAs<CFGConstructor>().getStmt();
+  case CFGElement::CXXRecordTypedCall:
+    return Elem->castAs<CFGCXXRecordTypedCall>().getStmt();
+  case CFGElement::AutomaticObjectDtor:
+    return Elem->castAs<CFGAutomaticObjDtor>().getTriggerStmt();
+  case CFGElement::DeleteDtor:
+    return Elem->castAs<CFGDeleteDtor>().getDeleteExpr();
+  case CFGElement::BaseDtor:
+    return nullptr;
+  case CFGElement::MemberDtor:
+    return nullptr;
+  case CFGElement::TemporaryDtor:
+    return Elem->castAs<CFGTemporaryDtor>().getBindTemporaryExpr();
+  case CFGElement::CleanupFunction:
+    return nullptr;
+  }
+  return nullptr;
+}
+
 void SymbolConjured::dumpToStream(raw_ostream &os) const {
   os << getKindStr() << getSymbolID() << '{' << T << ", LC" << LCtx->getID();
   if (auto *S = getStmt())

--- a/clang/test/Analysis/ftime-trace-no-init.cpp
+++ b/clang/test/Analysis/ftime-trace-no-init.cpp
@@ -1,0 +1,5 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,apiModeling %s -ftime-trace=%t.raw.json -verify
+// expected-no-diagnostics
+
+// GitHub issue 139779
+struct {} a; // no-crash


### PR DESCRIPTION
Fixes #139779.

The bug was introduced in #137355 in `SymbolConjured::getStmt`, when
trying to obtain a statement for a CFG initializer without an
initializer.  This commit adds a null check before access.

Previous PR #139820, Revert #139936

Additional notes since previous PR:

When conjuring a symbol, sometimes there is no valid CFG element, e.g. in the file causing the crash, there is no element at all in the CFG. In these cases, the CFG element reference in the expression engine will be invalid. As a consequence, there needs to be extra checks to ensure the validity of the CFG element reference.