### PR TITLE
[C++] Fix a crash with __thread and dependent types

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -558,6 +558,9 @@ Improvements to Clang's diagnostics
   between different Unicode character types (``char8_t``, ``char16_t``, ``char32_t``).
   This warning only triggers in C++ as these types are aliases in C. (#GH138526)
 
+- Fixed a crash when checking a ``__thread``-specified variable declaration
+  with a dependent type in C++. (#GH140509)
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14622,7 +14622,8 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
       Diag(var->getLocation(), diag::err_thread_nontrivial_dtor);
       if (getLangOpts().CPlusPlus11)
         Diag(var->getLocation(), diag::note_use_thread_local);
-    } else if (getLangOpts().CPlusPlus && var->hasInit()) {
+    } else if (getLangOpts().CPlusPlus && var->hasInit() &&
+               !var->getType()->isDependentType()) {
       if (!checkConstInit()) {
         // GNU C++98 edits for __thread, [basic.start.init]p4:
         //   An object of thread storage duration shall not require dynamic

--- a/clang/test/SemaCXX/thread-specifier.cpp
+++ b/clang/test/SemaCXX/thread-specifier.cpp
@@ -12,6 +12,12 @@ void instantiated() {
                                          expected-note {{use 'thread_local' to allow this}}
 }
 
+template <typename T>
+void nondependent_var() {
+  // Verify that the dependence of the initializer is what really matters.
+  static __thread int my_wrapper = T{};
+}
+
 struct S {
   S() {}
 };
@@ -19,6 +25,6 @@ struct S {
 void f() {
   instantiated<int>();
   instantiated<S>(); // expected-note {{in instantiation of function template specialization 'GH140509::instantiated<GH140509::S>' requested here}}
+  nondependent_var<int>();
 }
 } // namespace GH140509
-

--- a/clang/test/SemaCXX/thread-specifier.cpp
+++ b/clang/test/SemaCXX/thread-specifier.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++23 -verify %s
+
+namespace GH140509 {
+template <typename T>
+void not_instantiated() {
+  static __thread T my_wrapper;
+}
+
+template <typename T>
+void instantiated() {
+  static __thread T my_wrapper = T{}; // expected-error {{initializer for thread-local variable must be a constant expression}} \
+                                         expected-note {{use 'thread_local' to allow this}}
+}
+
+struct S {
+  S() {}
+};
+
+void f() {
+  instantiated<int>();
+  instantiated<S>(); // expected-note {{in instantiation of function template specialization 'GH140509::instantiated<GH140509::S>' requested here}}
+}
+} // namespace GH140509
+


### PR DESCRIPTION
We were checking whether the initializer is a valid constant expression even if the variable was dependent. Now we delay that checking until after the template has been instantiated.

Fixes #140509