### PR TITLE
[lldb-dap] Synchronously wait for breakpoints resolves in tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1070,7 +1070,10 @@ class DebugCommunication(object):
             "type": "request",
             "arguments": args_dict,
         }
-        return self.send_recv(command_dict)
+        response = self.send_recv(command_dict)
+        breakpoints = response["body"]["breakpoints"]
+        self._update_verified_breakpoints(breakpoints)
+        return response
 
     def request_dataBreakpointInfo(
         self, variablesReference, name, frameIndex=0, threadId=None

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1216,7 +1216,7 @@ class DebugCommunication(object):
         }
         return self.send_recv(command_dict)
 
-    def request_testGetTargetBreakpoints(self):
+    def request_testGetTargetBreakpoints(self, only_resolved=False):
         """A request packet used in the LLDB test suite to get all currently
         set breakpoint infos for all breakpoints currently set in the
         target.
@@ -1224,7 +1224,9 @@ class DebugCommunication(object):
         command_dict = {
             "command": "_testGetTargetBreakpoints",
             "type": "request",
-            "arguments": {},
+            "arguments": {
+                "onlyResolved": only_resolved,
+            },
         }
         return self.send_recv(command_dict)
 

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -315,9 +315,10 @@ class DebugCommunication(object):
 
     def _update_verified_breakpoints(self, breakpoints: list[Event]):
         for breakpoint in breakpoints:
-            self.resolved_breakpoints[str(breakpoint["id"])] = breakpoint.get(
-                "verified", False
-            )
+            if "id" in breakpoint:
+                self.resolved_breakpoints[str(breakpoint["id"])] = breakpoint.get(
+                    "verified", False
+                )
 
     def send_packet(self, command_dict: Request, set_sequence=True):
         """Take the "command_dict" python dictionary and encode it as a JSON
@@ -462,7 +463,6 @@ class DebugCommunication(object):
             if not event:
                 break
             breakpoint_events.append(event)
