### PR TITLE
[lldb-dap] Add ContinueRequestHandler unit test

### DIFF
--- a/lldb/unittests/DAP/CMakeLists.txt
+++ b/lldb/unittests/DAP/CMakeLists.txt
@@ -2,6 +2,7 @@ add_lldb_unittest(DAPTests
   DAPTest.cpp
   FifoFilesTest.cpp
   Handler/DisconnectTest.cpp
+  Handler/ContinueTest.cpp
   JSONUtilsTest.cpp
   LLDBUtilsTest.cpp
   ProtocolTypesTest.cpp

--- a/lldb/unittests/DAP/Handler/ContinueTest.cpp
+++ b/lldb/unittests/DAP/Handler/ContinueTest.cpp
@@ -1,0 +1,45 @@
+//===-- ContinueTest.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DAP.h"
+#include "Handler/RequestHandler.h"
+#include "Protocol/ProtocolRequests.h"
+#include "TestBase.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace lldb;
+using namespace lldb_dap;
+using namespace lldb_dap_tests;
+using namespace lldb_dap::protocol;
+
+class ContinueRequestHandlerTest : public DAPTestBase {};
+
+TEST_F(ContinueRequestHandlerTest, NotStopped) {
+  SBTarget target;
+  dap->debugger.SetSelectedTarget(target);
+
+  ContinueRequestHandler handler(*dap);
+
+  ContinueArguments args_all_threads;
+  args_all_threads.singleThread = false;
+  args_all_threads.threadId = 0;
+
+  auto result_all_threads = handler.Run(args_all_threads);
+  EXPECT_THAT_EXPECTED(result_all_threads,
+                       llvm::FailedWithMessage("not stopped"));
+
+  ContinueArguments args_single_thread;
+  args_single_thread.singleThread = true;
+  args_single_thread.threadId = 1234;
+
+  auto result_single_thread = handler.Run(args_single_thread);
+  EXPECT_THAT_EXPECTED(result_single_thread,
+                       llvm::FailedWithMessage("not stopped"));
+}


### PR DESCRIPTION
Add a simple unit test for the ContinueRequestHandler that checks that it returns an error when the (dummy process) is not stopped.