### PR TITLE
[CIR] Remove the empty verifier in cir.ifOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -553,7 +553,6 @@ def IfOp : CIR_Op<"if",
   let arguments = (ins CIR_BoolType:$condition);
   let regions = (region AnyRegion:$thenRegion, AnyRegion:$elseRegion);
   let hasCustomAssemblyFormat=1;
-  let hasVerifier=1;
   let skipDefaultBuilders=1;
   let builders = [
     OpBuilder<(ins "mlir::Value":$cond, "bool":$withElseRegion,

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -751,8 +751,6 @@ void cir::IfOp::build(OpBuilder &builder, OperationState &result, Value cond,
   elseBuilder(builder, result.location);
 }
 
-LogicalResult cir::IfOp::verify() { return success(); }
-
 //===----------------------------------------------------------------------===//
 // ScopeOp
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The empty verifier is redundant because cir::IfOp has no constraints to enforce its verify() always succeeds.