### PR TITLE
[Clang][Lex][NFC] Assert getExternalSource() in updateOutOfDateIdentifier

### DIFF
--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -759,6 +759,8 @@ void Preprocessor::HandlePoisonedIdentifier(Token & Identifier) {
 
 void Preprocessor::updateOutOfDateIdentifier(const IdentifierInfo &II) const {
   assert(II.isOutOfDate() && "not out of date");
+  assert(getExternalSource() &&
+         "getExternalSource() should not return nullptr");
   getExternalSource()->updateOutOfDateIdentifier(II);
 }
 


### PR DESCRIPTION
Static analysis flagged the unconditional access of getExternalSource(). We don't initialize ExternalSource during construction but via setExternalSource(). If this is not set it will violate the invariant covered by the assert.