### PR TITLE
[CodeGen] Avoid MachineModuleInfo in MachineModuleSlotTracker

### DIFF
--- a/llvm/include/llvm/CodeGen/MIRPrinter.h
+++ b/llvm/include/llvm/CodeGen/MIRPrinter.h
@@ -49,8 +49,8 @@ void printMIR(raw_ostream &OS, const Module &M);
 
 /// Print a machine function using the MIR serialization format to the given
 /// output stream.
-void printMIR(raw_ostream &OS, const MachineModuleInfo &MMI,
-              const MachineFunction &MF);
+void printMIR(raw_ostream &OS, MachineModuleInfo *MMI,
+              FunctionAnalysisManager *MFA, const MachineFunction &MF);
 
 /// Determine a possible list of successors of a basic block based on the
 /// basic block machine operand being used inside the block. This should give

--- a/llvm/include/llvm/CodeGen/MachineModuleSlotTracker.h
+++ b/llvm/include/llvm/CodeGen/MachineModuleSlotTracker.h
@@ -19,9 +19,12 @@ class MachineModuleInfo;
 class MachineFunction;
 class Module;
 
+using MFGetterFnT = std::function<MachineFunction *(const Function &)>;
+
 class MachineModuleSlotTracker : public ModuleSlotTracker {
   const Function &TheFunction;
-  const MachineModuleInfo &TheMMI;
+  MFGetterFnT MachineFunctionGetterFn;
+
   unsigned MDNStartSlot = 0, MDNEndSlot = 0;
 
   void processMachineFunctionMetadata(AbstractSlotTrackerStorage *AST,
@@ -33,8 +36,7 @@ class MachineModuleSlotTracker : public ModuleSlotTracker {
                               bool ShouldInitializeAllMetadata);
 
 public:
-  MachineModuleSlotTracker(const MachineModuleInfo &MMI,
-                           const MachineFunction *MF,
+  MachineModuleSlotTracker(MFGetterFnT Fn, const MachineFunction *MF,
                            bool ShouldInitializeAllMetadata = true);
   ~MachineModuleSlotTracker();
 

--- a/llvm/lib/CodeGen/MIRPrintingPass.cpp
+++ b/llvm/lib/CodeGen/MIRPrintingPass.cpp
@@ -27,12 +27,10 @@ PreservedAnalyses PrintMIRPreparePass::run(Module &M, ModuleAnalysisManager &) {
 
 PreservedAnalyses PrintMIRPass::run(MachineFunction &MF,
                                     MachineFunctionAnalysisManager &MFAM) {
-  auto &MAMP = MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF);
-  Module *M = MF.getFunction().getParent();
-  const MachineModuleInfo &MMI =
-      MAMP.getCachedResult<MachineModuleAnalysis>(*M)->getMMI();
+  auto &FAM = MFAM.getResult<FunctionAnalysisManagerMachineFunctionProxy>(MF)
+                  .getManager();
 
-  printMIR(OS, MMI, MF);
+  printMIR(OS, nullptr, &FAM, MF);
   return PreservedAnalyses::all();
 }
 
@@ -59,10 +57,10 @@ struct MIRPrintingPass : public MachineFunctionPass {
     std::string Str;
     raw_string_ostream StrOS(Str);
 
-    const MachineModuleInfo &MMI =
-        getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
+    MachineModuleInfo *MMI =
+        &getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
 
-    printMIR(StrOS, MMI, MF);
+    printMIR(StrOS, MMI, nullptr, MF);
     MachineFunctions.append(Str);
     return false;
   }

--- a/llvm/lib/CodeGen/MachineModuleSlotTracker.cpp
+++ b/llvm/lib/CodeGen/MachineModuleSlotTracker.cpp
@@ -39,7 +39,7 @@ void MachineModuleSlotTracker::processMachineModule(
       if (&F != &TheFunction)
         continue;
       MDNStartSlot = AST->getNextMetadataSlot();
-      if (auto *MF = TheMMI.getMachineFunction(F))
+      if (auto *MF = MachineFunctionGetterFn(F))
         processMachineFunctionMetadata(AST, *MF);
       MDNEndSlot = AST->getNextMetadataSlot();
       break;
@@ -52,7 +52,7 @@ void MachineModuleSlotTracker::processMachineFunction(
     bool ShouldInitializeAllMetadata) {
   if (!ShouldInitializeAllMetadata && F == &TheFunction) {
     MDNStartSlot = AST->getNextMetadataSlot();
-    if (auto *MF = TheMMI.getMachineFunction(*F))
+    if (auto *MF = MachineFunctionGetterFn(*F))
       processMachineFunctionMetadata(AST, *MF);
     MDNEndSlot = AST->getNextMetadataSlot();
   }
@@ -64,11 +64,10 @@ void MachineModuleSlotTracker::collectMachineMDNodes(
 }
 
 MachineModuleSlotTracker::MachineModuleSlotTracker(
-    const MachineModuleInfo &MMI, const MachineFunction *MF,
-    bool ShouldInitializeAllMetadata)
+    MFGetterFnT Fn, const MachineFunction *MF, bool ShouldInitializeAllMetadata)
     : ModuleSlotTracker(MF->getFunction().getParent(),
                         ShouldInitializeAllMetadata),
-      TheFunction(MF->getFunction()), TheMMI(MMI) {
+      TheFunction(MF->getFunction()), MachineFunctionGetterFn(Fn) {
   setProcessHook([this](AbstractSlotTrackerStorage *AST, const Module *M,
                         bool ShouldInitializeAllMetadata) {
     this->processMachineModule(AST, M, ShouldInitializeAllMetadata);


### PR DESCRIPTION
In NPM, MMI is not used to store machine functions so we need to use the analysis manager here.