### PR TITLE
[BOLT,test] Add --image-base to tests that use --section-start

### DIFF
--- a/bolt/test/AArch64/check-init-not-moved.s
+++ b/bolt/test/AArch64/check-init-not-moved.s
@@ -5,7 +5,7 @@
 # address. Test checks that _init is not moved.
 
 # RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
-# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -static -Wl,--section-start=.data=0x1000 -Wl,--section-start=.init=0x1004
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -static -Wl,--image-base=0,-Tdata=0x1000,--section-start=.init=0x1004
 # RUN: llvm-bolt %t.exe -o %t.bolt
 # RUN: llvm-nm %t.exe | FileCheck --check-prefix=CHECK-ORIGINAL %s
 # RUN: llvm-nm %t.bolt | FileCheck --check-prefix=CHECK-BOLTED %s

--- a/bolt/test/AArch64/pad-before-funcs.s
+++ b/bolt/test/AArch64/pad-before-funcs.s
@@ -8,7 +8,7 @@
 
 
 # RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
-# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -Wl,--section-start=.text=0x4000
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -Wl,--image-base=0x3000,--section-start=.text=0x4000
 # RUN: llvm-bolt %t.exe -o %t.bolt.0 --pad-funcs-before=_start:0
 # RUN: llvm-bolt %t.exe -o %t.bolt.4 --pad-funcs-before=_start:4
 # RUN: llvm-bolt %t.exe -o %t.bolt.8 --pad-funcs-before=_start:8

--- a/bolt/test/RISCV/reloc-jt.s
+++ b/bolt/test/RISCV/reloc-jt.s
@@ -1,6 +1,6 @@
 /// NOTE: assign section addresses explicitly to make the symbol difference
 /// calculation below less fragile.
-// RUN: %clang %cflags -Wl,--section-start=.text=0x1000,--section-start=.data=0x2000 -o %t %s
+// RUN: %clang %cflags -Wl,--image-base=0,--section-start=.text=0x1000,--section-start=.data=0x2000 -o %t %s
 // RUN: llvm-bolt -o %t.bolt %t
 // RUN: llvm-readelf -x .data %t.bolt | FileCheck %s
 

--- a/bolt/test/X86/double-rel-scan.s
+++ b/bolt/test/X86/double-rel-scan.s
@@ -6,7 +6,7 @@
 # REQUIRES: system-linux
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
-# RUN: ld.lld %t.o -o %t.exe -q --Ttext=0x80000
+# RUN: ld.lld %t.o -o %t.exe -q --image-base=0x80000 --Ttext=0x80000
 # RUN: llvm-bolt %t.exe --relocs -o %t.bolt --funcs=foo
 # RUN: llvm-objdump -d --print-imm-hex %t.exe \
 # RUN:   | FileCheck %s

--- a/bolt/test/X86/double-rel.s
+++ b/bolt/test/X86/double-rel.s
@@ -5,7 +5,7 @@
 # REQUIRES: system-linux
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
-# RUN: ld.lld %t.o -o %t.exe -q --Tdata=0x80000
+# RUN: ld.lld %t.o -o %t.exe -q --image-base=0x70000 --Tdata=0x80000
 # RUN: llvm-bolt %t.exe --relocs -o %t.null --print-only=_start --print-disasm \
 # RUN:   | FileCheck %s --check-prefix=CHECK-BOLT
 # RUN: llvm-objdump -d --print-imm-hex %t.exe \


### PR DESCRIPTION
When using -no-pie without a SECTIONS command, the linker uses the
target's default image base. If -Ttext= or --section-start specifies an
output section address below this base, the result is likely unintended.
LLD will give a diagnostic (#140187) and may change the behavior in the future.
It's good to set an explicit image base to avoid relying on its current
behavior. BOLT doesn't seem to care whether a PT_PHDR segment is
present.
