### PR TITLE
[LLVM][TableGen] Rename `ListInit::getValues()` to `getElements()`

### DIFF
--- a/clang/utils/TableGen/ClangOptionDocEmitter.cpp
+++ b/clang/utils/TableGen/ClangOptionDocEmitter.cpp
@@ -367,7 +367,7 @@ void emitOption(const DocumentedOption &Option, const Record *DocInfo,
        R->getValueAsListOfDefs("HelpTextsForVariants")) {
     // This is a list of visibilities.
     ArrayRef<const Init *> Visibilities =
-        VisibilityHelp->getValueAsListInit("Visibilities")->getValues();
+        VisibilityHelp->getValueAsListInit("Visibilities")->getElements();
 
     // See if any of the program's visibilities are in the list.
     for (StringRef DocInfoMask :

--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -486,7 +486,7 @@ public:
     return Idx;
   }
 
-  bool hasBody() const { return Body && !Body->getValues().empty(); }
+  bool hasBody() const { return Body && !Body->empty(); }
 
   void setNeededEarly() { NeededEarly = true; }
 
@@ -1436,14 +1436,14 @@ void Intrinsic::emitBodyAsBuiltinCall() {
 void Intrinsic::emitBody(StringRef CallPrefix) {
   std::vector<std::string> Lines;
 
-  if (!Body || Body->getValues().empty()) {
+  if (!Body || Body->empty()) {
     // Nothing specific to output - must output a builtin.
     emitBodyAsBuiltinCall();
     return;
   }
 
   // We have a list of "things to output". The last should be returned.
-  for (auto *I : Body->getValues()) {
+  for (auto *I : Body->getElements()) {
     if (const auto *SI = dyn_cast<StringInit>(I)) {
       Lines.push_back(replaceParamsIn(SI->getAsString()));
     } else if (const auto *DI = dyn_cast<DagInit>(I)) {

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -747,7 +747,7 @@ class ListInit final : public TypedInit,
                        public FoldingSetNode,
                        private TrailingObjects<ListInit, const Init *> {
   friend TrailingObjects;
-  unsigned NumValues;
+  unsigned NumElements;
 
 public:
   using const_iterator = const Init *const *;
@@ -769,11 +769,14 @@ public:
 
   void Profile(FoldingSetNodeID &ID) const;
 
-  ArrayRef<const Init *> getValues() const {
-    return ArrayRef(getTrailingObjects(), NumValues);
+  ArrayRef<const Init *> getElements() const {
+    return ArrayRef(getTrailingObjects(), NumElements);
   }
 
-  const Init *getElement(unsigned Idx) const { return getValues()[Idx]; }
+  LLVM_DEPRECATED("Use getElements instead", "getElements")
+  ArrayRef<const Init *> getValues() const { return getElements(); }
+
+  const Init *getElement(unsigned Idx) const { return getElements()[Idx]; }
 
   const RecTy *getElementType() const {
     return cast<ListRecTy>(getType())->getElementType();
@@ -794,11 +797,11 @@ public:
   bool isConcrete() const override;
   std::string getAsString() const override;
 
-  const_iterator begin() const { return getValues().begin(); }
-  const_iterator end() const { return getValues().end(); }
+  const_iterator begin() const { return getElements().begin(); }
+  const_iterator end() const { return getElements().end(); }
 
-  size_t         size () const { return NumValues;  }
-  bool           empty() const { return NumValues == 0; }
+  size_t size() const { return NumElements; }
+  bool empty() const { return NumElements == 0; }
 
   const Init *getBit(unsigned Bit) const override {
     llvm_unreachable("Illegal bit reference off list");

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -692,18 +692,19 @@ const Init *StringInit::convertInitializerTo(const RecTy *Ty) const {
   return nullptr;
 }
 
-static void ProfileListInit(FoldingSetNodeID &ID, ArrayRef<const Init *> Range,
+static void ProfileListInit(FoldingSetNodeID &ID,
+                            ArrayRef<const Init *> Elements,
                             const RecTy *EltTy) {
-  ID.AddInteger(Range.size());
+  ID.AddInteger(Elements.size());
   ID.AddPointer(EltTy);
 
-  for (const Init *I : Range)
-    ID.AddPointer(I);
+  for (const Init *E : Elements)
+    ID.AddPointer(E);
 }
 
 ListInit::ListInit(ArrayRef<const Init *> Elements, const RecTy *EltTy)
     : TypedInit(IK_ListInit, ListRecTy::get(EltTy)),
-      NumValues(Elements.size()) {
+      NumElements(Elements.size()) {
   llvm::uninitialized_copy(Elements, getTrailingObjects());
 }
 
@@ -729,7 +730,7 @@ const ListInit *ListInit::get(ArrayRef<const Init *> Elements,
 
 void ListInit::Profile(FoldingSetNodeID &ID) const {
   const RecTy *EltTy = cast<ListRecTy>(getType())->getElementType();
-  ProfileListInit(ID, getValues(), EltTy);
+  ProfileListInit(ID, getElements(), EltTy);
 }
 
 const Init *ListInit::convertInitializerTo(const RecTy *Ty) const {
@@ -738,13 +739,13 @@ const Init *ListInit::convertInitializerTo(const RecTy *Ty) const {
 
   if (const auto *LRT = dyn_cast<ListRecTy>(Ty)) {
     SmallVector<const Init *, 8> Elements;
-    Elements.reserve(getValues().size());
+    Elements.reserve(size());
 
     // Verify that all of the elements of the list are subclasses of the
     // appropriate class!
     bool Changed = false;
     const RecTy *ElementType = LRT->getElementType();
-    for (const Init *I : getValues())
+    for (const Init *I : getElements())
       if (const Init *CI = I->convertInitializerTo(ElementType)) {
         Elements.push_back(CI);
         if (CI != I)
@@ -773,7 +774,7 @@ const Init *ListInit::resolveReferences(Resolver &R) const {
   Resolved.reserve(size());
   bool Changed = false;
 
-  for (const Init *CurElt : getValues()) {
+  for (const Init *CurElt : getElements()) {
     const Init *E = CurElt->resolveReferences(R);
     Changed |= E != CurElt;
     Resolved.push_back(E);
@@ -944,9 +945,10 @@ const Init *UnOpInit::Fold(const Record *CurRec, bool IsFinal) const {
   case TAIL:
     if (const auto *LHSl = dyn_cast<ListInit>(LHS)) {
       assert(!LHSl->empty() && "Empty list in tail");
-      // Note the +1.  We can't just pass the result of getValues()
+      // Note the slice(1).  We can't just pass the result of getElements()
       // directly.
-      return ListInit::get(LHSl->getValues().slice(1), LHSl->getElementType());
+      return ListInit::get(LHSl->getElements().slice(1),
+                           LHSl->getElementType());
     }
     break;
 
@@ -1012,11 +1014,11 @@ const Init *UnOpInit::Fold(const Record *CurRec, bool IsFinal) const {
           [](const ListInit *List) -> std::optional<std::vector<const Init *>> {
         std::vector<const Init *> Flattened;
         // Concatenate elements of all the inner lists.
-        for (const Init *InnerInit : List->getValues()) {
+        for (const Init *InnerInit : List->getElements()) {
           const auto *InnerList = dyn_cast<ListInit>(InnerInit);
           if (!InnerList)
             return std::nullopt;
-          llvm::append_range(Flattened, InnerList->getValues());
+          llvm::append_range(Flattened, InnerList->getElements());
         };
         return Flattened;
       };
@@ -1116,7 +1118,7 @@ static const StringInit *interleaveStringList(const ListInit *List,
   SmallString<80> Result(Element->getValue());
   StringInit::StringFormat Fmt = StringInit::SF_String;
 
-  for (const Init *Elem : List->getValues().drop_front()) {
+  for (const Init *Elem : List->getElements().drop_front()) {
     Result.append(Delim->getValue());
     const auto *Element = dyn_cast<StringInit>(Elem);
     if (!Element)
@@ -1138,7 +1140,7 @@ static const StringInit *interleaveIntList(const ListInit *List,
     return nullptr;
   SmallString<80> Result(Element->getAsString());
 
-  for (const Init *Elem : List->getValues().drop_front()) {
+  for (const Init *Elem : List->getElements().drop_front()) {
     Result.append(Delim->getValue());
     const auto *Element = dyn_cast_or_null<IntInit>(
         Elem->convertInitializerTo(IntRecTy::get(RK)));
@@ -1720,7 +1722,7 @@ static const Init *FilterHelper(const Init *LHS, const Init *MHS,
   if (const auto *MHSl = dyn_cast<ListInit>(MHS)) {
     SmallVector<const Init *, 8> NewList;
 
-    for (const Init *Item : MHSl->getValues()) {
+    for (const Init *Item : MHSl->getElements()) {
       const Init *Include = ItemApply(LHS, Item, RHS, CurRec);
       if (!Include)
         return nullptr;
@@ -3092,7 +3094,7 @@ std::vector<const Record *>
 Record::getValueAsListOfDefs(StringRef FieldName) const {
   const ListInit *List = getValueAsListInit(FieldName);
   std::vector<const Record *> Defs;
-  for (const Init *I : List->getValues()) {
+  for (const Init *I : List->getElements()) {
     if (const auto *DI = dyn_cast<DefInit>(I))
       Defs.push_back(DI->getDef());
     else
@@ -3121,7 +3123,7 @@ std::vector<int64_t>
 Record::getValueAsListOfInts(StringRef FieldName) const {
   const ListInit *List = getValueAsListInit(FieldName);
   std::vector<int64_t> Ints;
-  for (const Init *I : List->getValues()) {
+  for (const Init *I : List->getElements()) {
     if (const auto *II = dyn_cast<IntInit>(I))
       Ints.push_back(II->getValue());
     else
@@ -3137,7 +3139,7 @@ std::vector<StringRef>
 Record::getValueAsListOfStrings(StringRef FieldName) const {
   const ListInit *List = getValueAsListInit(FieldName);
   std::vector<StringRef> Strings;
-  for (const Init *I : List->getValues()) {
+  for (const Init *I : List->getElements()) {
     if (const auto *SI = dyn_cast<StringInit>(I))
       Strings.push_back(SI->getValue());
     else

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -1402,7 +1402,7 @@ void AsmMatcherInfo::buildOperandClasses() {
     CI->Kind = ClassInfo::UserClass0 + Index;
 
     const ListInit *Supers = Rec->getValueAsListInit("SuperClasses");
-    for (const Init *I : Supers->getValues()) {
+    for (const Init *I : Supers->getElements()) {
       const DefInit *DI = dyn_cast<DefInit>(I);
       if (!DI) {
         PrintError(Rec->getLoc(), "Invalid super class reference!");

--- a/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
@@ -301,7 +301,7 @@ static TypeSigTy ComputeTypeSignature(const CodeGenIntrinsic &Int) {
   const Record *TypeInfo = Int.TheDef->getValueAsDef("TypeInfo");
   const ListInit *TypeList = TypeInfo->getValueAsListInit("TypeSig");
 
-  for (const auto *TypeListEntry : TypeList->getValues())
+  for (const auto *TypeListEntry : TypeList->getElements())
     TypeSig.emplace_back(cast<IntInit>(TypeListEntry)->getValue());
   return TypeSig;
 }

--- a/llvm/utils/TableGen/CallingConvEmitter.cpp
+++ b/llvm/utils/TableGen/CallingConvEmitter.cpp
@@ -154,7 +154,7 @@ void CallingConvEmitter::emitAction(const Record *Action, indent Indent,
     O << Indent << "static const MCPhysReg " << RLName << "[] = {\n";
     O << Indent << "  ";
     ListSeparator LS;
-    for (const Init *V : RL->getValues())
+    for (const Init *V : RL->getElements())
       O << LS << getQualifiedRegisterName(V);
     O << "\n" << Indent << "};\n";
   };

--- a/llvm/utils/TableGen/CodeGenMapTable.cpp
+++ b/llvm/utils/TableGen/CodeGenMapTable.cpp
@@ -137,7 +137,7 @@ public:
                                             "' has empty " +
                                             "`ValueCols' field!");
 
-    for (const Init *I : ColValList->getValues()) {
+    for (const Init *I : ColValList->getElements()) {
       const auto *ColI = cast<ListInit>(I);
 
       // Make sure that all the sub-lists in 'ValueCols' have same number of
@@ -228,7 +228,7 @@ void MapTableEmitter::buildRowInstrMap() {
   for (const Record *CurInstr : InstrDefs) {
     std::vector<const Init *> KeyValue;
     const ListInit *RowFields = InstrMapDesc.getRowFields();
-    for (const Init *RowField : RowFields->getValues()) {
+    for (const Init *RowField : RowFields->getElements()) {
       const RecordVal *RecVal = CurInstr->getValue(RowField);
       if (RecVal == nullptr)
         PrintFatalError(CurInstr->getLoc(),
@@ -303,7 +303,7 @@ const Record *MapTableEmitter::getInstrForColumn(const Record *KeyInstr,
   std::vector<const Init *> KeyValue;
 
   // Construct KeyValue using KeyInstr's values for RowFields.
-  for (const Init *RowField : RowFields->getValues()) {
+  for (const Init *RowField : RowFields->getElements()) {
     const Init *KeyInstrVal = KeyInstr->getValue(RowField)->getValue();
     KeyValue.push_back(KeyInstrVal);
   }
@@ -475,7 +475,7 @@ void MapTableEmitter::emitTablesWithFunc(raw_ostream &OS) {
   OS << "// " << InstrMapDesc.getName() << "\nLLVM_READONLY\n";
   OS << "int " << InstrMapDesc.getName() << "(uint16_t Opcode";
   if (ValueCols.size() > 1) {
-    for (const Init *CF : ColFields->getValues()) {
+    for (const Init *CF : ColFields->getElements()) {
       std::string ColName = CF->getAsUnquotedString();
       OS << ", enum " << ColName << " in" << ColName;
     }

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -1012,7 +1012,7 @@ std::string TreePredicateFn::getPredCode() const {
               " if (";
 
       ListSeparator LS(" && ");
-      for (const Init *Val : AddressSpaces->getValues()) {
+      for (const Init *Val : AddressSpaces->getElements()) {
         Code += LS;
 
         const IntInit *IntVal = dyn_cast<IntInit>(Val);
@@ -1489,7 +1489,7 @@ int PatternToMatch::getPatternComplexity(const CodeGenDAGPatterns &CGP) const {
 
 void PatternToMatch::getPredicateRecords(
     SmallVectorImpl<const Record *> &PredicateRecs) const {
-  for (const Init *I : Predicates->getValues()) {
+  for (const Init *I : Predicates->getElements()) {
     if (const DefInit *Pred = dyn_cast<DefInit>(I)) {
       const Record *Def = Pred->getDef();
       if (!Def->isSubClassOf("Predicate")) {
@@ -1934,7 +1934,7 @@ static unsigned GetNumNodeResults(const Record *Operator,
     const ListInit *LI = Operator->getValueAsListInit("Fragments");
     assert(LI && "Invalid Fragment");
     unsigned NumResults = 0;
-    for (const Init *I : LI->getValues()) {
+    for (const Init *I : LI->getElements()) {
       const Record *Op = nullptr;
       if (const DagInit *Dag = dyn_cast<DagInit>(I))
         if (const DefInit *DI = dyn_cast<DefInit>(Dag->getOperator()))
@@ -2855,7 +2855,7 @@ TreePattern::TreePattern(const Record *TheRec, const ListInit *RawPat,
                          bool isInput, CodeGenDAGPatterns &cdp)
     : TheRecord(TheRec), CDP(cdp), isInputPattern(isInput), HasError(false),
       Infer(*this) {
-  for (const Init *I : RawPat->getValues())
+  for (const Init *I : RawPat->getElements())
     Trees.push_back(ParseTreePattern(I, ""));
 }
 
@@ -3766,7 +3766,7 @@ static bool hasNullFragReference(const DagInit *DI) {
 /// hasNullFragReference - Return true if any DAG in the list references
 /// the null_frag operator.
 static bool hasNullFragReference(const ListInit *LI) {
-  for (const Init *I : LI->getValues()) {
+  for (const Init *I : LI->getElements()) {
     const DagInit *DI = dyn_cast<DagInit>(I);
     assert(DI && "non-dag in an instruction Pattern list?!");
     if (hasNullFragReference(DI))

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -771,7 +771,7 @@ CodeGenRegisterClass::CodeGenRegisterClass(CodeGenRegBank &RegBank,
 
   // Alternative allocation orders may be subsets.
   SetTheory::RecSet Order;
-  for (auto [Idx, AltOrderElem] : enumerate(AltOrders->getValues())) {
+  for (auto [Idx, AltOrderElem] : enumerate(AltOrders->getElements())) {
     RegBank.getSets().evaluate(AltOrderElem, Order, R->getLoc());
     Orders[1 + Idx].append(Order.begin(), Order.end());
     // Verify that all altorder members are regclass members.

--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -1404,7 +1404,7 @@ bool CombineRuleBuilder::addFeaturePredicates(RuleMatcher &M) {
     return true;
 
   const ListInit *Preds = RuleDef.getValueAsListInit("Predicates");
-  for (const Init *PI : Preds->getValues()) {
+  for (const Init *PI : Preds->getElements()) {
     const DefInit *Pred = dyn_cast<DefInit>(PI);
     if (!Pred)
       continue;

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -129,7 +129,7 @@ static std::string explainPredicates(const TreePatternNode &N) {
       OS << " AddressSpaces=[";
 
       StringRef AddrSpaceSeparator;
-      for (const Init *Val : AddrSpaces->getValues()) {
+      for (const Init *Val : AddrSpaces->getElements()) {
         const IntInit *IntVal = dyn_cast<IntInit>(Val);
         if (!IntVal)
           continue;
@@ -600,7 +600,7 @@ Expected<InstructionMatcher &> GlobalISelEmitter::addBuiltinPredicates(
     if (const ListInit *AddrSpaces = Predicate.getAddressSpaces()) {
       SmallVector<unsigned, 4> ParsedAddrSpaces;
 
-      for (const Init *Val : AddrSpaces->getValues()) {
+      for (const Init *Val : AddrSpaces->getElements()) {
         const IntInit *IntVal = dyn_cast<IntInit>(Val);
         if (!IntVal)
           return failedImport("Address space is not an integer");

--- a/llvm/utils/TableGen/OptionParserEmitter.cpp
+++ b/llvm/utils/TableGen/OptionParserEmitter.cpp
@@ -501,7 +501,7 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
     for (const Record *VisibilityHelp :
          R.getValueAsListOfDefs("HelpTextsForVariants")) {
       ArrayRef<const Init *> Visibilities =
-          VisibilityHelp->getValueAsListInit("Visibilities")->getValues();
+          VisibilityHelp->getValueAsListInit("Visibilities")->getElements();
 
       std::vector<std::string> VisibilityNames;
       for (const Init *Visibility : Visibilities)
@@ -523,11 +523,10 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
     OS << ", ";
     if (!isa<UnsetInit>(R.getValueInit("Values")))
       writeCstring(OS, R.getValueAsString("Values"));
-    else if (!isa<UnsetInit>(R.getValueInit("ValuesCode"))) {
+    else if (!isa<UnsetInit>(R.getValueInit("ValuesCode")))
       OS << getOptionName(R) << "_Values";
-    } else {
+    else
       OS << "nullptr";
-    }
   };
 
   auto IsMarshallingOption = [](const Record &R) {

--- a/mlir/lib/TableGen/AttrOrTypeDef.cpp
+++ b/mlir/lib/TableGen/AttrOrTypeDef.cpp
@@ -46,7 +46,7 @@ AttrOrTypeDef::AttrOrTypeDef(const Record *def) : def(def) {
   const auto *builderList =
       dyn_cast_or_null<ListInit>(def->getValueInit("builders"));
   if (builderList && !builderList->empty()) {
-    for (const Init *init : builderList->getValues()) {
+    for (const Init *init : builderList->getElements()) {
       AttrOrTypeBuilder builder(cast<DefInit>(init)->getDef(), def->getLoc());
 
       // Ensure that all parameters have names.

--- a/mlir/lib/TableGen/Interfaces.cpp
+++ b/mlir/lib/TableGen/Interfaces.cpp
@@ -85,7 +85,7 @@ Interface::Interface(const Record *def) : def(def) {
 
   // Initialize the interface methods.
   auto *listInit = dyn_cast<ListInit>(def->getValueInit("methods"));
-  for (const Init *init : listInit->getValues())
+  for (const Init *init : listInit->getElements())
     methods.emplace_back(cast<DefInit>(init)->getDef());
 
   // Initialize the interface base classes.
@@ -104,7 +104,7 @@ Interface::Interface(const Record *def) : def(def) {
         baseInterfaces.push_back(std::make_unique<Interface>(baseInterface));
         basesAdded.insert(baseInterface.getName());
       };
-  for (const Init *init : basesInit->getValues())
+  for (const Init *init : basesInit->getElements())
     addBaseInterfaceFn(Interface(cast<DefInit>(init)->getDef()));
 }
 

--- a/mlir/lib/TableGen/Operator.cpp
+++ b/mlir/lib/TableGen/Operator.cpp
@@ -781,7 +781,7 @@ void Operator::populateOpStructure() {
   // Populate the builders.
   auto *builderList = dyn_cast_or_null<ListInit>(def.getValueInit("builders"));
   if (builderList && !builderList->empty()) {
-    for (const Init *init : builderList->getValues())
+    for (const Init *init : builderList->getElements())
       builders.emplace_back(cast<DefInit>(init)->getDef(), def.getLoc());
   } else if (skipDefaultBuilders()) {
     PrintFatalError(

--- a/mlir/lib/Tools/mlir-tblgen/MlirTblgenMain.cpp
+++ b/mlir/lib/Tools/mlir-tblgen/MlirTblgenMain.cpp
@@ -70,7 +70,7 @@ static bool findUse(const Init *field, const Init *deprecatedInit,
   }
 
   if (const ListInit *li = dyn_cast<ListInit>(field)) {
-    return memoize(llvm::any_of(li->getValues(), [&](const Init *jt) {
+    return memoize(llvm::any_of(li->getElements(), [&](const Init *jt) {
       return findUse(jt, deprecatedInit, known);
     }));
   }


### PR DESCRIPTION
Rename `ListInit::getValues()` to `getElements()` to better match with other `ListInit` members like `getElement`. Keep `getValues()` for existing downstream code but mark it deprecated.