### PR TITLE
[DirectX] Add support for typedBufferLoad and Store for RWBuffer<double2> and RWBuffer<double>

### DIFF
--- a/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
+++ b/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
@@ -70,14 +70,14 @@ static bool isIntrinsicExpansion(Function &F) {
   case Intrinsic::vector_reduce_add:
   case Intrinsic::vector_reduce_fadd:
     return true;
-  case Intrinsic::dx_resource_load_typedbuffer: // want to transform double and
-                                                // double2
+  case Intrinsic::dx_resource_load_typedbuffer:
+    // We need to handle doubles and vector of doubles.
     return F.getReturnType()
         ->getStructElementType(0)
         ->getScalarType()
         ->isDoubleTy();
-  case Intrinsic::dx_resource_store_typedbuffer: // want to transform double and
-                                                 // double2
+  case Intrinsic::dx_resource_store_typedbuffer:
+    // We need to handle doubles and vector of doubles.
     return F.getFunctionType()->getParamType(2)->getScalarType()->isDoubleTy();
   }
   return false;

--- a/llvm/test/CodeGen/DirectX/BufferLoad.ll
+++ b/llvm/test/CodeGen/DirectX/BufferLoad.ll
@@ -202,7 +202,7 @@ define void @loadf64() {
   ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 1 }, i32 1, i1 false) #0
   %buffer = call target("dx.TypedBuffer", double, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
-          i32 0, i32 1, i32 1, i32 0, i1 false)
+          i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
 
   ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]], %dx.types.ResourceProperties { i32 4106, i32 266 }) #0
   %load = call { <2 x i32>, i1 } @llvm.dx.resource.load.typedbuffer(
@@ -218,7 +218,7 @@ define void @loadv2f64() {
   ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 1 }, i32 1, i1 false) #0
   %buffer = call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
-          i32 0, i32 1, i32 1, i32 0, i1 false)
+          i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
 
   ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]], %dx.types.ResourceProperties { i32 4106, i32 522 }) #0
   %load = call { <4 x i32>, i1 } @llvm.dx.resource.load.typedbuffer(

--- a/llvm/test/CodeGen/DirectX/BufferLoad.ll
+++ b/llvm/test/CodeGen/DirectX/BufferLoad.ll
@@ -197,4 +197,36 @@ define void @loadv4i16() {
   ret void
 }
 
+define void @loadf64() {
+  ; show dxil op lower can handle typedbuffer load where target is double but load type is <2 x i32>
+  ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 1 }, i32 1, i1 false) #0
+  %buffer = call target("dx.TypedBuffer", double, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
+          i32 0, i32 1, i32 1, i32 0, i1 false)
+
+  ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]], %dx.types.ResourceProperties { i32 4106, i32 266 }) #0
+  %load = call { <2 x i32>, i1 } @llvm.dx.resource.load.typedbuffer(
+      target("dx.TypedBuffer", double, 1, 0, 0) %buffer, i32 0)
+
+; CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle [[BA]], i32 0, i32 undef) #1
+  %val = extractvalue { <2 x i32>, i1 } %load, 0
+  ret void
+}
+
+define void @loadv2f64() {
+  ; show dxil op lower can handle typedbuffer load where target is double2 but load type is <4 x i32>
+  ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 1 }, i32 1, i1 false) #0
+  %buffer = call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
+          i32 0, i32 1, i32 1, i32 0, i1 false)
+
+  ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]], %dx.types.ResourceProperties { i32 4106, i32 522 }) #0
+  %load = call { <4 x i32>, i1 } @llvm.dx.resource.load.typedbuffer(
+      target("dx.TypedBuffer", <2 x double>, 1, 0, 0) %buffer, i32 0)
+
+  ; CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle [[BA]], i32 0, i32 undef) #1
+  %val = extractvalue { <4 x i32>, i1 } %load, 0
+  ret void
+}
+
 ; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(read) {{.*}}}

