### PR TITLE
[RISCV][Scheduler] Add scheduling definitions for 128-bit Zfa instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZfa.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZfa.td
@@ -177,17 +177,24 @@ def FLEQ_H : FPCmp_rr<0b1010010, 0b100, "fleq.h", FPR16>;
 
 let Predicates = [HasStdExtZfa, HasStdExtQ] in {
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in
-def FLI_Q : FPFLI_r<0b1111011, 0b00001, 0b000, FPR128, "fli.q">;
+def FLI_Q : FPFLI_r<0b1111011, 0b00001, 0b000, FPR128, "fli.q">,
+            Sched<[WriteFLI128]>;
 
+let SchedRW = [WriteFMinMax128, ReadFMinMax128, ReadFMinMax128] in {
 def FMINM_Q: FPALU_rr<0b0010111, 0b010, "fminm.q", FPR128, Commutable=1>;
 def FMAXM_Q: FPALU_rr<0b0010111, 0b011, "fmaxm.q", FPR128, Commutable=1>;
+}
 
-def FROUND_Q : FPUnaryOp_r_frm<0b0100011, 0b00100, FPR128, FPR128, "fround.q">;
+def FROUND_Q : FPUnaryOp_r_frm<0b0100011, 0b00100, FPR128, FPR128, "fround.q">,
+               Sched<[WriteFRoundF128, ReadFRoundF128]>;
 def FROUNDNX_Q : FPUnaryOp_r_frm<0b0100011, 0b00101, FPR128, FPR128, 
-                                 "froundnx.q">;
+                                 "froundnx.q">,
+                 Sched<[WriteFRoundF128, ReadFRoundF128]>;
 
+let SchedRW = [WriteFCmp128, ReadFCmp128, ReadFCmp128] in {
 def FLTQ_Q : FPCmp_rr<0b1010011, 0b101, "fltq.q", FPR128>;
 def FLEQ_Q : FPCmp_rr<0b1010011, 0b100, "fleq.q", FPR128>;
+}
 } // Predicates = [HasStdExtZfa, HasStdExtQ]
 
 let Predicates = [HasStdExtZfa, HasStdExtQ, IsRV64] in {

--- a/llvm/lib/Target/RISCV/RISCVSchedGenericOOO.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedGenericOOO.td
@@ -283,14 +283,12 @@ let Latency = 2 in {
   def : WriteRes<WriteFRoundF16, [GenericOOOFPU]>;
   def : WriteRes<WriteFRoundF32, [GenericOOOFPU]>;
   def : WriteRes<WriteFRoundF64, [GenericOOOFPU]>;
-  def : WriteRes<WriteFRoundF128, [GenericOOOFPU]>;
 }
 
 let Latency = 2 in {
   def : WriteRes<WriteFLI16, [GenericOOOFPU]>;
   def : WriteRes<WriteFLI32, [GenericOOOFPU]>;
   def : WriteRes<WriteFLI64, [GenericOOOFPU]>;
-  def : WriteRes<WriteFLI128, [GenericOOOFPU]>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -467,7 +465,6 @@ def : ReadAdvance<ReadXPERM, 0>;
 def : ReadAdvance<ReadFRoundF32, 0>;
 def : ReadAdvance<ReadFRoundF64, 0>;
 def : ReadAdvance<ReadFRoundF16, 0>;
-def : ReadAdvance<ReadFRoundF128, 0>;
 
 // Zfh extension
 def : ReadAdvance<ReadFCvtF16ToF64, 0>;
@@ -497,6 +494,7 @@ def : ReadAdvance<ReadFSqrt16, 0>;
 //===----------------------------------------------------------------------===//
 defm : UnsupportedSchedQ;
 defm : UnsupportedSchedV;
+defm : UnsupportedSchedZfaWithQ;
 defm : UnsupportedSchedZvk;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedXsfvcp;

--- a/llvm/lib/Target/RISCV/RISCVSchedGenericOOO.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedGenericOOO.td
@@ -283,12 +283,14 @@ let Latency = 2 in {
   def : WriteRes<WriteFRoundF16, [GenericOOOFPU]>;
   def : WriteRes<WriteFRoundF32, [GenericOOOFPU]>;
   def : WriteRes<WriteFRoundF64, [GenericOOOFPU]>;
+  def : WriteRes<WriteFRoundF128, [GenericOOOFPU]>;
 }
 
 let Latency = 2 in {
   def : WriteRes<WriteFLI16, [GenericOOOFPU]>;
   def : WriteRes<WriteFLI32, [GenericOOOFPU]>;
   def : WriteRes<WriteFLI64, [GenericOOOFPU]>;
+  def : WriteRes<WriteFLI128, [GenericOOOFPU]>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -465,6 +467,7 @@ def : ReadAdvance<ReadXPERM, 0>;
 def : ReadAdvance<ReadFRoundF32, 0>;
 def : ReadAdvance<ReadFRoundF64, 0>;
 def : ReadAdvance<ReadFRoundF16, 0>;
+def : ReadAdvance<ReadFRoundF128, 0>;
 
 // Zfh extension
 def : ReadAdvance<ReadFCvtF16ToF64, 0>;

--- a/llvm/lib/Target/RISCV/RISCVSchedule.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedule.td
@@ -445,21 +445,27 @@ def : ReadAdvance<ReadSFBALU, 0>;
 } // Unsupported = true
 }
 
-multiclass UnsupportedSchedZfa {
+multiclass UnsupportedSchedZfaWithQ {
+let Unsupported = true in {
+def : WriteRes<WriteFRoundF128, []>;
+def : WriteRes<WriteFLI128, []>;
+
+def : ReadAdvance<ReadFRoundF128, 0>;
+}
+}
+
+multiclass UnsupportedSchedZfa : UnsupportedSchedZfaWithQ {
 let Unsupported = true in {
 def : WriteRes<WriteFRoundF16, []>;
 def : WriteRes<WriteFRoundF32, []>;
 def : WriteRes<WriteFRoundF64, []>;
-def : WriteRes<WriteFRoundF128, []>;
 def : WriteRes<WriteFLI16, []>;
 def : WriteRes<WriteFLI32, []>;
 def : WriteRes<WriteFLI64, []>;
-def : WriteRes<WriteFLI128, []>;
 
 def : ReadAdvance<ReadFRoundF32, 0>;
 def : ReadAdvance<ReadFRoundF64, 0>;
 def : ReadAdvance<ReadFRoundF16, 0>;
-def : ReadAdvance<ReadFRoundF128, 0>;
 } // Unsupported = true
 }
 

--- a/llvm/lib/Target/RISCV/RISCVSchedule.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedule.td
@@ -97,6 +97,7 @@ def WriteFCvtF64ToF128 : SchedWrite;
 def WriteFRoundF32     : SchedWrite;
 def WriteFRoundF64     : SchedWrite;
 def WriteFRoundF16     : SchedWrite;
+def WriteFRoundF128    : SchedWrite;
 
 def WriteFClass16   : SchedWrite;    // 16-bit floating point classify
 def WriteFClass32   : SchedWrite;    // 32-bit floating point classify
@@ -125,6 +126,7 @@ def WriteFMovI64ToF64     : SchedWrite;    // RV64I only
 def WriteFLI16        : SchedWrite;    // Floating point constant load
 def WriteFLI32        : SchedWrite;    // Floating point constant load
 def WriteFLI64        : SchedWrite;    // Floating point constant load
+def WriteFLI128       : SchedWrite;    // Floating point constant load
 
 def WriteFLD16        : SchedWrite;    // Floating point sp load
 def WriteFLD32        : SchedWrite;    // Floating point sp load
@@ -244,6 +246,7 @@ def ReadFCvtF64ToF128    : SchedRead;
 def ReadFRoundF16        : SchedRead;
 def ReadFRoundF32        : SchedRead;
 def ReadFRoundF64        : SchedRead;
+def ReadFRoundF128       : SchedRead;
 
 def ReadFClass16         : SchedRead;
 def ReadFClass32         : SchedRead;
@@ -447,13 +450,16 @@ let Unsupported = true in {
 def : WriteRes<WriteFRoundF16, []>;
 def : WriteRes<WriteFRoundF32, []>;
 def : WriteRes<WriteFRoundF64, []>;
+def : WriteRes<WriteFRoundF128, []>;
 def : WriteRes<WriteFLI16, []>;
 def : WriteRes<WriteFLI32, []>;
 def : WriteRes<WriteFLI64, []>;
+def : WriteRes<WriteFLI128, []>;
 
 def : ReadAdvance<ReadFRoundF32, 0>;
 def : ReadAdvance<ReadFRoundF64, 0>;
 def : ReadAdvance<ReadFRoundF16, 0>;
+def : ReadAdvance<ReadFRoundF128, 0>;
 } // Unsupported = true
 }
 


### PR DESCRIPTION
Followup of #139495 and #139508