### PR TITLE
[LLVM][ADT] Add support for `std::string += Twine` operator

### DIFF
--- a/llvm/include/llvm/ADT/Twine.h
+++ b/llvm/include/llvm/ADT/Twine.h
@@ -275,8 +275,9 @@ namespace llvm {
       if (Str[0] != '\0') {
         LHS.cString = Str;
         LHSKind = CStringKind;
-      } else
+      } else {
         LHSKind = EmptyKind;
+      }
 
       assert(isValid() && "Invalid twine!");
     }
@@ -577,6 +578,8 @@ namespace llvm {
     RHS.print(OS);
     return OS;
   }
+
+  std::string &operator+=(std::string &LHS, const Twine &RHS);
 
   /// @}
 

--- a/llvm/lib/Support/Twine.cpp
+++ b/llvm/lib/Support/Twine.cpp
@@ -183,3 +183,9 @@ LLVM_DUMP_METHOD void Twine::dumpRepr() const {
   printRepr(dbgs());
 }
 #endif
+
+std::string &llvm::operator+=(std::string &LHS, const Twine &RHS) {
+  raw_string_ostream OS(LHS);
+  RHS.print(OS);
+  return LHS;
+}

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -3240,7 +3240,7 @@ static std::string
 getNameForFeatureBitset(ArrayRef<const Record *> FeatureBitset) {
   std::string Name = "AMFBS";
   for (const Record *Feature : FeatureBitset)
-    Name += ("_" + Feature->getName()).str();
+    Name += "_" + Feature->getName();
   return Name;
 }
 

--- a/llvm/utils/TableGen/AsmWriterEmitter.cpp
+++ b/llvm/utils/TableGen/AsmWriterEmitter.cpp
@@ -187,8 +187,7 @@ void AsmWriterEmitter::FindUniqueOperandCommands(
     auto I = llvm::find(UniqueOperandCommands, Command);
     if (I != UniqueOperandCommands.end()) {
       size_t idx = I - UniqueOperandCommands.begin();
-      InstrsForCase[idx] += ", ";
-      InstrsForCase[idx] += Inst.CGI->TheDef->getName();
+      InstrsForCase[idx] += ", " + Inst.CGI->TheDef->getName();
       InstIdxs[idx].push_back(i);
     } else {
       UniqueOperandCommands.push_back(std::move(Command));
@@ -228,10 +227,8 @@ void AsmWriterEmitter::FindUniqueOperandCommands(
 
       // Okay, everything in this command set has the same next operand.  Add it
       // to UniqueOperandCommands and remember that it was consumed.
-      std::string Command =
+      UniqueOperandCommands[CommandIdx] +=
           "    " + FirstInst.Operands[Op].getCode(PassSubtarget) + "\n";
-
-      UniqueOperandCommands[CommandIdx] += Command;
       InstOpsUsed[CommandIdx]++;
     }
   }

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -151,14 +151,11 @@ static void generateEnumClauseVal(ArrayRef<const Record *> Records,
            << "llvm::" << DirLang.getCppNamespace() << "::" << EnumName
            << "::" << CV->getName() << ";\n";
       }
-      EnumHelperFuncs += (Twine("LLVM_ABI ") + Twine(EnumName) + Twine(" get") +
-                          Twine(EnumName) + Twine("(StringRef);\n"))
-                             .str();
-
       EnumHelperFuncs +=
-          (Twine("LLVM_ABI llvm::StringRef get") + Twine(DirLang.getName()) +
-           Twine(EnumName) + Twine("Name(") + Twine(EnumName) + Twine(");\n"))
-              .str();
+          "LLVM_ABI " + EnumName + " get" + EnumName + "(StringRef);\n";
+
+      EnumHelperFuncs += "LLVM_ABI llvm::StringRef get" + DirLang.getName() +
+                         EnumName + "Name(" + EnumName + ");\n";
     }
   }
 }
