### PR TITLE
[VPlan] Clean up the function VPInstruction::generate for ComputeReductionResult, nfc

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -678,7 +678,6 @@ Value *VPInstruction::generate(VPTransformState &State) {
     }
     // Reduce all of the unrolled parts into a single vector.
     Value *ReducedPartRdx = RdxParts[0];
-    unsigned Op = RdxDesc.getOpcode();
     if (PhiR->isOrdered()) {
       ReducedPartRdx = RdxParts[UF - 1];
     } else {
@@ -687,11 +686,12 @@ Value *VPInstruction::generate(VPTransformState &State) {
       Builder.setFastMathFlags(RdxDesc.getFastMathFlags());
       for (unsigned Part = 1; Part < UF; ++Part) {
         Value *RdxPart = RdxParts[Part];
-        if (Op != Instruction::ICmp && Op != Instruction::FCmp)
-          ReducedPartRdx = Builder.CreateBinOp(
-              (Instruction::BinaryOps)Op, RdxPart, ReducedPartRdx, "bin.rdx");
-        else
+        if (RecurrenceDescriptor::isMinMaxRecurrenceKind(RK))
           ReducedPartRdx = createMinMaxOp(Builder, RK, ReducedPartRdx, RdxPart);
+        else
+          ReducedPartRdx =
+              Builder.CreateBinOp((Instruction::BinaryOps)RdxDesc.getOpcode(),
+                                  RdxPart, ReducedPartRdx, "bin.rdx");
       }
     }
 


### PR DESCRIPTION
When reducing unrolled parts, explicitly check for min/max reductions using the function RecurrenceDescriptor::isMinMaxRecurrenceKind. Only if the reduction is not min/max reduction, call RecurrenceDescriptor::getOpcode() to handle other cases via CreateBinOp.

Based on https://github.com/llvm/llvm-project/pull/140242
Related to https://github.com/llvm/llvm-project/pull/118393