### PR TITLE
[RISCV][Scheduler] Split `UnsupportedSchedZfa` by other fp extensions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedule.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedule.td
@@ -454,18 +454,31 @@ def : ReadAdvance<ReadFRoundF128, 0>;
 }
 }
 
-multiclass UnsupportedSchedZfa : UnsupportedSchedZfaWithQ {
+multiclass UnsupportedSchedZfaWithD : UnsupportedSchedZfaWithQ {
 let Unsupported = true in {
-def : WriteRes<WriteFRoundF16, []>;
-def : WriteRes<WriteFRoundF32, []>;
 def : WriteRes<WriteFRoundF64, []>;
-def : WriteRes<WriteFLI16, []>;
-def : WriteRes<WriteFLI32, []>;
 def : WriteRes<WriteFLI64, []>;
 
-def : ReadAdvance<ReadFRoundF32, 0>;
 def : ReadAdvance<ReadFRoundF64, 0>;
+}
+}
+
+multiclass UnsupportedSchedZfaWithZfh {
+let Unsupported = true in {
+def : WriteRes<WriteFRoundF16, []>;
+def : WriteRes<WriteFLI16, []>;
+
 def : ReadAdvance<ReadFRoundF16, 0>;
+}
+}
+
+multiclass UnsupportedSchedZfa : UnsupportedSchedZfaWithD,
+                                 UnsupportedSchedZfaWithZfh {
+let Unsupported = true in {
+def : WriteRes<WriteFRoundF32, []>;
+def : WriteRes<WriteFLI32, []>;
+
+def : ReadAdvance<ReadFRoundF32, 0>;
 } // Unsupported = true
 }
 


### PR DESCRIPTION
Originally posted by @wangpc-pp and @el-ev in https://github.com/llvm/llvm-project/pull/140003#discussion_r2090711052

> Probably `UnsupportedSchedZfaWithD`/`UnsupportedSchedZfaWithZfh` are also needed to be defined.

> Yeah, I tend to do that. Zfa is special because it is orthogonal to other floating-point extensions.