### PR TITLE
[libcxxabi] Add test to assert that ItaniumDemangle.h is the same

### DIFF
--- a/libcxxabi/test/configs/cmake-bridge.cfg.in
+++ b/libcxxabi/test/configs/cmake-bridge.cfg.in
@@ -27,6 +27,8 @@ config.test_exec_root = os.path.join('@LIBCXXABI_BINARY_DIR@', 'test')
 config.host_triple = '@LLVM_HOST_TRIPLE@'
 
 config.substitutions.append(('%{libcxx}', '@LIBCXXABI_LIBCXX_PATH@'))
+config.substitutions.append(('%{libcxxabi}', '@LIBCXXABI_SOURCE_DIR@'))
+config.substitutions.append(('%{llvm}', '@LLVM_MAIN_SRC_DIR@'))
 config.substitutions.append(('%{install-prefix}', '@LIBCXXABI_TESTING_INSTALL_PREFIX@'))
 config.substitutions.append(('%{include}', '@LIBCXXABI_TESTING_INSTALL_PREFIX@/include'))
 config.substitutions.append(('%{cxx-include}', '@LIBCXXABI_TESTING_INSTALL_PREFIX@/@LIBCXXABI_INSTALL_INCLUDE_DIR@'))

--- a/libcxxabi/test/itanium_demangle_matches_llvm.sh.test
+++ b/libcxxabi/test/itanium_demangle_matches_llvm.sh.test
@@ -1,0 +1,6 @@
+# This test diffs the ItaniumDemangle.h header in libcxxabi and LLVM to ensure
+# that they are the same.
+
+# RUN: tail -n +3 %{libcxxabi}/src/demangle/ItaniumDemangle.h > %t.libcxxabi_demangle
+# RUN: tail -n +3 %{llvm}/include/llvm/Demangle/ItaniumDemangle.h > %t.llvm_demangle
+# RUN: diff %t.libcxxabi_demangle %t.llvm_demangle


### PR DESCRIPTION
ItaniumDemangle.h exists in both llvm/ and libcxxabi/. These files are supposed to be copies of each other (minus the top two lines). This patch adds a test to assert that this is the case to enable tooling to automatically detect this as an issue, like in #139825. This makes it easier for contributors unfamiliar with the duplication to make changes/get appropriate reviews.

Ideally we would share the file and copy it from one place to the other but the ideal way to do this (based on previous discussion with libc++ maintainers) would be a new runtime library that clearly outlines requirements, so that is left for later with the test being used as a stopgap. This is a relatively common approach for structures shared between compiler-rt and LLVM.

This patch does make the test reference the LLVM source directory, but that should be fine given building libcxxabi is only supported through the runtimes build in the monorepo meaning it should always be available.