### PR TITLE
[HLSL][RootSiganture] Add parsing of new number params in StaticSampler

### DIFF
--- a/clang/include/clang/Lex/HLSLRootSignatureTokenKinds.def
+++ b/clang/include/clang/Lex/HLSLRootSignatureTokenKinds.def
@@ -102,6 +102,9 @@ KEYWORD(offset)
 
 // StaticSampler Keywords:
 KEYWORD(mipLODBias)
+KEYWORD(maxAnisotropy)
+KEYWORD(minLOD)
+KEYWORD(maxLOD)
 
 // Unbounded Enum:
 UNBOUNDED_ENUM(unbounded, "unbounded")

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -112,6 +112,7 @@ private:
   struct ParsedStaticSamplerParams {
     std::optional<llvm::hlsl::rootsig::Register> Reg;
     std::optional<float> MipLODBias;
+    std::optional<uint32_t> MaxAnisotropy;
   };
   std::optional<ParsedStaticSamplerParams> parseStaticSamplerParams();
 

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -114,6 +114,7 @@ private:
     std::optional<float> MipLODBias;
     std::optional<uint32_t> MaxAnisotropy;
     std::optional<float> MinLOD;
+    std::optional<float> MaxLOD;
   };
   std::optional<ParsedStaticSamplerParams> parseStaticSamplerParams();
 

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -113,6 +113,7 @@ private:
     std::optional<llvm::hlsl::rootsig::Register> Reg;
     std::optional<float> MipLODBias;
     std::optional<uint32_t> MaxAnisotropy;
