### PR TITLE
[clang-include-fixer] Remove an unused "using" decl (NFC)

### DIFF
--- a/clang-tools-extra/clang-include-fixer/find-all-symbols/SymbolInfo.cpp
+++ b/clang-tools-extra/clang-include-fixer/find-all-symbols/SymbolInfo.cpp
@@ -12,7 +12,6 @@
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
 
-using llvm::yaml::MappingTraits;
 using ContextType = clang::find_all_symbols::SymbolInfo::ContextType;
 using clang::find_all_symbols::SymbolInfo;
 using clang::find_all_symbols::SymbolAndSignals;


### PR DESCRIPTION
We do use MappingTraits in this file, but all uses are inside the
llvm::yaml namespace, so we don't rely on the "using" decl.
