### PR TITLE
[libc++] Remove _LIBCPP_HIDE_FROM_ABI from <ranges> and its subheaders

### DIFF
--- a/libcxx/include/__ranges/access.h
+++ b/libcxx/include/__ranges/access.h
@@ -55,14 +55,14 @@ concept __unqualified_begin =
 
 struct __fn {
   template <class _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp (&__t)[]) const noexcept
+  [[nodiscard]] constexpr auto operator()(_Tp (&__t)[]) const noexcept
     requires(sizeof(_Tp) >= 0) // Disallow incomplete element types.
   {
     return __t + 0;
   }
 
   template <class _Tp, size_t _Np>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp (&__t)[_Np]) const noexcept
+  [[nodiscard]] constexpr auto operator()(_Tp (&__t)[_Np]) const noexcept
     requires(sizeof(_Tp) >= 0) // Disallow incomplete element types.
   {
     return __t + 0;
@@ -70,15 +70,13 @@ struct __fn {
 
   template <class _Tp>
     requires __member_begin<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.begin()))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.begin()))) {
     return _LIBCPP_AUTO_CAST(__t.begin());
   }
 
   template <class _Tp>
     requires __unqualified_begin<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(begin(__t)))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(begin(__t)))) {
     return _LIBCPP_AUTO_CAST(begin(__t));
   }
 
@@ -119,7 +117,7 @@ concept __unqualified_end =
 
 struct __fn {
   template <class _Tp, size_t _Np>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp (&__t)[_Np]) const noexcept
+  [[nodiscard]] constexpr auto operator()(_Tp (&__t)[_Np]) const noexcept
     requires(sizeof(_Tp) >= 0) // Disallow incomplete element types.
   {
     return __t + _Np;
@@ -127,15 +125,13 @@ struct __fn {
 
   template <class _Tp>
     requires __member_end<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.end()))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.end()))) {
     return _LIBCPP_AUTO_CAST(__t.end());
   }
 
   template <class _Tp>
     requires __unqualified_end<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(end(__t)))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(end(__t)))) {
     return _LIBCPP_AUTO_CAST(end(__t));
   }
 
@@ -155,7 +151,7 @@ namespace __cbegin {
 struct __fn {
   template <class _Tp>
     requires is_lvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t))))
           -> decltype(ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t))) {
     return ranges::begin(static_cast<const remove_reference_t<_Tp>&>(__t));
@@ -163,7 +159,7 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::begin(static_cast<const _Tp&&>(__t))))
           -> decltype(ranges::begin(static_cast<const _Tp&&>(__t))) {
     return ranges::begin(static_cast<const _Tp&&>(__t));
@@ -183,7 +179,7 @@ namespace __cend {
 struct __fn {
   template <class _Tp>
     requires is_lvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t))))
           -> decltype(ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t))) {
     return ranges::end(static_cast<const remove_reference_t<_Tp>&>(__t));
@@ -191,8 +187,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::end(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::end(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::end(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::end(static_cast<const _Tp&&>(__t))) {
     return ranges::end(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/all.h
+++ b/libcxx/include/__ranges/all.h
@@ -39,14 +39,14 @@ namespace __all {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Tp>
     requires ranges::view<decay_t<_Tp>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t)))) -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))))
+      -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))) {
     return _LIBCPP_AUTO_CAST(std::forward<_Tp>(__t));
   }
 
   template <class _Tp>
     requires(!ranges::view<decay_t<_Tp>>) && requires(_Tp&& __t) { ranges::ref_view{std::forward<_Tp>(__t)}; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::ref_view{std::forward<_Tp>(__t)})) {
     return ranges::ref_view{std::forward<_Tp>(__t)};
   }
@@ -55,7 +55,7 @@ struct __fn : __range_adaptor_closure<__fn> {
     requires(
         !ranges::view<decay_t<_Tp>> && !requires(_Tp&& __t) { ranges::ref_view{std::forward<_Tp>(__t)}; } &&
         requires(_Tp&& __t) { ranges::owning_view{std::forward<_Tp>(__t)}; })
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::owning_view{std::forward<_Tp>(__t)})) {
     return ranges::owning_view{std::forward<_Tp>(__t)};
   }

