### PR TITLE
[clangd] Drop the optimization where only shards for modified files are updated in the background index

### DIFF
--- a/clang-tools-extra/clangd/index/Background.h
+++ b/clang-tools-extra/clangd/index/Background.h
@@ -190,12 +190,9 @@ private:
     bool HadErrors = false;
   };
 
-  /// Given index results from a TU, only update symbols coming from files with
-  /// different digests than \p ShardVersionsSnapshot. Also stores new index
-  /// information on IndexStorage.
-  void update(llvm::StringRef MainFile, IndexFileIn Index,
-              const llvm::StringMap<ShardVersion> &ShardVersionsSnapshot,
-              bool HadErrors);
+  /// Given index results from a TU, update symbols coming from all files. Also
+  /// stores new index information on IndexStorage.
+  void update(llvm::StringRef MainFile, IndexFileIn Index, bool HadErrors);
 
   // configuration
   const ThreadsafeFS &TFS;

--- a/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
+++ b/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
@@ -14,6 +14,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <deque>
+#include <optional>
 #include <thread>
 
 using ::testing::_;
@@ -213,10 +214,11 @@ TEST_F(BackgroundIndexTest, IndexTwoFiles) {
   CDB.setCompileCommand(testPath("root/B.cc"), Cmd);
 
   ASSERT_TRUE(Idx.blockUntilIdleForTest());
-  // B_CC is dropped as we don't collect symbols from A.h in this compilation.
+  // A_CC is dropped as A.h was now most recently indexed in the context of
+  // B.cc.
   EXPECT_THAT(runFuzzyFind(Idx, ""),
               UnorderedElementsAre(AllOf(named("common"), numReferences(5U)),
-                                   AllOf(named("A_CC"), numReferences(0U)),
+                                   AllOf(named("B_CC"), numReferences(0U)),
                                    AllOf(named("g"), numReferences(1U)),
                                    AllOf(named("f_b"), declared(), defined(),
                                          numReferences(1U))));
@@ -680,6 +682,76 @@ TEST_F(BackgroundIndexTest, Reindex) {
   EXPECT_EQ(1u, runFuzzyFind(Idx, "theOldFunction").size());
   EXPECT_EQ(0u, runFuzzyFind(Idx, "theNewFunction").size());
   EXPECT_EQ(OldShard, Storage.lookup(testPath("A.cc")));
+}
+
+// Test that restarting clangd properly updates the index with changes
+// to files since the last time the index was built.
+TEST_F(BackgroundIndexTest, UpdateAfterRestart) {
+  MockFS FS;
+  llvm::StringMap<std::string> Storage;
+  size_t CacheHits = 0;
+  MemoryShardStorage MSS(Storage, CacheHits);
+  auto CDB = std::make_unique<OverlayCDB>(/*Base=*/nullptr);
+  auto Idx = std::make_unique<BackgroundIndex>(
+      FS, *CDB, [&](llvm::StringRef) { return &MSS; },
+      BackgroundIndex::Options{});
+
+  // Create a header file containing a function declaration, and a source file
+  // containing a call to the function.
+  FS.Files[testPath("test.h")] = R"cpp(
+    #ifndef TEST_H
+    #define TEST_H
+    void waldo(int);
+    #endif
+  )cpp";
+  FS.Files[testPath("test.cc")] = R"cpp(
+    #include "test.h"
+    int main() {
+      waldo(42);
+    }
+  )cpp";
+
+  // Index the files in this state.
+  tooling::CompileCommand Cmd;
+  Cmd.Filename = "../test.cc";
+  Cmd.Directory = testPath("build");
+  Cmd.CommandLine = {"clang++", "../test.cc", "-fsyntax-only"};
+  CDB->setCompileCommand(testPath("test.cc"), Cmd);
+  ASSERT_TRUE(Idx->blockUntilIdleForTest());
+
+  // Verify that the function 'waldo' has two references in the index
+  // (the declaration, and the call site).
+  auto CheckRefCount = [&](std::string SymbolName) {
+    auto Syms = runFuzzyFind(*Idx, SymbolName);
+    EXPECT_THAT(Syms, UnorderedElementsAre(named(SymbolName)));
+    auto Sym = *Syms.begin();
+    return getRefs(*Idx, Sym.ID).numRefs();
+  };
+  EXPECT_EQ(CheckRefCount("waldo"), 2u);
+
+  // Modify the declaration of 'waldo' in a way that changes its SymbolID
+  // without changing how existing call sites are written. Here, we add
+  // a new parameter with a default argument.
+  FS.Files[testPath("test.h")] = R"cpp(
+    #ifndef TEST_H
+    #define TEST_H
+    void waldo(int, int = 0);
+    #endif
+  )cpp";
+
+  // Simulate clangd shutting down and restarting, and the background index
+  // being rebuilt after restart.
+  Idx = nullptr;
+  CDB = std::make_unique<OverlayCDB>(/*Base=*/nullptr);
+  Idx = std::make_unique<BackgroundIndex>(
+      FS, *CDB, [&](llvm::StringRef) { return &MSS; },
+      BackgroundIndex::Options{});
+  CDB->setCompileCommand(testPath("test.cc"), Cmd);
+  ASSERT_TRUE(Idx->blockUntilIdleForTest());
+
+  // The rebuild should have updated things so that 'waldo' now again has
+  // two references in the index.
+  EXPECT_EQ(CheckRefCount("waldo"), 2u);
 }
 
 class BackgroundIndexRebuilderTest : public testing::Test {


### PR DESCRIPTION
The optimization is not valid, given that the target of a symbol reference can change without the spelling of the reference (or anything else in the file containing the reference) changing, as illustrated in the added test case.

Partially fixes https://github.com/clangd/clangd/issues/1104