### PR TITLE
[clang-tidy] Do not flag strerror in concurrency-mt-unsafe

### DIFF
--- a/clang-tools-extra/clang-tidy/concurrency/MtUnsafeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/concurrency/MtUnsafeCheck.cpp
@@ -153,7 +153,6 @@ static const clang::StringRef GlibcFunctions[] = {
     "::sigsuspend",
     "::sleep",
     "::srand48",
-    "::strerror",
     "::strsignal",
     "::strtok",
     "::tcflow",

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -172,6 +172,10 @@ Changes in existing checks
   <clang-tidy/checks/cert/err33-c>` check by fixing false positives when
   a function name is just prefixed with a targeted function name.
 
+- Improved :doc:`concurrency-mt-unsafe
+  <clang-tidy/checks/concurrency/mt-unsafe>` check by fixing a false positive
+  where `strerror` was flagged as MT-unsafe.
+
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check by adding the option
   `AllowedTypes`, that excludes specified types from const-correctness

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -174,7 +174,7 @@ Changes in existing checks
 
 - Improved :doc:`concurrency-mt-unsafe
   <clang-tidy/checks/concurrency/mt-unsafe>` check by fixing a false positive
-  where `strerror` was flagged as MT-unsafe.
+  where ``strerror`` was flagged as MT-unsafe.
 
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check by adding the option

--- a/clang-tools-extra/test/clang-tidy/checkers/concurrency/mt-unsafe-glibc.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/concurrency/mt-unsafe-glibc.cpp
@@ -3,6 +3,7 @@
 extern unsigned int sleep (unsigned int __seconds);
 extern int *gmtime (const int *__timer);
 extern char *dirname (char *__path);
+extern char *strerror(int errnum);
 
 void foo() {
   sleep(2);
@@ -12,4 +13,6 @@ void foo() {
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: function is not thread safe [concurrency-mt-unsafe]
 
   dirname(nullptr);
+
+  strerror(0);
 }


### PR DESCRIPTION
The docs of the check state:

> Glibc’s list is compiled from GNU web documentation with a search for MT-Safe tag

And strerror fulfills exactly that: https://www.gnu.org/software/libc/manual/html_node/Error-Messages.html

> Function: char * strerror (int errnum)
> Preliminary: | MT-Safe | AS-Unsafe heap i18n | AC-Unsafe mem | See POSIX Safety Concepts.

So concurrency-mt-unsafe should not flag it.

Fixes #140515