### PR TITLE
[COFF][Mips] Set PrivateGlobalPrefix to .L

### DIFF
--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
@@ -53,5 +53,7 @@ MipsCOFFMCAsmInfo::MipsCOFFMCAsmInfo() {
 
   ExceptionsType = ExceptionHandling::WinEH;
 
+  PrivateGlobalPrefix = ".L";
+  PrivateLabelPrefix = ".L";
   AllowAtInName = true;
 }

--- a/llvm/test/CodeGen/Mips/private-global-prefix.ll
+++ b/llvm/test/CodeGen/Mips/private-global-prefix.ll
@@ -1,0 +1,24 @@
+; RUN: llc -mtriple=mipsel-w64-windows-gnu < %s | FileCheck %s -check-prefix=MIPSEL
+
+define void @f() {
+; MIPSEL-LABEL: f:
+; MIPSEL:       # %bb.0: # %entry
+; MIPSEL-NEXT:    addiu $sp, $sp, -24
+; MIPSEL-NEXT:    sw $ra, 20($sp)
+; MIPSEL-NEXT:    jal LeaveFoo
+; MIPSEL-NEXT:    nop
+; MIPSEL-NEXT:    jal LocalBar
+; MIPSEL-NEXT:    nop
+; MIPSEL-NEXT:    lw $ra, 20($sp)
+; MIPSEL-NEXT:    jr $ra
+; MIPSEL-NEXT:    addiu	$sp, $sp, 24
+
+entry:
+  call void @LeaveFoo()
+  call void @LocalBar()
+  ret void
+}
+
+declare void @LeaveFoo()
+declare void @LocalBar()
+


### PR DESCRIPTION
When calling external functions which start with `L`, would generate error: assembler label 'LeaveFoo' can not be undefined. This pr would fix this issue.

Fix #134914.