### PR TITLE
[Scalar] Avoid creating temporary instances of std::string (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
+++ b/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
@@ -2446,10 +2446,10 @@ public:
         return;
       } else {
         Ops.append(I->value_op_begin(), I->value_op_end());
-        write(std::string(I->getOpcodeName()));
+        write(I->getOpcodeName());
       }
 
-      write(std::string("("));
+      write("(");
 
       unsigned NumOpsToBreak = 1;
       if (match(Expr, m_Intrinsic<Intrinsic::matrix_column_major_load>()))


### PR DESCRIPTION
ExprLinearizer::write takes StringRef and immediately sends the
content to the stream without hanging onto the pointer, so we do not
need to create temporary instances of std::string.
