### PR TITLE
[libc++] Add CMake option to enable execute-only code generation on AArch64

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -318,6 +318,8 @@ endif()
 option(LIBCXX_HERMETIC_STATIC_LIBRARY
   "Do not export any symbols from the static library." ${LIBCXX_HERMETIC_STATIC_LIBRARY_DEFAULT})
 
+option(LIBCXX_EXECUTE_ONLY_CODE "Compile libc++ as execute-only." OFF)
+
 #===============================================================================
 # Check option configurations
 #===============================================================================
@@ -537,6 +539,17 @@ function(cxx_add_basic_build_flags target)
   # it easier to upgrade the library to a newer language standard without build
   # errors.
   target_compile_definitions(${target} PRIVATE -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES)
+
+  if (LIBCXX_EXECUTE_ONLY_CODE)
+    target_add_compile_flags_if_supported(${target} PRIVATE -mexecute-only)
+    if (NOT CXX_SUPPORTS_MEXECUTE_ONLY_FLAG)
+      target_add_compile_flags_if_supported(${target} PRIVATE -mpure-code)
+      if (NOT CXX_SUPPORTS_MPURE_CODE_FLAG)
+        message(SEND_ERROR "Compiler doesn't support -mexecute-only or "
+                           "-mpure-code option for target ${target}!")
+      endif()
+    endif()
+  endif()
 
   if (C_SUPPORTS_COMMENT_LIB_PRAGMA)
     if (LIBCXX_HAS_PTHREAD_LIB)


### PR DESCRIPTION
For a full toolchain supporting execute-only code generation the runtime libraries also need to be pre-compiled with it enabled. For libc++ this can now be enabled with the `LIBCXX_EXECUTE_ONLY_CODE` CMake option during build configuration.

Related RFC: https://discourse.llvm.org/t/rfc-execute-only-code-support-for-runtime-libraries-on-aarch64/86180