### PR TITLE
Implement src:*=sanitize for UBSan.

### DIFF
--- a/clang/include/clang/Basic/SanitizerSpecialCaseList.h
+++ b/clang/include/clang/Basic/SanitizerSpecialCaseList.h
@@ -44,9 +44,9 @@ public:
                  StringRef Category = StringRef()) const;
 
   // Query ignorelisted entries if any bit in Mask matches the entry's section.
-  // Return 0 if not found. If found, return the line number (starts with 1). 
+  // Return 0 if not found. If found, return the line number (starts with 1).
   unsigned inSectionBlame(SanitizerMask Mask, StringRef Prefix, StringRef Query,
-                 StringRef Category = StringRef()) const;
+                          StringRef Category = StringRef()) const;
 
 protected:
   // Initialize SanitizerSections.
@@ -54,7 +54,7 @@ protected:
 
   struct SanitizerSection {
     SanitizerSection(SanitizerMask SM, SectionEntries &E)
-        : Mask(SM), Entries(E){};
+        : Mask(SM), Entries(E) {};
 
     SanitizerMask Mask;
     SectionEntries &Entries;

--- a/clang/lib/Basic/SanitizerSpecialCaseList.cpp
+++ b/clang/lib/Basic/SanitizerSpecialCaseList.cpp
@@ -56,7 +56,12 @@ void SanitizerSpecialCaseList::createSanitizerSections() {
 bool SanitizerSpecialCaseList::inSection(SanitizerMask Mask, StringRef Prefix,
                                          StringRef Query,
                                          StringRef Category) const {
-  return inSectionBlame(Mask, Prefix, Query, Category) > 0;
+  for (auto &S : SanitizerSections)
+    if ((S.Mask & Mask) &&
+        SpecialCaseList::inSectionBlame(S.Entries, Prefix, Query, Category))
+      return true;
+
+  return false;
 }
 
 unsigned SanitizerSpecialCaseList::inSectionBlame(SanitizerMask Mask,

--- a/clang/test/CodeGen/ubsan-src-ignorelist-category.test
+++ b/clang/test/CodeGen/ubsan-src-ignorelist-category.test
@@ -17,7 +17,7 @@ src:*
 src:*/test1.c=sanitize
 src:*/test1.c
 
-//--- src.ignorelist.contradict1
+//--- src.ignorelist.contradict2
 src:*
 src:*/test1.c
 src:*/test1.c=sanitize


### PR DESCRIPTION

It is a draft implementation for "src:*=sanitize". It should be applied to all sanitizers.

Any srcs assigned to the sanitize category will have their sanitizer instrumentation remained ignored by "src:".  For example,

```
src:*
src:*/test1.c=sanitize
```

`test1.c` will still have the UBSan instrumented.

However
```
type:int
src:*/test1.c=sanitize
```
`test1.c` does not have the int type check. 


Conflicting entries are resolved by the latest entry, which takes precedence.

```
type:int
src:*/test1.c=sanitize
src:*/test1.c
```

`test1.c` will still have the UBSan instrumented.


Documents update will be in a new PR.
