### PR TITLE
[MLIR][LLVM] Improve inline asm importer

### DIFF
--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -330,8 +330,8 @@ private:
   /// Converts a single debug intrinsic.
   LogicalResult processDebugIntrinsic(llvm::DbgVariableIntrinsic *dbgIntr,
                                       DominanceInfo &domInfo);
-  /// Converts a asm inline call operand attributes into an array of attribute
-  /// suitable for `llvm.inline_asm`.
+  /// Converts LLMV IR asm inline call operand's attributes into an array of
+  /// MLIR attributes to be utilized in `llvm.inline_asm`.
   ArrayAttr convertAsmInlineOperandAttrs(const llvm::CallBase &llvmCall);
   /// Converts an LLVM intrinsic to an MLIR LLVM dialect operation if an MLIR
   /// counterpart exists. Otherwise, returns failure.

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -330,6 +330,9 @@ private:
   /// Converts a single debug intrinsic.
   LogicalResult processDebugIntrinsic(llvm::DbgVariableIntrinsic *dbgIntr,
                                       DominanceInfo &domInfo);
+  /// Converts a asm inline call operand attributes into an array of attribute
+  /// suitable for `llvm.inline_asm`.
+  ArrayAttr convertAsmInlineOperandAttrs(const llvm::CallBase &llvmCall);
   /// Converts an LLVM intrinsic to an MLIR LLVM dialect operation if an MLIR
   /// counterpart exists. Otherwise, returns failure.
   LogicalResult convertIntrinsic(llvm::CallInst *inst);

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -515,6 +515,8 @@ convertOperationImpl(Operation &opInst, llvm::IRBuilderBase &builder,
         if (!attr)
           continue;
         DictionaryAttr dAttr = cast<DictionaryAttr>(attr);
+        if (dAttr.empty())
+          continue;
         TypeAttr tAttr =
             cast<TypeAttr>(dAttr.get(InlineAsmOp::getElementTypeAttrName()));
         llvm::AttrBuilder b(moduleTranslation.getLLVMContext());

--- a/mlir/test/Target/LLVMIR/Import/instructions.ll
+++ b/mlir/test/Target/LLVMIR/Import/instructions.ll
@@ -542,10 +542,51 @@ define void @indirect_vararg_call(ptr addrspace(42) %fn) {
 ; CHECK-LABEL: @inlineasm
 ; CHECK-SAME:  %[[ARG1:[a-zA-Z0-9]+]]
 define i32 @inlineasm(i32 %arg1) {
-  ; CHECK:  %[[RES:.+]] = llvm.inline_asm has_side_effects "bswap $0", "=r,r" %[[ARG1]] : (i32) -> i32
-  %1 = call i32 asm "bswap $0", "=r,r"(i32 %arg1)
+  ; CHECK:  %[[RES:.+]] = llvm.inline_asm has_side_effects is_align_stack asm_dialect = intel "bswap $0", "=r,r" %[[ARG1]] : (i32) -> i32
+  %1 = call i32 asm sideeffect alignstack inteldialect "bswap $0", "=r,r"(i32 %arg1)
   ; CHECK: return %[[RES]]
   ret i32 %1
+}
+
+; // -----
+
+; CHECK-LABEL: @inlineasm2
+define void @inlineasm2() {
+  %p = alloca ptr, align 8
+  ; CHECK: {{.*}} = llvm.alloca %0 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  ; CHECK-NEXT: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = !llvm.ptr}] "", "*m,~{memory}" {{.*}} : (!llvm.ptr) -> !llvm.void
+  call void asm sideeffect "", "*m,~{memory}"(ptr elementtype(ptr) %p)
+  ret void
+}
+
+; // -----
+
+; CHECK: llvm.func @inlineasm3
+; CHECK-SAME:(%[[A0:.*]]: !llvm.ptr, %[[A1:.*]]: i64, %[[A2:.*]]: !llvm.ptr, %[[A3:.*]]: i64) {
+define void @inlineasm3(
+    ptr %ptr0,
+    i64 %b,
+    ptr %ptr1,
+    i64 %c
+  ) {
+  ; CHECK: llvm.inline_asm asm_dialect = att operand_attrs =
+  ; CHECK-SAME: [{elementtype = !llvm.array<16 x i64>}, {},
+  ; CHECK-SAME: {elementtype = !llvm.array<16 x i64>}, {}, {}, {},
+  ; CHECK-SAME: {elementtype = !llvm.array<16 x i64>}]
+  ; CHECK-SAME: "ldr x4, [$2], #8   \0A\09ldr x5, [$1]       \0A\09mul x6, x4, $4     \0A\09",
+  ; CHECK-SAME: "=r,=r,=r,=*m,r,*m,0,1,2,*m,~{x4},~{x5},~{x6},~{x7},~{cc}"
+  ; CHECK-SAME: %[[A0]], %[[A1]], %[[A2]], %[[A3]], %[[A0]], %[[A2]], %[[A0]] :
+  ; CHECK-SAME: (!llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.struct<(i64, ptr, ptr)>
+  %r = call { i64, ptr, ptr } asm "ldr x4, [$2], #8   \0A\09ldr x5, [$1]       \0A\09mul x6, x4, $4     \0A\09",
+  "=r,=r,=r,=*m,r,*m,0,1,2,*m,~{x4},~{x5},~{x6},~{x7},~{cc}"(
+    ptr elementtype([16 x i64]) %ptr0,
+    i64 %b,
+    ptr elementtype([16 x i64]) %ptr1,
+    i64 %c,
+    ptr %ptr0,
+    ptr %ptr1,
+    ptr elementtype([16 x i64]) %ptr0)
+  ret void
 }
 
 ; // -----


### PR DESCRIPTION
Add support for importing more information into InlineAsmOp: elementtype, side effects, align stack, asm dialect and operand attrs.