### PR TITLE
[OpenMP][Flang] Fix semantic check and scoping for declare mappers

### DIFF
--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3540,7 +3540,7 @@ WRAPPER_CLASS(OmpLocatorList, std::list<OmpLocator>);
 struct OmpMapperSpecifier {
   // Absent mapper-identifier is equivalent to DEFAULT.
   TUPLE_CLASS_BOILERPLATE(OmpMapperSpecifier);
-  std::tuple<std::optional<Name>, TypeSpec, Name> t;
+  std::tuple<std::string, TypeSpec, Name> t;
 };
 
 // Ref: [4.5:222:1-5], [5.0:305:20-27], [5.1:337:11-19], [5.2:139:18-23],

--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -1114,9 +1114,9 @@ void ClauseProcessor::processMapObjects(
         typeSpec = &object.sym()->GetType()->derivedTypeSpec();
 
       if (typeSpec) {
-        mapperIdName = typeSpec->name().ToString() + ".default";
-        mapperIdName =
-            converter.mangleName(mapperIdName, *typeSpec->GetScope());
+        mapperIdName = typeSpec->name().ToString() + ".omp.default.mapper";
+        if (auto *sym = converter.getCurrentScope().FindSymbol(mapperIdName))
+          mapperIdName = converter.mangleName(mapperIdName, sym->owner());
       }
     }
   };

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -2422,8 +2422,10 @@ genTargetOp(lower::AbstractConverter &converter, lower::SymMap &symTable,
       mlir::FlatSymbolRefAttr mapperId;
       if (sym.GetType()->category() == semantics::DeclTypeSpec::TypeDerived) {
         auto &typeSpec = sym.GetType()->derivedTypeSpec();
-        std::string mapperIdName = typeSpec.name().ToString() + ".default";
-        mapperIdName = converter.mangleName(mapperIdName, *typeSpec.GetScope());
+        std::string mapperIdName =
+            typeSpec.name().ToString() + ".omp.default.mapper";
+        if (auto *sym = converter.getCurrentScope().FindSymbol(mapperIdName))
+          mapperIdName = converter.mangleName(mapperIdName, sym->owner());
         if (converter.getModuleOp().lookupSymbol(mapperIdName))
           mapperId = mlir::FlatSymbolRefAttr::get(&converter.getMLIRContext(),
                                                   mapperIdName);
@@ -4005,24 +4007,16 @@ genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
   lower::StatementContext stmtCtx;
   const auto &spec =
       std::get<parser::OmpMapperSpecifier>(declareMapperConstruct.t);
-  const auto &mapperName{std::get<std::optional<parser::Name>>(spec.t)};
+  const auto &mapperName{std::get<std::string>(spec.t)};
   const auto &varType{std::get<parser::TypeSpec>(spec.t)};
   const auto &varName{std::get<parser::Name>(spec.t)};
   assert(varType.declTypeSpec->category() ==
              semantics::DeclTypeSpec::Category::TypeDerived &&
          "Expected derived type");
 
-  std::string mapperNameStr;
-  if (mapperName.has_value()) {
-    mapperNameStr = mapperName->ToString();
-    mapperNameStr =
-        converter.mangleName(mapperNameStr, mapperName->symbol->owner());
-  } else {
-    mapperNameStr =
-        varType.declTypeSpec->derivedTypeSpec().name().ToString() + ".default";
-    mapperNameStr = converter.mangleName(
-        mapperNameStr, *varType.declTypeSpec->derivedTypeSpec().GetScope());
-  }
+  std::string mapperNameStr = mapperName;
+  if (auto *sym = converter.getCurrentScope().FindSymbol(mapperNameStr))
+    mapperNameStr = converter.mangleName(mapperNameStr, sym->owner());
 
   // Save current insertion point before moving to the module scope to create
   // the DeclareMapperOp

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -1389,8 +1389,28 @@ TYPE_PARSER(
 TYPE_PARSER(sourced(construct<OpenMPDeclareTargetConstruct>(
     verbatim("DECLARE TARGET"_tok), Parser<OmpDeclareTargetSpecifier>{})))
 
+static OmpMapperSpecifier ConstructOmpMapperSpecifier(
+    std::optional<Name> &&mapperName, TypeSpec &&typeSpec, Name &&varName) {
+  // If a name is present, parse: name ":" typeSpec "::" name
+  // This matches the syntax: <mapper-name> : <type-spec> :: <variable-name>
+  if (mapperName.has_value() && mapperName->ToString() != "default") {
+    return OmpMapperSpecifier{
+        mapperName->ToString(), std::move(typeSpec), std::move(varName)};
+  }
+  // If the name is missing, use the DerivedTypeSpec name to construct the
+  // default mapper name.
+  // This matches the syntax: <type-spec> :: <variable-name>
+  if (auto *derived = std::get_if<DerivedTypeSpec>(&typeSpec.u)) {
+    return OmpMapperSpecifier{
+        std::get<Name>(derived->t).ToString() + ".omp.default.mapper",
+        std::move(typeSpec), std::move(varName)};
+  }
+  return OmpMapperSpecifier{std::string("omp.default.mapper"),
+      std::move(typeSpec), std::move(varName)};
+}
+
 // mapper-specifier
-TYPE_PARSER(construct<OmpMapperSpecifier>(
+TYPE_PARSER(applyFunction<OmpMapperSpecifier>(ConstructOmpMapperSpecifier,
     maybe(name / ":" / !":"_tok), typeSpec / "::", name))
 
 // OpenMP 5.2: 5.8.8 Declare Mapper Construct

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -1400,7 +1400,7 @@ static OmpMapperSpecifier ConstructOmpMapperSpecifier(
   // If the name is missing, use the DerivedTypeSpec name to construct the
   // default mapper name.
   // This matches the syntax: <type-spec> :: <variable-name>
-  if (auto *derived = std::get_if<DerivedTypeSpec>(&typeSpec.u)) {
+  if (DerivedTypeSpec * derived{std::get_if<DerivedTypeSpec>(&typeSpec.u)}) {
     return OmpMapperSpecifier{
         std::get<Name>(derived->t).ToString() + ".omp.default.mapper",
         std::move(typeSpec), std::move(varName)};

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -2093,7 +2093,11 @@ public:
     Walk(x.v, ",");
   }
   void Unparse(const OmpMapperSpecifier &x) {
-    Walk(std::get<std::optional<Name>>(x.t), ":");
+    const auto &mapperName = std::get<std::string>(x.t);
+    if (mapperName.find("omp.default.mapper") == std::string::npos) {
+      Walk(mapperName);
+      Put(":");
+    }
     Walk(std::get<TypeSpec>(x.t));
     Put("::");
     Walk(std::get<Name>(x.t));
@@ -2796,8 +2800,9 @@ public:
     BeginOpenMP();
     Word("!$OMP DECLARE MAPPER (");
     const auto &spec{std::get<OmpMapperSpecifier>(z.t)};
-    if (auto mapname{std::get<std::optional<Name>>(spec.t)}) {
-      Walk(mapname);
+    const auto &mapperName = std::get<std::string>(spec.t);
+    if (mapperName.find("omp.default.mapper") == std::string::npos) {
+      Walk(mapperName);
       Put(":");
     }
     Walk(std::get<TypeSpec>(spec.t));

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -2093,7 +2093,7 @@ public:
     Walk(x.v, ",");
   }
   void Unparse(const OmpMapperSpecifier &x) {
-    const auto &mapperName = std::get<std::string>(x.t);
+    const auto &mapperName{std::get<std::string>(x.t)};
     if (mapperName.find("omp.default.mapper") == std::string::npos) {
       Walk(mapperName);
       Put(":");
@@ -2800,7 +2800,7 @@ public:
     BeginOpenMP();
     Word("!$OMP DECLARE MAPPER (");
     const auto &spec{std::get<OmpMapperSpecifier>(z.t)};
-    const auto &mapperName = std::get<std::string>(spec.t);
+    const auto &mapperName{std::get<std::string>(spec.t)};
     if (mapperName.find("omp.default.mapper") == std::string::npos) {
       Walk(mapperName);
       Put(":");

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1767,7 +1767,9 @@ void OmpVisitor::ProcessMapperSpecifier(const parser::OmpMapperSpecifier &spec,
   // just following the natural flow, the map clauses gets processed before
   // the type has been fully processed.
   BeginDeclTypeSpec();
-
+  auto &mapperName{std::get<std::string>(spec.t)};
+  MakeSymbol(parser::CharBlock(mapperName), Attrs{},
+      MiscDetails{MiscDetails::Kind::ConstructName});
   PushScope(Scope::Kind::OtherConstruct, nullptr);
   Walk(std::get<parser::TypeSpec>(spec.t));
   auto &varName{std::get<parser::Name>(spec.t)};
@@ -1776,18 +1778,6 @@ void OmpVisitor::ProcessMapperSpecifier(const parser::OmpMapperSpecifier &spec,
   Walk(clauses);
   EndDeclTypeSpec();
   PopScope();
-
-  if (auto &mapperName{std::get<std::optional<parser::Name>>(spec.t)}) {
-    mapperName->symbol =
-        &MakeSymbol(*mapperName, MiscDetails{MiscDetails::Kind::ConstructName});
-  } else {
-    const auto &type = std::get<parser::TypeSpec>(spec.t);
-    static llvm::SmallVector<std::string> defaultNames;
-    defaultNames.emplace_back(
-        type.declTypeSpec->derivedTypeSpec().name().ToString() + ".default");
-    MakeSymbol(defaultNames.back(), Attrs{},
-        MiscDetails{MiscDetails::Kind::ConstructName});
-  }
 }
 
 void OmpVisitor::ProcessReductionSpecifier(

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -38,7 +38,6 @@
 #include "flang/Semantics/type.h"
 #include "flang/Support/Fortran.h"
 #include "flang/Support/default-kinds.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
 #include <list>
 #include <map>

--- a/flang/test/Lower/OpenMP/map-mapper.f90
+++ b/flang/test/Lower/OpenMP/map-mapper.f90
@@ -8,7 +8,7 @@ program p
    !$omp declare mapper(xx : t1 :: nn) map(to: nn, nn%x)
    !$omp declare mapper(t1 :: nn) map(from: nn)
 
-   !CHECK-LABEL: omp.declare_mapper @_QQFt1.default : !fir.type<_QFTt1{x:!fir.array<256xi32>}>
+   !CHECK-LABEL: omp.declare_mapper @_QQFt1.omp.default.mapper : !fir.type<_QFTt1{x:!fir.array<256xi32>}>
    !CHECK-LABEL: omp.declare_mapper @_QQFxx : !fir.type<_QFTt1{x:!fir.array<256xi32>}>
 
    type(t1) :: a, b
@@ -20,7 +20,7 @@ program p
    end do
    !$omp end target
 
-   !CHECK: %[[MAP_B:.*]] = omp.map.info var_ptr(%{{.*}} : {{.*}}, {{.*}}) map_clauses(tofrom) capture(ByRef) mapper(@_QQFt1.default) -> {{.*}} {name = "b"}
+   !CHECK: %[[MAP_B:.*]] = omp.map.info var_ptr(%{{.*}} : {{.*}}, {{.*}}) map_clauses(tofrom) capture(ByRef) mapper(@_QQFt1.omp.default.mapper) -> {{.*}} {name = "b"}
    !CHECK: omp.target map_entries(%[[MAP_B]] -> %{{.*}}, %{{.*}} -> %{{.*}} : {{.*}}, {{.*}}) {
    !$omp target map(mapper(default) : b)
    do i = 1, n

--- a/flang/test/Parser/OpenMP/declare-mapper-unparse.f90
+++ b/flang/test/Parser/OpenMP/declare-mapper-unparse.f90
@@ -7,36 +7,37 @@ program main
   type ty
      integer :: x
   end type ty
-  
+
 
 !CHECK: !$OMP DECLARE MAPPER (mymapper:ty::mapped) MAP(mapped,mapped%x)
   !$omp declare mapper(mymapper : ty :: mapped) map(mapped, mapped%x)
 
 !PARSE-TREE:      OpenMPDeclareMapperConstruct
 !PARSE-TREE:        OmpMapperSpecifier
-!PARSE-TREE:         Name = 'mymapper'
+!PARSE-TREE:         string = 'mymapper'
 !PARSE-TREE:         TypeSpec -> DerivedTypeSpec
 !PARSE-TREE:           Name = 'ty'
-!PARSE-TREE:         Name = 'mapped'    
-!PARSE-TREE:        OmpMapClause
-!PARSE-TREE:          OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'mapped'
-!PARSE-TREE:          OmpObject -> Designator -> DataRef -> StructureComponent
-!PARSE-TREE:           DataRef -> Name = 'mapped'
-!PARSE-TREE:           Name = 'x'  
-
-!CHECK: !$OMP DECLARE MAPPER (ty::mapped) MAP(mapped,mapped%x)
-  !$omp declare mapper(ty :: mapped) map(mapped, mapped%x)
-  
-!PARSE-TREE:      OpenMPDeclareMapperConstruct
-!PARSE-TREE:        OmpMapperSpecifier
-!PARSE-TREE:         TypeSpec -> DerivedTypeSpec
-!PARSE-TREE:           Name = 'ty'
-!PARSE-TREE:         Name = 'mapped'    
+!PARSE-TREE:         Name = 'mapped'
 !PARSE-TREE:        OmpMapClause
 !PARSE-TREE:          OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'mapped'
 !PARSE-TREE:          OmpObject -> Designator -> DataRef -> StructureComponent
 !PARSE-TREE:           DataRef -> Name = 'mapped'
 !PARSE-TREE:           Name = 'x'
-  
+
+!CHECK: !$OMP DECLARE MAPPER (ty::mapped) MAP(mapped,mapped%x)
+  !$omp declare mapper(ty :: mapped) map(mapped, mapped%x)
+
+!PARSE-TREE:      OpenMPDeclareMapperConstruct
+!PARSE-TREE:        OmpMapperSpecifier
+!PARSE-TREE:         string = 'ty.omp.default.mapper'
+!PARSE-TREE:         TypeSpec -> DerivedTypeSpec
+!PARSE-TREE:           Name = 'ty'
+!PARSE-TREE:         Name = 'mapped'
+!PARSE-TREE:        OmpMapClause
+!PARSE-TREE:          OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'mapped'
+!PARSE-TREE:          OmpObject -> Designator -> DataRef -> StructureComponent
+!PARSE-TREE:           DataRef -> Name = 'mapped'
+!PARSE-TREE:           Name = 'x'
+
 end program main
 !CHECK-LABEL: end program main

--- a/flang/test/Parser/OpenMP/metadirective-dirspec.f90
+++ b/flang/test/Parser/OpenMP/metadirective-dirspec.f90
@@ -78,7 +78,7 @@ end
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = declare mapper
 !PARSE-TREE: | | | OmpArgumentList -> OmpArgument -> OmpMapperSpecifier
-!PARSE-TREE: | | | | Name = 'mymapper'
+!PARSE-TREE: | | | | string = 'mymapper'
 !PARSE-TREE: | | | | TypeSpec -> IntrinsicTypeSpec -> IntegerTypeSpec ->
 !PARSE-TREE: | | | | Name = 'v'
 !PARSE-TREE: | | | OmpClauseList -> OmpClause -> Map -> OmpMapClause

--- a/flang/test/Semantics/OpenMP/declare-mapper-symbols.f90
+++ b/flang/test/Semantics/OpenMP/declare-mapper-symbols.f90
@@ -13,7 +13,7 @@ program main
 !! Note, symbols come out in their respective scope, but not in declaration order.
 !CHECK: mymapper: Misc ConstructName
 !CHECK: ty: DerivedType components: x
-!CHECK: ty.default: Misc ConstructName
+!CHECK: ty.omp.default.mapper: Misc ConstructName
 !CHECK: DerivedType scope: ty
 !CHECK: OtherConstruct scope:
 !CHECK: mapped (OmpMapToFrom) {{.*}} ObjectEntity type: TYPE(ty)

--- a/flang/test/Semantics/OpenMP/declare-mapper-symbols.f90
+++ b/flang/test/Semantics/OpenMP/declare-mapper-symbols.f90
@@ -2,23 +2,23 @@
 
 program main
 !CHECK-LABEL: MainProgram scope: main
-  implicit none
+   implicit none
 
-  type ty
-     integer :: x
-  end type ty
-  !$omp declare mapper(mymapper : ty :: mapped) map(mapped, mapped%x)
-  !$omp declare mapper(ty :: maptwo) map(maptwo, maptwo%x)
+   type ty
+      integer :: x
+   end type ty
+   !$omp declare mapper(mymapper : ty :: mapped) map(mapped, mapped%x)
+   !$omp declare mapper(ty :: maptwo) map(maptwo, maptwo%x)
 
 !! Note, symbols come out in their respective scope, but not in declaration order.
-!CHECK: default: Misc ConstructName
 !CHECK: mymapper: Misc ConstructName
 !CHECK: ty: DerivedType components: x
+!CHECK: ty.default: Misc ConstructName
 !CHECK: DerivedType scope: ty
 !CHECK: OtherConstruct scope:
 !CHECK: mapped (OmpMapToFrom) {{.*}} ObjectEntity type: TYPE(ty)
-!CHECK: OtherConstruct scope:  
+!CHECK: OtherConstruct scope:
 !CHECK: maptwo (OmpMapToFrom) {{.*}} ObjectEntity type: TYPE(ty)
-  
+
 end program main
 

--- a/flang/test/Semantics/OpenMP/declare-mapper03.f90
+++ b/flang/test/Semantics/OpenMP/declare-mapper03.f90
@@ -5,12 +5,8 @@ type :: t1
    integer :: y
 end type t1
 
-type :: t2
-   real :: y, z
-end type t2
-
 !error: 'default' is already declared in this scoping unit
 
 !$omp declare mapper(t1::x) map(x, x%y)
-!$omp declare mapper(t2::w) map(w, w%y, w%z)
+!$omp declare mapper(t1::x) map(x)
 end


### PR DESCRIPTION
The current semantic check in place is incorrect, this patch fixes this.

Up to 1 **'default'** named mapper should be allowed for each derived type.
The current semantic check only allows up to 1 **'default'** named mapper across all derived types.

This also makes sure that declare mappers follow proper scoping rules for both default and named mappers.

Co-authored-by: Raghu Maddhipatla <Raghu.Maddhipatla@amd.com>