### PR TITLE
[llvm] annotate interfaces in llvm/DebugInfo for DLL export

### DIFF
--- a/llvm/include/llvm/DebugInfo/BTF/BTFContext.h
+++ b/llvm/include/llvm/DebugInfo/BTF/BTFContext.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_DEBUGINFO_BTF_BTFCONTEXT_H
 #define LLVM_DEBUGINFO_BTF_BTFCONTEXT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/BTF/BTFParser.h"
 #include "llvm/DebugInfo/DIContext.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/BTF/BTFContext.h
+++ b/llvm/include/llvm/DebugInfo/BTF/BTFContext.h
@@ -14,12 +14,13 @@
 #ifndef LLVM_DEBUGINFO_BTF_BTFCONTEXT_H
 #define LLVM_DEBUGINFO_BTF_BTFCONTEXT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/BTF/BTFParser.h"
 #include "llvm/DebugInfo/DIContext.h"
 
 namespace llvm {
 
-class BTFContext final : public DIContext {
+class LLVM_ABI BTFContext final : public DIContext {
   BTFParser BTF;
 
 public:

--- a/llvm/include/llvm/DebugInfo/BTF/BTFParser.h
+++ b/llvm/include/llvm/DebugInfo/BTF/BTFParser.h
@@ -22,6 +22,7 @@
 #ifndef LLVM_DEBUGINFO_BTF_BTFPARSER_H
 #define LLVM_DEBUGINFO_BTF_BTFPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/BTF/BTF.h"
 #include "llvm/Object/ObjectFile.h"
@@ -74,32 +75,32 @@ class BTFParser {
 public:
   // Looks-up a string in the .BTF section's string table.
   // Offset is relative to string table start.
-  StringRef findString(uint32_t Offset) const;
+  LLVM_ABI StringRef findString(uint32_t Offset) const;
 
   // Search for line information for a specific address,
   // address match is exact (contrary to DWARFContext).
   // Return nullptr if no information found.
   // If information is present, return a pointer to object
   // owned by this class.
-  const BTF::BPFLineInfo *findLineInfo(SectionedAddress Address) const;
+  LLVM_ABI const BTF::BPFLineInfo *findLineInfo(SectionedAddress Address) const;
 
   // Search for CO-RE relocation information for a specific address.
   // Return nullptr if no information found.
   // If information is present, return a pointer to object
   // owned by this class.
-  const BTF::BPFFieldReloc *findFieldReloc(SectionedAddress Address) const;
+  LLVM_ABI const BTF::BPFFieldReloc *findFieldReloc(SectionedAddress Address) const;
 
   // Return a human readable representation of the CO-RE relocation
   // record, this is for display purpose only.
   // See implementation for details.
-  void symbolize(const BTF::BPFFieldReloc *Reloc,
+  LLVM_ABI void symbolize(const BTF::BPFFieldReloc *Reloc,
                  SmallVectorImpl<char> &Result) const;
 
   // Lookup BTF type definition with a specific index.
   // Return nullptr if no information found.
   // If information is present, return a pointer to object
   // owned by this class.
-  const BTF::CommonType *findType(uint32_t Id) const;
+  LLVM_ABI const BTF::CommonType *findType(uint32_t Id) const;
 
   // Return total number of known BTF types.
   size_t typesCount() const { return Types.size(); }
@@ -120,11 +121,11 @@ public:
   // - state of the BTFParser might be incomplete but is not invalid,
   //   queries might be run against it, but some (or all) information
   //   might be unavailable;
-  Error parse(const ObjectFile &Obj, const ParseOptions &Opts);
+  LLVM_ABI Error parse(const ObjectFile &Obj, const ParseOptions &Opts);
   Error parse(const ObjectFile &Obj) { return parse(Obj, {true, true, true}); }
 
   // Return true if `Obj` has .BTF and .BTF.ext sections.
-  static bool hasBTFSections(const ObjectFile &Obj);
+  LLVM_ABI static bool hasBTFSections(const ObjectFile &Obj);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/BTF/BTFParser.h
+++ b/llvm/include/llvm/DebugInfo/BTF/BTFParser.h
@@ -22,10 +22,10 @@
 #ifndef LLVM_DEBUGINFO_BTF_BTFPARSER_H
 #define LLVM_DEBUGINFO_BTF_BTFPARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/BTF/BTF.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 
 namespace llvm {
@@ -88,13 +88,14 @@ public:
   // Return nullptr if no information found.
   // If information is present, return a pointer to object
   // owned by this class.
-  LLVM_ABI const BTF::BPFFieldReloc *findFieldReloc(SectionedAddress Address) const;
+  LLVM_ABI const BTF::BPFFieldReloc *
+  findFieldReloc(SectionedAddress Address) const;
 
   // Return a human readable representation of the CO-RE relocation
   // record, this is for display purpose only.
   // See implementation for details.
   LLVM_ABI void symbolize(const BTF::BPFFieldReloc *Reloc,
-                 SmallVectorImpl<char> &Result) const;
+                          SmallVectorImpl<char> &Result) const;
 
   // Lookup BTF type definition with a specific index.
   // Return nullptr if no information found.

--- a/llvm/include/llvm/DebugInfo/CodeView/AppendingTypeTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/AppendingTypeTableBuilder.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_APPENDINGTYPETABLEBUILDER_H
 #define LLVM_DEBUGINFO_CODEVIEW_APPENDINGTYPETABLEBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
@@ -17,6 +16,7 @@
 #include "llvm/DebugInfo/CodeView/TypeCollection.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/CodeView/AppendingTypeTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/AppendingTypeTableBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_APPENDINGTYPETABLEBUILDER_H
 #define LLVM_DEBUGINFO_CODEVIEW_APPENDINGTYPETABLEBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
@@ -23,7 +24,7 @@ namespace codeview {
 
 class ContinuationRecordBuilder;
 
-class AppendingTypeTableBuilder : public TypeCollection {
+class LLVM_ABI AppendingTypeTableBuilder : public TypeCollection {
 
   BumpPtrAllocator &RecordStorage;
   SimpleTypeSerializer SimpleSerializer;

--- a/llvm/include/llvm/DebugInfo/CodeView/CVSymbolVisitor.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CVSymbolVisitor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CVSYMBOLVISITOR_H
 #define LLVM_DEBUGINFO_CODEVIEW_CVSYMBOLVISITOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/Support/Error.h"
 
@@ -24,13 +25,13 @@ public:
     std::optional<uint32_t> ChildRecursiveDepth;
   };
 
-  CVSymbolVisitor(SymbolVisitorCallbacks &Callbacks);
+  LLVM_ABI CVSymbolVisitor(SymbolVisitorCallbacks &Callbacks);
 
-  Error visitSymbolRecord(CVSymbol &Record);
-  Error visitSymbolRecord(CVSymbol &Record, uint32_t Offset);
-  Error visitSymbolStream(const CVSymbolArray &Symbols);
-  Error visitSymbolStream(const CVSymbolArray &Symbols, uint32_t InitialOffset);
-  Error visitSymbolStreamFiltered(const CVSymbolArray &Symbols,
+  LLVM_ABI Error visitSymbolRecord(CVSymbol &Record);
+  LLVM_ABI Error visitSymbolRecord(CVSymbol &Record, uint32_t Offset);
+  LLVM_ABI Error visitSymbolStream(const CVSymbolArray &Symbols);
+  LLVM_ABI Error visitSymbolStream(const CVSymbolArray &Symbols, uint32_t InitialOffset);
+  LLVM_ABI Error visitSymbolStreamFiltered(const CVSymbolArray &Symbols,
                                   const FilterOptions &Filter);
 
 private:

--- a/llvm/include/llvm/DebugInfo/CodeView/CVSymbolVisitor.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CVSymbolVisitor.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CVSYMBOLVISITOR_H
 #define LLVM_DEBUGINFO_CODEVIEW_CVSYMBOLVISITOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -30,9 +30,10 @@ public:
   LLVM_ABI Error visitSymbolRecord(CVSymbol &Record);
   LLVM_ABI Error visitSymbolRecord(CVSymbol &Record, uint32_t Offset);
   LLVM_ABI Error visitSymbolStream(const CVSymbolArray &Symbols);
-  LLVM_ABI Error visitSymbolStream(const CVSymbolArray &Symbols, uint32_t InitialOffset);
+  LLVM_ABI Error visitSymbolStream(const CVSymbolArray &Symbols,
+                                   uint32_t InitialOffset);
   LLVM_ABI Error visitSymbolStreamFiltered(const CVSymbolArray &Symbols,
-                                  const FilterOptions &Filter);
+                                           const FilterOptions &Filter);
 
 private:
   SymbolVisitorCallbacks &Callbacks;

--- a/llvm/include/llvm/DebugInfo/CodeView/CVTypeVisitor.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CVTypeVisitor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CVTYPEVISITOR_H
 #define LLVM_DEBUGINFO_CODEVIEW_CVTYPEVISITOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -30,24 +31,24 @@ enum VisitorDataSource {
                     // supply the bytes.
 };
 
-Error visitTypeRecord(CVType &Record, TypeIndex Index,
+LLVM_ABI Error visitTypeRecord(CVType &Record, TypeIndex Index,
                       TypeVisitorCallbacks &Callbacks,
                       VisitorDataSource Source = VDS_BytesPresent);
-Error visitTypeRecord(CVType &Record, TypeVisitorCallbacks &Callbacks,
+LLVM_ABI Error visitTypeRecord(CVType &Record, TypeVisitorCallbacks &Callbacks,
                       VisitorDataSource Source = VDS_BytesPresent);
 
-Error visitMemberRecord(CVMemberRecord Record, TypeVisitorCallbacks &Callbacks,
+LLVM_ABI Error visitMemberRecord(CVMemberRecord Record, TypeVisitorCallbacks &Callbacks,
                         VisitorDataSource Source = VDS_BytesPresent);
-Error visitMemberRecord(TypeLeafKind Kind, ArrayRef<uint8_t> Record,
+LLVM_ABI Error visitMemberRecord(TypeLeafKind Kind, ArrayRef<uint8_t> Record,
                         TypeVisitorCallbacks &Callbacks);
 
-Error visitMemberRecordStream(ArrayRef<uint8_t> FieldList,
+LLVM_ABI Error visitMemberRecordStream(ArrayRef<uint8_t> FieldList,
                               TypeVisitorCallbacks &Callbacks);
 
-Error visitTypeStream(const CVTypeArray &Types, TypeVisitorCallbacks &Callbacks,
+LLVM_ABI Error visitTypeStream(const CVTypeArray &Types, TypeVisitorCallbacks &Callbacks,
                       VisitorDataSource Source = VDS_BytesPresent);
-Error visitTypeStream(CVTypeRange Types, TypeVisitorCallbacks &Callbacks);
-Error visitTypeStream(TypeCollection &Types, TypeVisitorCallbacks &Callbacks);
+LLVM_ABI Error visitTypeStream(CVTypeRange Types, TypeVisitorCallbacks &Callbacks);
+LLVM_ABI Error visitTypeStream(TypeCollection &Types, TypeVisitorCallbacks &Callbacks);
 
 } // end namespace codeview
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/CVTypeVisitor.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CVTypeVisitor.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CVTYPEVISITOR_H
 #define LLVM_DEBUGINFO_CODEVIEW_CVTYPEVISITOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -32,23 +32,27 @@ enum VisitorDataSource {
 };
 
 LLVM_ABI Error visitTypeRecord(CVType &Record, TypeIndex Index,
-                      TypeVisitorCallbacks &Callbacks,
-                      VisitorDataSource Source = VDS_BytesPresent);
+                               TypeVisitorCallbacks &Callbacks,
+                               VisitorDataSource Source = VDS_BytesPresent);
 LLVM_ABI Error visitTypeRecord(CVType &Record, TypeVisitorCallbacks &Callbacks,
-                      VisitorDataSource Source = VDS_BytesPresent);
+                               VisitorDataSource Source = VDS_BytesPresent);
 
-LLVM_ABI Error visitMemberRecord(CVMemberRecord Record, TypeVisitorCallbacks &Callbacks,
-                        VisitorDataSource Source = VDS_BytesPresent);
+LLVM_ABI Error visitMemberRecord(CVMemberRecord Record,
+                                 TypeVisitorCallbacks &Callbacks,
+                                 VisitorDataSource Source = VDS_BytesPresent);
 LLVM_ABI Error visitMemberRecord(TypeLeafKind Kind, ArrayRef<uint8_t> Record,
-                        TypeVisitorCallbacks &Callbacks);
+                                 TypeVisitorCallbacks &Callbacks);
 
 LLVM_ABI Error visitMemberRecordStream(ArrayRef<uint8_t> FieldList,
-                              TypeVisitorCallbacks &Callbacks);
+                                       TypeVisitorCallbacks &Callbacks);
 
-LLVM_ABI Error visitTypeStream(const CVTypeArray &Types, TypeVisitorCallbacks &Callbacks,
-                      VisitorDataSource Source = VDS_BytesPresent);
-LLVM_ABI Error visitTypeStream(CVTypeRange Types, TypeVisitorCallbacks &Callbacks);
-LLVM_ABI Error visitTypeStream(TypeCollection &Types, TypeVisitorCallbacks &Callbacks);
+LLVM_ABI Error visitTypeStream(const CVTypeArray &Types,
+                               TypeVisitorCallbacks &Callbacks,
+                               VisitorDataSource Source = VDS_BytesPresent);
+LLVM_ABI Error visitTypeStream(CVTypeRange Types,
+                               TypeVisitorCallbacks &Callbacks);
+LLVM_ABI Error visitTypeStream(TypeCollection &Types,
+                               TypeVisitorCallbacks &Callbacks);
 
 } // end namespace codeview
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/CodeView.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeView.h
@@ -528,7 +528,8 @@ enum class EncodedFramePtrReg : uint8_t {
   BasePtr = 3,
 };
 
-LLVM_ABI RegisterId decodeFramePtrReg(EncodedFramePtrReg EncodedReg, CPUType CPU);
+LLVM_ABI RegisterId decodeFramePtrReg(EncodedFramePtrReg EncodedReg,
+                                      CPUType CPU);
 
 LLVM_ABI EncodedFramePtrReg encodeFramePtrReg(RegisterId Reg, CPUType CPU);
 

--- a/llvm/include/llvm/DebugInfo/CodeView/CodeView.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeView.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CODEVIEW_H
 #define LLVM_DEBUGINFO_CODEVIEW_CODEVIEW_H
 
+#include "llvm/Support/Compiler.h"
 #include <cinttypes>
 #include <type_traits>
 
@@ -527,9 +528,9 @@ enum class EncodedFramePtrReg : uint8_t {
   BasePtr = 3,
 };
 
-RegisterId decodeFramePtrReg(EncodedFramePtrReg EncodedReg, CPUType CPU);
+LLVM_ABI RegisterId decodeFramePtrReg(EncodedFramePtrReg EncodedReg, CPUType CPU);
 
-EncodedFramePtrReg encodeFramePtrReg(RegisterId Reg, CPUType CPU);
+LLVM_ABI EncodedFramePtrReg encodeFramePtrReg(RegisterId Reg, CPUType CPU);
 
 /// These values correspond to the THUNK_ORDINAL enumeration.
 enum class ThunkOrdinal : uint8_t {

--- a/llvm/include/llvm/DebugInfo/CodeView/CodeViewError.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeViewError.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CODEVIEWERROR_H
 #define LLVM_DEBUGINFO_CODEVIEW_CODEVIEWERROR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -31,7 +32,7 @@ struct is_error_code_enum<llvm::codeview::cv_error_code> : std::true_type {};
 
 namespace llvm {
 namespace codeview {
-const std::error_category &CVErrorCategory();
+LLVM_ABI const std::error_category &CVErrorCategory();
 
 inline std::error_code make_error_code(cv_error_code E) {
   return std::error_code(static_cast<int>(E), CVErrorCategory());
@@ -43,7 +44,7 @@ public:
   using ErrorInfo<CodeViewError,
                   StringError>::ErrorInfo; // inherit constructors
   CodeViewError(const Twine &S) : ErrorInfo(S, cv_error_code::unspecified) {}
-  static char ID;
+  LLVM_ABI static char ID;
 };
 
 } // namespace codeview

--- a/llvm/include/llvm/DebugInfo/CodeView/CodeViewRecordIO.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeViewRecordIO.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CODEVIEWRECORDIO_H
 #define LLVM_DEBUGINFO_CODEVIEW_CODEVIEWRECORDIO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeViewError.h"
 #include "llvm/Support/BinaryStreamReader.h"
 #include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cassert>
 #include <cstdint>
@@ -138,7 +138,7 @@ public:
   LLVM_ABI Error mapGuid(GUID &Guid, const Twine &Comment = "");
 
   LLVM_ABI Error mapStringZVectorZ(std::vector<StringRef> &Value,
-                          const Twine &Comment = "");
+                                   const Twine &Comment = "");
 
   template <typename SizeType, typename T, typename ElementMapper>
   Error mapVectorN(T &Items, const ElementMapper &Mapper,
@@ -198,9 +198,10 @@ public:
     return Error::success();
   }
 
-  LLVM_ABI Error mapByteVectorTail(ArrayRef<uint8_t> &Bytes, const Twine &Comment = "");
+  LLVM_ABI Error mapByteVectorTail(ArrayRef<uint8_t> &Bytes,
+                                   const Twine &Comment = "");
   LLVM_ABI Error mapByteVectorTail(std::vector<uint8_t> &Bytes,
-                          const Twine &Comment = "");
+                                   const Twine &Comment = "");
 
   LLVM_ABI Error padToAlignment(uint32_t Align);
   LLVM_ABI Error skipPadding();

--- a/llvm/include/llvm/DebugInfo/CodeView/CodeViewRecordIO.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeViewRecordIO.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CODEVIEWRECORDIO_H
 #define LLVM_DEBUGINFO_CODEVIEW_CODEVIEWRECORDIO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeViewError.h"
@@ -61,10 +62,10 @@ public:
   explicit CodeViewRecordIO(CodeViewRecordStreamer &Streamer)
       : Streamer(&Streamer) {}
 
-  Error beginRecord(std::optional<uint32_t> MaxLength);
-  Error endRecord();
+  LLVM_ABI Error beginRecord(std::optional<uint32_t> MaxLength);
+  LLVM_ABI Error endRecord();
 
-  Error mapInteger(TypeIndex &TypeInd, const Twine &Comment = "");
+  LLVM_ABI Error mapInteger(TypeIndex &TypeInd, const Twine &Comment = "");
 
   bool isStreaming() const {
     return (Streamer != nullptr) && (Reader == nullptr) && (Writer == nullptr);
@@ -76,7 +77,7 @@ public:
     return (Writer != nullptr) && (Streamer == nullptr) && (Reader == nullptr);
   }
 
-  uint32_t maxFieldLength() const;
+  LLVM_ABI uint32_t maxFieldLength() const;
 
   template <typename T> Error mapObject(T &Value) {
     if (isStreaming()) {
@@ -130,13 +131,13 @@ public:
     return Error::success();
   }
 
-  Error mapEncodedInteger(int64_t &Value, const Twine &Comment = "");
-  Error mapEncodedInteger(uint64_t &Value, const Twine &Comment = "");
-  Error mapEncodedInteger(APSInt &Value, const Twine &Comment = "");
-  Error mapStringZ(StringRef &Value, const Twine &Comment = "");
-  Error mapGuid(GUID &Guid, const Twine &Comment = "");
+  LLVM_ABI Error mapEncodedInteger(int64_t &Value, const Twine &Comment = "");
+  LLVM_ABI Error mapEncodedInteger(uint64_t &Value, const Twine &Comment = "");
+  LLVM_ABI Error mapEncodedInteger(APSInt &Value, const Twine &Comment = "");
+  LLVM_ABI Error mapStringZ(StringRef &Value, const Twine &Comment = "");
+  LLVM_ABI Error mapGuid(GUID &Guid, const Twine &Comment = "");
 
-  Error mapStringZVectorZ(std::vector<StringRef> &Value,
+  LLVM_ABI Error mapStringZVectorZ(std::vector<StringRef> &Value,
                           const Twine &Comment = "");
 
   template <typename SizeType, typename T, typename ElementMapper>
@@ -197,12 +198,12 @@ public:
     return Error::success();
   }
 
-  Error mapByteVectorTail(ArrayRef<uint8_t> &Bytes, const Twine &Comment = "");
-  Error mapByteVectorTail(std::vector<uint8_t> &Bytes,
+  LLVM_ABI Error mapByteVectorTail(ArrayRef<uint8_t> &Bytes, const Twine &Comment = "");
+  LLVM_ABI Error mapByteVectorTail(std::vector<uint8_t> &Bytes,
                           const Twine &Comment = "");
 
-  Error padToAlignment(uint32_t Align);
-  Error skipPadding();
+  LLVM_ABI Error padToAlignment(uint32_t Align);
+  LLVM_ABI Error skipPadding();
 
   uint64_t getStreamedLen() {
     if (isStreaming())

--- a/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CONTINUATIONRECORDBUILDER_H
 #define LLVM_DEBUGINFO_CODEVIEW_CONTINUATIONRECORDBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
@@ -38,17 +39,17 @@ class ContinuationRecordBuilder {
                              std::optional<TypeIndex> RefersTo);
 
 public:
-  ContinuationRecordBuilder();
-  ~ContinuationRecordBuilder();
+  LLVM_ABI ContinuationRecordBuilder();
+  LLVM_ABI ~ContinuationRecordBuilder();
 
-  void begin(ContinuationRecordKind RecordKind);
+  LLVM_ABI void begin(ContinuationRecordKind RecordKind);
 
   // This template is explicitly instantiated in the implementation file for all
   // supported types.  The method itself is ugly, so inlining it into the header
   // file clutters an otherwise straightforward interface.
   template <typename RecordType> void writeMemberType(RecordType &Record);
 
-  std::vector<CVType> end(TypeIndex Index);
+  LLVM_ABI std::vector<CVType> end(TypeIndex Index);
 };
 } // namespace codeview
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_CONTINUATIONRECORDBUILDER_H
 #define LLVM_DEBUGINFO_CODEVIEW_CONTINUATIONRECORDBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeRecordMapping.h"
 #include "llvm/Support/BinaryByteStream.h"
 #include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <vector>
 

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugChecksumsSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugChecksumsSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGCHECKSUMSSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGCHECKSUMSSUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -42,7 +43,7 @@ template <> struct VarStreamArrayExtractor<codeview::FileChecksumEntry> {
 public:
   using ContextType = void;
 
-  Error operator()(BinaryStreamRef Stream, uint32_t &Len,
+  LLVM_ABI Error operator()(BinaryStreamRef Stream, uint32_t &Len,
                    codeview::FileChecksumEntry &Item);
 };
 
@@ -62,8 +63,8 @@ public:
 
   bool valid() const { return Checksums.valid(); }
 
-  Error initialize(BinaryStreamReader Reader);
-  Error initialize(BinaryStreamRef Stream);
+  LLVM_ABI Error initialize(BinaryStreamReader Reader);
+  LLVM_ABI Error initialize(BinaryStreamRef Stream);
 
   Iterator begin() const { return Checksums.begin(); }
   Iterator end() const { return Checksums.end(); }
@@ -74,7 +75,7 @@ private:
   FileChecksumArray Checksums;
 };
 
-class DebugChecksumsSubsection final : public DebugSubsection {
+class LLVM_ABI DebugChecksumsSubsection final : public DebugSubsection {
 public:
   explicit DebugChecksumsSubsection(DebugStringTableSubsection &Strings);
 

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugChecksumsSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugChecksumsSubsection.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGCHECKSUMSSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGCHECKSUMSSUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -18,6 +17,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <vector>
@@ -44,7 +44,7 @@ public:
   using ContextType = void;
 
   LLVM_ABI Error operator()(BinaryStreamRef Stream, uint32_t &Len,
-                   codeview::FileChecksumEntry &Item);
+                            codeview::FileChecksumEntry &Item);
 };
 
 namespace codeview {

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugCrossExSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugCrossExSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGCROSSEXSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGCROSSEXSUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/Support/BinaryStreamArray.h"
@@ -34,8 +35,8 @@ public:
     return S->kind() == DebugSubsectionKind::CrossScopeExports;
   }
 
-  Error initialize(BinaryStreamReader Reader);
-  Error initialize(BinaryStreamRef Stream);
+  LLVM_ABI Error initialize(BinaryStreamReader Reader);
+  LLVM_ABI Error initialize(BinaryStreamRef Stream);
 
   Iterator begin() const { return References.begin(); }
   Iterator end() const { return References.end(); }
@@ -44,7 +45,7 @@ private:
   FixedStreamArray<CrossModuleExport> References;
 };
 
-class DebugCrossModuleExportsSubsection final : public DebugSubsection {
+class LLVM_ABI DebugCrossModuleExportsSubsection final : public DebugSubsection {
 public:
   DebugCrossModuleExportsSubsection()
       : DebugSubsection(DebugSubsectionKind::CrossScopeExports) {}

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugCrossExSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugCrossExSubsection.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGCROSSEXSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGCROSSEXSUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <map>
@@ -45,7 +45,8 @@ private:
   FixedStreamArray<CrossModuleExport> References;
 };
 
-class LLVM_ABI DebugCrossModuleExportsSubsection final : public DebugSubsection {
+class LLVM_ABI DebugCrossModuleExportsSubsection final
+    : public DebugSubsection {
 public:
   DebugCrossModuleExportsSubsection()
       : DebugSubsection(DebugSubsectionKind::CrossScopeExports) {}

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugCrossImpSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugCrossImpSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGCROSSIMPSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGCROSSIMPSUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -37,7 +38,7 @@ template <> struct VarStreamArrayExtractor<codeview::CrossModuleImportItem> {
 public:
   using ContextType = void;
 
-  Error operator()(BinaryStreamRef Stream, uint32_t &Len,
+  LLVM_ABI Error operator()(BinaryStreamRef Stream, uint32_t &Len,
                    codeview::CrossModuleImportItem &Item);
 };
 
@@ -57,8 +58,8 @@ public:
     return S->kind() == DebugSubsectionKind::CrossScopeImports;
   }
 
-  Error initialize(BinaryStreamReader Reader);
-  Error initialize(BinaryStreamRef Stream);
+  LLVM_ABI Error initialize(BinaryStreamReader Reader);
+  LLVM_ABI Error initialize(BinaryStreamRef Stream);
 
   Iterator begin() const { return References.begin(); }
   Iterator end() const { return References.end(); }
@@ -67,7 +68,7 @@ private:
   ReferenceArray References;
 };
 
-class DebugCrossModuleImportsSubsection final : public DebugSubsection {
+class LLVM_ABI DebugCrossModuleImportsSubsection final : public DebugSubsection {
 public:
   explicit DebugCrossModuleImportsSubsection(
       DebugStringTableSubsection &Strings)

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugCrossImpSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugCrossImpSubsection.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGCROSSIMPSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGCROSSIMPSUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
@@ -39,7 +39,7 @@ public:
   using ContextType = void;
 
   LLVM_ABI Error operator()(BinaryStreamRef Stream, uint32_t &Len,
-                   codeview::CrossModuleImportItem &Item);
+                            codeview::CrossModuleImportItem &Item);
 };
 
 namespace codeview {
@@ -68,7 +68,8 @@ private:
   ReferenceArray References;
 };
 
-class LLVM_ABI DebugCrossModuleImportsSubsection final : public DebugSubsection {
+class LLVM_ABI DebugCrossModuleImportsSubsection final
+    : public DebugSubsection {
 public:
   explicit DebugCrossModuleImportsSubsection(
       DebugStringTableSubsection &Strings)

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugFrameDataSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugFrameDataSubsection.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGFRAMEDATASUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGFRAMEDATASUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugFrameDataSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugFrameDataSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGFRAMEDATASUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGFRAMEDATASUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/Support/BinaryStreamArray.h"
@@ -29,8 +30,8 @@ public:
     return S->kind() == DebugSubsectionKind::FrameData;
   }
 
-  Error initialize(BinaryStreamReader Reader);
-  Error initialize(BinaryStreamRef Stream);
+  LLVM_ABI Error initialize(BinaryStreamReader Reader);
+  LLVM_ABI Error initialize(BinaryStreamRef Stream);
 
   FixedStreamArray<FrameData>::Iterator begin() const { return Frames.begin(); }
   FixedStreamArray<FrameData>::Iterator end() const { return Frames.end(); }
@@ -42,7 +43,7 @@ private:
   FixedStreamArray<FrameData> Frames;
 };
 
-class DebugFrameDataSubsection final : public DebugSubsection {
+class LLVM_ABI DebugFrameDataSubsection final : public DebugSubsection {
 public:
   DebugFrameDataSubsection(bool IncludeRelocPtr)
       : DebugSubsection(DebugSubsectionKind::FrameData),

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugInlineeLinesSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugInlineeLinesSubsection.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGINLINEELINESSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGINLINEELINESSUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
@@ -17,6 +16,7 @@
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamReader.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
@@ -51,7 +51,7 @@ struct InlineeSourceLine {
 
 template <> struct VarStreamArrayExtractor<codeview::InlineeSourceLine> {
   LLVM_ABI Error operator()(BinaryStreamRef Stream, uint32_t &Len,
-                   codeview::InlineeSourceLine &Item);
+                            codeview::InlineeSourceLine &Item);
 
   bool HasExtraFiles = false;
 };

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugInlineeLinesSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugInlineeLinesSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGINLINEELINESSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGINLINEELINESSUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
@@ -49,7 +50,7 @@ struct InlineeSourceLine {
 } // end namespace codeview
 
 template <> struct VarStreamArrayExtractor<codeview::InlineeSourceLine> {
-  Error operator()(BinaryStreamRef Stream, uint32_t &Len,
+  LLVM_ABI Error operator()(BinaryStreamRef Stream, uint32_t &Len,
                    codeview::InlineeSourceLine &Item);
 
   bool HasExtraFiles = false;
@@ -62,19 +63,19 @@ class DebugInlineeLinesSubsectionRef final : public DebugSubsectionRef {
   using Iterator = LinesArray::Iterator;
 
 public:
-  DebugInlineeLinesSubsectionRef();
+  LLVM_ABI DebugInlineeLinesSubsectionRef();
 
   static bool classof(const DebugSubsectionRef *S) {
     return S->kind() == DebugSubsectionKind::InlineeLines;
   }
 
-  Error initialize(BinaryStreamReader Reader);
+  LLVM_ABI Error initialize(BinaryStreamReader Reader);
   Error initialize(BinaryStreamRef Section) {
     return initialize(BinaryStreamReader(Section));
   }
 
   bool valid() const { return Lines.valid(); }
-  bool hasExtraFiles() const;
+  LLVM_ABI bool hasExtraFiles() const;
 
   Iterator begin() const { return Lines.begin(); }
   Iterator end() const { return Lines.end(); }
@@ -84,7 +85,7 @@ private:
   LinesArray Lines;
 };
 
-class DebugInlineeLinesSubsection final : public DebugSubsection {
+class LLVM_ABI DebugInlineeLinesSubsection final : public DebugSubsection {
 public:
   struct Entry {
     std::vector<support::ulittle32_t> ExtraFiles;

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugLinesSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugLinesSubsection.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGLINESSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGLINESSUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/DebugInfo/CodeView/Line.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
@@ -72,7 +72,7 @@ struct LineColumnEntry {
 class LineColumnExtractor {
 public:
   LLVM_ABI Error operator()(BinaryStreamRef Stream, uint32_t &Len,
-                   LineColumnEntry &Item);
+                            LineColumnEntry &Item);
 
   const LineFragmentHeader *Header = nullptr;
 };

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugLinesSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugLinesSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGLINESSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGLINESSUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
@@ -70,7 +71,7 @@ struct LineColumnEntry {
 
 class LineColumnExtractor {
 public:
-  Error operator()(BinaryStreamRef Stream, uint32_t &Len,
+  LLVM_ABI Error operator()(BinaryStreamRef Stream, uint32_t &Len,
                    LineColumnEntry &Item);
 
   const LineFragmentHeader *Header = nullptr;
@@ -83,27 +84,27 @@ class DebugLinesSubsectionRef final : public DebugSubsectionRef {
   using Iterator = LineInfoArray::Iterator;
 
 public:
-  DebugLinesSubsectionRef();
+  LLVM_ABI DebugLinesSubsectionRef();
 
   static bool classof(const DebugSubsectionRef *S) {
     return S->kind() == DebugSubsectionKind::Lines;
   }
 
-  Error initialize(BinaryStreamReader Reader);
+  LLVM_ABI Error initialize(BinaryStreamReader Reader);
 
   Iterator begin() const { return LinesAndColumns.begin(); }
   Iterator end() const { return LinesAndColumns.end(); }
 
   const LineFragmentHeader *header() const { return Header; }
 
-  bool hasColumnInfo() const;
+  LLVM_ABI bool hasColumnInfo() const;
 
 private:
   const LineFragmentHeader *Header = nullptr;
   LineInfoArray LinesAndColumns;
 };
 
-class DebugLinesSubsection final : public DebugSubsection {
+class LLVM_ABI DebugLinesSubsection final : public DebugSubsection {
   struct Block {
     Block(uint32_t ChecksumBufferOffset)
         : ChecksumBufferOffset(ChecksumBufferOffset) {}

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugStringTableSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugStringTableSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGSTRINGTABLESUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGSTRINGTABLESUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -30,16 +31,16 @@ namespace codeview {
 /// does not own the underlying storage for the buffer.
 class DebugStringTableSubsectionRef : public DebugSubsectionRef {
 public:
-  DebugStringTableSubsectionRef();
+  LLVM_ABI DebugStringTableSubsectionRef();
 
   static bool classof(const DebugSubsectionRef *S) {
     return S->kind() == DebugSubsectionKind::StringTable;
   }
 
-  Error initialize(BinaryStreamRef Contents);
-  Error initialize(BinaryStreamReader &Reader);
+  LLVM_ABI Error initialize(BinaryStreamRef Contents);
+  LLVM_ABI Error initialize(BinaryStreamReader &Reader);
 
-  Expected<StringRef> getString(uint32_t Offset) const;
+  LLVM_ABI Expected<StringRef> getString(uint32_t Offset) const;
 
   bool valid() const { return Stream.valid(); }
 
@@ -53,7 +54,7 @@ private:
 /// DebugStringTableSubsection owns the underlying storage for the table, and is
 /// capable of serializing the string table into a format understood by
 /// DebugStringTableSubsectionRef.
-class DebugStringTableSubsection : public DebugSubsection {
+class LLVM_ABI DebugStringTableSubsection : public DebugSubsection {
 public:
   DebugStringTableSubsection();
 

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugStringTableSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugStringTableSubsection.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGSTRINGTABLESUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGSTRINGTABLESUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGSUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/Support/Error.h"
 
@@ -18,7 +19,7 @@ namespace llvm {
 class BinaryStreamWriter;
 namespace codeview {
 
-class DebugSubsectionRef {
+class LLVM_ABI DebugSubsectionRef {
 public:
   explicit DebugSubsectionRef(DebugSubsectionKind Kind) : Kind(Kind) {}
   virtual ~DebugSubsectionRef();
@@ -31,7 +32,7 @@ protected:
   DebugSubsectionKind Kind;
 };
 
-class DebugSubsection {
+class LLVM_ABI DebugSubsection {
 public:
   explicit DebugSubsection(DebugSubsectionKind Kind) : Kind(Kind) {}
   virtual ~DebugSubsection();

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugSubsection.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGSUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <cstdint>

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugSubsectionRecord.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugSubsectionRecord.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGSUBSECTIONRECORD_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGSUBSECTIONRECORD_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
@@ -34,14 +35,14 @@ struct DebugSubsectionHeader {
 
 class DebugSubsectionRecord {
 public:
-  DebugSubsectionRecord();
-  DebugSubsectionRecord(DebugSubsectionKind Kind, BinaryStreamRef Data);
+  LLVM_ABI DebugSubsectionRecord();
+  LLVM_ABI DebugSubsectionRecord(DebugSubsectionKind Kind, BinaryStreamRef Data);
 
-  static Error initialize(BinaryStreamRef Stream, DebugSubsectionRecord &Info);
+  LLVM_ABI static Error initialize(BinaryStreamRef Stream, DebugSubsectionRecord &Info);
 
-  uint32_t getRecordLength() const;
-  DebugSubsectionKind kind() const;
-  BinaryStreamRef getRecordData() const;
+  LLVM_ABI uint32_t getRecordLength() const;
+  LLVM_ABI DebugSubsectionKind kind() const;
+  LLVM_ABI BinaryStreamRef getRecordData() const;
 
 private:
   DebugSubsectionKind Kind = DebugSubsectionKind::None;
@@ -50,15 +51,15 @@ private:
 
 class DebugSubsectionRecordBuilder {
 public:
-  DebugSubsectionRecordBuilder(std::shared_ptr<DebugSubsection> Subsection);
+  LLVM_ABI DebugSubsectionRecordBuilder(std::shared_ptr<DebugSubsection> Subsection);
 
   /// Use this to copy existing subsections directly from source to destination.
   /// For example, line table subsections in an object file only need to be
   /// relocated before being copied into the PDB.
-  DebugSubsectionRecordBuilder(const DebugSubsectionRecord &Contents);
+  LLVM_ABI DebugSubsectionRecordBuilder(const DebugSubsectionRecord &Contents);
 
-  uint32_t calculateSerializedLength() const;
-  Error commit(BinaryStreamWriter &Writer, CodeViewContainer Container) const;
+  LLVM_ABI uint32_t calculateSerializedLength() const;
+  LLVM_ABI Error commit(BinaryStreamWriter &Writer, CodeViewContainer Container) const;
 
 private:
   /// The subsection to build. Will be null if Contents is non-empty.

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugSubsectionRecord.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugSubsectionRecord.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGSUBSECTIONRECORD_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGSUBSECTIONRECORD_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MathExtras.h"
@@ -36,9 +36,11 @@ struct DebugSubsectionHeader {
 class DebugSubsectionRecord {
 public:
   LLVM_ABI DebugSubsectionRecord();
-  LLVM_ABI DebugSubsectionRecord(DebugSubsectionKind Kind, BinaryStreamRef Data);
+  LLVM_ABI DebugSubsectionRecord(DebugSubsectionKind Kind,
+                                 BinaryStreamRef Data);
 
-  LLVM_ABI static Error initialize(BinaryStreamRef Stream, DebugSubsectionRecord &Info);
+  LLVM_ABI static Error initialize(BinaryStreamRef Stream,
+                                   DebugSubsectionRecord &Info);
 
   LLVM_ABI uint32_t getRecordLength() const;
   LLVM_ABI DebugSubsectionKind kind() const;
@@ -51,7 +53,8 @@ private:
 
 class DebugSubsectionRecordBuilder {
 public:
-  LLVM_ABI DebugSubsectionRecordBuilder(std::shared_ptr<DebugSubsection> Subsection);
+  LLVM_ABI
+  DebugSubsectionRecordBuilder(std::shared_ptr<DebugSubsection> Subsection);
 
   /// Use this to copy existing subsections directly from source to destination.
   /// For example, line table subsections in an object file only need to be
@@ -59,7 +62,8 @@ public:
   LLVM_ABI DebugSubsectionRecordBuilder(const DebugSubsectionRecord &Contents);
 
   LLVM_ABI uint32_t calculateSerializedLength() const;
-  LLVM_ABI Error commit(BinaryStreamWriter &Writer, CodeViewContainer Container) const;
+  LLVM_ABI Error commit(BinaryStreamWriter &Writer,
+                        CodeViewContainer Container) const;
 
 private:
   /// The subsection to build. Will be null if Contents is non-empty.

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugSymbolsSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugSymbolsSubsection.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGSYMBOLSSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGSYMBOLSSUBSECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugSymbolsSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugSymbolsSubsection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_DEBUGSYMBOLSSUBSECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_DEBUGSYMBOLSSUBSECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsection.h"
 #include "llvm/Support/Error.h"
@@ -24,7 +25,7 @@ public:
     return S->kind() == DebugSubsectionKind::Symbols;
   }
 
-  Error initialize(BinaryStreamReader Reader);
+  LLVM_ABI Error initialize(BinaryStreamReader Reader);
 
   CVSymbolArray::Iterator begin() const { return Records.begin(); }
   CVSymbolArray::Iterator end() const { return Records.end(); }
@@ -33,7 +34,7 @@ private:
   CVSymbolArray Records;
 };
 
-class DebugSymbolsSubsection final : public DebugSubsection {
+class LLVM_ABI DebugSymbolsSubsection final : public DebugSubsection {
 public:
   DebugSymbolsSubsection() : DebugSubsection(DebugSubsectionKind::Symbols) {}
   static bool classof(const DebugSubsection *S) {

--- a/llvm/include/llvm/DebugInfo/CodeView/EnumTables.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/EnumTables.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_ENUMTABLES_H
 #define LLVM_DEBUGINFO_CODEVIEW_ENUMTABLES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/CodeView/EnumTables.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/EnumTables.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_ENUMTABLES_H
 #define LLVM_DEBUGINFO_CODEVIEW_ENUMTABLES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -18,37 +19,37 @@ namespace llvm {
 template <typename T> struct EnumEntry;
 namespace codeview {
 
-ArrayRef<EnumEntry<SymbolKind>> getSymbolTypeNames();
-ArrayRef<EnumEntry<TypeLeafKind>> getTypeLeafNames();
-ArrayRef<EnumEntry<uint16_t>> getRegisterNames(CPUType Cpu);
-ArrayRef<EnumEntry<uint32_t>> getPublicSymFlagNames();
-ArrayRef<EnumEntry<uint8_t>> getProcSymFlagNames();
-ArrayRef<EnumEntry<uint16_t>> getLocalFlagNames();
-ArrayRef<EnumEntry<uint8_t>> getFrameCookieKindNames();
-ArrayRef<EnumEntry<SourceLanguage>> getSourceLanguageNames();
-ArrayRef<EnumEntry<uint32_t>> getCompileSym2FlagNames();
-ArrayRef<EnumEntry<uint32_t>> getCompileSym3FlagNames();
-ArrayRef<EnumEntry<uint32_t>> getFileChecksumNames();
-ArrayRef<EnumEntry<unsigned>> getCPUTypeNames();
-ArrayRef<EnumEntry<uint32_t>> getFrameProcSymFlagNames();
-ArrayRef<EnumEntry<uint16_t>> getExportSymFlagNames();
-ArrayRef<EnumEntry<uint32_t>> getModuleSubstreamKindNames();
-ArrayRef<EnumEntry<uint8_t>> getThunkOrdinalNames();
-ArrayRef<EnumEntry<uint16_t>> getTrampolineNames();
-ArrayRef<EnumEntry<COFF::SectionCharacteristics>>
+LLVM_ABI ArrayRef<EnumEntry<SymbolKind>> getSymbolTypeNames();
+LLVM_ABI ArrayRef<EnumEntry<TypeLeafKind>> getTypeLeafNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getRegisterNames(CPUType Cpu);
+LLVM_ABI ArrayRef<EnumEntry<uint32_t>> getPublicSymFlagNames();
+LLVM_ABI ArrayRef<EnumEntry<uint8_t>> getProcSymFlagNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getLocalFlagNames();
+LLVM_ABI ArrayRef<EnumEntry<uint8_t>> getFrameCookieKindNames();
+LLVM_ABI ArrayRef<EnumEntry<SourceLanguage>> getSourceLanguageNames();
+LLVM_ABI ArrayRef<EnumEntry<uint32_t>> getCompileSym2FlagNames();
+LLVM_ABI ArrayRef<EnumEntry<uint32_t>> getCompileSym3FlagNames();
+LLVM_ABI ArrayRef<EnumEntry<uint32_t>> getFileChecksumNames();
+LLVM_ABI ArrayRef<EnumEntry<unsigned>> getCPUTypeNames();
+LLVM_ABI ArrayRef<EnumEntry<uint32_t>> getFrameProcSymFlagNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getExportSymFlagNames();
+LLVM_ABI ArrayRef<EnumEntry<uint32_t>> getModuleSubstreamKindNames();
+LLVM_ABI ArrayRef<EnumEntry<uint8_t>> getThunkOrdinalNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getTrampolineNames();
+LLVM_ABI ArrayRef<EnumEntry<COFF::SectionCharacteristics>>
 getImageSectionCharacteristicNames();
-ArrayRef<EnumEntry<uint16_t>> getClassOptionNames();
-ArrayRef<EnumEntry<uint8_t>> getMemberAccessNames();
-ArrayRef<EnumEntry<uint16_t>> getMethodOptionNames();
-ArrayRef<EnumEntry<uint16_t>> getMemberKindNames();
-ArrayRef<EnumEntry<uint8_t>> getPtrKindNames();
-ArrayRef<EnumEntry<uint8_t>> getPtrModeNames();
-ArrayRef<EnumEntry<uint16_t>> getPtrMemberRepNames();
-ArrayRef<EnumEntry<uint16_t>> getTypeModifierNames();
-ArrayRef<EnumEntry<uint8_t>> getCallingConventions();
-ArrayRef<EnumEntry<uint8_t>> getFunctionOptionEnum();
-ArrayRef<EnumEntry<uint16_t>> getLabelTypeEnum();
-ArrayRef<EnumEntry<uint16_t>> getJumpTableEntrySizeNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getClassOptionNames();
+LLVM_ABI ArrayRef<EnumEntry<uint8_t>> getMemberAccessNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getMethodOptionNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getMemberKindNames();
+LLVM_ABI ArrayRef<EnumEntry<uint8_t>> getPtrKindNames();
+LLVM_ABI ArrayRef<EnumEntry<uint8_t>> getPtrModeNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getPtrMemberRepNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getTypeModifierNames();
+LLVM_ABI ArrayRef<EnumEntry<uint8_t>> getCallingConventions();
+LLVM_ABI ArrayRef<EnumEntry<uint8_t>> getFunctionOptionEnum();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getLabelTypeEnum();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getJumpTableEntrySizeNames();
 
 } // end namespace codeview
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/Formatters.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/Formatters.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_FORMATTERS_H
 #define LLVM_DEBUGINFO_CODEVIEW_FORMATTERS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/GUID.h"
@@ -26,7 +27,7 @@ struct GUID;
 
 namespace detail {
 
-class GuidAdapter final : public FormatAdapter<ArrayRef<uint8_t>> {
+class LLVM_ABI GuidAdapter final : public FormatAdapter<ArrayRef<uint8_t>> {
   ArrayRef<uint8_t> Guid;
 
 public:

--- a/llvm/include/llvm/DebugInfo/CodeView/Formatters.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/Formatters.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_FORMATTERS_H
 #define LLVM_DEBUGINFO_CODEVIEW_FORMATTERS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/GUID.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"

--- a/llvm/include/llvm/DebugInfo/CodeView/GUID.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/GUID.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_GUID_H
 #define LLVM_DEBUGINFO_CODEVIEW_GUID_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <cstring>
 
@@ -46,7 +47,7 @@ inline bool operator!=(const GUID &LHS, const GUID &RHS) {
   return !(LHS == RHS);
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const GUID &Guid);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const GUID &Guid);
 
 } // namespace codeview
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/GlobalTypeTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/GlobalTypeTableBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_GLOBALTYPETABLEBUILDER_H
 #define LLVM_DEBUGINFO_CODEVIEW_GLOBALTYPETABLEBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
@@ -26,7 +27,7 @@ namespace codeview {
 
 class ContinuationRecordBuilder;
 
-class GlobalTypeTableBuilder : public TypeCollection {
+class LLVM_ABI GlobalTypeTableBuilder : public TypeCollection {
   /// Storage for records.  These need to outlive the TypeTableBuilder.
   BumpPtrAllocator &RecordStorage;
 

--- a/llvm/include/llvm/DebugInfo/CodeView/GlobalTypeTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/GlobalTypeTableBuilder.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_GLOBALTYPETABLEBUILDER_H
 #define LLVM_DEBUGINFO_CODEVIEW_GLOBALTYPETABLEBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
@@ -19,6 +18,7 @@
 #include "llvm/DebugInfo/CodeView/TypeHashing.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 

--- a/llvm/include/llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_LAZYRANDOMTYPECOLLECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_LAZYRANDOMTYPECOLLECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/TypeCollection.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryStreamArray.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/StringSaver.h"
 #include <cstdint>

--- a/llvm/include/llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_LAZYRANDOMTYPECOLLECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_LAZYRANDOMTYPECOLLECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/TypeCollection.h"
@@ -45,7 +46,7 @@ namespace codeview {
 /// require more than one linear scan.  For a type stream of N elements divided
 /// into M chunks of roughly equal size, this yields a worst case lookup time
 /// of O(N/M) and an amortized time of O(1).
-class LazyRandomTypeCollection : public TypeCollection {
+class LLVM_ABI LazyRandomTypeCollection : public TypeCollection {
   using PartialOffsetArray = FixedStreamArray<TypeIndexOffset>;
 
   struct CacheEntry {

--- a/llvm/include/llvm/DebugInfo/CodeView/Line.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/Line.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_LINE_H
 #define LLVM_DEBUGINFO_CODEVIEW_LINE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include <cinttypes>
 
@@ -32,7 +33,7 @@ public:
     StatementFlag = 0x80000000u
   };
 
-  LineInfo(uint32_t StartLine, uint32_t EndLine, bool IsStatement);
+  LLVM_ABI LineInfo(uint32_t StartLine, uint32_t EndLine, bool IsStatement);
   LineInfo(uint32_t LineData) : LineData(LineData) {}
 
   uint32_t getStartLine() const { return LineData & StartLineMask; }

--- a/llvm/include/llvm/DebugInfo/CodeView/MergingTypeTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/MergingTypeTableBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_MERGINGTYPETABLEBUILDER_H
 #define LLVM_DEBUGINFO_CODEVIEW_MERGINGTYPETABLEBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
@@ -25,7 +26,7 @@ struct LocallyHashedType;
 
 class ContinuationRecordBuilder;
 
-class MergingTypeTableBuilder : public TypeCollection {
+class LLVM_ABI MergingTypeTableBuilder : public TypeCollection {
   /// Storage for records.  These need to outlive the TypeTableBuilder.
   BumpPtrAllocator &RecordStorage;
 

--- a/llvm/include/llvm/DebugInfo/CodeView/MergingTypeTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/MergingTypeTableBuilder.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_MERGINGTYPETABLEBUILDER_H
 #define LLVM_DEBUGINFO_CODEVIEW_MERGINGTYPETABLEBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
@@ -18,6 +17,7 @@
 #include "llvm/DebugInfo/CodeView/TypeCollection.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/CodeView/RecordName.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/RecordName.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_RECORDNAME_H
 #define LLVM_DEBUGINFO_CODEVIEW_RECORDNAME_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include <string>
@@ -17,8 +18,8 @@ namespace llvm {
 namespace codeview {
 class TypeCollection;
 class TypeIndex;
-std::string computeTypeName(TypeCollection &Types, TypeIndex Index);
-StringRef getSymbolName(CVSymbol Sym);
+LLVM_ABI std::string computeTypeName(TypeCollection &Types, TypeIndex Index);
+LLVM_ABI StringRef getSymbolName(CVSymbol Sym);
 } // namespace codeview
 } // namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/CodeView/RecordName.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/RecordName.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_RECORDNAME_H
 #define LLVM_DEBUGINFO_CODEVIEW_RECORDNAME_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
+#include "llvm/Support/Compiler.h"
 #include <string>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/CodeView/RecordSerialization.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/RecordSerialization.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_RECORDSERIALIZATION_H
 #define LLVM_DEBUGINFO_CODEVIEW_RECORDSERIALIZATION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/CodeViewError.h"
 #include "llvm/Support/BinaryStreamReader.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cinttypes>

--- a/llvm/include/llvm/DebugInfo/CodeView/RecordSerialization.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/RecordSerialization.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_RECORDSERIALIZATION_H
 #define LLVM_DEBUGINFO_CODEVIEW_RECORDSERIALIZATION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -39,8 +40,8 @@ struct RecordPrefix {
 
 /// Reinterpret a byte array as an array of characters. Does not interpret as
 /// a C string, as StringRef has several helpers (split) that make that easy.
-StringRef getBytesAsCharacters(ArrayRef<uint8_t> LeafData);
-StringRef getBytesAsCString(ArrayRef<uint8_t> LeafData);
+LLVM_ABI StringRef getBytesAsCharacters(ArrayRef<uint8_t> LeafData);
+LLVM_ABI StringRef getBytesAsCString(ArrayRef<uint8_t> LeafData);
 
 inline Error consume(BinaryStreamReader &Reader) { return Error::success(); }
 
@@ -48,20 +49,20 @@ inline Error consume(BinaryStreamReader &Reader) { return Error::success(); }
 /// the type stream. If the value is positive and less than LF_NUMERIC (1 <<
 /// 15), it is emitted directly in Data. Otherwise, it has a tag like LF_CHAR
 /// that indicates the bitwidth and sign of the numeric data.
-Error consume(BinaryStreamReader &Reader, APSInt &Num);
+LLVM_ABI Error consume(BinaryStreamReader &Reader, APSInt &Num);
 
 /// Decodes a numeric leaf value that is known to be a particular type.
-Error consume_numeric(BinaryStreamReader &Reader, uint64_t &Value);
+LLVM_ABI Error consume_numeric(BinaryStreamReader &Reader, uint64_t &Value);
 
 /// Decodes signed and unsigned fixed-length integers.
-Error consume(BinaryStreamReader &Reader, uint32_t &Item);
-Error consume(BinaryStreamReader &Reader, int32_t &Item);
+LLVM_ABI Error consume(BinaryStreamReader &Reader, uint32_t &Item);
+LLVM_ABI Error consume(BinaryStreamReader &Reader, int32_t &Item);
 
 /// Decodes a null terminated string.
-Error consume(BinaryStreamReader &Reader, StringRef &Item);
+LLVM_ABI Error consume(BinaryStreamReader &Reader, StringRef &Item);
 
-Error consume(StringRef &Data, APSInt &Num);
-Error consume(StringRef &Data, uint32_t &Item);
+LLVM_ABI Error consume(StringRef &Data, APSInt &Num);
+LLVM_ABI Error consume(StringRef &Data, uint32_t &Item);
 
 /// Decodes an arbitrary object whose layout matches that of the underlying
 /// byte sequence, and returns a pointer to the object.

--- a/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SIMPLETYPESERIALIZER_H
 #define LLVM_DEBUGINFO_CODEVIEW_SIMPLETYPESERIALIZER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <vector>
 
@@ -20,8 +21,8 @@ class SimpleTypeSerializer {
   std::vector<uint8_t> ScratchBuffer;
 
 public:
-  SimpleTypeSerializer();
-  ~SimpleTypeSerializer();
+  LLVM_ABI SimpleTypeSerializer();
+  LLVM_ABI ~SimpleTypeSerializer();
 
   // This template is explicitly instantiated in the implementation file for all
   // supported types.  The method itself is ugly, so inlining it into the header

--- a/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SIMPLETYPESERIALIZER_H
 #define LLVM_DEBUGINFO_CODEVIEW_SIMPLETYPESERIALIZER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Compiler.h"
 #include <vector>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/CodeView/StringsAndChecksums.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/StringsAndChecksums.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_STRINGSANDCHECKSUMS_H
 #define LLVM_DEBUGINFO_CODEVIEW_STRINGSANDCHECKSUMS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsectionRecord.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {
@@ -27,11 +27,12 @@ public:
   LLVM_ABI StringsAndChecksumsRef();
 
   // If only a string table subsection is given, we find a checksums subsection.
-  LLVM_ABI explicit StringsAndChecksumsRef(const DebugStringTableSubsectionRef &Strings);
+  LLVM_ABI explicit StringsAndChecksumsRef(
+      const DebugStringTableSubsectionRef &Strings);
 
   // If both subsections are given, we don't need to find anything.
   LLVM_ABI StringsAndChecksumsRef(const DebugStringTableSubsectionRef &Strings,
-                         const DebugChecksumsSubsectionRef &Checksums);
+                                  const DebugChecksumsSubsectionRef &Checksums);
 
   LLVM_ABI void setStrings(const DebugStringTableSubsectionRef &Strings);
   LLVM_ABI void setChecksums(const DebugChecksumsSubsectionRef &CS);

--- a/llvm/include/llvm/DebugInfo/CodeView/StringsAndChecksums.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/StringsAndChecksums.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_STRINGSANDCHECKSUMS_H
 #define LLVM_DEBUGINFO_CODEVIEW_STRINGSANDCHECKSUMS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsectionRecord.h"
 #include <memory>
@@ -23,21 +24,21 @@ class DebugStringTableSubsectionRef;
 class StringsAndChecksumsRef {
 public:
   // If no subsections are known about initially, we find as much as we can.
-  StringsAndChecksumsRef();
+  LLVM_ABI StringsAndChecksumsRef();
 
   // If only a string table subsection is given, we find a checksums subsection.
-  explicit StringsAndChecksumsRef(const DebugStringTableSubsectionRef &Strings);
+  LLVM_ABI explicit StringsAndChecksumsRef(const DebugStringTableSubsectionRef &Strings);
 
   // If both subsections are given, we don't need to find anything.
-  StringsAndChecksumsRef(const DebugStringTableSubsectionRef &Strings,
+  LLVM_ABI StringsAndChecksumsRef(const DebugStringTableSubsectionRef &Strings,
                          const DebugChecksumsSubsectionRef &Checksums);
 
-  void setStrings(const DebugStringTableSubsectionRef &Strings);
-  void setChecksums(const DebugChecksumsSubsectionRef &CS);
+  LLVM_ABI void setStrings(const DebugStringTableSubsectionRef &Strings);
+  LLVM_ABI void setChecksums(const DebugChecksumsSubsectionRef &CS);
 
-  void reset();
-  void resetStrings();
-  void resetChecksums();
+  LLVM_ABI void reset();
+  LLVM_ABI void resetStrings();
+  LLVM_ABI void resetChecksums();
 
   template <typename T> void initialize(T &&FragmentRange) {
     for (const DebugSubsectionRecord &R : FragmentRange) {
@@ -70,8 +71,8 @@ public:
   bool hasChecksums() const { return Checksums != nullptr; }
 
 private:
-  void initializeStrings(const DebugSubsectionRecord &SR);
-  void initializeChecksums(const DebugSubsectionRecord &FCR);
+  LLVM_ABI void initializeStrings(const DebugSubsectionRecord &SR);
+  LLVM_ABI void initializeChecksums(const DebugSubsectionRecord &FCR);
 
   std::shared_ptr<DebugStringTableSubsectionRef> OwnedStrings;
   std::shared_ptr<DebugChecksumsSubsectionRef> OwnedChecksums;

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolDumper.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolDumper.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLDUMPER_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLDUMPER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/SymbolDumpDelegate.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <memory>

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolDumper.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolDumper.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLDUMPER_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLDUMPER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/SymbolDumpDelegate.h"
@@ -38,11 +39,11 @@ public:
   /// and true otherwise.  This should be called in order, since the dumper
   /// maintains state about previous records which are necessary for cross
   /// type references.
-  Error dump(CVRecord<SymbolKind> &Record);
+  LLVM_ABI Error dump(CVRecord<SymbolKind> &Record);
 
   /// Dumps the type records in Data. Returns false if there was a type stream
   /// parse error, and true otherwise.
-  Error dump(const CVSymbolArray &Symbols);
+  LLVM_ABI Error dump(const CVSymbolArray &Symbols);
 
   CPUType getCompilationCPUType() const { return CompilationCPUType; }
 

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolRecord.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolRecord.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORD_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORD_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -1023,7 +1024,7 @@ public:
   uint32_t RecordOffset = 0;
 };
 
-Expected<CVSymbol> readSymbolFromStream(BinaryStreamRef Stream,
+LLVM_ABI Expected<CVSymbol> readSymbolFromStream(BinaryStreamRef Stream,
                                         uint32_t Offset);
 
 } // end namespace codeview

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolRecord.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolRecord.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORD_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORD_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -20,6 +19,7 @@
 #include "llvm/DebugInfo/CodeView/RecordSerialization.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 #include "llvm/Support/BinaryStreamArray.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include <cstdint>
 #include <vector>
@@ -1025,7 +1025,7 @@ public:
 };
 
 LLVM_ABI Expected<CVSymbol> readSymbolFromStream(BinaryStreamRef Stream,
-                                        uint32_t Offset);
+                                                 uint32_t Offset);
 
 } // end namespace codeview
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolRecordHelpers.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolRecordHelpers.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORDHELPERS_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORDHELPERS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace codeview {
@@ -55,7 +55,7 @@ LLVM_ABI uint32_t getScopeEndOffset(const CVSymbol &Symbol);
 LLVM_ABI uint32_t getScopeParentOffset(const CVSymbol &Symbol);
 
 LLVM_ABI CVSymbolArray limitSymbolArrayToScope(const CVSymbolArray &Symbols,
-                                      uint32_t ScopeBegin);
+                                               uint32_t ScopeBegin);
 
 } // namespace codeview
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolRecordHelpers.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolRecordHelpers.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORDHELPERS_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORDHELPERS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 
@@ -50,10 +51,10 @@ inline bool symbolEndsScope(SymbolKind Kind) {
 
 /// Given a symbol P for which symbolOpensScope(P) == true, return the
 /// corresponding end offset.
-uint32_t getScopeEndOffset(const CVSymbol &Symbol);
-uint32_t getScopeParentOffset(const CVSymbol &Symbol);
+LLVM_ABI uint32_t getScopeEndOffset(const CVSymbol &Symbol);
+LLVM_ABI uint32_t getScopeParentOffset(const CVSymbol &Symbol);
 
-CVSymbolArray limitSymbolArrayToScope(const CVSymbolArray &Symbols,
+LLVM_ABI CVSymbolArray limitSymbolArrayToScope(const CVSymbolArray &Symbols,
                                       uint32_t ScopeBegin);
 
 } // namespace codeview

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolRecordMapping.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolRecordMapping.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORDMAPPING_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORDMAPPING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeViewRecordIO.h"
 #include "llvm/DebugInfo/CodeView/SymbolVisitorCallbacks.h"
 
@@ -17,7 +18,7 @@ class BinaryStreamReader;
 class BinaryStreamWriter;
 
 namespace codeview {
-class SymbolRecordMapping : public SymbolVisitorCallbacks {
+class LLVM_ABI SymbolRecordMapping : public SymbolVisitorCallbacks {
 public:
   explicit SymbolRecordMapping(BinaryStreamReader &Reader,
                                CodeViewContainer Container)

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolRecordMapping.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolRecordMapping.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORDMAPPING_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLRECORDMAPPING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CodeViewRecordIO.h"
 #include "llvm/DebugInfo/CodeView/SymbolVisitorCallbacks.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class BinaryStreamReader;

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolSerializer.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolSerializer.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLSERIALIZER_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLSERIALIZER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/RecordSerialization.h"
@@ -18,6 +17,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryByteStream.h"
 #include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <array>

--- a/llvm/include/llvm/DebugInfo/CodeView/SymbolSerializer.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SymbolSerializer.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_SYMBOLSERIALIZER_H
 #define LLVM_DEBUGINFO_CODEVIEW_SYMBOLSERIALIZER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/RecordSerialization.h"
@@ -25,7 +26,7 @@
 namespace llvm {
 namespace codeview {
 
-class SymbolSerializer : public SymbolVisitorCallbacks {
+class LLVM_ABI SymbolSerializer : public SymbolVisitorCallbacks {
   BumpPtrAllocator &Storage;
   // Since this is a fixed size buffer, use a stack allocated buffer.  This
   // yields measurable performance increase over the repeated heap allocations

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeDumpVisitor.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeDumpVisitor.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPEDUMPVISITOR_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPEDUMPVISITOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/TypeVisitorCallbacks.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class ScopedPrinter;

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeDumpVisitor.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeDumpVisitor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPEDUMPVISITOR_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPEDUMPVISITOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -25,7 +26,7 @@ struct MemberAttributes;
 class TypeCollection;
 
 /// Dumper for CodeView type streams found in COFF object files and PDB files.
-class TypeDumpVisitor : public TypeVisitorCallbacks {
+class LLVM_ABI TypeDumpVisitor : public TypeVisitorCallbacks {
 public:
   TypeDumpVisitor(TypeCollection &TpiTypes, ScopedPrinter *W,
                   bool PrintRecordBytes)

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPEHASHING_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPEHASHING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
@@ -36,7 +37,7 @@ struct LocallyHashedType {
   ArrayRef<uint8_t> RecordData;
 
   /// Given a type, compute its local hash.
-  static LocallyHashedType hashType(ArrayRef<uint8_t> RecordData);
+  LLVM_ABI static LocallyHashedType hashType(ArrayRef<uint8_t> RecordData);
 
   /// Given a sequence of types, compute all of the local hashes.
   template <typename Range>
@@ -103,7 +104,7 @@ struct GloballyHashedType {
   /// this record.  Due to the nature of global hashes incorporating the hashes
   /// of referenced records, this function requires a list of types and ids
   /// that RecordData might reference, indexable by TypeIndex.
-  static GloballyHashedType hashType(ArrayRef<uint8_t> RecordData,
+  LLVM_ABI static GloballyHashedType hashType(ArrayRef<uint8_t> RecordData,
                                      ArrayRef<GloballyHashedType> PreviousTypes,
                                      ArrayRef<GloballyHashedType> PreviousIds);
 
@@ -181,8 +182,8 @@ static_assert(std::is_trivially_copyable<GloballyHashedType>::value,
 } // namespace codeview
 
 template <> struct DenseMapInfo<codeview::LocallyHashedType> {
-  static codeview::LocallyHashedType Empty;
-  static codeview::LocallyHashedType Tombstone;
+  LLVM_ABI static codeview::LocallyHashedType Empty;
+  LLVM_ABI static codeview::LocallyHashedType Tombstone;
 
   static codeview::LocallyHashedType getEmptyKey() { return Empty; }
 
@@ -201,8 +202,8 @@ template <> struct DenseMapInfo<codeview::LocallyHashedType> {
 };
 
 template <> struct DenseMapInfo<codeview::GloballyHashedType> {
-  static codeview::GloballyHashedType Empty;
-  static codeview::GloballyHashedType Tombstone;
+  LLVM_ABI static codeview::GloballyHashedType Empty;
+  LLVM_ABI static codeview::GloballyHashedType Tombstone;
 
   static codeview::GloballyHashedType getEmptyKey() { return Empty; }
 

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPEHASHING_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPEHASHING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeCollection.h"
@@ -104,9 +104,10 @@ struct GloballyHashedType {
   /// this record.  Due to the nature of global hashes incorporating the hashes
   /// of referenced records, this function requires a list of types and ids
   /// that RecordData might reference, indexable by TypeIndex.
-  LLVM_ABI static GloballyHashedType hashType(ArrayRef<uint8_t> RecordData,
-                                     ArrayRef<GloballyHashedType> PreviousTypes,
-                                     ArrayRef<GloballyHashedType> PreviousIds);
+  LLVM_ABI static GloballyHashedType
+  hashType(ArrayRef<uint8_t> RecordData,
+           ArrayRef<GloballyHashedType> PreviousTypes,
+           ArrayRef<GloballyHashedType> PreviousIds);
 
   /// Given a sequence of bytes representing a record, compute a global hash for
   /// this record.  Due to the nature of global hashes incorporating the hashes

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeIndex.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeIndex.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPEINDEX_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPEINDEX_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include <cassert>
 #include <cinttypes>
@@ -285,8 +285,8 @@ struct TypeIndexOffset {
   support::ulittle32_t Offset;
 };
 
-LLVM_ABI void printTypeIndex(ScopedPrinter &Printer, StringRef FieldName, TypeIndex TI,
-                    TypeCollection &Types);
+LLVM_ABI void printTypeIndex(ScopedPrinter &Printer, StringRef FieldName,
+                             TypeIndex TI, TypeCollection &Types);
 }
 
 template <> struct DenseMapInfo<codeview::TypeIndex> {

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeIndex.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeIndex.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPEINDEX_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPEINDEX_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/Support/Endian.h"
 #include <cassert>
@@ -270,7 +271,7 @@ public:
     return A.toArrayIndex() - B.toArrayIndex();
   }
 
-  static StringRef simpleTypeName(TypeIndex TI);
+  LLVM_ABI static StringRef simpleTypeName(TypeIndex TI);
 
 private:
   support::ulittle32_t Index;
@@ -284,7 +285,7 @@ struct TypeIndexOffset {
   support::ulittle32_t Offset;
 };
 
-void printTypeIndex(ScopedPrinter &Printer, StringRef FieldName, TypeIndex TI,
+LLVM_ABI void printTypeIndex(ScopedPrinter &Printer, StringRef FieldName, TypeIndex TI,
                     TypeCollection &Types);
 }
 

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeIndexDiscovery.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeIndexDiscovery.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPEINDEXDISCOVERY_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPEINDEXDISCOVERY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 template <typename T> class SmallVectorImpl;
@@ -25,22 +25,22 @@ struct TiReference {
 };
 
 LLVM_ABI void discoverTypeIndices(ArrayRef<uint8_t> RecordData,
-                         SmallVectorImpl<TiReference> &Refs);
+                                  SmallVectorImpl<TiReference> &Refs);
 LLVM_ABI void discoverTypeIndices(const CVType &Type,
-                         SmallVectorImpl<TiReference> &Refs);
+                                  SmallVectorImpl<TiReference> &Refs);
 LLVM_ABI void discoverTypeIndices(const CVType &Type,
-                         SmallVectorImpl<TypeIndex> &Indices);
+                                  SmallVectorImpl<TypeIndex> &Indices);
 LLVM_ABI void discoverTypeIndices(ArrayRef<uint8_t> RecordData,
-                         SmallVectorImpl<TypeIndex> &Indices);
+                                  SmallVectorImpl<TypeIndex> &Indices);
 
 /// Discover type indices in symbol records. Returns false if this is an unknown
 /// record.
 LLVM_ABI bool discoverTypeIndicesInSymbol(const CVSymbol &Symbol,
-                                 SmallVectorImpl<TiReference> &Refs);
+                                          SmallVectorImpl<TiReference> &Refs);
 LLVM_ABI bool discoverTypeIndicesInSymbol(ArrayRef<uint8_t> RecordData,
-                                 SmallVectorImpl<TiReference> &Refs);
+                                          SmallVectorImpl<TiReference> &Refs);
 LLVM_ABI bool discoverTypeIndicesInSymbol(ArrayRef<uint8_t> RecordData,
-                                 SmallVectorImpl<TypeIndex> &Indices);
+                                          SmallVectorImpl<TypeIndex> &Indices);
 }
 }
 

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeIndexDiscovery.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeIndexDiscovery.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPEINDEXDISCOVERY_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPEINDEXDISCOVERY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 
@@ -23,22 +24,22 @@ struct TiReference {
   uint32_t Count;
 };
 
-void discoverTypeIndices(ArrayRef<uint8_t> RecordData,
+LLVM_ABI void discoverTypeIndices(ArrayRef<uint8_t> RecordData,
                          SmallVectorImpl<TiReference> &Refs);
-void discoverTypeIndices(const CVType &Type,
+LLVM_ABI void discoverTypeIndices(const CVType &Type,
                          SmallVectorImpl<TiReference> &Refs);
-void discoverTypeIndices(const CVType &Type,
+LLVM_ABI void discoverTypeIndices(const CVType &Type,
                          SmallVectorImpl<TypeIndex> &Indices);
-void discoverTypeIndices(ArrayRef<uint8_t> RecordData,
+LLVM_ABI void discoverTypeIndices(ArrayRef<uint8_t> RecordData,
                          SmallVectorImpl<TypeIndex> &Indices);
 
 /// Discover type indices in symbol records. Returns false if this is an unknown
 /// record.
-bool discoverTypeIndicesInSymbol(const CVSymbol &Symbol,
+LLVM_ABI bool discoverTypeIndicesInSymbol(const CVSymbol &Symbol,
                                  SmallVectorImpl<TiReference> &Refs);
-bool discoverTypeIndicesInSymbol(ArrayRef<uint8_t> RecordData,
+LLVM_ABI bool discoverTypeIndicesInSymbol(ArrayRef<uint8_t> RecordData,
                                  SmallVectorImpl<TiReference> &Refs);
-bool discoverTypeIndicesInSymbol(ArrayRef<uint8_t> RecordData,
+LLVM_ABI bool discoverTypeIndicesInSymbol(ArrayRef<uint8_t> RecordData,
                                  SmallVectorImpl<TypeIndex> &Indices);
 }
 }

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeRecordHelpers.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeRecordHelpers.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPERECORDHELPERS_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPERECORDHELPERS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace codeview {

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeRecordHelpers.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeRecordHelpers.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPERECORDHELPERS_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPERECORDHELPERS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 
@@ -18,11 +19,11 @@ namespace codeview {
 /// Given an arbitrary codeview type, determine if it is an LF_STRUCTURE,
 /// LF_CLASS, LF_INTERFACE, LF_UNION, or LF_ENUM with the forward ref class
 /// option.
-bool isUdtForwardRef(CVType CVT);
+LLVM_ABI bool isUdtForwardRef(CVType CVT);
 
 /// Given a CVType which is assumed to be an LF_MODIFIER, return the
 /// TypeIndex of the type that the LF_MODIFIER modifies.
-TypeIndex getModifiedType(const CVType &CVT);
+LLVM_ABI TypeIndex getModifiedType(const CVType &CVT);
 
 /// Return true if this record should be in the IPI stream of a PDB. In an
 /// object file, these record kinds will appear mixed into the .debug$T section.
@@ -56,11 +57,11 @@ inline bool isAggregate(CVType CVT) {
 }
 
 /// Given an arbitrary codeview type index, determine its size.
-uint64_t getSizeInBytesForTypeIndex(TypeIndex TI);
+LLVM_ABI uint64_t getSizeInBytesForTypeIndex(TypeIndex TI);
 
 /// Given an arbitrary codeview type, return the type's size in the case
 /// of aggregate (LF_STRUCTURE, LF_CLASS, LF_INTERFACE, LF_UNION).
-uint64_t getSizeInBytesForTypeRecord(CVType CVT);
+LLVM_ABI uint64_t getSizeInBytesForTypeRecord(CVType CVT);
 
 } // namespace codeview
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeRecordMapping.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeRecordMapping.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPERECORDMAPPING_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPERECORDMAPPING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/CodeViewRecordIO.h"
 #include "llvm/DebugInfo/CodeView/TypeVisitorCallbacks.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <optional>
 

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeRecordMapping.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeRecordMapping.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPERECORDMAPPING_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPERECORDMAPPING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/CodeViewRecordIO.h"
@@ -23,7 +24,7 @@ class BinaryStreamWriter;
 namespace codeview {
 class TypeIndex;
 struct CVMemberRecord;
-class TypeRecordMapping : public TypeVisitorCallbacks {
+class LLVM_ABI TypeRecordMapping : public TypeVisitorCallbacks {
 public:
   explicit TypeRecordMapping(BinaryStreamReader &Reader) : IO(Reader) {}
   explicit TypeRecordMapping(BinaryStreamWriter &Writer) : IO(Writer) {}

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeStreamMerger.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeStreamMerger.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPESTREAMMERGER_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPESTREAMMERGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/Support/Error.h"
@@ -42,7 +43,7 @@ struct PCHMergerInfo {
 ///
 /// \returns Error::success() if the operation succeeded, otherwise an
 /// appropriate error code.
-Error mergeTypeRecords(MergingTypeTableBuilder &Dest,
+LLVM_ABI Error mergeTypeRecords(MergingTypeTableBuilder &Dest,
                        SmallVectorImpl<TypeIndex> &SourceToDest,
                        const CVTypeArray &Types);
 
@@ -67,7 +68,7 @@ Error mergeTypeRecords(MergingTypeTableBuilder &Dest,
 ///
 /// \returns Error::success() if the operation succeeded, otherwise an
 /// appropriate error code.
-Error mergeIdRecords(MergingTypeTableBuilder &Dest, ArrayRef<TypeIndex> Types,
+LLVM_ABI Error mergeIdRecords(MergingTypeTableBuilder &Dest, ArrayRef<TypeIndex> Types,
                      SmallVectorImpl<TypeIndex> &SourceToDest,
                      const CVTypeArray &Ids);
 
@@ -86,26 +87,26 @@ Error mergeIdRecords(MergingTypeTableBuilder &Dest, ArrayRef<TypeIndex> Types,
 ///
 /// \returns Error::success() if the operation succeeded, otherwise an
 /// appropriate error code.
-Error mergeTypeAndIdRecords(MergingTypeTableBuilder &DestIds,
+LLVM_ABI Error mergeTypeAndIdRecords(MergingTypeTableBuilder &DestIds,
                             MergingTypeTableBuilder &DestTypes,
                             SmallVectorImpl<TypeIndex> &SourceToDest,
                             const CVTypeArray &IdsAndTypes,
                             std::optional<PCHMergerInfo> &PCHInfo);
 
-Error mergeTypeAndIdRecords(GlobalTypeTableBuilder &DestIds,
+LLVM_ABI Error mergeTypeAndIdRecords(GlobalTypeTableBuilder &DestIds,
                             GlobalTypeTableBuilder &DestTypes,
                             SmallVectorImpl<TypeIndex> &SourceToDest,
                             const CVTypeArray &IdsAndTypes,
                             ArrayRef<GloballyHashedType> Hashes,
                             std::optional<PCHMergerInfo> &PCHInfo);
 
-Error mergeTypeRecords(GlobalTypeTableBuilder &Dest,
+LLVM_ABI Error mergeTypeRecords(GlobalTypeTableBuilder &Dest,
                        SmallVectorImpl<TypeIndex> &SourceToDest,
                        const CVTypeArray &Types,
                        ArrayRef<GloballyHashedType> Hashes,
                        std::optional<PCHMergerInfo> &PCHInfo);
 
-Error mergeIdRecords(GlobalTypeTableBuilder &Dest, ArrayRef<TypeIndex> Types,
+LLVM_ABI Error mergeIdRecords(GlobalTypeTableBuilder &Dest, ArrayRef<TypeIndex> Types,
                      SmallVectorImpl<TypeIndex> &SourceToDest,
                      const CVTypeArray &Ids,
                      ArrayRef<GloballyHashedType> Hashes);

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeStreamMerger.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeStreamMerger.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPESTREAMMERGER_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPESTREAMMERGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -44,8 +44,8 @@ struct PCHMergerInfo {
 /// \returns Error::success() if the operation succeeded, otherwise an
 /// appropriate error code.
 LLVM_ABI Error mergeTypeRecords(MergingTypeTableBuilder &Dest,
-                       SmallVectorImpl<TypeIndex> &SourceToDest,
-                       const CVTypeArray &Types);
+                                SmallVectorImpl<TypeIndex> &SourceToDest,
+                                const CVTypeArray &Types);
 
 /// Merge one set of id records into another.  This method assumes
 /// that all records are id records, and there are no Type records present.
@@ -68,9 +68,10 @@ LLVM_ABI Error mergeTypeRecords(MergingTypeTableBuilder &Dest,
 ///
 /// \returns Error::success() if the operation succeeded, otherwise an
 /// appropriate error code.
-LLVM_ABI Error mergeIdRecords(MergingTypeTableBuilder &Dest, ArrayRef<TypeIndex> Types,
-                     SmallVectorImpl<TypeIndex> &SourceToDest,
-                     const CVTypeArray &Ids);
+LLVM_ABI Error mergeIdRecords(MergingTypeTableBuilder &Dest,
+                              ArrayRef<TypeIndex> Types,
+                              SmallVectorImpl<TypeIndex> &SourceToDest,
+                              const CVTypeArray &Ids);
 
 /// Merge a unified set of type and id records, splitting them into
 /// separate output streams.
@@ -88,28 +89,29 @@ LLVM_ABI Error mergeIdRecords(MergingTypeTableBuilder &Dest, ArrayRef<TypeIndex>
 /// \returns Error::success() if the operation succeeded, otherwise an
 /// appropriate error code.
 LLVM_ABI Error mergeTypeAndIdRecords(MergingTypeTableBuilder &DestIds,
-                            MergingTypeTableBuilder &DestTypes,
-                            SmallVectorImpl<TypeIndex> &SourceToDest,
-                            const CVTypeArray &IdsAndTypes,
-                            std::optional<PCHMergerInfo> &PCHInfo);
+                                     MergingTypeTableBuilder &DestTypes,
+                                     SmallVectorImpl<TypeIndex> &SourceToDest,
+                                     const CVTypeArray &IdsAndTypes,
+                                     std::optional<PCHMergerInfo> &PCHInfo);
 
 LLVM_ABI Error mergeTypeAndIdRecords(GlobalTypeTableBuilder &DestIds,
-                            GlobalTypeTableBuilder &DestTypes,
-                            SmallVectorImpl<TypeIndex> &SourceToDest,
-                            const CVTypeArray &IdsAndTypes,
-                            ArrayRef<GloballyHashedType> Hashes,
-                            std::optional<PCHMergerInfo> &PCHInfo);
+                                     GlobalTypeTableBuilder &DestTypes,
+                                     SmallVectorImpl<TypeIndex> &SourceToDest,
+                                     const CVTypeArray &IdsAndTypes,
+                                     ArrayRef<GloballyHashedType> Hashes,
+                                     std::optional<PCHMergerInfo> &PCHInfo);
 
 LLVM_ABI Error mergeTypeRecords(GlobalTypeTableBuilder &Dest,
-                       SmallVectorImpl<TypeIndex> &SourceToDest,
-                       const CVTypeArray &Types,
-                       ArrayRef<GloballyHashedType> Hashes,
-                       std::optional<PCHMergerInfo> &PCHInfo);
+                                SmallVectorImpl<TypeIndex> &SourceToDest,
+                                const CVTypeArray &Types,
+                                ArrayRef<GloballyHashedType> Hashes,
+                                std::optional<PCHMergerInfo> &PCHInfo);
 
-LLVM_ABI Error mergeIdRecords(GlobalTypeTableBuilder &Dest, ArrayRef<TypeIndex> Types,
-                     SmallVectorImpl<TypeIndex> &SourceToDest,
-                     const CVTypeArray &Ids,
-                     ArrayRef<GloballyHashedType> Hashes);
+LLVM_ABI Error mergeIdRecords(GlobalTypeTableBuilder &Dest,
+                              ArrayRef<TypeIndex> Types,
+                              SmallVectorImpl<TypeIndex> &SourceToDest,
+                              const CVTypeArray &Ids,
+                              ArrayRef<GloballyHashedType> Hashes);
 
 } // end namespace codeview
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeTableCollection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeTableCollection.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPETABLECOLLECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPETABLECOLLECTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/TypeCollection.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/StringSaver.h"
 
 #include <vector>

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeTableCollection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeTableCollection.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_CODEVIEW_TYPETABLECOLLECTION_H
 #define LLVM_DEBUGINFO_CODEVIEW_TYPETABLECOLLECTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/TypeCollection.h"
 #include "llvm/Support/StringSaver.h"
 
@@ -17,7 +18,7 @@
 namespace llvm {
 namespace codeview {
 
-class TypeTableCollection : public TypeCollection {
+class LLVM_ABI TypeTableCollection : public TypeCollection {
 public:
   explicit TypeTableCollection(ArrayRef<ArrayRef<uint8_t>> Records);
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFABBREVIATIONDECLARATION_H
 #define LLVM_DEBUGINFO_DWARF_DWARFABBREVIATIONDECLARATION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/Dwarf.h"
@@ -87,11 +88,11 @@ public:
     /// use the DWARFUnit to calculate the size of the Form, like for
     /// DW_AT_address and DW_AT_ref_addr, so this isn't just an accessor for
     /// the ByteSize member.
-    std::optional<int64_t> getByteSize(const DWARFUnit &U) const;
+    LLVM_ABI std::optional<int64_t> getByteSize(const DWARFUnit &U) const;
   };
   using AttributeSpecVector = SmallVector<AttributeSpec, 8>;
 
-  DWARFAbbreviationDeclaration();
+  LLVM_ABI DWARFAbbreviationDeclaration();
 
   uint32_t getCode() const { return Code; }
   uint8_t getCodeByteSize() const { return CodeByteSize; }
@@ -136,7 +137,7 @@ public:
   ///
   /// \param attr DWARF attribute to search for.
   /// \returns Optional index of the attribute if found, std::nullopt otherwise.
-  std::optional<uint32_t> findAttributeIndex(dwarf::Attribute attr) const;
+  LLVM_ABI std::optional<uint32_t> findAttributeIndex(dwarf::Attribute attr) const;
 
   /// Extract a DWARF form value from a DIE specified by DIE offset.
   ///
@@ -148,7 +149,7 @@ public:
   /// \param Attr DWARF attribute to search for.
   /// \param U the DWARFUnit the contains the DIE.
   /// \returns Optional DWARF form value if the attribute was extracted.
-  std::optional<DWARFFormValue> getAttributeValue(const uint64_t DIEOffset,
+  LLVM_ABI std::optional<DWARFFormValue> getAttributeValue(const uint64_t DIEOffset,
                                                   const dwarf::Attribute Attr,
                                                   const DWARFUnit &U) const;
 
@@ -159,7 +160,7 @@ public:
   /// code in the .debug_info data.
   /// \param U the DWARFUnit the contains the DIE.
   /// \returns an offset of the attribute.
-  uint64_t getAttributeOffsetFromIndex(uint32_t AttrIndex, uint64_t DIEOffset,
+  LLVM_ABI uint64_t getAttributeOffsetFromIndex(uint32_t AttrIndex, uint64_t DIEOffset,
                                        const DWARFUnit &U) const;
 
   /// Extract a DWARF form value from a DIE speccified by attribute index and
@@ -169,17 +170,17 @@ public:
   /// \param Offset offset of the attribute.
   /// \param U the DWARFUnit the contains the DIE.
   /// \returns Optional DWARF form value if the attribute was extracted.
-  std::optional<DWARFFormValue>
+  LLVM_ABI std::optional<DWARFFormValue>
   getAttributeValueFromOffset(uint32_t AttrIndex, uint64_t Offset,
                               const DWARFUnit &U) const;
 
-  llvm::Expected<ExtractState> extract(DataExtractor Data, uint64_t *OffsetPtr);
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI llvm::Expected<ExtractState> extract(DataExtractor Data, uint64_t *OffsetPtr);
+  LLVM_ABI void dump(raw_ostream &OS) const;
 
   // Return an optional byte size of all attribute data in this abbreviation
   // if a constant byte size can be calculated given a DWARFUnit. This allows
   // DWARF parsing to be faster as many DWARF DIEs have a fixed byte size.
-  std::optional<size_t> getFixedAttributesByteSize(const DWARFUnit &U) const;
+  LLVM_ABI std::optional<size_t> getFixedAttributesByteSize(const DWARFUnit &U) const;
 
 private:
   void clear();
@@ -204,7 +205,7 @@ private:
     /// \returns the size in bytes for all attribute data in this abbreviation.
     /// The returned size does not include bytes for the  ULEB128 abbreviation
     /// code
-    size_t getByteSize(const DWARFUnit &U) const;
+    LLVM_ABI size_t getByteSize(const DWARFUnit &U) const;
   };
 
   uint32_t Code;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFABBREVIATIONDECLARATION_H
 #define LLVM_DEBUGINFO_DWARF_DWARFABBREVIATIONDECLARATION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -137,7 +137,8 @@ public:
   ///
   /// \param attr DWARF attribute to search for.
   /// \returns Optional index of the attribute if found, std::nullopt otherwise.
-  LLVM_ABI std::optional<uint32_t> findAttributeIndex(dwarf::Attribute attr) const;
+  LLVM_ABI std::optional<uint32_t>
+  findAttributeIndex(dwarf::Attribute attr) const;
 
   /// Extract a DWARF form value from a DIE specified by DIE offset.
   ///
@@ -149,9 +150,9 @@ public:
   /// \param Attr DWARF attribute to search for.
   /// \param U the DWARFUnit the contains the DIE.
   /// \returns Optional DWARF form value if the attribute was extracted.
-  LLVM_ABI std::optional<DWARFFormValue> getAttributeValue(const uint64_t DIEOffset,
-                                                  const dwarf::Attribute Attr,
-                                                  const DWARFUnit &U) const;
+  LLVM_ABI std::optional<DWARFFormValue>
+  getAttributeValue(const uint64_t DIEOffset, const dwarf::Attribute Attr,
+                    const DWARFUnit &U) const;
 
   /// Compute an offset from a DIE specified by DIE offset and attribute index.
   ///
@@ -160,8 +161,9 @@ public:
   /// code in the .debug_info data.
   /// \param U the DWARFUnit the contains the DIE.
   /// \returns an offset of the attribute.
-  LLVM_ABI uint64_t getAttributeOffsetFromIndex(uint32_t AttrIndex, uint64_t DIEOffset,
-                                       const DWARFUnit &U) const;
+  LLVM_ABI uint64_t getAttributeOffsetFromIndex(uint32_t AttrIndex,
+                                                uint64_t DIEOffset,
+                                                const DWARFUnit &U) const;
 
   /// Extract a DWARF form value from a DIE speccified by attribute index and
   /// its offset.
@@ -174,13 +176,15 @@ public:
   getAttributeValueFromOffset(uint32_t AttrIndex, uint64_t Offset,
                               const DWARFUnit &U) const;
 
-  LLVM_ABI llvm::Expected<ExtractState> extract(DataExtractor Data, uint64_t *OffsetPtr);
+  LLVM_ABI llvm::Expected<ExtractState> extract(DataExtractor Data,
+                                                uint64_t *OffsetPtr);
   LLVM_ABI void dump(raw_ostream &OS) const;
 
   // Return an optional byte size of all attribute data in this abbreviation
   // if a constant byte size can be calculated given a DWARFUnit. This allows
   // DWARF parsing to be faster as many DWARF DIEs have a fixed byte size.
-  LLVM_ABI std::optional<size_t> getFixedAttributesByteSize(const DWARFUnit &U) const;
+  LLVM_ABI std::optional<size_t>
+  getFixedAttributesByteSize(const DWARFUnit &U) const;
 
 private:
   void clear();

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFACCELERATORTABLE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFACCELERATORTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <utility>
 
@@ -246,7 +246,7 @@ public:
   public:
     /// Construct a new iterator for the entries at \p DataOffset.
     LLVM_ABI SameNameIterator(const AppleAcceleratorTable &AccelTable,
-                     uint64_t DataOffset);
+                              uint64_t DataOffset);
 
     const Entry &operator*() {
       uint64_t OffsetCopy = Offset;
@@ -866,7 +866,8 @@ struct ObjCSelectorNames {
 /// If `Name` is the AT_name of a DIE which refers to an Objective-C selector,
 /// returns an instance of ObjCSelectorNames. The Selector and ClassName fields
 /// are guaranteed to be non-empty in the result.
-LLVM_ABI std::optional<ObjCSelectorNames> getObjCNamesIfSelector(StringRef Name);
+LLVM_ABI std::optional<ObjCSelectorNames>
+getObjCNamesIfSelector(StringRef Name);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFACCELERATORTABLE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFACCELERATORTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -29,7 +30,7 @@ class ScopedPrinter;
 /// DWARF 5 accelerator tables.
 /// TODO: Generalize the rest of the AppleAcceleratorTable interface and move it
 /// to this class.
-class DWARFAcceleratorTable {
+class LLVM_ABI DWARFAcceleratorTable {
 protected:
   DWARFDataExtractor AccelSection;
   DataExtractor StringSection;
@@ -97,7 +98,7 @@ public:
 
 /// This implements the Apple accelerator table format, a precursor of the
 /// DWARF 5 accelerator table format.
-class AppleAcceleratorTable : public DWARFAcceleratorTable {
+class LLVM_ABI AppleAcceleratorTable : public DWARFAcceleratorTable {
   struct Header {
     uint32_t Magic;
     uint16_t Version;
@@ -106,7 +107,7 @@ class AppleAcceleratorTable : public DWARFAcceleratorTable {
     uint32_t HashCount;
     uint32_t HeaderDataLength;
 
-    void dump(ScopedPrinter &W) const;
+    LLVM_ABI void dump(ScopedPrinter &W) const;
   };
 
   struct HeaderData {
@@ -116,7 +117,7 @@ class AppleAcceleratorTable : public DWARFAcceleratorTable {
     uint64_t DIEOffsetBase;
     SmallVector<std::pair<AtomType, Form>, 3> Atoms;
 
-    std::optional<uint64_t>
+    LLVM_ABI std::optional<uint64_t>
     extractOffset(std::optional<DWARFFormValue> Value) const;
   };
 
@@ -210,7 +211,7 @@ class AppleAcceleratorTable : public DWARFAcceleratorTable {
 
 public:
   /// Apple-specific implementation of an Accelerator Entry.
-  class Entry final : public DWARFAcceleratorTable::Entry {
+  class LLVM_ABI Entry final : public DWARFAcceleratorTable::Entry {
     const AppleAcceleratorTable &Table;
 
     Entry(const AppleAcceleratorTable &Table);
@@ -244,7 +245,7 @@ public:
 
   public:
     /// Construct a new iterator for the entries at \p DataOffset.
-    SameNameIterator(const AppleAcceleratorTable &AccelTable,
+    LLVM_ABI SameNameIterator(const AppleAcceleratorTable &AccelTable,
                      uint64_t DataOffset);
 
     const Entry &operator*() {
@@ -292,7 +293,7 @@ public:
 
     /// Reads the next Entry in the table, populating `Current`.
     /// If not possible (e.g. end of the section), becomes the end iterator.
-    void prepareNextEntryOrEnd();
+    LLVM_ABI void prepareNextEntryOrEnd();
 
     /// Reads the next string pointer and the entry count for that string,
     /// populating `NumEntriesToCome`.
@@ -301,7 +302,7 @@ public:
     void prepareNextStringOrEnd();
 
   public:
-    Iterator(const AppleAcceleratorTable &Table, bool SetEnd = false);
+    LLVM_ABI Iterator(const AppleAcceleratorTable &Table, bool SetEnd = false);
 
     Iterator &operator++() {
       prepareNextEntryOrEnd();
@@ -380,7 +381,7 @@ public:
 /// The last segment consists of a list of entries, which is a 0-terminated list
 /// referenced by the name table and interpreted with the help of the
 /// abbreviation table.
-class DWARFDebugNames : public DWARFAcceleratorTable {
+class LLVM_ABI DWARFDebugNames : public DWARFAcceleratorTable {
 public:
   class NameIndex;
   class NameIterator;
@@ -400,8 +401,8 @@ public:
     uint32_t AugmentationStringSize;
     SmallString<8> AugmentationString;
 
-    Error extract(const DWARFDataExtractor &AS, uint64_t *Offset);
-    void dump(ScopedPrinter &W) const;
+    LLVM_ABI Error extract(const DWARFDataExtractor &AS, uint64_t *Offset);
+    LLVM_ABI void dump(ScopedPrinter &W) const;
   };
 
   /// Index attribute and its encoding.
@@ -430,11 +431,11 @@ public:
         : AbbrevOffset(AbbrevOffset), Code(Code), Tag(Tag),
           Attributes(std::move(Attributes)) {}
 
-    void dump(ScopedPrinter &W) const;
+    LLVM_ABI void dump(ScopedPrinter &W) const;
   };
 
   /// DWARF v5-specific implementation of an Accelerator Entry.
-  class Entry final : public DWARFAcceleratorTable::Entry {
+  class LLVM_ABI Entry final : public DWARFAcceleratorTable::Entry {
     const NameIndex *NameIdx;
     const Abbrev *Abbr;
 
@@ -510,7 +511,7 @@ public:
 
   /// Error returned by NameIndex::getEntry to report it has reached the end of
   /// the entry list.
-  class SentinelError : public ErrorInfo<SentinelError> {
+  class LLVM_ABI SentinelError : public ErrorInfo<SentinelError> {
   public:
     static char ID;
 
@@ -521,8 +522,8 @@ public:
 private:
   /// DenseMapInfo for struct Abbrev.
   struct AbbrevMapInfo {
-    static Abbrev getEmptyKey();
-    static Abbrev getTombstoneKey();
+    LLVM_ABI static Abbrev getEmptyKey();
+    LLVM_ABI static Abbrev getTombstoneKey();
     static unsigned getHashValue(uint32_t Code) {
       return DenseMapInfo<uint32_t>::getHashValue(Code);
     }
@@ -633,32 +634,32 @@ public:
     DWARFDebugNamesOffsets getOffsets() const { return Offsets; }
 
     /// Reads offset of compilation unit CU. CU is 0-based.
-    uint64_t getCUOffset(uint32_t CU) const;
+    LLVM_ABI uint64_t getCUOffset(uint32_t CU) const;
     uint32_t getCUCount() const { return Hdr.CompUnitCount; }
 
     /// Reads offset of local type unit TU, TU is 0-based.
-    uint64_t getLocalTUOffset(uint32_t TU) const;
+    LLVM_ABI uint64_t getLocalTUOffset(uint32_t TU) const;
     uint32_t getLocalTUCount() const { return Hdr.LocalTypeUnitCount; }
 
     /// Reads signature of foreign type unit TU. TU is 0-based.
-    uint64_t getForeignTUSignature(uint32_t TU) const;
+    LLVM_ABI uint64_t getForeignTUSignature(uint32_t TU) const;
     uint32_t getForeignTUCount() const { return Hdr.ForeignTypeUnitCount; }
 
     /// Reads an entry in the Bucket Array for the given Bucket. The returned
     /// value is a (1-based) index into the Names, StringOffsets and
     /// EntryOffsets arrays. The input Bucket index is 0-based.
-    uint32_t getBucketArrayEntry(uint32_t Bucket) const;
+    LLVM_ABI uint32_t getBucketArrayEntry(uint32_t Bucket) const;
     uint32_t getBucketCount() const { return Hdr.BucketCount; }
 
     /// Reads an entry in the Hash Array for the given Index. The input Index
     /// is 1-based.
-    uint32_t getHashArrayEntry(uint32_t Index) const;
+    LLVM_ABI uint32_t getHashArrayEntry(uint32_t Index) const;
 
     /// Reads an entry in the Name Table for the given Index. The Name Table
     /// consists of two arrays -- String Offsets and Entry Offsets. The returned
     /// offsets are relative to the starts of respective sections. Input Index
     /// is 1-based.
-    NameTableEntry getNameTableEntry(uint32_t Index) const;
+    LLVM_ABI NameTableEntry getNameTableEntry(uint32_t Index) const;
 
     uint32_t getNameCount() const { return Hdr.NameCount; }
 
@@ -666,7 +667,7 @@ public:
       return Abbrevs;
     }
 
-    Expected<Entry> getEntry(uint64_t *Offset) const;
+    LLVM_ABI Expected<Entry> getEntry(uint64_t *Offset) const;
 
     /// Returns the Entry at the relative `Offset` from the start of the Entry
     /// pool.
@@ -676,18 +677,18 @@ public:
     }
 
     /// Look up all entries in this Name Index matching \c Key.
-    iterator_range<ValueIterator> equal_range(StringRef Key) const;
+    LLVM_ABI iterator_range<ValueIterator> equal_range(StringRef Key) const;
 
     NameIterator begin() const { return NameIterator(this, 1); }
     NameIterator end() const { return NameIterator(this, getNameCount() + 1); }
 
-    Error extract();
+    LLVM_ABI Error extract();
     uint64_t getUnitOffset() const { return Base; }
     uint64_t getNextUnitOffset() const {
       return Base + dwarf::getUnitLengthFieldByteSize(Hdr.Format) +
              Hdr.UnitLength;
     }
-    void dump(ScopedPrinter &W) const;
+    LLVM_ABI void dump(ScopedPrinter &W) const;
 
     friend class DWARFDebugNames;
   };
@@ -719,7 +720,7 @@ public:
     std::optional<uint64_t> findEntryOffsetInCurrentIndex();
     bool findInCurrentIndex();
     void searchFromStartOfCurrentIndex();
-    void next();
+    LLVM_ABI void next();
 
     /// Set the iterator to the "end" state.
     void setEnd() { *this = ValueIterator(); }
@@ -728,11 +729,11 @@ public:
     /// Create a "begin" iterator for looping over all entries in the
     /// accelerator table matching Key. The iterator will run through all Name
     /// Indexes in the section in sequence.
-    ValueIterator(const DWARFDebugNames &AccelTable, StringRef Key);
+    LLVM_ABI ValueIterator(const DWARFDebugNames &AccelTable, StringRef Key);
 
     /// Create a "begin" iterator for looping over all entries in a specific
     /// Name Index. Other indices in the section will not be visited.
-    ValueIterator(const NameIndex &NI, StringRef Key);
+    LLVM_ABI ValueIterator(const NameIndex &NI, StringRef Key);
 
     /// End marker.
     ValueIterator() = default;
@@ -840,7 +841,7 @@ public:
 /// Calculates the starting offsets for various sections within the
 /// .debug_names section.
 namespace dwarf {
-DWARFDebugNames::DWARFDebugNamesOffsets
+LLVM_ABI DWARFDebugNames::DWARFDebugNamesOffsets
 findDebugNamesOffsets(uint64_t EndOfHeaderOffset,
                       const DWARFDebugNames::Header &Hdr);
 }
@@ -849,7 +850,7 @@ findDebugNamesOffsets(uint64_t EndOfHeaderOffset,
 /// parameters, returns a substring of `Name` containing no template
 /// parameters.
 /// E.g.: StripTemplateParameters("foo<int>") = "foo".
-std::optional<StringRef> StripTemplateParameters(StringRef Name);
+LLVM_ABI std::optional<StringRef> StripTemplateParameters(StringRef Name);
 
 struct ObjCSelectorNames {
   /// For "-[A(Category) method:]", this would be "method:"
@@ -865,7 +866,7 @@ struct ObjCSelectorNames {
 /// If `Name` is the AT_name of a DIE which refers to an Objective-C selector,
 /// returns an instance of ObjCSelectorNames. The Selector and ClassName fields
 /// are guaranteed to be non-empty in the result.
-std::optional<ObjCSelectorNames> getObjCNamesIfSelector(StringRef Name);
+LLVM_ABI std::optional<ObjCSelectorNames> getObjCNamesIfSelector(StringRef Name);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAddressRange.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAddressRange.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFADDRESSRANGE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFADDRESSRANGE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -69,8 +69,9 @@ struct DWARFAddressRange {
     return true;
   }
 
-  LLVM_ABI void dump(raw_ostream &OS, uint32_t AddressSize, DIDumpOptions DumpOpts = {},
-            const DWARFObject *Obj = nullptr) const;
+  LLVM_ABI void dump(raw_ostream &OS, uint32_t AddressSize,
+                     DIDumpOptions DumpOpts = {},
+                     const DWARFObject *Obj = nullptr) const;
 };
 
 inline bool operator<(const DWARFAddressRange &LHS,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAddressRange.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAddressRange.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFADDRESSRANGE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFADDRESSRANGE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/Object/ObjectFile.h"
 #include <algorithm>
@@ -68,7 +69,7 @@ struct DWARFAddressRange {
     return true;
   }
 
-  void dump(raw_ostream &OS, uint32_t AddressSize, DIDumpOptions DumpOpts = {},
+  LLVM_ABI void dump(raw_ostream &OS, uint32_t AddressSize, DIDumpOptions DumpOpts = {},
             const DWARFObject *Obj = nullptr) const;
 };
 
@@ -82,7 +83,7 @@ inline bool operator==(const DWARFAddressRange &LHS,
   return std::tie(LHS.SectionIndex, LHS.LowPC, LHS.HighPC) == std::tie(RHS.SectionIndex, RHS.LowPC, RHS.HighPC);
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const DWARFAddressRange &R);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const DWARFAddressRange &R);
 
 /// DWARFAddressRangesVector - represents a set of absolute address ranges.
 using DWARFAddressRangesVector = std::vector<DWARFAddressRange>;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAttribute.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAttribute.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFATTRIBUTE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFATTRIBUTE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAttribute.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAttribute.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFATTRIBUTE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFATTRIBUTE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
 #include <cstdint>
@@ -40,11 +41,11 @@ struct DWARFAttribute {
   }
 
   /// Identify DWARF attributes that may contain a pointer to a location list.
-  static bool mayHaveLocationList(dwarf::Attribute Attr);
+  LLVM_ABI static bool mayHaveLocationList(dwarf::Attribute Attr);
 
   /// Identifies DWARF attributes that may contain a reference to a
   /// DWARF expression.
-  static bool mayHaveLocationExpr(dwarf::Attribute Attr);
+  LLVM_ABI static bool mayHaveLocationExpr(dwarf::Attribute Attr);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIProgram.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIProgram.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCFIPROGRAM_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCFIPROGRAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/DebugInfo/DWARF/DWARFExpression.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/TargetParser/Triple.h"
 #include <map>
@@ -47,10 +47,10 @@ public:
     std::optional<DWARFExpression> Expression;
 
     LLVM_ABI Expected<uint64_t> getOperandAsUnsigned(const CFIProgram &CFIP,
-                                            uint32_t OperandIdx) const;
+                                                     uint32_t OperandIdx) const;
 
     LLVM_ABI Expected<int64_t> getOperandAsSigned(const CFIProgram &CFIP,
-                                         uint32_t OperandIdx) const;
+                                                  uint32_t OperandIdx) const;
   };
 
   using InstrList = std::vector<Instruction>;
@@ -77,10 +77,12 @@ public:
   /// starting at *Offset and ending at EndOffset. *Offset is updated
   /// to EndOffset upon successful parsing, or indicates the offset
   /// where a problem occurred in case an error is returned.
-  LLVM_ABI Error parse(DWARFDataExtractor Data, uint64_t *Offset, uint64_t EndOffset);
+  LLVM_ABI Error parse(DWARFDataExtractor Data, uint64_t *Offset,
+                       uint64_t EndOffset);
 
-  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts, unsigned IndentLevel,
-            std::optional<uint64_t> InitialLocation) const;
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+                     unsigned IndentLevel,
+                     std::optional<uint64_t> InitialLocation) const;
 
   void addInstruction(const Instruction &I) { Instructions.push_back(I); }
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIProgram.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIProgram.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCFIPROGRAM_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCFIPROGRAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/iterator.h"
@@ -45,10 +46,10 @@ public:
     // Associated DWARF expression in case this instruction refers to one
     std::optional<DWARFExpression> Expression;
 
-    Expected<uint64_t> getOperandAsUnsigned(const CFIProgram &CFIP,
+    LLVM_ABI Expected<uint64_t> getOperandAsUnsigned(const CFIProgram &CFIP,
                                             uint32_t OperandIdx) const;
 
-    Expected<int64_t> getOperandAsSigned(const CFIProgram &CFIP,
+    LLVM_ABI Expected<int64_t> getOperandAsSigned(const CFIProgram &CFIP,
                                          uint32_t OperandIdx) const;
   };
 
@@ -76,15 +77,15 @@ public:
   /// starting at *Offset and ending at EndOffset. *Offset is updated
   /// to EndOffset upon successful parsing, or indicates the offset
   /// where a problem occurred in case an error is returned.
-  Error parse(DWARFDataExtractor Data, uint64_t *Offset, uint64_t EndOffset);
+  LLVM_ABI Error parse(DWARFDataExtractor Data, uint64_t *Offset, uint64_t EndOffset);
 
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts, unsigned IndentLevel,
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts, unsigned IndentLevel,
             std::optional<uint64_t> InitialLocation) const;
 
   void addInstruction(const Instruction &I) { Instructions.push_back(I); }
 
   /// Get a DWARF CFI call frame string for the given DW_CFA opcode.
-  StringRef callFrameString(unsigned Opcode) const;
+  LLVM_ABI StringRef callFrameString(unsigned Opcode) const;
 
 private:
   std::vector<Instruction> Instructions;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCompileUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCompileUnit.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCOMPILEUNIT_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCOMPILEUNIT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnit.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCompileUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCompileUnit.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCOMPILEUNIT_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCOMPILEUNIT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnit.h"
 
 namespace llvm {
@@ -19,7 +20,7 @@ class raw_ostream;
 struct DIDumpOptions;
 struct DWARFSection;
 
-class DWARFCompileUnit : public DWARFUnit {
+class LLVM_ABI DWARFCompileUnit : public DWARFUnit {
 public:
   DWARFCompileUnit(DWARFContext &Context, const DWARFSection &Section,
                    const DWARFUnitHeader &Header, const DWARFDebugAbbrev *DA,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCONTEXT_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCONTEXT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
@@ -45,7 +46,7 @@ class DWARFUnitIndex;
 /// DWARFContext
 /// This data structure is the top level entity that deals with dwarf debug
 /// information parsing. The actual data is supplied through DWARFObj.
-class DWARFContext : public DIContext {
+class LLVM_ABI DWARFContext : public DIContext {
 public:
   /// DWARFContextState
   /// This structure contains all member variables for DWARFContext that need
@@ -100,7 +101,7 @@ public:
     virtual bool isThreadSafe() const = 0;
 
     /// Parse a macro[.dwo] or macinfo[.dwo] section.
-    std::unique_ptr<DWARFDebugMacro>
+    LLVM_ABI std::unique_ptr<DWARFDebugMacro>
     parseMacroOrMacinfo(MacroSecType SectionType);
 
     virtual Error doWorkThreadSafely(function_ref<Error()> Work) = 0;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCONTEXT_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCONTEXT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
@@ -21,6 +20,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFUnit.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Error.h"
 #include "llvm/TargetParser/Host.h"

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDataExtractor.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDataExtractor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDATAEXTRACTOR_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDATAEXTRACTOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFSection.h"
 #include "llvm/Support/DataExtractor.h"
@@ -50,7 +51,7 @@ public:
   /// 64-bit length. Returns the actual length, and the DWARF format which is
   /// encoded in the field. In case of errors, it returns {0, DWARF32} and
   /// leaves the offset unchanged.
-  std::pair<uint64_t, dwarf::DwarfFormat>
+  LLVM_ABI std::pair<uint64_t, dwarf::DwarfFormat>
   getInitialLength(uint64_t *Off, Error *Err = nullptr) const;
 
   std::pair<uint64_t, dwarf::DwarfFormat> getInitialLength(Cursor &C) const {
@@ -59,7 +60,7 @@ public:
 
   /// Extracts a value and applies a relocation to the result if
   /// one exists for the given offset.
-  uint64_t getRelocatedValue(uint32_t Size, uint64_t *Off,
+  LLVM_ABI uint64_t getRelocatedValue(uint32_t Size, uint64_t *Off,
                              uint64_t *SectionIndex = nullptr,
                              Error *Err = nullptr) const;
   uint64_t getRelocatedValue(Cursor &C, uint32_t Size,
@@ -81,7 +82,7 @@ public:
   /// There is a DWARF encoding that uses a PC-relative adjustment.
   /// For these values, \p AbsPosOffset is used to fix them, which should
   /// reflect the absolute address of this pointer.
-  std::optional<uint64_t> getEncodedPointer(uint64_t *Offset, uint8_t Encoding,
+  LLVM_ABI std::optional<uint64_t> getEncodedPointer(uint64_t *Offset, uint8_t Encoding,
                                             uint64_t AbsPosOffset = 0) const;
 };
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDataExtractor.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDataExtractor.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDATAEXTRACTOR_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDATAEXTRACTOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFSection.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 
 namespace llvm {
@@ -61,8 +61,8 @@ public:
   /// Extracts a value and applies a relocation to the result if
   /// one exists for the given offset.
   LLVM_ABI uint64_t getRelocatedValue(uint32_t Size, uint64_t *Off,
-                             uint64_t *SectionIndex = nullptr,
-                             Error *Err = nullptr) const;
+                                      uint64_t *SectionIndex = nullptr,
+                                      Error *Err = nullptr) const;
   uint64_t getRelocatedValue(Cursor &C, uint32_t Size,
                              uint64_t *SectionIndex = nullptr) const {
     return getRelocatedValue(Size, &getOffset(C), SectionIndex, &getError(C));
@@ -82,8 +82,9 @@ public:
   /// There is a DWARF encoding that uses a PC-relative adjustment.
   /// For these values, \p AbsPosOffset is used to fix them, which should
   /// reflect the absolute address of this pointer.
-  LLVM_ABI std::optional<uint64_t> getEncodedPointer(uint64_t *Offset, uint8_t Encoding,
-                                            uint64_t AbsPosOffset = 0) const;
+  LLVM_ABI std::optional<uint64_t>
+  getEncodedPointer(uint64_t *Offset, uint8_t Encoding,
+                    uint64_t AbsPosOffset = 0) const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGABBREV_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGABBREV_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include <cstdint>
 #include <map>

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGABBREV_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGABBREV_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h"
 #include "llvm/Support/DataExtractor.h"
 #include <cstdint>
@@ -30,13 +31,13 @@ class DWARFAbbreviationDeclarationSet {
       std::vector<DWARFAbbreviationDeclaration>::const_iterator;
 
 public:
-  DWARFAbbreviationDeclarationSet();
+  LLVM_ABI DWARFAbbreviationDeclarationSet();
 
   uint64_t getOffset() const { return Offset; }
-  void dump(raw_ostream &OS) const;
-  Error extract(DataExtractor Data, uint64_t *OffsetPtr);
+  LLVM_ABI void dump(raw_ostream &OS) const;
+  LLVM_ABI Error extract(DataExtractor Data, uint64_t *OffsetPtr);
 
-  const DWARFAbbreviationDeclaration *
+  LLVM_ABI const DWARFAbbreviationDeclaration *
   getAbbreviationDeclaration(uint32_t AbbrCode) const;
 
   const_iterator begin() const {
@@ -47,7 +48,7 @@ public:
     return Decls.end();
   }
 
-  std::string getCodeRange() const;
+  LLVM_ABI std::string getCodeRange() const;
 
   uint32_t getFirstAbbrCode() const { return FirstAbbrCode; }
 
@@ -64,13 +65,13 @@ class DWARFDebugAbbrev {
   mutable std::optional<DataExtractor> Data;
 
 public:
-  DWARFDebugAbbrev(DataExtractor Data);
+  LLVM_ABI DWARFDebugAbbrev(DataExtractor Data);
 
-  Expected<const DWARFAbbreviationDeclarationSet *>
+  LLVM_ABI Expected<const DWARFAbbreviationDeclarationSet *>
   getAbbreviationDeclarationSet(uint64_t CUAbbrOffset) const;
 
-  void dump(raw_ostream &OS) const;
-  Error parse() const;
+  LLVM_ABI void dump(raw_ostream &OS) const;
+  LLVM_ABI Error parse() const;
 
   DWARFAbbreviationDeclarationSetMap::const_iterator begin() const {
     assert(!Data && "Must call parse before iterating over DWARFDebugAbbrev");

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugArangeSet.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugArangeSet.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGARANGESET_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGARANGESET_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/Support/Error.h"
@@ -46,7 +47,7 @@ public:
     uint64_t Length;
 
     uint64_t getEndAddress() const { return Address + Length; }
-    void dump(raw_ostream &OS, uint32_t AddressSize) const;
+    LLVM_ABI void dump(raw_ostream &OS, uint32_t AddressSize) const;
   };
 
 private:
@@ -60,10 +61,10 @@ private:
 public:
   DWARFDebugArangeSet() { clear(); }
 
-  void clear();
-  Error extract(DWARFDataExtractor data, uint64_t *offset_ptr,
+  LLVM_ABI void clear();
+  LLVM_ABI Error extract(DWARFDataExtractor data, uint64_t *offset_ptr,
                 function_ref<void(Error)> WarningHandler = nullptr);
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI void dump(raw_ostream &OS) const;
 
   uint64_t getCompileUnitDIEOffset() const { return HeaderData.CuOffset; }
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugArangeSet.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugArangeSet.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGARANGESET_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGARANGESET_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <vector>
@@ -63,7 +63,7 @@ public:
 
   LLVM_ABI void clear();
   LLVM_ABI Error extract(DWARFDataExtractor data, uint64_t *offset_ptr,
-                function_ref<void(Error)> WarningHandler = nullptr);
+                         function_ref<void(Error)> WarningHandler = nullptr);
   LLVM_ABI void dump(raw_ostream &OS) const;
 
   uint64_t getCompileUnitDIEOffset() const { return HeaderData.CuOffset; }

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGFRAME_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGFRAME_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/DebugInfo/DWARF/DWARFCFIProgram.h"
 #include "llvm/DebugInfo/DWARF/DWARFExpression.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/TargetParser/Triple.h"
 #include <map>
@@ -306,7 +306,7 @@ public:
   /// \param IndentLevel specify the indent level as an integer. The UnwindRow
   /// will be output to the stream preceded by 2 * IndentLevel number of spaces.
   LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
-            unsigned IndentLevel = 0) const;
+                     unsigned IndentLevel = 0) const;
 };
 
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const UnwindRow &Row);
@@ -350,7 +350,7 @@ public:
   /// \param IndentLevel specify the indent level as an integer. The UnwindRow
   /// will be output to the stream preceded by 2 * IndentLevel number of spaces.
   LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
-            unsigned IndentLevel = 0) const;
+                     unsigned IndentLevel = 0) const;
 
   /// Create an UnwindTable from a Common Information Entry (CIE).
   ///
@@ -554,13 +554,13 @@ public:
   // it is a .debug_frame section. EHFrameAddress should be different
   // than zero for correct parsing of .eh_frame addresses when they
   // use a PC-relative encoding.
-  LLVM_ABI DWARFDebugFrame(Triple::ArchType Arch,
-                  bool IsEH = false, uint64_t EHFrameAddress = 0);
+  LLVM_ABI DWARFDebugFrame(Triple::ArchType Arch, bool IsEH = false,
+                           uint64_t EHFrameAddress = 0);
   LLVM_ABI ~DWARFDebugFrame();
 
   /// Dump the section data into the given stream.
   LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
-            std::optional<uint64_t> Offset) const;
+                     std::optional<uint64_t> Offset) const;
 
   /// Parse the section from raw data. \p Data is assumed to contain the whole
   /// frame section contents to be parsed.

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGFRAME_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGFRAME_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/iterator.h"
@@ -93,12 +94,12 @@ public:
   /// Create a location whose rule is set to Unspecified. This means the
   /// register value might be in the same register but it wasn't specified in
   /// the unwind opcodes.
-  static UnwindLocation createUnspecified();
+  LLVM_ABI static UnwindLocation createUnspecified();
   /// Create a location where the value is undefined and not available. This can
   /// happen when a register is volatile and can't be recovered.
-  static UnwindLocation createUndefined();
+  LLVM_ABI static UnwindLocation createUndefined();
   /// Create a location where the value is known to be in the register itself.
-  static UnwindLocation createSame();
+  LLVM_ABI static UnwindLocation createSame();
   /// Create a location that is in (Deref == false) or at (Deref == true) the
   /// CFA plus an offset. Most registers that are spilled onto the stack use
   /// this rule. The rule for the register will use this rule and specify a
@@ -106,8 +107,8 @@ public:
   /// relative to a CFA value which is typically defined using the register
   /// plus offset location. \see createRegisterPlusOffset(...) for more
   /// information.
-  static UnwindLocation createIsCFAPlusOffset(int32_t Off);
-  static UnwindLocation createAtCFAPlusOffset(int32_t Off);
+  LLVM_ABI static UnwindLocation createIsCFAPlusOffset(int32_t Off);
+  LLVM_ABI static UnwindLocation createAtCFAPlusOffset(int32_t Off);
   /// Create a location where the saved value is in (Deref == false) or at
   /// (Deref == true) a regiser plus an offset and, optionally, in the specified
   /// address space (used mostly for the CFA).
@@ -116,18 +117,18 @@ public:
   /// frame pointer as the register, with an offset that accounts for all
   /// spilled registers and all local variables in a function, and Deref ==
   /// false.
-  static UnwindLocation
+  LLVM_ABI static UnwindLocation
   createIsRegisterPlusOffset(uint32_t Reg, int32_t Off,
                              std::optional<uint32_t> AddrSpace = std::nullopt);
-  static UnwindLocation
+  LLVM_ABI static UnwindLocation
   createAtRegisterPlusOffset(uint32_t Reg, int32_t Off,
                              std::optional<uint32_t> AddrSpace = std::nullopt);
   /// Create a location whose value is the result of evaluating a DWARF
   /// expression. This allows complex expressions to be evaluated in order to
   /// unwind a register or CFA value.
-  static UnwindLocation createIsDWARFExpression(DWARFExpression Expr);
-  static UnwindLocation createAtDWARFExpression(DWARFExpression Expr);
-  static UnwindLocation createIsConstant(int32_t Value);
+  LLVM_ABI static UnwindLocation createIsDWARFExpression(DWARFExpression Expr);
+  LLVM_ABI static UnwindLocation createAtDWARFExpression(DWARFExpression Expr);
+  LLVM_ABI static UnwindLocation createIsConstant(int32_t Value);
 
   Location getLocation() const { return Kind; }
   uint32_t getRegister() const { return RegNum; }
@@ -165,12 +166,12 @@ public:
   /// instead of from .debug_frame. This is needed for register number
   /// conversion because some register numbers differ between the two sections
   /// for certain architectures like x86.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const;
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const;
 
-  bool operator==(const UnwindLocation &RHS) const;
+  LLVM_ABI bool operator==(const UnwindLocation &RHS) const;
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const UnwindLocation &R);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const UnwindLocation &R);
 
 /// A class that can track all registers with locations in a UnwindRow object.
 ///
@@ -223,7 +224,7 @@ public:
   /// instead of from .debug_frame. This is needed for register number
   /// conversion because some register numbers differ between the two sections
   /// for certain architectures like x86.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const;
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const;
 
   /// Returns true if we have any register locations in this object.
   bool hasLocations() const { return !Locations.empty(); }
@@ -235,7 +236,7 @@ public:
   }
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const RegisterLocations &RL);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const RegisterLocations &RL);
 
 /// A class that represents a single row in the unwind table that is decoded by
 /// parsing the DWARF Call Frame Information opcodes.
@@ -304,11 +305,11 @@ public:
   ///
   /// \param IndentLevel specify the indent level as an integer. The UnwindRow
   /// will be output to the stream preceded by 2 * IndentLevel number of spaces.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
             unsigned IndentLevel = 0) const;
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const UnwindRow &Row);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const UnwindRow &Row);
 
 class CIE;
 class FDE;
@@ -348,7 +349,7 @@ public:
   ///
   /// \param IndentLevel specify the indent level as an integer. The UnwindRow
   /// will be output to the stream preceded by 2 * IndentLevel number of spaces.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
             unsigned IndentLevel = 0) const;
 
   /// Create an UnwindTable from a Common Information Entry (CIE).
@@ -359,7 +360,7 @@ public:
   ///
   /// \returns An error if the DWARF Call Frame Information opcodes have state
   /// machine errors, or a valid UnwindTable otherwise.
-  static Expected<UnwindTable> create(const CIE *Cie);
+  LLVM_ABI static Expected<UnwindTable> create(const CIE *Cie);
 
   /// Create an UnwindTable from a Frame Descriptor Entry (FDE).
   ///
@@ -369,7 +370,7 @@ public:
   ///
   /// \returns An error if the DWARF Call Frame Information opcodes have state
   /// machine errors, or a valid UnwindTable otherwise.
-  static Expected<UnwindTable> create(const FDE *Fde);
+  LLVM_ABI static Expected<UnwindTable> create(const FDE *Fde);
 
 private:
   RowContainer Rows;
@@ -396,7 +397,7 @@ private:
                   const RegisterLocations *InitialLocs);
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const UnwindTable &Rows);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const UnwindTable &Rows);
 
 /// An entry in either debug_frame or eh_frame. This entry can be a CIE or an
 /// FDE.
@@ -435,7 +436,7 @@ protected:
 };
 
 /// DWARF Common Information Entry (CIE)
-class CIE : public FrameEntry {
+class LLVM_ABI CIE : public FrameEntry {
 public:
   // CIEs (and FDEs) are simply container classes, so the only sensible way to
   // create them is by providing the full parsed contents in the constructor.
@@ -497,7 +498,7 @@ private:
 };
 
 /// DWARF Frame Description Entry (FDE)
-class FDE : public FrameEntry {
+class LLVM_ABI FDE : public FrameEntry {
 public:
   FDE(bool IsDWARF64, uint64_t Offset, uint64_t Length, uint64_t CIEPointer,
       uint64_t InitialLocation, uint64_t AddressRange, CIE *Cie,
@@ -553,17 +554,17 @@ public:
   // it is a .debug_frame section. EHFrameAddress should be different
   // than zero for correct parsing of .eh_frame addresses when they
   // use a PC-relative encoding.
-  DWARFDebugFrame(Triple::ArchType Arch,
+  LLVM_ABI DWARFDebugFrame(Triple::ArchType Arch,
                   bool IsEH = false, uint64_t EHFrameAddress = 0);
-  ~DWARFDebugFrame();
+  LLVM_ABI ~DWARFDebugFrame();
 
   /// Dump the section data into the given stream.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
             std::optional<uint64_t> Offset) const;
 
   /// Parse the section from raw data. \p Data is assumed to contain the whole
   /// frame section contents to be parsed.
-  Error parse(DWARFDataExtractor Data);
+  LLVM_ABI Error parse(DWARFDataExtractor Data);
 
   /// Return whether the section has any entries.
   bool empty() const { return Entries.empty(); }

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugInfoEntry.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugInfoEntry.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGINFOENTRY_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGINFOENTRY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h"
 #include <cstdint>
@@ -38,7 +39,7 @@ public:
   /// starting at a given offset. If DIE can't be extracted, returns false and
   /// doesn't change OffsetPtr.
   /// High performance extraction should use this call.
-  bool extractFast(const DWARFUnit &U, uint64_t *OffsetPtr,
+  LLVM_ABI bool extractFast(const DWARFUnit &U, uint64_t *OffsetPtr,
                    const DWARFDataExtractor &DebugInfoData, uint64_t UEndOffset,
                    uint32_t ParentIdx);
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugInfoEntry.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugInfoEntry.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGINFOENTRY_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGINFOENTRY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -40,8 +40,8 @@ public:
   /// doesn't change OffsetPtr.
   /// High performance extraction should use this call.
   LLVM_ABI bool extractFast(const DWARFUnit &U, uint64_t *OffsetPtr,
-                   const DWARFDataExtractor &DebugInfoData, uint64_t UEndOffset,
-                   uint32_t ParentIdx);
+                            const DWARFDataExtractor &DebugInfoData,
+                            uint64_t UEndOffset, uint32_t ParentIdx);
 
   uint64_t getOffset() const { return Offset; }
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGLINE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGLINE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DIContext.h"
@@ -53,11 +54,11 @@ public:
     bool HasSource = false;
 
     /// Update tracked content types with \p ContentType.
-    void trackContentType(dwarf::LineNumberEntryFormat ContentType);
+    LLVM_ABI void trackContentType(dwarf::LineNumberEntryFormat ContentType);
   };
 
   struct Prologue {
-    Prologue();
+    LLVM_ABI Prologue();
 
     /// The size in bytes of the statement information for this compilation unit
     /// (not including the total_length field itself).
@@ -101,43 +102,43 @@ public:
 
     uint32_t sizeofPrologueLength() const { return isDWARF64() ? 8 : 4; }
 
-    bool totalLengthIsValid() const;
+    LLVM_ABI bool totalLengthIsValid() const;
 
     /// Length of the prologue in bytes.
-    uint64_t getLength() const;
+    LLVM_ABI uint64_t getLength() const;
 
     /// Get DWARF-version aware access to the file name entry at the provided
     /// index.
-    const llvm::DWARFDebugLine::FileNameEntry &
+    LLVM_ABI const llvm::DWARFDebugLine::FileNameEntry &
     getFileNameEntry(uint64_t Index) const;
 
-    bool hasFileAtIndex(uint64_t FileIndex) const;
+    LLVM_ABI bool hasFileAtIndex(uint64_t FileIndex) const;
 
-    std::optional<uint64_t> getLastValidFileIndex() const;
+    LLVM_ABI std::optional<uint64_t> getLastValidFileIndex() const;
 
-    bool
+    LLVM_ABI bool
     getFileNameByIndex(uint64_t FileIndex, StringRef CompDir,
                        DILineInfoSpecifier::FileLineInfoKind Kind,
                        std::string &Result,
                        sys::path::Style Style = sys::path::Style::native) const;
 
-    void clear();
-    void dump(raw_ostream &OS, DIDumpOptions DumpOptions) const;
-    Error parse(DWARFDataExtractor Data, uint64_t *OffsetPtr,
+    LLVM_ABI void clear();
+    LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOptions) const;
+    LLVM_ABI Error parse(DWARFDataExtractor Data, uint64_t *OffsetPtr,
                 function_ref<void(Error)> RecoverableErrorHandler,
                 const DWARFContext &Ctx, const DWARFUnit *U = nullptr);
   };
 
   /// Standard .debug_line state machine structure.
   struct Row {
-    explicit Row(bool DefaultIsStmt = false);
+    LLVM_ABI explicit Row(bool DefaultIsStmt = false);
 
     /// Called after a row is appended to the matrix.
-    void postAppend();
-    void reset(bool DefaultIsStmt);
-    void dump(raw_ostream &OS) const;
+    LLVM_ABI void postAppend();
+    LLVM_ABI void reset(bool DefaultIsStmt);
+    LLVM_ABI void dump(raw_ostream &OS) const;
 
-    static void dumpTableHeader(raw_ostream &OS, unsigned Indent);
+    LLVM_ABI static void dumpTableHeader(raw_ostream &OS, unsigned Indent);
 
     static bool orderByAddress(const Row &LHS, const Row &RHS) {
       return std::tie(LHS.Address.SectionIndex, LHS.Address.Address) <
@@ -195,7 +196,7 @@ public:
   /// each compilation unit may consist of multiple sequences, which are not
   /// guaranteed to be in the order of ascending instruction address.
   struct Sequence {
-    Sequence();
+    LLVM_ABI Sequence();
 
     /// Sequence describes instructions at address range [LowPC, HighPC)
     /// and is described by line table rows [FirstRowIndex, LastRowIndex).
@@ -212,7 +213,7 @@ public:
     /// The offset into the line table where this sequence begins
     uint64_t StmtSeqOffset = UINT64_MAX;
 
-    void reset();
+    LLVM_ABI void reset();
 
     static bool orderByHighPC(const Sequence &LHS, const Sequence &RHS) {
       return std::tie(LHS.SectionIndex, LHS.HighPC) <
@@ -230,7 +231,7 @@ public:
   };
 
   struct LineTable {
-    LineTable();
+    LLVM_ABI LineTable();
 
     /// Represents an invalid row
     const uint32_t UnknownRowIndex = UINT32_MAX;
@@ -243,7 +244,7 @@ public:
 
     /// Returns the index of the row with file/line info for a given address,
     /// or UnknownRowIndex if there is no such row.
-    uint32_t lookupAddress(object::SectionedAddress Address,
+    LLVM_ABI uint32_t lookupAddress(object::SectionedAddress Address,
                            bool *IsApproximateLine = nullptr) const;
 
     /// Fills the Result argument with the indices of the rows that correspond
@@ -256,7 +257,7 @@ public:
     /// starting at the matching offset will be added to the result.
     ///
     /// Returns true if any rows were found.
-    bool lookupAddressRange(
+    LLVM_ABI bool lookupAddressRange(
         object::SectionedAddress Address, uint64_t Size,
         std::vector<uint32_t> &Result,
         std::optional<uint64_t> StmtSequenceOffset = std::nullopt) const;
@@ -282,21 +283,21 @@ public:
 
     /// Fills the Result argument with the file and line information
     /// corresponding to Address. Returns true on success.
-    bool getFileLineInfoForAddress(object::SectionedAddress Address,
+    LLVM_ABI bool getFileLineInfoForAddress(object::SectionedAddress Address,
                                    bool Approximate, const char *CompDir,
                                    DILineInfoSpecifier::FileLineInfoKind Kind,
                                    DILineInfo &Result) const;
 
     /// Extracts directory name by its Entry in include directories table
     /// in prologue. Returns true on success.
-    bool getDirectoryForEntry(const FileNameEntry &Entry,
+    LLVM_ABI bool getDirectoryForEntry(const FileNameEntry &Entry,
                               std::string &Directory) const;
 
-    void dump(raw_ostream &OS, DIDumpOptions DumpOptions) const;
-    void clear();
+    LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOptions) const;
+    LLVM_ABI void clear();
 
     /// Parse prologue and all rows.
-    Error parse(DWARFDataExtractor &DebugLineData, uint64_t *OffsetPtr,
+    LLVM_ABI Error parse(DWARFDataExtractor &DebugLineData, uint64_t *OffsetPtr,
                 const DWARFContext &Ctx, const DWARFUnit *U,
                 function_ref<void(Error)> RecoverableErrorHandler,
                 raw_ostream *OS = nullptr, bool Verbose = false);
@@ -336,19 +337,19 @@ public:
                            std::optional<uint64_t> StmtSequenceOffset) const;
   };
 
-  const LineTable *getLineTable(uint64_t Offset) const;
-  Expected<const LineTable *>
+  LLVM_ABI const LineTable *getLineTable(uint64_t Offset) const;
+  LLVM_ABI Expected<const LineTable *>
   getOrParseLineTable(DWARFDataExtractor &DebugLineData, uint64_t Offset,
                       const DWARFContext &Ctx, const DWARFUnit *U,
                       function_ref<void(Error)> RecoverableErrorHandler);
-  void clearLineTable(uint64_t Offset);
+  LLVM_ABI void clearLineTable(uint64_t Offset);
 
   /// Helper to allow for parsing of an entire .debug_line section in sequence.
   class SectionParser {
   public:
     using LineToUnitMap = std::map<uint64_t, DWARFUnit *>;
 
-    SectionParser(DWARFDataExtractor &Data, const DWARFContext &C,
+    LLVM_ABI SectionParser(DWARFDataExtractor &Data, const DWARFContext &C,
                   DWARFUnitVector::iterator_range Units);
 
     /// Get the next line table from the section. Report any issues via the
@@ -362,7 +363,7 @@ public:
     /// table as it parses it.
     /// \param Verbose - if true, the parser will print verbose information when
     /// printing to the output.
-    LineTable parseNext(function_ref<void(Error)> RecoverableErrorHandler,
+    LLVM_ABI LineTable parseNext(function_ref<void(Error)> RecoverableErrorHandler,
                         function_ref<void(Error)> UnrecoverableErrorHandler,
                         raw_ostream *OS = nullptr, bool Verbose = false);
 
@@ -373,7 +374,7 @@ public:
     /// parsing issues via this handler.
     /// \param UnrecoverableErrorHandler - report any unrecoverable prologue
     /// parsing issues via this handler.
-    void skip(function_ref<void(Error)> RecoverableErrorHandler,
+    LLVM_ABI void skip(function_ref<void(Error)> RecoverableErrorHandler,
               function_ref<void(Error)> UnrecoverableErrorHandler);
 
     /// Indicates if the parser has parsed as much as possible.
@@ -400,11 +401,11 @@ public:
 
 private:
   struct ParsingState {
-    ParsingState(struct LineTable *LT, uint64_t TableOffset,
+    LLVM_ABI ParsingState(struct LineTable *LT, uint64_t TableOffset,
                  function_ref<void(Error)> ErrorHandler);
 
-    void resetRowAndSequence(uint64_t Offset);
-    void appendRowToMatrix();
+    LLVM_ABI void resetRowAndSequence(uint64_t Offset);
+    LLVM_ABI void appendRowToMatrix();
 
     struct AddrOpIndexDelta {
       uint64_t AddrOffset;
@@ -413,7 +414,7 @@ private:
 
     /// Advance the address and op-index by the \p OperationAdvance value.
     /// \returns the amount advanced by.
-    AddrOpIndexDelta advanceAddrOpIndex(uint64_t OperationAdvance,
+    LLVM_ABI AddrOpIndexDelta advanceAddrOpIndex(uint64_t OperationAdvance,
                                         uint8_t Opcode, uint64_t OpcodeOffset);
 
     struct OpcodeAdvanceResults {
@@ -424,7 +425,7 @@ private:
 
     /// Advance the address and op-index as required by the specified \p Opcode.
     /// \returns the amount advanced by and the calculated adjusted opcode.
-    OpcodeAdvanceResults advanceForOpcode(uint8_t Opcode,
+    LLVM_ABI OpcodeAdvanceResults advanceForOpcode(uint8_t Opcode,
                                           uint64_t OpcodeOffset);
 
     struct SpecialOpcodeDelta {
@@ -435,7 +436,7 @@ private:
 
     /// Advance the line, address and op-index as required by the specified
     /// special \p Opcode. \returns the address, op-index and line delta.
-    SpecialOpcodeDelta handleSpecialOpcode(uint8_t Opcode,
+    LLVM_ABI SpecialOpcodeDelta handleSpecialOpcode(uint8_t Opcode,
                                            uint64_t OpcodeOffset);
 
     /// Line table we're currently parsing.

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGLINE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGLINE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnit.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/Path.h"
 #include <cstdint>
@@ -125,8 +125,8 @@ public:
     LLVM_ABI void clear();
     LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOptions) const;
     LLVM_ABI Error parse(DWARFDataExtractor Data, uint64_t *OffsetPtr,
-                function_ref<void(Error)> RecoverableErrorHandler,
-                const DWARFContext &Ctx, const DWARFUnit *U = nullptr);
+                         function_ref<void(Error)> RecoverableErrorHandler,
+                         const DWARFContext &Ctx, const DWARFUnit *U = nullptr);
   };
 
   /// Standard .debug_line state machine structure.
@@ -245,7 +245,7 @@ public:
     /// Returns the index of the row with file/line info for a given address,
     /// or UnknownRowIndex if there is no such row.
     LLVM_ABI uint32_t lookupAddress(object::SectionedAddress Address,
-                           bool *IsApproximateLine = nullptr) const;
+                                    bool *IsApproximateLine = nullptr) const;
 
     /// Fills the Result argument with the indices of the rows that correspond
     /// to the address range specified by \p Address and \p Size.
@@ -283,24 +283,23 @@ public:
 
     /// Fills the Result argument with the file and line information
     /// corresponding to Address. Returns true on success.
-    LLVM_ABI bool getFileLineInfoForAddress(object::SectionedAddress Address,
-                                   bool Approximate, const char *CompDir,
-                                   DILineInfoSpecifier::FileLineInfoKind Kind,
-                                   DILineInfo &Result) const;
+    LLVM_ABI bool getFileLineInfoForAddress(
+        object::SectionedAddress Address, bool Approximate, const char *CompDir,
+        DILineInfoSpecifier::FileLineInfoKind Kind, DILineInfo &Result) const;
 
     /// Extracts directory name by its Entry in include directories table
     /// in prologue. Returns true on success.
     LLVM_ABI bool getDirectoryForEntry(const FileNameEntry &Entry,
-                              std::string &Directory) const;
+                                       std::string &Directory) const;
 
     LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOptions) const;
     LLVM_ABI void clear();
 
     /// Parse prologue and all rows.
     LLVM_ABI Error parse(DWARFDataExtractor &DebugLineData, uint64_t *OffsetPtr,
-                const DWARFContext &Ctx, const DWARFUnit *U,
-                function_ref<void(Error)> RecoverableErrorHandler,
-                raw_ostream *OS = nullptr, bool Verbose = false);
+                         const DWARFContext &Ctx, const DWARFUnit *U,
+                         function_ref<void(Error)> RecoverableErrorHandler,
+                         raw_ostream *OS = nullptr, bool Verbose = false);
 
     using RowVector = std::vector<Row>;
     using RowIter = RowVector::const_iterator;
@@ -350,7 +349,7 @@ public:
     using LineToUnitMap = std::map<uint64_t, DWARFUnit *>;
 
     LLVM_ABI SectionParser(DWARFDataExtractor &Data, const DWARFContext &C,
-                  DWARFUnitVector::iterator_range Units);
+                           DWARFUnitVector::iterator_range Units);
 
     /// Get the next line table from the section. Report any issues via the
     /// handlers.
@@ -363,9 +362,10 @@ public:
     /// table as it parses it.
     /// \param Verbose - if true, the parser will print verbose information when
     /// printing to the output.
-    LLVM_ABI LineTable parseNext(function_ref<void(Error)> RecoverableErrorHandler,
-                        function_ref<void(Error)> UnrecoverableErrorHandler,
-                        raw_ostream *OS = nullptr, bool Verbose = false);
+    LLVM_ABI LineTable
+    parseNext(function_ref<void(Error)> RecoverableErrorHandler,
+              function_ref<void(Error)> UnrecoverableErrorHandler,
+              raw_ostream *OS = nullptr, bool Verbose = false);
 
     /// Skip the current line table and go to the following line table (if
     /// present) immediately.
@@ -375,7 +375,7 @@ public:
     /// \param UnrecoverableErrorHandler - report any unrecoverable prologue
     /// parsing issues via this handler.
     LLVM_ABI void skip(function_ref<void(Error)> RecoverableErrorHandler,
-              function_ref<void(Error)> UnrecoverableErrorHandler);
+                       function_ref<void(Error)> UnrecoverableErrorHandler);
 
     /// Indicates if the parser has parsed as much as possible.
     ///
@@ -402,7 +402,7 @@ public:
 private:
   struct ParsingState {
     LLVM_ABI ParsingState(struct LineTable *LT, uint64_t TableOffset,
-                 function_ref<void(Error)> ErrorHandler);
+                          function_ref<void(Error)> ErrorHandler);
 
     LLVM_ABI void resetRowAndSequence(uint64_t Offset);
     LLVM_ABI void appendRowToMatrix();
@@ -415,7 +415,8 @@ private:
     /// Advance the address and op-index by the \p OperationAdvance value.
     /// \returns the amount advanced by.
     LLVM_ABI AddrOpIndexDelta advanceAddrOpIndex(uint64_t OperationAdvance,
-                                        uint8_t Opcode, uint64_t OpcodeOffset);
+                                                 uint8_t Opcode,
+                                                 uint64_t OpcodeOffset);
 
     struct OpcodeAdvanceResults {
       uint64_t AddrDelta;
@@ -426,7 +427,7 @@ private:
     /// Advance the address and op-index as required by the specified \p Opcode.
     /// \returns the amount advanced by and the calculated adjusted opcode.
     LLVM_ABI OpcodeAdvanceResults advanceForOpcode(uint8_t Opcode,
-                                          uint64_t OpcodeOffset);
+                                                   uint64_t OpcodeOffset);
 
     struct SpecialOpcodeDelta {
       uint64_t Address;
@@ -437,7 +438,7 @@ private:
     /// Advance the line, address and op-index as required by the specified
     /// special \p Opcode. \returns the address, op-index and line delta.
     LLVM_ABI SpecialOpcodeDelta handleSpecialOpcode(uint8_t Opcode,
-                                           uint64_t OpcodeOffset);
+                                                    uint64_t OpcodeOffset);
 
     /// Line table we're currently parsing.
     struct LineTable *LineTable;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLoc.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLoc.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGLOC_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGLOC_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Errc.h"
 #include <cstdint>
 
@@ -65,10 +65,11 @@ public:
   /// iff it has successfully reched the end of the list. This means that one
   /// can attempt to parse another list after the current one (\p Offset will be
   /// updated to point past the end of the current list).
-  LLVM_ABI bool dumpLocationList(uint64_t *Offset, raw_ostream &OS,
-                        std::optional<object::SectionedAddress> BaseAddr,
-                        const DWARFObject &Obj, DWARFUnit *U,
-                        DIDumpOptions DumpOpts, unsigned Indent) const;
+  LLVM_ABI bool
+  dumpLocationList(uint64_t *Offset, raw_ostream &OS,
+                   std::optional<object::SectionedAddress> BaseAddr,
+                   const DWARFObject &Obj, DWARFUnit *U, DIDumpOptions DumpOpts,
+                   unsigned Indent) const;
 
   LLVM_ABI Error visitAbsoluteLocationList(
       uint64_t Offset, std::optional<object::SectionedAddress> BaseAddr,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLoc.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLoc.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGLOC_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGLOC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/Support/Errc.h"
@@ -64,12 +65,12 @@ public:
   /// iff it has successfully reched the end of the list. This means that one
   /// can attempt to parse another list after the current one (\p Offset will be
   /// updated to point past the end of the current list).
-  bool dumpLocationList(uint64_t *Offset, raw_ostream &OS,
+  LLVM_ABI bool dumpLocationList(uint64_t *Offset, raw_ostream &OS,
                         std::optional<object::SectionedAddress> BaseAddr,
                         const DWARFObject &Obj, DWARFUnit *U,
                         DIDumpOptions DumpOpts, unsigned Indent) const;
 
-  Error visitAbsoluteLocationList(
+  LLVM_ABI Error visitAbsoluteLocationList(
       uint64_t Offset, std::optional<object::SectionedAddress> BaseAddr,
       std::function<std::optional<object::SectionedAddress>(uint32_t)>
           LookupAddr,
@@ -85,7 +86,7 @@ protected:
                             const DWARFObject &Obj) const = 0;
 };
 
-class DWARFDebugLoc final : public DWARFLocationTable {
+class LLVM_ABI DWARFDebugLoc final : public DWARFLocationTable {
 public:
   /// A list of locations that contain one variable.
   struct LocationList {
@@ -121,7 +122,7 @@ protected:
                     const DWARFObject &Obj) const override;
 };
 
-class DWARFDebugLoclists final : public DWARFLocationTable {
+class LLVM_ABI DWARFDebugLoclists final : public DWARFLocationTable {
 public:
   DWARFDebugLoclists(DWARFDataExtractor Data, uint16_t Version)
       : DWARFLocationTable(std::move(Data)), Version(Version) {}
@@ -143,7 +144,7 @@ private:
   uint16_t Version;
 };
 
-class ResolverError : public ErrorInfo<ResolverError> {
+class LLVM_ABI ResolverError : public ErrorInfo<ResolverError> {
 public:
   static char ID;
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugPubTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugPubTable.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGPUBTABLE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGPUBTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <vector>
 
@@ -76,7 +76,7 @@ public:
   DWARFDebugPubTable() = default;
 
   LLVM_ABI void extract(DWARFDataExtractor Data, bool GnuStyle,
-               function_ref<void(Error)> RecoverableErrorHandler);
+                        function_ref<void(Error)> RecoverableErrorHandler);
 
   LLVM_ABI void dump(raw_ostream &OS) const;
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugPubTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugPubTable.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGPUBTABLE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGPUBTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -74,10 +75,10 @@ private:
 public:
   DWARFDebugPubTable() = default;
 
-  void extract(DWARFDataExtractor Data, bool GnuStyle,
+  LLVM_ABI void extract(DWARFDataExtractor Data, bool GnuStyle,
                function_ref<void(Error)> RecoverableErrorHandler);
 
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI void dump(raw_ostream &OS) const;
 
   ArrayRef<Set> getData() { return Sets; }
 };

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRangeList.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRangeList.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGRANGELIST_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGRANGELIST_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <vector>
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRangeList.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRangeList.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGRANGELIST_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGRANGELIST_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
 #include <cstdint>
 #include <vector>
@@ -51,7 +52,7 @@ public:
     /// 2. An address, which defines the appropriate base address for
     /// use in interpreting the beginning and ending address offsets of
     /// subsequent entries of the location list.
-    bool isBaseAddressSelectionEntry(uint8_t AddressSize) const;
+    LLVM_ABI bool isBaseAddressSelectionEntry(uint8_t AddressSize) const;
   };
 
 private:
@@ -63,15 +64,15 @@ private:
 public:
   DWARFDebugRangeList() { clear(); }
 
-  void clear();
-  void dump(raw_ostream &OS) const;
-  Error extract(const DWARFDataExtractor &data, uint64_t *offset_ptr);
+  LLVM_ABI void clear();
+  LLVM_ABI void dump(raw_ostream &OS) const;
+  LLVM_ABI Error extract(const DWARFDataExtractor &data, uint64_t *offset_ptr);
   const std::vector<RangeListEntry> &getEntries() { return Entries; }
 
   /// getAbsoluteRanges - Returns absolute address ranges defined by this range
   /// list. Has to be passed base address of the compile unit referencing this
   /// range list.
-  DWARFAddressRangesVector
+  LLVM_ABI DWARFAddressRangesVector
   getAbsoluteRanges(std::optional<object::SectionedAddress> BaseAddr) const;
 };
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRnglists.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRnglists.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGRNGLISTS_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGRNGLISTS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
@@ -35,8 +36,8 @@ struct RangeListEntry : public DWARFListEntryBase {
   uint64_t Value0;
   uint64_t Value1;
 
-  Error extract(DWARFDataExtractor Data, uint64_t *OffsetPtr);
-  void
+  LLVM_ABI Error extract(DWARFDataExtractor Data, uint64_t *OffsetPtr);
+  LLVM_ABI void
   dump(raw_ostream &OS, uint8_t AddrSize, uint8_t MaxEncodingStringLength,
        uint64_t &CurrentBase, DIDumpOptions DumpOpts,
        llvm::function_ref<std::optional<object::SectionedAddress>(uint32_t)>
@@ -48,13 +49,13 @@ struct RangeListEntry : public DWARFListEntryBase {
 class DWARFDebugRnglist : public DWARFListType<RangeListEntry> {
 public:
   /// Build a DWARFAddressRangesVector from a rangelist.
-  DWARFAddressRangesVector getAbsoluteRanges(
+  LLVM_ABI DWARFAddressRangesVector getAbsoluteRanges(
       std::optional<object::SectionedAddress> BaseAddr, uint8_t AddressByteSize,
       function_ref<std::optional<object::SectionedAddress>(uint32_t)>
           LookupPooledAddress) const;
 
   /// Build a DWARFAddressRangesVector from a rangelist.
-  DWARFAddressRangesVector
+  LLVM_ABI DWARFAddressRangesVector
   getAbsoluteRanges(std::optional<object::SectionedAddress> BaseAddr,
                     DWARFUnit &U) const;
 };

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRnglists.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRnglists.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDEBUGRNGLISTS_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDEBUGRNGLISTS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
 #include "llvm/DebugInfo/DWARF/DWARFListTable.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -55,9 +55,8 @@ public:
           LookupPooledAddress) const;
 
   /// Build a DWARFAddressRangesVector from a rangelist.
-  LLVM_ABI DWARFAddressRangesVector
-  getAbsoluteRanges(std::optional<object::SectionedAddress> BaseAddr,
-                    DWARFUnit &U) const;
+  LLVM_ABI DWARFAddressRangesVector getAbsoluteRanges(
+      std::optional<object::SectionedAddress> BaseAddr, DWARFUnit &U) const;
 };
 
 class DWARFDebugRnglistTable : public DWARFListTableBase<DWARFDebugRnglist> {

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDIE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDIE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
@@ -19,6 +18,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFAttribute.h"
 #include "llvm/DebugInfo/DWARF/DWARFDebugInfoEntry.h"
 #include "llvm/DebugInfo/DWARF/DWARFLocationExpression.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <iterator>
@@ -126,7 +126,7 @@ public:
   /// \param OS the stream to use for output.
   /// \param indent the number of characters to indent each line that is output.
   LLVM_ABI void dump(raw_ostream &OS, unsigned indent = 0,
-            DIDumpOptions DumpOpts = DIDumpOptions()) const;
+                     DIDumpOptions DumpOpts = DIDumpOptions()) const;
 
   /// Convenience zero-argument overload for debugging.
   LLVM_ABI LLVM_DUMP_METHOD void dump() const;
@@ -153,7 +153,8 @@ public:
   /// \returns an optional that has a valid DWARFFormValue for the first
   /// matching attribute in Attrs, or std::nullopt if none of the attributes in
   /// Attrs exist in this DIE.
-  LLVM_ABI std::optional<DWARFFormValue> find(ArrayRef<dwarf::Attribute> Attrs) const;
+  LLVM_ABI std::optional<DWARFFormValue>
+  find(ArrayRef<dwarf::Attribute> Attrs) const;
 
   /// Extract the first value of any attribute in Attrs from this DIE and
   /// recurse into any DW_AT_specification or DW_AT_abstract_origin referenced
@@ -180,8 +181,10 @@ public:
   /// \param Attr the attribute to extract.
   /// \returns a valid DWARFDie instance if the attribute exists, or an invalid
   /// DWARFDie object if it doesn't.
-  LLVM_ABI DWARFDie getAttributeValueAsReferencedDie(dwarf::Attribute Attr) const;
-  LLVM_ABI DWARFDie getAttributeValueAsReferencedDie(const DWARFFormValue &V) const;
+  LLVM_ABI DWARFDie
+  getAttributeValueAsReferencedDie(dwarf::Attribute Attr) const;
+  LLVM_ABI DWARFDie
+  getAttributeValueAsReferencedDie(const DWARFFormValue &V) const;
 
   LLVM_ABI DWARFDie resolveTypeUnitReference() const;
 
@@ -211,7 +214,7 @@ public:
   /// Retrieves DW_AT_low_pc and DW_AT_high_pc from CU.
   /// Returns true if both attributes are present.
   LLVM_ABI bool getLowAndHighPC(uint64_t &LowPC, uint64_t &HighPC,
-                       uint64_t &SectionIndex) const;
+                                uint64_t &SectionIndex) const;
 
   /// Get the address ranges for this DIE.
   ///
@@ -244,7 +247,7 @@ public:
   /// Returns null if no name is found.
   LLVM_ABI const char *getName(DINameKind Kind) const;
   LLVM_ABI void getFullName(raw_string_ostream &,
-                   std::string *OriginalFullName = nullptr) const;
+                            std::string *OriginalFullName = nullptr) const;
 
   /// Return the DIE short name resolving DW_AT_specification or
   /// DW_AT_abstract_origin references if necessary. Returns null if no name
@@ -261,7 +264,8 @@ public:
   /// for this subprogram by resolving DW_AT_sepcification or
   /// DW_AT_abstract_origin references if necessary.
   LLVM_ABI uint64_t getDeclLine() const;
-  LLVM_ABI std::string getDeclFile(DILineInfoSpecifier::FileLineInfoKind Kind) const;
+  LLVM_ABI std::string
+  getDeclFile(DILineInfoSpecifier::FileLineInfoKind Kind) const;
 
   /// Retrieves values of DW_AT_call_file, DW_AT_call_line and DW_AT_call_column
   /// from DIE (or zeroes if they are missing). This function looks for
@@ -276,7 +280,8 @@ public:
   /// \param CallDiscriminator filled in with non-zero if successful, zero if
   /// there is no DW_AT_GNU_discriminator attribute in this DIE.
   LLVM_ABI void getCallerFrame(uint32_t &CallFile, uint32_t &CallLine,
-                      uint32_t &CallColumn, uint32_t &CallDiscriminator) const;
+                               uint32_t &CallColumn,
+                               uint32_t &CallDiscriminator) const;
 
   class attribute_iterator;
 
@@ -484,7 +489,7 @@ inline std::reverse_iterator<DWARFDie::iterator> DWARFDie::rend() const {
 
 LLVM_ABI void dumpTypeQualifiedName(const DWARFDie &DIE, raw_ostream &OS);
 LLVM_ABI void dumpTypeUnqualifiedName(const DWARFDie &DIE, raw_ostream &OS,
-                             std::string *OriginalFullName = nullptr);
+                                      std::string *OriginalFullName = nullptr);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFDIE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFDIE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
@@ -85,50 +86,50 @@ public:
   bool isNULL() const { return getAbbreviationDeclarationPtr() == nullptr; }
 
   /// Returns true if DIE represents a subprogram (not inlined).
-  bool isSubprogramDIE() const;
+  LLVM_ABI bool isSubprogramDIE() const;
 
   /// Returns true if DIE represents a subprogram or an inlined subroutine.
-  bool isSubroutineDIE() const;
+  LLVM_ABI bool isSubroutineDIE() const;
 
   /// Get the parent of this DIE object.
   ///
   /// \returns a valid DWARFDie instance if this object has a parent or an
   /// invalid DWARFDie instance if it doesn't.
-  DWARFDie getParent() const;
+  LLVM_ABI DWARFDie getParent() const;
 
   /// Get the sibling of this DIE object.
   ///
   /// \returns a valid DWARFDie instance if this object has a sibling or an
   /// invalid DWARFDie instance if it doesn't.
-  DWARFDie getSibling() const;
+  LLVM_ABI DWARFDie getSibling() const;
 
   /// Get the previous sibling of this DIE object.
   ///
   /// \returns a valid DWARFDie instance if this object has a sibling or an
   /// invalid DWARFDie instance if it doesn't.
-  DWARFDie getPreviousSibling() const;
+  LLVM_ABI DWARFDie getPreviousSibling() const;
 
   /// Get the first child of this DIE object.
   ///
   /// \returns a valid DWARFDie instance if this object has children or an
   /// invalid DWARFDie instance if it doesn't.
-  DWARFDie getFirstChild() const;
+  LLVM_ABI DWARFDie getFirstChild() const;
 
   /// Get the last child of this DIE object.
   ///
   /// \returns a valid null DWARFDie instance if this object has children or an
   /// invalid DWARFDie instance if it doesn't.
-  DWARFDie getLastChild() const;
+  LLVM_ABI DWARFDie getLastChild() const;
 
   /// Dump the DIE and all of its attributes to the supplied stream.
   ///
   /// \param OS the stream to use for output.
   /// \param indent the number of characters to indent each line that is output.
-  void dump(raw_ostream &OS, unsigned indent = 0,
+  LLVM_ABI void dump(raw_ostream &OS, unsigned indent = 0,
             DIDumpOptions DumpOpts = DIDumpOptions()) const;
 
   /// Convenience zero-argument overload for debugging.
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
 
   /// Extract the specified attribute from this DIE.
   ///
@@ -139,7 +140,7 @@ public:
   /// \param Attr the attribute to extract.
   /// \returns an optional DWARFFormValue that will have the form value if the
   /// attribute was successfully extracted.
-  std::optional<DWARFFormValue> find(dwarf::Attribute Attr) const;
+  LLVM_ABI std::optional<DWARFFormValue> find(dwarf::Attribute Attr) const;
 
   /// Extract the first value of any attribute in Attrs from this DIE.
   ///
@@ -152,7 +153,7 @@ public:
   /// \returns an optional that has a valid DWARFFormValue for the first
   /// matching attribute in Attrs, or std::nullopt if none of the attributes in
   /// Attrs exist in this DIE.
-  std::optional<DWARFFormValue> find(ArrayRef<dwarf::Attribute> Attrs) const;
+  LLVM_ABI std::optional<DWARFFormValue> find(ArrayRef<dwarf::Attribute> Attrs) const;
 
   /// Extract the first value of any attribute in Attrs from this DIE and
   /// recurse into any DW_AT_specification or DW_AT_abstract_origin referenced
@@ -163,7 +164,7 @@ public:
   /// matching attribute in Attrs, or std::nullopt if none of the attributes in
   /// Attrs exist in this DIE or in any DW_AT_specification or
   /// DW_AT_abstract_origin DIEs.
-  std::optional<DWARFFormValue>
+  LLVM_ABI std::optional<DWARFFormValue>
   findRecursively(ArrayRef<dwarf::Attribute> Attrs) const;
 
   /// Extract the specified attribute from this DIE as the referenced DIE.
@@ -179,21 +180,21 @@ public:
   /// \param Attr the attribute to extract.
   /// \returns a valid DWARFDie instance if the attribute exists, or an invalid
   /// DWARFDie object if it doesn't.
-  DWARFDie getAttributeValueAsReferencedDie(dwarf::Attribute Attr) const;
-  DWARFDie getAttributeValueAsReferencedDie(const DWARFFormValue &V) const;
+  LLVM_ABI DWARFDie getAttributeValueAsReferencedDie(dwarf::Attribute Attr) const;
+  LLVM_ABI DWARFDie getAttributeValueAsReferencedDie(const DWARFFormValue &V) const;
 
-  DWARFDie resolveTypeUnitReference() const;
+  LLVM_ABI DWARFDie resolveTypeUnitReference() const;
 
-  DWARFDie resolveReferencedType(dwarf::Attribute Attr) const;
-  DWARFDie resolveReferencedType(const DWARFFormValue &V) const;
+  LLVM_ABI DWARFDie resolveReferencedType(dwarf::Attribute Attr) const;
+  LLVM_ABI DWARFDie resolveReferencedType(const DWARFFormValue &V) const;
   /// Extract the range base attribute from this DIE as absolute section offset.
   ///
   /// This is a utility function that checks for either the DW_AT_rnglists_base
   /// or DW_AT_GNU_ranges_base attribute.
   ///
   /// \returns anm optional absolute section offset value for the attribute.
-  std::optional<uint64_t> getRangesBaseAttribute() const;
-  std::optional<uint64_t> getLocBaseAttribute() const;
+  LLVM_ABI std::optional<uint64_t> getRangesBaseAttribute() const;
+  LLVM_ABI std::optional<uint64_t> getLocBaseAttribute() const;
 
   /// Get the DW_AT_high_pc attribute value as an address.
   ///
@@ -205,11 +206,11 @@ public:
   ///
   /// \param LowPC the low PC that might be needed to calculate the high PC.
   /// \returns an optional address value for the attribute.
-  std::optional<uint64_t> getHighPC(uint64_t LowPC) const;
+  LLVM_ABI std::optional<uint64_t> getHighPC(uint64_t LowPC) const;
 
   /// Retrieves DW_AT_low_pc and DW_AT_high_pc from CU.
   /// Returns true if both attributes are present.
-  bool getLowAndHighPC(uint64_t &LowPC, uint64_t &HighPC,
+  LLVM_ABI bool getLowAndHighPC(uint64_t &LowPC, uint64_t &HighPC,
                        uint64_t &SectionIndex) const;
 
   /// Get the address ranges for this DIE.
@@ -222,45 +223,45 @@ public:
   ///
   /// \returns a address range vector that might be empty if no address range
   /// information is available.
-  Expected<DWARFAddressRangesVector> getAddressRanges() const;
+  LLVM_ABI Expected<DWARFAddressRangesVector> getAddressRanges() const;
 
-  bool addressRangeContainsAddress(const uint64_t Address) const;
+  LLVM_ABI bool addressRangeContainsAddress(const uint64_t Address) const;
 
-  std::optional<uint64_t> getLanguage() const;
+  LLVM_ABI std::optional<uint64_t> getLanguage() const;
 
-  Expected<DWARFLocationExpressionsVector>
+  LLVM_ABI Expected<DWARFLocationExpressionsVector>
   getLocations(dwarf::Attribute Attr) const;
 
   /// If a DIE represents a subprogram (or inlined subroutine), returns its
   /// mangled name (or short name, if mangled is missing). This name may be
   /// fetched from specification or abstract origin for this subprogram.
   /// Returns null if no name is found.
-  const char *getSubroutineName(DINameKind Kind) const;
+  LLVM_ABI const char *getSubroutineName(DINameKind Kind) const;
 
   /// Return the DIE name resolving DW_AT_specification or DW_AT_abstract_origin
   /// references if necessary. For the LinkageName case it additionaly searches
   /// for ShortName if LinkageName is not found.
   /// Returns null if no name is found.
-  const char *getName(DINameKind Kind) const;
-  void getFullName(raw_string_ostream &,
+  LLVM_ABI const char *getName(DINameKind Kind) const;
+  LLVM_ABI void getFullName(raw_string_ostream &,
                    std::string *OriginalFullName = nullptr) const;
 
   /// Return the DIE short name resolving DW_AT_specification or
   /// DW_AT_abstract_origin references if necessary. Returns null if no name
   /// is found.
-  const char *getShortName() const;
+  LLVM_ABI const char *getShortName() const;
 
   /// Return the DIE linkage name resolving DW_AT_specification or
   /// DW_AT_abstract_origin references if necessary. Returns null if no name
   /// is found.
-  const char *getLinkageName() const;
+  LLVM_ABI const char *getLinkageName() const;
 
   /// Returns the declaration line (start line) for a DIE, assuming it specifies
   /// a subprogram. This may be fetched from specification or abstract origin
   /// for this subprogram by resolving DW_AT_sepcification or
   /// DW_AT_abstract_origin references if necessary.
-  uint64_t getDeclLine() const;
-  std::string getDeclFile(DILineInfoSpecifier::FileLineInfoKind Kind) const;
+  LLVM_ABI uint64_t getDeclLine() const;
+  LLVM_ABI std::string getDeclFile(DILineInfoSpecifier::FileLineInfoKind Kind) const;
 
   /// Retrieves values of DW_AT_call_file, DW_AT_call_line and DW_AT_call_column
   /// from DIE (or zeroes if they are missing). This function looks for
@@ -274,7 +275,7 @@ public:
   /// no DW_AT_call_column attribute in this DIE.
   /// \param CallDiscriminator filled in with non-zero if successful, zero if
   /// there is no DW_AT_GNU_discriminator attribute in this DIE.
-  void getCallerFrame(uint32_t &CallFile, uint32_t &CallLine,
+  LLVM_ABI void getCallerFrame(uint32_t &CallFile, uint32_t &CallLine,
                       uint32_t &CallColumn, uint32_t &CallDiscriminator) const;
 
   class attribute_iterator;
@@ -282,14 +283,14 @@ public:
   /// Get an iterator range to all attributes in the current DIE only.
   ///
   /// \returns an iterator range for the attributes of the current DIE.
-  iterator_range<attribute_iterator> attributes() const;
+  LLVM_ABI iterator_range<attribute_iterator> attributes() const;
 
   /// Gets the type size (in bytes) for this DIE.
   ///
   /// \param PointerSize the pointer size of the containing CU.
   /// \returns if this is a type DIE, or this DIE contains a DW_AT_type, returns
   /// the size of the type.
-  std::optional<uint64_t> getTypeSize(uint64_t PointerSize);
+  LLVM_ABI std::optional<uint64_t> getTypeSize(uint64_t PointerSize);
 
   class iterator;
 
@@ -324,10 +325,10 @@ class DWARFDie::attribute_iterator
 
 public:
   attribute_iterator() = delete;
-  explicit attribute_iterator(DWARFDie D, bool End);
+  LLVM_ABI explicit attribute_iterator(DWARFDie D, bool End);
 
-  attribute_iterator &operator++();
-  attribute_iterator &operator--();
+  LLVM_ABI attribute_iterator &operator++();
+  LLVM_ABI attribute_iterator &operator--();
   explicit operator bool() const { return AttrValue.isValid(); }
   const DWARFAttribute &operator*() const { return AttrValue; }
 };
@@ -481,8 +482,8 @@ inline std::reverse_iterator<DWARFDie::iterator> DWARFDie::rend() const {
   return std::make_reverse_iterator(begin());
 }
 
-void dumpTypeQualifiedName(const DWARFDie &DIE, raw_ostream &OS);
-void dumpTypeUnqualifiedName(const DWARFDie &DIE, raw_ostream &OS,
+LLVM_ABI void dumpTypeQualifiedName(const DWARFDie &DIE, raw_ostream &OS);
+LLVM_ABI void dumpTypeUnqualifiedName(const DWARFDie &DIE, raw_ostream &OS,
                              std::string *OriginalFullName = nullptr);
 
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFEXPRESSION_H
 #define LLVM_DEBUGINFO_DWARF_DWARFEXPRESSION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/BinaryFormat/Dwarf.h"
@@ -86,7 +87,7 @@ public:
   public:
     const Description &getDescription() const { return Desc; }
     uint8_t getCode() const { return Opcode; }
-    std::optional<unsigned> getSubCode() const;
+    LLVM_ABI std::optional<unsigned> getSubCode() const;
     uint64_t getNumOperands() const { return Operands.size(); }
     ArrayRef<uint64_t> getRawOperands() const { return Operands; };
     uint64_t getRawOperand(unsigned Idx) const { return Operands[Idx]; }
@@ -98,14 +99,14 @@ public:
     }
     uint64_t getEndOffset() const { return EndOffset; }
     bool isError() const { return Error; }
-    bool print(raw_ostream &OS, DIDumpOptions DumpOpts,
+    LLVM_ABI bool print(raw_ostream &OS, DIDumpOptions DumpOpts,
                const DWARFExpression *Expr, DWARFUnit *U) const;
 
     /// Verify \p Op. Does not affect the return of \a isError().
-    static bool verify(const Operation &Op, DWARFUnit *U);
+    LLVM_ABI static bool verify(const Operation &Op, DWARFUnit *U);
 
   private:
-    bool extract(DataExtractor Data, uint8_t AddressSize, uint64_t Offset,
+    LLVM_ABI bool extract(DataExtractor Data, uint8_t AddressSize, uint64_t Offset,
                  std::optional<dwarf::DwarfFormat> Format);
   };
 
@@ -152,24 +153,24 @@ public:
   iterator begin() const { return iterator(this, 0); }
   iterator end() const { return iterator(this, Data.getData().size()); }
 
-  void print(raw_ostream &OS, DIDumpOptions DumpOpts, DWARFUnit *U,
+  LLVM_ABI void print(raw_ostream &OS, DIDumpOptions DumpOpts, DWARFUnit *U,
              bool IsEH = false) const;
 
   /// Print the expression in a format intended to be compact and useful to a
   /// user, but not perfectly unambiguous, or capable of representing every
   /// valid DWARF expression. Returns true if the expression was sucessfully
   /// printed.
-  bool printCompact(raw_ostream &OS,
+  LLVM_ABI bool printCompact(raw_ostream &OS,
                     std::function<StringRef(uint64_t RegNum, bool IsEH)>
                         GetNameForDWARFReg = nullptr);
 
-  bool verify(DWARFUnit *U);
+  LLVM_ABI bool verify(DWARFUnit *U);
 
-  bool operator==(const DWARFExpression &RHS) const;
+  LLVM_ABI bool operator==(const DWARFExpression &RHS) const;
 
   StringRef getData() const { return Data.getData(); }
 
-  static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
+  LLVM_ABI static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
                                     DIDumpOptions DumpOpts, uint8_t Opcode,
                                     const ArrayRef<uint64_t> Operands);
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFEXPRESSION_H
 #define LLVM_DEBUGINFO_DWARF_DWARFEXPRESSION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 
 namespace llvm {
@@ -100,14 +100,15 @@ public:
     uint64_t getEndOffset() const { return EndOffset; }
     bool isError() const { return Error; }
     LLVM_ABI bool print(raw_ostream &OS, DIDumpOptions DumpOpts,
-               const DWARFExpression *Expr, DWARFUnit *U) const;
+                        const DWARFExpression *Expr, DWARFUnit *U) const;
 
     /// Verify \p Op. Does not affect the return of \a isError().
     LLVM_ABI static bool verify(const Operation &Op, DWARFUnit *U);
 
   private:
-    LLVM_ABI bool extract(DataExtractor Data, uint8_t AddressSize, uint64_t Offset,
-                 std::optional<dwarf::DwarfFormat> Format);
+    LLVM_ABI bool extract(DataExtractor Data, uint8_t AddressSize,
+                          uint64_t Offset,
+                          std::optional<dwarf::DwarfFormat> Format);
   };
 
   /// An iterator to go through the expression operations.
@@ -154,15 +155,16 @@ public:
   iterator end() const { return iterator(this, Data.getData().size()); }
 
   LLVM_ABI void print(raw_ostream &OS, DIDumpOptions DumpOpts, DWARFUnit *U,
-             bool IsEH = false) const;
+                      bool IsEH = false) const;
 
   /// Print the expression in a format intended to be compact and useful to a
   /// user, but not perfectly unambiguous, or capable of representing every
   /// valid DWARF expression. Returns true if the expression was sucessfully
   /// printed.
-  LLVM_ABI bool printCompact(raw_ostream &OS,
-                    std::function<StringRef(uint64_t RegNum, bool IsEH)>
-                        GetNameForDWARFReg = nullptr);
+  LLVM_ABI bool printCompact(
+      raw_ostream &OS,
+      std::function<StringRef(uint64_t RegNum, bool IsEH)> GetNameForDWARFReg =
+          nullptr);
 
   LLVM_ABI bool verify(DWARFUnit *U);
 
@@ -171,8 +173,9 @@ public:
   StringRef getData() const { return Data.getData(); }
 
   LLVM_ABI static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
-                                    DIDumpOptions DumpOpts, uint8_t Opcode,
-                                    const ArrayRef<uint64_t> Operands);
+                                             DIDumpOptions DumpOpts,
+                                             uint8_t Opcode,
+                                             const ArrayRef<uint64_t> Operands);
 
 private:
   DataExtractor Data;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFFORMVALUE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFFORMVALUE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DIContext.h"
@@ -66,36 +67,36 @@ private:
 public:
   DWARFFormValue(dwarf::Form F = dwarf::Form(0)) : Form(F) {}
 
-  static DWARFFormValue createFromSValue(dwarf::Form F, int64_t V);
-  static DWARFFormValue createFromUValue(dwarf::Form F, uint64_t V);
-  static DWARFFormValue createFromPValue(dwarf::Form F, const char *V);
-  static DWARFFormValue createFromBlockValue(dwarf::Form F,
+  LLVM_ABI static DWARFFormValue createFromSValue(dwarf::Form F, int64_t V);
+  LLVM_ABI static DWARFFormValue createFromUValue(dwarf::Form F, uint64_t V);
+  LLVM_ABI static DWARFFormValue createFromPValue(dwarf::Form F, const char *V);
+  LLVM_ABI static DWARFFormValue createFromBlockValue(dwarf::Form F,
                                              ArrayRef<uint8_t> D);
-  static DWARFFormValue createFromUnit(dwarf::Form F, const DWARFUnit *Unit,
+  LLVM_ABI static DWARFFormValue createFromUnit(dwarf::Form F, const DWARFUnit *Unit,
                                        uint64_t *OffsetPtr);
-  static std::optional<object::SectionedAddress>
+  LLVM_ABI static std::optional<object::SectionedAddress>
   getAsSectionedAddress(const ValueType &Val, const dwarf::Form Form,
                         const DWARFUnit *U);
 
   dwarf::Form getForm() const { return Form; }
   uint64_t getRawUValue() const { return Value.uval; }
 
-  bool isFormClass(FormClass FC) const;
+  LLVM_ABI bool isFormClass(FormClass FC) const;
   const DWARFUnit *getUnit() const { return U; }
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts = DIDumpOptions()) const;
-  void dumpSectionedAddress(raw_ostream &OS, DIDumpOptions DumpOpts,
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts = DIDumpOptions()) const;
+  LLVM_ABI void dumpSectionedAddress(raw_ostream &OS, DIDumpOptions DumpOpts,
                             object::SectionedAddress SA) const;
-  void dumpAddress(raw_ostream &OS, uint64_t Address) const;
-  static void dumpAddress(raw_ostream &OS, uint8_t AddressSize,
+  LLVM_ABI void dumpAddress(raw_ostream &OS, uint64_t Address) const;
+  LLVM_ABI static void dumpAddress(raw_ostream &OS, uint8_t AddressSize,
                           uint64_t Address);
-  static void dumpAddressSection(const DWARFObject &Obj, raw_ostream &OS,
+  LLVM_ABI static void dumpAddressSection(const DWARFObject &Obj, raw_ostream &OS,
                                  DIDumpOptions DumpOpts, uint64_t SectionIndex);
 
   /// Extracts a value in \p Data at offset \p *OffsetPtr. The information
   /// in \p FormParams is needed to interpret some forms. The optional
   /// \p Context and \p Unit allows extracting information if the form refers
   /// to other sections (e.g., .debug_str).
-  bool extractValue(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
+  LLVM_ABI bool extractValue(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
                     dwarf::FormParams FormParams,
                     const DWARFContext *Context = nullptr,
                     const DWARFUnit *Unit = nullptr);
@@ -107,19 +108,19 @@ public:
 
   /// getAsFoo functions below return the extracted value as Foo if only
   /// DWARFFormValue has form class is suitable for representing Foo.
-  std::optional<uint64_t> getAsRelativeReference() const;
-  std::optional<uint64_t> getAsDebugInfoReference() const;
-  std::optional<uint64_t> getAsSignatureReference() const;
-  std::optional<uint64_t> getAsSupplementaryReference() const;
-  std::optional<uint64_t> getAsUnsignedConstant() const;
-  std::optional<int64_t> getAsSignedConstant() const;
-  Expected<const char *> getAsCString() const;
-  std::optional<uint64_t> getAsAddress() const;
-  std::optional<object::SectionedAddress> getAsSectionedAddress() const;
-  std::optional<uint64_t> getAsSectionOffset() const;
-  std::optional<ArrayRef<uint8_t>> getAsBlock() const;
-  std::optional<uint64_t> getAsCStringOffset() const;
-  std::optional<uint64_t> getAsReferenceUVal() const;
+  LLVM_ABI std::optional<uint64_t> getAsRelativeReference() const;
+  LLVM_ABI std::optional<uint64_t> getAsDebugInfoReference() const;
+  LLVM_ABI std::optional<uint64_t> getAsSignatureReference() const;
+  LLVM_ABI std::optional<uint64_t> getAsSupplementaryReference() const;
+  LLVM_ABI std::optional<uint64_t> getAsUnsignedConstant() const;
+  LLVM_ABI std::optional<int64_t> getAsSignedConstant() const;
+  LLVM_ABI Expected<const char *> getAsCString() const;
+  LLVM_ABI std::optional<uint64_t> getAsAddress() const;
+  LLVM_ABI std::optional<object::SectionedAddress> getAsSectionedAddress() const;
+  LLVM_ABI std::optional<uint64_t> getAsSectionOffset() const;
+  LLVM_ABI std::optional<ArrayRef<uint8_t>> getAsBlock() const;
+  LLVM_ABI std::optional<uint64_t> getAsCStringOffset() const;
+  LLVM_ABI std::optional<uint64_t> getAsReferenceUVal() const;
   /// Correctly extract any file paths from a form value.
   ///
   /// These attributes can be in the from DW_AT_decl_file or DW_AT_call_file
@@ -131,7 +132,7 @@ public:
   ///
   /// \returns A valid string value on success, or std::nullopt if the form
   /// class is not FC_Constant, or if the file index is not valid.
-  std::optional<std::string>
+  LLVM_ABI std::optional<std::string>
   getAsFile(DILineInfoSpecifier::FileLineInfoKind Kind) const;
 
   /// Skip a form's value in \p DebugInfoData at the offset specified by
@@ -158,7 +159,7 @@ public:
   /// \param OffsetPtr A reference to the offset that will be updated.
   /// \param FormParams DWARF parameters to help interpret forms.
   /// \returns true on success, false if the form was not skipped.
-  static bool skipValue(dwarf::Form Form, DataExtractor DebugInfoData,
+  LLVM_ABI static bool skipValue(dwarf::Form Form, DataExtractor DebugInfoData,
                         uint64_t *OffsetPtr,
                         const dwarf::FormParams FormParams);
 
@@ -430,7 +431,7 @@ toBlock(const std::optional<DWARFFormValue> &V) {
 /// \param FC an attribute form class to check.
 /// \param DwarfVersion the version of DWARF debug info keeping the attribute.
 /// \returns true if specified \p Form belongs to the \p FC class.
-bool doesFormBelongToClass(dwarf::Form Form, DWARFFormValue::FormClass FC,
+LLVM_ABI bool doesFormBelongToClass(dwarf::Form Form, DWARFFormValue::FormClass FC,
                            uint16_t DwarfVersion);
 
 } // end namespace dwarf

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFFORMVALUE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFFORMVALUE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DIContext.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include <cstdint>
 
@@ -71,9 +71,9 @@ public:
   LLVM_ABI static DWARFFormValue createFromUValue(dwarf::Form F, uint64_t V);
   LLVM_ABI static DWARFFormValue createFromPValue(dwarf::Form F, const char *V);
   LLVM_ABI static DWARFFormValue createFromBlockValue(dwarf::Form F,
-                                             ArrayRef<uint8_t> D);
-  LLVM_ABI static DWARFFormValue createFromUnit(dwarf::Form F, const DWARFUnit *Unit,
-                                       uint64_t *OffsetPtr);
+                                                      ArrayRef<uint8_t> D);
+  LLVM_ABI static DWARFFormValue
+  createFromUnit(dwarf::Form F, const DWARFUnit *Unit, uint64_t *OffsetPtr);
   LLVM_ABI static std::optional<object::SectionedAddress>
   getAsSectionedAddress(const ValueType &Val, const dwarf::Form Form,
                         const DWARFUnit *U);
@@ -83,23 +83,26 @@ public:
 
   LLVM_ABI bool isFormClass(FormClass FC) const;
   const DWARFUnit *getUnit() const { return U; }
-  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts = DIDumpOptions()) const;
+  LLVM_ABI void dump(raw_ostream &OS,
+                     DIDumpOptions DumpOpts = DIDumpOptions()) const;
   LLVM_ABI void dumpSectionedAddress(raw_ostream &OS, DIDumpOptions DumpOpts,
-                            object::SectionedAddress SA) const;
+                                     object::SectionedAddress SA) const;
   LLVM_ABI void dumpAddress(raw_ostream &OS, uint64_t Address) const;
   LLVM_ABI static void dumpAddress(raw_ostream &OS, uint8_t AddressSize,
-                          uint64_t Address);
-  LLVM_ABI static void dumpAddressSection(const DWARFObject &Obj, raw_ostream &OS,
-                                 DIDumpOptions DumpOpts, uint64_t SectionIndex);
+                                   uint64_t Address);
+  LLVM_ABI static void dumpAddressSection(const DWARFObject &Obj,
+                                          raw_ostream &OS,
+                                          DIDumpOptions DumpOpts,
+                                          uint64_t SectionIndex);
 
   /// Extracts a value in \p Data at offset \p *OffsetPtr. The information
   /// in \p FormParams is needed to interpret some forms. The optional
   /// \p Context and \p Unit allows extracting information if the form refers
   /// to other sections (e.g., .debug_str).
-  LLVM_ABI bool extractValue(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
-                    dwarf::FormParams FormParams,
-                    const DWARFContext *Context = nullptr,
-                    const DWARFUnit *Unit = nullptr);
+  LLVM_ABI bool extractValue(const DWARFDataExtractor &Data,
+                             uint64_t *OffsetPtr, dwarf::FormParams FormParams,
+                             const DWARFContext *Context = nullptr,
+                             const DWARFUnit *Unit = nullptr);
 
   bool extractValue(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
                     dwarf::FormParams FormParams, const DWARFUnit *U) {
@@ -116,7 +119,8 @@ public:
   LLVM_ABI std::optional<int64_t> getAsSignedConstant() const;
   LLVM_ABI Expected<const char *> getAsCString() const;
   LLVM_ABI std::optional<uint64_t> getAsAddress() const;
-  LLVM_ABI std::optional<object::SectionedAddress> getAsSectionedAddress() const;
+  LLVM_ABI std::optional<object::SectionedAddress>
+  getAsSectionedAddress() const;
   LLVM_ABI std::optional<uint64_t> getAsSectionOffset() const;
   LLVM_ABI std::optional<ArrayRef<uint8_t>> getAsBlock() const;
   LLVM_ABI std::optional<uint64_t> getAsCStringOffset() const;
@@ -160,8 +164,8 @@ public:
   /// \param FormParams DWARF parameters to help interpret forms.
   /// \returns true on success, false if the form was not skipped.
   LLVM_ABI static bool skipValue(dwarf::Form Form, DataExtractor DebugInfoData,
-                        uint64_t *OffsetPtr,
-                        const dwarf::FormParams FormParams);
+                                 uint64_t *OffsetPtr,
+                                 const dwarf::FormParams FormParams);
 
 private:
   void dumpString(raw_ostream &OS) const;
@@ -431,8 +435,9 @@ toBlock(const std::optional<DWARFFormValue> &V) {
 /// \param FC an attribute form class to check.
 /// \param DwarfVersion the version of DWARF debug info keeping the attribute.
 /// \returns true if specified \p Form belongs to the \p FC class.
-LLVM_ABI bool doesFormBelongToClass(dwarf::Form Form, DWARFFormValue::FormClass FC,
-                           uint16_t DwarfVersion);
+LLVM_ABI bool doesFormBelongToClass(dwarf::Form Form,
+                                    DWARFFormValue::FormClass FC,
+                                    uint16_t DwarfVersion);
 
 } // end namespace dwarf
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFListTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFListTable.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFLISTTABLE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFLISTTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
@@ -110,7 +111,7 @@ public:
     llvm_unreachable("Invalid DWARF format (expected DWARF32 or DWARF64");
   }
 
-  void dump(DataExtractor Data, raw_ostream &OS,
+  LLVM_ABI void dump(DataExtractor Data, raw_ostream &OS,
             DIDumpOptions DumpOpts = {}) const;
   std::optional<uint64_t> getOffsetEntry(DataExtractor Data,
                                          uint32_t Index) const {
@@ -131,12 +132,12 @@ public:
   }
 
   /// Extract the table header and the array of offsets.
-  Error extract(DWARFDataExtractor Data, uint64_t *OffsetPtr);
+  LLVM_ABI Error extract(DWARFDataExtractor Data, uint64_t *OffsetPtr);
 
   /// Returns the length of the table, including the length field, or 0 if the
   /// length has not been determined (e.g. because the table has not yet been
   /// parsed, or there was a problem in parsing).
-  uint64_t length() const;
+  LLVM_ABI uint64_t length() const;
 };
 
 /// A class representing a table of lists as specified in the DWARF v5

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFListTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFListTable.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFLISTTABLE_H
 #define LLVM_DEBUGINFO_DWARF_DWARFLISTTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
@@ -112,7 +112,7 @@ public:
   }
 
   LLVM_ABI void dump(DataExtractor Data, raw_ostream &OS,
-            DIDumpOptions DumpOpts = {}) const;
+                     DIDumpOptions DumpOpts = {}) const;
   std::optional<uint64_t> getOffsetEntry(DataExtractor Data,
                                          uint32_t Index) const {
     if (Index >= HeaderData.OffsetEntryCount)

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFLocationExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFLocationExpression.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFLOCATIONEXPRESSION_H
 #define LLVM_DEBUGINFO_DWARF_DWARFLOCATIONEXPRESSION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
 
 namespace llvm {
@@ -38,7 +39,7 @@ inline bool operator!=(const DWARFLocationExpression &L,
   return !(L == R);
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const DWARFLocationExpression &Loc);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const DWARFLocationExpression &Loc);
 
 /// Represents a set of absolute location expressions.
 using DWARFLocationExpressionsVector = std::vector<DWARFLocationExpression>;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFLocationExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFLocationExpression.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFLOCATIONEXPRESSION_H
 #define LLVM_DEBUGINFO_DWARF_DWARFLOCATIONEXPRESSION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -39,7 +39,8 @@ inline bool operator!=(const DWARFLocationExpression &L,
   return !(L == R);
 }
 
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const DWARFLocationExpression &Loc);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const DWARFLocationExpression &Loc);
 
 /// Represents a set of absolute location expressions.
 using DWARFLocationExpressionsVector = std::vector<DWARFLocationExpression>;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFUNIT_H
 #define LLVM_DEBUGINFO_DWARF_DWARFUNIT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -81,11 +82,11 @@ public:
   /// Note that \p SectionKind is used as a hint to guess the unit type
   /// for DWARF formats prior to DWARFv5. In DWARFv5 the unit type is
   /// explicitly defined in the header and the hint is ignored.
-  Error extract(DWARFContext &Context, const DWARFDataExtractor &debug_info,
+  LLVM_ABI Error extract(DWARFContext &Context, const DWARFDataExtractor &debug_info,
                 uint64_t *offset_ptr, DWARFSectionKind SectionKind);
   // For units in DWARF Package File, remember the index entry and update
   // the abbreviation offset read by extract().
-  Error applyIndexEntry(const DWARFUnitIndex::Entry *Entry);
+  LLVM_ABI Error applyIndexEntry(const DWARFUnitIndex::Entry *Entry);
   uint64_t getOffset() const { return Offset; }
   const dwarf::FormParams &getFormParams() const { return FormParams; }
   uint16_t getVersion() const { return FormParams.Version; }
@@ -118,7 +119,7 @@ public:
   }
 };
 
-const DWARFUnitIndex &getDWARFUnitIndex(DWARFContext &Context,
+LLVM_ABI const DWARFUnitIndex &getDWARFUnitIndex(DWARFContext &Context,
                                         DWARFSectionKind Kind);
 
 bool isCompileUnit(const std::unique_ptr<DWARFUnit> &U);
@@ -140,26 +141,26 @@ public:
   using compile_unit_range =
       decltype(make_filter_range(std::declval<iterator_range>(), isCompileUnit));
 
-  DWARFUnit *getUnitForOffset(uint64_t Offset) const;
-  DWARFUnit *getUnitForIndexEntry(const DWARFUnitIndex::Entry &E);
+  LLVM_ABI DWARFUnit *getUnitForOffset(uint64_t Offset) const;
+  LLVM_ABI DWARFUnit *getUnitForIndexEntry(const DWARFUnitIndex::Entry &E);
 
   /// Read units from a .debug_info or .debug_types section.  Calls made
   /// before finishedInfoUnits() are assumed to be for .debug_info sections,
   /// calls after finishedInfoUnits() are for .debug_types sections.  Caller
   /// must not mix calls to addUnitsForSection and addUnitsForDWOSection.
-  void addUnitsForSection(DWARFContext &C, const DWARFSection &Section,
+  LLVM_ABI void addUnitsForSection(DWARFContext &C, const DWARFSection &Section,
                           DWARFSectionKind SectionKind);
   /// Read units from a .debug_info.dwo or .debug_types.dwo section.  Calls
   /// made before finishedInfoUnits() are assumed to be for .debug_info.dwo
   /// sections, calls after finishedInfoUnits() are for .debug_types.dwo
   /// sections.  Caller must not mix calls to addUnitsForSection and
   /// addUnitsForDWOSection.
-  void addUnitsForDWOSection(DWARFContext &C, const DWARFSection &DWOSection,
+  LLVM_ABI void addUnitsForDWOSection(DWARFContext &C, const DWARFSection &DWOSection,
                              DWARFSectionKind SectionKind, bool Lazy = false);
 
   /// Add an existing DWARFUnit to this UnitVector. This is used by the DWARF
   /// verifier to process unit separately.
-  DWARFUnit *addUnit(std::unique_ptr<DWARFUnit> Unit);
+  LLVM_ABI DWARFUnit *addUnit(std::unique_ptr<DWARFUnit> Unit);
 
   /// Returns number of all units held by this instance.
   unsigned getNumUnits() const { return size(); }
@@ -204,11 +205,11 @@ struct StrOffsetsContributionDescriptor {
   /// Determine whether a contribution to the string offsets table is
   /// consistent with the relevant section size and that its length is
   /// a multiple of the size of one of its entries.
-  Expected<StrOffsetsContributionDescriptor>
+  LLVM_ABI Expected<StrOffsetsContributionDescriptor>
   validateContributionSize(DWARFDataExtractor &DA);
 };
 
-class DWARFUnit {
+class LLVM_ABI DWARFUnit {
   DWARFContext &Context;
   /// Section containing this DWARFUnit.
   const DWARFSection &InfoSection;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFUNIT_H
 #define LLVM_DEBUGINFO_DWARF_DWARFUNIT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -22,6 +21,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFDie.h"
 #include "llvm/DebugInfo/DWARF/DWARFLocationExpression.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnitIndex.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include <cassert>
 #include <cstddef>
@@ -82,8 +82,9 @@ public:
   /// Note that \p SectionKind is used as a hint to guess the unit type
   /// for DWARF formats prior to DWARFv5. In DWARFv5 the unit type is
   /// explicitly defined in the header and the hint is ignored.
-  LLVM_ABI Error extract(DWARFContext &Context, const DWARFDataExtractor &debug_info,
-                uint64_t *offset_ptr, DWARFSectionKind SectionKind);
+  LLVM_ABI Error extract(DWARFContext &Context,
+                         const DWARFDataExtractor &debug_info,
+                         uint64_t *offset_ptr, DWARFSectionKind SectionKind);
   // For units in DWARF Package File, remember the index entry and update
   // the abbreviation offset read by extract().
   LLVM_ABI Error applyIndexEntry(const DWARFUnitIndex::Entry *Entry);
@@ -120,7 +121,7 @@ public:
 };
 
 LLVM_ABI const DWARFUnitIndex &getDWARFUnitIndex(DWARFContext &Context,
-                                        DWARFSectionKind Kind);
+                                                 DWARFSectionKind Kind);
 
 bool isCompileUnit(const std::unique_ptr<DWARFUnit> &U);
 
@@ -149,14 +150,16 @@ public:
   /// calls after finishedInfoUnits() are for .debug_types sections.  Caller
   /// must not mix calls to addUnitsForSection and addUnitsForDWOSection.
   LLVM_ABI void addUnitsForSection(DWARFContext &C, const DWARFSection &Section,
-                          DWARFSectionKind SectionKind);
+                                   DWARFSectionKind SectionKind);
   /// Read units from a .debug_info.dwo or .debug_types.dwo section.  Calls
   /// made before finishedInfoUnits() are assumed to be for .debug_info.dwo
   /// sections, calls after finishedInfoUnits() are for .debug_types.dwo
   /// sections.  Caller must not mix calls to addUnitsForSection and
   /// addUnitsForDWOSection.
-  LLVM_ABI void addUnitsForDWOSection(DWARFContext &C, const DWARFSection &DWOSection,
-                             DWARFSectionKind SectionKind, bool Lazy = false);
+  LLVM_ABI void addUnitsForDWOSection(DWARFContext &C,
+                                      const DWARFSection &DWOSection,
+                                      DWARFSectionKind SectionKind,
+                                      bool Lazy = false);
 
   /// Add an existing DWARFUnit to this UnitVector. This is used by the DWARF
   /// verifier to process unit separately.

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnitIndex.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnitIndex.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFUNITINDEX_H
 #define LLVM_DEBUGINFO_DWARF_DWARFUNITINDEX_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include <cstdint>
@@ -88,13 +89,13 @@ inline const char *toString(DWARFSectionKind Kind) {
 /// The conversion depends on the version of the index section.
 /// IndexVersion is expected to be either 2 for pre-standard GNU proposal
 /// or 5 for DWARFv5 package file.
-uint32_t serializeSectionKind(DWARFSectionKind Kind, unsigned IndexVersion);
+LLVM_ABI uint32_t serializeSectionKind(DWARFSectionKind Kind, unsigned IndexVersion);
 
 /// Convert a value read from an index section to the internal representation.
 ///
 /// The conversion depends on the index section version, which is expected
 /// to be either 2 for pre-standard GNU proposal or 5 for DWARFv5 package file.
-DWARFSectionKind deserializeSectionKind(uint32_t Value, unsigned IndexVersion);
+LLVM_ABI DWARFSectionKind deserializeSectionKind(uint32_t Value, unsigned IndexVersion);
 
 class DWARFUnitIndex {
   struct Header {
@@ -103,8 +104,8 @@ class DWARFUnitIndex {
     uint32_t NumUnits;
     uint32_t NumBuckets = 0;
 
-    bool parse(DataExtractor IndexData, uint64_t *OffsetPtr);
-    void dump(raw_ostream &OS) const;
+    LLVM_ABI bool parse(DataExtractor IndexData, uint64_t *OffsetPtr);
+    LLVM_ABI void dump(raw_ostream &OS) const;
   };
 
 public:
@@ -135,9 +136,9 @@ public:
     friend class DWARFUnitIndex;
 
   public:
-    const SectionContribution *getContribution(DWARFSectionKind Sec) const;
-    const SectionContribution *getContribution() const;
-    SectionContribution &getContribution();
+    LLVM_ABI const SectionContribution *getContribution(DWARFSectionKind Sec) const;
+    LLVM_ABI const SectionContribution *getContribution() const;
+    LLVM_ABI SectionContribution &getContribution();
 
     const SectionContribution *getContributions() const {
       return Contributions.get();
@@ -170,13 +171,13 @@ public:
 
   explicit operator bool() const { return Header.NumBuckets; }
 
-  bool parse(DataExtractor IndexData);
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI bool parse(DataExtractor IndexData);
+  LLVM_ABI void dump(raw_ostream &OS) const;
 
   uint32_t getVersion() const { return Header.Version; }
 
-  const Entry *getFromOffset(uint64_t Offset) const;
-  const Entry *getFromHash(uint64_t Offset) const;
+  LLVM_ABI const Entry *getFromOffset(uint64_t Offset) const;
+  LLVM_ABI const Entry *getFromHash(uint64_t Offset) const;
 
   ArrayRef<DWARFSectionKind> getColumnKinds() const {
     return ArrayRef(ColumnKinds.get(), Header.NumColumns);

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnitIndex.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnitIndex.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFUNITINDEX_H
 #define LLVM_DEBUGINFO_DWARF_DWARFUNITINDEX_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <memory>
 
@@ -89,13 +89,15 @@ inline const char *toString(DWARFSectionKind Kind) {
 /// The conversion depends on the version of the index section.
 /// IndexVersion is expected to be either 2 for pre-standard GNU proposal
 /// or 5 for DWARFv5 package file.
-LLVM_ABI uint32_t serializeSectionKind(DWARFSectionKind Kind, unsigned IndexVersion);
+LLVM_ABI uint32_t serializeSectionKind(DWARFSectionKind Kind,
+                                       unsigned IndexVersion);
 
 /// Convert a value read from an index section to the internal representation.
 ///
 /// The conversion depends on the index section version, which is expected
 /// to be either 2 for pre-standard GNU proposal or 5 for DWARFv5 package file.
-LLVM_ABI DWARFSectionKind deserializeSectionKind(uint32_t Value, unsigned IndexVersion);
+LLVM_ABI DWARFSectionKind deserializeSectionKind(uint32_t Value,
+                                                 unsigned IndexVersion);
 
 class DWARFUnitIndex {
   struct Header {
@@ -136,7 +138,8 @@ public:
     friend class DWARFUnitIndex;
 
   public:
-    LLVM_ABI const SectionContribution *getContribution(DWARFSectionKind Sec) const;
+    LLVM_ABI const SectionContribution *
+    getContribution(DWARFSectionKind Sec) const;
     LLVM_ABI const SectionContribution *getContribution() const;
     LLVM_ABI SectionContribution &getContribution();
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFVERIFIER_H
 #define LLVM_DEBUGINFO_DWARF_DWARFVERIFIER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
 #include "llvm/DebugInfo/DWARF/DWARFDie.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnitIndex.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <map>
 #include <mutex>
@@ -50,10 +50,12 @@ public:
       : IncludeDetail(includeDetail) {}
   void ShowDetail(bool showDetail) { IncludeDetail = showDetail; }
   size_t GetNumCategories() const { return Aggregation.size(); }
-  LLVM_ABI void Report(StringRef category, std::function<void()> detailCallback);
+  LLVM_ABI void Report(StringRef category,
+                       std::function<void()> detailCallback);
   LLVM_ABI void Report(StringRef category, StringRef sub_category,
-              std::function<void()> detailCallback);
-  LLVM_ABI void EnumerateResults(std::function<void(StringRef, unsigned)> handleCounts);
+                       std::function<void()> detailCallback);
+  LLVM_ABI void
+  EnumerateResults(std::function<void(StringRef, unsigned)> handleCounts);
   LLVM_ABI void EnumerateDetailedResultsFor(
       StringRef category,
       std::function<void(StringRef, unsigned)> handleCounts);
@@ -92,7 +94,8 @@ public:
     /// This is used for finding overlapping ranges in the DW_AT_ranges
     /// attribute of a DIE. It is also used as a set of address ranges that
     /// children address ranges must all be contained in.
-    LLVM_ABI std::optional<DWARFAddressRange> insert(const DWARFAddressRange &R);
+    LLVM_ABI std::optional<DWARFAddressRange>
+    insert(const DWARFAddressRange &R);
 
     /// Inserts the address range info. If any of its ranges overlaps with a
     /// range in an existing range info, the range info is *not* added and an
@@ -321,7 +324,8 @@ private:
                         const DataExtractor &StrData);
 
 public:
-  LLVM_ABI DWARFVerifier(raw_ostream &S, DWARFContext &D,
+  LLVM_ABI
+  DWARFVerifier(raw_ostream &S, DWARFContext &D,
                 DIDumpOptions DumpOpts = DIDumpOptions::getForSingleDIE());
 
   /// Verify the information in any of the following sections, if available:
@@ -384,9 +388,10 @@ public:
   ///
   /// \returns true if the .debug_line verifies successfully, false otherwise.
   LLVM_ABI bool handleDebugStrOffsets();
-  LLVM_ABI bool verifyDebugStrOffsets(std::optional<dwarf::DwarfFormat> LegacyFormat,
-                             StringRef SectionName, const DWARFSection &Section,
-                             StringRef StrData);
+  LLVM_ABI bool
+  verifyDebugStrOffsets(std::optional<dwarf::DwarfFormat> LegacyFormat,
+                        StringRef SectionName, const DWARFSection &Section,
+                        StringRef StrData);
 
   /// Emits any aggregate information collected, depending on the dump options
   LLVM_ABI void summarize();

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFVERIFIER_H
 #define LLVM_DEBUGINFO_DWARF_DWARFVERIFIER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
@@ -49,11 +50,11 @@ public:
       : IncludeDetail(includeDetail) {}
   void ShowDetail(bool showDetail) { IncludeDetail = showDetail; }
   size_t GetNumCategories() const { return Aggregation.size(); }
-  void Report(StringRef category, std::function<void()> detailCallback);
-  void Report(StringRef category, StringRef sub_category,
+  LLVM_ABI void Report(StringRef category, std::function<void()> detailCallback);
+  LLVM_ABI void Report(StringRef category, StringRef sub_category,
               std::function<void()> detailCallback);
-  void EnumerateResults(std::function<void(StringRef, unsigned)> handleCounts);
-  void EnumerateDetailedResultsFor(
+  LLVM_ABI void EnumerateResults(std::function<void(StringRef, unsigned)> handleCounts);
+  LLVM_ABI void EnumerateDetailedResultsFor(
       StringRef category,
       std::function<void(StringRef, unsigned)> handleCounts);
   /// Return the number of errors that have been reported.
@@ -91,7 +92,7 @@ public:
     /// This is used for finding overlapping ranges in the DW_AT_ranges
     /// attribute of a DIE. It is also used as a set of address ranges that
     /// children address ranges must all be contained in.
-    std::optional<DWARFAddressRange> insert(const DWARFAddressRange &R);
+    LLVM_ABI std::optional<DWARFAddressRange> insert(const DWARFAddressRange &R);
 
     /// Inserts the address range info. If any of its ranges overlaps with a
     /// range in an existing range info, the range info is *not* added and an
@@ -100,14 +101,14 @@ public:
     /// and the returned iterator will point to end().
     ///
     /// This is used for finding overlapping children of the same DIE.
-    die_range_info_iterator insert(const DieRangeInfo &RI);
+    LLVM_ABI die_range_info_iterator insert(const DieRangeInfo &RI);
 
     /// Return true if ranges in this object contains all ranges within RHS.
-    bool contains(const DieRangeInfo &RHS) const;
+    LLVM_ABI bool contains(const DieRangeInfo &RHS) const;
 
     /// Return true if any range in this object intersects with any range in
     /// RHS. Identical ranges are not considered to be intersecting.
-    bool intersects(const DieRangeInfo &RHS) const;
+    LLVM_ABI bool intersects(const DieRangeInfo &RHS) const;
   };
 
 private:
@@ -320,7 +321,7 @@ private:
                         const DataExtractor &StrData);
 
 public:
-  DWARFVerifier(raw_ostream &S, DWARFContext &D,
+  LLVM_ABI DWARFVerifier(raw_ostream &S, DWARFContext &D,
                 DIDumpOptions DumpOpts = DIDumpOptions::getForSingleDIE());
 
   /// Verify the information in any of the following sections, if available:
@@ -331,7 +332,7 @@ public:
   ///
   /// \returns true if .debug_abbrev and .debug_abbrev.dwo verify successfully,
   /// false otherwise.
-  bool handleDebugAbbrev();
+  LLVM_ABI bool handleDebugAbbrev();
 
   /// Verify the information in the .debug_info and .debug_types sections.
   ///
@@ -339,7 +340,7 @@ public:
   /// constructed with.
   ///
   /// \returns true if all sections verify successfully, false otherwise.
-  bool handleDebugInfo();
+  LLVM_ABI bool handleDebugInfo();
 
   /// Verify the information in the .debug_cu_index section.
   ///
@@ -348,7 +349,7 @@ public:
   ///
   /// \returns true if the .debug_cu_index verifies successfully, false
   /// otherwise.
-  bool handleDebugCUIndex();
+  LLVM_ABI bool handleDebugCUIndex();
 
   /// Verify the information in the .debug_tu_index section.
   ///
@@ -357,7 +358,7 @@ public:
   ///
   /// \returns true if the .debug_tu_index verifies successfully, false
   /// otherwise.
-  bool handleDebugTUIndex();
+  LLVM_ABI bool handleDebugTUIndex();
 
   /// Verify the information in the .debug_line section.
   ///
@@ -365,7 +366,7 @@ public:
   /// constructed with.
   ///
   /// \returns true if the .debug_line verifies successfully, false otherwise.
-  bool handleDebugLine();
+  LLVM_ABI bool handleDebugLine();
 
   /// Verify the information in accelerator tables, if they exist.
   ///
@@ -374,7 +375,7 @@ public:
   ///
   /// \returns true if the existing Apple-style accelerator tables verify
   /// successfully, false otherwise.
-  bool handleAccelTables();
+  LLVM_ABI bool handleAccelTables();
 
   /// Verify the information in the .debug_str_offsets[.dwo].
   ///
@@ -382,13 +383,13 @@ public:
   /// constructed with.
   ///
   /// \returns true if the .debug_line verifies successfully, false otherwise.
-  bool handleDebugStrOffsets();
-  bool verifyDebugStrOffsets(std::optional<dwarf::DwarfFormat> LegacyFormat,
+  LLVM_ABI bool handleDebugStrOffsets();
+  LLVM_ABI bool verifyDebugStrOffsets(std::optional<dwarf::DwarfFormat> LegacyFormat,
                              StringRef SectionName, const DWARFSection &Section,
                              StringRef StrData);
 
   /// Emits any aggregate information collected, depending on the dump options
-  void summarize();
+  LLVM_ABI void summarize();
 };
 
 static inline bool operator<(const DWARFVerifier::DieRangeInfo &LHS,

--- a/llvm/include/llvm/DebugInfo/GSYM/CallSiteInfo.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/CallSiteInfo.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_CALLSITEINFO_H
 #define LLVM_DEBUGINFO_GSYM_CALLSITEINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -63,14 +64,14 @@ struct CallSiteInfo {
   /// \param Data The binary stream to read the data from.
   /// \param Offset The current offset within the data stream.
   /// \returns A CallSiteInfo or an error describing the issue.
-  static llvm::Expected<CallSiteInfo> decode(DataExtractor &Data,
+  LLVM_ABI static llvm::Expected<CallSiteInfo> decode(DataExtractor &Data,
                                              uint64_t &Offset);
 
   /// Encode this CallSiteInfo object into a FileWriter stream.
   ///
   /// \param O The binary stream to write the data to.
   /// \returns An error object that indicates success or failure.
-  llvm::Error encode(FileWriter &O) const;
+  LLVM_ABI llvm::Error encode(FileWriter &O) const;
 };
 
 struct CallSiteInfoCollection {
@@ -80,13 +81,13 @@ struct CallSiteInfoCollection {
   ///
   /// \param Data The binary stream to read the data from.
   /// \returns A CallSiteInfoCollection or an error describing the issue.
-  static llvm::Expected<CallSiteInfoCollection> decode(DataExtractor &Data);
+  LLVM_ABI static llvm::Expected<CallSiteInfoCollection> decode(DataExtractor &Data);
 
   /// Encode this CallSiteInfoCollection object into a FileWriter stream.
   ///
   /// \param O The binary stream to write the data to.
   /// \returns An error object that indicates success or failure.
-  llvm::Error encode(FileWriter &O) const;
+  LLVM_ABI llvm::Error encode(FileWriter &O) const;
 };
 
 class CallSiteInfoLoader {
@@ -107,7 +108,7 @@ public:
   /// file to be loaded.
   /// \returns An `llvm::Error` indicating success or describing any issues
   /// encountered during the loading process.
-  llvm::Error loadYAML(StringRef YAMLFile);
+  LLVM_ABI llvm::Error loadYAML(StringRef YAMLFile);
 
 private:
   /// Builds a map from function names to FunctionInfo pointers based on the
@@ -136,8 +137,8 @@ private:
   std::vector<FunctionInfo> &Funcs;
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const CallSiteInfo &CSI);
-raw_ostream &operator<<(raw_ostream &OS, const CallSiteInfoCollection &CSIC);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const CallSiteInfo &CSI);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const CallSiteInfoCollection &CSIC);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/CallSiteInfo.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/CallSiteInfo.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_GSYM_CALLSITEINFO_H
 #define LLVM_DEBUGINFO_GSYM_CALLSITEINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <vector>
 
@@ -65,7 +65,7 @@ struct CallSiteInfo {
   /// \param Offset The current offset within the data stream.
   /// \returns A CallSiteInfo or an error describing the issue.
   LLVM_ABI static llvm::Expected<CallSiteInfo> decode(DataExtractor &Data,
-                                             uint64_t &Offset);
+                                                      uint64_t &Offset);
 
   /// Encode this CallSiteInfo object into a FileWriter stream.
   ///
@@ -81,7 +81,8 @@ struct CallSiteInfoCollection {
   ///
   /// \param Data The binary stream to read the data from.
   /// \returns A CallSiteInfoCollection or an error describing the issue.
-  LLVM_ABI static llvm::Expected<CallSiteInfoCollection> decode(DataExtractor &Data);
+  LLVM_ABI static llvm::Expected<CallSiteInfoCollection>
+  decode(DataExtractor &Data);
 
   /// Encode this CallSiteInfoCollection object into a FileWriter stream.
   ///
@@ -138,7 +139,8 @@ private:
 };
 
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const CallSiteInfo &CSI);
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const CallSiteInfoCollection &CSIC);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const CallSiteInfoCollection &CSIC);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/DwarfTransformer.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/DwarfTransformer.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_GSYM_DWARFTRANSFORMER_H
 #define LLVM_DEBUGINFO_GSYM_DWARFTRANSFORMER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/DebugInfo/GSYM/ExtractRanges.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/GSYM/DwarfTransformer.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/DwarfTransformer.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_DWARFTRANSFORMER_H
 #define LLVM_DEBUGINFO_GSYM_DWARFTRANSFORMER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/DebugInfo/GSYM/ExtractRanges.h"
@@ -57,9 +58,9 @@ public:
   ///
   /// \returns An error indicating any fatal issues that happen when parsing
   /// the DWARF, or Error::success() if all goes well.
-  llvm::Error convert(uint32_t NumThreads, OutputAggregator &OS);
+  LLVM_ABI llvm::Error convert(uint32_t NumThreads, OutputAggregator &OS);
 
-  llvm::Error verify(StringRef GsymPath, OutputAggregator &OS);
+  LLVM_ABI llvm::Error verify(StringRef GsymPath, OutputAggregator &OS);
 
 private:
 

--- a/llvm/include/llvm/DebugInfo/GSYM/ExtractRanges.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/ExtractRanges.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_GSYM_EXTRACTRANGES_H
 #define LLVM_DEBUGINFO_GSYM_EXTRACTRANGES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/AddressRanges.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 #include <stdint.h>
@@ -38,8 +38,9 @@ class FileWriter;
 /// address.
 /// @{
 LLVM_ABI AddressRange decodeRange(DataExtractor &Data, uint64_t BaseAddr,
-                         uint64_t &Offset);
-LLVM_ABI void encodeRange(const AddressRange &Range, FileWriter &O, uint64_t BaseAddr);
+                                  uint64_t &Offset);
+LLVM_ABI void encodeRange(const AddressRange &Range, FileWriter &O,
+                          uint64_t BaseAddr);
 /// @}
 
 /// Skip an address range object in the specified data a the specified
@@ -54,10 +55,10 @@ LLVM_ABI void skipRange(DataExtractor &Data, uint64_t &Offset);
 /// See the AddressRange comment for the encode and decode methods for full
 /// details.
 /// @{
-LLVM_ABI void decodeRanges(AddressRanges &Ranges, DataExtractor &Data, uint64_t BaseAddr,
-                  uint64_t &Offset);
+LLVM_ABI void decodeRanges(AddressRanges &Ranges, DataExtractor &Data,
+                           uint64_t BaseAddr, uint64_t &Offset);
 LLVM_ABI void encodeRanges(const AddressRanges &Ranges, FileWriter &O,
-                  uint64_t BaseAddr);
+                           uint64_t BaseAddr);
 /// @}
 
 /// Skip an address range object in the specified data a the specified

--- a/llvm/include/llvm/DebugInfo/GSYM/ExtractRanges.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/ExtractRanges.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_EXTRACTRANGES_H
 #define LLVM_DEBUGINFO_GSYM_EXTRACTRANGES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/AddressRanges.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
@@ -36,9 +37,9 @@ class FileWriter;
 /// encoded addresses easy to relocate as we just need to relocate one base
 /// address.
 /// @{
-AddressRange decodeRange(DataExtractor &Data, uint64_t BaseAddr,
+LLVM_ABI AddressRange decodeRange(DataExtractor &Data, uint64_t BaseAddr,
                          uint64_t &Offset);
-void encodeRange(const AddressRange &Range, FileWriter &O, uint64_t BaseAddr);
+LLVM_ABI void encodeRange(const AddressRange &Range, FileWriter &O, uint64_t BaseAddr);
 /// @}
 
 /// Skip an address range object in the specified data a the specified
@@ -47,15 +48,15 @@ void encodeRange(const AddressRange &Range, FileWriter &O, uint64_t BaseAddr);
 /// \param Data The binary stream to read the data from.
 ///
 /// \param Offset The byte offset within \a Data.
-void skipRange(DataExtractor &Data, uint64_t &Offset);
+LLVM_ABI void skipRange(DataExtractor &Data, uint64_t &Offset);
 
 /// Address ranges are decoded and encoded to be relative to a base address.
 /// See the AddressRange comment for the encode and decode methods for full
 /// details.
 /// @{
-void decodeRanges(AddressRanges &Ranges, DataExtractor &Data, uint64_t BaseAddr,
+LLVM_ABI void decodeRanges(AddressRanges &Ranges, DataExtractor &Data, uint64_t BaseAddr,
                   uint64_t &Offset);
-void encodeRanges(const AddressRanges &Ranges, FileWriter &O,
+LLVM_ABI void encodeRanges(const AddressRanges &Ranges, FileWriter &O,
                   uint64_t BaseAddr);
 /// @}
 
@@ -67,13 +68,13 @@ void encodeRanges(const AddressRanges &Ranges, FileWriter &O,
 /// \param Offset The byte offset within \a Data.
 ///
 /// \returns The number of address ranges that were skipped.
-uint64_t skipRanges(DataExtractor &Data, uint64_t &Offset);
+LLVM_ABI uint64_t skipRanges(DataExtractor &Data, uint64_t &Offset);
 
 } // namespace gsym
 
-raw_ostream &operator<<(raw_ostream &OS, const AddressRange &R);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const AddressRange &R);
 
-raw_ostream &operator<<(raw_ostream &OS, const AddressRanges &AR);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const AddressRanges &AR);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/GSYM/FileWriter.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/FileWriter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_FILEWRITER_H
 #define LLVM_DEBUGINFO_GSYM_FILEWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Endian.h"
 
@@ -33,51 +34,51 @@ class FileWriter {
 public:
   FileWriter(llvm::raw_pwrite_stream &S, llvm::endianness B)
       : OS(S), ByteOrder(B) {}
-  ~FileWriter();
+  LLVM_ABI ~FileWriter();
   /// Write a single uint8_t value into the stream at the current file
   /// position.
   ///
   /// \param   Value The value to write into the stream.
-  void writeU8(uint8_t Value);
+  LLVM_ABI void writeU8(uint8_t Value);
 
   /// Write a single uint16_t value into the stream at the current file
   /// position. The value will be byte swapped if needed to match the byte
   /// order specified during construction.
   ///
   /// \param   Value The value to write into the stream.
-  void writeU16(uint16_t Value);
+  LLVM_ABI void writeU16(uint16_t Value);
 
   /// Write a single uint32_t value into the stream at the current file
   /// position. The value will be byte swapped if needed to match the byte
   /// order specified during construction.
   ///
   /// \param   Value The value to write into the stream.
-  void writeU32(uint32_t Value);
+  LLVM_ABI void writeU32(uint32_t Value);
 
   /// Write a single uint64_t value into the stream at the current file
   /// position. The value will be byte swapped if needed to match the byte
   /// order specified during construction.
   ///
   /// \param   Value The value to write into the stream.
-  void writeU64(uint64_t Value);
+  LLVM_ABI void writeU64(uint64_t Value);
 
   /// Write the value into the stream encoded using signed LEB128 at the
   /// current file position.
   ///
   /// \param   Value The value to write into the stream.
-  void writeSLEB(int64_t Value);
+  LLVM_ABI void writeSLEB(int64_t Value);
 
   /// Write the value into the stream encoded using unsigned LEB128 at the
   /// current file position.
   ///
   /// \param   Value The value to write into the stream.
-  void writeULEB(uint64_t Value);
+  LLVM_ABI void writeULEB(uint64_t Value);
 
   /// Write an array of uint8_t values into the stream at the current file
   /// position.
   ///
   /// \param   Data An array of values to write into the stream.
-  void writeData(llvm::ArrayRef<uint8_t> Data);
+  LLVM_ABI void writeData(llvm::ArrayRef<uint8_t> Data);
 
   /// Write a NULL terminated C string into the stream at the current file
   /// position. The entire contents of Str will be written into the steam at
@@ -86,7 +87,7 @@ public:
   /// characters unless the additional NULL characters are desired.
   ///
   /// \param   Str The value to write into the stream.
-  void writeNullTerminated(llvm::StringRef Str);
+  LLVM_ABI void writeNullTerminated(llvm::StringRef Str);
 
   /// Fixup a uint32_t value at the specified offset in the stream. This
   /// function will save the current file position, seek to the specified
@@ -95,20 +96,20 @@ public:
   ///
   /// \param   Value The value to write into the stream.
   /// \param   Offset The offset at which to write the Value within the stream.
-  void fixup32(uint32_t Value, uint64_t Offset);
+  LLVM_ABI void fixup32(uint32_t Value, uint64_t Offset);
 
   /// Pad with zeroes at the current file position until the current file
   /// position matches the specified alignment.
   ///
   /// \param  Align An integer speciying the desired alignment. This does not
   ///         need to be a power of two.
-  void alignTo(size_t Align);
+  LLVM_ABI void alignTo(size_t Align);
 
   /// Return the current offset within the file.
   ///
   /// \return The unsigned offset from the start of the file of the current
   ///         file position.
-  uint64_t tell();
+  LLVM_ABI uint64_t tell();
 
   llvm::raw_pwrite_stream &get_stream() {
     return OS;

--- a/llvm/include/llvm/DebugInfo/GSYM/FileWriter.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/FileWriter.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_GSYM_FILEWRITER_H
 #define LLVM_DEBUGINFO_GSYM_FILEWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 
 #include <stddef.h>

--- a/llvm/include/llvm/DebugInfo/GSYM/FunctionInfo.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/FunctionInfo.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_GSYM_FUNCTIONINFO_H
 #define LLVM_DEBUGINFO_GSYM_FUNCTIONINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/DebugInfo/GSYM/CallSiteInfo.h"
 #include "llvm/DebugInfo/GSYM/ExtractRanges.h"
@@ -18,6 +17,7 @@
 #include "llvm/DebugInfo/GSYM/LookupResult.h"
 #include "llvm/DebugInfo/GSYM/MergedFunctionsInfo.h"
 #include "llvm/DebugInfo/GSYM/StringTable.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -140,7 +140,7 @@ struct FunctionInfo {
   /// \returns An FunctionInfo or an error describing the issue that was
   /// encountered during decoding.
   LLVM_ABI static llvm::Expected<FunctionInfo> decode(DataExtractor &Data,
-                                             uint64_t BaseAddr);
+                                                      uint64_t BaseAddr);
 
   /// Encode this object into FileWriter stream.
   ///
@@ -156,7 +156,8 @@ struct FunctionInfo {
   ///
   /// \returns An error object that indicates failure or the offset of the
   /// function info that was successfully written into the stream.
-  LLVM_ABI llvm::Expected<uint64_t> encode(FileWriter &O, bool NoPadding = false) const;
+  LLVM_ABI llvm::Expected<uint64_t> encode(FileWriter &O,
+                                           bool NoPadding = false) const;
 
   /// Encode this function info into the internal byte cache and return the size
   /// in bytes.

--- a/llvm/include/llvm/DebugInfo/GSYM/FunctionInfo.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/FunctionInfo.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_FUNCTIONINFO_H
 #define LLVM_DEBUGINFO_GSYM_FUNCTIONINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/DebugInfo/GSYM/CallSiteInfo.h"
 #include "llvm/DebugInfo/GSYM/ExtractRanges.h"
@@ -138,7 +139,7 @@ struct FunctionInfo {
   ///
   /// \returns An FunctionInfo or an error describing the issue that was
   /// encountered during decoding.
-  static llvm::Expected<FunctionInfo> decode(DataExtractor &Data,
+  LLVM_ABI static llvm::Expected<FunctionInfo> decode(DataExtractor &Data,
                                              uint64_t BaseAddr);
 
   /// Encode this object into FileWriter stream.
@@ -155,7 +156,7 @@ struct FunctionInfo {
   ///
   /// \returns An error object that indicates failure or the offset of the
   /// function info that was successfully written into the stream.
-  llvm::Expected<uint64_t> encode(FileWriter &O, bool NoPadding = false) const;
+  LLVM_ABI llvm::Expected<uint64_t> encode(FileWriter &O, bool NoPadding = false) const;
 
   /// Encode this function info into the internal byte cache and return the size
   /// in bytes.
@@ -167,7 +168,7 @@ struct FunctionInfo {
   ///
   /// \returns The size in bytes of the FunctionInfo if it were to be encoded
   /// into a byte stream.
-  uint64_t cacheEncoding();
+  LLVM_ABI uint64_t cacheEncoding();
 
   /// Lookup an address within a FunctionInfo object's data stream.
   ///
@@ -194,7 +195,7 @@ struct FunctionInfo {
   /// \returns An LookupResult or an error describing the issue that was
   /// encountered during decoding. An error should only be returned if the
   /// address is not contained in the FunctionInfo or if the data is corrupted.
-  static llvm::Expected<LookupResult>
+  LLVM_ABI static llvm::Expected<LookupResult>
   lookup(DataExtractor &Data, const GsymReader &GR, uint64_t FuncAddr,
          uint64_t Addr,
          std::optional<DataExtractor> *MergedFuncsData = nullptr);
@@ -238,7 +239,7 @@ inline bool operator<(const FunctionInfo &LHS, const FunctionInfo &RHS) {
          std::tie(RHS.Range, RHS.Inline, RHS.OptLineTable);
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const FunctionInfo &R);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const FunctionInfo &R);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -309,8 +309,9 @@ public:
   ///                    a single GSYM file that contains all function
   ///                    information will be created.
   /// \returns An error object that indicates success or failure of the save.
-  LLVM_ABI llvm::Error save(StringRef Path, llvm::endianness ByteOrder,
-                   std::optional<uint64_t> SegmentSize = std::nullopt) const;
+  LLVM_ABI llvm::Error
+  save(StringRef Path, llvm::endianness ByteOrder,
+       std::optional<uint64_t> SegmentSize = std::nullopt) const;
 
   /// Encode a GSYM into the file writer stream at the current position.
   ///
@@ -351,8 +352,8 @@ public:
   /// \param   Path The path to the file to insert.
   /// \param   Style The path style for the "Path" parameter.
   /// \returns The unique file index for the inserted file.
-  LLVM_ABI uint32_t insertFile(StringRef Path,
-                      sys::path::Style Style = sys::path::Style::native);
+  LLVM_ABI uint32_t
+  insertFile(StringRef Path, sys::path::Style Style = sys::path::Style::native);
 
   /// Add a function info to this GSYM creator.
   ///
@@ -403,8 +404,8 @@ public:
   ///
   /// \param  Callback A callback function that will get called with each
   ///         FunctionInfo. If the callback returns false, stop iterating.
-  LLVM_ABI void forEachFunctionInfo(
-      std::function<bool(FunctionInfo &)> const &Callback);
+  LLVM_ABI void
+  forEachFunctionInfo(std::function<bool(FunctionInfo &)> const &Callback);
 
   /// Thread safe const iteration over all function infos.
   ///

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_GSYMCREATOR_H
 #define LLVM_DEBUGINFO_GSYM_GSYMCREATOR_H
 
+#include "llvm/Support/Compiler.h"
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -292,7 +293,7 @@ class GsymCreator {
   }
 
 public:
-  GsymCreator(bool Quiet = false);
+  LLVM_ABI GsymCreator(bool Quiet = false);
 
   /// Save a GSYM file to a stand alone file.
   ///
@@ -308,14 +309,14 @@ public:
   ///                    a single GSYM file that contains all function
   ///                    information will be created.
   /// \returns An error object that indicates success or failure of the save.
-  llvm::Error save(StringRef Path, llvm::endianness ByteOrder,
+  LLVM_ABI llvm::Error save(StringRef Path, llvm::endianness ByteOrder,
                    std::optional<uint64_t> SegmentSize = std::nullopt) const;
 
   /// Encode a GSYM into the file writer stream at the current position.
   ///
   /// \param O The stream to save the binary data to
   /// \returns An error object that indicates success or failure of the save.
-  llvm::Error encode(FileWriter &O) const;
+  LLVM_ABI llvm::Error encode(FileWriter &O) const;
 
   /// Insert a string into the GSYM string table.
   ///
@@ -327,7 +328,7 @@ public:
   ///             the string is owned by another object that will stay around
   ///             long enough for the GsymCreator to save the GSYM file.
   /// \returns The unique 32 bit offset into the string table.
-  uint32_t insertString(StringRef S, bool Copy = true);
+  LLVM_ABI uint32_t insertString(StringRef S, bool Copy = true);
 
   /// Retrieve a string from the GSYM string table given its offset.
   ///
@@ -337,7 +338,7 @@ public:
   /// \param Offset The offset of the string to retrieve, previously returned by
   /// insertString.
   /// \returns The string at the given offset in the string table.
-  StringRef getString(uint32_t Offset);
+  LLVM_ABI StringRef getString(uint32_t Offset);
 
   /// Insert a file into this GSYM creator.
   ///
@@ -350,7 +351,7 @@ public:
   /// \param   Path The path to the file to insert.
   /// \param   Style The path style for the "Path" parameter.
   /// \returns The unique file index for the inserted file.
-  uint32_t insertFile(StringRef Path,
+  LLVM_ABI uint32_t insertFile(StringRef Path,
                       sys::path::Style Style = sys::path::Style::native);
 
   /// Add a function info to this GSYM creator.
@@ -360,7 +361,7 @@ public:
   /// offsets for names and other strings.
   ///
   /// \param   FI The function info object to emplace into our functions list.
-  void addFunctionInfo(FunctionInfo &&FI);
+  LLVM_ABI void addFunctionInfo(FunctionInfo &&FI);
 
   /// Load call site information from a YAML file.
   ///
@@ -369,7 +370,7 @@ public:
   ///
   /// \param YAMLFile The path to the YAML file containing call site
   /// information.
-  llvm::Error loadCallSitesFromYAML(StringRef YAMLFile);
+  LLVM_ABI llvm::Error loadCallSitesFromYAML(StringRef YAMLFile);
 
   /// Organize merged FunctionInfo's
   ///
@@ -378,7 +379,7 @@ public:
   ///
   /// \param  Out Output stream to report information about how merged
   /// FunctionInfo's were handled.
-  void prepareMergedFunctions(OutputAggregator &Out);
+  LLVM_ABI void prepareMergedFunctions(OutputAggregator &Out);
 
   /// Finalize the data in the GSYM creator prior to saving the data out.
   ///
@@ -389,7 +390,7 @@ public:
   ///         function infos, and function infos that were merged or removed.
   /// \returns An error object that indicates success or failure of the
   ///          finalize.
-  llvm::Error finalize(OutputAggregator &OS);
+  LLVM_ABI llvm::Error finalize(OutputAggregator &OS);
 
   /// Set the UUID value.
   ///
@@ -402,19 +403,19 @@ public:
   ///
   /// \param  Callback A callback function that will get called with each
   ///         FunctionInfo. If the callback returns false, stop iterating.
-  void forEachFunctionInfo(
+  LLVM_ABI void forEachFunctionInfo(
       std::function<bool(FunctionInfo &)> const &Callback);
 
   /// Thread safe const iteration over all function infos.
   ///
   /// \param  Callback A callback function that will get called with each
   ///         FunctionInfo. If the callback returns false, stop iterating.
-  void forEachFunctionInfo(
+  LLVM_ABI void forEachFunctionInfo(
       std::function<bool(const FunctionInfo &)> const &Callback) const;
 
   /// Get the current number of FunctionInfo objects contained in this
   /// object.
-  size_t getNumFunctionInfos() const;
+  LLVM_ABI size_t getNumFunctionInfos() const;
 
   /// Set valid .text address ranges that all functions must be contained in.
   void SetValidTextRanges(AddressRanges &TextRanges) {
@@ -445,7 +446,7 @@ public:
   ///
   /// \returns True if the address is in the valid text ranges or if no valid
   ///          text ranges have been set, false otherwise.
-  bool IsValidTextAddress(uint64_t Addr) const;
+  LLVM_ABI bool IsValidTextAddress(uint64_t Addr) const;
 
   /// Set the base address to use for the GSYM file.
   ///
@@ -484,7 +485,7 @@ public:
   /// \returns An expected unique pointer to a GsymCreator or an error. The
   /// returned unique pointer can be NULL if there are no more functions to
   /// encode.
-  llvm::Expected<std::unique_ptr<GsymCreator>>
+  LLVM_ABI llvm::Expected<std::unique_ptr<GsymCreator>>
   createSegment(uint64_t SegmentSize, size_t &FuncIdx) const;
 };
 

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymReader.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymReader.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_GSYM_GSYMREADER_H
 #define LLVM_DEBUGINFO_GSYM_GSYMREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/GSYM/FileEntry.h"
 #include "llvm/DebugInfo/GSYM/FunctionInfo.h"
 #include "llvm/DebugInfo/GSYM/Header.h"
 #include "llvm/DebugInfo/GSYM/LineEntry.h"
 #include "llvm/DebugInfo/GSYM/StringTable.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ErrorOr.h"
@@ -114,7 +114,8 @@ public:
   /// \returns An expected FunctionInfo that contains the function info object
   /// or an error object that indicates reason for failing get the function
   /// info object.
-  LLVM_ABI llvm::Expected<FunctionInfo> getFunctionInfoAtIndex(uint64_t AddrIdx) const;
+  LLVM_ABI llvm::Expected<FunctionInfo>
+  getFunctionInfoAtIndex(uint64_t AddrIdx) const;
 
   /// Lookup an address in the a GSYM.
   ///
@@ -150,7 +151,8 @@ public:
   ///
   /// \returns A vector of LookupResult objects, where the first element is the
   /// primary result, followed by results for any merged functions
-  LLVM_ABI llvm::Expected<std::vector<LookupResult>> lookupAll(uint64_t Addr) const;
+  LLVM_ABI llvm::Expected<std::vector<LookupResult>>
+  lookupAll(uint64_t Addr) const;
 
   /// Get a string from the string table.
   ///
@@ -189,7 +191,8 @@ public:
   ///
   /// \param Indent The indentation as number of spaces. Used when dumping as an
   /// item within MergedFunctionsInfo.
-  LLVM_ABI void dump(raw_ostream &OS, const FunctionInfo &FI, uint32_t Indent = 0);
+  LLVM_ABI void dump(raw_ostream &OS, const FunctionInfo &FI,
+                     uint32_t Indent = 0);
 
   /// Dump a MergedFunctionsInfo object.
   ///
@@ -223,7 +226,7 @@ public:
   /// \param Indent The indentation as number of spaces. Used when dumping as an
   /// item from within MergedFunctionsInfo.
   LLVM_ABI void dump(raw_ostream &OS, const CallSiteInfoCollection &CSIC,
-            uint32_t Indent = 0);
+                     uint32_t Indent = 0);
 
   /// Dump a LineTable object.
   ///
@@ -250,7 +253,8 @@ public:
   ///
   /// \param Indent The indentation as number of spaces. Used for recurive
   /// dumping.
-  LLVM_ABI void dump(raw_ostream &OS, const InlineInfo &II, uint32_t Indent = 0);
+  LLVM_ABI void dump(raw_ostream &OS, const InlineInfo &II,
+                     uint32_t Indent = 0);
 
   /// Dump a FileEntry object.
   ///
@@ -362,7 +366,6 @@ protected:
   /// object that indicates reason for failing to read the GSYM.
   LLVM_ABI static llvm::Expected<llvm::gsym::GsymReader>
   create(std::unique_ptr<MemoryBuffer> &MemBuffer);
-
 
   /// Given an address, find the address index.
   ///

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymReader.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymReader.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_GSYMREADER_H
 #define LLVM_DEBUGINFO_GSYM_GSYMREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/GSYM/FileEntry.h"
 #include "llvm/DebugInfo/GSYM/FunctionInfo.h"
@@ -66,15 +67,15 @@ class GsymReader {
   std::unique_ptr<SwappedData> Swap;
 
 public:
-  GsymReader(GsymReader &&RHS);
-  ~GsymReader();
+  LLVM_ABI GsymReader(GsymReader &&RHS);
+  LLVM_ABI ~GsymReader();
 
   /// Construct a GsymReader from a file on disk.
   ///
   /// \param Path The file path the GSYM file to read.
   /// \returns An expected GsymReader that contains the object or an error
   /// object that indicates reason for failing to read the GSYM.
-  static llvm::Expected<GsymReader> openFile(StringRef Path);
+  LLVM_ABI static llvm::Expected<GsymReader> openFile(StringRef Path);
 
   /// Construct a GsymReader from a buffer.
   ///
@@ -82,11 +83,11 @@ public:
   /// returned object on success.
   /// \returns An expected GsymReader that contains the object or an error
   /// object that indicates reason for failing to read the GSYM.
-  static llvm::Expected<GsymReader> copyBuffer(StringRef Bytes);
+  LLVM_ABI static llvm::Expected<GsymReader> copyBuffer(StringRef Bytes);
 
   /// Access the GSYM header.
   /// \returns A native endian version of the GSYM header.
-  const Header &getHeader() const;
+  LLVM_ABI const Header &getHeader() const;
 
   /// Get the full function info for an address.
   ///
@@ -104,7 +105,7 @@ public:
   /// \returns An expected FunctionInfo that contains the function info object
   /// or an error object that indicates reason for failing to lookup the
   /// address.
-  llvm::Expected<FunctionInfo> getFunctionInfo(uint64_t Addr) const;
+  LLVM_ABI llvm::Expected<FunctionInfo> getFunctionInfo(uint64_t Addr) const;
 
   /// Get the full function info given an address index.
   ///
@@ -113,7 +114,7 @@ public:
   /// \returns An expected FunctionInfo that contains the function info object
   /// or an error object that indicates reason for failing get the function
   /// info object.
-  llvm::Expected<FunctionInfo> getFunctionInfoAtIndex(uint64_t AddrIdx) const;
+  LLVM_ABI llvm::Expected<FunctionInfo> getFunctionInfoAtIndex(uint64_t AddrIdx) const;
 
   /// Lookup an address in the a GSYM.
   ///
@@ -135,7 +136,7 @@ public:
   /// \returns An expected LookupResult that contains only the information
   /// needed for the current address, or an error object that indicates reason
   /// for failing to lookup the address.
-  llvm::Expected<LookupResult>
+  LLVM_ABI llvm::Expected<LookupResult>
   lookup(uint64_t Addr,
          std::optional<DataExtractor> *MergedFuncsData = nullptr) const;
 
@@ -149,7 +150,7 @@ public:
   ///
   /// \returns A vector of LookupResult objects, where the first element is the
   /// primary result, followed by results for any merged functions
-  llvm::Expected<std::vector<LookupResult>> lookupAll(uint64_t Addr) const;
+  LLVM_ABI llvm::Expected<std::vector<LookupResult>> lookupAll(uint64_t Addr) const;
 
   /// Get a string from the string table.
   ///
@@ -175,7 +176,7 @@ public:
   /// Dump the entire Gsym data contained in this object.
   ///
   /// \param  OS The output stream to dump to.
-  void dump(raw_ostream &OS);
+  LLVM_ABI void dump(raw_ostream &OS);
 
   /// Dump a FunctionInfo object.
   ///
@@ -188,7 +189,7 @@ public:
   ///
   /// \param Indent The indentation as number of spaces. Used when dumping as an
   /// item within MergedFunctionsInfo.
-  void dump(raw_ostream &OS, const FunctionInfo &FI, uint32_t Indent = 0);
+  LLVM_ABI void dump(raw_ostream &OS, const FunctionInfo &FI, uint32_t Indent = 0);
 
   /// Dump a MergedFunctionsInfo object.
   ///
@@ -198,7 +199,7 @@ public:
   /// \param  OS The output stream to dump to.
   ///
   /// \param MFI The object to dump.
-  void dump(raw_ostream &OS, const MergedFunctionsInfo &MFI);
+  LLVM_ABI void dump(raw_ostream &OS, const MergedFunctionsInfo &MFI);
 
   /// Dump a CallSiteInfo object.
   ///
@@ -208,7 +209,7 @@ public:
   /// \param OS The output stream to dump to.
   ///
   /// \param CSI The CallSiteInfo object to dump.
-  void dump(raw_ostream &OS, const CallSiteInfo &CSI);
+  LLVM_ABI void dump(raw_ostream &OS, const CallSiteInfo &CSI);
 
   /// Dump a CallSiteInfoCollection object.
   ///
@@ -221,7 +222,7 @@ public:
   ///
   /// \param Indent The indentation as number of spaces. Used when dumping as an
   /// item from within MergedFunctionsInfo.
-  void dump(raw_ostream &OS, const CallSiteInfoCollection &CSIC,
+  LLVM_ABI void dump(raw_ostream &OS, const CallSiteInfoCollection &CSIC,
             uint32_t Indent = 0);
 
   /// Dump a LineTable object.
@@ -236,7 +237,7 @@ public:
   ///
   /// \param Indent The indentation as number of spaces. Used when dumping as an
   /// item from within MergedFunctionsInfo.
-  void dump(raw_ostream &OS, const LineTable &LT, uint32_t Indent = 0);
+  LLVM_ABI void dump(raw_ostream &OS, const LineTable &LT, uint32_t Indent = 0);
 
   /// Dump a InlineInfo object.
   ///
@@ -249,7 +250,7 @@ public:
   ///
   /// \param Indent The indentation as number of spaces. Used for recurive
   /// dumping.
-  void dump(raw_ostream &OS, const InlineInfo &II, uint32_t Indent = 0);
+  LLVM_ABI void dump(raw_ostream &OS, const InlineInfo &II, uint32_t Indent = 0);
 
   /// Dump a FileEntry object.
   ///
@@ -259,7 +260,7 @@ public:
   /// \param  OS The output stream to dump to.
   ///
   /// \param FE The object to dump.
-  void dump(raw_ostream &OS, std::optional<FileEntry> FE);
+  LLVM_ABI void dump(raw_ostream &OS, std::optional<FileEntry> FE);
 
   /// Get the number of addresses in this Gsym file.
   uint32_t getNumAddresses() const {
@@ -273,7 +274,7 @@ public:
   /// \param Index A index into the address table.
   /// \returns A resolved virtual address for adddress in the address table
   /// or std::nullopt if Index is out of bounds.
-  std::optional<uint64_t> getAddress(size_t Index) const;
+  LLVM_ABI std::optional<uint64_t> getAddress(size_t Index) const;
 
 protected:
 
@@ -359,7 +360,7 @@ protected:
   /// GsymReader.
   /// \returns An expected GsymReader that contains the object or an error
   /// object that indicates reason for failing to read the GSYM.
-  static llvm::Expected<llvm::gsym::GsymReader>
+  LLVM_ABI static llvm::Expected<llvm::gsym::GsymReader>
   create(std::unique_ptr<MemoryBuffer> &MemBuffer);
 
 
@@ -372,7 +373,7 @@ protected:
   /// \returns An index into the address table. This index can be used to
   /// extract the FunctionInfo data's offset from the AddrInfoOffsets array.
   /// Returns an error if the address isn't in the GSYM with details of why.
-  Expected<uint64_t> getAddressIndex(const uint64_t Addr) const;
+  LLVM_ABI Expected<uint64_t> getAddressIndex(const uint64_t Addr) const;
 
   /// Given an address index, get the offset for the FunctionInfo.
   ///
@@ -383,7 +384,7 @@ protected:
   /// \param Index An index into the address table.
   /// \returns An optional GSYM data offset for the offset of the FunctionInfo
   /// that needs to be decoded.
-  std::optional<uint64_t> getAddressInfoOffset(size_t Index) const;
+  LLVM_ABI std::optional<uint64_t> getAddressInfoOffset(size_t Index) const;
 
   /// Given an address, find the correct function info data and function
   /// address.
@@ -404,7 +405,7 @@ protected:
   ///
   /// \returns An valid data extractor on success, or an error if we fail to
   /// find the address in a function info or corrrectly decode the data
-  llvm::Expected<llvm::DataExtractor>
+  LLVM_ABI llvm::Expected<llvm::DataExtractor>
   getFunctionInfoDataForAddress(uint64_t Addr, uint64_t &FuncStartAddr) const;
 
   /// Get the function data and address given an address index.
@@ -414,7 +415,7 @@ protected:
   /// \returns An expected FunctionInfo that contains the function info object
   /// or an error object that indicates reason for failing to lookup the
   /// address.
-  llvm::Expected<llvm::DataExtractor>
+  LLVM_ABI llvm::Expected<llvm::DataExtractor>
   getFunctionInfoDataAtIndex(uint64_t AddrIdx, uint64_t &FuncStartAddr) const;
 };
 

--- a/llvm/include/llvm/DebugInfo/GSYM/Header.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/Header.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_HEADER_H
 #define LLVM_DEBUGINFO_GSYM_HEADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <cstddef>
@@ -98,7 +99,7 @@ struct Header {
   ///
   /// \returns An error if anything is wrong in the header, or Error::success()
   /// if there are no errors.
-  llvm::Error checkForError() const;
+  LLVM_ABI llvm::Error checkForError() const;
 
   /// Decode an object from a binary data stream.
   ///
@@ -108,7 +109,7 @@ struct Header {
   ///
   /// \returns A Header or an error describing the issue that was
   /// encountered during decoding.
-  static llvm::Expected<Header> decode(DataExtractor &Data);
+  LLVM_ABI static llvm::Expected<Header> decode(DataExtractor &Data);
 
   /// Encode this object into FileWriter stream.
   ///
@@ -117,11 +118,11 @@ struct Header {
   ///
   /// \returns An error object that indicates success or failure of the
   /// encoding process.
-  llvm::Error encode(FileWriter &O) const;
+  LLVM_ABI llvm::Error encode(FileWriter &O) const;
 };
 
-bool operator==(const Header &LHS, const Header &RHS);
-raw_ostream &operator<<(raw_ostream &OS, const llvm::gsym::Header &H);
+LLVM_ABI bool operator==(const Header &LHS, const Header &RHS);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const llvm::gsym::Header &H);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/InlineInfo.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/InlineInfo.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_GSYM_INLINEINFO_H
 #define LLVM_DEBUGINFO_GSYM_INLINEINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/GSYM/ExtractRanges.h"
 #include "llvm/DebugInfo/GSYM/LineEntry.h"
 #include "llvm/DebugInfo/GSYM/LookupResult.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <stdint.h>
 #include <vector>
@@ -119,8 +119,8 @@ struct InlineInfo {
   ///          Error::success() for all other cases, even when no information
   ///          is added to \a SrcLocs.
   LLVM_ABI static llvm::Error lookup(const GsymReader &GR, DataExtractor &Data,
-                            uint64_t BaseAddr, uint64_t Addr,
-                            SourceLocations &SrcLocs);
+                                     uint64_t BaseAddr, uint64_t Addr,
+                                     SourceLocations &SrcLocs);
 
   /// Lookup an address in the InlineInfo object
   ///
@@ -149,7 +149,7 @@ struct InlineInfo {
   /// \returns An InlineInfo or an error describing the issue that was
   /// encountered during decoding.
   LLVM_ABI static llvm::Expected<InlineInfo> decode(DataExtractor &Data,
-                                           uint64_t BaseAddr);
+                                                    uint64_t BaseAddr);
 
   /// Encode this InlineInfo object into FileWriter stream.
   ///

--- a/llvm/include/llvm/DebugInfo/GSYM/InlineInfo.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/InlineInfo.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_INLINEINFO_H
 #define LLVM_DEBUGINFO_GSYM_INLINEINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/GSYM/ExtractRanges.h"
 #include "llvm/DebugInfo/GSYM/LineEntry.h"
 #include "llvm/DebugInfo/GSYM/LookupResult.h"
@@ -117,7 +118,7 @@ struct InlineInfo {
   /// \returns An error if the inline information is corrupt, or
   ///          Error::success() for all other cases, even when no information
   ///          is added to \a SrcLocs.
-  static llvm::Error lookup(const GsymReader &GR, DataExtractor &Data,
+  LLVM_ABI static llvm::Error lookup(const GsymReader &GR, DataExtractor &Data,
                             uint64_t BaseAddr, uint64_t Addr,
                             SourceLocations &SrcLocs);
 
@@ -132,7 +133,7 @@ struct InlineInfo {
   ///
   /// \returns optional vector of InlineInfo objects that describe the
   /// inline call stack for a given address, false otherwise.
-  std::optional<InlineArray> getInlineStack(uint64_t Addr) const;
+  LLVM_ABI std::optional<InlineArray> getInlineStack(uint64_t Addr) const;
 
   /// Decode an InlineInfo object from a binary data stream.
   ///
@@ -147,7 +148,7 @@ struct InlineInfo {
   /// another InlineInfo object.
   /// \returns An InlineInfo or an error describing the issue that was
   /// encountered during decoding.
-  static llvm::Expected<InlineInfo> decode(DataExtractor &Data,
+  LLVM_ABI static llvm::Expected<InlineInfo> decode(DataExtractor &Data,
                                            uint64_t BaseAddr);
 
   /// Encode this InlineInfo object into FileWriter stream.
@@ -163,7 +164,7 @@ struct InlineInfo {
   ///
   /// \returns An error object that indicates success or failure or the
   /// encoding process.
-  llvm::Error encode(FileWriter &O, uint64_t BaseAddr) const;
+  LLVM_ABI llvm::Error encode(FileWriter &O, uint64_t BaseAddr) const;
 
   /// Compare InlineInfo objects.
   ///
@@ -174,7 +175,7 @@ struct InlineInfo {
   /// to the GSYM file. We have seen cases where LTO messes up the inline
   /// function information for the same address range, so this helps ensure we
   /// get the most descriptive information we can for an address range.
-  bool operator<(const InlineInfo &RHS) const;
+  LLVM_ABI bool operator<(const InlineInfo &RHS) const;
 };
 
 inline bool operator==(const InlineInfo &LHS, const InlineInfo &RHS) {
@@ -183,7 +184,7 @@ inline bool operator==(const InlineInfo &LHS, const InlineInfo &RHS) {
          LHS.Children == RHS.Children;
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const InlineInfo &FI);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const InlineInfo &FI);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/LineTable.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/LineTable.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_LINETABLE_H
 #define LLVM_DEBUGINFO_GSYM_LINETABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/GSYM/LineEntry.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
@@ -136,7 +137,7 @@ public:
   /// initialize the line table row prior to parsing any opcodes.
   ///
   /// \returns An LineEntry object if a match is found, error otherwise.
-  static Expected<LineEntry> lookup(DataExtractor &Data, uint64_t BaseAddr,
+  LLVM_ABI static Expected<LineEntry> lookup(DataExtractor &Data, uint64_t BaseAddr,
                                     uint64_t Addr);
 
   /// Decode an LineTable object from a binary data stream.
@@ -151,7 +152,7 @@ public:
   ///
   /// \returns An LineTable or an error describing the issue that was
   /// encountered during decoding.
-  static llvm::Expected<LineTable> decode(DataExtractor &Data,
+  LLVM_ABI static llvm::Expected<LineTable> decode(DataExtractor &Data,
                                           uint64_t BaseAddr);
   /// Encode this LineTable object into FileWriter stream.
   ///
@@ -163,7 +164,7 @@ public:
   ///
   /// \returns An error object that indicates success or failure or the
   /// encoding process.
-  llvm::Error encode(FileWriter &O, uint64_t BaseAddr) const;
+  LLVM_ABI llvm::Error encode(FileWriter &O, uint64_t BaseAddr) const;
   bool empty() const { return Lines.empty(); }
   void clear() { Lines.clear(); }
   /// Return the first line entry if the line table isn't empty.
@@ -225,7 +226,7 @@ public:
 
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const gsym::LineTable &LT);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const gsym::LineTable &LT);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/LineTable.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/LineTable.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_GSYM_LINETABLE_H
 #define LLVM_DEBUGINFO_GSYM_LINETABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/GSYM/LineEntry.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <vector>
@@ -137,8 +137,8 @@ public:
   /// initialize the line table row prior to parsing any opcodes.
   ///
   /// \returns An LineEntry object if a match is found, error otherwise.
-  LLVM_ABI static Expected<LineEntry> lookup(DataExtractor &Data, uint64_t BaseAddr,
-                                    uint64_t Addr);
+  LLVM_ABI static Expected<LineEntry> lookup(DataExtractor &Data,
+                                             uint64_t BaseAddr, uint64_t Addr);
 
   /// Decode an LineTable object from a binary data stream.
   ///
@@ -153,7 +153,7 @@ public:
   /// \returns An LineTable or an error describing the issue that was
   /// encountered during decoding.
   LLVM_ABI static llvm::Expected<LineTable> decode(DataExtractor &Data,
-                                          uint64_t BaseAddr);
+                                                   uint64_t BaseAddr);
   /// Encode this LineTable object into FileWriter stream.
   ///
   /// \param O The binary stream to write the data to at the current file

--- a/llvm/include/llvm/DebugInfo/GSYM/LookupResult.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/LookupResult.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_LOOKUPRESULT_H
 #define LLVM_DEBUGINFO_GSYM_LOOKUPRESULT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/AddressRanges.h"
 #include "llvm/ADT/StringRef.h"
 #include <inttypes.h>
@@ -31,7 +32,7 @@ inline bool operator==(const SourceLocation &LHS, const SourceLocation &RHS) {
          LHS.Line == RHS.Line && LHS.Offset == RHS.Offset;
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const SourceLocation &R);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SourceLocation &R);
 
 using SourceLocations = std::vector<SourceLocation>;
 
@@ -76,7 +77,7 @@ struct LookupResult {
   /// - Call site info was not included when creating the GSYM file
   std::vector<StringRef> CallSiteFuncRegex;
 
-  std::string getSourceFile(uint32_t Index) const;
+  LLVM_ABI std::string getSourceFile(uint32_t Index) const;
 };
 
 inline bool operator==(const LookupResult &LHS, const LookupResult &RHS) {
@@ -91,7 +92,7 @@ inline bool operator==(const LookupResult &LHS, const LookupResult &RHS) {
   return LHS.Locations == RHS.Locations;
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const LookupResult &R);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const LookupResult &R);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/LookupResult.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/LookupResult.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_GSYM_LOOKUPRESULT_H
 #define LLVM_DEBUGINFO_GSYM_LOOKUPRESULT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/AddressRanges.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <inttypes.h>
 #include <vector>
 

--- a/llvm/include/llvm/DebugInfo/GSYM/MergedFunctionsInfo.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/MergedFunctionsInfo.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_MERGEDFUNCTIONSINFO_H
 #define LLVM_DEBUGINFO_GSYM_MERGEDFUNCTIONSINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/GSYM/ExtractRanges.h"
 #include "llvm/Support/Error.h"
 #include <stdint.h>
@@ -24,7 +25,7 @@ struct FunctionInfo;
 struct MergedFunctionsInfo {
   std::vector<FunctionInfo> MergedFunctions;
 
-  void clear();
+  LLVM_ABI void clear();
 
   /// Query if a MergedFunctionsInfo object is valid.
   ///
@@ -40,7 +41,7 @@ struct MergedFunctionsInfo {
   ///
   /// \returns An llvm::Expected containing a vector of DataExtractor objects on
   /// success, or an error object if parsing fails.
-  static llvm::Expected<std::vector<DataExtractor>>
+  LLVM_ABI static llvm::Expected<std::vector<DataExtractor>>
   getFuncsDataExtractors(DataExtractor &Data);
 
   /// Decode an MergedFunctionsInfo object from a binary data stream.
@@ -53,7 +54,7 @@ struct MergedFunctionsInfo {
   ///
   /// \returns An MergedFunctionsInfo or an error describing the issue that was
   /// encountered during decoding.
-  static llvm::Expected<MergedFunctionsInfo> decode(DataExtractor &Data,
+  LLVM_ABI static llvm::Expected<MergedFunctionsInfo> decode(DataExtractor &Data,
                                                     uint64_t BaseAddr);
 
   /// Encode this MergedFunctionsInfo object into FileWriter stream.
@@ -62,10 +63,10 @@ struct MergedFunctionsInfo {
   /// position.
   /// \returns An error object that indicates success or failure for the
   /// encoding process.
-  llvm::Error encode(FileWriter &O) const;
+  LLVM_ABI llvm::Error encode(FileWriter &O) const;
 };
 
-bool operator==(const MergedFunctionsInfo &LHS, const MergedFunctionsInfo &RHS);
+LLVM_ABI bool operator==(const MergedFunctionsInfo &LHS, const MergedFunctionsInfo &RHS);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/MergedFunctionsInfo.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/MergedFunctionsInfo.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_GSYM_MERGEDFUNCTIONSINFO_H
 #define LLVM_DEBUGINFO_GSYM_MERGEDFUNCTIONSINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/GSYM/ExtractRanges.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <stdint.h>
 #include <vector>
@@ -54,8 +54,8 @@ struct MergedFunctionsInfo {
   ///
   /// \returns An MergedFunctionsInfo or an error describing the issue that was
   /// encountered during decoding.
-  LLVM_ABI static llvm::Expected<MergedFunctionsInfo> decode(DataExtractor &Data,
-                                                    uint64_t BaseAddr);
+  LLVM_ABI static llvm::Expected<MergedFunctionsInfo>
+  decode(DataExtractor &Data, uint64_t BaseAddr);
 
   /// Encode this MergedFunctionsInfo object into FileWriter stream.
   ///
@@ -66,7 +66,8 @@ struct MergedFunctionsInfo {
   LLVM_ABI llvm::Error encode(FileWriter &O) const;
 };
 
-LLVM_ABI bool operator==(const MergedFunctionsInfo &LHS, const MergedFunctionsInfo &RHS);
+LLVM_ABI bool operator==(const MergedFunctionsInfo &LHS,
+                         const MergedFunctionsInfo &RHS);
 
 } // namespace gsym
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/GSYM/ObjectFileTransformer.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/ObjectFileTransformer.h
@@ -41,7 +41,8 @@ public:
   /// \returns An error indicating any fatal issues that happen when parsing
   /// the DWARF, or Error::success() if all goes well.
   LLVM_ABI static llvm::Error convert(const object::ObjectFile &Obj,
-                             OutputAggregator &Output, GsymCreator &Gsym);
+                                      OutputAggregator &Output,
+                                      GsymCreator &Gsym);
 };
 
 } // namespace gsym

--- a/llvm/include/llvm/DebugInfo/GSYM/ObjectFileTransformer.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/ObjectFileTransformer.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_GSYM_OBJECTFILETRANSFORMER_H
 #define LLVM_DEBUGINFO_GSYM_OBJECTFILETRANSFORMER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -39,7 +40,7 @@ public:
   ///
   /// \returns An error indicating any fatal issues that happen when parsing
   /// the DWARF, or Error::success() if all goes well.
-  static llvm::Error convert(const object::ObjectFile &Obj,
+  LLVM_ABI static llvm::Error convert(const object::ObjectFile &Obj,
                              OutputAggregator &Output, GsymCreator &Gsym);
 };
 

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVCompare.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVCompare.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVCOMPARE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVCOMPARE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVObject.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace logicalview {

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVCompare.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVCompare.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVCOMPARE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVCOMPARE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVObject.h"
 
 namespace llvm {
@@ -54,27 +55,27 @@ class LVCompare final {
 
 public:
   LVCompare() = delete;
-  LVCompare(raw_ostream &OS);
+  LLVM_ABI LVCompare(raw_ostream &OS);
   LVCompare(const LVCompare &) = delete;
   LVCompare &operator=(const LVCompare &) = delete;
   ~LVCompare() = default;
 
-  static LVCompare &getInstance();
+  LLVM_ABI static LVCompare &getInstance();
 
   // Scopes stack used during the missing/added reporting.
   void push(LVScope *Scope) { ScopeStack.push_back(Scope); }
   void pop() { ScopeStack.pop_back(); }
 
   // Perform comparison between the 'Reference' and 'Target' scopes tree.
-  Error execute(LVReader *ReferenceReader, LVReader *TargetReader);
+  LLVM_ABI Error execute(LVReader *ReferenceReader, LVReader *TargetReader);
 
   void addPassEntry(LVReader *Reader, LVElement *Element, LVComparePass Pass) {
     PassTable.emplace_back(Reader, Element, Pass);
   }
   const LVPassTable &getPassTable() const & { return PassTable; }
 
-  void printItem(LVElement *Element, LVComparePass Pass);
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void printItem(LVElement *Element, LVComparePass Pass);
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVElement.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVElement.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVELEMENT_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVELEMENT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVObject.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/MathExtras.h"
@@ -70,7 +71,7 @@ using LVElementRequest = std::vector<LVElementGetFunction>;
 // lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp.
 constexpr unsigned int DWARF_CHAR_BIT = 8u;
 
-class LVElement : public LVObject {
+class LLVM_ABI LVElement : public LVObject {
   enum class Property {
     IsLine,   // A logical line.
     IsScope,  // A logical scope.

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVElement.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVElement.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVELEMENT_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVELEMENT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVObject.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 #include <map>
 #include <set>

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLine.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLine.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVLINE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVLINE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVElement.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace logicalview {

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLine.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLine.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVLINE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVLINE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVElement.h"
 
 namespace llvm {
@@ -37,7 +38,7 @@ using LVLineDispatch = std::map<LVLineKind, LVLineGetFunction>;
 using LVLineRequest = std::vector<LVLineGetFunction>;
 
 // Class to represent a logical line.
-class LVLine : public LVElement {
+class LLVM_ABI LVLine : public LVElement {
   // Typed bitvector with kinds for this line.
   LVProperties<LVLineKind> Kinds;
   static LVLineDispatch Dispatch;
@@ -111,7 +112,7 @@ public:
 };
 
 // Class to represent a DWARF line record object.
-class LVLineDebug final : public LVLine {
+class LLVM_ABI LVLineDebug final : public LVLine {
   // Discriminator value (DW_LNE_set_discriminator). The DWARF standard
   // defines the discriminator as an unsigned LEB128 integer.
   uint32_t Discriminator = 0;
@@ -140,7 +141,7 @@ public:
 };
 
 // Class to represent an assembler line extracted from the text section.
-class LVLineAssembler final : public LVLine {
+class LLVM_ABI LVLineAssembler final : public LVLine {
 public:
   LVLineAssembler() : LVLine() { setIsLineAssembler(); }
   LVLineAssembler(const LVLineAssembler &) = delete;

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLocation.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLocation.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVLOCATION_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVLOCATION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVObject.h"
 
 namespace llvm {
@@ -44,17 +45,17 @@ public:
   ~LVOperation() = default;
 
   LVSmall getOpcode() const { return Opcode; }
-  std::string getOperandsDWARFInfo();
-  std::string getOperandsCodeViewInfo();
+  LLVM_ABI std::string getOperandsDWARFInfo();
+  LLVM_ABI std::string getOperandsCodeViewInfo();
 
-  void print(raw_ostream &OS, bool Full = true) const;
+  LLVM_ABI void print(raw_ostream &OS, bool Full = true) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() { print(dbgs()); }
 #endif
 };
 
-class LVLocation : public LVObject {
+class LLVM_ABI LVLocation : public LVObject {
   enum class Property {
     IsAddressRange,
     IsBaseClassOffset,
@@ -164,7 +165,7 @@ public:
 #endif
 };
 
-class LVLocationSymbol final : public LVLocation {
+class LLVM_ABI LVLocationSymbol final : public LVLocation {
   // Location descriptors for the active range.
   std::unique_ptr<LVOperations> Entries;
 

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLocation.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLocation.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVLOCATION_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVLOCATION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVObject.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace logicalview {

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVObject.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVObject.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVOBJECT_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVOBJECT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVSupport.h"
+#include "llvm/Support/Compiler.h"
 #include <limits>
 #include <list>
 #include <string>

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVObject.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVObject.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVOBJECT_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVOBJECT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
@@ -54,11 +55,11 @@ class LVType;
 class LVOptions;
 class LVPatterns;
 
-StringRef typeNone();
-StringRef typeVoid();
-StringRef typeInt();
-StringRef typeUnknown();
-StringRef emptyString();
+LLVM_ABI StringRef typeNone();
+LLVM_ABI StringRef typeVoid();
+LLVM_ABI StringRef typeInt();
+LLVM_ABI StringRef typeUnknown();
+LLVM_ABI StringRef emptyString();
 
 using LVElementSetFunction = void (LVElement::*)();
 using LVElementGetFunction = bool (LVElement::*)() const;
@@ -105,7 +106,7 @@ struct LVCounter {
   }
 };
 
-class LVObject {
+class LLVM_ABI LVObject {
   enum class Property {
     IsLocation,          // Location.
     IsGlobalReference,   // This object is being referenced from another CU.

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVOptions.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVOptions.h
@@ -14,12 +14,12 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVOPTIONS_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVOPTIONS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVLine.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVScope.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVSymbol.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVType.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Regex.h"
 #include <set>
 #include <string>

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVOptions.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVOptions.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVOPTIONS_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVOPTIONS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVLine.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVScope.h"
@@ -293,8 +294,8 @@ public:
   }
 
   // Access to command line options, pattern and printing information.
-  static LVOptions *getOptions();
-  static void setOptions(LVOptions *Options);
+  LLVM_ABI static LVOptions *getOptions();
+  LLVM_ABI static void setOptions(LVOptions *Options);
 
   LVOptions() = default;
   LVOptions(const LVOptions &) = default;
@@ -307,7 +308,7 @@ public:
   // In the case of logical view comparison, some options related to
   // attributes must be set or reset for a proper comparison.
   // Resolve any dependencies between command line options.
-  void resolveDependencies();
+  LLVM_ABI void resolveDependencies();
   size_t indentationSize() const { return IndentationSize; }
 
   LVAttribute Attribute;
@@ -435,7 +436,7 @@ public:
   // General shortcuts to some combinations.
   BOOL_FUNCTION(General, CollectRanges);
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
@@ -505,7 +506,7 @@ class LVPatterns final {
     }
   }
 
-  void addElement(LVElement *Element);
+  LLVM_ABI void addElement(LVElement *Element);
 
   template <typename T, typename U>
   void resolveGenericPatternMatch(T *Element, const U &Requests) {
@@ -548,7 +549,7 @@ class LVPatterns final {
                          bool IgnoreCase, bool UseRegex);
 
 public:
-  static LVPatterns *getPatterns();
+  LLVM_ABI static LVPatterns *getPatterns();
 
   LVPatterns() {
     ElementDispatch = LVElement::getDispatch();
@@ -592,9 +593,9 @@ public:
     addRequest(Selection, TypeDispatch, TypeRequest);
   }
 
-  void updateReportOptions();
+  LLVM_ABI void updateReportOptions();
 
-  bool matchPattern(StringRef Input, const LVMatchInfo &MatchInfo);
+  LLVM_ABI bool matchPattern(StringRef Input, const LVMatchInfo &MatchInfo);
   // Match a pattern (--select='pattern').
   bool matchGenericPattern(StringRef Input) {
     return matchPattern(Input, GenericMatchInfo);
@@ -619,20 +620,20 @@ public:
     resolveGenericPatternMatch(Type, TypeRequest);
   }
 
-  void addPatterns(StringSet<> &Patterns, LVMatchInfo &Filters);
+  LLVM_ABI void addPatterns(StringSet<> &Patterns, LVMatchInfo &Filters);
 
   // Add generic and offset patterns info.
-  void addGenericPatterns(StringSet<> &Patterns);
-  void addOffsetPatterns(const LVOffsetSet &Patterns);
+  LLVM_ABI void addGenericPatterns(StringSet<> &Patterns);
+  LLVM_ABI void addOffsetPatterns(const LVOffsetSet &Patterns);
 
   // Conditions to print an object.
-  bool printElement(const LVLine *Line) const;
-  bool printObject(const LVLocation *Location) const;
-  bool printElement(const LVScope *Scope) const;
-  bool printElement(const LVSymbol *Symbol) const;
-  bool printElement(const LVType *Type) const;
+  LLVM_ABI bool printElement(const LVLine *Line) const;
+  LLVM_ABI bool printObject(const LVLocation *Location) const;
+  LLVM_ABI bool printElement(const LVScope *Scope) const;
+  LLVM_ABI bool printElement(const LVSymbol *Symbol) const;
+  LLVM_ABI bool printElement(const LVType *Type) const;
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVRange.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVRange.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVRANGE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVRANGE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntervalTree.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVObject.h"
 
@@ -46,7 +47,7 @@ public:
 // scope; the addresses are stored in ascending order and can overlap.
 using LVRangeEntries = std::vector<LVRangeEntry>;
 
-class LVRange final : public LVObject {
+class LLVM_ABI LVRange final : public LVObject {
   /// Map of where a user value is live, and its location.
   using LVRangesTree = IntervalTree<LVAddress, LVScope *>;
   using LVAllocator = LVRangesTree::Allocator;

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVRange.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVRange.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVRANGE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVRANGE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntervalTree.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVObject.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace logicalview {

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVReader.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVREADER_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVOptions.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVRange.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ScopedPrinter.h"
@@ -43,7 +43,7 @@ public:
 
   LLVM_ABI Error createSplitFolder(StringRef Where);
   LLVM_ABI std::error_code open(std::string Name, std::string Extension,
-                       raw_ostream &OS);
+                                raw_ostream &OS);
   void close() {
     if (OutputFile) {
       OutputFile->os().close();

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVReader.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVREADER_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVOptions.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVRange.h"
 #include "llvm/Support/Errc.h"
@@ -40,8 +41,8 @@ public:
   LVSplitContext &operator=(const LVSplitContext &) = delete;
   ~LVSplitContext() = default;
 
-  Error createSplitFolder(StringRef Where);
-  std::error_code open(std::string Name, std::string Extension,
+  LLVM_ABI Error createSplitFolder(StringRef Where);
+  LLVM_ABI std::error_code open(std::string Name, std::string Extension,
                        raw_ostream &OS);
   void close() {
     if (OutputFile) {
@@ -57,7 +58,7 @@ public:
 /// The logical reader owns of all the logical elements created during
 /// the debug information parsing. For its creation it uses a specific
 /// bump allocator for each type of logical element.
-class LVReader {
+class LLVM_ABI LVReader {
   LVBinaryType BinaryType;
 
   // Context used by '--output=split' command line option.

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVScope.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVScope.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSCOPE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSCOPE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVElement.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVLocation.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVSort.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include <list>
 #include <map>
 #include <set>

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVScope.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVScope.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSCOPE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSCOPE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVElement.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVLocation.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVSort.h"
@@ -71,7 +72,7 @@ using LVOffsetSymbolMap = std::map<LVOffset, LVSymbol *>;
 using LVTagOffsetsMap = std::map<dwarf::Tag, LVOffsets>;
 
 // Class to represent a DWARF Scope.
-class LVScope : public LVElement {
+class LLVM_ABI LVScope : public LVElement {
   enum class Property {
     HasDiscriminator,
     CanHaveRanges,
@@ -331,7 +332,7 @@ public:
 };
 
 // Class to represent a DWARF Union/Structure/Class.
-class LVScopeAggregate final : public LVScope {
+class LLVM_ABI LVScopeAggregate final : public LVScope {
   LVScope *Reference = nullptr; // DW_AT_specification, DW_AT_abstract_origin.
   size_t EncodedArgsIndex = 0;  // Template encoded arguments.
 
@@ -369,7 +370,7 @@ public:
 };
 
 // Class to represent a DWARF Template alias.
-class LVScopeAlias final : public LVScope {
+class LLVM_ABI LVScopeAlias final : public LVScope {
 public:
   LVScopeAlias() : LVScope() {
     setIsTemplateAlias();
@@ -386,7 +387,7 @@ public:
 };
 
 // Class to represent a DWARF array (DW_TAG_array_type).
-class LVScopeArray final : public LVScope {
+class LLVM_ABI LVScopeArray final : public LVScope {
 public:
   LVScopeArray() : LVScope() { setIsArray(); }
   LVScopeArray(const LVScopeArray &) = delete;
@@ -402,7 +403,7 @@ public:
 };
 
 // Class to represent a DWARF Compilation Unit (CU).
-class LVScopeCompileUnit final : public LVScope {
+class LLVM_ABI LVScopeCompileUnit final : public LVScope {
   // Names (files and directories) used by the Compile Unit.
   std::vector<size_t> Filenames;
 
@@ -622,7 +623,7 @@ public:
 };
 
 // Class to represent a DWARF enumerator (DW_TAG_enumeration_type).
-class LVScopeEnumeration final : public LVScope {
+class LLVM_ABI LVScopeEnumeration final : public LVScope {
 public:
   LVScopeEnumeration() : LVScope() { setIsEnumeration(); }
   LVScopeEnumeration(const LVScopeEnumeration &) = delete;
@@ -637,7 +638,7 @@ public:
 
 // Class to represent a DWARF formal parameter pack
 // (DW_TAG_GNU_formal_parameter_pack).
-class LVScopeFormalPack final : public LVScope {
+class LLVM_ABI LVScopeFormalPack final : public LVScope {
 public:
   LVScopeFormalPack() : LVScope() { setIsTemplatePack(); }
   LVScopeFormalPack(const LVScopeFormalPack &) = delete;
@@ -651,7 +652,7 @@ public:
 };
 
 // Class to represent a DWARF Function.
-class LVScopeFunction : public LVScope {
+class LLVM_ABI LVScopeFunction : public LVScope {
   LVScope *Reference = nullptr; // DW_AT_specification, DW_AT_abstract_origin.
   size_t LinkageNameIndex = 0;  // Function DW_AT_linkage_name attribute.
   size_t EncodedArgsIndex = 0;  // Template encoded arguments.
@@ -703,7 +704,7 @@ public:
 };
 
 // Class to represent a DWARF inlined function.
-class LVScopeFunctionInlined final : public LVScopeFunction {
+class LLVM_ABI LVScopeFunctionInlined final : public LVScopeFunction {
   size_t CallFilenameIndex = 0;
   uint32_t CallLineNumber = 0;
   uint32_t Discriminator = 0;
@@ -746,7 +747,7 @@ public:
 };
 
 // Class to represent a DWARF subroutine type.
-class LVScopeFunctionType final : public LVScopeFunction {
+class LLVM_ABI LVScopeFunctionType final : public LVScopeFunction {
 public:
   LVScopeFunctionType() : LVScopeFunction() { setIsFunctionType(); }
   LVScopeFunctionType(const LVScopeFunctionType &) = delete;
@@ -757,7 +758,7 @@ public:
 };
 
 // Class to represent a DWARF Module.
-class LVScopeModule final : public LVScope {
+class LLVM_ABI LVScopeModule final : public LVScope {
 public:
   LVScopeModule() : LVScope() {
     setIsModule();
@@ -774,7 +775,7 @@ public:
 };
 
 // Class to represent a DWARF Namespace.
-class LVScopeNamespace final : public LVScope {
+class LLVM_ABI LVScopeNamespace final : public LVScope {
   LVScope *Reference = nullptr; // Reference to DW_AT_extension attribute.
 
 public:
@@ -804,7 +805,7 @@ public:
 };
 
 // Class to represent the binary file being analyzed.
-class LVScopeRoot final : public LVScope {
+class LLVM_ABI LVScopeRoot final : public LVScope {
   size_t FileFormatNameIndex = 0;
 
 public:
@@ -838,7 +839,7 @@ public:
 
 // Class to represent a DWARF template parameter pack
 // (DW_TAG_GNU_template_parameter_pack).
-class LVScopeTemplatePack final : public LVScope {
+class LLVM_ABI LVScopeTemplatePack final : public LVScope {
 public:
   LVScopeTemplatePack() : LVScope() { setIsTemplatePack(); }
   LVScopeTemplatePack(const LVScopeTemplatePack &) = delete;

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSort.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSort.h
@@ -33,17 +33,17 @@ using LVSortFunction = LVSortValue (*)(const LVObject *LHS,
                                        const LVObject *RHS);
 
 // Get the comparator function, based on the command line options.
-LVSortFunction getSortFunction();
+LLVM_ABI LVSortFunction getSortFunction();
 
 // Comparator functions that can be used for sorting.
-LVSortValue compareKind(const LVObject *LHS, const LVObject *RHS);
-LVSortValue compareLine(const LVObject *LHS, const LVObject *RHS);
-LVSortValue compareName(const LVObject *LHS, const LVObject *RHS);
-LVSortValue compareOffset(const LVObject *LHS, const LVObject *RHS);
-LVSortValue compareRange(const LVObject *LHS, const LVObject *RHS);
-LVSortValue sortByKind(const LVObject *LHS, const LVObject *RHS);
-LVSortValue sortByLine(const LVObject *LHS, const LVObject *RHS);
-LVSortValue sortByName(const LVObject *LHS, const LVObject *RHS);
+LLVM_ABI LVSortValue compareKind(const LVObject *LHS, const LVObject *RHS);
+LLVM_ABI LVSortValue compareLine(const LVObject *LHS, const LVObject *RHS);
+LLVM_ABI LVSortValue compareName(const LVObject *LHS, const LVObject *RHS);
+LLVM_ABI LVSortValue compareOffset(const LVObject *LHS, const LVObject *RHS);
+LLVM_ABI LVSortValue compareRange(const LVObject *LHS, const LVObject *RHS);
+LLVM_ABI LVSortValue sortByKind(const LVObject *LHS, const LVObject *RHS);
+LLVM_ABI LVSortValue sortByLine(const LVObject *LHS, const LVObject *RHS);
+LLVM_ABI LVSortValue sortByName(const LVObject *LHS, const LVObject *RHS);
 
 } // end namespace logicalview
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSort.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSort.h
@@ -13,6 +13,8 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSORT_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSORT_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 namespace logicalview {
 

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSupport.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSupport.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSUPPORT_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSUPPORT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVStringPool.h"
@@ -28,7 +29,7 @@ namespace llvm {
 namespace logicalview {
 
 // Returns the unique string pool instance.
-LVStringPool &getStringPool();
+LLVM_ABI LVStringPool &getStringPool();
 
 using LVStringRefs = std::vector<StringRef>;
 using LVLexicalComponent = std::tuple<StringRef, StringRef>;
@@ -210,8 +211,8 @@ public:
 };
 
 // Unified and flattened pathnames.
-std::string transformPath(StringRef Path);
-std::string flattenedFilePath(StringRef Path);
+LLVM_ABI std::string transformPath(StringRef Path);
+LLVM_ABI std::string flattenedFilePath(StringRef Path);
 
 inline std::string formattedKind(StringRef Kind) {
   return (Twine("{") + Twine(Kind) + Twine("}")).str();
@@ -229,9 +230,9 @@ inline std::string formattedNames(StringRef Name1, StringRef Name2) {
 // scopes, such as: name, name<..>, scope::name, scope::..::name, etc.
 // The string can have multiple references to template instantiations.
 // It returns the inner most component.
-LVLexicalComponent getInnerComponent(StringRef Name);
-LVStringRefs getAllLexicalComponents(StringRef Name);
-std::string getScopedName(const LVStringRefs &Components,
+LLVM_ABI LVLexicalComponent getInnerComponent(StringRef Name);
+LLVM_ABI LVStringRefs getAllLexicalComponents(StringRef Name);
+LLVM_ABI std::string getScopedName(const LVStringRefs &Components,
                           StringRef BaseName = {});
 
 // These are the values assigned to the debug location record IDs.

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSupport.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSupport.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSUPPORT_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSUPPORT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVStringPool.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/Path.h"
@@ -233,7 +233,7 @@ inline std::string formattedNames(StringRef Name1, StringRef Name2) {
 LLVM_ABI LVLexicalComponent getInnerComponent(StringRef Name);
 LLVM_ABI LVStringRefs getAllLexicalComponents(StringRef Name);
 LLVM_ABI std::string getScopedName(const LVStringRefs &Components,
-                          StringRef BaseName = {});
+                                   StringRef BaseName = {});
 
 // These are the values assigned to the debug location record IDs.
 // See DebugInfo/CodeView/CodeViewSymbols.def.

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSymbol.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSymbol.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSYMBOL_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSYMBOL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVElement.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace logicalview {

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSymbol.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSymbol.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSYMBOL_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSYMBOL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVElement.h"
 
 namespace llvm {
@@ -33,7 +34,7 @@ using LVSymbolKindSet = std::set<LVSymbolKind>;
 using LVSymbolDispatch = std::map<LVSymbolKind, LVSymbolGetFunction>;
 using LVSymbolRequest = std::vector<LVSymbolGetFunction>;
 
-class LVSymbol final : public LVElement {
+class LLVM_ABI LVSymbol final : public LVElement {
   enum class Property { HasLocation, FillGaps, LastEntry };
 
   // Typed bitvector with kinds and properties for this symbol.

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVType.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVType.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVTYPE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVTYPE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVElement.h"
 
 namespace llvm {
@@ -48,7 +49,7 @@ using LVTypeDispatch = std::map<LVTypeKind, LVTypeGetFunction>;
 using LVTypeRequest = std::vector<LVTypeGetFunction>;
 
 // Class to represent a DWARF Type.
-class LVType : public LVElement {
+class LLVM_ABI LVType : public LVElement {
   enum class Property { IsSubrangeCount, LastEntry };
 
   // Typed bitvector with kinds and properties for this type.
@@ -152,7 +153,7 @@ public:
 };
 
 // Class to represent DW_TAG_typedef_type.
-class LVTypeDefinition final : public LVType {
+class LLVM_ABI LVTypeDefinition final : public LVType {
 public:
   LVTypeDefinition() : LVType() {
     setIsTypedef();
@@ -175,7 +176,7 @@ public:
 };
 
 // Class to represent a DW_TAG_enumerator.
-class LVTypeEnumerator final : public LVType {
+class LLVM_ABI LVTypeEnumerator final : public LVType {
   // Index in the String pool representing any initial value.
   size_t ValueIndex = 0;
 
@@ -204,7 +205,7 @@ public:
 };
 
 // Class to represent DW_TAG_imported_module / DW_TAG_imported_declaration.
-class LVTypeImport final : public LVType {
+class LLVM_ABI LVTypeImport final : public LVType {
 public:
   LVTypeImport() : LVType() { setIncludeInPrint(); }
   LVTypeImport(const LVTypeImport &) = delete;
@@ -218,7 +219,7 @@ public:
 };
 
 // Class to represent a DWARF Template parameter holder (type or param).
-class LVTypeParam final : public LVType {
+class LLVM_ABI LVTypeParam final : public LVType {
   // Index in the String pool representing any initial value.
   size_t ValueIndex = 0;
 
@@ -247,7 +248,7 @@ public:
 };
 
 // Class to represent a DW_TAG_subrange_type.
-class LVTypeSubrange final : public LVType {
+class LLVM_ABI LVTypeSubrange final : public LVType {
   // Values describing the subrange bounds.
   int64_t LowerBound = 0; // DW_AT_lower_bound or DW_AT_count value.
   int64_t UpperBound = 0; // DW_AT_upper_bound value.

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVType.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVType.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVTYPE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVTYPE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVElement.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace logicalview {

--- a/llvm/include/llvm/DebugInfo/LogicalView/LVReaderHandler.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/LVReaderHandler.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_READERS_LVREADERHANDLER_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_READERS_LVREADERHANDLER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVReader.h"
 #include "llvm/DebugInfo/PDB/Native/PDBFile.h"
@@ -52,7 +53,7 @@ class LVReaderHandler {
                       object::Archive &Arch);
   Error handleBuffer(LVReaders &Readers, StringRef Filename,
                      MemoryBufferRef Buffer, StringRef ExePath = {});
-  Error handleFile(LVReaders &Readers, StringRef Filename,
+  LLVM_ABI Error handleFile(LVReaders &Readers, StringRef Filename,
                    StringRef ExePath = {});
   Error handleMach(LVReaders &Readers, StringRef Filename,
                    object::MachOUniversalBinary &Mach);
@@ -77,7 +78,7 @@ public:
   Error createReader(StringRef Filename, LVReaders &Readers) {
     return handleFile(Readers, Filename);
   }
-  Error process();
+  LLVM_ABI Error process();
 
   Expected<std::unique_ptr<LVReader>> createReader(StringRef Pathname) {
     LVReaders Readers;
@@ -86,7 +87,7 @@ public:
     return std::move(Readers[0]);
   }
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }

--- a/llvm/include/llvm/DebugInfo/LogicalView/LVReaderHandler.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/LVReaderHandler.h
@@ -13,13 +13,13 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_READERS_LVREADERHANDLER_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_READERS_LVREADERHANDLER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVReader.h"
 #include "llvm/DebugInfo/PDB/Native/PDBFile.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/MachOUniversal.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/ScopedPrinter.h"
 #include <string>
@@ -54,7 +54,7 @@ class LVReaderHandler {
   Error handleBuffer(LVReaders &Readers, StringRef Filename,
                      MemoryBufferRef Buffer, StringRef ExePath = {});
   LLVM_ABI Error handleFile(LVReaders &Readers, StringRef Filename,
-                   StringRef ExePath = {});
+                            StringRef ExePath = {});
   Error handleMach(LVReaders &Readers, StringRef Filename,
                    object::MachOUniversalBinary &Mach);
   Error handleObject(LVReaders &Readers, StringRef Filename,

--- a/llvm/include/llvm/DebugInfo/MSF/MSFBuilder.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MSFBuilder.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_MSF_MSFBUILDER_H
 #define LLVM_DEBUGINFO_MSF_MSFBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <utility>
@@ -56,9 +56,9 @@ public:
   /// is specified, or `MinBlockCount` does not leave enough room for the
   /// mandatory reserved blocks required by an MSF file.
   LLVM_ABI static Expected<MSFBuilder> create(BumpPtrAllocator &Allocator,
-                                     uint32_t BlockSize,
-                                     uint32_t MinBlockCount = 0,
-                                     bool CanGrow = true);
+                                              uint32_t BlockSize,
+                                              uint32_t MinBlockCount = 0,
+                                              bool CanGrow = true);
 
   /// Request the block map to be at a specific block address.  This is useful
   /// when editing a MSF and you want the layout to be as stable as possible.
@@ -72,7 +72,8 @@ public:
   /// particular stream to occupy the original set of blocks.  If the given
   /// blocks are already allocated, or if the number of blocks specified is
   /// incorrect for the given stream size, this function will return an Error.
-  LLVM_ABI Expected<uint32_t> addStream(uint32_t Size, ArrayRef<uint32_t> Blocks);
+  LLVM_ABI Expected<uint32_t> addStream(uint32_t Size,
+                                        ArrayRef<uint32_t> Blocks);
 
   /// Add a stream to the MSF file with the given size, occupying any available
   /// blocks that the builder decides to use.  This is useful when building a
@@ -115,7 +116,8 @@ public:
   LLVM_ABI Expected<MSFLayout> generateLayout();
 
   /// Write the MSF layout to the underlying file.
-  LLVM_ABI Expected<FileBufferByteStream> commit(StringRef Path, MSFLayout &Layout);
+  LLVM_ABI Expected<FileBufferByteStream> commit(StringRef Path,
+                                                 MSFLayout &Layout);
 
   BumpPtrAllocator &getAllocator() { return Allocator; }
 

--- a/llvm/include/llvm/DebugInfo/MSF/MSFBuilder.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MSFBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_MSF_MSFBUILDER_H
 #define LLVM_DEBUGINFO_MSF_MSFBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -54,67 +55,67 @@ public:
   /// failed.  Currently the only way this can fail is if an invalid block size
   /// is specified, or `MinBlockCount` does not leave enough room for the
   /// mandatory reserved blocks required by an MSF file.
-  static Expected<MSFBuilder> create(BumpPtrAllocator &Allocator,
+  LLVM_ABI static Expected<MSFBuilder> create(BumpPtrAllocator &Allocator,
                                      uint32_t BlockSize,
                                      uint32_t MinBlockCount = 0,
                                      bool CanGrow = true);
 
   /// Request the block map to be at a specific block address.  This is useful
   /// when editing a MSF and you want the layout to be as stable as possible.
-  Error setBlockMapAddr(uint32_t Addr);
-  Error setDirectoryBlocksHint(ArrayRef<uint32_t> DirBlocks);
-  void setFreePageMap(uint32_t Fpm);
-  void setUnknown1(uint32_t Unk1);
+  LLVM_ABI Error setBlockMapAddr(uint32_t Addr);
+  LLVM_ABI Error setDirectoryBlocksHint(ArrayRef<uint32_t> DirBlocks);
+  LLVM_ABI void setFreePageMap(uint32_t Fpm);
+  LLVM_ABI void setUnknown1(uint32_t Unk1);
 
   /// Add a stream to the MSF file with the given size, occupying the given
   /// list of blocks.  This is useful when reading a MSF file and you want a
   /// particular stream to occupy the original set of blocks.  If the given
   /// blocks are already allocated, or if the number of blocks specified is
   /// incorrect for the given stream size, this function will return an Error.
-  Expected<uint32_t> addStream(uint32_t Size, ArrayRef<uint32_t> Blocks);
+  LLVM_ABI Expected<uint32_t> addStream(uint32_t Size, ArrayRef<uint32_t> Blocks);
 
   /// Add a stream to the MSF file with the given size, occupying any available
   /// blocks that the builder decides to use.  This is useful when building a
   /// new PDB file from scratch and you don't care what blocks a stream occupies
   /// but you just want it to work.
-  Expected<uint32_t> addStream(uint32_t Size);
+  LLVM_ABI Expected<uint32_t> addStream(uint32_t Size);
 
   /// Update the size of an existing stream.  This will allocate or deallocate
   /// blocks as needed to match the requested size.  This can fail if `CanGrow`
   /// was set to false when initializing the `MSFBuilder`.
-  Error setStreamSize(uint32_t Idx, uint32_t Size);
+  LLVM_ABI Error setStreamSize(uint32_t Idx, uint32_t Size);
 
   /// Get the total number of streams in the MSF layout.  This should return 1
   /// for every call to `addStream`.
-  uint32_t getNumStreams() const;
+  LLVM_ABI uint32_t getNumStreams() const;
 
   /// Get the size of a stream by index.
-  uint32_t getStreamSize(uint32_t StreamIdx) const;
+  LLVM_ABI uint32_t getStreamSize(uint32_t StreamIdx) const;
 
   /// Get the list of blocks allocated to a particular stream.
-  ArrayRef<uint32_t> getStreamBlocks(uint32_t StreamIdx) const;
+  LLVM_ABI ArrayRef<uint32_t> getStreamBlocks(uint32_t StreamIdx) const;
 
   /// Get the total number of blocks that will be allocated to actual data in
   /// this MSF file.
-  uint32_t getNumUsedBlocks() const;
+  LLVM_ABI uint32_t getNumUsedBlocks() const;
 
   /// Get the total number of blocks that exist in the MSF file but are not
   /// allocated to any valid data.
-  uint32_t getNumFreeBlocks() const;
+  LLVM_ABI uint32_t getNumFreeBlocks() const;
 
   /// Get the total number of blocks in the MSF file.  In practice this is equal
   /// to `getNumUsedBlocks() + getNumFreeBlocks()`.
-  uint32_t getTotalBlockCount() const;
+  LLVM_ABI uint32_t getTotalBlockCount() const;
 
   /// Check whether a particular block is allocated or free.
-  bool isBlockFree(uint32_t Idx) const;
+  LLVM_ABI bool isBlockFree(uint32_t Idx) const;
 
   /// Finalize the layout and build the headers and structures that describe the
   /// MSF layout and can be written directly to the MSF file.
-  Expected<MSFLayout> generateLayout();
+  LLVM_ABI Expected<MSFLayout> generateLayout();
 
   /// Write the MSF layout to the underlying file.
-  Expected<FileBufferByteStream> commit(StringRef Path, MSFLayout &Layout);
+  LLVM_ABI Expected<FileBufferByteStream> commit(StringRef Path, MSFLayout &Layout);
 
   BumpPtrAllocator &getAllocator() { return Allocator; }
 

--- a/llvm/include/llvm/DebugInfo/MSF/MSFCommon.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MSFCommon.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_MSF_MSFCOMMON_H
 #define LLVM_DEBUGINFO_MSF_MSFCOMMON_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/Support/Endian.h"
@@ -83,7 +84,7 @@ public:
 /// Determine the layout of the FPM stream, given the MSF layout.  An FPM
 /// stream spans 1 or more blocks, each at equally spaced intervals throughout
 /// the file.
-MSFStreamLayout getFpmStreamLayout(const MSFLayout &Msf,
+LLVM_ABI MSFStreamLayout getFpmStreamLayout(const MSFLayout &Msf,
                                    bool IncludeUnusedFpmData = false,
                                    bool AltFpm = false);
 
@@ -176,7 +177,7 @@ inline uint32_t getNumFpmIntervals(const MSFLayout &L,
                             AltFpm ? L.alternateFpmBlock() : L.mainFpmBlock());
 }
 
-Error validateSuperBlock(const SuperBlock &SB);
+LLVM_ABI Error validateSuperBlock(const SuperBlock &SB);
 
 } // end namespace msf
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/MSF/MSFCommon.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MSFCommon.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_MSF_MSFCOMMON_H
 #define LLVM_DEBUGINFO_MSF_MSFCOMMON_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MathExtras.h"
@@ -85,8 +85,8 @@ public:
 /// stream spans 1 or more blocks, each at equally spaced intervals throughout
 /// the file.
 LLVM_ABI MSFStreamLayout getFpmStreamLayout(const MSFLayout &Msf,
-                                   bool IncludeUnusedFpmData = false,
-                                   bool AltFpm = false);
+                                            bool IncludeUnusedFpmData = false,
+                                            bool AltFpm = false);
 
 inline bool isValidBlockSize(uint32_t Size) {
   switch (Size) {

--- a/llvm/include/llvm/DebugInfo/MSF/MSFError.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MSFError.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_MSF_MSFERROR_H
 #define LLVM_DEBUGINFO_MSF_MSFERROR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -36,7 +37,7 @@ struct is_error_code_enum<llvm::msf::msf_error_code> : std::true_type {};
 
 namespace llvm {
 namespace msf {
-const std::error_category &MSFErrCategory();
+LLVM_ABI const std::error_category &MSFErrCategory();
 
 inline std::error_code make_error_code(msf_error_code E) {
   return std::error_code(static_cast<int>(E), MSFErrCategory());
@@ -67,7 +68,7 @@ public:
     llvm_unreachable("msf error code not implemented");
   }
 
-  static char ID;
+  LLVM_ABI static char ID;
 };
 } // namespace msf
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/MSF/MappedBlockStream.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MappedBlockStream.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_MSF_MAPPEDBLOCKSTREAM_H
 #define LLVM_DEBUGINFO_MSF_MAPPEDBLOCKSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/MSF/MSFCommon.h"
@@ -34,7 +35,7 @@ namespace msf {
 /// the MSF.  MappedBlockStream provides methods for reading from and writing
 /// to one of these streams transparently, as if it were a contiguous sequence
 /// of bytes.
-class MappedBlockStream : public BinaryStream {
+class LLVM_ABI MappedBlockStream : public BinaryStream {
   friend class WritableMappedBlockStream;
 
 public:
@@ -102,7 +103,7 @@ private:
   DenseMap<uint32_t, std::vector<CacheEntry>> CacheMap;
 };
 
-class WritableMappedBlockStream : public WritableBinaryStream {
+class LLVM_ABI WritableMappedBlockStream : public WritableBinaryStream {
 public:
   static std::unique_ptr<WritableMappedBlockStream>
   createStream(uint32_t BlockSize, const MSFStreamLayout &Layout,

--- a/llvm/include/llvm/DebugInfo/MSF/MappedBlockStream.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MappedBlockStream.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_MSF_MAPPEDBLOCKSTREAM_H
 #define LLVM_DEBUGINFO_MSF_MAPPEDBLOCKSTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/MSF/MSFCommon.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryStream.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>

--- a/llvm/include/llvm/DebugInfo/PDB/GenericError.h
+++ b/llvm/include/llvm/DebugInfo/PDB/GenericError.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_GENERICERROR_H
 #define LLVM_DEBUGINFO_PDB_GENERICERROR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -32,7 +33,7 @@ struct is_error_code_enum<llvm::pdb::pdb_error_code> : std::true_type {};
 
 namespace llvm {
 namespace pdb {
-const std::error_category &PDBErrCategory();
+LLVM_ABI const std::error_category &PDBErrCategory();
 
 inline std::error_code make_error_code(pdb_error_code E) {
   return std::error_code(static_cast<int>(E), PDBErrCategory());
@@ -43,7 +44,7 @@ class PDBError : public ErrorInfo<PDBError, StringError> {
 public:
   using ErrorInfo<PDBError, StringError>::ErrorInfo; // inherit constructors
   PDBError(const Twine &S) : ErrorInfo(S, pdb_error_code::unspecified) {}
-  static char ID;
+  LLVM_ABI static char ID;
 };
 } // namespace pdb
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBFrameData.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBFrameData.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBFRAMEDATA_H
 #define LLVM_DEBUGINFO_PDB_IPDBFRAMEDATA_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <string>
 
@@ -17,7 +18,7 @@ namespace pdb {
 
 /// IPDBFrameData defines an interface used to represent a frame data of some
 /// code block.
-class IPDBFrameData {
+class LLVM_ABI IPDBFrameData {
 public:
   virtual ~IPDBFrameData();
 

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBInjectedSource.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBInjectedSource.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBINJECTEDSOURCE_H
 #define LLVM_DEBUGINFO_PDB_IPDBINJECTEDSOURCE_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <string>
 
@@ -18,7 +19,7 @@ namespace pdb {
 /// which were injected directly into the PDB file during the compilation
 /// process.  This is used, for example, to add natvis files to a PDB, but
 /// in theory could be used to add arbitrary source code.
-class IPDBInjectedSource {
+class LLVM_ABI IPDBInjectedSource {
 public:
   virtual ~IPDBInjectedSource();
 

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBLineNumber.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBLineNumber.h
@@ -9,11 +9,12 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBLINENUMBER_H
 #define LLVM_DEBUGINFO_PDB_IPDBLINENUMBER_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
 namespace pdb {
-class IPDBLineNumber {
+class LLVM_ABI IPDBLineNumber {
 public:
   virtual ~IPDBLineNumber();
 

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBRawSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBRawSymbol.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBRAWSYMBOL_H
 #define LLVM_DEBUGINFO_PDB_IPDBRAWSYMBOL_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBTypes.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/SmallVector.h"
@@ -32,7 +33,7 @@ enum class PdbSymbolIdField : uint32_t {
   LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ All)
 };
 
-void dumpSymbolIdField(raw_ostream &OS, StringRef Name, SymIndexId Value,
+LLVM_ABI void dumpSymbolIdField(raw_ostream &OS, StringRef Name, SymIndexId Value,
                        int Indent, const IPDBSession &Session,
                        PdbSymbolIdField FieldId, PdbSymbolIdField ShowFlags,
                        PdbSymbolIdField RecurseFlags);
@@ -42,7 +43,7 @@ void dumpSymbolIdField(raw_ostream &OS, StringRef Name, SymIndexId Value,
 /// all properties that are valid for any symbol type.  This interface is then
 /// wrapped by a concrete class which exposes only those set of methods valid
 /// for this particular symbol type.  See PDBSymbol.h for more details.
-class IPDBRawSymbol {
+class LLVM_ABI IPDBRawSymbol {
 public:
   virtual ~IPDBRawSymbol();
 

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBRawSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBRawSymbol.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBRAWSYMBOL_H
 #define LLVM_DEBUGINFO_PDB_IPDBRAWSYMBOL_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBTypes.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {
@@ -33,10 +33,10 @@ enum class PdbSymbolIdField : uint32_t {
   LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ All)
 };
 
-LLVM_ABI void dumpSymbolIdField(raw_ostream &OS, StringRef Name, SymIndexId Value,
-                       int Indent, const IPDBSession &Session,
-                       PdbSymbolIdField FieldId, PdbSymbolIdField ShowFlags,
-                       PdbSymbolIdField RecurseFlags);
+LLVM_ABI void
+dumpSymbolIdField(raw_ostream &OS, StringRef Name, SymIndexId Value, int Indent,
+                  const IPDBSession &Session, PdbSymbolIdField FieldId,
+                  PdbSymbolIdField ShowFlags, PdbSymbolIdField RecurseFlags);
 
 /// IPDBRawSymbol defines an interface used to represent an arbitrary symbol.
 /// It exposes a monolithic interface consisting of accessors for the union of

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBSession.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBSession.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBSESSION_H
 #define LLVM_DEBUGINFO_PDB_IPDBSESSION_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBSession.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBSession.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBSESSION_H
 #define LLVM_DEBUGINFO_PDB_IPDBSESSION_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 #include "llvm/ADT/StringRef.h"
@@ -22,7 +23,7 @@ class PDBSymbolExe;
 
 /// IPDBSession defines an interface used to provide a context for querying
 /// debug information from a debug data source (for example, a PDB).
-class IPDBSession {
+class LLVM_ABI IPDBSession {
 public:
   virtual ~IPDBSession();
 

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBSourceFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBSourceFile.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBSOURCEFILE_H
 #define LLVM_DEBUGINFO_PDB_IPDBSOURCEFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 #include <string>
 

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBSourceFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBSourceFile.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_IPDBSOURCEFILE_H
 #define LLVM_DEBUGINFO_PDB_IPDBSOURCEFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBTypes.h"
 #include <memory>
 #include <string>
@@ -20,7 +21,7 @@ namespace pdb {
 
 /// IPDBSourceFile defines an interface used to represent source files whose
 /// information are stored in the PDB.
-class IPDBSourceFile {
+class LLVM_ABI IPDBSourceFile {
 public:
   virtual ~IPDBSourceFile();
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptor.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptor.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULEDESCRIPTOR_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULEDESCRIPTOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 
@@ -29,7 +29,8 @@ public:
   DbiModuleDescriptor(const DbiModuleDescriptor &Info) = default;
   DbiModuleDescriptor &operator=(const DbiModuleDescriptor &Info) = default;
 
-  LLVM_ABI static Error initialize(BinaryStreamRef Stream, DbiModuleDescriptor &Info);
+  LLVM_ABI static Error initialize(BinaryStreamRef Stream,
+                                   DbiModuleDescriptor &Info);
 
   LLVM_ABI bool hasECInfo() const;
   LLVM_ABI uint16_t getTypeServerIndex() const;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptor.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULEDESCRIPTOR_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULEDESCRIPTOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/BinaryStreamRef.h"
 #include "llvm/Support/Error.h"
@@ -28,24 +29,24 @@ public:
   DbiModuleDescriptor(const DbiModuleDescriptor &Info) = default;
   DbiModuleDescriptor &operator=(const DbiModuleDescriptor &Info) = default;
 
-  static Error initialize(BinaryStreamRef Stream, DbiModuleDescriptor &Info);
+  LLVM_ABI static Error initialize(BinaryStreamRef Stream, DbiModuleDescriptor &Info);
 
-  bool hasECInfo() const;
-  uint16_t getTypeServerIndex() const;
-  uint16_t getModuleStreamIndex() const;
-  uint32_t getSymbolDebugInfoByteSize() const;
-  uint32_t getC11LineInfoByteSize() const;
-  uint32_t getC13LineInfoByteSize() const;
-  uint32_t getNumberOfFiles() const;
-  uint32_t getSourceFileNameIndex() const;
-  uint32_t getPdbFilePathNameIndex() const;
+  LLVM_ABI bool hasECInfo() const;
+  LLVM_ABI uint16_t getTypeServerIndex() const;
+  LLVM_ABI uint16_t getModuleStreamIndex() const;
+  LLVM_ABI uint32_t getSymbolDebugInfoByteSize() const;
+  LLVM_ABI uint32_t getC11LineInfoByteSize() const;
+  LLVM_ABI uint32_t getC13LineInfoByteSize() const;
+  LLVM_ABI uint32_t getNumberOfFiles() const;
+  LLVM_ABI uint32_t getSourceFileNameIndex() const;
+  LLVM_ABI uint32_t getPdbFilePathNameIndex() const;
 
-  StringRef getModuleName() const;
-  StringRef getObjFileName() const;
+  LLVM_ABI StringRef getModuleName() const;
+  LLVM_ABI StringRef getObjFileName() const;
 
-  uint32_t getRecordLength() const;
+  LLVM_ABI uint32_t getRecordLength() const;
 
-  const SectionContrib &getSectionContrib() const;
+  LLVM_ABI const SectionContrib &getSectionContrib() const;
 
 private:
   StringRef ModuleName;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptorBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptorBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULEDESCRIPTORBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULEDESCRIPTORBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
@@ -64,16 +65,16 @@ class DbiModuleDescriptorBuilder {
   friend class DbiStreamBuilder;
 
 public:
-  DbiModuleDescriptorBuilder(StringRef ModuleName, uint32_t ModIndex,
+  LLVM_ABI DbiModuleDescriptorBuilder(StringRef ModuleName, uint32_t ModIndex,
                              msf::MSFBuilder &Msf);
-  ~DbiModuleDescriptorBuilder();
+  LLVM_ABI ~DbiModuleDescriptorBuilder();
 
   DbiModuleDescriptorBuilder(const DbiModuleDescriptorBuilder &) = delete;
   DbiModuleDescriptorBuilder &
   operator=(const DbiModuleDescriptorBuilder &) = delete;
 
-  void setPdbFilePathNI(uint32_t NI);
-  void setObjFileName(StringRef Name);
+  LLVM_ABI void setPdbFilePathNI(uint32_t NI);
+  LLVM_ABI void setObjFileName(StringRef Name);
 
   // Callback to merge one source of unmerged symbols.
   using MergeSymbolsCallback = Error (*)(void *Ctx, void *Symbols,
@@ -88,21 +89,21 @@ public:
     StringTableFixups = std::move(Fixups);
   }
 
-  void setFirstSectionContrib(const SectionContrib &SC);
-  void addSymbol(codeview::CVSymbol Symbol);
-  void addSymbolsInBulk(ArrayRef<uint8_t> BulkSymbols);
+  LLVM_ABI void setFirstSectionContrib(const SectionContrib &SC);
+  LLVM_ABI void addSymbol(codeview::CVSymbol Symbol);
+  LLVM_ABI void addSymbolsInBulk(ArrayRef<uint8_t> BulkSymbols);
 
   // Add symbols of known size which will be merged (rewritten) when committing
   // the PDB to disk.
-  void addUnmergedSymbols(void *SymSrc, uint32_t SymLength);
+  LLVM_ABI void addUnmergedSymbols(void *SymSrc, uint32_t SymLength);
 
-  void
+  LLVM_ABI void
   addDebugSubsection(std::shared_ptr<codeview::DebugSubsection> Subsection);
 
-  void
+  LLVM_ABI void
   addDebugSubsection(const codeview::DebugSubsectionRecord &SubsectionContents);
 
-  uint16_t getStreamIndex() const;
+  LLVM_ABI uint16_t getStreamIndex() const;
   StringRef getModuleName() const { return ModuleName; }
   StringRef getObjFileName() const { return ObjFileName; }
 
@@ -110,22 +111,22 @@ public:
 
   ArrayRef<std::string> source_files() const { return SourceFiles; }
 
-  uint32_t calculateSerializedLength() const;
+  LLVM_ABI uint32_t calculateSerializedLength() const;
 
   /// Return the offset within the module symbol stream of the next symbol
   /// record passed to addSymbol. Add four to account for the signature.
   uint32_t getNextSymbolOffset() const { return SymbolByteSize + 4; }
 
-  void finalize();
-  Error finalizeMsfLayout();
+  LLVM_ABI void finalize();
+  LLVM_ABI Error finalizeMsfLayout();
 
   /// Commit the DBI descriptor to the DBI stream.
-  Error commit(BinaryStreamWriter &ModiWriter);
+  LLVM_ABI Error commit(BinaryStreamWriter &ModiWriter);
 
   /// Commit the accumulated symbols to the module symbol stream. Safe to call
   /// in parallel on different DbiModuleDescriptorBuilder objects. Only modifies
   /// the pre-allocated stream in question.
-  Error commitSymbolStream(const msf::MSFLayout &MsfLayout,
+  LLVM_ABI Error commitSymbolStream(const msf::MSFLayout &MsfLayout,
                            WritableBinaryStreamRef MsfBuffer);
 
 private:

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptorBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptorBuilder.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULEDESCRIPTORBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULEDESCRIPTORBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsectionRecord.h"
 #include "llvm/DebugInfo/PDB/Native/RawTypes.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <string>
@@ -66,7 +66,7 @@ class DbiModuleDescriptorBuilder {
 
 public:
   LLVM_ABI DbiModuleDescriptorBuilder(StringRef ModuleName, uint32_t ModIndex,
-                             msf::MSFBuilder &Msf);
+                                      msf::MSFBuilder &Msf);
   LLVM_ABI ~DbiModuleDescriptorBuilder();
 
   DbiModuleDescriptorBuilder(const DbiModuleDescriptorBuilder &) = delete;
@@ -127,7 +127,7 @@ public:
   /// in parallel on different DbiModuleDescriptorBuilder objects. Only modifies
   /// the pre-allocated stream in question.
   LLVM_ABI Error commitSymbolStream(const msf::MSFLayout &MsfLayout,
-                           WritableBinaryStreamRef MsfBuffer);
+                                    WritableBinaryStreamRef MsfBuffer);
 
 private:
   uint32_t calculateC13DebugInfoSize() const;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleList.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleList.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULELIST_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULELIST_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
@@ -34,22 +35,22 @@ class DbiModuleSourceFilesIterator
   using BaseType = typename DbiModuleSourceFilesIterator::iterator_facade_base;
 
 public:
-  DbiModuleSourceFilesIterator(const DbiModuleList &Modules, uint32_t Modi,
+  LLVM_ABI DbiModuleSourceFilesIterator(const DbiModuleList &Modules, uint32_t Modi,
                                uint16_t Filei);
   DbiModuleSourceFilesIterator() = default;
   DbiModuleSourceFilesIterator(const DbiModuleSourceFilesIterator &R) = default;
   DbiModuleSourceFilesIterator &
   operator=(const DbiModuleSourceFilesIterator &R) = default;
 
-  bool operator==(const DbiModuleSourceFilesIterator &R) const;
+  LLVM_ABI bool operator==(const DbiModuleSourceFilesIterator &R) const;
 
   const StringRef &operator*() const { return ThisValue; }
   StringRef &operator*() { return ThisValue; }
 
-  bool operator<(const DbiModuleSourceFilesIterator &RHS) const;
-  std::ptrdiff_t operator-(const DbiModuleSourceFilesIterator &R) const;
-  DbiModuleSourceFilesIterator &operator+=(std::ptrdiff_t N);
-  DbiModuleSourceFilesIterator &operator-=(std::ptrdiff_t N);
+  LLVM_ABI bool operator<(const DbiModuleSourceFilesIterator &RHS) const;
+  LLVM_ABI std::ptrdiff_t operator-(const DbiModuleSourceFilesIterator &R) const;
+  LLVM_ABI DbiModuleSourceFilesIterator &operator+=(std::ptrdiff_t N);
+  LLVM_ABI DbiModuleSourceFilesIterator &operator-=(std::ptrdiff_t N);
 
 private:
   void setValue();
@@ -68,17 +69,17 @@ class DbiModuleList {
   friend DbiModuleSourceFilesIterator;
 
 public:
-  Error initialize(BinaryStreamRef ModInfo, BinaryStreamRef FileInfo);
+  LLVM_ABI Error initialize(BinaryStreamRef ModInfo, BinaryStreamRef FileInfo);
 
-  Expected<StringRef> getFileName(uint32_t Index) const;
-  uint32_t getModuleCount() const;
-  uint32_t getSourceFileCount() const;
-  uint16_t getSourceFileCount(uint32_t Modi) const;
+  LLVM_ABI Expected<StringRef> getFileName(uint32_t Index) const;
+  LLVM_ABI uint32_t getModuleCount() const;
+  LLVM_ABI uint32_t getSourceFileCount() const;
+  LLVM_ABI uint16_t getSourceFileCount(uint32_t Modi) const;
 
-  iterator_range<DbiModuleSourceFilesIterator>
+  LLVM_ABI iterator_range<DbiModuleSourceFilesIterator>
   source_files(uint32_t Modi) const;
 
-  DbiModuleDescriptor getModuleDescriptor(uint32_t Modi) const;
+  LLVM_ABI DbiModuleDescriptor getModuleDescriptor(uint32_t Modi) const;
 
 private:
   Error initializeModInfo(BinaryStreamRef ModInfo);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleList.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleList.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULELIST_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBIMODULELIST_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/DebugInfo/PDB/Native/DbiModuleDescriptor.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cstddef>
@@ -35,8 +35,8 @@ class DbiModuleSourceFilesIterator
   using BaseType = typename DbiModuleSourceFilesIterator::iterator_facade_base;
 
 public:
-  LLVM_ABI DbiModuleSourceFilesIterator(const DbiModuleList &Modules, uint32_t Modi,
-                               uint16_t Filei);
+  LLVM_ABI DbiModuleSourceFilesIterator(const DbiModuleList &Modules,
+                                        uint32_t Modi, uint16_t Filei);
   DbiModuleSourceFilesIterator() = default;
   DbiModuleSourceFilesIterator(const DbiModuleSourceFilesIterator &R) = default;
   DbiModuleSourceFilesIterator &
@@ -48,7 +48,8 @@ public:
   StringRef &operator*() { return ThisValue; }
 
   LLVM_ABI bool operator<(const DbiModuleSourceFilesIterator &RHS) const;
-  LLVM_ABI std::ptrdiff_t operator-(const DbiModuleSourceFilesIterator &R) const;
+  LLVM_ABI std::ptrdiff_t
+  operator-(const DbiModuleSourceFilesIterator &R) const;
   LLVM_ABI DbiModuleSourceFilesIterator &operator+=(std::ptrdiff_t N);
   LLVM_ABI DbiModuleSourceFilesIterator &operator-=(std::ptrdiff_t N);
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiStream.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBISTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBISTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/DebugFrameDataSubsection.h"
 #include "llvm/DebugInfo/PDB/Native/DbiModuleList.h"
 #include "llvm/DebugInfo/PDB/Native/PDBStringTable.h"
@@ -17,6 +16,7 @@
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 
@@ -86,10 +86,12 @@ public:
   LLVM_ABI bool hasOldFpoRecords() const;
   LLVM_ABI FixedStreamArray<object::FpoData> getOldFpoRecords() const;
   LLVM_ABI bool hasNewFpoRecords() const;
-  LLVM_ABI const codeview::DebugFrameDataSubsectionRef &getNewFpoRecords() const;
+  LLVM_ABI const codeview::DebugFrameDataSubsectionRef &
+  getNewFpoRecords() const;
 
   LLVM_ABI FixedStreamArray<SecMapEntry> getSectionMap() const;
-  LLVM_ABI void visitSectionContributions(ISectionContribVisitor &Visitor) const;
+  LLVM_ABI void
+  visitSectionContributions(ISectionContribVisitor &Visitor) const;
 
   LLVM_ABI Expected<StringRef> getECName(uint32_t NI) const;
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiStream.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBISTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBISTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/DebugFrameDataSubsection.h"
 #include "llvm/DebugInfo/PDB/Native/DbiModuleList.h"
 #include "llvm/DebugInfo/PDB/Native/PDBStringTable.h"
@@ -40,57 +41,57 @@ class DbiStream {
   friend class DbiStreamBuilder;
 
 public:
-  explicit DbiStream(std::unique_ptr<BinaryStream> Stream);
-  ~DbiStream();
-  Error reload(PDBFile *Pdb);
+  LLVM_ABI explicit DbiStream(std::unique_ptr<BinaryStream> Stream);
+  LLVM_ABI ~DbiStream();
+  LLVM_ABI Error reload(PDBFile *Pdb);
 
-  PdbRaw_DbiVer getDbiVersion() const;
-  uint32_t getAge() const;
-  uint16_t getPublicSymbolStreamIndex() const;
-  uint16_t getGlobalSymbolStreamIndex() const;
+  LLVM_ABI PdbRaw_DbiVer getDbiVersion() const;
+  LLVM_ABI uint32_t getAge() const;
+  LLVM_ABI uint16_t getPublicSymbolStreamIndex() const;
+  LLVM_ABI uint16_t getGlobalSymbolStreamIndex() const;
 
-  uint16_t getFlags() const;
-  bool isIncrementallyLinked() const;
-  bool hasCTypes() const;
-  bool isStripped() const;
+  LLVM_ABI uint16_t getFlags() const;
+  LLVM_ABI bool isIncrementallyLinked() const;
+  LLVM_ABI bool hasCTypes() const;
+  LLVM_ABI bool isStripped() const;
 
-  uint16_t getBuildNumber() const;
-  uint16_t getBuildMajorVersion() const;
-  uint16_t getBuildMinorVersion() const;
+  LLVM_ABI uint16_t getBuildNumber() const;
+  LLVM_ABI uint16_t getBuildMajorVersion() const;
+  LLVM_ABI uint16_t getBuildMinorVersion() const;
 
-  uint16_t getPdbDllRbld() const;
-  uint32_t getPdbDllVersion() const;
+  LLVM_ABI uint16_t getPdbDllRbld() const;
+  LLVM_ABI uint32_t getPdbDllVersion() const;
 
-  uint32_t getSymRecordStreamIndex() const;
+  LLVM_ABI uint32_t getSymRecordStreamIndex() const;
 
-  PDB_Machine getMachineType() const;
+  LLVM_ABI PDB_Machine getMachineType() const;
 
   const DbiStreamHeader *getHeader() const { return Header; }
 
-  BinarySubstreamRef getSectionContributionData() const;
-  BinarySubstreamRef getSecMapSubstreamData() const;
-  BinarySubstreamRef getModiSubstreamData() const;
-  BinarySubstreamRef getFileInfoSubstreamData() const;
-  BinarySubstreamRef getTypeServerMapSubstreamData() const;
-  BinarySubstreamRef getECSubstreamData() const;
+  LLVM_ABI BinarySubstreamRef getSectionContributionData() const;
+  LLVM_ABI BinarySubstreamRef getSecMapSubstreamData() const;
+  LLVM_ABI BinarySubstreamRef getModiSubstreamData() const;
+  LLVM_ABI BinarySubstreamRef getFileInfoSubstreamData() const;
+  LLVM_ABI BinarySubstreamRef getTypeServerMapSubstreamData() const;
+  LLVM_ABI BinarySubstreamRef getECSubstreamData() const;
 
   /// If the given stream type is present, returns its stream index. If it is
   /// not present, returns InvalidStreamIndex.
-  uint32_t getDebugStreamIndex(DbgHeaderType Type) const;
+  LLVM_ABI uint32_t getDebugStreamIndex(DbgHeaderType Type) const;
 
-  const DbiModuleList &modules() const;
+  LLVM_ABI const DbiModuleList &modules() const;
 
-  FixedStreamArray<object::coff_section> getSectionHeaders() const;
+  LLVM_ABI FixedStreamArray<object::coff_section> getSectionHeaders() const;
 
-  bool hasOldFpoRecords() const;
-  FixedStreamArray<object::FpoData> getOldFpoRecords() const;
-  bool hasNewFpoRecords() const;
-  const codeview::DebugFrameDataSubsectionRef &getNewFpoRecords() const;
+  LLVM_ABI bool hasOldFpoRecords() const;
+  LLVM_ABI FixedStreamArray<object::FpoData> getOldFpoRecords() const;
+  LLVM_ABI bool hasNewFpoRecords() const;
+  LLVM_ABI const codeview::DebugFrameDataSubsectionRef &getNewFpoRecords() const;
 
-  FixedStreamArray<SecMapEntry> getSectionMap() const;
-  void visitSectionContributions(ISectionContribVisitor &Visitor) const;
+  LLVM_ABI FixedStreamArray<SecMapEntry> getSectionMap() const;
+  LLVM_ABI void visitSectionContributions(ISectionContribVisitor &Visitor) const;
 
-  Expected<StringRef> getECName(uint32_t NI) const;
+  LLVM_ABI Expected<StringRef> getECName(uint32_t NI) const;
 
 private:
   Error initializeSectionContributionData();

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiStreamBuilder.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBISTREAMBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBISTREAMBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/Object/COFF.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include "llvm/DebugInfo/CodeView/DebugFrameDataSubsection.h"
@@ -69,13 +69,16 @@ public:
   LLVM_ABI void addNewFpoData(const codeview::FrameData &FD);
   LLVM_ABI void addOldFpoData(const object::FpoData &Fpo);
 
-  LLVM_ABI Expected<DbiModuleDescriptorBuilder &> addModuleInfo(StringRef ModuleName);
-  LLVM_ABI Error addModuleSourceFile(DbiModuleDescriptorBuilder &Module, StringRef File);
+  LLVM_ABI Expected<DbiModuleDescriptorBuilder &>
+  addModuleInfo(StringRef ModuleName);
+  LLVM_ABI Error addModuleSourceFile(DbiModuleDescriptorBuilder &Module,
+                                     StringRef File);
   LLVM_ABI Expected<uint32_t> getSourceFileNameIndex(StringRef FileName);
 
   LLVM_ABI Error finalizeMsfLayout();
 
-  LLVM_ABI Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef MsfBuffer);
+  LLVM_ABI Error commit(const msf::MSFLayout &Layout,
+                        WritableBinaryStreamRef MsfBuffer);
 
   void addSectionContrib(const SectionContrib &SC) {
     SectionContribs.emplace_back(SC);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiStreamBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_DBISTREAMBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_DBISTREAMBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/COFF.h"
@@ -39,49 +40,49 @@ class DbiModuleDescriptorBuilder;
 
 class DbiStreamBuilder {
 public:
-  DbiStreamBuilder(msf::MSFBuilder &Msf);
-  ~DbiStreamBuilder();
+  LLVM_ABI DbiStreamBuilder(msf::MSFBuilder &Msf);
+  LLVM_ABI ~DbiStreamBuilder();
 
   DbiStreamBuilder(const DbiStreamBuilder &) = delete;
   DbiStreamBuilder &operator=(const DbiStreamBuilder &) = delete;
 
-  void setVersionHeader(PdbRaw_DbiVer V);
-  void setAge(uint32_t A);
-  void setBuildNumber(uint16_t B);
-  void setBuildNumber(uint8_t Major, uint8_t Minor);
-  void setPdbDllVersion(uint16_t V);
-  void setPdbDllRbld(uint16_t R);
-  void setFlags(uint16_t F);
-  void setMachineType(PDB_Machine M);
-  void setMachineType(COFF::MachineTypes M);
+  LLVM_ABI void setVersionHeader(PdbRaw_DbiVer V);
+  LLVM_ABI void setAge(uint32_t A);
+  LLVM_ABI void setBuildNumber(uint16_t B);
+  LLVM_ABI void setBuildNumber(uint8_t Major, uint8_t Minor);
+  LLVM_ABI void setPdbDllVersion(uint16_t V);
+  LLVM_ABI void setPdbDllRbld(uint16_t R);
+  LLVM_ABI void setFlags(uint16_t F);
+  LLVM_ABI void setMachineType(PDB_Machine M);
+  LLVM_ABI void setMachineType(COFF::MachineTypes M);
 
   // Add given bytes as a new stream.
-  Error addDbgStream(pdb::DbgHeaderType Type, ArrayRef<uint8_t> Data);
+  LLVM_ABI Error addDbgStream(pdb::DbgHeaderType Type, ArrayRef<uint8_t> Data);
 
-  uint32_t addECName(StringRef Name);
+  LLVM_ABI uint32_t addECName(StringRef Name);
 
-  uint32_t calculateSerializedLength() const;
+  LLVM_ABI uint32_t calculateSerializedLength() const;
 
-  void setGlobalsStreamIndex(uint32_t Index);
-  void setPublicsStreamIndex(uint32_t Index);
-  void setSymbolRecordStreamIndex(uint32_t Index);
-  void addNewFpoData(const codeview::FrameData &FD);
-  void addOldFpoData(const object::FpoData &Fpo);
+  LLVM_ABI void setGlobalsStreamIndex(uint32_t Index);
+  LLVM_ABI void setPublicsStreamIndex(uint32_t Index);
+  LLVM_ABI void setSymbolRecordStreamIndex(uint32_t Index);
+  LLVM_ABI void addNewFpoData(const codeview::FrameData &FD);
+  LLVM_ABI void addOldFpoData(const object::FpoData &Fpo);
 
-  Expected<DbiModuleDescriptorBuilder &> addModuleInfo(StringRef ModuleName);
-  Error addModuleSourceFile(DbiModuleDescriptorBuilder &Module, StringRef File);
-  Expected<uint32_t> getSourceFileNameIndex(StringRef FileName);
+  LLVM_ABI Expected<DbiModuleDescriptorBuilder &> addModuleInfo(StringRef ModuleName);
+  LLVM_ABI Error addModuleSourceFile(DbiModuleDescriptorBuilder &Module, StringRef File);
+  LLVM_ABI Expected<uint32_t> getSourceFileNameIndex(StringRef FileName);
 
-  Error finalizeMsfLayout();
+  LLVM_ABI Error finalizeMsfLayout();
 
-  Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef MsfBuffer);
+  LLVM_ABI Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef MsfBuffer);
 
   void addSectionContrib(const SectionContrib &SC) {
     SectionContribs.emplace_back(SC);
   }
 
   // Populate the Section Map from COFF section headers.
-  void createSectionMap(ArrayRef<llvm::object::coff_section> SecHdrs);
+  LLVM_ABI void createSectionMap(ArrayRef<llvm::object::coff_section> SecHdrs);
 
 private:
   struct DebugStream {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/FormatUtil.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/FormatUtil.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_FORMATUTIL_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_FORMATUTIL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -50,14 +50,15 @@ LLVM_ABI std::string formatSectionCharacteristics(
     StringRef Separator,
     CharacteristicStyle Style = CharacteristicStyle::HeaderDefinition);
 
-LLVM_ABI std::string typesetItemList(ArrayRef<std::string> Opts, uint32_t IndentLevel,
-                            uint32_t GroupSize, StringRef Sep);
+LLVM_ABI std::string typesetItemList(ArrayRef<std::string> Opts,
+                                     uint32_t IndentLevel, uint32_t GroupSize,
+                                     StringRef Sep);
 
 LLVM_ABI std::string typesetStringList(uint32_t IndentLevel,
-                              ArrayRef<StringRef> Strings);
+                                       ArrayRef<StringRef> Strings);
 
 LLVM_ABI std::string formatChunkKind(codeview::DebugSubsectionKind Kind,
-                            bool Friendly = true);
+                                     bool Friendly = true);
 LLVM_ABI std::string formatSymbolKind(codeview::SymbolKind K);
 LLVM_ABI std::string formatTypeLeafKind(codeview::TypeLeafKind K);
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/FormatUtil.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/FormatUtil.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_FORMATUTIL_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_FORMATUTIL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/StringRef.h"
@@ -38,27 +39,27 @@ template <typename T> std::string formatUnknownEnum(T Value) {
   return formatv("unknown ({0})", llvm::to_underlying(Value)).str();
 }
 
-std::string formatSegmentOffset(uint16_t Segment, uint32_t Offset);
+LLVM_ABI std::string formatSegmentOffset(uint16_t Segment, uint32_t Offset);
 
 enum class CharacteristicStyle {
   HeaderDefinition, // format as windows header definition
   Descriptive,      // format as human readable words
 };
-std::string formatSectionCharacteristics(
+LLVM_ABI std::string formatSectionCharacteristics(
     uint32_t IndentLevel, uint32_t C, uint32_t FlagsPerLine,
     StringRef Separator,
     CharacteristicStyle Style = CharacteristicStyle::HeaderDefinition);
 
-std::string typesetItemList(ArrayRef<std::string> Opts, uint32_t IndentLevel,
+LLVM_ABI std::string typesetItemList(ArrayRef<std::string> Opts, uint32_t IndentLevel,
                             uint32_t GroupSize, StringRef Sep);
 
-std::string typesetStringList(uint32_t IndentLevel,
+LLVM_ABI std::string typesetStringList(uint32_t IndentLevel,
                               ArrayRef<StringRef> Strings);
 
-std::string formatChunkKind(codeview::DebugSubsectionKind Kind,
+LLVM_ABI std::string formatChunkKind(codeview::DebugSubsectionKind Kind,
                             bool Friendly = true);
-std::string formatSymbolKind(codeview::SymbolKind K);
-std::string formatTypeLeafKind(codeview::TypeLeafKind K);
+LLVM_ABI std::string formatSymbolKind(codeview::SymbolKind K);
+LLVM_ABI std::string formatTypeLeafKind(codeview::TypeLeafKind K);
 
 /// Returns the number of digits in the given integer.
 inline int NumDigits(uint64_t N) {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/GSIStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/GSIStreamBuilder.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_GSISTREAMBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_GSISTREAMBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/PDB/Native/GlobalsStream.h"
 #include "llvm/DebugInfo/PDB/Native/RawConstants.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -55,7 +55,8 @@ public:
 
   LLVM_ABI Error finalizeMsfLayout();
 
-  LLVM_ABI Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef Buffer);
+  LLVM_ABI Error commit(const msf::MSFLayout &Layout,
+                        WritableBinaryStreamRef Buffer);
 
   uint32_t getPublicsStreamIndex() const { return PublicsStreamIndex; }
   uint32_t getGlobalsStreamIndex() const { return GlobalsStreamIndex; }

--- a/llvm/include/llvm/DebugInfo/PDB/Native/GSIStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/GSIStreamBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_GSISTREAMBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_GSISTREAMBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -46,30 +47,30 @@ struct SymbolDenseMapInfo;
 class GSIStreamBuilder {
 
 public:
-  explicit GSIStreamBuilder(msf::MSFBuilder &Msf);
-  ~GSIStreamBuilder();
+  LLVM_ABI explicit GSIStreamBuilder(msf::MSFBuilder &Msf);
+  LLVM_ABI ~GSIStreamBuilder();
 
   GSIStreamBuilder(const GSIStreamBuilder &) = delete;
   GSIStreamBuilder &operator=(const GSIStreamBuilder &) = delete;
 
-  Error finalizeMsfLayout();
+  LLVM_ABI Error finalizeMsfLayout();
 
-  Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef Buffer);
+  LLVM_ABI Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef Buffer);
 
   uint32_t getPublicsStreamIndex() const { return PublicsStreamIndex; }
   uint32_t getGlobalsStreamIndex() const { return GlobalsStreamIndex; }
   uint32_t getRecordStreamIndex() const { return RecordStreamIndex; }
 
   // Add public symbols in bulk.
-  void addPublicSymbols(std::vector<BulkPublic> &&PublicsIn);
+  LLVM_ABI void addPublicSymbols(std::vector<BulkPublic> &&PublicsIn);
 
-  void addGlobalSymbol(const codeview::ProcRefSym &Sym);
-  void addGlobalSymbol(const codeview::DataSym &Sym);
-  void addGlobalSymbol(const codeview::ConstantSym &Sym);
+  LLVM_ABI void addGlobalSymbol(const codeview::ProcRefSym &Sym);
+  LLVM_ABI void addGlobalSymbol(const codeview::DataSym &Sym);
+  LLVM_ABI void addGlobalSymbol(const codeview::ConstantSym &Sym);
 
   // Add a pre-serialized global symbol record. The caller must ensure that the
   // symbol data remains alive until the global stream is committed to disk.
-  void addGlobalSymbol(const codeview::CVSymbol &Sym);
+  LLVM_ABI void addGlobalSymbol(const codeview::CVSymbol &Sym);
 
 private:
   void finalizePublicBuckets();

--- a/llvm/include/llvm/DebugInfo/PDB/Native/GlobalsStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/GlobalsStream.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_GLOBALSSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_GLOBALSSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/PDB/Native/RawTypes.h"
@@ -55,7 +56,7 @@ public:
   FixedStreamArray<support::ulittle32_t> HashBuckets;
   std::array<int32_t, IPHR_HASH + 1> BucketMap;
 
-  Error read(BinaryStreamReader &Reader);
+  LLVM_ABI Error read(BinaryStreamReader &Reader);
 
   uint32_t getVerSignature() const { return HashHdr->VerSignature; }
   uint32_t getVerHeader() const { return HashHdr->VerHdr; }
@@ -69,12 +70,12 @@ public:
 
 class GlobalsStream {
 public:
-  explicit GlobalsStream(std::unique_ptr<msf::MappedBlockStream> Stream);
-  ~GlobalsStream();
+  LLVM_ABI explicit GlobalsStream(std::unique_ptr<msf::MappedBlockStream> Stream);
+  LLVM_ABI ~GlobalsStream();
   const GSIHashTable &getGlobalsTable() const { return GlobalsTable; }
-  Error reload();
+  LLVM_ABI Error reload();
 
-  std::vector<std::pair<uint32_t, codeview::CVSymbol>>
+  LLVM_ABI std::vector<std::pair<uint32_t, codeview::CVSymbol>>
   findRecordsByName(StringRef Name, const SymbolStream &Symbols) const;
 
 private:

--- a/llvm/include/llvm/DebugInfo/PDB/Native/GlobalsStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/GlobalsStream.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_GLOBALSSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_GLOBALSSTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/PDB/Native/RawTypes.h"
 #include "llvm/Support/BinaryStreamArray.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 
@@ -70,7 +70,8 @@ public:
 
 class GlobalsStream {
 public:
-  LLVM_ABI explicit GlobalsStream(std::unique_ptr<msf::MappedBlockStream> Stream);
+  LLVM_ABI explicit GlobalsStream(
+      std::unique_ptr<msf::MappedBlockStream> Stream);
   LLVM_ABI ~GlobalsStream();
   const GSIHashTable &getGlobalsTable() const { return GlobalsTable; }
   LLVM_ABI Error reload();

--- a/llvm/include/llvm/DebugInfo/PDB/Native/Hash.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/Hash.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_HASH_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_HASH_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/Hash.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/Hash.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_HASH_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_HASH_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include <cstdint>
@@ -16,9 +17,9 @@
 namespace llvm {
 namespace pdb {
 
-uint32_t hashStringV1(StringRef Str);
-uint32_t hashStringV2(StringRef Str);
-uint32_t hashBufferV8(ArrayRef<uint8_t> Data);
+LLVM_ABI uint32_t hashStringV1(StringRef Str);
+LLVM_ABI uint32_t hashStringV2(StringRef Str);
+LLVM_ABI uint32_t hashBufferV8(ArrayRef<uint8_t> Data);
 
 } // end namespace pdb
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/PDB/Native/HashTable.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/HashTable.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_HASHTABLE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_HASHTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SparseBitVector.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/DebugInfo/PDB/Native/RawError.h"
@@ -25,8 +26,8 @@ namespace llvm {
 
 namespace pdb {
 
-Error readSparseBitVector(BinaryStreamReader &Stream, SparseBitVector<> &V);
-Error writeSparseBitVector(BinaryStreamWriter &Writer, SparseBitVector<> &Vec);
+LLVM_ABI Error readSparseBitVector(BinaryStreamReader &Stream, SparseBitVector<> &V);
+LLVM_ABI Error writeSparseBitVector(BinaryStreamWriter &Writer, SparseBitVector<> &Vec);
 
 template <typename ValueT> class HashTable;
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/HashTable.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/HashTable.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_HASHTABLE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_HASHTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SparseBitVector.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/DebugInfo/PDB/Native/RawError.h"
 #include "llvm/Support/BinaryStreamReader.h"
 #include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
@@ -26,8 +26,10 @@ namespace llvm {
 
 namespace pdb {
 
-LLVM_ABI Error readSparseBitVector(BinaryStreamReader &Stream, SparseBitVector<> &V);
-LLVM_ABI Error writeSparseBitVector(BinaryStreamWriter &Writer, SparseBitVector<> &Vec);
+LLVM_ABI Error readSparseBitVector(BinaryStreamReader &Stream,
+                                   SparseBitVector<> &V);
+LLVM_ABI Error writeSparseBitVector(BinaryStreamWriter &Writer,
+                                    SparseBitVector<> &Vec);
 
 template <typename ValueT> class HashTable;
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/InfoStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/InfoStream.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_INFOSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_INFOSTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/DebugInfo/CodeView/GUID.h"
 #include "llvm/DebugInfo/PDB/Native/NamedStreamMap.h"
 #include "llvm/DebugInfo/PDB/Native/RawConstants.h"
 #include "llvm/Support/BinaryStream.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/InfoStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/InfoStream.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_INFOSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_INFOSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/DebugInfo/CodeView/GUID.h"
 #include "llvm/DebugInfo/PDB/Native/NamedStreamMap.h"
@@ -25,30 +26,30 @@ class InfoStream {
   friend class InfoStreamBuilder;
 
 public:
-  InfoStream(std::unique_ptr<BinaryStream> Stream);
+  LLVM_ABI InfoStream(std::unique_ptr<BinaryStream> Stream);
 
-  Error reload();
+  LLVM_ABI Error reload();
 
-  uint32_t getStreamSize() const;
+  LLVM_ABI uint32_t getStreamSize() const;
 
   const InfoStreamHeader *getHeader() const { return Header; }
 
-  bool containsIdStream() const;
-  PdbRaw_ImplVer getVersion() const;
-  uint32_t getSignature() const;
-  uint32_t getAge() const;
-  codeview::GUID getGuid() const;
-  uint32_t getNamedStreamMapByteSize() const;
+  LLVM_ABI bool containsIdStream() const;
+  LLVM_ABI PdbRaw_ImplVer getVersion() const;
+  LLVM_ABI uint32_t getSignature() const;
+  LLVM_ABI uint32_t getAge() const;
+  LLVM_ABI codeview::GUID getGuid() const;
+  LLVM_ABI uint32_t getNamedStreamMapByteSize() const;
 
-  PdbRaw_Features getFeatures() const;
-  ArrayRef<PdbRaw_FeatureSig> getFeatureSignatures() const;
+  LLVM_ABI PdbRaw_Features getFeatures() const;
+  LLVM_ABI ArrayRef<PdbRaw_FeatureSig> getFeatureSignatures() const;
 
-  const NamedStreamMap &getNamedStreams() const;
+  LLVM_ABI const NamedStreamMap &getNamedStreams() const;
 
-  BinarySubstreamRef getNamedStreamsBuffer() const;
+  LLVM_ABI BinarySubstreamRef getNamedStreamsBuffer() const;
 
-  Expected<uint32_t> getNamedStreamIndex(llvm::StringRef Name) const;
-  StringMap<uint32_t> named_streams() const;
+  LLVM_ABI Expected<uint32_t> getNamedStreamIndex(llvm::StringRef Name) const;
+  LLVM_ABI StringMap<uint32_t> named_streams() const;
 
 private:
   std::unique_ptr<BinaryStream> Stream;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/InfoStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/InfoStreamBuilder.h
@@ -27,7 +27,8 @@ class NamedStreamMap;
 
 class InfoStreamBuilder {
 public:
-  LLVM_ABI InfoStreamBuilder(msf::MSFBuilder &Msf, NamedStreamMap &NamedStreams);
+  LLVM_ABI InfoStreamBuilder(msf::MSFBuilder &Msf,
+                             NamedStreamMap &NamedStreams);
   InfoStreamBuilder(const InfoStreamBuilder &) = delete;
   InfoStreamBuilder &operator=(const InfoStreamBuilder &) = delete;
 
@@ -53,7 +54,7 @@ public:
   LLVM_ABI Error finalizeMsfLayout();
 
   LLVM_ABI Error commit(const msf::MSFLayout &Layout,
-               WritableBinaryStreamRef Buffer) const;
+                        WritableBinaryStreamRef Buffer) const;
 
 private:
   msf::MSFBuilder &Msf;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/InfoStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/InfoStreamBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_INFOSTREAMBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_INFOSTREAMBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include "llvm/DebugInfo/CodeView/GUID.h"
@@ -26,32 +27,32 @@ class NamedStreamMap;
 
 class InfoStreamBuilder {
 public:
-  InfoStreamBuilder(msf::MSFBuilder &Msf, NamedStreamMap &NamedStreams);
+  LLVM_ABI InfoStreamBuilder(msf::MSFBuilder &Msf, NamedStreamMap &NamedStreams);
   InfoStreamBuilder(const InfoStreamBuilder &) = delete;
   InfoStreamBuilder &operator=(const InfoStreamBuilder &) = delete;
 
-  void setVersion(PdbRaw_ImplVer V);
-  void addFeature(PdbRaw_FeatureSig Sig);
+  LLVM_ABI void setVersion(PdbRaw_ImplVer V);
+  LLVM_ABI void addFeature(PdbRaw_FeatureSig Sig);
 
   // If this is true, the PDB contents are hashed and this hash is used as
   // PDB GUID and as Signature. The age is always 1.
-  void setHashPDBContentsToGUID(bool B);
+  LLVM_ABI void setHashPDBContentsToGUID(bool B);
 
   // These only have an effect if hashPDBContentsToGUID() is false.
-  void setSignature(uint32_t S);
-  void setAge(uint32_t A);
-  void setGuid(codeview::GUID G);
+  LLVM_ABI void setSignature(uint32_t S);
+  LLVM_ABI void setAge(uint32_t A);
+  LLVM_ABI void setGuid(codeview::GUID G);
 
   bool hashPDBContentsToGUID() const { return HashPDBContentsToGUID; }
   uint32_t getAge() const { return Age; }
   codeview::GUID getGuid() const { return Guid; }
   std::optional<uint32_t> getSignature() const { return Signature; }
 
-  uint32_t finalize();
+  LLVM_ABI uint32_t finalize();
 
-  Error finalizeMsfLayout();
+  LLVM_ABI Error finalizeMsfLayout();
 
-  Error commit(const msf::MSFLayout &Layout,
+  LLVM_ABI Error commit(const msf::MSFLayout &Layout,
                WritableBinaryStreamRef Buffer) const;
 
 private:

--- a/llvm/include/llvm/DebugInfo/PDB/Native/InputFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/InputFile.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_INPUTFILE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_INPUTFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/iterator.h"
@@ -19,6 +18,7 @@
 #include "llvm/DebugInfo/PDB/Native/ModuleDebugStream.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -62,7 +62,7 @@ public:
   InputFile(InputFile &&Other) = default;
 
   LLVM_ABI static Expected<InputFile> open(StringRef Path,
-                                  bool AllowUnknownFile = false);
+                                           bool AllowUnknownFile = false);
 
   LLVM_ABI PDBFile &pdb();
   LLVM_ABI const PDBFile &pdb() const;
@@ -98,10 +98,10 @@ public:
   LLVM_ABI Expected<StringRef> getNameFromChecksums(uint32_t Offset) const;
 
   LLVM_ABI void formatFromFileName(LinePrinter &Printer, StringRef File,
-                          bool Append = false) const;
+                                   bool Append = false) const;
 
   LLVM_ABI void formatFromChecksumsOffset(LinePrinter &Printer, uint32_t Offset,
-                                 bool Append = false) const;
+                                          bool Append = false) const;
 
   LLVM_ABI StringRef name() const;
 
@@ -156,10 +156,10 @@ private:
 LLVM_ABI Expected<ModuleDebugStreamRef>
 getModuleDebugStream(PDBFile &File, StringRef &ModuleName, uint32_t Index);
 LLVM_ABI Expected<ModuleDebugStreamRef> getModuleDebugStream(PDBFile &File,
-                                                    uint32_t Index);
+                                                             uint32_t Index);
 
 LLVM_ABI bool shouldDumpSymbolGroup(uint32_t Idx, const SymbolGroup &Group,
-                           const FilterOptions &Filters);
+                                    const FilterOptions &Filters);
 
 // TODO: Change these callbacks to be function_refs (de-templatify them).
 template <typename CallbackT>

--- a/llvm/include/llvm/DebugInfo/PDB/Native/InputFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/InputFile.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_INPUTFILE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_INPUTFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/iterator.h"
@@ -57,57 +58,57 @@ public:
   InputFile(PDBFile *Pdb) { PdbOrObj = Pdb; }
   InputFile(object::COFFObjectFile *Obj) { PdbOrObj = Obj; }
   InputFile(MemoryBuffer *Buffer) { PdbOrObj = Buffer; }
-  ~InputFile();
+  LLVM_ABI ~InputFile();
   InputFile(InputFile &&Other) = default;
 
-  static Expected<InputFile> open(StringRef Path,
+  LLVM_ABI static Expected<InputFile> open(StringRef Path,
                                   bool AllowUnknownFile = false);
 
-  PDBFile &pdb();
-  const PDBFile &pdb() const;
-  object::COFFObjectFile &obj();
-  const object::COFFObjectFile &obj() const;
-  MemoryBuffer &unknown();
-  const MemoryBuffer &unknown() const;
+  LLVM_ABI PDBFile &pdb();
+  LLVM_ABI const PDBFile &pdb() const;
+  LLVM_ABI object::COFFObjectFile &obj();
+  LLVM_ABI const object::COFFObjectFile &obj() const;
+  LLVM_ABI MemoryBuffer &unknown();
+  LLVM_ABI const MemoryBuffer &unknown() const;
 
-  StringRef getFilePath() const;
+  LLVM_ABI StringRef getFilePath() const;
 
-  bool hasTypes() const;
-  bool hasIds() const;
+  LLVM_ABI bool hasTypes() const;
+  LLVM_ABI bool hasIds() const;
 
-  codeview::LazyRandomTypeCollection &types();
-  codeview::LazyRandomTypeCollection &ids();
+  LLVM_ABI codeview::LazyRandomTypeCollection &types();
+  LLVM_ABI codeview::LazyRandomTypeCollection &ids();
 
-  iterator_range<SymbolGroupIterator> symbol_groups();
-  SymbolGroupIterator symbol_groups_begin();
-  SymbolGroupIterator symbol_groups_end();
+  LLVM_ABI iterator_range<SymbolGroupIterator> symbol_groups();
+  LLVM_ABI SymbolGroupIterator symbol_groups_begin();
+  LLVM_ABI SymbolGroupIterator symbol_groups_end();
 
-  bool isPdb() const;
-  bool isObj() const;
-  bool isUnknown() const;
+  LLVM_ABI bool isPdb() const;
+  LLVM_ABI bool isObj() const;
+  LLVM_ABI bool isUnknown() const;
 };
 
 class SymbolGroup {
   friend class SymbolGroupIterator;
 
 public:
-  explicit SymbolGroup(InputFile *File, uint32_t GroupIndex = 0);
+  LLVM_ABI explicit SymbolGroup(InputFile *File, uint32_t GroupIndex = 0);
 
-  Expected<StringRef> getNameFromStringTable(uint32_t Offset) const;
-  Expected<StringRef> getNameFromChecksums(uint32_t Offset) const;
+  LLVM_ABI Expected<StringRef> getNameFromStringTable(uint32_t Offset) const;
+  LLVM_ABI Expected<StringRef> getNameFromChecksums(uint32_t Offset) const;
 
-  void formatFromFileName(LinePrinter &Printer, StringRef File,
+  LLVM_ABI void formatFromFileName(LinePrinter &Printer, StringRef File,
                           bool Append = false) const;
 
-  void formatFromChecksumsOffset(LinePrinter &Printer, uint32_t Offset,
+  LLVM_ABI void formatFromChecksumsOffset(LinePrinter &Printer, uint32_t Offset,
                                  bool Append = false) const;
 
-  StringRef name() const;
+  LLVM_ABI StringRef name() const;
 
   codeview::DebugSubsectionArray getDebugSubsections() const {
     return Subsections;
   }
-  const ModuleDebugStreamRef &getPdbModuleStream() const;
+  LLVM_ABI const ModuleDebugStreamRef &getPdbModuleStream() const;
 
   const InputFile &getFile() const { return *File; }
   InputFile &getFile() { return *File; }
@@ -132,16 +133,16 @@ class SymbolGroupIterator
     : public iterator_facade_base<SymbolGroupIterator,
                                   std::forward_iterator_tag, SymbolGroup> {
 public:
-  SymbolGroupIterator();
-  explicit SymbolGroupIterator(InputFile &File);
+  LLVM_ABI SymbolGroupIterator();
+  LLVM_ABI explicit SymbolGroupIterator(InputFile &File);
   SymbolGroupIterator(const SymbolGroupIterator &Other) = default;
   SymbolGroupIterator &operator=(const SymbolGroupIterator &R) = default;
 
-  const SymbolGroup &operator*() const;
-  SymbolGroup &operator*();
+  LLVM_ABI const SymbolGroup &operator*() const;
+  LLVM_ABI SymbolGroup &operator*();
 
-  bool operator==(const SymbolGroupIterator &R) const;
-  SymbolGroupIterator &operator++();
+  LLVM_ABI bool operator==(const SymbolGroupIterator &R) const;
+  LLVM_ABI SymbolGroupIterator &operator++();
 
 private:
   void scanToNextDebugS();
@@ -152,12 +153,12 @@ private:
   SymbolGroup Value;
 };
 
-Expected<ModuleDebugStreamRef>
+LLVM_ABI Expected<ModuleDebugStreamRef>
 getModuleDebugStream(PDBFile &File, StringRef &ModuleName, uint32_t Index);
-Expected<ModuleDebugStreamRef> getModuleDebugStream(PDBFile &File,
+LLVM_ABI Expected<ModuleDebugStreamRef> getModuleDebugStream(PDBFile &File,
                                                     uint32_t Index);
 
-bool shouldDumpSymbolGroup(uint32_t Idx, const SymbolGroup &Group,
+LLVM_ABI bool shouldDumpSymbolGroup(uint32_t Idx, const SymbolGroup &Group,
                            const FilterOptions &Filters);
 
 // TODO: Change these callbacks to be function_refs (de-templatify them).

--- a/llvm/include/llvm/DebugInfo/PDB/Native/LinePrinter.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/LinePrinter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_LINEPRINTER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_LINEPRINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -51,15 +52,15 @@ class LinePrinter {
   friend class WithColor;
 
 public:
-  LinePrinter(int Indent, bool UseColor, raw_ostream &Stream,
+  LLVM_ABI LinePrinter(int Indent, bool UseColor, raw_ostream &Stream,
               const FilterOptions &Filters);
 
-  void Indent(uint32_t Amount = 0);
-  void Unindent(uint32_t Amount = 0);
-  void NewLine();
+  LLVM_ABI void Indent(uint32_t Amount = 0);
+  LLVM_ABI void Unindent(uint32_t Amount = 0);
+  LLVM_ABI void NewLine();
 
-  void printLine(const Twine &T);
-  void print(const Twine &T);
+  LLVM_ABI void printLine(const Twine &T);
+  LLVM_ABI void print(const Twine &T);
   template <typename... Ts> void formatLine(const char *Fmt, Ts &&...Items) {
     printLine(formatv(Fmt, std::forward<Ts>(Items)...));
   }
@@ -67,27 +68,27 @@ public:
     print(formatv(Fmt, std::forward<Ts>(Items)...));
   }
 
-  void formatBinary(StringRef Label, ArrayRef<uint8_t> Data,
+  LLVM_ABI void formatBinary(StringRef Label, ArrayRef<uint8_t> Data,
                     uint64_t StartOffset);
-  void formatBinary(StringRef Label, ArrayRef<uint8_t> Data, uint64_t BaseAddr,
+  LLVM_ABI void formatBinary(StringRef Label, ArrayRef<uint8_t> Data, uint64_t BaseAddr,
                     uint64_t StartOffset);
 
-  void formatMsfStreamData(StringRef Label, PDBFile &File, uint32_t StreamIdx,
+  LLVM_ABI void formatMsfStreamData(StringRef Label, PDBFile &File, uint32_t StreamIdx,
                            StringRef StreamPurpose, uint64_t Offset,
                            uint64_t Size);
-  void formatMsfStreamData(StringRef Label, PDBFile &File,
+  LLVM_ABI void formatMsfStreamData(StringRef Label, PDBFile &File,
                            const msf::MSFStreamLayout &Stream,
                            BinarySubstreamRef Substream);
-  void formatMsfStreamBlocks(PDBFile &File, const msf::MSFStreamLayout &Stream);
+  LLVM_ABI void formatMsfStreamBlocks(PDBFile &File, const msf::MSFStreamLayout &Stream);
 
   bool hasColor() const { return UseColor; }
   raw_ostream &getStream() { return OS; }
   int getIndentLevel() const { return CurrentIndent; }
 
-  bool IsClassExcluded(const ClassLayout &Class);
-  bool IsTypeExcluded(llvm::StringRef TypeName, uint64_t Size);
-  bool IsSymbolExcluded(llvm::StringRef SymbolName);
-  bool IsCompilandExcluded(llvm::StringRef CompilandName);
+  LLVM_ABI bool IsClassExcluded(const ClassLayout &Class);
+  LLVM_ABI bool IsTypeExcluded(llvm::StringRef TypeName, uint64_t Size);
+  LLVM_ABI bool IsSymbolExcluded(llvm::StringRef SymbolName);
+  LLVM_ABI bool IsCompilandExcluded(llvm::StringRef CompilandName);
 
   const FilterOptions &getFilters() const { return Filters; }
 
@@ -169,8 +170,8 @@ enum class PDB_ColorItem {
 
 class WithColor {
 public:
-  WithColor(LinePrinter &P, PDB_ColorItem C);
-  ~WithColor();
+  LLVM_ABI WithColor(LinePrinter &P, PDB_ColorItem C);
+  LLVM_ABI ~WithColor();
 
   raw_ostream &get() { return OS; }
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/LinePrinter.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/LinePrinter.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_LINEPRINTER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_LINEPRINTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/DebugInfo/PDB/Native/FormatUtil.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/raw_ostream.h"
@@ -53,7 +53,7 @@ class LinePrinter {
 
 public:
   LLVM_ABI LinePrinter(int Indent, bool UseColor, raw_ostream &Stream,
-              const FilterOptions &Filters);
+                       const FilterOptions &Filters);
 
   LLVM_ABI void Indent(uint32_t Amount = 0);
   LLVM_ABI void Unindent(uint32_t Amount = 0);
@@ -69,17 +69,18 @@ public:
   }
 
   LLVM_ABI void formatBinary(StringRef Label, ArrayRef<uint8_t> Data,
-                    uint64_t StartOffset);
-  LLVM_ABI void formatBinary(StringRef Label, ArrayRef<uint8_t> Data, uint64_t BaseAddr,
-                    uint64_t StartOffset);
+                             uint64_t StartOffset);
+  LLVM_ABI void formatBinary(StringRef Label, ArrayRef<uint8_t> Data,
+                             uint64_t BaseAddr, uint64_t StartOffset);
 
-  LLVM_ABI void formatMsfStreamData(StringRef Label, PDBFile &File, uint32_t StreamIdx,
-                           StringRef StreamPurpose, uint64_t Offset,
-                           uint64_t Size);
   LLVM_ABI void formatMsfStreamData(StringRef Label, PDBFile &File,
-                           const msf::MSFStreamLayout &Stream,
-                           BinarySubstreamRef Substream);
-  LLVM_ABI void formatMsfStreamBlocks(PDBFile &File, const msf::MSFStreamLayout &Stream);
+                                    uint32_t StreamIdx, StringRef StreamPurpose,
+                                    uint64_t Offset, uint64_t Size);
+  LLVM_ABI void formatMsfStreamData(StringRef Label, PDBFile &File,
+                                    const msf::MSFStreamLayout &Stream,
+                                    BinarySubstreamRef Substream);
+  LLVM_ABI void formatMsfStreamBlocks(PDBFile &File,
+                                      const msf::MSFStreamLayout &Stream);
 
   bool hasColor() const { return UseColor; }
   raw_ostream &getStream() { return OS; }

--- a/llvm/include/llvm/DebugInfo/PDB/Native/ModuleDebugStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/ModuleDebugStream.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_MODULEDEBUGSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_MODULEDEBUGSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsectionRecord.h"
@@ -32,42 +33,42 @@ class ModuleDebugStreamRef {
   using DebugSubsectionIterator = codeview::DebugSubsectionArray::Iterator;
 
 public:
-  ModuleDebugStreamRef(const DbiModuleDescriptor &Module,
+  LLVM_ABI ModuleDebugStreamRef(const DbiModuleDescriptor &Module,
                        std::unique_ptr<msf::MappedBlockStream> Stream);
   ModuleDebugStreamRef(ModuleDebugStreamRef &&Other) = default;
   ModuleDebugStreamRef(const ModuleDebugStreamRef &Other) = default;
-  ~ModuleDebugStreamRef();
+  LLVM_ABI ~ModuleDebugStreamRef();
 
-  Error reload();
+  LLVM_ABI Error reload();
 
   uint32_t signature() const { return Signature; }
 
-  iterator_range<codeview::CVSymbolArray::Iterator>
+  LLVM_ABI iterator_range<codeview::CVSymbolArray::Iterator>
   symbols(bool *HadError) const;
 
   const codeview::CVSymbolArray &getSymbolArray() const { return SymbolArray; }
-  const codeview::CVSymbolArray
+  LLVM_ABI const codeview::CVSymbolArray
   getSymbolArrayForScope(uint32_t ScopeBegin) const;
 
-  BinarySubstreamRef getSymbolsSubstream() const;
-  BinarySubstreamRef getC11LinesSubstream() const;
-  BinarySubstreamRef getC13LinesSubstream() const;
-  BinarySubstreamRef getGlobalRefsSubstream() const;
+  LLVM_ABI BinarySubstreamRef getSymbolsSubstream() const;
+  LLVM_ABI BinarySubstreamRef getC11LinesSubstream() const;
+  LLVM_ABI BinarySubstreamRef getC13LinesSubstream() const;
+  LLVM_ABI BinarySubstreamRef getGlobalRefsSubstream() const;
 
   ModuleDebugStreamRef &operator=(ModuleDebugStreamRef &&Other) = delete;
 
-  codeview::CVSymbol readSymbolAtOffset(uint32_t Offset) const;
+  LLVM_ABI codeview::CVSymbol readSymbolAtOffset(uint32_t Offset) const;
 
-  iterator_range<DebugSubsectionIterator> subsections() const;
+  LLVM_ABI iterator_range<DebugSubsectionIterator> subsections() const;
   codeview::DebugSubsectionArray getSubsectionsArray() const {
     return Subsections;
   }
 
-  bool hasDebugSubsections() const;
+  LLVM_ABI bool hasDebugSubsections() const;
 
-  Error commit();
+  LLVM_ABI Error commit();
 
-  Expected<codeview::DebugChecksumsSubsectionRef>
+  LLVM_ABI Expected<codeview::DebugChecksumsSubsectionRef>
   findChecksumsSubsection() const;
 
 private:

--- a/llvm/include/llvm/DebugInfo/PDB/Native/ModuleDebugStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/ModuleDebugStream.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_MODULEDEBUGSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_MODULEDEBUGSTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/DebugSubsectionRecord.h"
 #include "llvm/DebugInfo/PDB/Native/DbiModuleDescriptor.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <memory>
@@ -34,7 +34,7 @@ class ModuleDebugStreamRef {
 
 public:
   LLVM_ABI ModuleDebugStreamRef(const DbiModuleDescriptor &Module,
-                       std::unique_ptr<msf::MappedBlockStream> Stream);
+                                std::unique_ptr<msf::MappedBlockStream> Stream);
   ModuleDebugStreamRef(ModuleDebugStreamRef &&Other) = default;
   ModuleDebugStreamRef(const ModuleDebugStreamRef &Other) = default;
   LLVM_ABI ~ModuleDebugStreamRef();

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NamedStreamMap.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NamedStreamMap.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_NAMEDSTREAMMAP_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_NAMEDSTREAMMAP_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/PDB/Native/HashTable.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NamedStreamMap.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NamedStreamMap.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_NAMEDSTREAMMAP_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_NAMEDSTREAMMAP_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/PDB/Native/HashTable.h"
@@ -27,31 +28,31 @@ class NamedStreamMap;
 struct NamedStreamMapTraits {
   NamedStreamMap *NS;
 
-  explicit NamedStreamMapTraits(NamedStreamMap &NS);
-  uint16_t hashLookupKey(StringRef S) const;
-  StringRef storageKeyToLookupKey(uint32_t Offset) const;
-  uint32_t lookupKeyToStorageKey(StringRef S);
+  LLVM_ABI explicit NamedStreamMapTraits(NamedStreamMap &NS);
+  LLVM_ABI uint16_t hashLookupKey(StringRef S) const;
+  LLVM_ABI StringRef storageKeyToLookupKey(uint32_t Offset) const;
+  LLVM_ABI uint32_t lookupKeyToStorageKey(StringRef S);
 };
 
 class NamedStreamMap {
   friend class NamedStreamMapBuilder;
 
 public:
-  NamedStreamMap();
+  LLVM_ABI NamedStreamMap();
 
-  Error load(BinaryStreamReader &Stream);
-  Error commit(BinaryStreamWriter &Writer) const;
-  uint32_t calculateSerializedLength() const;
+  LLVM_ABI Error load(BinaryStreamReader &Stream);
+  LLVM_ABI Error commit(BinaryStreamWriter &Writer) const;
+  LLVM_ABI uint32_t calculateSerializedLength() const;
 
-  uint32_t size() const;
-  bool get(StringRef Stream, uint32_t &StreamNo) const;
-  void set(StringRef Stream, uint32_t StreamNo);
+  LLVM_ABI uint32_t size() const;
+  LLVM_ABI bool get(StringRef Stream, uint32_t &StreamNo) const;
+  LLVM_ABI void set(StringRef Stream, uint32_t StreamNo);
 
-  uint32_t appendStringData(StringRef S);
-  StringRef getString(uint32_t Offset) const;
-  uint32_t hashString(uint32_t Offset) const;
+  LLVM_ABI uint32_t appendStringData(StringRef S);
+  LLVM_ABI StringRef getString(uint32_t Offset) const;
+  LLVM_ABI uint32_t hashString(uint32_t Offset) const;
 
-  StringMap<uint32_t> entries() const;
+  LLVM_ABI StringMap<uint32_t> entries() const;
 
 private:
   NamedStreamMapTraits HashTraits;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeRawSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeRawSymbol.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_NATIVERAWSYMBOL_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_NATIVERAWSYMBOL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <memory>
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeRawSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeRawSymbol.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_NATIVERAWSYMBOL_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_NATIVERAWSYMBOL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
 #include <cstdint>
 #include <memory>
@@ -18,7 +19,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeRawSymbol : public IPDBRawSymbol {
+class LLVM_ABI NativeRawSymbol : public IPDBRawSymbol {
   friend class SymbolCache;
   virtual void initialize() {}
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeSession.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeSession.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_NATIVESESSION_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_NATIVESESSION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/PDB/IPDBSession.h"
@@ -29,7 +30,7 @@ class PDBSymbolCompiland;
 class PDBSymbolExe;
 template <typename ChildType> class IPDBEnumChildren;
 
-class NativeSession : public IPDBSession {
+class LLVM_ABI NativeSession : public IPDBSession {
   struct PdbSearchOptions {
     StringRef ExePath;
     // FIXME: Add other PDB search options (_NT_SYMBOL_PATH, symsrv)

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeSession.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeSession.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_NATIVESESSION_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_NATIVESESSION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/PDB/IPDBSession.h"
 #include "llvm/DebugInfo/PDB/Native/SymbolCache.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeSourceFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeSourceFile.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_NATIVESOURCEFILE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_NATIVESOURCEFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/DebugChecksumsSubsection.h"
 #include "llvm/DebugInfo/PDB/IPDBSourceFile.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
@@ -19,7 +20,7 @@ class PDBSymbolCompiland;
 template <typename ChildType> class IPDBEnumChildren;
 class NativeSession;
 
-class NativeSourceFile : public IPDBSourceFile {
+class LLVM_ABI NativeSourceFile : public IPDBSourceFile {
 public:
   explicit NativeSourceFile(NativeSession &Session, uint32_t FileId,
                             const codeview::FileChecksumEntry &Checksum);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeSourceFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeSourceFile.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_NATIVESOURCEFILE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_NATIVESOURCEFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/DebugChecksumsSubsection.h"
 #include "llvm/DebugInfo/PDB/IPDBSourceFile.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace pdb {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBFile.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PDBFILE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PDBFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/MSF/IMSFFile.h"
 #include "llvm/DebugInfo/MSF/MSFCommon.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBFile.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PDBFILE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PDBFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/MSF/IMSFFile.h"
 #include "llvm/DebugInfo/MSF/MSFCommon.h"
 #include "llvm/Support/Allocator.h"
@@ -37,7 +38,7 @@ class PublicsStream;
 class SymbolStream;
 class TpiStream;
 
-class PDBFile : public msf::IMSFFile {
+class LLVM_ABI PDBFile : public msf::IMSFFile {
   friend PDBFileBuilder;
 
 public:

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBFileBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBFileBuilder.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PDBFILEBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PDBFILEBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/PDB/Native/HashTable.h"
 #include "llvm/DebugInfo/PDB/Native/NamedStreamMap.h"
 #include "llvm/DebugInfo/PDB/Native/PDBStringTableBuilder.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <memory>
@@ -60,7 +60,8 @@ public:
 
   LLVM_ABI Expected<uint32_t> getNamedStreamIndex(StringRef Name) const;
   LLVM_ABI Error addNamedStream(StringRef Name, StringRef Data);
-  LLVM_ABI void addInjectedSource(StringRef Name, std::unique_ptr<MemoryBuffer> Buffer);
+  LLVM_ABI void addInjectedSource(StringRef Name,
+                                  std::unique_ptr<MemoryBuffer> Buffer);
 
 private:
   struct InjectedSourceDescriptor {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBFileBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBFileBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PDBFILEBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PDBFILEBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/PDB/Native/HashTable.h"
@@ -38,28 +39,28 @@ class TpiStreamBuilder;
 
 class PDBFileBuilder {
 public:
-  explicit PDBFileBuilder(BumpPtrAllocator &Allocator);
-  ~PDBFileBuilder();
+  LLVM_ABI explicit PDBFileBuilder(BumpPtrAllocator &Allocator);
+  LLVM_ABI ~PDBFileBuilder();
   PDBFileBuilder(const PDBFileBuilder &) = delete;
   PDBFileBuilder &operator=(const PDBFileBuilder &) = delete;
 
-  Error initialize(uint32_t BlockSize);
+  LLVM_ABI Error initialize(uint32_t BlockSize);
 
-  msf::MSFBuilder &getMsfBuilder();
-  InfoStreamBuilder &getInfoBuilder();
-  DbiStreamBuilder &getDbiBuilder();
-  TpiStreamBuilder &getTpiBuilder();
-  TpiStreamBuilder &getIpiBuilder();
-  PDBStringTableBuilder &getStringTableBuilder();
-  GSIStreamBuilder &getGsiBuilder();
+  LLVM_ABI msf::MSFBuilder &getMsfBuilder();
+  LLVM_ABI InfoStreamBuilder &getInfoBuilder();
+  LLVM_ABI DbiStreamBuilder &getDbiBuilder();
+  LLVM_ABI TpiStreamBuilder &getTpiBuilder();
+  LLVM_ABI TpiStreamBuilder &getIpiBuilder();
+  LLVM_ABI PDBStringTableBuilder &getStringTableBuilder();
+  LLVM_ABI GSIStreamBuilder &getGsiBuilder();
 
   // If HashPDBContentsToGUID is true on the InfoStreamBuilder, Guid is filled
   // with the computed PDB GUID on return.
-  Error commit(StringRef Filename, codeview::GUID *Guid);
+  LLVM_ABI Error commit(StringRef Filename, codeview::GUID *Guid);
 
-  Expected<uint32_t> getNamedStreamIndex(StringRef Name) const;
-  Error addNamedStream(StringRef Name, StringRef Data);
-  void addInjectedSource(StringRef Name, std::unique_ptr<MemoryBuffer> Buffer);
+  LLVM_ABI Expected<uint32_t> getNamedStreamIndex(StringRef Name) const;
+  LLVM_ABI Error addNamedStream(StringRef Name, StringRef Data);
+  LLVM_ABI void addInjectedSource(StringRef Name, std::unique_ptr<MemoryBuffer> Buffer);
 
 private:
   struct InjectedSourceDescriptor {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTable.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTable.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PDBSTRINGTABLE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PDBSTRINGTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/DebugStringTableSubsection.h"
 #include "llvm/Support/BinaryStreamArray.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
@@ -38,7 +38,8 @@ public:
 
   LLVM_ABI FixedStreamArray<support::ulittle32_t> name_ids() const;
 
-  LLVM_ABI const codeview::DebugStringTableSubsectionRef &getStringTable() const;
+  LLVM_ABI const codeview::DebugStringTableSubsectionRef &
+  getStringTable() const;
 
 private:
   Error readHeader(BinaryStreamReader &Reader);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTable.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTable.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PDBSTRINGTABLE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PDBSTRINGTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/DebugStringTableSubsection.h"
 #include "llvm/Support/BinaryStreamArray.h"
@@ -25,19 +26,19 @@ struct PDBStringTableHeader;
 
 class PDBStringTable {
 public:
-  Error reload(BinaryStreamReader &Reader);
+  LLVM_ABI Error reload(BinaryStreamReader &Reader);
 
-  uint32_t getByteSize() const;
-  uint32_t getNameCount() const;
-  uint32_t getHashVersion() const;
-  uint32_t getSignature() const;
+  LLVM_ABI uint32_t getByteSize() const;
+  LLVM_ABI uint32_t getNameCount() const;
+  LLVM_ABI uint32_t getHashVersion() const;
+  LLVM_ABI uint32_t getSignature() const;
 
-  Expected<StringRef> getStringForID(uint32_t ID) const;
-  Expected<uint32_t> getIDForString(StringRef Str) const;
+  LLVM_ABI Expected<StringRef> getStringForID(uint32_t ID) const;
+  LLVM_ABI Expected<uint32_t> getIDForString(StringRef Str) const;
 
-  FixedStreamArray<support::ulittle32_t> name_ids() const;
+  LLVM_ABI FixedStreamArray<support::ulittle32_t> name_ids() const;
 
-  const codeview::DebugStringTableSubsectionRef &getStringTable() const;
+  LLVM_ABI const codeview::DebugStringTableSubsectionRef &getStringTable() const;
 
 private:
   Error readHeader(BinaryStreamReader &Reader);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTableBuilder.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PDBSTRINGTABLEBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PDBSTRINGTABLEBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/DebugStringTableSubsection.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTableBuilder.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PDBSTRINGTABLEBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PDBSTRINGTABLEBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/DebugStringTableSubsection.h"
 #include "llvm/Support/Error.h"
@@ -34,25 +35,25 @@ class PDBStringTableBuilder;
 struct StringTableHashTraits {
   PDBStringTableBuilder *Table;
 
-  explicit StringTableHashTraits(PDBStringTableBuilder &Table);
-  uint32_t hashLookupKey(StringRef S) const;
-  StringRef storageKeyToLookupKey(uint32_t Offset) const;
-  uint32_t lookupKeyToStorageKey(StringRef S);
+  LLVM_ABI explicit StringTableHashTraits(PDBStringTableBuilder &Table);
+  LLVM_ABI uint32_t hashLookupKey(StringRef S) const;
+  LLVM_ABI StringRef storageKeyToLookupKey(uint32_t Offset) const;
+  LLVM_ABI uint32_t lookupKeyToStorageKey(StringRef S);
 };
 
 class PDBStringTableBuilder {
 public:
   // If string S does not exist in the string table, insert it.
   // Returns the ID for S.
-  uint32_t insert(StringRef S);
+  LLVM_ABI uint32_t insert(StringRef S);
 
-  uint32_t getIdForString(StringRef S) const;
-  StringRef getStringForId(uint32_t Id) const;
+  LLVM_ABI uint32_t getIdForString(StringRef S) const;
+  LLVM_ABI StringRef getStringForId(uint32_t Id) const;
 
-  uint32_t calculateSerializedSize() const;
-  Error commit(BinaryStreamWriter &Writer) const;
+  LLVM_ABI uint32_t calculateSerializedSize() const;
+  LLVM_ABI Error commit(BinaryStreamWriter &Writer) const;
 
-  void setStrings(const codeview::DebugStringTableSubsection &Strings);
+  LLVM_ABI void setStrings(const codeview::DebugStringTableSubsection &Strings);
 
 private:
   uint32_t calculateHashTableSize() const;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PublicsStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PublicsStream.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PUBLICSSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PUBLICSSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/PDB/Native/GlobalsStream.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/Error.h"
@@ -23,13 +24,13 @@ struct SectionOffset;
 
 class PublicsStream {
 public:
-  PublicsStream(std::unique_ptr<msf::MappedBlockStream> Stream);
-  ~PublicsStream();
-  Error reload();
+  LLVM_ABI PublicsStream(std::unique_ptr<msf::MappedBlockStream> Stream);
+  LLVM_ABI ~PublicsStream();
+  LLVM_ABI Error reload();
 
-  uint32_t getSymHash() const;
-  uint16_t getThunkTableSection() const;
-  uint32_t getThunkTableOffset() const;
+  LLVM_ABI uint32_t getSymHash() const;
+  LLVM_ABI uint16_t getThunkTableSection() const;
+  LLVM_ABI uint32_t getThunkTableOffset() const;
   const GSIHashTable &getPublicsTable() const { return PublicsTable; }
   FixedStreamArray<support::ulittle32_t> getAddressMap() const {
     return AddressMap;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PublicsStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PublicsStream.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_PUBLICSSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_PUBLICSSTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/PDB/Native/GlobalsStream.h"
 #include "llvm/Support/BinaryStreamArray.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/RawError.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/RawError.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_RAWERROR_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_RAWERROR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -38,7 +39,7 @@ struct is_error_code_enum<llvm::pdb::raw_error_code> : std::true_type {};
 
 namespace llvm {
 namespace pdb {
-const std::error_category &RawErrCategory();
+LLVM_ABI const std::error_category &RawErrCategory();
 
 inline std::error_code make_error_code(raw_error_code E) {
   return std::error_code(static_cast<int>(E), RawErrCategory());
@@ -49,7 +50,7 @@ class RawError : public ErrorInfo<RawError, StringError> {
 public:
   using ErrorInfo<RawError, StringError>::ErrorInfo; // inherit constructors
   RawError(const Twine &S) : ErrorInfo(S, raw_error_code::unspecified) {}
-  static char ID;
+  LLVM_ABI static char ID;
 };
 } // namespace pdb
 } // namespace llvm

--- a/llvm/include/llvm/DebugInfo/PDB/Native/SymbolCache.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/SymbolCache.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLCACHE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLCACHE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -19,6 +18,7 @@
 #include "llvm/DebugInfo/PDB/Native/NativeRawSymbol.h"
 #include "llvm/DebugInfo/PDB/Native/NativeSourceFile.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 #include <memory>
 #include <vector>
@@ -171,8 +171,9 @@ public:
 
   LLVM_ABI SymIndexId getOrCreateGlobalSymbolByOffset(uint32_t Offset);
   LLVM_ABI SymIndexId getOrCreateInlineSymbol(codeview::InlineSiteSym Sym,
-                                     uint64_t ParentAddr, uint16_t Modi,
-                                     uint32_t RecordOffset) const;
+                                              uint64_t ParentAddr,
+                                              uint16_t Modi,
+                                              uint32_t RecordOffset) const;
 
   LLVM_ABI std::unique_ptr<PDBSymbol>
   findSymbolBySectOffset(uint32_t Sect, uint32_t Offset, PDB_SymType Type);
@@ -180,7 +181,8 @@ public:
   LLVM_ABI std::unique_ptr<IPDBEnumLineNumbers>
   findLineNumbersByVA(uint64_t VA, uint32_t Length) const;
 
-  LLVM_ABI std::unique_ptr<PDBSymbolCompiland> getOrCreateCompiland(uint32_t Index);
+  LLVM_ABI std::unique_ptr<PDBSymbolCompiland>
+  getOrCreateCompiland(uint32_t Index);
   LLVM_ABI uint32_t getNumCompilands() const;
 
   LLVM_ABI std::unique_ptr<PDBSymbol> getSymbolById(SymIndexId SymbolId) const;
@@ -192,7 +194,8 @@ public:
     return static_cast<ConcreteT &>(getNativeSymbolById(SymbolId));
   }
 
-  LLVM_ABI std::unique_ptr<IPDBSourceFile> getSourceFileById(SymIndexId FileId) const;
+  LLVM_ABI std::unique_ptr<IPDBSourceFile>
+  getSourceFileById(SymIndexId FileId) const;
   LLVM_ABI SymIndexId
   getOrCreateSourceFile(const codeview::FileChecksumEntry &Checksum) const;
 };

--- a/llvm/include/llvm/DebugInfo/PDB/Native/SymbolCache.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/SymbolCache.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLCACHE_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLCACHE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -121,7 +122,7 @@ class SymbolCache {
                                                           uint32_t Offset);
 
 public:
-  SymbolCache(NativeSession &Session, DbiStream *Dbi);
+  LLVM_ABI SymbolCache(NativeSession &Session, DbiStream *Dbi);
 
   template <typename ConcreteSymbolT, typename... Args>
   SymIndexId createSymbol(Args &&...ConstructorArgs) const {
@@ -142,16 +143,16 @@ public:
     return Id;
   }
 
-  std::unique_ptr<IPDBEnumSymbols>
+  LLVM_ABI std::unique_ptr<IPDBEnumSymbols>
   createTypeEnumerator(codeview::TypeLeafKind Kind);
 
-  std::unique_ptr<IPDBEnumSymbols>
+  LLVM_ABI std::unique_ptr<IPDBEnumSymbols>
   createTypeEnumerator(std::vector<codeview::TypeLeafKind> Kinds);
 
-  std::unique_ptr<IPDBEnumSymbols>
+  LLVM_ABI std::unique_ptr<IPDBEnumSymbols>
   createGlobalsEnumerator(codeview::SymbolKind Kind);
 
-  SymIndexId findSymbolByTypeIndex(codeview::TypeIndex TI) const;
+  LLVM_ABI SymIndexId findSymbolByTypeIndex(codeview::TypeIndex TI) const;
 
   template <typename ConcreteSymbolT, typename... Args>
   SymIndexId getOrCreateFieldListMember(codeview::TypeIndex FieldListTI,
@@ -168,31 +169,31 @@ public:
     return SymId;
   }
 
-  SymIndexId getOrCreateGlobalSymbolByOffset(uint32_t Offset);
-  SymIndexId getOrCreateInlineSymbol(codeview::InlineSiteSym Sym,
+  LLVM_ABI SymIndexId getOrCreateGlobalSymbolByOffset(uint32_t Offset);
+  LLVM_ABI SymIndexId getOrCreateInlineSymbol(codeview::InlineSiteSym Sym,
                                      uint64_t ParentAddr, uint16_t Modi,
                                      uint32_t RecordOffset) const;
 
-  std::unique_ptr<PDBSymbol>
+  LLVM_ABI std::unique_ptr<PDBSymbol>
   findSymbolBySectOffset(uint32_t Sect, uint32_t Offset, PDB_SymType Type);
 
-  std::unique_ptr<IPDBEnumLineNumbers>
+  LLVM_ABI std::unique_ptr<IPDBEnumLineNumbers>
   findLineNumbersByVA(uint64_t VA, uint32_t Length) const;
 
-  std::unique_ptr<PDBSymbolCompiland> getOrCreateCompiland(uint32_t Index);
-  uint32_t getNumCompilands() const;
+  LLVM_ABI std::unique_ptr<PDBSymbolCompiland> getOrCreateCompiland(uint32_t Index);
+  LLVM_ABI uint32_t getNumCompilands() const;
 
-  std::unique_ptr<PDBSymbol> getSymbolById(SymIndexId SymbolId) const;
+  LLVM_ABI std::unique_ptr<PDBSymbol> getSymbolById(SymIndexId SymbolId) const;
 
-  NativeRawSymbol &getNativeSymbolById(SymIndexId SymbolId) const;
+  LLVM_ABI NativeRawSymbol &getNativeSymbolById(SymIndexId SymbolId) const;
 
   template <typename ConcreteT>
   ConcreteT &getNativeSymbolById(SymIndexId SymbolId) const {
     return static_cast<ConcreteT &>(getNativeSymbolById(SymbolId));
   }
 
-  std::unique_ptr<IPDBSourceFile> getSourceFileById(SymIndexId FileId) const;
-  SymIndexId
+  LLVM_ABI std::unique_ptr<IPDBSourceFile> getSourceFileById(SymIndexId FileId) const;
+  LLVM_ABI SymIndexId
   getOrCreateSourceFile(const codeview::FileChecksumEntry &Checksum) const;
 };
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/SymbolStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/SymbolStream.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 
 #include "llvm/Support/Error.h"
@@ -21,20 +22,20 @@ namespace pdb {
 
 class SymbolStream {
 public:
-  SymbolStream(std::unique_ptr<msf::MappedBlockStream> Stream);
-  ~SymbolStream();
-  Error reload();
+  LLVM_ABI SymbolStream(std::unique_ptr<msf::MappedBlockStream> Stream);
+  LLVM_ABI ~SymbolStream();
+  LLVM_ABI Error reload();
 
   const codeview::CVSymbolArray &getSymbolArray() const {
     return SymbolRecords;
   }
 
-  codeview::CVSymbol readRecord(uint32_t Offset) const;
+  LLVM_ABI codeview::CVSymbol readRecord(uint32_t Offset) const;
 
-  iterator_range<codeview::CVSymbolArray::Iterator>
+  LLVM_ABI iterator_range<codeview::CVSymbolArray::Iterator>
   getSymbols(bool *HadError) const;
 
-  Error commit();
+  LLVM_ABI Error commit();
 
 private:
   codeview::CVSymbolArray SymbolRecords;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/SymbolStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/SymbolStream.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLSTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLSTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
+#include "llvm/Support/Compiler.h"
 
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiHashing.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiHashing.h
@@ -9,13 +9,14 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_TPIHASHING_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_TPIHASHING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/TypeRecord.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
 namespace pdb {
 
-Expected<uint32_t> hashTypeRecord(const llvm::codeview::CVType &Type);
+LLVM_ABI Expected<uint32_t> hashTypeRecord(const llvm::codeview::CVType &Type);
 
 struct TagRecordHash {
   explicit TagRecordHash(codeview::ClassRecord CR, uint32_t Full,
@@ -63,7 +64,7 @@ private:
 
 /// Given a CVType referring to a class, structure, union, or enum, compute
 /// the hash of its forward decl and full decl.
-Expected<TagRecordHash> hashTagRecord(const codeview::CVType &Type);
+LLVM_ABI Expected<TagRecordHash> hashTagRecord(const codeview::CVType &Type);
 
 } // end namespace pdb
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiHashing.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiHashing.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_TPIHASHING_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_TPIHASHING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/TypeRecord.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiStream.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_TPISTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_TPISTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/PDB/Native/HashTable.h"
 #include "llvm/DebugInfo/PDB/Native/RawConstants.h"
@@ -35,43 +36,43 @@ class TpiStream {
   friend class TpiStreamBuilder;
 
 public:
-  TpiStream(PDBFile &File, std::unique_ptr<msf::MappedBlockStream> Stream);
-  ~TpiStream();
-  Error reload();
+  LLVM_ABI TpiStream(PDBFile &File, std::unique_ptr<msf::MappedBlockStream> Stream);
+  LLVM_ABI ~TpiStream();
+  LLVM_ABI Error reload();
 
-  PdbRaw_TpiVer getTpiVersion() const;
+  LLVM_ABI PdbRaw_TpiVer getTpiVersion() const;
 
-  uint32_t TypeIndexBegin() const;
-  uint32_t TypeIndexEnd() const;
-  uint32_t getNumTypeRecords() const;
-  uint16_t getTypeHashStreamIndex() const;
-  uint16_t getTypeHashStreamAuxIndex() const;
+  LLVM_ABI uint32_t TypeIndexBegin() const;
+  LLVM_ABI uint32_t TypeIndexEnd() const;
+  LLVM_ABI uint32_t getNumTypeRecords() const;
+  LLVM_ABI uint16_t getTypeHashStreamIndex() const;
+  LLVM_ABI uint16_t getTypeHashStreamAuxIndex() const;
 
-  uint32_t getHashKeySize() const;
-  uint32_t getNumHashBuckets() const;
-  FixedStreamArray<support::ulittle32_t> getHashValues() const;
-  FixedStreamArray<codeview::TypeIndexOffset> getTypeIndexOffsets() const;
-  HashTable<support::ulittle32_t> &getHashAdjusters();
+  LLVM_ABI uint32_t getHashKeySize() const;
+  LLVM_ABI uint32_t getNumHashBuckets() const;
+  LLVM_ABI FixedStreamArray<support::ulittle32_t> getHashValues() const;
+  LLVM_ABI FixedStreamArray<codeview::TypeIndexOffset> getTypeIndexOffsets() const;
+  LLVM_ABI HashTable<support::ulittle32_t> &getHashAdjusters();
 
-  codeview::CVTypeRange types(bool *HadError) const;
+  LLVM_ABI codeview::CVTypeRange types(bool *HadError) const;
   const codeview::CVTypeArray &typeArray() const { return TypeRecords; }
 
   codeview::LazyRandomTypeCollection &typeCollection() { return *Types; }
 
-  Expected<codeview::TypeIndex>
+  LLVM_ABI Expected<codeview::TypeIndex>
   findFullDeclForForwardRef(codeview::TypeIndex ForwardRefTI) const;
 
-  std::vector<codeview::TypeIndex> findRecordsByName(StringRef Name) const;
+  LLVM_ABI std::vector<codeview::TypeIndex> findRecordsByName(StringRef Name) const;
 
-  codeview::CVType getType(codeview::TypeIndex Index);
+  LLVM_ABI codeview::CVType getType(codeview::TypeIndex Index);
 
-  BinarySubstreamRef getTypeRecordsSubstream() const;
+  LLVM_ABI BinarySubstreamRef getTypeRecordsSubstream() const;
 
-  Error commit();
+  LLVM_ABI Error commit();
 
-  void buildHashMap();
+  LLVM_ABI void buildHashMap();
 
-  bool supportsTypeLookup() const;
+  LLVM_ABI bool supportsTypeLookup() const;
 
 private:
   PDBFile &Pdb;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiStream.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_TPISTREAM_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_TPISTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/PDB/Native/HashTable.h"
 #include "llvm/DebugInfo/PDB/Native/RawConstants.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 
 #include "llvm/Support/Error.h"
 
@@ -36,7 +36,8 @@ class TpiStream {
   friend class TpiStreamBuilder;
 
 public:
-  LLVM_ABI TpiStream(PDBFile &File, std::unique_ptr<msf::MappedBlockStream> Stream);
+  LLVM_ABI TpiStream(PDBFile &File,
+                     std::unique_ptr<msf::MappedBlockStream> Stream);
   LLVM_ABI ~TpiStream();
   LLVM_ABI Error reload();
 
@@ -51,7 +52,8 @@ public:
   LLVM_ABI uint32_t getHashKeySize() const;
   LLVM_ABI uint32_t getNumHashBuckets() const;
   LLVM_ABI FixedStreamArray<support::ulittle32_t> getHashValues() const;
-  LLVM_ABI FixedStreamArray<codeview::TypeIndexOffset> getTypeIndexOffsets() const;
+  LLVM_ABI FixedStreamArray<codeview::TypeIndexOffset>
+  getTypeIndexOffsets() const;
   LLVM_ABI HashTable<support::ulittle32_t> &getHashAdjusters();
 
   LLVM_ABI codeview::CVTypeRange types(bool *HadError) const;
@@ -62,7 +64,8 @@ public:
   LLVM_ABI Expected<codeview::TypeIndex>
   findFullDeclForForwardRef(codeview::TypeIndex ForwardRefTI) const;
 
-  LLVM_ABI std::vector<codeview::TypeIndex> findRecordsByName(StringRef Name) const;
+  LLVM_ABI std::vector<codeview::TypeIndex>
+  findRecordsByName(StringRef Name) const;
 
   LLVM_ABI codeview::CVType getType(codeview::TypeIndex Index);
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiStreamBuilder.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_TPISTREAMBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_TPISTREAMBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 #include "llvm/DebugInfo/PDB/Native/RawConstants.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <vector>
@@ -46,15 +46,18 @@ public:
   TpiStreamBuilder &operator=(const TpiStreamBuilder &) = delete;
 
   LLVM_ABI void setVersionHeader(PdbRaw_TpiVer Version);
-  LLVM_ABI void addTypeRecord(ArrayRef<uint8_t> Type, std::optional<uint32_t> Hash);
-  LLVM_ABI void addTypeRecords(ArrayRef<uint8_t> Types, ArrayRef<uint16_t> Sizes,
-                      ArrayRef<uint32_t> Hashes);
+  LLVM_ABI void addTypeRecord(ArrayRef<uint8_t> Type,
+                              std::optional<uint32_t> Hash);
+  LLVM_ABI void addTypeRecords(ArrayRef<uint8_t> Types,
+                               ArrayRef<uint16_t> Sizes,
+                               ArrayRef<uint32_t> Hashes);
 
   LLVM_ABI Error finalizeMsfLayout();
 
   uint32_t getRecordCount() const { return TypeRecordCount; }
 
-  LLVM_ABI Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef Buffer);
+  LLVM_ABI Error commit(const msf::MSFLayout &Layout,
+                        WritableBinaryStreamRef Buffer);
 
   LLVM_ABI uint32_t calculateSerializedLength();
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiStreamBuilder.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_NATIVE_TPISTREAMBUILDER_H
 #define LLVM_DEBUGINFO_PDB_NATIVE_TPISTREAMBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
 #include "llvm/DebugInfo/PDB/Native/RawConstants.h"
@@ -38,24 +39,24 @@ struct TpiStreamHeader;
 
 class TpiStreamBuilder {
 public:
-  explicit TpiStreamBuilder(msf::MSFBuilder &Msf, uint32_t StreamIdx);
-  ~TpiStreamBuilder();
+  LLVM_ABI explicit TpiStreamBuilder(msf::MSFBuilder &Msf, uint32_t StreamIdx);
+  LLVM_ABI ~TpiStreamBuilder();
 
   TpiStreamBuilder(const TpiStreamBuilder &) = delete;
   TpiStreamBuilder &operator=(const TpiStreamBuilder &) = delete;
 
-  void setVersionHeader(PdbRaw_TpiVer Version);
-  void addTypeRecord(ArrayRef<uint8_t> Type, std::optional<uint32_t> Hash);
-  void addTypeRecords(ArrayRef<uint8_t> Types, ArrayRef<uint16_t> Sizes,
+  LLVM_ABI void setVersionHeader(PdbRaw_TpiVer Version);
+  LLVM_ABI void addTypeRecord(ArrayRef<uint8_t> Type, std::optional<uint32_t> Hash);
+  LLVM_ABI void addTypeRecords(ArrayRef<uint8_t> Types, ArrayRef<uint16_t> Sizes,
                       ArrayRef<uint32_t> Hashes);
 
-  Error finalizeMsfLayout();
+  LLVM_ABI Error finalizeMsfLayout();
 
   uint32_t getRecordCount() const { return TypeRecordCount; }
 
-  Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef Buffer);
+  LLVM_ABI Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef Buffer);
 
-  uint32_t calculateSerializedLength();
+  LLVM_ABI uint32_t calculateSerializedLength();
 
 private:
   void updateTypeIndexOffsets(ArrayRef<uint16_t> Sizes);

--- a/llvm/include/llvm/DebugInfo/PDB/PDB.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDB.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDB_H
 #define LLVM_DEBUGINFO_PDB_PDB_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
 #include "llvm/Support/Error.h"
@@ -19,10 +20,10 @@ namespace pdb {
 
 class IPDBSession;
 
-Error loadDataForPDB(PDB_ReaderType Type, StringRef Path,
+LLVM_ABI Error loadDataForPDB(PDB_ReaderType Type, StringRef Path,
                      std::unique_ptr<IPDBSession> &Session);
 
-Error loadDataForEXE(PDB_ReaderType Type, StringRef Path,
+LLVM_ABI Error loadDataForEXE(PDB_ReaderType Type, StringRef Path,
                      std::unique_ptr<IPDBSession> &Session);
 
 } // end namespace pdb

--- a/llvm/include/llvm/DebugInfo/PDB/PDB.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDB.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDB_H
 #define LLVM_DEBUGINFO_PDB_PDB_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <memory>
 
@@ -21,10 +21,10 @@ namespace pdb {
 class IPDBSession;
 
 LLVM_ABI Error loadDataForPDB(PDB_ReaderType Type, StringRef Path,
-                     std::unique_ptr<IPDBSession> &Session);
+                              std::unique_ptr<IPDBSession> &Session);
 
 LLVM_ABI Error loadDataForEXE(PDB_ReaderType Type, StringRef Path,
-                     std::unique_ptr<IPDBSession> &Session);
+                              std::unique_ptr<IPDBSession> &Session);
 
 } // end namespace pdb
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/PDB/PDBExtras.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBExtras.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBEXTRAS_H
 #define LLVM_DEBUGINFO_PDB_PDBEXTRAS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
@@ -22,26 +23,26 @@ namespace pdb {
 
 using TagStats = std::unordered_map<PDB_SymType, int>;
 
-raw_ostream &operator<<(raw_ostream &OS, const PDB_VariantType &Value);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_CallingConv &Conv);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_BuiltinType &Type);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_DataKind &Data);
-raw_ostream &operator<<(raw_ostream &OS,
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_VariantType &Value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_CallingConv &Conv);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_BuiltinType &Type);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_DataKind &Data);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                         const llvm::codeview::CPURegister &CpuReg);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_LocType &Loc);
-raw_ostream &operator<<(raw_ostream &OS, const codeview::ThunkOrdinal &Thunk);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_Checksum &Checksum);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_Lang &Lang);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_SymType &Tag);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_MemberAccess &Access);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_UdtType &Type);
-raw_ostream &operator<<(raw_ostream &OS, const PDB_Machine &Machine);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_LocType &Loc);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const codeview::ThunkOrdinal &Thunk);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_Checksum &Checksum);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_Lang &Lang);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_SymType &Tag);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_MemberAccess &Access);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_UdtType &Type);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_Machine &Machine);
 
-raw_ostream &operator<<(raw_ostream &OS, const Variant &Value);
-raw_ostream &operator<<(raw_ostream &OS, const VersionInfo &Version);
-raw_ostream &operator<<(raw_ostream &OS, const TagStats &Stats);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const Variant &Value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const VersionInfo &Version);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const TagStats &Stats);
 
-raw_ostream& dumpPDBSourceCompression(raw_ostream& OS, uint32_t Compression);
+LLVM_ABI raw_ostream& dumpPDBSourceCompression(raw_ostream& OS, uint32_t Compression);
 
 template <typename T>
 void dumpSymbolField(raw_ostream &OS, StringRef Name, T Value, int Indent) {

--- a/llvm/include/llvm/DebugInfo/PDB/PDBExtras.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBExtras.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBEXTRAS_H
 #define LLVM_DEBUGINFO_PDB_PDBEXTRAS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
 #include <unordered_map>
@@ -28,13 +28,15 @@ LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_CallingConv &Conv);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_BuiltinType &Type);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_DataKind &Data);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
-                        const llvm::codeview::CPURegister &CpuReg);
+                                 const llvm::codeview::CPURegister &CpuReg);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_LocType &Loc);
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const codeview::ThunkOrdinal &Thunk);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const codeview::ThunkOrdinal &Thunk);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_Checksum &Checksum);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_Lang &Lang);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_SymType &Tag);
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_MemberAccess &Access);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const PDB_MemberAccess &Access);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_UdtType &Type);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PDB_Machine &Machine);
 
@@ -42,7 +44,8 @@ LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const Variant &Value);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const VersionInfo &Version);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const TagStats &Stats);
 
-LLVM_ABI raw_ostream& dumpPDBSourceCompression(raw_ostream& OS, uint32_t Compression);
+LLVM_ABI raw_ostream &dumpPDBSourceCompression(raw_ostream &OS,
+                                               uint32_t Compression);
 
 template <typename T>
 void dumpSymbolField(raw_ostream &OS, StringRef Name, T Value, int Indent) {

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymDumper.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymDumper.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMDUMPER_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMDUMPER_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBTypes.h"
 
 namespace llvm {
@@ -16,7 +17,7 @@ namespace llvm {
 class raw_ostream;
 namespace pdb {
 
-class PDBSymDumper {
+class LLVM_ABI PDBSymDumper {
 public:
   PDBSymDumper(bool ShouldRequireImpl);
   virtual ~PDBSymDumper();

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymDumper.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymDumper.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMDUMPER_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMDUMPER_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbol.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOL_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOL_H
 
-#include "llvm/Support/Compiler.h"
 #include "IPDBRawSymbol.h"
 #include "PDBExtras.h"
 #include "PDBTypes.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 
 #define FORWARD_SYMBOL_METHOD(MethodName)                                      \
   decltype(auto) MethodName() const { return RawSymbol->MethodName(); }

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbol.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOL_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOL_H
 
+#include "llvm/Support/Compiler.h"
 #include "IPDBRawSymbol.h"
 #include "PDBExtras.h"
 #include "PDBTypes.h"
@@ -68,7 +69,7 @@ public:                                                                        \
 /// valid for that particular symbol type, as described in the Microsoft
 /// reference "Lexical and Class Hierarchy of Symbol Types":
 /// https://msdn.microsoft.com/en-us/library/370hs6k4.aspx
-class PDBSymbol {
+class LLVM_ABI PDBSymbol {
   static std::unique_ptr<PDBSymbol> createSymbol(const IPDBSession &PDBSession,
                                                  PDB_SymType Tag);
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCompiland.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCompiland.h
@@ -8,9 +8,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLCOMPILAND_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLCOMPILAND_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 #include <string>
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCompiland.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCompiland.h
@@ -8,6 +8,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLCOMPILAND_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLCOMPILAND_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 #include <string>
@@ -18,7 +19,7 @@ class raw_ostream;
 
 namespace pdb {
 
-class PDBSymbolCompiland : public PDBSymbol {
+class LLVM_ABI PDBSymbolCompiland : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Compiland)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolData.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolData.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLDATA_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLDATA_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
@@ -19,7 +20,7 @@ namespace pdb {
 
 class PDBSymDumper;
 
-class PDBSymbolData : public PDBSymbol {
+class LLVM_ABI PDBSymbolData : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Data)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolData.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolData.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLDATA_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLDATA_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolExe.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolExe.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLEXE_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLEXE_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -18,7 +19,7 @@ class raw_ostream;
 
 namespace pdb {
 
-class PDBSymbolExe : public PDBSymbol {
+class LLVM_ABI PDBSymbolExe : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Exe)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolExe.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolExe.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLEXE_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLEXE_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFunc.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFunc.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNC_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNC_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
+#include "llvm/Support/Compiler.h"
 
 #include "PDBSymbol.h"
 #include "PDBTypes.h"

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFunc.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFunc.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNC_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
 
 #include "PDBSymbol.h"
@@ -23,7 +24,7 @@ class PDBSymbolData;
 class PDBSymbolTypeFunctionSig;
 template <typename ChildType> class IPDBEnumChildren;
 
-class PDBSymbolFunc : public PDBSymbol {
+class LLVM_ABI PDBSymbolFunc : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Function)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFuncDebugEnd.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFuncDebugEnd.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNCDEBUGEND_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNCDEBUGEND_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolFuncDebugEnd : public PDBSymbol {
+class LLVM_ABI PDBSymbolFuncDebugEnd : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::FuncDebugEnd)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFuncDebugEnd.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFuncDebugEnd.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNCDEBUGEND_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNCDEBUGEND_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFuncDebugStart.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFuncDebugStart.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNCDEBUGSTART_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNCDEBUGSTART_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFuncDebugStart.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFuncDebugStart.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNCDEBUGSTART_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNCDEBUGSTART_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolFuncDebugStart : public PDBSymbol {
+class LLVM_ABI PDBSymbolFuncDebugStart : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::FuncDebugStart)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolLabel.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolLabel.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLLABEL_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLLABEL_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolLabel : public PDBSymbol {
+class LLVM_ABI PDBSymbolLabel : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Label)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolLabel.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolLabel.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLLABEL_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLLABEL_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolPublicSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolPublicSymbol.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLPUBLICSYMBOL_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLPUBLICSYMBOL_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolPublicSymbol : public PDBSymbol {
+class LLVM_ABI PDBSymbolPublicSymbol : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::PublicSymbol)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolPublicSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolPublicSymbol.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLPUBLICSYMBOL_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLPUBLICSYMBOL_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolThunk.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolThunk.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTHUNK_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTHUNK_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolThunk : public PDBSymbol {
+class LLVM_ABI PDBSymbolThunk : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Thunk)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolThunk.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolThunk.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTHUNK_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTHUNK_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeArray.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeArray.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEARRAY_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEARRAY_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeArray : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeArray : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::ArrayType)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeArray.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeArray.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEARRAY_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEARRAY_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeBaseClass.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeBaseClass.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEBASECLASS_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEBASECLASS_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -20,7 +21,7 @@ namespace pdb {
 
 class PDBSymDumper;
 
-class PDBSymbolTypeBaseClass : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeBaseClass : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::BaseClass)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeBaseClass.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeBaseClass.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEBASECLASS_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEBASECLASS_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeBuiltin.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeBuiltin.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEBUILTIN_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEBUILTIN_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeBuiltin.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeBuiltin.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEBUILTIN_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEBUILTIN_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeBuiltin : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeBuiltin : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::BuiltinType)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeEnum.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeEnum.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEENUM_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEENUM_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeEnum.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeEnum.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEENUM_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEENUM_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -21,7 +22,7 @@ namespace pdb {
 class PDBSymDumper;
 class PDBSymbolTypeBuiltin;
 
-class PDBSymbolTypeEnum : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeEnum : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Enum)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFunctionArg.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFunctionArg.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEFUNCTIONARG_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEFUNCTIONARG_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeFunctionArg : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeFunctionArg : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::FunctionArg)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFunctionArg.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFunctionArg.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEFUNCTIONARG_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEFUNCTIONARG_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFunctionSig.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFunctionSig.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEFUNCTIONSIG_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEFUNCTIONSIG_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -17,7 +18,7 @@ namespace llvm {
 class raw_ostream;
 namespace pdb {
 
-class PDBSymbolTypeFunctionSig : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeFunctionSig : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::FunctionSig)
 public:
   std::unique_ptr<IPDBEnumSymbols> getArguments() const;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFunctionSig.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFunctionSig.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEFUNCTIONSIG_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEFUNCTIONSIG_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypePointer.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypePointer.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEPOINTER_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEPOINTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypePointer.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypePointer.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEPOINTER_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEPOINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypePointer : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypePointer : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::PointerType)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeTypedef.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeTypedef.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPETYPEDEF_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPETYPEDEF_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeTypedef : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeTypedef : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Typedef)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeTypedef.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeTypedef.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPETYPEDEF_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPETYPEDEF_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEUDT_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEUDT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
+#include "llvm/Support/Compiler.h"
 
 #include "PDBSymbol.h"
 #include "PDBTypes.h"

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEUDT_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEUDT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
 
 #include "PDBSymbol.h"
@@ -20,7 +21,7 @@ namespace pdb {
 
 class PDBSymDumper;
 
-class PDBSymbolTypeUDT : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeUDT : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::UDT)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeVTable.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeVTable.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEVTABLE_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEVTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeVTable : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeVTable : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::VTable)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeVTable.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeVTable.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEVTABLE_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEVTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeVTableShape.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeVTableShape.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEVTABLESHAPE_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEVTABLESHAPE_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeVTableShape : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeVTableShape : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::VTableShape)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeVTableShape.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeVTableShape.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEVTABLESHAPE_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLTYPEVTABLESHAPE_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolUnknown.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolUnknown.h
@@ -9,13 +9,14 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLUNKNOWN_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLUNKNOWN_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 
 namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolUnknown : public PDBSymbol {
+class LLVM_ABI PDBSymbolUnknown : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CUSTOM_TYPE(S->getSymTag() == PDB_SymType::None ||
                                  S->getSymTag() >= PDB_SymType::Max)
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolUnknown.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolUnknown.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLUNKNOWN_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLUNKNOWN_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolUsingNamespace.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolUsingNamespace.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLUSINGNAMESPACE_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLUSINGNAMESPACE_H
 
-#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolUsingNamespace.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolUsingNamespace.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_PDBSYMBOLUSINGNAMESPACE_H
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLUSINGNAMESPACE_H
 
+#include "llvm/Support/Compiler.h"
 #include "PDBSymbol.h"
 #include "PDBTypes.h"
 
@@ -16,7 +17,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolUsingNamespace : public PDBSymbol {
+class LLVM_ABI PDBSymbolUsingNamespace : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::UsingNamespace)
 
 public:

--- a/llvm/include/llvm/DebugInfo/PDB/UDTLayout.h
+++ b/llvm/include/llvm/DebugInfo/PDB/UDTLayout.h
@@ -15,8 +15,10 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/PDB/PDBSymbol.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolData.h"
+#include "llvm/DebugInfo/PDB/PDBSymbolFunc.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeBaseClass.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeBuiltin.h"
+#include "llvm/DebugInfo/PDB/PDBSymbolTypeFunctionSig.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeVTable.h"
 #include <cstdint>
@@ -115,6 +117,10 @@ public:
                 const std::string &Name, uint32_t OffsetInParent, uint32_t Size,
                 bool IsElided);
 
+  // Explicitly non-copyable.
+  UDTLayoutBase(UDTLayoutBase const&) = delete;
+  UDTLayoutBase& operator=(UDTLayoutBase const&) = delete;
+
   uint32_t tailPadding() const override;
   ArrayRef<LayoutItemBase *> layout_items() const { return LayoutItems; }
   ArrayRef<BaseClassLayout *> bases() const { return AllBases; }
@@ -163,8 +169,6 @@ class LLVM_ABI ClassLayout : public UDTLayoutBase {
 public:
   explicit ClassLayout(const PDBSymbolTypeUDT &UDT);
   explicit ClassLayout(std::unique_ptr<PDBSymbolTypeUDT> UDT);
-
-  ClassLayout(ClassLayout &&Other) = default;
 
   const PDBSymbolTypeUDT &getClass() const { return UDT; }
   uint32_t immediatePadding() const override;

--- a/llvm/include/llvm/DebugInfo/PDB/UDTLayout.h
+++ b/llvm/include/llvm/DebugInfo/PDB/UDTLayout.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_PDB_UDTLAYOUT_H
 #define LLVM_DEBUGINFO_PDB_UDTLAYOUT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -30,7 +31,7 @@ class BaseClassLayout;
 class ClassLayout;
 class UDTLayoutBase;
 
-class LayoutItemBase {
+class LLVM_ABI LayoutItemBase {
 public:
   LayoutItemBase(const UDTLayoutBase *Parent, const PDBSymbol *Symbol,
                  const std::string &Name, uint32_t OffsetInParent,
@@ -70,7 +71,7 @@ protected:
 
 class VBPtrLayoutItem : public LayoutItemBase {
 public:
-  VBPtrLayoutItem(const UDTLayoutBase &Parent,
+  LLVM_ABI VBPtrLayoutItem(const UDTLayoutBase &Parent,
                   std::unique_ptr<PDBSymbolTypeBuiltin> Sym, uint32_t Offset,
                   uint32_t Size);
 
@@ -82,12 +83,12 @@ private:
 
 class DataMemberLayoutItem : public LayoutItemBase {
 public:
-  DataMemberLayoutItem(const UDTLayoutBase &Parent,
+  LLVM_ABI DataMemberLayoutItem(const UDTLayoutBase &Parent,
                        std::unique_ptr<PDBSymbolData> DataMember);
 
-  const PDBSymbolData &getDataMember();
-  bool hasUDTLayout() const;
-  const ClassLayout &getUDTLayout() const;
+  LLVM_ABI const PDBSymbolData &getDataMember();
+  LLVM_ABI bool hasUDTLayout() const;
+  LLVM_ABI const ClassLayout &getUDTLayout() const;
 
 private:
   std::unique_ptr<PDBSymbolData> DataMember;
@@ -96,7 +97,7 @@ private:
 
 class VTableLayoutItem : public LayoutItemBase {
 public:
-  VTableLayoutItem(const UDTLayoutBase &Parent,
+  LLVM_ABI VTableLayoutItem(const UDTLayoutBase &Parent,
                    std::unique_ptr<PDBSymbolTypeVTable> VTable);
 
   uint32_t getElementSize() const { return ElementSize; }
@@ -106,7 +107,7 @@ private:
   std::unique_ptr<PDBSymbolTypeVTable> VTable;
 };
 
-class UDTLayoutBase : public LayoutItemBase {
+class LLVM_ABI UDTLayoutBase : public LayoutItemBase {
   template <typename T> using UniquePtrVector = std::vector<std::unique_ptr<T>>;
 
 public:
@@ -146,7 +147,7 @@ protected:
 
 class BaseClassLayout : public UDTLayoutBase {
 public:
-  BaseClassLayout(const UDTLayoutBase &Parent, uint32_t OffsetInParent,
+  LLVM_ABI BaseClassLayout(const UDTLayoutBase &Parent, uint32_t OffsetInParent,
                   bool Elide, std::unique_ptr<PDBSymbolTypeBaseClass> Base);
 
   const PDBSymbolTypeBaseClass &getBase() const { return *Base; }
@@ -158,7 +159,7 @@ private:
   bool IsVirtualBase;
 };
 
-class ClassLayout : public UDTLayoutBase {
+class LLVM_ABI ClassLayout : public UDTLayoutBase {
 public:
   explicit ClassLayout(const PDBSymbolTypeUDT &UDT);
   explicit ClassLayout(std::unique_ptr<PDBSymbolTypeUDT> UDT);

--- a/llvm/include/llvm/DebugInfo/PDB/UDTLayout.h
+++ b/llvm/include/llvm/DebugInfo/PDB/UDTLayout.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_DEBUGINFO_PDB_UDTLAYOUT_H
 #define LLVM_DEBUGINFO_PDB_UDTLAYOUT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -21,6 +20,7 @@
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeFunctionSig.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeVTable.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -74,8 +74,8 @@ protected:
 class VBPtrLayoutItem : public LayoutItemBase {
 public:
   LLVM_ABI VBPtrLayoutItem(const UDTLayoutBase &Parent,
-                  std::unique_ptr<PDBSymbolTypeBuiltin> Sym, uint32_t Offset,
-                  uint32_t Size);
+                           std::unique_ptr<PDBSymbolTypeBuiltin> Sym,
+                           uint32_t Offset, uint32_t Size);
 
   bool isVBPtr() const override { return true; }
 
@@ -86,7 +86,7 @@ private:
 class DataMemberLayoutItem : public LayoutItemBase {
 public:
   LLVM_ABI DataMemberLayoutItem(const UDTLayoutBase &Parent,
-                       std::unique_ptr<PDBSymbolData> DataMember);
+                                std::unique_ptr<PDBSymbolData> DataMember);
 
   LLVM_ABI const PDBSymbolData &getDataMember();
   LLVM_ABI bool hasUDTLayout() const;
@@ -100,7 +100,7 @@ private:
 class VTableLayoutItem : public LayoutItemBase {
 public:
   LLVM_ABI VTableLayoutItem(const UDTLayoutBase &Parent,
-                   std::unique_ptr<PDBSymbolTypeVTable> VTable);
+                            std::unique_ptr<PDBSymbolTypeVTable> VTable);
 
   uint32_t getElementSize() const { return ElementSize; }
 
@@ -118,8 +118,8 @@ public:
                 bool IsElided);
 
   // Explicitly non-copyable.
-  UDTLayoutBase(UDTLayoutBase const&) = delete;
-  UDTLayoutBase& operator=(UDTLayoutBase const&) = delete;
+  UDTLayoutBase(UDTLayoutBase const &) = delete;
+  UDTLayoutBase &operator=(UDTLayoutBase const &) = delete;
 
   uint32_t tailPadding() const override;
   ArrayRef<LayoutItemBase *> layout_items() const { return LayoutItems; }
@@ -154,7 +154,8 @@ protected:
 class BaseClassLayout : public UDTLayoutBase {
 public:
   LLVM_ABI BaseClassLayout(const UDTLayoutBase &Parent, uint32_t OffsetInParent,
-                  bool Elide, std::unique_ptr<PDBSymbolTypeBaseClass> Base);
+                           bool Elide,
+                           std::unique_ptr<PDBSymbolTypeBaseClass> Base);
 
   const PDBSymbolTypeBaseClass &getBase() const { return *Base; }
   bool isVirtualBase() const { return IsVirtualBase; }

--- a/llvm/include/llvm/DebugInfo/Symbolize/DIPrinter.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/DIPrinter.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_SYMBOLIZE_DIPRINTER_H
 #define LLVM_DEBUGINFO_SYMBOLIZE_DIPRINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/JSON.h"
 #include <memory>
@@ -67,7 +68,7 @@ struct PrinterConfig {
 
 using ErrorHandler = std::function<void(const ErrorInfoBase &, StringRef)>;
 
-class PlainPrinterBase : public DIPrinter {
+class LLVM_ABI PlainPrinterBase : public DIPrinter {
 protected:
   raw_ostream &OS;
   ErrorHandler ErrHandler;
@@ -104,7 +105,7 @@ public:
   void listEnd() override {}
 };
 
-class LLVMPrinter : public PlainPrinterBase {
+class LLVM_ABI LLVMPrinter : public PlainPrinterBase {
 private:
   void printSimpleLocation(StringRef Filename, const DILineInfo &Info) override;
   void printStartAddress(const DILineInfo &Info) override;
@@ -115,7 +116,7 @@ public:
       : PlainPrinterBase(OS, EH, Config) {}
 };
 
-class GNUPrinter : public PlainPrinterBase {
+class LLVM_ABI GNUPrinter : public PlainPrinterBase {
 private:
   void printSimpleLocation(StringRef Filename, const DILineInfo &Info) override;
 
@@ -125,7 +126,7 @@ public:
 
 };
 
-class JSONPrinter : public DIPrinter {
+class LLVM_ABI JSONPrinter : public DIPrinter {
 private:
   raw_ostream &OS;
   PrinterConfig Config;

--- a/llvm/include/llvm/DebugInfo/Symbolize/DIPrinter.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/DIPrinter.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_DEBUGINFO_SYMBOLIZE_DIPRINTER_H
 #define LLVM_DEBUGINFO_SYMBOLIZE_DIPRINTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/JSON.h"
 #include <memory>
 #include <vector>
@@ -123,7 +123,6 @@ private:
 public:
   GNUPrinter(raw_ostream &OS, ErrorHandler EH, PrinterConfig &Config)
       : PlainPrinterBase(OS, EH, Config) {}
-
 };
 
 class LLVM_ABI JSONPrinter : public DIPrinter {

--- a/llvm/include/llvm/DebugInfo/Symbolize/Markup.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Markup.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_DEBUGINFO_SYMBOLIZE_MARKUP_H
 #define LLVM_DEBUGINFO_SYMBOLIZE_MARKUP_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -50,7 +51,7 @@ struct MarkupNode {
 /// Parses a log containing symbolizer markup into a sequence of nodes.
 class MarkupParser {
 public:
-  MarkupParser(StringSet<> MultilineTags = {});
+  LLVM_ABI MarkupParser(StringSet<> MultilineTags = {});
 
   /// Parses an individual \p Line of input.
   ///
@@ -64,14 +65,14 @@ public:
   /// either the end or something that cannot be part of an element is
   /// encountered. This may only occur after multiple calls to parseLine(),
   /// corresponding to the lines of the multi-line element.
-  void parseLine(StringRef Line);
+  LLVM_ABI void parseLine(StringRef Line);
 
   /// Inform the parser of that the input stream has ended.
   ///
   /// This allows the parser to finish any deferred processing (e.g., an
   /// in-progress multi-line element) and may cause nextNode() to return
   /// additional nodes.
-  void flush();
+  LLVM_ABI void flush();
 
   /// Returns the next node in the input sequence.
   ///
@@ -79,7 +80,7 @@ public:
   /// previous call.
   ///
   /// \returns the next markup node or std::nullopt if none remain.
-  std::optional<MarkupNode> nextNode();
+  LLVM_ABI std::optional<MarkupNode> nextNode();
 
   bool isSGR(const MarkupNode &Node) const {
     return SGRSyntax.match(Node.Text);

--- a/llvm/include/llvm/DebugInfo/Symbolize/Markup.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Markup.h
@@ -16,10 +16,10 @@
 #ifndef LLVM_DEBUGINFO_SYMBOLIZE_MARKUP_H
 #define LLVM_DEBUGINFO_SYMBOLIZE_MARKUP_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Regex.h"
 
 namespace llvm {

--- a/llvm/include/llvm/DebugInfo/Symbolize/MarkupFilter.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/MarkupFilter.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_DEBUGINFO_SYMBOLIZE_MARKUPFILTER_H
 #define LLVM_DEBUGINFO_SYMBOLIZE_MARKUPFILTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/Symbolize/Markup.h"
 #include "llvm/Object/BuildID.h"
@@ -31,7 +32,7 @@ class LLVMSymbolizer;
 /// text.
 class MarkupFilter {
 public:
-  MarkupFilter(raw_ostream &OS, LLVMSymbolizer &Symbolizer,
+  LLVM_ABI MarkupFilter(raw_ostream &OS, LLVMSymbolizer &Symbolizer,
                std::optional<bool> ColorsEnabled = std::nullopt);
 
   /// Filters a line containing symbolizer markup and writes the human-readable
@@ -39,10 +40,10 @@ public:
   ///
   /// Invalid or unimplemented markup elements are removed. Some output may be
   /// deferred until future filter() or finish() call.
-  void filter(std::string &&InputLine);
+  LLVM_ABI void filter(std::string &&InputLine);
 
   /// Records that the input stream has ended and writes any deferred output.
-  void finish();
+  LLVM_ABI void finish();
 
 private:
   struct Module {
@@ -58,8 +59,8 @@ private:
     std::string Mode; // Lowercase
     uint64_t ModuleRelativeAddr;
 
-    bool contains(uint64_t Addr) const;
-    uint64_t getModuleRelativeAddr(uint64_t Addr) const;
+    LLVM_ABI bool contains(uint64_t Addr) const;
+    LLVM_ABI uint64_t getModuleRelativeAddr(uint64_t Addr) const;
   };
 
   // An informational module line currently being constructed. As many mmap

--- a/llvm/include/llvm/DebugInfo/Symbolize/MarkupFilter.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/MarkupFilter.h
@@ -15,10 +15,10 @@
 #ifndef LLVM_DEBUGINFO_SYMBOLIZE_MARKUPFILTER_H
 #define LLVM_DEBUGINFO_SYMBOLIZE_MARKUPFILTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/Symbolize/Markup.h"
 #include "llvm/Object/BuildID.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 #include <map>
@@ -33,7 +33,7 @@ class LLVMSymbolizer;
 class MarkupFilter {
 public:
   LLVM_ABI MarkupFilter(raw_ostream &OS, LLVMSymbolizer &Symbolizer,
-               std::optional<bool> ColorsEnabled = std::nullopt);
+                        std::optional<bool> ColorsEnabled = std::nullopt);
 
   /// Filters a line containing symbolizer markup and writes the human-readable
   /// results to the output stream.

--- a/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_DEBUGINFO_SYMBOLIZE_SYMBOLIZE_H
 #define LLVM_DEBUGINFO_SYMBOLIZE_SYMBOLIZE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/ilist_node.h"
 #include "llvm/ADT/simple_ilist.h"
@@ -71,57 +72,57 @@ public:
             : static_cast<size_t>(4ULL * 1024 * 1024 * 1024) /* 4 GiB */;
   };
 
-  LLVMSymbolizer();
-  LLVMSymbolizer(const Options &Opts);
+  LLVM_ABI LLVMSymbolizer();
+  LLVM_ABI LLVMSymbolizer(const Options &Opts);
 
-  ~LLVMSymbolizer();
+  LLVM_ABI ~LLVMSymbolizer();
 
   // Overloads accepting ObjectFile does not support COFF currently
-  Expected<DILineInfo> symbolizeCode(const ObjectFile &Obj,
+  LLVM_ABI Expected<DILineInfo> symbolizeCode(const ObjectFile &Obj,
                                      object::SectionedAddress ModuleOffset);
-  Expected<DILineInfo> symbolizeCode(StringRef ModuleName,
+  LLVM_ABI Expected<DILineInfo> symbolizeCode(StringRef ModuleName,
                                      object::SectionedAddress ModuleOffset);
-  Expected<DILineInfo> symbolizeCode(ArrayRef<uint8_t> BuildID,
+  LLVM_ABI Expected<DILineInfo> symbolizeCode(ArrayRef<uint8_t> BuildID,
                                      object::SectionedAddress ModuleOffset);
-  Expected<DIInliningInfo>
+  LLVM_ABI Expected<DIInliningInfo>
   symbolizeInlinedCode(const ObjectFile &Obj,
                        object::SectionedAddress ModuleOffset);
-  Expected<DIInliningInfo>
+  LLVM_ABI Expected<DIInliningInfo>
   symbolizeInlinedCode(StringRef ModuleName,
                        object::SectionedAddress ModuleOffset);
-  Expected<DIInliningInfo>
+  LLVM_ABI Expected<DIInliningInfo>
   symbolizeInlinedCode(ArrayRef<uint8_t> BuildID,
                        object::SectionedAddress ModuleOffset);
 
-  Expected<DIGlobal> symbolizeData(const ObjectFile &Obj,
+  LLVM_ABI Expected<DIGlobal> symbolizeData(const ObjectFile &Obj,
                                    object::SectionedAddress ModuleOffset);
-  Expected<DIGlobal> symbolizeData(StringRef ModuleName,
+  LLVM_ABI Expected<DIGlobal> symbolizeData(StringRef ModuleName,
                                    object::SectionedAddress ModuleOffset);
-  Expected<DIGlobal> symbolizeData(ArrayRef<uint8_t> BuildID,
+  LLVM_ABI Expected<DIGlobal> symbolizeData(ArrayRef<uint8_t> BuildID,
                                    object::SectionedAddress ModuleOffset);
-  Expected<std::vector<DILocal>>
+  LLVM_ABI Expected<std::vector<DILocal>>
   symbolizeFrame(const ObjectFile &Obj, object::SectionedAddress ModuleOffset);
-  Expected<std::vector<DILocal>>
+  LLVM_ABI Expected<std::vector<DILocal>>
   symbolizeFrame(StringRef ModuleName, object::SectionedAddress ModuleOffset);
-  Expected<std::vector<DILocal>>
+  LLVM_ABI Expected<std::vector<DILocal>>
   symbolizeFrame(ArrayRef<uint8_t> BuildID,
                  object::SectionedAddress ModuleOffset);
 
-  Expected<std::vector<DILineInfo>>
+  LLVM_ABI Expected<std::vector<DILineInfo>>
   findSymbol(const ObjectFile &Obj, StringRef Symbol, uint64_t Offset);
-  Expected<std::vector<DILineInfo>>
+  LLVM_ABI Expected<std::vector<DILineInfo>>
   findSymbol(StringRef ModuleName, StringRef Symbol, uint64_t Offset);
-  Expected<std::vector<DILineInfo>>
+  LLVM_ABI Expected<std::vector<DILineInfo>>
   findSymbol(ArrayRef<uint8_t> BuildID, StringRef Symbol, uint64_t Offset);
 
-  void flush();
+  LLVM_ABI void flush();
 
   // Evict entries from the binary cache until it is under the maximum size
   // given in the options. Calling this invalidates references in the DI...
   // objects returned by the methods above.
-  void pruneCache();
+  LLVM_ABI void pruneCache();
 
-  static std::string
+  LLVM_ABI static std::string
   DemangleName(StringRef Name, const SymbolizableModule *DbiModuleDescriptor);
 
   void setBuildIDFetcher(std::unique_ptr<BuildIDFetcher> Fetcher) {
@@ -132,7 +133,7 @@ public:
   /// Only one attempt is made to load a module, and errors during loading are
   /// only reported once. Subsequent calls to get module info for a module that
   /// failed to load will return nullptr.
-  Expected<SymbolizableModule *> getOrCreateModuleInfo(StringRef ModuleName);
+  LLVM_ABI Expected<SymbolizableModule *> getOrCreateModuleInfo(StringRef ModuleName);
 
 private:
   // Bundles together object file with code/data and object file with
@@ -240,7 +241,7 @@ public:
 
   // Add an action to be performed when the binary is evicted, before all
   // previously registered evictors.
-  void pushEvictor(std::function<void()> Evictor);
+  LLVM_ABI void pushEvictor(std::function<void()> Evictor);
 
   // Run all registered evictors in the reverse of the order in which they were
   // added.

--- a/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
@@ -13,13 +13,13 @@
 #ifndef LLVM_DEBUGINFO_SYMBOLIZE_SYMBOLIZE_H
 #define LLVM_DEBUGINFO_SYMBOLIZE_SYMBOLIZE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/ilist_node.h"
 #include "llvm/ADT/simple_ilist.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/BuildID.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <algorithm>
 #include <cstdint>
@@ -78,12 +78,13 @@ public:
   LLVM_ABI ~LLVMSymbolizer();
 
   // Overloads accepting ObjectFile does not support COFF currently
-  LLVM_ABI Expected<DILineInfo> symbolizeCode(const ObjectFile &Obj,
-                                     object::SectionedAddress ModuleOffset);
-  LLVM_ABI Expected<DILineInfo> symbolizeCode(StringRef ModuleName,
-                                     object::SectionedAddress ModuleOffset);
-  LLVM_ABI Expected<DILineInfo> symbolizeCode(ArrayRef<uint8_t> BuildID,
-                                     object::SectionedAddress ModuleOffset);
+  LLVM_ABI Expected<DILineInfo>
+  symbolizeCode(const ObjectFile &Obj, object::SectionedAddress ModuleOffset);
+  LLVM_ABI Expected<DILineInfo>
+  symbolizeCode(StringRef ModuleName, object::SectionedAddress ModuleOffset);
+  LLVM_ABI Expected<DILineInfo>
+  symbolizeCode(ArrayRef<uint8_t> BuildID,
+                object::SectionedAddress ModuleOffset);
   LLVM_ABI Expected<DIInliningInfo>
   symbolizeInlinedCode(const ObjectFile &Obj,
                        object::SectionedAddress ModuleOffset);
@@ -94,12 +95,13 @@ public:
   symbolizeInlinedCode(ArrayRef<uint8_t> BuildID,
                        object::SectionedAddress ModuleOffset);
 
-  LLVM_ABI Expected<DIGlobal> symbolizeData(const ObjectFile &Obj,
-                                   object::SectionedAddress ModuleOffset);
-  LLVM_ABI Expected<DIGlobal> symbolizeData(StringRef ModuleName,
-                                   object::SectionedAddress ModuleOffset);
-  LLVM_ABI Expected<DIGlobal> symbolizeData(ArrayRef<uint8_t> BuildID,
-                                   object::SectionedAddress ModuleOffset);
+  LLVM_ABI Expected<DIGlobal>
+  symbolizeData(const ObjectFile &Obj, object::SectionedAddress ModuleOffset);
+  LLVM_ABI Expected<DIGlobal>
+  symbolizeData(StringRef ModuleName, object::SectionedAddress ModuleOffset);
+  LLVM_ABI Expected<DIGlobal>
+  symbolizeData(ArrayRef<uint8_t> BuildID,
+                object::SectionedAddress ModuleOffset);
   LLVM_ABI Expected<std::vector<DILocal>>
   symbolizeFrame(const ObjectFile &Obj, object::SectionedAddress ModuleOffset);
   LLVM_ABI Expected<std::vector<DILocal>>
@@ -133,7 +135,8 @@ public:
   /// Only one attempt is made to load a module, and errors during loading are
   /// only reported once. Subsequent calls to get module info for a module that
   /// failed to load will return nullptr.
-  LLVM_ABI Expected<SymbolizableModule *> getOrCreateModuleInfo(StringRef ModuleName);
+  LLVM_ABI Expected<SymbolizableModule *>
+  getOrCreateModuleInfo(StringRef ModuleName);
 
 private:
   // Bundles together object file with code/data and object file with

--- a/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp
+++ b/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp
@@ -244,8 +244,8 @@ std::vector<CVType> ContinuationRecordBuilder::end(TypeIndex Index) {
 // implement this in the cpp file.
 #define TYPE_RECORD(EnumName, EnumVal, Name)
 #define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
-#define MEMBER_RECORD(EnumName, EnumVal, Name)                                 \
-  template void llvm::codeview::ContinuationRecordBuilder::writeMemberType(    \
+#define MEMBER_RECORD(EnumName, EnumVal, Name)  \
+  template LLVM_ABI void llvm::codeview::ContinuationRecordBuilder::writeMemberType(  \
       Name##Record &Record);
 #define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
 #include "llvm/DebugInfo/CodeView/CodeViewTypes.def"

--- a/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp
+++ b/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp
@@ -244,8 +244,9 @@ std::vector<CVType> ContinuationRecordBuilder::end(TypeIndex Index) {
 // implement this in the cpp file.
 #define TYPE_RECORD(EnumName, EnumVal, Name)
 #define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
-#define MEMBER_RECORD(EnumName, EnumVal, Name)  \
-  template LLVM_ABI void llvm::codeview::ContinuationRecordBuilder::writeMemberType(  \
+#define MEMBER_RECORD(EnumName, EnumVal, Name)                                 \
+  template LLVM_ABI void                                                       \
+  llvm::codeview::ContinuationRecordBuilder::writeMemberType(                  \
       Name##Record &Record);
 #define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
 #include "llvm/DebugInfo/CodeView/CodeViewTypes.def"

--- a/llvm/lib/DebugInfo/CodeView/SimpleTypeSerializer.cpp
+++ b/llvm/lib/DebugInfo/CodeView/SimpleTypeSerializer.cpp
@@ -11,6 +11,7 @@
 #include "llvm/DebugInfo/CodeView/RecordSerialization.h"
 #include "llvm/DebugInfo/CodeView/TypeRecordMapping.h"
 #include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/Compiler.h"
 
 using namespace llvm;
 using namespace llvm::codeview;
@@ -59,9 +60,9 @@ ArrayRef<uint8_t> SimpleTypeSerializer::serialize(T &Record) {
 
 // Explicitly instantiate the member function for each known type so that we can
 // implement this in the cpp file.
-#define TYPE_RECORD(EnumName, EnumVal, Name)                                   \
-  template ArrayRef<uint8_t> llvm::codeview::SimpleTypeSerializer::serialize(  \
-      Name##Record &Record);
+#define TYPE_RECORD(EnumName, EnumVal, Name)  \
+  template LLVM_ABI ArrayRef<uint8_t>         \
+  llvm::codeview::SimpleTypeSerializer::serialize(Name##Record &Record);
 #define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
 #define MEMBER_RECORD(EnumName, EnumVal, Name)
 #define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)

--- a/llvm/lib/DebugInfo/CodeView/SimpleTypeSerializer.cpp
+++ b/llvm/lib/DebugInfo/CodeView/SimpleTypeSerializer.cpp
@@ -60,8 +60,8 @@ ArrayRef<uint8_t> SimpleTypeSerializer::serialize(T &Record) {
 
 // Explicitly instantiate the member function for each known type so that we can
 // implement this in the cpp file.
-#define TYPE_RECORD(EnumName, EnumVal, Name)  \
-  template LLVM_ABI ArrayRef<uint8_t>         \
+#define TYPE_RECORD(EnumName, EnumVal, Name)                                   \
+  template LLVM_ABI ArrayRef<uint8_t>                                          \
   llvm::codeview::SimpleTypeSerializer::serialize(Name##Record &Record);
 #define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
 #define MEMBER_RECORD(EnumName, EnumVal, Name)


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/DebugInfo` library. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS on Linux:
- Add `#include "llvm/Support/Compiler.h"` to files where it was not auto-added by IDS due to no pre-existing block of include statements.
- Explicitly make classes non-copyable where needed to due IDS adding LLVM_ABI at the class level
- Add `LLVM_ABI` and to exported APIs defined via X-macro

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang