### PR TITLE
[clang] Emit convergence tokens for loop in global array init

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -2042,6 +2042,8 @@ void CodeGenFunction::EmitCXXAggrConstructorCall(const CXXConstructorDecl *ctor,
   cur->addIncoming(arrayBegin, entryBB);
 
   // Inside the loop body, emit the constructor call on the array element.
+  if (CGM.shouldEmitConvergenceTokens())
+    ConvergenceTokenStack.push_back(emitConvergenceLoopToken(loopBB));
 
   // The alignment of the base, adjusted by the size of a single element,
   // provides a conservative estimate of the alignment of every element.
@@ -2100,6 +2102,9 @@ void CodeGenFunction::EmitCXXAggrConstructorCall(const CXXConstructorDecl *ctor,
 
   // Patch the earlier check to skip over the loop.
   if (zeroCheckBranch) zeroCheckBranch->setSuccessor(0, contBB);
+
+  if (CGM.shouldEmitConvergenceTokens())
+    ConvergenceTokenStack.pop_back();
 
   EmitBlock(contBB);
 }

--- a/clang/test/CodeGenHLSL/convergence/global_array.hlsl
+++ b/clang/test/CodeGenHLSL/convergence/global_array.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -Wno-hlsl-implicit-binding -finclude-default-header -triple spirv-unknown-vulkan-compute -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s
+
+// CHECK: define internal spir_func void @__cxx_global_var_init()
+// CHECK: [[entry_token:%.*]] = call token @llvm.experimental.convergence.entry()
+// CHECK: br label %[[loop_entry:.*]]
+
+// CHECK: [[loop_entry]]:
+// CHECK: [[loop_token:%.*]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[entry_token]]) ]
+// CHECK: call void {{.*}} [ "convergencectrl"(token [[loop_token]]) ]
+// CHECK: br i1 {{%.*}} label {{%.*}} label %[[loop_entry]]
+RWBuffer<float> e[2];
+
+[numthreads(4,1,1)]
+void main() {
+}
+


### PR DESCRIPTION
When initializing a global array, a loop is generated, but no
convergence is emitted for the loop. This fixes that up.
