### PR TITLE
[Clang] Fix deduction of explicit object member functions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -710,6 +710,7 @@ Bug Fixes to C++ Support
 - Clang now correctly parses arbitrary order of ``[[]]``, ``__attribute__`` and ``alignas`` attributes for declarations (#GH133107)
 - Fixed a crash when forming an invalid function type in a dependent context. (#GH138657) (#GH115725) (#GH68852)
 - Clang no longer segfaults when there is a configuration mismatch between modules and their users (http://crbug.com/400353616).
+- Fix an incorrect deduction when calling an explicit object member function template through an overload set address.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12576,6 +12576,7 @@ public:
       bool PartialOverloading, bool AggregateDeductionCandidate,
       bool PartialOrdering, QualType ObjectType,
       Expr::Classification ObjectClassification,
+      bool ForOverloadSetAddressResolution,
       llvm::function_ref<bool(ArrayRef<QualType>)> CheckNonDependent);
 
   /// Deduce template arguments when taking the address of a function

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7846,6 +7846,8 @@ static void AddMethodTemplateCandidateImmediately(
           MethodTmpl, ExplicitTemplateArgs, Args, Specialization, Info,
           PartialOverloading, /*AggregateDeductionCandidate=*/false,
           /*PartialOrdering=*/false, ObjectType, ObjectClassification,
+          CandidateSet.getKind() ==
+              clang::OverloadCandidateSet::CSK_AddressOfOverloadSet,
           [&](ArrayRef<QualType> ParamTypes) {
             return S.CheckNonDependentConversions(
                 MethodTmpl, ParamTypes, Args, CandidateSet, Conversions,
@@ -7960,6 +7962,8 @@ static void AddTemplateOverloadCandidateImmediately(
           /*PartialOrdering=*/false,
           /*ObjectType=*/QualType(),
           /*ObjectClassification=*/Expr::Classification(),
+          CandidateSet.getKind() ==
+              OverloadCandidateSet::CSK_AddressOfOverloadSet,
           [&](ArrayRef<QualType> ParamTypes) {
             return S.CheckNonDependentConversions(
                 FunctionTemplate, ParamTypes, Args, CandidateSet, Conversions,

--- a/clang/test/SemaCXX/cxx2b-deducing-this.cpp
+++ b/clang/test/SemaCXX/cxx2b-deducing-this.cpp
@@ -926,6 +926,33 @@ struct C {
     (&fref)();
   }
 };
+
+struct CTpl {
+  template <typename T>
+  constexpr int c(this const CTpl&, T) {  // #P2797-ctpl-1
+      return 42;
+  }
+
+  template <typename T>
+  void c(T)&; // #P2797-ctpl-2
+
+  template <typename T>
+  static void c(T = 0, T = 0);  // #P2797-ctpl-3
+
+  void d() {
+    c(0);               // expected-error {{call to member function 'c' is ambiguous}}
+                        // expected-note@#P2797-ctpl-1{{candidate}}
+                        // expected-note@#P2797-ctpl-2{{candidate}}
+                        // expected-note@#P2797-ctpl-3{{candidate}}
+    (CTpl::c)(0);       // expected-error {{call to member function 'c' is ambiguous}}
+                        // expected-note@#P2797-ctpl-1{{candidate}}
+                        // expected-note@#P2797-ctpl-2{{candidate}}
+                        // expected-note@#P2797-ctpl-3{{candidate}}
+
+    static_assert((&CTpl::c)(CTpl{}, 0) == 42); // selects #1
+  }
+};
+
 }
 
 namespace GH85992 {


### PR DESCRIPTION
When taking the address of an overload set containing an explicit object member, we should not take the
explicit object parameter into account.