### PR TITLE
[flang] [Preprocessor] Fix ignoring OpenMP directive when preceded by a MACRO

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -564,7 +564,7 @@ bool Prescanner::MustSkipToEndOfLine() const {
     return true; // skip over ignored columns in right margin (73:80)
   } else if (*at_ == '!' && !inCharLiteral_ &&
       (!inFixedForm_ || tabInCurrentLine_ || column_ != 6)) {
-    return !IsCompilerDirectiveSentinel(at_);
+    return !IsCompilerDirectiveSentinel(at_ + 1);
   } else {
     return false;
   }

--- a/flang/test/Preprocessing/bug117693.F90
+++ b/flang/test/Preprocessing/bug117693.F90
@@ -1,0 +1,14 @@
+! RUN: %flang -fopenmp -E %s 2>&1 | FileCheck %s
+! CHECK: !$OMP PARALLEL DO
+! CHECK: !$OMP END PARALLEL DO
+program main
+IMPLICIT NONE
+INTEGER:: I
+#define OMPSUPPORT
+INTEGER :: omp_id
+OMPSUPPORT !$OMP PARALLEL DO
+DO I=1,100
+print *, omp_id
+ENDDO
+OMPSUPPORT !$OMP END PARALLEL DO
+end program


### PR DESCRIPTION
When a macro is followed by OpenMP pragma it is considered as comment and ignored. The function IsCompilerDirectiveSentinel expects the compiler directive argument without the prefix comment character. This is fixed in this commit.

Fixes #117693