### PR TITLE
[libTooling] Fix `constructExprArgs` for direct-init and implicit construction

### DIFF
--- a/clang/unittests/Tooling/RangeSelectorTest.cpp
+++ b/clang/unittests/Tooling/RangeSelectorTest.cpp
@@ -50,6 +50,9 @@ template <typename M> TestMatch matchCode(StringRef Code, M Matcher) {
   auto Matches = ast_matchers::match(Matcher, Context);
   // We expect a single, exact match.
   assert(Matches.size() != 0 && "no matches found");
+  if (Matches.size() != 1) {
+    Context.getTranslationUnitDecl()->dumpColor();
+  }
   assert(Matches.size() == 1 && "too many matches");
 
   return TestMatch{std::move(ASTUnit), MatchResult(Matches[0], &Context)};

--- a/clang/unittests/Tooling/RangeSelectorTest.cpp
+++ b/clang/unittests/Tooling/RangeSelectorTest.cpp
@@ -693,6 +693,49 @@ TEST(RangeSelectorTest, ConstructExprNoArgs) {
   EXPECT_THAT_EXPECTED(select(constructExprArgs(ID), Match), HasValue(""));
 }
 
+TEST(RangeSelectorTest, ConstructExprArgsDirectInitialization) {
+  const StringRef Code = R"cc(
+    struct C {
+      C(int, int);
+    };
+    void f() {
+      C c(1, 2);
+    }
+  )cc";
+  const char *ID = "id";
+  TestMatch Match = matchCode(Code, cxxConstructExpr().bind(ID));
+  EXPECT_THAT_EXPECTED(select(constructExprArgs(ID), Match), HasValue("1, 2"));
+}
+
+TEST(RangeSelectorTest, ConstructExprArgsDirectBraceInitialization) {
+  const StringRef Code = R"cc(
+    struct C {
+      C(int, int);
+    };
+    void f() {
+      C c{1, 2};
+    }
+  )cc";
+  const char *ID = "id";
+  TestMatch Match = matchCode(Code, cxxConstructExpr().bind(ID));
+  EXPECT_THAT_EXPECTED(select(constructExprArgs(ID), Match), HasValue("1, 2"));
+}
+
+TEST(RangeSelectorTest, ConstructExprArgsImplicitConstruction) {
+  const StringRef Code = R"cc(
+    struct C {
+      C(int, int = 42);
+    };
+    void sink(C);
+    void f() {
+      sink(1);
+    }
+  )cc";
+  const char *ID = "id";
+  TestMatch Match = matchCode(Code, cxxConstructExpr().bind(ID));
+  EXPECT_THAT_EXPECTED(select(constructExprArgs(ID), Match), HasValue("1"));
+}
+
 TEST(RangeSelectorTest, StatementsOp) {
   StringRef Code = R"cc(
     void g();

--- a/clang/unittests/Tooling/RangeSelectorTest.cpp
+++ b/clang/unittests/Tooling/RangeSelectorTest.cpp
@@ -50,9 +50,6 @@ template <typename M> TestMatch matchCode(StringRef Code, M Matcher) {
   auto Matches = ast_matchers::match(Matcher, Context);
   // We expect a single, exact match.
   assert(Matches.size() != 0 && "no matches found");
-  if (Matches.size() != 1) {
-    Context.getTranslationUnitDecl()->dumpColor();
-  }
   assert(Matches.size() == 1 && "too many matches");
 
   return TestMatch{std::move(ASTUnit), MatchResult(Matches[0], &Context)};
@@ -735,7 +732,10 @@ TEST(RangeSelectorTest, ConstructExprArgsImplicitConstruction) {
     }
   )cc";
   const char *ID = "id";
-  TestMatch Match = matchCode(Code, cxxConstructExpr().bind(ID));
+  TestMatch Match = matchCode(
+      Code,
+      cxxConstructExpr(ignoringElidableConstructorCall(cxxConstructExpr()))
+          .bind(ID));
   EXPECT_THAT_EXPECTED(select(constructExprArgs(ID), Match), HasValue("1"));
 }
 


### PR DESCRIPTION
Use `getParenOrBraceRange()` to get the location of the opening paren or braces instead of searching backwards from the first argument.

For implicit construction, get the range surrounding the first and last arguments.