### PR TITLE
[lldb-dap] Remove spurious move (NFC)

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -873,11 +873,10 @@ static std::optional<T> getArgumentsIfRequest(const Message &pm,
 
   T args;
   llvm::json::Path::Root root;
-  if (!fromJSON(req->arguments, args, root)) {
+  if (!fromJSON(req->arguments, args, root))
     return std::nullopt;
-  }
 
-  return std::move(args);
+  return args;
 }
 
 llvm::Error DAP::Loop() {


### PR DESCRIPTION
getArgumentsIfRequest is returning a local variable by value. Using std::move is not needed and may inhibit copy elision. Also fixes the braces around a single-line if.