### PR TITLE
[llvm][NFC] Update LocalVarDef::CVRegister to fix size MS ABI

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
@@ -70,7 +70,7 @@ public:
 
     /// Register containing the data or the register base of the memory
     /// location containing the data.
-    uint16_t CVRegister;
+    uint32_t CVRegister : 16;
 
     uint64_t static toOpaqueValue(const LocalVarDef DR) {
       uint64_t Val = 0;


### PR DESCRIPTION
LocalVarDef::CVRegister being a uint16_t is not enough for the fields to be packed with the MS ABI.

This makes the field a 16 bit a uint32_t