### PR TITLE
[lldb][lldb-dap] Basic implementation of a deferred request.

### DIFF
--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -339,7 +339,7 @@ struct DAP {
   /// listeing for its breakpoint events.
   void SetTarget(const lldb::SBTarget target);
 
-  bool HandleObject(const protocol::Message &M);
+  bool HandleObject(const protocol::Message &M, bool &defer);
 
   /// Disconnect the DAP session.
   llvm::Error Disconnect();

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -160,4 +160,8 @@ void AttachRequestHandler::PostRun() const {
     dap.target.GetProcess().Continue();
 }
 
+bool AttachRequestHandler::DeferRequest() const {
+  return !dap.configuration_done;
+}
+
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
@@ -88,4 +88,8 @@ void LaunchRequestHandler::PostRun() const {
     dap.target.GetProcess().Continue();
 }
 
+bool LaunchRequestHandler::DeferRequest() const {
+  return !dap.configuration_done;
+}
+
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -46,7 +46,11 @@ public:
 
   virtual ~BaseRequestHandler() = default;
 
-  void Run(const protocol::Request &);
+  /// Return `true` if the request should be deferred.
+  [[nodiscard]]
+  bool Run(const protocol::Request &);
+
+  virtual bool DeferRequest() const { return false; };
 
   virtual void operator()(const protocol::Request &request) const = 0;
 
@@ -203,6 +207,7 @@ public:
   static llvm::StringLiteral GetCommand() { return "attach"; }
   llvm::Error Run(const protocol::AttachRequestArguments &args) const override;
   void PostRun() const override;
+  bool DeferRequest() const override;
 };
 
 class BreakpointLocationsRequestHandler
@@ -302,6 +307,7 @@ public:
   llvm::Error
   Run(const protocol::LaunchRequestArguments &arguments) const override;
   void PostRun() const override;
+  bool DeferRequest() const override;
 };
 
 class RestartRequestHandler : public LegacyRequestHandler {

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -50,7 +50,10 @@ public:
   [[nodiscard]]
   bool Run(const protocol::Request &);
 
-  virtual bool DeferRequest() const { return false; };
+  [[nodiscard]]
+  virtual bool DeferRequest() const {
+    return false;
+  }
 
   virtual void operator()(const protocol::Request &request) const = 0;
 


### PR DESCRIPTION
Fixes #140154

Basic implementation of defering requests. 

It no longer depends on a white list of request, So if there is any future breakpoint types added to the DAP specification. it will not break existing binary. 

It can further be extended to defer depending of the request arguments. 