### PR TITLE
[Clang] Fix parsing of expressions of the form (T())[/*...*/]

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -710,6 +710,7 @@ Bug Fixes to C++ Support
 - Clang now correctly parses arbitrary order of ``[[]]``, ``__attribute__`` and ``alignas`` attributes for declarations (#GH133107)
 - Fixed a crash when forming an invalid function type in a dependent context. (#GH138657) (#GH115725) (#GH68852)
 - Clang no longer segfaults when there is a configuration mismatch between modules and their users (http://crbug.com/400353616).
+- Fix parsing of expressions of the form ``((T))[expr]``. (#GH20723)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -4639,6 +4639,10 @@ private:
   ParseLambdaIntroducer(LambdaIntroducer &Intro,
                         LambdaIntroducerTentativeParse *Tentative = nullptr);
 
+  /// Tries to determine if an expression of the form (S())[...]...
+  /// is a type-cast followed by a lambda, or a subscript expression
+  bool IsLambdaAfterTypeCast();
+
   /// ParseLambdaExpressionAfterIntroducer - Parse the rest of a lambda
   /// expression.
   ExprResult ParseLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro);

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -1585,8 +1585,10 @@ ExprResult Parser::ParseCastExpression(CastParseKind ParseKind,
         }
         break;
       }
-      Res = ParseLambdaExpression();
-      break;
+      if (isTypeCast != TypeCastState::IsTypeCast || IsLambdaAfterTypeCast()) {
+        Res = ParseLambdaExpression();
+        break;
+      }
     }
     if (getLangOpts().ObjC) {
       Res = ParseObjCMessageExpression();

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -705,8 +705,8 @@ bool Parser::IsLambdaAfterTypeCast() {
   SkipUntil(tok::r_square);
 
   auto IsLambdaKWOrAttribute = [&]() {
-    // These keyworks that either can appear somewhere in a lambda declarator,
-    // or cannot appear in a cast expression and we recover in favor of lambdas
+    // These are keyworks that can appear somewhere in a lambda declarator,
+    // or cannot appear in a cast-expression and we recover in favor of lambdas
     if (Tok.isOneOf(tok::kw___declspec, tok::kw___noinline__, tok::kw_noexcept,
                     tok::kw_throw, tok::kw_mutable, tok::kw___attribute,
                     tok::kw_constexpr, tok::kw_consteval, tok::kw_static,

--- a/clang/test/Parser/cxx0x-lambda-expressions.cpp
+++ b/clang/test/Parser/cxx0x-lambda-expressions.cpp
@@ -213,8 +213,8 @@ struct S {
 };
 }
 
-#if __cplusplus >= 201103L
 namespace GH20723 {
+#if __cplusplus >= 201103L
 struct S {
     S operator[](int);
     S operator()();
@@ -228,9 +228,25 @@ void f() {
     static_assert(__is_same_as(decltype((S())[n] < 0), S), "");
     static_assert(__is_same_as(decltype((S())[n]->a), long), "");
 }
+#endif
+#if __cplusplus >= 202302
+struct S2 {
+    S2 operator[]();
+    S2* operator->();
+    template <typename U>
+    constexpr static int trailing = 0;
+};
+
+template <typename T>
+struct trailing{};
+
+void f2() {
+  static_assert(__is_same_as(decltype((S2())[]->trailing<int>), const int));
+  (void)[]->trailing<int>{return {};}();
 }
 #endif
 
+}
 
 struct S {
   template <typename T>

--- a/clang/test/Parser/cxx1z-constexpr-lambdas.cpp
+++ b/clang/test/Parser/cxx1z-constexpr-lambdas.cpp
@@ -1,26 +1,34 @@
-// RUN: %clang_cc1 -std=c++23 %s -verify
-// RUN: %clang_cc1 -std=c++20 %s -verify
-// RUN: %clang_cc1 -std=c++17 %s -verify
-// RUN: %clang_cc1 -std=c++14 %s -verify
-// RUN: %clang_cc1 -std=c++11 %s -verify
+// RUN: %clang_cc1 -std=c++23 %s -verify -Wno-unused "-DTYPE_CAST="
+// RUN: %clang_cc1 -std=c++20 %s -verify -Wno-unused "-DTYPE_CAST="
+// RUN: %clang_cc1 -std=c++17 %s -verify -Wno-unused "-DTYPE_CAST="
+// RUN: %clang_cc1 -std=c++14 %s -verify -Wno-unused "-DTYPE_CAST="
+// RUN: %clang_cc1 -std=c++11 %s -verify -Wno-unused "-DTYPE_CAST="
 
-auto XL0 = [] constexpr { return true; };
+// RUN: %clang_cc1 -std=c++23 %s -verify "-DTYPE_CAST=(void)"
+// RUN: %clang_cc1 -std=c++20 %s -verify "-DTYPE_CAST=(void)"
+// RUN: %clang_cc1 -std=c++17 %s -verify "-DTYPE_CAST=(void)"
+// RUN: %clang_cc1 -std=c++14 %s -verify "-DTYPE_CAST=(void)"
+// RUN: %clang_cc1 -std=c++11 %s -verify "-DTYPE_CAST=(void)"
+
+void test() {
+
+TYPE_CAST [] constexpr { return true; };
 #if __cplusplus <= 201402L
 // expected-warning@-2 {{is a C++17 extension}}
 #endif
 #if __cplusplus <= 202002L
 // expected-warning@-5 {{lambda without a parameter clause is a C++23 extension}}
 #endif
-auto XL1 = []() mutable //
+TYPE_CAST []() mutable //
     mutable             // expected-error{{cannot appear multiple times}}
     mutable {};         // expected-error{{cannot appear multiple times}}
 
 #if __cplusplus > 201402L
-auto XL2 = [] () constexpr mutable constexpr { }; //expected-error{{cannot appear multiple times}}
-auto L = []() mutable constexpr { };
-auto L2 = []() constexpr { };
-auto L4 = []() constexpr mutable { }; 
-auto XL16 = [] () constexpr
+TYPE_CAST [] () constexpr mutable constexpr { }; //expected-error{{cannot appear multiple times}}
+TYPE_CAST []() mutable constexpr { };
+TYPE_CAST []() constexpr { };
+TYPE_CAST []() constexpr mutable { };
+TYPE_CAST [] () constexpr
                   mutable
                   constexpr   //expected-error{{cannot appear multiple times}}
                   mutable     //expected-error{{cannot appear multiple times}}
@@ -31,8 +39,10 @@ auto XL16 = [] () constexpr
 
 #else
 auto L = []() mutable constexpr {return 0; }; //expected-warning{{is a C++17 extension}}
-auto L2 = []() constexpr { return 0;};//expected-warning{{is a C++17 extension}}
-auto L4 = []() constexpr mutable { return 0; }; //expected-warning{{is a C++17 extension}}
+TYPE_CAST []() constexpr { return 0;};//expected-warning{{is a C++17 extension}}
+TYPE_CAST []() constexpr mutable { return 0; }; //expected-warning{{is a C++17 extension}}
 #endif
+
+}
 
 

--- a/clang/test/Parser/cxx2a-template-lambdas.cpp
+++ b/clang/test/Parser/cxx2a-template-lambdas.cpp
@@ -1,37 +1,43 @@
-// RUN: %clang_cc1 -std=c++23 %s -verify
-// RUN: %clang_cc1 -std=c++20 %s -verify
+// RUN: %clang_cc1 -std=c++23 %s -verify -Wno-unused "-DTYPE_CAST="
+// RUN: %clang_cc1 -std=c++20 %s -verify -Wno-unused "-DTYPE_CAST="
+// RUN: %clang_cc1 -std=c++23 %s -verify "-DTYPE_CAST=(void)"
+// RUN: %clang_cc1 -std=c++20 %s -verify "-DTYPE_CAST=(void)"
 
-auto L0 = []<> { }; //expected-error {{cannot be empty}}
+void test() {
 
-auto L1 = []<typename T1, typename T2> { };
-auto L2 = []<typename T1, typename T2>(T1 arg1, T2 arg2) -> T1 { };
-auto L3 = []<typename T>(auto arg) { T t; };
-auto L4 = []<int I>() { };
+TYPE_CAST []<> { }; //expected-error {{cannot be empty}}
+
+TYPE_CAST []<typename T1, typename T2> { };
+TYPE_CAST []<typename T1, typename T2>(T1 arg1, T2 arg2) -> T1 { };
+TYPE_CAST []<typename T>(auto arg) { T t; };
+TYPE_CAST []<int I>() { };
 
 // http://llvm.org/PR49736
-auto L5 = []<auto>(){};
-auto L6 = []<auto>{};
-auto L7 = []<auto>() noexcept {};
-auto L8 = []<auto> noexcept {};
+TYPE_CAST []<auto>(){};
+TYPE_CAST []<auto>{};
+TYPE_CAST []<auto>() noexcept {};
+TYPE_CAST []<auto> noexcept {};
 #if __cplusplus <= 202002L
 // expected-warning@-2 {{lambda without a parameter clause is a C++23 extension}}
 #endif
-auto L9 = []<auto> requires true {};
-auto L10 = []<auto> requires true(){};
-auto L11 = []<auto> requires true() noexcept {};
-auto L12 = []<auto> requires true noexcept {};
+TYPE_CAST []<auto> requires true {};
+TYPE_CAST []<auto> requires true(){};
+TYPE_CAST []<auto> requires true() noexcept {};
+TYPE_CAST []<auto> requires true noexcept {};
 #if __cplusplus <= 202002L
 // expected-warning@-2 {{is a C++23 extension}}
 #endif
-auto L13 = []<auto>() noexcept requires true {};
-auto L14 = []<auto> requires true() noexcept requires true {};
+TYPE_CAST []<auto>() noexcept requires true {};
+TYPE_CAST []<auto> requires true() noexcept requires true {};
 
-auto XL0 = []<auto> noexcept requires true {};               // expected-error {{expected body of lambda expression}}
-auto XL1 = []<auto> requires true noexcept requires true {}; // expected-error {{expected body}}
+TYPE_CAST []<auto> noexcept requires true {};               // expected-error {{expected body of lambda expression}}
+TYPE_CAST []<auto> requires true noexcept requires true {}; // expected-error {{expected body}}
 #if __cplusplus <= 202002L
 // expected-warning@-3 {{is a C++23 extension}}
 // expected-warning@-3 {{is a C++23 extension}}
 #endif
+
+}
 
 namespace GH64962 {
 void f() {

--- a/clang/test/Parser/cxx2b-lambdas.cpp
+++ b/clang/test/Parser/cxx2b-lambdas.cpp
@@ -1,88 +1,109 @@
-// RUN: %clang_cc1 -std=c++03 %s -verify                -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions -Wno-c++14-extensions -Wno-c++11-extensions
-// RUN: %clang_cc1 -std=c++11 %s -verify=expected,cxx11 -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions -Wno-c++14-extensions
-// RUN: %clang_cc1 -std=c++14 %s -verify                -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions
-// RUN: %clang_cc1 -std=c++17 %s -verify                -Wno-c++23-extensions -Wno-c++20-extensions
-// RUN: %clang_cc1 -std=c++20 %s -verify                -Wno-c++23-extensions
-// RUN: %clang_cc1 -std=c++23 %s -verify
+// RUN: %clang_cc1 -std=c++03 %s "-DTYPE_CAST=" -verify                -Wno-unused -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions -Wno-c++14-extensions -Wno-c++11-extensions
+// RUN: %clang_cc1 -std=c++11 %s "-DTYPE_CAST=" -verify=expected,cxx11 -Wno-unused -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions -Wno-c++14-extensions
+// RUN: %clang_cc1 -std=c++14 %s "-DTYPE_CAST=" -verify                -Wno-unused -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions
+// RUN: %clang_cc1 -std=c++17 %s "-DTYPE_CAST=" -verify                -Wno-unused -Wno-c++23-extensions -Wno-c++20-extensions
+// RUN: %clang_cc1 -std=c++20 %s "-DTYPE_CAST=" -verify                -Wno-unused -Wno-c++23-extensions
+// RUN: %clang_cc1 -std=c++23 %s "-DTYPE_CAST=" -verify                -Wno-unused
 
-auto LL0 = [] {};
-auto LL1 = []() {};
-auto LL2 = []() mutable {};
+// RUN: %clang_cc1 -std=c++03 %s "-DTYPE_CAST=(void)" -verify                -Wno-unused -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions -Wno-c++14-extensions -Wno-c++11-extensions
+// RUN: %clang_cc1 -std=c++11 %s "-DTYPE_CAST=(void)" -verify=expected,cxx11 -Wno-unused -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions -Wno-c++14-extensions
+// RUN: %clang_cc1 -std=c++14 %s "-DTYPE_CAST=(void)" -verify                -Wno-unused -Wno-c++23-extensions -Wno-c++20-extensions -Wno-c++17-extensions
+// RUN: %clang_cc1 -std=c++17 %s "-DTYPE_CAST=(void)" -verify                -Wno-unused -Wno-c++23-extensions -Wno-c++20-extensions
+// RUN: %clang_cc1 -std=c++20 %s "-DTYPE_CAST=(void)" -verify                -Wno-unused -Wno-c++23-extensions
+// RUN: %clang_cc1 -std=c++23 %s "-DTYPE_CAST=(void)" -verify                -Wno-unused
+
+void test() {
+
+TYPE_CAST [] {};
+TYPE_CAST []() {};
+TYPE_CAST []() mutable {};
 #if __cplusplus >= 201103L
-auto LL3 = []() constexpr {}; // cxx11-error {{return type 'void' is not a literal type}}
+TYPE_CAST []() constexpr {}; // cxx11-error {{return type 'void' is not a literal type}}
 #endif
 
 #if __cplusplus >= 201103L
-auto L0 = [] constexpr {}; // cxx11-error {{return type 'void' is not a literal type}}
+TYPE_CAST [] constexpr {}; // cxx11-error {{return type 'void' is not a literal type}}
 #endif
-auto L1 = [] mutable {};
+TYPE_CAST [] mutable {};
 #if __cplusplus >= 201103L
-auto L2 = [] noexcept {};
-auto L3 = [] constexpr mutable {}; // cxx11-error {{return type 'void' is not a literal type}}
-auto L4 = [] mutable constexpr {}; // cxx11-error {{return type 'void' is not a literal type}}
-auto L5 = [] constexpr mutable noexcept {}; // cxx11-error {{return type 'void' is not a literal type}}
+TYPE_CAST [] noexcept {};
+TYPE_CAST [] constexpr mutable {}; // cxx11-error {{return type 'void' is not a literal type}}
+TYPE_CAST [] mutable constexpr {}; // cxx11-error {{return type 'void' is not a literal type}}
+TYPE_CAST [] constexpr mutable noexcept {}; // cxx11-error {{return type 'void' is not a literal type}}
 #endif
-auto L6 = [s = 1] mutable {};
+TYPE_CAST [s = 1] mutable {};
 #if __cplusplus >= 201103L
-auto L7 = [s = 1] constexpr mutable noexcept {}; // cxx11-error {{return type 'void' is not a literal type}}
+TYPE_CAST [s = 1] constexpr mutable noexcept {}; // cxx11-error {{return type 'void' is not a literal type}}
 #endif
-auto L8 = [] -> bool { return true; };
-auto L9 = []<typename T> { return true; };
+TYPE_CAST [] -> bool { return true; };
+TYPE_CAST []<typename T> { return true; };
 #if __cplusplus >= 201103L
-auto L10 = []<typename T> noexcept { return true; };
+TYPE_CAST []<typename T> noexcept { return true; };
 #endif
-auto L11 = []<typename T> -> bool { return true; };
+TYPE_CAST []<typename T> -> bool { return true; };
 #if __cplusplus >= 202002L
-auto L12 = [] consteval {};
-auto L13 = []() requires true {}; // expected-error{{non-templated function cannot have a requires clause}}
-auto L14 = []<auto> requires true() requires true {};
-auto L15 = []<auto> requires true noexcept {};
+TYPE_CAST [] consteval {};
+TYPE_CAST []() requires true {}; // expected-error{{non-templated function cannot have a requires clause}}
+TYPE_CAST []<auto> requires true() requires true {};
+TYPE_CAST []<auto> requires true noexcept {};
 #endif
-auto L16 = [] [[maybe_unused]]{};
+TYPE_CAST [] [[maybe_unused]]{};
 
 #if __cplusplus >= 201103L
-auto XL0 = [] mutable constexpr mutable {};    // expected-error{{cannot appear multiple times}} cxx11-error {{return type 'void' is not a literal type}}
-auto XL1 = [] constexpr mutable constexpr {};  // expected-error{{cannot appear multiple times}} cxx11-error {{return type 'void' is not a literal type}}
-auto XL2 = []) constexpr mutable constexpr {}; // expected-error{{expected body of lambda expression}}
-auto XL3 = []( constexpr mutable constexpr {}; // expected-error{{invalid storage class specifier}} \
-                                               // expected-error{{function parameter cannot be constexpr}} \
-                                               // expected-error{{a type specifier is required}} \
-                                               // expected-error{{expected ')'}} \
-                                               // expected-note{{to match this '('}} \
-                                               // expected-error{{expected body}} \
-                                               // expected-warning{{duplicate 'constexpr'}}
+TYPE_CAST [] mutable constexpr mutable {};    // expected-error{{cannot appear multiple times}} cxx11-error {{return type 'void' is not a literal type}}
+TYPE_CAST [] constexpr mutable constexpr {};  // expected-error{{cannot appear multiple times}} cxx11-error {{return type 'void' is not a literal type}}
+
+[]) constexpr mutable constexpr {}; // expected-error{{expected body of lambda expression}}
+[]( constexpr mutable constexpr {}; // expected-error{{invalid storage class specifier}} \
+                                    // expected-error{{function parameter cannot be constexpr}} \
+                                    // expected-error{{a type specifier is required}} \
+                                    // expected-error{{expected ')'}} \
+                                    // expected-note{{to match this '('}} \
+                                    // expected-error{{expected body}} \
+                                    // expected-warning{{duplicate 'constexpr'}}
+
 #endif
 
 // http://llvm.org/PR49736
-auto XL4 = [] requires true {}; // expected-error{{expected body}}
-#if __cplusplus >= 201703L
-auto XL5 = []<auto> requires true requires true {}; // expected-error{{expected body}}
-auto XL6 = []<auto> requires true noexcept requires true {}; // expected-error{{expected body}}
+
+#if __cplusplus >= 202002L
+[] requires true {}; // expected-error{{expected body}}
+(void)[] requires true {}; // expected-error{{expected body}}
+#else
+[] requires true {}; // expected-error{{expected body}}
+(void)[] requires true {}; // expected-error{{expected expression}}
 #endif
 
-auto XL7 = []() static static {}; // expected-error {{cannot appear multiple times}}
-auto XL8 = []() static mutable {}; // expected-error {{cannot be both mutable and static}}
+#if __cplusplus >= 201703L
+TYPE_CAST []<auto> requires true requires true {}; // expected-error{{expected body}}
+TYPE_CAST []<auto> requires true noexcept requires true {}; // expected-error{{expected body}}
+#endif
+
+TYPE_CAST []() static static {}; // expected-error {{cannot appear multiple times}}
+TYPE_CAST []() static mutable {}; // expected-error {{cannot be both mutable and static}}
 #if __cplusplus >= 202002L
-auto XL9 = []() static consteval {};
+TYPE_CAST []() static consteval {};
 #endif
 #if __cplusplus >= 201103L
-auto XL10 = []() static constexpr {}; // cxx11-error {{return type 'void' is not a literal type}}
+TYPE_CAST []() static constexpr {}; // cxx11-error {{return type 'void' is not a literal type}}
 #endif
 
-auto XL11 = [] static {};
-auto XL12 = []() static {};
-auto XL13 = []() static extern {};  // expected-error {{expected body of lambda expression}}
-auto XL14 = []() extern {};  // expected-error {{expected body of lambda expression}}
+TYPE_CAST [] static {};
+TYPE_CAST []() static {};
+TYPE_CAST []() static extern {};  // expected-error {{expected body of lambda expression}}
+TYPE_CAST []() extern {};  // expected-error {{expected body of lambda expression}}
+
+}
 
 
 void static_captures() {
   int x;
-  auto SC1 = [&]() static {}; // expected-error {{a static lambda cannot have any captures}}
-  auto SC4 = [x]() static {}; // expected-error {{a static lambda cannot have any captures}}
-  auto SC2 = [&x]() static {}; // expected-error {{a static lambda cannot have any captures}}
-  auto SC3 = [y=x]() static {}; // expected-error {{a static lambda cannot have any captures}}
-  auto SC5 = [&y = x]() static {}; // expected-error {{a static lambda cannot have any captures}}
-  auto SC6 = [=]() static {}; // expected-error {{a static lambda cannot have any captures}}
+  TYPE_CAST [&]() static {}; // expected-error {{a static lambda cannot have any captures}}
+  TYPE_CAST [x]() static {}; // expected-error {{a static lambda cannot have any captures}}
+  TYPE_CAST [&x]() static {}; // expected-error {{a static lambda cannot have any captures}}
+  TYPE_CAST [y=x]() static {}; // expected-error {{a static lambda cannot have any captures}}
+  TYPE_CAST [&y = x]() static {}; // expected-error {{a static lambda cannot have any captures}}
+  TYPE_CAST [=]() static {}; // expected-error {{a static lambda cannot have any captures}}
   struct X {
     int z;
     void f() {


### PR DESCRIPTION
When tentatively parsing cast expressions, we were assuming `[` was the start of a lambda expression.

However, the expression might instead by a subscripted parenthesized postfix expression.

Therefore, we need to check if the expression is in fact a lambda.

We do that by looking for an open brace, bailing early when possible.

Fixes #20723
