### PR TITLE
[libunwind] Add CMake option to enable execute-only code generation on AArch64

### DIFF
--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -332,7 +332,7 @@ if (C_SUPPORTS_COMMENT_LIB_PRAGMA)
   endif()
 endif()
 
-if (LLVM_EXECUTE_ONLY_CODE)
+if (RUNTIMES_EXECUTE_ONLY_CODE)
   add_compile_definitions(_LIBUNWIND_EXECUTE_ONLY_CODE)
 endif()
 

--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -55,7 +55,6 @@ option(LIBUNWIND_USE_FRAME_HEADER_CACHE "Cache frame headers for unwinding. Requ
 option(LIBUNWIND_REMEMBER_HEAP_ALLOC "Use heap instead of the stack for .cfi_remember_state." OFF)
 option(LIBUNWIND_INSTALL_HEADERS "Install the libunwind headers." ON)
 option(LIBUNWIND_ENABLE_FRAME_APIS "Include libgcc-compatible frame apis." OFF)
-option(LIBUNWIND_EXECUTE_ONLY_CODE "Compile libunwind as execute-only." OFF)
 
 set(LIBUNWIND_LIBDIR_SUFFIX "${LLVM_LIBDIR_SUFFIX}" CACHE STRING
     "Define suffix of library directory name (32/64)")
@@ -109,11 +108,6 @@ else()
 endif()
 option(LIBUNWIND_HIDE_SYMBOLS
   "Do not export any symbols from the static library." ${LIBUNWIND_DEFAULT_HIDE_SYMBOLS})
-
-if (LIBUNWIND_EXECUTE_ONLY_CODE AND NOT LLVM_RUNTIMES_BUILD)
-  message(SEND_ERROR "LIBUNWIND_EXECUTE_ONLY_CODE is only supported "
-                     "for runtimes build of libunwind.")
-endif()
 
 # If toolchain is FPXX, we switch to FP64 to save the full FPRs. See:
 # https://web.archive.org/web/20180828210612/https://dmz-portal.mips.com/wiki/MIPS_O32_ABI_-_FR0_and_FR1_Interlinking
@@ -338,15 +332,7 @@ if (C_SUPPORTS_COMMENT_LIB_PRAGMA)
   endif()
 endif()
 
-if (LIBUNWIND_EXECUTE_ONLY_CODE)
-  add_compile_flags_if_supported(-mexecute-only)
-  if (NOT CXX_SUPPORTS_MEXECUTE_ONLY_FLAG)
-    add_compile_flags_if_supported(-mpure-code)
-    if (NOT CXX_SUPPORTS_MPURE_CODE_FLAG)
-      message(SEND_ERROR
-        "Compiler doesn't support -mexecute-only or -mpure-code option!")
-    endif()
-  endif()
+if (LLVM_EXECUTE_ONLY_CODE)
   add_compile_definitions(_LIBUNWIND_EXECUTE_ONLY_CODE)
 endif()
 

--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -55,6 +55,7 @@ option(LIBUNWIND_USE_FRAME_HEADER_CACHE "Cache frame headers for unwinding. Requ
 option(LIBUNWIND_REMEMBER_HEAP_ALLOC "Use heap instead of the stack for .cfi_remember_state." OFF)
 option(LIBUNWIND_INSTALL_HEADERS "Install the libunwind headers." ON)
 option(LIBUNWIND_ENABLE_FRAME_APIS "Include libgcc-compatible frame apis." OFF)
+option(LIBUNWIND_EXECUTE_ONLY_CODE "Compile libunwind as execute-only." OFF)
 
 set(LIBUNWIND_LIBDIR_SUFFIX "${LLVM_LIBDIR_SUFFIX}" CACHE STRING
     "Define suffix of library directory name (32/64)")
@@ -108,6 +109,11 @@ else()
 endif()
 option(LIBUNWIND_HIDE_SYMBOLS
   "Do not export any symbols from the static library." ${LIBUNWIND_DEFAULT_HIDE_SYMBOLS})
+
+if (LIBUNWIND_EXECUTE_ONLY_CODE AND NOT LLVM_RUNTIMES_BUILD)
+  message(SEND_ERROR "LIBUNWIND_EXECUTE_ONLY_CODE is only supported "
+                     "for runtimes build of libunwind.")
+endif()
 
 # If toolchain is FPXX, we switch to FP64 to save the full FPRs. See:
 # https://web.archive.org/web/20180828210612/https://dmz-portal.mips.com/wiki/MIPS_O32_ABI_-_FR0_and_FR1_Interlinking
@@ -330,6 +336,18 @@ if (C_SUPPORTS_COMMENT_LIB_PRAGMA)
   if (LIBUNWIND_HAS_PTHREAD_LIB)
     add_definitions(-D_LIBUNWIND_LINK_PTHREAD_LIB)
   endif()
+endif()
+
+if (LIBUNWIND_EXECUTE_ONLY_CODE)
+  add_compile_flags_if_supported(-mexecute-only)
+  if (NOT CXX_SUPPORTS_MEXECUTE_ONLY_FLAG)
+    add_compile_flags_if_supported(-mpure-code)
+    if (NOT CXX_SUPPORTS_MPURE_CODE_FLAG)
+      message(SEND_ERROR
+        "Compiler doesn't support -mexecute-only or -mpure-code option!")
+    endif()
+  endif()
+  add_compile_definitions(_LIBUNWIND_EXECUTE_ONLY_CODE)
 endif()
 
 #===============================================================================

--- a/libunwind/src/UnwindRegistersRestore.S
+++ b/libunwind/src/UnwindRegistersRestore.S
@@ -18,6 +18,8 @@
 
 #if defined(_AIX)
   .toc
+#elif defined(__aarch64__) && defined(__ELF__) && defined(_LIBUNWIND_EXECUTE_ONLY_CODE)
+  .section .text,"axy",@progbits,unique,0
 #else
   .text
 #endif

--- a/libunwind/src/UnwindRegistersSave.S
+++ b/libunwind/src/UnwindRegistersSave.S
@@ -18,6 +18,8 @@
 
 #if defined(_AIX)
     .toc
+#elif defined(__aarch64__) && defined(__ELF__) && defined(_LIBUNWIND_EXECUTE_ONLY_CODE)
+    .section .text,"axy",@progbits,unique,0
 #else
     .text
 #endif


### PR DESCRIPTION
For a full toolchain supporting execute-only code generation the runtime libraries also need to be pre-compiled with it enabled. The generic `RUNTIMES_EXECUTE_ONLY_CODE` CMake option can now be used during build configuration to enable execute-only code generation in libunwind.

Related RFC: https://discourse.llvm.org/t/rfc-execute-only-code-support-for-runtime-libraries-on-aarch64/86180