### PR TITLE
[libc++][NFC] Replace a few "namespace std" with the correct macro

### DIFF
--- a/libcxx/include/initializer_list
+++ b/libcxx/include/initializer_list
@@ -53,10 +53,9 @@ template<class E> const E* end(initializer_list<E> il) noexcept; // constexpr in
 #    pragma GCC system_header
 #  endif
 
-namespace std // purposefully not versioned
-{
-
 #  ifndef _LIBCPP_CXX03_LANG
+
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 template <class _Ep>
 class _LIBCPP_NO_SPECIALIZATIONS initializer_list {
@@ -95,9 +94,9 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Ep* end(initia
   return __il.end();
 }
 
-#  endif // !defined(_LIBCPP_CXX03_LANG)
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
-} // namespace std
+#  endif // !defined(_LIBCPP_CXX03_LANG)
 
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -244,8 +244,8 @@ namespace std {
 _LIBCPP_PUSH_MACROS
 #  include <__undef_macros>
 
-namespace std // purposefully not using versioning namespace
-{
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
+_LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
 class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_AVAILABILITY_BAD_OPTIONAL_ACCESS bad_optional_access : public exception {
 public:
@@ -257,7 +257,8 @@ public:
   const char* what() const _NOEXCEPT override;
 };
 
-} // namespace std
+_LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #  if _LIBCPP_STD_VER >= 17
 

--- a/libcxx/include/stdexcept
+++ b/libcxx/include/stdexcept
@@ -73,8 +73,8 @@ public:
 
 _LIBCPP_END_NAMESPACE_STD
 
-namespace std // purposefully not using versioning namespace
-{
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
+_LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
 class _LIBCPP_EXPORTED_FROM_ABI logic_error : public exception {
 #  ifndef _LIBCPP_ABI_VCRUNTIME
@@ -207,7 +207,8 @@ public:
 #  endif
 };
 
-} // namespace std
+_LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 

--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -76,8 +76,8 @@ public:
 #    include <vcruntime_typeinfo.h>
 #  else
 
-namespace std // purposefully not using versioning namespace
-{
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
+_LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
 #    if defined(_LIBCPP_ABI_MICROSOFT)
 
@@ -348,7 +348,8 @@ public:
   const char* what() const _NOEXCEPT override;
 };
 
-} // namespace std
+_LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #  endif // defined(_LIBCPP_ABI_VCRUNTIME)
 


### PR DESCRIPTION
We've added a new macro for the unversioned `namespace std` cases in #133009, but it seems we've missed a few places. This fixes the places I just found.
