### PR TITLE
SparseAnalysis: support ReturnLike terminators

### DIFF
--- a/mlir/test/Analysis/DataFlow/test-return-like.mlir
+++ b/mlir/test/Analysis/DataFlow/test-return-like.mlir
@@ -1,0 +1,19 @@
+// RUN: mlir-opt --test-integer-lattice %s | FileCheck %s
+
+// CHECK-LABEL: @test_returnlike
+// CHECK: analysis_return_like_region_op
+// CHECK-NEXT: arith.constant {test.operand_lattices = [], test.result_lattices = [0 : index]} 1 : i32
+// CHECK-NEXT: region_yield
+// CHECK-SAME: {test.operand_lattices = [0 : index], test.result_lattices = []}
+
+// The core of the return-like test: the operand lattices of the yield forward
+// to the result lattices of the enclosing region-holding op
+
+// CHECK-NEXT: }) {test.operand_lattices = [], test.result_lattices = [0 : index]} : () -> i32
+func.func @test_returnlike() {
+  %0 = "test.analysis_return_like_region_op"() ({
+    %0 = arith.constant 1 : i32
+    "test.region_yield" (%0) : (i32) -> ()
+  }) : () -> i32
+  return
+}

--- a/mlir/test/lib/Analysis/CMakeLists.txt
+++ b/mlir/test/lib/Analysis/CMakeLists.txt
@@ -17,6 +17,7 @@ add_mlir_library(MLIRTestAnalysis
   DataFlow/TestDenseForwardDataFlowAnalysis.cpp
   DataFlow/TestLivenessAnalysis.cpp
   DataFlow/TestSparseBackwardDataFlowAnalysis.cpp
+  DataFlow/TestSparseForwardDataFlowAnalysis.cpp
 
   EXCLUDE_FROM_LIBMLIR
 

--- a/mlir/test/lib/Analysis/DataFlow/TestSparseForwardDataFlowAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestSparseForwardDataFlowAnalysis.cpp
@@ -1,0 +1,141 @@
+//===- TestForwardDataFlowAnalysis.cpp - Test dead code analysis ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+using namespace mlir::dataflow;
+
+namespace {
+
+class IntegerState {
+public:
+  IntegerState() : value(0) {}
+  explicit IntegerState(int value) : value(value) {}
+  ~IntegerState() = default;
+
+  int get() const { return value; }
+
+  bool operator==(const IntegerState &rhs) const { return value == rhs.value; }
+
+  static IntegerState join(const IntegerState &lhs, const IntegerState &rhs) {
+    return IntegerState{std::max(lhs.get(), rhs.get())};
+  }
+
+  void print(llvm::raw_ostream &os) const {
+    os << "IntegerState(" << value << ")";
+  }
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       const IntegerState &state) {
+    state.print(os);
+    return os;
+  }
+
+private:
+  int value;
+};
+
+/// This lattice represents, for a given value, the set of memory resources that
+/// this value, or anything derived from this value, is potentially written to.
+struct IntegerLattice : public Lattice<IntegerState> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(IntegerLattice)
+  using Lattice::Lattice;
+};
+
+/// An analysis that, by going backwards along the dataflow graph, annotates
+/// each value with all the memory resources it (or anything derived from it)
+/// is eventually written to.
+class IntegerLatticeAnalysis
+    : public SparseForwardDataFlowAnalysis<IntegerLattice> {
+public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+
+  LogicalResult visitOperation(Operation *op,
+                               ArrayRef<const IntegerLattice *> operands,
+                               ArrayRef<IntegerLattice *> results) override;
+
+  void setToEntryState(IntegerLattice *lattice) override {
+    propagateIfChanged(lattice, lattice->join(IntegerState()));
+  }
+};
+
+LogicalResult IntegerLatticeAnalysis::visitOperation(
+    Operation *op, ArrayRef<const IntegerLattice *> operands,
+    ArrayRef<IntegerLattice *> results) {
+  for (auto *operand : operands) {
+    for (auto *result : results) {
+      propagateIfChanged(result, result->join(*operand));
+    }
+  }
+  return success();
+}
+
+} // end anonymous namespace
+
+namespace {
+struct TestIntegerLatticePass
+    : public PassWrapper<TestIntegerLatticePass, OperationPass<>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestIntegerLatticePass)
+
+  TestIntegerLatticePass() = default;
+  TestIntegerLatticePass(const TestIntegerLatticePass &other)
+      : PassWrapper(other) {}
+
+  StringRef getArgument() const override { return "test-integer-lattice"; }
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *ctx = &getContext();
+
+    DataFlowSolver solver;
+    solver.load<DeadCodeAnalysis>();
+    solver.load<SparseConstantPropagation>();
+    solver.load<IntegerLatticeAnalysis>();
+    if (failed(solver.initializeAndRun(op)))
+      return signalPassFailure();
+
+    // Walk the IR and attach operand and result lattices as attributes to each
+    // operation.
+    op->walk([&](Operation *op) {
+      SmallVector<Attribute> operandAttrs;
+      SmallVector<Attribute> resultAttrs;
+      for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
+        const IntegerLattice *lattice =
+            solver.lookupState<IntegerLattice>(operand);
+        assert(lattice && "expected a sparse lattice");
+        operandAttrs.push_back(
+            IntegerAttr::get(IndexType::get(ctx), lattice->getValue().get()));
+      }
+      for (auto [index, result] : llvm::enumerate(op->getResults())) {
+        const IntegerLattice *lattice =
+            solver.lookupState<IntegerLattice>(result);
+        assert(lattice && "expected a sparse lattice");
+        resultAttrs.push_back(
+            IntegerAttr::get(IndexType::get(ctx), lattice->getValue().get()));
+      }
+
+      op->setAttr("test.operand_lattices", ArrayAttr::get(ctx, operandAttrs));
+      op->setAttr("test.result_lattices", ArrayAttr::get(ctx, resultAttrs));
+    });
+  }
+};
+} // end anonymous namespace
+
+namespace mlir {
+namespace test {
+void registerTestIntegerLatticePass() {
+  PassRegistration<TestIntegerLatticePass>();
+}
+} // end namespace test
+} // end namespace mlir

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3507,4 +3507,14 @@ def TestAllocWithMultipleResults : TEST_Op<"alloc_with_multiple_results"> {
   }];
 }
 
