### PR TITLE
[NFC][Clang] Adopt simplified `getTrailingObjects` in DeclFriend

### DIFF
--- a/clang/include/clang/AST/DeclFriend.h
+++ b/clang/include/clang/AST/DeclFriend.h
@@ -90,8 +90,7 @@ private:
       : Decl(Decl::Friend, DC, L), Friend(Friend), FriendLoc(FriendL),
         EllipsisLoc(EllipsisLoc), UnsupportedFriend(false),
         NumTPLists(FriendTypeTPLists.size()) {
-    for (unsigned i = 0; i < NumTPLists; ++i)
-      getTrailingObjects<TemplateParameterList *>()[i] = FriendTypeTPLists[i];
+    llvm::copy(FriendTypeTPLists, getTrailingObjects());
   }
 
   FriendDecl(EmptyShell Empty, unsigned NumFriendTypeTPLists)
@@ -132,8 +131,7 @@ public:
   }
 
   TemplateParameterList *getFriendTypeTemplateParameterList(unsigned N) const {
-    assert(N < NumTPLists);
-    return getTrailingObjects<TemplateParameterList *>()[N];
+    return getTrailingObjects(NumTPLists)[N];
   }
 
   /// If this friend declaration doesn't name a type, return the inner
@@ -153,10 +151,9 @@ public:
   /// Retrieves the source range for the friend declaration.
   SourceRange getSourceRange() const override LLVM_READONLY {
     if (TypeSourceInfo *TInfo = getFriendType()) {
-      SourceLocation StartL =
-          (NumTPLists == 0) ? getFriendLoc()
-                            : getTrailingObjects<TemplateParameterList *>()[0]
-                                  ->getTemplateLoc();
+      SourceLocation StartL = (NumTPLists == 0)
+                                  ? getFriendLoc()
+                                  : getTrailingObjects()[0]->getTemplateLoc();
       SourceLocation EndL = isPackExpansion() ? getEllipsisLoc()
                                               : TInfo->getTypeLoc().getEndLoc();
       return SourceRange(StartL, EndL);

--- a/clang/include/clang/AST/DeclGroup.h
+++ b/clang/include/clang/AST/DeclGroup.h
@@ -37,14 +37,10 @@ public:
 
   unsigned size() const { return NumDecls; }
 
-  Decl*& operator[](unsigned i) {
-    assert (i < NumDecls && "Out-of-bounds access.");
-    return getTrailingObjects<Decl *>()[i];
-  }
+  Decl *&operator[](unsigned i) { return getTrailingObjects(NumDecls)[i]; }
 
   Decl* const& operator[](unsigned i) const {
-    assert (i < NumDecls && "Out-of-bounds access.");
-    return getTrailingObjects<Decl *>()[i];
+    return getTrailingObjects(NumDecls)[i];
   }
 };
 

--- a/clang/include/clang/AST/DeclObjC.h
+++ b/clang/include/clang/AST/DeclObjC.h
@@ -678,7 +678,7 @@ public:
   /// Iterate through the type parameters in the list.
   using iterator = ObjCTypeParamDecl **;
 
-  iterator begin() { return getTrailingObjects<ObjCTypeParamDecl *>(); }
+  iterator begin() { return getTrailingObjects(); }
 
   iterator end() { return begin() + size(); }
 
@@ -688,9 +688,7 @@ public:
   // Iterate through the type parameters in the list.
   using const_iterator = ObjCTypeParamDecl * const *;
 
-  const_iterator begin() const {
-    return getTrailingObjects<ObjCTypeParamDecl *>();
-  }
+  const_iterator begin() const { return getTrailingObjects(); }
 
   const_iterator end() const {
     return begin() + size();

--- a/clang/lib/AST/DeclGroup.cpp
+++ b/clang/lib/AST/DeclGroup.cpp
@@ -28,6 +28,5 @@ DeclGroup* DeclGroup::Create(ASTContext &C, Decl **Decls, unsigned NumDecls) {
 DeclGroup::DeclGroup(unsigned numdecls, Decl** decls) : NumDecls(numdecls) {
   assert(numdecls > 0);
   assert(decls);
-  std::uninitialized_copy(decls, decls + numdecls,
-                          getTrailingObjects<Decl *>());
+  std::uninitialized_copy(decls, decls + numdecls, getTrailingObjects());
 }


### PR DESCRIPTION
- Adopt non-templated `getTrailingObjects` in DeclFriend, DeclGroup, and DeclObjC
- Use indexing into ArrayRef returned by `getTrailingObjects` and eliminate explicit OOB asserts.