### PR TITLE
[HLSL][SPIRV] Implement the SPIR-V target type for cbuffers.

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -47,7 +47,7 @@ static const unsigned SPIRDefIsPrivMap[] = {
     0,  // ptr32_uptr
     0,  // ptr64
     0,  // hlsl_groupshared
-    2,  // hlsl_constant
+    12, // hlsl_constant
     10, // hlsl_private
     11, // hlsl_device
     // Wasm address space values for this target are dummy values,

--- a/clang/lib/CodeGen/Targets/SPIR.cpp
+++ b/clang/lib/CodeGen/Targets/SPIR.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ABIInfoImpl.h"
+#include "HLSLBufferLayoutBuilder.h"
 #include "TargetInfo.h"
 
 using namespace clang;
@@ -410,9 +411,19 @@ llvm::Type *CommonSPIRTargetCodeGenInfo::getHLSLType(
                                     {RuntimeArrayType},
                                     {StorageClass, IsWritable});
   }
-  case llvm::dxil::ResourceClass::CBuffer:
-    llvm_unreachable("CBuffer handles are not implemented for SPIR-V yet");
+  case llvm::dxil::ResourceClass::CBuffer: {
+    QualType ContainedTy = ResType->getContainedType();
+    if (ContainedTy.isNull() || !ContainedTy->isStructureType())
+      return nullptr;
+
+    llvm::Type *BufferLayoutTy =
+        HLSLBufferLayoutBuilder(CGM, "spirv.Layout")
+            .createLayoutType(ContainedTy->getAsStructureType(), Packoffsets);
+    uint32_t StorageClass = /* Uniform storage class */ 2;
+    return llvm::TargetExtType::get(Ctx, "spirv.VulkanBuffer", {BufferLayoutTy},
+                                    {StorageClass, false});
     break;
+  }
   case llvm::dxil::ResourceClass::Sampler:
     return llvm::TargetExtType::get(Ctx, "spirv.Sampler");
   }

--- a/clang/test/CodeGenHLSL/default_cbuffer.hlsl
+++ b/clang/test/CodeGenHLSL/default_cbuffer.hlsl
@@ -1,12 +1,19 @@
-// RUN: %clang_cc1 -Wno-hlsl-implicit-binding -finclude-default-header -triple dxil-pc-shadermodel6.3-compute -fnative-half-type -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s
+// RUN: %clang_cc1 -Wno-hlsl-implicit-binding -finclude-default-header -triple dxil-pc-shadermodel6.3-compute -fnative-half-type -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefixes=CHECK,DXIL
+// RUN: %clang_cc1 -Wno-hlsl-implicit-binding -finclude-default-header -triple spirv-pc-vulkan1.3-compute -fnative-half-type -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefixes=CHECK,SPIRV
 
-// CHECK: %"__cblayout_$Globals" = type <{ float, float, target("dx.Layout", %__cblayout_S, 4, 0) }>
+// DXIL: %"__cblayout_$Globals" = type <{ float, float, target("dx.Layout", %__cblayout_S, 4, 0) }>
+// SPIRV: %"__cblayout_$Globals" = type <{ float, float, target("spirv.Layout", %__cblayout_S, 4, 0) }>
 // CHECK: %__cblayout_S = type <{ float }>
 
-// CHECK-DAG: @"$Globals.cb" = global target("dx.CBuffer", target("dx.Layout", %"__cblayout_$Globals", 20, 0, 4, 16))
-// CHECK-DAG: @a = external addrspace(2) global float
-// CHECK-DAG: @g = external addrspace(2) global float
-// CHECK-DAG: @h = external addrspace(2) global target("dx.Layout", %__cblayout_S, 4, 0), align 4
+// DXIL-DAG: @"$Globals.cb" = global target("dx.CBuffer", target("dx.Layout", %"__cblayout_$Globals", 20, 0, 4, 16))
+// DXIL-DAG: @a = external addrspace(2) global float
+// DXIL-DAG: @g = external addrspace(2) global float
+// DXIL-DAG: @h = external addrspace(2) global target("dx.Layout", %__cblayout_S, 4, 0), align 4
+
+// SPIRV-DAG: @"$Globals.cb" = global target("spirv.VulkanBuffer", target("spirv.Layout", %"__cblayout_$Globals", 20, 0, 4, 16), 2, 0)
+// SPIRV-DAG: @a = external addrspace(12) global float
+// SPIRV-DAG: @g = external addrspace(12) global float
+// SPIRV-DAG: @h = external addrspace(12) global target("spirv.Layout", %__cblayout_S, 4, 0), align 8
 
 struct EmptyStruct {
 };
@@ -35,4 +42,5 @@ void main() {
 }
 
 // CHECK: !hlsl.cbs = !{![[CB:.*]]}
-// CHECK: ![[CB]] = !{ptr @"$Globals.cb", ptr addrspace(2) @a, ptr addrspace(2) @g, ptr addrspace(2) @h}
+// DXIL: ![[CB]] = !{ptr @"$Globals.cb", ptr addrspace(2) @a, ptr addrspace(2) @g, ptr addrspace(2) @h}
+// SPIRV: ![[CB]] = !{ptr @"$Globals.cb", ptr addrspace(12) @a, ptr addrspace(12) @g, ptr addrspace(12) @h}


### PR DESCRIPTION
This change implement the type used to represent cbuffer for SPIR-V.

Fixes https://github.com/llvm/llvm-project/issues/138274.
