### PR TITLE
[RISCV] Add reusable SelectCC_GPR_riirr multiclass. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21017,7 +21017,7 @@ static MachineBasicBlock *emitSelectPseudo(MachineInstr &MI,
 
   auto Next = next_nodbg(MI.getIterator(), BB->instr_end());
   if ((MI.getOpcode() != RISCV::Select_GPR_Using_CC_GPR &&
-       MI.getOpcode() != RISCV::Select_GPR_Using_CC_Imm) &&
+       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm5) &&
       Next != BB->end() && Next->getOpcode() == MI.getOpcode() &&
       Next->getOperand(5).getReg() == MI.getOperand(0).getReg() &&
       Next->getOperand(5).isKill())
@@ -21350,11 +21350,11 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
            "ReadCounterWide is only to be used on riscv32");
     return emitReadCounterWidePseudo(MI, BB);
   case RISCV::Select_GPR_Using_CC_GPR:
-  case RISCV::Select_GPR_Using_CC_Imm:
-  case RISCV::Select_GPR_Using_CC_Simm5NonZero:
-  case RISCV::Select_GPR_Using_CC_Uimm5NonZero:
-  case RISCV::Select_GPR_Using_CC_Simm16NonZero:
-  case RISCV::Select_GPR_Using_CC_Uimm16NonZero:
+  case RISCV::Select_GPR_Using_CC_SImm5:
+  case RISCV::Select_GPR_Using_CC_SImm5NonZero:
+  case RISCV::Select_GPR_Using_CC_UImm5NonZero:
+  case RISCV::Select_GPR_Using_CC_SImm16NonZero:
+  case RISCV::Select_GPR_Using_CC_UImm16NonZero:
   case RISCV::Select_FPR16_Using_CC_GPR:
   case RISCV::Select_FPR16INX_Using_CC_GPR:
   case RISCV::Select_FPR32_Using_CC_GPR:

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1645,6 +1645,14 @@ let Predicates = [HasStdExtC, OptForMinSize] in {
   def : SelectCompressOpt<SETNE>;
 }
 