--- a/llvm/test/CodeGen/DirectX/BufferLoadDouble.ll
+++ b/llvm/test/CodeGen/DirectX/BufferLoadDouble.ll
@@ -11,8 +11,6 @@ define void @loadf64() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
           i32 0, i32 1, i32 1, i32 0, i1 false)
 
-  ret void
-
   ; check we load an <2 x i32> instead of a double
   ; CHECK-NOT: call {double, i1} @llvm.dx.resource.load.typedbuffer
   ; CHECK: [[L0:%.*]] = call { <2 x i32>, i1 }
@@ -23,14 +21,10 @@ define void @loadf64() {
 
   ; check we extract the two i32 and construct a double
   ; CHECK: [[D0:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 0
-  ; CHECK: [[Lo:%.*]] = extractelement <2 x i32> [[D0]], i64 0
-  ; CHECK: [[Hi:%.*]] = extractelement <2 x i32> [[D0]], i64 1
+  ; CHECK: [[Lo:%.*]] = extractelement <2 x i32> [[D0]], i32 0
+  ; CHECK: [[Hi:%.*]] = extractelement <2 x i32> [[D0]], i32 1
   ; CHECK: [[DBL:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo]], i32 [[Hi]])
-  ; construct a new {double, i1}
-  ; CHECK: [[CB:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 1
-  ; CHECK: [[S1:%.*]] = insertvalue { double, i1 } poison, double [[DBL]], 0
-  ; CHECK: [[S2:%.*]] = insertvalue { double, i1 } [[S1]], i1 [[CB]], 1
-  ; CHECK: extractvalue { double, i1 } [[S2]], 0
+  ; CHECK-NOT: extractvalue { double, i1 }
   %data0 = extractvalue {double, i1} %load0, 0
   ret void
 }
@@ -53,19 +47,15 @@ define void @loadv2f64() {
 
   ; check we extract the 4 i32 and construct a <2 x double>
   ; CHECK: [[D0:%.*]] = extractvalue { <4 x i32>, i1 } [[L0]], 0
-  ; CHECK: [[Lo1:%.*]] = extractelement <4 x i32> [[D0]], i64 0
-  ; CHECK: [[Hi1:%.*]] = extractelement <4 x i32> [[D0]], i64 1
-  ; CHECK: [[Lo2:%.*]] = extractelement <4 x i32> [[D0]], i64 2
-  ; CHECK: [[Hi2:%.*]] = extractelement <4 x i32> [[D0]], i64 3
+  ; CHECK: [[Lo1:%.*]] = extractelement <4 x i32> [[D0]], i32 0
+  ; CHECK: [[Hi1:%.*]] = extractelement <4 x i32> [[D0]], i32 1
+  ; CHECK: [[Lo2:%.*]] = extractelement <4 x i32> [[D0]], i32 2
+  ; CHECK: [[Hi2:%.*]] = extractelement <4 x i32> [[D0]], i32 3
   ; CHECK: [[Dbl1:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo1]], i32 [[Hi1]])
-  ; CHECK: [[Vec:%.*]] = insertelement <2 x double> poison, double [[Dbl1]], i64 0
+  ; CHECK: [[Vec:%.*]] = insertelement <2 x double> poison, double [[Dbl1]], i32 0
   ; CHECK: [[Dbl2:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo2]], i32 [[Hi2]])
-  ; CHECK: [[Vec2:%.*]] = insertelement <2 x double> [[Vec]], double [[Dbl2]], i64 1
-  ; construct a new {<2 x double>, i1}
-  ; CHECK: [[CB:%.*]] = extractvalue { <4 x i32>, i1 } [[L0]], 1
-  ; CHECK: [[S1:%.*]] = insertvalue { <2 x double>, i1 } poison, <2 x double> [[Vec2]], 0
-  ; CHECK: [[S2:%.*]] = insertvalue { <2 x double>, i1 } [[S1]], i1 [[CB]], 1
-  ; CHECK: extractvalue { <2 x double>, i1 } [[S2]], 0
+  ; CHECK: [[Vec2:%.*]] = insertelement <2 x double> [[Vec]], double [[Dbl2]], i32 1
+  ; CHECK-NOT: extractvalue { <2 x double>, i1 }
   %data0 = extractvalue { <2 x double>, i1 } %load0, 0
   ret void
 }
@@ -80,8 +70,6 @@ define void @loadf64WithCheckBit() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
           i32 0, i32 1, i32 1, i32 0, i1 false)
 