@@ -883,8 +880,7 @@ static void generateDirectiveClauseSets(const DirectiveLanguage &DirLang,
                                         DirectiveClauseFE FE, raw_ostream &OS) {
 
   std::string IfDefName{"GEN_"};
-  IfDefName += getFESpelling(FE).upper();
-  IfDefName += "_DIRECTIVE_CLAUSE_SETS";
+  IfDefName += getFESpelling(FE).upper() + "_DIRECTIVE_CLAUSE_SETS";
   IfDefScope Scope(IfDefName, OS);
 
   OS << "\n";
@@ -927,8 +923,7 @@ static void generateDirectiveClauseSets(const DirectiveLanguage &DirLang,
 static void generateDirectiveClauseMap(const DirectiveLanguage &DirLang,
                                        DirectiveClauseFE FE, raw_ostream &OS) {
   std::string IfDefName{"GEN_"};
-  IfDefName += getFESpelling(FE).upper();
-  IfDefName += "_DIRECTIVE_CLAUSE_MAP";
+  IfDefName += getFESpelling(FE).upper() + "_DIRECTIVE_CLAUSE_MAP";
   IfDefScope Scope(IfDefName, OS);
 
   OS << "\n";

--- a/llvm/utils/TableGen/CodeGenMapTable.cpp
+++ b/llvm/utils/TableGen/CodeGenMapTable.cpp
@@ -377,8 +377,7 @@ unsigned MapTableEmitter::emitBinSearchTable(raw_ostream &OS) {
     for (const Record *ColInstr : ColInstrs) {
       if (ColInstr) {
         RelExists = true;
-        OutStr += ", ";
-        OutStr += ColInstr->getName();
+        OutStr += ", " + ColInstr->getName();
       } else {
         OutStr += ", (uint16_t)-1U";
       }

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -1028,16 +1028,13 @@ std::string TreePredicateFn::getPredCode() const {
     }
 
     int64_t MinAlign = getMinAlignment();
-    if (MinAlign > 0) {
-      Code += "if (cast<MemSDNode>(N)->getAlign() < Align(";
-      Code += utostr(MinAlign);
-      Code += "))\nreturn false;\n";
-    }
+    if (MinAlign > 0)
+      Code += "if (cast<MemSDNode>(N)->getAlign() < Align(" + Twine(MinAlign) +
+              "))\nreturn false;\n";
 
     if (const Record *MemoryVT = getMemoryVT())
-      Code += ("if (cast<MemSDNode>(N)->getMemoryVT() != MVT::" +
-               MemoryVT->getName() + ") return false;\n")
-                  .str();
+      Code += "if (cast<MemSDNode>(N)->getMemoryVT() != MVT::" +
+              MemoryVT->getName() + ") return false;\n";
   }
 
   if (isAtomic() && isAtomicOrderingMonotonic())
@@ -1100,10 +1097,9 @@ std::string TreePredicateFn::getPredCode() const {
     StringRef SDNodeName = isLoad() ? "LoadSDNode" : "StoreSDNode";
 
     if (isUnindexed())
-      Code += ("if (cast<" + SDNodeName +
-               ">(N)->getAddressingMode() != ISD::UNINDEXED) "
-               "return false;\n")
-                  .str();
+      Code += "if (cast<" + SDNodeName +
+              ">(N)->getAddressingMode() != ISD::UNINDEXED) "
+              "return false;\n";
 
     if (isLoad()) {
       if ((isNonExtLoad() + isAnyExtLoad() + isSignExtLoad() +
@@ -1137,10 +1133,9 @@ std::string TreePredicateFn::getPredCode() const {
     }
 
     if (const Record *ScalarMemoryVT = getScalarMemoryVT())
-      Code += ("if (cast<" + SDNodeName +
-               ">(N)->getMemoryVT().getScalarType() != MVT::" +
-               ScalarMemoryVT->getName() + ") return false;\n")
-                  .str();
+      Code += "if (cast<" + SDNodeName +
+              ">(N)->getMemoryVT().getScalarType() != MVT::" +
+              ScalarMemoryVT->getName() + ") return false;\n";
   }
 
   if (hasNoUse())
@@ -1148,8 +1143,8 @@ std::string TreePredicateFn::getPredCode() const {
   if (hasOneUse())
     Code += "if (!N->hasNUsesOfValue(1, 0)) return false;\n";
 
-  std::string PredicateCode =
-      PatFragRec->getRecord()->getValueAsString("PredicateCode").str();
+  StringRef PredicateCode =
+      PatFragRec->getRecord()->getValueAsString("PredicateCode");
 
   Code += PredicateCode;
 

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -1413,10 +1413,8 @@ CodeGenSubRegIndex *CodeGenRegBank::getConcatSubRegIndex(
   std::string Name = Parts.front()->getName();
   const unsigned UnknownSize = (uint16_t)-1;
 
-  for (const CodeGenSubRegIndex *Part : ArrayRef(Parts).drop_front()) {
-    Name += '_';
-    Name += Part->getName();
-  }
+  for (const CodeGenSubRegIndex *Part : ArrayRef(Parts).drop_front())
+    Name += "_" + Part->getName();
 
   Idx = createSubRegIndex(Name, Parts.front()->getNamespace());
   Idx->ConcatenationOf.assign(Parts.begin(), Parts.end());

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -307,10 +307,8 @@ void MatcherGen::EmitOperatorMatchCode(const TreePatternNode &N,
     // "MY_PAT:op1:op2". We should already have validated that the uses are
     // consistent.
     std::string PatternName = N.getOperator()->getName().str();
-    for (const TreePatternNode &Child : N.children()) {
-      PatternName += ":";
-      PatternName += Child.getName();
-    }
+    for (const TreePatternNode &Child : N.children())
+      PatternName += ":" + Child.getName();
 
     if (recordUniqueNode(PatternName)) {
       auto NodeAndOpNum = std::pair(&N, NextRecordedOperandNo - 1);
@@ -467,11 +465,9 @@ bool MatcherGen::recordUniqueNode(ArrayRef<std::string> Names) {
   if (Entry == 0) {
     // If it is a named node, we must emit a 'Record' opcode.
     std::string WhatFor;
-    for (const std::string &Name : Names) {
-      if (!WhatFor.empty())
-        WhatFor += ',';
-      WhatFor += "$" + Name;
-    }
+    ListSeparator LS(",");
+    for (const std::string &Name : Names)
+      WhatFor += Twine(LS) + "$" + Name;
     AddMatcher(new RecordMatcher(WhatFor, NextRecordedOperandNo));
     Entry = ++NextRecordedOperandNo;
     NewRecord = true;

--- a/llvm/utils/TableGen/FastISelEmitter.cpp
+++ b/llvm/utils/TableGen/FastISelEmitter.cpp
@@ -428,8 +428,7 @@ static std::string PhysRegForNode(const TreePatternNode &Op,
 
   PhysReg += cast<StringInit>(OpLeafRec->getValue("Namespace")->getValue())
                  ->getValue();
-  PhysReg += "::";
-  PhysReg += Target.getRegBank().getReg(OpLeafRec)->getName();
+  PhysReg += "::" + Target.getRegBank().getReg(OpLeafRec)->getName();
   return PhysReg;
 }
 

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -173,9 +173,8 @@ InstrInfoEmitter::GetOperandInfo(const CodeGenInstruction &Inst) {
         Res += "|(1<<MCOI::BranchTarget)";
 
       // Fill in operand type.
-      Res += ", ";
       assert(!Op.OperandType.empty() && "Invalid operand type.");
-      Res += Op.OperandType;
+      Res += ", " + Op.OperandType;
 
       // Fill in constraint info.
       Res += ", ";
@@ -186,7 +185,7 @@ InstrInfoEmitter::GetOperandInfo(const CodeGenInstruction &Inst) {
         Res += "MCOI_EARLY_CLOBBER";
       } else {
         assert(Constraint.isTied());
-        Res += "MCOI_TIED_TO(" + utostr(Constraint.getTiedOperand()) + ")";
+        Res += "MCOI_TIED_TO(" + Twine(Constraint.getTiedOperand()) + ")";
       }
 
       Result.push_back(Res);
@@ -616,7 +615,7 @@ static std::string
 getNameForFeatureBitset(ArrayRef<const Record *> FeatureBitset) {
   std::string Name = "CEFBS";
   for (const Record *Feature : FeatureBitset)
-    Name += ("_" + Feature->getName()).str();
+    Name += "_" + Feature->getName();
   return Name;
 }
 

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -428,7 +428,7 @@ void SubtargetEmitter::formItineraryStageString(const std::string &Name,
 
     // Form string as ,{ cycles, u1 | u2 | ... | un, timeinc, kind }
     int Cycles = Stage->getValueAsInt("Cycles");
-    ItinString += "  { " + itostr(Cycles) + ", ";
+    ItinString += "  { " + Twine(Cycles) + ", ";
 
     // Get unit list
     ConstRecVec UnitList = Stage->getValueAsListOfDefs("Units");
@@ -436,16 +436,16 @@ void SubtargetEmitter::formItineraryStageString(const std::string &Name,
     // For each unit
     for (unsigned J = 0, M = UnitList.size(); J < M;) {
       // Add name and bitwise or
-      ItinString += Name + "FU::" + UnitList[J]->getName().str();
+      ItinString += Name + "FU::" + UnitList[J]->getName();
       if (++J < M)
         ItinString += " | ";
     }
 
     int TimeInc = Stage->getValueAsInt("TimeInc");
-    ItinString += ", " + itostr(TimeInc);
+    ItinString += ", " + Twine(TimeInc);
 
     int Kind = Stage->getValueAsInt("Kind");
-    ItinString += ", (llvm::InstrStage::ReservationKinds)" + itostr(Kind);
+    ItinString += ", (llvm::InstrStage::ReservationKinds)" + Twine(Kind);
 
     // Close off stage
     ItinString += " }";
@@ -470,8 +470,7 @@ void SubtargetEmitter::formItineraryOperandCycleString(
   ListSeparator LS;
   for (int OCycle : OperandCycleList) {
     // Next operand cycle
-    ItinString += LS;
-    ItinString += "  " + itostr(OCycle);
+    ItinString += Twine(LS) + "  " + itostr(OCycle);
   }
 }
 
@@ -483,14 +482,10 @@ void SubtargetEmitter::formItineraryBypassString(const std::string &Name,
   unsigned N = BypassList.size();
   unsigned I = 0;
   ListSeparator LS;
-  for (; I < N; ++I) {
-    ItinString += LS;
-    ItinString += Name + "Bypass::" + BypassList[I]->getName().str();
-  }
-  for (; I < NOperandCycles; ++I) {
-    ItinString += LS;
-    ItinString += " 0";
-  }
+  for (; I < N; ++I)
+    ItinString += Twine(LS) + Name + "Bypass::" + BypassList[I]->getName();
+  for (; I < NOperandCycles; ++I)
+    ItinString += LS + " 0";
 }
 
 //


### PR DESCRIPTION
TableGen backends have frequence occurrence of code that can use this operator to build strings. 