### PR TITLE
[HLSL][RootSignature] Add parsing of floats for StaticSampler

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1856,7 +1856,11 @@ def err_hlsl_unexpected_end_of_params
     : Error<"expected %0 to denote end of parameters, or, another valid parameter of %1">;
 def err_hlsl_rootsig_repeat_param : Error<"specified the same parameter '%0' multiple times">;
 def err_hlsl_rootsig_missing_param : Error<"did not specify mandatory parameter '%0'">;
-def err_hlsl_number_literal_overflow : Error<"integer literal is too large to be represented as a 32-bit %select{signed |}0 integer type">;
+def err_hlsl_number_literal_overflow : Error<
+  "%select{integer|float}0 literal is too large to be represented as a "
+  "%select{32-bit %select{signed|}1 integer|float}0 type">;
+def err_hlsl_number_literal_underflow : Error<
+  "float literal has a magnitude that is too small to be represented as a float type">;
 def err_hlsl_rootsig_non_zero_flag : Error<"flag value is neither a literal 0 nor a named value">;
 
 } // end of Parser diagnostics

--- a/clang/include/clang/Lex/HLSLRootSignatureTokenKinds.def
+++ b/clang/include/clang/Lex/HLSLRootSignatureTokenKinds.def
@@ -100,6 +100,9 @@ KEYWORD(flags)
 KEYWORD(numDescriptors)
 KEYWORD(offset)
 
+// StaticSampler Keywords:
+KEYWORD(mipLODBias)
+
 // Unbounded Enum:
 UNBOUNDED_ENUM(unbounded, "unbounded")
 

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -111,6 +111,7 @@ private:
 
   struct ParsedStaticSamplerParams {
     std::optional<llvm::hlsl::rootsig::Register> Reg;
+    std::optional<float> MipLODBias;
   };
   std::optional<ParsedStaticSamplerParams> parseStaticSamplerParams();
 

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -118,6 +118,7 @@ private:
   // Common parsing methods
   std::optional<uint32_t> parseUIntParam();
   std::optional<llvm::hlsl::rootsig::Register> parseRegister();
+  std::optional<float> parseFloatParam();
 
   /// Parsing methods of various enums
   std::optional<llvm::hlsl::rootsig::ShaderVisibility> parseShaderVisibility();
@@ -129,6 +130,9 @@ private:
   /// Use NumericLiteralParser to convert CurToken.NumSpelling into a unsigned
   /// 32-bit integer
   std::optional<uint32_t> handleUIntLiteral();
+  /// Use NumericLiteralParser to convert CurToken.NumSpelling into a unsigned
+  /// 32-bit integer
+  std::optional<int32_t> handleIntLiteral(bool Negated);
 
   /// Flags may specify the value of '0' to denote that there should be no
   /// flags set.

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -130,9 +130,11 @@ private:
   /// Use NumericLiteralParser to convert CurToken.NumSpelling into a unsigned
   /// 32-bit integer
   std::optional<uint32_t> handleUIntLiteral();
-  /// Use NumericLiteralParser to convert CurToken.NumSpelling into a unsigned
+  /// Use NumericLiteralParser to convert CurToken.NumSpelling into a signed
   /// 32-bit integer
   std::optional<int32_t> handleIntLiteral(bool Negated);
+  /// Use NumericLiteralParser to convert CurToken.NumSpelling into a float
+  std::optional<float> handleFloatLiteral(bool Negated);
 
   /// Flags may specify the value of '0' to denote that there should be no
   /// flags set.

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -134,6 +134,14 @@ private:
   /// 32-bit integer
   std::optional<int32_t> handleIntLiteral(bool Negated);
   /// Use NumericLiteralParser to convert CurToken.NumSpelling into a float
