### PR TITLE
[HLSL][RootSignature] Add parsing for empty RootDescriptors

### DIFF
--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -73,6 +73,7 @@ private:
   /// Root Element parse methods:
   std::optional<llvm::hlsl::rootsig::RootFlags> parseRootFlags();
   std::optional<llvm::hlsl::rootsig::RootConstants> parseRootConstants();
+  std::optional<llvm::hlsl::rootsig::RootParam> parseRootParam();
   std::optional<llvm::hlsl::rootsig::DescriptorTable> parseDescriptorTable();
   std::optional<llvm::hlsl::rootsig::DescriptorTableClause>
   parseDescriptorTableClause();

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -73,7 +73,7 @@ private:
   /// Root Element parse methods:
   std::optional<llvm::hlsl::rootsig::RootFlags> parseRootFlags();
   std::optional<llvm::hlsl::rootsig::RootConstants> parseRootConstants();
-  std::optional<llvm::hlsl::rootsig::RootParam> parseRootParam();
+  std::optional<llvm::hlsl::rootsig::RootDescriptor> parseRootDescriptor();
   std::optional<llvm::hlsl::rootsig::DescriptorTable> parseDescriptorTable();
   std::optional<llvm::hlsl::rootsig::DescriptorTableClause>
   parseDescriptorTableClause();

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -50,10 +50,10 @@ bool RootSignatureParser::parse() {
 
     if (tryConsumeExpectedToken(
             {TokenKind::kw_CBV, TokenKind::kw_SRV, TokenKind::kw_UAV})) {
-      auto RootParam = parseRootParam();
-      if (!RootParam.has_value())
+      auto Descriptor = parseRootDescriptor();
+      if (!Descriptor.has_value())
         return true;
-      Elements.push_back(*RootParam);
+      Elements.push_back(*Descriptor);
     }
   } while (tryConsumeExpectedToken(TokenKind::pu_comma));
 
@@ -163,30 +163,30 @@ std::optional<RootConstants> RootSignatureParser::parseRootConstants() {
   return Constants;
 }
 
