### PR TITLE
[mlir] Check for int limits when converting gpu dims

### DIFF
--- a/mlir/lib/Conversion/GPUCommon/IndexIntrinsicsOpLowering.h
+++ b/mlir/lib/Conversion/GPUCommon/IndexIntrinsicsOpLowering.h
@@ -116,7 +116,9 @@ public:
 
     if (upperBound && intrType != IntrType::None) {
       int32_t min = (intrType == IntrType::Dim ? 1 : 0);
-      int32_t max = *upperBound + (intrType == IntrType::Id ? 0 : 1);
+      int32_t max = *upperBound == INT_MAX
+                        ? *upperBound
+                        : *upperBound + (intrType == IntrType::Id ? 0 : 1);
       newOp->setAttr("range", LLVM::ConstantRangeAttr::get(
                                   rewriter.getContext(), 32, min, max));
     }

--- a/mlir/lib/Conversion/GPUCommon/IndexIntrinsicsOpLowering.h
+++ b/mlir/lib/Conversion/GPUCommon/IndexIntrinsicsOpLowering.h
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include <limits>
 
 namespace mlir {
 namespace gpu {
@@ -116,7 +117,7 @@ public:
 
     if (upperBound && intrType != IntrType::None) {
       int32_t min = (intrType == IntrType::Dim ? 1 : 0);
-      int32_t max = *upperBound == INT_MAX
+      int32_t max = *upperBound == std::numeric_limits<int32_t>::max()
                         ? *upperBound
                         : *upperBound + (intrType == IntrType::Id ? 0 : 1);
       newOp->setAttr("range", LLVM::ConstantRangeAttr::get(

--- a/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
@@ -763,3 +763,16 @@ gpu.module @test_module {
 gpu.module @test_custom_data_layout attributes {llvm.data_layout = "e"} {
 
 }
+
+// -----
+
+gpu.module @test_module {
+  // CHECK32-LABEL: func @gpu_dim_int_max_upper_bound()
+  func.func @gpu_dim_int_max_upper_bound()
+      -> (index) {
+
+    // CHECK32: rocdl.workgroup.dim.x range <i32, 1, 2147483647> : i32
+    %bDimX = gpu.block_dim x upper_bound 2147483647
+    func.return %bDimX : index
+  }
+}


### PR DESCRIPTION
When the upper_bound of a gpu dim op (like `gpu.block_dim`) is the maximum i32 integer value, the op conversion for it causes overflow by adding 1 to convert the bound from closed to open. This fixes the bug by clamping the open bound to the maximum i32 value.