### PR TITLE
NFC: Refactor MIRPrinter into state struct and functions

### DIFF
--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -94,77 +94,17 @@ struct FrameIndexOperand {
   }
 };
 
-/// This class prints out the machine functions using the MIR serialization
-/// format.
-class MIRPrinter {
-  raw_ostream &OS;
-  const MachineModuleInfo &MMI;
+struct MFPrintState {
+  MachineModuleSlotTracker MST;
   DenseMap<const uint32_t *, unsigned> RegisterMaskIds;
   /// Maps from stack object indices to operand indices which will be used when
   /// printing frame index machine operands.
   DenseMap<int, FrameIndexOperand> StackObjectOperandMapping;
-
-public:
-  MIRPrinter(raw_ostream &OS, const MachineModuleInfo &MMI)
-      : OS(OS), MMI(MMI) {}
-
-  void print(const MachineFunction &MF);
-
-  void convert(yaml::MachineFunction &YamlMF, const MachineFunction &MF,
-               const MachineRegisterInfo &RegInfo,
-               const TargetRegisterInfo *TRI);
-  void convert(ModuleSlotTracker &MST, yaml::MachineFrameInfo &YamlMFI,
-               const MachineFrameInfo &MFI);
-  void convert(yaml::MachineFunction &MF,
-               const MachineConstantPool &ConstantPool);
-  void convert(ModuleSlotTracker &MST, yaml::MachineJumpTable &YamlJTI,
-               const MachineJumpTableInfo &JTI);
-  void convertStackObjects(yaml::MachineFunction &YMF,
-                           const MachineFunction &MF, ModuleSlotTracker &MST);
-  void convertEntryValueObjects(yaml::MachineFunction &YMF,
-                                const MachineFunction &MF,
-                                ModuleSlotTracker &MST);
-  void convertCallSiteObjects(yaml::MachineFunction &YMF,
-                              const MachineFunction &MF,
-                              ModuleSlotTracker &MST);
-  void convertMachineMetadataNodes(yaml::MachineFunction &YMF,
-                                   const MachineFunction &MF,
-                                   MachineModuleSlotTracker &MST);
-  void convertCalledGlobals(yaml::MachineFunction &YMF,
-                            const MachineFunction &MF,
-                            MachineModuleSlotTracker &MST);
-
-private:
-  void initRegisterMaskIds(const MachineFunction &MF);
-};
-
-/// This class prints out the machine instructions using the MIR serialization
-/// format.
-class MIPrinter {
-  raw_ostream &OS;
-  ModuleSlotTracker &MST;
-  const DenseMap<const uint32_t *, unsigned> &RegisterMaskIds;
-  const DenseMap<int, FrameIndexOperand> &StackObjectOperandMapping;
   /// Synchronization scope names registered with LLVMContext.
   SmallVector<StringRef, 8> SSNs;
 
-  bool canPredictSuccessors(const MachineBasicBlock &MBB) const;
-
-public:
-  MIPrinter(raw_ostream &OS, ModuleSlotTracker &MST,
-            const DenseMap<const uint32_t *, unsigned> &RegisterMaskIds,
-            const DenseMap<int, FrameIndexOperand> &StackObjectOperandMapping)
-      : OS(OS), MST(MST), RegisterMaskIds(RegisterMaskIds),
-        StackObjectOperandMapping(StackObjectOperandMapping) {}
-
-  void print(const MachineBasicBlock &MBB);
-
-  void print(const MachineInstr &MI);
-  void printStackObjectReference(int FrameIndex);
-  void print(const MachineInstr &MI, unsigned OpIdx,
-             const TargetRegisterInfo *TRI, const TargetInstrInfo *TII,
-             bool ShouldPrintRegisterTies, SmallBitVector &PrintedTypes,
-             const MachineRegisterInfo &MRI, bool PrintDef = true);
+  MFPrintState(const MachineModuleInfo &MMI, const MachineFunction &MF)
+      : MST(MMI, &MF) {}
 };
 
 } // end anonymous namespace
