### PR TITLE
Add modernize-use-span linter check

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
@@ -42,6 +42,7 @@ add_clang_library(clangTidyModernizeModule STATIC
   UseNullptrCheck.cpp
   UseOverrideCheck.cpp
   UseRangesCheck.cpp
+  UseSpanCheck.cpp
   UseStartsEndsWithCheck.cpp
   UseStdFormatCheck.cpp
   UseStdNumbersCheck.cpp

--- a/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
@@ -43,6 +43,7 @@
 #include "UseNullptrCheck.h"
 #include "UseOverrideCheck.h"
 #include "UseRangesCheck.h"
+#include "UseSpanCheck.h"
 #include "UseStartsEndsWithCheck.h"
 #include "UseStdFormatCheck.h"
 #include "UseStdNumbersCheck.h"
@@ -80,6 +81,8 @@ public:
     CheckFactories.registerCheck<UseIntegerSignComparisonCheck>(
         "modernize-use-integer-sign-comparison");
     CheckFactories.registerCheck<UseRangesCheck>("modernize-use-ranges");
+    CheckFactories.registerCheck<UseSpanCheck>(
+        "modernize-use-span");
     CheckFactories.registerCheck<UseStartsEndsWithCheck>(
         "modernize-use-starts-ends-with");
     CheckFactories.registerCheck<UseStdFormatCheck>("modernize-use-std-format");

--- a/clang-tools-extra/clang-tidy/modernize/UseSpanCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseSpanCheck.cpp
@@ -1,0 +1,142 @@
+//===--- UseSpanCheck.cpp - clang-tidy ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "UseSpanCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Lex/Lexer.h"
+#include "../utils/IncludeInserter.h"
+#include <string>
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::modernize {
+
+namespace {
+AST_MATCHER(QualType, isRefToVectorOrArray) {
+  if (!Node->isReferenceType())
+    return false;
+
+  QualType PointeeType = Node->getPointeeType();
+
+  const Type *UnqualifiedType = PointeeType.getTypePtr()->getUnqualifiedDesugaredType();
+  if (!UnqualifiedType || !UnqualifiedType->isRecordType())
+    return false;
+
+  const CXXRecordDecl *Record = UnqualifiedType->getAsCXXRecordDecl();
+  if (!Record)
+    return false;
+
+  const std::string Name = Record->getQualifiedNameAsString();
+  return Name == "std::vector" || Name == "std::array";
+}
+} // namespace
+
+UseSpanCheck::UseSpanCheck(StringRef Name, ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      Inserter(utils::IncludeSorter::IS_LLVM, areDiagsSelfContained()) {}
+
+void UseSpanCheck::registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
+                                       Preprocessor *ModuleExpanderPP) {
+  Inserter.registerPreprocessor(PP);
+}
+
+void UseSpanCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      functionDecl(
+          forEachDescendant(
+              parmVarDecl(hasType(qualType(isRefToVectorOrArray())))
+                  .bind("param"))),
+      this);
+}
+
+void UseSpanCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *Param = Result.Nodes.getNodeAs<ParmVarDecl>("param");
+  if (!Param)
+    return;
+
+  QualType ParamType = Param->getType();
+  if (!ParamType->isReferenceType())
+    return;
+
+  // Get the pointee type (the vector/array type)
+  QualType PointeeType = ParamType->getPointeeType();
+  bool IsConst = PointeeType.isConstQualified();
+
+  const Type *UnqualifiedType = PointeeType.getTypePtr()->getUnqualifiedDesugaredType();
+  if (!UnqualifiedType || !UnqualifiedType->isRecordType())
+    return;
+
+  const CXXRecordDecl *Record = UnqualifiedType->getAsCXXRecordDecl();
+  if (!Record)
+    return;
+
+  const std::string RecordName = Record->getQualifiedNameAsString();
+  if (RecordName != "std::vector" && RecordName != "std::array")
+    return;
+
+  // Check if it's a template specialization
+  if (!isa<ClassTemplateSpecializationDecl>(Record))
+    return;
+
+  // Get the template arguments
+  const auto *TemplateSpecRecord = cast<ClassTemplateSpecializationDecl>(Record);
+  const TemplateArgumentList &Args = TemplateSpecRecord->getTemplateArgs();
+  if (Args.size() < 1)
+    return;
+
+  // Get the element type from the first template argument
+  const TemplateArgument &Arg = Args[0];
+  if (Arg.getKind() != TemplateArgument::Type)
+    return;
+
+  QualType ElementType = Arg.getAsType();
+
+  // Get the source range for the parameter type
+  TypeSourceInfo *TSI = Param->getTypeSourceInfo();
+  TypeLoc TL = TSI->getTypeLoc();
+
+  // Get the source range for the entire type, including qualifiers
+  SourceRange TypeRange = TL.getSourceRange();
+
+  // Create the diagnostic
+  auto Diag = diag(Param->getBeginLoc(),
+                  "parameter %0 is reference to %1; consider using std::span instead")
+      << Param
+      << (RecordName == "std::vector" ? "std::vector" : "std::array");
+
+  // Create the fix-it hint
+  std::string SpanType;
+  std::string ElementTypeWithConst = IsConst ? "const " + ElementType.getAsString() : ElementType.getAsString();
+
+  // For std::array, we should preserve the size in the span
+  if (RecordName == "std::array" && Args.size() >= 2) {
+    const TemplateArgument &SizeArg = Args[1];
+    if (SizeArg.getKind() == TemplateArgument::Integral) {
+      llvm::APSInt Size = SizeArg.getAsIntegral();
+      // Convert APSInt to string
+      SmallString<16> SizeStr;
+      Size.toString(SizeStr, 10);
+      SpanType = "std::span<" + ElementTypeWithConst + ", " + SizeStr.str().str() + ">";
+    } else {
+      SpanType = "std::span<" + ElementTypeWithConst + ">";
+    }
+  } else {
+    SpanType = "std::span<" + ElementTypeWithConst + ">";
+  }
+
+  // Create the replacement for the entire type including qualifiers
+  Diag << FixItHint::CreateReplacement(TypeRange, SpanType);
+
+  // Add the include for <span>
+  Diag << Inserter.createIncludeInsertion(
+      Result.SourceManager->getFileID(Param->getBeginLoc()),
+      "<span>");
+}
+
+} // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseSpanCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseSpanCheck.h
@@ -1,0 +1,39 @@
+//===--- UseSpanCheck.h - clang-tidy ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USESPANCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USESPANCHECK_H
+
+#include "../ClangTidyCheck.h"
+#include "../utils/IncludeInserter.h"
+
+namespace clang::tidy::modernize {
+
+/// Suggests replacing const references to std::vector and std::array with
+/// std::span.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-span.html
+class UseSpanCheck : public ClangTidyCheck {
+public:
+  UseSpanCheck(StringRef Name, ClangTidyContext *Context);
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
+                           Preprocessor *ModuleExpanderPP) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus20;
+  }
+
+private:
+  utils::IncludeInserter Inserter;
+};
+
+} // namespace clang::tidy::modernize
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USESPANCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -136,6 +136,12 @@ New checks
   Finds potentially erroneous calls to ``reset`` method on smart pointers when
   the pointee type also has a ``reset`` method.
 