-std::optional<RootParam> RootSignatureParser::parseRootParam() {
+std::optional<RootDescriptor> RootSignatureParser::parseRootDescriptor() {
   assert((CurToken.TokKind == TokenKind::kw_CBV ||
           CurToken.TokKind == TokenKind::kw_SRV ||
           CurToken.TokKind == TokenKind::kw_UAV) &&
          "Expects to only be invoked starting at given keyword");
 
-  TokenKind ParamKind = CurToken.TokKind;
+  TokenKind DescriptorKind = CurToken.TokKind;
 
   if (consumeExpectedToken(TokenKind::pu_l_paren, diag::err_expected_after,
                            CurToken.TokKind))
     return std::nullopt;
 
-  RootParam Param;
-  switch (ParamKind) {
+  RootDescriptor Descriptor;
+  switch (DescriptorKind) {
   default:
     llvm_unreachable("Switch for consumed token was not provided");
   case TokenKind::kw_CBV:
-    Param.Type = ParamType::CBuffer;
+    Descriptor.Type = DescriptorType::CBuffer;
     break;
   case TokenKind::kw_SRV:
-    Param.Type = ParamType::SRV;
+    Descriptor.Type = DescriptorType::SRV;
     break;
   case TokenKind::kw_UAV:
-    Param.Type = ParamType::UAV;
+    Descriptor.Type = DescriptorType::UAV;
     break;
   }
 
@@ -195,7 +195,7 @@ std::optional<RootParam> RootSignatureParser::parseRootParam() {
                            /*param of=*/TokenKind::kw_RootConstants))
     return std::nullopt;
 
-  return Param;
+  return Descriptor;
 }
 
 std::optional<DescriptorTable> RootSignatureParser::parseDescriptorTable() {

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -344,7 +344,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootFlagsTest) {
   ASSERT_TRUE(Consumer->isSatisfied());
 }
 
-TEST_F(ParseHLSLRootSignatureTest, ValidParseRootParamsTest) {
+TEST_F(ParseHLSLRootSignatureTest, ValidParseRootDescriptorsTest) {
   const llvm::StringLiteral Source = R"cc(
     CBV(),
     SRV(),
@@ -367,16 +367,16 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootParamsTest) {
   ASSERT_EQ(Elements.size(), 3u);
 
   RootElement Elem = Elements[0];
-  ASSERT_TRUE(std::holds_alternative<RootParam>(Elem));
-  ASSERT_EQ(std::get<RootParam>(Elem).Type, ParamType::CBuffer);
+  ASSERT_TRUE(std::holds_alternative<RootDescriptor>(Elem));
+  ASSERT_EQ(std::get<RootDescriptor>(Elem).Type, DescriptorType::CBuffer);
 
   Elem = Elements[1];
-  ASSERT_TRUE(std::holds_alternative<RootParam>(Elem));
-  ASSERT_EQ(std::get<RootParam>(Elem).Type, ParamType::SRV);
+  ASSERT_TRUE(std::holds_alternative<RootDescriptor>(Elem));
+  ASSERT_EQ(std::get<RootDescriptor>(Elem).Type, DescriptorType::SRV);
 
   Elem = Elements[2];
-  ASSERT_TRUE(std::holds_alternative<RootParam>(Elem));
-  ASSERT_EQ(std::get<RootParam>(Elem).Type, ParamType::UAV);
+  ASSERT_TRUE(std::holds_alternative<RootDescriptor>(Elem));
+  ASSERT_EQ(std::get<RootDescriptor>(Elem).Type, DescriptorType::UAV);
 
   ASSERT_TRUE(Consumer->isSatisfied());
 }

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -85,6 +85,11 @@ struct RootConstants {
   ShaderVisibility Visibility = ShaderVisibility::All;
 };
 
+using ParamType = llvm::dxil::ResourceClass;
+struct RootParam {
+  ParamType Type;
+};
+
 // Models the end of a descriptor table and stores its visibility
 struct DescriptorTable {
   ShaderVisibility Visibility = ShaderVisibility::All;
@@ -125,8 +130,8 @@ struct DescriptorTableClause {
   void dump(raw_ostream &OS) const;
 };
 
-/// Models RootElement : RootFlags | RootConstants | DescriptorTable
-///  | DescriptorTableClause
+/// Models RootElement : RootFlags | RootConstants | RootParam
+///  | DescriptorTable | DescriptorTableClause
 ///
 /// A Root Signature is modeled in-memory by an array of RootElements. These
 /// aim to map closely to their DSL grammar reprsentation defined in the spec.
@@ -140,9 +145,8 @@ struct DescriptorTableClause {
 /// The DescriptorTable is modelled by having its Clauses as the previous
 /// RootElements in the array, and it holds a data member for the Visibility
 /// parameter.
-using RootElement = std::variant<RootFlags, RootConstants, DescriptorTable,
-                                 DescriptorTableClause>;
-
+using RootElement = std::variant<RootFlags, RootConstants, RootParam,
+                                 DescriptorTable, DescriptorTableClause>;
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements);
 
 class MetadataBuilder {

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -85,9 +85,10 @@ struct RootConstants {
   ShaderVisibility Visibility = ShaderVisibility::All;
 };
 
-using ParamType = llvm::dxil::ResourceClass;
-struct RootParam {
-  ParamType Type;
+using DescriptorType = llvm::dxil::ResourceClass;
+// Models RootDescriptor : CBV | SRV | UAV, by collecting like parameters
+struct RootDescriptor {
+  DescriptorType Type;
 };
 
 // Models the end of a descriptor table and stores its visibility
@@ -130,7 +131,7 @@ struct DescriptorTableClause {
   void dump(raw_ostream &OS) const;
 };
 
-/// Models RootElement : RootFlags | RootConstants | RootParam
+/// Models RootElement : RootFlags | RootConstants | RootDescriptor
 ///  | DescriptorTable | DescriptorTableClause
 ///
 /// A Root Signature is modeled in-memory by an array of RootElements. These
@@ -145,8 +146,9 @@ struct DescriptorTableClause {
 /// The DescriptorTable is modelled by having its Clauses as the previous
 /// RootElements in the array, and it holds a data member for the Visibility
 /// parameter.
-using RootElement = std::variant<RootFlags, RootConstants, RootParam,
+using RootElement = std::variant<RootFlags, RootConstants, RootDescriptor,
                                  DescriptorTable, DescriptorTableClause>;
+
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements);
 
 class MetadataBuilder {


### PR DESCRIPTION
- define the RootDescriptor in-memory struct containing its type
- add test harness for testing

First part of https://github.com/llvm/llvm-project/issues/126577