### PR TITLE
[flang] Fix crash in error recovery

### DIFF
--- a/flang/test/Semantics/bug869.f90
+++ b/flang/test/Semantics/bug869.f90
@@ -1,0 +1,10 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Regression test for crash
+subroutine sub(xx)
+  type(*) :: xx
+  type ty
+  end type
+  type(ty) obj
+  !ERROR: TYPE(*) dummy argument may only be used as an actual argument
+  obj = ty(xx)
+end


### PR DESCRIPTION
When a TYPE(*) dummy argument is erroneously used as a component value in a structure constructor, semantics crashes if the structure constructor had been initially parsed as a potential function reference.  Clean out stale typed expressions when reanalyzing the reconstructed parse subtree to ensure that errors are caught the next time around.