+  ///
+  /// This matches the behaviour of DXC, which is as follows:
+  ///  - convert the spelling with `strtod`
+  ///  - check for a float overflow
+  ///  - cast the double to a float
+  /// The behaviour of `strtod` is replicated using:
+  ///  Semantics: llvm::APFloat::Semantics::S_IEEEdouble
+  ///  RoundingMode: llvm::RoundingMode::NearestTiesToEven
   std::optional<float> handleFloatLiteral(bool Negated);
 
   /// Flags may specify the value of '0' to denote that there should be no

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -878,7 +878,7 @@ std::optional<uint32_t> RootSignatureParser::handleUIntLiteral() {
   assert(Literal.isIntegerLiteral() &&
          "NumSpelling can only consist of digits");
 
-  llvm::APSInt Val = llvm::APSInt(32, /*IsUnsigned=*/true);
+  llvm::APSInt Val(32, /*IsUnsigned=*/true);
   if (Literal.GetIntegerValue(Val)) {
     // Report that the value has overflowed
     PP.getDiagnostics().Report(CurToken.TokLoc,
@@ -901,7 +901,7 @@ std::optional<int32_t> RootSignatureParser::handleIntLiteral(bool Negated) {
   assert(Literal.isIntegerLiteral() &&
          "NumSpelling can only consist of digits");
 
-  llvm::APSInt Val = llvm::APSInt(32, /*IsUnsigned=*/true);
+  llvm::APSInt Val(32, /*IsUnsigned=*/true);
   // GetIntegerValue will overwrite Val from the parsed Literal and return
   // true if it overflows as a 32-bit unsigned int. Then check that it also
   // doesn't overflow as a signed 32-bit int.
@@ -937,9 +937,8 @@ std::optional<float> RootSignatureParser::handleFloatLiteral(bool Negated) {
   auto DXCSemantics = llvm::APFloat::Semantics::S_IEEEdouble;
   auto DXCRoundingMode = llvm::RoundingMode::NearestTiesToEven;
 
-  llvm::APFloat Val =
-      llvm::APFloat(llvm::APFloat::EnumToSemantics(DXCSemantics));
-  llvm::APFloat::opStatus Status = Literal.GetFloatValue(Val, DXCRoundingMode);
+  llvm::APFloat Val(llvm::APFloat::EnumToSemantics(DXCSemantics));
+  llvm::APFloat::opStatus Status(Literal.GetFloatValue(Val, DXCRoundingMode));
 
   // Note: we do not error when opStatus::opInexact by itself as this just
   // denotes that rounding occured but not that it is invalid

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -747,7 +747,7 @@ std::optional<float> RootSignatureParser::parseFloatParam() {
   }
 
   if (Negated && tryConsumeExpectedToken(TokenKind::int_literal)) {
-    std::optional<int32_t> = handleIntLiteral(Negated);
+    std::optional<int32_t> Int = handleIntLiteral(Negated);
     if (!Int.has_value())
       return std::nullopt;
     return (float)Int.value();

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <float.h>
-
 #include "clang/Parse/ParseHLSLRootSignature.h"
 
 #include "clang/Lex/LiteralSupport.h"
@@ -969,7 +967,8 @@ std::optional<float> RootSignatureParser::handleFloatLiteral(bool Negated) {
     Val = -Val;
 
   double DoubleVal = Val.convertToDouble();
-  if (FLT_MAX < DoubleVal || DoubleVal < -FLT_MAX) {
+  double FloatMax = double(std::numeric_limits<float>::max());
+  if (FloatMax < DoubleVal || DoubleVal < -FloatMax) {
     // Report that the value has overflowed
     PP.getDiagnostics().Report(CurToken.TokLoc,
                                diag::err_hlsl_number_literal_overflow)

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -743,14 +743,14 @@ std::optional<float> RootSignatureParser::parseFloatParam() {
     std::optional<uint32_t> UInt = handleUIntLiteral();
     if (!UInt.has_value())
       return std::nullopt;
-    return (float)UInt.value();
+    return float(UInt.value());
   }
 
   if (Negated && tryConsumeExpectedToken(TokenKind::int_literal)) {
     std::optional<int32_t> Int = handleIntLiteral(Negated);
     if (!Int.has_value())
       return std::nullopt;
-    return (float)Int.value();
+    return float(Int.value());
   }
 
   if (tryConsumeExpectedToken(TokenKind::float_literal)) {
@@ -905,8 +905,7 @@ std::optional<int32_t> RootSignatureParser::handleIntLiteral(bool Negated) {
   // GetIntegerValue will overwrite Val from the parsed Literal and return
   // true if it overflows as a 32-bit unsigned int. Then check that it also
   // doesn't overflow as a signed 32-bit int.
-  int64_t MaxMagnitude =
-      -static_cast<int64_t>(std::numeric_limits<int32_t>::min());
+  int64_t MaxMagnitude = -int64_t(std::numeric_limits<int32_t>::min());
   if (Literal.GetIntegerValue(Val) || MaxMagnitude < Val.getExtValue()) {
     // Report that the value has overflowed
     PP.getDiagnostics().Report(CurToken.TokLoc,
@@ -918,7 +917,7 @@ std::optional<int32_t> RootSignatureParser::handleIntLiteral(bool Negated) {
   if (Negated)
     Val = -Val;
 
-  return static_cast<int32_t>(Val.getExtValue());
+  return int32_t(Val.getExtValue());
 }
 
 std::optional<float> RootSignatureParser::handleFloatLiteral(bool Negated) {

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -740,17 +740,17 @@ std::optional<float> RootSignatureParser::parseFloatParam() {
 
   // DXC will treat a postive signed integer as unsigned
   if (!Negated && tryConsumeExpectedToken(TokenKind::int_literal)) {
-    auto UInt = handleUIntLiteral();
+    std::optional<uint32_t> UInt = handleUIntLiteral();
     if (!UInt.has_value())
       return std::nullopt;
     return (float)UInt.value();
   } else if (tryConsumeExpectedToken(TokenKind::int_literal)) {
-    auto Int = handleIntLiteral(Negated);
+    std::optional<int32_t> = handleIntLiteral(Negated);
     if (!Int.has_value())
       return std::nullopt;
     return (float)Int.value();
   } else if (tryConsumeExpectedToken(TokenKind::float_literal)) {
-    auto Float = handleFloatLiteral(Negated);
+    std::optional<float> Float = handleFloatLiteral(Negated);
     if (!Float.has_value())
       return std::nullopt;
     return Float.value();

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -740,8 +740,8 @@ std::optional<float> RootSignatureParser::parseFloatParam() {
       tryConsumeExpectedToken({TokenKind::pu_plus, TokenKind::pu_minus});
   bool Negated = Signed && CurToken.TokKind == TokenKind::pu_minus;
 
-  // Handle an uint and interpret it as a float
-  if (!Signed && tryConsumeExpectedToken(TokenKind::int_literal)) {
+  // DXC will treat a postive signed integer as unsigned
+  if (!Negated && tryConsumeExpectedToken(TokenKind::int_literal)) {
     auto UInt = handleUIntLiteral();
     if (!UInt.has_value())
       return std::nullopt;

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -682,7 +682,7 @@ RootSignatureParser::parseStaticSamplerParams() {
       auto MipLODBias = parseFloatParam();
       if (!MipLODBias.has_value())
         return std::nullopt;
-      Params.MipLODBias = (float)*MipLODBias;
+      Params.MipLODBias = MipLODBias;
     }
   } while (tryConsumeExpectedToken(TokenKind::pu_comma));
 

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -900,7 +900,7 @@ std::optional<int32_t> RootSignatureParser::handleIntLiteral(bool Negated) {
          "NumSpelling can only consist of digits");
 
   llvm::APSInt Val = llvm::APSInt(32, true);
-  if (Literal.GetIntegerValue(Val) || INT32_MAX < Val.getExtValue()) {
+  if (Literal.GetIntegerValue(Val)) {
     // Report that the value has overflowed
     PP.getDiagnostics().Report(CurToken.TokLoc,
                                diag::err_hlsl_number_literal_overflow)

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -881,7 +881,7 @@ std::optional<uint32_t> RootSignatureParser::handleUIntLiteral() {
     // Report that the value has overflowed
     PP.getDiagnostics().Report(CurToken.TokLoc,
                                diag::err_hlsl_number_literal_overflow)
-        << 0 << CurToken.NumSpelling;
+        << /*integer type*/ 0 << /*is signed*/ 0;
     return std::nullopt;
   }
 
@@ -904,7 +904,7 @@ std::optional<int32_t> RootSignatureParser::handleIntLiteral(bool Negated) {
     // Report that the value has overflowed
     PP.getDiagnostics().Report(CurToken.TokLoc,
                                diag::err_hlsl_number_literal_overflow)
-        << 0 << CurToken.NumSpelling;
+        << /*integer type*/ 0 << /*is signed*/ 1;
     return std::nullopt;
   }
 
@@ -923,8 +923,8 @@ std::optional<float> RootSignatureParser::handleFloatLiteral(bool Negated) {
     return std::nullopt; // Error has already been reported so just return
 
   assert(Literal.isFloatingLiteral() &&
-         "NumSpelling is consistent with isNumberChar in "
-         "LexHLSLRootSignature.cpp");
+         "NumSpelling consists only of [0-9.ef+-]. Any malformed NumSpelling "
+         "will be caught and reported by NumericLiteralParser.");
 
   // DXC used `strtod` to convert the token string to a float which corresponds
   // to:
@@ -935,16 +935,40 @@ std::optional<float> RootSignatureParser::handleFloatLiteral(bool Negated) {
       llvm::APFloat(llvm::APFloat::EnumToSemantics(DXCSemantics));
   llvm::APFloat::opStatus Status = Literal.GetFloatValue(Val, DXCRoundingMode);
 
-  // The float is valid with opInexect as this just denotes if rounding occured
-  if (Status != llvm::APFloat::opStatus::opOK &&
-      Status != llvm::APFloat::opStatus::opInexact)
+  // Note: we do not error when opStatus::opInexact by itself as this just
+  // denotes that rounding occured but not that it is invalid
+  assert(!(Status & llvm::APFloat::opStatus::opInvalidOp) &&
+         "NumSpelling consists only of [0-9.ef+-]. Any malformed NumSpelling "
+         "will be caught and reported by NumericLiteralParser.");
+
+  assert(!(Status & llvm::APFloat::opStatus::opDivByZero) &&
+         "It is not possible for a division to be performed when "
+         "constructing an APFloat from a string");
+
+  if (Status & llvm::APFloat::opStatus::opUnderflow) {
+    // Report that the value has underflowed
+    PP.getDiagnostics().Report(CurToken.TokLoc,
+                               diag::err_hlsl_number_literal_underflow);
     return std::nullopt;
+  }
+
+  if (Status & llvm::APFloat::opStatus::opOverflow) {
+    // Report that the value has overflowed
+    PP.getDiagnostics().Report(CurToken.TokLoc,
+                               diag::err_hlsl_number_literal_overflow)
+        << /*float type*/ 1;
+    return std::nullopt;
+  }
 
   if (Negated)
     Val = -Val;
 
   double DoubleVal = Val.convertToDouble();
   if (FLT_MAX < DoubleVal || DoubleVal < -FLT_MAX) {
+    // Report that the value has overflowed
+    PP.getDiagnostics().Report(CurToken.TokLoc,
+                               diag::err_hlsl_number_literal_overflow)
+        << /*float type*/ 1;
     return std::nullopt;
   }
 

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -744,12 +744,16 @@ std::optional<float> RootSignatureParser::parseFloatParam() {
     if (!UInt.has_value())
       return std::nullopt;
     return (float)UInt.value();
-  } else if (tryConsumeExpectedToken(TokenKind::int_literal)) {
+  }
+
+  if (Negated && tryConsumeExpectedToken(TokenKind::int_literal)) {
     std::optional<int32_t> = handleIntLiteral(Negated);
     if (!Int.has_value())
       return std::nullopt;
     return (float)Int.value();
-  } else if (tryConsumeExpectedToken(TokenKind::float_literal)) {
+  }
+
+  if (tryConsumeExpectedToken(TokenKind::float_literal)) {
     std::optional<float> Float = handleFloatLiteral(Negated);
     if (!Float.has_value())
       return std::nullopt;

--- a/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
@@ -136,6 +136,8 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexAllTokensTest) {
     space visibility flags
     numDescriptors offset
 
+    mipLODBias
+
     unbounded
     DESCRIPTOR_RANGE_OFFSET_APPEND
 

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -247,7 +247,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.ViewType, RegisterType::SReg);
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.Number, 0u);
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.f);
 
   ASSERT_TRUE(Consumer->isSatisfied());
 }
@@ -284,47 +284,47 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
 
   RootElement Elem = Elements[0];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.f);
 
   Elem = Elements[1];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 1.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 1.f);
 
   Elem = Elements[2];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, -1.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, -1.f);
 
   Elem = Elements[3];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 42.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 42.f);
 
   Elem = Elements[4];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 4.2f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 4.2f);
 
   Elem = Elements[5];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, -.42f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, -.42f);
 
   Elem = Elements[6];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 420.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 420.f);
 
   Elem = Elements[7];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.000000000042f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.000000000042f);
 
   Elem = Elements[8];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 42.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 42.f);
 
   Elem = Elements[9];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 4.2f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 4.2f);
 
   Elem = Elements[10];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 420000000000.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 420000000000.f);
 
   Elem = Elements[11];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -256,7 +256,15 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
   const llvm::StringLiteral Source = R"cc(
     StaticSampler(s0, mipLODBias = 0),
     StaticSampler(s0, mipLODBias = +1),
-    StaticSampler(s0, mipLODBias = -1)
+    StaticSampler(s0, mipLODBias = -1),
+    StaticSampler(s0, mipLODBias = 42.),
+    StaticSampler(s0, mipLODBias = +4.2),
+    StaticSampler(s0, mipLODBias = -.42),
+    StaticSampler(s0, mipLODBias = .42e+3),
+    StaticSampler(s0, mipLODBias = 42E-12),
+    StaticSampler(s0, mipLODBias = 42.f),
+    StaticSampler(s0, mipLODBias = 4.2F),
+    StaticSampler(s0, mipLODBias = 42.e+10f),
   )cc";
 
   TrivialModuleLoader ModLoader;
@@ -283,6 +291,38 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
   Elem = Elements[2];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
   ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, -1.f);
+
+  Elem = Elements[3];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 42.f);
+
+  Elem = Elements[4];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 4.2f);
+
+  Elem = Elements[5];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, -.42f);
+
+  Elem = Elements[6];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 420.f);
+
+  Elem = Elements[7];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.000000000042f);
+
+  Elem = Elements[8];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 42.f);
+
+  Elem = Elements[9];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 4.2f);
+
+  Elem = Elements[10];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 420000000000.f);
 
   ASSERT_TRUE(Consumer->isSatisfied());
 }

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -803,6 +803,28 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedNumberTest) {
   ASSERT_TRUE(Consumer->isSatisfied());
 }
 