-  ret void
-
   ; check we load an <2 x i32> instead of a double
   ; CHECK-NOT: call {double, i1} @llvm.dx.resource.load.typedbuffer
   ; CHECK: [[L0:%.*]] = call { <2 x i32>, i1 }
@@ -92,16 +80,12 @@ define void @loadf64WithCheckBit() {
 
   ; check we extract the two i32 and construct a double
   ; CHECK: [[D0:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 0
-  ; CHECK: [[Lo:%.*]] = extractelement <2 x i32> [[D0]], i64 0
-  ; CHECK: [[Hi:%.*]] = extractelement <2 x i32> [[D0]], i64 1
+  ; CHECK: [[Lo:%.*]] = extractelement <2 x i32> [[D0]], i32 0
+  ; CHECK: [[Hi:%.*]] = extractelement <2 x i32> [[D0]], i32 1
   ; CHECK: [[DBL:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo]], i32 [[Hi]])
-  ; construct a new {double, i1}
-  ; CHECK: [[CB:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 1
-  ; CHECK: [[S1:%.*]] = insertvalue { double, i1 } poison, double [[DBL]], 0
-  ; CHECK: [[S2:%.*]] = insertvalue { double, i1 } [[S1]], i1 [[CB]], 1
-  ; CHECK: extractvalue { double, i1 } [[S2]], 0
   %data0 = extractvalue {double, i1} %load0, 0
-  ; CHECK: extractvalue { double, i1 } [[S2]], 1
+  ; CHECK: extractvalue { <2 x i32>, i1 } [[L0]], 1
+  ; CHECK-NOT: extractvalue { double, i1 }
   %cb = extractvalue {double, i1} %load0, 1
   ret void
 }

--- a/llvm/test/CodeGen/DirectX/BufferLoadDouble.ll
+++ b/llvm/test/CodeGen/DirectX/BufferLoadDouble.ll
@@ -6,10 +6,10 @@ define void @loadf64() {
   ; check the handle from binding is unchanged
   ; CHECK: [[B:%.*]] = call target("dx.TypedBuffer", double, 1, 0, 0)
   ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
-  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false)
+  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
   %buffer = call target("dx.TypedBuffer", double, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
-          i32 0, i32 1, i32 1, i32 0, i1 false)
+          i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
 
   ; check we load an <2 x i32> instead of a double
   ; CHECK-NOT: call {double, i1} @llvm.dx.resource.load.typedbuffer
@@ -33,10 +33,10 @@ define void @loadv2f64() {
   ; check the handle from binding is unchanged
   ; CHECK: [[B:%.*]] = call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
   ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
-  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false)
+  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
   %buffer = call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
-          i32 0, i32 1, i32 1, i32 0, i1 false)
+          i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
 
   ; check we load an <4 x i32> instead of a double2
   ; CHECK: [[L0:%.*]] = call { <4 x i32>, i1 }
@@ -65,10 +65,10 @@ define void @loadf64WithCheckBit() {
   ; check the handle from binding is unchanged
   ; CHECK: [[B:%.*]] = call target("dx.TypedBuffer", double, 1, 0, 0)
   ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
-  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false)
+  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
   %buffer = call target("dx.TypedBuffer", double, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
-          i32 0, i32 1, i32 1, i32 0, i1 false)
+          i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
 
   ; check we load an <2 x i32> instead of a double
   ; CHECK-NOT: call {double, i1} @llvm.dx.resource.load.typedbuffer

--- a/llvm/test/CodeGen/DirectX/BufferLoadDouble.ll
+++ b/llvm/test/CodeGen/DirectX/BufferLoadDouble.ll
@@ -1,0 +1,58 @@
+; RUN: opt -S -dxil-intrinsic-expansion %s | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+define void @loadf64() {
+  ; check the handle from binding is unchanged
+  ; CHECK: [[B:%.*]] = call target("dx.TypedBuffer", double, 1, 0, 0)
+  ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
+  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false)
+  %buffer = call target("dx.TypedBuffer", double, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
+          i32 0, i32 1, i32 1, i32 0, i1 false)
+
+  ; check we load an <2 x i32> instead of a double
+  ; CHECK: [[L0:%.*]] = call { <2 x i32>, i1 }
+  ; CHECK-SAME: @llvm.dx.resource.load.typedbuffer.v2i32.tdx.TypedBuffer_f64_1_0_0t(
+  ; CHECK-SAME: target("dx.TypedBuffer", double, 1, 0, 0) [[B]], i32 0)	
+  %load0 = call {double, i1} @llvm.dx.resource.load.typedbuffer(
+      target("dx.TypedBuffer", double, 1, 0, 0) %buffer, i32 0)
+
+  ; check we extract the two i32 and construct a double
+  ; CHECK: [[D0:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 0
+  ; CHECK: [[Lo:%.*]] = extractelement <2 x i32> [[D0]], i64 0
+  ; CHECK: [[Hi:%.*]] = extractelement <2 x i32> [[D0]], i64 1
+  ; CHECK: call double @llvm.dx.asdouble.i32(i32 [[Lo]], i32 [[Hi]])
+  %data0 = extractvalue {double, i1} %load0, 0
+  ret void
+}
+
+define void @loadv2f64() {
+  ; check the handle from binding is unchanged
+  ; CHECK: [[B:%.*]] = call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
+  ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
+  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false)
+  %buffer = call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
+          i32 0, i32 1, i32 1, i32 0, i1 false)
+
+  ; check we load an <4 x i32> instead of a double2
+  ; CHECK: [[L0:%.*]] = call { <4 x i32>, i1 }
+  ; CHECK-SAME: @llvm.dx.resource.load.typedbuffer.v4i32.tdx.TypedBuffer_v2f64_1_0_0t(
+  ; CHECK-SAME: target("dx.TypedBuffer", <2 x double>, 1, 0, 0) [[B]], i32 0)
+  %load0 = call { <2 x double>, i1 } @llvm.dx.resource.load.typedbuffer(
+      target("dx.TypedBuffer", <2 x double>, 1, 0, 0) %buffer, i32 0)
+
+  ; check we extract the 4 i32 and construct a <2 x double>
+  ; CHECK: [[D0:%.*]] = extractvalue { <4 x i32>, i1 } [[L0]], 0
+  ; CHECK: [[Lo1:%.*]] = extractelement <4 x i32> [[D0]], i64 0
+  ; CHECK: [[Hi1:%.*]] = extractelement <4 x i32> [[D0]], i64 1
+  ; CHECK: [[Lo2:%.*]] = extractelement <4 x i32> [[D0]], i64 2
+  ; CHECK: [[Hi2:%.*]] = extractelement <4 x i32> [[D0]], i64 3
+  ; CHECK: [[Dbl1:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo1]], i32 [[Hi1]])
+  ; CHECK: [[Vec:%.*]] = insertelement <2 x double> poison, double [[Dbl1]], i64 0
+  ; CHECK: [[Dbl2:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo2]], i32 [[Hi2]])
+  ; CHECK: insertelement <2 x double> [[Vec]], double [[Dbl2]], i64 1
+  %data0 = extractvalue { <2 x double>, i1 } %load0, 0
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/BufferLoadDouble.ll
+++ b/llvm/test/CodeGen/DirectX/BufferLoadDouble.ll
@@ -11,7 +11,10 @@ define void @loadf64() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
           i32 0, i32 1, i32 1, i32 0, i1 false)
 