+// ==------------------------------------------------------------------------===//
+// Test Analysis ReturnLike
+//===----------------------------------------------------------------------===//
+def AnalysisReturnLikeRegionOp : TEST_Op<"analysis_return_like_region_op",
+      [SingleBlockImplicitTerminator<"RegionYieldOp">]> {
+  let regions = (region AnyRegion:$region);
+  let results = (outs AnyType:$result);
+}
+
+
 #endif // TEST_OPS

--- a/mlir/tools/mlir-opt/mlir-opt.cpp
+++ b/mlir/tools/mlir-opt/mlir-opt.cpp
@@ -105,6 +105,7 @@ void registerTestComposeSubView();
 void registerTestMultiBuffering();
 void registerTestIRVisitorsPass();
 void registerTestGenericIRVisitorsPass();
+void registerTestIntegerLatticePass();
 void registerTestInterfaces();
 void registerTestIRVisitorsPass();
 void registerTestLastModifiedPass();
@@ -249,6 +250,7 @@ void registerTestPasses() {
   mlir::test::registerTestMultiBuffering();
   mlir::test::registerTestIRVisitorsPass();
   mlir::test::registerTestGenericIRVisitorsPass();
+  mlir::test::registerTestIntegerLatticePass();
   mlir::test::registerTestInterfaces();
   mlir::test::registerTestIRVisitorsPass();
   mlir::test::registerTestLastModifiedPass();


### PR DESCRIPTION
This PR adds support in sparse analysis for non-control flow region-bearing ops that have return-like terminators. By default it propagates the terminator's operand lattices to the containing op's result lattices, and also allows the analysis subclass to override this behavior.

Cf. https://discourse.llvm.org/t/how-should-non-control-flow-region-bearing-ops-be-used-with-by-dataflow-analyses/ for context