### PR TITLE
[RISCV] Add Xqcibi Select_GPR_Using_CC_<Imm> Pseudos to isSelectPseudo

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21018,7 +21018,11 @@ static MachineBasicBlock *emitSelectPseudo(MachineInstr &MI,
 
   auto Next = next_nodbg(MI.getIterator(), BB->instr_end());
   if ((MI.getOpcode() != RISCV::Select_GPR_Using_CC_GPR &&
-       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm5) &&
+       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm5 &&
+       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm5NonZero &&
+       MI.getOpcode() != RISCV::Select_GPR_Using_CC_UImm5NonZero &&
+       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm16NonZero &&
+       MI.getOpcode() != RISCV::Select_GPR_Using_CC_UImm16NonZero) &&
       Next != BB->end() && Next->getOpcode() == MI.getOpcode() &&
       Next->getOperand(5).getReg() == MI.getOperand(0).getReg() &&
       Next->getOperand(5).isKill())

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21018,11 +21018,11 @@ static MachineBasicBlock *emitSelectPseudo(MachineInstr &MI,
 
   auto Next = next_nodbg(MI.getIterator(), BB->instr_end());
   if ((MI.getOpcode() != RISCV::Select_GPR_Using_CC_GPR &&
-       MI.getOpcode() != RISCV::Select_GPR_Using_CV_CC_SImm5 &&
-       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_QC_CC_SImm5NonZero &&
-       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_QC_CC_UImm5NonZero &&
-       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_QC_CC_SImm16NonZero &&
-       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_QC_CC_UImm16NonZero) &&
+       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm5_CV &&
+       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_CC_SImm5NonZero_QC &&
+       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_CC_UImm5NonZero_QC &&
+       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_CC_SImm16NonZero_QC &&
+       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_CC_UImm16NonZero_QC) &&
       Next != BB->end() && Next->getOpcode() == MI.getOpcode() &&
       Next->getOperand(5).getReg() == MI.getOperand(0).getReg() &&
       Next->getOperand(5).isKill())
@@ -21355,11 +21355,11 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
            "ReadCounterWide is only to be used on riscv32");
     return emitReadCounterWidePseudo(MI, BB);
   case RISCV::Select_GPR_Using_CC_GPR:
-  case RISCV::Select_GPR_Using_CV_CC_SImm5:
-  case RISCV::Select_GPRNoX0_Using_QC_CC_SImm5NonZero:
-  case RISCV::Select_GPRNoX0_Using_QC_CC_UImm5NonZero:
-  case RISCV::Select_GPRNoX0_Using_QC_CC_SImm16NonZero:
-  case RISCV::Select_GPRNoX0_Using_QC_CC_UImm16NonZero:
+  case RISCV::Select_GPR_Using_CC_SImm5_CV:
+  case RISCV::Select_GPRNoX0_Using_CC_SImm5NonZero_QC:
+  case RISCV::Select_GPRNoX0_Using_CC_UImm5NonZero_QC:
+  case RISCV::Select_GPRNoX0_Using_CC_SImm16NonZero_QC:
+  case RISCV::Select_GPRNoX0_Using_CC_UImm16NonZero_QC:
   case RISCV::Select_FPR16_Using_CC_GPR:
   case RISCV::Select_FPR16INX_Using_CC_GPR:
   case RISCV::Select_FPR32_Using_CC_GPR:

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21018,11 +21018,11 @@ static MachineBasicBlock *emitSelectPseudo(MachineInstr &MI,
 
   auto Next = next_nodbg(MI.getIterator(), BB->instr_end());
   if ((MI.getOpcode() != RISCV::Select_GPR_Using_CC_GPR &&
-       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm5 &&
-       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm5NonZero &&
-       MI.getOpcode() != RISCV::Select_GPR_Using_CC_UImm5NonZero &&
-       MI.getOpcode() != RISCV::Select_GPR_Using_CC_SImm16NonZero &&
-       MI.getOpcode() != RISCV::Select_GPR_Using_CC_UImm16NonZero) &&
+       MI.getOpcode() != RISCV::Select_GPR_Using_CV_CC_SImm5 &&
+       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_QC_CC_SImm5NonZero &&
+       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_QC_CC_UImm5NonZero &&
+       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_QC_CC_SImm16NonZero &&
+       MI.getOpcode() != RISCV::Select_GPRNoX0_Using_QC_CC_UImm16NonZero) &&
       Next != BB->end() && Next->getOpcode() == MI.getOpcode() &&
       Next->getOperand(5).getReg() == MI.getOperand(0).getReg() &&
       Next->getOperand(5).isKill())
