### PR TITLE
[MLIR][LLVM] Add import-structs-as-literals flag to the IR import

### DIFF
--- a/mlir/include/mlir/Target/LLVMIR/Import.h
+++ b/mlir/include/mlir/Target/LLVMIR/Import.h
@@ -46,10 +46,14 @@ class ModuleOp;
 /// registered an explicit intrinsic operation. Warning: passes that rely on
 /// matching explicit intrinsic operations may not work properly if this flag is
 /// enabled.
+/// The `importStructsAsLiterals` flag (default off) ensures that all structs
+/// are imported as literal structs, even when they are named in the LLVM
+/// module.
 OwningOpRef<ModuleOp> translateLLVMIRToModule(
     std::unique_ptr<llvm::Module> llvmModule, MLIRContext *context,
     bool emitExpensiveWarnings = true, bool dropDICompositeTypeElements = false,
-    bool loadAllDialects = true, bool preferUnregisteredIntrinsics = false);
+    bool loadAllDialects = true, bool preferUnregisteredIntrinsics = false,
+    bool importStructsAsLiterals = false);
 
 /// Translate the given LLVM data layout into an MLIR equivalent using the DLTI
 /// dialect.

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -48,7 +48,7 @@ class ModuleImport {
 public:
   ModuleImport(ModuleOp mlirModule, std::unique_ptr<llvm::Module> llvmModule,
                bool emitExpensiveWarnings, bool importEmptyDICompositeTypes,
-               bool preferUnregisteredIntrinsics);
+               bool preferUnregisteredIntrinsics, bool importStructsAsLiterals);
 
   /// Calls the LLVMImportInterface initialization that queries the registered
   /// dialect interfaces for the supported LLVM IR intrinsics and metadata kinds

--- a/mlir/include/mlir/Target/LLVMIR/TypeFromLLVM.h
+++ b/mlir/include/mlir/Target/LLVMIR/TypeFromLLVM.h
@@ -17,8 +17,6 @@
 #include <memory>
 
 namespace llvm {
-class DataLayout;
-class LLVMContext;
 class Type;
 } // namespace llvm
 
@@ -38,7 +36,8 @@ class TypeFromLLVMIRTranslatorImpl;
 /// reused across translations.
 class TypeFromLLVMIRTranslator {
 public:
-  TypeFromLLVMIRTranslator(MLIRContext &context);
+  TypeFromLLVMIRTranslator(MLIRContext &context,
+                           bool importStructsAsLiterals = false);
   ~TypeFromLLVMIRTranslator();
 
   /// Translates the given LLVM IR type to the MLIR LLVM dialect.

--- a/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
+++ b/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
@@ -44,6 +44,12 @@ void registerFromLLVMIRTranslation() {
           "of using dialect supported intrinsics"),
       llvm::cl::init(false));
 
+  static llvm::cl::opt<bool> importStructsAsLiterals(
+      "import-structs-as-literals",
+      llvm::cl::desc("Controls if structs should be imported as literal "
+                     "structs, i.e., nameless structs."),
+      llvm::cl::init(false));
+
   TranslateToMLIRRegistration registration(
       "import-llvm", "Translate LLVMIR to MLIR",
       [](llvm::SourceMgr &sourceMgr,
@@ -70,7 +76,7 @@ void registerFromLLVMIRTranslation() {
         return translateLLVMIRToModule(
             std::move(llvmModule), context, emitExpensiveWarnings,
             dropDICompositeTypeElements, /*loadAllDialects=*/true,
-            preferUnregisteredIntrinsics);
+            preferUnregisteredIntrinsics, importStructsAsLiterals);
       },
       [](DialectRegistry &registry) {
         // Register the DLTI dialect used to express the data layout

--- a/mlir/test/Target/LLVMIR/Import/import-structs-as-literals.ll
+++ b/mlir/test/Target/LLVMIR/Import/import-structs-as-literals.ll
@@ -1,0 +1,13 @@
+; RUN: mlir-translate -import-llvm -import-structs-as-literals -split-input-file %s | FileCheck %s
+
+%named = type {i32, i8, i16, i32}
+
+; CHECK: @named
+; CHECK-SAME: !llvm.struct<(i32, i8, i16, i32)>
+@named = external global %named
+
+%opaque = type opaque
+
+; CHECK: @opaque
+; CHECK-SAME: !llvm.struct<()>
+@opaque = external global %opaque


### PR DESCRIPTION
This commit introduces the `import-structs-as-literals` option to the MLIR import. This ensures that all struct types are imported as literal structs, even when they are named in LLVM IR.