### PR TITLE
[clang-tidy][NFC] Refactor `modernize-use-trailing-return-type-check` check code and tests

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -113,7 +113,7 @@ private:
 };
 } // namespace
 
-constexpr llvm::StringLiteral Message =
+constexpr llvm::StringLiteral MessageFunction =
     "use a trailing return type for this function";
 
 static SourceLocation expandIfMacroId(SourceLocation Loc,
@@ -125,7 +125,7 @@ static SourceLocation expandIfMacroId(SourceLocation Loc,
   return Loc;
 }
 
-SourceLocation UseTrailingReturnTypeCheck::findTrailingReturnTypeSourceLocation(
+static SourceLocation findTrailingReturnTypeSourceLocation(
     const FunctionDecl &F, const FunctionTypeLoc &FTL, const ASTContext &Ctx,
     const SourceManager &SM, const LangOptions &LangOpts) {
   // We start with the location of the closing parenthesis.
@@ -217,10 +217,11 @@ classifyToken(const FunctionDecl &F, Preprocessor &PP, Token Tok) {
   return CT;
 }
 
-std::optional<SmallVector<ClassifiedToken, 8>>
-UseTrailingReturnTypeCheck::classifyTokensBeforeFunctionName(
-    const FunctionDecl &F, const ASTContext &Ctx, const SourceManager &SM,
-    const LangOptions &LangOpts) {
+static std::optional<SmallVector<ClassifiedToken, 8>>
+classifyTokensBeforeFunctionName(const FunctionDecl &F, const ASTContext &Ctx,
+                                 const SourceManager &SM,
+                                 const LangOptions &LangOpts,
+                                 Preprocessor *PP) {
   SourceLocation BeginF = expandIfMacroId(F.getBeginLoc(), SM);
   SourceLocation BeginNameF = expandIfMacroId(F.getLocation(), SM);
 
@@ -242,7 +243,6 @@ UseTrailingReturnTypeCheck::classifyTokensBeforeFunctionName(
         const MacroInfo *MI = PP->getMacroInfo(&Info);
         if (!MI || MI->isFunctionLike()) {
           // Cannot handle function style macros.
-          diag(F.getLocation(), Message);
           return std::nullopt;
         }
       }
@@ -253,10 +253,8 @@ UseTrailingReturnTypeCheck::classifyTokensBeforeFunctionName(
 
     if (std::optional<ClassifiedToken> CT = classifyToken(F, *PP, T))
       ClassifiedTokens.push_back(*CT);
-    else {
-      diag(F.getLocation(), Message);
+    else
       return std::nullopt;
-    }
   }
 
   return ClassifiedTokens;
@@ -273,9 +271,10 @@ static bool hasAnyNestedLocalQualifiers(QualType Type) {
   return Result;
 }
 
-SourceRange UseTrailingReturnTypeCheck::findReturnTypeAndCVSourceRange(
-    const FunctionDecl &F, const TypeLoc &ReturnLoc, const ASTContext &Ctx,
-    const SourceManager &SM, const LangOptions &LangOpts) {
+static SourceRange
+findReturnTypeAndCVSourceRange(const FunctionDecl &F, const TypeLoc &ReturnLoc,
+                               const ASTContext &Ctx, const SourceManager &SM,
+                               const LangOptions &LangOpts, Preprocessor *PP) {
 
   // We start with the range of the return type and expand to neighboring
   // qualifiers (const, volatile and restrict).
@@ -283,7 +282,6 @@ SourceRange UseTrailingReturnTypeCheck::findReturnTypeAndCVSourceRange(
   if (ReturnTypeRange.isInvalid()) {
     // Happens if e.g. clang cannot resolve all includes and the return type is
     // unknown.
-    diag(F.getLocation(), Message);
     return {};
   }
 
@@ -294,7 +292,7 @@ SourceRange UseTrailingReturnTypeCheck::findReturnTypeAndCVSourceRange(
 
   // Include qualifiers to the left and right of the return type.
   std::optional<SmallVector<ClassifiedToken, 8>> MaybeTokens =
-      classifyTokensBeforeFunctionName(F, Ctx, SM, LangOpts);
+      classifyTokensBeforeFunctionName(F, Ctx, SM, LangOpts, PP);
   if (!MaybeTokens)
     return {};
   const SmallVector<ClassifiedToken, 8> &Tokens = *MaybeTokens;
@@ -331,10 +329,11 @@ SourceRange UseTrailingReturnTypeCheck::findReturnTypeAndCVSourceRange(
   return ReturnTypeRange;
 }
 
-void UseTrailingReturnTypeCheck::keepSpecifiers(
-    std::string &ReturnType, std::string &Auto, SourceRange ReturnTypeCVRange,
-    const FunctionDecl &F, const FriendDecl *Fr, const ASTContext &Ctx,
-    const SourceManager &SM, const LangOptions &LangOpts) {
+static void keepSpecifiers(std::string &ReturnType, std::string &Auto,
+                           SourceRange ReturnTypeCVRange, const FunctionDecl &F,
+                           const FriendDecl *Fr, const ASTContext &Ctx,
+                           const SourceManager &SM, const LangOptions &LangOpts,
+                           Preprocessor *PP) {
   // Check if there are specifiers inside the return type. E.g. unsigned
   // inline int.
   const auto *M = dyn_cast<CXXMethodDecl>(&F);
@@ -346,7 +345,7 @@ void UseTrailingReturnTypeCheck::keepSpecifiers(
   // Tokenize return type. If it contains macros which contain a mix of
   // qualifiers, specifiers and types, give up.
   std::optional<SmallVector<ClassifiedToken, 8>> MaybeTokens =
-      classifyTokensBeforeFunctionName(F, Ctx, SM, LangOpts);
+      classifyTokensBeforeFunctionName(F, Ctx, SM, LangOpts, PP);
   if (!MaybeTokens)
     return;
 
@@ -382,6 +381,10 @@ void UseTrailingReturnTypeCheck::keepSpecifiers(
     DeletedChars += TLengthWithWS;
   }
 }
+
+UseTrailingReturnTypeCheck::UseTrailingReturnTypeCheck(
+    StringRef Name, ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context) {}
 
 void UseTrailingReturnTypeCheck::registerMatchers(MatchFinder *Finder) {
   auto F = functionDecl(
@@ -423,7 +426,7 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
   if (F->getDeclaredReturnType()->isFunctionPointerType() ||
       F->getDeclaredReturnType()->isMemberFunctionPointerType() ||
       F->getDeclaredReturnType()->isMemberPointerType()) {
-    diag(F->getLocation(), Message);
+    diag(F->getLocation(), MessageFunction);
     return;
   }
 
@@ -440,24 +443,26 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
     // FIXME: This may happen if we have __attribute__((...)) on the function.
     // We abort for now. Remove this when the function type location gets
     // available in clang.
-    diag(F->getLocation(), Message);
+    diag(F->getLocation(), MessageFunction);
     return;
   }
 
   SourceLocation InsertionLoc =
       findTrailingReturnTypeSourceLocation(*F, FTL, Ctx, SM, LangOpts);
   if (InsertionLoc.isInvalid()) {
-    diag(F->getLocation(), Message);
+    diag(F->getLocation(), MessageFunction);
     return;
   }
 
   // Using the declared return type via F->getDeclaredReturnType().getAsString()
   // discards user formatting and order of const, volatile, type, whitespace,
   // space before & ... .
-  SourceRange ReturnTypeCVRange =
-      findReturnTypeAndCVSourceRange(*F, FTL.getReturnLoc(), Ctx, SM, LangOpts);
-  if (ReturnTypeCVRange.isInvalid())
+  SourceRange ReturnTypeCVRange = findReturnTypeAndCVSourceRange(
+      *F, FTL.getReturnLoc(), Ctx, SM, LangOpts, PP);
+  if (ReturnTypeCVRange.isInvalid()) {
+    diag(F->getLocation(), MessageFunction);
     return;
+  }
 
   // Check if unqualified names in the return type conflict with other entities
   // after the rewrite.
@@ -470,7 +475,7 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
   UnqualNameVisitor UNV{*F};
   UNV.TraverseTypeLoc(FTL.getReturnLoc());
   if (UNV.Collision) {
-    diag(F->getLocation(), Message);
+    diag(F->getLocation(), MessageFunction);
     return;
   }
 
@@ -486,10 +491,10 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
   std::string Auto = NeedSpaceAfterAuto ? "auto " : "auto";
   std::string ReturnType =
       std::string(tooling::fixit::getText(ReturnTypeCVRange, Ctx));
-  keepSpecifiers(ReturnType, Auto, ReturnTypeCVRange, *F, Fr, Ctx, SM,
-                 LangOpts);
+  keepSpecifiers(ReturnType, Auto, ReturnTypeCVRange, *F, Fr, Ctx, SM, LangOpts,
+                 PP);
 
-  diag(F->getLocation(), Message)
+  diag(F->getLocation(), MessageFunction)
       << FixItHint::CreateReplacement(ReturnTypeCVRange, Auto)
       << FixItHint::CreateInsertion(InsertionLoc, " -> " + ReturnType);
 }

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -113,7 +113,7 @@ private:
 };
 } // namespace
 
-constexpr llvm::StringLiteral MessageFunction =
+constexpr llvm::StringLiteral ErrorMessageOnFunction =
     "use a trailing return type for this function";
 
 static SourceLocation expandIfMacroId(SourceLocation Loc,
@@ -422,7 +422,7 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
   if (F->getDeclaredReturnType()->isFunctionPointerType() ||
       F->getDeclaredReturnType()->isMemberFunctionPointerType() ||
       F->getDeclaredReturnType()->isMemberPointerType()) {
-    diag(F->getLocation(), MessageFunction);
+    diag(F->getLocation(), ErrorMessageOnFunction);
     return;
   }
 
@@ -439,14 +439,14 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
     // FIXME: This may happen if we have __attribute__((...)) on the function.
     // We abort for now. Remove this when the function type location gets
     // available in clang.
-    diag(F->getLocation(), MessageFunction);
+    diag(F->getLocation(), ErrorMessageOnFunction);
     return;
   }
 
   SourceLocation InsertionLoc =
       findTrailingReturnTypeSourceLocation(*F, FTL, Ctx, SM, LangOpts);
   if (InsertionLoc.isInvalid()) {
-    diag(F->getLocation(), MessageFunction);
+    diag(F->getLocation(), ErrorMessageOnFunction);
     return;
   }
 
@@ -456,7 +456,7 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
   SourceRange ReturnTypeCVRange = findReturnTypeAndCVSourceRange(
       *F, FTL.getReturnLoc(), Ctx, SM, LangOpts, PP);
   if (ReturnTypeCVRange.isInvalid()) {
-    diag(F->getLocation(), MessageFunction);
+    diag(F->getLocation(), ErrorMessageOnFunction);
     return;
   }
 
@@ -471,7 +471,7 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
   UnqualNameVisitor UNV{*F};
   UNV.TraverseTypeLoc(FTL.getReturnLoc());
   if (UNV.Collision) {
-    diag(F->getLocation(), MessageFunction);
+    diag(F->getLocation(), ErrorMessageOnFunction);
     return;
   }
 
@@ -490,7 +490,7 @@ void UseTrailingReturnTypeCheck::check(const MatchFinder::MatchResult &Result) {
   keepSpecifiers(ReturnType, Auto, ReturnTypeCVRange, *F, Fr, Ctx, SM, LangOpts,
                  PP);
 
-  diag(F->getLocation(), MessageFunction)
+  diag(F->getLocation(), ErrorMessageOnFunction)
       << FixItHint::CreateReplacement(ReturnTypeCVRange, Auto)
       << FixItHint::CreateInsertion(InsertionLoc, " -> " + ReturnType);
 }

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -382,10 +382,6 @@ static void keepSpecifiers(std::string &ReturnType, std::string &Auto,
   }
 }
 
-UseTrailingReturnTypeCheck::UseTrailingReturnTypeCheck(
-    StringRef Name, ClangTidyContext *Context)
-    : ClangTidyCheck(Name, Context) {}
-
 void UseTrailingReturnTypeCheck::registerMatchers(MatchFinder *Finder) {
   auto F = functionDecl(
                unless(anyOf(hasTrailingReturn(), returns(voidType()),

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.h
@@ -11,7 +11,6 @@
 
 #include "../ClangTidyCheck.h"
 #include "clang/Lex/Token.h"
-#include <optional>
 
 namespace clang::tidy::modernize {
 
@@ -27,8 +26,7 @@ struct ClassifiedToken {
 /// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-trailing-return-type.html
 class UseTrailingReturnTypeCheck : public ClangTidyCheck {
 public:
-  UseTrailingReturnTypeCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  UseTrailingReturnTypeCheck(StringRef Name, ClangTidyContext *Context);
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus11;
   }
@@ -39,23 +37,6 @@ public:
 
 private:
   Preprocessor *PP = nullptr;
-
-  SourceLocation findTrailingReturnTypeSourceLocation(
-      const FunctionDecl &F, const FunctionTypeLoc &FTL, const ASTContext &Ctx,
-      const SourceManager &SM, const LangOptions &LangOpts);
-  std::optional<SmallVector<ClassifiedToken, 8>>
-  classifyTokensBeforeFunctionName(const FunctionDecl &F, const ASTContext &Ctx,
-                                   const SourceManager &SM,
-                                   const LangOptions &LangOpts);
-  SourceRange findReturnTypeAndCVSourceRange(const FunctionDecl &F,
-                                             const TypeLoc &ReturnLoc,
-                                             const ASTContext &Ctx,
-                                             const SourceManager &SM,
-                                             const LangOptions &LangOpts);
-  void keepSpecifiers(std::string &ReturnType, std::string &Auto,
-                      SourceRange ReturnTypeCVRange, const FunctionDecl &F,
-                      const FriendDecl *Fr, const ASTContext &Ctx,
-                      const SourceManager &SM, const LangOptions &LangOpts);
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.h
@@ -27,7 +27,7 @@ struct ClassifiedToken {
 class UseTrailingReturnTypeCheck : public ClangTidyCheck {
 public:
   UseTrailingReturnTypeCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {};
+      : ClangTidyCheck(Name, Context) {}
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus11;
   }

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.h
@@ -26,7 +26,8 @@ struct ClassifiedToken {
 /// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-trailing-return-type.html
 class UseTrailingReturnTypeCheck : public ClangTidyCheck {
 public:
-  UseTrailingReturnTypeCheck(StringRef Name, ClangTidyContext *Context);
+  UseTrailingReturnTypeCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {};
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus11;
   }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-cxx20.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++20 %s modernize-use-trailing-return-type %t
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-trailing-return-type %t
 
 namespace std {
 template <typename T, typename U>


### PR DESCRIPTION
- Deleted unused includes
- Deleted useless braces
- Converted private methods to static function to improve compilations speed and readability
- Modernized tests to use `cxx-or-later` 