### PR TITLE
[llvm] revert preprocessor dump method guards from llvm::ScaledNumber

### DIFF
--- a/llvm/include/llvm/Support/ScaledNumber.h
+++ b/llvm/include/llvm/Support/ScaledNumber.h
@@ -424,10 +424,7 @@ class ScaledNumberBase {
 public:
   static constexpr int DefaultPrecision = 10;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  LLVM_DUMP_METHOD static void dump(uint64_t D, int16_t E, int Width);
-#endif
-
+  LLVM_ABI static void dump(uint64_t D, int16_t E, int Width);
   LLVM_ABI static raw_ostream &print(raw_ostream &OS, uint64_t D, int16_t E,
                                      int Width, unsigned Precision);
   LLVM_ABI static std::string toString(uint64_t D, int16_t E, int Width,
@@ -610,12 +607,7 @@ public:
                      unsigned Precision = DefaultPrecision) const {
     return ScaledNumberBase::print(OS, Digits, Scale, Width, Precision);
   }
-
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  LLVM_DUMP_METHOD void dump() const {
-    return ScaledNumberBase::dump(Digits, Scale, Width);
-  }
-#endif
+  void dump() const { return ScaledNumberBase::dump(Digits, Scale, Width); }
 
   ScaledNumber &operator+=(const ScaledNumber &X) {
     std::tie(Digits, Scale) =

--- a/llvm/lib/Support/ScaledNumber.cpp
+++ b/llvm/lib/Support/ScaledNumber.cpp
@@ -317,9 +317,7 @@ raw_ostream &ScaledNumberBase::print(raw_ostream &OS, uint64_t D, int16_t E,
   return OS << toString(D, E, Width, Precision);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-LLVM_DUMP_METHOD void ScaledNumberBase::dump(uint64_t D, int16_t E, int Width) {
+void ScaledNumberBase::dump(uint64_t D, int16_t E, int Width) {
   print(dbgs(), D, E, Width, 0) << "[" << Width << ":" << D << "*2^" << E
                                 << "]";
 }
-#endif


### PR DESCRIPTION
## Purpose
Reverts the preprocessor guards added to the `dump()` methods in `llvm/Support/ScaledNumber.h`  in #139938 so that the header can be included when building an external project in debug mode against a release LLVM build.

## Overview
This is a clean revert of two files modified in #139938. The rest of that change should not cause similar problems.

## Background
The following  new build error was reported on #139938, which was merged last week:
```
module.cpp:(.text._ZNK4llvm12ScaledNumberImE4dumpEv[_ZNK4llvm12ScaledNumberImE4dumpEv]+0x34): undefined reference to `llvm::ScaledNumberBase::dump(unsigned long, short, int)'
```
See further discussion on #139938.

## Validation
Implemented a simple external LLVM project to reproduce the issue.
Verified the the following link failure is observed on LLVM main (Windows + Clang) without this change:
```
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\PROGRA~1\LLVM\bin\CLANG_~1.EXE -nostartfiles -nostdlib -O0 -g -Xclang -gcodeview -D_DEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrtd -Xlinker /subsystem:console  -fuse-ld=lld-link CMakeFiles/llvm-dump-test.dir/main.cxx.obj -o llvm-dump-test.exe -Xlinker /MANIFEST:EMBED -Xlinker /implib:llvm-dump-test.lib -Xlinker /pdb:llvm-dump-test.pdb -Xlinker /version:0.0   -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -loldnames  && cd ."
lld-link: error: undefined symbol: public: static void __cdecl llvm::ScaledNumberBase::dump(unsigned __int64, short, int)
>>> referenced by S:\llvm\llvm-project\llvm\include\llvm\Support\ScaledNumber.h:614
>>>               CMakeFiles/llvm-dump-test.dir/main.cxx.obj:(public: void __cdecl llvm::ScaledNumber<unsigned __int64>::dump(void) const)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
Verified the link issue is resolved after applying this change.

Also, manually included all header files that were modified in #139938 in the test program and verified there are no other link errors.