### PR TITLE
[OpenMP] Add diagnostic for 'factor' width mismatch in 'unroll partial'

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11700,6 +11700,8 @@ def err_omp_negative_expression_in_clause : Error<
   "argument to '%0' clause must be a %select{non-negative|strictly positive}1 integer value">;
 def err_omp_large_expression_in_clause : Error<
   "argument to '%0' clause requires a value that can be represented by a 64-bit">;
+def err_omp_unroll_factor_width_mismatch : Error<
+  "unroll factor has width %0 but the iteration variable %1 is only %2 bits wide">;
 def err_omp_not_integral : Error<
   "expression must have integral or unscoped enumeration "
   "type, not %0">;

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -14985,13 +14985,13 @@ StmtResult SemaOpenMP::ActOnOpenMPUnrollDirective(ArrayRef<OMPClause *> Clauses,
                                                /*SuppressExprDiags=*/false)
              .isUsable())
       return StmtError();
-    // Checking if Iterator Variable Type can hold the Factor Width
-    unsigned FactorValWidth = FactorVal->getIntegerConstantExpr(Context)->getActiveBits();
-    unsigned IteratorVWidth = Context.getTypeSize(OrigVar->getType());
-    if ( FactorValWidth > IteratorVWidth ) {
+    // Check that the iterator variable’s type can hold the factor’s bit-width
+    unsigned factorValWidth =
+        FactorVal->getIntegerConstantExpr(Context)->getActiveBits();
+    unsigned iteratorVWidth = Context.getTypeSize(OrigVar->getType());
+    if (factorValWidth > iteratorVWidth) {
       Diag(FactorVal->getExprLoc(), diag::err_omp_unroll_factor_width_mismatch)
-          << FactorValWidth << OrigVar->getType()
-          << IteratorVWidth;
+          << factorValWidth << OrigVar->getType() << iteratorVWidth;
       return StmtError();
     }
 

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -14980,13 +14980,19 @@ StmtResult SemaOpenMP::ActOnOpenMPUnrollDirective(ArrayRef<OMPClause *> Clauses,
   SourceLocation FactorLoc;
   if (Expr *FactorVal = PartialClause->getFactor();
       FactorVal && !FactorVal->containsErrors()) {
-    if (!VerifyPositiveIntegerConstantInClause(FactorVal,OMPC_partial,/*StrictlyPositive=*/true,/*SuppressExprDiags=*/false).isUsable()) {
-    return StmtError();
+    if (!VerifyPositiveIntegerConstantInClause(FactorVal, OMPC_partial,
+                                               /*StrictlyPositive=*/true,
+                                               /*SuppressExprDiags=*/false)
+             .isUsable()) {
+      return StmtError();
     }
     // Checking if Itertor Variable Type can hold the Factor Width
-    if (FactorVal->EvaluateKnownConstInt(Context).getBitWidth() > Context.getTypeSize(IVTy)) {
-          Diag(FactorVal->getExprLoc(), diag::err_omp_hint_clause_no_name);
-          return StmtError();
+    if (FactorVal->getIntegerConstantExpr(Context)->getBitWidth() >
+        Context.getTypeSize(IVTy)) {
+      Diag(FactorVal->getExprLoc(), diag::err_omp_unroll_factor_width_mismatch)
+          << FactorVal->getIntegerConstantExpr(Context)->getBitWidth() << IVTy
+          << Context.getTypeSize(IVTy);
+      return StmtError();
     }
 
     Factor = FactorVal->getIntegerConstantExpr(Context)->getZExtValue();

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -14983,12 +14983,11 @@ StmtResult SemaOpenMP::ActOnOpenMPUnrollDirective(ArrayRef<OMPClause *> Clauses,
     if (!VerifyPositiveIntegerConstantInClause(FactorVal, OMPC_partial,
                                                /*StrictlyPositive=*/true,
                                                /*SuppressExprDiags=*/false)
-             .isUsable()) {
+             .isUsable())
       return StmtError();
-    }
     // Checking if Iterator Variable Type can hold the Factor Width
-    auto FactorValWidth = FactorVal->getIntegerConstantExpr(Context)->getActiveBits();
-    auto IteratorVWidth = Context.getTypeSize(OrigVar->getType());
+    unsigned FactorValWidth = FactorVal->getIntegerConstantExpr(Context)->getActiveBits();
+    unsigned IteratorVWidth = Context.getTypeSize(OrigVar->getType());
     if ( FactorValWidth > IteratorVWidth ) {
       Diag(FactorVal->getExprLoc(), diag::err_omp_unroll_factor_width_mismatch)
           << FactorValWidth << OrigVar->getType()
@@ -14998,7 +14997,6 @@ StmtResult SemaOpenMP::ActOnOpenMPUnrollDirective(ArrayRef<OMPClause *> Clauses,
 
     Factor = FactorVal->getIntegerConstantExpr(Context)->getZExtValue();
     FactorLoc = FactorVal->getExprLoc();
-
   } else {
     // TODO: Use a better profitability model.
     Factor = 2;

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -14986,12 +14986,12 @@ StmtResult SemaOpenMP::ActOnOpenMPUnrollDirective(ArrayRef<OMPClause *> Clauses,
              .isUsable())
       return StmtError();
     // Check that the iterator variable’s type can hold the factor’s bit-width
-    unsigned factorValWidth =
+    unsigned FactorValWidth =
         FactorVal->getIntegerConstantExpr(Context)->getActiveBits();
-    unsigned iteratorVWidth = Context.getTypeSize(OrigVar->getType());
-    if (factorValWidth > iteratorVWidth) {
+    unsigned IteratorVWidth = Context.getTypeSize(OrigVar->getType());
+    if (FactorValWidth > IteratorVWidth) {
       Diag(FactorVal->getExprLoc(), diag::err_omp_unroll_factor_width_mismatch)
-          << factorValWidth << OrigVar->getType() << iteratorVWidth;
+          << FactorValWidth << OrigVar->getType() << IteratorVWidth;
       return StmtError();
     }
 

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -14986,12 +14986,13 @@ StmtResult SemaOpenMP::ActOnOpenMPUnrollDirective(ArrayRef<OMPClause *> Clauses,
              .isUsable()) {
       return StmtError();
     }
-    // Checking if Itertor Variable Type can hold the Factor Width
-    if (FactorVal->getIntegerConstantExpr(Context)->getBitWidth() >
-        Context.getTypeSize(IVTy)) {
+    // Checking if Iterator Variable Type can hold the Factor Width
+    auto FactorValWidth = FactorVal->getIntegerConstantExpr(Context)->getActiveBits();
+    auto IteratorVWidth = Context.getTypeSize(OrigVar->getType());
+    if ( FactorValWidth > IteratorVWidth ) {
       Diag(FactorVal->getExprLoc(), diag::err_omp_unroll_factor_width_mismatch)
-          << FactorVal->getIntegerConstantExpr(Context)->getBitWidth() << IVTy
-          << Context.getTypeSize(IVTy);
+          << FactorValWidth << OrigVar->getType()
+          << IteratorVWidth;
       return StmtError();
     }
 

--- a/clang/test/OpenMP/unroll_messages.cpp
+++ b/clang/test/OpenMP/unroll_messages.cpp
@@ -59,14 +59,22 @@ void func(int n) {
   #pragma omp unroll partial(0)
   for (int i = 0; i < n; ++i) {}
 
-  // expected-error@+1 {{unroll factor has width 64 but the iteration variable 'int' is only 32 bits wide}}
+  // expected-error@+1 {{unroll factor has width 36 but the iteration variable 'int' is only 32 bits wide}}
   #pragma omp unroll partial(0xFFFFFFFFF)
-  for (int i = 0; i < 10; i++)
+  for (int i = 0; i < 10; i++) {}
 
   // expected-error@+2 {{integer literal is too large to be represented in any integer type}}
   // expected-error@+1 {{argument to 'partial' clause must be a strictly positive integer value}}
   #pragma omp unroll partial(0x10000000000000000)
-  for (int i = 0; i < 10; i++)
+  for (int i = 0; i < 10; i++) {}
+
+  // expected-error@+1 {{unroll factor has width 12 but the iteration variable 'char' is only 8 bits wide}}
+  #pragma omp unroll partial(0xFFF)
+  for (char i = 0; i < 10; i++) {}
+
+  // expected-error@+1 {{unroll factor has width 20 but the iteration variable 'short' is only 16 bits wide}}
+  #pragma omp unroll partial(0xFFFFF)
+  for (short i = 0; i < 10; i++) {}
 
   // expected-error@+1 {{directive '#pragma omp unroll' cannot contain more than one 'partial' clause}}
   #pragma omp unroll partial partial

--- a/clang/test/OpenMP/unroll_messages.cpp
+++ b/clang/test/OpenMP/unroll_messages.cpp
@@ -58,8 +58,17 @@ void func(int n) {
   // expected-error@+1 {{argument to 'partial' clause must be a strictly positive integer value}} 
   #pragma omp unroll partial(0)
   for (int i = 0; i < n; ++i) {}
-    
-  // expected-error@+1 {{directive '#pragma omp unroll' cannot contain more than one 'partial' clause}} 
+
+  // expected-error@+1 {{unroll factor has width 64 but the iteration variable 'int' is only 32 bits wide}}
+  #pragma omp unroll partial(0xFFFFFFFFF)
+  for (int i = 0; i < 10; i++)
+
+  // expected-error@+2 {{integer literal is too large to be represented in any integer type}}
+  // expected-error@+1 {{argument to 'partial' clause must be a strictly positive integer value}}
+  #pragma omp unroll partial(0x10000000000000000)
+  for (int i = 0; i < 10; i++)
+
+  // expected-error@+1 {{directive '#pragma omp unroll' cannot contain more than one 'partial' clause}}
   #pragma omp unroll partial partial
   for (int i = 0; i < n; ++i) {}
 


### PR DESCRIPTION
This patch fixes #139268 by preventing an assertion failure when a user specifies a factor in `unroll partial` that either exceeds the signed 64-bit limit or the bit-width of the loop’s iteration variable.
 

  - Used `VerifyPositiveIntegerConstantInClause` to ensure the factor is strictly positive and fits in signed 64 bits. 
 
  -  Checking the factors bit-width to the iteration variable’s width, emitting a new `err_omp_unroll_factor_width_mismatch` diagnostic if it’s larger

  - Added some tests
  
  - Ran tests by calling `llvm-lit -v clang/test/OpenMP` 
  
![screen](https://github.com/user-attachments/assets/d9c08568-9973-48f2-918d-4ba037f1413c)

