### PR TITLE
[include-cleaner] Add --fail-on-changes option

### DIFF
--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -115,6 +115,11 @@ cl::opt<bool> DisableRemove{
     cl::init(false),
     cl::cat(IncludeCleaner),
 };
+cl::opt<bool> FailOnChanges{
+    "fail-on-changes",
+    cl::desc("Exit with a non-zero exit code if changes are suggested"),
+    cl::cat(IncludeCleaner),
+};
 
 std::atomic<unsigned> Errors = ATOMIC_VAR_INIT(0);
 
@@ -410,5 +415,6 @@ int main(int argc, const char **argv) {
       }
     }
   }
-  return ErrorCode || Errors != 0;
+  return ErrorCode || Errors != 0 ||
+         (FailOnChanges && Factory.editedFiles().size() != 0);
 }


### PR DESCRIPTION
When integrating clang-include-cleaner into a test suite, it's useful to have it exit with a nonzero exit status when there are suggested changes to includes so let's add --fail-on-changes to make that possible.