### PR TITLE
[mlir] Fix bazel build after `c798e19`.

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMInterfaces.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMInterfaces.cpp
@@ -12,7 +12,6 @@
 
 #include "mlir/Dialect/LLVMIR/LLVMInterfaces.h"
 
-#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/PatternMatch.h"
 


### PR DESCRIPTION
`@llvm-project//mlir:LLVMDialect` builds fine without the header. Don't think it was needed.