### PR TITLE
[Clang] Fix a regression introduced by #140073

### DIFF
--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -435,7 +435,8 @@ class Sema;
 
           // A function pointer type can be resolved to a member function type,
           // which is still an identity conversion.
-          if (auto *N = T->getAs<MemberPointerType>())
+          if (auto *N = T->getAs<MemberPointerType>();
+              N && N->isMemberFunctionPointer())
             T = C.getDecayedType(N->getPointeeType());
           return T;
         };

--- a/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
+++ b/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
@@ -251,3 +251,26 @@ void f() {
   e.g(&N::f);
 }
 }
+
+#if __cplusplus >= 201402
+namespace PointerToMemData {
+struct N {
+  int field;
+};
+template <typename It, typename T>
+struct B {
+  B(It, T);
+  template <typename It2>
+  B(B<It2, T>);
+};
+template <typename T>
+struct C {
+  auto g() { return B<int, T>(0, T{}); }
+};
+void f() {
+  using T = decltype(C<decltype(&N::field)>{}.g());
+}
+
+}
+
+#endif


### PR DESCRIPTION
Pointer to data member don't decay, assuming they do caused an assertion failure.