### PR TITLE
MCParser: Move LCurly/RCurly testing into tokenIsStartOfStatement

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -1760,15 +1760,6 @@ bool AsmParser::parseStatement(ParseStatementInfo &Info,
     // Treat '.' as a valid identifier in this context.
     Lex();
     IDVal = ".";
-  } else if (Lexer.is(AsmToken::LCurly)) {
-    // Treat '{' as a valid identifier in this context.
-    Lex();
-    IDVal = "{";
-
-  } else if (Lexer.is(AsmToken::RCurly)) {
-    // Treat '}' as a valid identifier in this context.
-    Lex();
-    IDVal = "}";
   } else if (getTargetParser().tokenIsStartOfStatement(ID.getKind())) {
     Lex();
     IDVal = ID.getString();

--- a/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
+++ b/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
@@ -110,6 +110,7 @@ class HexagonAsmParser : public MCTargetAsmParser {
 
   bool equalIsAsmAssignment() override { return false; }
   bool isLabel(AsmToken &Token) override;
+  bool tokenIsStartOfStatement(AsmToken::TokenKind Token) override;
 
   void Warning(SMLoc L, const Twine &Msg) { Parser.Warning(L, Msg); }
   bool Error(SMLoc L, const Twine &Msg) { return Parser.Error(L, Msg); }
@@ -1005,6 +1006,10 @@ bool HexagonAsmParser::isLabel(AsmToken &Token) {
   if (!matchRegister(DotSplit.first.lower()))
     return true;
   return false;
+}
+
+bool HexagonAsmParser::tokenIsStartOfStatement(AsmToken::TokenKind Token) {
+  return Token == AsmToken::LCurly || Token == AsmToken::RCurly;
 }
 
 bool HexagonAsmParser::handleNoncontigiousRegister(bool Contigious,

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -124,6 +124,10 @@ private:
     return Result;
   }
 
+  bool tokenIsStartOfStatement(AsmToken::TokenKind Token) override {
+    return Token == AsmToken::LCurly;
+  }
+
   X86TargetStreamer &getTargetStreamer() {
     assert(getParser().getStreamer().getTargetStreamer() &&
            "do not have a target streamer");

--- a/llvm/test/MC/AsmParser/token.s
+++ b/llvm/test/MC/AsmParser/token.s
@@ -1,0 +1,7 @@
+## Tested invalid statement start tokens. X86 supports "{". Use a different target.
+# REQUIRES: aarch64-registered-target
+
+# RUN: not llvm-mc -triple=aarch64 %s 2>&1 | FileCheck %s
+
+# CHECK: [[#@LINE+1]]:2: error: unexpected token at start of statement
+ {insn}


### PR DESCRIPTION
Commit 8a0453e23abf27433b7539b2da2060d2df9fb39c (2015) added LCurly and
RCurly cases for Hexagon instruction bundles. While gas x86 also adopted
`{` in 2017 for pseudo prefixes (see `tc_symbol_chars`), `{` remains
uncommon among targets. Move `{` and `}` parsing into the newly
introduced `tokenIsStartOfStatement` hook (#137997).
