### PR TITLE
[CLANGD] [NFC] Fix proposed by static analyzer.

### DIFF
--- a/clang-tools-extra/clangd/index/FileIndex.cpp
+++ b/clang-tools-extra/clangd/index/FileIndex.cpp
@@ -79,7 +79,8 @@ SlabTuple indexSymbols(ASTContext &AST, Preprocessor &PP,
 
   SymbolCollector Collector(std::move(CollectorOpts));
   Collector.setPreprocessor(PP);
-  index::indexTopLevelDecls(AST, PP, DeclsToIndex, Collector, IndexOpts);
+  index::indexTopLevelDecls(AST, PP, DeclsToIndex, Collector,
+                            std::move(IndexOpts));
   if (MacroRefsToIndex)
     Collector.handleMacros(*MacroRefsToIndex);
 


### PR DESCRIPTION
This fixes an issue reported by the sanitizer with the following error message:
`copy_constructor_call: IndexOpts` is passed by value as a parameter to` clang::index::IndexingOptions::IndexingOptions` instead of being moved.