+    std::optional<float> MinLOD;
   };
   std::optional<ParsedStaticSamplerParams> parseStaticSamplerParams();
 

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -381,13 +381,13 @@ std::optional<StaticSampler> RootSignatureParser::parseStaticSampler() {
     Sampler.MipLODBias = Params->MipLODBias.value();
 
   if (Params->MaxAnisotropy.has_value())
-    Sampler.MaxAnisotropy= Params->MaxAnisotropy.value();
+    Sampler.MaxAnisotropy = Params->MaxAnisotropy.value();
 
   if (Params->MinLOD.has_value())
-    Sampler.MinLOD= Params->MinLOD.value();
+    Sampler.MinLOD = Params->MinLOD.value();
 
   if (Params->MaxLOD.has_value())
-    Sampler.MaxLOD= Params->MaxLOD.value();
+    Sampler.MaxLOD = Params->MaxLOD.value();
 
   if (consumeExpectedToken(TokenKind::pu_r_paren,
                            diag::err_hlsl_unexpected_end_of_params,
@@ -720,7 +720,7 @@ RootSignatureParser::parseStaticSamplerParams() {
       if (consumeExpectedToken(TokenKind::pu_equal))
         return std::nullopt;
 
-      auto MinLOD= parseFloatParam();
+      auto MinLOD = parseFloatParam();
       if (!MinLOD.has_value())
         return std::nullopt;
       Params.MinLOD = MinLOD;
@@ -737,7 +737,7 @@ RootSignatureParser::parseStaticSamplerParams() {
       if (consumeExpectedToken(TokenKind::pu_equal))
         return std::nullopt;
 
-      auto MaxLOD= parseFloatParam();
+      auto MaxLOD = parseFloatParam();
       if (!MaxLOD.has_value())
         return std::nullopt;
       Params.MaxLOD = MaxLOD;

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -386,6 +386,9 @@ std::optional<StaticSampler> RootSignatureParser::parseStaticSampler() {
   if (Params->MinLOD.has_value())
     Sampler.MinLOD= Params->MinLOD.value();
 
+  if (Params->MaxLOD.has_value())
+    Sampler.MaxLOD= Params->MaxLOD.value();
+
   if (consumeExpectedToken(TokenKind::pu_r_paren,
                            diag::err_hlsl_unexpected_end_of_params,
                            /*param of=*/TokenKind::kw_StaticSampler))
@@ -721,6 +724,23 @@ RootSignatureParser::parseStaticSamplerParams() {
       if (!MinLOD.has_value())
         return std::nullopt;
       Params.MinLOD = MinLOD;
+    }
+
+    // `maxLOD` `=` NUMBER
+    if (tryConsumeExpectedToken(TokenKind::kw_maxLOD)) {
+      if (Params.MaxLOD.has_value()) {
+        getDiags().Report(CurToken.TokLoc, diag::err_hlsl_rootsig_repeat_param)
+            << CurToken.TokKind;
+        return std::nullopt;
+      }
+
+      if (consumeExpectedToken(TokenKind::pu_equal))
+        return std::nullopt;
+
+      auto MaxLOD= parseFloatParam();
+      if (!MaxLOD.has_value())
+        return std::nullopt;
+      Params.MaxLOD = MaxLOD;
     }
   } while (tryConsumeExpectedToken(TokenKind::pu_comma));
 

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -380,6 +380,9 @@ std::optional<StaticSampler> RootSignatureParser::parseStaticSampler() {
   if (Params->MipLODBias.has_value())
     Sampler.MipLODBias = Params->MipLODBias.value();
 
+  if (Params->MaxAnisotropy.has_value())
+    Sampler.MaxAnisotropy= Params->MaxAnisotropy.value();
+
   if (consumeExpectedToken(TokenKind::pu_r_paren,
                            diag::err_hlsl_unexpected_end_of_params,
                            /*param of=*/TokenKind::kw_StaticSampler))
@@ -681,6 +684,23 @@ RootSignatureParser::parseStaticSamplerParams() {
       if (!MipLODBias.has_value())
         return std::nullopt;
       Params.MipLODBias = MipLODBias;
+    }
+
+    // `maxAnisotropy` `=` POS_INT
+    if (tryConsumeExpectedToken(TokenKind::kw_maxAnisotropy)) {
+      if (Params.MaxAnisotropy.has_value()) {
+        getDiags().Report(CurToken.TokLoc, diag::err_hlsl_rootsig_repeat_param)
+            << CurToken.TokKind;
+        return std::nullopt;
+      }
+
+      if (consumeExpectedToken(TokenKind::pu_equal))
+        return std::nullopt;
+
+      auto MaxAnisotropy = parseUIntParam();
+      if (!MaxAnisotropy.has_value())
+        return std::nullopt;
+      Params.MaxAnisotropy = MaxAnisotropy;
     }
   } while (tryConsumeExpectedToken(TokenKind::pu_comma));
 

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -383,6 +383,9 @@ std::optional<StaticSampler> RootSignatureParser::parseStaticSampler() {
   if (Params->MaxAnisotropy.has_value())
     Sampler.MaxAnisotropy= Params->MaxAnisotropy.value();
 
+  if (Params->MinLOD.has_value())
+    Sampler.MinLOD= Params->MinLOD.value();
+
   if (consumeExpectedToken(TokenKind::pu_r_paren,
                            diag::err_hlsl_unexpected_end_of_params,
                            /*param of=*/TokenKind::kw_StaticSampler))
@@ -701,6 +704,23 @@ RootSignatureParser::parseStaticSamplerParams() {
       if (!MaxAnisotropy.has_value())
         return std::nullopt;
       Params.MaxAnisotropy = MaxAnisotropy;
+    }
+
+    // `minLOD` `=` NUMBER
+    if (tryConsumeExpectedToken(TokenKind::kw_minLOD)) {
+      if (Params.MinLOD.has_value()) {
+        getDiags().Report(CurToken.TokLoc, diag::err_hlsl_rootsig_repeat_param)
+            << CurToken.TokKind;
+        return std::nullopt;
+      }
+
+      if (consumeExpectedToken(TokenKind::pu_equal))
+        return std::nullopt;
+
+      auto MinLOD= parseFloatParam();
+      if (!MinLOD.has_value())
+        return std::nullopt;
+      Params.MinLOD = MinLOD;
     }
   } while (tryConsumeExpectedToken(TokenKind::pu_comma));
 

--- a/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
@@ -136,7 +136,7 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexAllTokensTest) {
     space visibility flags
     numDescriptors offset
 
-    mipLODBias
+    mipLODBias maxAnisotropy minLOD maxLOD
 
     unbounded
     DESCRIPTOR_RANGE_OFFSET_APPEND

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -254,8 +254,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.Number, 0u);
   ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.f);
   ASSERT_EQ(std::get<StaticSampler>(Elem).MaxAnisotropy, 16u);
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MinLOD, 0.f);
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MaxLOD, 3.402823466e+38f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MinLOD, 0.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MaxLOD, 3.402823466e+38f);
 
   // Check values can be set as expected
   Elem = Elements[1];
@@ -264,8 +264,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.Number, 0u);
   ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 230.f);
   ASSERT_EQ(std::get<StaticSampler>(Elem).MaxAnisotropy, 3u);
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MinLOD, 4.2f);
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MaxLOD, 9000.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MinLOD, 4.2f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MaxLOD, 9000.f);
 
   ASSERT_TRUE(Consumer->isSatisfied());
 }

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -225,7 +225,11 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
 
 TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   const llvm::StringLiteral Source = R"cc(