@@ -21355,11 +21355,11 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
            "ReadCounterWide is only to be used on riscv32");
     return emitReadCounterWidePseudo(MI, BB);
   case RISCV::Select_GPR_Using_CC_GPR:
-  case RISCV::Select_GPR_Using_CC_SImm5:
-  case RISCV::Select_GPR_Using_CC_SImm5NonZero:
-  case RISCV::Select_GPR_Using_CC_UImm5NonZero:
-  case RISCV::Select_GPR_Using_CC_SImm16NonZero:
-  case RISCV::Select_GPR_Using_CC_UImm16NonZero:
+  case RISCV::Select_GPR_Using_CV_CC_SImm5:
+  case RISCV::Select_GPRNoX0_Using_QC_CC_SImm5NonZero:
+  case RISCV::Select_GPRNoX0_Using_QC_CC_UImm5NonZero:
+  case RISCV::Select_GPRNoX0_Using_QC_CC_SImm16NonZero:
+  case RISCV::Select_GPRNoX0_Using_QC_CC_UImm16NonZero:
   case RISCV::Select_FPR16_Using_CC_GPR:
   case RISCV::Select_FPR16INX_Using_CC_GPR:
   case RISCV::Select_FPR32_Using_CC_GPR:

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1646,12 +1646,12 @@ let Predicates = [HasStdExtC, OptForMinSize] in {
   def : SelectCompressOpt<SETNE>;
 }
 
