### PR TITLE
[BOLT] Avoid repeated hash lookups (NFC)

### DIFF
--- a/bolt/include/bolt/Profile/DataReader.h
+++ b/bolt/include/bolt/Profile/DataReader.h
@@ -114,10 +114,8 @@ struct FuncBranchData {
 
   FuncBranchData() {}
 
-  FuncBranchData(StringRef Name, ContainerTy Data)
-      : Name(Name), Data(std::move(Data)) {}
-
-  FuncBranchData(StringRef Name, ContainerTy Data, ContainerTy EntryData)
+  FuncBranchData(StringRef Name, ContainerTy Data = ContainerTy(),
+                 ContainerTy EntryData = ContainerTy())
       : Name(Name), Data(std::move(Data)), EntryData(std::move(EntryData)) {}
 
   ErrorOr<const BranchInfo &> getBranch(uint64_t From, uint64_t To) const;

--- a/bolt/include/bolt/Profile/DataReader.h
+++ b/bolt/include/bolt/Profile/DataReader.h
@@ -205,7 +205,7 @@ struct FuncMemData {
 
   FuncMemData() {}
 
-  FuncMemData(StringRef Name, ContainerTy Data)
+  FuncMemData(StringRef Name, ContainerTy Data = ContainerTy())
       : Name(Name), Data(std::move(Data)) {}
 };
 
@@ -241,7 +241,7 @@ struct FuncBasicSampleData {
   StringRef Name;
   ContainerTy Data;
 
-  FuncBasicSampleData(StringRef Name, ContainerTy Data)
+  FuncBasicSampleData(StringRef Name, ContainerTy Data = ContainerTy())
       : Name(Name), Data(std::move(Data)) {}
 
   /// Get the number of samples recorded in [Start, End)

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -1088,26 +1088,11 @@ bool DataReader::hasMemData() {
 
 std::error_code DataReader::parseInNoLBRMode() {
   auto GetOrCreateFuncEntry = [&](StringRef Name) {
-    auto I = NamesToBasicSamples.find(Name);
-    if (I == NamesToBasicSamples.end()) {
-      bool Success;
-      std::tie(I, Success) = NamesToBasicSamples.insert(std::make_pair(
-          Name, FuncBasicSampleData(Name, FuncBasicSampleData::ContainerTy())));
-
-      assert(Success && "unexpected result of insert");
-    }
-    return I;
+    return NamesToBasicSamples.try_emplace(Name, Name).first;
   };
 
   auto GetOrCreateFuncMemEntry = [&](StringRef Name) {
-    auto I = NamesToMemEvents.find(Name);
-    if (I == NamesToMemEvents.end()) {
-      bool Success;
-      std::tie(I, Success) = NamesToMemEvents.insert(
-          std::make_pair(Name, FuncMemData(Name, FuncMemData::ContainerTy())));
-      assert(Success && "unexpected result of insert");
-    }
-    return I;
+    return NamesToMemEvents.try_emplace(Name, Name).first;
   };
 
   while (hasBranchData()) {

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -1136,26 +1136,11 @@ std::error_code DataReader::parseInNoLBRMode() {
 
 std::error_code DataReader::parse() {
   auto GetOrCreateFuncEntry = [&](StringRef Name) {
-    auto I = NamesToBranches.find(Name);
-    if (I == NamesToBranches.end()) {
-      bool Success;
-      std::tie(I, Success) = NamesToBranches.insert(std::make_pair(
-          Name, FuncBranchData(Name, FuncBranchData::ContainerTy(),
-                               FuncBranchData::ContainerTy())));
-      assert(Success && "unexpected result of insert");
-    }
-    return I;
+    return NamesToBranches.try_emplace(Name, Name).first;
   };
 
   auto GetOrCreateFuncMemEntry = [&](StringRef Name) {
-    auto I = NamesToMemEvents.find(Name);
-    if (I == NamesToMemEvents.end()) {
-      bool Success;
-      std::tie(I, Success) = NamesToMemEvents.insert(
-          std::make_pair(Name, FuncMemData(Name, FuncMemData::ContainerTy())));
-      assert(Success && "unexpected result of insert");
-    }
-    return I;
+    return NamesToMemEvents.try_emplace(Name, Name).first;
   };
 
   Col = 0;


### PR DESCRIPTION
We can use try_emplace to succinctly implement GetOrCreateFuncEntry
and GetOrCreateFuncMemEntry.  Since it's a bit mouthful to say
FuncBasicSampleData::ContainerTy(), this patch changes the second
parameters to default ones.
