### PR TITLE
[libc++] Remove _LIBCPP_HIDE_FROM_ABI from <string_view>

### DIFF
--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -269,8 +269,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // TODO: This is a workaround for some vendors to carry a downstream diff to accept `nullptr` in
 //       string_view constructors. This can be refactored when this exact form isn't needed anymore.
 template <class _Traits>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR inline size_t
-__char_traits_length_checked(const typename _Traits::char_type* __s) _NOEXCEPT {
+_LIBCPP_CONSTEXPR inline size_t __char_traits_length_checked(const typename _Traits::char_type* __s) _NOEXCEPT {
   // This needs to be a single statement for C++11 constexpr
   return _LIBCPP_ASSERT_NON_NULL(
              __s != nullptr, "null pointer passed to non-null argument of char_traits<...>::length"),
@@ -311,15 +310,13 @@ public:
                 "traits_type::char_type must be the same type as CharT");
 
   // [string.view.cons], construct/copy
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI basic_string_view() _NOEXCEPT : __data_(nullptr), __size_(0) {}
+  _LIBCPP_CONSTEXPR basic_string_view() _NOEXCEPT : __data_(nullptr), __size_(0) {}
 
-  _LIBCPP_HIDE_FROM_ABI basic_string_view(const basic_string_view&) _NOEXCEPT = default;
+  basic_string_view(const basic_string_view&) _NOEXCEPT = default;
 
-  _LIBCPP_HIDE_FROM_ABI basic_string_view& operator=(const basic_string_view&) _NOEXCEPT = default;
+  basic_string_view& operator=(const basic_string_view&) _NOEXCEPT = default;
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI basic_string_view(const _CharT* __s, size_type __len) _NOEXCEPT
-      : __data_(__s),
-        __size_(__len) {
+  _LIBCPP_CONSTEXPR basic_string_view(const _CharT* __s, size_type __len) _NOEXCEPT : __data_(__s), __size_(__len) {
 #  if _LIBCPP_STD_VER >= 14
     // Allocations must fit in `ptrdiff_t` for pointer arithmetic to work. If `__len` exceeds it, the input
     // range could not have been valid. Most likely the caller underflowed some arithmetic and inadvertently
@@ -335,8 +332,7 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   template <contiguous_iterator _It, sized_sentinel_for<_It> _End>
     requires(is_same_v<iter_value_t<_It>, _CharT> && !is_convertible_v<_End, size_type>)
-  constexpr _LIBCPP_HIDE_FROM_ABI basic_string_view(_It __begin, _End __end)
-      : __data_(std::to_address(__begin)), __size_(__end - __begin) {
+  constexpr basic_string_view(_It __begin, _End __end) : __data_(std::to_address(__begin)), __size_(__end - __begin) {
     _LIBCPP_ASSERT_VALID_INPUT_RANGE(
         (__end - __begin) >= 0, "std::string_view::string_view(iterator, sentinel) received invalid range");
   }
@@ -348,11 +344,10 @@ public:
              ranges::sized_range<_Range> && is_same_v<ranges::range_value_t<_Range>, _CharT> &&
              !is_convertible_v<_Range, const _CharT*> &&
              (!requires(remove_cvref_t<_Range>& __d) { __d.operator std::basic_string_view<_CharT, _Traits>(); }))
-  constexpr explicit _LIBCPP_HIDE_FROM_ABI basic_string_view(_Range&& __r)
-      : __data_(ranges::data(__r)), __size_(ranges::size(__r)) {}
+  constexpr explicit basic_string_view(_Range&& __r) : __data_(ranges::data(__r)), __size_(ranges::size(__r)) {}
 #  endif // _LIBCPP_STD_VER >= 23
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI basic_string_view(const _CharT* __s)
+  _LIBCPP_CONSTEXPR basic_string_view(const _CharT* __s)
       : __data_(__s), __size_(std::__char_traits_length_checked<_Traits>(__s)) {}
 
 #  if _LIBCPP_STD_VER >= 23
@@ -360,11 +355,11 @@ public:
 #  endif
 
   // [string.view.iterators], iterators
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_iterator begin() const _NOEXCEPT { return cbegin(); }
+  _LIBCPP_CONSTEXPR const_iterator begin() const _NOEXCEPT { return cbegin(); }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_iterator end() const _NOEXCEPT { return cend(); }
+  _LIBCPP_CONSTEXPR const_iterator end() const _NOEXCEPT { return cend(); }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR const_iterator cbegin() const _NOEXCEPT {
 #  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
     return std::__make_bounded_iter(data(), data(), data() + size());
 #  else
@@ -372,7 +367,7 @@ public:
 #  endif
   }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR const_iterator cend() const _NOEXCEPT {
 #  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
     return std::__make_bounded_iter(data() + size(), data(), data() + size());
 #  else
@@ -380,65 +375,65 @@ public:
 #  endif
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_HIDE_FROM_ABI const_reverse_iterator rbegin() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 const_reverse_iterator rbegin() const _NOEXCEPT {
     return const_reverse_iterator(cend());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_HIDE_FROM_ABI const_reverse_iterator rend() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 const_reverse_iterator rend() const _NOEXCEPT {
     return const_reverse_iterator(cbegin());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_HIDE_FROM_ABI const_reverse_iterator crbegin() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 const_reverse_iterator crbegin() const _NOEXCEPT {
     return const_reverse_iterator(cend());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_HIDE_FROM_ABI const_reverse_iterator crend() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 const_reverse_iterator crend() const _NOEXCEPT {
     return const_reverse_iterator(cbegin());
   }
 
   // [string.view.capacity], capacity
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI size_type size() const _NOEXCEPT { return __size_; }
+  _LIBCPP_CONSTEXPR size_type size() const _NOEXCEPT { return __size_; }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI size_type length() const _NOEXCEPT { return __size_; }
+  _LIBCPP_CONSTEXPR size_type length() const _NOEXCEPT { return __size_; }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR size_type max_size() const _NOEXCEPT {
     return numeric_limits<size_type>::max() / sizeof(value_type);
   }
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool empty() const _NOEXCEPT { return __size_ == 0; }
+  [[__nodiscard__]] _LIBCPP_CONSTEXPR bool empty() const _NOEXCEPT { return __size_ == 0; }
 
   // [string.view.access], element access
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_reference operator[](size_type __pos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR const_reference operator[](size_type __pos) const _NOEXCEPT {
     return _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__pos < size(), "string_view[] index out of bounds"), __data_[__pos];
   }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_reference at(size_type __pos) const {
+  _LIBCPP_CONSTEXPR const_reference at(size_type __pos) const {
     return __pos >= size() ? (__throw_out_of_range("string_view::at"), __data_[0]) : __data_[__pos];
   }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_reference front() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR const_reference front() const _NOEXCEPT {
     return _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "string_view::front(): string is empty"), __data_[0];
   }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_reference back() const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR const_reference back() const _NOEXCEPT {
     return _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "string_view::back(): string is empty"), __data_[__size_ - 1];
   }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_pointer data() const _NOEXCEPT { return __data_; }
+  _LIBCPP_CONSTEXPR const_pointer data() const _NOEXCEPT { return __data_; }
 
   // [string.view.modifiers], modifiers:
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI void remove_prefix(size_type __n) _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 void remove_prefix(size_type __n) _NOEXCEPT {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__n <= size(), "remove_prefix() can't remove more than size()");
     __data_ += __n;
     __size_ -= __n;
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI void remove_suffix(size_type __n) _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 void remove_suffix(size_type __n) _NOEXCEPT {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__n <= size(), "remove_suffix() can't remove more than size()");
     __size_ -= __n;
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI void swap(basic_string_view& __other) _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 void swap(basic_string_view& __other) _NOEXCEPT {
     const value_type* __p = __data_;
     __data_               = __other.__data_;
     __other.__data_       = __p;
@@ -448,8 +443,7 @@ public:
     __other.__size_ = __sz;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type
-  copy(_CharT* __s, size_type __n, size_type __pos = 0) const {
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type copy(_CharT* __s, size_type __n, size_type __pos = 0) const {
     if (__pos > size())
       std::__throw_out_of_range("string_view::copy");
     size_type __rlen = std::min(__n, size() - __pos);
@@ -457,7 +451,7 @@ public:
     return __rlen;
   }
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI basic_string_view substr(size_type __pos = 0, size_type __n = npos) const {
+  _LIBCPP_CONSTEXPR basic_string_view substr(size_type __pos = 0, size_type __n = npos) const {
     // Use the `__assume_valid` form of the constructor to avoid an unnecessary check. Any substring of a view is a
     // valid view. In particular, `size()` is known to be smaller than `numeric_limits<difference_type>::max()`, so the
     // new size is also smaller. See also https://github.com/llvm/llvm-project/issues/91634.
@@ -473,133 +467,117 @@ public:
     return __retval;
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI int
-  compare(size_type __pos1, size_type __n1, basic_string_view __sv) const {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 int compare(size_type __pos1, size_type __n1, basic_string_view __sv) const {
     return substr(__pos1, __n1).compare(__sv);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI int
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 int
   compare(size_type __pos1, size_type __n1, basic_string_view __sv, size_type __pos2, size_type __n2) const {
     return substr(__pos1, __n1).compare(__sv.substr(__pos2, __n2));
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI int compare(const _CharT* __s) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 int compare(const _CharT* __s) const _NOEXCEPT {
     return compare(basic_string_view(__s));
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI int
-  compare(size_type __pos1, size_type __n1, const _CharT* __s) const {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 int compare(size_type __pos1, size_type __n1, const _CharT* __s) const {
     return substr(__pos1, __n1).compare(basic_string_view(__s));
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI int
-  compare(size_type __pos1, size_type __n1, const _CharT* __s, size_type __n2) const {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 int compare(size_type __pos1, size_type __n1, const _CharT* __s, size_type __n2) const {
     return substr(__pos1, __n1).compare(basic_string_view(__s, __n2));
   }
 
   // find
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find(basic_string_view __s, size_type __pos = 0) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find(basic_string_view __s, size_type __pos = 0) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s.size() == 0 || __s.data() != nullptr, "string_view::find(): received nullptr");
     return std::__str_find<value_type, size_type, traits_type, npos>(data(), size(), __s.data(), __pos, __s.size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type find(_CharT __c, size_type __pos = 0) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find(_CharT __c, size_type __pos = 0) const _NOEXCEPT {
     return std::__str_find<value_type, size_type, traits_type, npos>(data(), size(), __c, __pos);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find(const _CharT* __s, size_type __pos, size_type __n) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find(const _CharT* __s, size_type __pos, size_type __n) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "string_view::find(): received nullptr");
     return std::__str_find<value_type, size_type, traits_type, npos>(data(), size(), __s, __pos, __n);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find(const _CharT* __s, size_type __pos = 0) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find(const _CharT* __s, size_type __pos = 0) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s != nullptr, "string_view::find(): received nullptr");
     return std::__str_find<value_type, size_type, traits_type, npos>(
         data(), size(), __s, __pos, traits_type::length(__s));
   }
 
   // rfind
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  rfind(basic_string_view __s, size_type __pos = npos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type rfind(basic_string_view __s, size_type __pos = npos) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s.size() == 0 || __s.data() != nullptr, "string_view::find(): received nullptr");
     return std::__str_rfind<value_type, size_type, traits_type, npos>(data(), size(), __s.data(), __pos, __s.size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  rfind(_CharT __c, size_type __pos = npos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type rfind(_CharT __c, size_type __pos = npos) const _NOEXCEPT {
     return std::__str_rfind<value_type, size_type, traits_type, npos>(data(), size(), __c, __pos);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  rfind(const _CharT* __s, size_type __pos, size_type __n) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type rfind(const _CharT* __s, size_type __pos, size_type __n) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "string_view::rfind(): received nullptr");
     return std::__str_rfind<value_type, size_type, traits_type, npos>(data(), size(), __s, __pos, __n);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  rfind(const _CharT* __s, size_type __pos = npos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type rfind(const _CharT* __s, size_type __pos = npos) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s != nullptr, "string_view::rfind(): received nullptr");
     return std::__str_rfind<value_type, size_type, traits_type, npos>(
         data(), size(), __s, __pos, traits_type::length(__s));
   }
 
   // find_first_of
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_first_of(basic_string_view __s, size_type __pos = 0) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_first_of(basic_string_view __s, size_type __pos = 0) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s.size() == 0 || __s.data() != nullptr, "string_view::find_first_of(): received nullptr");
     return std::__str_find_first_of<value_type, size_type, traits_type, npos>(
         data(), size(), __s.data(), __pos, __s.size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_first_of(_CharT __c, size_type __pos = 0) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_first_of(_CharT __c, size_type __pos = 0) const _NOEXCEPT {
     return find(__c, __pos);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type
   find_first_of(const _CharT* __s, size_type __pos, size_type __n) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "string_view::find_first_of(): received nullptr");
     return std::__str_find_first_of<value_type, size_type, traits_type, npos>(data(), size(), __s, __pos, __n);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_first_of(const _CharT* __s, size_type __pos = 0) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_first_of(const _CharT* __s, size_type __pos = 0) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s != nullptr, "string_view::find_first_of(): received nullptr");
     return std::__str_find_first_of<value_type, size_type, traits_type, npos>(
         data(), size(), __s, __pos, traits_type::length(__s));
   }
 
   // find_last_of
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_last_of(basic_string_view __s, size_type __pos = npos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_last_of(basic_string_view __s, size_type __pos = npos) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s.size() == 0 || __s.data() != nullptr, "string_view::find_last_of(): received nullptr");
     return std::__str_find_last_of<value_type, size_type, traits_type, npos>(
         data(), size(), __s.data(), __pos, __s.size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_last_of(_CharT __c, size_type __pos = npos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_last_of(_CharT __c, size_type __pos = npos) const _NOEXCEPT {
     return rfind(__c, __pos);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type
   find_last_of(const _CharT* __s, size_type __pos, size_type __n) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "string_view::find_last_of(): received nullptr");
     return std::__str_find_last_of<value_type, size_type, traits_type, npos>(data(), size(), __s, __pos, __n);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_last_of(const _CharT* __s, size_type __pos = npos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_last_of(const _CharT* __s, size_type __pos = npos) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s != nullptr, "string_view::find_last_of(): received nullptr");
     return std::__str_find_last_of<value_type, size_type, traits_type, npos>(
         data(), size(), __s, __pos, traits_type::length(__s));
   }
 
   // find_first_not_of
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type
   find_first_not_of(basic_string_view __s, size_type __pos = 0) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(
         __s.size() == 0 || __s.data() != nullptr, "string_view::find_first_not_of(): received nullptr");
@@ -607,26 +585,24 @@ public:
         data(), size(), __s.data(), __pos, __s.size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_first_not_of(_CharT __c, size_type __pos = 0) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_first_not_of(_CharT __c, size_type __pos = 0) const _NOEXCEPT {
     return std::__str_find_first_not_of<value_type, size_type, traits_type, npos>(data(), size(), __c, __pos);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type
   find_first_not_of(const _CharT* __s, size_type __pos, size_type __n) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "string_view::find_first_not_of(): received nullptr");
     return std::__str_find_first_not_of<value_type, size_type, traits_type, npos>(data(), size(), __s, __pos, __n);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_first_not_of(const _CharT* __s, size_type __pos = 0) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_first_not_of(const _CharT* __s, size_type __pos = 0) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s != nullptr, "string_view::find_first_not_of(): received nullptr");
     return std::__str_find_first_not_of<value_type, size_type, traits_type, npos>(
         data(), size(), __s, __pos, traits_type::length(__s));
   }
 
   // find_last_not_of
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type
   find_last_not_of(basic_string_view __s, size_type __pos = npos) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(
         __s.size() == 0 || __s.data() != nullptr, "string_view::find_last_not_of(): received nullptr");
@@ -634,56 +610,46 @@ public:
         data(), size(), __s.data(), __pos, __s.size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_last_not_of(_CharT __c, size_type __pos = npos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_last_not_of(_CharT __c, size_type __pos = npos) const _NOEXCEPT {
     return std::__str_find_last_not_of<value_type, size_type, traits_type, npos>(data(), size(), __c, __pos);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type
   find_last_not_of(const _CharT* __s, size_type __pos, size_type __n) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "string_view::find_last_not_of(): received nullptr");
     return std::__str_find_last_not_of<value_type, size_type, traits_type, npos>(data(), size(), __s, __pos, __n);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI size_type
-  find_last_not_of(const _CharT* __s, size_type __pos = npos) const _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 size_type find_last_not_of(const _CharT* __s, size_type __pos = npos) const _NOEXCEPT {
     _LIBCPP_ASSERT_NON_NULL(__s != nullptr, "string_view::find_last_not_of(): received nullptr");
     return std::__str_find_last_not_of<value_type, size_type, traits_type, npos>(
         data(), size(), __s, __pos, traits_type::length(__s));
   }
 
 #  if _LIBCPP_STD_VER >= 20
-  constexpr _LIBCPP_HIDE_FROM_ABI bool starts_with(basic_string_view __s) const noexcept {
+  constexpr bool starts_with(basic_string_view __s) const noexcept {
     return size() >= __s.size() && compare(0, __s.size(), __s) == 0;
   }
 
-  constexpr _LIBCPP_HIDE_FROM_ABI bool starts_with(value_type __c) const noexcept {
-    return !empty() && _Traits::eq(front(), __c);
-  }
+  constexpr bool starts_with(value_type __c) const noexcept { return !empty() && _Traits::eq(front(), __c); }
 
-  constexpr _LIBCPP_HIDE_FROM_ABI bool starts_with(const value_type* __s) const noexcept {
-    return starts_with(basic_string_view(__s));
-  }
+  constexpr bool starts_with(const value_type* __s) const noexcept { return starts_with(basic_string_view(__s)); }
 
-  constexpr _LIBCPP_HIDE_FROM_ABI bool ends_with(basic_string_view __s) const noexcept {
+  constexpr bool ends_with(basic_string_view __s) const noexcept {
     return size() >= __s.size() && compare(size() - __s.size(), npos, __s) == 0;
   }
 
-  constexpr _LIBCPP_HIDE_FROM_ABI bool ends_with(value_type __c) const noexcept {
-    return !empty() && _Traits::eq(back(), __c);
-  }
+  constexpr bool ends_with(value_type __c) const noexcept { return !empty() && _Traits::eq(back(), __c); }
 
-  constexpr _LIBCPP_HIDE_FROM_ABI bool ends_with(const value_type* __s) const noexcept {
-    return ends_with(basic_string_view(__s));
-  }
+  constexpr bool ends_with(const value_type* __s) const noexcept { return ends_with(basic_string_view(__s)); }
 #  endif
 
 #  if _LIBCPP_STD_VER >= 23
-  constexpr _LIBCPP_HIDE_FROM_ABI bool contains(basic_string_view __sv) const noexcept { return find(__sv) != npos; }
+  constexpr bool contains(basic_string_view __sv) const noexcept { return find(__sv) != npos; }
 
-  constexpr _LIBCPP_HIDE_FROM_ABI bool contains(value_type __c) const noexcept { return find(__c) != npos; }
+  constexpr bool contains(value_type __c) const noexcept { return find(__c) != npos; }
 
-  constexpr _LIBCPP_HIDE_FROM_ABI bool contains(const value_type* __s) const { return find(__s) != npos; }
+  constexpr bool contains(const value_type* __s) const { return find(__s) != npos; }
 #  endif
 
 private:
@@ -692,8 +658,7 @@ private:
   // This is the same as the pointer and length constructor, but without the additional hardening checks. It is intended
   // for use within the class, when the class invariants already guarantee the resulting object is valid. The compiler
   // usually cannot eliminate the redundant checks because it does not know class invariants.
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
-  basic_string_view(__assume_valid, const _CharT* __s, size_type __len) _NOEXCEPT
+  _LIBCPP_CONSTEXPR basic_string_view(__assume_valid, const _CharT* __s, size_type __len) _NOEXCEPT
       : __data_(__s),
         __size_(__len) {}
 
@@ -730,9 +695,8 @@ basic_string_view(_Range) -> basic_string_view<ranges::range_value_t<_Range>>;
 // The dummy default template parameters are used to work around a MSVC issue with mangling, see VSO-409326 for details.
 // This applies to the other sufficient overloads below for the other comparison operators.
 template <class _CharT, class _Traits, int = 1>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator==(basic_string_view<_CharT, _Traits> __lhs,
-           __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator==(basic_string_view<_CharT, _Traits> __lhs,
+                                              __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
   if (__lhs.size() != __rhs.size())
     return false;
   return __lhs.compare(__rhs) == 0;
@@ -741,8 +705,8 @@ operator==(basic_string_view<_CharT, _Traits> __lhs,
 #  if _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI constexpr auto operator<=>(basic_string_view<_CharT, _Traits> __lhs,
-                                                 type_identity_t<basic_string_view<_CharT, _Traits>> __rhs) noexcept {
+constexpr auto operator<=>(basic_string_view<_CharT, _Traits> __lhs,
+                           type_identity_t<basic_string_view<_CharT, _Traits>> __rhs) noexcept {
   if constexpr (requires { typename _Traits::comparison_category; }) {
     // [string.view]/4
     static_assert(
@@ -758,7 +722,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto operator<=>(basic_string_view<_CharT, _Trai
 // operator ==
 
 template <class _CharT, class _Traits>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator==(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   if (__lhs.size() != __rhs.size())
     return false;
@@ -766,127 +730,116 @@ operator==(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _
 }
 
 template <class _CharT, class _Traits, int = 2>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator==(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
-           basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator==(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
+                                              basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs == __rhs;
 }
 
 // operator !=
 template <class _CharT, class _Traits>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator!=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return !(__lhs == __rhs);
 }
 
 template <class _CharT, class _Traits, int = 1>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator!=(basic_string_view<_CharT, _Traits> __lhs,
-           __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator!=(basic_string_view<_CharT, _Traits> __lhs,
+                                              __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
   return !(__lhs == __rhs);
 }
 
 template <class _CharT, class _Traits, int = 2>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator!=(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
-           basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator!=(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
+                                              basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return !(__lhs == __rhs);
 }
 
 // operator <
 template <class _CharT, class _Traits>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator<(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) < 0;
 }
 
 template <class _CharT, class _Traits, int = 1>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator<(basic_string_view<_CharT, _Traits> __lhs,
-          __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator<(basic_string_view<_CharT, _Traits> __lhs,
+                                             __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) < 0;
 }
 
 template <class _CharT, class _Traits, int = 2>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator<(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
-          basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator<(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
+                                             basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) < 0;
 }
 
 // operator >
 template <class _CharT, class _Traits>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator>(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) > 0;
 }
 
 template <class _CharT, class _Traits, int = 1>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator>(basic_string_view<_CharT, _Traits> __lhs,
-          __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator>(basic_string_view<_CharT, _Traits> __lhs,
+                                             __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) > 0;
 }
 
 template <class _CharT, class _Traits, int = 2>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator>(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
-          basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator>(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
+                                             basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) > 0;
 }
 
 // operator <=
 template <class _CharT, class _Traits>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator<=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) <= 0;
 }
 
 template <class _CharT, class _Traits, int = 1>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator<=(basic_string_view<_CharT, _Traits> __lhs,
-           __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator<=(basic_string_view<_CharT, _Traits> __lhs,
+                                              __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) <= 0;
 }
 
 template <class _CharT, class _Traits, int = 2>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator<=(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
-           basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator<=(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
+                                              basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) <= 0;
 }
 
 // operator >=
 template <class _CharT, class _Traits>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator>=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) >= 0;
 }
 
 template <class _CharT, class _Traits, int = 1>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator>=(basic_string_view<_CharT, _Traits> __lhs,
-           __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator>=(basic_string_view<_CharT, _Traits> __lhs,
+                                              __type_identity_t<basic_string_view<_CharT, _Traits> > __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) >= 0;
 }
 
 template <class _CharT, class _Traits, int = 2>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
-operator>=(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
-           basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator>=(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
+                                              basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT {
   return __lhs.compare(__rhs) >= 0;
 }
 
 #  endif //  _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
+basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, basic_string_view<_CharT, _Traits> __str);
 
 // [string.view.hash]
 template <class _CharT>
 struct __string_view_hash : public __unary_function<basic_string_view<_CharT, char_traits<_CharT> >, size_t> {
-  _LIBCPP_HIDE_FROM_ABI size_t operator()(const basic_string_view<_CharT, char_traits<_CharT> > __val) const _NOEXCEPT {
+  size_t operator()(const basic_string_view<_CharT, char_traits<_CharT> > __val) const _NOEXCEPT {
     return std::__do_string_hash(__val.data(), __val.data() + __val.size());
   }
 };
@@ -913,31 +866,27 @@ struct hash<basic_string_view<wchar_t, char_traits<wchar_t> > > : __string_view_
 #  if _LIBCPP_STD_VER >= 14
 inline namespace literals {
 inline namespace string_view_literals {
-inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char> operator""sv(const char* __str, size_t __len) noexcept {
+inline constexpr basic_string_view<char> operator""sv(const char* __str, size_t __len) noexcept {
   return basic_string_view<char>(__str, __len);
 }
 
 #    if _LIBCPP_HAS_WIDE_CHARACTERS
-inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<wchar_t>
-operator""sv(const wchar_t* __str, size_t __len) noexcept {
+inline constexpr basic_string_view<wchar_t> operator""sv(const wchar_t* __str, size_t __len) noexcept {
   return basic_string_view<wchar_t>(__str, __len);
 }
 #    endif
 
 #    if _LIBCPP_HAS_CHAR8_T
-inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char8_t>
-operator""sv(const char8_t* __str, size_t __len) noexcept {
+inline constexpr basic_string_view<char8_t> operator""sv(const char8_t* __str, size_t __len) noexcept {
   return basic_string_view<char8_t>(__str, __len);
 }
 #    endif
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char16_t>
-operator""sv(const char16_t* __str, size_t __len) noexcept {
+inline constexpr basic_string_view<char16_t> operator""sv(const char16_t* __str, size_t __len) noexcept {
   return basic_string_view<char16_t>(__str, __len);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char32_t>
-operator""sv(const char32_t* __str, size_t __len) noexcept {
+inline constexpr basic_string_view<char32_t> operator""sv(const char32_t* __str, size_t __len) noexcept {
   return basic_string_view<char32_t>(__str, __len);
 }
 } // namespace string_view_literals


### PR DESCRIPTION
After #131156 we don't need `_LIBCPP_HIDE_FROM_ABI` everywhere anymore. This removes the now unnecessary annotations from `<string_view>`.
