### PR TITLE
[CodeGen] Use std::tie to implement a comparison functor (NFC)

### DIFF
--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -575,9 +575,8 @@ void MIRPrinter::convertCallSiteObjects(yaml::MachineFunction &YMF,
   // Sort call info by position of call instructions.
   llvm::sort(YMF.CallSitesInfo.begin(), YMF.CallSitesInfo.end(),
              [](yaml::CallSiteInfo A, yaml::CallSiteInfo B) {
-               if (A.CallLocation.BlockNum == B.CallLocation.BlockNum)
-                 return A.CallLocation.Offset < B.CallLocation.Offset;
-               return A.CallLocation.BlockNum < B.CallLocation.BlockNum;
+               return std::tie(A.CallLocation.BlockNum, A.CallLocation.Offset) <
+                      std::tie(B.CallLocation.BlockNum, B.CallLocation.Offset);
              });
 }
 


### PR DESCRIPTION
std::tie simplifies the lexicographical comparison while making the
code a little more consistent within MIRPrinter.cpp as we have a very
similar comparison functor in MIRPrinter::convertCalledGlobals, about
30 lines below the code this patch touches.