-    StaticSampler(s0, mipLODBias = 0)
+    StaticSampler(s0),
+    StaticSampler(s0, maxAnisotropy = 3,
+      minLOD = 4.2f, mipLODBias = 0.23e+3,
+      maxLOD = 9000,
+    )
   )cc";
 
   TrivialModuleLoader ModLoader;
@@ -241,13 +245,27 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
 
   ASSERT_FALSE(Parser.parse());
 
-  ASSERT_EQ(Elements.size(), 1u);
+  ASSERT_EQ(Elements.size(), 2u);
 
+  // Check default values are as expected
   RootElement Elem = Elements[0];
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.ViewType, RegisterType::SReg);
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.Number, 0u);
   ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 0.f);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MaxAnisotropy, 16u);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MinLOD, 0.f);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MaxLOD, 3.402823466e+38f);
+
+  // Check values can be set as expected
+  Elem = Elements[1];
+  ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
+  ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.ViewType, RegisterType::SReg);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.Number, 0u);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 230.f);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MaxAnisotropy, 3u);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MinLOD, 4.2f);
+  ASSERT_EQ(std::get<StaticSampler>(Elem).MaxLOD, 9000.f);
 
   ASSERT_TRUE(Consumer->isSatisfied());
 }

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -262,7 +262,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   ASSERT_TRUE(std::holds_alternative<StaticSampler>(Elem));
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.ViewType, RegisterType::SReg);
   ASSERT_EQ(std::get<StaticSampler>(Elem).Reg.Number, 0u);
-  ASSERT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 230.f);
+  ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MipLODBias, 230.f);
   ASSERT_EQ(std::get<StaticSampler>(Elem).MaxAnisotropy, 3u);
   ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MinLOD, 4.2f);
   ASSERT_FLOAT_EQ(std::get<StaticSampler>(Elem).MaxLOD, 9000.f);

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -164,6 +164,7 @@ struct StaticSampler {
   float MipLODBias = 0.f;
   uint32_t MaxAnisotropy = 16;
   float MinLOD = 0.f;
+  float MaxLOD = 3.402823466e+38f;
 };
 
 /// Models RootElement : RootFlags | RootConstants | RootParam

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -162,6 +162,7 @@ raw_ostream &operator<<(raw_ostream &OS, const DescriptorTableClause &Clause);
 struct StaticSampler {
   Register Reg;
   float MipLODBias = 0.f;
+  uint32_t MaxAnisotropy = 16;
 };
 
 /// Models RootElement : RootFlags | RootConstants | RootParam

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -163,6 +163,7 @@ struct StaticSampler {
   Register Reg;
   float MipLODBias = 0.f;
   uint32_t MaxAnisotropy = 16;
+  float MinLOD = 0.f;
 };
 
 /// Models RootElement : RootFlags | RootConstants | RootParam

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -164,7 +164,7 @@ struct StaticSampler {
   float MipLODBias = 0.f;
   uint32_t MaxAnisotropy = 16;
   float MinLOD = 0.f;
-  float MaxLOD = 3.402823466e+38f; // FLT_MAX
+  float MaxLOD = std::numeric_limits<float>::max();
 };
 
 /// Models RootElement : RootFlags | RootConstants | RootParam

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -164,7 +164,7 @@ struct StaticSampler {
   float MipLODBias = 0.f;
   uint32_t MaxAnisotropy = 16;
   float MinLOD = 0.f;
-  float MaxLOD = 3.402823466e+38f;
+  float MaxLOD = 3.402823466e+38f; // FLT_MAX
 };
 
 /// Models RootElement : RootFlags | RootConstants | RootParam


### PR DESCRIPTION
 - defines in-memory reprsentation of `maxAnisotropy`, `minLOD` and `maxLOD`
 - integrates parsing of these number parameters with their respective, `parseUInt` and `parseFloat` respectively
 - adds basic unit tests to demonstrate setting functionality

Part 3 of https://github.com/llvm/llvm-project/issues/126574