### PR TITLE
[NFC][Clang] Adopt simplified `getTrailingObjects` in DeclCXX

### DIFF
--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -2606,9 +2606,6 @@ class CXXConstructorDecl final
   size_t numTrailingObjects(OverloadToken<InheritedConstructor>) const {
     return CXXConstructorDeclBits.IsInheritingConstructor;
   }
-  size_t numTrailingObjects(OverloadToken<ExplicitSpecifier>) const {
-    return CXXConstructorDeclBits.HasTrailingExplicitSpecifier;
-  }
 
   ExplicitSpecifier getExplicitSpecifierInternal() const {
     if (CXXConstructorDeclBits.HasTrailingExplicitSpecifier)
@@ -2625,8 +2622,12 @@ class CXXConstructorDecl final
   };
 
   uint64_t getTrailingAllocKind() const {
-    return numTrailingObjects(OverloadToken<InheritedConstructor>()) |
-           (numTrailingObjects(OverloadToken<ExplicitSpecifier>()) << 1);
+    uint64_t Kind = 0;
+    if (CXXConstructorDeclBits.IsInheritingConstructor)
+      Kind |= TAKInheritsConstructor;
+    if (CXXConstructorDeclBits.HasTrailingExplicitSpecifier)
+      Kind |= TAKHasTailExplicit;
+    return Kind;
   }
 
 public:
@@ -3864,7 +3865,7 @@ class UsingPackDecl final
                   InstantiatedFrom ? InstantiatedFrom->getDeclName()
                                    : DeclarationName()),
         InstantiatedFrom(InstantiatedFrom), NumExpansions(UsingDecls.size()) {
-    llvm::uninitialized_copy(UsingDecls, getTrailingObjects<NamedDecl *>());
+    llvm::uninitialized_copy(UsingDecls, getTrailingObjects());
   }
 
   void anchor() override;
@@ -3882,7 +3883,7 @@ public:
   /// Get the set of using declarations that this pack expanded into. Note that
   /// some of these may still be unresolved.
   ArrayRef<NamedDecl *> expansions() const {
-    return getTrailingObjects<NamedDecl *>(NumExpansions);
+    return getTrailingObjects(NumExpansions);
   }
 
   static UsingPackDecl *Create(ASTContext &C, DeclContext *DC,
@@ -4235,7 +4236,7 @@ class DecompositionDecl final
       : VarDecl(Decomposition, C, DC, StartLoc, LSquareLoc, nullptr, T, TInfo,
                 SC),
         NumBindings(Bindings.size()) {
-    llvm::uninitialized_copy(Bindings, getTrailingObjects<BindingDecl *>());
+    llvm::uninitialized_copy(Bindings, getTrailingObjects());
     for (auto *B : Bindings) {
       B->setDecomposedDecl(this);
       if (B->isParameterPack() && B->getBinding()) {
@@ -4262,8 +4263,8 @@ public:
                                                unsigned NumBindings);
 
   // Provide the range of bindings which may have a nested pack.
-  llvm::ArrayRef<BindingDecl *> bindings() const {
-    return {getTrailingObjects<BindingDecl *>(), NumBindings};
+  ArrayRef<BindingDecl *> bindings() const {
+    return getTrailingObjects(NumBindings);
   }
 
   // Provide a flattened range to visit each binding.

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -3449,9 +3449,8 @@ UsingPackDecl *UsingPackDecl::CreateDeserialized(ASTContext &C, GlobalDeclID ID,
   size_t Extra = additionalSizeToAlloc<NamedDecl *>(NumExpansions);
   auto *Result = new (C, ID, Extra) UsingPackDecl(nullptr, nullptr, {});
   Result->NumExpansions = NumExpansions;
-  auto *Trail = Result->getTrailingObjects<NamedDecl *>();
-  for (unsigned I = 0; I != NumExpansions; ++I)
-    new (Trail + I) NamedDecl*(nullptr);
+  auto *Trail = Result->getTrailingObjects();
+  std::uninitialized_fill_n(Trail, NumExpansions, nullptr);
   return Result;
 }
 
@@ -3610,9 +3609,8 @@ DecompositionDecl *DecompositionDecl::CreateDeserialized(ASTContext &C,
                         QualType(), nullptr, StorageClass(), {});
   // Set up and clean out the bindings array.
   Result->NumBindings = NumBindings;
-  auto *Trail = Result->getTrailingObjects<BindingDecl *>();
-  for (unsigned I = 0; I != NumBindings; ++I)
-    new (Trail + I) BindingDecl*(nullptr);
+  auto *Trail = Result->getTrailingObjects();
+  std::uninitialized_fill_n(Trail, NumBindings, nullptr);
   return Result;
 }
 


### PR DESCRIPTION
- Adopt non-templated and ArrayRef returning forms of `getTrailingObjects`.
- Replace some initialization loop with std::uninitialized_fill_n.
- Remove unneeded `numTrailingObjects` for last trailing type.