### PR TITLE
[NVPTX] Do not emit `.target debug` if only line tables are requested

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -745,8 +745,8 @@ void NVPTXAsmPrinter::emitHeader(Module &M, raw_ostream &O,
     switch(CU->getEmissionKind()) {
     case DICompileUnit::NoDebug:
     case DICompileUnit::DebugDirectivesOnly:
-      break;
     case DICompileUnit::LineTablesOnly:
+      break;
     case DICompileUnit::FullDebug:
       HasFullDebugInfo = true;
       break;

--- a/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll
+++ b/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll
@@ -9,7 +9,7 @@
 ;__device__ void bar() {}
 ;}
 
-; CHECK: .target sm_{{[0-9]+}}, debug
+; CHECK: .target sm_{{[0-9]+}}
 
 ; CHECK: .visible .func foo()
 ; CHECK: .loc [[FOO:[0-9]+]] 1 31


### PR DESCRIPTION
According to [*], only the deprecated `@@DWARF` directives require setting `.target debug`.

[*]: https://docs.nvidia.com/cuda/parallel-thread-execution/#debugging-directives