### PR TITLE
[lldb-dap] Adding additional asserts to unit tests.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -590,33 +590,30 @@ class DebugCommunication(object):
 
     def request_attach(
         self,
-        /,
-        program=None,
-        pid=None,
-        waitFor=None,
-        trace=None,
-        initCommands=None,
-        preRunCommands=None,
-        stopCommands=None,
-        exitCommands=None,
-        attachCommands=None,
-        terminateCommands=None,
-        coreFile=None,
+        *,
+        program: Optional[str] = None,
+        pid: Optional[int] = None,
+        waitFor=False,
+        initCommands: Optional[list[str]] = None,
+        preRunCommands: Optional[list[str]] = None,
+        attachCommands: Optional[list[str]] = None,
+        postRunCommands: Optional[list[str]] = None,
+        stopCommands: Optional[list[str]] = None,
+        exitCommands: Optional[list[str]] = None,
+        terminateCommands: Optional[list[str]] = None,
+        coreFile: Optional[str] = None,
         stopOnAttach=True,
-        postRunCommands=None,
-        sourceMap=None,
-        gdbRemotePort=None,
-        gdbRemoteHostname=None,
+        sourceMap: Optional[Union[list[tuple[str, str]], dict[str, str]]] = None,
+        gdbRemotePort: Optional[int] = None,
+        gdbRemoteHostname: Optional[str] = None,
     ):
         args_dict = {}
         if pid is not None:
             args_dict["pid"] = pid
         if program is not None:
             args_dict["program"] = program
-        if waitFor is not None:
+        if waitFor:
             args_dict["waitFor"] = waitFor
-        if trace:
-            args_dict["trace"] = trace
         args_dict["initCommands"] = self.init_commands
         if initCommands:
             args_dict["initCommands"].extend(initCommands)
@@ -822,33 +819,32 @@ class DebugCommunication(object):
 
     def request_launch(
         self,
-        program: Optional[str],
-        /,
+        program: str,
+        *,
         args: Optional[list[str]] = None,
-        cwd=None,
-        env=None,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
         stopOnEntry=True,
         disableASLR=True,
         disableSTDIO=False,
         shellExpandArguments=False,
-        trace=False,
-        initCommands=None,
-        preRunCommands=None,
-        stopCommands=None,
-        exitCommands=None,
-        terminateCommands=None,
-        sourcePath=None,
-        debuggerRoot=None,
-        launchCommands=None,
-        sourceMap=None,
         runInTerminal=False,
-        postRunCommands=None,
         enableAutoVariableSummaries=False,
         displayExtendedBacktrace=False,
         enableSyntheticChildDebugging=False,
-        commandEscapePrefix=None,
-        customFrameFormat=None,
-        customThreadFormat=None,
+        initCommands: Optional[list[str]] = None,
+        preRunCommands: Optional[list[str]] = None,
+        launchCommands: Optional[list[str]] = None,
+        postRunCommands: Optional[list[str]] = None,
+        stopCommands: Optional[list[str]] = None,
+        exitCommands: Optional[list[str]] = None,
+        terminateCommands: Optional[list[str]] = None,
+        sourceMap: Optional[Union[list[tuple[str, str]], dict[str, str]]] = None,
+        sourcePath: Optional[str] = None,
+        debuggerRoot: Optional[str] = None,
+        commandEscapePrefix: Optional[str] = None,
+        customFrameFormat: Optional[str] = None,
+        customThreadFormat: Optional[str] = None,
     ):
         args_dict = {"program": program}
         if args:
@@ -863,8 +859,6 @@ class DebugCommunication(object):
             args_dict["disableSTDIO"] = disableSTDIO
         if shellExpandArguments:
             args_dict["shellExpandArguments"] = shellExpandArguments
-        if trace:
-            args_dict["trace"] = trace
         args_dict["initCommands"] = self.init_commands
         if initCommands:
             args_dict["initCommands"].extend(initCommands)
