### PR TITLE
[clang-tidy][NFC] Refactor `modernize-pass-by-value` check code and tests

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
@@ -166,9 +166,8 @@ static bool hasRValueOverload(const CXXConstructorDecl *Ctor,
   };
 
   for (const auto *Candidate : Record->ctors()) {
-    if (IsRValueOverload(Candidate)) {
+    if (IsRValueOverload(Candidate))
       return true;
-    }
   }
   return false;
 }

--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.h
@@ -12,8 +12,6 @@
 #include "../ClangTidyCheck.h"
 #include "../utils/IncludeInserter.h"
 
-#include <memory>
-
 namespace clang::tidy::modernize {
 
 class PassByValueCheck : public ClangTidyCheck {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
@@ -32,7 +32,7 @@ struct A {
 Movable GlobalObj;
 struct B {
   B(const Movable &M) : M(GlobalObj) {}
-  // CHECK-FIXES: B(const Movable &M) : M(GlobalObj) {}
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   Movable M;
 };
 
@@ -40,11 +40,11 @@ struct B {
 struct C {
   // Tests extra-reference in body.
   C(const Movable &M) : M(M) { this->i = M.a; }
-  // CHECK-FIXES: C(const Movable &M) : M(M) { this->i = M.a; }
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
 
   // Tests extra-reference in init-list.
   C(const Movable &M, int) : M(M), i(M.a) {}
-  // CHECK-FIXES: C(const Movable &M, int) : M(M), i(M.a) {}
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   Movable M;
   int i;
 };
@@ -70,7 +70,7 @@ struct E {
 // Test with object that can't be moved.
 struct F {
   F(const NotMovable &NM) : NM(NM) {}
-  // CHECK-FIXES: F(const NotMovable &NM) : NM(NM) {}
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   NotMovable NM;
 };
 
@@ -112,7 +112,8 @@ struct I {
 // Test that templates aren't modified.
 template <typename T> struct J {
   J(const T &M) : M(M) {}
-  // CHECK-FIXES: J(const T &M) : M(M) {}
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
+  // CHECK-FIXES-NOT: J(T M) : M(std::move(M)) {}
   T M;
 };
 J<Movable> j1(Movable());
@@ -129,13 +130,14 @@ struct MovableTemplateT
 template <class T>
 struct J2 {
   J2(const MovableTemplateT<T>& A);
-  // CHECK-FIXES: J2(const MovableTemplateT<T>& A);
+  // CHECK-FIXES-NOT: J2(MovableTemplateT<T> A);
   MovableTemplateT<T> M;
 };
 
 template <class T>
 J2<T>::J2(const MovableTemplateT<T>& A) : M(A) {}
-// CHECK-FIXES: J2<T>::J2(const MovableTemplateT<T>& A) : M(A) {}
+// CHECK-MESSAGES-NOT: :[[@LINE-1]]:11: warning: pass by value and use std::move
+// CHECK-FIXES-NOT: J2<T>::J2(MovableTemplateT<T> A) : M(std::move(A)) {}
 J2<int> j3(MovableTemplateT<int>{});
 
 struct K_Movable {
@@ -182,7 +184,7 @@ struct O {
 // Test with a const-value parameter.
 struct P {
   P(const Movable M) : M(M) {}
-  // CHECK-FIXES: P(const Movable M) : M(M) {}
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   Movable M;
 };
 
@@ -215,7 +217,7 @@ struct R {
 // Test with rvalue parameter.
 struct S {
   S(Movable &&M) : M(M) {}
-  // CHECK-FIXES: S(Movable &&M) : M(M) {}
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   Movable M;
 };
 
@@ -225,13 +227,13 @@ template <typename T, int N> struct array { T A[N]; };
 // cause problems with performance-move-const-arg, as it will revert it.
 struct T {
   T(array<int, 10> a) : a_(a) {}
-  // CHECK-FIXES: T(array<int, 10> a) : a_(a) {}
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   array<int, 10> a_;
 };
 
 struct U {
   U(const POD &M) : M(M) {}
-  // CHECK-FIXES: U(const POD &M) : M(M) {}
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   POD M;
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
@@ -32,7 +32,6 @@ struct A {
 Movable GlobalObj;
 struct B {
   B(const Movable &M) : M(GlobalObj) {}
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   Movable M;
 };
 
@@ -40,11 +39,9 @@ struct B {
 struct C {
   // Tests extra-reference in body.
   C(const Movable &M) : M(M) { this->i = M.a; }
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
 
   // Tests extra-reference in init-list.
   C(const Movable &M, int) : M(M), i(M.a) {}
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   Movable M;
   int i;
 };
@@ -70,7 +67,6 @@ struct E {
 // Test with object that can't be moved.
 struct F {
   F(const NotMovable &NM) : NM(NM) {}
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   NotMovable NM;
 };
 
@@ -112,8 +108,6 @@ struct I {
 // Test that templates aren't modified.
 template <typename T> struct J {
   J(const T &M) : M(M) {}
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
-  // CHECK-FIXES-NOT: J(T M) : M(std::move(M)) {}
   T M;
 };
 J<Movable> j1(Movable());
@@ -130,14 +124,11 @@ struct MovableTemplateT
 template <class T>
 struct J2 {
   J2(const MovableTemplateT<T>& A);
-  // CHECK-FIXES-NOT: J2(MovableTemplateT<T> A);
   MovableTemplateT<T> M;
 };
 
 template <class T>
 J2<T>::J2(const MovableTemplateT<T>& A) : M(A) {}
-// CHECK-MESSAGES-NOT: :[[@LINE-1]]:11: warning: pass by value and use std::move
-// CHECK-FIXES-NOT: J2<T>::J2(MovableTemplateT<T> A) : M(std::move(A)) {}
 J2<int> j3(MovableTemplateT<int>{});
 
 struct K_Movable {
@@ -184,7 +175,6 @@ struct O {
 // Test with a const-value parameter.
 struct P {
   P(const Movable M) : M(M) {}
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   Movable M;
 };
 
@@ -217,7 +207,6 @@ struct R {
 // Test with rvalue parameter.
 struct S {
   S(Movable &&M) : M(M) {}
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   Movable M;
 };
 
@@ -227,13 +216,11 @@ template <typename T, int N> struct array { T A[N]; };
 // cause problems with performance-move-const-arg, as it will revert it.
 struct T {
   T(array<int, 10> a) : a_(a) {}
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   array<int, 10> a_;
 };
 
 struct U {
   U(const POD &M) : M(M) {}
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:5: warning: pass by value and use std::move
   POD M;
 };
 


### PR DESCRIPTION
- Deleted unused includes
- Deleted useless braces
- Modernized tests to use `CHECK-MESSAGES-NOT` and `CHECK-FIXES-NOT` for better readability and maintainability