### PR TITLE
Revert "[Clang] Profile singly-resolved UnresolvedLookupExpr with the declaration"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -741,7 +741,6 @@ Bug Fixes to C++ Support
 - Fixed the handling of pack indexing types in the constraints of a member function redeclaration. (#GH138255)
 - Clang now correctly parses arbitrary order of ``[[]]``, ``__attribute__`` and ``alignas`` attributes for declarations (#GH133107)
 - Fixed a crash when forming an invalid function type in a dependent context. (#GH138657) (#GH115725) (#GH68852)
-- Fixed a function declaration mismatch that caused inconsistencies between concepts and variable template declarations. (#GH139476)
 - Clang no longer segfaults when there is a configuration mismatch between modules and their users (http://crbug.com/400353616).
 - Fix an incorrect deduction when calling an explicit object member function template through an overload set address.
 - Fixed bug in constant evaluation that would allow using the value of a

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -2189,10 +2189,7 @@ StmtProfiler::VisitCXXPseudoDestructorExpr(const CXXPseudoDestructorExpr *S) {
 
 void StmtProfiler::VisitOverloadExpr(const OverloadExpr *S) {
   VisitExpr(S);
-  if (S->getNumDecls() == 1)
-    VisitDecl(*S->decls_begin());
-  else
-    VisitNestedNameSpecifier(S->getQualifier());
+  VisitNestedNameSpecifier(S->getQualifier());
   VisitName(S->getName(), /*TreatAsDecl*/ true);
   ID.AddBoolean(S->hasExplicitTemplateArgs());
   if (S->hasExplicitTemplateArgs())

--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -853,18 +853,3 @@ template <int... Ts>
 requires C<Ts...[0]>
 auto TplClass<int>::buggy() -> void {}
 }
-
-namespace GH139476 {
-
-namespace moo {
-  template <typename T>
-  constexpr bool baa = true;
-
-  template <typename T> requires baa<T>
-  void caw();
-}
-
-template <typename T> requires moo::baa<T>
-void moo::caw() {}
-
-}


### PR DESCRIPTION
This introduced a bug where noexcept specifiers are involved, as reported in https://github.com/llvm/llvm-project/pull/140029#issuecomment-2892259764

Addressing that doesn't seem trivial at the moment, so I'll need some time to think it over; in the meantime let's
revert the offending patch.

Reverts llvm/llvm-project#140029