+TEST_F(ParseHLSLRootSignatureTest, InvalidParseOverflowedNegativeNumberTest) {
+  // This test will check that parsing fails due to a unsigned integer having
+  // too large of a magnitude to be interpreted as its negative
+  const llvm::StringLiteral Source = R"cc(
+    StaticSampler(s0, mipLODBias = -4294967295)
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
 TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedFloatTest) {
   // This test will check that the lexing fails due to a float overflow
   const llvm::StringLiteral Source = R"cc(

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -793,6 +793,90 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedNumberTest) {
   ASSERT_TRUE(Consumer->isSatisfied());
 }
 
+TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedFloatTest) {
+  // This test will check that the lexing fails due to a float overflow
+  const llvm::StringLiteral Source = R"cc(
+    StaticSampler(s0, mipLODBias = 3.402823467e+38F)
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
+TEST_F(ParseHLSLRootSignatureTest, InvalidLexNegOverflowedFloatTest) {
+  // This test will check that the lexing fails due to negative float overflow
+  const llvm::StringLiteral Source = R"cc(
+    StaticSampler(s0, mipLODBias = -3.402823467e+38F)
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
+TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedDoubleTest) {
+  // This test will check that the lexing fails due to an overflow of double
+  const llvm::StringLiteral Source = R"cc(
+    StaticSampler(s0, mipLODBias = 1.e+500)
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
+TEST_F(ParseHLSLRootSignatureTest, InvalidLexUnderflowFloatTest) {
+  // This test will check that the lexing fails due to double underflow
+  const llvm::StringLiteral Source = R"cc(
+    StaticSampler(s0, mipLODBias = 10e-309)
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_number_literal_underflow);
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
 TEST_F(ParseHLSLRootSignatureTest, InvalidNonZeroFlagsTest) {
   // This test will check that parsing fails when a non-zero integer literal
   // is given to flags

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -225,7 +225,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
 
 TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   const llvm::StringLiteral Source = R"cc(
-    StaticSampler(s0)
+    StaticSampler(s0, mipLODBias = 0)
   )cc";
 
   TrivialModuleLoader ModLoader;
@@ -247,6 +247,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.ViewType, RegisterType::SReg);
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.Number, 0u);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0u);
 
   ASSERT_TRUE(Consumer->isSatisfied());
 }

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -265,6 +265,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
     StaticSampler(s0, mipLODBias = 42.f),
     StaticSampler(s0, mipLODBias = 4.2F),
     StaticSampler(s0, mipLODBias = 42.e+10f),
