### PR TITLE
Limit Number of Values used for SCEV Calculation

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -1492,6 +1492,9 @@ private:
   /// Memoized values for the getConstantMultiple
   DenseMap<const SCEV *, APInt> ConstantMultipleCache;
 
+  // Holds how many more Values we can consider in current SCEV calculation
+  std::optional<unsigned> MaxNumOfValuesToConsider;
+
   /// Return the Value set from which the SCEV expr is generated.
   ArrayRef<Value *> getSCEVValues(const SCEV *S);
 
@@ -1770,6 +1773,11 @@ private:
   /// *add* recurrences with loop invariant steps aren't represented by
   /// SCEVUnknowns and thus don't use this mechanism.
   ConstantRange getRangeForUnknownRecurrence(const SCEVUnknown *U);
+
+  /// Return a SCEV expression for the full generality of the specified
+  /// expression. Return Unknown if the SCEV Calculation involves more Values
+  // than MaxNumOfValuesToConsider
+  const SCEV *getSCEVWithLimits(Value *V);
 
   /// We know that there is no SCEV for the specified value.  Analyze the
   /// expression recursively.


### PR DESCRIPTION
In large IRs, it is possible that the number of Values involved in a certain SCEV calculation are too many, and because SCEV is calculated recursively, this can lead to a Stack Overflow Error, in trying to compute SCEV for all those values. This patch addresses this issue by limiting SCEV calculation when number of Values involved in the calculation crosses some threshold.

## A little bit of Background:
At Azul Systems, our Fuzzer generated a test case, the IR for which was pretty huge, and while attempting to calculate SCEV on the IR, SCEV crashed with a Stack overflow error. After some investigation we found that a certain SCEV calculation needed 6.2 MB of stack space to successfully complete, whereas our default Stack Size limit was set to 2 MB. This is a case where SCEV calculation is very memory intensive, and we need some way by which we can gracefully stop SCEV calculation if it exceeds some threshold. I thought having a threshold on number of Values involved in the SCEV calculation might be a good way to implement this constraint, but I am open to suggestions on how better this can be implemented.

I am not very familiar with SCEV code and its use-cases, and I am still acclimatising myself to it. I chose to implement this patch by having a State Variable `MaxNumOfValuesToConsider` in the ScalarEvolution class because I considered it easier than the alternative, ie, Modify the internal and External API of ScalarEvolution class to include `MaxNumberOfValuesToConsider` as a function argument. However, I am open to suggestions on how this can be better implemented. 

I will add lit tests/modify failing tests once the design of the patch is finalized.

cc @nikic 