### PR TITLE
[HIP] Add warning for -mwavefrontsize64 on gfx10+ architectures

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -200,6 +200,9 @@ def err_drv_opt_unsupported_input_type : Error<
   "'%0' invalid for input of type %1">;
 def err_drv_amdgpu_ieee_without_no_honor_nans : Error<
   "invalid argument '-mno-amdgpu-ieee' only allowed with relaxed NaN handling">;
+def warn_drv_unsupported_wave64 : Warning<
+  "wavefront size 64 is not supported by HIP runtime on AMD GPU architecture "
+  "gfx10 and above">, InGroup<UnsupportedWave64>;
 def err_drv_argument_not_allowed_with : Error<
   "invalid argument '%0' not allowed with '%1'">;
 def err_drv_cannot_open_randomize_layout_seed_file : Error<

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -148,6 +148,7 @@ def UnsupportedFPOpt : DiagGroup<"unsupported-floating-point-opt">;
 def UnsupportedCB : DiagGroup<"unsupported-cb">;
 def UnsupportedGPOpt : DiagGroup<"unsupported-gpopt">;
 def UnsupportedTargetOpt : DiagGroup<"unsupported-target-opt">;
+def UnsupportedWave64 : DiagGroup<"unsupported-wave64">;
 def NonLiteralNullConversion : DiagGroup<"non-literal-null-conversion">;
 def NullConversion : DiagGroup<"null-conversion">;
 def ImplicitConversionFloatingPointToBool :

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -89,8 +89,13 @@ public:
       const llvm::opt::ArgList &DriverArgs, const JobAction &JA,
       const llvm::fltSemantics *FPType = nullptr) const override;
 
-  static bool isWave64(const llvm::opt::ArgList &DriverArgs,
-                       llvm::AMDGPU::GPUKind Kind);
+  /// Return whether the GPU of kind \p Kind has wavefront size 64 by driver
+  /// arguments \p DriverArgs. When \p Explicit is true, only return true
+  /// if wavefront size is set to 64 by arguments explicitly. When
+  /// \p DiagInvalid is true, diagnose invalid -mwavefrontsize64 arguments.
+  static bool isWave64(const Driver &D, const llvm::opt::ArgList &DriverArgs,
+                       llvm::AMDGPU::GPUKind Kind, bool DiagInvalid = false,
+                       bool Explicit = false);
   /// Needed for using lto.
   bool HasNativeLLVMSupport() const override {
     return true;

--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -227,6 +227,9 @@ void HIPAMDToolChain::addClangTargetOptions(
 
   assert(DeviceOffloadingKind == Action::OFK_HIP &&
          "Only HIP offloading kinds are supported for GPUs.");
+  const StringRef GpuArch = getGPUArch(DriverArgs);
+  auto Kind = llvm::AMDGPU::parseArchAMDGCN(GpuArch);
+  (void)isWave64(getDriver(), DriverArgs, Kind, /*DiagInvalid=*/true);
 
   CC1Args.append({"-fcuda-is-device", "-fno-threadsafe-statics"});
 

--- a/clang/test/Driver/hip-toolchain-features.hip
+++ b/clang/test/Driver/hip-toolchain-features.hip
@@ -70,6 +70,12 @@
 // RUN: %clang -### --target=x86_64-linux-gnu -fgpu-rdc -nogpulib \
 // RUN:   -nogpuinc --offload-arch=gfx1010 --no-offload-new-driver %s \
 // RUN:   -mno-wavefrontsize64 -mwavefrontsize64 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=WAVE64-WARN
+// WAVE64-WARN: warning: wavefront size 64 is not supported by HIP runtime on AMD GPU architecture gfx10 and above
+
+// RUN: %clang -### --target=x86_64-linux-gnu -fgpu-rdc -nogpulib \
+// RUN:   -nogpuinc --offload-arch=gfx1010 --no-offload-new-driver %s \
+// RUN:   -mno-wavefrontsize64 -mwavefrontsize64 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=WAVE64
 // WAVE64: {{.*}}clang{{.*}} "-target-feature" "+wavefrontsize64"
 // WAVE64-NOT: "-target-feature" "{{.*}}wavefrontsize16"


### PR DESCRIPTION


Wavefront size 64 is not fully supported for HIP on gfx10+ architectures
and is not tested. Previously, HIP headers relied on predefined macros
to detect wavefront size and emit pragma errors for unsupported
configurations. However, due to a design change where Clang no longer
emits predefined macros for wavefront size (replacing them with builtin
functions), HIP headers can no longer detect and diagnose invalid
wavefront size usage.

This patch adds driver-level diagnostics to fill this gap by emitting
a warning when -mwavefrontsize64 is used with gfx10+ architectures in
HIP compilation:

"wavefront size 64 is not supported by HIP runtime on AMD GPU architecture
gfx10 and above"

The warning uses the "unsupported-wave64" group, allowing:
- HIP runtime to enforce errors via -Werror=unsupported-wave64 in CMake
- Users to suppress warnings with -Wno-unsupported-wave64 if needed
- Compilation to proceed while informing users of potential issues

This approach provides the necessary diagnostic capability while maintaining
flexibility for both HIP runtime policy enforcement and user control.
Existing HIP builds continue to work unchanged, and future ROCm releases
can adopt this warning-based approach when available.
