### PR TITLE
Don't collect from phi nodes which are not fully constructed yet

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -15823,7 +15823,9 @@ void ScalarEvolution::LoopGuards::collectFromBlock(
       Depth < MaxLoopGuardCollectionDepth) {
     SmallDenseMap<const BasicBlock *, LoopGuards> IncomingGuards;
     for (auto &Phi : Pair.second->phis())
-      collectFromPHI(SE, Guards, Phi, VisitedBlocks, IncomingGuards, Depth);
+      // We don't collect from PHIs that are under construction.
+      if (Pair.second->hasNPredecessors(Phi.getNumIncomingValues()))
+        collectFromPHI(SE, Guards, Phi, VisitedBlocks, IncomingGuards, Depth);
   }
 
   // Now apply the information from the collected conditions to


### PR DESCRIPTION
This fixes two issues reported for Enzyme+Rust in https://github.com/EnzymeAD/rust/issues/196,
based on help by @wsmoses 

I have minimized one of the issues into a minimal IR reproducer, which crashes Enzyme when it calls llvm's scev.
https://github.com/EnzymeAD/Enzyme/issues/2310#issuecomment-2869004751

However, I'm unsure how to make a unit test for it, since it seems like opt seems to automatically verify input while parsing.

So if I either remove a branch towards a bb with a phi node (but not the corresponding entry from the phi node), or vice versa, I get

> PHINode should have one entry for each predecessor of its parent basic block!

cc @nikic since we discussed it last week