### PR TITLE
[DAGCombiner] Remove hasOneUse check from sext+sext_inreg to sext_inreg combine

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -14117,7 +14117,7 @@ SDValue DAGCombiner::visitSIGN_EXTEND(SDNode *N) {
       }
 
       // If the trunc wasn't legal, try to fold to (sext_inreg (anyext x))
-      if ((!LegalTypes || TLI.isTypeLegal(VT)) && N0.hasOneUse()) {
+      if (!LegalTypes || TLI.isTypeLegal(VT)) {
         SDValue ExtSrc = DAG.getAnyExtOrTrunc(N00, DL, VT);
         return DAG.getNode(ISD::SIGN_EXTEND_INREG, DL, VT, ExtSrc,
                            N0->getOperand(1));


### PR DESCRIPTION
The hasOneUseCheck does not really add anything and makes the combine too
restrictive. Upcoming patches benefit from removing the hasOneUse check.