### PR TITLE
[utils][TableGen] Unify name qualifications in DirectiveEmitter

### DIFF
--- a/llvm/test/TableGen/directive1.td
+++ b/llvm/test/TableGen/directive1.td
@@ -98,7 +98,7 @@ def TDL_DirA : Directive<"dira"> {
 // CHECK-EMPTY:
 // CHECK-NEXT:  static constexpr std::size_t Directive_enumSize = 1;
 // CHECK-EMPTY:
-// CHECK-NEXT:  constexpr auto TDLD_dira = llvm::tdl::Directive::TDLD_dira;
+// CHECK-NEXT:  constexpr auto TDLD_dira = Directive::TDLD_dira;
 // CHECK-EMPTY:
 // CHECK-NEXT:  enum class Clause {
 // CHECK-NEXT:    TDLC_clausea,
@@ -108,9 +108,9 @@ def TDL_DirA : Directive<"dira"> {
 // CHECK-EMPTY:
 // CHECK-NEXT:  static constexpr std::size_t Clause_enumSize = 3;
 // CHECK-EMPTY:
-// CHECK-NEXT:  constexpr auto TDLC_clausea = llvm::tdl::Clause::TDLC_clausea;
-// CHECK-NEXT:  constexpr auto TDLC_clauseb = llvm::tdl::Clause::TDLC_clauseb;
-// CHECK-NEXT:  constexpr auto TDLC_clausec = llvm::tdl::Clause::TDLC_clausec;
+// CHECK-NEXT:  constexpr auto TDLC_clausea = Clause::TDLC_clausea;
+// CHECK-NEXT:  constexpr auto TDLC_clauseb = Clause::TDLC_clauseb;
+// CHECK-NEXT:  constexpr auto TDLC_clausec = Clause::TDLC_clausec;
 // CHECK-EMPTY:
 // CHECK-NEXT:  enum class AKind {
 // CHECK-NEXT:    TDLCV_vala=1,
@@ -118,18 +118,18 @@ def TDL_DirA : Directive<"dira"> {
 // CHECK-NEXT:    TDLCV_valc=3,
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT:  constexpr auto TDLCV_vala = llvm::tdl::AKind::TDLCV_vala;
-// CHECK-NEXT:  constexpr auto TDLCV_valb = llvm::tdl::AKind::TDLCV_valb;
-// CHECK-NEXT:  constexpr auto TDLCV_valc = llvm::tdl::AKind::TDLCV_valc;
+// CHECK-NEXT:  constexpr auto TDLCV_vala = AKind::TDLCV_vala;
+// CHECK-NEXT:  constexpr auto TDLCV_valb = AKind::TDLCV_valb;
+// CHECK-NEXT:  constexpr auto TDLCV_valc = AKind::TDLCV_valc;
 // CHECK-EMPTY:
 // CHECK-NEXT:  // Enumeration helper functions
-// CHECK-NEXT:  LLVM_ABI Directive getTdlDirectiveKind(llvm::StringRef Str);
+// CHECK-NEXT:  LLVM_ABI Directive getTdlDirectiveKind(StringRef Str);
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI llvm::StringRef getTdlDirectiveName(Directive D);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlDirectiveName(Directive D);
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI Clause getTdlClauseKind(llvm::StringRef Str);
+// CHECK-NEXT:  LLVM_ABI Clause getTdlClauseKind(StringRef Str);
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI llvm::StringRef getTdlClauseName(Clause C);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlClauseName(Clause C);
 // CHECK-EMPTY:
 // CHECK-NEXT:  /// Return true if \p C is a valid clause for \p D in version \p Version.
 // CHECK-NEXT:  LLVM_ABI bool isAllowedClauseForDirective(Directive D, Clause C, unsigned Version);
@@ -138,8 +138,8 @@ def TDL_DirA : Directive<"dira"> {
 // CHECK-NEXT:  LLVM_ABI Association getDirectiveAssociation(Directive D);
 // CHECK-NEXT:  LLVM_ABI Category getDirectiveCategory(Directive D);
 // CHECK-NEXT:  LLVM_ABI SourceLanguage getDirectiveLanguages(Directive D);
-// CHECK-NEXT:  LLVM_ABI AKind getAKind(StringRef);
-// CHECK-NEXT:  LLVM_ABI llvm::StringRef getTdlAKindName(AKind);
+// CHECK-NEXT:  LLVM_ABI AKind getAKind(StringRef Str);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlAKindName(AKind x);
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace tdl
 // CHECK-NEXT:  } // namespace llvm
@@ -155,8 +155,8 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-NEXT:    // Sets for dira
 // IMPL-EMPTY:
 // IMPL-NEXT:    static  allowedClauses_TDLD_dira {
-// IMPL-NEXT:      llvm::tdl::Clause::TDLC_clausea,
-// IMPL-NEXT:      llvm::tdl::Clause::TDLC_clauseb,
+// IMPL-NEXT:      Clause::TDLC_clausea,
+// IMPL-NEXT:      Clause::TDLC_clauseb,
 // IMPL-NEXT:    };
 // IMPL-EMPTY:
 // IMPL-NEXT:    static  allowedOnceClauses_TDLD_dira {
@@ -311,13 +311,13 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-EMPTY:
 // IMPL-NEXT:  #include "llvm/Support/ErrorHandling.h"
 // IMPL-EMPTY:
-// IMPL-NEXT:  Directive llvm::tdl::getTdlDirectiveKind(llvm::StringRef Str) {
-// IMPL-NEXT:    return llvm::StringSwitch<Directive>(Str)
+// IMPL-NEXT:  llvm::tdl::Directive llvm::tdl::getTdlDirectiveKind(llvm::StringRef Str) {
+// IMPL-NEXT:    return StringSwitch<Directive>(Str)
 // IMPL-NEXT:      .Case("dira",TDLD_dira)
 // IMPL-NEXT:      .Default(TDLD_dira);
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlDirectiveName(Directive Kind) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlDirectiveName(llvm::tdl::Directive Kind) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case TDLD_dira:
 // IMPL-NEXT:        return "dira";
@@ -325,15 +325,15 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Directive kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  Clause llvm::tdl::getTdlClauseKind(llvm::StringRef Str) {
-// IMPL-NEXT:    return llvm::StringSwitch<Clause>(Str)
+// IMPL-NEXT:  llvm::tdl::Clause llvm::tdl::getTdlClauseKind(llvm::StringRef Str) {
+// IMPL-NEXT:    return StringSwitch<Clause>(Str)
 // IMPL-NEXT:      .Case("clausea",TDLC_clausea)
 // IMPL-NEXT:      .Case("clauseb",TDLC_clauseb)
 // IMPL-NEXT:      .Case("clausec",TDLC_clausec)
 // IMPL-NEXT:      .Default(TDLC_clauseb);
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlClauseName(Clause Kind) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlClauseName(llvm::tdl::Clause Kind) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case TDLC_clausea:
 // IMPL-NEXT:        return "clausea";
@@ -345,8 +345,8 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Clause kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  AKind llvm::tdl::getAKind(llvm::StringRef Str) {
-// IMPL-NEXT:    return llvm::StringSwitch<AKind>(Str)
+// IMPL-NEXT:  llvm::tdl::AKind llvm::tdl::getAKind(llvm::StringRef Str) {
+// IMPL-NEXT:    return StringSwitch<AKind>(Str)
 // IMPL-NEXT:      .Case("vala",TDLCV_vala)
 // IMPL-NEXT:      .Case("valb",TDLCV_valb)
 // IMPL-NEXT:      .Case("valc",TDLCV_valc)
@@ -365,9 +365,9 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl AKind kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  bool llvm::tdl::isAllowedClauseForDirective(Directive D, Clause C, unsigned Version) {
-// IMPL-NEXT:    assert(unsigned(D) <= llvm::tdl::Directive_enumSize);
-// IMPL-NEXT:    assert(unsigned(C) <= llvm::tdl::Clause_enumSize);
+// IMPL-NEXT:  bool llvm::tdl::isAllowedClauseForDirective(llvm::tdl::Directive D, llvm::tdl::Clause C, unsigned Version) {
+// IMPL-NEXT:    assert(unsigned(D) <= Directive_enumSize);
+// IMPL-NEXT:    assert(unsigned(C) <= Clause_enumSize);
 // IMPL-NEXT:    switch (D) {
 // IMPL-NEXT:      case TDLD_dira:
 // IMPL-NEXT:        switch (C) {
@@ -385,24 +385,24 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-EMPTY:
 // IMPL-NEXT:  llvm::tdl::Association llvm::tdl::getDirectiveAssociation(llvm::tdl::Directive Dir) {
 // IMPL-NEXT:    switch (Dir) {
-// IMPL-NEXT:    case llvm::tdl::Directive::TDLD_dira:
-// IMPL-NEXT:      return llvm::tdl::Association::None;
+// IMPL-NEXT:    case TDLD_dira:
+// IMPL-NEXT:      return Association::None;
 // IMPL-NEXT:    } // switch (Dir)
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
 // IMPL-NEXT:  llvm::tdl::Category llvm::tdl::getDirectiveCategory(llvm::tdl::Directive Dir) {
 // IMPL-NEXT:    switch (Dir) {
-// IMPL-NEXT:    case llvm::tdl::TDLD_dira:
-// IMPL-NEXT:      return llvm::tdl::Category::Executable;
+// IMPL-NEXT:    case TDLD_dira:
+// IMPL-NEXT:      return Category::Executable;
 // IMPL-NEXT:    } // switch (Dir)
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
 // IMPL-NEXT:  llvm::tdl::SourceLanguage llvm::tdl::getDirectiveLanguages(llvm::tdl::Directive D) {
 // IMPL-NEXT:    switch (D) {
-// IMPL-NEXT:    case llvm::tdl::TDLD_dira:
-// IMPL-NEXT:      return llvm::tdl::SourceLanguage::C | llvm::tdl::SourceLanguage::Fortran;
+// IMPL-NEXT:    case TDLD_dira:
+// IMPL-NEXT:      return SourceLanguage::C | SourceLanguage::Fortran;
 // IMPL-NEXT:    } // switch(D)
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }

--- a/llvm/test/TableGen/directive2.td
+++ b/llvm/test/TableGen/directive2.td
@@ -99,13 +99,13 @@ def TDL_DirA : Directive<"dira"> {
 // CHECK-NEXT:  static constexpr std::size_t Clause_enumSize = 4;
 // CHECK-EMPTY:
 // CHECK-NEXT:  // Enumeration helper functions
-// CHECK-NEXT:  LLVM_ABI Directive getTdlDirectiveKind(llvm::StringRef Str);
+// CHECK-NEXT:  LLVM_ABI Directive getTdlDirectiveKind(StringRef Str);
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI llvm::StringRef getTdlDirectiveName(Directive D);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlDirectiveName(Directive D);
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI Clause getTdlClauseKind(llvm::StringRef Str);
+// CHECK-NEXT:  LLVM_ABI Clause getTdlClauseKind(StringRef Str);
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI llvm::StringRef getTdlClauseName(Clause C);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlClauseName(Clause C);
 // CHECK-EMPTY:
 // CHECK-NEXT:  /// Return true if \p C is a valid clause for \p D in version \p Version.
 // CHECK-NEXT:  LLVM_ABI bool isAllowedClauseForDirective(Directive D, Clause C, unsigned Version);
@@ -127,8 +127,8 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-NEXT:   // Sets for dira
 // IMPL-EMPTY:
 // IMPL-NEXT:   static  allowedClauses_TDLD_dira {
-// IMPL-NEXT:     llvm::tdl::Clause::TDLC_clausea,
-// IMPL-NEXT:     llvm::tdl::Clause::TDLC_clauseb,
+// IMPL-NEXT:     Clause::TDLC_clausea,
+// IMPL-NEXT:     Clause::TDLC_clauseb,
 // IMPL-NEXT:   };
 // IMPL-EMPTY:
 // IMPL-NEXT:   static  allowedOnceClauses_TDLD_dira {
@@ -259,13 +259,13 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-EMPTY:
 // IMPL-NEXT:  #include "llvm/Support/ErrorHandling.h"
 // IMPL-EMPTY:
-// IMPL-NEXT:  Directive llvm::tdl::getTdlDirectiveKind(llvm::StringRef Str) {
-// IMPL-NEXT:    return llvm::StringSwitch<Directive>(Str)
+// IMPL-NEXT:  llvm::tdl::Directive llvm::tdl::getTdlDirectiveKind(llvm::StringRef Str) {
+// IMPL-NEXT:    return StringSwitch<Directive>(Str)
 // IMPL-NEXT:      .Case("dira",TDLD_dira)
 // IMPL-NEXT:      .Default(TDLD_dira);
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlDirectiveName(Directive Kind) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlDirectiveName(llvm::tdl::Directive Kind) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case TDLD_dira:
 // IMPL-NEXT:        return "dira";
@@ -273,8 +273,8 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Directive kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  Clause llvm::tdl::getTdlClauseKind(llvm::StringRef Str) {
-// IMPL-NEXT:    return llvm::StringSwitch<Clause>(Str)
+// IMPL-NEXT:  llvm::tdl::Clause llvm::tdl::getTdlClauseKind(llvm::StringRef Str) {
+// IMPL-NEXT:    return StringSwitch<Clause>(Str)
 // IMPL-NEXT:      .Case("clausea",TDLC_clauseb)
 // IMPL-NEXT:      .Case("clauseb",TDLC_clauseb)
 // IMPL-NEXT:      .Case("clausec",TDLC_clausec)
@@ -282,7 +282,7 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-NEXT:      .Default(TDLC_clauseb);
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlClauseName(Clause Kind) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlClauseName(llvm::tdl::Clause Kind) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case TDLC_clausea:
 // IMPL-NEXT:        return "clausea";
@@ -296,9 +296,9 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Clause kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  bool llvm::tdl::isAllowedClauseForDirective(Directive D, Clause C, unsigned Version) {
-// IMPL-NEXT:    assert(unsigned(D) <= llvm::tdl::Directive_enumSize);
-// IMPL-NEXT:    assert(unsigned(C) <= llvm::tdl::Clause_enumSize);
+// IMPL-NEXT:  bool llvm::tdl::isAllowedClauseForDirective(llvm::tdl::Directive D, llvm::tdl::Clause C, unsigned Version) {
+// IMPL-NEXT:    assert(unsigned(D) <= Directive_enumSize);
+// IMPL-NEXT:    assert(unsigned(C) <= Clause_enumSize);
 // IMPL-NEXT:    switch (D) {
 // IMPL-NEXT:      case TDLD_dira:
 // IMPL-NEXT:        switch (C) {
@@ -316,24 +316,24 @@ def TDL_DirA : Directive<"dira"> {
 // IMPL-EMPTY:
 // IMPL-NEXT:  llvm::tdl::Association llvm::tdl::getDirectiveAssociation(llvm::tdl::Directive Dir) {
 // IMPL-NEXT:    switch (Dir) {
-// IMPL-NEXT:    case llvm::tdl::Directive::TDLD_dira:
-// IMPL-NEXT:      return llvm::tdl::Association::Block;
+// IMPL-NEXT:    case TDLD_dira:
+// IMPL-NEXT:      return Association::Block;
 // IMPL-NEXT:    } // switch (Dir)
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
 // IMPL-NEXT:  llvm::tdl::Category llvm::tdl::getDirectiveCategory(llvm::tdl::Directive Dir) {
 // IMPL-NEXT:    switch (Dir) {
-// IMPL-NEXT:    case llvm::tdl::TDLD_dira:
-// IMPL-NEXT:      return llvm::tdl::Category::Declarative;
+// IMPL-NEXT:    case TDLD_dira:
+// IMPL-NEXT:      return Category::Declarative;
 // IMPL-NEXT:    } // switch (Dir)
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
 // IMPL-NEXT:  llvm::tdl::SourceLanguage llvm::tdl::getDirectiveLanguages(llvm::tdl::Directive D) {
 // IMPL-NEXT:    switch (D) {
-// IMPL-NEXT:    case llvm::tdl::TDLD_dira:
-// IMPL-NEXT:      return llvm::tdl::SourceLanguage::C | llvm::tdl::SourceLanguage::Fortran;
+// IMPL-NEXT:    case TDLD_dira:
+// IMPL-NEXT:      return SourceLanguage::C | SourceLanguage::Fortran;
 // IMPL-NEXT:    } // switch(D)
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TableGen/DirectiveEmitter.h"
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
@@ -71,8 +72,7 @@ static void generateEnumClass(ArrayRef<const Record *> Records, raw_ostream &OS,
     for (const auto &R : Records) {
       BaseRecord Rec(R);
       OS << "constexpr auto " << Prefix << Rec.getFormattedName() << " = "
-         << "llvm::" << DirLang.getCppNamespace() << "::" << Enum
-         << "::" << Prefix << Rec.getFormattedName() << ";\n";
+         << Enum << "::" << Prefix << Rec.getFormattedName() << ";\n";
     }
   }
 }
@@ -86,8 +86,8 @@ static void generateEnumBitmask(ArrayRef<const Record *> Records,
                                 const DirectiveLanguage &DirLang,
                                 bool ExportEnums) {
   assert(Records.size() <= 64 && "Too many values for a bitmask");
-  llvm::StringRef Type = Records.size() <= 32 ? "uint32_t" : "uint64_t";
-  llvm::StringRef TypeSuffix = Records.size() <= 32 ? "U" : "ULL";
+  StringRef Type = Records.size() <= 32 ? "uint32_t" : "uint64_t";
+  StringRef TypeSuffix = Records.size() <= 32 ? "U" : "ULL";
 
   OS << "\n";
   OS << "enum class " << Enum << " : " << Type << " {\n";
@@ -113,8 +113,7 @@ static void generateEnumBitmask(ArrayRef<const Record *> Records,
     for (const auto &R : Records) {
       BaseRecord Rec(R);
       OS << "constexpr auto " << Prefix << Rec.getFormattedName() << " = "
-         << "llvm::" << DirLang.getCppNamespace() << "::" << Enum
-         << "::" << Prefix << Rec.getFormattedName() << ";\n";
+         << Enum << "::" << Prefix << Rec.getFormattedName() << ";\n";
     }
   }
 }
@@ -147,17 +146,16 @@ static void generateEnumClauseVal(ArrayRef<const Record *> Records,
     if (DirLang.hasMakeEnumAvailableInNamespace()) {
       OS << "\n";
       for (const auto &CV : ClauseVals) {
-        OS << "constexpr auto " << CV->getName() << " = "
-           << "llvm::" << DirLang.getCppNamespace() << "::" << EnumName
+        OS << "constexpr auto " << CV->getName() << " = " << EnumName
            << "::" << CV->getName() << ";\n";
       }
       EnumHelperFuncs += (Twine("LLVM_ABI ") + Twine(EnumName) + Twine(" get") +
-                          Twine(EnumName) + Twine("(StringRef);\n"))
+                          Twine(EnumName) + Twine("(StringRef Str);\n"))
                              .str();
 
       EnumHelperFuncs +=
-          (Twine("LLVM_ABI llvm::StringRef get") + Twine(DirLang.getName()) +
-           Twine(EnumName) + Twine("Name(") + Twine(EnumName) + Twine(");\n"))
+          (Twine("LLVM_ABI StringRef get") + Twine(DirLang.getName()) +
+           Twine(EnumName) + Twine("Name(") + Twine(EnumName) + Twine(" x);\n"))
               .str();
     }
   }
@@ -287,20 +285,20 @@ static void emitDirectivesDecl(const RecordKeeper &Records, raw_ostream &OS) {
   OS << "\n";
   OS << "// Enumeration helper functions\n";
   OS << "LLVM_ABI Directive get" << DirLang.getName()
-     << "DirectiveKind(llvm::StringRef Str);\n";
+     << "DirectiveKind(StringRef Str);\n";
   OS << "\n";
   // For OpenMP the signature is
   //   getOpenMPDirectiveName(Directive D, unsigned V)
-  OS << "LLVM_ABI llvm::StringRef get" << DirLang.getName()
+  OS << "LLVM_ABI StringRef get" << DirLang.getName()
      << "DirectiveName(Directive D";
   if (DirLang.getCppNamespace() == "omp")
     OS << ", unsigned = 0";
   OS << ");\n";
   OS << "\n";
   OS << "LLVM_ABI Clause get" << DirLang.getName()
-     << "ClauseKind(llvm::StringRef Str);\n";
+     << "ClauseKind(StringRef Str);\n";
   OS << "\n";
-  OS << "LLVM_ABI llvm::StringRef get" << DirLang.getName()
+  OS << "LLVM_ABI StringRef get" << DirLang.getName()
      << "ClauseName(Clause C);\n";
   OS << "\n";
   OS << "/// Return true if \\p C is a valid clause for \\p D in version \\p "
@@ -335,7 +333,8 @@ static void generateGetName(ArrayRef<const Record *> Records, raw_ostream &OS,
   //   getOpenMPDirectiveName(Directive D, unsigned V)
   OS << "\n";
   OS << "llvm::StringRef llvm::" << DirLang.getCppNamespace() << "::get"
-     << DirLang.getName() << Enum << "Name(" << Enum << " Kind";
+     << DirLang.getName() << Enum << "Name(llvm::" << DirLang.getCppNamespace()
+     << "::" << Enum << " Kind";
   if (DirLang.getCppNamespace() == "omp" && Enum == "Directive")
     OS << ", unsigned";
   OS << ") {\n";
@@ -366,9 +365,10 @@ static void generateGetKind(ArrayRef<const Record *> Records, raw_ostream &OS,
   BaseRecord DefaultRec(*DefaultIt);
 
   OS << "\n";
-  OS << Enum << " llvm::" << DirLang.getCppNamespace() << "::get"
-     << DirLang.getName() << Enum << "Kind(llvm::StringRef Str) {\n";
-  OS << "  return llvm::StringSwitch<" << Enum << ">(Str)\n";
+  OS << "llvm::" << DirLang.getCppNamespace() << "::" << Enum
+     << " llvm::" << DirLang.getCppNamespace() << "::get" << DirLang.getName()
+     << Enum << "Kind(llvm::StringRef Str) {\n";
+  OS << "  return StringSwitch<" << Enum << ">(Str)\n";
 
   for (const auto &R : Records) {
     BaseRecord Rec(R);
@@ -411,9 +411,10 @@ static void generateGetKindClauseVal(const DirectiveLanguage &DirLang,
     }
 
     OS << "\n";
-    OS << EnumName << " llvm::" << DirLang.getCppNamespace() << "::get"
-       << EnumName << "(llvm::StringRef Str) {\n";
-    OS << "  return llvm::StringSwitch<" << EnumName << ">(Str)\n";
+    OS << "llvm::" << DirLang.getCppNamespace() << "::" << EnumName
+       << " llvm::" << DirLang.getCppNamespace() << "::get" << EnumName
+       << "(llvm::StringRef Str) {\n";
+    OS << "  return StringSwitch<" << EnumName << ">(Str)\n";
     for (const auto &CV : ClauseVals) {
       ClauseVal CVal(CV);
       OS << "    .Case(\"" << CVal.getFormattedName() << "\"," << CV->getName()
@@ -474,11 +475,11 @@ static void generateIsAllowedClause(const DirectiveLanguage &DirLang,
   OS << "\n";
   OS << "bool llvm::" << DirLang.getCppNamespace()
      << "::isAllowedClauseForDirective("
-     << "Directive D, Clause C, unsigned Version) {\n";
-  OS << "  assert(unsigned(D) <= llvm::" << DirLang.getCppNamespace()
-     << "::Directive_enumSize);\n";
-  OS << "  assert(unsigned(C) <= llvm::" << DirLang.getCppNamespace()
-     << "::Clause_enumSize);\n";
+     << "llvm::" << DirLang.getCppNamespace()
+     << "::Directive D, llvm::" << DirLang.getCppNamespace()
+     << "::Clause C, unsigned Version) {\n";
+  OS << "  assert(unsigned(D) <= Directive_enumSize);\n";
+  OS << "  assert(unsigned(C) <= Clause_enumSize);\n";
 
   OS << "  switch (D) {\n";
 
@@ -760,26 +761,19 @@ static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
 
   OS << '\n';
 
-  auto GetQualifiedName = [&](StringRef Formatted) -> std::string {
-    return (Twine("llvm::") + DirLang.getCppNamespace() +
-            "::Directive::" + DirLang.getDirectivePrefix() + Formatted)
-        .str();
-  };
-
   std::string DirectiveTypeName =
       "llvm::" + DirLang.getCppNamespace().str() + "::Directive";
-  std::string AssociationTypeName =
-      "llvm::" + DirLang.getCppNamespace().str() + "::Association";
 
-  OS << AssociationTypeName << " llvm::" << DirLang.getCppNamespace()
+  OS << "llvm::" << DirLang.getCppNamespace()
+     << "::Association llvm::" << DirLang.getCppNamespace()
      << "::getDirectiveAssociation(" << DirectiveTypeName << " Dir) {\n";
   OS << "  switch (Dir) {\n";
   for (const Record *R : DirLang.getDirectives()) {
     if (auto F = AsMap.find(R); F != AsMap.end()) {
       Directive Dir(R);
-      OS << "  case " << GetQualifiedName(Dir.getFormattedName()) << ":\n";
-      OS << "    return " << AssociationTypeName
-         << "::" << GetAssocName(F->second) << ";\n";
+      OS << "  case " << DirLang.getDirectivePrefix() << Dir.getFormattedName()
+         << ":\n";
+      OS << "    return Association::" << GetAssocName(F->second) << ";\n";
     }
   }
   OS << "  } // switch (Dir)\n";
@@ -789,20 +783,18 @@ static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
 
 static void generateGetDirectiveCategory(const DirectiveLanguage &DirLang,
                                          raw_ostream &OS) {
-  std::string LangNamespace = "llvm::" + DirLang.getCppNamespace().str();
-  std::string CategoryTypeName = LangNamespace + "::Category";
-  std::string CategoryNamespace = CategoryTypeName + "::";
-
   OS << '\n';
-  OS << CategoryTypeName << ' ' << LangNamespace << "::getDirectiveCategory("
-     << getDirectiveType(DirLang) << " Dir) {\n";
+  OS << "llvm::" << DirLang.getCppNamespace()
+     << "::Category llvm::" << DirLang.getCppNamespace()
+     << "::getDirectiveCategory(" << getDirectiveType(DirLang) << " Dir) {\n";
   OS << "  switch (Dir) {\n";
 
   for (const Record *R : DirLang.getDirectives()) {
     Directive D(R);
-    OS << "  case " << getDirectiveName(DirLang, R) << ":\n";
-    OS << "    return " << CategoryNamespace
-       << D.getCategory()->getValueAsString("name") << ";\n";
+    OS << "  case " << DirLang.getDirectivePrefix() << D.getFormattedName()
+       << ":\n";
+    OS << "    return Category::" << D.getCategory()->getValueAsString("name")
+       << ";\n";
   }
   OS << "  } // switch (Dir)\n";
   OS << "  llvm_unreachable(\"Unexpected directive\");\n";
@@ -811,23 +803,21 @@ static void generateGetDirectiveCategory(const DirectiveLanguage &DirLang,
 
 static void generateGetDirectiveLanguages(const DirectiveLanguage &DirLang,
                                           raw_ostream &OS) {
-  std::string LangNamespace = "llvm::" + DirLang.getCppNamespace().str();
-  std::string LanguageTypeName = LangNamespace + "::SourceLanguage";
-  std::string LanguageNamespace = LanguageTypeName + "::";
-
   OS << '\n';
-  OS << LanguageTypeName << ' ' << LangNamespace << "::getDirectiveLanguages("
-     << getDirectiveType(DirLang) << " D) {\n";
+  OS << "llvm::" << DirLang.getCppNamespace()
+     << "::SourceLanguage llvm::" << DirLang.getCppNamespace()
+     << "::getDirectiveLanguages(" << getDirectiveType(DirLang) << " D) {\n";
   OS << "  switch (D) {\n";
 
   for (const Record *R : DirLang.getDirectives()) {
     Directive D(R);
-    OS << "  case " << getDirectiveName(DirLang, R) << ":\n";
+    OS << "  case " << DirLang.getDirectivePrefix() << D.getFormattedName()
+       << ":\n";
     OS << "    return ";
     llvm::interleave(
         D.getSourceLanguages(), OS,
         [&](const Record *L) {
-          OS << LanguageNamespace << BaseRecord::getFormattedName(L);
+          OS << "SourceLanguage::" << BaseRecord::getFormattedName(L);
         },
         " | ");
     OS << ";\n";
@@ -858,23 +848,22 @@ static void generateClauseSet(ArrayRef<const Record *> Clauses, raw_ostream &OS,
                               DirectiveClauseFE FE) {
 
   OS << "\n";
-  OS << "  static " << DirLang.getClauseEnumSetClass() << " " << ClauseSetPrefix
+  OS << "static " << DirLang.getClauseEnumSetClass() << " " << ClauseSetPrefix
      << DirLang.getDirectivePrefix() << Dir.getFormattedName() << " {\n";
 
   for (const auto &C : Clauses) {
     VersionedClause VerClause(C);
     if (FE == DirectiveClauseFE::Flang) {
-      OS << "    llvm::" << DirLang.getCppNamespace()
-         << "::Clause::" << DirLang.getClausePrefix()
+      OS << "  Clause::" << DirLang.getClausePrefix()
          << VerClause.getClause().getFormattedName() << ",\n";
     } else {
       assert(FE == DirectiveClauseFE::Clang);
       assert(DirLang.getName() == "OpenACC");
-      OS << "   clang::OpenACCClauseKind::"
+      OS << "  OpenACCClauseKind::"
          << VerClause.getClause().getClangAccSpelling() << ",\n";
     }
   }
-  OS << "  };\n";
+  OS << "};\n";
 }
 
 // Generate an enum set for the 4 kinds of clauses linked to a directive.
@@ -901,7 +890,7 @@ static void generateDirectiveClauseSets(const DirectiveLanguage &DirLang,
 
   for (const Directive Dir : DirLang.getDirectives()) {
     OS << "\n";
-    OS << "  // Sets for " << Dir.getName() << "\n";
+    OS << "// Sets for " << Dir.getName() << "\n";
 
     generateClauseSet(Dir.getAllowedClauses(), OS, "allowedClauses_", Dir,
                       DirLang, FE);
@@ -917,7 +906,8 @@ static void generateDirectiveClauseSets(const DirectiveLanguage &DirLang,
   for (auto Ns : reverse(Namespaces))
     OS << "} // namespace " << Ns << "\n";
 
-  OS << "} // namespace llvm\n";
+  OS << "} // namespace " << (FE == DirectiveClauseFE::Flang ? "llvm" : "clang")
+     << "\n";
 }
 
 // Generate a map of directive (key) with DirectiveClauses struct as values.

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -442,7 +442,6 @@ static void generateGetKindClauseVal(const DirectiveLanguage &DirLang,
 
 static void generateCaseForVersionedClauses(ArrayRef<const Record *> Clauses,
                                             raw_ostream &OS,
-                                            StringRef DirectiveName,
                                             const DirectiveLanguage &DirLang,
                                             StringSet<> &Cases) {
   for (const VersionedClause VerClause : Clauses) {
@@ -496,17 +495,17 @@ static void generateIsAllowedClause(const DirectiveLanguage &DirLang,
 
       StringSet<> Cases;
 
-      generateCaseForVersionedClauses(Dir.getAllowedClauses(), OS,
-                                      Dir.getName(), DirLang, Cases);
+      generateCaseForVersionedClauses(Dir.getAllowedClauses(), OS, DirLang,
+                                      Cases);
 
-      generateCaseForVersionedClauses(Dir.getAllowedOnceClauses(), OS,
-                                      Dir.getName(), DirLang, Cases);
+      generateCaseForVersionedClauses(Dir.getAllowedOnceClauses(), OS, DirLang,
+                                      Cases);
 
       generateCaseForVersionedClauses(Dir.getAllowedExclusiveClauses(), OS,
-                                      Dir.getName(), DirLang, Cases);
+                                      DirLang, Cases);
 
-      generateCaseForVersionedClauses(Dir.getRequiredClauses(), OS,
-                                      Dir.getName(), DirLang, Cases);
+      generateCaseForVersionedClauses(Dir.getRequiredClauses(), OS, DirLang,
+                                      Cases);
 
       OS << "        default:\n";
       OS << "          return false;\n";


### PR DESCRIPTION
Remove extraneous qualifications from names when
- the name is explicitly enclosed by corresponding namespaces, and
- the name is in a body of a function defined in corresponding namespaces. Otherwise add missing qualifications.

This applies to individual sections of TableGen output, and makes name lookup independent of the context in which these sections are included.