### PR TITLE
[LLVM][SVE] Relax optimizeIncrementingWhile constant operand requirements.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5744,12 +5744,10 @@ static SDValue optimizeIncrementingWhile(SDNode *N, SelectionDAG &DAG,
   unsigned Op0 = N->getOpcode() == ISD::INTRINSIC_WO_CHAIN ? 1 : 0;
   unsigned Op1 = N->getOpcode() == ISD::INTRINSIC_WO_CHAIN ? 2 : 1;
 
-  if (!isa<ConstantSDNode>(N->getOperand(Op0)) ||
-      !isa<ConstantSDNode>(N->getOperand(Op1)))
+  if (!isa<ConstantSDNode>(N->getOperand(Op1)))
     return SDValue();
 
   SDLoc dl(N);
-  APInt X = N->getConstantOperandAPInt(Op0);
   APInt Y = N->getConstantOperandAPInt(Op1);
 
   // When the second operand is the maximum value, comparisons that include
@@ -5757,6 +5755,11 @@ static SDValue optimizeIncrementingWhile(SDNode *N, SelectionDAG &DAG,
   if (IsEqual)
     if (IsSigned ? Y.isMaxSignedValue() : Y.isMaxValue())
       return DAG.getConstant(1, dl, N->getValueType(0));
+
+  if (!isa<ConstantSDNode>(N->getOperand(Op0)))
+    return SDValue();
+
+  APInt X = N->getConstantOperandAPInt(Op0);
 
   bool Overflow;
   APInt NumActiveElems =

--- a/llvm/test/CodeGen/AArch64/sve-intrinsics-while.ll
+++ b/llvm/test/CodeGen/AArch64/sve-intrinsics-while.ll
@@ -128,12 +128,13 @@ define <vscale x 16 x i1> @whilele_b_ii_dont_fold_to_ptrue_overflow() {
   ret <vscale x 16 x i1> %out
 }
 
-define <vscale x 16 x i1> @whilele_b_ii_known_always_true() {
+define <vscale x 16 x i1> @whilele_b_ii_known_always_true(i32 %a) {
 ; CHECK-LABEL: whilele_b_ii_known_always_true:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ptrue p0.b
+; CHECK-NEXT:    mov w8, #2147483647 // =0x7fffffff
+; CHECK-NEXT:    whilele p0.b, w0, w8
 ; CHECK-NEXT:    ret
-  %out = call <vscale x 16 x i1> @llvm.aarch64.sve.whilele.nxv16i1.i32(i32 2147483646, i32 2147483647)
+  %out = call <vscale x 16 x i1> @llvm.aarch64.sve.whilele.nxv16i1.i32(i32 %a, i32 2147483647)
   ret <vscale x 16 x i1> %out
 }
 
@@ -387,12 +388,13 @@ define <vscale x 16 x i1> @whilels_b_ii_dont_fold_to_ptrue_overflow() {
   ret <vscale x 16 x i1> %out
 }
 
-define <vscale x 16 x i1> @whilels_b_ii_known_always_true() {
+define <vscale x 16 x i1> @whilels_b_ii_known_always_true(i32 %a) {
 ; CHECK-LABEL: whilels_b_ii_known_always_true:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ptrue p0.b
+; CHECK-NEXT:    mov w8, #-1 // =0xffffffff
+; CHECK-NEXT:    whilels p0.b, w0, w8
 ; CHECK-NEXT:    ret
-  %out = call <vscale x 16 x i1> @llvm.aarch64.sve.whilels.nxv16i1.i32(i32 4294967294, i32 4294967295)
+  %out = call <vscale x 16 x i1> @llvm.aarch64.sve.whilels.nxv16i1.i32(i32 %a, i32 4294967295)
   ret <vscale x 16 x i1> %out
 }
 

--- a/llvm/test/CodeGen/AArch64/sve-intrinsics-while.ll
+++ b/llvm/test/CodeGen/AArch64/sve-intrinsics-while.ll
@@ -131,8 +131,7 @@ define <vscale x 16 x i1> @whilele_b_ii_dont_fold_to_ptrue_overflow() {
 define <vscale x 16 x i1> @whilele_b_ii_known_always_true(i32 %a) {
 ; CHECK-LABEL: whilele_b_ii_known_always_true:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, #2147483647 // =0x7fffffff
-; CHECK-NEXT:    whilele p0.b, w0, w8
+; CHECK-NEXT:    ptrue p0.b
 ; CHECK-NEXT:    ret
   %out = call <vscale x 16 x i1> @llvm.aarch64.sve.whilele.nxv16i1.i32(i32 %a, i32 2147483647)
   ret <vscale x 16 x i1> %out
@@ -391,8 +390,7 @@ define <vscale x 16 x i1> @whilels_b_ii_dont_fold_to_ptrue_overflow() {
 define <vscale x 16 x i1> @whilels_b_ii_known_always_true(i32 %a) {
 ; CHECK-LABEL: whilels_b_ii_known_always_true:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, #-1 // =0xffffffff
-; CHECK-NEXT:    whilels p0.b, w0, w8
+; CHECK-NEXT:    ptrue p0.b
 ; CHECK-NEXT:    ret
   %out = call <vscale x 16 x i1> @llvm.aarch64.sve.whilels.nxv16i1.i32(i32 %a, i32 4294967295)
   ret <vscale x 16 x i1> %out


### PR DESCRIPTION
Only the latter part of optimizeIncrementingWhile requires a constant first operand and so the initial bailout code is preventing the obvious whilele(X,MAX_INT) -> splat(true) combine.