### PR TITLE
[lldb][lldb-dap] show modules pane if supported by the adapter

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -787,7 +787,7 @@
         {
           "id": "lldb-dap.modules",
           "name": "Modules",
-          "when": "inDebugMode && debugType == 'lldb-dap'",
+          "when": "inDebugMode && debugType == 'lldb-dap' && lldb-dap.showModules",
           "icon": "$(symbol-module)"
         }
       ]

--- a/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
@@ -52,6 +52,7 @@ export class DebugSessionTracker
   createDebugAdapterTracker(
     session: vscode.DebugSession,
   ): vscode.ProviderResult<vscode.DebugAdapterTracker> {
+    this.showModulesTreeView(false);
     return {
       onDidSendMessage: (message) => this.onDidSendMessage(session, message),
       onExit: () => this.onExit(session),
@@ -71,6 +72,14 @@ export class DebugSessionTracker
   private onExit(session: vscode.DebugSession) {
     this.modules.delete(session);
     this.modulesChanged.fire();
+  }
+
+  private showModulesTreeView(showModules: boolean) {
+    vscode.commands.executeCommand(
+      "setContext",
+      "lldb-dap.showModules",
+      showModules,
+    );
   }
 
   private onDidSendMessage(
@@ -102,6 +111,8 @@ export class DebugSessionTracker
           console.error("unexpected module event reason");
           break;
       }
+
+      this.showModulesTreeView(modules.length > 0);
       this.modules.set(session, modules);
       this.modulesChanged.fire();
     }

--- a/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
@@ -35,14 +35,24 @@ export class DebugSessionTracker
    * The modules are kept in an array to maintain the load order of the modules.
    */
   private modules = new Map<vscode.DebugSession, DebugProtocol.Module[]>();
-  private modulesChanged = new vscode.EventEmitter<void>();
+  private modulesChanged = new vscode.EventEmitter<
+    vscode.DebugSession | undefined
+  >();
 
   /**
    * Fired when modules are changed for any active debug session.
    *
    * Use `debugSessionModules` to retieve the active modules for a given debug session.
    */
-  onDidChangeModules: vscode.Event<void> = this.modulesChanged.event;
+  onDidChangeModules: vscode.Event<vscode.DebugSession | undefined> =
+    this.modulesChanged.event;
+
+  constructor() {
+    this.onDidChangeModules(this.moduleChangedListener, this);
+    vscode.debug.onDidChangeActiveDebugSession((session) =>
+      this.modulesChanged.fire(session),
+    );
+  }
 
   dispose() {
     this.modules.clear();
@@ -52,7 +62,6 @@ export class DebugSessionTracker
   createDebugAdapterTracker(
     session: vscode.DebugSession,
   ): vscode.ProviderResult<vscode.DebugAdapterTracker> {
-    this.showModulesTreeView(false);
     return {
       onDidSendMessage: (message) => this.onDidSendMessage(session, message),
       onExit: () => this.onExit(session),
@@ -71,11 +80,7 @@ export class DebugSessionTracker
   /** Clear information from the active session. */
   private onExit(session: vscode.DebugSession) {
     this.modules.delete(session);
-    // close when there is no more sessions
-    if (this.modules.size <= 0) {
-      this.showModulesTreeView(false);
-    }
-    this.modulesChanged.fire();
+    this.modulesChanged.fire(undefined);
   }
 
   private showModulesTreeView(showModules: boolean) {
@@ -84,6 +89,18 @@ export class DebugSessionTracker
       "lldb-dap.showModules",
       showModules,
     );
+  }
+
+  private moduleChangedListener(session: vscode.DebugSession | undefined) {
+    if (!session) {
+      this.showModulesTreeView(false);
+      return;
+    }
+
+    if (session == vscode.debug.activeDebugSession) {
+      const sessionHasModules = this.modules.get(session) != undefined;
+      this.showModulesTreeView(sessionHasModules);
+    }
   }
 
   private onDidSendMessage(
@@ -102,9 +119,6 @@ export class DebugSessionTracker
           } else {
             modules.push(module);
           }
-          if (modules.length == 1) {
-            this.showModulesTreeView(true);
-          }
           break;
         }
         case "removed": {
@@ -119,7 +133,7 @@ export class DebugSessionTracker
           break;
       }
       this.modules.set(session, modules);
-      this.modulesChanged.fire();
+      this.modulesChanged.fire(session);
     }
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
@@ -118,7 +118,6 @@ export class DebugSessionTracker
           console.error("unexpected module event reason");
           break;
       }
-
       this.modules.set(session, modules);
       this.modulesChanged.fire();
     }

--- a/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
@@ -71,6 +71,10 @@ export class DebugSessionTracker
   /** Clear information from the active session. */
   private onExit(session: vscode.DebugSession) {
     this.modules.delete(session);
+    // close when there is no more sessions
+    if (this.modules.size <= 0) {
+      this.showModulesTreeView(false);
+    }
     this.modulesChanged.fire();
   }
 
@@ -98,6 +102,9 @@ export class DebugSessionTracker
           } else {
             modules.push(module);
           }
+          if (modules.length == 1) {
+            this.showModulesTreeView(true);
+          }
           break;
         }
         case "removed": {
@@ -112,7 +119,6 @@ export class DebugSessionTracker
           break;
       }
 
-      this.showModulesTreeView(modules.length > 0);
       this.modules.set(session, modules);
       this.modulesChanged.fire();
     }

--- a/lldb/tools/lldb-dap/src-ts/ui/modules-data-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/ui/modules-data-provider.ts
@@ -52,9 +52,6 @@ export class ModulesDataProvider implements vscode.TreeDataProvider<TreeData> {
 
   constructor(private readonly tracker: DebugSessionTracker) {
     tracker.onDidChangeModules(() => this.changeTreeData.fire());
-    vscode.debug.onDidChangeActiveDebugSession(() =>
-      this.changeTreeData.fire(),
-    );
   }
 
   getTreeItem(module: TreeData): vscode.TreeItem {


### PR DESCRIPTION
Fixes #140589
Added logic to dynamically set the `lldb-dap.showModules` context based on the presence of modules in the debug session.