### PR TITLE
[CIR][NFC] Fix an unused variable warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCXXExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXExpr.cpp
@@ -113,7 +113,7 @@ RValue CIRGenFunction::emitCXXMemberOrOperatorMemberCallExpr(
     thisPtr = emitLValue(base);
   }
 
-  if (const CXXConstructorDecl *ctor = dyn_cast<CXXConstructorDecl>(md)) {
+  if (isa<CXXConstructorDecl>(md)) {
     cgm.errorNYI(ce->getSourceRange(),
                  "emitCXXMemberOrOperatorMemberCallExpr: constructor call");
     return RValue::get(nullptr);
@@ -127,29 +127,29 @@ RValue CIRGenFunction::emitCXXMemberOrOperatorMemberCallExpr(
       cgm.errorNYI(ce->getSourceRange(),
                    "emitCXXMemberOrOperatorMemberCallExpr: trivial assignment");
       return RValue::get(nullptr);
-    } else {
-      assert(md->getParent()->mayInsertExtraPadding() &&
-             "unknown trivial member function");
     }
+
+    assert(md->getParent()->mayInsertExtraPadding() &&
+           "unknown trivial member function");
   }
 
   // Compute the function type we're calling
   const CXXMethodDecl *calleeDecl = md;
   const CIRGenFunctionInfo *fInfo = nullptr;
-  if (const auto *dtor = dyn_cast<CXXDestructorDecl>(calleeDecl)) {
+  if (isa<CXXDestructorDecl>(calleeDecl)) {
     cgm.errorNYI(ce->getSourceRange(),
                  "emitCXXMemberOrOperatorMemberCallExpr: destructor call");
     return RValue::get(nullptr);
-  } else {
-    fInfo = &cgm.getTypes().arrangeCXXMethodDeclaration(calleeDecl);
   }
+
+  fInfo = &cgm.getTypes().arrangeCXXMethodDeclaration(calleeDecl);
 
   mlir::Type ty = cgm.getTypes().getFunctionType(*fInfo);
 
   assert(!cir::MissingFeatures::sanitizers());
   assert(!cir::MissingFeatures::emitTypeCheck());
 
-  if (const auto *dtor = dyn_cast<CXXDestructorDecl>(calleeDecl)) {
+  if (isa<CXXDestructorDecl>(calleeDecl)) {
     cgm.errorNYI(ce->getSourceRange(),
                  "emitCXXMemberOrOperatorMemberCallExpr: destructor call");
     return RValue::get(nullptr);


### PR DESCRIPTION
This fixes a warning where a variable assigned in 'if' statement wasn't referenced again, and where else is used when 'if' has returns statement in the if-else statement