### PR TITLE
Fix CI after #138708

### DIFF
--- a/third-party/unittest/googletest/README.LLVM
+++ b/third-party/unittest/googletest/README.LLVM
@@ -19,3 +19,6 @@ Modified as follows:
 * Added StringRef support to include/gtest/internal/custom/gtest-printers.h.
 * Added LLVM printable value support to include/gtest/gtest-message.h and
   include/gtest/gtest-printers.h.
+* Modified `PrintTo(char16_t c, ::std::ostream* os)` and
+ `PrintTo(char16_t c, ::std::ostream* os)` in include/gtest/gtest-printers.h.
+  to work around https://github.com/google/googletest/issues/4762

--- a/third-party/unittest/googletest/include/gtest/gtest-printers.h
+++ b/third-party/unittest/googletest/include/gtest/gtest-printers.h
@@ -510,11 +510,15 @@ GTEST_API_ void PrintTo(wchar_t wc, ::std::ostream* os);
 
 GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
 inline void PrintTo(char16_t c, ::std::ostream* os) {
-  PrintTo(ImplicitCast_<char32_t>(c), os);
+  // FIXME: the cast from char16_t to char32_t may be incorrect
+  // for a lone surrogate
+  PrintTo(static_cast<char32_t>(c), os);
 }
 #ifdef __cpp_lib_char8_t
 inline void PrintTo(char8_t c, ::std::ostream* os) {
-  PrintTo(ImplicitCast_<char32_t>(c), os);
+  // FIXME: the cast from char8_t to char32_t may be incorrect
+  // for c > 0x7F
+  PrintTo(static_cast<char32_t>(c), os);
 }
 #endif
 


### PR DESCRIPTION
Silence a warning in gtest casting a char8_t/char16_t to char32_t.

Note that this cast, as well as the behavior of `PrintTo(char32_t)` is incorrect when printing a code unit that does not represent a code point.