### PR TITLE
[mlir][tensor] Add shape inference support for `tensor.concat` op.

### DIFF
--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -806,7 +806,7 @@ struct InferConcatOperandTypes : public OpRewritePattern<ConcatOp> {
 
     int64_t dim = concatOp.getDim();
     ArrayRef<int64_t> inferredResultShape =
-        concatOp.inferResultType(dim, concatOp->getOperandTypes()).getShape();
+        ConcatOp::inferResultType(dim, concatOp->getOperandTypes()).getShape();
 
     // Find operands for which a more static shape can be inferred.
     SmallVector<std::tuple<size_t, RankedTensorType>> refinedTypes;
@@ -861,7 +861,7 @@ struct InferConcatResultType : public OpRewritePattern<ConcatOp> {
                                 PatternRewriter &rewriter) const override {
     int64_t dim = concatOp.getDim();
     RankedTensorType inferredResultType =
-        concatOp.inferResultType(dim, concatOp->getOperandTypes());
+        ConcatOp::inferResultType(dim, concatOp->getOperandTypes());
 
     // The result type should be at least as static as inferred result type.
     if (preservesStaticInformation(inferredResultType,
@@ -874,7 +874,7 @@ struct InferConcatResultType : public OpRewritePattern<ConcatOp> {
     rewriter.replaceOpWithNewOp<CastOp>(concatOp, concatOp.getResultType(),
                                         newConcatOp);
 
-    return llvm::success();
+    return success();
   }
 };
 } // namespace

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -826,10 +826,9 @@ struct InferConcatOperandTypes : public OpRewritePattern<ConcatOp> {
         auto castOp =
             rewriter.create<CastOp>(concatOp->getLoc(), inferredOperandType,
                                     concatOp.getOperand(operandIdx));
-        rewriter.modifyOpInPlace(
-            concatOp, [=, operandIdx = (size_t)operandIdx] {
-              concatOp->setOperand(operandIdx, castOp->getResult(0));
-            });
+        rewriter.modifyOpInPlace(concatOp, [=, operandIdx = operandIdx] {
+          concatOp->setOperand(operandIdx, castOp->getResult(0));
+        });
       }
     }
 

--- a/mlir/test/Dialect/Tensor/canonicalize.mlir
+++ b/mlir/test/Dialect/Tensor/canonicalize.mlir
@@ -136,6 +136,32 @@ func.func @fold_concat(%arg0: tensor<1x2x?xi32>) -> (tensor<1x2x3xi32>, tensor<1
 
 // -----
 
+// CHECK-LABEL: infer_concat_operand_types
+// CHECK-SAME: %[[ARG0:.+]]: tensor<?x12xi32>
+// CHECK-SAME: %[[ARG1:.+]]: tensor<?x?xi32>
+func.func @infer_concat_operand_types(%arg0: tensor<?x12xi32>, %arg1: tensor<?x?xi32>) -> (tensor<?x12xi32>) {
+  // CHECK-NEXT: %[[CAST:.+]] = tensor.cast %[[ARG1]] : tensor<?x?xi32> to tensor<?x12xi32>
+  %0 = tensor.concat dim(0) %arg0, %arg1: (tensor<?x12xi32>, tensor<?x?xi32>) -> tensor<?x12xi32>
+  // CHECK-NEXT: %[[CONCAT:.+]] = tensor.concat dim(0) %[[ARG0]], %[[CAST]] : (tensor<?x12xi32>, tensor<?x12xi32>) -> tensor<?x12xi32>
+  return %0 : tensor<?x12xi32>
+  // CHECK-NEXT: return %[[CONCAT]] : tensor<?x12xi32>
+}
+
+// -----
+
+// CHECK-LABEL: infer_concat_return_type
+// CHECK-SAME: %[[ARG0:.+]]: tensor<5x12xi32>
+// CHECK-SAME: %[[ARG1:.+]]: tensor<?x12xi32>
+func.func @infer_concat_return_type(%arg0: tensor<5x12xi32>, %arg1: tensor<?x12xi32>) -> (tensor<?x?xi32>) {
+  %0 = tensor.concat dim(0) %arg0, %arg1: (tensor<5x12xi32>, tensor<?x12xi32>) -> tensor<?x?xi32>
+  // CHECK-NEXT: %[[CONCAT:.+]] = tensor.concat dim(0) %[[ARG0]], %[[ARG1]] : (tensor<5x12xi32>, tensor<?x12xi32>) -> tensor<?x12xi32>
+  // CHECK-NEXT: %[[CAST:.+]] = tensor.cast %[[CONCAT]] : tensor<?x12xi32> to tensor<?x?xi32>
+  return %0 : tensor<?x?xi32>
+  // CHECK-NEXT: return %[[CAST]] : tensor<?x?xi32>
+}
+
+// -----
+
 // CHECK-LABEL: func @fold_extract
 func.func @fold_extract(%arg0 : index) -> (f32, f16, f16, i32, complex<f32>) {
   %const_0 = arith.constant 0 : index


### PR DESCRIPTION
## description
`tensor.concat` requires operands and the result to match on all dimensions except the concatenation dimension. If one operand is already static in those dimensions, the other operands and result type may safely be refined to that same static shape. This PR adds canonicalization patterns to refine `tensor.concat` types and propagate static shapes to other canonicalization patterns through casts.

## example
```mlir
%2 = tensor.concat dim(0) %0, %1: (tensor<?x12xi32>, tensor<?x?xi32>) ->tensor<?x12xi32>
```
becomes:
 ```mlir
%cast = tensor.cast %1 : tensor<?x?xi32> to tensor<?x12xi32>
%2 = tensor.concat dim(0) %0, %cast : (tensor<?x12xi32>, tensor<?x12xi32>)  -> tensor<?x12xi32>
 ```