+- New :doc:`modernize-use-span
+  <clang-tidy/checks/modernize/use-span>` check.
+
+  Suggests replacing const references to std::vector and std::array with
+  std::span.
+
 New check aliases
 ^^^^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -310,6 +310,7 @@ Clang-Tidy Checks
    :doc:`modernize-use-nullptr <modernize/use-nullptr>`, "Yes"
    :doc:`modernize-use-override <modernize/use-override>`, "Yes"
    :doc:`modernize-use-ranges <modernize/use-ranges>`, "Yes"
+   :doc:`modernize-use-span <modernize/use-span>`, "Yes"
    :doc:`modernize-use-starts-ends-with <modernize/use-starts-ends-with>`, "Yes"
    :doc:`modernize-use-std-format <modernize/use-std-format>`, "Yes"
    :doc:`modernize-use-std-numbers <modernize/use-std-numbers>`, "Yes"

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-span.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-span.rst
@@ -1,0 +1,48 @@
+.. title:: clang-tidy - modernize-use-span
+
+modernize-use-span
+==================
+
+This check suggests using ``std::span`` in function parameters when taking a
+range of contiguous elements by reference. ``std::span`` can accept vectors,
+arrays, and C-style arrays, so the function is no longer bound to a specific
+container type.
+
+This check implements `R.14<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-ap>``
+from the C++ Core Guidelines.
+
+This check requires C++20 or later.
+
+Examples
+--------
+
+.. code-block:: c++
+
+  // Before
+  void process(const std::vector<int>& vec) {
+    for (const auto& val : vec) {
+      // Process val
+    }
+  }
+
+  void analyze(const std::array<double, 5>& arr) {
+    for (const auto& val : arr) {
+      // Analyze val
+    }
+  }
+
+  // After
+  void process(std::span<const int> vec) {
+    for (const auto& val : vec) {
+      // Process val
+    }
+  }
+
+  void analyze(std::span<const double, 5> arr) {
+    for (const auto& val : arr) {
+      // Analyze val
+    }
+  }
+
+The transformed code can now accept any contiguous container of the appropriate
+element type and optionally specified length.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-span.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-span.cpp
@@ -1,0 +1,131 @@
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-span %t
+
+// Mock std::vector and std::array for testing
+using size_t = unsigned long;
+using ptrdiff_t = long;
+
+namespace std {
+template <typename T>
+struct remove_cv { using type = T; };
+template <typename T>
+using remove_cv_t = typename remove_cv<T>::type;
+
+template <typename Iter>
+class reverse_iterator {};
+
+template <typename T>
+class vector {
+public:
+  using value_type = T;
+  using iterator = T*;
+  using const_iterator = const T*;
+  const_iterator begin() const { return nullptr; }
+  const_iterator end() const { return nullptr; }
+};
+
+template <typename T, size_t N>
+class array {
+public:
+  using value_type = T;
+  using iterator = T*;
+  using const_iterator = const T*;
+  const_iterator begin() const { return nullptr; }
+  const_iterator end() const { return nullptr; }
+};
+
+template <typename T, size_t Extent = size_t(-1)>
+class span {
+public:
+  using element_type = T;
+  using value_type = std::remove_cv_t<T>;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using iterator = pointer;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+};
+} // namespace std
+
+// Test cases that should trigger the check
+
+// Case 1: Function with const reference to std::vector
+void processVector(const std::vector<int>& vec) {
+// CHECK-MESSAGES: :[[@LINE-1]]:23: warning: parameter 'vec' is const reference to std::vector; consider using std::span instead [modernize-use-span]
+// CHECK-FIXES: void processVector(std::span<const int> vec) {
+  int sum = 0;
+  for (const auto& val : vec) {
+    sum += val;
+  }
+}
+
+// Case 2: Function with const reference to std::array
+void processArray(const std::array<double, 5>& arr) {
+// CHECK-MESSAGES: :[[@LINE-1]]:22: warning: parameter 'arr' is const reference to std::array; consider using std::span instead [modernize-use-span]
+// CHECK-FIXES: void processArray(std::span<const double, 5> arr) {
+  double sum = 0.0;
+  for (const auto& val : arr) {
+    sum += val;
+  }
+}
+
+// Case 3: Method with const reference to std::vector
+class DataProcessor {
+public:
+  void process(const std::vector<float>& data) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: parameter 'data' is const reference to std::vector; consider using std::span instead [modernize-use-span]
+  // CHECK-FIXES: void process(std::span<const float> data) {
+    // Process data
+  }
+};
+
+// Case 4: Function with multiple parameters including const reference to std::vector
+void multiParam(int a, const std::vector<char>& chars, double b) {
+// CHECK-MESSAGES: :[[@LINE-1]]:31: warning: parameter 'chars' is const reference to std::vector; consider using std::span instead [modernize-use-span]
+// CHECK-FIXES: void multiParam(int a, std::span<const char> chars, double b) {
+  // Process chars
+}
+
+// Case 5: Non-const reference to std::vector that modifies an element
+void modifyVector(std::vector<int>& vec) {
+// CHECK-MESSAGES: :[[@LINE-1]]:23: warning: parameter 'vec' is reference to std::vector; consider using std::span instead [modernize-use-span]
+// CHECK-FIXES: void modifyVector(std::span<int> vec) {
+  vec[42] = 1;
+}
+
+// Case 5b: Non-const reference to std::array
+void modifyArray(std::array<double, 5>& arr) {
+// CHECK-MESSAGES: :[[@LINE-1]]:22: warning: parameter 'arr' is reference to std::array; consider using std::span instead [modernize-use-span]
+// CHECK-FIXES: void modifyArray(std::span<double, 5> arr) {
+  // Modify arr
+}
+
+// Test cases that should NOT trigger the check
+
+// Case 6: Const reference to a different container
+void processOtherContainer(const int& str) {
+  // Process str
+}
+
+// Case 7: Value parameter
+void copyVector(std::vector<int> vec) {
+  // Process vec
+}
+
+// Case 8: Const value parameter
+void constCopyVector(const std::vector<int> vec) {
+  // Process vec
+}
+
+// Case 9: Function with rvalue reference
+void moveVector(std::vector<int>&& vec) {
+  // Move from vec
+}
+
+// Case 10: Template function
+template <typename T>
+void processTemplate(const std::vector<T>& vec) {
+  // Process vec
+}


### PR DESCRIPTION
This linter check recommends using `std::span` in function parameters over C-arrays or references to `std::vector` and `std::array`. This is because a `std::span` can take in arguments of C-arrays, vectors, arrays, or any contiguous data structure. The C++ Core Guidelines recommend using spans to pass non-owning views of contiguous memory.

The check triggers as long as contiguous data structure is used in a way that would be supported by `std::span`. For instance, if a function takes a vector, calling `push_back` or using the vector in another function call that needs a vector would prevent this check from triggering

The applied fixit recommends either a compile-time length defined `std::span` (in case of replacing a std::array) or a runtime defined length (in case of replacing std::vector).

TODO:

- [ ] Support C-arrays (needed for C++ Core Guidelines [R.14](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r14-avoid--parameters-prefer-span) )
- [ ] Refactor cv-qualified parameters properly (this current refactors `const std::vector<int>&` to `const std::span<const int>` when it should be `std::span<const int>`, because `std::span` doesn't propagate `const`. **I have no idea how to do this, so I would appreciate advice.**
- [ ] Decide if pointers that are only accessed with an array index should be checked (this is needed for full support of C++ Core Guidelines [I.13](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#i13-do-not-pass-an-array-as-a-single-pointer) and [F.24](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f24-use-a-spant-or-a-span_pt-to-designate-a-half-open-sequence) )
- [ ] Maybe add option for refactoring to `gsl::span` or custom span wrappers?
- [ ] Create test cases for all of the possible refactorings.
- [ ] Mock vector and array properly in the test cases.
- [ ] Actually write the "only refactor if operators are supported by `std::span`" logic