### PR TITLE
Follow style configuration in clangd when inserting missing includes

### DIFF
--- a/clang-tools-extra/clangd/IncludeCleaner.cpp
+++ b/clang-tools-extra/clangd/IncludeCleaner.cpp
@@ -143,7 +143,7 @@ std::vector<Diag> generateMissingIncludeDiagnostics(
 
     llvm::StringRef HeaderRef{Spelling};
     bool Angled = HeaderRef.starts_with("<");
-    for (auto Filter : AngledHeaders) {
+    for (auto &Filter : AngledHeaders) {
       if (Filter(HeaderRef)) {
         Angled = true;
         break;

--- a/clang-tools-extra/clangd/IncludeCleaner.cpp
+++ b/clang-tools-extra/clangd/IncludeCleaner.cpp
@@ -159,6 +159,11 @@ std::vector<Diag> generateMissingIncludeDiagnostics(
     if (!Replacement.has_value())
       continue;
 
+    if (Angled && Spelling.front() == '\"') {
+      Spelling.front() = '<';
+      Spelling.back() = '>';
+    }
+
     Diag &D = Result.emplace_back();
     D.Message =
         llvm::formatv("No header providing \"{0}\" is directly included",

--- a/clang-tools-extra/clangd/IncludeCleaner.cpp
+++ b/clang-tools-extra/clangd/IncludeCleaner.cpp
@@ -164,9 +164,9 @@ std::vector<Diag> generateMissingIncludeDiagnostics(
     if (!Replacement.has_value())
       continue;
 
-    if (Angled && Spelling.front() == '\"') {
-      Spelling.front() = '<';
-      Spelling.back() = '>';
+    if (Angled != (Spelling.front() == '<')) {
+      Spelling.front() = Angled ? '<' : '"';
+      Spelling.back() = Angled ? '>' : '"';
     }
 
     Diag &D = Result.emplace_back();

--- a/clang-tools-extra/clangd/IncludeCleaner.h
+++ b/clang-tools-extra/clangd/IncludeCleaner.h
@@ -57,11 +57,10 @@ IncludeCleanerFindings
 computeIncludeCleanerFindings(ParsedAST &AST,
                               bool AnalyzeAngledIncludes = false);
 
-std::vector<Diag>
-issueIncludeCleanerDiagnostics(ParsedAST &AST, llvm::StringRef Code,
-                               const IncludeCleanerFindings &Findings,
-                               const ThreadsafeFS &TFS,
-                               HeaderFilter IgnoreHeader = {});
+std::vector<Diag> issueIncludeCleanerDiagnostics(
+    ParsedAST &AST, llvm::StringRef Code,
+    const IncludeCleanerFindings &Findings, const ThreadsafeFS &TFS,
+    HeaderFilter IgnoreHeader = {}, HeaderFilter AngledHeaders = {});
 
 /// Converts the clangd include representation to include-cleaner
 /// include representation.

--- a/clang-tools-extra/clangd/IncludeCleaner.h
+++ b/clang-tools-extra/clangd/IncludeCleaner.h
@@ -60,7 +60,8 @@ computeIncludeCleanerFindings(ParsedAST &AST,
 std::vector<Diag> issueIncludeCleanerDiagnostics(
     ParsedAST &AST, llvm::StringRef Code,
     const IncludeCleanerFindings &Findings, const ThreadsafeFS &TFS,
-    HeaderFilter IgnoreHeader = {}, HeaderFilter AngledHeaders = {});
+    HeaderFilter IgnoreHeader = {}, HeaderFilter AngledHeaders = {},
+    HeaderFilter QuotedHeaders = {});
 
 /// Converts the clangd include representation to include-cleaner
 /// include representation.

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -381,9 +381,9 @@ std::vector<Diag> getIncludeCleanerDiags(ParsedAST &AST, llvm::StringRef Code,
     Findings.MissingIncludes.clear();
   if (SuppressUnused)
     Findings.UnusedIncludes.clear();
-  return issueIncludeCleanerDiagnostics(AST, Code, Findings, TFS,
-                                        Cfg.Diagnostics.Includes.IgnoreHeader,
-                                        Cfg.Style.AngledHeaders);
+  return issueIncludeCleanerDiagnostics(
+      AST, Code, Findings, TFS, Cfg.Diagnostics.Includes.IgnoreHeader,
+      Cfg.Style.AngledHeaders, Cfg.Style.QuotedHeaders);
 }
 
 tidy::ClangTidyCheckFactories

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -382,7 +382,8 @@ std::vector<Diag> getIncludeCleanerDiags(ParsedAST &AST, llvm::StringRef Code,
   if (SuppressUnused)
     Findings.UnusedIncludes.clear();
   return issueIncludeCleanerDiagnostics(AST, Code, Findings, TFS,
-                                        Cfg.Diagnostics.Includes.IgnoreHeader);
+                                        Cfg.Diagnostics.Includes.IgnoreHeader,
+                                        Cfg.Style.AngledHeaders);
 }
 
 tidy::ClangTidyCheckFactories

--- a/clang-tools-extra/clangd/unittests/IncludeCleanerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/IncludeCleanerTests.cpp
@@ -315,12 +315,12 @@ $insert_f[[]]$insert_vector[[]]
                 withFix({Fix(MainFile.range("insert_b"), "#include \"b.h\"\n",
                              "#include \"b.h\""),
                          FixMessage("add all missing includes")})),
-          AllOf(Diag(MainFile.range("b_angled"),
-                     "No header providing \"b_angled\" is directly included"),
-                withFix(
-                    {Fix(MainFile.range("insert_b_angled"),
-                         "#include <b_angled.h>\n", "#include \"b_angled.h\""),
-                     FixMessage("add all missing includes")})),
+          AllOf(
+              Diag(MainFile.range("b_angled"),
+                   "No header providing \"b_angled\" is directly included"),
+              withFix({Fix(MainFile.range("insert_b_angled"),
+                           "#include <b_angled.h>\n", "#include <b_angled.h>"),
+                       FixMessage("add all missing includes")})),
           AllOf(Diag(MainFile.range("bar"),
                      "No header providing \"ns::Bar\" is directly included"),
                 withFix({Fix(MainFile.range("insert_d"),

--- a/clang-tools-extra/clangd/unittests/IncludeCleanerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/IncludeCleanerTests.cpp
@@ -282,7 +282,8 @@ $insert_vector[[]]
 
   TU.AdditionalFiles["system/e.h"] = guard("#include <f.h>");
   TU.AdditionalFiles["system/f.h"] = guard("void f();");
-  TU.AdditionalFiles["system/quoted2_wrapper.h"] = guard("#include <system/quoted2.h>");
+  TU.AdditionalFiles["system/quoted2_wrapper.h"] =
+      guard("#include <system/quoted2.h>");
   TU.AdditionalFiles["system/quoted2.h"] = guard("void quoted2();");
   TU.ExtraArgs.push_back("-isystem" + testPath("system"));
 
@@ -340,12 +341,12 @@ $insert_vector[[]]
               withFix({Fix(MainFile.range("insert_quoted"),
                            "#include \"quoted.h\"\n", "#include \"quoted.h\""),
                        FixMessage("add all missing includes")})),
-          AllOf(
-              Diag(MainFile.range("quoted2"),
-                   "No header providing \"quoted2\" is directly included"),
-              withFix({Fix(MainFile.range("insert_quoted2"),
-                           "#include \"quoted2.h\"\n", "#include \"quoted2.h\""),
-                       FixMessage("add all missing includes")})),
+          AllOf(Diag(MainFile.range("quoted2"),
+                     "No header providing \"quoted2\" is directly included"),
+                withFix(
+                    {Fix(MainFile.range("insert_quoted2"),
+                         "#include \"quoted2.h\"\n", "#include \"quoted2.h\""),
+                     FixMessage("add all missing includes")})),
           AllOf(Diag(MainFile.range("bar"),
                      "No header providing \"ns::Bar\" is directly included"),
                 withFix({Fix(MainFile.range("insert_d"),

--- a/clang-tools-extra/clangd/unittests/IncludeCleanerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/IncludeCleanerTests.cpp
@@ -301,8 +301,12 @@ $insert_f[[]]$insert_vector[[]]
   Findings.UnusedIncludes.clear();
   std::vector<clangd::Diag> Diags = issueIncludeCleanerDiagnostics(
       AST, TU.Code, Findings, MockFS(),
-      {[](llvm::StringRef Header) { return Header.ends_with("buzz.h"); }},
-      {[](llvm::StringRef Header) { return Header.contains("b_angled.h"); }});
+      /*IgnoreHeaders=*/{[](llvm::StringRef Header) {
+        return Header.ends_with("buzz.h");
+      }},
+      /*AngledHeaders=*/{[](llvm::StringRef Header) {
+        return Header.contains("b_angled.h");
+      }});
   EXPECT_THAT(
       Diags,
       UnorderedElementsAre(


### PR DESCRIPTION
The missing include diagnostic has the capability to introduce the necessary headers into the source file. However, it does not currently follow the inclusion style found in the `.clangd` file. For example, if the file explicitly mentions that headers should be include with angled brackets, they could be included with quotes instead. More details in https://github.com/llvm/llvm-project/issues/138740. This PR fixes this gap, so that the style configuration is followed.