-
         return breakpoint_events
 
     def wait_for_breakpoints_to_be_verified(

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -68,7 +68,7 @@ class DAPTestCaseBase(TestBase):
         for breakpoint in breakpoints:
             breakpoint_ids.append("%i" % (breakpoint["id"]))
         if wait_for_resolve:
-            self.wait_for_breakpoints_to_resolve(breakpoint_ids, timeout=10)
+            self.wait_for_breakpoints_to_resolve(breakpoint_ids)
         return breakpoint_ids
 
     def set_source_breakpoints_assembly(self, source_reference, lines, data=None):
@@ -102,7 +102,7 @@ class DAPTestCaseBase(TestBase):
         for breakpoint in breakpoints:
             breakpoint_ids.append("%i" % (breakpoint["id"]))
         if wait_for_resolve:
-            self.wait_for_breakpoints_to_resolve(breakpoint_ids, timeout=10)
+            self.wait_for_breakpoints_to_resolve(breakpoint_ids)
         return breakpoint_ids
 
     def wait_for_breakpoints_to_resolve(

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -49,7 +49,9 @@ class DAPTestCaseBase(TestBase):
         self.build_and_create_debug_adapter(dictionary={"EXE": unique_name})
         return self.getBuildArtifact(unique_name)
 
-    def set_source_breakpoints(self, source_path, lines, data=None, wait_for_resolve=True):
+    def set_source_breakpoints(
+        self, source_path, lines, data=None, wait_for_resolve=True
+    ):
         """Sets source breakpoints and returns an array of strings containing
         the breakpoint IDs ("1", "2") for each breakpoint that was set.
         Parameter data is array of data objects for breakpoints.
@@ -83,7 +85,9 @@ class DAPTestCaseBase(TestBase):
             breakpoint_ids.append("%i" % (breakpoint["id"]))
         return breakpoint_ids
 
-    def set_function_breakpoints(self, functions, condition=None, hitCondition=None, wait_for_resolve=True):
+    def set_function_breakpoints(
+        self, functions, condition=None, hitCondition=None, wait_for_resolve=True
+    ):
         """Sets breakpoints by function name given an array of function names
         and returns an array of strings containing the breakpoint IDs
         ("1", "2") for each breakpoint that was set.
@@ -100,24 +104,36 @@ class DAPTestCaseBase(TestBase):
         if wait_for_resolve:
             self.wait_for_breakpoints_to_resolve(breakpoint_ids, timeout=10)
         return breakpoint_ids
-    
-    def wait_for_breakpoints_to_resolve(self, breakpoint_ids: list[str], timeout: Optional[float] = None):
+
+    def wait_for_breakpoints_to_resolve(
+        self, breakpoint_ids: list[str], timeout: Optional[float] = None
+    ):
         unresolved_breakpoints = set(breakpoint_ids)
-        
+
         # Check already resolved breakpoints
-        resolved_breakpoints = self.dap_server.request_testGetTargetBreakpoints(only_resolved=True)["body"]["breakpoints"]
+        resolved_breakpoints = self.dap_server.request_testGetTargetBreakpoints(
+            only_resolved=True
+        )["body"]["breakpoints"]
         for resolved_breakpoint in resolved_breakpoints:
             unresolved_breakpoints.discard(str(resolved_breakpoint["id"]))
 
         while len(unresolved_breakpoints) > 0:
-            breakpoint_event = self.dap_server.wait_for_event("breakpoint", timeout=timeout)
+            breakpoint_event = self.dap_server.wait_for_event(
+                "breakpoint", timeout=timeout
+            )
             if breakpoint_event is None:
                 break
 
             if breakpoint_event["body"]["reason"] in ["changed", "new"]:
-                unresolved_breakpoints.discard(str(breakpoint_event["body"]["breakpoint"]["id"]))
+                unresolved_breakpoints.discard(
+                    str(breakpoint_event["body"]["breakpoint"]["id"])
+                )
 
-        self.assertEqual(len(unresolved_breakpoints), 0, f"Expected to resolve all breakpoints. Unresolved breakpoint ids: {unresolved_breakpoints}")
+        self.assertEqual(
+            len(unresolved_breakpoints),
+            0,
+            f"Expected to resolve all breakpoints. Unresolved breakpoint ids: {unresolved_breakpoints}",
+        )
 
     def waitUntil(self, condition_callback):
         for _ in range(20):

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -71,7 +71,9 @@ class DAPTestCaseBase(TestBase):
             self.wait_for_breakpoints_to_resolve(breakpoint_ids)
         return breakpoint_ids
 
-    def set_source_breakpoints_assembly(self, source_reference, lines, data=None):
+    def set_source_breakpoints_assembly(
+        self, source_reference, lines, data=None, wait_for_resolve=True
+    ):
         response = self.dap_server.request_setBreakpoints(
             Source(source_reference=source_reference),
             lines,
@@ -83,6 +85,8 @@ class DAPTestCaseBase(TestBase):
         breakpoint_ids = []
         for breakpoint in breakpoints:
             breakpoint_ids.append("%i" % (breakpoint["id"]))
+        if wait_for_resolve:
+            self.wait_for_breakpoints_to_resolve(breakpoint_ids)
         return breakpoint_ids
 
     def set_function_breakpoints(

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
@@ -12,7 +12,6 @@ import lldbdap_testcase
 import os
 
 
-@skip("Temporarily disable the breakpoint tests")
 class TestDAP_setBreakpoints(lldbdap_testcase.DAPTestCaseBase):
     def setUp(self):
         lldbdap_testcase.DAPTestCaseBase.setUp(self)

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setFunctionBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setFunctionBreakpoints.py
@@ -10,7 +10,6 @@ from lldbsuite.test import lldbutil
 import lldbdap_testcase
 
 
-@skip("Temporarily disable the breakpoint tests")
 class TestDAP_setFunctionBreakpoints(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_set_and_clear(self):

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -16,9 +16,11 @@ class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact(program_basename)
         self.build_and_launch(program)
         functions = ["foo"]
-        
+
         # This breakpoint will be resolved only when the libfoo module is loaded
-        breakpoint_ids = self.set_function_breakpoints(functions, wait_for_resolve=False)
+        breakpoint_ids = self.set_function_breakpoints(
+            functions, wait_for_resolve=False
+        )
         self.assertEqual(len(breakpoint_ids), len(functions), "expect one breakpoint")
         self.continue_to_breakpoints(breakpoint_ids)
         active_modules = self.dap_server.get_modules()

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -16,7 +16,9 @@ class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact(program_basename)
         self.build_and_launch(program)
         functions = ["foo"]
-        breakpoint_ids = self.set_function_breakpoints(functions)
+        
+        # This breakpoint will be resolved only when the libfoo module is loaded
+        breakpoint_ids = self.set_function_breakpoints(functions, wait_for_resolve=False)
         self.assertEqual(len(breakpoint_ids), len(functions), "expect one breakpoint")
         self.continue_to_breakpoints(breakpoint_ids)
         active_modules = self.dap_server.get_modules()

--- a/lldb/test/API/tools/lldb-dap/terminated-event/TestDAP_terminatedEvent.py
+++ b/lldb/test/API/tools/lldb-dap/terminated-event/TestDAP_terminatedEvent.py
@@ -35,10 +35,12 @@ class TestDAP_terminatedEvent(lldbdap_testcase.DAPTestCaseBase):
         self.build_and_launch(program)
         # Set breakpoints
         functions = ["foo"]
-        breakpoint_ids = self.set_function_breakpoints(functions)
+        
+        # This breakpoint will be resolved only when the libfoo module is loaded
+        breakpoint_ids = self.set_function_breakpoints(functions, wait_for_resolve=False)
         self.assertEqual(len(breakpoint_ids), len(functions), "expect one breakpoint")
         main_bp_line = line_number("main.cpp", "// main breakpoint 1")
-        breakpoint_ids.append(self.set_source_breakpoints("main.cpp", [main_bp_line]))
+        breakpoint_ids.append(self.set_source_breakpoints("main.cpp", [main_bp_line], wait_for_resolve=False))
 
         self.continue_to_breakpoints(breakpoint_ids)
         self.continue_to_exit()

--- a/lldb/test/API/tools/lldb-dap/terminated-event/TestDAP_terminatedEvent.py
+++ b/lldb/test/API/tools/lldb-dap/terminated-event/TestDAP_terminatedEvent.py
@@ -35,12 +35,18 @@ class TestDAP_terminatedEvent(lldbdap_testcase.DAPTestCaseBase):
         self.build_and_launch(program)
         # Set breakpoints
         functions = ["foo"]
-        
+
         # This breakpoint will be resolved only when the libfoo module is loaded
-        breakpoint_ids = self.set_function_breakpoints(functions, wait_for_resolve=False)
+        breakpoint_ids = self.set_function_breakpoints(
+            functions, wait_for_resolve=False
+        )
         self.assertEqual(len(breakpoint_ids), len(functions), "expect one breakpoint")
         main_bp_line = line_number("main.cpp", "// main breakpoint 1")
-        breakpoint_ids.append(self.set_source_breakpoints("main.cpp", [main_bp_line], wait_for_resolve=False))
+        breakpoint_ids.append(
+            self.set_source_breakpoints(
+                "main.cpp", [main_bp_line], wait_for_resolve=False
+            )
+        )
 
         self.continue_to_breakpoints(breakpoint_ids)
         self.continue_to_exit()

--- a/lldb/tools/lldb-dap/Handler/TestGetTargetBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/TestGetTargetBreakpointsRequestHandler.cpp
@@ -15,18 +15,12 @@ namespace lldb_dap {
 
 void TestGetTargetBreakpointsRequestHandler::operator()(
     const llvm::json::Object &request) const {
-  const auto *arguments = request.getObject("arguments");
-  bool only_resolved = GetBoolean(arguments, "onlyResolved").value_or(false);
-
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Array response_breakpoints;
   for (uint32_t i = 0; dap.target.GetBreakpointAtIndex(i).IsValid(); ++i) {
-    const auto target_bp = dap.target.GetBreakpointAtIndex(i);
-    if (!only_resolved || target_bp.GetNumResolvedLocations() > 0) {
-      auto bp = Breakpoint(dap, target_bp);
-      response_breakpoints.push_back(bp.ToProtocolBreakpoint());
-    }
+    auto bp = Breakpoint(dap, dap.target.GetBreakpointAtIndex(i));
+    response_breakpoints.push_back(bp.ToProtocolBreakpoint());
   }
   llvm::json::Object body;
   body.try_emplace("breakpoints", std::move(response_breakpoints));

--- a/lldb/tools/lldb-dap/Handler/TestGetTargetBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/TestGetTargetBreakpointsRequestHandler.cpp
@@ -15,12 +15,18 @@ namespace lldb_dap {
 
 void TestGetTargetBreakpointsRequestHandler::operator()(
     const llvm::json::Object &request) const {
+  const auto *arguments = request.getObject("arguments");
+  bool only_resolved = GetBoolean(arguments, "onlyResolved").value_or(false);
+
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Array response_breakpoints;
   for (uint32_t i = 0; dap.target.GetBreakpointAtIndex(i).IsValid(); ++i) {
-    auto bp = Breakpoint(dap, dap.target.GetBreakpointAtIndex(i));
-    response_breakpoints.push_back(bp.ToProtocolBreakpoint());
+    const auto target_bp = dap.target.GetBreakpointAtIndex(i);
+    if (!only_resolved || target_bp.GetNumResolvedLocations() > 0) {
+      auto bp = Breakpoint(dap, target_bp);
+      response_breakpoints.push_back(bp.ToProtocolBreakpoint());
+    }
   }
   llvm::json::Object body;
   body.try_emplace("breakpoints", std::move(response_breakpoints));


### PR DESCRIPTION
Attempt to improve tests by synchronously waiting for breakpoints to resolve. Not sure if it will fix all the tests but I think it should make the tests more stable