### PR TITLE
[LLVM][TableGen] Simplify `DagInit::get`

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1438,11 +1438,23 @@ public:
   }
 
   static const DagInit *get(const Init *V, const StringInit *VN,
-                            ArrayRef<const Init *> ArgRange,
-                            ArrayRef<const StringInit *> NameRange);
+                            ArrayRef<const Init *> Args,
+                            ArrayRef<const StringInit *> ArgNames);
+
+  static const DagInit *get(const Init *V, ArrayRef<const Init *> Args,
+                            ArrayRef<const StringInit *> ArgNames) {
+    return DagInit::get(V, nullptr, Args, ArgNames);
+  }
+
   static const DagInit *
   get(const Init *V, const StringInit *VN,
       ArrayRef<std::pair<const Init *, const StringInit *>> ArgAndNames);
+
+  static const DagInit *
+  get(const Init *V,
+      ArrayRef<std::pair<const Init *, const StringInit *>> ArgAndNames) {
+    return DagInit::get(V, nullptr, ArgAndNames);
+  }
 
   void Profile(FoldingSetNodeID &ID) const;
 

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1309,7 +1309,7 @@ const Init *BinOpInit::Fold(const Record *CurRec) const {
       SmallVector<std::pair<const Init *, const StringInit *>, 8> Args;
       llvm::append_range(Args, LHSs->getArgAndNames());
       llvm::append_range(Args, RHSs->getArgAndNames());
-      return DagInit::get(Op, nullptr, Args);
+      return DagInit::get(Op, Args);
     }
     break;
   }
@@ -1504,7 +1504,7 @@ const Init *BinOpInit::Fold(const Record *CurRec) const {
     const auto *Dag = dyn_cast<DagInit>(LHS);
     const auto *Op = dyn_cast<DefInit>(RHS);
     if (Dag && Op)
-      return DagInit::get(Op, nullptr, Dag->getArgs(), Dag->getArgNames());
+      return DagInit::get(Op, Dag->getArgs(), Dag->getArgNames());
     break;
   }
   case ADD:
@@ -1687,7 +1687,7 @@ static const Init *ForeachDagApply(const Init *LHS, const DagInit *MHSd,
   }
 
   if (Change)
-    return DagInit::get(Val, nullptr, NewArgs);
+    return DagInit::get(Val, NewArgs);
   return MHSd;
 }
 
@@ -1825,7 +1825,7 @@ const Init *TernOpInit::Fold(const Record *CurRec) const {
           return this;
         Children.emplace_back(Node, dyn_cast<StringInit>(Name));
       }
-      return DagInit::get(LHS, nullptr, Children);
+      return DagInit::get(LHS, Children);
     }
     break;
   }

--- a/llvm/utils/TableGen/AsmWriterEmitter.cpp
+++ b/llvm/utils/TableGen/AsmWriterEmitter.cpp
@@ -1031,13 +1031,10 @@ void AsmWriterEmitter::EmitPrintAliasInstruction(raw_ostream &O) {
         // Change (any_of FeatureAll, (any_of ...)) to (any_of FeatureAll, ...).
         if (IsOr && D->getNumArgs() == 2 && isa<DagInit>(D->getArg(1))) {
           const DagInit *RHS = cast<DagInit>(D->getArg(1));
-          SmallVector<const Init *> Args{D->getArg(0)};
-          SmallVector<const StringInit *> ArgNames{D->getArgName(0)};
-          for (unsigned i = 0, e = RHS->getNumArgs(); i != e; ++i) {
-            Args.push_back(RHS->getArg(i));
-            ArgNames.push_back(RHS->getArgName(i));
-          }
-          D = DagInit::get(D->getOperator(), nullptr, Args, ArgNames);
+          SmallVector<std::pair<const Init *, const StringInit *>> Args{
+              *D->getArgAndNames().begin()};
+          llvm::append_range(Args, RHS->getArgAndNames());
+          D = DagInit::get(D->getOperator(), Args);
         }
 
         for (auto *Arg : D->getArgs()) {

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -2906,11 +2906,7 @@ TreePatternNodePtr TreePattern::ParseTreePattern(const Init *TheInit,
     // TreePatternNode of its own.  For example:
     ///   (foo GPR, imm) -> (foo GPR, (imm))
     if (R->isSubClassOf("SDNode") || R->isSubClassOf("PatFrags"))
-      return ParseTreePattern(
-          DagInit::get(
-              DI, nullptr,
-              std::vector<std::pair<const Init *, const StringInit *>>()),
-          OpName);
+      return ParseTreePattern(DagInit::get(DI, {}), OpName);
 
     // Input argument?
     TreePatternNodePtr Res = makeIntrusiveRefCnt<TreePatternNode>(DI, 1);
@@ -3413,10 +3409,8 @@ void CodeGenDAGPatterns::ParseDefaultOperands() {
 
     // Clone the DefaultInfo dag node, changing the operator from 'ops' to
     // SomeSDnode so that we can parse this.
-    std::vector<std::pair<const Init *, const StringInit *>> Ops;
-    for (unsigned op = 0, e = DefaultInfo->getNumArgs(); op != e; ++op)
-      Ops.emplace_back(DefaultInfo->getArg(op), DefaultInfo->getArgName(op));
-    const DagInit *DI = DagInit::get(SomeSDNode, nullptr, Ops);
+    const DagInit *DI = DagInit::get(SomeSDNode, DefaultInfo->getArgs(),
+                                     DefaultInfo->getArgNames());
 
     // Create a TreePattern to parse this.
     TreePattern P(DefaultOps[i], DI, false, *this);

--- a/llvm/utils/TableGen/Common/VarLenCodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/Common/VarLenCodeEmitterGen.cpp
@@ -213,8 +213,9 @@ void VarLenInst::buildRec(const DagInit *DI) {
     if (NeedSwap) {
       // Normalization: Hi bit should always be the second argument.
       const Init *const NewArgs[] = {OperandName, LoBit, HiBit};
-      Segments.push_back({NumBits,
-                          DagInit::get(DI->getOperator(), nullptr, NewArgs, {}),
+      // TODO: This creates an invalid DagInit with 3 Args but 0 ArgNames.
+      // Extend unit test to exercise this and fix it.
+      Segments.push_back({NumBits, DagInit::get(DI->getOperator(), NewArgs, {}),
                           CustomEncoder, CustomDecoder});
     } else {
       Segments.push_back({NumBits, DI, CustomEncoder, CustomDecoder});


### PR DESCRIPTION
- Add `DagInit::get` overloads that do not need ValName to be specified.
- Fix some calls to either not create temporary arrays for DAG args or use the std::pair<> overload.