### PR TITLE
[libc++] Fix set::operator= when instantiating with a std::pair

### DIFF
--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -1281,7 +1281,7 @@ private:
   }
   _LIBCPP_HIDE_FROM_ABI void __move_assign_alloc(__tree&, false_type) _NOEXCEPT {}
 
-  template <class _From, __enable_if_t<__is_pair_v<__remove_cvref_t<_From> >, int> = 0>
+  template <class _From, class _ValueT = _Tp, __enable_if_t<__is_tree_value_type<_ValueT>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI static void __assign_value(__get_node_value_type_t<value_type>& __lhs, _From&& __rhs) {
     using __key_type = typename _NodeTypes::key_type;
 
@@ -1291,7 +1291,7 @@ private:
     __lhs.second                         = std::forward<_From>(__rhs).second;
   }
 
-  template <class _To, class _From, class _ValueT = _Tp, __enable_if_t<!__is_pair_v<__remove_cvref_t<_From> >, int> = 0>
+  template <class _To, class _From, class _ValueT = _Tp, __enable_if_t<!__is_tree_value_type<_ValueT>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI static void __assign_value(_To& __lhs, _From&& __rhs) {
     __lhs = std::forward<_From>(__rhs);
   }

--- a/libcxx/test/std/containers/associative/set/set.cons/copy_assign.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/set.cons/copy_assign.pass.cpp
@@ -80,5 +80,15 @@ int main(int, char**) {
     assert(*std::next(mo.begin(), 2) == 3);
   }
 
+  { // Test with std::pair, since we have some special handling for pairs inside __tree
+    std::pair<int, int> arr[] = {
+        std::make_pair(1, 2), std::make_pair(2, 3), std::make_pair(3, 4), std::make_pair(4, 5)};
+    std::set<std::pair<int, int> > a(arr, arr + 4);
+    std::set<std::pair<int, int> > b;
+
+    b = a;
+    assert(a == b);
+  }
+
   return 0;
 }


### PR DESCRIPTION
This has been introduced by #134819, most likely due to a merge conflict I didn't resolve properly (I thought I did in that patch what I'm now doing here).
