### PR TITLE
[clang][bytecode] Check destructors for temporaries

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -37,6 +37,7 @@ bool Context::isPotentialConstantExpr(State &Parent, const FunctionDecl *FD) {
   Compiler<ByteCodeEmitter>(*this, *P).compileFunc(
       FD, const_cast<Function *>(Func));
 
+  ++EvalID;
   // And run it.
   if (!Run(Parent, Func))
     return false;

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1373,6 +1373,8 @@ static bool checkConstructor(InterpState &S, CodePtr OpPC, const Function *Func,
 bool CheckDestructor(InterpState &S, CodePtr OpPC, const Pointer &Ptr) {
   if (!CheckLive(S, OpPC, Ptr, AK_Destroy))
     return false;
+  if (!CheckTemporary(S, OpPC, Ptr, AK_Destroy))
+    return false;
 
   // Can't call a dtor on a global variable.
   if (Ptr.block()->isStatic()) {

--- a/clang/test/AST/ByteCode/cxx20.cpp
+++ b/clang/test/AST/ByteCode/cxx20.cpp
@@ -997,3 +997,13 @@ namespace NastyChar {
   template <ToNastyChar t> constexpr auto to_nasty_char() { return t; }
   constexpr auto result = to_nasty_char<"12345">();
 }
+
+namespace TempDtor {
+  struct A {
+    int n;
+  };
+  constexpr A &&a_ref = A(); // both-note {{temporary created here}}
+  constexpr void destroy_extern_2() { // both-error {{never produces a constant expression}}
+    a_ref.~A(); // both-note {{destruction of temporary is not allowed in a constant expression outside the expression that created the temporary}}
+  }
+}


### PR DESCRIPTION
Also, increase the EvalID in isPotentialConstantExpr(), since this is its own evaluation.