### PR TITLE
[ProfileData] Restore Core as a dependency for the ProfileData library

### DIFF
--- a/llvm/lib/ProfileData/CMakeLists.txt
+++ b/llvm/lib/ProfileData/CMakeLists.txt
@@ -26,6 +26,7 @@ add_llvm_component_library(LLVMProfileData
 
   LINK_COMPONENTS
   BitstreamReader
+  Core
   Object
   Support
   Demangle


### PR DESCRIPTION
#140505 dropped the dependency on core but it's still needed as indicated by the failing dynamically linked builds.