+  ret void
+
   ; check we load an <2 x i32> instead of a double
+  ; CHECK-NOT: call {double, i1} @llvm.dx.resource.load.typedbuffer
   ; CHECK: [[L0:%.*]] = call { <2 x i32>, i1 }
   ; CHECK-SAME: @llvm.dx.resource.load.typedbuffer.v2i32.tdx.TypedBuffer_f64_1_0_0t(
   ; CHECK-SAME: target("dx.TypedBuffer", double, 1, 0, 0) [[B]], i32 0)	
@@ -22,7 +25,12 @@ define void @loadf64() {
   ; CHECK: [[D0:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 0
   ; CHECK: [[Lo:%.*]] = extractelement <2 x i32> [[D0]], i64 0
   ; CHECK: [[Hi:%.*]] = extractelement <2 x i32> [[D0]], i64 1
-  ; CHECK: call double @llvm.dx.asdouble.i32(i32 [[Lo]], i32 [[Hi]])
+  ; CHECK: [[DBL:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo]], i32 [[Hi]])
+  ; construct a new {double, i1}
+  ; CHECK: [[CB:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 1
+  ; CHECK: [[S1:%.*]] = insertvalue { double, i1 } poison, double [[DBL]], 0
+  ; CHECK: [[S2:%.*]] = insertvalue { double, i1 } [[S1]], i1 [[CB]], 1
+  ; CHECK: extractvalue { double, i1 } [[S2]], 0
   %data0 = extractvalue {double, i1} %load0, 0
   ret void
 }
@@ -52,7 +60,48 @@ define void @loadv2f64() {
   ; CHECK: [[Dbl1:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo1]], i32 [[Hi1]])
   ; CHECK: [[Vec:%.*]] = insertelement <2 x double> poison, double [[Dbl1]], i64 0
   ; CHECK: [[Dbl2:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo2]], i32 [[Hi2]])
-  ; CHECK: insertelement <2 x double> [[Vec]], double [[Dbl2]], i64 1
+  ; CHECK: [[Vec2:%.*]] = insertelement <2 x double> [[Vec]], double [[Dbl2]], i64 1
+  ; construct a new {<2 x double>, i1}
+  ; CHECK: [[CB:%.*]] = extractvalue { <4 x i32>, i1 } [[L0]], 1
+  ; CHECK: [[S1:%.*]] = insertvalue { <2 x double>, i1 } poison, <2 x double> [[Vec2]], 0
+  ; CHECK: [[S2:%.*]] = insertvalue { <2 x double>, i1 } [[S1]], i1 [[CB]], 1
+  ; CHECK: extractvalue { <2 x double>, i1 } [[S2]], 0
   %data0 = extractvalue { <2 x double>, i1 } %load0, 0
+  ret void
+}
+
+; show we properly handle extracting the check bit
+define void @loadf64WithCheckBit() {
+  ; check the handle from binding is unchanged
+  ; CHECK: [[B:%.*]] = call target("dx.TypedBuffer", double, 1, 0, 0)
+  ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
+  ; CHECK-SAME: i32 0, i32 1, i32 1, i32 0, i1 false)
+  %buffer = call target("dx.TypedBuffer", double, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
+          i32 0, i32 1, i32 1, i32 0, i1 false)
+
+  ret void
+
+  ; check we load an <2 x i32> instead of a double
+  ; CHECK-NOT: call {double, i1} @llvm.dx.resource.load.typedbuffer
+  ; CHECK: [[L0:%.*]] = call { <2 x i32>, i1 }
+  ; CHECK-SAME: @llvm.dx.resource.load.typedbuffer.v2i32.tdx.TypedBuffer_f64_1_0_0t(
+  ; CHECK-SAME: target("dx.TypedBuffer", double, 1, 0, 0) [[B]], i32 0)	
+  %load0 = call {double, i1} @llvm.dx.resource.load.typedbuffer(
+      target("dx.TypedBuffer", double, 1, 0, 0) %buffer, i32 0)
+
+  ; check we extract the two i32 and construct a double
+  ; CHECK: [[D0:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 0
+  ; CHECK: [[Lo:%.*]] = extractelement <2 x i32> [[D0]], i64 0
+  ; CHECK: [[Hi:%.*]] = extractelement <2 x i32> [[D0]], i64 1
+  ; CHECK: [[DBL:%.*]] = call double @llvm.dx.asdouble.i32(i32 [[Lo]], i32 [[Hi]])
+  ; construct a new {double, i1}
+  ; CHECK: [[CB:%.*]] = extractvalue { <2 x i32>, i1 } [[L0]], 1
+  ; CHECK: [[S1:%.*]] = insertvalue { double, i1 } poison, double [[DBL]], 0
+  ; CHECK: [[S2:%.*]] = insertvalue { double, i1 } [[S1]], i1 [[CB]], 1
+  ; CHECK: extractvalue { double, i1 } [[S2]], 0
+  %data0 = extractvalue {double, i1} %load0, 0
+  ; CHECK: extractvalue { double, i1 } [[S2]], 1
+  %cb = extractvalue {double, i1} %load0, 1
   ret void
 }

--- a/llvm/test/CodeGen/DirectX/BufferStore.ll
+++ b/llvm/test/CodeGen/DirectX/BufferStore.ll
@@ -161,3 +161,44 @@ define void @store_scalarized_floats(float %data0, float %data1, float %data2, f
 
   ret void
 }
+
+define void @storef64(<2 x i32> %0) {
+  ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217,
+  ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]]
+  
+  %buffer = tail call target("dx.TypedBuffer", double, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
+          i32 0, i32 0, i32 1, i32 0, i1 false)
+
+  ; The temporary casts should all have been cleaned up
+  ; CHECK-NOT: %dx.resource.casthandle
+
+  ; CHECK: [[D0:%.*]] = extractelement <2 x i32> %0, i32 0
+  ; CHECK: [[D1:%.*]] = extractelement <2 x i32> %0, i32 1
+  ; CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle [[BA]], i32 0, i32 undef, i32 %2, i32 %3, i32 %2, i32 %2, i8 15)
+  call void @llvm.dx.resource.store.typedbuffer(
+      target("dx.TypedBuffer", double, 1, 0, 0) %buffer, i32 0, <2 x i32> %0)
+  ret void
+}
+
+define void @storev2f64(<4 x i32> %0) {
+  ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217,
+  ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]]
+  
+  %buffer = tail call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
+          i32 0, i32 0, i32 1, i32 0, i1 false)
+
+  ; The temporary casts should all have been cleaned up
+  ; CHECK-NOT: %dx.resource.casthandle
+
+  ; CHECK: [[D0:%.*]] = extractelement <4 x i32> %0, i32 0
+  ; CHECK: [[D1:%.*]] = extractelement <4 x i32> %0, i32 1
+  ; CHECK: [[D2:%.*]] = extractelement <4 x i32> %0, i32 2
+  ; CHECK: [[D3:%.*]] = extractelement <4 x i32> %0, i32 3
+  ; CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle [[BA]], i32 0, i32 undef, i32 [[D0]], i32 [[D1]], i32 [[D2]], i32 [[D3]], i8 15)
+  call void @llvm.dx.resource.store.typedbuffer(
+      target("dx.TypedBuffer", <2 x double>, 1, 0, 0) %buffer, i32 0,
+      <4 x i32> %0)
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/BufferStore.ll
+++ b/llvm/test/CodeGen/DirectX/BufferStore.ll
@@ -168,7 +168,7 @@ define void @storef64(<2 x i32> %0) {
   
   %buffer = tail call target("dx.TypedBuffer", double, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
-          i32 0, i32 0, i32 1, i32 0, i1 false)
+          i32 0, i32 0, i32 1, i32 0, i1 false, ptr null)
 
   ; The temporary casts should all have been cleaned up
   ; CHECK-NOT: %dx.resource.casthandle
