### PR TITLE
Optimize watchman to ignore the build/ directory.

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,4 @@
+{
+    "ignore_vcs": [".git", ".jj", ".hg", ".svn"],
+    "ignore_dirs": ["build"]
+}


### PR DESCRIPTION
This prevents watchman from overflowing the inotify system buffer when attempting to watch for changes to source code in llvm-project.

Watchman is extremely fast and can scan for changes to all of LLVM in 0.01 seconds. However, when the buffer overflows, it has to assume all files have changed, and can take a very long time.

My use case:
I use the version control system JJ (which wraps git), and when you run a command like "jj status", it can use the filesystem monitor "watchman" to quickly determine what files have changed, which can significantly improve the performance of commands.

Example use case:
An editor such as vscode could use watchman to read when files change automatically without having to refresh it.