### PR TITLE
Revert "[llvm][NFC] Use `llvm::sort()`"

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SeedCollector.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SeedCollector.h
@@ -141,10 +141,11 @@ public:
                   "Expected LoadInst or StoreInst!");
     assert(all_of(Seeds, [](auto *S) { return isa<LoadOrStoreT>(S); }) &&
            "Expected Load or Store instructions!");
-    llvm::sort(Seeds, [&SE](Instruction *I0, Instruction *I1) {
+    auto Cmp = [&SE](Instruction *I0, Instruction *I1) {
       return Utils::atLowerAddress(cast<LoadOrStoreT>(I0),
                                    cast<LoadOrStoreT>(I1), SE);
-    });
+    };
+    std::sort(Seeds.begin(), Seeds.end(), Cmp);
   }
   explicit MemSeedBundle(LoadOrStoreT *MemI) : SeedBundle(MemI) {
     static_assert(std::is_same<LoadOrStoreT, LoadInst>::value ||

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -2333,10 +2333,11 @@ static AssignmentTrackingLowering::OverlapMap buildOverlapMapAndRecordDeclares(
   // order of fragment size - there should be no duplicates.
   for (auto &Pair : FragmentMap) {
     SmallVector<DebugVariable, 8> &Frags = Pair.second;
-    llvm::sort(Frags, [](const DebugVariable &Next, const DebugVariable &Elmt) {
-      return Elmt.getFragmentOrDefault().SizeInBits >
-             Next.getFragmentOrDefault().SizeInBits;
-    });
+    std::sort(Frags.begin(), Frags.end(),
+              [](const DebugVariable &Next, const DebugVariable &Elmt) {
+                return Elmt.getFragmentOrDefault().SizeInBits >
+                       Next.getFragmentOrDefault().SizeInBits;
+              });
     // Check for duplicates.
     assert(std::adjacent_find(Frags.begin(), Frags.end()) == Frags.end());
   }

--- a/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
+++ b/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
@@ -1056,9 +1056,9 @@ void llvm::extractInstructionFeatures(
   // frequency vector, mapping each instruction to its associated MBB.
 
   // Start off by sorting the segments based on the beginning slot index.
-  llvm::sort(LRPosInfo, [](LRStartEndInfo A, LRStartEndInfo B) {
-    return A.Begin < B.Begin;
-  });
+  std::sort(
+      LRPosInfo.begin(), LRPosInfo.end(),
+      [](LRStartEndInfo A, LRStartEndInfo B) { return A.Begin < B.Begin; });
   size_t InstructionIndex = 0;
   size_t CurrentSegmentIndex = 0;
   SlotIndex CurrentIndex = LRPosInfo[0].Begin;

--- a/llvm/lib/DWARFLinker/Parallel/ArrayList.h
+++ b/llvm/lib/DWARFLinker/Parallel/ArrayList.h
@@ -82,7 +82,7 @@ public:
     forEach([&](T &Item) { SortedItems.push_back(Item); });
 
     if (SortedItems.size()) {
-      llvm::sort(SortedItems, Comparator);
+      std::sort(SortedItems.begin(), SortedItems.end(), Comparator);
 
       size_t SortedItemIdx = 0;
       forEach([&](T &Item) { Item = SortedItems[SortedItemIdx++]; });

--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -1142,9 +1142,8 @@ void JITDylib::dump(raw_ostream &OS) {
     std::vector<std::pair<SymbolStringPtr, SymbolTableEntry *>> SymbolsSorted;
     for (auto &KV : Symbols)
       SymbolsSorted.emplace_back(KV.first, &KV.second);
-    llvm::sort(SymbolsSorted, [](const auto &L, const auto &R) {
-      return *L.first < *R.first;
-    });
+    std::sort(SymbolsSorted.begin(), SymbolsSorted.end(),
+              [](const auto &L, const auto &R) { return *L.first < *R.first; });
 
     for (auto &KV : SymbolsSorted) {
       OS << "    \"" << *KV.first << "\": ";

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/DebugInfoSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/DebugInfoSupport.cpp
@@ -49,7 +49,7 @@ static void preserveDWARFSection(LinkGraph &G, Section &Sec) {
 static SmallVector<char, 0> getSectionData(Section &Sec) {
   SmallVector<char, 0> SecData;
   SmallVector<Block *, 8> SecBlocks(Sec.blocks().begin(), Sec.blocks().end());
-  llvm::sort(SecBlocks, [](Block *LHS, Block *RHS) {
+  std::sort(SecBlocks.begin(), SecBlocks.end(), [](Block *LHS, Block *RHS) {
     return LHS->getAddress() < RHS->getAddress();
   });
   // Convert back to what object file would have, one blob of section content

--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -488,7 +488,7 @@ RawInstrProfReader<IntPtrT>::getTemporalProfTraces(
     return TemporalProfTraces;
   }
   // Sort functions by their timestamps to build the trace.
-  llvm::sort(TemporalProfTimestamps);
+  std::sort(TemporalProfTimestamps.begin(), TemporalProfTimestamps.end());
   TemporalProfTraceTy Trace;
   if (Weight)
     Trace.Weight = *Weight;

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -589,7 +589,7 @@ void PipelineSolver::populateReadyList(
   }
 
   if (UseCostHeur)
-    llvm::sort(ReadyList, llvm::less_second());
+    std::sort(ReadyList.begin(), ReadyList.end(), llvm::less_second());
 
   assert(ReadyList.size() == CurrSU.second.size());
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUPreloadKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPreloadKernelArguments.cpp
@@ -224,7 +224,7 @@ public:
 
     // Allocate loads in order of offset. We need to be sure that the implicit
     // argument can actually be preloaded.
-    llvm::sort(ImplicitArgLoads, less_second());
+    std::sort(ImplicitArgLoads.begin(), ImplicitArgLoads.end(), less_second());
 
     // If we fail to preload any implicit argument we know we don't have SGPRs
     // to preload any subsequent ones with larger offsets. Find the first

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -6844,8 +6844,8 @@ bool ARMPipelinerLoopInfo::tooMuchRegisterPressure(SwingSchedulerDAG &SSD,
          ++Stage) {
       std::deque<SUnit *> Instrs =
           SMS.getInstructions(Cycle + Stage * SMS.getInitiationInterval());
-      llvm::sort(Instrs,
-                 [](SUnit *A, SUnit *B) { return A->NodeNum > B->NodeNum; });
+      std::sort(Instrs.begin(), Instrs.end(),
+                [](SUnit *A, SUnit *B) { return A->NodeNum > B->NodeNum; });
       llvm::append_range(ProposedSchedule, Instrs);
     }
 

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -106,7 +106,7 @@ bool SPIRVExtensionsParser::parse(cl::Option &O, StringRef ArgName,
                                   std::set<SPIRV::Extension::Extension> &Vals) {
   SmallVector<StringRef, 10> Tokens;
   ArgValue.split(Tokens, ",", -1, false);
-  llvm::sort(Tokens);
+  std::sort(Tokens.begin(), Tokens.end());
 
   std::set<SPIRV::Extension::Extension> EnabledExtensions;
 

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -660,14 +660,14 @@ class SPIRVStructurizer : public FunctionPass {
     Instruction *InsertionPoint = *MergeInstructions.begin();
 
     PartialOrderingVisitor Visitor(F);
-    llvm::sort(MergeInstructions,
-               [&Visitor](Instruction *Left, Instruction *Right) {
-                 if (Left == Right)
-                   return false;
-                 BasicBlock *RightMerge = getDesignatedMergeBlock(Right);
-                 BasicBlock *LeftMerge = getDesignatedMergeBlock(Left);
-                 return !Visitor.compare(RightMerge, LeftMerge);
-               });
+    std::sort(MergeInstructions.begin(), MergeInstructions.end(),
+              [&Visitor](Instruction *Left, Instruction *Right) {
+                if (Left == Right)
+                  return false;
+                BasicBlock *RightMerge = getDesignatedMergeBlock(Right);
+                BasicBlock *LeftMerge = getDesignatedMergeBlock(Left);
+                return !Visitor.compare(RightMerge, LeftMerge);
+              });
 
     for (Instruction *I : MergeInstructions) {
       I->moveBefore(InsertionPoint->getIterator());

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -662,7 +662,7 @@ PartialOrderingVisitor::PartialOrderingVisitor(Function &F) {
   for (auto &[BB, Info] : BlockToOrder)
     Order.emplace_back(BB);
 
-  llvm::sort(Order, [&](const auto &LHS, const auto &RHS) {
+  std::sort(Order.begin(), Order.end(), [&](const auto &LHS, const auto &RHS) {
     return compare(LHS, RHS);
   });
 }

--- a/llvm/lib/TargetParser/AArch64TargetParser.cpp
+++ b/llvm/lib/TargetParser/AArch64TargetParser.cpp
@@ -227,10 +227,10 @@ AArch64::printEnabledExtensions(const std::set<StringRef> &EnabledFeatureNames) 
       EnabledExtensionsInfo.push_back(*ExtInfo);
   }
 
-  llvm::sort(EnabledExtensionsInfo,
-             [](const ExtensionInfo &Lhs, const ExtensionInfo &Rhs) {
-               return Lhs.ArchFeatureName < Rhs.ArchFeatureName;
-             });
+  std::sort(EnabledExtensionsInfo.begin(), EnabledExtensionsInfo.end(),
+            [](const ExtensionInfo &Lhs, const ExtensionInfo &Rhs) {
+              return Lhs.ArchFeatureName < Rhs.ArchFeatureName;
+            });
 
   for (const auto &Ext : EnabledExtensionsInfo) {
     outs() << "    "

--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -2945,7 +2945,7 @@ void CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::ContextNode::print(
   // Make a copy of the computed context ids that we can sort for stability.
   auto ContextIds = getContextIds();
   std::vector<uint32_t> SortedIds(ContextIds.begin(), ContextIds.end());
-  llvm::sort(SortedIds);
+  std::sort(SortedIds.begin(), SortedIds.end());
   for (auto Id : SortedIds)
     OS << " " << Id;
   OS << "\n";
@@ -2977,7 +2977,7 @@ void CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::ContextEdge::print(
      << " AllocTypes: " << getAllocTypeString(AllocTypes);
   OS << " ContextIds:";
   std::vector<uint32_t> SortedIds(ContextIds.begin(), ContextIds.end());
-  llvm::sort(SortedIds);
+  std::sort(SortedIds.begin(), SortedIds.end());
   for (auto Id : SortedIds)
     OS << " " << Id;
 }
@@ -3012,7 +3012,7 @@ void CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::printTotalSizes(
     DenseSet<uint32_t> ContextIds = Node->getContextIds();
     auto AllocTypeFromCall = getAllocationCallType(Node->Call);
     std::vector<uint32_t> SortedIds(ContextIds.begin(), ContextIds.end());
-    llvm::sort(SortedIds);
+    std::sort(SortedIds.begin(), SortedIds.end());
     for (auto Id : SortedIds) {
       auto TypeI = ContextIdToAllocationType.find(Id);
       assert(TypeI != ContextIdToAllocationType.end());
@@ -3211,7 +3211,7 @@ private:
     std::string IdString = "ContextIds:";
     if (ContextIds.size() < 100) {
       std::vector<uint32_t> SortedIds(ContextIds.begin(), ContextIds.end());
-      llvm::sort(SortedIds);
+      std::sort(SortedIds.begin(), SortedIds.end());
       for (auto Id : SortedIds)
         IdString += (" " + Twine(Id)).str();
     } else {

--- a/llvm/lib/Transforms/Utils/CodeLayout.cpp
+++ b/llvm/lib/Transforms/Utils/CodeLayout.cpp
@@ -986,15 +986,16 @@ private:
     }
 
     // Sorting chains by density in the decreasing order.
-    llvm::sort(SortedChains, [&](const ChainT *L, const ChainT *R) {
-      // Place the entry point at the beginning of the order.
-      if (L->isEntry() != R->isEntry())
-        return L->isEntry();
+    std::sort(SortedChains.begin(), SortedChains.end(),
+              [&](const ChainT *L, const ChainT *R) {
+                // Place the entry point at the beginning of the order.
+                if (L->isEntry() != R->isEntry())
+                  return L->isEntry();
 
-      // Compare by density and break ties by chain identifiers.
-      return std::make_tuple(-L->density(), L->Id) <
-             std::make_tuple(-R->density(), R->Id);
-    });
+                // Compare by density and break ties by chain identifiers.
+                return std::make_tuple(-L->density(), L->Id) <
+                       std::make_tuple(-R->density(), R->Id);
+              });
 
     // Collect the nodes in the order specified by their chains.
     std::vector<uint64_t> Order;
@@ -1354,12 +1355,14 @@ private:
     }
 
     // Sort chains by density in the decreasing order.
-    llvm::sort(SortedChains, [&](const ChainT *L, const ChainT *R) {
-      const double DL = ChainDensity[L];
-      const double DR = ChainDensity[R];
-      // Compare by density and break ties by chain identifiers.
-      return std::make_tuple(-DL, L->Id) < std::make_tuple(-DR, R->Id);
-    });
+    std::sort(SortedChains.begin(), SortedChains.end(),
+              [&](const ChainT *L, const ChainT *R) {
+                const double DL = ChainDensity[L];
+                const double DR = ChainDensity[R];
+                // Compare by density and break ties by chain identifiers.
+                return std::make_tuple(-DL, L->Id) <
+                       std::make_tuple(-DR, R->Id);
+              });
 
     // Collect the nodes in the order specified by their chains.
     std::vector<uint64_t> Order;

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -1459,9 +1459,10 @@ Error Session::FileInfo::registerMultiStubEntry(
                      Sym.getTargetFlags());
 
   // Let's keep stubs ordered by ascending address.
-  llvm::sort(Entry, [](const MemoryRegionInfo &L, const MemoryRegionInfo &R) {
-    return L.getTargetAddress() < R.getTargetAddress();
-  });
+  std::sort(Entry.begin(), Entry.end(),
+            [](const MemoryRegionInfo &L, const MemoryRegionInfo &R) {
+              return L.getTargetAddress() < R.getTargetAddress();
+            });
 
   return Error::success();
 }

--- a/llvm/utils/TableGen/ExegesisEmitter.cpp
+++ b/llvm/utils/TableGen/ExegesisEmitter.cpp
@@ -141,7 +141,8 @@ void ExegesisEmitter::emitPfmCountersInfo(const Record &Def,
            ValidationCounter->getValueAsDef("EventType")->getName(),
            getPfmCounterId(ValidationCounter->getValueAsString("Counter"))});
     }
-    llvm::sort(ValidationCounters, EventNumberLess);
+    std::sort(ValidationCounters.begin(), ValidationCounters.end(),
+              EventNumberLess);
     OS << "\nstatic const std::pair<ValidationEvent, const char*> " << Target
        << Def.getName() << "ValidationCounters[] = {\n";
     for (const ValidationCounterInfo &VCI : ValidationCounters) {


### PR DESCRIPTION
Reverts llvm/llvm-project#140335
Causing test failures on [llvm-clang-x86_64-expensive-checks-ubuntu](https://lab.llvm.org/buildbot/#/builders/187) and [llvm-clang-x86_64-expensive-checks-debian](https://lab.llvm.org/buildbot/#/builders/16)