### PR TITLE
[clang][bytecode] Do not diagnose volatile reads in CPCE mode

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2936,13 +2936,14 @@ inline bool InvalidCast(InterpState &S, CodePtr OpPC, CastKind Kind,
         << static_cast<unsigned>(Kind) << S.Current->getRange(OpPC);
     return !Fatal;
   } else if (Kind == CastKind::Volatile) {
-    // FIXME: Technically not a cast.
-    const auto *E = cast<CastExpr>(S.Current->getExpr(OpPC));
-    if (S.getLangOpts().CPlusPlus)
-      S.FFDiag(E, diag::note_constexpr_access_volatile_type)
-          << AK_Read << E->getSubExpr()->getType();
-    else
-      S.FFDiag(E);
+    if (!S.checkingPotentialConstantExpression()) {
+      const auto *E = cast<CastExpr>(S.Current->getExpr(OpPC));
+      if (S.getLangOpts().CPlusPlus)
+        S.FFDiag(E, diag::note_constexpr_access_volatile_type)
+            << AK_Read << E->getSubExpr()->getType();
+      else
+        S.FFDiag(E);
+    }
 
     return false;
   } else if (Kind == CastKind::Dynamic) {

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -233,3 +233,13 @@ namespace IntToPtrCast {
   constexpr intptr_t i = f((intptr_t)&foo - 10); // both-error{{constexpr variable 'i' must be initialized by a constant expression}} \
                                                  // both-note{{reinterpret_cast}}
 }
+
+namespace Volatile {
+  constexpr int f(volatile int &&r) {
+    return r; // both-note {{read of volatile-qualified type 'volatile int'}}
+  }
+  struct S {
+    int j : f(0); // both-error {{constant expression}} \
+                  // both-note {{in call to 'f(0)'}}
+  };
+}


### PR DESCRIPTION
This matches the diagnostic output of the current interpreter.