### PR TITLE
[lldb-dap] Listen for broadcast classes.

### DIFF
--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -334,8 +334,7 @@ struct DAP {
   ///     An SBTarget object.
   lldb::SBTarget CreateTarget(lldb::SBError &error);
 
-  /// Set given target object as a current target for lldb-dap and start
-  /// listeing for its breakpoint events.
+  /// Set given target object as a current target for lldb-dap.
   void SetTarget(const lldb::SBTarget target);
 
   bool HandleObject(const protocol::Message &M);

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -96,7 +96,9 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
       if (llvm::Error err = dap.RunAttachCommands(args.attachCommands))
         return err;
 
-      dap.target = dap.debugger.GetSelectedTarget();
+      // The custom commands might have created a new target so we should use
+      // the selected target after these commands are run.
+      dap.SetTarget(dap.debugger.GetSelectedTarget());
 
       // Validate the attachCommand results.
       if (!dap.target.GetProcess().IsValid())

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -209,7 +209,7 @@ llvm::Error BaseRequestHandler::LaunchProcess(
 
       // The custom commands might have created a new target so we should use
       // the selected target after these commands are run.
-      dap.target = dap.debugger.GetSelectedTarget();
+      dap.SetTarget(dap.debugger.GetSelectedTarget());
     }
   }
 


### PR DESCRIPTION
The recent change to the startup flow has highlighted a problem with breakpoint events being missed.

Previously, we would handle `attach`/`launch` commands immediately, leaving the process in a suspended until the `configurationDone` command was sent.

If a breakpoint was set between the `attach`/`launch` and the `configurationDone` request, it may have been resolved immediately, but there was a chance the module was not yet loaded.

With the new startup flow, the breakpoint is always set before the target is loaded. For some targets, this is fine and the breakpoint event fires eventually and marks the breakpoint as verified. However, if a `attach`/`launch` request has `attachCommands`/`launchCommands` that create a new target then we will miss the breakpoint events associated with that target because we haven't configured the target broadcaster for the debugger. We only configure that in the `DAP::SetTarget` call, which happens after the events would have occurred.

To address this, I adjusted the `DAP::EventThread` to listen for the broadcast class instead of an individual broadcaster.

I think this may also fix the unstable `TestDAP_breakpointEvents` tests.

We're not using the `Debugger::DefaultEventHandler` https://github.com/llvm/llvm-project/blob/090f46d8d246762401c41c5486dde299382d6c90/lldb/source/Core/Debugger.cpp#L2048 which is why these broadcast classes are not registered on our debugger instance in lldb-dap.