### PR TITLE
[libc++] Optimizations for uniform_int_distribution

### DIFF
--- a/libcxx/include/__random/uniform_int_distribution.h
+++ b/libcxx/include/__random/uniform_int_distribution.h
@@ -9,6 +9,7 @@
 #ifndef _LIBCPP___RANDOM_UNIFORM_INT_DISTRIBUTION_H
 #define _LIBCPP___RANDOM_UNIFORM_INT_DISTRIBUTION_H
 
+#include <__assert>
 #include <__bit/countl.h>
 #include <__config>
 #include <__cstddef/size_t.h>
@@ -64,7 +65,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI __independent_bits_engine(_Engine& __e, size_t __w);
 
   // generating functions
-  _LIBCPP_HIDE_FROM_ABI result_type operator()() { return __eval(integral_constant<bool, _Rp != 0>()); }
+  _LIBCPP_HIDE_FROM_ABI result_type operator()() { return __eval(integral_constant<bool, (_Rp & (_Rp - 1)) != 0>()); }
 
 private:
   _LIBCPP_HIDE_FROM_ABI result_type __eval(false_type);
@@ -74,49 +75,66 @@ private:
 template <class _Engine, class _UIntType>
 __independent_bits_engine<_Engine, _UIntType>::__independent_bits_engine(_Engine& __e, size_t __w)
     : __e_(__e), __w_(__w) {
-  __n_  = __w_ / __m + (__w_ % __m != 0);
-  __w0_ = __w_ / __n_;
-  if (_Rp == 0)
-    __y0_ = _Rp;
-  else if (__w0_ < _WDt)
-    __y0_ = (_Rp >> __w0_) << __w0_;
-  else
-    __y0_ = 0;
-  if (_Rp - __y0_ > __y0_ / __n_) {
-    ++__n_;
+  _LIBCPP_ASSERT_INTERNAL(
+      __w_ <= numeric_limits<result_type>::digits, "cannot sample more bits than result_type can hold");
+  _LIBCPP_ASSERT_INTERNAL(__w_ > 0, "must sample a positive number of bits");
+  if (__w_ <= __m) {
+    __n_ = __n0_ = 1;
+    __w0_        = __w_;
+    __mask0_ = __mask1_ = ~_Engine_result_type(0) >> (_EDt - __w0_);
+    __y0_ = __y1_ = _Rp & ~__mask0_;
+  } else {
+    __n_     = (__w_ + __m - 1) / __m;
     __w0_ = __w_ / __n_;
-    if (__w0_ < _WDt)
-      __y0_ = (_Rp >> __w0_) << __w0_;
-    else
-      __y0_ = 0;
+    __mask0_ = __mask1_ = ~_Engine_result_type(0) >> (_EDt - __w0_);
+    __y0_ = __y1_ = _Rp & ~__mask0_;
+    if _LIBCPP_CONSTEXPR_SINCE_CXX17 ((_Rp & (_Rp - 1)) != 0) {
+      if (_Rp - __y0_ > __y0_ / __n_) {
+        ++__n_;
+        __w0_    = __w_ / __n_;
+        __mask0_ = __mask1_ = ~_Engine_result_type(0) >> (_EDt - __w0_);
+        __y0_ = __y1_ = _Rp & ~__mask0_;
+      }
+    }
+    size_t __n1 = __w_ % __n_;
+    __n0_       = __n_ - __n1;
+    if (__n1 > 0) {
+      __mask1_ = ~_Engine_result_type(0) >> (_EDt - (__w0_ + 1));
+      __y1_    = _Rp & ~__mask1_;
+    }
   }
-  __n0_ = __n_ - __w_ % __n_;
-  if (__w0_ < _WDt - 1)
-    __y1_ = (_Rp >> (__w0_ + 1)) << (__w0_ + 1);
-  else
-    __y1_ = 0;
-  __mask0_ = __w0_ > 0 ? _Engine_result_type(~0) >> (_EDt - __w0_) : _Engine_result_type(0);
-  __mask1_ = __w0_ < _EDt - 1 ? _Engine_result_type(~0) >> (_EDt - (__w0_ + 1)) : _Engine_result_type(~0);
 }
 
 template <class _Engine, class _UIntType>
 inline _UIntType __independent_bits_engine<_Engine, _UIntType>::__eval(false_type) {
-  return static_cast<result_type>(__e_() & __mask0_);
+  result_type __sp = (__e_() - _Engine::min()) & __mask0_;
+  for (size_t __k = 1; __k < __n0_; ++__k) {
+    __sp <<= __w0_;
+    __sp += (__e_() - _Engine::min()) & __mask0_;
+  }
+  for (size_t __k = __n0_; __k < __n_; ++__k) {
+    __sp <<= __w0_ + 1;
+    __sp += (__e_() - _Engine::min()) & __mask1_;
+  }
+  return __sp;
 }
 
 template <class _Engine, class _UIntType>
 _UIntType __independent_bits_engine<_Engine, _UIntType>::__eval(true_type) {
-  const size_t __w_rt = numeric_limits<result_type>::digits;
-  result_type __sp    = 0;
-  for (size_t __k = 0; __k < __n0_; ++__k) {
+  result_type __sp;
+  {
     _Engine_result_type __u;
     do {
       __u = __e_() - _Engine::min();
     } while (__u >= __y0_);
-    if (__w0_ < __w_rt)
-      __sp <<= __w0_;
-    else
-      __sp = 0;
+    __sp = __u & __mask0_;
+  }
+  for (size_t __k = 1; __k < __n0_; ++__k) {
+    _Engine_result_type __u;
+    do {
+      __u = __e_() - _Engine::min();
+    } while (__u >= __y0_);
+    __sp <<= __w0_;
     __sp += __u & __mask0_;
   }
   for (size_t __k = __n0_; __k < __n_; ++__k) {
@@ -124,10 +142,7 @@ _UIntType __independent_bits_engine<_Engine, _UIntType>::__eval(true_type) {
     do {
       __u = __e_() - _Engine::min();
     } while (__u >= __y1_);
-    if (__w0_ < __w_rt - 1)
-      __sp <<= __w0_ + 1;
-    else
-      __sp = 0;
+    __sp <<= __w0_ + 1;
     __sp += __u & __mask1_;
   }
   return __sp;
@@ -218,9 +233,9 @@ typename uniform_int_distribution<_IntType>::result_type uniform_int_distributio
   typedef __independent_bits_engine<_URNG, _UIntType> _Eng;
   if (__rp == 0)
     return static_cast<result_type>(_Eng(__g, __dt)());
-  size_t __w = __dt - std::__countl_zero(__rp) - 1;
-  if ((__rp & (numeric_limits<_UIntType>::max() >> (__dt - __w))) != 0)
-    ++__w;
+  size_t __w = __dt - std::__countl_zero(__rp);
+  if ((__rp & (__rp - 1)) == 0)
+    return static_cast<result_type>(_Eng(__g, __w - 1)() + __p.a());
   _Eng __e(__g, __w);
   _UIntType __u;
   do {

--- a/libcxx/test/benchmarks/numeric/rand.uni.int.bench.cpp
+++ b/libcxx/test/benchmarks/numeric/rand.uni.int.bench.cpp
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: c++03
+
+#include <cstdint>
+#include <random>
+
+#include <benchmark/benchmark.h>
+
+template <typename Eng, std::uint64_t Max>
+static void bm_uniform_int_distribution(benchmark::State& state) {
+  Eng eng;
+  std::uniform_int_distribution<std::uint64_t> dist(1ull, Max);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(dist(eng));
+  }
+}
+
+// n = 1
+// Best Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, 1ull << 20>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, 1ull << 20>);
+// Worst Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, (1ull << 19) + 1ull>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, (1ull << 19) + 1ull>);
+// Median Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, (1ull << 19) + (1ull << 18)>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, (1ull << 19) + (1ull << 18)>);
+
+// n = 2, n0 = 2
+// Best Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, 1ull << 40>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, 1ull << 40>);
+// Worst Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, (1ull << 39) + 1ull>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, (1ull << 39) + 1ull>);
+// Median Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, (1ull << 39) + (1ull << 38)>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, (1ull << 39) + (1ull << 38)>);
+
+// n = 2, n0 = 1
+// Best Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, 1ull << 41>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, 1ull << 41>);
+// Worst Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, (1ull << 40) + 1ull>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, (1ull << 40) + 1ull>);
+// Median Case
+BENCHMARK(bm_uniform_int_distribution<std::minstd_rand0, (1ull << 40) + (1ull << 39)>);
+BENCHMARK(bm_uniform_int_distribution<std::ranlux24_base, (1ull << 40) + (1ull << 39)>);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
I noticed that the implementation for `std::uniform_int_distribution` in libc++ often has worse performance than other implementations. While it might be useful to change the implementation to one that rejects less samples, such a change would result in the output of the distribution changing, which could break programs dependent on the behavior. Instead, this PR attempts to optimize the existing implementation without changing the output of the distribution.

In libc++, `std::uniform_int_distribution` uses `__independent_bits_engine` to produce n-bit random numbers. The implementation of `__independent_bits_engine` is based on the specification for `std::independent_bits_engine`, except that the value for n is specified as a runtime value. However, the design of `std::independent_bits_engine` was optimized for the case where n is known at compile time. The algorithm used requires calculating a number of values, which `std::independent_bits_engine` can calculate at compile time, avoiding any runtime performance penalty. However, the use of this algorithm for `std::uniform_int_distribution` results in these values having to be calculated for every output generated, which ends up accounting for a significant portion of the algorithm's runtime.

While analyzing the definitions of the values that need to be generated and the algorithm in general, I identified two common cases where the algorithm could be simplified:

* When R is a power of two, y0 = R, and if it's used, y1 = R. This means that the algorithm will never reject any samples generated, allowing it to use a simplified implementation of `__eval` that limits branching and doesn't read the values for y0 or y1 (allowing the optimizer to potentially eliminate the variables entirely). Additionally, the check for the condition R - y0 <= floor(y0 / n) simplifies to 0 <= floor(R / n), which is always true, meaning we can skip this check entirely when generating the required values.
* When w <= m, we know that the result of evaluating the required values will always result in n = 1. This is because, when n = ceil(w / m) = 1, R - y0 <= floor(y0 / n) can be simplified to just R <= 2\*y0, which is always true. (You can see it's always true by noting that the definitions for y0 and m gives y0 >= 2^m and R < 2^(m+1)). With this, we can provide an optimized implementation for this case that skips the multiple divisions that are required for larger values of w.

Additionally, I noticed that pretty much every use of a bit shift in the original implementation was guarded by an if clause that ensured the shift value did not cause UB. However, these checks introduce complexity and branching that can impact performance. I was able to remove these if statements by carefully considering what all the possible shift values can be. Note, I'm working with the assumption that 0 < w <= numeric_limits<result_type>::digits, which appears to be a safe assumption to make about w given how `__independent_bits_engine` is used by `std::uniform_int_distribution`.

* For computing mask0, the method used is already safe. The definition of w0 ensures that 0 < w0 <= EDt, so the value for (EDt - w0) is in the range 0 <= (EDt - w0) < EDt, which is the valid range for the shift.
* For computing y0, the current method requires checking that w0 < EDt, since it's possible that w0 = EDt. This optimization handles this case by changing the evaluation of y0 to not use any shifts, and instead use the value of mask0. This prevents the possibility of UB from an invalid shift value by simply not performing any shifts.
* For computing mask1 and y1, we have that if n > n0, then w0 + 1 <= EDt. This means that this case can be handled with the same method used for mask0 and y0. For the case where n = n0, then the values for mask1 and y1 go unused, and so we don't need to calculate them anyways. To avoid uninitialized variable warnings, this change defaults to using mask1 = mask0 and y1 = y0.
* For the shifts in `__eval`, the case where n > 1 will never result in a shift value that results in UB. This is because the relation n0\*w0 + (n - n0)\*(w0 + 1) = w gives that w0 < w, and if n > n0, w0 + 1 < w. This means the only case that needs to be handled is when n = 1. This is done by manually unrolling the k = 0 iteration and removing the shift step from it. This makes the assumptions that n > 0 and n0 > 0, but this is always true given w > 0 and n - n0 < n respectively (the latter being given by the "mod n" in the definition of n0).

All together, these changes provide minor performance improvements for sampling large ranges and significant performance improvements for sampling small ranges. The only other thing to note with this is that it removes the specific (and optimized) case for when Rp = 0 (representing R = 2^WDt) that was present previously. However, the optimizations for power-of-two values for R apply to this case as well, and there doesn't appear to be much benefit to trying to further optimize this case. This change also reuses the overload for `__eval` previously used for the Rp = 0 special case for handling power-of-two values of R.