+    StaticSampler(s0, mipLODBias = -2147483648),
+    StaticSampler(s0, mipLODBias = 2147483648),
   )cc";
 
   TrivialModuleLoader ModLoader;
@@ -323,6 +325,14 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
   Elem = Elements[10];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
   ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 420000000000.f);
+
+  Elem = Elements[11];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, -2147483648.f);
+
+  Elem = Elements[12];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 2147483648.f);
 
   ASSERT_TRUE(Consumer->isSatisfied());
 }

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -157,6 +157,7 @@ raw_ostream &operator<<(raw_ostream &OS, const DescriptorTableClause &Clause);
 
 struct StaticSampler {
   Register Reg;
+  float MipLODBias = 0.f;
 };
 
 /// Models RootElement : RootFlags | RootConstants | RootParam


### PR DESCRIPTION
- defines in-memory representaiton of MipLODBias to allow for testing of a float parameter
- defines `handleInt` and `handleFloat` to handle converting a token's `NumSpelling` into a valid float
- plugs this into `parseFloatParam` to fill in the MipLODBias param

The parsing of floats is required to match the behaviour of DXC. This behaviour is outlined as follows:
- if the number is an integer then convert it using `_atoi64`, check for overflow and static_cast this to a float
- if the number is a float then convert it using `strtod`, check for float overflow and static_cast this to a float, this will implicitly also check for double over/underflow and if the string is malformed then it will return an error

This pr matches this behaviour by parsing as, uint/int accordingly and then casting, or, by using the correct APFloat semantics/rounding mode with `NumericLiteralParser`.

- adds testing of error diagnostics and valid float param values to demonstrate functionality

Part 2 of https://github.com/llvm/llvm-project/issues/126574