### PR TITLE
[lldb] optionally match the `__debug` namespace for libstdc++ containers.

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -592,7 +592,7 @@ class NodeAllocator {
 public:
   void reset() { Alloc.Reset(); }
 
-  template <typename T, typename... Args> T *makeNode(Args &&... args) {
+  template <typename T, typename... Args> T *makeNode(Args &&...args) {
     return new (Alloc.Allocate(sizeof(T), alignof(T)))
         T(std::forward<Args>(args)...);
   }
@@ -614,7 +614,7 @@ public:
   ManglingSubstitutor() : Base(nullptr, nullptr) {}
 
   template <typename... Ts>
-  ConstString substitute(llvm::StringRef Mangled, Ts &&... Vals) {
+  ConstString substitute(llvm::StringRef Mangled, Ts &&...Vals) {
     this->getDerived().reset(Mangled, std::forward<Ts>(Vals)...);
     return substituteImpl(Mangled);
   }
@@ -1449,47 +1449,50 @@ static void LoadLibStdcppFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   stl_deref_flags.SetFrontEndWantsDereference();
 
   cpp_category_sp->AddTypeSynthetic(
-      "^std::vector<.+>(( )?&)?$", eFormatterMatchRegex,
+      "^std::(__debug::)?vector<.+>(( )?&)?$", eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_synth_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdVectorSynthProvider")));
   cpp_category_sp->AddTypeSynthetic(
-      "^std::map<.+> >(( )?&)?$", eFormatterMatchRegex,
+      "^std::(__debug::)?map<.+> >(( )?&)?$", eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_synth_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdMapLikeSynthProvider")));
   cpp_category_sp->AddTypeSynthetic(
-      "^std::deque<.+>(( )?&)?$", eFormatterMatchRegex,
+      "^std::(__debug)?deque<.+>(( )?&)?$", eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_deref_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdDequeSynthProvider")));
   cpp_category_sp->AddTypeSynthetic(
-      "^std::set<.+> >(( )?&)?$", eFormatterMatchRegex,
+      "^std::(__debug::)?set<.+> >(( )?&)?$", eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_deref_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdMapLikeSynthProvider")));
   cpp_category_sp->AddTypeSynthetic(
-      "^std::multimap<.+> >(( )?&)?$", eFormatterMatchRegex,
+      "^std::(__debug::)?multimap<.+> >(( )?&)?$", eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_deref_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdMapLikeSynthProvider")));
   cpp_category_sp->AddTypeSynthetic(
-      "^std::multiset<.+> >(( )?&)?$", eFormatterMatchRegex,
+      "^std::(__debug::)?multiset<.+> >(( )?&)?$", eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_deref_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdMapLikeSynthProvider")));
   cpp_category_sp->AddTypeSynthetic(
-      "^std::unordered_(multi)?(map|set)<.+> >$", eFormatterMatchRegex,
+      "^std::(__debug::)?unordered_(multi)?(map|set)<.+> >$",
+      eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_deref_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdUnorderedMapSynthProvider")));
   cpp_category_sp->AddTypeSynthetic(
-      "^std::(__cxx11::)?list<.+>(( )?&)?$", eFormatterMatchRegex,
+      "^std::((__debug::)?|(__cxx11::)?)list<.+>(( )?&)?$",
+      eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_deref_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdListSynthProvider")));
   cpp_category_sp->AddTypeSynthetic(
-      "^std::(__cxx11::)?forward_list<.+>(( )?&)?$", eFormatterMatchRegex,
+      "^std::((__debug::)?|(__cxx11::)?)forward_list<.+>(( )?&)?$",
+      eFormatterMatchRegex,
       SyntheticChildrenSP(new ScriptedSyntheticChildren(
           stl_synth_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.StdForwardListSynthProvider")));
@@ -1501,44 +1504,47 @@ static void LoadLibStdcppFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
 
   stl_summary_flags.SetDontShowChildren(false);
   stl_summary_flags.SetSkipPointers(false);
-  cpp_category_sp->AddTypeSummary("^std::bitset<.+>(( )?&)?$",
+  cpp_category_sp->AddTypeSummary("^std::(__debug::)?bitset<.+>(( )?&)?$",
                                   eFormatterMatchRegex,
                                   TypeSummaryImplSP(new StringSummaryFormat(
                                       stl_summary_flags, "size=${svar%#}")));
-  cpp_category_sp->AddTypeSummary("^std::vector<.+>(( )?&)?$",
+  cpp_category_sp->AddTypeSummary("^std::(__debug::)?vector<.+>(( )?&)?$",
                                   eFormatterMatchRegex,
                                   TypeSummaryImplSP(new StringSummaryFormat(
                                       stl_summary_flags, "size=${svar%#}")));
-  cpp_category_sp->AddTypeSummary("^std::map<.+> >(( )?&)?$",
+  cpp_category_sp->AddTypeSummary("^std::(__debug::)?map<.+> >(( )?&)?$",
                                   eFormatterMatchRegex,
                                   TypeSummaryImplSP(new StringSummaryFormat(
                                       stl_summary_flags, "size=${svar%#}")));
-  cpp_category_sp->AddTypeSummary("^std::set<.+> >(( )?&)?$",
+  cpp_category_sp->AddTypeSummary("^std::(__debug::)?set<.+> >(( )?&)?$",
                                   eFormatterMatchRegex,
                                   TypeSummaryImplSP(new StringSummaryFormat(
                                       stl_summary_flags, "size=${svar%#}")));
-  cpp_category_sp->AddTypeSummary("^std::deque<.+>(( )?&)?$",
+  cpp_category_sp->AddTypeSummary("^std::(__debug::)?deque<.+>(( )?&)?$",
                                   eFormatterMatchRegex,
                                   TypeSummaryImplSP(new StringSummaryFormat(
                                       stl_summary_flags, "size=${svar%#}")));
-  cpp_category_sp->AddTypeSummary("^std::multimap<.+> >(( )?&)?$",
+  cpp_category_sp->AddTypeSummary("^std::(__debug::)?multimap<.+> >(( )?&)?$",
                                   eFormatterMatchRegex,
                                   TypeSummaryImplSP(new StringSummaryFormat(
                                       stl_summary_flags, "size=${svar%#}")));
-  cpp_category_sp->AddTypeSummary("^std::multiset<.+> >(( )?&)?$",
-                                  eFormatterMatchRegex,
-                                  TypeSummaryImplSP(new StringSummaryFormat(
-                                      stl_summary_flags, "size=${svar%#}")));
-  cpp_category_sp->AddTypeSummary("^std::unordered_(multi)?(map|set)<.+> >$",
-                                  eFormatterMatchRegex,
-                                  TypeSummaryImplSP(new StringSummaryFormat(
-                                      stl_summary_flags, "size=${svar%#}")));
-  cpp_category_sp->AddTypeSummary("^std::(__cxx11::)?list<.+>(( )?&)?$",
+  cpp_category_sp->AddTypeSummary("^std::(__debug::)?multiset<.+> >(( )?&)?$",
                                   eFormatterMatchRegex,
                                   TypeSummaryImplSP(new StringSummaryFormat(
                                       stl_summary_flags, "size=${svar%#}")));
   cpp_category_sp->AddTypeSummary(
-      "^std::(__cxx11::)?forward_list<.+>(( )?&)?$", eFormatterMatchRegex,
+      "^std::(__debug::)?unordered_(multi)?(map|set)<.+> >$",
+      eFormatterMatchRegex,
+      TypeSummaryImplSP(
+          new StringSummaryFormat(stl_summary_flags, "size=${svar%#}")));
+  cpp_category_sp->AddTypeSummary(
+      "^std::((__debug::)?|(__cxx11::)?)list<.+>(( )?&)?$",
+      eFormatterMatchRegex,
+      TypeSummaryImplSP(
+          new StringSummaryFormat(stl_summary_flags, "size=${svar%#}")));
+  cpp_category_sp->AddTypeSummary(
+      "^std::((__debug::)?|(__cxx11::)?)forward_list<.+>(( )?&)?$",
+      eFormatterMatchRegex,
       TypeSummaryImplSP(new ScriptSummaryFormat(
           stl_summary_flags,
           "lldb.formatters.cpp.gnu_libstdcpp.ForwardListSummaryProvider")));
@@ -1592,7 +1598,7 @@ static void LoadLibStdcppFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   AddCXXSynthetic(
       cpp_category_sp,
       lldb_private::formatters::LibStdcppBitsetSyntheticFrontEndCreator,
-      "std::bitset synthetic child", "^std::bitset<.+>(( )?&)?$",
+      "std::bitset synthetic child", "^std::(__debug::)?bitset<.+>(( )?&)?$",
       stl_deref_flags, true);
 
   AddCXXSynthetic(
@@ -1731,8 +1737,11 @@ lldb::TypeCategoryImplSP CPlusPlusLanguage::GetFormatters() {
     DataVisualization::Categories::GetCategory(ConstString(GetPluginName()),
                                                g_category);
     if (g_category) {
-      LoadLibStdcppFormatters(g_category);
+      // NOTE: the libstdcpp formatters are loaded after libcxx formatters
+      // because of a conflict matching the `__debug`namespace in libstdcpp.
+      // since lldb priorities the last loaded matching formatter.
       LoadLibCxxFormatters(g_category);
+      LoadLibStdcppFormatters(g_category);
       LoadSystemFormatters(g_category);
     }
   });

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1740,7 +1740,7 @@ lldb::TypeCategoryImplSP CPlusPlusLanguage::GetFormatters() {
       // NOTE: the libstdcpp formatters are loaded after libcxx formatters
       // because we don't want to the libcxx formatters to match the potential
       // `__debug` inline namespace that libstdcpp may use. since LLDB
-      // priorities the last loaded matching formatter.
+      // prioritizes the last loaded matching formatter.
       LoadLibCxxFormatters(g_category);
       LoadLibStdcppFormatters(g_category);
       LoadSystemFormatters(g_category);

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1738,8 +1738,9 @@ lldb::TypeCategoryImplSP CPlusPlusLanguage::GetFormatters() {
                                                g_category);
     if (g_category) {
       // NOTE: the libstdcpp formatters are loaded after libcxx formatters
-      // because of a conflict matching the `__debug`namespace in libstdcpp.
-      // since lldb priorities the last loaded matching formatter.
+      // because we don't want to the libcxx formatters to match the potential
+      // `__debug` inline namespace that libstdcpp may use. since LLDB
+      // priorities the last loaded matching formatter.
       LoadLibCxxFormatters(g_category);
       LoadLibStdcppFormatters(g_category);
       LoadSystemFormatters(g_category);

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1739,8 +1739,8 @@ lldb::TypeCategoryImplSP CPlusPlusLanguage::GetFormatters() {
     if (g_category) {
       // NOTE: the libstdcpp formatters are loaded after libcxx formatters
       // because we don't want to the libcxx formatters to match the potential
-      // `__debug` inline namespace that libstdcpp may use. since LLDB
-      // prioritizes the last loaded matching formatter.
+      // `__debug` inline namespace that libstdcpp may use.
+      // LLDB prioritizes the last loaded matching formatter.
       LoadLibCxxFormatters(g_category);
       LoadLibStdcppFormatters(g_category);
       LoadSystemFormatters(g_category);

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-categories/TestDataFormatterCategories.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-categories/TestDataFormatterCategories.py
@@ -335,5 +335,7 @@ class CategoriesDataFormatterTestCase(TestBase):
 
         # and also validate that one can print formatters for a language
         self.expect(
-            "type summary list -l c++", substrs=["vector", "map", "list", "string"]
+            "type summary list -l c++",
+            substrs=["vector", "map", "list", "string"],
+            ordered=False,
         )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
@@ -19,13 +19,12 @@ class StdMapDataFormatterTestCase(TestBase):
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
     def test_with_run_command(self):
-        build_args = {"EXE": "a.out"}
-        self.with_run_command("", build_args)
+        self.with_run_command("", {})
 
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
     def test_with_run_command_debug(self):
-        build_args = {"CXXFLAGS": "-D_GLIBCXX_DEBUG", "EXE": "debug_a.out"}
+        build_args = {"CXXFLAGS_EXTRAS": "-D_GLIBCXX_DEBUG"}
         self.with_run_command("__debug::", build_args)
 
     def with_run_command(self, namespace: str, dictionary: dict):
@@ -64,7 +63,6 @@ class StdMapDataFormatterTestCase(TestBase):
 
         match = f"std::{namespace}map<"
         self.runCmd(
-            'type summary add -x "std::map<" --summary-string "map has ${svar%#} items" -e'
             f'type summary add -x "{match}" --summary-string "map has ${{svar%#}} items" -e'
         )
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
@@ -19,7 +19,7 @@ class StdMapDataFormatterTestCase(TestBase):
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
     def test_with_run_command(self):
-        self.with_run_command("", {})
+        self.with_run_command()
 
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
@@ -27,15 +27,10 @@ class StdMapDataFormatterTestCase(TestBase):
         build_args = {"CXXFLAGS_EXTRAS": "-D_GLIBCXX_DEBUG"}
         self.with_run_command("__debug::", build_args)
 
-    def with_run_command(self, namespace: str, dictionary: dict):
+    def with_run_command(self, namespace: str, dictionary: Optional[dict] = None):
         """Test that that file and class static variables display correctly."""
-        self.build()
-        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
         self.build(dictionary=dictionary)
-        artifact_name = dictionary.get("EXE", "a.out")
-        self.runCmd(
-            "file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET
-        )
+        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
 
         lldbutil.run_break_set_by_source_regexp(self, "Set break point at this line.")
 
@@ -61,9 +56,8 @@ class StdMapDataFormatterTestCase(TestBase):
 
         self.runCmd("frame variable ii --show-types")
 
-        match = f"std::{namespace}map<"
         self.runCmd(
-            f'type summary add -x "{match}" --summary-string "map has ${{svar%#}} items" -e'
+            f'type summary add -x "std::{namespace}map<" --summary-string "map has ${{svar%#}} items" -e'
         )
 
         self.expect("frame variable ii", substrs=["map has 0 items", "{}"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
@@ -2,7 +2,7 @@
 Test lldb data formatter subsystem.
 """
 
-
+from typing import Optional
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
@@ -27,7 +27,7 @@ class StdMapDataFormatterTestCase(TestBase):
         build_args = {"CXXFLAGS_EXTRAS": "-D_GLIBCXX_DEBUG"}
         self.with_run_command("__debug::", build_args)
 
-    def with_run_command(self, namespace: str, dictionary: Optional[dict] = None):
+    def with_run_command(self, namespace: str = "", dictionary: Optional[dict] = None):
         """Test that that file and class static variables display correctly."""
         self.build(dictionary=dictionary)
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
@@ -18,9 +18,21 @@ class StdVBoolDataFormatterTestCase(TestBase):
 
     @add_test_categories(["libstdcxx"])
     def test_with_run_command(self):
+        self.with_run_command({})
+
+    @add_test_categories(["libstdcxx"])
+    def test_with_run_command_debug(self):
+        build_args = {"CXXFLAGS": "-D_GLIBCXX_DEBUG"}
+        self.with_run_command(build_args)
+
+    def with_run_command(self, dictionary: dict):
         """Test that that file and class static variables display correctly."""
-        self.build()
-        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
+        self.build(dictionary=dictionary)
+        artifact_name = dictionary.get("EXE", "a.out")
+        self.runCmd("file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET)
+        self.runCmd(
+            "file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET
+        )
 
         lldbutil.run_break_set_by_file_and_line(
             self, "main.cpp", self.line, num_expected_locations=-1

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
@@ -3,6 +3,7 @@ Test lldb data formatter subsystem.
 """
 
 
+from typing import Optional
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -26,13 +27,10 @@ class StdVBoolDataFormatterTestCase(TestBase):
         build_args = {"CXXFLAGS_EXTRAS": "-D_GLIBCXX_DEBUG"}
         self.with_run_command(build_args)
 
-    def with_run_command(self, dictionary: dict):
+    def with_run_command(self, dictionary: Optional[dict] = None):
         """Test that that file and class static variables display correctly."""
         self.build(dictionary=dictionary)
-        artifact_name = dictionary.get("EXE", "a.out")
-        self.runCmd(
-            "file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET
-        )
+        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
 
         lldbutil.run_break_set_by_file_and_line(
             self, "main.cpp", self.line, num_expected_locations=-1

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
@@ -20,7 +20,7 @@ class StdVBoolDataFormatterTestCase(TestBase):
     @skip
     @add_test_categories(["libstdcxx"])
     def test_with_run_command(self):
-        self.with_run_command({})
+        self.with_run_command()
 
     @add_test_categories(["libstdcxx"])
     def test_with_run_command_debug(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
@@ -16,20 +16,20 @@ class StdVBoolDataFormatterTestCase(TestBase):
         # Find the line number to break at.
         self.line = line_number("main.cpp", "// Set break point at this line.")
 
+    @skip
     @add_test_categories(["libstdcxx"])
     def test_with_run_command(self):
         self.with_run_command({})
 
     @add_test_categories(["libstdcxx"])
     def test_with_run_command_debug(self):
-        build_args = {"CXXFLAGS": "-D_GLIBCXX_DEBUG"}
+        build_args = {"CXXFLAGS_EXTRAS": "-D_GLIBCXX_DEBUG"}
         self.with_run_command(build_args)
 
     def with_run_command(self, dictionary: dict):
         """Test that that file and class static variables display correctly."""
         self.build(dictionary=dictionary)
         artifact_name = dictionary.get("EXE", "a.out")
-        self.runCmd("file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET)
         self.runCmd(
             "file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET
         )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
@@ -3,6 +3,7 @@ Test lldb data formatter subsystem.
 """
 
 
+from typing import Optional
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -19,7 +20,7 @@ class StdVectorDataFormatterTestCase(TestBase):
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
     def test_with_run_command(self):
-        self.with_run_command({})
+        self.with_run_command()
 
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
@@ -27,13 +28,10 @@ class StdVectorDataFormatterTestCase(TestBase):
         build_args = {"CXXFLAGS_EXTRAS": "-D_GLIBCXX_DEBUG"}
         self.with_run_command(build_args)
 
-    def with_run_command(self, dictionary: dict):
+    def with_run_command(self, dictionary: Optional[dict] = None):
         """Test that that file and class static variables display correctly."""
         self.build(dictionary=dictionary)
-        artifact_name = "a.out"
-        self.runCmd(
-            "file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET
-        )
+        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
 
         lldbutil.run_break_set_by_source_regexp(self, "Set break point at this line.")
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
@@ -19,9 +19,19 @@ class StdVectorDataFormatterTestCase(TestBase):
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
     def test_with_run_command(self):
+        self.with_run_command({})
+
+    @add_test_categories(["libstdcxx"])
+    @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
+    def test_with_run_command_debug(self):
+        build_args = {"CXXFLAGS": "-D_GLIBCXX_DEBUG"}
+        self.with_run_command(build_args)
+
+    def with_run_command(self, dictionary: dict):
         """Test that that file and class static variables display correctly."""
-        self.build()
-        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
+        self.build(dictionary=dictionary)
+        artifact_name = "a.out"
+        self.runCmd("file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET)
 
         lldbutil.run_break_set_by_source_regexp(self, "Set break point at this line.")
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
@@ -24,14 +24,16 @@ class StdVectorDataFormatterTestCase(TestBase):
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
     def test_with_run_command_debug(self):
-        build_args = {"CXXFLAGS": "-D_GLIBCXX_DEBUG"}
+        build_args = {"CXXFLAGS_EXTRAS": "-D_GLIBCXX_DEBUG"}
         self.with_run_command(build_args)
 
     def with_run_command(self, dictionary: dict):
         """Test that that file and class static variables display correctly."""
         self.build(dictionary=dictionary)
         artifact_name = "a.out"
-        self.runCmd("file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET)
+        self.runCmd(
+            "file " + self.getBuildArtifact(artifact_name), CURRENT_EXECUTABLE_SET
+        )
 
         lldbutil.run_break_set_by_source_regexp(self, "Set break point at this line.")
 


### PR DESCRIPTION
Fixes #60841