### PR TITLE
[Clang] Fix an assertion in the resolution of perfect matches

### DIFF
--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -430,8 +430,8 @@ class Sema;
       if (!ReferenceBinding) {
 #ifndef NDEBUG
         auto Decay = [&](QualType T) {
-          T = (T->isArrayType() || T->isFunctionType()) ? C.getDecayedType(T)
-                                                        : T;
+          if (T->isArrayType() || T->isFunctionType())
+            T = C.getDecayedType(T);
 
           // A function pointer type can be resolved to a member function type,
           // which is still an identity conversion.

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -430,8 +430,14 @@ class Sema;
       if (!ReferenceBinding) {
 #ifndef NDEBUG
         auto Decay = [&](QualType T) {
-          return (T->isArrayType() || T->isFunctionType()) ? C.getDecayedType(T)
-                                                           : T;
+          T = (T->isArrayType() || T->isFunctionType()) ? C.getDecayedType(T)
+                                                        : T;
+
+          // A function pointer type can be resolved to a member function type,
+          // which is still an identity conversion.
+          if (auto *N = T->getAs<MemberPointerType>())
+            T = C.getDecayedType(N->getPointeeType());
+          return T;
         };
         // The types might differ if there is an array-to-pointer conversion
         // an function-to-pointer conversion, or lvalue-to-rvalue conversion.

--- a/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
+++ b/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
@@ -232,3 +232,22 @@ struct InitListAreNotPerfectCpy {
 };
 
 InitListAreNotPerfectCpy InitListAreNotPerfectCpy_test({InitListAreNotPerfectCpy{}});
+
+namespace PointerToMemFunc {
+template <typename>
+class A;
+struct N {
+  template <typename T>
+  void f(T);
+};
+template <typename T>
+struct E {
+  template <class = A<int>>
+  void g() = delete;
+  void g(void (T::*)(char));
+};
+void f() {
+  E<N> e;
+  e.g(&N::f);
+}
+}


### PR DESCRIPTION
Function pointers can have an identity conversion to a pointer to member function if they are resolved to a member function.

Fix a regression introduced by #136203