### PR TITLE
[AArch64] When printing SYS aliases, use explicit `NeedsReg` flag from tablegen (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -3917,6 +3917,7 @@ bool AArch64AsmParser::parseSysAlias(StringRef Name, SMLoc NameLoc,
   const AsmToken &Tok = getTok();
   StringRef Op = Tok.getString();
   SMLoc S = Tok.getLoc();
+  bool ExpectRegister = true;
 
   if (Mnemonic == "ic") {
     const AArch64IC::IC *IC = AArch64IC::lookupICByName(Op);
@@ -3927,6 +3928,7 @@ bool AArch64AsmParser::parseSysAlias(StringRef Name, SMLoc NameLoc,
       setRequiredFeatureString(IC->getRequiredFeatures(), Str);
       return TokError(Str);
     }
+    ExpectRegister = IC->NeedsReg;
     createSysAlias(IC->Encoding, Operands, S);
   } else if (Mnemonic == "dc") {
     const AArch64DC::DC *DC = AArch64DC::lookupDCByName(Op);
@@ -3957,6 +3959,7 @@ bool AArch64AsmParser::parseSysAlias(StringRef Name, SMLoc NameLoc,
       setRequiredFeatureString(TLBI->getRequiredFeatures(), Str);
       return TokError(Str);
     }
+    ExpectRegister = TLBI->NeedsReg;
     createSysAlias(TLBI->Encoding, Operands, S);
   } else if (Mnemonic == "cfp" || Mnemonic == "dvp" || Mnemonic == "cpp" || Mnemonic == "cosp") {
 
@@ -3987,7 +3990,6 @@ bool AArch64AsmParser::parseSysAlias(StringRef Name, SMLoc NameLoc,
 
   Lex(); // Eat operand.
 
-  bool ExpectRegister = !Op.contains_insensitive("all");
   bool HasRegister = false;
 
   // Check for the optional register operand.


### PR DESCRIPTION
Currently, when printing SYS aliases, the first instruction operand is compared with the string constant "all" to decide if a register needs to be parsed as the next operand.

For example, `TLBI VMALLE1IS` contains "all" so no register is expected, but `TLBI IPAS2E1IS` doesn't match, so a register is expected.

Future AArch64 SYS aliases won't always match this pattern, so use the (already provided) explicit `NeedsReg` bit flag provided in tablegen to check if a register is required to be parsed. This is already used by the code in `AArch64InstPrinter.cpp`, so now we are consistent in this source file too.

No test files have been changed, since this is a non-functional change, and all AArch64 test cases continue to pass after this change.