### PR TITLE
[dsym][test][nfc] Remove DIE offsets.

### DIFF
--- a/llvm/test/tools/dsymutil/X86/op-convert-offset.test
+++ b/llvm/test/tools/dsymutil/X86/op-convert-offset.test
@@ -42,12 +42,14 @@ OBJ:                   DW_AT_location        (DW_OP_breg2 RCX+0, DW_OP_constu 0x
 OBJ:                   DW_AT_name    ("b")
 OBJ:                   DW_AT_type    (0x000000af "_Bool")
 
-DSYM: 0x00000084:   DW_TAG_base_type
+DSYM:               DW_TAG_compile_unit
+DSYM:               DW_TAG_compile_unit
+DSYM:               DW_TAG_base_type
 DSYM:                 DW_AT_name      ("DW_ATE_unsigned_1")
 DSYM:                 DW_AT_encoding  (DW_ATE_unsigned)
 DSYM:                 DW_AT_byte_size (0x01)
 
-DSYM: 0x0000009b:     DW_TAG_formal_parameter
+DSYM:              DW_TAG_formal_parameter
 DSYM:                   DW_AT_location        (DW_OP_breg2 RCX+0, DW_OP_constu 0xff, DW_OP_and, DW_OP_convert (0x00000084) "DW_ATE_unsigned_1", DW_OP_convert (0x00000088) "DW_ATE_unsigned_8", DW_OP_stack_value)
 DSYM:                   DW_AT_name    ("b")
 DSYM:                   DW_AT_type    ({{.*}} "_Bool")


### PR DESCRIPTION
This test seems to be non-determistic recently.
Changed it not to rely on offsets.