### PR TITLE
[InstCombine] handle (X + A) % Op1 for small X, A

### DIFF
--- a/llvm/test/Transforms/InstCombine/urem-via-cmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/urem-via-cmp-select.ll
@@ -27,7 +27,10 @@ define i8 @urem_assume_a(i8 %x, i8 %n, i8 %a) {
 ; CHECK-NEXT:    [[CMP_A:%.*]] = icmp ult i8 [[A:%.*]], [[N]]
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 [[CMP_A]])
 ; CHECK-NEXT:    [[ADD:%.*]] = add nuw i8 [[X_FR]], [[A]]
-; CHECK-NEXT:    [[OUT:%.*]] = urem i8 [[ADD]], [[N]]
+; CHECK-NEXT:    [[ADD_FROZEN:%.*]] = freeze i8 [[ADD]]
+; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ult i8 [[ADD_FROZEN]], [[N]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[DOTNOT]], i8 0, i8 [[N]]
+; CHECK-NEXT:    [[OUT:%.*]] = sub i8 [[ADD_FROZEN]], [[TMP1]]
 ; CHECK-NEXT:    ret i8 [[OUT]]
 ;
   %cmp = icmp ult i8 %x, %n
@@ -231,7 +234,10 @@ define i8 @urem_without_assume_a(i8 %arg, i8 %arg2, i8 %a) {
 ; CHECK-NEXT:    [[X_REM:%.*]] = urem i8 [[ARG:%.*]], [[ARG2:%.*]]
 ; CHECK-NEXT:    [[A_REM:%.*]] = urem i8 [[A:%.*]], [[ARG2]]
 ; CHECK-NEXT:    [[ADDD:%.*]] = add i8 [[X_REM]], [[A_REM]]
-; CHECK-NEXT:    [[OUT:%.*]] = urem i8 [[ADDD]], [[ARG2]]
+; CHECK-NEXT:    [[ADD_FROZEN:%.*]] = freeze i8 [[ADDD]]
+; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ult i8 [[ADD_FROZEN]], [[ARG2]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[DOTNOT]], i8 0, i8 [[ARG2]]
+; CHECK-NEXT:    [[OUT:%.*]] = sub i8 [[ADD_FROZEN]], [[TMP1]]
 ; CHECK-NEXT:    ret i8 [[OUT]]
 ;
   %x_rem = urem i8 %arg, %arg2


### PR DESCRIPTION
Allows LLVM to optimize rem out of loops like this:

```c
void c(void)
{
 unsigned m = 0;
 for(int i = 0; i < x; i++)
 {
 m += 7;
 m %= 600;
 g(m);
 }
}
```

by replacing it with `m + 7 >= 600 ? m + 7 - 600 : m + 7`

Alive2 proof: https://alive2.llvm.org/ce/z/NXHJJD


```llvm
define noundef i16 @src(i16 noundef %x, i16 noundef %n, i16 noundef %a) unnamed_addr  {
start:
  %_3 = icmp ult i16 %x, %n
  tail call void @llvm.assume(i1 %_3)
  %_4 = icmp ult i16 %a, %n
  tail call void @llvm.assume(i1 %_4)
  %_6 = add nuw i16 %x, %a
  %0 = urem i16 %_6, %n
  ret i16 %0
}

define noundef i16 @tgt(i16 noundef %x, i16 noundef %n, i16 noundef %a) unnamed_addr  {
start:
  %_3 = icmp ult i16 %x, %n
  tail call void @llvm.assume(i1 %_3)
  %_4 = icmp ult i16 %a, %n
  tail call void @llvm.assume(i1 %_4)
  %_6 = add nuw i16 %x, %a
  %w = icmp uge i16 %_6, %n
  %_7 = sub nuw i16 %_6, %n
  %0 = select i1 %w, i16 %_7, i16 %_6
  ret i16 %0
}

declare void @llvm.assume(i1 noundef) 
```

I added the equivalents of tests for `(X + 1) % Op1`, except for `urem_with_dominating_condition` and `urem_with_dominating_condition_false` which don't get matched by the pattern matcher and don't get optimized. I couldn't find a reason for this in my code, the reason is likely outside it. If I were to add these, these would be:

```llvm
; https://alive2.llvm.org/ce/z/Y6jvTf
define i8 @urem_with_dominating_condition_a(i8 %x, i8 %n, i8 %a) {
start:
  %cond = icmp ult i8 %x, %n
  br i1 %cond, label %.bb0, label %.bb2
.bb0:
  %cond2 = icmp ult i8 %a, %n
  br i1 %cond2, label %.bb1, label %.bb2
.bb1:
  %add = add i8 %x, %a
  %out = urem i8 %add, %n
  ret i8 %out
.bb2:
  ret i8 0
}

; Revert the dominating condition and target branch at the same time.
define i8 @urem_with_dominating_condition_false_a(i8 %x, i8 %n, i8 %a) {
start:
  %cond = icmp uge i8 %x, %n
  br i1 %cond, label %.bb2, label %.bb0 ; Swap the branch targets
.bb0:
  %cond2 = icmp uge i8 %a, %n
  br i1 %cond2, label %.bb2, label %.bb1 ; Swap the branch targets
.bb1:
  %add = add i8 %x, %a
  %out = urem i8 %add, %n
  ret i8 %out
.bb2:
  ret i8 0
}
```