### PR TITLE
[TableGen] Tach getInputFilename to return StringRef (NFC)

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1981,7 +1981,7 @@ public:
   detail::RecordKeeperImpl &getImpl() { return *Impl; }
 
   /// Get the main TableGen input file's name.
-  const std::string getInputFilename() const { return InputFilename; }
+  StringRef getInputFilename() const { return InputFilename; }
 
   /// Get the map of classes.
   const RecordMap &getClasses() const { return Classes; }

--- a/mlir/lib/TableGen/CodeGenHelpers.cpp
+++ b/mlir/lib/TableGen/CodeGenHelpers.cpp
@@ -27,7 +27,7 @@ using namespace mlir::tblgen;
 static std::string getUniqueOutputLabel(const RecordKeeper &records,
                                         StringRef tag) {
   // Use the input file name when generating a unique name.
-  std::string inputFilename = records.getInputFilename();
+  StringRef inputFilename = records.getInputFilename();
 
   // Drop all but the base filename.
   StringRef nameRef = sys::path::filename(inputFilename);


### PR DESCRIPTION
AFAICT, all callers of getInputFilename consume the string right away.
Nobody seems to rely on the "copy" behavior that comes with returning
"const std::string".
