### PR TITLE
[Verifier] Add checks for range attribute on ImmArg

### DIFF
--- a/llvm/test/Assembler/immarg-param-attribute.ll
+++ b/llvm/test/Assembler/immarg-param-attribute.ll
@@ -6,6 +6,9 @@ declare void @llvm.test.immarg.intrinsic.i32(i32 immarg)
 ; CHECK: declare void @llvm.test.immarg.intrinsic.f32(float immarg)
 declare void @llvm.test.immarg.intrinsic.f32(float immarg)
 
+; CHECK: declare void @llvm.test.immarg.range.intrinsic.i32(i32 immarg range(i32 -2, 14))
+declare void @llvm.test.immarg.range.intrinsic.i32(i32 immarg range(i32 -2, 14))
+
 ; CHECK-LABEL: @call_llvm.test.immarg.intrinsic.i32(
 define void @call_llvm.test.immarg.intrinsic.i32() {
   ; CHECK: call void @llvm.test.immarg.intrinsic.i32(i32 0)
@@ -35,5 +38,21 @@ define void @call_llvm.test.immarg.intrinsic.f32() {
 define void @on_callsite_and_declaration() {
   ; CHECK: call void @llvm.test.immarg.intrinsic.i32(i32 immarg 0)
   call void @llvm.test.immarg.intrinsic.i32(i32 immarg 0)
+  ret void
+}
+
+; CHECK-LABEL: @test_int_immarg_with_range(
+define void @test_int_immarg_with_range() {
+  ; CHECK: call void @llvm.test.immarg.range.intrinsic.i32(i32 -2)
+  call void @llvm.test.immarg.range.intrinsic.i32(i32 -2)
+
+  ; CHECK: call void @llvm.test.immarg.range.intrinsic.i32(i32 0)
+  call void @llvm.test.immarg.range.intrinsic.i32(i32 0)
+
+  ; CHECK: call void @llvm.test.immarg.range.intrinsic.i32(i32 5)
+  call void @llvm.test.immarg.range.intrinsic.i32(i32 5)
+
+  ; CHECK: call void @llvm.test.immarg.range.intrinsic.i32(i32 13)
+  call void @llvm.test.immarg.range.intrinsic.i32(i32 13)
   ret void
 }

--- a/llvm/test/Assembler/invalid-immarg.ll
+++ b/llvm/test/Assembler/invalid-immarg.ll
@@ -1,34 +1,34 @@
 ; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.byval(ptr byval(i32) immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.inalloca(ptr inalloca(i32) immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.inreg(i32 inreg immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.nest(ptr nest immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.sret(ptr sret(i32) immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.zeroext(i32 zeroext immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.signext(i32 signext immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.returned(i32 returned immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.noalias(ptr noalias immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.readnone(ptr readnone immarg)
 
-; CHECK: Attribute 'immarg' is incompatible with other attributes
+; CHECK: Attribute 'immarg' is incompatible with other attributes except the 'range' attribute
 declare void @llvm.immarg.readonly(ptr readonly immarg)

--- a/llvm/test/Assembler/invalid-immarg4.ll
+++ b/llvm/test/Assembler/invalid-immarg4.ll
@@ -1,0 +1,4 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: Attribute 'range(i32 1, 145)' applied to incompatible type!
+declare void @llvm.test.immarg.range.intrinsic.f32(float immarg range(i32 1, 145))

--- a/llvm/test/Assembler/invalid-immarg5.ll
+++ b/llvm/test/Assembler/invalid-immarg5.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+declare void @llvm.test.immarg.range.intrinsic.i32(i32 immarg range(i32 -3, 4))
+
+define void @test_int_immarg_with_range() {
+  ; CHECK: immarg value -4 out of range [-3, 4)
+  call void @llvm.test.immarg.range.intrinsic.i32(i32 -4)
+  ret void
+}


### PR DESCRIPTION
This patch implements verifier checks for range
attributes on ImmArg. This enables validation
of the range of ImmArg operands in intrinsics,
when the intrinsic definition includes the range
information.