### PR TITLE
[Clang] suggest headers on undeclared errors 

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5984,6 +5984,7 @@ def err_unexpected_typedef : Error<
 def err_unexpected_namespace : Error<
   "unexpected namespace name %0: expected expression">;
 def err_undeclared_var_use : Error<"use of undeclared identifier %0">;
+def note_include_for_declaration : Note<"perhaps `#include %0` is needed?">;
 def ext_undeclared_unqual_id_with_dependent_base : ExtWarn<
   "use of undeclared identifier %0; "
   "unqualified lookup into dependent bases of class template %1 is a Microsoft extension">,

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -114,4 +114,5 @@ add_clang_library(clangSema
   clangEdit
   clangLex
   clangSupport
-  )
+  clangToolingInclusionsStdlib
+)

--- a/clang/test/CXX/dcl.decl/dcl.decomp/p3.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.decomp/p3.cpp
@@ -26,14 +26,18 @@ void no_get_1() {
     auto [a0, a1] = A(); // expected-error {{decomposes into 3 elements}}
     auto [b0, b1] = B(); // expected-error {{decomposes into 3 elements}}
   }
-  auto [a0, a1, a2] = A(); // expected-error {{undeclared identifier 'get'}} expected-note {{in implicit initialization of binding declaration 'a0'}}
+  auto [a0, a1, a2] = A(); // expected-error {{undeclared identifier 'get'}} \
+                           // expected-note {{perhaps `#include <ranges>` is needed?}} \
+                           // expected-note {{in implicit initialization of binding declaration 'a0'}}
 }
 
 int get(A);
 
 void no_get_2() {
   // FIXME: This diagnostic is not great.
-  auto [a0, a1, a2] = A(); // expected-error {{undeclared identifier 'get'}} expected-note {{in implicit initialization of binding declaration 'a0'}}
+  auto [a0, a1, a2] = A(); // expected-error {{undeclared identifier 'get'}} \
+                           // expected-note {{perhaps `#include <ranges>` is needed?}} \
+                           // expected-note {{in implicit initialization of binding declaration 'a0'}}
 }
 
 template<int> float &get(A); // expected-note 2 {{no known conversion}}
@@ -172,7 +176,9 @@ template<int> int get(ADL::X);
 template<> struct std::tuple_size<ADL::X> { static const int value = 1; };
 template<> struct std::tuple_element<0, ADL::X> { typedef int type; };
 void adl_only_bad() {
-  auto [x] = ADL::X(); // expected-error {{undeclared identifier 'get'}} expected-note {{in implicit init}}
+  auto [x] = ADL::X(); // expected-error {{undeclared identifier 'get'}} \
+                       // expected-note {{perhaps `#include <ranges>` is needed?}} \
+                       // expected-note {{in implicit init}}
 }
 
 template<typename ElemType, typename GetTypeLV, typename GetTypeRV>

--- a/clang/test/CXX/drs/cwg3xx.cpp
+++ b/clang/test/CXX/drs/cwg3xx.cpp
@@ -1474,6 +1474,7 @@ namespace cwg387 { // cwg387: 2.8
       a = gcd(a, b);
       b = gcd(3, 4);
       // expected-error@-1 {{use of undeclared identifier 'gcd'}}
+      // expected-note@-2 {{perhaps `#include <numeric>` is needed?}}
     }
   }
 
@@ -1489,6 +1490,7 @@ namespace cwg387 { // cwg387: 2.8
       a = gcd(a, b);
       b = gcd(3, 4);
       // expected-error@-1 {{use of undeclared identifier 'gcd'}}
+      // expected-note@-2 {{perhaps `#include <numeric>` is needed?}}
     }
   }
 } // namespace cwg387

--- a/clang/test/Modules/implicit-declared-allocation-functions.cppm
+++ b/clang/test/Modules/implicit-declared-allocation-functions.cppm
@@ -17,14 +17,14 @@ export void alloc_wrapper() {
   //   std::align_­val_­t is ill-formed unless a standard library declaration
   //   ([cstddef.syn], [new.syn], [std.modules]) of that name precedes
   //   ([basic.lookup.general]) the use of that name.
-  void *b = ::operator new((std::size_t)32); // expected-error {{use of undeclared identifier 'std'}}
-  void *c = ::operator new((std::size_t)32, // expected-error {{use of undeclared identifier 'std'}}
-                           (std::align_val_t)64); // expected-error {{use of undeclared identifier 'std'}}
+  void *b = ::operator new((std::size_t)32); // expected-error {{use of undeclared identifier 'std'}} expected-note {{perhaps `#include <cstddef>` is needed?}}
+  void *c = ::operator new((std::size_t)32, // expected-error {{use of undeclared identifier 'std'}} expected-note {{perhaps `#include <cstddef>` is needed?}}
+                           (std::align_val_t)64); // expected-error {{use of undeclared identifier 'std'}} expected-note {{perhaps `#include <new>` is needed?}}
 
   ::operator delete(a);
-  ::operator delete(b, (std::size_t)32); // expected-error {{use of undeclared identifier 'std'}}
-  ::operator delete(c, (std::size_t)32,  // expected-error {{use of undeclared identifier 'std'}}
-                       (std::align_val_t)64); // expected-error {{use of undeclared identifier 'std'}}
+  ::operator delete(b, (std::size_t)32); // expected-error {{use of undeclared identifier 'std'}} expected-note {{perhaps `#include <cstddef>` is needed?}}
+  ::operator delete(c, (std::size_t)32,  // expected-error {{use of undeclared identifier 'std'}} expected-note {{perhaps `#include <cstddef>` is needed?}}
+                       (std::align_val_t)64); // expected-error {{use of undeclared identifier 'std'}} expected-note {{perhaps `#include <new>` is needed?}}
 }
 
 //--- new

