### PR TITLE
[libc++] Don't instantiate allocators in __tree on an incomplete type

### DIFF
--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -911,8 +911,7 @@ public:
 private:
   typedef std::__value_type<key_type, mapped_type> __value_type;
   typedef __map_value_compare<key_type, value_type, key_compare> __vc;
-  typedef __rebind_alloc<allocator_traits<allocator_type>, __value_type> __allocator_type;
-  typedef __tree<__value_type, __vc, __allocator_type> __base;
+  typedef __tree<__value_type, __vc, allocator_type> __base;
   typedef typename __base::__node_traits __node_traits;
   typedef allocator_traits<allocator_type> __alloc_traits;
 
@@ -1596,8 +1595,7 @@ public:
 private:
   typedef std::__value_type<key_type, mapped_type> __value_type;
   typedef __map_value_compare<key_type, value_type, key_compare> __vc;
-  typedef __rebind_alloc<allocator_traits<allocator_type>, __value_type> __allocator_type;
-  typedef __tree<__value_type, __vc, __allocator_type> __base;
+  typedef __tree<__value_type, __vc, allocator_type> __base;
   typedef typename __base::__node_traits __node_traits;
   typedef allocator_traits<allocator_type> __alloc_traits;
 

--- a/libcxx/test/std/containers/associative/map/incomplete_type.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/incomplete_type.pass.cpp
@@ -13,6 +13,7 @@
 
 #include <map>
 
+#include "min_allocator.h"
 #include "test_macros.h"
 
 struct A {
@@ -27,6 +28,9 @@ inline bool operator==(A const& L, A const& R) { return &L == &R; }
 inline bool operator<(A const& L, A const& R) { return L.data < R.data; }
 int main(int, char**) {
   A a;
+
+  // Make sure that the allocator isn't rebound to and incomplete type
+  std::map<int, int, std::less<int>, complete_type_allocator<std::pair<const int, int> > > m;
 
   return 0;
 }

--- a/libcxx/test/support/min_allocator.h
+++ b/libcxx/test/support/min_allocator.h
@@ -403,6 +403,27 @@ public:
 };
 
 template <class T>
+class complete_type_allocator {
+public:
+  using value_type = T;
+
+  // Make sure that value_type is a complete when min_allocator is instantiated
+  static_assert(TEST_ALIGNOF(value_type) != 0, "");
+
+  TEST_CONSTEXPR_CXX20 complete_type_allocator() TEST_NOEXCEPT {}
+
+  template <class U>
+  TEST_CONSTEXPR_CXX20 explicit complete_type_allocator(complete_type_allocator<U>) TEST_NOEXCEPT {}
+
+  TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) { return static_cast<T*>(std::allocator<T>().allocate(n)); }
+
+  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t n) { std::allocator<T>().deallocate(p, n); }
+
+  TEST_CONSTEXPR_CXX20 friend bool operator==(complete_type_allocator, complete_type_allocator) { return true; }
+  TEST_CONSTEXPR_CXX20 friend bool operator!=(complete_type_allocator, complete_type_allocator) { return false; }
+};
+
+template <class T>
 class explicit_allocator
 {
 public:


### PR DESCRIPTION
This causes a mismatch between `value_type` and `allocator_type::value_type` in `__tree`, but I think that's acceptable. `__tree` primarily gets a `__value_type` wrapper due to potential ABI breaks and unwraps it to the same as `allocator_type::value_type` in the end. A cleanup patch will also change `__tree::value_type` to be the same as `allocator_type::value_type`, making the type mismatch only visible where `__tree` is instantiated in `map`.
