### PR TITLE
[NFC][MemProf] Move types shared between Analysis, ProfileData and ModuleSummary (Core) to a separate header

### DIFF
--- a/llvm/include/llvm/Analysis/MemoryProfileInfo.h
+++ b/llvm/include/llvm/Analysis/MemoryProfileInfo.h
@@ -13,8 +13,9 @@
 #ifndef LLVM_ANALYSIS_MEMORYPROFILEINFO_H
 #define LLVM_ANALYSIS_MEMORYPROFILEINFO_H
 
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Metadata.h"
-#include "llvm/IR/ModuleSummaryIndex.h"
+#include "llvm/ProfileData/MemProfCommon.h"
 #include <map>
 
 namespace llvm {

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -27,6 +27,7 @@
 #include "llvm/IR/ConstantRange.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/Module.h"
+#include "llvm/ProfileData/MemProfCommon.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/InterleavedRange.h"
@@ -306,14 +307,6 @@ template <> struct DenseMapInfo<ValueInfo> {
   static unsigned getHashValue(ValueInfo I) { return hash_value(I.getRef()); }
 };
 
-// For optional hinted size reporting, holds a pair of the full stack id
-// (pre-trimming, from the full context in the profile), and the associated
-// total profiled size.
-struct ContextTotalSize {
-  uint64_t FullStackId;
-  uint64_t TotalSize;
-};
-
 /// Summary of memprof callsite metadata.
 struct CallsiteInfo {
   // Actual callee function.
@@ -349,19 +342,6 @@ inline raw_ostream &operator<<(raw_ostream &OS, const CallsiteInfo &SNI) {
   OS << " StackIds: " << llvm::interleaved(SNI.StackIdIndices);
   return OS;
 }
-
-// Allocation type assigned to an allocation reached by a given context.
-// More can be added, now this is cold, notcold and hot.
-// Values should be powers of two so that they can be ORed, in particular to
-// track allocations that have different behavior with different calling
-// contexts.
-enum class AllocationType : uint8_t {
-  None = 0,
-  NotCold = 1,
-  Cold = 2,
-  Hot = 4,
-  All = 7 // This should always be set to the OR of all values.
-};
 
 /// Summary of a single MIB in a memprof metadata on allocations.
 struct MIBInfo {

--- a/llvm/include/llvm/ProfileData/MemProfCommon.h
+++ b/llvm/include/llvm/ProfileData/MemProfCommon.h
@@ -1,0 +1,43 @@
+//===- MemProfCommon.h - MemProf support ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains common types used by different parts of the MemProf code.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PROFILEDATA_MEMPROFCOMMON_H
+#define LLVM_PROFILEDATA_MEMPROFCOMMON_H
+
+#include <cstdint>
+
+namespace llvm {
+
+// For optional hinted size reporting, holds a pair of the full stack id
+// (pre-trimming, from the full context in the profile), and the associated
+// total profiled size.
+struct ContextTotalSize {
+  uint64_t FullStackId;
+  uint64_t TotalSize;
+};
+
+// Allocation type assigned to an allocation reached by a given context.
+// More can be added, now this is cold, notcold and hot.
+// Values should be powers of two so that they can be ORed, in particular to
+// track allocations that have different behavior with different calling
+// contexts.
+enum class AllocationType : uint8_t {
+  None = 0,
+  NotCold = 1,
+  Cold = 2,
+  Hot = 4,
+  All = 7 // This should always be set to the OR of all values.
+};
+
+} // namespace llvm
+
+#endif // LLVM_PROFILEDATA_MEMPROFCOMMON_H

--- a/llvm/lib/ProfileData/CMakeLists.txt
+++ b/llvm/lib/ProfileData/CMakeLists.txt
@@ -26,7 +26,6 @@ add_llvm_component_library(LLVMProfileData
 
   LINK_COMPONENTS
   BitstreamReader
-  Core
   Object
   Support
   Demangle

--- a/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
@@ -46,6 +46,7 @@
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include <map>
 #include <set>
+#include <unordered_set>
 
 using namespace llvm;
 using namespace llvm::memprof;


### PR DESCRIPTION
Part of a larger refactoring with the following goals
1. Reduce the size of MemProf.h 
2. Avoid including ModuleSummaryIndex just for a couple of types