### PR TITLE
[lldb] Properly cache the result of MachProcess::GetPlatform

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -398,7 +398,7 @@ private:
 
   pid_t m_pid;           // Process ID of child process
   cpu_type_t m_cpu_type; // The CPU type of this process
-  uint32_t m_platform;   // The platform of this process
+  std::optional<uint32_t> m_platform;   // The platform of this process
   int m_child_stdin;
   int m_child_stdout;
   int m_child_stderr;

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -398,7 +398,7 @@ private:
 
   pid_t m_pid;           // Process ID of child process
   cpu_type_t m_cpu_type; // The CPU type of this process
-  std::optional<uint32_t> m_platform;   // The platform of this process
+  std::optional<uint32_t> m_platform; // The platform of this process
   int m_child_stdin;
   int m_child_stdout;
   int m_child_stderr;

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -1039,9 +1039,9 @@ struct dyld_process_cache_info {
 };
 
 uint32_t MachProcess::GetPlatform() {
-  if (m_platform == 0)
+  if (!m_platform)
     m_platform = MachProcess::GetProcessPlatformViaDYLDSPI();
-  return m_platform;
+  return *m_platform;
 }
 
 uint32_t MachProcess::GetProcessPlatformViaDYLDSPI() {
@@ -1323,7 +1323,7 @@ void MachProcess::Clear(bool detaching) {
   // Clear any cached thread list while the pid and task are still valid
 
   m_task.Clear();
-  m_platform = 0;
+  m_platform.reset();
   // Now clear out all member variables
   m_pid = INVALID_NUB_PROCESS;
   if (!detaching)
@@ -1754,7 +1754,7 @@ bool MachProcess::Detach() {
 
   // NULL our task out as we have already restored all exception ports
   m_task.Clear();
-  m_platform = 0;
+  m_platform.reset();
 
   // Clear out any notion of the process we once were
   const bool detaching = true;


### PR DESCRIPTION
If `MachProcess::GetProcessPlatformViaDYLDSPI` fails and return 0, we don't
want to call it everytime as it won't change the result. So use
std::optional to cache wether we already calculated the value.

Alleviate the impact of issue #140610