### PR TITLE
[clang][analysis] Thread Safety Analysis: Handle parenthesis

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1671,7 +1671,7 @@ void ThreadSafetyAnalyzer::checkAccess(const FactSet &FSet, const Expr *Exp,
         // Guard against self-initialization. e.g., int &i = i;
         if (E == Exp)
           break;
-        Exp = E;
+        Exp = E->IgnoreImplicit()->IgnoreParenCasts();
         continue;
       }
     }

--- a/clang/test/Analysis/thread-safety-handle-parenthesis.cpp
+++ b/clang/test/Analysis/thread-safety-handle-parenthesis.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -verify -fsyntax-only -std=c++20 -Wthread-safety %s
+
+class __attribute__((lockable)) Lock {};
+
+void sink_protected(int) {}
+
+class Baz {
+public:
+    Lock lock_;
+    int protected_num_ __attribute__((guarded_by(lock_))) = 1;
+};
+
+void baz_paran_test() {
+    Baz baz;     
+    int& n = baz.protected_num_;
+    sink_protected(n); // expected-warning{{reading variable 'protected_num_' requires holding mutex 'baz.lock_'}}
+    int& n2 = (baz.protected_num_);
+    sink_protected(n2); // expected-warning{{reading variable 'protected_num_' requires holding mutex 'baz.lock_'}}
+}

--- a/clang/test/Analysis/thread-safety-handle-parenthesis.cpp
+++ b/clang/test/Analysis/thread-safety-handle-parenthesis.cpp
@@ -10,7 +10,7 @@ public:
     int protected_num_ __attribute__((guarded_by(lock_))) = 1;
 };
 
-void baz_paran_test() {
+void paren_test() {
     Baz baz;     
     int& n = baz.protected_num_;
     sink_protected(n); // expected-warning{{reading variable 'protected_num_' requires holding mutex 'baz.lock_'}}

--- a/clang/test/Analysis/thread-safety-handle-parenthesis.cpp
+++ b/clang/test/Analysis/thread-safety-handle-parenthesis.cpp
@@ -1,10 +1,10 @@
-// RUN: %clang_cc1 -verify -fsyntax-only -std=c++20 -Wthread-safety %s
+// RUN: %clang_cc1 -verify -fsyntax-only -Wthread-safety %s
 
-class __attribute__((lockable)) Lock {};
+struct __attribute__((lockable)) Lock {};
 
-void sink_protected(int) {}
+void sink_protected(int);
 
-class Baz {
+struct Baz {
 public:
     Lock lock_;
     int protected_num_ __attribute__((guarded_by(lock_))) = 1;


### PR DESCRIPTION
When the variable guared by a lock was enclosed in parenthesis, access
violation warnings were not emitted. This patch fixes it and adds a
regression test.
