### PR TITLE
[lld][WebAssembly] Set the target-cpu in LTO config

### DIFF
--- a/lld/wasm/LTO.cpp
+++ b/lld/wasm/LTO.cpp
@@ -59,6 +59,7 @@ static lto::Config createConfig() {
   c.DisableVerify = ctx.arg.disableVerify;
   c.DiagHandler = diagnosticHandler;
   c.OptLevel = ctx.arg.ltoo;
+  c.CPU = getCPUStr();
   c.MAttrs = getMAttrs();
   c.CGOptLevel = ctx.arg.ltoCgo;
   c.DebugPassManager = ctx.arg.ltoDebugPassManager;


### PR DESCRIPTION
I couldn't find an existing way to pass -mcpu=lime1 equivalent to LTO codegen.
This commit would privide one. With this commit, you can do so by passing
`-mllvm -mcpu=lime1` to wasm-ld.
