### PR TITLE
[LLDB][Progress-On-Dap] Have indeterminate progress actually send events.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -81,7 +81,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
 
         self.verify_progress_events(
             expected_title="Progress tester: Initial Indeterminate Detail",
-            expected_message="Step 1",
+            expected_message="Step 2",
             only_verify_first_update=True,
         )
 

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 import json
 import os
 import time
+import re
 
 import lldbdap_testcase
 
@@ -16,6 +17,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         self,
         expected_title,
         expected_message=None,
+        expected_message_regex=None,
         expected_not_in_message=None,
         only_verify_first_update=False,
     ):
@@ -36,6 +38,8 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
                     continue
                 if expected_message is not None:
                     self.assertIn(expected_message, message)
+                if expected_message_regex is not None:
+                    self.assertTrue(re.match(expected_message_regex, message))
                 if expected_not_in_message is not None:
                     self.assertNotIn(expected_not_in_message, message)
                 update_found = True
@@ -81,8 +85,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
 
         self.verify_progress_events(
             expected_title="Progress tester: Initial Indeterminate Detail",
-            expected_message="Step 2",
-            only_verify_first_update=True,
+            expected_message_regex=r"Step [0-9]+",
         )
 
         # Test no details indeterminate.

--- a/lldb/tools/lldb-dap/ProgressEvent.cpp
+++ b/lldb/tools/lldb-dap/ProgressEvent.cpp
@@ -77,16 +77,19 @@ ProgressEvent::Create(uint64_t progress_id, std::optional<StringRef> message,
   if (event.GetEventType() == progressStart && event.GetEventName().empty())
     return std::nullopt;
 
-  if (prev_event && prev_event->EqualsForIDE(event))
+  if (prev_event && prev_event->EqualsForIDE(event, total))
     return std::nullopt;
 
   return event;
 }
 
-bool ProgressEvent::EqualsForIDE(const ProgressEvent &other) const {
+bool ProgressEvent::EqualsForIDE(const ProgressEvent &other, uint64_t total) const {
   return m_progress_id == other.m_progress_id &&
-         m_event_type == other.m_event_type &&
-         m_percentage == other.m_percentage;
+         m_event_type == other.m_event_type && 
+         // If we check the percentage of a non-deterministic event
+         // we will basically never send the event, because N+1/Uint64_max
+         // will always be an infinitesimally small change.
+         (total != UINT64_MAX && m_percentage == other.m_percentage);
 }
 
 ProgressEventType ProgressEvent::GetEventType() const { return m_event_type; }

--- a/lldb/tools/lldb-dap/ProgressEvent.cpp
+++ b/lldb/tools/lldb-dap/ProgressEvent.cpp
@@ -77,19 +77,19 @@ ProgressEvent::Create(uint64_t progress_id, std::optional<StringRef> message,
   if (event.GetEventType() == progressStart && event.GetEventName().empty())
     return std::nullopt;
 
-  if (prev_event && prev_event->EqualsForIDE(event, total))
+  if (prev_event && prev_event->EqualsForIDE(event))
     return std::nullopt;
 
   return event;
 }
 
-bool ProgressEvent::EqualsForIDE(const ProgressEvent &other, uint64_t total) const {
+bool ProgressEvent::EqualsForIDE(const ProgressEvent &other) const {
   return m_progress_id == other.m_progress_id &&
-         m_event_type == other.m_event_type && 
+         m_event_type == other.m_event_type &&
          // If we check the percentage of a non-deterministic event
          // we will basically never send the event, because N+1/Uint64_max
          // will always be an infinitesimally small change.
-         (total != UINT64_MAX && m_percentage == other.m_percentage);
+         (m_percentage != std::nullopt && m_percentage == other.m_percentage);
 }
 
 ProgressEventType ProgressEvent::GetEventType() const { return m_event_type; }

--- a/lldb/tools/lldb-dap/ProgressEvent.cpp
+++ b/lldb/tools/lldb-dap/ProgressEvent.cpp
@@ -86,10 +86,7 @@ ProgressEvent::Create(uint64_t progress_id, std::optional<StringRef> message,
 bool ProgressEvent::EqualsForIDE(const ProgressEvent &other) const {
   return m_progress_id == other.m_progress_id &&
          m_event_type == other.m_event_type &&
-         // If we check the percentage of a non-deterministic event
-         // we will basically never send the event, because N+1/Uint64_max
-         // will always be an infinitesimally small change.
-         (m_percentage != std::nullopt && m_percentage == other.m_percentage);
+         m_percentage == other.m_percentage && m_message == other.m_message;
 }
 
 ProgressEventType ProgressEvent::GetEventType() const { return m_event_type; }

--- a/lldb/tools/lldb-dap/ProgressEvent.h
+++ b/lldb/tools/lldb-dap/ProgressEvent.h
@@ -54,7 +54,7 @@ public:
   /// \return
   ///       \b true if two event messages would result in the same event for the
   ///       IDE, e.g. same rounded percentage.
-  bool EqualsForIDE(const ProgressEvent &other, uint64_t total) const;
+  bool EqualsForIDE(const ProgressEvent &other) const;
 
   llvm::StringRef GetEventName() const;
 

--- a/lldb/tools/lldb-dap/ProgressEvent.h
+++ b/lldb/tools/lldb-dap/ProgressEvent.h
@@ -54,7 +54,7 @@ public:
   /// \return
   ///       \b true if two event messages would result in the same event for the
   ///       IDE, e.g. same rounded percentage.
-  bool EqualsForIDE(const ProgressEvent &other) const;
+  bool EqualsForIDE(const ProgressEvent &other, uint64_t total) const;
 
   llvm::StringRef GetEventName() const;
 


### PR DESCRIPTION
Recently, I got a report how a user 'hung', and come to find out it's actually because DAP is checking percentage, and on non-deterministic events, we will effectively never send a progress event to DAP. Here we short circuit and don't view percentages for DAP messages and solely depend on the DAP 250ms throttle, which is probably still too aggressive, but better than no updates.