--- a/clang/test/Modules/macro-reexport.cpp
+++ b/clang/test/Modules/macro-reexport.cpp
@@ -21,13 +21,13 @@
 #include "f1.h"
 void f() { return assert(true); } // expected-error {{undeclared identifier 'd'}}
 #include "e2.h" // undefines d1's macro
-void g() { return assert(true); } // expected-error {{undeclared identifier 'assert'}}
+void g() { return assert(true); } // expected-error {{undeclared identifier 'assert'}} expected-note {{perhaps `#include <cassert>` is needed?}}
 #elif defined(D1)
 #include "e1.h" // undefines c1's macro but not d1's macro
 #include "d1.h"
 void f() { return assert(true); } // expected-error {{undeclared identifier 'd'}}
 #include "e2.h" // undefines d1's macro
-void g() { return assert(true); } // expected-error {{undeclared identifier 'assert'}}
+void g() { return assert(true); } // expected-error {{undeclared identifier 'assert'}} expected-note {{perhaps `#include <cassert>` is needed?}}
 #elif defined(D2)
 #include "d2.h"
 void f() { return assert(true); } // expected-error {{undeclared identifier 'b'}}
@@ -35,5 +35,5 @@ void f() { return assert(true); } // expected-error {{undeclared identifier 'b'}
 // e2 undefines d1's macro, which overrides c1's macro.
 #include "e2.h"
 #include "c1.h"
-void f() { return assert(true); } // expected-error {{undeclared identifier 'assert'}}
+void f() { return assert(true); } // expected-error {{undeclared identifier 'assert'}} expected-note {{perhaps `#include <cassert>` is needed?}}
 #endif

--- a/clang/test/OpenMP/allocate_modifiers_messages.cpp
+++ b/clang/test/OpenMP/allocate_modifiers_messages.cpp
@@ -108,6 +108,7 @@ int main() {
   #pragma omp scope private(b) allocate(align
   // expected-error@+1 {{duplicate modifier 'align' in 'allocate' clause}}
   #pragma omp scope private(a) allocate(align(8), align(4) : a)
+  // expected-note@+6 {{perhaps `#include <memory>` is needed?}}
   // expected-error@+5 {{use of undeclared identifier 'align'}}
   // expected-error@+4 {{expected ',' or ')' in 'allocate' clause}}
   // expected-error@+3 {{expected ')'}}

--- a/clang/test/Sema/builtin-setjmp.c
+++ b/clang/test/Sema/builtin-setjmp.c
@@ -35,11 +35,13 @@ void use(void) {
   setjmp(0);
   #if NO_SETJMP
   // cxx-error@-2 {{undeclared identifier 'setjmp'}}
-  // c-error@-3 {{call to undeclared function 'setjmp'; ISO C99 and later do not support implicit function declarations}}
+  // cxx-note@-3 {{perhaps `#include <csetjmp>` is needed?}}
+  // c-error@-4 {{call to undeclared function 'setjmp'; ISO C99 and later do not support implicit function declarations}}
   #elif ONLY_JMP_BUF
-  // cxx-error@-5 {{undeclared identifier 'setjmp'}}
-  // c-error@-6 {{call to undeclared library function 'setjmp' with type 'int (jmp_buf)' (aka 'int (int *)'); ISO C99 and later do not support implicit function declarations}}
-  // c-note@-7 {{include the header <setjmp.h> or explicitly provide a declaration for 'setjmp'}}
+  // cxx-error@-6 {{undeclared identifier 'setjmp'}}
+  // cxx-note@-7 {{perhaps `#include <csetjmp>` is needed?}}
+  // c-error@-8 {{call to undeclared library function 'setjmp' with type 'int (jmp_buf)' (aka 'int (int *)'); ISO C99 and later do not support implicit function declarations}}
+  // c-note@-9 {{include the header <setjmp.h> or explicitly provide a declaration for 'setjmp'}}
   #else
   // cxx-no-diagnostics
   #endif

--- a/clang/test/Sema/note-suggest-header.cpp
+++ b/clang/test/Sema/note-suggest-header.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+void f(void) {
+  int_val2 = 0; // expected-error{{use of undeclared identifier}}
+  sin(0); // expected-error{{use of undeclared identifier 'sin'}} \
+          // expected-note{{perhaps `#include <cmath>` is needed?}}
+
+  std::cout << "Hello world\n"; // expected-error{{use of undeclared identifier 'std'}} \
+                                // expected-note{{perhaps `#include <iostream>` is needed?}}
+}

--- a/clang/test/SemaCXX/no-implicit-builtin-decls.cpp
+++ b/clang/test/SemaCXX/no-implicit-builtin-decls.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 
 void f() {
-  void *p = malloc(sizeof(int) * 10); // expected-error{{use of undeclared identifier 'malloc'}}
+  void *p = malloc(sizeof(int) * 10); // expected-error{{use of undeclared identifier 'malloc'}} expected-note {{perhaps `#include <cstdlib>` is needed?}}
 }
 
 int malloc(double);


### PR DESCRIPTION
When a “use of undeclared identifier” error happens for a function listed in StdSymbolMap, emit a note telling the user which header to include.
Because nested-name-specifier errors occur before the function name is known, perform this lookup later in isCXXDeclarationSpecifier() after a parse failure.