### PR TITLE
[NFCI][cfi] Refactor into 'SanitizerInfoFromCFICheckKind'

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -2782,7 +2782,7 @@ void CodeGenFunction::EmitTypeMetadataCodeForVCall(const CXXRecordDecl *RD,
 /// Converts the CFITypeCheckKind into SanitizerKind::SanitizerOrdinal and
 /// llvm::SanitizerStatKind.
 static std::pair<SanitizerKind::SanitizerOrdinal, llvm::SanitizerStatKind>
-ParseCFITypeCheckKind(CodeGenFunction::CFITypeCheckKind TCK) {
+SanitizerInfoFromCFICheckKind(CodeGenFunction::CFITypeCheckKind TCK) {
   SanitizerKind::SanitizerOrdinal M;
   llvm::SanitizerStatKind SSK;
 
@@ -2875,7 +2875,7 @@ void CodeGenFunction::EmitVTablePtrCheck(const CXXRecordDecl *RD,
       !CGM.HasHiddenLTOVisibility(RD))
     return;
 
-  auto [M, SSK] = ParseCFITypeCheckKind(TCK);
+  auto [M, SSK] = SanitizerInfoFromCFICheckKind(TCK);
 
   std::string TypeName = RD->getQualifiedNameAsString();
   if (getContext().getNoSanitizeList().containsType(

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -2783,33 +2783,23 @@ void CodeGenFunction::EmitTypeMetadataCodeForVCall(const CXXRecordDecl *RD,
 /// llvm::SanitizerStatKind.
 static std::pair<SanitizerKind::SanitizerOrdinal, llvm::SanitizerStatKind>
 SanitizerInfoFromCFICheckKind(CodeGenFunction::CFITypeCheckKind TCK) {
-  SanitizerKind::SanitizerOrdinal M;
-  llvm::SanitizerStatKind SSK;
-
   switch (TCK) {
   case CodeGenFunction::CFITCK_VCall:
-    M = SanitizerKind::SO_CFIVCall;
-    SSK = llvm::SanStat_CFI_VCall;
-    break;
+    return std::make_pair(SanitizerKind::SO_CFIVCall, llvm::SanStat_CFI_VCall);
   case CodeGenFunction::CFITCK_NVCall:
-    M = SanitizerKind::SO_CFINVCall;
-    SSK = llvm::SanStat_CFI_NVCall;
-    break;
+    return std::make_pair(SanitizerKind::SO_CFINVCall,
+                          llvm::SanStat_CFI_NVCall);
   case CodeGenFunction::CFITCK_DerivedCast:
-    M = SanitizerKind::SO_CFIDerivedCast;
-    SSK = llvm::SanStat_CFI_DerivedCast;
-    break;
+    return std::make_pair(SanitizerKind::SO_CFIDerivedCast,
+                          llvm::SanStat_CFI_DerivedCast);
   case CodeGenFunction::CFITCK_UnrelatedCast:
-    M = SanitizerKind::SO_CFIUnrelatedCast;
-    SSK = llvm::SanStat_CFI_UnrelatedCast;
-    break;
+    return std::make_pair(SanitizerKind::SO_CFIUnrelatedCast,
+                          llvm::SanStat_CFI_UnrelatedCast);
   case CodeGenFunction::CFITCK_ICall:
   case CodeGenFunction::CFITCK_NVMFCall:
   case CodeGenFunction::CFITCK_VMFCall:
     llvm_unreachable("unexpected sanitizer kind");
   }
-
-  return std::make_pair(M, SSK);
 }
 
 void CodeGenFunction::EmitVTablePtrCheckForCall(const CXXRecordDecl *RD,

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -2779,31 +2779,33 @@ void CodeGenFunction::EmitTypeMetadataCodeForVCall(const CXXRecordDecl *RD,
   }
 }
 
-std::pair<SanitizerKind::SanitizerOrdinal, llvm::SanitizerStatKind>
-CodeGenFunction::ParseCFITypeCheckKind(CFITypeCheckKind TCK) {
+/// Converts the CFITypeCheckKind into SanitizerKind::SanitizerOrdinal and
+/// llvm::SanitizerStatKind.
+static std::pair<SanitizerKind::SanitizerOrdinal, llvm::SanitizerStatKind>
+ParseCFITypeCheckKind(CodeGenFunction::CFITypeCheckKind TCK) {
   SanitizerKind::SanitizerOrdinal M;
   llvm::SanitizerStatKind SSK;
 
   switch (TCK) {
-  case CFITCK_VCall:
+  case CodeGenFunction::CFITCK_VCall:
     M = SanitizerKind::SO_CFIVCall;
     SSK = llvm::SanStat_CFI_VCall;
     break;
-  case CFITCK_NVCall:
+  case CodeGenFunction::CFITCK_NVCall:
     M = SanitizerKind::SO_CFINVCall;
     SSK = llvm::SanStat_CFI_NVCall;
     break;
-  case CFITCK_DerivedCast:
+  case CodeGenFunction::CFITCK_DerivedCast:
     M = SanitizerKind::SO_CFIDerivedCast;
     SSK = llvm::SanStat_CFI_DerivedCast;
     break;
-  case CFITCK_UnrelatedCast:
+  case CodeGenFunction::CFITCK_UnrelatedCast:
     M = SanitizerKind::SO_CFIUnrelatedCast;
     SSK = llvm::SanStat_CFI_UnrelatedCast;
     break;
-  case CFITCK_ICall:
-  case CFITCK_NVMFCall:
-  case CFITCK_VMFCall:
+  case CodeGenFunction::CFITCK_ICall:
+  case CodeGenFunction::CFITCK_NVMFCall:
+  case CodeGenFunction::CFITCK_VMFCall:
     llvm_unreachable("unexpected sanitizer kind");
   }
 

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3358,11 +3358,6 @@ public:
                      SanitizerSet SkippedChecks = SanitizerSet(),
                      llvm::Value *ArraySize = nullptr);
 
-  /// Converts the CFITypeCheckKind into SanitizerKind::SanitizerOrdinal and
-  /// llvm::SanitizerStatKind.
-  static std::pair<SanitizerKind::SanitizerOrdinal, llvm::SanitizerStatKind>
-  ParseCFITypeCheckKind(CFITypeCheckKind TCK);
-
   /// Emit a check that \p Base points into an array object, which
   /// we can access at index \p Index. \p Accessed should be \c false if we
   /// this expression is used as an lvalue, for instance in "&Arr[Idx]".

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3358,6 +3358,11 @@ public:
                      SanitizerSet SkippedChecks = SanitizerSet(),
                      llvm::Value *ArraySize = nullptr);
 
+  /// Converts the CFITypeCheckKind into SanitizerKind::SanitizerOrdinal and
+  /// llvm::SanitizerStatKind.
+  static std::pair<SanitizerKind::SanitizerOrdinal, llvm::SanitizerStatKind>
+  ParseCFITypeCheckKind(CFITypeCheckKind TCK);
+
   /// Emit a check that \p Base points into an array object, which
   /// we can access at index \p Index. \p Accessed should be \c false if we
   /// this expression is used as an lvalue, for instance in "&Arr[Idx]".


### PR DESCRIPTION
This refactors existing code into a 'SanitizerInfoFromCFICheckKind' helper function. This will be useful in future work to annotate CFI checks with debug info (https://github.com/llvm/llvm-project/pull/139809).