@@ -191,8 +131,47 @@ static void printRegMIR(Register Reg, yaml::StringValue &Dest,
   OS << printReg(Reg, TRI);
 }
 
-void MIRPrinter::print(const MachineFunction &MF) {
-  initRegisterMaskIds(MF);
+static DenseMap<const uint32_t *, unsigned>
+initRegisterMaskIds(const MachineFunction &MF) {
+  DenseMap<const uint32_t *, unsigned> RegisterMaskIds;
+  const auto *TRI = MF.getSubtarget().getRegisterInfo();
+  unsigned I = 0;
+  for (const uint32_t *Mask : TRI->getRegMasks())
+    RegisterMaskIds.insert(std::make_pair(Mask, I++));
+  return RegisterMaskIds;
+}
+
+static void printMBB(raw_ostream &OS, MFPrintState &State,
+                     const MachineBasicBlock &MBB);
+static void convertMRI(yaml::MachineFunction &YamlMF, const MachineFunction &MF,
+                       const MachineRegisterInfo &RegInfo,
+                       const TargetRegisterInfo *TRI);
+static void convertMCP(yaml::MachineFunction &MF,
+                       const MachineConstantPool &ConstantPool);
+static void convertMJTI(ModuleSlotTracker &MST, yaml::MachineJumpTable &YamlJTI,
+                        const MachineJumpTableInfo &JTI);
+static void convertMFI(ModuleSlotTracker &MST, yaml::MachineFrameInfo &YamlMFI,
+                       const MachineFrameInfo &MFI);
+static void convertStackObjects(yaml::MachineFunction &YMF,
+                                const MachineFunction &MF,
+                                ModuleSlotTracker &MST, MFPrintState &State);
+static void convertEntryValueObjects(yaml::MachineFunction &YMF,
+                                     const MachineFunction &MF,
+                                     ModuleSlotTracker &MST);
+static void convertCallSiteObjects(yaml::MachineFunction &YMF,
+                                   const MachineFunction &MF,
+                                   ModuleSlotTracker &MST);
+static void convertMachineMetadataNodes(yaml::MachineFunction &YMF,
+                                        const MachineFunction &MF,
+                                        MachineModuleSlotTracker &MST);
+static void convertCalledGlobals(yaml::MachineFunction &YMF,
+                                 const MachineFunction &MF,
+                                 MachineModuleSlotTracker &MST);
+
+static void printMF(raw_ostream &OS, const MachineModuleInfo &MMI,
+                    const MachineFunction &MF) {
+  MFPrintState State(MMI, MF);
+  State.RegisterMaskIds = initRegisterMaskIds(MF);
 
   yaml::MachineFunction YamlMF;
   YamlMF.Name = MF.getName();
@@ -229,11 +208,11 @@ void MIRPrinter::print(const MachineFunction &MF) {
   YamlMF.NoVRegs = MF.getProperties().hasProperty(
       MachineFunctionProperties::Property::NoVRegs);
 
-  convert(YamlMF, MF, MF.getRegInfo(), MF.getSubtarget().getRegisterInfo());
-  MachineModuleSlotTracker MST(MMI, &MF);
+  convertMRI(YamlMF, MF, MF.getRegInfo(), MF.getSubtarget().getRegisterInfo());
+  MachineModuleSlotTracker &MST = State.MST;
   MST.incorporateFunction(MF.getFunction());
-  convert(MST, YamlMF.FrameInfo, MF.getFrameInfo());
-  convertStackObjects(YamlMF, MF, MST);
+  convertMFI(MST, YamlMF.FrameInfo, MF.getFrameInfo());
+  convertStackObjects(YamlMF, MF, MST, State);
   convertEntryValueObjects(YamlMF, MF, MST);
   convertCallSiteObjects(YamlMF, MF, MST);
   for (const auto &Sub : MF.DebugValueSubstitutions) {
@@ -245,9 +224,9 @@ void MIRPrinter::print(const MachineFunction &MF) {
                                               Sub.Subreg});
   }
   if (const auto *ConstantPool = MF.getConstantPool())
-    convert(YamlMF, *ConstantPool);
+    convertMCP(YamlMF, *ConstantPool);
   if (const auto *JumpTableInfo = MF.getJumpTableInfo())
-    convert(MST, YamlMF.JumpTableInfo, *JumpTableInfo);
+    convertMJTI(MST, YamlMF.JumpTableInfo, *JumpTableInfo);
 
   const TargetMachine &TM = MF.getTarget();
   YamlMF.MachineFuncInfo =
@@ -258,8 +237,7 @@ void MIRPrinter::print(const MachineFunction &MF) {
   for (const auto &MBB : MF) {
     if (IsNewlineNeeded)
       StrOS << "\n";
-    MIPrinter(StrOS, MST, RegisterMaskIds, StackObjectOperandMapping)
-        .print(MBB);
+    printMBB(StrOS, State, MBB);
     IsNewlineNeeded = true;
   }
   // Convert machine metadata collected during the print of the machine
@@ -325,10 +303,9 @@ static void printRegFlags(Register Reg,
     RegisterFlags.push_back(yaml::FlowStringValue(Flag.str()));
 }
 
-void MIRPrinter::convert(yaml::MachineFunction &YamlMF,
-                         const MachineFunction &MF,
-                         const MachineRegisterInfo &RegInfo,
-                         const TargetRegisterInfo *TRI) {
+static void convertMRI(yaml::MachineFunction &YamlMF, const MachineFunction &MF,
+                       const MachineRegisterInfo &RegInfo,
+                       const TargetRegisterInfo *TRI) {
   YamlMF.TracksRegLiveness = RegInfo.tracksLiveness();
 
   // Print the virtual register definitions.
@@ -368,9 +345,8 @@ void MIRPrinter::convert(yaml::MachineFunction &YamlMF,
   }
 }
 
-void MIRPrinter::convert(ModuleSlotTracker &MST,
-                         yaml::MachineFrameInfo &YamlMFI,
-                         const MachineFrameInfo &MFI) {
+static void convertMFI(ModuleSlotTracker &MST, yaml::MachineFrameInfo &YamlMFI,
+                       const MachineFrameInfo &MFI) {
   YamlMFI.IsFrameAddressTaken = MFI.isFrameAddressTaken();
   YamlMFI.IsReturnAddressTaken = MFI.isReturnAddressTaken();
   YamlMFI.HasStackMap = MFI.hasStackMap();
@@ -400,9 +376,9 @@ void MIRPrinter::convert(ModuleSlotTracker &MST,
   }
 }
 
-void MIRPrinter::convertEntryValueObjects(yaml::MachineFunction &YMF,
-                                          const MachineFunction &MF,
-                                          ModuleSlotTracker &MST) {
+static void convertEntryValueObjects(yaml::MachineFunction &YMF,
+                                     const MachineFunction &MF,
+                                     ModuleSlotTracker &MST) {
   const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
   for (const MachineFunction::VariableDbgInfo &DebugVar :
        MF.getEntryValueVariableDbgInfo()) {
@@ -413,9 +389,20 @@ void MIRPrinter::convertEntryValueObjects(yaml::MachineFunction &YMF,
   }
 }
 
-void MIRPrinter::convertStackObjects(yaml::MachineFunction &YMF,
-                                     const MachineFunction &MF,
-                                     ModuleSlotTracker &MST) {
+static void printStackObjectReference(raw_ostream &OS,
+                                      const MFPrintState &State,
+                                      int FrameIndex) {
+  auto ObjectInfo = State.StackObjectOperandMapping.find(FrameIndex);
+  assert(ObjectInfo != State.StackObjectOperandMapping.end() &&
+         "Invalid frame index");
+  const FrameIndexOperand &Operand = ObjectInfo->second;
+  MachineOperand::printStackObjectReference(OS, Operand.ID, Operand.IsFixed,
+                                            Operand.Name);
+}
+
+static void convertStackObjects(yaml::MachineFunction &YMF,
+                                const MachineFunction &MF,
+                                ModuleSlotTracker &MST, MFPrintState &State) {
   const MachineFrameInfo &MFI = MF.getFrameInfo();
   const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
 
@@ -446,7 +433,7 @@ void MIRPrinter::convertStackObjects(yaml::MachineFunction &YMF,
     // Save the ID' position in FixedStackObjects storage vector.
     FixedStackObjectsIdx[ID] = YMF.FixedStackObjects.size();
     YMF.FixedStackObjects.push_back(std::move(YamlObject));
-    StackObjectOperandMapping.insert(
+    State.StackObjectOperandMapping.insert(
         std::make_pair(I, FrameIndexOperand::createFixed(ID)));
   }
 
@@ -480,7 +467,7 @@ void MIRPrinter::convertStackObjects(yaml::MachineFunction &YMF,
     // Save the ID' position in StackObjects storage vector.
     StackObjectsIdx[ID] = YMF.StackObjects.size();
     YMF.StackObjects.push_back(YamlObject);
-    StackObjectOperandMapping.insert(std::make_pair(
+    State.StackObjectOperandMapping.insert(std::make_pair(
         I, FrameIndexOperand::create(YamlObject.Name.Value, ID)));
   }
 
@@ -519,14 +506,12 @@ void MIRPrinter::convertStackObjects(yaml::MachineFunction &YMF,
   // converting the stack objects.
   if (MFI.hasStackProtectorIndex()) {
     raw_string_ostream StrOS(YMF.FrameInfo.StackProtector.Value);
-    MIPrinter(StrOS, MST, RegisterMaskIds, StackObjectOperandMapping)
-        .printStackObjectReference(MFI.getStackProtectorIndex());
+    printStackObjectReference(StrOS, State, MFI.getStackProtectorIndex());
   }
 
   if (MFI.hasFunctionContextIndex()) {
     raw_string_ostream StrOS(YMF.FrameInfo.FunctionContext.Value);
-    MIPrinter(StrOS, MST, RegisterMaskIds, StackObjectOperandMapping)
-        .printStackObjectReference(MFI.getFunctionContextIndex());
+    printStackObjectReference(StrOS, State, MFI.getFunctionContextIndex());
   }
 
   // Print the debug variable information.
@@ -547,9 +532,9 @@ void MIRPrinter::convertStackObjects(yaml::MachineFunction &YMF,
   }
 }
 
-void MIRPrinter::convertCallSiteObjects(yaml::MachineFunction &YMF,
-                                        const MachineFunction &MF,
-                                        ModuleSlotTracker &MST) {
+static void convertCallSiteObjects(yaml::MachineFunction &YMF,
+                                   const MachineFunction &MF,
+                                   ModuleSlotTracker &MST) {
   const auto *TRI = MF.getSubtarget().getRegisterInfo();
   for (auto CSInfo : MF.getCallSitesInfo()) {
     yaml::CallSiteInfo YmlCS;
@@ -580,9 +565,9 @@ void MIRPrinter::convertCallSiteObjects(yaml::MachineFunction &YMF,
              });
 }
 
-void MIRPrinter::convertMachineMetadataNodes(yaml::MachineFunction &YMF,
-                                             const MachineFunction &MF,
-                                             MachineModuleSlotTracker &MST) {
+static void convertMachineMetadataNodes(yaml::MachineFunction &YMF,
+                                        const MachineFunction &MF,
+                                        MachineModuleSlotTracker &MST) {
   MachineModuleSlotTracker::MachineMDNodeListType MDList;
   MST.collectMachineMDNodes(MDList);
   for (auto &MD : MDList) {
@@ -593,9 +578,9 @@ void MIRPrinter::convertMachineMetadataNodes(yaml::MachineFunction &YMF,
   }
 }
 
-void MIRPrinter::convertCalledGlobals(yaml::MachineFunction &YMF,
-                                      const MachineFunction &MF,
-                                      MachineModuleSlotTracker &MST) {
+static void convertCalledGlobals(yaml::MachineFunction &YMF,
+                                 const MachineFunction &MF,
+                                 MachineModuleSlotTracker &MST) {
   for (const auto &[CallInst, CG] : MF.getCalledGlobals()) {
     yaml::MachineInstrLoc CallSite;
     CallSite.BlockNum = CallInst->getParent()->getNumber();
@@ -615,8 +600,8 @@ void MIRPrinter::convertCalledGlobals(yaml::MachineFunction &YMF,
              });
 }
 
-void MIRPrinter::convert(yaml::MachineFunction &MF,
-                         const MachineConstantPool &ConstantPool) {
+static void convertMCP(yaml::MachineFunction &MF,
+                       const MachineConstantPool &ConstantPool) {
   unsigned ID = 0;
   for (const MachineConstantPoolEntry &Constant : ConstantPool.getConstants()) {
     std::string Str;
@@ -636,9 +621,8 @@ void MIRPrinter::convert(yaml::MachineFunction &MF,
   }
 }
 
-void MIRPrinter::convert(ModuleSlotTracker &MST,
-                         yaml::MachineJumpTable &YamlJTI,
-                         const MachineJumpTableInfo &JTI) {
+static void convertMJTI(ModuleSlotTracker &MST, yaml::MachineJumpTable &YamlJTI,
+                        const MachineJumpTableInfo &JTI) {
   YamlJTI.Kind = JTI.getEntryKind();
   unsigned ID = 0;
   for (const auto &Table : JTI.getJumpTables()) {
@@ -653,13 +637,6 @@ void MIRPrinter::convert(ModuleSlotTracker &MST,
     }
     YamlJTI.Entries.push_back(std::move(Entry));
   }
-}
-
-void MIRPrinter::initRegisterMaskIds(const MachineFunction &MF) {
-  const auto *TRI = MF.getSubtarget().getRegisterInfo();
-  unsigned I = 0;
-  for (const uint32_t *Mask : TRI->getRegMasks())
-    RegisterMaskIds.insert(std::make_pair(Mask, I++));
 }
 
 void llvm::guessSuccessors(const MachineBasicBlock &MBB,
@@ -683,7 +660,7 @@ void llvm::guessSuccessors(const MachineBasicBlock &MBB,
   IsFallthrough = I == MBB.end() || !I->isBarrier();
 }
 
-bool MIPrinter::canPredictSuccessors(const MachineBasicBlock &MBB) const {
+static bool canPredictSuccessors(const MachineBasicBlock &MBB) {
   SmallVector<MachineBasicBlock*,8> GuessedSuccs;
   bool GuessedFallthrough;
   guessSuccessors(MBB, GuessedSuccs, GuessedFallthrough);
@@ -701,12 +678,24 @@ bool MIPrinter::canPredictSuccessors(const MachineBasicBlock &MBB) const {
   return std::equal(MBB.succ_begin(), MBB.succ_end(), GuessedSuccs.begin());
 }
 
-void MIPrinter::print(const MachineBasicBlock &MBB) {
+static void printMI(raw_ostream &OS, MFPrintState &State,
+                    const MachineInstr &MI);
+
+static void printMIOperand(raw_ostream &OS, MFPrintState &State,
+                           const MachineInstr &MI, unsigned OpIdx,
+                           const TargetRegisterInfo *TRI,
+                           const TargetInstrInfo *TII,
+                           bool ShouldPrintRegisterTies,
+                           SmallBitVector &PrintedTypes,
+                           const MachineRegisterInfo &MRI, bool PrintDef);
+
+void printMBB(raw_ostream &OS, MFPrintState &State,
+              const MachineBasicBlock &MBB) {
   assert(MBB.getNumber() >= 0 && "Invalid MBB number");
   MBB.printName(OS,
                 MachineBasicBlock::PrintNameIr |
                     MachineBasicBlock::PrintNameAttributes,
-                &MST);
+                &State.MST);
   OS << ":\n";
 
   bool HasLineAttributes = false;
@@ -758,7 +747,7 @@ void MIPrinter::print(const MachineBasicBlock &MBB) {
       IsInBundle = false;
     }
     OS.indent(IsInBundle ? 4 : 2);
-    print(MI);
+    printMI(OS, State, MI);
     if (!IsInBundle && MI.getFlag(MachineInstr::BundledSucc)) {
       OS << " {";
       IsInBundle = true;
@@ -769,7 +758,8 @@ void MIPrinter::print(const MachineBasicBlock &MBB) {
     OS.indent(2) << "}\n";
 }
 
-void MIPrinter::print(const MachineInstr &MI) {
+static void printMI(raw_ostream &OS, MFPrintState &State,
+                    const MachineInstr &MI) {
   const auto *MF = MI.getMF();
   const auto &MRI = MF->getRegInfo();
   const auto &SubTarget = MF->getSubtarget();
@@ -789,8 +779,8 @@ void MIPrinter::print(const MachineInstr &MI) {
     if (!MO.isReg() || !MO.isDef() || MO.isImplicit())
       break;
     OS << LS;
-    print(MI, I, TRI, TII, ShouldPrintRegisterTies, PrintedTypes, MRI,
-          /*PrintDef=*/false);
+    printMIOperand(OS, State, MI, I, TRI, TII, ShouldPrintRegisterTies,
+                   PrintedTypes, MRI, /*PrintDef=*/false);
   }
 
   if (I)
@@ -844,7 +834,8 @@ void MIPrinter::print(const MachineInstr &MI) {
     OS << ' ';
     for (; I < E; ++I) {
       OS << LS;
-      print(MI, I, TRI, TII, ShouldPrintRegisterTies, PrintedTypes, MRI);
+      printMIOperand(OS, State, MI, I, TRI, TII, ShouldPrintRegisterTies,
+                     PrintedTypes, MRI, /*PrintDef=*/true);
     }
   }
 
@@ -860,15 +851,15 @@ void MIPrinter::print(const MachineInstr &MI) {
   }
   if (MDNode *HeapAllocMarker = MI.getHeapAllocMarker()) {
     OS << LS << " heap-alloc-marker ";
-    HeapAllocMarker->printAsOperand(OS, MST);
+    HeapAllocMarker->printAsOperand(OS, State.MST);
   }
   if (MDNode *PCSections = MI.getPCSections()) {
     OS << LS << " pcsections ";
-    PCSections->printAsOperand(OS, MST);
+    PCSections->printAsOperand(OS, State.MST);
   }
   if (MDNode *MMRA = MI.getMMRAMetadata()) {
     OS << LS << " mmra ";
-    MMRA->printAsOperand(OS, MST);
+    MMRA->printAsOperand(OS, State.MST);
   }
   if (uint32_t CFIType = MI.getCFIType())
     OS << LS << " cfi-type " << CFIType;
@@ -879,7 +870,7 @@ void MIPrinter::print(const MachineInstr &MI) {
   if (PrintLocations) {
     if (const DebugLoc &DL = MI.getDebugLoc()) {
       OS << LS << " debug-location ";
-      DL->printAsOperand(OS, MST);
+      DL->printAsOperand(OS, State.MST);
     }
   }
 
@@ -890,18 +881,9 @@ void MIPrinter::print(const MachineInstr &MI) {
     LS = ListSeparator();
     for (const auto *Op : MI.memoperands()) {
       OS << LS;
-      Op->print(OS, MST, SSNs, Context, &MFI, TII);
+      Op->print(OS, State.MST, State.SSNs, Context, &MFI, TII);
     }
   }
-}
-
-void MIPrinter::printStackObjectReference(int FrameIndex) {
-  auto ObjectInfo = StackObjectOperandMapping.find(FrameIndex);
-  assert(ObjectInfo != StackObjectOperandMapping.end() &&
-         "Invalid frame index");
-  const FrameIndexOperand &Operand = ObjectInfo->second;
-  MachineOperand::printStackObjectReference(OS, Operand.ID, Operand.IsFixed,
-                                            Operand.Name);
 }
 
 static std::string formatOperandComment(std::string Comment) {
@@ -910,11 +892,13 @@ static std::string formatOperandComment(std::string Comment) {
   return std::string(" /* " + Comment + " */");
 }
 
-void MIPrinter::print(const MachineInstr &MI, unsigned OpIdx,
-                      const TargetRegisterInfo *TRI, const TargetInstrInfo *TII,
-                      bool ShouldPrintRegisterTies,
-                      SmallBitVector &PrintedTypes,
-                      const MachineRegisterInfo &MRI, bool PrintDef) {
+static void printMIOperand(raw_ostream &OS, MFPrintState &State,
+                           const MachineInstr &MI, unsigned OpIdx,
+                           const TargetRegisterInfo *TRI,
+                           const TargetInstrInfo *TII,
+                           bool ShouldPrintRegisterTies,
+                           SmallBitVector &PrintedTypes,
+                           const MachineRegisterInfo &MRI, bool PrintDef) {
   LLT TypeToPrint = MI.getTypeToPrint(OpIdx, PrintedTypes, MRI);
   const MachineOperand &Op = MI.getOperand(OpIdx);
   std::string MOComment = TII->createMIROperandComment(MI, Op, OpIdx, TRI);
@@ -948,15 +932,17 @@ void MIPrinter::print(const MachineInstr &MI, unsigned OpIdx,
     unsigned TiedOperandIdx = 0;
     if (ShouldPrintRegisterTies && Op.isReg() && Op.isTied() && !Op.isDef())
       TiedOperandIdx = Op.getParent()->findTiedOperandIdx(OpIdx);
-    Op.print(OS, MST, TypeToPrint, OpIdx, PrintDef, /*IsStandalone=*/false,
-             ShouldPrintRegisterTies, TiedOperandIdx, TRI);
+    Op.print(OS, State.MST, TypeToPrint, OpIdx, PrintDef,
+             /*IsStandalone=*/false, ShouldPrintRegisterTies, TiedOperandIdx,
+             TRI);
     OS << formatOperandComment(MOComment);
     break;
   }
   case MachineOperand::MO_FrameIndex:
-    printStackObjectReference(Op.getIndex());
+    printStackObjectReference(OS, State, Op.getIndex());
     break;
   case MachineOperand::MO_RegisterMask: {
+    const auto &RegisterMaskIds = State.RegisterMaskIds;
     auto RegMaskInfo = RegisterMaskIds.find(Op.getRegMask());
     if (RegMaskInfo != RegisterMaskIds.end())
       OS << StringRef(TRI->getRegMaskNames()[RegMaskInfo->second]).lower();
@@ -1003,7 +989,5 @@ void llvm::printMIR(raw_ostream &OS, const MachineModuleInfo &MMI,
   // in dbg.value format.
   ScopedDbgInfoFormatSetter FormatSetter(
       const_cast<Function &>(MF.getFunction()), UseNewDbgInfoFormat);
-
-  MIRPrinter Printer(OS, MMI);
-  Printer.print(MF);
+  printMF(OS, MMI, MF);
 }


### PR DESCRIPTION
Moves `MIRPRinter` and `MIPrinter` fields into a new `MFPrintState`
struct. Turns methods into independent functions.

- This slightly simplifies the code.
- In the future this will allow to pass the state around to other printing functions
   without the need to expose classes in the public headers.
