### PR TITLE
[lldb-dap] launch the adapter from the workspace folder.

### DIFF
--- a/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
@@ -184,6 +184,7 @@ export async function createDebugAdapterExecutable(
       ...configEnvironment,
       ...env,
     },
+    cwd: workspaceFolder!!.uri.fsPath,
   };
   const dbgArgs = await getDAPArguments(workspaceFolder, configuration);
 


### PR DESCRIPTION
if the `cwd` option is empty this means the adapter is created in the home folder.

Any relative file saved is in the home folder. The files should be relative to the current workspace folder.