### PR TITLE
[HVX] Support lowering of setuo, seto.

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -349,6 +349,8 @@ HexagonTargetLowering::initializeHVXLowering() {
   setCondCodeAction(ISD::SETULE, MVT::v64f16, Expand);
   setCondCodeAction(ISD::SETUGE, MVT::v64f16, Expand);
   setCondCodeAction(ISD::SETULT, MVT::v64f16, Expand);
+  setCondCodeAction(ISD::SETUO, MVT::v64f16, Expand);
+  setCondCodeAction(ISD::SETO, MVT::v64f16, Expand);
 
   setCondCodeAction(ISD::SETNE,  MVT::v32f32, Expand);
   setCondCodeAction(ISD::SETLE,  MVT::v32f32, Expand);
@@ -362,6 +364,8 @@ HexagonTargetLowering::initializeHVXLowering() {
   setCondCodeAction(ISD::SETULE, MVT::v32f32, Expand);
   setCondCodeAction(ISD::SETUGE, MVT::v32f32, Expand);
   setCondCodeAction(ISD::SETULT, MVT::v32f32, Expand);
+  setCondCodeAction(ISD::SETUO, MVT::v32f32, Expand);
+  setCondCodeAction(ISD::SETO, MVT::v32f32, Expand);
 
   // Boolean vectors.
 

--- a/llvm/test/CodeGen/Hexagon/inst_setcc_uno_uo.ll
+++ b/llvm/test/CodeGen/Hexagon/inst_setcc_uno_uo.ll
@@ -1,4 +1,4 @@
-;; RUN: llc --mtriple=hexagon -mattr=+hvx79,+hvx-length128b %s -o - | FileCheck %s
+;; RUN: llc --mtriple=hexagon -mattr=+hvxv79,+hvx-length128b %s -o - | FileCheck %s
 
 define dso_local void @store_isnan_f32(ptr %a, ptr %isnan_a) local_unnamed_addr {
 entry:

--- a/llvm/test/CodeGen/Hexagon/inst_setcc_uno_uo.ll
+++ b/llvm/test/CodeGen/Hexagon/inst_setcc_uno_uo.ll
@@ -1,4 +1,4 @@
-;; RUN: llc --mtriple=hexagon -mcpu=hexagonv79 -mattr=+hvx,+hvx-length128b %s -o - | FileCheck %s
+;; RUN: llc --mtriple=hexagon -mattr=+hvx79,+hvx-length128b %s -o - | FileCheck %s
 
 define dso_local void @store_isnan_f32(ptr %a, ptr %isnan_a) local_unnamed_addr {
 entry:

--- a/llvm/test/MC/Hexagon/inst_setcc_uno_uo.ll
+++ b/llvm/test/MC/Hexagon/inst_setcc_uno_uo.ll
@@ -1,0 +1,20 @@
+;; RUN: llc -mv79 -mhvx %s -o - | FileCheck %s
+source_filename = "isnan.c"
+target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
+target triple = "hexagon"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite)
+define dso_local void @foo(ptr noundef readonly captures(none) %a, ptr noundef writeonly captures(none) %isnan_a) local_unnamed_addr #0 {
+entry:
+  %arrayidx = getelementptr inbounds nuw float, ptr %a, i32 0
+  %0 = load <32 x float>, ptr %arrayidx, align 4
+  %.ripple.vectorized = fcmp uno <32 x float> %0, zeroinitializer
+  %arrayidx1 = getelementptr inbounds nuw i8, ptr %isnan_a, i32 0
+  %storedv.ripple.LS.instance = zext <32 x i1> %.ripple.vectorized to <32 x i8>
+  store <32 x i8> %storedv.ripple.LS.instance, ptr %arrayidx1, align 1
+  ret void
+}
+
+;; CHECK: vcmp.eq
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="hexagonv79" "target-features"="+hmx,+hvx-length128b,+hvxv79,+v79,-long-calls" }

--- a/llvm/test/MC/Hexagon/inst_setcc_uno_uo.ll
+++ b/llvm/test/MC/Hexagon/inst_setcc_uno_uo.ll
@@ -1,20 +1,28 @@
-;; RUN: llc -mv79 -mhvx %s -o - | FileCheck %s
-source_filename = "isnan.c"
-target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
-target triple = "hexagon"
+;; RUN: llc --mtriple=hexagon -mattr=+hvxv79,+hvx-length128b %s -o - | FileCheck %s
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite)
-define dso_local void @foo(ptr noundef readonly captures(none) %a, ptr noundef writeonly captures(none) %isnan_a) local_unnamed_addr #0 {
+define dso_local void @store_isnan_f32(ptr %a, ptr %isnan_a) local_unnamed_addr {
 entry:
   %arrayidx = getelementptr inbounds nuw float, ptr %a, i32 0
   %0 = load <32 x float>, ptr %arrayidx, align 4
-  %.ripple.vectorized = fcmp uno <32 x float> %0, zeroinitializer
-  %arrayidx1 = getelementptr inbounds nuw i8, ptr %isnan_a, i32 0
-  %storedv.ripple.LS.instance = zext <32 x i1> %.ripple.vectorized to <32 x i8>
-  store <32 x i8> %storedv.ripple.LS.instance, ptr %arrayidx1, align 1
+  %.vectorized = fcmp uno <32 x float> %0, zeroinitializer
+  %.LS.instance = zext <32 x i1> %.vectorized to <32 x i32>
+  %arrayidx1 = getelementptr inbounds nuw i32, ptr %isnan_a, i32 0
+  store <32 x i32> %.LS.instance, ptr %arrayidx1, align 4
+  ret void
+}
+;; CHECK: store_isnan_f32
+;; CHECK: vcmp.eq({{v[0-9]+.w}},{{v[0-9]+.w}})
+
+define dso_local void @store_isnan_f16(ptr  %a, ptr %isnan_a) local_unnamed_addr {
+entry:
+  %arrayidx = getelementptr inbounds nuw half, ptr %a, i32 0
+  %0 = load <64 x half>, ptr %arrayidx, align 2
+  %.vectorized = fcmp uno <64 x half> %0, zeroinitializer
+  %conv.LS.instance = zext <64 x i1> %.vectorized to <64 x i16>
+  %arrayidx1 = getelementptr inbounds nuw i16, ptr %isnan_a, i32 0
+  store <64 x i16> %conv.LS.instance, ptr %arrayidx1, align 2
   ret void
 }
 
-;; CHECK: vcmp.eq
-
-attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="hexagonv79" "target-features"="+hmx,+hvx-length128b,+hvxv79,+v79,-long-calls" }
+;; CHECK: store_isnan_f16
+;; CHECK: vcmp.eq({{v[0-9]+.h}},{{v[0-9]+.h}})

--- a/llvm/test/MC/Hexagon/inst_setcc_uno_uo.ll
+++ b/llvm/test/MC/Hexagon/inst_setcc_uno_uo.ll
@@ -1,4 +1,4 @@
-;; RUN: llc --mtriple=hexagon -mattr=+hvxv79,+hvx-length128b %s -o - | FileCheck %s
+;; RUN: llc --mtriple=hexagon -mcpu=hexagonv79 -mattr=+hvx,+hvx-length128b %s -o - | FileCheck %s
 
 define dso_local void @store_isnan_f32(ptr %a, ptr %isnan_a) local_unnamed_addr {
 entry:


### PR DESCRIPTION
The provided regression, `Hexagon/inst_setcc_uno_uo.ll`, fails prior to this patch.