### PR TITLE
[clang][bytecode] Use a SmallVector for EvalEmitter's locals

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -20,7 +20,7 @@ EvalEmitter::EvalEmitter(Context &Ctx, Program &P, State &Parent,
     : Ctx(Ctx), P(P), S(Parent, P, Stk, Ctx, this), EvalResult(&Ctx) {}
 
 EvalEmitter::~EvalEmitter() {
-  for (auto &[K, V] : Locals) {
+  for (auto &V : Locals) {
     Block *B = reinterpret_cast<Block *>(V.get());
     if (B->isInitialized())
       B->invokeDtor();
@@ -112,7 +112,7 @@ Scope::Local EvalEmitter::createLocal(Descriptor *D) {
 
   // Register the local.
   unsigned Off = Locals.size();
-  Locals.insert({Off, std::move(Memory)});
+  Locals.push_back(std::move(Memory));
   return {Off, D};
 }
 

--- a/clang/lib/AST/ByteCode/EvalEmitter.h
+++ b/clang/lib/AST/ByteCode/EvalEmitter.h
@@ -111,12 +111,11 @@ private:
   std::optional<PtrCallback> PtrCB;
 
   /// Temporaries which require storage.
-  llvm::DenseMap<unsigned, std::unique_ptr<char[]>> Locals;
+  llvm::SmallVector<std::unique_ptr<char[]>> Locals;
 
   Block *getLocal(unsigned Index) const {
-    auto It = Locals.find(Index);
-    assert(It != Locals.end() && "Missing local variable");
-    return reinterpret_cast<Block *>(It->second.get());
+    assert(Index < Locals.size());
+    return reinterpret_cast<Block *>(Locals[Index].get());
   }
 
   void updateGlobalTemporaries();


### PR DESCRIPTION
The offset we return for them are just indices, so we can use a vector here.