### PR TITLE
[MLIR][Utils] Fix the overflow issue in computeSuffixProductImpl for 32-bit system. 

### DIFF
--- a/mlir/lib/Dialect/Utils/IndexingUtils.cpp
+++ b/mlir/lib/Dialect/Utils/IndexingUtils.cpp
@@ -24,7 +24,7 @@ SmallVector<ExprType> computeSuffixProductImpl(ArrayRef<ExprType> sizes,
   if (sizes.empty())
     return {};
   SmallVector<ExprType> strides(sizes.size(), unit);
-  for (int64_t r = strides.size() - 2; r >= 0; --r)
+  for (int64_t r = static_cast<int64_t>(strides.size()) - 2; r >= 0; --r)
     strides[r] = strides[r + 1] * sizes[r + 1];
   return strides;
 }


### PR DESCRIPTION
In `int64_t r = strides.size() - 2`, it may cause overflow on 32-bit system when strides.size() is 1, because `strides.size()` is a `size_t` which is a `unsigned int` (32-bit), leading a wrong computation of 1 - 2 = 4294967295 on unsigned int after casting to int64_t. 