### PR TITLE
[llvm] Fix test breakage in Vectorize/VPlanVerifierTest.cpp

### DIFF
--- a/llvm/unittests/Transforms/Vectorize/VPlanVerifierTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanVerifierTest.cpp
@@ -174,7 +174,7 @@ TEST_F(VPVerifierTest, VPPhiIncomingValueDoesntDominateIncomingBlock) {
                "  EMIT vp<%1> = phi [ vp<%2>, preheader ]",
                ::testing::internal::GetCapturedStderr().c_str());
 #else
-  EXPECT_STREQ("Incoming def at index 0 does not dominate incoming block!\n" ::
+  EXPECT_STREQ("Incoming def at index 0 does not dominate incoming block!\n", ::
                    testing::internal::GetCapturedStderr()
                        .c_str());
 #endif


### PR DESCRIPTION
Fix test breakage in Vectorize/VPlanVerifierTest.cpp introduced in change 849990479 (typo).