+multiclass SelectCC_GPR_riirr<DAGOperand valty, DAGOperand imm> {
+  let usesCustomInserter = 1 in
+  def Select_GPR_Using_CC_ # NAME
+      : Pseudo<(outs valty:$dst),
+               (ins GPR:$lhs, imm:$imm, cond_code:$cc,
+                valty:$truev, valty:$falsev), []>;
+}
+
 /// Branches and jumps
 
 // Match `riscv_brcc` and lower to the appropriate RISC-V branch instruction.

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1647,7 +1647,7 @@ let Predicates = [HasStdExtC, OptForMinSize] in {
 
 multiclass SelectCC_GPR_riirr<DAGOperand valty, DAGOperand imm> {
   let usesCustomInserter = 1 in
-  def Select_GPR_Using_CC_ # NAME
+  def Select_GPR_Using_ # NAME
       : Pseudo<(outs valty:$dst),
                (ins GPR:$lhs, imm:$imm, cond_code:$cc,
                 valty:$truev, valty:$falsev), []>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -802,16 +802,12 @@ let Predicates = [HasVendorXCVbi, IsRV32], AddedComplexity = 2 in {
   def : Pat<(riscv_brcc GPR:$rs1, simm5:$imm5, SETNE, bb:$imm12),
             (CV_BNEIMM GPR:$rs1, simm5:$imm5, bare_simm13_lsb0:$imm12)>;
 
-  let usesCustomInserter = 1 in
-  def Select_GPR_Using_CC_Imm : Pseudo<(outs GPR:$dst),
-                             (ins GPR:$lhs, simm5:$imm5, cond_code:$cc,
-                              GPR:$truev, GPR:$falsev), []>;
-
+  defm SImm5 : SelectCC_GPR_riirr<GPR, simm5>;
 
   class Selectbi<CondCode Cond>
       : Pat<(riscv_selectcc_frag:$cc (i32 GPR:$lhs), simm5:$Constant, Cond,
                                      (i32 GPR:$truev), GPR:$falsev),
-            (Select_GPR_Using_CC_Imm GPR:$lhs, simm5:$Constant,
+            (Select_GPR_Using_CC_SImm5 GPR:$lhs, simm5:$Constant,
              (IntCCtoRISCVCCCV $cc), GPR:$truev, GPR:$falsev)>;
 
   def : Selectbi<SETEQ>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -802,7 +802,7 @@ let Predicates = [HasVendorXCVbi, IsRV32], AddedComplexity = 2 in {
   def : Pat<(riscv_brcc GPR:$rs1, simm5:$imm5, SETNE, bb:$imm12),
             (CV_BNEIMM GPR:$rs1, simm5:$imm5, bare_simm13_lsb0:$imm12)>;
 
-  defm SImm5 : SelectCC_GPR_riirr<GPR, simm5>;
+  defm CC_SImm5 : SelectCC_GPR_riirr<GPR, simm5>;
 
   class Selectbi<CondCode Cond>
       : Pat<(riscv_selectcc_frag:$cc (i32 GPR:$lhs), simm5:$Constant, Cond,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -1327,10 +1327,10 @@ class Bcci48Pat<CondCode Cond, QCIBranchInst48_rii Inst, DAGOperand InTyImm>
     : Pat<(riscv_brcc (XLenVT GPRNoX0:$rs1), InTyImm:$rs2, Cond, bb:$imm12),
           (Inst GPRNoX0:$rs1, InTyImm:$rs2, bare_simm13_lsb0:$imm12)>;
 
-defm SImm5NonZero  : SelectCC_GPR_riirr<GPR, simm5nonzero>;
-defm UImm5NonZero  : SelectCC_GPR_riirr<GPR, uimm5nonzero>;
-defm SImm16NonZero : SelectCC_GPR_riirr<GPR, simm16nonzero>;
-defm UImm16NonZero : SelectCC_GPR_riirr<GPR, uimm16nonzero>;
+defm CC_SImm5NonZero  : SelectCC_GPR_riirr<GPR, simm5nonzero>;
+defm CC_UImm5NonZero  : SelectCC_GPR_riirr<GPR, uimm5nonzero>;
+defm CC_SImm16NonZero : SelectCC_GPR_riirr<GPR, simm16nonzero>;
+defm CC_UImm16NonZero : SelectCC_GPR_riirr<GPR, uimm16nonzero>;
 
 class SelectQCbi<CondCode Cond, DAGOperand InTyImm, Pseudo OpNode >
     : Pat<(riscv_selectcc_frag:$cc (i32 GPR:$lhs), InTyImm:$Constant, Cond,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -1327,20 +1327,10 @@ class Bcci48Pat<CondCode Cond, QCIBranchInst48_rii Inst, DAGOperand InTyImm>
     : Pat<(riscv_brcc (XLenVT GPRNoX0:$rs1), InTyImm:$rs2, Cond, bb:$imm12),
           (Inst GPRNoX0:$rs1, InTyImm:$rs2, bare_simm13_lsb0:$imm12)>;
 
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0, usesCustomInserter = 1 in {
-  def Select_GPR_Using_CC_Simm5NonZero : Pseudo<(outs GPR:$dst),
-                                                (ins GPR:$lhs, simm5nonzero:$imm5,
-                                                 cond_code:$cc, GPR:$truev, GPR:$falsev), []>;
-  def Select_GPR_Using_CC_Uimm5NonZero : Pseudo<(outs GPR:$dst),
-                                                (ins GPR:$lhs, uimm5nonzero:$imm5,
-                                                 cond_code:$cc, GPR:$truev, GPR:$falsev), []>;
-  def Select_GPR_Using_CC_Simm16NonZero : Pseudo<(outs GPR:$dst),
-                                                 (ins GPR:$lhs, simm16nonzero:$imm16,
-                                                  cond_code:$cc, GPR:$truev, GPR:$falsev), []>;
-  def Select_GPR_Using_CC_Uimm16NonZero : Pseudo<(outs GPR:$dst),
-                                                 (ins GPR:$lhs, uimm16nonzero:$imm16,
-                                                  cond_code:$cc, GPR:$truev, GPR:$falsev), []>;
-}
+defm SImm5NonZero  : SelectCC_GPR_riirr<GPR, simm5nonzero>;
+defm UImm5NonZero  : SelectCC_GPR_riirr<GPR, uimm5nonzero>;
+defm SImm16NonZero : SelectCC_GPR_riirr<GPR, simm16nonzero>;
+defm UImm16NonZero : SelectCC_GPR_riirr<GPR, uimm16nonzero>;
 
 class SelectQCbi<CondCode Cond, DAGOperand InTyImm, Pseudo OpNode >
     : Pat<(riscv_selectcc_frag:$cc (i32 GPR:$lhs), InTyImm:$Constant, Cond,
@@ -1419,19 +1409,19 @@ def : Bcci48Pat<SETGE, QC_E_BGEI, simm16nonzero>;
 def : Bcci48Pat<SETULT, QC_E_BLTUI, uimm16nonzero>;
 def : Bcci48Pat<SETUGE, QC_E_BGEUI, uimm16nonzero>;
 
-def : SelectQCbi<SETEQ, simm5nonzero, Select_GPR_Using_CC_Simm5NonZero>;
-def : SelectQCbi<SETNE, simm5nonzero, Select_GPR_Using_CC_Simm5NonZero>;
-def : SelectQCbi<SETLT, simm5nonzero, Select_GPR_Using_CC_Simm5NonZero>;
-def : SelectQCbi<SETGE, simm5nonzero, Select_GPR_Using_CC_Simm5NonZero>;
-def : SelectQCbi<SETULT, uimm5nonzero, Select_GPR_Using_CC_Uimm5NonZero>;
-def : SelectQCbi<SETUGE, uimm5nonzero, Select_GPR_Using_CC_Uimm5NonZero>;
+def : SelectQCbi<SETEQ, simm5nonzero, Select_GPR_Using_CC_SImm5NonZero>;
+def : SelectQCbi<SETNE, simm5nonzero, Select_GPR_Using_CC_SImm5NonZero>;
+def : SelectQCbi<SETLT, simm5nonzero, Select_GPR_Using_CC_SImm5NonZero>;
+def : SelectQCbi<SETGE, simm5nonzero, Select_GPR_Using_CC_SImm5NonZero>;
+def : SelectQCbi<SETULT, uimm5nonzero, Select_GPR_Using_CC_UImm5NonZero>;
+def : SelectQCbi<SETUGE, uimm5nonzero, Select_GPR_Using_CC_UImm5NonZero>;
 
-def : SelectQCbi<SETEQ, simm16nonzero, Select_GPR_Using_CC_Simm16NonZero>;
-def : SelectQCbi<SETNE, simm16nonzero, Select_GPR_Using_CC_Simm16NonZero>;
-def : SelectQCbi<SETLT, simm16nonzero, Select_GPR_Using_CC_Simm16NonZero>;
-def : SelectQCbi<SETGE, simm16nonzero, Select_GPR_Using_CC_Simm16NonZero>;
-def : SelectQCbi<SETULT, uimm16nonzero, Select_GPR_Using_CC_Uimm16NonZero>;
-def : SelectQCbi<SETUGE, uimm16nonzero, Select_GPR_Using_CC_Uimm16NonZero>;
+def : SelectQCbi<SETEQ, simm16nonzero, Select_GPR_Using_CC_SImm16NonZero>;
+def : SelectQCbi<SETNE, simm16nonzero, Select_GPR_Using_CC_SImm16NonZero>;
+def : SelectQCbi<SETLT, simm16nonzero, Select_GPR_Using_CC_SImm16NonZero>;
+def : SelectQCbi<SETGE, simm16nonzero, Select_GPR_Using_CC_SImm16NonZero>;
+def : SelectQCbi<SETULT, uimm16nonzero, Select_GPR_Using_CC_UImm16NonZero>;
+def : SelectQCbi<SETUGE, uimm16nonzero, Select_GPR_Using_CC_UImm16NonZero>;
 } // let Predicates = [HasVendorXqcibi, IsRV32], AddedComplexity = 2
 
 let Predicates = [HasVendorXqcibm, IsRV32] in {

--- a/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
@@ -49,7 +49,7 @@ def isSelectPseudo
                    MCReturnStatement<
                      CheckOpcode<[
                        Select_GPR_Using_CC_GPR,
-                       Select_GPR_Using_CC_Imm,
+                       Select_GPR_Using_CC_SImm5,
                        Select_FPR16_Using_CC_GPR,
                        Select_FPR16INX_Using_CC_GPR,
                        Select_FPR32_Using_CC_GPR,


### PR DESCRIPTION
Add reusable SelectCC_GPR_riirr multiclass. Allow Select_GPR_Using_CC_* in XCV and Xqci to share a commom multiclass implmentation.