--- a/libcxx/include/__ranges/as_rvalue_view.h
+++ b/libcxx/include/__ranges/as_rvalue_view.h
@@ -42,33 +42,33 @@ class as_rvalue_view : public view_interface<as_rvalue_view<_View>> {
   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_ = _View();
 
 public:
-  _LIBCPP_HIDE_FROM_ABI as_rvalue_view()
+  as_rvalue_view()
     requires default_initializable<_View>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit as_rvalue_view(_View __base) : __base_(std::move(__base)) {}
+  constexpr explicit as_rvalue_view(_View __base) : __base_(std::move(__base)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
+  constexpr auto begin()
     requires(!__simple_view<_View>)
   {
     return move_iterator(ranges::begin(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires range<const _View>
   {
     return move_iterator(ranges::begin(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  constexpr auto end()
     requires(!__simple_view<_View>)
   {
     if constexpr (common_range<_View>) {
@@ -78,7 +78,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires range<const _View>
   {
     if constexpr (common_range<const _View>) {
@@ -88,13 +88,13 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires sized_range<_View>
   {
     return ranges::size(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<const _View>
   {
     return ranges::size(__base_);
@@ -111,7 +111,7 @@ namespace views {
 namespace __as_rvalue {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto
+  [[nodiscard]] static constexpr auto
   operator()(_Range&& __range) noexcept(noexcept(as_rvalue_view(std::forward<_Range>(__range))))
       -> decltype(/*--------------------------*/ as_rvalue_view(std::forward<_Range>(__range))) {
     return /*---------------------------------*/ as_rvalue_view(std::forward<_Range>(__range));
@@ -119,7 +119,7 @@ struct __fn : __range_adaptor_closure<__fn> {
 
   template <class _Range>
     requires same_as<range_rvalue_reference_t<_Range>, range_reference_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto
+  [[nodiscard]] static constexpr auto
   operator()(_Range&& __range) noexcept(noexcept(views::all(std::forward<_Range>(__range))))
       -> decltype(/*--------------------------*/ views::all(std::forward<_Range>(__range))) {
     return /*---------------------------------*/ views::all(std::forward<_Range>(__range));

--- a/libcxx/include/__ranges/chunk_by_view.h
+++ b/libcxx/include/__ranges/chunk_by_view.h
@@ -64,7 +64,7 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS chunk_by_view : public view_interface
 
   class __iterator;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_View> __find_next(iterator_t<_View> __current) {
+  constexpr iterator_t<_View> __find_next(iterator_t<_View> __current) {
     // Note: this duplicates a check in `optional` but provides a better error message.
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __pred_.__has_value(), "Trying to call __find_next() on a chunk_by_view that does not have a valid predicate.");
@@ -75,7 +75,7 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS chunk_by_view : public view_interface
         ranges::adjacent_find(__current, ranges::end(__base_), __reversed_pred), 1, ranges::end(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_View> __find_prev(iterator_t<_View> __current)
+  constexpr iterator_t<_View> __find_prev(iterator_t<_View> __current)
     requires bidirectional_range<_View>
   {
     // Attempting to decrement a begin iterator is a no-op (`__find_prev` would return the same argument given to it).
@@ -93,24 +93,24 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS chunk_by_view : public view_interface
   }
 
 public:
-  _LIBCPP_HIDE_FROM_ABI chunk_by_view()
+  chunk_by_view()
     requires default_initializable<_View> && default_initializable<_Pred>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit chunk_by_view(_View __base, _Pred __pred)
+  constexpr explicit chunk_by_view(_View __base, _Pred __pred)
       : __base_(std::move(__base)), __pred_(in_place, std::move(__pred)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Pred& pred() const { return *__pred_; }
+  constexpr const _Pred& pred() const { return *__pred_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator begin() {
+  constexpr __iterator begin() {
     // Note: this duplicates a check in `optional` but provides a better error message.
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __pred_.__has_value(), "Trying to call begin() on a chunk_by_view that does not have a valid predicate.");
@@ -122,7 +122,7 @@ public:
     return {*this, std::move(__first), *__cached_begin_};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() {
+  constexpr auto end() {
     if constexpr (common_range<_View>) {
       return __iterator{*this, ranges::end(__base_), ranges::end(__base_)};
     } else {
@@ -143,8 +143,7 @@ class chunk_by_view<_View, _Pred>::__iterator {
   _LIBCPP_NO_UNIQUE_ADDRESS iterator_t<_View> __current_ = iterator_t<_View>();
   _LIBCPP_NO_UNIQUE_ADDRESS iterator_t<_View> __next_    = iterator_t<_View>();
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(
-      chunk_by_view& __parent, iterator_t<_View> __current, iterator_t<_View> __next)
+  constexpr __iterator(chunk_by_view& __parent, iterator_t<_View> __current, iterator_t<_View> __next)
       : __parent_(std::addressof(__parent)), __current_(__current), __next_(__next) {}
 
 public:
@@ -153,16 +152,16 @@ public:
   using iterator_category = input_iterator_tag;
   using iterator_concept  = conditional_t<bidirectional_range<_View>, bidirectional_iterator_tag, forward_iterator_tag>;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator() = default;
+  __iterator() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr value_type operator*() const {
+  constexpr value_type operator*() const {
     // If the iterator is at end, this would return an empty range which can be checked by the calling code and doesn't
     // necessarily lead to a bad access.
     _LIBCPP_ASSERT_PEDANTIC(__current_ != __next_, "Trying to dereference past-the-end chunk_by_view iterator.");
     return {__current_, __next_};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+  constexpr __iterator& operator++() {
     // Attempting to increment an end iterator is a no-op (`__find_next` would return the same argument given to it).
     _LIBCPP_ASSERT_PEDANTIC(__current_ != __next_, "Trying to increment past end chunk_by_view iterator.");
     __current_ = __next_;
@@ -170,13 +169,13 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int) {
+  constexpr __iterator operator++(int) {
     auto __tmp = *this;
     ++*this;
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator--()
+  constexpr __iterator& operator--()
     requires bidirectional_range<_View>
   {
     __next_    = __current_;
@@ -184,7 +183,7 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator--(int)
+  constexpr __iterator operator--(int)
     requires bidirectional_range<_View>
   {
     auto __tmp = *this;
@@ -192,20 +191,18 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y) {
+  friend constexpr bool operator==(const __iterator& __x, const __iterator& __y) {
     return __x.__current_ == __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, default_sentinel_t) {
-    return __x.__current_ == __x.__next_;
-  }
+  friend constexpr bool operator==(const __iterator& __x, default_sentinel_t) { return __x.__current_ == __x.__next_; }
 };
 
 namespace views {
 namespace __chunk_by {
 struct __fn {
   template <class _Range, class _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Pred&& __pred) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Pred&& __pred) const
       noexcept(noexcept(/**/ chunk_by_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred))))
           -> decltype(/*--*/ chunk_by_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred))) {
     return /*-------------*/ chunk_by_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred));
@@ -213,7 +210,7 @@ struct __fn {
 
   template <class _Pred>
     requires constructible_from<decay_t<_Pred>, _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Pred&& __pred) const
+  [[nodiscard]] constexpr auto operator()(_Pred&& __pred) const
       noexcept(is_nothrow_constructible_v<decay_t<_Pred>, _Pred>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Pred>(__pred)));
   }

--- a/libcxx/include/__ranges/common_view.h
+++ b/libcxx/include/__ranges/common_view.h
@@ -44,28 +44,28 @@ class common_view : public view_interface<common_view<_View>> {
   _View __base_ = _View();
 
 public:
-  _LIBCPP_HIDE_FROM_ABI common_view()
+  common_view()
     requires default_initializable<_View>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit common_view(_View __v) : __base_(std::move(__v)) {}
+  constexpr explicit common_view(_View __v) : __base_(std::move(__v)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() {
+  constexpr auto begin() {
     if constexpr (random_access_range<_View> && sized_range<_View>)
       return ranges::begin(__base_);
     else
       return common_iterator<iterator_t<_View>, sentinel_t<_View>>(ranges::begin(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires range<const _View>
   {
     if constexpr (random_access_range<const _View> && sized_range<const _View>)
@@ -74,14 +74,14 @@ public:
       return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>(ranges::begin(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() {
+  constexpr auto end() {
     if constexpr (random_access_range<_View> && sized_range<_View>)
       return ranges::begin(__base_) + ranges::size(__base_);
     else
       return common_iterator<iterator_t<_View>, sentinel_t<_View>>(ranges::end(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires range<const _View>
   {
     if constexpr (random_access_range<const _View> && sized_range<const _View>)
@@ -90,13 +90,13 @@ public:
       return common_iterator<iterator_t<const _View>, sentinel_t<const _View>>(ranges::end(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires sized_range<_View>
   {
     return ranges::size(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<const _View>
   {
     return ranges::size(__base_);
@@ -114,14 +114,16 @@ namespace __common {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires common_range<_Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(
-      noexcept(views::all(std::forward<_Range>(__range)))) -> decltype(views::all(std::forward<_Range>(__range))) {
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(views::all(std::forward<_Range>(__range))))
+          -> decltype(views::all(std::forward<_Range>(__range))) {
     return views::all(std::forward<_Range>(__range));
   }
 
   template <class _Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(noexcept(common_view{
-      std::forward<_Range>(__range)})) -> decltype(common_view{std::forward<_Range>(__range)}) {
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(common_view{std::forward<_Range>(__range)}))
+          -> decltype(common_view{std::forward<_Range>(__range)}) {
     return common_view{std::forward<_Range>(__range)};
   }
 };

--- a/libcxx/include/__ranges/counted.h
+++ b/libcxx/include/__ranges/counted.h
@@ -42,7 +42,7 @@ namespace __counted {
 
 struct __fn {
   template <contiguous_iterator _It>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto
+  static constexpr auto
   __go(_It __it,
        iter_difference_t<_It> __count) noexcept(noexcept(span(std::to_address(__it), static_cast<size_t>(__count))))
   // Deliberately omit return-type SFINAE, because to_address is not SFINAE-friendly
@@ -51,13 +51,14 @@ struct __fn {
   }
 
   template <random_access_iterator _It>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_It __it, iter_difference_t<_It> __count) noexcept(
-      noexcept(subrange(__it, __it + __count))) -> decltype(subrange(__it, __it + __count)) {
+  static constexpr auto
+  __go(_It __it, iter_difference_t<_It> __count) noexcept(noexcept(subrange(__it, __it + __count)))
+      -> decltype(subrange(__it, __it + __count)) {
     return subrange(__it, __it + __count);
   }
 
   template <class _It>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_It __it, iter_difference_t<_It> __count) noexcept(
+  static constexpr auto __go(_It __it, iter_difference_t<_It> __count) noexcept(
       noexcept(subrange(counted_iterator(std::move(__it), __count), default_sentinel)))
       -> decltype(subrange(counted_iterator(std::move(__it), __count), default_sentinel)) {
     return subrange(counted_iterator(std::move(__it), __count), default_sentinel);
@@ -65,7 +66,7 @@ struct __fn {
 
   template <class _It, convertible_to<iter_difference_t<_It>> _Diff>
     requires input_or_output_iterator<decay_t<_It>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_It&& __it, _Diff&& __count) const
+  [[nodiscard]] constexpr auto operator()(_It&& __it, _Diff&& __count) const
       noexcept(noexcept(__go(std::forward<_It>(__it), std::forward<_Diff>(__count))))
           -> decltype(__go(std::forward<_It>(__it), std::forward<_Diff>(__count))) {
     return __go(std::forward<_It>(__it), std::forward<_Diff>(__count));

--- a/libcxx/include/__ranges/dangling.h
+++ b/libcxx/include/__ranges/dangling.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct dangling {
   dangling() = default;
-  _LIBCPP_HIDE_FROM_ABI constexpr dangling(auto&&...) noexcept {}
+  constexpr dangling(auto&&...) noexcept {}
 };
 
 template <range _Rp>

--- a/libcxx/include/__ranges/data.h
+++ b/libcxx/include/__ranges/data.h
@@ -51,13 +51,12 @@ concept __ranges_begin_invocable = !__member_data<_Tp> && __can_borrow<_Tp> && r
 
 struct __fn {
   template <__member_data _Tp>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(__t.data())) {
+  constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(__t.data())) {
     return __t.data();
   }
 
   template <__ranges_begin_invocable _Tp>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(std::to_address(ranges::begin(__t)))) {
+  constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(std::to_address(ranges::begin(__t)))) {
     return std::to_address(ranges::begin(__t));
   }
 };
@@ -75,7 +74,7 @@ namespace __cdata {
 struct __fn {
   template <class _Tp>
     requires is_lvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t))))
           -> decltype(ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t))) {
     return ranges::data(static_cast<const remove_reference_t<_Tp>&>(__t));
@@ -83,8 +82,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::data(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::data(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::data(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::data(static_cast<const _Tp&&>(__t))) {
     return ranges::data(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/drop_view.h
+++ b/libcxx/include/__ranges/drop_view.h
@@ -70,24 +70,23 @@ class drop_view : public view_interface<drop_view<_View>> {
   _View __base_                                    = _View();
 
 public:
-  _LIBCPP_HIDE_FROM_ABI drop_view()
+  drop_view()
     requires default_initializable<_View>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23
-  drop_view(_View __base, range_difference_t<_View> __count)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 drop_view(_View __base, range_difference_t<_View> __count)
       : __count_(__count), __base_(std::move(__base)) {
     _LIBCPP_ASSERT_UNCATEGORIZED(__count_ >= 0, "count must be greater than or equal to zero.");
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
+  constexpr auto begin()
     requires(!(__simple_view<_View> && random_access_range<const _View> && sized_range<const _View>))
   {
     if constexpr (random_access_range<_View> && sized_range<_View>) {
@@ -104,38 +103,38 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires random_access_range<const _View> && sized_range<const _View>
   {
     const auto __dist = std::min(ranges::distance(__base_), __count_);
     return ranges::begin(__base_) + __dist;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  constexpr auto end()
     requires(!__simple_view<_View>)
   {
     return ranges::end(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires range<const _View>
   {
     return ranges::end(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __size(auto& __self) {
+  static constexpr auto __size(auto& __self) {
     const auto __s = ranges::size(__self.__base_);
     const auto __c = static_cast<decltype(__s)>(__self.__count_);
     return __s < __c ? 0 : __s - __c;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires sized_range<_View>
   {
     return __size(*this);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<const _View>
   {
     return __size(*this);
@@ -210,7 +209,7 @@ struct __fn {
   // [range.drop.overview]: the `empty_view` case.
   template <class _Range, convertible_to<range_difference_t<_Range>> _Np>
     requires __is_empty_view<remove_cvref_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&&) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Np&&) const
       noexcept(noexcept(_LIBCPP_AUTO_CAST(std::forward<_Range>(__range))))
           -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Range>(__range))) {
     return _LIBCPP_AUTO_CAST(std::forward<_Range>(__range));
@@ -223,7 +222,7 @@ struct __fn {
             class _Dist     = range_difference_t<_Range>>
     requires(!__is_empty_view<_RawRange> && random_access_range<_RawRange> && sized_range<_RawRange> &&
              __is_passthrough_specialization<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __rng, _Np&& __n) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __rng, _Np&& __n) const
       noexcept(noexcept(__passthrough_type_t<_RawRange>(
           ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)), ranges::end(__rng))))
           -> decltype(__passthrough_type_t<_RawRange>(
@@ -241,11 +240,11 @@ struct __fn {
             class _Dist     = range_difference_t<_Range>>
     requires(!__is_empty_view<_RawRange> && random_access_range<_RawRange> && sized_range<_RawRange> &&
              __is_subrange_specialization_with_store_size<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __rng, _Np&& __n) const noexcept(noexcept(
-      _RawRange(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)),
-                ranges::end(__rng),
-                std::__to_unsigned_like(ranges::distance(__rng) -
-                                        std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n))))))
+  [[nodiscard]] constexpr auto operator()(_Range&& __rng, _Np&& __n) const noexcept(noexcept(_RawRange(
+      ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)),
+      ranges::end(__rng),
+      std::__to_unsigned_like(ranges::distance(__rng) -
+                              std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n))))))
       -> decltype(_RawRange(
           // Note: deliberately not forwarding `__rng` to guard against double moves.
           ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)),
@@ -266,7 +265,7 @@ struct __fn {
             class _RawRange = remove_cvref_t<_Range>,
             class _Dist     = range_difference_t<_Range>>
     requires (__is_repeat_specialization<_RawRange> && sized_range<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&& __n) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Np&& __n) const
     noexcept(noexcept(views::repeat(*__range.__value_, ranges::distance(__range) - std::min<_Dist>(ranges::distance(__range), std::forward<_Np>(__n)))))
     -> decltype(      views::repeat(*__range.__value_, ranges::distance(__range) - std::min<_Dist>(ranges::distance(__range), std::forward<_Np>(__n))))
     { return          views::repeat(*__range.__value_, ranges::distance(__range) - std::min<_Dist>(ranges::distance(__range), std::forward<_Np>(__n))); }
@@ -277,8 +276,7 @@ struct __fn {
             class _RawRange = remove_cvref_t<_Range>,
             class _Dist     = range_difference_t<_Range>>
     requires (__is_repeat_specialization<_RawRange> && !sized_range<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI
-  constexpr auto operator()(_Range&& __range, _Np&&) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Np&&) const
     noexcept(noexcept(_LIBCPP_AUTO_CAST(std::forward<_Range>(__range))))
     -> decltype(      _LIBCPP_AUTO_CAST(std::forward<_Range>(__range)))
     { return          _LIBCPP_AUTO_CAST(std::forward<_Range>(__range)); }
@@ -289,15 +287,15 @@ struct __fn {
   template <class _Range, convertible_to<range_difference_t<_Range>> _Np, class _RawRange = remove_cvref_t<_Range>>
   // Note: without specifically excluding the other cases, GCC sees this overload as ambiguous with the other
   // overloads.
-    requires(!(__is_empty_view<_RawRange> ||
+    requires(
+        !(__is_empty_view<_RawRange> ||
 #  if _LIBCPP_STD_VER >= 23
-               __is_repeat_specialization<_RawRange> ||
+          __is_repeat_specialization<_RawRange> ||
 #  endif
-               (__is_subrange_specialization_with_store_size<_RawRange> && sized_range<_RawRange> &&
-                random_access_range<_RawRange>) ||
-               (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> &&
-                random_access_range<_RawRange>)))
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&& __n) const
+          (__is_subrange_specialization_with_store_size<_RawRange> && sized_range<_RawRange> &&
+           random_access_range<_RawRange>) ||
+          (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> && random_access_range<_RawRange>)))
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Np&& __n) const
       noexcept(noexcept(drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n))))
           -> decltype(drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n))) {
     return drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n));
@@ -305,8 +303,7 @@ struct __fn {
 
   template <class _Np>
     requires constructible_from<decay_t<_Np>, _Np>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Np&& __n) const
-      noexcept(is_nothrow_constructible_v<decay_t<_Np>, _Np>) {
+  [[nodiscard]] constexpr auto operator()(_Np&& __n) const noexcept(is_nothrow_constructible_v<decay_t<_Np>, _Np>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Np>(__n)));
   }
 };

--- a/libcxx/include/__ranges/drop_while_view.h
+++ b/libcxx/include/__ranges/drop_while_view.h
@@ -50,24 +50,24 @@ template <view _View, class _Pred>
   requires input_range<_View> && is_object_v<_Pred> && indirect_unary_predicate<const _Pred, iterator_t<_View>>
 class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS drop_while_view : public view_interface<drop_while_view<_View, _Pred>> {
 public:
-  _LIBCPP_HIDE_FROM_ABI drop_while_view()
+  drop_while_view()
     requires default_initializable<_View> && default_initializable<_Pred>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 drop_while_view(_View __base, _Pred __pred)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 drop_while_view(_View __base, _Pred __pred)
       : __base_(std::move(__base)), __pred_(std::in_place, std::move(__pred)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Pred& pred() const { return *__pred_; }
+  constexpr const _Pred& pred() const { return *__pred_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() {
+  constexpr auto begin() {
     // Note: this duplicates a check in `optional` but provides a better error message.
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __pred_.__has_value(),
@@ -83,7 +83,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() { return ranges::end(__base_); }
+  constexpr auto end() { return ranges::end(__base_); }
 
 private:
   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_ = _View();
@@ -105,7 +105,7 @@ namespace __drop_while {
 
 struct __fn {
   template <class _Range, class _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Pred&& __pred) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Pred&& __pred) const
       noexcept(noexcept(/**/ drop_while_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred))))
           -> decltype(/*--*/ drop_while_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred))) {
     return /*-------------*/ drop_while_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred));
@@ -113,7 +113,7 @@ struct __fn {
 
   template <class _Pred>
     requires constructible_from<decay_t<_Pred>, _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Pred&& __pred) const
+  [[nodiscard]] constexpr auto operator()(_Pred&& __pred) const
       noexcept(is_nothrow_constructible_v<decay_t<_Pred>, _Pred>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Pred>(__pred)));
   }

--- a/libcxx/include/__ranges/elements_view.h
+++ b/libcxx/include/__ranges/elements_view.h
@@ -71,63 +71,63 @@ private:
   class __sentinel;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI elements_view()
+  elements_view()
     requires default_initializable<_View>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit elements_view(_View __base) : __base_(std::move(__base)) {}
+  constexpr explicit elements_view(_View __base) : __base_(std::move(__base)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
+  constexpr auto begin()
     requires(!__simple_view<_View>)
   {
     return __iterator</*_Const=*/false>(ranges::begin(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires range<const _View>
   {
     return __iterator</*_Const=*/true>(ranges::begin(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  constexpr auto end()
     requires(!__simple_view<_View> && !common_range<_View>)
   {
     return __sentinel</*_Const=*/false>{ranges::end(__base_)};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  constexpr auto end()
     requires(!__simple_view<_View> && common_range<_View>)
   {
     return __iterator</*_Const=*/false>{ranges::end(__base_)};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires range<const _View>
   {
     return __sentinel</*_Const=*/true>{ranges::end(__base_)};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires common_range<const _View>
   {
     return __iterator</*_Const=*/true>{ranges::end(__base_)};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires sized_range<_View>
   {
     return ranges::size(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<const _View>
   {
     return ranges::size(__base_);
@@ -175,7 +175,7 @@ class elements_view<_View, _Np>::__iterator
 
   iterator_t<_Base> __current_ = iterator_t<_Base>();
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr decltype(auto) __get_element(const iterator_t<_Base>& __i) {
+  static constexpr decltype(auto) __get_element(const iterator_t<_Base>& __i) {
     if constexpr (is_reference_v<range_reference_t<_Base>>) {
       return std::get<_Np>(*__i);
     } else {
@@ -201,30 +201,30 @@ public:
   using value_type       = remove_cvref_t<tuple_element_t<_Np, range_value_t<_Base>>>;
   using difference_type  = range_difference_t<_Base>;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator()
+  __iterator()
     requires default_initializable<iterator_t<_Base>>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __iterator(iterator_t<_Base> __current) : __current_(std::move(__current)) {}
+  constexpr explicit __iterator(iterator_t<_Base> __current) : __current_(std::move(__current)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(__iterator<!_Const> __i)
+  constexpr __iterator(__iterator<!_Const> __i)
     requires _Const && convertible_to<iterator_t<_View>, iterator_t<_Base>>
       : __current_(std::move(__i.__current_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const iterator_t<_Base>& base() const& noexcept { return __current_; }
+  constexpr const iterator_t<_Base>& base() const& noexcept { return __current_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_Base> base() && { return std::move(__current_); }
+  constexpr iterator_t<_Base> base() && { return std::move(__current_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator*() const { return __get_element(__current_); }
+  constexpr decltype(auto) operator*() const { return __get_element(__current_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+  constexpr __iterator& operator++() {
     ++__current_;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator++(int) { ++__current_; }
+  constexpr void operator++(int) { ++__current_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int)
+  constexpr __iterator operator++(int)
     requires forward_range<_Base>
   {
     auto __temp = *this;
@@ -232,14 +232,14 @@ public:
     return __temp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator--()
+  constexpr __iterator& operator--()
     requires bidirectional_range<_Base>
   {
     --__current_;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator--(int)
+  constexpr __iterator operator--(int)
     requires bidirectional_range<_Base>
   {
     auto __temp = *this;
@@ -247,81 +247,81 @@ public:
     return __temp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator+=(difference_type __n)
+  constexpr __iterator& operator+=(difference_type __n)
     requires random_access_range<_Base>
   {
     __current_ += __n;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator-=(difference_type __n)
+  constexpr __iterator& operator-=(difference_type __n)
     requires random_access_range<_Base>
   {
     __current_ -= __n;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator[](difference_type __n) const
+  constexpr decltype(auto) operator[](difference_type __n) const
     requires random_access_range<_Base>
   {
     return __get_element(__current_ + __n);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
     requires equality_comparable<iterator_t<_Base>>
   {
     return __x.__current_ == __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator<(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return __x.__current_ < __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator>(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return __y < __x;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator<=(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return !(__y < __x);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator>=(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return !(__x < __y);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
+  friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>>
   {
     return __x.__current_ <=> __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(const __iterator& __x, difference_type __y)
+  friend constexpr __iterator operator+(const __iterator& __x, difference_type __y)
     requires random_access_range<_Base>
   {
     return __iterator{__x} += __y;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(difference_type __x, const __iterator& __y)
+  friend constexpr __iterator operator+(difference_type __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return __y + __x;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator-(const __iterator& __x, difference_type __y)
+  friend constexpr __iterator operator-(const __iterator& __x, difference_type __y)
     requires random_access_range<_Base>
   {
     return __iterator{__x} -= __y;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y)
+  friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y)
     requires sized_sentinel_for<iterator_t<_Base>, iterator_t<_Base>>
   {
     return __x.__current_ - __y.__current_;
@@ -342,37 +342,37 @@ private:
   friend class __sentinel;
 
   template <bool _AnyConst>
-  _LIBCPP_HIDE_FROM_ABI static constexpr decltype(auto) __get_current(const __iterator<_AnyConst>& __iter) {
+  static constexpr decltype(auto) __get_current(const __iterator<_AnyConst>& __iter) {
     return (__iter.__current_);
   }
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
+  __sentinel() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(sentinel_t<_Base> __end) : __end_(std::move(__end)) {}
+  constexpr explicit __sentinel(sentinel_t<_Base> __end) : __end_(std::move(__end)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __sentinel(__sentinel<!_Const> __other)
+  constexpr __sentinel(__sentinel<!_Const> __other)
     requires _Const && convertible_to<sentinel_t<_View>, sentinel_t<_Base>>
       : __end_(std::move(__other.__end_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_Base> base() const { return __end_; }
+  constexpr sentinel_t<_Base> base() const { return __end_; }
 
   template <bool _OtherConst>
     requires sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
+  friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
     return __get_current(__x) == __y.__end_;
   }
 
   template <bool _OtherConst>
     requires sized_sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr range_difference_t<__maybe_const<_OtherConst, _View>>
+  friend constexpr range_difference_t<__maybe_const<_OtherConst, _View>>
   operator-(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
     return __get_current(__x) - __y.__end_;
   }
 
   template <bool _OtherConst>
     requires sized_sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr range_difference_t<__maybe_const<_OtherConst, _View>>
+  friend constexpr range_difference_t<__maybe_const<_OtherConst, _View>>
   operator-(const __sentinel& __x, const __iterator<_OtherConst>& __y) {
     return __x.__end_ - __get_current(__y);
   }
@@ -392,7 +392,7 @@ namespace __elements {
 template <size_t _Np>
 struct __fn : __range_adaptor_closure<__fn<_Np>> {
   template <class _Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
       /**/ noexcept(noexcept(elements_view<all_t<_Range&&>, _Np>(std::forward<_Range>(__range))))
       /*------*/ -> decltype(elements_view<all_t<_Range&&>, _Np>(std::forward<_Range>(__range))) {
     /*-------------*/ return elements_view<all_t<_Range&&>, _Np>(std::forward<_Range>(__range));

--- a/libcxx/include/__ranges/empty.h
+++ b/libcxx/include/__ranges/empty.h
@@ -42,17 +42,17 @@ concept __can_compare_begin_end = !__member_empty<_Tp> && !__can_invoke_size<_Tp
 
 struct __fn {
   template <__member_empty _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp&& __t) const noexcept(noexcept(bool(__t.empty()))) {
+  [[nodiscard]] constexpr bool operator()(_Tp&& __t) const noexcept(noexcept(bool(__t.empty()))) {
     return bool(__t.empty());
   }
 
   template <__can_invoke_size _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp&& __t) const noexcept(noexcept(ranges::size(__t))) {
+  [[nodiscard]] constexpr bool operator()(_Tp&& __t) const noexcept(noexcept(ranges::size(__t))) {
     return ranges::size(__t) == 0;
   }
 
   template <__can_compare_begin_end _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr bool operator()(_Tp&& __t) const
       noexcept(noexcept(bool(ranges::begin(__t) == ranges::end(__t)))) {
     return ranges::begin(__t) == ranges::end(__t);
   }

--- a/libcxx/include/__ranges/empty_view.h
+++ b/libcxx/include/__ranges/empty_view.h
@@ -29,11 +29,11 @@ template <class _Tp>
   requires is_object_v<_Tp>
 class empty_view : public view_interface<empty_view<_Tp>> {
 public:
-  _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* begin() noexcept { return nullptr; }
-  _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* end() noexcept { return nullptr; }
-  _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* data() noexcept { return nullptr; }
-  _LIBCPP_HIDE_FROM_ABI static constexpr size_t size() noexcept { return 0; }
-  _LIBCPP_HIDE_FROM_ABI static constexpr bool empty() noexcept { return true; }
+  static constexpr _Tp* begin() noexcept { return nullptr; }
+  static constexpr _Tp* end() noexcept { return nullptr; }
+  static constexpr _Tp* data() noexcept { return nullptr; }
+  static constexpr size_t size() noexcept { return 0; }
+  static constexpr bool empty() noexcept { return true; }
 };
 
 template <class _Tp>

--- a/libcxx/include/__ranges/filter_view.h
+++ b/libcxx/include/__ranges/filter_view.h
@@ -68,24 +68,24 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS filter_view : public view_interface<f
   class __sentinel;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI filter_view()
+  filter_view()
     requires default_initializable<_View> && default_initializable<_Pred>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 filter_view(_View __base, _Pred __pred)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 filter_view(_View __base, _Pred __pred)
       : __base_(std::move(__base)), __pred_(in_place, std::move(__pred)) {}
 
   template <class _Vp = _View>
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_Vp>
   {
     return __base_;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Pred const& pred() const { return *__pred_; }
+  constexpr _Pred const& pred() const { return *__pred_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator begin() {
+  constexpr __iterator begin() {
     // Note: this duplicates a check in `optional` but provides a better error message.
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __pred_.__has_value(), "Trying to call begin() on a filter_view that does not have a valid predicate.");
@@ -99,7 +99,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() {
+  constexpr auto end() {
     if constexpr (common_range<_View>)
       return __iterator{*this, ranges::end(__base_)};
     else
@@ -141,30 +141,30 @@ public:
   using value_type      = range_value_t<_View>;
   using difference_type = range_difference_t<_View>;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator()
+  __iterator()
     requires default_initializable<iterator_t<_View>>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(filter_view& __parent, iterator_t<_View> __current)
+  constexpr __iterator(filter_view& __parent, iterator_t<_View> __current)
       : __current_(std::move(__current)), __parent_(std::addressof(__parent)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_View> const& base() const& noexcept { return __current_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_View> base() && { return std::move(__current_); }
+  constexpr iterator_t<_View> const& base() const& noexcept { return __current_; }
+  constexpr iterator_t<_View> base() && { return std::move(__current_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr range_reference_t<_View> operator*() const { return *__current_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_View> operator->() const
+  constexpr range_reference_t<_View> operator*() const { return *__current_; }
+  constexpr iterator_t<_View> operator->() const
     requires __has_arrow<iterator_t<_View>> && copyable<iterator_t<_View>>
   {
     return __current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+  constexpr __iterator& operator++() {
     __current_ =
         ranges::find_if(std::move(++__current_), ranges::end(__parent_->__base_), std::ref(*__parent_->__pred_));
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator++(int) { ++*this; }
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int)
+  constexpr void operator++(int) { ++*this; }
+  constexpr __iterator operator++(int)
     requires forward_range<_View>
   {
     auto __tmp = *this;
@@ -172,7 +172,7 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator--()
+  constexpr __iterator& operator--()
     requires bidirectional_range<_View>
   {
     do {
@@ -180,7 +180,7 @@ public:
     } while (!std::invoke(*__parent_->__pred_, *__current_));
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator--(int)
+  constexpr __iterator operator--(int)
     requires bidirectional_range<_View>
   {
     auto __tmp = *this;
@@ -188,18 +188,18 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(__iterator const& __x, __iterator const& __y)
+  friend constexpr bool operator==(__iterator const& __x, __iterator const& __y)
     requires equality_comparable<iterator_t<_View>>
   {
     return __x.__current_ == __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr range_rvalue_reference_t<_View>
+  friend constexpr range_rvalue_reference_t<_View>
   iter_move(__iterator const& __it) noexcept(noexcept(ranges::iter_move(__it.__current_))) {
     return ranges::iter_move(__it.__current_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr void
+  friend constexpr void
   iter_swap(__iterator const& __x,
             __iterator const& __y) noexcept(noexcept(ranges::iter_swap(__x.__current_, __y.__current_)))
     requires indirectly_swappable<iterator_t<_View>>
@@ -214,13 +214,13 @@ class filter_view<_View, _Pred>::__sentinel {
 public:
   sentinel_t<_View> __end_ = sentinel_t<_View>();
 
-  _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
+  __sentinel() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(filter_view& __parent) : __end_(ranges::end(__parent.__base_)) {}
+  constexpr explicit __sentinel(filter_view& __parent) : __end_(ranges::end(__parent.__base_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_View> base() const { return __end_; }
+  constexpr sentinel_t<_View> base() const { return __end_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(__iterator const& __x, __sentinel const& __y) {
+  friend constexpr bool operator==(__iterator const& __x, __sentinel const& __y) {
     return __x.__current_ == __y.__end_;
   }
 };
@@ -229,7 +229,7 @@ namespace views {
 namespace __filter {
 struct __fn {
   template <class _Range, class _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Pred&& __pred) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Pred&& __pred) const
       noexcept(noexcept(filter_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred))))
           -> decltype(filter_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred))) {
     return filter_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred));
@@ -237,7 +237,7 @@ struct __fn {
 
   template <class _Pred>
     requires constructible_from<decay_t<_Pred>, _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Pred&& __pred) const
+  [[nodiscard]] constexpr auto operator()(_Pred&& __pred) const
       noexcept(is_nothrow_constructible_v<decay_t<_Pred>, _Pred>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Pred>(__pred)));
   }

--- a/libcxx/include/__ranges/iota_view.h
+++ b/libcxx/include/__ranges/iota_view.h
@@ -119,24 +119,22 @@ class iota_view : public view_interface<iota_view<_Start, _BoundSentinel>> {
 
     _Start __value_ = _Start();
 
-    _LIBCPP_HIDE_FROM_ABI __iterator()
+    __iterator()
       requires default_initializable<_Start>
     = default;
 
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __iterator(_Start __value) : __value_(std::move(__value)) {}
+    constexpr explicit __iterator(_Start __value) : __value_(std::move(__value)) {}
 
-    _LIBCPP_HIDE_FROM_ABI constexpr _Start operator*() const noexcept(is_nothrow_copy_constructible_v<_Start>) {
-      return __value_;
-    }
+    constexpr _Start operator*() const noexcept(is_nothrow_copy_constructible_v<_Start>) { return __value_; }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+    constexpr __iterator& operator++() {
       ++__value_;
       return *this;
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr void operator++(int) { ++*this; }
+    constexpr void operator++(int) { ++*this; }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int)
+    constexpr __iterator operator++(int)
       requires incrementable<_Start>
     {
       auto __tmp = *this;
@@ -144,14 +142,14 @@ class iota_view : public view_interface<iota_view<_Start, _BoundSentinel>> {
       return __tmp;
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator--()
+    constexpr __iterator& operator--()
       requires __decrementable<_Start>
     {
       --__value_;
       return *this;
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator--(int)
+    constexpr __iterator operator--(int)
       requires __decrementable<_Start>
     {
       auto __tmp = *this;
@@ -159,7 +157,7 @@ class iota_view : public view_interface<iota_view<_Start, _BoundSentinel>> {
       return __tmp;
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator+=(difference_type __n)
+    constexpr __iterator& operator+=(difference_type __n)
       requires __advanceable<_Start>
     {
       if constexpr (__integer_like<_Start> && !__signed_integer_like<_Start>) {
@@ -174,7 +172,7 @@ class iota_view : public view_interface<iota_view<_Start, _BoundSentinel>> {
       return *this;
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator-=(difference_type __n)
+    constexpr __iterator& operator-=(difference_type __n)
       requires __advanceable<_Start>
     {
       if constexpr (__integer_like<_Start> && !__signed_integer_like<_Start>) {
@@ -189,69 +187,69 @@ class iota_view : public view_interface<iota_view<_Start, _BoundSentinel>> {
       return *this;
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr _Start operator[](difference_type __n) const
+    constexpr _Start operator[](difference_type __n) const
       requires __advanceable<_Start>
     {
       return _Start(__value_ + __n);
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
+    friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
       requires equality_comparable<_Start>
     {
       return __x.__value_ == __y.__value_;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(const __iterator& __x, const __iterator& __y)
+    friend constexpr bool operator<(const __iterator& __x, const __iterator& __y)
       requires totally_ordered<_Start>
     {
       return __x.__value_ < __y.__value_;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(const __iterator& __x, const __iterator& __y)
+    friend constexpr bool operator>(const __iterator& __x, const __iterator& __y)
       requires totally_ordered<_Start>
     {
       return __y < __x;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(const __iterator& __x, const __iterator& __y)
+    friend constexpr bool operator<=(const __iterator& __x, const __iterator& __y)
       requires totally_ordered<_Start>
     {
       return !(__y < __x);
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(const __iterator& __x, const __iterator& __y)
+    friend constexpr bool operator>=(const __iterator& __x, const __iterator& __y)
       requires totally_ordered<_Start>
     {
       return !(__x < __y);
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
+    friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
       requires totally_ordered<_Start> && three_way_comparable<_Start>
     {
       return __x.__value_ <=> __y.__value_;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(__iterator __i, difference_type __n)
+    friend constexpr __iterator operator+(__iterator __i, difference_type __n)
       requires __advanceable<_Start>
     {
       __i += __n;
       return __i;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(difference_type __n, __iterator __i)
+    friend constexpr __iterator operator+(difference_type __n, __iterator __i)
       requires __advanceable<_Start>
     {
       return __i + __n;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator-(__iterator __i, difference_type __n)
+    friend constexpr __iterator operator-(__iterator __i, difference_type __n)
       requires __advanceable<_Start>
     {
       __i -= __n;
       return __i;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y)
+    friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y)
       requires __advanceable<_Start>
     {
       if constexpr (__integer_like<_Start>) {
@@ -274,23 +272,20 @@ class iota_view : public view_interface<iota_view<_Start, _BoundSentinel>> {
     _BoundSentinel __bound_sentinel_ = _BoundSentinel();
 
   public:
-    _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(_BoundSentinel __bound_sentinel)
-        : __bound_sentinel_(std::move(__bound_sentinel)) {}
+    __sentinel() = default;
+    constexpr explicit __sentinel(_BoundSentinel __bound_sentinel) : __bound_sentinel_(std::move(__bound_sentinel)) {}
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __sentinel& __y) {
+    friend constexpr bool operator==(const __iterator& __x, const __sentinel& __y) {
       return __x.__value_ == __y.__bound_sentinel_;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr iter_difference_t<_Start>
-    operator-(const __iterator& __x, const __sentinel& __y)
+    friend constexpr iter_difference_t<_Start> operator-(const __iterator& __x, const __sentinel& __y)
       requires sized_sentinel_for<_BoundSentinel, _Start>
     {
       return __x.__value_ - __y.__bound_sentinel_;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr iter_difference_t<_Start>
-    operator-(const __sentinel& __x, const __iterator& __y)
+    friend constexpr iter_difference_t<_Start> operator-(const __sentinel& __x, const __iterator& __y)
       requires sized_sentinel_for<_BoundSentinel, _Start>
     {
       return -(__y - __x);
@@ -301,13 +296,13 @@ class iota_view : public view_interface<iota_view<_Start, _BoundSentinel>> {
   _BoundSentinel __bound_sentinel_ = _BoundSentinel();
 
 public:
-  _LIBCPP_HIDE_FROM_ABI iota_view()
+  iota_view()
     requires default_initializable<_Start>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit iota_view(_Start __value) : __value_(std::move(__value)) {}
+  constexpr explicit iota_view(_Start __value) : __value_(std::move(__value)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23
   iota_view(type_identity_t<_Start> __value, type_identity_t<_BoundSentinel> __bound_sentinel)
       : __value_(std::move(__value)), __bound_sentinel_(std::move(__bound_sentinel)) {
     // Validate the precondition if possible.
@@ -317,36 +312,36 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 iota_view(__iterator __first, __iterator __last)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 iota_view(__iterator __first, __iterator __last)
     requires same_as<_Start, _BoundSentinel>
       : iota_view(std::move(__first.__value_), std::move(__last.__value_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 iota_view(__iterator __first, _BoundSentinel __last)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 iota_view(__iterator __first, _BoundSentinel __last)
     requires same_as<_BoundSentinel, unreachable_sentinel_t>
       : iota_view(std::move(__first.__value_), std::move(__last)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 iota_view(__iterator __first, __sentinel __last)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 iota_view(__iterator __first, __sentinel __last)
     requires(!same_as<_Start, _BoundSentinel> && !same_as<_BoundSentinel, unreachable_sentinel_t>)
       : iota_view(std::move(__first.__value_), std::move(__last.__bound_sentinel_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator begin() const { return __iterator{__value_}; }
+  constexpr __iterator begin() const { return __iterator{__value_}; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const {
+  constexpr auto end() const {
     if constexpr (same_as<_BoundSentinel, unreachable_sentinel_t>)
       return unreachable_sentinel;
     else
       return __sentinel{__bound_sentinel_};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator end() const
+  constexpr __iterator end() const
     requires same_as<_Start, _BoundSentinel>
   {
     return __iterator{__bound_sentinel_};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr bool empty() const { return __value_ == __bound_sentinel_; }
+  constexpr bool empty() const { return __value_ == __bound_sentinel_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires(same_as<_Start, _BoundSentinel> && __advanceable<_Start>) ||
             (integral<_Start> && integral<_BoundSentinel>) || sized_sentinel_for<_BoundSentinel, _Start>
   {
@@ -374,14 +369,13 @@ namespace views {
 namespace __iota {
 struct __fn {
   template <class _Start>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Start&& __start) const
-      noexcept(noexcept(ranges::iota_view(std::forward<_Start>(__start))))
-          -> decltype(ranges::iota_view(std::forward<_Start>(__start))) {
+  constexpr auto operator()(_Start&& __start) const noexcept(noexcept(ranges::iota_view(std::forward<_Start>(__start))))
+      -> decltype(ranges::iota_view(std::forward<_Start>(__start))) {
     return ranges::iota_view(std::forward<_Start>(__start));
   }
 
   template <class _Start, class _BoundSentinel>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Start&& __start, _BoundSentinel&& __bound_sentinel) const noexcept(
+  constexpr auto operator()(_Start&& __start, _BoundSentinel&& __bound_sentinel) const noexcept(
       noexcept(ranges::iota_view(std::forward<_Start>(__start), std::forward<_BoundSentinel>(__bound_sentinel))))
       -> decltype(ranges::iota_view(std::forward<_Start>(__start), std::forward<_BoundSentinel>(__bound_sentinel))) {
     return ranges::iota_view(std::forward<_Start>(__start), std::forward<_BoundSentinel>(__bound_sentinel));

--- a/libcxx/include/__ranges/istream_view.h
+++ b/libcxx/include/__ranges/istream_view.h
@@ -43,15 +43,15 @@ class basic_istream_view : public view_interface<basic_istream_view<_Val, _CharT
   class __iterator;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit basic_istream_view(basic_istream<_CharT, _Traits>& __stream)
+  constexpr explicit basic_istream_view(basic_istream<_CharT, _Traits>& __stream)
       : __stream_(std::addressof(__stream)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() {
+  constexpr auto begin() {
     *__stream_ >> __value_;
     return __iterator{*this};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr default_sentinel_t end() const noexcept { return default_sentinel; }
+  constexpr default_sentinel_t end() const noexcept { return default_sentinel; }
 
 private:
   basic_istream<_CharT, _Traits>* __stream_;
@@ -66,34 +66,30 @@ public:
   using difference_type  = ptrdiff_t;
   using value_type       = _Val;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __iterator(basic_istream_view<_Val, _CharT, _Traits>& __parent) noexcept
+  constexpr explicit __iterator(basic_istream_view<_Val, _CharT, _Traits>& __parent) noexcept
       : __parent_(std::addressof(__parent)) {}
 
-  __iterator(const __iterator&)                  = delete;
-  _LIBCPP_HIDE_FROM_ABI __iterator(__iterator&&) = default;
+  __iterator(const __iterator&) = delete;
+  __iterator(__iterator&&)      = default;
 
-  __iterator& operator=(const __iterator&)                  = delete;
-  _LIBCPP_HIDE_FROM_ABI __iterator& operator=(__iterator&&) = default;
+  __iterator& operator=(const __iterator&) = delete;
+  __iterator& operator=(__iterator&&)      = default;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator& operator++() {
+  __iterator& operator++() {
     *__parent_->__stream_ >> __parent_->__value_;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI void operator++(int) { ++*this; }
+  void operator++(int) { ++*this; }
 
-  _LIBCPP_HIDE_FROM_ABI _Val& operator*() const { return __parent_->__value_; }
+  _Val& operator*() const { return __parent_->__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend bool operator==(const __iterator& __x, default_sentinel_t) {
-    return !*__x.__get_parent_stream();
-  }
+  friend bool operator==(const __iterator& __x, default_sentinel_t) { return !*__x.__get_parent_stream(); }
 
 private:
   basic_istream_view<_Val, _CharT, _Traits>* __parent_;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr basic_istream<_CharT, _Traits>* __get_parent_stream() const {
-    return __parent_->__stream_;
-  }
+  constexpr basic_istream<_CharT, _Traits>* __get_parent_stream() const { return __parent_->__stream_; }
 };
 
 template <class _Val>
@@ -113,7 +109,7 @@ struct __fn {
   template <class _Up, class _UnCVRef = remove_cvref_t<_Up>>
     requires derived_from<_UnCVRef, basic_istream<typename _UnCVRef::char_type,
                                                   typename _UnCVRef::traits_type>>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Up&& __u) const
+  constexpr auto operator()(_Up&& __u) const
     noexcept(noexcept(basic_istream_view<_Tp, typename _UnCVRef::char_type,
                                               typename _UnCVRef::traits_type>(std::forward<_Up>(__u))))
     -> decltype(      basic_istream_view<_Tp, typename _UnCVRef::char_type,

--- a/libcxx/include/__ranges/join_view.h
+++ b/libcxx/include/__ranges/join_view.h
@@ -94,21 +94,21 @@ private:
   _LIBCPP_NO_UNIQUE_ADDRESS _InnerCache __inner_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI join_view()
+  join_view()
     requires default_initializable<_View>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit join_view(_View __base) : __base_(std::move(__base)) {}
+  constexpr explicit join_view(_View __base) : __base_(std::move(__base)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() {
+  constexpr auto begin() {
     if constexpr (forward_range<_View>) {
       constexpr bool __use_const = __simple_view<_View> && is_reference_v<range_reference_t<_View>>;
       return __iterator<__use_const>{*this, ranges::begin(__base_)};
@@ -119,14 +119,14 @@ public:
   }
 
   template <class _V2 = _View>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires forward_range<const _V2> && is_reference_v<range_reference_t<const _V2>> &&
              input_range<range_reference_t<const _V2>>
   {
     return __iterator<true>{*this, ranges::begin(__base_)};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() {
+  constexpr auto end() {
     if constexpr (forward_range<_View> && is_reference_v<_InnerRange> && forward_range<_InnerRange> &&
                   common_range<_View> && common_range<_InnerRange>)
       return __iterator<__simple_view<_View>>{*this, ranges::end(__base_)};
@@ -135,7 +135,7 @@ public:
   }
 
   template <class _V2 = _View>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires forward_range<const _V2> && is_reference_v<range_reference_t<const _V2>> &&
              input_range<range_reference_t<const _V2>>
   {
@@ -161,17 +161,17 @@ private:
   sentinel_t<_Base> __end_      = sentinel_t<_Base>();
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
+  __sentinel() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(_Parent& __parent) : __end_(ranges::end(__parent.__base_)) {}
+  constexpr explicit __sentinel(_Parent& __parent) : __end_(ranges::end(__parent.__base_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __sentinel(__sentinel<!_Const> __s)
+  constexpr __sentinel(__sentinel<!_Const> __s)
     requires _Const && convertible_to<sentinel_t<_View>, sentinel_t<_Base>>
       : __end_(std::move(__s.__end_)) {}
 
   template <bool _OtherConst>
     requires sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
+  friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
     return __x.__get_outer() == __y.__end_;
   }
 };
@@ -208,7 +208,7 @@ private:
   optional<_Inner> __inner_;
   _Parent* __parent_ = nullptr;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr void __satisfy() {
+  constexpr void __satisfy() {
     for (; __get_outer() != ranges::end(__parent_->__base_); ++__get_outer()) {
       auto&& __inner = [this]() -> auto&& {
         if constexpr (__ref_is_glvalue)
@@ -225,7 +225,7 @@ private:
       __inner_.reset();
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Outer& __get_outer() {
+  constexpr _Outer& __get_outer() {
     if constexpr (forward_range<_Base>) {
       return __outer_;
     } else {
@@ -233,7 +233,7 @@ private:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Outer& __get_outer() const {
+  constexpr const _Outer& __get_outer() const {
     if constexpr (forward_range<_Base>) {
       return __outer_;
     } else {
@@ -241,19 +241,19 @@ private:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(_Parent& __parent, _Outer __outer)
+  constexpr __iterator(_Parent& __parent, _Outer __outer)
     requires forward_range<_Base>
       : __outer_(std::move(__outer)), __parent_(std::addressof(__parent)) {
     __satisfy();
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __iterator(_Parent& __parent)
+  constexpr explicit __iterator(_Parent& __parent)
     requires(!forward_range<_Base>)
       : __parent_(std::addressof(__parent)) {
     __satisfy();
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(_Parent* __parent, _Outer __outer, _Inner __inner)
+  constexpr __iterator(_Parent* __parent, _Outer __outer, _Inner __inner)
     requires forward_range<_Base>
       : __outer_(std::move(__outer)), __inner_(std::move(__inner)), __parent_(__parent) {}
 
@@ -270,21 +270,21 @@ public:
 
   using difference_type = common_type_t< range_difference_t<_Base>, range_difference_t<range_reference_t<_Base>>>;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator() = default;
+  __iterator() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(__iterator<!_Const> __i)
+  constexpr __iterator(__iterator<!_Const> __i)
     requires _Const && convertible_to<iterator_t<_View>, _Outer> && convertible_to<iterator_t<_InnerRange>, _Inner>
       : __outer_(std::move(__i.__outer_)), __inner_(std::move(__i.__inner_)), __parent_(__i.__parent_) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator*() const { return **__inner_; }
+  constexpr decltype(auto) operator*() const { return **__inner_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Inner operator->() const
+  constexpr _Inner operator->() const
     requires __has_arrow<_Inner> && copyable<_Inner>
   {
     return *__inner_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+  constexpr __iterator& operator++() {
     auto __get_inner_range = [&]() -> decltype(auto) {
       if constexpr (__ref_is_glvalue)
         return *__get_outer();
@@ -298,9 +298,9 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator++(int) { ++*this; }
+  constexpr void operator++(int) { ++*this; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int)
+  constexpr __iterator operator++(int)
     requires __ref_is_glvalue && forward_range<_Base> && forward_range<range_reference_t<_Base>>
   {
     auto __tmp = *this;
@@ -308,7 +308,7 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator--()
+  constexpr __iterator& operator--()
     requires __ref_is_glvalue && bidirectional_range<_Base> && bidirectional_range<range_reference_t<_Base>> &&
              common_range<range_reference_t<_Base>>
   {
@@ -324,7 +324,7 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator--(int)
+  constexpr __iterator operator--(int)
     requires __ref_is_glvalue && bidirectional_range<_Base> && bidirectional_range<range_reference_t<_Base>> &&
              common_range<range_reference_t<_Base>>
   {
@@ -333,18 +333,18 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
     requires __ref_is_glvalue && forward_range<_Base> && equality_comparable<iterator_t<range_reference_t<_Base>>>
   {
     return __x.__outer_ == __y.__outer_ && __x.__inner_ == __y.__inner_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr decltype(auto)
+  friend constexpr decltype(auto)
   iter_move(const __iterator& __i) noexcept(noexcept(ranges::iter_move(*__i.__inner_))) {
     return ranges::iter_move(*__i.__inner_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr void
+  friend constexpr void
   iter_swap(const __iterator& __x,
             const __iterator& __y) noexcept(noexcept(ranges::iter_swap(*__x.__inner_, *__y.__inner_)))
     requires indirectly_swappable<_Inner>
@@ -360,7 +360,7 @@ namespace views {
 namespace __join_view {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
       noexcept(noexcept(join_view<all_t<_Range&&>>(std::forward<_Range>(__range))))
           -> decltype(join_view<all_t<_Range&&>>(std::forward<_Range>(__range))) {
     return join_view<all_t<_Range&&>>(std::forward<_Range>(__range));
@@ -384,7 +384,7 @@ struct __segmented_iterator_traits<_JoinViewIterator> {
 
   // TODO: Would it make sense to enable the optimization for other iterator types?
 
-  static constexpr _LIBCPP_HIDE_FROM_ABI __segment_iterator __segment(_JoinViewIterator __iter) {
+  static constexpr __segment_iterator __segment(_JoinViewIterator __iter) {
     if (ranges::empty(__iter.__parent_->__base_))
       return {};
     if (!__iter.__inner_.has_value())
@@ -392,7 +392,7 @@ struct __segmented_iterator_traits<_JoinViewIterator> {
     return __segment_iterator(__iter.__outer_, __iter.__parent_);
   }
 
-  static constexpr _LIBCPP_HIDE_FROM_ABI __local_iterator __local(_JoinViewIterator __iter) {
+  static constexpr __local_iterator __local(_JoinViewIterator __iter) {
     if (ranges::empty(__iter.__parent_->__base_))
       return {};
     if (!__iter.__inner_.has_value())
@@ -400,16 +400,11 @@ struct __segmented_iterator_traits<_JoinViewIterator> {
     return *__iter.__inner_;
   }
 
-  static constexpr _LIBCPP_HIDE_FROM_ABI __local_iterator __begin(__segment_iterator __iter) {
-    return ranges::begin(*__iter.__get_iter());
-  }
+  static constexpr __local_iterator __begin(__segment_iterator __iter) { return ranges::begin(*__iter.__get_iter()); }
 
-  static constexpr _LIBCPP_HIDE_FROM_ABI __local_iterator __end(__segment_iterator __iter) {
-    return ranges::end(*__iter.__get_iter());
-  }
+  static constexpr __local_iterator __end(__segment_iterator __iter) { return ranges::end(*__iter.__get_iter()); }
 
-  static constexpr _LIBCPP_HIDE_FROM_ABI _JoinViewIterator
-  __compose(__segment_iterator __seg_iter, __local_iterator __local_iter) {
+  static constexpr _JoinViewIterator __compose(__segment_iterator __seg_iter, __local_iterator __local_iter) {
     return _JoinViewIterator(
         std::move(__seg_iter).__get_data(), std::move(__seg_iter).__get_iter(), std::move(__local_iter));
   }

--- a/libcxx/include/__ranges/lazy_split_view.h
+++ b/libcxx/include/__ranges/lazy_split_view.h
@@ -82,48 +82,48 @@ class lazy_split_view : public view_interface<lazy_split_view<_View, _Pattern>> 
   struct __inner_iterator;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI lazy_split_view()
+  lazy_split_view()
     requires default_initializable<_View> && default_initializable<_Pattern>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 lazy_split_view(_View __base, _Pattern __pattern)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 lazy_split_view(_View __base, _Pattern __pattern)
       : __base_(std::move(__base)), __pattern_(std::move(__pattern)) {}
 
   template <input_range _Range>
     requires constructible_from<_View, views::all_t<_Range>> &&
                  constructible_from<_Pattern, single_view<range_value_t<_Range>>>
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 lazy_split_view(_Range&& __r, range_value_t<_Range> __e)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 lazy_split_view(_Range&& __r, range_value_t<_Range> __e)
       : __base_(views::all(std::forward<_Range>(__r))), __pattern_(views::single(std::move(__e))) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() {
+  constexpr auto begin() {
     if constexpr (forward_range<_View>) {
-      return __outer_iterator < __simple_view<_View> && __simple_view < _Pattern >> {*this, ranges::begin(__base_)};
+      return __outer_iterator<__simple_view<_View> && __simple_view< _Pattern >>{*this, ranges::begin(__base_)};
     } else {
       __current_.__emplace(ranges::begin(__base_));
       return __outer_iterator<false>{*this};
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires forward_range<_View> && forward_range<const _View>
   {
     return __outer_iterator<true>{*this, ranges::begin(__base_)};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  constexpr auto end()
     requires forward_range<_View> && common_range<_View>
   {
-    return __outer_iterator < __simple_view<_View> && __simple_view < _Pattern >> {*this, ranges::end(__base_)};
+    return __outer_iterator< __simple_view<_View> && __simple_view< _Pattern >>{*this, ranges::end(__base_)};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const {
+  constexpr auto end() const {
     if constexpr (forward_range<_View> && forward_range<const _View> && common_range<const _View>) {
       return __outer_iterator<true>{*this, ranges::end(__base_)};
     } else {
@@ -155,7 +155,7 @@ private:
     _LIBCPP_NO_UNIQUE_ADDRESS _MaybeCurrent __current_ = _MaybeCurrent();
     bool __trailing_empty_                             = false;
 
-    [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto& __current() noexcept {
+    [[nodiscard]] constexpr auto& __current() noexcept {
       if constexpr (forward_range<_View>) {
         return __current_;
       } else {
@@ -163,7 +163,7 @@ private:
       }
     }
 
-    [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr const auto& __current() const noexcept {
+    [[nodiscard]] constexpr const auto& __current() const noexcept {
       if constexpr (forward_range<_View>) {
         return __current_;
       } else {
@@ -173,7 +173,7 @@ private:
 
     // Workaround for the GCC issue that doesn't allow calling `__parent_->__base_` from friend functions (because
     // `__base_` is private).
-    [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto& __parent_base() const noexcept { return __parent_->__base_; }
+    [[nodiscard]] constexpr auto& __parent_base() const noexcept { return __parent_->__base_; }
 
   public:
     // using iterator_category = inherited;
@@ -185,30 +185,30 @@ private:
       __outer_iterator __i_ = __outer_iterator();
 
     public:
-      _LIBCPP_HIDE_FROM_ABI value_type() = default;
-      _LIBCPP_HIDE_FROM_ABI constexpr explicit value_type(__outer_iterator __i) : __i_(std::move(__i)) {}
+      value_type() = default;
+      constexpr explicit value_type(__outer_iterator __i) : __i_(std::move(__i)) {}
 
-      _LIBCPP_HIDE_FROM_ABI constexpr __inner_iterator<_Const> begin() const { return __inner_iterator<_Const>{__i_}; }
-      _LIBCPP_HIDE_FROM_ABI constexpr default_sentinel_t end() const noexcept { return default_sentinel; }
+      constexpr __inner_iterator<_Const> begin() const { return __inner_iterator<_Const>{__i_}; }
+      constexpr default_sentinel_t end() const noexcept { return default_sentinel; }
     };
 
-    _LIBCPP_HIDE_FROM_ABI __outer_iterator() = default;
+    __outer_iterator() = default;
 
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __outer_iterator(_Parent& __parent)
+    constexpr explicit __outer_iterator(_Parent& __parent)
       requires(!forward_range<_Base>)
         : __parent_(std::addressof(__parent)) {}
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __outer_iterator(_Parent& __parent, iterator_t<_Base> __current)
+    constexpr __outer_iterator(_Parent& __parent, iterator_t<_Base> __current)
       requires forward_range<_Base>
         : __parent_(std::addressof(__parent)), __current_(std::move(__current)) {}
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __outer_iterator(__outer_iterator<!_Const> __i)
+    constexpr __outer_iterator(__outer_iterator<!_Const> __i)
       requires _Const && convertible_to<iterator_t<_View>, iterator_t<_Base>>
         : __parent_(__i.__parent_), __current_(std::move(__i.__current_)) {}
 
-    _LIBCPP_HIDE_FROM_ABI constexpr value_type operator*() const { return value_type{*this}; }
+    constexpr value_type operator*() const { return value_type{*this}; }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __outer_iterator& operator++() {
+    constexpr __outer_iterator& operator++() {
       const auto __end = ranges::end(__parent_->__base_);
       if (__current() == __end) {
         __trailing_empty_ = false;
@@ -247,7 +247,7 @@ private:
       return *this;
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator++(int) {
+    constexpr decltype(auto) operator++(int) {
       if constexpr (forward_range<_Base>) {
         auto __tmp = *this;
         ++*this;
@@ -258,13 +258,13 @@ private:
       }
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __outer_iterator& __x, const __outer_iterator& __y)
+    friend constexpr bool operator==(const __outer_iterator& __x, const __outer_iterator& __y)
       requires forward_range<_Base>
     {
       return __x.__current_ == __y.__current_ && __x.__trailing_empty_ == __y.__trailing_empty_;
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __outer_iterator& __x, default_sentinel_t) {
+    friend constexpr bool operator==(const __outer_iterator& __x, default_sentinel_t) {
       _LIBCPP_ASSERT_NON_NULL(__x.__parent_ != nullptr, "Cannot call comparison on a default-constructed iterator.");
       return __x.__current() == ranges::end(__x.__parent_base()) && !__x.__trailing_empty_;
     }
@@ -293,7 +293,7 @@ private:
     // Note: these private functions are necessary because GCC doesn't allow calls to private members of `__i_` from
     // free functions that are friends of `inner-iterator`.
 
-    _LIBCPP_HIDE_FROM_ABI constexpr bool __is_done() const {
+    constexpr bool __is_done() const {
       _LIBCPP_ASSERT_NON_NULL(__i_.__parent_ != nullptr, "Cannot call comparison on a default-constructed iterator.");
 
       auto [__pcur, __pend] = ranges::subrange{__i_.__parent_->__pattern_};
@@ -326,11 +326,9 @@ private:
       }
     }
 
-    [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto& __outer_current() noexcept { return __i_.__current(); }
+    [[nodiscard]] constexpr auto& __outer_current() noexcept { return __i_.__current(); }
 
-    [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr const auto& __outer_current() const noexcept {
-      return __i_.__current();
-    }
+    [[nodiscard]] constexpr const auto& __outer_current() const noexcept { return __i_.__current(); }
 
   public:
     // using iterator_category = inherited;
@@ -338,20 +336,20 @@ private:
     using value_type       = range_value_t<_Base>;
     using difference_type  = range_difference_t<_Base>;
 
-    _LIBCPP_HIDE_FROM_ABI __inner_iterator() = default;
+    __inner_iterator() = default;
 
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __inner_iterator(__outer_iterator<_Const> __i) : __i_(std::move(__i)) {}
+    constexpr explicit __inner_iterator(__outer_iterator<_Const> __i) : __i_(std::move(__i)) {}
 
-    _LIBCPP_HIDE_FROM_ABI constexpr const iterator_t<_Base>& base() const& noexcept { return __i_.__current(); }
-    _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_Base> base() &&
+    constexpr const iterator_t<_Base>& base() const& noexcept { return __i_.__current(); }
+    constexpr iterator_t<_Base> base() &&
       requires forward_range<_View>
     {
       return std::move(__i_.__current());
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator*() const { return *__i_.__current(); }
+    constexpr decltype(auto) operator*() const { return *__i_.__current(); }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __inner_iterator& operator++() {
+    constexpr __inner_iterator& operator++() {
       __incremented_ = true;
 
       if constexpr (!forward_range<_Base>) {
@@ -364,7 +362,7 @@ private:
       return *this;
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator++(int) {
+    constexpr decltype(auto) operator++(int) {
       if constexpr (forward_range<_Base>) {
         auto __tmp = *this;
         ++*this;
@@ -375,24 +373,21 @@ private:
       }
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __inner_iterator& __x, const __inner_iterator& __y)
+    friend constexpr bool operator==(const __inner_iterator& __x, const __inner_iterator& __y)
       requires forward_range<_Base>
     {
       return __x.__outer_current() == __y.__outer_current();
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __inner_iterator& __x, default_sentinel_t) {
-      return __x.__is_done();
-    }
+    friend constexpr bool operator==(const __inner_iterator& __x, default_sentinel_t) { return __x.__is_done(); }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr decltype(auto)
+    friend constexpr decltype(auto)
     iter_move(const __inner_iterator& __i) noexcept(noexcept(ranges::iter_move(__i.__outer_current()))) {
       return ranges::iter_move(__i.__outer_current());
     }
 
-    _LIBCPP_HIDE_FROM_ABI friend constexpr void iter_swap(
-        const __inner_iterator& __x,
-        const __inner_iterator& __y) noexcept(noexcept(ranges::iter_swap(__x.__outer_current(), __y.__outer_current())))
+    friend constexpr void iter_swap(const __inner_iterator& __x, const __inner_iterator& __y) noexcept(
+        noexcept(ranges::iter_swap(__x.__outer_current(), __y.__outer_current())))
       requires indirectly_swappable<iterator_t<_Base>>
     {
       ranges::iter_swap(__x.__outer_current(), __y.__outer_current());
@@ -404,14 +399,14 @@ template <class _Range, class _Pattern>
 lazy_split_view(_Range&&, _Pattern&&) -> lazy_split_view<views::all_t<_Range>, views::all_t<_Pattern>>;
 
 template <input_range _Range>
-lazy_split_view(_Range&&,
-                range_value_t<_Range>) -> lazy_split_view<views::all_t<_Range>, single_view<range_value_t<_Range>>>;
+lazy_split_view(_Range&&, range_value_t<_Range>)
+    -> lazy_split_view<views::all_t<_Range>, single_view<range_value_t<_Range>>>;
 
 namespace views {
 namespace __lazy_split_view {
 struct __fn {
   template <class _Range, class _Pattern>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Pattern&& __pattern) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Pattern&& __pattern) const
       noexcept(noexcept(lazy_split_view(std::forward<_Range>(__range), std::forward<_Pattern>(__pattern))))
           -> decltype(lazy_split_view(std::forward<_Range>(__range), std::forward<_Pattern>(__pattern))) {
     return lazy_split_view(std::forward<_Range>(__range), std::forward<_Pattern>(__pattern));
@@ -419,7 +414,7 @@ struct __fn {
 
   template <class _Pattern>
     requires constructible_from<decay_t<_Pattern>, _Pattern>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Pattern&& __pattern) const
+  [[nodiscard]] constexpr auto operator()(_Pattern&& __pattern) const
       noexcept(is_nothrow_constructible_v<decay_t<_Pattern>, _Pattern>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Pattern>(__pattern)));
   }

--- a/libcxx/include/__ranges/movable_box.h
+++ b/libcxx/include/__ranges/movable_box.h
@@ -59,19 +59,17 @@ class __movable_box {
 public:
   template <class... _Args>
     requires is_constructible_v<_Tp, _Args...>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __movable_box(in_place_t, _Args&&... __args) noexcept(
-      is_nothrow_constructible_v<_Tp, _Args...>)
+  constexpr explicit __movable_box(in_place_t, _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __val_(in_place, std::forward<_Args>(__args)...) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __movable_box() noexcept(is_nothrow_default_constructible_v<_Tp>)
+  constexpr __movable_box() noexcept(is_nothrow_default_constructible_v<_Tp>)
     requires default_initializable<_Tp>
       : __val_(in_place) {}
 
-  _LIBCPP_HIDE_FROM_ABI __movable_box(__movable_box const&) = default;
-  _LIBCPP_HIDE_FROM_ABI __movable_box(__movable_box&&)      = default;
+  __movable_box(__movable_box const&) = default;
+  __movable_box(__movable_box&&)      = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __movable_box&
-  operator=(__movable_box const& __other) noexcept(is_nothrow_copy_constructible_v<_Tp>)
+  constexpr __movable_box& operator=(__movable_box const& __other) noexcept(is_nothrow_copy_constructible_v<_Tp>)
 #  if _LIBCPP_STD_VER >= 23
     requires copy_constructible<_Tp>
 #  endif
@@ -85,12 +83,11 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI __movable_box& operator=(__movable_box&&)
+  __movable_box& operator=(__movable_box&&)
     requires movable<_Tp>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __movable_box&
-  operator=(__movable_box&& __other) noexcept(is_nothrow_move_constructible_v<_Tp>) {
+  constexpr __movable_box& operator=(__movable_box&& __other) noexcept(is_nothrow_move_constructible_v<_Tp>) {
     if (this != std::addressof(__other)) {
       if (__other.__has_value())
         __val_.emplace(std::move(*__other));
@@ -100,13 +97,13 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp const& operator*() const noexcept { return *__val_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp& operator*() noexcept { return *__val_; }
+  constexpr _Tp const& operator*() const noexcept { return *__val_; }
+  constexpr _Tp& operator*() noexcept { return *__val_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Tp* operator->() const noexcept { return __val_.operator->(); }
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp* operator->() noexcept { return __val_.operator->(); }
+  constexpr const _Tp* operator->() const noexcept { return __val_.operator->(); }
+  constexpr _Tp* operator->() noexcept { return __val_.operator->(); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr bool __has_value() const noexcept { return __val_.has_value(); }
+  constexpr bool __has_value() const noexcept { return __val_.has_value(); }
 };
 
 // This partial specialization implements an optimization for when we know we don't need to store
@@ -166,8 +163,7 @@ struct __movable_box_holder {
   _Tp __val_;
 
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __movable_box_holder(in_place_t, _Args&&... __args)
-      : __val_(std::forward<_Args>(__args)...) {}
+  constexpr explicit __movable_box_holder(in_place_t, _Args&&... __args) : __val_(std::forward<_Args>(__args)...) {}
 };
 
 template <class _Tp>
@@ -176,8 +172,7 @@ struct __movable_box_holder<_Tp> {
   _LIBCPP_NO_UNIQUE_ADDRESS _Tp __val_;
 
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __movable_box_holder(in_place_t, _Args&&... __args)
-      : __val_(std::forward<_Args>(__args)...) {}
+  constexpr explicit __movable_box_holder(in_place_t, _Args&&... __args) : __val_(std::forward<_Args>(__args)...) {}
 };
 
 template <__movable_box_object _Tp>
@@ -188,27 +183,27 @@ class __movable_box<_Tp> {
 public:
   template <class... _Args>
     requires is_constructible_v<_Tp, _Args...>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __movable_box(in_place_t __inplace, _Args&&... __args) noexcept(
-      is_nothrow_constructible_v<_Tp, _Args...>)
+  constexpr explicit __movable_box(in_place_t __inplace,
+                                   _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __holder_(__inplace, std::forward<_Args>(__args)...) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __movable_box() noexcept(is_nothrow_default_constructible_v<_Tp>)
+  constexpr __movable_box() noexcept(is_nothrow_default_constructible_v<_Tp>)
     requires default_initializable<_Tp>
       : __holder_(in_place_t{}) {}
 
-  _LIBCPP_HIDE_FROM_ABI __movable_box(__movable_box const&) = default;
-  _LIBCPP_HIDE_FROM_ABI __movable_box(__movable_box&&)      = default;
+  __movable_box(__movable_box const&) = default;
+  __movable_box(__movable_box&&)      = default;
 
   // Implementation of assignment operators in case we perform optimization (1)
-  _LIBCPP_HIDE_FROM_ABI __movable_box& operator=(__movable_box const&)
+  __movable_box& operator=(__movable_box const&)
     requires copyable<_Tp>
   = default;
-  _LIBCPP_HIDE_FROM_ABI __movable_box& operator=(__movable_box&&)
+  __movable_box& operator=(__movable_box&&)
     requires movable<_Tp>
   = default;
 
   // Implementation of assignment operators in case we perform optimization (2)
-  _LIBCPP_HIDE_FROM_ABI constexpr __movable_box& operator=(__movable_box const& __other) noexcept {
+  constexpr __movable_box& operator=(__movable_box const& __other) noexcept {
     static_assert(is_nothrow_copy_constructible_v<_Tp>);
     static_assert(!__can_use_no_unique_address<_Tp>);
     if (this != std::addressof(__other)) {
@@ -218,7 +213,7 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __movable_box& operator=(__movable_box&& __other) noexcept {
+  constexpr __movable_box& operator=(__movable_box&& __other) noexcept {
     static_assert(is_nothrow_move_constructible_v<_Tp>);
     static_assert(!__can_use_no_unique_address<_Tp>);
     if (this != std::addressof(__other)) {
@@ -228,13 +223,13 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp const& operator*() const noexcept { return __holder_.__val_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp& operator*() noexcept { return __holder_.__val_; }
+  constexpr _Tp const& operator*() const noexcept { return __holder_.__val_; }
+  constexpr _Tp& operator*() noexcept { return __holder_.__val_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Tp* operator->() const noexcept { return std::addressof(__holder_.__val_); }
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp* operator->() noexcept { return std::addressof(__holder_.__val_); }
+  constexpr const _Tp* operator->() const noexcept { return std::addressof(__holder_.__val_); }
+  constexpr _Tp* operator->() noexcept { return std::addressof(__holder_.__val_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr bool __has_value() const noexcept { return true; }
+  constexpr bool __has_value() const noexcept { return true; }
 };
 } // namespace ranges
 

--- a/libcxx/include/__ranges/non_propagating_cache.h
+++ b/libcxx/include/__ranges/non_propagating_cache.h
@@ -44,51 +44,48 @@ class __non_propagating_cache {
   // constructing the contained type from an iterator.
   struct __wrapper {
     template <class... _Args>
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __wrapper(__forward_tag, _Args&&... __args)
-        : __t_(std::forward<_Args>(__args)...) {}
+    constexpr explicit __wrapper(__forward_tag, _Args&&... __args) : __t_(std::forward<_Args>(__args)...) {}
     template <class _Fn>
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __wrapper(__from_tag, _Fn const& __f) : __t_(__f()) {}
+    constexpr explicit __wrapper(__from_tag, _Fn const& __f) : __t_(__f()) {}
     _Tp __t_;
   };
 
   optional<__wrapper> __value_ = nullopt;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __non_propagating_cache() = default;
+  __non_propagating_cache() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __non_propagating_cache(__non_propagating_cache const&) noexcept
-      : __value_(nullopt) {}
+  constexpr __non_propagating_cache(__non_propagating_cache const&) noexcept : __value_(nullopt) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __non_propagating_cache(__non_propagating_cache&& __other) noexcept
-      : __value_(nullopt) {
+  constexpr __non_propagating_cache(__non_propagating_cache&& __other) noexcept : __value_(nullopt) {
     __other.__value_.reset();
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __non_propagating_cache& operator=(__non_propagating_cache const& __other) noexcept {
+  constexpr __non_propagating_cache& operator=(__non_propagating_cache const& __other) noexcept {
     if (this != std::addressof(__other)) {
       __value_.reset();
     }
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __non_propagating_cache& operator=(__non_propagating_cache&& __other) noexcept {
+  constexpr __non_propagating_cache& operator=(__non_propagating_cache&& __other) noexcept {
     __value_.reset();
     __other.__value_.reset();
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp& operator*() { return __value_->__t_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp const& operator*() const { return __value_->__t_; }
+  constexpr _Tp& operator*() { return __value_->__t_; }
+  constexpr _Tp const& operator*() const { return __value_->__t_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr bool __has_value() const { return __value_.has_value(); }
+  constexpr bool __has_value() const { return __value_.has_value(); }
 
   template <class _Fn>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp& __emplace_from(_Fn const& __f) {
+  constexpr _Tp& __emplace_from(_Fn const& __f) {
     return __value_.emplace(__from_tag{}, __f).__t_;
   }
 
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp& __emplace(_Args&&... __args) {
+  constexpr _Tp& __emplace(_Args&&... __args) {
     return __value_.emplace(__forward_tag{}, std::forward<_Args>(__args)...).__t_;
   }
 };

--- a/libcxx/include/__ranges/owning_view.h
+++ b/libcxx/include/__ranges/owning_view.h
@@ -41,60 +41,60 @@ class owning_view : public view_interface<owning_view<_Rp>> {
   _Rp __r_ = _Rp();
 
 public:
-  _LIBCPP_HIDE_FROM_ABI owning_view()
+  owning_view()
     requires default_initializable<_Rp>
   = default;
-  _LIBCPP_HIDE_FROM_ABI constexpr owning_view(_Rp&& __r) : __r_(std::move(__r)) {}
+  constexpr owning_view(_Rp&& __r) : __r_(std::move(__r)) {}
 
-  _LIBCPP_HIDE_FROM_ABI owning_view(owning_view&&)            = default;
-  _LIBCPP_HIDE_FROM_ABI owning_view& operator=(owning_view&&) = default;
+  owning_view(owning_view&&)            = default;
+  owning_view& operator=(owning_view&&) = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Rp& base() & noexcept { return __r_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Rp& base() const& noexcept { return __r_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr _Rp&& base() && noexcept { return std::move(__r_); }
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Rp&& base() const&& noexcept { return std::move(__r_); }
+  constexpr _Rp& base() & noexcept { return __r_; }
+  constexpr const _Rp& base() const& noexcept { return __r_; }
+  constexpr _Rp&& base() && noexcept { return std::move(__r_); }
+  constexpr const _Rp&& base() const&& noexcept { return std::move(__r_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_Rp> begin() { return ranges::begin(__r_); }
-  _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_Rp> end() { return ranges::end(__r_); }
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr iterator_t<_Rp> begin() { return ranges::begin(__r_); }
+  constexpr sentinel_t<_Rp> end() { return ranges::end(__r_); }
+  constexpr auto begin() const
     requires range<const _Rp>
   {
     return ranges::begin(__r_);
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires range<const _Rp>
   {
     return ranges::end(__r_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr bool empty()
+  constexpr bool empty()
     requires requires { ranges::empty(__r_); }
   {
     return ranges::empty(__r_);
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr bool empty() const
+  constexpr bool empty() const
     requires requires { ranges::empty(__r_); }
   {
     return ranges::empty(__r_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires sized_range<_Rp>
   {
     return ranges::size(__r_);
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<const _Rp>
   {
     return ranges::size(__r_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto data()
+  constexpr auto data()
     requires contiguous_range<_Rp>
   {
     return ranges::data(__r_);
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr auto data() const
+  constexpr auto data() const
     requires contiguous_range<const _Rp>
   {
     return ranges::data(__r_);

--- a/libcxx/include/__ranges/range_adaptor.h
+++ b/libcxx/include/__ranges/range_adaptor.h
@@ -53,7 +53,7 @@ struct __range_adaptor_closure {};
 // i.e. something that can be called via the `x | f` notation.
 template <class _Fn>
 struct __pipeable : _Fn, __range_adaptor_closure<__pipeable<_Fn>> {
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __pipeable(_Fn&& __f) : _Fn(std::move(__f)) {}
+  constexpr explicit __pipeable(_Fn&& __f) : _Fn(std::move(__f)) {}
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(__pipeable);
 
@@ -69,14 +69,14 @@ concept _RangeAdaptorClosure = !ranges::range<remove_cvref_t<_Tp>> && requires {
 
 template <ranges::range _Range, _RangeAdaptorClosure _Closure>
   requires invocable<_Closure, _Range>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto)
+[[nodiscard]] constexpr decltype(auto)
 operator|(_Range&& __range, _Closure&& __closure) noexcept(is_nothrow_invocable_v<_Closure, _Range>) {
   return std::invoke(std::forward<_Closure>(__closure), std::forward<_Range>(__range));
 }
 
 template <_RangeAdaptorClosure _Closure, _RangeAdaptorClosure _OtherClosure>
   requires constructible_from<decay_t<_Closure>, _Closure> && constructible_from<decay_t<_OtherClosure>, _OtherClosure>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator|(_Closure&& __c1, _OtherClosure&& __c2) noexcept(
+[[nodiscard]] constexpr auto operator|(_Closure&& __c1, _OtherClosure&& __c2) noexcept(
     is_nothrow_constructible_v<decay_t<_Closure>, _Closure> &&
     is_nothrow_constructible_v<decay_t<_OtherClosure>, _OtherClosure>) {
   return __pipeable(std::__compose(std::forward<_OtherClosure>(__c2), std::forward<_Closure>(__c1)));

--- a/libcxx/include/__ranges/rbegin.h
+++ b/libcxx/include/__ranges/rbegin.h
@@ -58,21 +58,19 @@ concept __can_reverse =
 struct __fn {
   template <class _Tp>
     requires __member_rbegin<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.rbegin()))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.rbegin()))) {
     return _LIBCPP_AUTO_CAST(__t.rbegin());
   }
 
   template <class _Tp>
     requires __unqualified_rbegin<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(rbegin(__t)))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(rbegin(__t)))) {
     return _LIBCPP_AUTO_CAST(rbegin(__t));
   }
 
   template <class _Tp>
     requires __can_reverse<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(ranges::end(__t))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(ranges::end(__t))) {
     return std::make_reverse_iterator(ranges::end(__t));
   }
 
@@ -92,7 +90,7 @@ namespace __crbegin {
 struct __fn {
   template <class _Tp>
     requires is_lvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t))))
           -> decltype(ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t))) {
     return ranges::rbegin(static_cast<const remove_reference_t<_Tp>&>(__t));
@@ -100,7 +98,7 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::rbegin(static_cast<const _Tp&&>(__t))))
           -> decltype(ranges::rbegin(static_cast<const _Tp&&>(__t))) {
     return ranges::rbegin(static_cast<const _Tp&&>(__t));

--- a/libcxx/include/__ranges/ref_view.h
+++ b/libcxx/include/__ranges/ref_view.h
@@ -48,27 +48,26 @@ class ref_view : public view_interface<ref_view<_Range>> {
 public:
   template <class _Tp>
     requires __different_from<_Tp, ref_view> && convertible_to<_Tp, _Range&> && requires { __fun(std::declval<_Tp>()); }
-  _LIBCPP_HIDE_FROM_ABI constexpr ref_view(_Tp&& __t)
-      : __range_(std::addressof(static_cast<_Range&>(std::forward<_Tp>(__t)))) {}
+  constexpr ref_view(_Tp&& __t) : __range_(std::addressof(static_cast<_Range&>(std::forward<_Tp>(__t)))) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Range& base() const { return *__range_; }
+  constexpr _Range& base() const { return *__range_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_Range> begin() const { return ranges::begin(*__range_); }
-  _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_Range> end() const { return ranges::end(*__range_); }
+  constexpr iterator_t<_Range> begin() const { return ranges::begin(*__range_); }
+  constexpr sentinel_t<_Range> end() const { return ranges::end(*__range_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr bool empty() const
+  constexpr bool empty() const
     requires requires { ranges::empty(*__range_); }
   {
     return ranges::empty(*__range_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<_Range>
   {
     return ranges::size(*__range_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto data() const
+  constexpr auto data() const
     requires contiguous_range<_Range>
   {
     return ranges::data(*__range_);

--- a/libcxx/include/__ranges/rend.h
+++ b/libcxx/include/__ranges/rend.h
@@ -61,22 +61,19 @@ class __fn {
 public:
   template <class _Tp>
     requires __member_rend<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.rend()))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.rend()))) {
     return _LIBCPP_AUTO_CAST(__t.rend());
   }
 
   template <class _Tp>
     requires __unqualified_rend<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(rend(__t)))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCPP_AUTO_CAST(rend(__t)))) {
     return _LIBCPP_AUTO_CAST(rend(__t));
   }
 
   template <class _Tp>
     requires __can_reverse<_Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(ranges::begin(__t))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(ranges::begin(__t))) {
     return std::make_reverse_iterator(ranges::begin(__t));
   }
 
@@ -96,7 +93,7 @@ namespace __crend {
 struct __fn {
   template <class _Tp>
     requires is_lvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t))))
           -> decltype(ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t))) {
     return ranges::rend(static_cast<const remove_reference_t<_Tp>&>(__t));
@@ -104,8 +101,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::rend(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::rend(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::rend(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::rend(static_cast<const _Tp&&>(__t))) {
     return ranges::rend(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/repeat_view.h
+++ b/libcxx/include/__ranges/repeat_view.h
@@ -80,18 +80,18 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS repeat_view : public view_interface<r
   class __iterator;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI repeat_view()
+  repeat_view()
     requires default_initializable<_Tp>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit repeat_view(const _Tp& __value, _Bound __bound_sentinel = _Bound())
+  constexpr explicit repeat_view(const _Tp& __value, _Bound __bound_sentinel = _Bound())
     requires copy_constructible<_Tp>
       : __value_(in_place, __value), __bound_(__bound_sentinel) {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t>)
       _LIBCPP_ASSERT_UNCATEGORIZED(__bound_ >= 0, "The value of bound must be greater than or equal to 0");
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit repeat_view(_Tp&& __value, _Bound __bound_sentinel = _Bound())
+  constexpr explicit repeat_view(_Tp&& __value, _Bound __bound_sentinel = _Bound())
       : __value_(in_place, std::move(__value)), __bound_(__bound_sentinel) {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t>)
       _LIBCPP_ASSERT_UNCATEGORIZED(__bound_ >= 0, "The value of bound must be greater than or equal to 0");
@@ -99,7 +99,7 @@ public:
 
   template <class... _TpArgs, class... _BoundArgs>
     requires(constructible_from<_Tp, _TpArgs...> && constructible_from<_Bound, _BoundArgs...>)
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit repeat_view(
+  constexpr explicit repeat_view(
       piecewise_construct_t, tuple<_TpArgs...> __value_args, tuple<_BoundArgs...> __bound_args = tuple<>{})
       : __value_(in_place, std::make_from_tuple<_Tp>(std::move(__value_args))),
         __bound_(std::make_from_tuple<_Bound>(std::move(__bound_args))) {
@@ -108,17 +108,17 @@ public:
           __bound_ >= 0, "The behavior is undefined if Bound is not unreachable_sentinel_t and bound is negative");
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator begin() const { return __iterator(std::addressof(*__value_)); }
+  constexpr __iterator begin() const { return __iterator(std::addressof(*__value_)); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator end() const
+  constexpr __iterator end() const
     requires(!same_as<_Bound, unreachable_sentinel_t>)
   {
     return __iterator(std::addressof(*__value_), __bound_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr unreachable_sentinel_t end() const noexcept { return unreachable_sentinel; }
+  constexpr unreachable_sentinel_t end() const noexcept { return unreachable_sentinel; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires(!same_as<_Bound, unreachable_sentinel_t>)
   {
     return std::__to_unsigned_like(__bound_);
@@ -141,7 +141,7 @@ class repeat_view<_Tp, _Bound>::__iterator {
 
   using _IndexT _LIBCPP_NODEBUG = conditional_t<same_as<_Bound, unreachable_sentinel_t>, ptrdiff_t, _Bound>;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __iterator(const _Tp* __value, _IndexT __bound_sentinel = _IndexT())
+  constexpr explicit __iterator(const _Tp* __value, _IndexT __bound_sentinel = _IndexT())
       : __value_(__value), __current_(__bound_sentinel) {}
 
 public:
@@ -150,74 +150,74 @@ public:
   using value_type        = _Tp;
   using difference_type   = __repeat_view_iterator_difference_t<_IndexT>;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator() = default;
+  __iterator() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Tp& operator*() const noexcept { return *__value_; }
+  constexpr const _Tp& operator*() const noexcept { return *__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+  constexpr __iterator& operator++() {
     ++__current_;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int) {
+  constexpr __iterator operator++(int) {
     auto __tmp = *this;
     ++*this;
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator--() {
+  constexpr __iterator& operator--() {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t>)
       _LIBCPP_ASSERT_UNCATEGORIZED(__current_ > 0, "The value of bound must be greater than or equal to 0");
     --__current_;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator--(int) {
+  constexpr __iterator operator--(int) {
     auto __tmp = *this;
     --*this;
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator+=(difference_type __n) {
+  constexpr __iterator& operator+=(difference_type __n) {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t>)
       _LIBCPP_ASSERT_UNCATEGORIZED(__current_ + __n >= 0, "The value of bound must be greater than or equal to 0");
     __current_ += __n;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator-=(difference_type __n) {
+  constexpr __iterator& operator-=(difference_type __n) {
     if constexpr (!same_as<_Bound, unreachable_sentinel_t>)
       _LIBCPP_ASSERT_UNCATEGORIZED(__current_ - __n >= 0, "The value of bound must be greater than or equal to 0");
     __current_ -= __n;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Tp& operator[](difference_type __n) const noexcept { return *(*this + __n); }
+  constexpr const _Tp& operator[](difference_type __n) const noexcept { return *(*this + __n); }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y) {
+  friend constexpr bool operator==(const __iterator& __x, const __iterator& __y) {
     return __x.__current_ == __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y) {
+  friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y) {
     return __x.__current_ <=> __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(__iterator __i, difference_type __n) {
+  friend constexpr __iterator operator+(__iterator __i, difference_type __n) {
     __i += __n;
     return __i;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(difference_type __n, __iterator __i) {
+  friend constexpr __iterator operator+(difference_type __n, __iterator __i) {
     __i += __n;
     return __i;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator-(__iterator __i, difference_type __n) {
+  friend constexpr __iterator operator-(__iterator __i, difference_type __n) {
     __i -= __n;
     return __i;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y) {
+  friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y) {
     return static_cast<difference_type>(__x.__current_) - static_cast<difference_type>(__y.__current_);
   }
 
@@ -231,13 +231,13 @@ namespace views {
 namespace __repeat {
 struct __fn {
   template <class _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Tp&& __value)
+  [[nodiscard]] static constexpr auto operator()(_Tp&& __value)
     noexcept(noexcept(ranges::repeat_view<decay_t<_Tp>>(std::forward<_Tp>(__value))))
     -> decltype(      ranges::repeat_view<decay_t<_Tp>>(std::forward<_Tp>(__value)))
     { return          ranges::repeat_view<decay_t<_Tp>>(std::forward<_Tp>(__value)); }
 
   template <class _Tp, class _Bound>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Tp&& __value, _Bound&& __bound_sentinel)
+  [[nodiscard]] static constexpr auto operator()(_Tp&& __value, _Bound&& __bound_sentinel)
     noexcept(noexcept(ranges::repeat_view(std::forward<_Tp>(__value), std::forward<_Bound>(__bound_sentinel))))
     -> decltype(      ranges::repeat_view(std::forward<_Tp>(__value), std::forward<_Bound>(__bound_sentinel)))
     { return          ranges::repeat_view(std::forward<_Tp>(__value), std::forward<_Bound>(__bound_sentinel)); }

--- a/libcxx/include/__ranges/reverse_view.h
+++ b/libcxx/include/__ranges/reverse_view.h
@@ -53,21 +53,21 @@ class reverse_view : public view_interface<reverse_view<_View>> {
   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_          = _View();
 
 public:
-  _LIBCPP_HIDE_FROM_ABI reverse_view()
+  reverse_view()
     requires default_initializable<_View>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit reverse_view(_View __view) : __base_(std::move(__view)) {}
+  constexpr explicit reverse_view(_View __view) : __base_(std::move(__view)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr reverse_iterator<iterator_t<_View>> begin() {
+  constexpr reverse_iterator<iterator_t<_View>> begin() {
     if constexpr (_UseCache)
       if (__cached_begin_.__has_value())
         return *__cached_begin_;
@@ -78,35 +78,33 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr reverse_iterator<iterator_t<_View>> begin()
+  constexpr reverse_iterator<iterator_t<_View>> begin()
     requires common_range<_View>
   {
     return std::make_reverse_iterator(ranges::end(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires common_range<const _View>
   {
     return std::make_reverse_iterator(ranges::end(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr reverse_iterator<iterator_t<_View>> end() {
-    return std::make_reverse_iterator(ranges::begin(__base_));
-  }
+  constexpr reverse_iterator<iterator_t<_View>> end() { return std::make_reverse_iterator(ranges::begin(__base_)); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires common_range<const _View>
   {
     return std::make_reverse_iterator(ranges::begin(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires sized_range<_View>
   {
     return ranges::size(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<const _View>
   {
     return ranges::size(__base_);
@@ -156,7 +154,7 @@ struct __unwrapped_reverse_subrange<subrange<reverse_iterator<_Iter>, reverse_it
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires __is_reverse_view<remove_cvref_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
       noexcept(noexcept(std::forward<_Range>(__range).base())) -> decltype(std::forward<_Range>(__range).base()) {
     return std::forward<_Range>(__range).base();
   }
@@ -164,7 +162,7 @@ struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range,
             class _UnwrappedSubrange = typename __unwrapped_reverse_subrange<remove_cvref_t<_Range>>::type>
     requires __is_sized_reverse_subrange<remove_cvref_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
       noexcept(noexcept(_UnwrappedSubrange(__range.end().base(), __range.begin().base(), __range.size())))
           -> decltype(_UnwrappedSubrange(__range.end().base(), __range.begin().base(), __range.size())) {
     return _UnwrappedSubrange(__range.end().base(), __range.begin().base(), __range.size());
@@ -173,7 +171,7 @@ struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range,
             class _UnwrappedSubrange = typename __unwrapped_reverse_subrange<remove_cvref_t<_Range>>::type>
     requires __is_unsized_reverse_subrange<remove_cvref_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
       noexcept(noexcept(_UnwrappedSubrange(__range.end().base(), __range.begin().base())))
           -> decltype(_UnwrappedSubrange(__range.end().base(), __range.begin().base())) {
     return _UnwrappedSubrange(__range.end().base(), __range.begin().base());
@@ -182,8 +180,9 @@ struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires(!__is_reverse_view<remove_cvref_t<_Range>> && !__is_sized_reverse_subrange<remove_cvref_t<_Range>> &&
              !__is_unsized_reverse_subrange<remove_cvref_t<_Range>>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(noexcept(reverse_view{
-      std::forward<_Range>(__range)})) -> decltype(reverse_view{std::forward<_Range>(__range)}) {
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(reverse_view{std::forward<_Range>(__range)}))
+          -> decltype(reverse_view{std::forward<_Range>(__range)}) {
     return reverse_view{std::forward<_Range>(__range)};
   }
 };

--- a/libcxx/include/__ranges/single_view.h
+++ b/libcxx/include/__ranges/single_view.h
@@ -45,39 +45,38 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS single_view : public view_interface<s
   _LIBCPP_NO_UNIQUE_ADDRESS __movable_box<_Tp> __value_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI single_view()
+  single_view()
     requires default_initializable<_Tp>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit single_view(const _Tp& __t)
+  constexpr explicit single_view(const _Tp& __t)
 #  if _LIBCPP_STD_VER >= 23
     requires copy_constructible<_Tp>
 #  endif
       : __value_(in_place, __t) {
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit single_view(_Tp&& __t) : __value_(in_place, std::move(__t)) {}
+  constexpr explicit single_view(_Tp&& __t) : __value_(in_place, std::move(__t)) {}
 
   template <class... _Args>
     requires constructible_from<_Tp, _Args...>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit single_view(in_place_t, _Args&&... __args)
-      : __value_{in_place, std::forward<_Args>(__args)...} {}
+  constexpr explicit single_view(in_place_t, _Args&&... __args) : __value_{in_place, std::forward<_Args>(__args)...} {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp* begin() noexcept { return data(); }
+  constexpr _Tp* begin() noexcept { return data(); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Tp* begin() const noexcept { return data(); }
+  constexpr const _Tp* begin() const noexcept { return data(); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp* end() noexcept { return data() + 1; }
+  constexpr _Tp* end() noexcept { return data() + 1; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Tp* end() const noexcept { return data() + 1; }
+  constexpr const _Tp* end() const noexcept { return data() + 1; }
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr bool empty() noexcept { return false; }
+  static constexpr bool empty() noexcept { return false; }
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr size_t size() noexcept { return 1; }
+  static constexpr size_t size() noexcept { return 1; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Tp* data() noexcept { return __value_.operator->(); }
+  constexpr _Tp* data() noexcept { return __value_.operator->(); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Tp* data() const noexcept { return __value_.operator->(); }
+  constexpr const _Tp* data() const noexcept { return __value_.operator->(); }
 };
 
 template <class _Tp>
@@ -88,7 +87,7 @@ namespace __single_view {
 
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range) const
       noexcept(noexcept(single_view<decay_t<_Range&&>>(std::forward<_Range>(__range))))
           -> decltype(single_view<decay_t<_Range&&>>(std::forward<_Range>(__range))) {
     return single_view<decay_t<_Range&&>>(std::forward<_Range>(__range));

--- a/libcxx/include/__ranges/size.h
+++ b/libcxx/include/__ranges/size.h
@@ -68,33 +68,33 @@ concept __difference =
 struct __fn {
   // `[range.prim.size]`: the array case (for rvalues).
   template <class _Tp, size_t _Sz>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr size_t operator()(_Tp (&&)[_Sz]) const noexcept {
+  [[nodiscard]] constexpr size_t operator()(_Tp (&&)[_Sz]) const noexcept {
     return _Sz;
   }
 
   // `[range.prim.size]`: the array case (for lvalues).
   template <class _Tp, size_t _Sz>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr size_t operator()(_Tp (&)[_Sz]) const noexcept {
+  [[nodiscard]] constexpr size_t operator()(_Tp (&)[_Sz]) const noexcept {
     return _Sz;
   }
 
   // `[range.prim.size]`: `auto(t.size())` is a valid expression.
   template <__member_size _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr __integer_like auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr __integer_like auto operator()(_Tp&& __t) const
       noexcept(noexcept(_LIBCPP_AUTO_CAST(__t.size()))) {
     return _LIBCPP_AUTO_CAST(__t.size());
   }
 
   // `[range.prim.size]`: `auto(size(t))` is a valid expression.
   template <__unqualified_size _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr __integer_like auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr __integer_like auto operator()(_Tp&& __t) const
       noexcept(noexcept(_LIBCPP_AUTO_CAST(size(__t)))) {
     return _LIBCPP_AUTO_CAST(size(__t));
   }
 
   // [range.prim.size]: the `to-unsigned-like` case.
   template <__difference _Tp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+  [[nodiscard]] constexpr auto operator()(_Tp&& __t) const
       noexcept(noexcept(std::__to_unsigned_like(ranges::end(__t) - ranges::begin(__t))))
           -> decltype(std::__to_unsigned_like(ranges::end(__t) - ranges::begin(__t))) {
     return std::__to_unsigned_like(ranges::end(__t) - ranges::begin(__t));

--- a/libcxx/include/__ranges/split_view.h
+++ b/libcxx/include/__ranges/split_view.h
@@ -74,36 +74,35 @@ private:
   }
 
 public:
-  _LIBCPP_HIDE_FROM_ABI split_view()
+  split_view()
     requires default_initializable<_View> && default_initializable<_Pattern>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 split_view(_View __base, _Pattern __pattern)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 split_view(_View __base, _Pattern __pattern)
       : __base_(std::move(__base)), __pattern_(std::move((__pattern))) {}
 
   template <forward_range _Range>
     requires constructible_from<_View, views::all_t<_Range>> &&
                  constructible_from<_Pattern, single_view<range_value_t<_Range>>>
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23
-  split_view(_Range&& __range, range_value_t<_Range> __elem)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 split_view(_Range&& __range, range_value_t<_Range> __elem)
       : __base_(views::all(std::forward<_Range>(__range))), __pattern_(views::single(std::move(__elem))) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator begin() {
+  constexpr __iterator begin() {
     if (!__cached_begin_.__has_value()) {
       __cached_begin_.__emplace(__find_next(ranges::begin(__base_)));
     }
     return {*this, ranges::begin(__base_), *__cached_begin_};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() {
+  constexpr auto end() {
     if constexpr (common_range<_View>) {
       return __iterator{*this, ranges::end(__base_), {}};
     } else {
@@ -136,17 +135,17 @@ public:
   using value_type        = subrange<iterator_t<_View>>;
   using difference_type   = range_difference_t<_View>;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator() = default;
+  __iterator() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(
+  constexpr __iterator(
       split_view<_View, _Pattern>& __parent, iterator_t<_View> __current, subrange<iterator_t<_View>> __next)
       : __parent_(std::addressof(__parent)), __cur_(std::move(__current)), __next_(std::move(__next)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_View> base() const { return __cur_; }
+  constexpr iterator_t<_View> base() const { return __cur_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr value_type operator*() const { return {__cur_, __next_.begin()}; }
+  constexpr value_type operator*() const { return {__cur_, __next_.begin()}; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+  constexpr __iterator& operator++() {
     __cur_ = __next_.begin();
     if (__cur_ != ranges::end(__parent_->__base_)) {
       __cur_ = __next_.end();
@@ -162,13 +161,13 @@ public:
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int) {
+  constexpr __iterator operator++(int) {
     auto __tmp = *this;
     ++*this;
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y) {
+  friend constexpr bool operator==(const __iterator& __x, const __iterator& __y) {
     return __x.__cur_ == __y.__cur_ && __x.__trailing_empty_ == __y.__trailing_empty_;
   }
 };
@@ -180,19 +179,16 @@ struct split_view<_View, _Pattern>::__sentinel {
 private:
   _LIBCPP_NO_UNIQUE_ADDRESS sentinel_t<_View> __end_ = sentinel_t<_View>();
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr bool __equals(const __iterator& __x, const __sentinel& __y) {
+  static constexpr bool __equals(const __iterator& __x, const __sentinel& __y) {
     return __x.__cur_ == __y.__end_ && !__x.__trailing_empty_;
   }
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
+  __sentinel() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(split_view<_View, _Pattern>& __parent)
-      : __end_(ranges::end(__parent.__base_)) {}
+  constexpr explicit __sentinel(split_view<_View, _Pattern>& __parent) : __end_(ranges::end(__parent.__base_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __sentinel& __y) {
-    return __equals(__x, __y);
-  }
+  friend constexpr bool operator==(const __iterator& __x, const __sentinel& __y) { return __equals(__x, __y); }
 };
 
 namespace views {
@@ -200,8 +196,7 @@ namespace __split_view {
 struct __fn {
   // clang-format off
   template <class _Range, class _Pattern>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI
-  constexpr auto operator()(_Range&& __range, _Pattern&& __pattern) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Pattern&& __pattern) const
     noexcept(noexcept(split_view(std::forward<_Range>(__range), std::forward<_Pattern>(__pattern))))
     -> decltype(      split_view(std::forward<_Range>(__range), std::forward<_Pattern>(__pattern)))
     { return          split_view(std::forward<_Range>(__range), std::forward<_Pattern>(__pattern)); }
@@ -209,7 +204,7 @@ struct __fn {
 
   template <class _Pattern>
     requires constructible_from<decay_t<_Pattern>, _Pattern>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Pattern&& __pattern) const
+  [[nodiscard]] constexpr auto operator()(_Pattern&& __pattern) const
       noexcept(is_nothrow_constructible_v<decay_t<_Pattern>, _Pattern>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Pattern>(__pattern)));
   }

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -80,7 +80,7 @@ public:
 private:
   static constexpr bool _MustProvideSizeAtConstruction = !_StoreSize; // just to improve compiler diagnostics
   struct _Empty {
-    _LIBCPP_HIDE_FROM_ABI constexpr _Empty(auto) noexcept {}
+    constexpr _Empty(auto) noexcept {}
   };
   using _Size _LIBCPP_NODEBUG = conditional_t<_StoreSize, make_unsigned_t<iter_difference_t<_Iter>>, _Empty>;
   _LIBCPP_NO_UNIQUE_ADDRESS _Iter __begin_ = _Iter();
@@ -88,15 +88,15 @@ private:
   _LIBCPP_NO_UNIQUE_ADDRESS _Size __size_  = 0;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI subrange()
+  subrange()
     requires default_initializable<_Iter>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr subrange(__convertible_to_non_slicing<_Iter> auto __iter, _Sent __sent)
+  constexpr subrange(__convertible_to_non_slicing<_Iter> auto __iter, _Sent __sent)
     requires _MustProvideSizeAtConstruction
       : __begin_(std::move(__iter)), __end_(std::move(__sent)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr subrange(
+  constexpr subrange(
       __convertible_to_non_slicing<_Iter> auto __iter, _Sent __sent, make_unsigned_t<iter_difference_t<_Iter>> __n)
     requires(_Kind == subrange_kind::sized)
       : __begin_(std::move(__iter)), __end_(std::move(__sent)), __size_(__n) {
@@ -108,46 +108,46 @@ public:
   template <__different_from<subrange> _Range>
     requires borrowed_range<_Range> && __convertible_to_non_slicing<iterator_t<_Range>, _Iter> &&
              convertible_to<sentinel_t<_Range>, _Sent>
-             _LIBCPP_HIDE_FROM_ABI constexpr subrange(_Range&& __range)
+             constexpr subrange(_Range&& __range)
                requires(!_StoreSize)
       : subrange(ranges::begin(__range), ranges::end(__range)) {}
 
   template <__different_from<subrange> _Range>
     requires borrowed_range<_Range> && __convertible_to_non_slicing<iterator_t<_Range>, _Iter> &&
              convertible_to<sentinel_t<_Range>, _Sent>
-             _LIBCPP_HIDE_FROM_ABI constexpr subrange(_Range&& __range)
+             constexpr subrange(_Range&& __range)
                requires _StoreSize && sized_range<_Range>
       : subrange(__range, ranges::size(__range)) {}
 
   template <borrowed_range _Range>
     requires __convertible_to_non_slicing<iterator_t<_Range>, _Iter> &&
              convertible_to<sentinel_t<_Range>, _Sent>
-             _LIBCPP_HIDE_FROM_ABI constexpr subrange(_Range&& __range, make_unsigned_t<iter_difference_t<_Iter>> __n)
+             constexpr subrange(_Range&& __range, make_unsigned_t<iter_difference_t<_Iter>> __n)
                requires(_Kind == subrange_kind::sized)
       : subrange(ranges::begin(__range), ranges::end(__range), __n) {}
 
   template <__pair_like_convertible_from<const _Iter&, const _Sent&> _Pair>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator _Pair() const {
+  constexpr operator _Pair() const {
     return _Pair(__begin_, __end_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter begin() const
+  constexpr _Iter begin() const
     requires copyable<_Iter>
   {
     return __begin_;
   }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter begin()
+  [[nodiscard]] constexpr _Iter begin()
     requires(!copyable<_Iter>)
   {
     return std::move(__begin_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Sent end() const { return __end_; }
+  constexpr _Sent end() const { return __end_; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool empty() const { return __begin_ == __end_; }
+  [[nodiscard]] constexpr bool empty() const { return __begin_ == __end_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr make_unsigned_t<iter_difference_t<_Iter>> size() const
+  constexpr make_unsigned_t<iter_difference_t<_Iter>> size() const
     requires(_Kind == subrange_kind::sized)
   {
     if constexpr (_StoreSize)
@@ -156,7 +156,7 @@ public:
       return std::__to_unsigned_like(__end_ - __begin_);
   }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange next(iter_difference_t<_Iter> __n = 1) const&
+  [[nodiscard]] constexpr subrange next(iter_difference_t<_Iter> __n = 1) const&
     requires forward_iterator<_Iter>
   {
     auto __tmp = *this;
@@ -164,12 +164,12 @@ public:
     return __tmp;
   }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange next(iter_difference_t<_Iter> __n = 1) && {
+  [[nodiscard]] constexpr subrange next(iter_difference_t<_Iter> __n = 1) && {
     advance(__n);
     return std::move(*this);
   }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange prev(iter_difference_t<_Iter> __n = 1) const
+  [[nodiscard]] constexpr subrange prev(iter_difference_t<_Iter> __n = 1) const
     requires bidirectional_iterator<_Iter>
   {
     auto __tmp = *this;
@@ -177,7 +177,7 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr subrange& advance(iter_difference_t<_Iter> __n) {
+  constexpr subrange& advance(iter_difference_t<_Iter> __n) {
     if constexpr (bidirectional_iterator<_Iter>) {
       if (__n < 0) {
         ranges::advance(__begin_, __n);
@@ -201,11 +201,12 @@ template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
 subrange(_Iter, _Sent, make_unsigned_t<iter_difference_t<_Iter>>) -> subrange<_Iter, _Sent, subrange_kind::sized>;
 
 template <borrowed_range _Range>
-subrange(_Range&&) -> subrange<iterator_t<_Range>,
-                               sentinel_t<_Range>,
-                               (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
-                                   ? subrange_kind::sized
-                                   : subrange_kind::unsized>;
+subrange(_Range&&)
+    -> subrange<iterator_t<_Range>,
+                sentinel_t<_Range>,
+                (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
+                    ? subrange_kind::sized
+                    : subrange_kind::unsized>;
 
 template <borrowed_range _Range>
 subrange(_Range&&, make_unsigned_t<range_difference_t<_Range>>)
@@ -213,7 +214,7 @@ subrange(_Range&&, make_unsigned_t<range_difference_t<_Range>>)
 
 template <size_t _Index, class _Iter, class _Sent, subrange_kind _Kind>
   requires((_Index == 0 && copyable<_Iter>) || _Index == 1)
-_LIBCPP_HIDE_FROM_ABI constexpr auto get(const subrange<_Iter, _Sent, _Kind>& __subrange) {
+constexpr auto get(const subrange<_Iter, _Sent, _Kind>& __subrange) {
   if constexpr (_Index == 0)
     return __subrange.begin();
   else
@@ -222,7 +223,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto get(const subrange<_Iter, _Sent, _Kind>& __
 
 template <size_t _Index, class _Iter, class _Sent, subrange_kind _Kind>
   requires(_Index < 2)
-_LIBCPP_HIDE_FROM_ABI constexpr auto get(subrange<_Iter, _Sent, _Kind>&& __subrange) {
+constexpr auto get(subrange<_Iter, _Sent, _Kind>&& __subrange) {
   if constexpr (_Index == 0)
     return __subrange.begin();
   else

--- a/libcxx/include/__ranges/take_view.h
+++ b/libcxx/include/__ranges/take_view.h
@@ -65,25 +65,24 @@ class take_view : public view_interface<take_view<_View>> {
   class __sentinel;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI take_view()
+  take_view()
     requires default_initializable<_View>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23
-  take_view(_View __base, range_difference_t<_View> __count)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 take_view(_View __base, range_difference_t<_View> __count)
       : __base_(std::move(__base)), __count_(__count) {
     _LIBCPP_ASSERT_UNCATEGORIZED(__count >= 0, "count has to be greater than or equal to zero");
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
+  constexpr auto begin()
     requires(!__simple_view<_View>)
   {
     if constexpr (sized_range<_View>) {
@@ -99,7 +98,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires range<const _View>
   {
     if constexpr (sized_range<const _View>) {
@@ -115,7 +114,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  constexpr auto end()
     requires(!__simple_view<_View>)
   {
     if constexpr (sized_range<_View>) {
@@ -129,7 +128,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires range<const _View>
   {
     if constexpr (sized_range<const _View>) {
@@ -143,14 +142,14 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires sized_range<_View>
   {
     auto __n = ranges::size(__base_);
     return ranges::min(__n, static_cast<decltype(__n)>(__count_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<const _View>
   {
     auto __n = ranges::size(__base_);
@@ -170,23 +169,23 @@ class take_view<_View>::__sentinel {
   friend class take_view<_View>::__sentinel;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
+  __sentinel() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(sentinel_t<_Base> __end) : __end_(std::move(__end)) {}
+  constexpr explicit __sentinel(sentinel_t<_Base> __end) : __end_(std::move(__end)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __sentinel(__sentinel<!_Const> __s)
+  constexpr __sentinel(__sentinel<!_Const> __s)
     requires _Const && convertible_to<sentinel_t<_View>, sentinel_t<_Base>>
       : __end_(std::move(__s.__end_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_Base> base() const { return __end_; }
+  constexpr sentinel_t<_Base> base() const { return __end_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const _Iter<_Const>& __lhs, const __sentinel& __rhs) {
+  friend constexpr bool operator==(const _Iter<_Const>& __lhs, const __sentinel& __rhs) {
     return __lhs.count() == 0 || __lhs.base() == __rhs.__end_;
   }
 
   template <bool _OtherConst = !_Const>
     requires sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const _Iter<_OtherConst>& __lhs, const __sentinel& __rhs) {
+  friend constexpr bool operator==(const _Iter<_OtherConst>& __lhs, const __sentinel& __rhs) {
     return __lhs.count() == 0 || __lhs.base() == __rhs.__end_;
   }
 };
@@ -250,7 +249,7 @@ struct __fn {
   // [range.take.overview]: the `empty_view` case.
   template <class _Range, convertible_to<range_difference_t<_Range>> _Np>
     requires __is_empty_view<remove_cvref_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&&) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Np&&) const
       noexcept(noexcept(_LIBCPP_AUTO_CAST(std::forward<_Range>(__range))))
           -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Range>(__range))) {
     return _LIBCPP_AUTO_CAST(std::forward<_Range>(__range));
@@ -263,7 +262,7 @@ struct __fn {
             class _Dist     = range_difference_t<_Range>>
     requires(!__is_empty_view<_RawRange> && random_access_range<_RawRange> && sized_range<_RawRange> &&
              __is_passthrough_specialization<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto
+  [[nodiscard]] constexpr auto
   operator()(_Range&& __rng, _Np&& __n) const noexcept(noexcept(__passthrough_type_t<_RawRange>(
       ranges::begin(__rng), ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)))))
       -> decltype(__passthrough_type_t<_RawRange>(
@@ -284,8 +283,7 @@ struct __fn {
               random_access_range<_RawRange> &&
               sized_range<_RawRange> &&
               __is_iota_specialization<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI
-  constexpr auto operator()(_Range&& __rng, _Np&& __n) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __rng, _Np&& __n) const
     noexcept(noexcept(ranges::iota_view(
                               *ranges::begin(__rng),
                               *(ranges::begin(__rng) + std::min<_Dist>(ranges::distance(__rng), std::forward<_Np>(__n)))
@@ -307,7 +305,7 @@ struct __fn {
             class _RawRange = remove_cvref_t<_Range>,
             class _Dist     = range_difference_t<_Range>>
     requires(__is_repeat_specialization<_RawRange> && sized_range<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&& __n) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Np&& __n) const
     noexcept(noexcept(views::repeat(*__range.__value_, std::min<_Dist>(ranges::distance(__range), std::forward<_Np>(__n)))))
     -> decltype(      views::repeat(*__range.__value_, std::min<_Dist>(ranges::distance(__range), std::forward<_Np>(__n))))
     { return          views::repeat(*__range.__value_, std::min<_Dist>(ranges::distance(__range), std::forward<_Np>(__n))); }
@@ -318,7 +316,7 @@ struct __fn {
             class _RawRange = remove_cvref_t<_Range>,
             class _Dist     = range_difference_t<_Range>>
     requires(__is_repeat_specialization<_RawRange> && !sized_range<_RawRange>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&& __n) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Np&& __n) const
     noexcept(noexcept(views::repeat(*__range.__value_, static_cast<_Dist>(__n))))
     -> decltype(      views::repeat(*__range.__value_, static_cast<_Dist>(__n)))
     { return          views::repeat(*__range.__value_, static_cast<_Dist>(__n)); }
@@ -336,7 +334,7 @@ struct __fn {
                (__is_iota_specialization<_RawRange> && sized_range<_RawRange> && random_access_range<_RawRange>) ||
                (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> &&
                 random_access_range<_RawRange>)))
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&& __n) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Np&& __n) const
       noexcept(noexcept(take_view(std::forward<_Range>(__range), std::forward<_Np>(__n))))
           -> decltype(take_view(std::forward<_Range>(__range), std::forward<_Np>(__n))) {
     return take_view(std::forward<_Range>(__range), std::forward<_Np>(__n));
@@ -344,8 +342,7 @@ struct __fn {
 
   template <class _Np>
     requires constructible_from<decay_t<_Np>, _Np>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Np&& __n) const
-      noexcept(is_nothrow_constructible_v<decay_t<_Np>, _Np>) {
+  [[nodiscard]] constexpr auto operator()(_Np&& __n) const noexcept(is_nothrow_constructible_v<decay_t<_Np>, _Np>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Np>(__n)));
   }
 };

--- a/libcxx/include/__ranges/take_while_view.h
+++ b/libcxx/include/__ranges/take_while_view.h
@@ -54,42 +54,42 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS take_while_view : public view_interfa
   _LIBCPP_NO_UNIQUE_ADDRESS __movable_box<_Pred> __pred_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI take_while_view()
+  take_while_view()
     requires default_initializable<_View> && default_initializable<_Pred>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 take_while_view(_View __base, _Pred __pred)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 take_while_view(_View __base, _Pred __pred)
       : __base_(std::move(__base)), __pred_(std::in_place, std::move(__pred)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const _Pred& pred() const { return *__pred_; }
+  constexpr const _Pred& pred() const { return *__pred_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
+  constexpr auto begin()
     requires(!__simple_view<_View>)
   {
     return ranges::begin(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires range<const _View> && indirect_unary_predicate<const _Pred, iterator_t<const _View>>
   {
     return ranges::begin(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  constexpr auto end()
     requires(!__simple_view<_View>)
   {
     return __sentinel</*_Const=*/false>(ranges::end(__base_), std::addressof(*__pred_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires range<const _View> && indirect_unary_predicate<const _Pred, iterator_t<const _View>>
   {
     return __sentinel</*_Const=*/true>(ranges::end(__base_), std::addressof(*__pred_));
@@ -111,25 +111,24 @@ class take_while_view<_View, _Pred>::__sentinel {
   friend class __sentinel<!_Const>;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
+  __sentinel() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(sentinel_t<_Base> __end, const _Pred* __pred)
+  constexpr explicit __sentinel(sentinel_t<_Base> __end, const _Pred* __pred)
       : __end_(std::move(__end)), __pred_(__pred) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __sentinel(__sentinel<!_Const> __s)
+  constexpr __sentinel(__sentinel<!_Const> __s)
     requires _Const && convertible_to<sentinel_t<_View>, sentinel_t<_Base>>
       : __end_(std::move(__s.__end_)), __pred_(__s.__pred_) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_Base> base() const { return __end_; }
+  constexpr sentinel_t<_Base> base() const { return __end_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const iterator_t<_Base>& __x, const __sentinel& __y) {
+  friend constexpr bool operator==(const iterator_t<_Base>& __x, const __sentinel& __y) {
     return __x == __y.__end_ || !std::invoke(*__y.__pred_, *__x);
   }
 
   template <bool _OtherConst = !_Const>
     requires sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool
-  operator==(const iterator_t<__maybe_const<_OtherConst, _View>>& __x, const __sentinel& __y) {
+  friend constexpr bool operator==(const iterator_t<__maybe_const<_OtherConst, _View>>& __x, const __sentinel& __y) {
     return __x == __y.__end_ || !std::invoke(*__y.__pred_, *__x);
   }
 };
@@ -139,7 +138,7 @@ namespace __take_while {
 
 struct __fn {
   template <class _Range, class _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Pred&& __pred) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Pred&& __pred) const
       noexcept(noexcept(/**/ take_while_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred))))
           -> decltype(/*--*/ take_while_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred))) {
     return /*-------------*/ take_while_view(std::forward<_Range>(__range), std::forward<_Pred>(__pred));
@@ -147,7 +146,7 @@ struct __fn {
 
   template <class _Pred>
     requires constructible_from<decay_t<_Pred>, _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Pred&& __pred) const
+  [[nodiscard]] constexpr auto operator()(_Pred&& __pred) const
       noexcept(is_nothrow_constructible_v<decay_t<_Pred>, _Pred>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Pred>(__pred)));
   }

--- a/libcxx/include/__ranges/to.h
+++ b/libcxx/include/__ranges/to.h
@@ -78,7 +78,7 @@ concept __always_false = false;
 // `ranges::to` base template -- the `_Container` type is a simple type template parameter.
 template <class _Container, input_range _Range, class... _Args>
   requires(!view<_Container>)
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Container to(_Range&& __range, _Args&&... __args) {
+[[nodiscard]] constexpr _Container to(_Range&& __range, _Args&&... __args) {
   // Mandates: C is a cv-unqualified class type.
   static_assert(!is_const_v<_Container>, "The target container cannot be const-qualified, please remove the const");
   static_assert(
@@ -161,7 +161,7 @@ struct __minimal_input_iterator {
 // Deduces the full type of the container from the given template template parameter.
 template <template <class...> class _Container, input_range _Range, class... _Args>
 struct _Deducer {
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __deduce_func() {
+  static constexpr auto __deduce_func() {
     using _InputIter = __minimal_input_iterator<_Range>;
 
     // Case 1 -- can construct directly from the given range.
@@ -196,7 +196,7 @@ struct _Deducer {
 // `ranges::to` specialization -- `_Container` is a template template parameter requiring deduction to figure out the
 // container element type.
 template <template <class...> class _Container, input_range _Range, class... _Args>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto to(_Range&& __range, _Args&&... __args) {
+[[nodiscard]] constexpr auto to(_Range&& __range, _Args&&... __args) {
   using _DeduceExpr = typename _Deducer<_Container, _Range, _Args...>::type;
   return ranges::to<_DeduceExpr>(std::forward<_Range>(__range), std::forward<_Args>(__args)...);
 }
@@ -205,7 +205,7 @@ template <template <class...> class _Container, input_range _Range, class... _Ar
 // parameter.
 template <class _Container, class... _Args>
   requires(!view<_Container>)
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto to(_Args&&... __args) {
+[[nodiscard]] constexpr auto to(_Args&&... __args) {
   // Mandates: C is a cv-unqualified class type.
   static_assert(!is_const_v<_Container>, "The target container cannot be const-qualified, please remove the const");
   static_assert(
@@ -223,7 +223,7 @@ template <class _Container, class... _Args>
 // Range adaptor closure object 2 -- wrapping the `ranges::to` version where `_Container` is a template template
 // parameter.
 template <template <class...> class _Container, class... _Args>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto to(_Args&&... __args) {
+[[nodiscard]] constexpr auto to(_Args&&... __args) {
   // clang-format off
   auto __to_func = []<input_range _Range, class... _Tail,
                       class _DeducedExpr = typename _Deducer<_Container, _Range, _Tail...>::type>

--- a/libcxx/include/__ranges/transform_view.h
+++ b/libcxx/include/__ranges/transform_view.h
@@ -82,50 +82,50 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS transform_view : public view_interfac
   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_ = _View();
 
 public:
-  _LIBCPP_HIDE_FROM_ABI transform_view()
+  transform_view()
     requires default_initializable<_View> && default_initializable<_Fn>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 transform_view(_View __base, _Fn __func)
+  constexpr _LIBCPP_EXPLICIT_SINCE_CXX23 transform_view(_View __base, _Fn __func)
       : __func_(std::in_place, std::move(__func)), __base_(std::move(__base)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator<false> begin() { return __iterator<false>{*this, ranges::begin(__base_)}; }
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator<true> begin() const
+  constexpr __iterator<false> begin() { return __iterator<false>{*this, ranges::begin(__base_)}; }
+  constexpr __iterator<true> begin() const
     requires range<const _View> && __regular_invocable_with_range_ref<const _Fn&, const _View>
   {
     return __iterator<true>(*this, ranges::begin(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __sentinel<false> end() { return __sentinel<false>(ranges::end(__base_)); }
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator<false> end()
+  constexpr __sentinel<false> end() { return __sentinel<false>(ranges::end(__base_)); }
+  constexpr __iterator<false> end()
     requires common_range<_View>
   {
     return __iterator<false>(*this, ranges::end(__base_));
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr __sentinel<true> end() const
+  constexpr __sentinel<true> end() const
     requires range<const _View> && __regular_invocable_with_range_ref<const _Fn&, const _View>
   {
     return __sentinel<true>(ranges::end(__base_));
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator<true> end() const
+  constexpr __iterator<true> end() const
     requires common_range<const _View> && __regular_invocable_with_range_ref<const _Fn&, const _View>
   {
     return __iterator<true>(*this, ranges::end(__base_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires sized_range<_View>
   {
     return ranges::size(__base_);
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires sized_range<const _View>
   {
     return ranges::size(__base_);
@@ -196,37 +196,36 @@ public:
   using value_type       = remove_cvref_t<invoke_result_t<__maybe_const<_Const, _Fn>&, range_reference_t<_Base>>>;
   using difference_type  = range_difference_t<_Base>;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator()
+  __iterator()
     requires default_initializable<iterator_t<_Base>>
   = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(_Parent& __parent, iterator_t<_Base> __current)
+  constexpr __iterator(_Parent& __parent, iterator_t<_Base> __current)
       : __parent_(std::addressof(__parent)), __current_(std::move(__current)) {}
 
   // Note: `__i` should always be `__iterator<false>`, but directly using
   // `__iterator<false>` is ill-formed when `_Const` is false
   // (see http://wg21.link/class.copy.ctor#5).
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(__iterator<!_Const> __i)
+  constexpr __iterator(__iterator<!_Const> __i)
     requires _Const && convertible_to<iterator_t<_View>, iterator_t<_Base>>
       : __parent_(__i.__parent_), __current_(std::move(__i.__current_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr const iterator_t<_Base>& base() const& noexcept { return __current_; }
+  constexpr const iterator_t<_Base>& base() const& noexcept { return __current_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr iterator_t<_Base> base() && { return std::move(__current_); }
+  constexpr iterator_t<_Base> base() && { return std::move(__current_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator*() const
-      noexcept(noexcept(std::invoke(*__parent_->__func_, *__current_))) {
+  constexpr decltype(auto) operator*() const noexcept(noexcept(std::invoke(*__parent_->__func_, *__current_))) {
     return std::invoke(*__parent_->__func_, *__current_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+  constexpr __iterator& operator++() {
     ++__current_;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator++(int) { ++__current_; }
+  constexpr void operator++(int) { ++__current_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int)
+  constexpr __iterator operator++(int)
     requires forward_range<_Base>
   {
     auto __tmp = *this;
@@ -234,14 +233,14 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator--()
+  constexpr __iterator& operator--()
     requires bidirectional_range<_Base>
   {
     --__current_;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator--(int)
+  constexpr __iterator operator--(int)
     requires bidirectional_range<_Base>
   {
     auto __tmp = *this;
@@ -249,82 +248,82 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator+=(difference_type __n)
+  constexpr __iterator& operator+=(difference_type __n)
     requires random_access_range<_Base>
   {
     __current_ += __n;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator-=(difference_type __n)
+  constexpr __iterator& operator-=(difference_type __n)
     requires random_access_range<_Base>
   {
     __current_ -= __n;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator[](difference_type __n) const
+  constexpr decltype(auto) operator[](difference_type __n) const
       noexcept(noexcept(std::invoke(*__parent_->__func_, __current_[__n])))
     requires random_access_range<_Base>
   {
     return std::invoke(*__parent_->__func_, __current_[__n]);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
     requires equality_comparable<iterator_t<_Base>>
   {
     return __x.__current_ == __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator<(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return __x.__current_ < __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator>(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return __x.__current_ > __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator<=(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return __x.__current_ <= __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator>=(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base>
   {
     return __x.__current_ >= __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
+  friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
     requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>>
   {
     return __x.__current_ <=> __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(__iterator __i, difference_type __n)
+  friend constexpr __iterator operator+(__iterator __i, difference_type __n)
     requires random_access_range<_Base>
   {
     return __iterator{*__i.__parent_, __i.__current_ + __n};
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(difference_type __n, __iterator __i)
+  friend constexpr __iterator operator+(difference_type __n, __iterator __i)
     requires random_access_range<_Base>
   {
     return __iterator{*__i.__parent_, __i.__current_ + __n};
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator-(__iterator __i, difference_type __n)
+  friend constexpr __iterator operator-(__iterator __i, difference_type __n)
     requires random_access_range<_Base>
   {
     return __iterator{*__i.__parent_, __i.__current_ - __n};
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y)
+  friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y)
     requires sized_sentinel_for<iterator_t<_Base>, iterator_t<_Base>>
   {
     return __x.__current_ - __y.__current_;
@@ -351,35 +350,35 @@ class transform_view<_View, _Fn>::__sentinel {
   friend class transform_view<_View, _Fn>::__sentinel;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
+  __sentinel() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(sentinel_t<_Base> __end) : __end_(__end) {}
+  constexpr explicit __sentinel(sentinel_t<_Base> __end) : __end_(__end) {}
 
   // Note: `__i` should always be `__sentinel<false>`, but directly using
   // `__sentinel<false>` is ill-formed when `_Const` is false
   // (see http://wg21.link/class.copy.ctor#5).
-  _LIBCPP_HIDE_FROM_ABI constexpr __sentinel(__sentinel<!_Const> __i)
+  constexpr __sentinel(__sentinel<!_Const> __i)
     requires _Const && convertible_to<sentinel_t<_View>, sentinel_t<_Base>>
       : __end_(std::move(__i.__end_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_Base> base() const { return __end_; }
+  constexpr sentinel_t<_Base> base() const { return __end_; }
 
   template <bool _OtherConst>
     requires sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
+  friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
     return __x.__current_ == __y.__end_;
   }
 
   template <bool _OtherConst>
     requires sized_sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr range_difference_t<__maybe_const<_OtherConst, _View>>
+  friend constexpr range_difference_t<__maybe_const<_OtherConst, _View>>
   operator-(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
     return __x.__current_ - __y.__end_;
   }
 
   template <bool _OtherConst>
     requires sized_sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr range_difference_t<__maybe_const<_OtherConst, _View>>
+  friend constexpr range_difference_t<__maybe_const<_OtherConst, _View>>
   operator-(const __sentinel& __x, const __iterator<_OtherConst>& __y) {
     return __x.__end_ - __y.__current_;
   }
@@ -389,7 +388,7 @@ namespace views {
 namespace __transform {
 struct __fn {
   template <class _Range, class _Fn>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Fn&& __f) const
+  [[nodiscard]] constexpr auto operator()(_Range&& __range, _Fn&& __f) const
       noexcept(noexcept(transform_view(std::forward<_Range>(__range), std::forward<_Fn>(__f))))
           -> decltype(transform_view(std::forward<_Range>(__range), std::forward<_Fn>(__f))) {
     return transform_view(std::forward<_Range>(__range), std::forward<_Fn>(__f));
@@ -397,8 +396,7 @@ struct __fn {
 
   template <class _Fn>
     requires constructible_from<decay_t<_Fn>, _Fn>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Fn&& __f) const
-      noexcept(is_nothrow_constructible_v<decay_t<_Fn>, _Fn>) {
+  [[nodiscard]] constexpr auto operator()(_Fn&& __f) const noexcept(is_nothrow_constructible_v<decay_t<_Fn>, _Fn>) {
     return __pipeable(std::__bind_back(*this, std::forward<_Fn>(__f)));
   }
 };

--- a/libcxx/include/__ranges/view_interface.h
+++ b/libcxx/include/__ranges/view_interface.h
@@ -39,19 +39,19 @@ namespace ranges {
 template <class _Derived>
   requires is_class_v<_Derived> && same_as<_Derived, remove_cv_t<_Derived>>
 class view_interface {
-  _LIBCPP_HIDE_FROM_ABI constexpr _Derived& __derived() noexcept {
+  constexpr _Derived& __derived() noexcept {
     static_assert(sizeof(_Derived) && derived_from<_Derived, view_interface> && view<_Derived>);
     return static_cast<_Derived&>(*this);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Derived const& __derived() const noexcept {
+  constexpr _Derived const& __derived() const noexcept {
     static_assert(sizeof(_Derived) && derived_from<_Derived, view_interface> && view<_Derived>);
     return static_cast<_Derived const&>(*this);
   }
 
 public:
   template <class _D2 = _Derived>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool empty()
+  [[nodiscard]] constexpr bool empty()
     requires sized_range<_D2> || forward_range<_D2>
   {
     if constexpr (sized_range<_D2>) {
@@ -62,7 +62,7 @@ public:
   }
 
   template <class _D2 = _Derived>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool empty() const
+  [[nodiscard]] constexpr bool empty() const
     requires sized_range<const _D2> || forward_range<const _D2>
   {
     if constexpr (sized_range<const _D2>) {
@@ -73,49 +73,49 @@ public:
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit operator bool()
+  constexpr explicit operator bool()
     requires requires(_D2& __t) { ranges::empty(__t); }
   {
     return !ranges::empty(__derived());
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit operator bool() const
+  constexpr explicit operator bool() const
     requires requires(const _D2& __t) { ranges::empty(__t); }
   {
     return !ranges::empty(__derived());
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto data()
+  constexpr auto data()
     requires contiguous_iterator<iterator_t<_D2>>
   {
     return std::to_address(ranges::begin(__derived()));
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto data() const
+  constexpr auto data() const
     requires range<const _D2> && contiguous_iterator<iterator_t<const _D2>>
   {
     return std::to_address(ranges::begin(__derived()));
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires forward_range<_D2> && sized_sentinel_for<sentinel_t<_D2>, iterator_t<_D2>>
   {
     return std::__to_unsigned_like(ranges::end(__derived()) - ranges::begin(__derived()));
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires forward_range<const _D2> && sized_sentinel_for<sentinel_t<const _D2>, iterator_t<const _D2>>
   {
     return std::__to_unsigned_like(ranges::end(__derived()) - ranges::begin(__derived()));
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) front()
+  constexpr decltype(auto) front()
     requires forward_range<_D2>
   {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
@@ -124,7 +124,7 @@ public:
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) front() const
+  constexpr decltype(auto) front() const
     requires forward_range<const _D2>
   {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
@@ -133,7 +133,7 @@ public:
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) back()
+  constexpr decltype(auto) back()
     requires bidirectional_range<_D2> && common_range<_D2>
   {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
@@ -142,7 +142,7 @@ public:
   }
 
   template <class _D2 = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) back() const
+  constexpr decltype(auto) back() const
     requires bidirectional_range<const _D2> && common_range<const _D2>
   {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
@@ -151,12 +151,12 @@ public:
   }
 
   template <random_access_range _RARange = _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator[](range_difference_t<_RARange> __index) {
+  constexpr decltype(auto) operator[](range_difference_t<_RARange> __index) {
     return ranges::begin(__derived())[__index];
   }
 
   template <random_access_range _RARange = const _Derived>
-  _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator[](range_difference_t<_RARange> __index) const {
+  constexpr decltype(auto) operator[](range_difference_t<_RARange> __index) const {
     return ranges::begin(__derived())[__index];
   }
 };

--- a/libcxx/include/__ranges/zip_view.h
+++ b/libcxx/include/__ranges/zip_view.h
@@ -58,7 +58,7 @@ concept __zip_is_common =
     ((random_access_range<_Ranges> && ...) && (sized_range<_Ranges> && ...));
 
 template <class _Fun, class _Tuple>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __tuple_transform(_Fun&& __f, _Tuple&& __tuple) {
+constexpr auto __tuple_transform(_Fun&& __f, _Tuple&& __tuple) {
   return std::apply(
       [&]<class... _Types>(_Types&&... __elements) {
         return tuple<invoke_result_t<_Fun&, _Types>...>(std::invoke(__f, std::forward<_Types>(__elements))...);
@@ -67,7 +67,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __tuple_transform(_Fun&& __f, _Tuple&& __tu
 }
 
 template <class _Fun, class _Tuple>
-_LIBCPP_HIDE_FROM_ABI constexpr void __tuple_for_each(_Fun&& __f, _Tuple&& __tuple) {
+constexpr void __tuple_for_each(_Fun&& __f, _Tuple&& __tuple) {
   std::apply(
       [&]<class... _Types>(_Types&&... __elements) {
         (static_cast<void>(std::invoke(__f, std::forward<_Types>(__elements))), ...);
@@ -76,10 +76,9 @@ _LIBCPP_HIDE_FROM_ABI constexpr void __tuple_for_each(_Fun&& __f, _Tuple&& __tup
 }
 
 template <class _Fun, class _Tuple1, class _Tuple2, size_t... _Indices>
-_LIBCPP_HIDE_FROM_ABI constexpr tuple<
-    invoke_result_t<_Fun&,
-                    typename tuple_element<_Indices, remove_cvref_t<_Tuple1>>::type,
-                    typename tuple_element<_Indices, remove_cvref_t<_Tuple2>>::type>...>
+constexpr tuple<invoke_result_t<_Fun&,
+                                typename tuple_element<_Indices, remove_cvref_t<_Tuple1>>::type,
+                                typename tuple_element<_Indices, remove_cvref_t<_Tuple2>>::type>...>
 __tuple_zip_transform(_Fun&& __f, _Tuple1&& __tuple1, _Tuple2&& __tuple2, index_sequence<_Indices...>) {
   return {std::invoke(__f,
                       std::get<_Indices>(std::forward<_Tuple1>(__tuple1)),
@@ -87,7 +86,7 @@ __tuple_zip_transform(_Fun&& __f, _Tuple1&& __tuple1, _Tuple2&& __tuple2, index_
 }
 
 template <class _Fun, class _Tuple1, class _Tuple2>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __tuple_zip_transform(_Fun&& __f, _Tuple1&& __tuple1, _Tuple2&& __tuple2) {
+constexpr auto __tuple_zip_transform(_Fun&& __f, _Tuple1&& __tuple1, _Tuple2&& __tuple2) {
   return ranges::__tuple_zip_transform(
       __f,
       std::forward<_Tuple1>(__tuple1),
@@ -96,15 +95,14 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __tuple_zip_transform(_Fun&& __f, _Tuple1&&
 }
 
 template <class _Fun, class _Tuple1, class _Tuple2, size_t... _Indices>
-_LIBCPP_HIDE_FROM_ABI constexpr void
-__tuple_zip_for_each(_Fun&& __f, _Tuple1&& __tuple1, _Tuple2&& __tuple2, index_sequence<_Indices...>) {
+constexpr void __tuple_zip_for_each(_Fun&& __f, _Tuple1&& __tuple1, _Tuple2&& __tuple2, index_sequence<_Indices...>) {
   (std::invoke(
        __f, std::get<_Indices>(std::forward<_Tuple1>(__tuple1)), std::get<_Indices>(std::forward<_Tuple2>(__tuple2))),
    ...);
 }
 
 template <class _Fun, class _Tuple1, class _Tuple2>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __tuple_zip_for_each(_Fun&& __f, _Tuple1&& __tuple1, _Tuple2&& __tuple2) {
+constexpr auto __tuple_zip_for_each(_Fun&& __f, _Tuple1&& __tuple1, _Tuple2&& __tuple2) {
   return ranges::__tuple_zip_for_each(
       __f,
       std::forward<_Tuple1>(__tuple1),
@@ -113,7 +111,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __tuple_zip_for_each(_Fun&& __f, _Tuple1&& 
 }
 
 template <class _Tuple1, class _Tuple2>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __tuple_any_equals(const _Tuple1& __tuple1, const _Tuple2& __tuple2) {
+constexpr bool __tuple_any_equals(const _Tuple1& __tuple1, const _Tuple2& __tuple2) {
   const auto __equals = ranges::__tuple_zip_transform(std::equal_to<>(), __tuple1, __tuple2);
   return std::apply([](auto... __bools) { return (__bools || ...); }, __equals);
 }
@@ -121,7 +119,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool __tuple_any_equals(const _Tuple1& __tuple1,
 // abs in cstdlib is not constexpr
 // TODO : remove __abs once P0533R9 is implemented.
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr _Tp __abs(_Tp __t) {
+constexpr _Tp __abs(_Tp __t) {
   return __t < 0 ? -__t : __t;
 }
 
@@ -137,23 +135,23 @@ class zip_view : public view_interface<zip_view<_Views...>> {
   class __sentinel;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI zip_view() = default;
+  zip_view() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit zip_view(_Views... __views) : __views_(std::move(__views)...) {}
+  constexpr explicit zip_view(_Views... __views) : __views_(std::move(__views)...) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
+  constexpr auto begin()
     requires(!(__simple_view<_Views> && ...))
   {
     return __iterator<false>(ranges::__tuple_transform(ranges::begin, __views_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  constexpr auto begin() const
     requires(range<const _Views> && ...)
   {
     return __iterator<true>(ranges::__tuple_transform(ranges::begin, __views_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  constexpr auto end()
     requires(!(__simple_view<_Views> && ...))
   {
     if constexpr (!__zip_is_common<_Views...>) {
@@ -165,7 +163,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  constexpr auto end() const
     requires(range<const _Views> && ...)
   {
     if constexpr (!__zip_is_common<const _Views...>) {
@@ -177,7 +175,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  constexpr auto size()
     requires(sized_range<_Views> && ...)
   {
     return std::apply(
@@ -188,7 +186,7 @@ public:
         ranges::__tuple_transform(ranges::size, __views_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  constexpr auto size() const
     requires(sized_range<const _Views> && ...)
   {
     return std::apply(
@@ -240,7 +238,7 @@ template <bool _Const>
 class zip_view<_Views...>::__iterator : public __zip_view_iterator_category_base<_Const, _Views...> {
   tuple<iterator_t<__maybe_const<_Const, _Views>>...> __current_;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __iterator(tuple<iterator_t<__maybe_const<_Const, _Views>>...> __current)
+  constexpr explicit __iterator(tuple<iterator_t<__maybe_const<_Const, _Views>>...> __current)
       : __current_(std::move(__current)) {}
 
   template <bool>
@@ -256,24 +254,24 @@ public:
   using value_type       = tuple<range_value_t<__maybe_const<_Const, _Views>>...>;
   using difference_type  = common_type_t<range_difference_t<__maybe_const<_Const, _Views>>...>;
 
-  _LIBCPP_HIDE_FROM_ABI __iterator() = default;
+  __iterator() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator(__iterator<!_Const> __i)
+  constexpr __iterator(__iterator<!_Const> __i)
     requires _Const && (convertible_to<iterator_t<_Views>, iterator_t<__maybe_const<_Const, _Views>>> && ...)
       : __current_(std::move(__i.__current_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator*() const {
+  constexpr auto operator*() const {
     return ranges::__tuple_transform([](auto& __i) -> decltype(auto) { return *__i; }, __current_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator++() {
+  constexpr __iterator& operator++() {
     ranges::__tuple_for_each([](auto& __i) { ++__i; }, __current_);
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator++(int) { ++*this; }
+  constexpr void operator++(int) { ++*this; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator++(int)
+  constexpr __iterator operator++(int)
     requires __zip_all_forward<_Const, _Views...>
   {
     auto __tmp = *this;
@@ -281,14 +279,14 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator--()
+  constexpr __iterator& operator--()
     requires __zip_all_bidirectional<_Const, _Views...>
   {
     ranges::__tuple_for_each([](auto& __i) { --__i; }, __current_);
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator operator--(int)
+  constexpr __iterator operator--(int)
     requires __zip_all_bidirectional<_Const, _Views...>
   {
     auto __tmp = *this;
@@ -296,28 +294,28 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator+=(difference_type __x)
+  constexpr __iterator& operator+=(difference_type __x)
     requires __zip_all_random_access<_Const, _Views...>
   {
     ranges::__tuple_for_each([&]<class _Iter>(_Iter& __i) { __i += iter_difference_t<_Iter>(__x); }, __current_);
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __iterator& operator-=(difference_type __x)
+  constexpr __iterator& operator-=(difference_type __x)
     requires __zip_all_random_access<_Const, _Views...>
   {
     ranges::__tuple_for_each([&]<class _Iter>(_Iter& __i) { __i -= iter_difference_t<_Iter>(__x); }, __current_);
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator[](difference_type __n) const
+  constexpr auto operator[](difference_type __n) const
     requires __zip_all_random_access<_Const, _Views...>
   {
     return ranges::__tuple_transform(
         [&]<class _Iter>(_Iter& __i) -> decltype(auto) { return __i[iter_difference_t<_Iter>(__n)]; }, __current_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
+  friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
     requires(equality_comparable<iterator_t<__maybe_const<_Const, _Views>>> && ...)
   {
     if constexpr (__zip_all_bidirectional<_Const, _Views...>) {
@@ -327,13 +325,13 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
+  friend constexpr auto operator<=>(const __iterator& __x, const __iterator& __y)
     requires __zip_all_random_access<_Const, _Views...>
   {
     return __x.__current_ <=> __y.__current_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(const __iterator& __i, difference_type __n)
+  friend constexpr __iterator operator+(const __iterator& __i, difference_type __n)
     requires __zip_all_random_access<_Const, _Views...>
   {
     auto __r = __i;
@@ -341,13 +339,13 @@ public:
     return __r;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator+(difference_type __n, const __iterator& __i)
+  friend constexpr __iterator operator+(difference_type __n, const __iterator& __i)
     requires __zip_all_random_access<_Const, _Views...>
   {
     return __i + __n;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr __iterator operator-(const __iterator& __i, difference_type __n)
+  friend constexpr __iterator operator-(const __iterator& __i, difference_type __n)
     requires __zip_all_random_access<_Const, _Views...>
   {
     auto __r = __i;
@@ -355,7 +353,7 @@ public:
     return __r;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y)
+  friend constexpr difference_type operator-(const __iterator& __x, const __iterator& __y)
     requires(sized_sentinel_for<iterator_t<__maybe_const<_Const, _Views>>, iterator_t<__maybe_const<_Const, _Views>>> &&
              ...)
   {
@@ -369,13 +367,13 @@ public:
         __diffs);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr auto iter_move(const __iterator& __i) noexcept(
+  friend constexpr auto iter_move(const __iterator& __i) noexcept(
       (noexcept(ranges::iter_move(std::declval<const iterator_t<__maybe_const<_Const, _Views>>&>())) && ...) &&
       (is_nothrow_move_constructible_v<range_rvalue_reference_t<__maybe_const<_Const, _Views>>> && ...)) {
     return ranges::__tuple_transform(ranges::iter_move, __i.__current_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr void iter_swap(const __iterator& __l, const __iterator& __r) noexcept(
+  friend constexpr void iter_swap(const __iterator& __l, const __iterator& __r) noexcept(
       (noexcept(ranges::iter_swap(std::declval<const iterator_t<__maybe_const<_Const, _Views>>&>(),
                                   std::declval<const iterator_t<__maybe_const<_Const, _Views>>&>())) &&
        ...))
@@ -391,29 +389,27 @@ template <bool _Const>
 class zip_view<_Views...>::__sentinel {
   tuple<sentinel_t<__maybe_const<_Const, _Views>>...> __end_;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit __sentinel(tuple<sentinel_t<__maybe_const<_Const, _Views>>...> __end)
-      : __end_(__end) {}
+  constexpr explicit __sentinel(tuple<sentinel_t<__maybe_const<_Const, _Views>>...> __end) : __end_(__end) {}
 
   friend class zip_view<_Views...>;
 
   // hidden friend cannot access private member of iterator because they are friends of friends
   template <bool _OtherConst>
-  _LIBCPP_HIDE_FROM_ABI static constexpr decltype(auto)
-  __iter_current(zip_view<_Views...>::__iterator<_OtherConst> const& __it) {
+  static constexpr decltype(auto) __iter_current(zip_view<_Views...>::__iterator<_OtherConst> const& __it) {
     return (__it.__current_);
   }
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __sentinel() = default;
+  __sentinel() = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr __sentinel(__sentinel<!_Const> __i)
+  constexpr __sentinel(__sentinel<!_Const> __i)
     requires _Const && (convertible_to<sentinel_t<_Views>, sentinel_t<__maybe_const<_Const, _Views>>> && ...)
       : __end_(std::move(__i.__end_)) {}
 
   template <bool _OtherConst>
     requires(sentinel_for<sentinel_t<__maybe_const<_Const, _Views>>, iterator_t<__maybe_const<_OtherConst, _Views>>> &&
              ...)
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
+  friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
     return ranges::__tuple_any_equals(__iter_current(__x), __y.__end_);
   }
 
@@ -421,7 +417,7 @@ public:
     requires(
         sized_sentinel_for<sentinel_t<__maybe_const<_Const, _Views>>, iterator_t<__maybe_const<_OtherConst, _Views>>> &&
         ...)
-  _LIBCPP_HIDE_FROM_ABI friend constexpr common_type_t<range_difference_t<__maybe_const<_OtherConst, _Views>>...>
+  friend constexpr common_type_t<range_difference_t<__maybe_const<_OtherConst, _Views>>...>
   operator-(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
     const auto __diffs = ranges::__tuple_zip_transform(minus<>(), __iter_current(__x), __y.__end_);
     return std::apply(
@@ -438,7 +434,7 @@ public:
     requires(
         sized_sentinel_for<sentinel_t<__maybe_const<_Const, _Views>>, iterator_t<__maybe_const<_OtherConst, _Views>>> &&
         ...)
-  _LIBCPP_HIDE_FROM_ABI friend constexpr common_type_t<range_difference_t<__maybe_const<_OtherConst, _Views>>...>
+  friend constexpr common_type_t<range_difference_t<__maybe_const<_OtherConst, _Views>>...>
   operator-(const __sentinel& __y, const __iterator<_OtherConst>& __x) {
     return -(__x - __y);
   }
@@ -451,10 +447,10 @@ namespace views {
 namespace __zip {
 
 struct __fn {
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()() noexcept { return empty_view<tuple<>>{}; }
+  static constexpr auto operator()() noexcept { return empty_view<tuple<>>{}; }
 
   template <class... _Ranges>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto
+  static constexpr auto
   operator()(_Ranges&&... __rs) noexcept(noexcept(zip_view<all_t<_Ranges&&>...>(std::forward<_Ranges>(__rs)...)))
       -> decltype(zip_view<all_t<_Ranges&&>...>(std::forward<_Ranges>(__rs)...)) {
     return zip_view<all_t<_Ranges>...>(std::forward<_Ranges>(__rs)...);


### PR DESCRIPTION
After #131156 we don't need `_LIBCPP_HIDE_FROM_ABI` everywhere anymore. This removes the now unnecessary annotations from `<ranges>` and its subheaders.
