### PR TITLE
[libc++abi] Add CMake option to enable execute-only code generation on AArch64

### DIFF
--- a/libcxxabi/CMakeLists.txt
+++ b/libcxxabi/CMakeLists.txt
@@ -143,6 +143,8 @@ endif()
 option(LIBCXXABI_HERMETIC_STATIC_LIBRARY
   "Do not export any symbols from the static library." ${LIBCXXABI_HERMETIC_STATIC_LIBRARY_DEFAULT})
 
+option(LIBCXXABI_EXECUTE_ONLY_CODE "Compile libc++abi as execute-only." OFF)
+
 if(MINGW)
   set(LIBCXXABI_DEFAULT_TEST_CONFIG "llvm-libc++abi-mingw.cfg.in")
 elseif(WIN32) # clang-cl
@@ -443,6 +445,17 @@ endif()
 if (C_SUPPORTS_COMMENT_LIB_PRAGMA)
   if (LIBCXXABI_HAS_PTHREAD_LIB)
     add_definitions(-D_LIBCXXABI_LINK_PTHREAD_LIB)
+  endif()
+endif()
+
+if (LIBCXXABI_EXECUTE_ONLY_CODE)
+  add_compile_flags_if_supported(-mexecute-only)
+  if (NOT CXX_SUPPORTS_MEXECUTE_ONLY_FLAG)
+    add_compile_flags_if_supported(-mpure-code)
+    if (NOT CXX_SUPPORTS_MPURE_CODE_FLAG)
+      message(SEND_ERROR
+        "Compiler doesn't support -mexecute-only or -mpure-code option!")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
For a full toolchain supporting execute-only code generation the runtime libraries also need to be pre-compiled with it enabled. For libc++abi this can now be enabled with the `LIBCXXABI_EXECUTE_ONLY_CODE` CMake option during build configuration.

Related RFC: https://discourse.llvm.org/t/rfc-execute-only-code-support-for-runtime-libraries-on-aarch64/86180