### PR TITLE
[NFC] Address more bit-field storage sizes

### DIFF
--- a/lld/wasm/InputChunks.h
+++ b/lld/wasm/InputChunks.h
@@ -99,15 +99,15 @@ public:
   // the beginning of the output section this chunk was assigned to.
   int32_t outSecOff = 0;
 
-  uint8_t sectionKind : 3;
+  uint32_t sectionKind : 3;
 
   // Signals that the section is part of the output.  The garbage collector,
   // and COMDAT handling can set a sections' Live bit.
   // If GC is disabled, all sections start out as live by default.
-  unsigned live : 1;
+  uint32_t live : 1;
 
   // Signals the chunk was discarded by COMDAT handling.
-  unsigned discarded : 1;
+  uint32_t discarded : 1;
 
 protected:
   InputChunk(ObjFile *f, Kind k, StringRef name, uint32_t alignment = 0,

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -101,7 +101,7 @@ namespace Foundation1010 {
       uint32_t _used;
       uint32_t _offset;
       uint32_t _size : 28;
-      uint64_t _priv1 : 4;
+      uint32_t _priv1 : 4;
       uint32_t _priv2;
       uint32_t _data;
     };

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -119,7 +119,7 @@ private:
 
   struct DataDescriptor_64 {
     uint64_t _used : 58;
-    uint32_t _szidx : 6;
+    uint64_t _szidx : 6;
   };
 
   struct DictionaryItemDescriptor {
@@ -273,7 +273,7 @@ namespace Foundation1100 {
     
     struct DataDescriptor_64 {
       uint64_t _used : 58;
-      uint32_t _kvo : 1;
+      uint64_t _kvo : 1;
       uint64_t _size;
       uint64_t _mutations;
       uint64_t _objs_addr;
@@ -308,7 +308,7 @@ namespace Foundation1428 {
     
     struct DataDescriptor_64 {
       uint64_t _used : 58;
-      uint32_t _kvo : 1;
+      uint64_t _kvo : 1;
       uint64_t _size;
       uint64_t _buffer;
       uint64_t GetSize() { return _size; }

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -62,7 +62,7 @@ private:
 
   struct DataDescriptor_64 {
     uint64_t _used : 58;
-    uint32_t _szidx : 6;
+    uint64_t _szidx : 6;
   };
 
   struct SetItemDescriptor {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.h
@@ -189,7 +189,7 @@ protected:
   // If it is zero, then the DIE doesn't have children,
   // or the DWARF claimed it had children but the DIE
   // only contained a single NULL terminating child.
-  uint32_t m_sibling_idx : 31, m_has_children : 1;
+  uint64_t m_sibling_idx : 31, m_has_children : 1;
   uint16_t m_abbr_idx = 0;
   /// A copy of the DW_TAG value so we don't have to go through the compile
   /// unit abbrev table


### PR DESCRIPTION
Follow on work from #139825.

As previously this is fixing a few more cases where adjacent bit-fields
have types with different base storage sizes, as the MS ABI will not
pack those bit-fields.