@@ -187,7 +187,7 @@ define void @storev2f64(<4 x i32> %0) {
   
   %buffer = tail call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
-          i32 0, i32 0, i32 1, i32 0, i1 false)
+          i32 0, i32 0, i32 1, i32 0, i1 false, ptr null)
 
   ; The temporary casts should all have been cleaned up
   ; CHECK-NOT: %dx.resource.casthandle

--- a/llvm/test/CodeGen/DirectX/BufferStoreDouble.ll
+++ b/llvm/test/CodeGen/DirectX/BufferStoreDouble.ll
@@ -5,10 +5,10 @@ target triple = "dxil-pc-shadermodel6.6-compute"
 define void @storef64(double %0) {
   ; CHECK: [[B:%.*]] = tail call target("dx.TypedBuffer", double, 1, 0, 0)
   ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
-  ; CHECK-SAME: i32 0, i32 0, i32 1, i32 0, i1 false)
+  ; CHECK-SAME: i32 0, i32 0, i32 1, i32 0, i1 false, ptr null)
   %buffer = tail call target("dx.TypedBuffer", double, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
-          i32 0, i32 0, i32 1, i32 0, i1 false)
+          i32 0, i32 0, i32 1, i32 0, i1 false, ptr null)
 
   ; check we split the double and store the lo and hi bits
   ; CHECK: [[SD:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double %0)
@@ -28,10 +28,10 @@ define void @storef64(double %0) {
 define void @storev2f64(<2 x double> %0) {
   ; CHECK: [[B:%.*]] = tail call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
   ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
-  ; CHECK-SAME: i32 0, i32 0, i32 1, i32 0, i1 false)
+  ; CHECK-SAME: i32 0, i32 0, i32 1, i32 0, i1 false, ptr null)
   %buffer = tail call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
-          i32 0, i32 0, i32 1, i32 0, i1 false)
+          i32 0, i32 0, i32 1, i32 0, i1 false, ptr null)
 
   ; CHECK: [[SD:%.*]] = call { <2 x i32>, <2 x i32> }
   ; CHECK-SAME: @llvm.dx.splitdouble.v2i32(<2 x double> %0)