-multiclass SelectCC_GPR_riirr<DAGOperand outvalty, DAGOperand invalty, DAGOperand imm> {
+multiclass SelectCC_GPR_riirr<DAGOperand valty, DAGOperand imm> {
   let usesCustomInserter = 1 in
-  def Select_GPR_Using_ # NAME
-      : Pseudo<(outs outvalty:$dst),
-               (ins invalty:$lhs, imm:$imm, cond_code:$cc,
-                outvalty:$truev, outvalty:$falsev), []>;
+  def Select_# valty #_Using_ # NAME
+      : Pseudo<(outs valty:$dst),
+               (ins valty:$lhs, imm:$imm, cond_code:$cc,
+                valty:$truev, valty:$falsev), []>;
 }
 
 /// Branches and jumps

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1646,12 +1646,12 @@ let Predicates = [HasStdExtC, OptForMinSize] in {
   def : SelectCompressOpt<SETNE>;
 }
 
-multiclass SelectCC_GPR_riirr<DAGOperand valty, DAGOperand imm> {
+multiclass SelectCC_GPR_riirr<DAGOperand outvalty, DAGOperand invalty, DAGOperand imm> {
   let usesCustomInserter = 1 in
   def Select_GPR_Using_ # NAME
-      : Pseudo<(outs valty:$dst),
-               (ins GPR:$lhs, imm:$imm, cond_code:$cc,
-                valty:$truev, valty:$falsev), []>;
+      : Pseudo<(outs outvalty:$dst),
+               (ins invalty:$lhs, imm:$imm, cond_code:$cc,
+                outvalty:$truev, outvalty:$falsev), []>;
 }
 
 /// Branches and jumps

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -802,12 +802,12 @@ let Predicates = [HasVendorXCVbi, IsRV32], AddedComplexity = 2 in {
   def : Pat<(riscv_brcc GPR:$rs1, simm5:$imm5, SETNE, bb:$imm12),
             (CV_BNEIMM GPR:$rs1, simm5:$imm5, bare_simm13_lsb0:$imm12)>;
 
-  defm CC_SImm5 : SelectCC_GPR_riirr<GPR, GPR, simm5>;
+  defm CV_CC_SImm5 : SelectCC_GPR_riirr<GPR, simm5>;
 
   class Selectbi<CondCode Cond>
       : Pat<(riscv_selectcc_frag:$cc (i32 GPR:$lhs), simm5:$Constant, Cond,
                                      (i32 GPR:$truev), GPR:$falsev),
-            (Select_GPR_Using_CC_SImm5 GPR:$lhs, simm5:$Constant,
+            (Select_GPR_Using_CV_CC_SImm5 GPR:$lhs, simm5:$Constant,
              (IntCCtoRISCVCCCV $cc), GPR:$truev, GPR:$falsev)>;
 
   def : Selectbi<SETEQ>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -802,12 +802,12 @@ let Predicates = [HasVendorXCVbi, IsRV32], AddedComplexity = 2 in {
   def : Pat<(riscv_brcc GPR:$rs1, simm5:$imm5, SETNE, bb:$imm12),
             (CV_BNEIMM GPR:$rs1, simm5:$imm5, bare_simm13_lsb0:$imm12)>;
 
-  defm CV_CC_SImm5 : SelectCC_GPR_riirr<GPR, simm5>;
+  defm CC_SImm5_CV : SelectCC_GPR_riirr<GPR, simm5>;
 
   class Selectbi<CondCode Cond>
       : Pat<(riscv_selectcc_frag:$cc (i32 GPR:$lhs), simm5:$Constant, Cond,
                                      (i32 GPR:$truev), GPR:$falsev),
-            (Select_GPR_Using_CV_CC_SImm5 GPR:$lhs, simm5:$Constant,
+            (Select_GPR_Using_CC_SImm5_CV GPR:$lhs, simm5:$Constant,
              (IntCCtoRISCVCCCV $cc), GPR:$truev, GPR:$falsev)>;
 
   def : Selectbi<SETEQ>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -802,7 +802,7 @@ let Predicates = [HasVendorXCVbi, IsRV32], AddedComplexity = 2 in {
   def : Pat<(riscv_brcc GPR:$rs1, simm5:$imm5, SETNE, bb:$imm12),
             (CV_BNEIMM GPR:$rs1, simm5:$imm5, bare_simm13_lsb0:$imm12)>;
 
-  defm CC_SImm5 : SelectCC_GPR_riirr<GPR, simm5>;
+  defm CC_SImm5 : SelectCC_GPR_riirr<GPR, GPR, simm5>;
 
   class Selectbi<CondCode Cond>
       : Pat<(riscv_selectcc_frag:$cc (i32 GPR:$lhs), simm5:$Constant, Cond,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -1327,10 +1327,10 @@ class Bcci48Pat<CondCode Cond, QCIBranchInst48_rii Inst, DAGOperand InTyImm>
     : Pat<(riscv_brcc (XLenVT GPRNoX0:$rs1), InTyImm:$rs2, Cond, bb:$imm12),
           (Inst GPRNoX0:$rs1, InTyImm:$rs2, bare_simm13_lsb0:$imm12)>;
 
-defm QC_CC_SImm5NonZero  : SelectCC_GPR_riirr<GPRNoX0, simm5nonzero>;
-defm QC_CC_UImm5NonZero  : SelectCC_GPR_riirr<GPRNoX0, uimm5nonzero>;
-defm QC_CC_SImm16NonZero : SelectCC_GPR_riirr<GPRNoX0, simm16nonzero>;
-defm QC_CC_UImm16NonZero : SelectCC_GPR_riirr<GPRNoX0, uimm16nonzero>;
+defm CC_SImm5NonZero_QC  : SelectCC_GPR_riirr<GPRNoX0, simm5nonzero>;
+defm CC_UImm5NonZero_QC  : SelectCC_GPR_riirr<GPRNoX0, uimm5nonzero>;
+defm CC_SImm16NonZero_QC : SelectCC_GPR_riirr<GPRNoX0, simm16nonzero>;
+defm CC_UImm16NonZero_QC : SelectCC_GPR_riirr<GPRNoX0, uimm16nonzero>;
 
 class SelectQCbi<CondCode Cond, DAGOperand InTyImm, Pseudo OpNode >
     : Pat<(riscv_selectcc_frag:$cc (i32 GPRNoX0:$lhs), InTyImm:$Constant, Cond,
@@ -1409,19 +1409,19 @@ def : Bcci48Pat<SETGE, QC_E_BGEI, simm16nonzero>;
 def : Bcci48Pat<SETULT, QC_E_BLTUI, uimm16nonzero>;
 def : Bcci48Pat<SETUGE, QC_E_BGEUI, uimm16nonzero>;
 
-def : SelectQCbi<SETEQ, simm5nonzero, Select_GPRNoX0_Using_QC_CC_SImm5NonZero>;
-def : SelectQCbi<SETNE, simm5nonzero, Select_GPRNoX0_Using_QC_CC_SImm5NonZero>;
-def : SelectQCbi<SETLT, simm5nonzero, Select_GPRNoX0_Using_QC_CC_SImm5NonZero>;
-def : SelectQCbi<SETGE, simm5nonzero, Select_GPRNoX0_Using_QC_CC_SImm5NonZero>;
-def : SelectQCbi<SETULT, uimm5nonzero, Select_GPRNoX0_Using_QC_CC_UImm5NonZero>;
-def : SelectQCbi<SETUGE, uimm5nonzero, Select_GPRNoX0_Using_QC_CC_UImm5NonZero>;
+def : SelectQCbi<SETEQ, simm5nonzero, Select_GPRNoX0_Using_CC_SImm5NonZero_QC>;
+def : SelectQCbi<SETNE, simm5nonzero, Select_GPRNoX0_Using_CC_SImm5NonZero_QC>;
+def : SelectQCbi<SETLT, simm5nonzero, Select_GPRNoX0_Using_CC_SImm5NonZero_QC>;
+def : SelectQCbi<SETGE, simm5nonzero, Select_GPRNoX0_Using_CC_SImm5NonZero_QC>;
+def : SelectQCbi<SETULT, uimm5nonzero, Select_GPRNoX0_Using_CC_UImm5NonZero_QC>;
+def : SelectQCbi<SETUGE, uimm5nonzero, Select_GPRNoX0_Using_CC_UImm5NonZero_QC>;
 
-def : SelectQCbi<SETEQ, simm16nonzero, Select_GPRNoX0_Using_QC_CC_SImm16NonZero>;
-def : SelectQCbi<SETNE, simm16nonzero, Select_GPRNoX0_Using_QC_CC_SImm16NonZero>;
-def : SelectQCbi<SETLT, simm16nonzero, Select_GPRNoX0_Using_QC_CC_SImm16NonZero>;
-def : SelectQCbi<SETGE, simm16nonzero, Select_GPRNoX0_Using_QC_CC_SImm16NonZero>;
-def : SelectQCbi<SETULT, uimm16nonzero, Select_GPRNoX0_Using_QC_CC_UImm16NonZero>;
-def : SelectQCbi<SETUGE, uimm16nonzero, Select_GPRNoX0_Using_QC_CC_UImm16NonZero>;
+def : SelectQCbi<SETEQ, simm16nonzero, Select_GPRNoX0_Using_CC_SImm16NonZero_QC>;
+def : SelectQCbi<SETNE, simm16nonzero, Select_GPRNoX0_Using_CC_SImm16NonZero_QC>;
+def : SelectQCbi<SETLT, simm16nonzero, Select_GPRNoX0_Using_CC_SImm16NonZero_QC>;
+def : SelectQCbi<SETGE, simm16nonzero, Select_GPRNoX0_Using_CC_SImm16NonZero_QC>;
+def : SelectQCbi<SETULT, uimm16nonzero, Select_GPRNoX0_Using_CC_UImm16NonZero_QC>;
+def : SelectQCbi<SETUGE, uimm16nonzero, Select_GPRNoX0_Using_CC_UImm16NonZero_QC>;
 } // let Predicates = [HasVendorXqcibi, IsRV32], AddedComplexity = 2
 
 let Predicates = [HasVendorXqcibm, IsRV32] in {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -1327,10 +1327,10 @@ class Bcci48Pat<CondCode Cond, QCIBranchInst48_rii Inst, DAGOperand InTyImm>
     : Pat<(riscv_brcc (XLenVT GPRNoX0:$rs1), InTyImm:$rs2, Cond, bb:$imm12),
           (Inst GPRNoX0:$rs1, InTyImm:$rs2, bare_simm13_lsb0:$imm12)>;
 
-defm CC_SImm5NonZero  : SelectCC_GPR_riirr<GPRNoX0, GPRNoX0, simm5nonzero>;
-defm CC_UImm5NonZero  : SelectCC_GPR_riirr<GPRNoX0, GPRNoX0, uimm5nonzero>;
-defm CC_SImm16NonZero : SelectCC_GPR_riirr<GPRNoX0, GPRNoX0, simm16nonzero>;
-defm CC_UImm16NonZero : SelectCC_GPR_riirr<GPRNoX0, GPRNoX0, uimm16nonzero>;
+defm QC_CC_SImm5NonZero  : SelectCC_GPR_riirr<GPRNoX0, simm5nonzero>;
+defm QC_CC_UImm5NonZero  : SelectCC_GPR_riirr<GPRNoX0, uimm5nonzero>;
+defm QC_CC_SImm16NonZero : SelectCC_GPR_riirr<GPRNoX0, simm16nonzero>;
+defm QC_CC_UImm16NonZero : SelectCC_GPR_riirr<GPRNoX0, uimm16nonzero>;
 
 class SelectQCbi<CondCode Cond, DAGOperand InTyImm, Pseudo OpNode >
     : Pat<(riscv_selectcc_frag:$cc (i32 GPRNoX0:$lhs), InTyImm:$Constant, Cond,
@@ -1409,19 +1409,19 @@ def : Bcci48Pat<SETGE, QC_E_BGEI, simm16nonzero>;
 def : Bcci48Pat<SETULT, QC_E_BLTUI, uimm16nonzero>;
 def : Bcci48Pat<SETUGE, QC_E_BGEUI, uimm16nonzero>;
 
-def : SelectQCbi<SETEQ, simm5nonzero, Select_GPR_Using_CC_SImm5NonZero>;
-def : SelectQCbi<SETNE, simm5nonzero, Select_GPR_Using_CC_SImm5NonZero>;
-def : SelectQCbi<SETLT, simm5nonzero, Select_GPR_Using_CC_SImm5NonZero>;
-def : SelectQCbi<SETGE, simm5nonzero, Select_GPR_Using_CC_SImm5NonZero>;
-def : SelectQCbi<SETULT, uimm5nonzero, Select_GPR_Using_CC_UImm5NonZero>;
-def : SelectQCbi<SETUGE, uimm5nonzero, Select_GPR_Using_CC_UImm5NonZero>;
+def : SelectQCbi<SETEQ, simm5nonzero, Select_GPRNoX0_Using_QC_CC_SImm5NonZero>;
+def : SelectQCbi<SETNE, simm5nonzero, Select_GPRNoX0_Using_QC_CC_SImm5NonZero>;
+def : SelectQCbi<SETLT, simm5nonzero, Select_GPRNoX0_Using_QC_CC_SImm5NonZero>;
+def : SelectQCbi<SETGE, simm5nonzero, Select_GPRNoX0_Using_QC_CC_SImm5NonZero>;
+def : SelectQCbi<SETULT, uimm5nonzero, Select_GPRNoX0_Using_QC_CC_UImm5NonZero>;
+def : SelectQCbi<SETUGE, uimm5nonzero, Select_GPRNoX0_Using_QC_CC_UImm5NonZero>;
 
-def : SelectQCbi<SETEQ, simm16nonzero, Select_GPR_Using_CC_SImm16NonZero>;
-def : SelectQCbi<SETNE, simm16nonzero, Select_GPR_Using_CC_SImm16NonZero>;
-def : SelectQCbi<SETLT, simm16nonzero, Select_GPR_Using_CC_SImm16NonZero>;
-def : SelectQCbi<SETGE, simm16nonzero, Select_GPR_Using_CC_SImm16NonZero>;
-def : SelectQCbi<SETULT, uimm16nonzero, Select_GPR_Using_CC_UImm16NonZero>;
-def : SelectQCbi<SETUGE, uimm16nonzero, Select_GPR_Using_CC_UImm16NonZero>;
+def : SelectQCbi<SETEQ, simm16nonzero, Select_GPRNoX0_Using_QC_CC_SImm16NonZero>;
+def : SelectQCbi<SETNE, simm16nonzero, Select_GPRNoX0_Using_QC_CC_SImm16NonZero>;
+def : SelectQCbi<SETLT, simm16nonzero, Select_GPRNoX0_Using_QC_CC_SImm16NonZero>;
+def : SelectQCbi<SETGE, simm16nonzero, Select_GPRNoX0_Using_QC_CC_SImm16NonZero>;
+def : SelectQCbi<SETULT, uimm16nonzero, Select_GPRNoX0_Using_QC_CC_UImm16NonZero>;
+def : SelectQCbi<SETUGE, uimm16nonzero, Select_GPRNoX0_Using_QC_CC_UImm16NonZero>;
 } // let Predicates = [HasVendorXqcibi, IsRV32], AddedComplexity = 2
 
 let Predicates = [HasVendorXqcibm, IsRV32] in {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -1327,16 +1327,16 @@ class Bcci48Pat<CondCode Cond, QCIBranchInst48_rii Inst, DAGOperand InTyImm>
     : Pat<(riscv_brcc (XLenVT GPRNoX0:$rs1), InTyImm:$rs2, Cond, bb:$imm12),
           (Inst GPRNoX0:$rs1, InTyImm:$rs2, bare_simm13_lsb0:$imm12)>;
 
-defm CC_SImm5NonZero  : SelectCC_GPR_riirr<GPR, simm5nonzero>;
-defm CC_UImm5NonZero  : SelectCC_GPR_riirr<GPR, uimm5nonzero>;
-defm CC_SImm16NonZero : SelectCC_GPR_riirr<GPR, simm16nonzero>;
-defm CC_UImm16NonZero : SelectCC_GPR_riirr<GPR, uimm16nonzero>;
+defm CC_SImm5NonZero  : SelectCC_GPR_riirr<GPRNoX0, GPRNoX0, simm5nonzero>;
+defm CC_UImm5NonZero  : SelectCC_GPR_riirr<GPRNoX0, GPRNoX0, uimm5nonzero>;
+defm CC_SImm16NonZero : SelectCC_GPR_riirr<GPRNoX0, GPRNoX0, simm16nonzero>;
+defm CC_UImm16NonZero : SelectCC_GPR_riirr<GPRNoX0, GPRNoX0, uimm16nonzero>;
 
 class SelectQCbi<CondCode Cond, DAGOperand InTyImm, Pseudo OpNode >
-    : Pat<(riscv_selectcc_frag:$cc (i32 GPR:$lhs), InTyImm:$Constant, Cond,
-                                   (i32 GPR:$truev), GPR:$falsev),
-          (OpNode GPR:$lhs, InTyImm:$Constant,
-           (IntCCtoQCRISCVCC $cc), GPR:$truev, GPR:$falsev)>;
+    : Pat<(riscv_selectcc_frag:$cc (i32 GPRNoX0:$lhs), InTyImm:$Constant, Cond,
+                                   (i32 GPRNoX0:$truev), GPRNoX0:$falsev),
+          (OpNode GPRNoX0:$lhs, InTyImm:$Constant,
+           (IntCCtoQCRISCVCC $cc), GPRNoX0:$truev, GPRNoX0:$falsev)>;
 
 /// Simple arithmetic operations
 

--- a/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
@@ -49,11 +49,11 @@ def isSelectPseudo
                    MCReturnStatement<
                      CheckOpcode<[
                        Select_GPR_Using_CC_GPR,
-                       Select_GPR_Using_CV_CC_SImm5,
-                       Select_GPRNoX0_Using_QC_CC_SImm5NonZero,
-                       Select_GPRNoX0_Using_QC_CC_UImm5NonZero,
-                       Select_GPRNoX0_Using_QC_CC_SImm16NonZero,
-                       Select_GPRNoX0_Using_QC_CC_UImm16NonZero,
+                       Select_GPR_Using_CC_SImm5_CV,
+                       Select_GPRNoX0_Using_CC_SImm5NonZero_QC,
+                       Select_GPRNoX0_Using_CC_UImm5NonZero_QC,
+                       Select_GPRNoX0_Using_CC_SImm16NonZero_QC,
+                       Select_GPRNoX0_Using_CC_UImm16NonZero_QC,
                        Select_FPR16_Using_CC_GPR,
                        Select_FPR16INX_Using_CC_GPR,
                        Select_FPR32_Using_CC_GPR,

--- a/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
@@ -49,11 +49,11 @@ def isSelectPseudo
                    MCReturnStatement<
                      CheckOpcode<[
                        Select_GPR_Using_CC_GPR,
-                       Select_GPR_Using_CC_SImm5,
-                       Select_GPR_Using_CC_SImm5NonZero,
-                       Select_GPR_Using_CC_UImm5NonZero,
-                       Select_GPR_Using_CC_SImm16NonZero,
-                       Select_GPR_Using_CC_UImm16NonZero,
+                       Select_GPR_Using_CV_CC_SImm5,
+                       Select_GPRNoX0_Using_QC_CC_SImm5NonZero,
+                       Select_GPRNoX0_Using_QC_CC_UImm5NonZero,
+                       Select_GPRNoX0_Using_QC_CC_SImm16NonZero,
+                       Select_GPRNoX0_Using_QC_CC_UImm16NonZero,
                        Select_FPR16_Using_CC_GPR,
                        Select_FPR16INX_Using_CC_GPR,
                        Select_FPR32_Using_CC_GPR,

--- a/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
@@ -50,6 +50,10 @@ def isSelectPseudo
                      CheckOpcode<[
                        Select_GPR_Using_CC_GPR,
                        Select_GPR_Using_CC_SImm5,
+                       Select_GPR_Using_CC_SImm5NonZero,
+                       Select_GPR_Using_CC_UImm5NonZero,
+                       Select_GPR_Using_CC_SImm16NonZero,
+                       Select_GPR_Using_CC_UImm16NonZero,
                        Select_FPR16_Using_CC_GPR,
                        Select_FPR16INX_Using_CC_GPR,
                        Select_FPR32_Using_CC_GPR,

--- a/llvm/test/CodeGen/RISCV/xqcibi.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibi.ll
@@ -355,5 +355,32 @@ t:
   ret i32 1
 }
 
+define i1 @selectcc(i64 %0) {
+; RV32I-LABEL: selectcc:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    li a2, 512
+; RV32I-NEXT:    beq a1, a2, .LBB12_2
+; RV32I-NEXT:  # %bb.1: # %entry
+; RV32I-NEXT:    sltiu a0, a1, 513
+; RV32I-NEXT:    xori a0, a0, 1
+; RV32I-NEXT:    ret
+; RV32I-NEXT:  .LBB12_2:
+; RV32I-NEXT:    snez a0, a0
+; RV32I-NEXT:    ret
+;
+; RV32IXQCIBI-LABEL: selectcc:
+; RV32IXQCIBI:       # %bb.0: # %entry
+; RV32IXQCIBI-NEXT:    qc.e.beqi a1, 512, .LBB12_2
+; RV32IXQCIBI-NEXT:  # %bb.1: # %entry
+; RV32IXQCIBI-NEXT:    sltiu a0, a1, 513
+; RV32IXQCIBI-NEXT:    xori a0, a0, 1
+; RV32IXQCIBI-NEXT:    ret
+; RV32IXQCIBI-NEXT:  .LBB12_2:
+; RV32IXQCIBI-NEXT:    snez a0, a0
+; RV32IXQCIBI-NEXT:    ret
+entry:
+  %cmp10.i = icmp ugt i64 %0, 2199023255552
+  ret i1 %cmp10.i
+}
 
 !0 = !{!"branch_weights", i32 1, i32 99}


### PR DESCRIPTION
Not adding them was leading to a crash when trying to expand these pseudo instructions.

I've also fixed the register class types for the Xqcibi instructions in these pseudo instructions which was incorrect and was exposed by the machine verifier while running the test case added in this patch.

Fixes #140697 