### PR TITLE
[clang-tidy] Add UnusedIncludes/MissingIncludes options to misc-include-cleaner

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.h
@@ -47,6 +47,10 @@ private:
   std::vector<StringRef> IgnoreHeaders;
   // Whether emit only one finding per usage of a symbol.
   const bool DeduplicateFindings;
+  // Whether to report unused includes.
+  const bool UnusedIncludes;
+  // Whether to report missing includes.
+  const bool MissingIncludes;
   llvm::SmallVector<llvm::Regex> IgnoreHeadersRegex;
   bool shouldIgnore(const include_cleaner::Header &H);
 };

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -180,6 +180,11 @@ Changes in existing checks
   `AnalyzePointers` option and fixing false positives when using const array
   type.
 
+- Improved :doc:`misc-include-cleaner
+  <clang-tidy/checks/misc/include-cleaner>` check by adding the options
+  `UnusedIncludes` and `MissingIncludes`, which specify whether the check should
+  report unused or missing includes respectively.
+
 - Improved :doc:`misc-redundant-expression
   <clang-tidy/checks/misc/redundant-expression>` check by providing additional
   examples and fixing some macro related false positives.
@@ -204,7 +209,7 @@ Changes in existing checks
   diagnosing designated initializers for ``std::array`` initializations.
 
 - Improved :doc:`modernize-use-ranges
-  <clang-tidy/checks/modernize/use-ranges>` check by updating suppress 
+  <clang-tidy/checks/modernize/use-ranges>` check by updating suppress
   warnings logic for ``nullptr`` in ``std::find``.
 
 - Improved :doc:`modernize-use-starts-ends-with

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
@@ -38,3 +38,14 @@ Options
 
    A boolean that controls whether the check should deduplicate findings for the
    same symbol. Defaults to `true`.
+
+.. option:: UnusedIncludes
+
+   A boolean that controls whether the check should report unused includes
+   (includes that are not used directly). Defaults to `true`.
+
+.. option:: MissingIncludes
+
+   A boolean that controls whether the check should report missing includes
+   (header files from which symbols are used but which are not directly included).
+   Defaults to `true`.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/include-cleaner-wrong-config.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/include-cleaner-wrong-config.cpp
@@ -1,0 +1,10 @@
+// RUN: %check_clang_tidy %s misc-include-cleaner %t \
+// RUN: -config='{CheckOptions: \
+// RUN:  {"misc-include-cleaner.UnusedIncludes": false,\
+// RUN:   "misc-include-cleaner.MissingIncludes": false,\
+// RUN:  }}' -- -I%S/Inputs -isystem%S/Inputs/system -fno-delayed-template-parsing
+
+// CHECK-MESSAGES: warning: The check 'misc-include-cleaner' will not perform any analysis because 'UnusedIncludes' and 'MissingIncludes' are both false. [clang-tidy-config]
+
+#include "bar.h"
+// CHECK-FIXES-NOT: {{^}}#include "baz.h"{{$}}


### PR DESCRIPTION
These mimick the same options from clangd and allow using the check to only check for unused includes or missing includes.