### PR TITLE
[DAGCombiner] Fix the "subtraction if above a constant threshold" miscompile

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -12141,15 +12141,17 @@ SDValue DAGCombiner::visitSELECT(SDNode *N) {
     APInt C;
     if (sd_match(Cond1, m_ConstInt(C)) && hasUMin(VT)) {
       if (CC == ISD::SETUGT && Cond0 == N2 &&
-          sd_match(N1, m_Add(m_Specific(N2), m_SpecificInt(~C))))
-        return DAG.getNode(
-            ISD::UMIN, DL, VT,
-            DAG.getNode(ISD::ADD, DL, VT, N2, DAG.getConstant(~C, DL, VT)), N2);
+          sd_match(N1, m_Add(m_Specific(N2), m_SpecificInt(~C)))) {
+        SDValue AddC = DAG.getConstant(~C, DL, VT);
+        SDValue Add = DAG.getNode(ISD::ADD, DL, VT, N2, AddC);
+        return DAG.getNode(ISD::UMIN, DL, VT, Add, N2);
+      }
       if (CC == ISD::SETULT && Cond0 == N1 &&
-          sd_match(N2, m_Add(m_Specific(N1), m_SpecificInt(-C))))
-        return DAG.getNode(
-            ISD::UMIN, DL, VT, N1,
-            DAG.getNode(ISD::ADD, DL, VT, N1, DAG.getConstant(-C, DL, VT)));
+          sd_match(N2, m_Add(m_Specific(N1), m_SpecificInt(-C)))) {
+        SDValue AddC = DAG.getConstant(-C, DL, VT);
+        SDValue Add = DAG.getNode(ISD::ADD, DL, VT, N1, AddC);
+        return DAG.getNode(ISD::UMIN, DL, VT, N1, Add);
+      }
     }
   }
 

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -12140,11 +12140,16 @@ SDValue DAGCombiner::visitSELECT(SDNode *N) {
     // (select (ult x, C), x, (add x, -C)) -> (umin x, (add x, -C))
     APInt C;
     if (sd_match(Cond1, m_ConstInt(C)) && hasUMin(VT)) {
-      if ((CC == ISD::SETUGT && Cond0 == N2 &&
-           sd_match(N1, m_Add(m_Specific(N2), m_SpecificInt(~C)))) ||
-          (CC == ISD::SETULT && Cond0 == N1 &&
-           sd_match(N2, m_Add(m_Specific(N1), m_SpecificInt(-C)))))
-        return DAG.getNode(ISD::UMIN, DL, VT, N1, N2);
+      if (CC == ISD::SETUGT && Cond0 == N2 &&
+          sd_match(N1, m_Add(m_Specific(N2), m_SpecificInt(~C))))
+        return DAG.getNode(
+            ISD::UMIN, DL, VT,
+            DAG.getNode(ISD::ADD, DL, VT, N2, DAG.getConstant(~C, DL, VT)), N2);
+      if (CC == ISD::SETULT && Cond0 == N1 &&
+          sd_match(N2, m_Add(m_Specific(N1), m_SpecificInt(-C))))
+        return DAG.getNode(
+            ISD::UMIN, DL, VT, N1,
+            DAG.getNode(ISD::ADD, DL, VT, N1, DAG.getConstant(-C, DL, VT)));
     }
   }
 

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -12142,12 +12142,15 @@ SDValue DAGCombiner::visitSELECT(SDNode *N) {
     if (sd_match(Cond1, m_ConstInt(C)) && hasUMin(VT)) {
       if (CC == ISD::SETUGT && Cond0 == N2 &&
           sd_match(N1, m_Add(m_Specific(N2), m_SpecificInt(~C)))) {
+        // The resulting code relies on an unsigned wrap in ADD.
+        // Recreating ADD to drop possible nuw/nsw flags.
         SDValue AddC = DAG.getConstant(~C, DL, VT);
         SDValue Add = DAG.getNode(ISD::ADD, DL, VT, N2, AddC);
         return DAG.getNode(ISD::UMIN, DL, VT, Add, N2);
       }
       if (CC == ISD::SETULT && Cond0 == N1 &&
           sd_match(N2, m_Add(m_Specific(N1), m_SpecificInt(-C)))) {
+        // Ditto.
         SDValue AddC = DAG.getConstant(-C, DL, VT);
         SDValue Add = DAG.getNode(ISD::ADD, DL, VT, N1, AddC);
         return DAG.getNode(ISD::UMIN, DL, VT, N1, Add);

--- a/llvm/test/CodeGen/RISCV/rv32zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbb.ll
@@ -1932,7 +1932,10 @@ define i7 @sub_if_uge_C_nsw_i7(i7 %a) {
 ; RV32ZBB-LABEL: sub_if_uge_C_nsw_i7:
 ; RV32ZBB:       # %bb.0:
 ; RV32ZBB-NEXT:    ori a0, a0, 51
+; RV32ZBB-NEXT:    andi a1, a0, 127
 ; RV32ZBB-NEXT:    addi a0, a0, 17
+; RV32ZBB-NEXT:    andi a0, a0, 92
+; RV32ZBB-NEXT:    minu a0, a0, a1
 ; RV32ZBB-NEXT:    ret
   %x = or i7 %a, 51
   %c = icmp ugt i7 %x, -18
@@ -1955,7 +1958,10 @@ define i7 @sub_if_uge_C_swapped_nsw_i7(i7 %a) {
 ; RV32ZBB-LABEL: sub_if_uge_C_swapped_nsw_i7:
 ; RV32ZBB:       # %bb.0:
 ; RV32ZBB-NEXT:    ori a0, a0, 51
+; RV32ZBB-NEXT:    andi a1, a0, 127
 ; RV32ZBB-NEXT:    addi a0, a0, 17
+; RV32ZBB-NEXT:    andi a0, a0, 92
+; RV32ZBB-NEXT:    minu a0, a1, a0
 ; RV32ZBB-NEXT:    ret
   %x = or i7 %a, 51
   %c = icmp ult i7 %x, -17

--- a/llvm/test/CodeGen/RISCV/rv32zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbb.ll
@@ -1917,3 +1917,49 @@ define i32 @sub_if_uge_C_swapped_i32(i32 %x) {
   %cond = select i1 %cmp, i32 %x, i32 %sub
   ret i32 %cond
 }
+
+define i7 @sub_if_uge_C_nsw_i7(i7 %a) {
+; RV32I-LABEL: sub_if_uge_C_nsw_i7:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    ori a0, a0, 51
+; RV32I-NEXT:    andi a1, a0, 127
+; RV32I-NEXT:    sltiu a1, a1, 111
+; RV32I-NEXT:    addi a1, a1, -1
+; RV32I-NEXT:    andi a1, a1, 17
+; RV32I-NEXT:    add a0, a0, a1
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: sub_if_uge_C_nsw_i7:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    ori a0, a0, 51
+; RV32ZBB-NEXT:    addi a0, a0, 17
+; RV32ZBB-NEXT:    ret
+  %x = or i7 %a, 51
+  %c = icmp ugt i7 %x, -18
+  %add = add nsw i7 %x, 17
+  %s = select i1 %c, i7 %add, i7 %x
+  ret i7 %s
+}
+
+define i7 @sub_if_uge_C_swapped_nsw_i7(i7 %a) {
+; RV32I-LABEL: sub_if_uge_C_swapped_nsw_i7:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    ori a0, a0, 51
+; RV32I-NEXT:    andi a1, a0, 127
+; RV32I-NEXT:    sltiu a1, a1, 111
+; RV32I-NEXT:    addi a1, a1, -1
+; RV32I-NEXT:    andi a1, a1, 17
+; RV32I-NEXT:    add a0, a0, a1
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: sub_if_uge_C_swapped_nsw_i7:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    ori a0, a0, 51
+; RV32ZBB-NEXT:    addi a0, a0, 17
+; RV32ZBB-NEXT:    ret
+  %x = or i7 %a, 51
+  %c = icmp ult i7 %x, -17
+  %add = add nsw i7 %x, 17
+  %s = select i1 %c, i7 %x, i7 %add
+  ret i7 %s
+}

--- a/llvm/test/CodeGen/RISCV/rv64zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbb.ll
@@ -2087,7 +2087,10 @@ define i7 @sub_if_uge_C_nsw_i7(i7 %a) {
 ; RV64ZBB-LABEL: sub_if_uge_C_nsw_i7:
 ; RV64ZBB:       # %bb.0:
 ; RV64ZBB-NEXT:    ori a0, a0, 51
+; RV64ZBB-NEXT:    andi a1, a0, 127
 ; RV64ZBB-NEXT:    addi a0, a0, 17
+; RV64ZBB-NEXT:    andi a0, a0, 92
+; RV64ZBB-NEXT:    minu a0, a0, a1
 ; RV64ZBB-NEXT:    ret
   %x = or i7 %a, 51
   %c = icmp ugt i7 %x, -18
@@ -2110,7 +2113,10 @@ define i7 @sub_if_uge_C_swapped_nsw_i7(i7 %a) {
 ; RV64ZBB-LABEL: sub_if_uge_C_swapped_nsw_i7:
 ; RV64ZBB:       # %bb.0:
 ; RV64ZBB-NEXT:    ori a0, a0, 51
+; RV64ZBB-NEXT:    andi a1, a0, 127
 ; RV64ZBB-NEXT:    addi a0, a0, 17
+; RV64ZBB-NEXT:    andi a0, a0, 92
+; RV64ZBB-NEXT:    minu a0, a1, a0
 ; RV64ZBB-NEXT:    ret
   %x = or i7 %a, 51
   %c = icmp ult i7 %x, -17

--- a/llvm/test/CodeGen/RISCV/rv64zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbb.ll
@@ -2072,3 +2072,49 @@ define i32 @sub_if_uge_C_swapped_i32(i32 signext %x) {
   %cond = select i1 %cmp, i32 %x, i32 %sub
   ret i32 %cond
 }
+
+define i7 @sub_if_uge_C_nsw_i7(i7 %a) {
+; RV64I-LABEL: sub_if_uge_C_nsw_i7:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    ori a0, a0, 51
+; RV64I-NEXT:    andi a1, a0, 127
+; RV64I-NEXT:    sltiu a1, a1, 111
+; RV64I-NEXT:    addi a1, a1, -1
+; RV64I-NEXT:    andi a1, a1, 17
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBB-LABEL: sub_if_uge_C_nsw_i7:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    ori a0, a0, 51
+; RV64ZBB-NEXT:    addi a0, a0, 17
+; RV64ZBB-NEXT:    ret
+  %x = or i7 %a, 51
+  %c = icmp ugt i7 %x, -18
+  %add = add nsw i7 %x, 17
+  %s = select i1 %c, i7 %add, i7 %x
+  ret i7 %s
+}
+
+define i7 @sub_if_uge_C_swapped_nsw_i7(i7 %a) {
+; RV64I-LABEL: sub_if_uge_C_swapped_nsw_i7:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    ori a0, a0, 51
+; RV64I-NEXT:    andi a1, a0, 127
+; RV64I-NEXT:    sltiu a1, a1, 111
+; RV64I-NEXT:    addi a1, a1, -1
+; RV64I-NEXT:    andi a1, a1, 17
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBB-LABEL: sub_if_uge_C_swapped_nsw_i7:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    ori a0, a0, 51
+; RV64ZBB-NEXT:    addi a0, a0, 17
+; RV64ZBB-NEXT:    ret
+  %x = or i7 %a, 51
+  %c = icmp ult i7 %x, -17
+  %add = add nsw i7 %x, 17
+  %s = select i1 %c, i7 %x, i7 %add
+  ret i7 %s
+}


### PR DESCRIPTION
This fixes #135194 incorrectly reusing the existing `add nuw/nsw`
while the transformed code relies on an unsigned wrap.