### PR TITLE
[lldb][lldb-dap][tests] Make sure evaluate test exists with no errors.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -116,7 +116,7 @@ class DAPTestCaseBase(TestBase):
                 # location.
                 description = body["description"]
                 for breakpoint_id in breakpoint_ids:
-                    match_desc = "breakpoint %s." % (breakpoint_id)
+                    match_desc = f"breakpoint {breakpoint_id}."
                     if match_desc in description:
                         return
         self.assertTrue(False, f"breakpoint not hit, stopped_events={stopped_events}")
@@ -311,6 +311,9 @@ class DAPTestCaseBase(TestBase):
     def continue_to_next_stop(self, timeout=DEFAULT_TIMEOUT):
         self.do_continue()
         return self.dap_server.wait_for_stopped(timeout)
+
+    def continue_to_breakpoint(self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT):
+        self.continue_to_breakpoints((breakpoint_id), timeout)
 
     def continue_to_breakpoints(self, breakpoint_ids, timeout=DEFAULT_TIMEOUT):
         self.do_continue()

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -5,10 +5,8 @@ Test lldb-dap completions request
 import re
 
 import lldbdap_testcase
-import dap_server
-from lldbsuite.test import lldbutil
-from lldbsuite.test.decorators import *
-from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.lldbtest import line_number
 
 
 class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
@@ -45,20 +43,34 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
             enableAutoVariableSummaries=enableAutoVariableSummaries,
         )
         source = "main.cpp"
-        self.set_source_breakpoints(
-            source,
-            [
-                line_number(source, "// breakpoint 1"),
-                line_number(source, "// breakpoint 2"),
-                line_number(source, "// breakpoint 3"),
-                line_number(source, "// breakpoint 4"),
-                line_number(source, "// breakpoint 5"),
-                line_number(source, "// breakpoint 6"),
-                line_number(source, "// breakpoint 7"),
-                line_number(source, "// breakpoint 8"),
-            ],
+        breakpoint_lines = [
+            line_number(source, "// breakpoint 1"),
+            line_number(source, "// breakpoint 2"),
+            line_number(source, "// breakpoint 3"),
+            line_number(source, "// breakpoint 4"),
+            line_number(source, "// breakpoint 5"),
+            line_number(source, "// breakpoint 6"),
+            line_number(source, "// breakpoint 7"),
+            line_number(source, "// breakpoint 8"),
+        ]
+        breakpoint_ids = self.set_source_breakpoints(source, breakpoint_lines)
+
+        self.assertEqual(
+            len(breakpoint_ids),
+            len(breakpoint_lines),
+            "Did not resolve all the breakpoints.",
         )
-        self.continue_to_next_stop()
+        (
+            breakpoint_1,
+            breakpoint_2,
+            breakpoint_3,
+            breakpoint_4,
+            breakpoint_5,
+            breakpoint_6,
+            breakpoint_7,
+            breakpoint_8,
+        ) = breakpoint_ids
+        self.continue_to_breakpoint(breakpoint_1)
 
         # Expressions at breakpoint 1, which is in main
         self.assertEvaluate("var1", "20")
@@ -124,7 +136,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
             self.assertEvaluateFailure("foo_var")
 
         # Expressions at breakpoint 2, which is an anonymous block
-        self.continue_to_next_stop()
+        self.continue_to_breakpoint(breakpoint_2)
         self.assertEvaluate("var1", "20")
         self.assertEvaluate("var2", "2")  # different variable with the same name
         self.assertEvaluate("static_int", "42")
@@ -162,7 +174,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
             self.assertEvaluateFailure("foo_var")
 
         # Expressions at breakpoint 3, which is inside a_function
-        self.continue_to_next_stop()
+        self.continue_to_breakpoint(breakpoint_3)
         self.assertEvaluate("list", "42")
         self.assertEvaluate("static_int", "42")
         self.assertEvaluate("non_static_int", "43")
@@ -188,27 +200,29 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
             self.assertEvaluateFailure("foo_var")
 
         # Now we check that values are updated after stepping
-        self.continue_to_next_stop()
+        self.continue_to_breakpoint(breakpoint_4)
         self.assertEvaluate("my_vec", "size=2")
-        self.continue_to_next_stop()
+        self.continue_to_breakpoint(breakpoint_5)
         self.assertEvaluate("my_vec", "size=3")
 
         self.assertEvaluate("my_map", "size=2")
-        self.continue_to_next_stop()
+        self.continue_to_breakpoint(breakpoint_6)
         self.assertEvaluate("my_map", "size=3")
 
         self.assertEvaluate("my_bool_vec", "size=1")
-        self.continue_to_next_stop()
+        self.continue_to_breakpoint(breakpoint_7)
         self.assertEvaluate("my_bool_vec", "size=2")
 
+        self.continue_to_breakpoint(breakpoint_8)
         # Test memory read, especially with 'empty' repeat commands.
         if context == "repl":
-            self.continue_to_next_stop()
             self.assertEvaluate("memory read -c 1 &my_ints", ".* 05 .*\n")
             self.assertEvaluate("", ".* 0a .*\n")
             self.assertEvaluate("", ".* 0f .*\n")
             self.assertEvaluate("", ".* 14 .*\n")
             self.assertEvaluate("", ".* 19 .*\n")
+
+        self.continue_to_exit()
 
     @skipIfWindows
     def test_generic_evaluate_expressions(self):

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -60,16 +60,14 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
             len(breakpoint_lines),
             "Did not resolve all the breakpoints.",
         )
-        (
-            breakpoint_1,
-            breakpoint_2,
-            breakpoint_3,
-            breakpoint_4,
-            breakpoint_5,
-            breakpoint_6,
-            breakpoint_7,
-            breakpoint_8,
-        ) = breakpoint_ids
+        breakpoint_1 = breakpoint_ids[0]
+        breakpoint_2 = breakpoint_ids[1]
+        breakpoint_3 = breakpoint_ids[2]
+        breakpoint_4 = breakpoint_ids[3]
+        breakpoint_5 = breakpoint_ids[4]
+        breakpoint_6 = breakpoint_ids[5]
+        breakpoint_7 = breakpoint_ids[6]
+        breakpoint_8 = breakpoint_ids[7]
         self.continue_to_breakpoint(breakpoint_1)
 
         # Expressions at breakpoint 1, which is in main


### PR DESCRIPTION
I was running the tests and encounted this 

```sh
TIMEOUT: lldb-api :: tools/lldb-dap/gotoTargets/TestDAP_gotoTargets.py (55 of 55)
******************** TEST 'lldb-api :: tools/lldb-dap/gotoTargets/TestDAP_gotoTargets.py' FAILED ********************
Script:
--
/usr/bin/python3.13 /path/to/llvm-project/lldb/test/API/dotest.py  ...
Exit Code: -9
Timeout: Reached timeout of 600 seconds

Command Output (stdout):
```
We are not checking if it exits correctly after the evaluate test. Not 100% sure but it may have caused the test failure on windows. 

I may be the case for other tests. 