### PR TITLE
[libclang/python] Add `Cursor.from_translation_unit`

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -1595,6 +1595,10 @@ class Cursor(Structure):
     def from_location(tu: TranslationUnit, location: SourceLocation) -> Cursor | None:
         return Cursor.from_result(conf.lib.clang_getCursor(tu, location), tu)
 
+    @staticmethod
+    def from_translation_unit(tu: TranslationUnit) -> Cursor | None:
+        return Cursor.from_result(conf.lib.clang_getTranslationUnitCursor(tu), tu)
+
     # This function is not null-guarded because it is used in cursor_null_guard itself
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Cursor):

--- a/clang/bindings/python/tests/cindex/test_cursor.py
+++ b/clang/bindings/python/tests/cindex/test_cursor.py
@@ -1064,3 +1064,9 @@ struct B {};
             nc.is_definition()
         with self.assertRaises(Exception):
             nc.spelling
+
+    def test_cursor_from_tu(self):
+        tu = get_tu("int a = 0;")
+        cursor = Cursor.from_translation_unit(tu)
+        reference_cursor = tu.cursor
+        self.assertEqual(cursor, reference_cursor)        

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -959,6 +959,7 @@ Sanitizers
 Python Binding Changes
 ----------------------
 - Made ``Cursor`` hashable.
+- Added ``Cursor.from_translation_unit``, mirroring ``TranslationUnit.cursor``.
 - Added ``Cursor.has_attrs``, a binding for ``clang_Cursor_hasAttrs``, to check
   whether a cursor has any attributes.
 - Added ``Cursor.specialized_template``, a binding for


### PR DESCRIPTION
This should complete the list of things `Cursor` can be made from.