### PR TITLE
[CGData] Return ArrayRef<std::string> in getNames (NFC)

### DIFF
--- a/llvm/include/llvm/CGData/StableFunctionMap.h
+++ b/llvm/include/llvm/CGData/StableFunctionMap.h
@@ -78,7 +78,7 @@ struct StableFunctionMap {
   const HashFuncsMapType &getFunctionMap() const { return HashToFuncs; }
 
   /// Get the NameToId vector for serialization.
-  const SmallVector<std::string> getNames() const { return IdToName; }
+  ArrayRef<std::string> getNames() const { return IdToName; }
 
   /// Get an existing ID associated with the given name or create a new ID if it
   /// doesn't exist.

--- a/llvm/lib/CGData/StableFunctionMapRecord.cpp
+++ b/llvm/lib/CGData/StableFunctionMapRecord.cpp
@@ -86,7 +86,7 @@ void StableFunctionMapRecord::serialize(raw_ostream &OS,
   support::endian::Writer Writer(OS, endianness::little);
 
   // Write Names.
-  auto Names = FunctionMap->getNames();
+  ArrayRef<std::string> Names = FunctionMap->getNames();
   uint32_t ByteSize = 4;
   Writer.write<uint32_t>(Names.size());
   for (auto &Name : Names) {

--- a/llvm/lib/CGData/StableFunctionMapRecord.cpp
+++ b/llvm/lib/CGData/StableFunctionMapRecord.cpp
@@ -86,7 +86,7 @@ void StableFunctionMapRecord::serialize(raw_ostream &OS,
   support::endian::Writer Writer(OS, endianness::little);
 
   // Write Names.
-  auto &Names = FunctionMap->getNames();
+  auto Names = FunctionMap->getNames();
   uint32_t ByteSize = 4;
   Writer.write<uint32_t>(Names.size());
   for (auto &Name : Names) {


### PR DESCRIPTION
All uses of getNames is read access to the list of names, so we can
just return ArrayRef<std::string>.  There is no need to make a copy as
we prepare a return value.
