### PR TITLE
[Clang][AArch64]Add FP8 ACLE macros implementation

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -596,6 +596,33 @@ void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
   if (HasSMEB16B16)
     Builder.defineMacro("__ARM_FEATURE_SME_B16B16", "1");
 
+  if (HasFP8)
+    Builder.defineMacro("__ARM_FEATURE_FP8", "1");
+
+  if (HasFP8FMA)
+    Builder.defineMacro("__ARM_FEATURE_FP8FMA", "1");
+
+  if (HasFP8DOT2)
+    Builder.defineMacro("__ARM_FEATURE_FP8DOT2", "1");
+
+  if (HasFP8DOT4)
+    Builder.defineMacro("__ARM_FEATURE_FP8DOT4", "1");
+
+  if (HasSSVE_FP8DOT2)
+    Builder.defineMacro("__ARM_FEATURE_SSVE_FP8DOT2", "1");
+
+  if (HasSSVE_FP8DOT4)
+    Builder.defineMacro("__ARM_FEATURE_SSVE_FP8DOT4", "1");
+
+  if (HasSSVE_FP8FMA)
+    Builder.defineMacro("__ARM_FEATURE_SSVE_FP8FMA", "1");
+
+  if (HasSME_F8F32)
+    Builder.defineMacro("__ARM_FEATURE_SME_F8F32", "1");
+
+  if (HasSME_F8F16)
+    Builder.defineMacro("__ARM_FEATURE_SME_F8F16", "1");
+
   if (HasCRC)
     Builder.defineMacro("__ARM_FEATURE_CRC32", "1");
 
@@ -885,6 +912,15 @@ bool AArch64TargetInfo::hasFeature(StringRef Feature) const {
       .Cases("ls64", "ls64_v", "ls64_accdata", HasLS64)
       .Case("wfxt", HasWFxT)
       .Case("rcpc3", HasRCPC3)
+      .Case("fp8", HasFP8)
+      .Case("fp8fma", HasFP8FMA)
+      .Case("fp8dot2", HasFP8DOT2)
+      .Case("fp8dot4", HasFP8DOT4)
+      .Case("ssve-fp8dot2", HasSSVE_FP8DOT2)
+      .Case("ssve-fp8dot4", HasSSVE_FP8DOT4)
+      .Case("ssve-fp8fma", HasSSVE_FP8FMA)
+      .Case("sme-f8f32", HasSME_F8F32)
+      .Case("sme-f8f16", HasSME_F8F16)
       .Default(false);
 }
 
@@ -1045,6 +1081,29 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasFullFP16 = true;
       HasSVEB16B16 = true;
       HasSMEB16B16 = true;
+    }
+
+    if (Feature == "+fp8")
+      HasFP8 = true;
+    if (Feature == "+fp8fma")
+      HasFP8FMA = true;
+    if (Feature == "+fp8dot2")
+      HasFP8DOT2 = true;
+    if (Feature == "+fp8dot4")
+      HasFP8DOT4 = true;
+    if (Feature == "+ssve-fp8dot2")
+      HasSSVE_FP8DOT2 = true;
+    if (Feature == "+ssve-fp8dot4")
+      HasSSVE_FP8DOT4 = true;
+    if (Feature == "+ssve-fp8fma")
+      HasSSVE_FP8FMA = true;
+    if (Feature == "+sme-f8f32") {
+      HasSME2 = true;
+      HasSME_F8F32 = true;
+    }
+    if (Feature == "+sme-f8f16") {
+      HasSME2 = true;
+      HasSME_F8F16 = true;
     }
     if (Feature == "+sb")
       HasSB = true;

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1097,14 +1097,10 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasSSVE_FP8DOT4 = true;
     if (Feature == "+ssve-fp8fma")
       HasSSVE_FP8FMA = true;