--- a/llvm/test/CodeGen/DirectX/BufferStoreDouble.ll
+++ b/llvm/test/CodeGen/DirectX/BufferStoreDouble.ll
@@ -1,0 +1,47 @@
+; RUN: opt -S -dxil-intrinsic-expansion %s | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+define void @storef64(double %0) {
+  ; CHECK: [[B:%.*]] = tail call target("dx.TypedBuffer", double, 1, 0, 0)
+  ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
+  ; CHECK-SAME: i32 0, i32 0, i32 1, i32 0, i1 false)
+  %buffer = tail call target("dx.TypedBuffer", double, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
+          i32 0, i32 0, i32 1, i32 0, i1 false)
+
+  ; check we split the double and store the lo and hi bits
+  ; CHECK: [[SD:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double %0)
+  ; CHECK: [[Lo:%.*]] = extractvalue { i32, i32 } [[SD]], 0
+  ; CHECK: [[Hi:%.*]] = extractvalue { i32, i32 } [[SD]], 1
+  ; CHECK: [[Vec1:%.*]] = insertelement <2 x i32> poison, i32 [[Lo]], i64 0
+  ; CHECK: [[Vec2:%.*]] = insertelement <2 x i32> [[Vec1]], i32 [[Hi]], i64 1
+  ; CHECK: call void @llvm.dx.resource.store.typedbuffer.tdx.TypedBuffer_f64_1_0_0t.v2i32(
+  ; CHECK-SAME: target("dx.TypedBuffer", double, 1, 0, 0) [[B]], i32 0, <2 x i32> [[Vec2]])
+  call void @llvm.dx.resource.store.typedbuffer(
+      target("dx.TypedBuffer", double, 1, 0, 0) %buffer, i32 0,
+      double %0)
+  ret void
+}
+
+
+define void @storev2f64(<2 x double> %0) {
+  ; CHECK: [[B:%.*]] = tail call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
+  ; CHECK-SAME: @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
+  ; CHECK-SAME: i32 0, i32 0, i32 1, i32 0, i1 false)
+  %buffer = tail call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
+          i32 0, i32 0, i32 1, i32 0, i1 false)
+
+  ; CHECK: [[SD:%.*]] = call { <2 x i32>, <2 x i32> }
+  ; CHECK-SAME: @llvm.dx.splitdouble.v2i32(<2 x double> %0)
+  ; CHECK: [[Lo:%.*]] = extractvalue { <2 x i32>, <2 x i32> } [[SD]], 0
+  ; CHECK: [[Hi:%.*]] = extractvalue { <2 x i32>, <2 x i32> } [[SD]], 1
+  ; CHECK: [[Vec:%.*]] = shufflevector <2 x i32> [[Lo]], <2 x i32> [[Hi]], <4 x i32> <i32 0, i32 2, i32 1, i32 3>
+  ; CHECK: call void @llvm.dx.resource.store.typedbuffer.tdx.TypedBuffer_v2f64_1_0_0t.v4i32(
+  ; CHECK-SAME: target("dx.TypedBuffer", <2 x double>, 1, 0, 0) [[B]], i32 0, <4 x i32> [[Vec]])
+  call void @llvm.dx.resource.store.typedbuffer(
+      target("dx.TypedBuffer", <2 x double>, 1, 0, 0) %buffer, i32 0,
+      <2 x double> %0)
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/BufferStoreDouble.ll
+++ b/llvm/test/CodeGen/DirectX/BufferStoreDouble.ll
@@ -14,8 +14,8 @@ define void @storef64(double %0) {
   ; CHECK: [[SD:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double %0)
   ; CHECK: [[Lo:%.*]] = extractvalue { i32, i32 } [[SD]], 0
   ; CHECK: [[Hi:%.*]] = extractvalue { i32, i32 } [[SD]], 1
-  ; CHECK: [[Vec1:%.*]] = insertelement <2 x i32> poison, i32 [[Lo]], i64 0
-  ; CHECK: [[Vec2:%.*]] = insertelement <2 x i32> [[Vec1]], i32 [[Hi]], i64 1
+  ; CHECK: [[Vec1:%.*]] = insertelement <2 x i32> poison, i32 [[Lo]], i32 0
+  ; CHECK: [[Vec2:%.*]] = insertelement <2 x i32> [[Vec1]], i32 [[Hi]], i32 1
   ; CHECK: call void @llvm.dx.resource.store.typedbuffer.tdx.TypedBuffer_f64_1_0_0t.v2i32(
   ; CHECK-SAME: target("dx.TypedBuffer", double, 1, 0, 0) [[B]], i32 0, <2 x i32> [[Vec2]])
   call void @llvm.dx.resource.store.typedbuffer(


### PR DESCRIPTION
typedBufferLoad of double/double2 is expanded to a typedBufferLoad of a <2 x i32>/<4 x i32> and asdouble
typedBufferStore of a double/double2 is expanded to a splitdouble and a typedBufferStore of a <2 x i32>/<4 x i32>
Add tests showing result of intrinsic expansion for typedBufferLoad and typedBufferStore
Add tests showing dxil op lowering can handle typedBufferLoad and typedBufferStore where the target type doesn't match the typedBufferLoad and typedBufferStore type
Closes #104423 