### PR TITLE
[libclang/python] Simplify __eq__ operators

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -335,9 +335,7 @@ class SourceLocation(Structure):
         return conf.lib.clang_Location_isInSystemHeader(self)  # type: ignore [no-any-return]
 
     def __eq__(self, other):
-        if not isinstance(other, SourceLocation):
-            return False
-        return conf.lib.clang_equalLocations(self, other)  # type: ignore [no-any-return]
+        return isinstance(other, SourceLocation) and conf.lib.clang_equalLocations(self, other)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -395,9 +393,7 @@ class SourceRange(Structure):
         return conf.lib.clang_getRangeEnd(self)  # type: ignore [no-any-return]
 
     def __eq__(self, other):
-        if not isinstance(other, SourceRange):
-            return False
-        return conf.lib.clang_equalRanges(self, other)  # type: ignore [no-any-return]
+        return isinstance(other, SourceRange) and conf.lib.clang_equalRanges(self, other)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -1599,9 +1595,7 @@ class Cursor(Structure):
 
     # This function is not null-guarded because it is used in cursor_null_guard itself
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Cursor):
-            return False
-        return conf.lib.clang_equalCursors(self, other)  # type: ignore [no-any-return]
+        return isinstance(other, Cursor) and conf.lib.clang_equalCursors(self, other)
 
     # Not null-guarded for consistency with __eq__
     def __ne__(self, other: object) -> bool:

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -395,7 +395,9 @@ class SourceRange(Structure):
     def __eq__(self, other):
         return isinstance(other, SourceRange) and conf.lib.clang_equalRanges(self, other)
 
-    def __ne__(self, other):
+        return isinstance(other, SourceRange) and conf.lib.clang_equalRanges(
+            self, other
+        )
         return not self.__eq__(other)
 
     def __contains__(self, other):

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -335,7 +335,9 @@ class SourceLocation(Structure):
         return conf.lib.clang_Location_isInSystemHeader(self)  # type: ignore [no-any-return]
 
     def __eq__(self, other):
-        return isinstance(other, SourceLocation) and conf.lib.clang_equalLocations(self, other)
+        return isinstance(other, SourceLocation) and conf.lib.clang_equalLocations(
+            self, other
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -395,11 +395,11 @@ class SourceRange(Structure):
         return conf.lib.clang_getRangeEnd(self)  # type: ignore [no-any-return]
 
     def __eq__(self, other):
-        return isinstance(other, SourceRange) and conf.lib.clang_equalRanges(self, other)
-
         return isinstance(other, SourceRange) and conf.lib.clang_equalRanges(
             self, other
         )
+
+    def __ne__(self, other):
         return not self.__eq__(other)
 
     def __contains__(self, other):


### PR DESCRIPTION
This allows us to remove a few type: ignores.