### PR TITLE
[llvm] prepare explicit template instantiations in llvm/DebugInfo for DLL export annotations

### DIFF
--- a/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
+#include "llvm/DebugInfo/CodeView/TypeRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeRecordMapping.h"
 #include "llvm/Support/BinaryByteStream.h"
 #include "llvm/Support/BinaryStreamWriter.h"
@@ -50,6 +51,19 @@ public:
 
   std::vector<CVType> end(TypeIndex Index);
 };
+
+#define TYPE_RECORD(EnumName, EnumVal, Name)
+#define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
+#define MEMBER_RECORD(EnumName, EnumVal, Name)                                 \
+  extern template void ContinuationRecordBuilder::writeMemberType(             \
+      Name##Record &Record);
+#define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
+#include "llvm/DebugInfo/CodeView/CodeViewTypes.def"
+#undef TYPE_RECORD
+#undef TYPE_RECORD_ALIAS
+#undef MEMBER_RECORD
+#undef MEMBER_RECORD_ALIAS
+
 } // namespace codeview
 } // namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
@@ -10,6 +10,7 @@
 #define LLVM_DEBUGINFO_CODEVIEW_SIMPLETYPESERIALIZER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/DebugInfo/CodeView/TypeRecord.h"
 #include <vector>
 
 namespace llvm {
@@ -31,6 +32,18 @@ public:
   // Don't allow serialization of field list records using this interface.
   ArrayRef<uint8_t> serialize(const FieldListRecord &Record) = delete;
 };
+
+#define TYPE_RECORD(EnumName, EnumVal, Name)                                   \
+  extern template ArrayRef<uint8_t> SimpleTypeSerializer::serialize(           \
+      Name##Record &Record);
+#define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
+#define MEMBER_RECORD(EnumName, EnumVal, Name)
+#define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
+#include "llvm/DebugInfo/CodeView/CodeViewTypes.def"
+#undef TYPE_RECORD
+#undef TYPE_RECORD_ALIAS
+#undef MEMBER_RECORD
+#undef MEMBER_RECORD_ALIAS
 
 } // end namespace codeview
 } // end namespace llvm


### PR DESCRIPTION
## Purpose

This patch prepares the llvm/DebugInfo library for public interface annotations in support of an LLVM Windows DLL (shared library) build, tracked in #109483. The purpose of this patch is to make the upcoming codemod of this library more straight-forward. It is not expected to impact any functionality.

## Overview
Adds declarations to the header files for two explicit specialized methods:
* `ContinuationRecordBuilder::writeMemberType`
* `SimpleTypeSerializer::serialize`

These specializations are already defined the corresponding implementation files:
* [`llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp`](https://github.com/llvm/llvm-project/blob/main/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp#L243-L251)
* [`llvm/lib/DebugInfo/CodeView/SimpleTypeSerializer.cpp`](https://github.com/llvm/llvm-project/blob/main/llvm/lib/DebugInfo/CodeView/SimpleTypeSerializer.cpp#L60-L68)

This patch will not impact functionality, it just ensures they're exposed as part of the public ABI so they can be annotated for export in a subsequent patch.

## Background

The LLVM Windows DLL effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307). 

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang