### PR TITLE
[lldb-dap] Take two at refactoring the startup sequence.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
@@ -52,7 +52,7 @@ class TestDAP_breakpointEvents(lldbdap_testcase.DAPTestCaseBase):
         # breakpoint events for these breakpoints but not for ones that are not
         # set via the command interpreter.
         bp_command = "breakpoint set --file foo.cpp --line %u" % (foo_bp2_line)
-        self.build_and_launch(program, stopOnEntry=True, preRunCommands=[bp_command])
+        self.build_and_launch(program, preRunCommands=[bp_command])
         main_bp_id = 0
         foo_bp_id = 0
         # Set breakpoints and verify that they got set correctly

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -44,7 +44,7 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
         Tests cancelling a pending request.
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
 
         # Use a relatively short timeout since this is only to ensure the
         # following request is queued.
@@ -76,7 +76,7 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
         Tests cancelling an inflight request.
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
 
         blocking_seq = self.async_blocking_request(duration=self.DEFAULT_TIMEOUT / 2)
         # Wait for the sleep to start to cancel the inflight request.

--- a/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
+++ b/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
@@ -46,17 +46,12 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
     def setup_debuggee(self):
         program = self.getBuildArtifact("a.out")
         source = "main.cpp"
-        self.build_and_launch(
-            program,
-            stopOnEntry=True,
-            sourceBreakpoints=[
-                (
-                    source,
-                    [
-                        line_number(source, "// breakpoint 1"),
-                        line_number(source, "// breakpoint 2"),
-                    ],
-                ),
+        self.build_and_launch(program)
+        self.set_source_breakpoints(
+            source,
+            [
+                line_number(source, "// breakpoint 1"),
+                line_number(source, "// breakpoint 2"),
             ],
         )
 

--- a/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
+++ b/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
@@ -53,7 +53,7 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
         character.
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
         source = "main.cpp"
         breakpoint1_line = line_number(source, "// breakpoint 1")
         lines = [breakpoint1_line]
@@ -66,6 +66,7 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
         # Cause a "scopes" to be sent for frame zero which should update the
         # selected thread and frame to frame 0.
         self.dap_server.get_local_variables(frameIndex=0)
+
         # Verify frame #0 is selected in the command interpreter by running
         # the "frame select" command with no frame index which will print the
         # currently selected frame.
@@ -74,15 +75,15 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
         # Cause a "scopes" to be sent for frame one which should update the
         # selected thread and frame to frame 1.
         self.dap_server.get_local_variables(frameIndex=1)
+
         # Verify frame #1 is selected in the command interpreter by running
         # the "frame select" command with no frame index which will print the
         # currently selected frame.
-
         self.check_lldb_command("frame select", "frame #1", "frame 1 is selected")
 
     def test_custom_escape_prefix(self):
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True, commandEscapePrefix="::")
+        self.build_and_launch(program, commandEscapePrefix="::")
         source = "main.cpp"
         breakpoint1_line = line_number(source, "// breakpoint 1")
         breakpoint_ids = self.set_source_breakpoints(source, [breakpoint1_line])
@@ -97,7 +98,7 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
 
     def test_empty_escape_prefix(self):
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True, commandEscapePrefix="")
+        self.build_and_launch(program, commandEscapePrefix="")
         source = "main.cpp"
         breakpoint1_line = line_number(source, "// breakpoint 1")
         breakpoint_ids = self.set_source_breakpoints(source, [breakpoint1_line])
@@ -114,7 +115,7 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
     def test_exit_status_message_sigterm(self):
         source = "main.cpp"
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True, commandEscapePrefix="")
+        self.build_and_launch(program, commandEscapePrefix="")
         breakpoint1_line = line_number(source, "// breakpoint 1")
         breakpoint_ids = self.set_source_breakpoints(source, [breakpoint1_line])
         self.continue_to_breakpoints(breakpoint_ids)
@@ -168,7 +169,7 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
 
     def test_diagnositcs(self):
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
 
         core = self.getBuildArtifact("minidump.core")
         self.yaml2obj("minidump.yaml", core)

--- a/lldb/test/API/tools/lldb-dap/console/TestDAP_redirection_to_console.py
+++ b/lldb/test/API/tools/lldb-dap/console/TestDAP_redirection_to_console.py
@@ -16,9 +16,7 @@ class TestDAP_redirection_to_console(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(
-            program,
-            stopOnEntry=True,
-            lldbDAPEnv={"LLDB_DAP_TEST_STDOUT_STDERR_REDIRECTION": ""},
+            program, lldbDAPEnv={"LLDB_DAP_TEST_STDOUT_STDERR_REDIRECTION": ""}
         )
 
         source = "main.cpp"

--- a/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
+++ b/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
@@ -19,6 +19,7 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
 
         self.create_debug_adapter()
         self.attach(program=exe_file, coreFile=core_file)
+        self.dap_server.request_configurationDone()
 
         expected_frames = [
             {

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -43,7 +43,6 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         self.build_and_launch(
             program,
             enableAutoVariableSummaries=enableAutoVariableSummaries,
-            stopOnEntry=True,
         )
         source = "main.cpp"
         self.set_source_breakpoints(

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -87,7 +87,8 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
-
+        self.dap_server.request_configurationDone()
+        self.dap_server.wait_for_stopped()
         self.assertTrue(
             len(self.dap_server.thread_stop_reasons) > 0,
             "expected stopped event during launch",
@@ -357,7 +358,6 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         terminateCommands = ["expr 4+2"]
         self.build_and_launch(
             program,
-            stopOnEntry=True,
             initCommands=initCommands,
             preRunCommands=preRunCommands,
             postRunCommands=postRunCommands,

--- a/lldb/test/API/tools/lldb-dap/module-event/TestDAP_module_event.py
+++ b/lldb/test/API/tools/lldb-dap/module-event/TestDAP_module_event.py
@@ -10,7 +10,7 @@ class TestDAP_module_event(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_module_event(self):
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
 
         source = "main.cpp"
         breakpoint1_line = line_number(source, "// breakpoint 1")

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -14,7 +14,7 @@ class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
     def run_test(self, symbol_basename, expect_debug_info_size):
         program_basename = "a.out.stripped"
         program = self.getBuildArtifact(program_basename)
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
         functions = ["foo"]
         breakpoint_ids = self.set_function_breakpoints(functions)
         self.assertEqual(len(breakpoint_ids), len(functions), "expect one breakpoint")
@@ -108,7 +108,7 @@ class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_compile_units(self):
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
         source = "main.cpp"
         main_source_path = self.getSourcePath(source)
         breakpoint1_line = line_number(source, "// breakpoint 1")

--- a/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
+++ b/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
@@ -20,7 +20,7 @@ class TestDAP_repl_mode_detection(lldbdap_testcase.DAPTestCaseBase):
 
     def test_completions(self):
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
 
         source = "main.cpp"
         breakpoint1_line = line_number(source, "// breakpoint 1")

--- a/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart.py
+++ b/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart.py
@@ -35,7 +35,7 @@ class TestDAP_restart(lldbdap_testcase.DAPTestCaseBase):
         # Restart then check we stop back at A and program state has been reset.
         resp = self.dap_server.request_restart()
         self.assertTrue(resp["success"])
-        self.continue_to_breakpoints([bp_A])
+        self.verify_breakpoint_hit([bp_A])
         self.assertEqual(
             int(self.dap_server.get_local_variable_value("i")),
             0,
@@ -50,6 +50,9 @@ class TestDAP_restart(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program, stopOnEntry=True)
         [bp_main] = self.set_function_breakpoints(["main"])
+
+        self.dap_server.request_configurationDone()
+        self.dap_server.wait_for_stopped()
         # Once the "configuration done" event is sent, we should get a stopped
         # event immediately because of stopOnEntry.
         self.assertTrue(

--- a/lldb/test/API/tools/lldb-dap/send-event/TestDAP_sendEvent.py
+++ b/lldb/test/API/tools/lldb-dap/send-event/TestDAP_sendEvent.py
@@ -24,7 +24,6 @@ class TestDAP_sendEvent(lldbdap_testcase.DAPTestCaseBase):
         }
         self.build_and_launch(
             program,
-            sourceBreakpoints=[(source, [breakpoint_line])],
             stopCommands=[
                 "lldb-dap send-event my-custom-event-no-body",
                 "lldb-dap send-event my-custom-event '{}'".format(
@@ -32,6 +31,8 @@ class TestDAP_sendEvent(lldbdap_testcase.DAPTestCaseBase):
                 ),
             ],
         )
+        self.set_source_breakpoints(source, [breakpoint_line])
+        self.continue_to_next_stop()
 
         custom_event = self.dap_server.wait_for_event(
             filter=["my-custom-event-no-body"]

--- a/lldb/test/API/tools/lldb-dap/stackTrace/TestDAP_stackTrace.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/TestDAP_stackTrace.py
@@ -61,7 +61,7 @@ class TestDAP_stackTrace(lldbdap_testcase.DAPTestCaseBase):
         Tests the 'stackTrace' packet and all its variants.
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
         source = "main.c"
         self.source_path = os.path.join(os.getcwd(), source)
         self.recurse_end = line_number(source, "recurse end")

--- a/lldb/test/API/tools/lldb-dap/stackTraceDisassemblyDisplay/TestDAP_stackTraceDisassemblyDisplay.py
+++ b/lldb/test/API/tools/lldb-dap/stackTraceDisassemblyDisplay/TestDAP_stackTraceDisassemblyDisplay.py
@@ -37,7 +37,7 @@ class TestDAP_stackTraceMissingSourcePath(lldbdap_testcase.DAPTestCaseBase):
             breakpoint_line = line_number(other_source_file, "// Break here")
 
             program = self.getBuildArtifact("a.out")
-            self.build_and_launch(program, stopOnEntry=True, commandEscapePrefix="")
+            self.build_and_launch(program, commandEscapePrefix="")
 
             breakpoint_ids = self.set_source_breakpoints(
                 other_source_file, [breakpoint_line]

--- a/lldb/test/API/tools/lldb-dap/startDebugging/TestDAP_startDebugging.py
+++ b/lldb/test/API/tools/lldb-dap/startDebugging/TestDAP_startDebugging.py
@@ -15,7 +15,7 @@ class TestDAP_startDebugging(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         source = "main.c"
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
 
         breakpoint_line = line_number(source, "// breakpoint")
 

--- a/lldb/test/API/tools/lldb-dap/stop-hooks/TestDAP_stop_hooks.py
+++ b/lldb/test/API/tools/lldb-dap/stop-hooks/TestDAP_stop_hooks.py
@@ -15,7 +15,7 @@ class TestDAP_stop_hooks(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         preRunCommands = ["target stop-hook add -o help"]
-        self.build_and_launch(program, stopOnEntry=True, preRunCommands=preRunCommands)
+        self.build_and_launch(program, preRunCommands=preRunCommands)
         breakpoint_ids = self.set_function_breakpoints(["main"])
         # This request hangs if the race happens, because, in that case, the
         # command interpreter is in synchronous mode while lldb-dap expects

--- a/lldb/test/API/tools/lldb-dap/threads/TestDAP_threads.py
+++ b/lldb/test/API/tools/lldb-dap/threads/TestDAP_threads.py
@@ -50,7 +50,9 @@ class TestDAP_threads(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(
-            program, customThreadFormat="This is thread index #${thread.index}"
+            program,
+            customThreadFormat="This is thread index #${thread.index}",
+            stopCommands=["thread list"],
         )
         source = "main.c"
         breakpoint_line = line_number(source, "// break here")
@@ -63,5 +65,6 @@ class TestDAP_threads(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_breakpoints(breakpoint_ids)
         # We are stopped at the second thread
         threads = self.dap_server.get_threads()
+        print("got thread", threads)
         self.assertEqual(threads[0]["name"], "This is thread index #1")
         self.assertEqual(threads[1]["name"], "This is thread index #2")

--- a/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
+++ b/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
@@ -13,14 +13,11 @@ class TestDAP_variables_children(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(
             program,
-            stopOnEntry=True,
             preRunCommands=[
                 "command script import '%s'" % self.getSourcePath("formatter.py")
             ],
         )
         source = "main.cpp"
-        breakpoint1_line = line_number(source, "// break here")
-
         breakpoint_ids = self.set_source_breakpoints(
             source, [line_number(source, "// break here")]
         )
@@ -47,7 +44,7 @@ class TestDAP_variables_children(lldbdap_testcase.DAPTestCaseBase):
         Test the stepping out of a function with return value show the children correctly
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
+        self.build_and_launch(program)
 
         function_name = "test_return_variable_with_children"
         breakpoint_ids = self.set_function_breakpoints([function_name])

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -444,7 +444,6 @@ private:
 
   /// Queue for all incoming messages.
   std::deque<protocol::Message> m_queue;
-  std::deque<protocol::Message> m_pending_queue;
   std::mutex m_queue_mutex;
   std::condition_variable m_queue_cv;
 

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -140,24 +140,7 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
 }
 
 void AttachRequestHandler::PostRun() const {
-  if (!dap.target.GetProcess().IsValid())
-    return;
-
-  // Clients can request a baseline of currently existing threads after
-  // we acknowledge the configurationDone request.
-  // Client requests the baseline of currently existing threads after
-  // a successful or attach by sending a 'threads' request
-  // right after receiving the configurationDone response.
-  // Obtain the list of threads before we resume the process
-  dap.initial_thread_list =
-      GetThreads(dap.target.GetProcess(), dap.thread_format);
-
-  SendProcessEvent(dap, Attach);
-
-  if (dap.stop_at_entry)
-    SendThreadStoppedEvent(dap);
-  else
-    dap.target.GetProcess().Continue();
+  dap.SendJSON(CreateEventObject("initialized"));
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/ConfigurationDoneRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ConfigurationDoneRequestHandler.cpp
@@ -9,49 +9,53 @@
 #include "DAP.h"
 #include "EventHelper.h"
 #include "JSONUtils.h"
+#include "Protocol/ProtocolRequests.h"
 #include "RequestHandler.h"
+#include "lldb/API/SBDebugger.h"
+
+using namespace llvm;
+using namespace lldb_dap::protocol;
 
 namespace lldb_dap {
 
-// "ConfigurationDoneRequest": {
-//   "allOf": [ { "$ref": "#/definitions/Request" }, {
-//             "type": "object",
-//             "description": "ConfigurationDone request; value of command field
-//             is 'configurationDone'.\nThe client of the debug protocol must
-//             send this request at the end of the sequence of configuration
-//             requests (which was started by the InitializedEvent).",
-//             "properties": {
-//             "command": {
-//             "type": "string",
-//             "enum": [ "configurationDone" ]
-//             },
-//             "arguments": {
-//             "$ref": "#/definitions/ConfigurationDoneArguments"
-//             }
-//             },
-//             "required": [ "command" ]
-//             }]
-// },
-// "ConfigurationDoneArguments": {
-//   "type": "object",
-//   "description": "Arguments for 'configurationDone' request.\nThe
-//   configurationDone request has no standardized attributes."
-// },
-// "ConfigurationDoneResponse": {
-//   "allOf": [ { "$ref": "#/definitions/Response" }, {
-//             "type": "object",
-//             "description": "Response to 'configurationDone' request. This is
-//             just an acknowledgement, so no body field is required."
-//             }]
-// },
+/// This request indicates that the client has finished initialization of the
+/// debug adapter.
+///
+/// So it is the last request in the sequence of configuration requests (which
+/// was started by the `initialized` event).
+///
+/// Clients should only call this request if the corresponding capability
+/// `supportsConfigurationDoneRequest` is true.
+llvm::Error
+ConfigurationDoneRequestHandler::Run(const ConfigurationDoneArguments &) const {
+  dap.configuration_done = true;
 
-void ConfigurationDoneRequestHandler::operator()(
-    const llvm::json::Object &request) const {
-  dap.SetConfigurationDone();
+  // Ensure any command scripts did not leave us in an unexpected state.
+  lldb::SBProcess process = dap.target.GetProcess();
+  if (!process.IsValid() ||
+      !lldb::SBDebugger::StateIsStoppedState(process.GetState()))
+    return make_error<DAPError>(
+        "Expected process to be stopped.\r\n\r\nProcess is in an unexpected "
+        "state and may have missed an initial configuration. Please check that "
+        "any debugger command scripts are not resuming the process during the "
+        "launch sequence.");
 
-  llvm::json::Object response;
-  FillResponse(request, response);
-  dap.SendJSON(llvm::json::Value(std::move(response)));
+  // Clients can request a baseline of currently existing threads after
+  // we acknowledge the configurationDone request.
+  // Client requests the baseline of currently existing threads after
+  // a successful or attach by sending a 'threads' request
+  // right after receiving the configurationDone response.
+  // Obtain the list of threads before we resume the process
+  dap.initial_thread_list = GetThreads(process, dap.thread_format);
+
+  SendProcessEvent(dap, dap.is_attach ? Attach : Launch);
+
+  if (dap.stop_at_entry)
+    SendThreadStoppedEvent(dap);
+  else
+    process.Continue();
+
+  return Error::success();
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -78,7 +78,3 @@ llvm::Expected<InitializeResponse> InitializeRequestHandler::Run(
 
   return dap.GetCapabilities();
 }
-
-void InitializeRequestHandler::PostRun() const {
-  dap.SendJSON(CreateEventObject("initialized"));
-}

--- a/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
@@ -67,25 +67,7 @@ Error LaunchRequestHandler::Run(const LaunchRequestArguments &arguments) const {
 }
 
 void LaunchRequestHandler::PostRun() const {
-  if (!dap.target.GetProcess().IsValid())
-    return;
-
-  // Clients can request a baseline of currently existing threads after
-  // we acknowledge the configurationDone request.
-  // Client requests the baseline of currently existing threads after
-  // a successful or attach by sending a 'threads' request
-  // right after receiving the configurationDone response.
-  // Obtain the list of threads before we resume the process
-  dap.initial_thread_list =
-      GetThreads(dap.target.GetProcess(), dap.thread_format);
-
-  // Attach happens when launching with runInTerminal.
-  SendProcessEvent(dap, dap.is_attach ? Attach : Launch);
-
-  if (dap.stop_at_entry)
-    SendThreadStoppedEvent(dap);
-  else
-    dap.target.GetProcess().Continue();
+  dap.SendJSON(CreateEventObject("initialized"));
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/JSON.h"
 #include <optional>
 #include <type_traits>
+#include <variant>
 
 template <typename T> struct is_optional : std::false_type {};
 
@@ -87,6 +88,34 @@ class LegacyRequestHandler : public BaseRequestHandler {
   }
 };
 
+template <typename Args>
+llvm::Expected<Args> parseArgs(const protocol::Request &request) {
+  if (!is_optional_v<Args> && !request.arguments)
+    return llvm::make_error<DAPError>(
+        llvm::formatv("arguments required for command '{0}' "
+                      "but none received",
+                      request.command)
+            .str());
+
+  Args arguments;
+  llvm::json::Path::Root root("arguments");
+  if (request.arguments && !fromJSON(*request.arguments, arguments, root)) {
+    std::string parse_failure;
+    llvm::raw_string_ostream OS(parse_failure);
+    OS << "invalid arguments for request '" << request.command
+       << "': " << llvm::toString(root.getError()) << "\n";
+    root.printErrorContext(*request.arguments, OS);
+    return llvm::make_error<DAPError>(parse_failure);
+  }
+
+  return arguments;
+}
+template <>
+inline llvm::Expected<protocol::EmptyArguments>
+parseArgs(const protocol::Request &request) {
+  return std::nullopt;
+}
+
 /// Base class for handling DAP requests. Handlers should declare their
 /// arguments and response body types like:
 ///
@@ -102,10 +131,8 @@ class RequestHandler : public BaseRequestHandler {
     response.request_seq = request.seq;
     response.command = request.command;
 
-    if (!is_optional_v<Args> && !request.arguments) {
-      DAP_LOG(dap.log,
-              "({0}) malformed request {1}, expected arguments but got none",
-              dap.transport.GetClientName(), request.command);
+    llvm::Expected<Args> arguments = parseArgs<Args>(request);
+    if (!arguments) {
       HandleErrorResponse(
           llvm::make_error<DAPError>(
               llvm::formatv("arguments required for command '{0}' "
@@ -117,27 +144,14 @@ class RequestHandler : public BaseRequestHandler {
       return;
     }
 
-    Args arguments;
-    llvm::json::Path::Root root("arguments");
-    if (request.arguments && !fromJSON(*request.arguments, arguments, root)) {
-      std::string parse_failure;
-      llvm::raw_string_ostream OS(parse_failure);
-      OS << "invalid arguments for request '" << request.command
-         << "': " << llvm::toString(root.getError()) << "\n";
-      root.printErrorContext(*request.arguments, OS);
-      HandleErrorResponse(llvm::make_error<DAPError>(parse_failure), response);
-      dap.Send(response);
-      return;
-    }
-
     if constexpr (std::is_same_v<Resp, llvm::Error>) {
-      if (llvm::Error err = Run(arguments)) {
+      if (llvm::Error err = Run(*arguments)) {
         HandleErrorResponse(std::move(err), response);
       } else {
         response.success = true;
       }
     } else {
-      Resp body = Run(arguments);
+      Resp body = Run(*arguments);
       if (llvm::Error err = body.takeError()) {
         HandleErrorResponse(std::move(err), response);
       } else {
@@ -246,14 +260,17 @@ public:
   Run(const protocol::ContinueArguments &args) const override;
 };
 
-class ConfigurationDoneRequestHandler : public LegacyRequestHandler {
+class ConfigurationDoneRequestHandler
+    : public RequestHandler<protocol::ConfigurationDoneArguments,
+                            protocol::ConfigurationDoneResponse> {
 public:
-  using LegacyRequestHandler::LegacyRequestHandler;
+  using RequestHandler::RequestHandler;
   static llvm::StringLiteral GetCommand() { return "configurationDone"; }
   FeatureSet GetSupportedFeatures() const override {
     return {protocol::eAdapterFeatureConfigurationDoneRequest};
   }
-  void operator()(const llvm::json::Object &request) const override;
+  protocol::ConfigurationDoneResponse
+  Run(const protocol::ConfigurationDoneArguments &) const override;
 };
 
 class DisconnectRequestHandler
@@ -297,7 +314,6 @@ public:
   static llvm::StringLiteral GetCommand() { return "initialize"; }
   llvm::Expected<protocol::InitializeResponse>
   Run(const protocol::InitializeRequestArguments &args) const override;
-  void PostRun() const override;
 };
 
 class LaunchRequestHandler

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -132,14 +132,8 @@ class RequestHandler : public BaseRequestHandler {
     response.command = request.command;
 
     llvm::Expected<Args> arguments = parseArgs<Args>(request);
-    if (!arguments) {
-      HandleErrorResponse(
-          llvm::make_error<DAPError>(
-              llvm::formatv("arguments required for command '{0}' "
-                            "but none received",
-                            request.command)
-                  .str()),
-          response);
+    if (llvm::Error err = arguments.takeError()) {
+      HandleErrorResponse(std::move(err), response);
       dap.Send(response);
       return;
     }

--- a/lldb/tools/lldb-dap/Protocol/ProtocolBase.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolBase.h
@@ -148,6 +148,9 @@ struct ErrorResponseBody {
 };
 llvm::json::Value toJSON(const ErrorResponseBody &);
 
+/// This is a placehold for requests with an empty, null or undefined arguments.
+using EmptyArguments = std::optional<std::monostate>;
+
 /// This is just an acknowledgement, so no body field is required.
 using VoidResponse = llvm::Error;
 

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -370,6 +370,13 @@ struct ContinueResponseBody {
 };
 llvm::json::Value toJSON(const ContinueResponseBody &);
 
+/// Arguments for `configurationDone` request.
+using ConfigurationDoneArguments = EmptyArguments;
+
+/// Response to `configurationDone` request. This is just an acknowledgement, so
+/// no body field is required.
+using ConfigurationDoneResponse = VoidResponse;
+
 /// Arguments for `setVariable` request.
 struct SetVariableArguments {
   /// The reference of the variable container. The `variablesReference` must


### PR DESCRIPTION
This is more straight forward refactor of the startup sequence that reverts parts of ba29e60f9a2222bd5e883579bb78db13fc5a7588. Unlike my previous attempt, I ended up removing the pending request queue and not including an `AsyncReqeustHandler` because I don't think we actually need that at the moment.

The key is that during the startup flow there are 2 parallel operations happening in the DAP that have different triggers.

* The `initialize` request is sent and once the response is received the `launch` or `attach` is sent.
* When the `initialized` event is recieved the `setBreakpionts` and other config requests are made followed by the `configurationDone` event.

I moved the `initialized` event back to happen in the `PostRun` of the `launch` or `attach` request handlers. This ensures that we have a valid target by the time the configuration calls are made. I added also added a few extra validations that to the `configurationeDone` handler to ensure we're in an expected state.

I've also fixed up the tests to match the new flow. With the other additional test fixes in 087a5d2ec7897cd99d3787820711fec76a8e1792 I think we've narrowed down the main source of test instability that motivated the startup sequence change.