### PR TITLE
[AArch64] Restrict .variant_pcs directive to ELF targets

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -1344,10 +1344,12 @@ AArch64AsmPrinter::getCodeViewJumpTableInfo(int JTI,
 }
 
 void AArch64AsmPrinter::emitFunctionEntryLabel() {
-  if (MF->getFunction().getCallingConv() == CallingConv::AArch64_VectorCall ||
-      MF->getFunction().getCallingConv() ==
-          CallingConv::AArch64_SVE_VectorCall ||
-      MF->getInfo<AArch64FunctionInfo>()->isSVECC()) {
+  const Triple &TT = TM.getTargetTriple();
+  if (TT.isOSBinFormatELF() &&
+      (MF->getFunction().getCallingConv() == CallingConv::AArch64_VectorCall ||
+       MF->getFunction().getCallingConv() ==
+           CallingConv::AArch64_SVE_VectorCall ||
+       MF->getInfo<AArch64FunctionInfo>()->isSVECC())) {
     auto *TS =
         static_cast<AArch64TargetStreamer *>(OutStreamer->getTargetStreamer());
     TS->emitDirectiveVariantPCS(CurrentFnSym);
@@ -1355,8 +1357,7 @@ void AArch64AsmPrinter::emitFunctionEntryLabel() {
 
   AsmPrinter::emitFunctionEntryLabel();
 
-  if (TM.getTargetTriple().isWindowsArm64EC() &&
-      !MF->getFunction().hasLocalLinkage()) {
+  if (TT.isWindowsArm64EC() && !MF->getFunction().hasLocalLinkage()) {
     // For ARM64EC targets, a function definition's name is mangled differently
     // from the normal symbol, emit required aliases here.
     auto emitFunctionAlias = [&](MCSymbol *Src, MCSymbol *Dst) {

--- a/llvm/test/CodeGen/AArch64/variant-pcs.ll
+++ b/llvm/test/CodeGen/AArch64/variant-pcs.ll
@@ -1,6 +1,13 @@
 ; RUN: llc -mtriple=aarch64-linux-gnu -mattr=+sve -o - %s | FileCheck %s --check-prefix=CHECK-ASM --strict-whitespace
+; RUN: llc -mtriple=arm64-apple-macosx -mattr=+sve -o - %s | FileCheck %s --check-prefix=CHECK-ASM-NON-ELF-TARGET
 ; RUN: llc -mtriple=aarch64-linux-gnu -mattr=+sve -filetype=obj -o - %s \
 ; RUN:   | llvm-readobj --symbols - | FileCheck %s --check-prefix=CHECK-OBJ
+; RUN: llc -mtriple=arm64-apple-macosx -mattr=+sve -filetype=obj -o - %s \
+; RUN:   | llvm-readobj --symbols - | FileCheck %s --check-prefix=CHECK-OBJ-NON-ELF-TARGET
+
+; .variant_pcs directive should only be emitted for ELF targets.
+; CHECK-ASM-NON-ELF-TARGET-NOT: .variant_pcs
+; CHECK-OBJ-NON-ELF-TARGET-NOT: Other [ (0x80)
 
 define i32 @base_pcs() {
 ; CHECK-ASM-LABEL: base_pcs:


### PR DESCRIPTION
Directive was implemented in c87bd2d8eb37 to support lazy binding and is emitted for vector PCS functions. It's specific to ELF but is currently emitted for all binary formats and crashing on non-ELF targets.

Fixes #138260