### PR TITLE
update_mir_test_checks: keep commment embedded in MIR

### DIFF
--- a/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/x86-dead-def.mir
+++ b/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/x86-dead-def.mir
@@ -14,5 +14,6 @@ body:             |
   bb.1:
     dead %0:gr32(s32) = G_CONSTANT i32 0
     dead undef %1.sub_32bit:gr64(s32) = G_CONSTANT i32 1
+    ; Keep meaningful comment.
     undef %2.sub_32bit:gr64(s32) = G_CONSTANT i32 2
 ...

--- a/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/x86-dead-def.mir.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/x86-dead-def.mir.expected
@@ -18,5 +18,6 @@ body:             |
     ; CHECK-NEXT: undef [[C2:%[0-9]+]].sub_32bit:gr64(s32) = G_CONSTANT i32 2
     dead %0:gr32(s32) = G_CONSTANT i32 0
     dead undef %1.sub_32bit:gr64(s32) = G_CONSTANT i32 1
+    ; Keep meaningful comment.
     undef %2.sub_32bit:gr64(s32) = G_CONSTANT i32 2
 ...

--- a/llvm/utils/update_mir_test_checks.py
+++ b/llvm/utils/update_mir_test_checks.py
@@ -339,9 +339,9 @@ def mangle_vreg(opcode, current_names):
 
 
 def should_add_line_to_output(input_line, prefix_set):
-    # Skip any check lines that we're handling as well as comments
+    # Skip any check lines that we're handling as well as blank comment.
     m = common.CHECK_RE.match(input_line)
-    if (m and m.group(1) in prefix_set) or re.search("^[ \t]*;", input_line):
+    if (m and m.group(1) in prefix_set) or input_line.strip() == ";":
         return False
     return True
 


### PR DESCRIPTION
We often add inline comment in mir. It is useful to keep them.