### PR TITLE
[HLSL][NFC] Add resource globals created for metadata to test baseline

### DIFF
--- a/llvm/test/CodeGen/DirectX/Metadata/srv_metadata.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/srv_metadata.ll
@@ -84,6 +84,15 @@ define void @test() #0 {
 
 attributes #0 = { noinline nounwind "hlsl.shader"="compute" }
 
+; CHECK: @0 = external constant %TypedBuffer
+; CHECK: @1 = external constant %TypedBuffer.0
+; CHECK: @2 = external constant %TypedBuffer.1
+; CHECK: @3 = external constant %TypedBuffer.2
+; CHECK: @4 = external constant %ByteAddressBuffer
+; CHECK: @5 = external constant %StructuredBuffer
+; CHECK: @6 = external constant %TypedBuffer.3
+; CHECK: @7 = external constant %TypedBuffer.4
+
 ; CHECK: !dx.resources = !{[[ResList:[!][0-9]+]]}
 
 ; CHECK: [[ResList]] = !{[[SRVList:[!][0-9]+]], null, null, null}

--- a/llvm/test/CodeGen/DirectX/Metadata/uav_metadata.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/uav_metadata.ll
@@ -108,6 +108,18 @@ define void @test() #0 {
 
 attributes #0 = { noinline nounwind "hlsl.shader"="compute" }
 
+; CHECK: @0 = external constant %RWTypedBuffer
+; CHECK: @1 = external constant %RWTypedBuffer.0
+; CHECK: @2 = external constant %RWTypedBuffer.1
+; CHECK: @3 = external constant %RWTypedBuffer.2
+; CHECK: @4 = external constant %RWByteAddressBuffer
+; CHECK: @5 = external constant %RWStructuredBuffer
+; CHECK: @6 = external constant %RasterizerOrderedTypedBuffer
+; CHECK: @7 = external constant %RasterizerOrderedStructuredBuffer
+; CHECK: @8 = external constant %RasterizerOrderedByteAddressBuffer
+; CHECK: @9 = external constant %RWTypedBuffer.3
+; CHECK: @10 = external constant %RWTypedBuffer.4
+
 ; CHECK: !dx.resources = !{[[ResList:[!][0-9]+]]}
 
 ; CHECK: [[ResList]] = !{null, [[UAVList:[!][0-9]+]], null, null}


### PR DESCRIPTION
Adds checks for resource globals that were created for DXIL metadata. The names of the globals and the names of the types will be changing soon. Adding these to the baseline will make it easier to see what is changing.