### PR TITLE
[lldb][nfc]Temporarily disable test on non-x86 because output-redirec…

### DIFF
--- a/lldb/test/Shell/Commands/list-header.test
+++ b/lldb/test/Shell/Commands/list-header.test
@@ -1,3 +1,5 @@
+# REQUIRES: x86
+
 ## Test that `list header.h:<line>` works correctly when header is available.
 ## 
 # RUN: split-file %s %t


### PR DESCRIPTION
because output-redirection doesn't work properly