### PR TITLE
[LLVM][TableGen] Use StringRef for various members `CGIOperandList::OperandInfo`

### DIFF
--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -1908,7 +1908,7 @@ void MatchableInfo::buildAliasResultOperands(bool AliasConstraintsAreChecked) {
     }
 
     // Handle all the suboperands for this operand.
-    const std::string &OpName = OpInfo.Name;
+    StringRef OpName = OpInfo.Name;
     for (; AliasOpNo < LastOpNo &&
            CGA.ResultInstOperandIndex[AliasOpNo].first == Idx;
          ++AliasOpNo) {

--- a/llvm/utils/TableGen/CodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/CodeEmitterGen.cpp
@@ -142,8 +142,8 @@ bool CodeEmitterGen::addCodeToMergeInOperand(const Record *R,
   }
 
   std::pair<unsigned, unsigned> SO = CGI.Operands.getSubOperandNumber(OpIdx);
-  const std::string EncoderMethodName =
-      CGI.Operands[SO.first].EncoderMethodNames[SO.second].str();
+  StringRef EncoderMethodName =
+      CGI.Operands[SO.first].EncoderMethodNames[SO.second];
 
   if (UseAPInt)
     Case += "      op.clearAllBits();\n";
@@ -152,13 +152,14 @@ bool CodeEmitterGen::addCodeToMergeInOperand(const Record *R,
 
   // If the source operand has a custom encoder, use it.
   if (!EncoderMethodName.empty()) {
+    raw_string_ostream CaseOS(Case);
+    CaseOS << indent(6);
     if (UseAPInt) {
-      Case += "      " + EncoderMethodName + "(MI, " + utostr(OpIdx);
-      Case += ", op";
+      CaseOS << EncoderMethodName << "(MI, " + utostr(OpIdx) << ", op";
     } else {
-      Case += "      op = " + EncoderMethodName + "(MI, " + utostr(OpIdx);
+      CaseOS << "op = " << EncoderMethodName << "(MI, " << utostr(OpIdx);
     }
-    Case += ", Fixups, STI);\n";
+    CaseOS << ", Fixups, STI);\n";
   } else {
     if (UseAPInt) {
       Case +=

--- a/llvm/utils/TableGen/CodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/CodeEmitterGen.cpp
@@ -142,8 +142,8 @@ bool CodeEmitterGen::addCodeToMergeInOperand(const Record *R,
   }
 
   std::pair<unsigned, unsigned> SO = CGI.Operands.getSubOperandNumber(OpIdx);
-  std::string &EncoderMethodName =
-      CGI.Operands[SO.first].EncoderMethodNames[SO.second];
+  const std::string EncoderMethodName =
+      CGI.Operands[SO.first].EncoderMethodNames[SO.second].str();
 
   if (UseAPInt)
     Case += "      op.clearAllBits();\n";

--- a/llvm/utils/TableGen/Common/AsmWriterInst.cpp
+++ b/llvm/utils/TableGen/Common/AsmWriterInst.cpp
@@ -177,7 +177,7 @@ AsmWriterInst::AsmWriterInst(const CodeGenInstruction &CGI, unsigned CGIIndex,
         CGIOperandList::OperandInfo OpInfo = CGI.Operands[OpNo];
 
         unsigned MIOp = OpInfo.MIOperandNo;
-        Operands.emplace_back(OpInfo.PrinterMethodName, MIOp, Modifier,
+        Operands.emplace_back(OpInfo.PrinterMethodName.str(), MIOp, Modifier,
                               AsmWriterOperand::isMachineInstrOperand,
                               OpInfo.OperandType == "MCOI::OPERAND_PCREL");
       }

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -633,7 +633,7 @@ class TreePatternNode : public RefCountedBase<TreePatternNode> {
 
   /// Name - The name given to this node with the :$foo notation.
   ///
-  std::string Name;
+  StringRef Name;
 
   std::vector<ScopedName> NamesAsPredicateArg;
 
@@ -667,8 +667,8 @@ public:
   }
 
   bool hasName() const { return !Name.empty(); }
-  const std::string &getName() const { return Name; }
-  void setName(StringRef N) { Name.assign(N.begin(), N.end()); }
+  StringRef getName() const { return Name; }
+  void setName(StringRef N) { Name = N; }
 
   const std::vector<ScopedName> &getNamesAsPredicateArg() const {
     return NamesAsPredicateArg;
@@ -826,7 +826,7 @@ public: // Higher level manipulation routines.
   /// SubstituteFormalArguments - Replace the formal arguments in this tree
   /// with actual values specified by ArgMap.
   void
-  SubstituteFormalArguments(std::map<std::string, TreePatternNodePtr> &ArgMap);
+  SubstituteFormalArguments(std::map<StringRef, TreePatternNodePtr> &ArgMap);
 
   /// InlinePatternFragments - If \p T pattern refers to any pattern
   /// fragments, return the set of inlined versions (this can be more than
@@ -1261,12 +1261,14 @@ private:
                        ArrayRef<const Record *> InstImpResults,
                        bool ShouldIgnore = false);
   void AddPatternToMatch(TreePattern *Pattern, PatternToMatch &&PTM);
-  void FindPatternInputsAndOutputs(
-      TreePattern &I, TreePatternNodePtr Pat,
-      std::map<std::string, TreePatternNodePtr> &InstInputs,
-      MapVector<std::string, TreePatternNodePtr,
-                std::map<std::string, unsigned>> &InstResults,
-      std::vector<const Record *> &InstImpResults);
+
+  using InstInputsTy = std::map<StringRef, TreePatternNodePtr>;
+  using InstResultsTy =
+      MapVector<StringRef, TreePatternNodePtr, std::map<StringRef, unsigned>>;
+  void FindPatternInputsAndOutputs(TreePattern &I, TreePatternNodePtr Pat,
+                                   InstInputsTy &InstInputs,
+                                   InstResultsTy &InstResults,
+                                   std::vector<const Record *> &InstImpResults);
   unsigned getNewUID();
 };
 

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
@@ -78,23 +78,23 @@ CGIOperandList::CGIOperandList(const Record *R) : TheDef(R) {
                                        "' instruction!");
 
     const Record *Rec = Arg->getDef();
-    std::string PrintMethod = "printOperand";
-    std::string EncoderMethod;
+    StringRef PrintMethod = "printOperand";
+    StringRef EncoderMethod;
     std::string OperandType = "OPERAND_UNKNOWN";
     std::string OperandNamespace = "MCOI";
     unsigned NumOps = 1;
     const DagInit *MIOpInfo = nullptr;
     if (Rec->isSubClassOf("RegisterOperand")) {
-      PrintMethod = Rec->getValueAsString("PrintMethod").str();
+      PrintMethod = Rec->getValueAsString("PrintMethod");
       OperandType = Rec->getValueAsString("OperandType").str();
       OperandNamespace = Rec->getValueAsString("OperandNamespace").str();
-      EncoderMethod = Rec->getValueAsString("EncoderMethod").str();
+      EncoderMethod = Rec->getValueAsString("EncoderMethod");
     } else if (Rec->isSubClassOf("Operand")) {
-      PrintMethod = Rec->getValueAsString("PrintMethod").str();
+      PrintMethod = Rec->getValueAsString("PrintMethod");
       OperandType = Rec->getValueAsString("OperandType").str();
       OperandNamespace = Rec->getValueAsString("OperandNamespace").str();
       // If there is an explicit encoder method, use it.
-      EncoderMethod = Rec->getValueAsString("EncoderMethod").str();
+      EncoderMethod = Rec->getValueAsString("EncoderMethod");
       MIOpInfo = Rec->getValueAsDag("MIOperandInfo");
 
       // Verify that MIOpInfo has an 'ops' root value.
@@ -139,8 +139,8 @@ CGIOperandList::CGIOperandList(const Record *R) : TheDef(R) {
                           " has the same name as a previous operand!");
 
     OperandInfo &OpInfo = OperandList.emplace_back(
-        Rec, ArgName.str(), std::string(std::move(PrintMethod)),
-        OperandNamespace + "::" + OperandType, MIOperandNo, NumOps, MIOpInfo);
+        Rec, ArgName, PrintMethod, OperandNamespace + "::" + OperandType,
+        MIOperandNo, NumOps, MIOpInfo);
 
     if (SubArgDag) {
       if (SubArgDag->getNumArgs() != NumOps) {
@@ -182,7 +182,7 @@ CGIOperandList::CGIOperandList(const Record *R) : TheDef(R) {
     } else if (!EncoderMethod.empty()) {
       // If we have no explicit sub-op dag, but have an top-level encoder
       // method, the single encoder will multiple sub-ops, itself.
-      OpInfo.EncoderMethodNames[0] = std::move(EncoderMethod);
+      OpInfo.EncoderMethodNames[0] = EncoderMethod;
       for (unsigned j = 1; j < NumOps; ++j)
         OpInfo.DoNotEncode[j] = true;
     }

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.h
@@ -77,18 +77,18 @@ public:
 
     /// Name - If this operand was assigned a symbolic name, this is it,
     /// otherwise, it's empty.
-    std::string Name;
+    StringRef Name;
 
     /// The names of sub-operands, if given, otherwise empty.
-    std::vector<std::string> SubOpNames;
+    std::vector<StringRef> SubOpNames;
 
     /// PrinterMethodName - The method used to print operands of this type in
     /// the asmprinter.
-    std::string PrinterMethodName;
+    StringRef PrinterMethodName;
 
     /// The method used to get the machine operand value for binary
     /// encoding, per sub-operand. If empty, uses "getMachineOpValue".
-    std::vector<std::string> EncoderMethodNames;
+    std::vector<StringRef> EncoderMethodNames;
 
     /// OperandType - A value from MCOI::OperandType representing the type of
     /// the operand.
@@ -116,13 +116,13 @@ public:
     /// track constraint info for each.
     std::vector<ConstraintInfo> Constraints;
 
-    OperandInfo(const Record *R, const std::string &N, const std::string &PMN,
+    OperandInfo(const Record *R, StringRef Name, StringRef PrinterMethodName,
                 const std::string &OT, unsigned MION, unsigned MINO,
                 const DagInit *MIOI)
-        : Rec(R), Name(N), SubOpNames(MINO), PrinterMethodName(PMN),
-          EncoderMethodNames(MINO), OperandType(OT), MIOperandNo(MION),
-          MINumOperands(MINO), DoNotEncode(MINO), MIOperandInfo(MIOI),
-          Constraints(MINO) {}
+        : Rec(R), Name(Name), SubOpNames(MINO),
+          PrinterMethodName(PrinterMethodName), EncoderMethodNames(MINO),
+          OperandType(OT), MIOperandNo(MION), MINumOperands(MINO),
+          DoNotEncode(MINO), MIOperandInfo(MIOI), Constraints(MINO) {}
 
     /// getTiedOperand - If this operand is tied to another one, return the
     /// other operand number.  Otherwise, return -1.

--- a/llvm/utils/TableGen/Common/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.h
@@ -714,7 +714,7 @@ class CheckComplexPatMatcher : public Matcher {
   unsigned MatchNumber;
 
   /// Name - The name of the node we're matching, for comment emission.
-  std::string Name;
+  StringRef Name;
 
   /// FirstResult - This is the first slot in the RecordedNodes list that the
   /// result of the match populates.
@@ -722,14 +722,14 @@ class CheckComplexPatMatcher : public Matcher {
 
 public:
   CheckComplexPatMatcher(const ComplexPattern &pattern, unsigned matchnumber,
-                         const std::string &name, unsigned firstresult)
+                         StringRef name, unsigned firstresult)
       : Matcher(CheckComplexPat), Pattern(pattern), MatchNumber(matchnumber),
         Name(name), FirstResult(firstresult) {}
 
   const ComplexPattern &getPattern() const { return Pattern; }
   unsigned getMatchNumber() const { return MatchNumber; }
 
-  std::string getName() const { return Name; }
+  StringRef getName() const { return Name; }
   unsigned getFirstResult() const { return FirstResult; }
 
   static bool classof(const Matcher *N) {

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -508,7 +508,7 @@ void MatcherGen::EmitMatchCode(const TreePatternNode &N,
   // we already saw this in the pattern, emit code to verify dagness.
   SmallVector<std::string, 4> Names;
   if (!N.getName().empty())
-    Names.push_back(N.getName());
+    Names.push_back(N.getName().str());
 
   for (const ScopedName &Name : N.getNamesAsPredicateArg()) {
     Names.push_back(

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -849,7 +849,7 @@ Expected<InstructionMatcher &> GlobalISelEmitter::createAndImportSelDAGMatcher(
     const Init *SrcInit = Src.getLeafValue();
     if (const IntInit *SrcIntInit = dyn_cast<IntInit>(SrcInit)) {
       OperandMatcher &OM =
-          InsnMatcher.addOperand(OpIdx++, Src.getName(), TempOpIdx);
+          InsnMatcher.addOperand(OpIdx++, Src.getName().str(), TempOpIdx);
       OM.addPredicate<LiteralIntOperandMatcher>(SrcIntInit->getValue());
     } else {
       return failedImport(
@@ -883,8 +883,8 @@ Expected<InstructionMatcher &> GlobalISelEmitter::createAndImportSelDAGMatcher(
         if (!CCDef || !CCDef->isSubClassOf("CondCode"))
           return failedImport("Unable to handle CondCode");
 
-        OperandMatcher &OM =
-            InsnMatcher.addOperand(OpIdx++, SrcChild.getName(), TempOpIdx);
+        OperandMatcher &OM = InsnMatcher.addOperand(
+            OpIdx++, SrcChild.getName().str(), TempOpIdx);
         StringRef PredType = IsFCmp ? CCDef->getValueAsString("FCmpPredicate")
                                     : CCDef->getValueAsString("ICmpPredicate");
 
@@ -930,8 +930,8 @@ Expected<InstructionMatcher &> GlobalISelEmitter::createAndImportSelDAGMatcher(
         // For G_INTRINSIC/G_INTRINSIC_W_SIDE_EFFECTS, the operand immediately
         // following the defs is an intrinsic ID.
         if (I == 0) {
-          OperandMatcher &OM =
-              InsnMatcher.addOperand(OpIdx++, SrcChild.getName(), TempOpIdx);
+          OperandMatcher &OM = InsnMatcher.addOperand(
+              OpIdx++, SrcChild.getName().str(), TempOpIdx);
           OM.addPredicate<IntrinsicIDOperandMatcher>(II);
           continue;
         }


### PR DESCRIPTION
- Change `Name`, `SubopNames`, `PrinterMethodName`, and `EncoderMethodNames` to be stored as StringRef.
- Also changed `CheckComplexPatMatcher::Name` to StringRef as a fallout from the above.

Verified that all the tablegen generated files within LLVM are unchanged.