### PR TITLE
[flang-rt] Optimise ShallowCopy and use it in CopyInAssign

### DIFF
--- a/flang-rt/include/flang-rt/runtime/descriptor.h
+++ b/flang-rt/include/flang-rt/runtime/descriptor.h
@@ -453,9 +453,9 @@ private:
 public:
   RT_API_ATTRS DescriptorIterator(const Descriptor &descriptor)
       : descriptor(descriptor) {
-    descriptor.GetLowerBounds(subscripts);
-    if constexpr (RANK == 1) {
-      elementOffset = descriptor.SubscriptByteOffset(0, subscripts[0]);
+    // We do not need the subscripts to iterate over a rank-1 array
+    if constexpr (RANK != 1) {
+      descriptor.GetLowerBounds(subscripts);
     }
   };
 
@@ -466,7 +466,7 @@ public:
       offset = elementOffset;
       // The compiler might be able to optimise this better if we know the rank
       // at compile time
-    } else if (RANK != -1) {
+    } else if constexpr (RANK != -1) {
       for (int j{0}; j < RANK; ++j) {
         offset += descriptor.SubscriptByteOffset(j, subscripts[j]);
       }
@@ -481,7 +481,7 @@ public:
   RT_API_ATTRS void Advance() {
     if constexpr (RANK == 1) {
       elementOffset += descriptor.GetDimension(0).ByteStride();
-    } else if (RANK != -1) {
+    } else if constexpr (RANK != -1) {
       for (int j{0}; j < RANK; ++j) {
         const Dimension &dim{descriptor.GetDimension(j)};
         if (subscripts[j]++ < dim.UpperBound()) {

--- a/flang-rt/include/flang-rt/runtime/descriptor.h
+++ b/flang-rt/include/flang-rt/runtime/descriptor.h
@@ -440,34 +440,55 @@ static_assert(sizeof(Descriptor) == sizeof(ISO::CFI_cdesc_t));
 // Lightweight iterator-like API to simplify specialising Descriptor indexing
 // in cases where it can improve application performance. On account of the
 // purpose of this API being performance optimisation, it is up to the user to
-// do all the necessary checks to make sure the RANK1=true variant can be used
+// do all the necessary checks to make sure the specialised variants can be used
 // safely and that Advance() is not called more times than the number of
 // elements in the Descriptor allows for.
-template <bool RANK1 = false> class DescriptorIterator {
+// Default RANK=-1 supports aray descriptors of any rank up to maxRank.
+template <int RANK = -1> class DescriptorIterator {
 private:
   const Descriptor &descriptor;
   SubscriptValue subscripts[maxRank];
   std::size_t elementOffset = 0;
 
 public:
-  DescriptorIterator(const Descriptor &descriptor) : descriptor(descriptor) {
+  RT_API_ATTRS DescriptorIterator(const Descriptor &descriptor)
+      : descriptor(descriptor) {
     descriptor.GetLowerBounds(subscripts);
-    if constexpr (RANK1) {
+    if constexpr (RANK == 1) {
       elementOffset = descriptor.SubscriptByteOffset(0, subscripts[0]);
     }
   };
 
-  template <typename A> A *Get() {
-    if constexpr (RANK1) {
-      return descriptor.OffsetElement<A>(elementOffset);
+  template <typename A> RT_API_ATTRS A *Get() {
+    std::size_t offset = 0;
+    // The rank-1 case doesn't require looping at all
+    if constexpr (RANK == 1) {
+      offset = elementOffset;
+      // The compiler might be able to optimise this better if we know the rank
+      // at compile time
+    } else if (RANK != -1) {
+      for (int j{0}; j < RANK; ++j) {
+        offset += descriptor.SubscriptByteOffset(j, subscripts[j]);
+      }
+      // General fallback
     } else {
-      return descriptor.Element<A>(subscripts);
+      offset = descriptor.SubscriptsToByteOffset(subscripts);
     }
+
+    return descriptor.OffsetElement<A>(offset);
   }
 
-  void Advance() {
-    if constexpr (RANK1) {
+  RT_API_ATTRS void Advance() {
+    if constexpr (RANK == 1) {
       elementOffset += descriptor.GetDimension(0).ByteStride();
+    } else if (RANK != -1) {
+      for (int j{0}; j < RANK; ++j) {
+        const Dimension &dim{descriptor.GetDimension(j)};
+        if (subscripts[j]++ < dim.UpperBound()) {
+          break;
+        }
+        subscripts[j] = dim.LowerBound();
+      }
     } else {
       descriptor.IncrementSubscripts(subscripts);
     }

--- a/flang-rt/include/flang-rt/runtime/descriptor.h
+++ b/flang-rt/include/flang-rt/runtime/descriptor.h
@@ -448,7 +448,7 @@ template <int RANK = -1> class DescriptorIterator {
 private:
   const Descriptor &descriptor;
   SubscriptValue subscripts[maxRank];
-  std::size_t elementOffset = 0;
+  std::size_t elementOffset{0};
 
 public:
   RT_API_ATTRS DescriptorIterator(const Descriptor &descriptor)
@@ -460,7 +460,7 @@ public:
   };
 
   template <typename A> RT_API_ATTRS A *Get() {
-    std::size_t offset = 0;
+    std::size_t offset{0};
     // The rank-1 case doesn't require looping at all
     if constexpr (RANK == 1) {
       offset = elementOffset;

--- a/flang-rt/include/flang-rt/runtime/tools.h
+++ b/flang-rt/include/flang-rt/runtime/tools.h
@@ -511,10 +511,13 @@ inline RT_API_ATTRS const char *FindCharacter(
 // Copy payload data from one allocated descriptor to another.
 // Assumes element counts and element sizes match, and that both
 // descriptors are allocated.
+template <bool RANK1 = false>
 RT_API_ATTRS void ShallowCopyDiscontiguousToDiscontiguous(
     const Descriptor &to, const Descriptor &from);
+template <bool RANK1 = false>
 RT_API_ATTRS void ShallowCopyDiscontiguousToContiguous(
     const Descriptor &to, const Descriptor &from);
+template <bool RANK1 = false>
 RT_API_ATTRS void ShallowCopyContiguousToDiscontiguous(
     const Descriptor &to, const Descriptor &from);
 RT_API_ATTRS void ShallowCopy(const Descriptor &to, const Descriptor &from,

--- a/flang-rt/include/flang-rt/runtime/tools.h
+++ b/flang-rt/include/flang-rt/runtime/tools.h
@@ -511,13 +511,13 @@ inline RT_API_ATTRS const char *FindCharacter(
 // Copy payload data from one allocated descriptor to another.
 // Assumes element counts and element sizes match, and that both
 // descriptors are allocated.
-template <bool RANK1 = false>
+template <typename P = char, int RANK = -1>
 RT_API_ATTRS void ShallowCopyDiscontiguousToDiscontiguous(
     const Descriptor &to, const Descriptor &from);
-template <bool RANK1 = false>
+template <typename P = char, int RANK = -1>
 RT_API_ATTRS void ShallowCopyDiscontiguousToContiguous(
     const Descriptor &to, const Descriptor &from);
-template <bool RANK1 = false>
+template <typename P = char, int RANK = -1>
 RT_API_ATTRS void ShallowCopyContiguousToDiscontiguous(
     const Descriptor &to, const Descriptor &from);
 RT_API_ATTRS void ShallowCopy(const Descriptor &to, const Descriptor &from,

--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -492,21 +492,11 @@ RT_API_ATTRS void Assign(Descriptor &to, const Descriptor &from,
         terminator.Crash("unexpected type code %d in blank padded Assign()",
             to.type().raw());
       }
-    } else {
-      // We can't simply call ShallowCopy due to edge cases such as character
-      // truncation or assignments where the RHS is a scalar.
-      if (toElementBytes == fromElementBytes && to.IsContiguous()) {
-        if (to.rank() == 1 && from.rank() == 1) {
-          ShallowCopyDiscontiguousToContiguous<true>(to, from);
-        } else {
-          ShallowCopyDiscontiguousToContiguous<false>(to, from);
-        }
-      } else {
-        if (to.rank() == 1 && from.rank() == 1) {
-          ShallowCopyDiscontiguousToDiscontiguous<true>(to, from);
-        } else {
-          ShallowCopyDiscontiguousToDiscontiguous<false>(to, from);
-        }
+    } else { // elemental copies, possibly with character truncation
+      for (std::size_t n{toElements}; n-- > 0;
+          to.IncrementSubscripts(toAt), from.IncrementSubscripts(fromAt)) {
+        memmoveFct(to.Element<char>(toAt), from.Element<const char>(fromAt),
+            toElementBytes);
       }
     }
   }
@@ -598,7 +588,8 @@ void RTDEF(CopyInAssign)(Descriptor &temp, const Descriptor &var,
   temp = var;
   temp.set_base_addr(nullptr);
   temp.raw().attribute = CFI_attribute_allocatable;
-  RTNAME(AssignTemporary)(temp, var, sourceFile, sourceLine);
+  temp.Allocate(kNoAsyncId);
+  ShallowCopy(temp, var);
 }
 
 void RTDEF(CopyOutAssign)(
@@ -607,9 +598,10 @@ void RTDEF(CopyOutAssign)(
 
   // Copyout from the temporary must not cause any finalizations
   // for LHS. The variable must be properly initialized already.
-  if (var)
-    Assign(*var, temp, terminator, NoAssignFlags);
-  temp.Destroy(/*finalize=*/false, /*destroyPointers=*/false, &terminator);
+  if (var) {
+    ShallowCopy(*var, temp);
+  }
+  temp.Deallocate();
 }
 
 void RTDEF(AssignExplicitLengthCharacter)(Descriptor &to,

--- a/flang-rt/lib/runtime/tools.cpp
+++ b/flang-rt/lib/runtime/tools.cpp
@@ -218,8 +218,8 @@ template <typename P>
 RT_API_ATTRS void ShallowCopyRank(const Descriptor &to, const Descriptor &from,
     bool toIsContiguous, bool fromIsContiguous) {
   // Try to call a specialised ShallowCopy variant from rank-1 up to maxRank
-  bool specialized = ShallowCopyRankSpecialize<P, 1>::execute(
-      to, from, toIsContiguous, fromIsContiguous);
+  bool specialized{ShallowCopyRankSpecialize<P, 1>::execute(
+      to, from, toIsContiguous, fromIsContiguous)};
   if (!specialized) {
     ShallowCopyInner<P>(to, from, toIsContiguous, fromIsContiguous);
   }

--- a/flang-rt/unittests/Runtime/Assign.cpp
+++ b/flang-rt/unittests/Runtime/Assign.cpp
@@ -1,0 +1,55 @@
+//===-- unittests/Runtime/Assign.cpp ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Runtime/assign.h"
+#include "tools.h"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace Fortran::runtime;
+using Fortran::common::TypeCategory;
+
+TEST(Assign, RTNAME(CopyInAssign)) {
+  // contiguous -> contiguous copy in
+  auto intArray{MakeArray<TypeCategory::Integer, 1>(
+      std::vector<int>{2, 3}, std::vector<int>{1, 2, 3, 4, 5, 6}, sizeof(int))};
+  StaticDescriptor<2> staticIntResult;
+  Descriptor &intResult{staticIntResult.descriptor()};
+
+  RTNAME(CopyInAssign(intResult, *intArray));
+  ASSERT_TRUE(intResult.IsAllocated());
+  ASSERT_TRUE(intResult.IsContiguous());
+  ASSERT_EQ(intResult.type(), intArray->type());
+  ASSERT_EQ(intResult.ElementBytes(), sizeof(int));
+  EXPECT_EQ(intResult.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(intResult.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(intResult.GetDimension(1).LowerBound(), 1);
+  EXPECT_EQ(intResult.GetDimension(1).Extent(), 3);
+  int expected[6] = {1, 2, 3, 4, 5, 6};
+  EXPECT_EQ(
+      std::memcmp(intResult.OffsetElement<int>(0), expected, 6 * sizeof(int)),
+      0);
+  intResult.Destroy();
+
+  // discontiguous -> contiguous rank-1 copy in
+  intArray = MakeArray<TypeCategory::Integer, 1>(std::vector<int>{8},
+      std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8}, sizeof(int));
+  StaticDescriptor<1> staticIntResultStrided;
+  Descriptor &intResultStrided{staticIntResultStrided.descriptor()};
+  // Treat the descriptor as a strided array of 4
+  intArray->GetDimension(0).SetByteStride(sizeof(int) * 2);
+  intArray->GetDimension(0).SetExtent(4);
+  RTNAME(CopyInAssign(intResultStrided, *intArray));
+
+  int expectedStrided[4] = {1, 3, 5, 7};
+  EXPECT_EQ(std::memcmp(intResultStrided.OffsetElement<int>(0), expectedStrided,
+                4 * sizeof(int)),
+      0);
+
+  intResultStrided.Destroy();
+}

--- a/flang-rt/unittests/Runtime/CMakeLists.txt
+++ b/flang-rt/unittests/Runtime/CMakeLists.txt
@@ -10,6 +10,7 @@ add_flangrt_unittest(RuntimeTests
   AccessTest.cpp
   Allocatable.cpp
   ArrayConstructor.cpp
+  Assign.cpp
   BufferTest.cpp
   CharacterTest.cpp
   CommandTest.cpp


### PR DESCRIPTION
Using Descriptor.Element<>() when iterating through a rank-1 array is currently inefficient, because the generic implementation suitable for arrays of any rank makes the compiler unable to perform optimisations that would make the rank-1 case considerably faster.

This is currently done inside ShallowCopy, as well as by CopyInAssign, where the implementation of elemental copies (inside Assign) is equivalent to ShallowCopyDiscontiguousToDiscontiguous.

To address that, add a DescriptorIterator abstraction specialised for arrays of various ranks, and use that throughout ShallowCopy to iterate over the arrays.

Furthermore, depending on the pointer type passed to memcpy, the optimiser can remove the memcpy calls from ShallowCopy altogether which can result in substantial performance improvements on its own. Specialise ShallowCopy for various element pointer types to make these optimisations possible.

Finally, replace the call to Assign inside CopyInAssign with a call to newly optimised ShallowCopy.

For the thornado-mini application, this reduces the runtime by 27.7%.