-    if (Feature == "+sme-f8f32") {
-      HasSME2 = true;
+    if (Feature == "+sme-f8f32")
       HasSME_F8F32 = true;
-    }
-    if (Feature == "+sme-f8f16") {
-      HasSME2 = true;
+    if (Feature == "+sme-f8f16")
       HasSME_F8F16 = true;
-    }
     if (Feature == "+sb")
       HasSB = true;
     if (Feature == "+predres")

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -106,6 +106,15 @@ class LLVM_LIBRARY_VISIBILITY AArch64TargetInfo : public TargetInfo {
   bool HasSMEF16F16 = false;
   bool HasSMEB16B16 = false;
   bool HasSME2p1 = false;
+  bool HasFP8 = false;
+  bool HasFP8FMA = false;
+  bool HasFP8DOT2 = false;
+  bool HasFP8DOT4 = false;
+  bool HasSSVE_FP8DOT2 = false;
+  bool HasSSVE_FP8DOT4 = false;
+  bool HasSSVE_FP8FMA = false;
+  bool HasSME_F8F32 = false;
+  bool HasSME_F8F16 = false;
   bool HasSB = false;
   bool HasPredRes = false;
   bool HasSSBS = false;

--- a/clang/test/Preprocessor/aarch64-target-features.c
+++ b/clang/test/Preprocessor/aarch64-target-features.c
@@ -744,3 +744,34 @@
 // CHECK-SMEB16B16: __ARM_FEATURE_SME2 1
 // CHECK-SMEB16B16: __ARM_FEATURE_SME_B16B16 1
 // CHECK-SMEB16B16: __ARM_FEATURE_SVE_B16B16 1
+//
+//  RUN: %clang --target=aarch64 -march=armv9-a+fp8 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-FP8 %s
+// CHECK-FP8: __ARM_FEATURE_FP8 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+fp8fma -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-FP8FMA %s
+// CHECK-FP8FMA: __ARM_FEATURE_FP8FMA 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+fp8dot2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-FP8DOT2 %s
+// CHECK-FP8DOT2: __ARM_FEATURE_FP8DOT2 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+fp8dot4 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-FP8DOT4 %s
+// CHECK-FP8DOT4: __ARM_FEATURE_FP8DOT4 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8dot2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8DOT2 %s
+// CHECK-SSVE-FP8DOT2: __ARM_FEATURE_SSVE_FP8DOT2 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8dot4 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8DOT4 %s
+// CHECK-SSVE-FP8DOT4: __ARM_FEATURE_SSVE_FP8DOT4 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8fma -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8FMA %s
+// CHECK-SSVE-FP8FMA: __ARM_FEATURE_SSVE_FP8FMA 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+sme-f8f32 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SMEF8F32 %s
+// CHECK-SMEF8F32: __ARM_FEATURE_LOCALLY_STREAMING 1
+// CHECK-SMEF8F32: __ARM_FEATURE_SME2 1
+// CHECK-SMEF8F32: __ARM_FEATURE_SME_F8F32 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+sme-f8f16 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SMEF8F16 %s
+// CHECK-SMEF8F16: __ARM_FEATURE_LOCALLY_STREAMING 1
+// CHECK-SMEF8F16: __ARM_FEATURE_SME2 1
+// CHECK-SMEF8F16: __ARM_FEATURE_SME_F8F16 1

--- a/clang/test/Preprocessor/aarch64-target-features.c
+++ b/clang/test/Preprocessor/aarch64-target-features.c
@@ -749,29 +749,33 @@
 // CHECK-FP8: __ARM_FEATURE_FP8 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+fp8fma -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-FP8FMA %s
+// CHECK-FP8FMA: __ARM_FEATURE_FP8 1
 // CHECK-FP8FMA: __ARM_FEATURE_FP8FMA 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+fp8dot2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-FP8DOT2 %s
+// CHECK-FP8DOT2: __ARM_FEATURE_FP8 1
 // CHECK-FP8DOT2: __ARM_FEATURE_FP8DOT2 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+fp8dot4 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-FP8DOT4 %s
+// CHECK-FP8DOT4: __ARM_FEATURE_FP8 1
 // CHECK-FP8DOT4: __ARM_FEATURE_FP8DOT4 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8dot2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8DOT2 %s
+// CHECK-SSVE-FP8DOT2: __ARM_FEATURE_SME2 1
 // CHECK-SSVE-FP8DOT2: __ARM_FEATURE_SSVE_FP8DOT2 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8dot4 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8DOT4 %s
+// CHECK-SSVE-FP8DOT4: __ARM_FEATURE_SME2 1
 // CHECK-SSVE-FP8DOT4: __ARM_FEATURE_SSVE_FP8DOT4 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8fma -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8FMA %s
+// CHECK-SSVE-FP8FMA: __ARM_FEATURE_SME2 1
 // CHECK-SSVE-FP8FMA: __ARM_FEATURE_SSVE_FP8FMA 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+sme-f8f32 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SMEF8F32 %s
-// CHECK-SMEF8F32: __ARM_FEATURE_LOCALLY_STREAMING 1
 // CHECK-SMEF8F32: __ARM_FEATURE_SME2 1
 // CHECK-SMEF8F32: __ARM_FEATURE_SME_F8F32 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+sme-f8f16 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SMEF8F16 %s
-// CHECK-SMEF8F16: __ARM_FEATURE_LOCALLY_STREAMING 1
 // CHECK-SMEF8F16: __ARM_FEATURE_SME2 1
 // CHECK-SMEF8F16: __ARM_FEATURE_SME_F8F16 1

--- a/clang/test/Preprocessor/aarch64-target-features.c
+++ b/clang/test/Preprocessor/aarch64-target-features.c
@@ -761,21 +761,26 @@
 // CHECK-FP8DOT4: __ARM_FEATURE_FP8DOT4 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8dot2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8DOT2 %s
+// CHECK-SSVE-FP8DOT2: __ARM_FEATURE_FP8 1
 // CHECK-SSVE-FP8DOT2: __ARM_FEATURE_SME2 1
 // CHECK-SSVE-FP8DOT2: __ARM_FEATURE_SSVE_FP8DOT2 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8dot4 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8DOT4 %s
+// CHECK-SSVE-FP8DOT4: __ARM_FEATURE_FP8 1
 // CHECK-SSVE-FP8DOT4: __ARM_FEATURE_SME2 1
 // CHECK-SSVE-FP8DOT4: __ARM_FEATURE_SSVE_FP8DOT4 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+ssve-fp8fma -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-FP8FMA %s
+// CHECK-SSVE-FP8FMA: __ARM_FEATURE_FP8 1
 // CHECK-SSVE-FP8FMA: __ARM_FEATURE_SME2 1
 // CHECK-SSVE-FP8FMA: __ARM_FEATURE_SSVE_FP8FMA 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+sme-f8f32 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SMEF8F32 %s
+// CHECK-SMEF8F32: __ARM_FEATURE_FP8 1
 // CHECK-SMEF8F32: __ARM_FEATURE_SME2 1
 // CHECK-SMEF8F32: __ARM_FEATURE_SME_F8F32 1
 
 // RUN: %clang --target=aarch64 -march=armv9-a+sme-f8f16 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SMEF8F16 %s
+// CHECK-SMEF8F16: __ARM_FEATURE_FP8 1
 // CHECK-SMEF8F16: __ARM_FEATURE_SME2 1
 // CHECK-SMEF8F16: __ARM_FEATURE_SME_F8F16 1


### PR DESCRIPTION
This patch implements the macros described in the ACLE[1]

[1] https://github.com/ARM-software/acle/blob/main/main/acle.md#modal-8-bit-floating-point-extensions