### PR TITLE
[Clang] Use correct evaluation contexts when instantiating a var without initializer

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -746,6 +746,7 @@ Bug Fixes to C++ Support
 - Fixed bug in constant evaluation that would allow using the value of a
   reference in its own initializer in C++23 mode (#GH131330).
 - Clang could incorrectly instantiate functions in discarded contexts (#GH140449)
+- Fix instantiation of default-initialized variable template specialization. (#GH140632) (#GH140622)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/CodeGenCXX/cxx1y-variable-template.cpp
+++ b/clang/test/CodeGenCXX/cxx1y-variable-template.cpp
@@ -18,7 +18,7 @@ int init_arr();
 template<typename T> template<typename U> template<typename V> int Outer<T>::Inner<U>::arr[sizeof(T) + sizeof(U) + sizeof(V)] = { init_arr() };
 int *p = Outer<char[100]>::Inner<char[20]>::arr<char[3]>;
 
-//CHECK : @_ZN8GH1406221gIiEE = linkonce_odr constant %"struct.GH140622::S" zeroinitializer
+//CHECK: @_ZN8GH1406221gIiEE = linkonce_odr constant %"struct.GH140622::S" zeroinitializer
 namespace GH140622 {
 template <typename> struct S {};
 template <typename T> constexpr S<T> g;

--- a/clang/test/CodeGenCXX/cxx1y-variable-template.cpp
+++ b/clang/test/CodeGenCXX/cxx1y-variable-template.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++1y -triple x86_64-linux-gnu -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++1y -Wno-unused-value -triple x86_64-linux-gnu -emit-llvm -o - %s | FileCheck %s
 
 // Check that we keep the 'extern' when we instantiate the definition of this
 // variable template specialization.
@@ -17,6 +17,16 @@ Outer<char[100]> outer_int;
 int init_arr();
 template<typename T> template<typename U> template<typename V> int Outer<T>::Inner<U>::arr[sizeof(T) + sizeof(U) + sizeof(V)] = { init_arr() };
 int *p = Outer<char[100]>::Inner<char[20]>::arr<char[3]>;
+
+//CHECK : @_ZN8GH1406221gIiEE = linkonce_odr constant %"struct.GH140622::S" zeroinitializer
+namespace GH140622 {
+template <typename> struct S {};
+template <typename T> constexpr S<T> g;
+void test() {
+    constexpr auto x = 42;
+    x, g<int>;
+}
+}
 
 namespace PR35456 {
 // CHECK: @_ZN7PR354561nILi0EEE = linkonce_odr global i32 0

--- a/clang/test/SemaCXX/cxx1y-variable-templates_top_level.cpp
+++ b/clang/test/SemaCXX/cxx1y-variable-templates_top_level.cpp
@@ -1,6 +1,8 @@
-// RUN: %clang_cc1 -std=c++98 -verify -fsyntax-only -Wno-c++11-extensions -Wno-c++1y-extensions %s -DPRECXX11
-// RUN: %clang_cc1 -std=c++11 -verify -fsyntax-only -Wno-c++1y-extensions %s
-// RUN: %clang_cc1 -std=c++1y -verify -fsyntax-only %s
+// RUN: %clang_cc1 -std=c++98 -verify -fsyntax-only -Wno-unused-value -Wno-c++11-extensions -Wno-c++1y-extensions %s -DPRECXX11
+// RUN: %clang_cc1 -std=c++11 -verify -fsyntax-only -Wno-unused-value -Wno-c++1y-extensions %s
+// RUN: %clang_cc1 -std=c++17 -verify -fsyntax-only -Wno-unused-value %s
+// RUN: %clang_cc1 -std=c++2c -verify -fsyntax-only -Wno-unused-value %s
+
 
 #ifdef PRECXX11
   #define CONST const
@@ -509,4 +511,33 @@ auto b<I, I * 2, 5> = b<I, I * 2, 5l>; // expected-error {{variable template par
 template <> auto b<0, 0, 0> = b<0, 0, 0>; // expected-error {{variable template explicit specialization 'b<0, 0, 0>' declared with deduced type 'auto' cannot appear in its own initializer}}
 }
 
+#endif
+
+#if __cplusplus > 201702L
+namespace GH140622 {
+template <typename> struct S {};
+
+struct Outer {
+    template <typename T>
+    static constexpr S<T> g;
+};
+
+template <typename T>
+struct OuterTpl {
+    static constexpr S<T> f;
+    template <typename U>
+    static constexpr S<U> g;
+};
+
+template <typename T>
+constexpr S<T> g;
+
+void test() {
+    constexpr auto x = 42;
+    x, g<int>,
+    Outer::g<int>,
+    OuterTpl<int>::f,
+    OuterTpl<int>::g<int>;
+}
+}
 #endif


### PR DESCRIPTION
The evaluation context was improperly set up, such that we were trying to set up cleanups for a global variable at the point of use, which led to incorrect diagnostics about the variable not being capturable.

Fixes #140632
Fixes #140622