### PR TITLE
[mlir][ByteCodeReader] Fix bugs in EncodingReader::alignTo

### DIFF
--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -107,7 +107,8 @@ public:
       return emitError("expected alignment to be a power-of-two");
 
     auto isUnaligned = [&](const uint8_t *ptr) {
-      return ((uintptr_t)ptr & (alignment - 1)) != 0;
+      unsigned offset = ptr - buffer.begin();
+      return (offset & (alignment - 1)) != 0;
     };
 
     // Shift the reader position to the next alignment boundary.
@@ -1506,7 +1507,7 @@ private:
     UseListOrderStorage(bool isIndexPairEncoding,
                         SmallVector<unsigned, 4> &&indices)
         : indices(std::move(indices)),
-          isIndexPairEncoding(isIndexPairEncoding){};
+          isIndexPairEncoding(isIndexPairEncoding) {};
     /// The vector containing the information required to reorder the
     /// use-list of a value.
     SmallVector<unsigned, 4> indices;


### PR DESCRIPTION
It seems that the number of padding value should be computed based on the relative distance between `ptr` and `buffer.begin()` (instead of the absolute address of `ptr`). Otherwise, the skipped padding value will be indeterministic and depends on the initial alignment of `buffer.begin()`?

Or is there any implicit assumption on the alignment of buffer that holds the bytecode?

See https://github.com/llvm/llvm-project/blob/755acb174ab2a176eabd33d55ec4024e9f353e9d/mlir/lib/Bytecode/Writer/BytecodeWriter.cpp#L198 for how ByteCoderWriter emits padding values.