@@ -1271,7 +1265,7 @@ class DebugAdapterServer(DebugCommunication):
     @classmethod
     def launch(
         cls,
-        /,
+        *,
         executable: str,
         env: Optional[dict[str, str]] = None,
         log_file: Optional[TextIO] = None,

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -12,6 +12,13 @@ import signal
 import sys
 import threading
 import time
+from typing import Any, Optional, Union, BinaryIO, TextIO
+
+## DAP type references
+Event = dict[str, Any]
+Request = dict[str, Any]
+Response = dict[str, Any]
+ProtocolMessage = Union[Event, Request, Response]
 
 
 def dump_memory(base_addr, data, num_per_line, outfile):
@@ -98,55 +105,40 @@ def dump_dap_log(log_file):
     print("========= END =========", file=sys.stderr)
 
 
-def read_packet_thread(vs_comm, log_file):
-    done = False
-    try:
-        while not done:
-            packet = read_packet(vs_comm.recv, trace_file=vs_comm.trace_file)
-            # `packet` will be `None` on EOF. We want to pass it down to
-            # handle_recv_packet anyway so the main thread can handle unexpected
-            # termination of lldb-dap and stop waiting for new packets.
-            done = not vs_comm.handle_recv_packet(packet)
-    finally:
-        # Wait for the process to fully exit before dumping the log file to
-        # ensure we have the entire log contents.
-        if vs_comm.process is not None:
-            try:
-                # Do not wait forever, some logs are better than none.
-                vs_comm.process.wait(timeout=20)
-            except subprocess.TimeoutExpired:
-                pass
-        dump_dap_log(log_file)
-
-
 class DebugCommunication(object):
-    def __init__(self, recv, send, init_commands, log_file=None):
-        self.trace_file = None
+    def __init__(
+        self,
+        recv: BinaryIO,
+        send: BinaryIO,
+        init_commands: list[str],
+        log_file: Optional[TextIO] = None,
+    ):
+        # For debugging test failures, try setting `trace_file = sys.stderr`.
+        self.trace_file: Optional[TextIO] = None
+        self.log_file = log_file
         self.send = send
         self.recv = recv
-        self.recv_packets = []
+        self.recv_packets: list[Optional[ProtocolMessage]] = []
         self.recv_condition = threading.Condition()
-        self.recv_thread = threading.Thread(
-            target=read_packet_thread, args=(self, log_file)
-        )
+        self.recv_thread = threading.Thread(target=self._read_packet_thread)
         self.process_event_body = None
-        self.exit_status = None
+        self.exit_status: Optional[int] = None
         self.initialize_body = None
-        self.thread_stop_reasons = {}
-        self.progress_events = []
+        self.progress_events: list[Event] = []
         self.reverse_requests = []
         self.sequence = 1
         self.threads = None
+        self.thread_stop_reasons = {}
         self.recv_thread.start()
         self.output_condition = threading.Condition()
-        self.output = {}
+        self.output: dict[str, list[str]] = {}
         self.configuration_done_sent = False
         self.frame_scopes = {}
         self.init_commands = init_commands
         self.disassembled_instructions = {}
 
     @classmethod
-    def encode_content(cls, s):
+    def encode_content(cls, s: str) -> bytes:
         return ("Content-Length: %u\r\n\r\n%s" % (len(s), s)).encode("utf-8")
 
     @classmethod
@@ -155,6 +147,18 @@ class DebugCommunication(object):
             raise ValueError("command mismatch in response")
         if command["seq"] != response["request_seq"]:
             raise ValueError("seq mismatch in response")
+
+    def _read_packet_thread(self):
+        done = False
+        try:
+            while not done:
+                packet = read_packet(self.recv, trace_file=self.trace_file)
+                # `packet` will be `None` on EOF. We want to pass it down to
+                # handle_recv_packet anyway so the main thread can handle unexpected
+                # termination of lldb-dap and stop waiting for new packets.
+                done = not self._handle_recv_packet(packet)
+        finally:
+            dump_dap_log(self.log_file)
 
     def get_modules(self):
         module_list = self.request_modules()["body"]["modules"]
@@ -190,13 +194,13 @@ class DebugCommunication(object):
                     break
         return collected_output if collected_output else None
 
-    def enqueue_recv_packet(self, packet):
+    def _enqueue_recv_packet(self, packet: Optional[ProtocolMessage]):
         self.recv_condition.acquire()
         self.recv_packets.append(packet)
         self.recv_condition.notify()
         self.recv_condition.release()
 
-    def handle_recv_packet(self, packet):
+    def _handle_recv_packet(self, packet: Optional[ProtocolMessage]) -> bool:
         """Called by the read thread that is waiting for all incoming packets
         to store the incoming packet in "self.recv_packets" in a thread safe
         way. This function will then signal the "self.recv_condition" to
@@ -205,7 +209,7 @@ class DebugCommunication(object):
         """
         # If EOF, notify the read thread by enqueuing a None.
         if not packet:
-            self.enqueue_recv_packet(None)
+            self._enqueue_recv_packet(None)
             return False
 
         # Check the packet to see if is an event packet
@@ -235,6 +239,18 @@ class DebugCommunication(object):
                 # When a new process is attached or launched, remember the
                 # details that are available in the body of the event
                 self.process_event_body = body
+            elif event == "exited":
+                # Process exited, mark the status to indicate the process is not
+                # alive.
+                self.exit_status = body["exitCode"]
+            elif event == "continued":
+                # When the process continues, clear the known threads and
+                # thread_stop_reasons.
+                all_threads_continued = body.get("allThreadsContinued", True)
+                tid = body["threadId"]
+                if tid in self.thread_stop_reasons:
+                    del self.thread_stop_reasons[tid]
+                self._process_continued(all_threads_continued)
             elif event == "stopped":
                 # Each thread that stops with a reason will send a
                 # 'stopped' event. We need to remember the thread stop
@@ -252,10 +268,16 @@ class DebugCommunication(object):
         elif packet_type == "response":
             if packet["command"] == "disconnect":
                 keepGoing = False
-        self.enqueue_recv_packet(packet)
+        self._enqueue_recv_packet(packet)
         return keepGoing
 
-    def send_packet(self, command_dict, set_sequence=True):
+    def _process_continued(self, all_threads_continued: bool):
+        self.threads = None
+        self.frame_scopes = {}
+        if all_threads_continued:
+            self.thread_stop_reasons = {}
+
+    def send_packet(self, command_dict: Request, set_sequence=True):
         """Take the "command_dict" python dictionary and encode it as a JSON
         string and send the contents as a packet to the VSCode debug
         adapter"""
@@ -273,7 +295,12 @@ class DebugCommunication(object):
             self.send.write(self.encode_content(json_str))
             self.send.flush()
 
-    def recv_packet(self, filter_type=None, filter_event=None, timeout=None):
+    def recv_packet(
+        self,
+        filter_type: Optional[str] = None,
+        filter_event: Optional[Union[str, list[str]]] = None,
+        timeout: Optional[float] = None,
+    ) -> Optional[ProtocolMessage]:
         """Get a JSON packet from the VSCode debug adapter. This function
         assumes a thread that reads packets is running and will deliver
         any received packets by calling handle_recv_packet(...). This
@@ -308,8 +335,6 @@ class DebugCommunication(object):
                 return None
             finally:
                 self.recv_condition.release()
-
-        return None
 
     def send_recv(self, command):
         """Send a command python dictionary as JSON and receive the JSON
@@ -360,47 +385,36 @@ class DebugCommunication(object):
 
         return None
 
-    def wait_for_event(self, filter=None, timeout=None):
-        while True:
-            return self.recv_packet(
-                filter_type="event", filter_event=filter, timeout=timeout
-            )
-        return None
+    def wait_for_event(
+        self, filter: Union[str, list[str]], timeout: Optional[float] = None
+    ) -> Optional[Event]:
+        """Wait for the first event that matches the filter."""
+        return self.recv_packet(
+            filter_type="event", filter_event=filter, timeout=timeout
+        )
 
-    def wait_for_events(self, events, timeout=None):
-        """Wait for a list of events in `events` in any order.
-        Return the events not hit before the timeout expired"""
-        events = events[:]  # Make a copy to avoid modifying the input
-        while events:
-            event_dict = self.wait_for_event(filter=events, timeout=timeout)
-            if event_dict is None:
-                break
-            events.remove(event_dict["event"])
-        return events
-
-    def wait_for_stopped(self, timeout=None):
+    def wait_for_stopped(
+        self, timeout: Optional[float] = None
+    ) -> Optional[list[Event]]:
         stopped_events = []
         stopped_event = self.wait_for_event(
             filter=["stopped", "exited"], timeout=timeout
         )
-        exited = False
         while stopped_event:
             stopped_events.append(stopped_event)
             # If we exited, then we are done
             if stopped_event["event"] == "exited":
-                self.exit_status = stopped_event["body"]["exitCode"]
-                exited = True
                 break
             # Otherwise we stopped and there might be one or more 'stopped'
             # events for each thread that stopped with a reason, so keep
             # checking for more 'stopped' events and return all of them
-            stopped_event = self.wait_for_event(filter="stopped", timeout=0.25)
-        if exited:
-            self.threads = []
+            stopped_event = self.wait_for_event(
+                filter=["stopped", "exited"], timeout=0.25
+            )
         return stopped_events
 
-    def wait_for_breakpoint_events(self, timeout=None):
-        breakpoint_events = []
+    def wait_for_breakpoint_events(self, timeout: Optional[float] = None):
+        breakpoint_events: list[Event] = []
         while True:
             event = self.wait_for_event("breakpoint", timeout=timeout)
             if not event:
@@ -408,14 +422,14 @@ class DebugCommunication(object):
             breakpoint_events.append(event)
         return breakpoint_events
 
-    def wait_for_exited(self):
-        event_dict = self.wait_for_event("exited")
+    def wait_for_exited(self, timeout: Optional[float] = None):
+        event_dict = self.wait_for_event("exited", timeout=timeout)
         if event_dict is None:
             raise ValueError("didn't get exited event")
         return event_dict
 
-    def wait_for_terminated(self):
-        event_dict = self.wait_for_event("terminated")
+    def wait_for_terminated(self, timeout: Optional[float] = None):
+        event_dict = self.wait_for_event("terminated", timeout)
         if event_dict is None:
             raise ValueError("didn't get terminated event")
         return event_dict
@@ -576,6 +590,7 @@ class DebugCommunication(object):
 
     def request_attach(
         self,
+        /,
         program=None,
         pid=None,
         waitFor=None,
@@ -671,7 +686,7 @@ class DebugCommunication(object):
         self.threads = None
         self.frame_scopes = {}
 
-    def request_continue(self, threadId=None):
+    def request_continue(self, threadId=None, singleThread=False):
         if self.exit_status is not None:
             raise ValueError("request_continue called after process exited")
         # If we have launched or attached, then the first continue is done by
@@ -681,13 +696,18 @@ class DebugCommunication(object):
         args_dict = {}
         if threadId is None:
             threadId = self.get_thread_id()
-        args_dict["threadId"] = threadId
+        if threadId:
+            args_dict["threadId"] = threadId
+        if singleThread:
+            args_dict["singleThread"] = True
         command_dict = {
             "command": "continue",
             "type": "request",
             "arguments": args_dict,
         }
         response = self.send_recv(command_dict)
+        if response["success"]:
+            self._process_continued(response["body"]["allThreadsContinued"])
         # Caller must still call wait_for_stopped.
         return response
 
@@ -775,7 +795,7 @@ class DebugCommunication(object):
         }
         return self.send_recv(command_dict)
 
-    def request_initialize(self, sourceInitFile):
+    def request_initialize(self, sourceInitFile=False):
         command_dict = {
             "command": "initialize",
             "type": "request",
@@ -802,11 +822,12 @@ class DebugCommunication(object):
 
     def request_launch(
         self,
-        program,
-        args=None,
+        program: Optional[str],
+        /,
+        args: Optional[list[str]] = None,
         cwd=None,
         env=None,
-        stopOnEntry=False,
+        stopOnEntry=True,
         disableASLR=True,
         disableSTDIO=False,
         shellExpandArguments=False,
@@ -1190,7 +1211,8 @@ class DebugCommunication(object):
 
     def terminate(self):
         self.send.close()
-        # self.recv.close()
+        if self.recv_thread.is_alive():
+            self.recv_thread.join()
 
     def request_setInstructionBreakpoints(self, memory_reference=[]):
         breakpoints = []
@@ -1211,11 +1233,11 @@ class DebugCommunication(object):
 class DebugAdapterServer(DebugCommunication):
     def __init__(
         self,
-        executable=None,
-        connection=None,
-        init_commands=[],
-        log_file=None,
-        env=None,
+        executable: Optional[str] = None,
+        connection: Optional[str] = None,
+        init_commands: list[str] = [],
+        log_file: Optional[TextIO] = None,
+        env: Optional[dict[str, str]] = None,
     ):
         self.process = None
         self.connection = None
@@ -1247,7 +1269,14 @@ class DebugAdapterServer(DebugCommunication):
             )
 
     @classmethod
-    def launch(cls, /, executable, env=None, log_file=None, connection=None):
+    def launch(
+        cls,
+        /,
+        executable: str,
+        env: Optional[dict[str, str]] = None,
+        log_file: Optional[TextIO] = None,
+        connection: Optional[str] = None,
+    ) -> tuple[subprocess.Popen, Optional[str]]:
         adapter_env = os.environ.copy()
         if env is not None:
             adapter_env.update(env)
@@ -1289,26 +1318,29 @@ class DebugAdapterServer(DebugCommunication):
 
         return (process, connection)
 
-    def get_pid(self):
+    def get_pid(self) -> int:
         if self.process:
             return self.process.pid
         return -1
 
     def terminate(self):
-        super(DebugAdapterServer, self).terminate()
-        if self.process is not None:
-            process = self.process
-            self.process = None
-            try:
-                # When we close stdin it should signal the lldb-dap that no
-                # new messages will arrive and it should shutdown on its own.
-                process.stdin.close()
-                process.wait(timeout=20)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait()
-            if process.returncode != 0:
-                raise DebugAdapterProcessError(process.returncode)
+        try:
+            if self.process is not None:
+                process = self.process
+                self.process = None
+                try:
+                    # When we close stdin it should signal the lldb-dap that no
+                    # new messages will arrive and it should shutdown on its
+                    # own.
+                    process.stdin.close()
+                    process.wait(timeout=20)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+                if process.returncode != 0:
+                    raise DebugAdapterProcessError(process.returncode)
+        finally:
+            super(DebugAdapterServer, self).terminate()
 
 
 class DebugAdapterError(Exception):

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -16,8 +16,10 @@ import time
 
 
 def spawn_and_wait(program, delay):
+    print("spawn_and_wait started...", time.time())
     if delay:
         time.sleep(delay)
+    print("starting process... ", time.time())
     process = subprocess.Popen(
         [program], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
@@ -26,8 +28,6 @@ def spawn_and_wait(program, delay):
 
 class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
     def set_and_hit_breakpoint(self, continueToExit=True):
-        self.dap_server.wait_for_stopped()
-
         source = "main.c"
         breakpoint1_line = line_number(source, "// breakpoint 1")
         lines = [breakpoint1_line]
@@ -36,7 +36,12 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(
             len(breakpoint_ids), len(lines), "expect correct number of breakpoints"
         )
-        self.continue_to_breakpoints(breakpoint_ids)
+        # Test binary will sleep for 10s, offset the breakpoint timeout
+        # accordingly.
+        timeout_offset = 10
+        self.continue_to_breakpoints(
+            breakpoint_ids, timeout=timeout_offset + self.timeoutval
+        )
         if continueToExit:
             self.continue_to_exit()
 
@@ -160,7 +165,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         # Continue after launch and hit the "pause()" call and stop the target.
         # Get output from the console. This should contain both the
         # "stopCommands" that were run after we stop.
-        self.dap_server.request_continue()
+        self.verify_continue()
         time.sleep(0.5)
         self.dap_server.request_pause()
         self.dap_server.wait_for_stopped()
@@ -198,9 +203,6 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         )
 
     @skipIfNetBSD  # Hangs on NetBSD as well
-    @skipIf(
-        archs=["arm", "aarch64"]
-    )  # Example of a flaky run http://lab.llvm.org:8011/builders/lldb-aarch64-ubuntu/builds/5517/steps/test/logs/stdio
     def test_terminate_commands(self):
         """
         Tests that the "terminateCommands", that can be passed during

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -2,24 +2,18 @@
 Test lldb-dap attach request
 """
 
-import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 import lldbdap_testcase
-import os
-import shutil
 import subprocess
-import tempfile
 import threading
 import time
 
 
 def spawn_and_wait(program, delay):
-    print("spawn_and_wait started...", time.time())
     if delay:
         time.sleep(delay)
-    print("starting process... ", time.time())
     process = subprocess.Popen(
         [program], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
@@ -40,7 +34,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         # accordingly.
         timeout_offset = 10
         self.continue_to_breakpoints(
-            breakpoint_ids, timeout=timeout_offset + self.timeoutval
+            breakpoint_ids, timeout=timeout_offset + self.DEFAULT_TIMEOUT
         )
         if continueToExit:
             self.continue_to_exit()
@@ -165,7 +159,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         # Continue after launch and hit the "pause()" call and stop the target.
         # Get output from the console. This should contain both the
         # "stopCommands" that were run after we stop.
-        self.verify_continue()
+        self.do_continue()
         time.sleep(0.5)
         self.dap_server.request_pause()
         self.dap_server.wait_for_stopped()

--- a/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
@@ -60,7 +60,7 @@ class TestDAP_breakpointEvents(lldbdap_testcase.DAPTestCaseBase):
         response = self.dap_server.request_setBreakpoints(
             main_source_path, [main_bp_line]
         )
-        self.assertTrue(response)
+        self.assertTrue(response["success"])
         breakpoints = response["body"]["breakpoints"]
         for breakpoint in breakpoints:
             main_bp_id = breakpoint["id"]
@@ -72,7 +72,7 @@ class TestDAP_breakpointEvents(lldbdap_testcase.DAPTestCaseBase):
         response = self.dap_server.request_setBreakpoints(
             foo_source_path, [foo_bp1_line]
         )
-        self.assertTrue(response)
+        self.assertTrue(response["success"])
         breakpoints = response["body"]["breakpoints"]
         for breakpoint in breakpoints:
             foo_bp_id = breakpoint["id"]
@@ -80,9 +80,6 @@ class TestDAP_breakpointEvents(lldbdap_testcase.DAPTestCaseBase):
             self.assertFalse(
                 breakpoint["verified"], "expect foo breakpoint to not be verified"
             )
-
-        # Make sure we're stopped.
-        self.dap_server.wait_for_stopped()
 
         # Flush the breakpoint events.
         self.dap_server.wait_for_breakpoint_events(timeout=5)

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -51,7 +51,7 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
         blocking_seq = self.async_blocking_request(duration=1.0)
         # Use a longer timeout to ensure we catch if the request was interrupted
         # properly.
-        pending_seq = self.async_blocking_request(duration=self.timeoutval / 2)
+        pending_seq = self.async_blocking_request(duration=self.DEFAULT_TIMEOUT / 2)
         cancel_seq = self.async_cancel(requestId=pending_seq)
 
         blocking_resp = self.dap_server.recv_packet(filter_type=["response"])
@@ -78,10 +78,10 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
 
-        blocking_seq = self.async_blocking_request(duration=self.timeoutval / 2)
+        blocking_seq = self.async_blocking_request(duration=self.DEFAULT_TIMEOUT / 2)
         # Wait for the sleep to start to cancel the inflight request.
         self.collect_console(
-            timeout_secs=self.timeoutval,
+            timeout_secs=self.DEFAULT_TIMEOUT,
             pattern="starting sleep",
         )
         cancel_seq = self.async_cancel(requestId=blocking_seq)

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbdap_testcase
 
 
-class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
+class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
     def send_async_req(self, command: str, arguments={}) -> int:
         seq = self.dap_server.sequence
         self.dap_server.send_packet(
@@ -45,7 +45,6 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
-        self.continue_to_next_stop()
 
         # Use a relatively short timeout since this is only to ensure the
         # following request is queued.
@@ -78,7 +77,6 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
-        self.continue_to_next_stop()
 
         blocking_seq = self.async_blocking_request(duration=self.timeoutval / 2)
         # Wait for the sleep to start to cancel the inflight request.

--- a/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
+++ b/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
@@ -75,11 +75,12 @@ class TestDAP_commands(lldbdap_testcase.DAPTestCaseBase):
         )
         command_abort_on_error = "settings set foo bar"
         program = self.build_and_create_debug_adapter_for_attach()
-        self.attach(
-            program,
+        resp = self.attach(
+            program=program,
             attachCommands=["?!" + command_quiet, "!" + command_abort_on_error],
             expectFailure=True,
         )
+        self.assertFalse(resp["success"], "expected 'attach' failure")
         full_output = self.collect_console(
             timeout_secs=1.0,
             pattern=command_abort_on_error,

--- a/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
+++ b/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
@@ -43,12 +43,12 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         for not_expected_item in not_expected_list:
             self.assertNotIn(not_expected_item, actual_list)
 
-    def setup_debugee(self, stopOnEntry=False):
+    def setup_debuggee(self):
         program = self.getBuildArtifact("a.out")
         source = "main.cpp"
         self.build_and_launch(
             program,
-            stopOnEntry=stopOnEntry,
+            stopOnEntry=True,
             sourceBreakpoints=[
                 (
                     source,
@@ -64,7 +64,7 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests completion requests for lldb commands, within "repl-mode=command"
         """
-        self.setup_debugee()
+        self.setup_debuggee()
         self.continue_to_next_stop()
 
         res = self.dap_server.request_evaluate(
@@ -143,7 +143,7 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests completion requests in "repl-mode=variable"
         """
-        self.setup_debugee()
+        self.setup_debuggee()
         self.continue_to_next_stop()
 
         res = self.dap_server.request_evaluate(
@@ -241,7 +241,7 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests completion requests in "repl-mode=auto"
         """
-        self.setup_debugee(stopOnEntry=True)
+        self.setup_debuggee()
 
         res = self.dap_server.request_evaluate(
             "`lldb-dap repl-mode auto", context="repl"

--- a/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
+++ b/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
@@ -177,7 +177,7 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
         )
 
         diagnostics = self.collect_important(
-            timeout_secs=self.timeoutval, pattern="minidump file"
+            timeout_secs=self.DEFAULT_TIMEOUT, pattern="minidump file"
         )
 
         self.assertIn(

--- a/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
+++ b/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
@@ -2,7 +2,6 @@
 Test lldb-dap coreFile attaching
 """
 
-
 import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -19,7 +18,7 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
         core_file = os.path.join(current_dir, "linux-x86_64.core")
 
         self.create_debug_adapter()
-        self.attach(exe_file, coreFile=core_file)
+        self.attach(program=exe_file, coreFile=core_file)
 
         expected_frames = [
             {
@@ -51,7 +50,8 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(self.get_stackFrames(), expected_frames)
 
         # Resuming should have no effect and keep the process stopped
-        self.continue_to_next_stop()
+        resp = self.dap_server.request_continue()
+        self.assertFalse(resp["success"])
         self.assertEqual(self.get_stackFrames(), expected_frames)
 
         self.dap_server.request_next(threadId=32259)
@@ -67,7 +67,7 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
         self.create_debug_adapter()
 
         source_map = [["/home/labath/test", current_dir]]
-        self.attach(exe_file, coreFile=core_file, sourceMap=source_map)
+        self.attach(program=exe_file, coreFile=core_file, sourceMap=source_map)
 
         self.assertIn(current_dir, self.get_stackFrames()[0]["source"]["path"])
 
@@ -81,6 +81,6 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
         self.create_debug_adapter()
 
         source_map = {"/home/labath/test": current_dir}
-        self.attach(exe_file, coreFile=core_file, sourceMap=source_map)
+        self.attach(program=exe_file, coreFile=core_file, sourceMap=source_map)
 
         self.assertIn(current_dir, self.get_stackFrames()[0]["source"]["path"])

--- a/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
+++ b/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
@@ -16,6 +16,7 @@ class TestDAP_exception(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
+        self.verify_continue()
 
         self.assertTrue(self.verify_stop_exception_info("signal SIGABRT"))
         exceptionInfo = self.get_exceptionInfo()

--- a/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
+++ b/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
@@ -16,7 +16,7 @@ class TestDAP_exception(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
-        self.verify_continue()
+        self.do_continue()
 
         self.assertTrue(self.verify_stop_exception_info("signal SIGABRT"))
         exceptionInfo = self.get_exceptionInfo()

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -90,15 +90,16 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
 
-        stopped_events = self.dap_server.wait_for_stopped()
-        for stopped_event in stopped_events:
-            if "body" in stopped_event:
-                body = stopped_event["body"]
-                if "reason" in body:
-                    reason = body["reason"]
-                    self.assertNotEqual(
-                        reason, "breakpoint", 'verify stop isn\'t "main" breakpoint'
-                    )
+        self.assertTrue(
+            len(self.dap_server.thread_stop_reasons) > 0,
+            "expected stopped event during launch",
+        )
+        for _, body in self.dap_server.thread_stop_reasons.items():
+            if "reason" in body:
+                reason = body["reason"]
+                self.assertNotEqual(
+                    reason, "breakpoint", 'verify stop isn\'t "main" breakpoint'
+                )
 
     @skipIfWindows
     def test_cwd(self):
@@ -531,7 +532,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
 
         terminateCommands = ["expr 4+2"]
         self.launch(
-            program=program,
+            program,
             stopOnEntry=True,
             terminateCommands=terminateCommands,
             disconnectAutomatically=False,

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -75,9 +75,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         self.dap_server.request_disconnect()
 
         # Wait until the underlying lldb-dap process dies.
-        self.dap_server.process.wait(
-            timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval
-        )
+        self.dap_server.process.wait(timeout=self.DEFAULT_TIMEOUT)
 
         # Check the return code
         self.assertEqual(self.dap_server.process.poll(), 0)
@@ -394,14 +392,14 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         # Get output from the console. This should contain both the
         # "stopCommands" that were run after the first breakpoint was hit
         self.continue_to_breakpoints(breakpoint_ids)
-        output = self.get_console(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
+        output = self.get_console(timeout=self.DEFAULT_TIMEOUT)
         self.verify_commands("stopCommands", output, stopCommands)
 
         # Continue again and hit the second breakpoint.
         # Get output from the console. This should contain both the
         # "stopCommands" that were run after the second breakpoint was hit
         self.continue_to_breakpoints(breakpoint_ids)
-        output = self.get_console(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
+        output = self.get_console(timeout=self.DEFAULT_TIMEOUT)
         self.verify_commands("stopCommands", output, stopCommands)
 
         # Continue until the program exits
@@ -463,21 +461,21 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         self.verify_commands("launchCommands", output, launchCommands)
         # Verify the "stopCommands" here
         self.continue_to_next_stop()
-        output = self.get_console(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
+        output = self.get_console(timeout=self.DEFAULT_TIMEOUT)
         self.verify_commands("stopCommands", output, stopCommands)
 
         # Continue and hit the second breakpoint.
         # Get output from the console. This should contain both the
         # "stopCommands" that were run after the first breakpoint was hit
         self.continue_to_next_stop()
-        output = self.get_console(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
+        output = self.get_console(timeout=self.DEFAULT_TIMEOUT)
         self.verify_commands("stopCommands", output, stopCommands)
 
         # Continue until the program exits
         self.continue_to_exit()
         # Get output from the console. This should contain both the
         # "exitCommands" that were run after the second breakpoint was hit
-        output = self.get_console(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
+        output = self.get_console(timeout=self.DEFAULT_TIMEOUT)
         self.verify_commands("exitCommands", output, exitCommands)
 
     def test_failing_launch_commands(self):

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -14,7 +14,7 @@ class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
     def run_test(self, symbol_basename, expect_debug_info_size):
         program_basename = "a.out.stripped"
         program = self.getBuildArtifact(program_basename)
-        self.build_and_launch(program)
+        self.build_and_launch(program, stopOnEntry=True)
         functions = ["foo"]
         breakpoint_ids = self.set_function_breakpoints(functions)
         self.assertEqual(len(breakpoint_ids), len(functions), "expect one breakpoint")
@@ -108,7 +108,7 @@ class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_compile_units(self):
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
+        self.build_and_launch(program, stopOnEntry=True)
         source = "main.cpp"
         main_source_path = self.getSourcePath(source)
         breakpoint1_line = line_number(source, "// breakpoint 1")

--- a/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
+++ b/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
@@ -37,14 +37,14 @@ class TestDAP_output(lldbdap_testcase.DAPTestCaseBase):
         # Disconnecting from the server to ensure any pending IO is flushed.
         self.dap_server.request_disconnect()
 
-        output += self.get_stdout(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
+        output += self.get_stdout(timeout=self.DEFAULT_TIMEOUT)
         self.assertTrue(output and len(output) > 0, "expect program stdout")
         self.assertIn(
             "abcdefghi\r\nhello world\r\nfinally\0\0",
             output,
             "full stdout not found in: " + repr(output),
         )
-        console = self.get_console(timeout=self.timeoutval)
+        console = self.get_console(timeout=self.DEFAULT_TIMEOUT)
         self.assertTrue(console and len(console) > 0, "expect dap messages")
         self.assertIn(
             "out\0\0\r\nerr\0\0\r\n", console, f"full console message not found"

--- a/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart.py
+++ b/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart.py
@@ -22,9 +22,8 @@ class TestDAP_restart(lldbdap_testcase.DAPTestCaseBase):
         [bp_A, bp_B] = self.set_source_breakpoints("main.c", [line_A, line_B])
 
         # Verify we hit A, then B.
-        self.verify_breakpoint_hit([bp_A])
-        self.dap_server.request_continue()
-        self.verify_breakpoint_hit([bp_B])
+        self.continue_to_breakpoints([bp_A])
+        self.continue_to_breakpoints([bp_B])
 
         # Make sure i has been modified from its initial value of 0.
         self.assertEqual(
@@ -34,8 +33,9 @@ class TestDAP_restart(lldbdap_testcase.DAPTestCaseBase):
         )
 
         # Restart then check we stop back at A and program state has been reset.
-        self.dap_server.request_restart()
-        self.verify_breakpoint_hit([bp_A])
+        resp = self.dap_server.request_restart()
+        self.assertTrue(resp["success"])
+        self.continue_to_breakpoints([bp_A])
         self.assertEqual(
             int(self.dap_server.get_local_variable_value("i")),
             0,
@@ -50,27 +50,26 @@ class TestDAP_restart(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
         [bp_main] = self.set_function_breakpoints(["main"])
-        self.dap_server.request_configurationDone()
-
         # Once the "configuration done" event is sent, we should get a stopped
         # event immediately because of stopOnEntry.
-        stopped_events = self.dap_server.wait_for_stopped()
-        for stopped_event in stopped_events:
-            if "body" in stopped_event:
-                body = stopped_event["body"]
-                if "reason" in body:
-                    reason = body["reason"]
-                    self.assertNotEqual(
-                        reason, "breakpoint", 'verify stop isn\'t "main" breakpoint'
-                    )
+        self.assertTrue(
+            len(self.dap_server.thread_stop_reasons) > 0,
+            "expected stopped event during launch",
+        )
+        for _, body in self.dap_server.thread_stop_reasons.items():
+            if "reason" in body:
+                reason = body["reason"]
+                self.assertNotEqual(
+                    reason, "breakpoint", 'verify stop isn\'t "main" breakpoint'
+                )
 
         # Then, if we continue, we should hit the breakpoint at main.
-        self.dap_server.request_continue()
-        self.verify_breakpoint_hit([bp_main])
+        self.continue_to_breakpoints([bp_main])
 
         # Restart and check that we still get a stopped event before reaching
         # main.
-        self.dap_server.request_restart()
+        resp = self.dap_server.request_restart()
+        self.assertTrue(resp["success"])
         stopped_events = self.dap_server.wait_for_stopped()
         for stopped_event in stopped_events:
             if "body" in stopped_event:
@@ -96,8 +95,7 @@ class TestDAP_restart(lldbdap_testcase.DAPTestCaseBase):
         [bp_A] = self.set_source_breakpoints("main.c", [line_A])
 
         # Verify we hit A, then B.
-        self.dap_server.request_configurationDone()
-        self.verify_breakpoint_hit([bp_A])
+        self.continue_to_breakpoints([bp_A])
 
         # We don't set any arguments in the initial launch request, so argc
         # should be 1.
@@ -109,7 +107,7 @@ class TestDAP_restart(lldbdap_testcase.DAPTestCaseBase):
 
         # Restart with some extra 'args' and check that the new argc reflects
         # the updated launch config.
-        self.dap_server.request_restart(
+        resp = self.dap_server.request_restart(
             restartArguments={
                 "arguments": {
                     "program": program,
@@ -117,6 +115,7 @@ class TestDAP_restart(lldbdap_testcase.DAPTestCaseBase):
                 }
             }
         )
+        self.assertTrue(resp["success"])
         self.verify_breakpoint_hit([bp_A])
         self.assertEqual(
             int(self.dap_server.get_local_variable_value("argc")),

--- a/lldb/test/API/tools/lldb-dap/stop-hooks/TestDAP_stop_hooks.py
+++ b/lldb/test/API/tools/lldb-dap/stop-hooks/TestDAP_stop_hooks.py
@@ -2,7 +2,6 @@
 Test stop hooks
 """
 
-
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 import lldbdap_testcase
@@ -17,10 +16,6 @@ class TestDAP_stop_hooks(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         preRunCommands = ["target stop-hook add -o help"]
         self.build_and_launch(program, stopOnEntry=True, preRunCommands=preRunCommands)
-
-        # The first stop is on entry.
-        self.dap_server.wait_for_stopped()
-
         breakpoint_ids = self.set_function_breakpoints(["main"])
         # This request hangs if the race happens, because, in that case, the
         # command interpreter is in synchronous mode while lldb-dap expects

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -116,7 +116,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
         self.create_debug_adapter()
         self.assertTrue(os.path.exists(program), "executable must exist")
 
-        self.launch(program=program, initCommands=initCommands)
+        self.launch(program, initCommands=initCommands)
 
         functions = ["main"]
         breakpoint_ids = self.set_function_breakpoints(functions)

--- a/lldb/tools/lldb-dap/DAPError.cpp
+++ b/lldb/tools/lldb-dap/DAPError.cpp
@@ -8,6 +8,7 @@
 
 #include "DAPError.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
 #include <system_error>
 
 namespace lldb_dap {
@@ -23,6 +24,14 @@ DAPError::DAPError(std::string message, std::error_code EC, bool show_user,
 void DAPError::log(llvm::raw_ostream &OS) const { OS << m_message; }
 
 std::error_code DAPError::convertToErrorCode() const {
+  return llvm::inconvertibleErrorCode();
+}
+
+char NotStoppedError::ID;
+
+void NotStoppedError::log(llvm::raw_ostream &OS) const { OS << "not stopped"; }
+
+std::error_code NotStoppedError::convertToErrorCode() const {
   return llvm::inconvertibleErrorCode();
 }
 

--- a/lldb/tools/lldb-dap/DAPError.h
+++ b/lldb/tools/lldb-dap/DAPError.h
@@ -13,7 +13,7 @@
 
 namespace lldb_dap {
 
-/// An Error that is reported as a DAP Error Message, which may be presented to
+/// An error that is reported as a DAP Error Message, which may be presented to
 /// the user.
 class DAPError : public llvm::ErrorInfo<DAPError> {
 public:
@@ -38,6 +38,15 @@ private:
   bool m_show_user;
   std::optional<std::string> m_url;
   std::optional<std::string> m_url_label;
+};
+
+/// An error that indicates the current request handler cannot execute because
+/// the process is not stopped.
+class NotStoppedError : public llvm::ErrorInfo<NotStoppedError> {
+public:
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override;
+  std::error_code convertToErrorCode() const override;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/ContinueRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ContinueRequestHandler.cpp
@@ -31,6 +31,9 @@ ContinueRequestHandler::Run(const ContinueArguments &args) const {
   SBProcess process = dap.target.GetProcess();
   SBError error;
 
+  if (!SBDebugger::StateIsStoppedState(process.GetState()))
+    return make_error<NotStoppedError>();
+
   if (args.singleThread)
     dap.GetLLDBThread(args.threadId).Resume(error);
   else
@@ -40,7 +43,7 @@ ContinueRequestHandler::Run(const ContinueArguments &args) const {
     return ToError(error);
 
   ContinueResponseBody body;
-  body.allThreadsContinued = args.singleThread;
+  body.allThreadsContinued = !args.singleThread;
   return body;
 }
 


### PR DESCRIPTION
Adding an assert that the 'continue' request succeeds caused a number of tests to fail. This showed a number of tests that were not specifying if they should be stopped or not at key points in the test. This is likely contributing to these tests being flaky since the debugger is not in the expected state.

Additionally, I spent a little time trying to improve the readability of the dap_server.py and lldbdap_testcase.py.