### PR TITLE
[BOLT] Remove unused local variables (NFC)

### DIFF
--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -676,7 +676,6 @@ static void writeDWARF5LocList(uint32_t &NumberOfEntries, DIEValue &AttrInfo,
     return;
   }
 
-  std::vector<uint64_t> OffsetsArray;
   auto writeExpression = [&](uint32_t Index) -> void {
     const DebugLocationEntry &Entry = LocList[Index];
     encodeULEB128(Entry.Expr.size(), LocBodyStream);

--- a/bolt/lib/Passes/FrameAnalysis.cpp
+++ b/bolt/lib/Passes/FrameAnalysis.cpp
@@ -320,7 +320,6 @@ bool FrameAnalysis::updateArgsTouchedFor(const BinaryFunction &BF, MCInst &Inst,
   if (!BC.MIB->isCall(Inst))
     return false;
 
-  std::set<int64_t> Res;
   const MCSymbol *TargetSymbol = BC.MIB->getTargetSymbol(Inst);
   // If indirect call, we conservatively assume it accesses all stack positions
   if (TargetSymbol == nullptr) {

--- a/bolt/lib/Passes/HFSort.cpp
+++ b/bolt/lib/Passes/HFSort.cpp
@@ -239,7 +239,6 @@ std::vector<Cluster> clusterize(const CallGraph &Cg) {
 }
 
 std::vector<Cluster> randomClusters(const CallGraph &Cg) {
-  std::vector<NodeId> FuncIds(Cg.numNodes(), 0);
   std::vector<Cluster> Clusters;
   Clusters.reserve(Cg.numNodes());
 

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -4703,7 +4703,6 @@ RewriteInstance::getOutputSections(ELFObjectFile<ELFT> *File,
   }
 
   // Assign indices to sections.
-  std::unordered_map<std::string, uint64_t> NameToIndex;
   for (uint32_t Index = 1; Index < OutputSections.size(); ++Index)
     OutputSections[Index].first->setIndex(Index);
 

--- a/bolt/tools/bat-dump/bat-dump.cpp
+++ b/bolt/tools/bat-dump/bat-dump.cpp
@@ -73,16 +73,6 @@ static void report_error(StringRef Message, Error E) {
   exit(1);
 }
 
-static std::string GetExecutablePath(const char *Argv0) {
-  SmallString<256> ExecutablePath(Argv0);
-  // Do a PATH lookup if Argv0 isn't a valid path.
-  if (!llvm::sys::fs::exists(ExecutablePath))
-    if (llvm::ErrorOr<std::string> P =
-            llvm::sys::findProgramByName(ExecutablePath))
-      ExecutablePath = *P;
-  return std::string(ExecutablePath);
-}
-
 void dumpBATFor(llvm::object::ELFObjectFileBase *InputFile) {
   BoltAddressTranslation BAT;
   if (!BAT.enabledFor(InputFile)) {
@@ -163,7 +153,6 @@ int main(int argc, char **argv) {
     report_error(opts::InputFilename, errc::no_such_file_or_directory);
 
   ToolName = argv[0];
-  std::string ToolPath = GetExecutablePath(argv[0]);
   Expected<llvm::object::OwningBinary<llvm::object::Binary>> BinaryOrErr =
       llvm::object::createBinary(opts::InputFilename);
   if (Error E = BinaryOrErr.takeError())


### PR DESCRIPTION
While I'm at it, this patch removes GetExecutablePath, which becomes
unused after removing the sole use.
