### PR TITLE
[clang][bytecode] Optimize classify() further

### DIFF
--- a/clang/lib/AST/ByteCode/Context.h
+++ b/clang/lib/AST/ByteCode/Context.h
@@ -137,6 +137,9 @@ private:
   std::unique_ptr<Program> P;
   /// ID identifying an evaluation.
   unsigned EvalID = 0;
+  /// Cached widths (in bits) of common types, for a faster classify().
+  unsigned IntWidth;
+  unsigned LongWidth;
 };
 
 } // namespace interp


### PR DESCRIPTION
Try to do as few checks as possible. Check for builtin types only once, then look at the BuiltinType Kind. For integers, we cache the int and long size, since those are used a lot and the ASTContext::getIntWidth() call is costly.