### PR TITLE
[PowerPC][NFC] clean up if-else block in PPCRegisterInfo.cpp

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
@@ -1635,37 +1635,44 @@ PPCRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   }
 
   // Special case for pseudo-ops SPILL_CR and RESTORE_CR, etc.
-  if (OpC == PPC::SPILL_CR) {
+  switch (OpC) {
+  case PPC::SPILL_CR:
     lowerCRSpilling(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::RESTORE_CR) {
+  case PPC::RESTORE_CR:
     lowerCRRestore(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::SPILL_CRBIT) {
+  case PPC::SPILL_CRBIT:
     lowerCRBitSpilling(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::RESTORE_CRBIT) {
+  case PPC::RESTORE_CRBIT:
     lowerCRBitRestore(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::SPILL_ACC || OpC == PPC::SPILL_UACC) {
+  case PPC::SPILL_ACC:
+  case PPC::SPILL_UACC:
     lowerACCSpilling(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::RESTORE_ACC || OpC == PPC::RESTORE_UACC) {
+  case PPC::RESTORE_ACC:
+  case PPC::RESTORE_UACC:
     lowerACCRestore(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::STXVP && DisableAutoPairedVecSt) {
-    lowerOctWordSpilling(II, FrameIndex);
-    return true;
-  } else if (OpC == PPC::SPILL_WACC) {
+  case PPC::STXVP: {
+    if (DisableAutoPairedVecSt) {
+      lowerOctWordSpilling(II, FrameIndex);
+      return true;
+    }
+    break;
+  }
+  case PPC::SPILL_WACC:
     lowerWACCSpilling(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::RESTORE_WACC) {
+  case PPC::RESTORE_WACC:
     lowerWACCRestore(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::SPILL_QUADWORD) {
+  case PPC::SPILL_QUADWORD:
     lowerQuadwordSpilling(II, FrameIndex);
     return true;
-  } else if (OpC == PPC::RESTORE_QUADWORD) {
+  case PPC::RESTORE_QUADWORD:
     lowerQuadwordRestore(II, FrameIndex);
     return true;
   }

--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
@@ -1611,6 +1611,8 @@ PPCRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   unsigned OpC = MI.getOpcode();
 
   switch (OpC) {
+  default:
+    break;
   case PPC::DYNAREAOFFSET:
   case PPC::DYNAREAOFFSET8:
     lowerDynamicAreaOffset(II);

--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
@@ -1610,33 +1610,33 @@ PPCRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   // Get the instruction opcode.
   unsigned OpC = MI.getOpcode();
 
-  if ((OpC == PPC::DYNAREAOFFSET || OpC == PPC::DYNAREAOFFSET8)) {
+  switch (OpC) {
+  case PPC::DYNAREAOFFSET:
+  case PPC::DYNAREAOFFSET8:
     lowerDynamicAreaOffset(II);
     // lowerDynamicAreaOffset erases II
     return true;
+  case PPC::DYNALLOC:
+  case PPC::DYNALLOC8: {
+    // Special case for dynamic alloca.
+    if (FPSI && FrameIndex == FPSI) {
+      lowerDynamicAlloc(II); // lowerDynamicAlloc erases II
+      return true;
+    }
+    break;
   }
-
-  // Special case for dynamic alloca.
-  if (FPSI && FrameIndex == FPSI &&
-      (OpC == PPC::DYNALLOC || OpC == PPC::DYNALLOC8)) {
-    lowerDynamicAlloc(II);
-    // lowerDynamicAlloc erases II
-    return true;
+  case PPC::PREPARE_PROBED_ALLOCA_64:
+  case PPC::PREPARE_PROBED_ALLOCA_32:
+  case PPC::PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_64:
+  case PPC::PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_32: {
+    if (FPSI && FrameIndex == FPSI) {
+      lowerPrepareProbedAlloca(II); // lowerPrepareProbedAlloca erases II
+      return true;
+    }
+    break;
   }
-
-  if (FPSI && FrameIndex == FPSI &&
-      (OpC == PPC::PREPARE_PROBED_ALLOCA_64 ||
-       OpC == PPC::PREPARE_PROBED_ALLOCA_32 ||
-       OpC == PPC::PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_64 ||
-       OpC == PPC::PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_32)) {
-    lowerPrepareProbedAlloca(II);
-    // lowerPrepareProbedAlloca erases II
-    return true;
-  }
-
-  // Special case for pseudo-ops SPILL_CR and RESTORE_CR, etc.
-  switch (OpC) {
   case PPC::SPILL_CR:
+    // Special case for pseudo-ops SPILL_CR and RESTORE_CR, etc.
     lowerCRSpilling(II, FrameIndex);
     return true;
   case PPC::RESTORE_CR:


### PR DESCRIPTION
 Move all if-else conditions into a switch stmt for handling spills.
