### PR TITLE
[llvm] annotate interfaces in llvm/ExecutionEngine for DLL export

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/ExecutionEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/ExecutionEngine.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_EXECUTIONENGINE_H
 #define LLVM_EXECUTIONENGINE_EXECUTIONENGINE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/ExecutionEngine.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -88,7 +89,7 @@ public:
   /// Erase an entry from the mapping table.
   ///
   /// \returns The address that \p ToUnmap was mapped to.
-  uint64_t RemoveMapping(StringRef Name);
+  LLVM_ABI uint64_t RemoveMapping(StringRef Name);
 };
 
 using FunctionCreator = std::function<void *(const std::string &)>;
@@ -96,7 +97,7 @@ using FunctionCreator = std::function<void *(const std::string &)>;
 /// Abstract interface for implementation execution of LLVM modules,
 /// designed to support both interpreter and just-in-time (JIT) compiler
 /// implementations.
-class ExecutionEngine {
+class LLVM_ABI ExecutionEngine {
   /// The state object holding the global address mapping, which must be
   /// accessed synchronously.
   //
@@ -550,13 +551,13 @@ private:
 
 public:
   /// Default constructor for EngineBuilder.
-  EngineBuilder();
+  LLVM_ABI EngineBuilder();
 
   /// Constructor for EngineBuilder.
-  EngineBuilder(std::unique_ptr<Module> M);
+  LLVM_ABI EngineBuilder(std::unique_ptr<Module> M);
 
   // Out-of-line since we don't have the def'n of RTDyldMemoryManager here.
-  ~EngineBuilder();
+  LLVM_ABI ~EngineBuilder();
 
   /// setEngineKind - Controls whether the user wants the interpreter, the JIT,
   /// or whichever engine works.  This option defaults to EngineKind::Either.
@@ -571,12 +572,12 @@ public:
   /// to create anything other than MCJIT will cause a runtime error. If create()
   /// is called and is successful, the created engine takes ownership of the
   /// memory manager. This option defaults to NULL.
-  EngineBuilder &setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager> mcjmm);
+  LLVM_ABI EngineBuilder &setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager> mcjmm);
 
-  EngineBuilder&
+  LLVM_ABI EngineBuilder&
   setMemoryManager(std::unique_ptr<MCJITMemoryManager> MM);
 
-  EngineBuilder &setSymbolResolver(std::unique_ptr<LegacyJITSymbolResolver> SR);
+  LLVM_ABI EngineBuilder &setSymbolResolver(std::unique_ptr<LegacyJITSymbolResolver> SR);
 
   /// setErrorStr - Set the error string to write to on error.  This option
   /// defaults to NULL.
@@ -645,11 +646,11 @@ public:
     this->EmulatedTLS = EmulatedTLS;
   }
 
-  TargetMachine *selectTarget();
+  LLVM_ABI TargetMachine *selectTarget();
 
   /// selectTarget - Pick a target either via -march or by guessing the native
   /// arch.  Add any CPU features specified via -mcpu or -mattr.
-  TargetMachine *selectTarget(const Triple &TargetTriple,
+  LLVM_ABI TargetMachine *selectTarget(const Triple &TargetTriple,
                               StringRef MArch,
                               StringRef MCPU,
                               const SmallVectorImpl<std::string>& MAttrs);
@@ -658,7 +659,7 @@ public:
     return create(selectTarget());
   }
 
-  ExecutionEngine *create(TargetMachine *TM);
+  LLVM_ABI ExecutionEngine *create(TargetMachine *TM);
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).

--- a/llvm/include/llvm/ExecutionEngine/ExecutionEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/ExecutionEngine.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_EXECUTIONENGINE_EXECUTIONENGINE_H
 #define LLVM_EXECUTIONENGINE_EXECUTIONENGINE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/ExecutionEngine.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -26,6 +25,7 @@
 #include "llvm/Object/Binary.h"
 #include "llvm/Support/CBindingWrapping.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Mutex.h"
 #include "llvm/Target/TargetMachine.h"
@@ -572,12 +572,14 @@ public:
   /// to create anything other than MCJIT will cause a runtime error. If create()
   /// is called and is successful, the created engine takes ownership of the
   /// memory manager. This option defaults to NULL.
-  LLVM_ABI EngineBuilder &setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager> mcjmm);
+  LLVM_ABI EngineBuilder &
+  setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager> mcjmm);
 
-  LLVM_ABI EngineBuilder&
+  LLVM_ABI EngineBuilder &
   setMemoryManager(std::unique_ptr<MCJITMemoryManager> MM);
 
-  LLVM_ABI EngineBuilder &setSymbolResolver(std::unique_ptr<LegacyJITSymbolResolver> SR);
+  LLVM_ABI EngineBuilder &
+  setSymbolResolver(std::unique_ptr<LegacyJITSymbolResolver> SR);
 
   /// setErrorStr - Set the error string to write to on error.  This option
   /// defaults to NULL.
@@ -650,10 +652,9 @@ public:
 
   /// selectTarget - Pick a target either via -march or by guessing the native
   /// arch.  Add any CPU features specified via -mcpu or -mattr.
-  LLVM_ABI TargetMachine *selectTarget(const Triple &TargetTriple,
-                              StringRef MArch,
-                              StringRef MCPU,
-                              const SmallVectorImpl<std::string>& MAttrs);
+  LLVM_ABI TargetMachine *
+  selectTarget(const Triple &TargetTriple, StringRef MArch, StringRef MCPU,
+               const SmallVectorImpl<std::string> &MAttrs);
 
   ExecutionEngine *create() {
     return create(selectTarget());

--- a/llvm/include/llvm/ExecutionEngine/Interpreter.h
+++ b/llvm/include/llvm/ExecutionEngine/Interpreter.h
@@ -15,8 +15,9 @@
 #define LLVM_EXECUTIONENGINE_INTERPRETER_H
 
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
+#include "llvm/Support/Compiler.h"
 
-extern "C" void LLVMLinkInInterpreter();
+extern "C" LLVM_ABI void LLVMLinkInInterpreter();
 
 namespace {
   struct ForceInterpreterLinking {

--- a/llvm/include/llvm/ExecutionEngine/JITEventListener.h
+++ b/llvm/include/llvm/ExecutionEngine/JITEventListener.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITEVENTLISTENER_H
 #define LLVM_EXECUTIONENGINE_JITEVENTLISTENER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/ExecutionEngine.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
@@ -37,7 +38,7 @@ class ObjectFile;
 /// profilers and debuggers that need to know where functions have been emitted.
 ///
 /// The default implementation of each method does nothing.
-class JITEventListener {
+class LLVM_ABI JITEventListener {
 public:
   using ObjectKey = uint64_t;
 

--- a/llvm/include/llvm/ExecutionEngine/JITEventListener.h
+++ b/llvm/include/llvm/ExecutionEngine/JITEventListener.h
@@ -14,12 +14,12 @@
 #ifndef LLVM_EXECUTIONENGINE_JITEVENTLISTENER_H
 #define LLVM_EXECUTIONENGINE_JITEVENTLISTENER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/ExecutionEngine.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/Support/CBindingWrapping.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {

--- a/llvm/include/llvm/ExecutionEngine/JITLink/EHFrameSupport.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/EHFrameSupport.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_EHFRAMESUPPORT_H
 #define LLVM_EXECUTIONENGINE_JITLINK_EHFRAMESUPPORT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/TargetParser/Triple.h"
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/EHFrameSupport.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/EHFrameSupport.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_EHFRAMESUPPORT_H
 #define LLVM_EXECUTIONENGINE_JITLINK_EHFRAMESUPPORT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/Support/Error.h"
@@ -36,7 +37,7 @@ public:
   /// second to PC-begin, third (if present) to LSDA.
   ///
   /// It is illegal to call this function on a block with four or more edges.
-  static EHFrameCFIBlockInspector FromEdgeScan(Block &B);
+  LLVM_ABI static EHFrameCFIBlockInspector FromEdgeScan(Block &B);
 
   /// Returns true if this frame is an FDE, false for a CIE.
   bool isFDE() const { return CIEEdge != nullptr; }
@@ -85,7 +86,7 @@ private:
 
 /// Returns a pointer to the DWARF eh-frame section if the graph contains a
 /// non-empty one, otherwise returns null.
-Section *getEHFrameSection(LinkGraph &G);
+LLVM_ABI Section *getEHFrameSection(LinkGraph &G);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLink.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLink.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_JITLINK_H
 #define LLVM_EXECUTIONENGINE_JITLINK_JITLINK_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
@@ -49,7 +50,7 @@ class Section;
 
 /// Base class for errors originating in JIT linker, e.g. missing relocation
 /// support.
-class JITLinkError : public ErrorInfo<JITLinkError> {
+class LLVM_ABI JITLinkError : public ErrorInfo<JITLinkError> {
 public:
   static char ID;
 
@@ -105,7 +106,7 @@ private:
 
 /// Returns the string name of the given generic edge kind, or "unknown"
 /// otherwise. Useful for debugging.
-const char *getGenericEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getGenericEdgeKindName(Edge::Kind K);
 
 /// Base class for Addressable entities (externals, absolutes, blocks).
 class Addressable {
@@ -389,7 +390,7 @@ inline orc::ExecutorAddr alignToBlock(orc::ExecutorAddr Addr, const Block &B) {
 // Returns true if the given blocks contains exactly one valid c-string.
 // Zero-fill blocks of size 1 count as valid empty strings. Content blocks
 // must end with a zero, and contain no zeros before the end.
-bool isCStringBlock(Block &B);
+LLVM_ABI bool isCStringBlock(Block &B);
 
 /// Describes symbol linkage. This can be used to resolve definition clashes.
 enum class Linkage : uint8_t {
@@ -401,7 +402,7 @@ enum class Linkage : uint8_t {
 using TargetFlagsType = uint8_t;
 
 /// For errors and debugging output.
-const char *getLinkageName(Linkage L);
+LLVM_ABI const char *getLinkageName(Linkage L);
 
 /// Defines the scope in which this symbol should be visible:
 ///   Default -- Visible in the public interface of the linkage unit.
@@ -412,9 +413,9 @@ const char *getLinkageName(Linkage L);
 enum class Scope : uint8_t { Default, Hidden, SideEffectsOnly, Local };
 
 /// For debugging output.
-const char *getScopeName(Scope S);
+LLVM_ABI const char *getScopeName(Scope S);
 
-raw_ostream &operator<<(raw_ostream &OS, const Block &B);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const Block &B);
 
 /// Symbol representation.
 ///
@@ -708,9 +709,9 @@ private:
   size_t Size = 0;
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const Symbol &A);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const Symbol &A);
 
-void printEdge(raw_ostream &OS, const Block &B, const Edge &E,
+LLVM_ABI void printEdge(raw_ostream &OS, const Block &B, const Edge &E,
                StringRef EdgeKindName);
 
 /// Represents an object file section.
@@ -731,7 +732,7 @@ public:
   using block_iterator = BlockSet::iterator;
   using const_block_iterator = BlockSet::const_iterator;
 
-  ~Section();
+  LLVM_ABI ~Section();
 
   // Sections are not movable or copyable.
   Section(const Section &) = delete;
@@ -1039,7 +1040,7 @@ public:
   LinkGraph &operator=(const LinkGraph &) = delete;
   LinkGraph(LinkGraph &&) = delete;
   LinkGraph &operator=(LinkGraph &&) = delete;
-  ~LinkGraph();
+  LLVM_ABI ~LinkGraph();
 
   /// Returns the name of this graph (usually the name of the original
   /// underlying MemoryBuffer).
@@ -1658,10 +1659,10 @@ public:
   orc::shared::AllocActions &allocActions() { return AAs; }
 
   /// Dump the graph.
-  void dump(raw_ostream &OS);
+  LLVM_ABI void dump(raw_ostream &OS);
 
 private:
-  std::vector<Block *> splitBlockImpl(std::vector<Block *> Blocks,
+  LLVM_ABI std::vector<Block *> splitBlockImpl(std::vector<Block *> Blocks,
                                       SplitBlockCache *Cache);
 
   // Put the BumpPtrAllocator first so that we don't free any of the underlying
@@ -1894,7 +1895,7 @@ struct PassConfiguration {
 ///        the two types once we have an OrcSupport library.
 enum class SymbolLookupFlags { RequiredSymbol, WeaklyReferencedSymbol };
 
-raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupFlags &LF);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupFlags &LF);
 
 /// A map of symbol names to resolved addresses.
 using AsyncLookupResult =
@@ -1902,7 +1903,7 @@ using AsyncLookupResult =
 
 /// A function object to call with a resolved symbol map (See AsyncLookupResult)
 /// or an error if resolution failed.
-class JITLinkAsyncLookupContinuation {
+class LLVM_ABI JITLinkAsyncLookupContinuation {
 public:
   virtual ~JITLinkAsyncLookupContinuation() = default;
   virtual void run(Expected<AsyncLookupResult> LR) = 0;
@@ -1929,7 +1930,7 @@ createLookupContinuation(Continuation Cont) {
 }
 
 /// Holds context for a single jitLink invocation.
-class JITLinkContext {
+class LLVM_ABI JITLinkContext {
 public:
   using LookupMap = DenseMap<orc::SymbolStringPtr, SymbolLookupFlags>;
 
@@ -1995,13 +1996,13 @@ private:
 
 /// Marks all symbols in a graph live. This can be used as a default,
 /// conservative mark-live implementation.
-Error markAllSymbolsLive(LinkGraph &G);
+LLVM_ABI Error markAllSymbolsLive(LinkGraph &G);
 
 /// Create an out of range error for the given edge in the given block.
-Error makeTargetOutOfRangeError(const LinkGraph &G, const Block &B,
+LLVM_ABI Error makeTargetOutOfRangeError(const LinkGraph &G, const Block &B,
                                 const Edge &E);
 
-Error makeAlignmentError(llvm::orc::ExecutorAddr Loc, uint64_t Value, int N,
+LLVM_ABI Error makeAlignmentError(llvm::orc::ExecutorAddr Loc, uint64_t Value, int N,
                          const Edge &E);
 
 /// Creates a new pointer block in the given section and returns an
@@ -2016,7 +2017,7 @@ using AnonymousPointerCreator =
                              Symbol *InitialTarget, uint64_t InitialAddend)>;
 
 /// Get target-specific AnonymousPointerCreator
-AnonymousPointerCreator getAnonymousPointerCreator(const Triple &TT);
+LLVM_ABI AnonymousPointerCreator getAnonymousPointerCreator(const Triple &TT);
 
 /// Create a jump stub that jumps via the pointer at the given symbol and
 /// an anonymous symbol pointing to it. Return the anonymous symbol.
@@ -2026,7 +2027,7 @@ using PointerJumpStubCreator = unique_function<Symbol &(
     LinkGraph &G, Section &StubSection, Symbol &PointerSymbol)>;
 
 /// Get target-specific PointerJumpStubCreator
-PointerJumpStubCreator getPointerJumpStubCreator(const Triple &TT);
+LLVM_ABI PointerJumpStubCreator getPointerJumpStubCreator(const Triple &TT);
 
 /// Base case for edge-visitors where the visitor-list is empty.
 inline void visitEdge(LinkGraph &G, Block *B, Edge &E) {}
@@ -2063,17 +2064,17 @@ void visitExistingEdges(LinkGraph &G, VisitorTs &&...Vs) {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromObject(MemoryBufferRef ObjectBuffer,
                           std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// Create a \c LinkGraph defining the given absolute symbols.
-std::unique_ptr<LinkGraph>
+LLVM_ABI std::unique_ptr<LinkGraph>
 absoluteSymbolsLinkGraph(Triple TT, std::shared_ptr<orc::SymbolStringPool> SSP,
                          orc::SymbolMap Symbols);
 
 /// Link the given graph.
-void link(std::unique_ptr<LinkGraph> G, std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link(std::unique_ptr<LinkGraph> G, std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLink.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLink.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_JITLINK_H
 #define LLVM_EXECUTIONENGINE_JITLINK_JITLINK_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
@@ -28,6 +27,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryStreamReader.h"
 #include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -712,7 +712,7 @@ private:
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const Symbol &A);
 
 LLVM_ABI void printEdge(raw_ostream &OS, const Block &B, const Edge &E,
-               StringRef EdgeKindName);
+                        StringRef EdgeKindName);
 
 /// Represents an object file section.
 class Section {
@@ -1663,7 +1663,7 @@ public:
 
 private:
   LLVM_ABI std::vector<Block *> splitBlockImpl(std::vector<Block *> Blocks,
-                                      SplitBlockCache *Cache);
+                                               SplitBlockCache *Cache);
 
   // Put the BumpPtrAllocator first so that we don't free any of the underlying
   // memory until the Symbol/Addressable destructors have been run.
@@ -2000,10 +2000,10 @@ LLVM_ABI Error markAllSymbolsLive(LinkGraph &G);
 
 /// Create an out of range error for the given edge in the given block.
 LLVM_ABI Error makeTargetOutOfRangeError(const LinkGraph &G, const Block &B,
-                                const Edge &E);
+                                         const Edge &E);
 
-LLVM_ABI Error makeAlignmentError(llvm::orc::ExecutorAddr Loc, uint64_t Value, int N,
-                         const Edge &E);
+LLVM_ABI Error makeAlignmentError(llvm::orc::ExecutorAddr Loc, uint64_t Value,
+                                  int N, const Edge &E);
 
 /// Creates a new pointer block in the given section and returns an
 /// Anonymous symbol pointing to it.
@@ -2074,7 +2074,8 @@ absoluteSymbolsLinkGraph(Triple TT, std::shared_ptr<orc::SymbolStringPool> SSP,
                          orc::SymbolMap Symbols);
 
 /// Link the given graph.
-LLVM_ABI void link(std::unique_ptr<LinkGraph> G, std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link(std::unique_ptr<LinkGraph> G,
+                   std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_JITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_JITLINK_JITLINKMEMORYMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkDylib.h"
@@ -22,6 +21,7 @@
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
 #include "llvm/Support/Memory.h"
@@ -322,9 +322,9 @@ public:
       JITLinkMemoryManager::InFlightAlloc::OnFinalizedFunction;
 
   LLVM_ABI static void Create(JITLinkMemoryManager &MemMgr,
-                     std::shared_ptr<orc::SymbolStringPool> SSP, Triple TT,
-                     const JITLinkDylib *JD, SegmentMap Segments,
-                     OnCreatedFunction OnCreated);
+                              std::shared_ptr<orc::SymbolStringPool> SSP,
+                              Triple TT, const JITLinkDylib *JD,
+                              SegmentMap Segments, OnCreatedFunction OnCreated);
 
   LLVM_ABI static Expected<SimpleSegmentAlloc>
   Create(JITLinkMemoryManager &MemMgr,

--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_JITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_JITLINK_JITLINKMEMORYMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkDylib.h"
@@ -43,7 +44,7 @@ class Section;
 ///
 /// Instances of this class may be accessed concurrently from multiple threads
 /// and their implemetations should include any necessary synchronization.
-class JITLinkMemoryManager {
+class LLVM_ABI JITLinkMemoryManager {
 public:
 
   /// Represents a finalized allocation.
@@ -118,7 +119,7 @@ public:
   ///
   /// If abandon is called then working memory and executor memory should both
   /// be freed.
-  class InFlightAlloc {
+  class LLVM_ABI InFlightAlloc {
   public:
     using OnFinalizedFunction = unique_function<void(Expected<FinalizedAlloc>)>;
     using OnAbandonedFunction = unique_function<void(Error)>;
@@ -250,7 +251,7 @@ private:
   using SegmentMap = orc::AllocGroupSmallMap<Segment>;
 
 public:
-  BasicLayout(LinkGraph &G);
+  LLVM_ABI BasicLayout(LinkGraph &G);
 
   /// Return a reference to the graph this allocation was created from.
   LinkGraph &getGraph() { return G; }
@@ -264,7 +265,7 @@ public:
   ///
   /// This function will return an error if any segment has an alignment that
   /// is higher than a page.
-  Expected<ContiguousPageBasedLayoutSizes>
+  LLVM_ABI Expected<ContiguousPageBasedLayoutSizes>
   getContiguousPageBasedLayoutSizes(uint64_t PageSize);
 
   /// Returns an iterator over the segments of the layout.
@@ -273,12 +274,12 @@ public:
   }
 
   /// Apply the layout to the graph.
-  Error apply();
+  LLVM_ABI Error apply();
 
   /// Returns a reference to the AllocActions in the graph.
   /// This convenience function saves callers from having to #include
   /// LinkGraph.h if all they need are allocation actions.
-  orc::shared::AllocActions &graphAllocActions();
+  LLVM_ABI orc::shared::AllocActions &graphAllocActions();
 
 private:
   LinkGraph &G;
@@ -320,22 +321,22 @@ public:
   using OnFinalizedFunction =
       JITLinkMemoryManager::InFlightAlloc::OnFinalizedFunction;
 
-  static void Create(JITLinkMemoryManager &MemMgr,
+  LLVM_ABI static void Create(JITLinkMemoryManager &MemMgr,
                      std::shared_ptr<orc::SymbolStringPool> SSP, Triple TT,
                      const JITLinkDylib *JD, SegmentMap Segments,
                      OnCreatedFunction OnCreated);
 
-  static Expected<SimpleSegmentAlloc>
+  LLVM_ABI static Expected<SimpleSegmentAlloc>
   Create(JITLinkMemoryManager &MemMgr,
          std::shared_ptr<orc::SymbolStringPool> SSP, Triple TT,
          const JITLinkDylib *JD, SegmentMap Segments);
 
-  SimpleSegmentAlloc(SimpleSegmentAlloc &&);
-  SimpleSegmentAlloc &operator=(SimpleSegmentAlloc &&);
-  ~SimpleSegmentAlloc();
+  LLVM_ABI SimpleSegmentAlloc(SimpleSegmentAlloc &&);
+  LLVM_ABI SimpleSegmentAlloc &operator=(SimpleSegmentAlloc &&);
+  LLVM_ABI ~SimpleSegmentAlloc();
 
   /// Returns the SegmentInfo for the given group.
-  SegmentInfo getSegInfo(orc::AllocGroup AG);
+  LLVM_ABI SegmentInfo getSegInfo(orc::AllocGroup AG);
 
   /// Finalize all groups (async version).
   void finalize(OnFinalizedFunction OnFinalized) {
@@ -359,7 +360,7 @@ private:
 };
 
 /// A JITLinkMemoryManager that allocates in-process memory.
-class InProcessMemoryManager : public JITLinkMemoryManager {
+class LLVM_ABI InProcessMemoryManager : public JITLinkMemoryManager {
 public:
   class IPInFlightAlloc;
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/MachO.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/MachO.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_MACHO_H
 #define LLVM_EXECUTIONENGINE_JITLINK_MACHO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MachOObjectFormat.h"
 
@@ -24,7 +25,7 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromMachOObject(MemoryBufferRef ObjectBuffer,
                                std::shared_ptr<orc::SymbolStringPool> SSP);
 
@@ -32,7 +33,7 @@ createLinkGraphFromMachOObject(MemoryBufferRef ObjectBuffer,
 ///
 /// Uses conservative defaults for GOT and stub handling based on the target
 /// platform.
-void link_MachO(std::unique_ptr<LinkGraph> G,
+LLVM_ABI void link_MachO(std::unique_ptr<LinkGraph> G,
                 std::unique_ptr<JITLinkContext> Ctx);
 
 /// Get a pointer to the standard MachO data section (creates an empty
@@ -56,7 +57,7 @@ inline Section &getMachODefaultTextSection(LinkGraph &G) {
 }
 
 /// Gets or creates a MachO header for the current LinkGraph.
-Expected<Symbol &> getOrCreateLocalMachOHeader(LinkGraph &G);
+LLVM_ABI Expected<Symbol &> getOrCreateLocalMachOHeader(LinkGraph &G);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/MachO.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/MachO.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_MACHO_H
 #define LLVM_EXECUTIONENGINE_JITLINK_MACHO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MachOObjectFormat.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace jitlink {
@@ -34,7 +34,7 @@ createLinkGraphFromMachOObject(MemoryBufferRef ObjectBuffer,
 /// Uses conservative defaults for GOT and stub handling based on the target
 /// platform.
 LLVM_ABI void link_MachO(std::unique_ptr<LinkGraph> G,
-                std::unique_ptr<JITLinkContext> Ctx);
+                         std::unique_ptr<JITLinkContext> Ctx);
 
 /// Get a pointer to the standard MachO data section (creates an empty
 /// section with RW- permissions and standard lifetime if one does not

--- a/llvm/include/llvm/ExecutionEngine/JITLink/MachO_arm64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/MachO_arm64.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_MACHO_ARM64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_MACHO_ARM64_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 
 namespace llvm {
@@ -23,7 +24,7 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_arm64(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_arm64(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a MachO arm64 object file.
@@ -35,16 +36,16 @@ Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_arm64(
 /// If PostPrunePasses is empty then a default GOT-and-stubs insertion pass will
 /// be inserted. If PostPrunePasses is not empty then the caller is responsible
 /// for including a pass to insert GOT and stub edges.
-void link_MachO_arm64(std::unique_ptr<LinkGraph> G,
+LLVM_ABI void link_MachO_arm64(std::unique_ptr<LinkGraph> G,
                       std::unique_ptr<JITLinkContext> Ctx);
 
 /// Returns a pass suitable for splitting __eh_frame sections in MachO/x86-64
 /// objects.
-LinkGraphPassFunction createEHFrameSplitterPass_MachO_arm64();
+LLVM_ABI LinkGraphPassFunction createEHFrameSplitterPass_MachO_arm64();
 
 /// Returns a pass suitable for fixing missing edges in an __eh_frame section
 /// in a MachO/x86-64 object.
-LinkGraphPassFunction createEHFrameEdgeFixerPass_MachO_arm64();
+LLVM_ABI LinkGraphPassFunction createEHFrameEdgeFixerPass_MachO_arm64();
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/MachO_arm64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/MachO_arm64.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_MACHO_ARM64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_MACHO_ARM64_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace jitlink {
@@ -24,7 +24,8 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-LLVM_ABI Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_arm64(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromMachOObject_arm64(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a MachO arm64 object file.
@@ -37,7 +38,7 @@ LLVM_ABI Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_arm
 /// be inserted. If PostPrunePasses is not empty then the caller is responsible
 /// for including a pass to insert GOT and stub edges.
 LLVM_ABI void link_MachO_arm64(std::unique_ptr<LinkGraph> G,
-                      std::unique_ptr<JITLinkContext> Ctx);
+                               std::unique_ptr<JITLinkContext> Ctx);
 
 /// Returns a pass suitable for splitting __eh_frame sections in MachO/x86-64
 /// objects.

--- a/llvm/include/llvm/ExecutionEngine/JITLink/MachO_x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/MachO_x86_64.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_MACHO_X86_64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_MACHO_X86_64_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace jitlink {
@@ -24,7 +24,8 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-LLVM_ABI Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_x86_64(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromMachOObject_x86_64(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given LinkGraph.
@@ -37,7 +38,7 @@ LLVM_ABI Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_x86
 /// be inserted. If PostPrunePasses is not empty then the caller is responsible
 /// for including a pass to insert GOT and stub edges.
 LLVM_ABI void link_MachO_x86_64(std::unique_ptr<LinkGraph> G,
-                       std::unique_ptr<JITLinkContext> Ctx);
+                                std::unique_ptr<JITLinkContext> Ctx);
 
 /// Returns a pass suitable for splitting __eh_frame sections in MachO/x86-64
 /// objects.

--- a/llvm/include/llvm/ExecutionEngine/JITLink/MachO_x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/MachO_x86_64.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_MACHO_X86_64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_MACHO_X86_64_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 
 namespace llvm {
@@ -23,7 +24,7 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_x86_64(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_x86_64(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given LinkGraph.
@@ -35,16 +36,16 @@ Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromMachOObject_x86_64(
 /// If PostPrunePasses is empty then a default GOT-and-stubs insertion pass will
 /// be inserted. If PostPrunePasses is not empty then the caller is responsible
 /// for including a pass to insert GOT and stub edges.
-void link_MachO_x86_64(std::unique_ptr<LinkGraph> G,
+LLVM_ABI void link_MachO_x86_64(std::unique_ptr<LinkGraph> G,
                        std::unique_ptr<JITLinkContext> Ctx);
 
 /// Returns a pass suitable for splitting __eh_frame sections in MachO/x86-64
 /// objects.
-LinkGraphPassFunction createEHFrameSplitterPass_MachO_x86_64();
+LLVM_ABI LinkGraphPassFunction createEHFrameSplitterPass_MachO_x86_64();
 
 /// Returns a pass suitable for fixing missing edges in an __eh_frame section
 /// in a MachO/x86-64 object.
-LinkGraphPassFunction createEHFrameEdgeFixerPass_MachO_x86_64();
+LLVM_ABI LinkGraphPassFunction createEHFrameEdgeFixerPass_MachO_x86_64();
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_AARCH32
 #define LLVM_EXECUTIONENGINE_JITLINK_AARCH32
 
+#include "llvm/Support/Compiler.h"
 #include "TableManager.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
@@ -24,7 +25,7 @@ namespace jitlink {
 namespace aarch32 {
 
 /// Check whether the given target flags are set for this Symbol.
-bool hasTargetFlags(Symbol &Sym, TargetFlagsType Flags);
+LLVM_ABI bool hasTargetFlags(Symbol &Sym, TargetFlagsType Flags);
 
 /// JITLink-internal AArch32 fixup kinds
 enum EdgeKind_aarch32 : Edge::Kind {
@@ -117,10 +118,10 @@ enum TargetFlags_aarch32 : TargetFlagsType {
 };
 
 /// Human-readable name for a given CPU architecture kind
-const char *getCPUArchName(ARMBuildAttrs::CPUArch K);
+LLVM_ABI const char *getCPUArchName(ARMBuildAttrs::CPUArch K);
 
 /// Get a human-readable name for the given AArch32 edge kind.
-const char *getEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getEdgeKindName(Edge::Kind K);
 
 /// AArch32 uses stubs for a number of purposes, like branch range extension
 /// or interworking between Arm and Thumb instruction subsets.
@@ -173,7 +174,7 @@ struct HalfWords {
 
 /// FixupInfo base class is required for dynamic lookups.
 struct FixupInfoBase {
-  static const FixupInfoBase *getDynFixupInfo(Edge::Kind K);
+  LLVM_ABI static const FixupInfoBase *getDynFixupInfo(Edge::Kind K);
   virtual ~FixupInfoBase() {}
 };
 
@@ -270,15 +271,15 @@ template <> struct FixupInfo<Thumb_MovwPrelNC> : public FixupInfoThumbMov {
 };
 
 /// Helper function to read the initial addend for Data-class relocations.
-Expected<int64_t> readAddendData(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+LLVM_ABI Expected<int64_t> readAddendData(LinkGraph &G, Block &B, Edge::OffsetT Offset,
                                  Edge::Kind Kind);
 
 /// Helper function to read the initial addend for Arm-class relocations.
-Expected<int64_t> readAddendArm(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+LLVM_ABI Expected<int64_t> readAddendArm(LinkGraph &G, Block &B, Edge::OffsetT Offset,
                                 Edge::Kind Kind);
 
 /// Helper function to read the initial addend for Thumb-class relocations.
-Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+LLVM_ABI Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B, Edge::OffsetT Offset,
                                   Edge::Kind Kind, const ArmConfig &ArmCfg);
 
 /// Read the initial addend for a REL-type relocation. It's the value encoded
@@ -300,13 +301,13 @@ inline Expected<int64_t> readAddend(LinkGraph &G, Block &B,
 }
 
 /// Helper function to apply the fixup for Data-class relocations.
-Error applyFixupData(LinkGraph &G, Block &B, const Edge &E);
+LLVM_ABI Error applyFixupData(LinkGraph &G, Block &B, const Edge &E);
 
 /// Helper function to apply the fixup for Arm-class relocations.
-Error applyFixupArm(LinkGraph &G, Block &B, const Edge &E);
+LLVM_ABI Error applyFixupArm(LinkGraph &G, Block &B, const Edge &E);
 
 /// Helper function to apply the fixup for Thumb-class relocations.
-Error applyFixupThumb(LinkGraph &G, Block &B, const Edge &E,
+LLVM_ABI Error applyFixupThumb(LinkGraph &G, Block &B, const Edge &E,
                       const ArmConfig &ArmCfg);
 
 /// Apply fixup expression for edge to block content.
@@ -332,8 +333,8 @@ class GOTBuilder : public TableManager<GOTBuilder> {
 public:
   static StringRef getSectionName() { return "$__GOT"; }
 
-  bool visitEdge(LinkGraph &G, Block *B, Edge &E);
-  Symbol &createEntry(LinkGraph &G, Symbol &Target);
+  LLVM_ABI bool visitEdge(LinkGraph &G, Block *B, Edge &E);
+  LLVM_ABI Symbol &createEntry(LinkGraph &G, Symbol &Target);
 
 private:
   Section *GOTSection = nullptr;
@@ -353,7 +354,7 @@ public:
   }
 
   /// Implements link-graph traversal via visitExistingEdges()
-  bool visitEdge(LinkGraph &G, Block *B, Edge &E);
+  LLVM_ABI bool visitEdge(LinkGraph &G, Block *B, Edge &E);
 
 private:
   // Each stub uses a single block that can have 2 entryponts, one for Arm and
@@ -387,7 +388,7 @@ public:
   }
 
   /// Implements link-graph traversal via visitExistingEdges().
-  bool visitEdge(LinkGraph &G, Block *B, Edge &E);
+  LLVM_ABI bool visitEdge(LinkGraph &G, Block *B, Edge &E);
 
 private:
   // Two slots per external: Arm and Thumb

--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_AARCH32
 #define LLVM_EXECUTIONENGINE_JITLINK_AARCH32
 
-#include "llvm/Support/Compiler.h"
 #include "TableManager.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/ARMBuildAttributes.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -271,16 +271,18 @@ template <> struct FixupInfo<Thumb_MovwPrelNC> : public FixupInfoThumbMov {
 };
 
 /// Helper function to read the initial addend for Data-class relocations.
-LLVM_ABI Expected<int64_t> readAddendData(LinkGraph &G, Block &B, Edge::OffsetT Offset,
-                                 Edge::Kind Kind);
+LLVM_ABI Expected<int64_t>
+readAddendData(LinkGraph &G, Block &B, Edge::OffsetT Offset, Edge::Kind Kind);
 
 /// Helper function to read the initial addend for Arm-class relocations.
-LLVM_ABI Expected<int64_t> readAddendArm(LinkGraph &G, Block &B, Edge::OffsetT Offset,
-                                Edge::Kind Kind);
+LLVM_ABI Expected<int64_t> readAddendArm(LinkGraph &G, Block &B,
+                                         Edge::OffsetT Offset, Edge::Kind Kind);
 
 /// Helper function to read the initial addend for Thumb-class relocations.
-LLVM_ABI Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B, Edge::OffsetT Offset,
-                                  Edge::Kind Kind, const ArmConfig &ArmCfg);
+LLVM_ABI Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B,
+                                           Edge::OffsetT Offset,
+                                           Edge::Kind Kind,
+                                           const ArmConfig &ArmCfg);
 
 /// Read the initial addend for a REL-type relocation. It's the value encoded
 /// in the immediate field of the fixup location by the compiler.
@@ -308,7 +310,7 @@ LLVM_ABI Error applyFixupArm(LinkGraph &G, Block &B, const Edge &E);
 
 /// Helper function to apply the fixup for Thumb-class relocations.
 LLVM_ABI Error applyFixupThumb(LinkGraph &G, Block &B, const Edge &E,
-                      const ArmConfig &ArmCfg);
+                               const ArmConfig &ArmCfg);
 
 /// Apply fixup expression for edge to block content.
 inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,

--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch64.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_AARCH64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_AARCH64_H
 
-#include "llvm/Support/Compiler.h"
 #include "TableManager.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace jitlink {

--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch64.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_AARCH64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_AARCH64_H
 
+#include "llvm/Support/Compiler.h"
 #include "TableManager.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
@@ -418,7 +419,7 @@ enum EdgeKind_aarch64 : Edge::Kind {
 
 /// Returns a string name for the given aarch64 edge. For debugging purposes
 /// only
-const char *getEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getEdgeKindName(Edge::Kind K);
 
 // Returns whether the Instr is LD/ST (imm12)
 inline bool isLoadStoreImm12(uint32_t Instr) {
@@ -697,7 +698,7 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
 constexpr uint64_t PointerSize = 8;
 
 /// AArch64 null pointer content.
-extern const char NullPointerContent[PointerSize];
+LLVM_ABI extern const char NullPointerContent[PointerSize];
 
 /// AArch64 pointer jump stub content.
 ///
@@ -706,7 +707,7 @@ extern const char NullPointerContent[PointerSize];
 ///   ADRP x16, ptr@page21
 ///   LDR  x16, [x16, ptr@pageoff12]
 ///   BR   x16
-extern const char PointerJumpStubContent[12];
+LLVM_ABI extern const char PointerJumpStubContent[12];
 
 /// Creates a new pointer block in the given section and returns an
 /// Anonymous symbol pointing to it.
@@ -761,7 +762,7 @@ inline Symbol &createAnonymousPointerJumpStub(LinkGraph &G,
 /// address (and stack pointer) on the stack and calls the given reentry symbol:
 ///   STP  x29, x30, [sp, #-16]!
 ///   BL   <reentry-symbol>
-extern const char ReentryTrampolineContent[8];
+LLVM_ABI extern const char ReentryTrampolineContent[8];
 
 /// Create a block of N reentry trampolines.
 inline Block &createReentryTrampolineBlock(LinkGraph &G,
@@ -853,7 +854,7 @@ private:
     return *GOTSection;
   }
 
-  void registerExistingEntries();
+  LLVM_ABI void registerExistingEntries();
 
   Section *GOTSection = nullptr;
 };
@@ -894,14 +895,14 @@ public:
     return *StubsSection;
   }
 
-  void registerExistingEntries();
+  LLVM_ABI void registerExistingEntries();
 
   GOTTableManager &GOT;
   Section *StubsSection = nullptr;
 };
 
 /// Returns the name of the pointer signing function section.
-const char *getPointerSigningFunctionSectionName();
+LLVM_ABI const char *getPointerSigningFunctionSectionName();
 
 /// Creates a pointer signing function section, block, and symbol to reserve
 /// space for a signing function for this LinkGraph. Clients should insert this
@@ -911,7 +912,7 @@ const char *getPointerSigningFunctionSectionName();
 /// No new Pointer64Auth edges can be inserted into the graph between when this
 /// pass is run and when the pass below runs (since there will not be sufficient
 /// space reserved in the signing function to write the signing code for them).
-Error createEmptyPointerSigningFunction(LinkGraph &G);
+LLVM_ABI Error createEmptyPointerSigningFunction(LinkGraph &G);
 
 /// Given a LinkGraph containing Pointer64Authenticated edges, transform those
 /// edges to Pointer64 and add signing code to the pointer signing function
@@ -921,7 +922,7 @@ Error createEmptyPointerSigningFunction(LinkGraph &G);
 /// This function will add a $__ptrauth_sign section with finalization-lifetime
 /// containing an anonymous function that will sign all pointers in the graph.
 /// An allocation action will be added to run this function during finalization.
-Error lowerPointer64AuthEdgesToSigningFunction(LinkGraph &G);
+LLVM_ABI Error lowerPointer64AuthEdgesToSigningFunction(LinkGraph &G);
 
 } // namespace aarch64
 } // namespace jitlink

--- a/llvm/include/llvm/ExecutionEngine/JITLink/loongarch.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/loongarch.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_LOONGARCH_H
 #define LLVM_EXECUTIONENGINE_JITLINK_LOONGARCH_H
 
-#include "llvm/Support/Compiler.h"
 #include "TableManager.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/LEB128.h"
 
 namespace llvm {

--- a/llvm/include/llvm/ExecutionEngine/JITLink/loongarch.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/loongarch.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_LOONGARCH_H
 #define LLVM_EXECUTIONENGINE_JITLINK_LOONGARCH_H
 
+#include "llvm/Support/Compiler.h"
 #include "TableManager.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
@@ -322,7 +323,7 @@ enum EdgeKind_loongarch : Edge::Kind {
 
 /// Returns a string name for the given loongarch edge. For debugging purposes
 /// only.
-const char *getEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getEdgeKindName(Edge::Kind K);
 
 // Returns extract bits Val[Hi:Lo].
 inline uint32_t extractBits(uint64_t Val, unsigned Hi, unsigned Lo) {
@@ -562,7 +563,7 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E) {
 }
 
 /// loongarch null pointer content.
-extern const char NullPointerContent[8];
+LLVM_ABI extern const char NullPointerContent[8];
 inline ArrayRef<char> getGOTEntryBlockContent(LinkGraph &G) {
   return {reinterpret_cast<const char *>(NullPointerContent),
           G.getPointerSize()};
@@ -576,8 +577,8 @@ inline ArrayRef<char> getGOTEntryBlockContent(LinkGraph &G) {
 ///   ld.[w/d]  $t8, %pageoff12(ptr)
 ///   jr        $t8
 constexpr size_t StubEntrySize = 12;
-extern const uint8_t LA64StubContent[StubEntrySize];
-extern const uint8_t LA32StubContent[StubEntrySize];
+LLVM_ABI extern const uint8_t LA64StubContent[StubEntrySize];
+LLVM_ABI extern const uint8_t LA32StubContent[StubEntrySize];
 inline ArrayRef<char> getStubBlockContent(LinkGraph &G) {
   auto StubContent =
       G.getPointerSize() == 8 ? LA64StubContent : LA32StubContent;

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ppc64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ppc64.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_PPC64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_PPC64_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/TableManager.h"
 #include "llvm/Support/Endian.h"
@@ -73,11 +74,11 @@ enum PLTCallStubKind {
   LongBranchNoTOC,
 };
 
-extern const char NullPointerContent[8];
-extern const char PointerJumpStubContent_big[20];
-extern const char PointerJumpStubContent_little[20];
-extern const char PointerJumpStubNoTOCContent_big[32];
-extern const char PointerJumpStubNoTOCContent_little[32];
+LLVM_ABI extern const char NullPointerContent[8];
+LLVM_ABI extern const char PointerJumpStubContent_big[20];
+LLVM_ABI extern const char PointerJumpStubContent_little[20];
+LLVM_ABI extern const char PointerJumpStubNoTOCContent_big[32];
+LLVM_ABI extern const char PointerJumpStubNoTOCContent_little[32];
 
 struct PLTCallStubReloc {
   Edge::Kind K;
@@ -259,7 +260,7 @@ private:
 
 /// Returns a string name for the given ppc64 edge. For debugging purposes
 /// only.
-const char *getEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getEdgeKindName(Edge::Kind K);
 
 inline static uint16_t ha(uint64_t x) { return (x + 0x8000) >> 16; }
 inline static uint64_t lo(uint64_t x) { return x & 0xffff; }

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ppc64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ppc64.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_PPC64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_PPC64_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/TableManager.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 
 namespace llvm::jitlink::ppc64 {

--- a/llvm/include/llvm/ExecutionEngine/JITLink/riscv.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/riscv.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_RISCV_H
 #define LLVM_EXECUTIONENGINE_JITLINK_RISCV_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 
 namespace llvm {
@@ -224,7 +225,7 @@ enum EdgeKind_riscv : Edge::Kind {
 
 /// Returns a string name for the given riscv edge. For debugging purposes
 /// only
-const char *getEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getEdgeKindName(Edge::Kind K);
 } // namespace riscv
 } // namespace jitlink
 } // namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/riscv.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/riscv.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_RISCV_H
 #define LLVM_EXECUTIONENGINE_JITLINK_RISCV_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace jitlink {

--- a/llvm/include/llvm/ExecutionEngine/JITLink/x86.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/x86.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_X86_H
 #define LLVM_EXECUTIONENGINE_JITLINK_X86_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/TableManager.h"
 
@@ -177,7 +178,7 @@ enum EdgeKind_x86 : Edge::Kind {
 
 /// Returns a string name for the given x86 edge. For debugging purposes
 /// only
-const char *getEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getEdgeKindName(Edge::Kind K);
 
 /// Apply fixup expression for edge to block content.
 inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
@@ -254,14 +255,14 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
 constexpr uint32_t PointerSize = 4;
 
 /// x86 null pointer content.
-extern const char NullPointerContent[PointerSize];
+LLVM_ABI extern const char NullPointerContent[PointerSize];
 
 /// x86 pointer jump stub content.
 ///
 /// Contains the instruction sequence for an indirect jump via an in-memory
 /// pointer:
 ///   jmpq *ptr
-extern const char PointerJumpStubContent[6];
+LLVM_ABI extern const char PointerJumpStubContent[6];
 
 /// Creates a new pointer block in the given section and returns an anonymous
 /// symbol pointing to it.
@@ -405,7 +406,7 @@ public:
 /// 2. BranchPCRel32ToPtrJumpStubRelaxable. For this edge kind, if the target is
 /// in range, replace a indirect jump by plt stub with a direct jump to the
 /// target
-Error optimizeGOTAndStubAccesses(LinkGraph &G);
+LLVM_ABI Error optimizeGOTAndStubAccesses(LinkGraph &G);
 
 } // namespace llvm::jitlink::x86
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/x86.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/x86.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_X86_H
 #define LLVM_EXECUTIONENGINE_JITLINK_X86_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/TableManager.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm::jitlink::x86 {
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_X86_64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_X86_64_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/TableManager.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace jitlink {

--- a/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_X86_64_H
 #define LLVM_EXECUTIONENGINE_JITLINK_X86_64_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/TableManager.h"
 
@@ -432,7 +433,7 @@ enum EdgeKind_x86_64 : Edge::Kind {
 
 /// Returns a string name for the given x86-64 edge. For debugging purposes
 /// only.
-const char *getEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getEdgeKindName(Edge::Kind K);
 
 /// Apply fixup expression for edge to block content.
 inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
@@ -586,14 +587,14 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
 constexpr uint64_t PointerSize = 8;
 
 /// x86-64 null pointer content.
-extern const char NullPointerContent[PointerSize];
+LLVM_ABI extern const char NullPointerContent[PointerSize];
 
 /// x86-64 pointer jump stub content.
 ///
 /// Contains the instruction sequence for an indirect jump via an in-memory
 /// pointer:
 ///   jmpq *ptr(%rip)
-extern const char PointerJumpStubContent[6];
+LLVM_ABI extern const char PointerJumpStubContent[6];
 
 /// Creates a new pointer block in the given section and returns an anonymous
 /// symbol pointing to it.
@@ -646,7 +647,7 @@ inline Symbol &createAnonymousPointerJumpStub(LinkGraph &G,
 /// Contains the instruction sequence for a trampoline that stores its return
 /// address on the stack and calls <reentry-symbol>:
 ///   call  <reentry-symbol>
-extern const char ReentryTrampolineContent[5];
+LLVM_ABI extern const char ReentryTrampolineContent[5];
 
 /// Create a block of N reentry trampolines.
 inline Block &createReentryTrampolineBlock(LinkGraph &G,
@@ -726,7 +727,7 @@ private:
     return *GOTSection;
   }
 
-  void registerExistingEntries();
+  LLVM_ABI void registerExistingEntries();
 
   Section *GOTSection = nullptr;
 };
@@ -770,7 +771,7 @@ public:
     return *StubsSection;
   }
 
-  void registerExistingEntries();
+  LLVM_ABI void registerExistingEntries();
 
   GOTTableManager &GOT;
   Section *StubsSection = nullptr;
@@ -782,7 +783,7 @@ public:
 /// 2. BranchPCRel32ToPtrJumpStubRelaxable. For this edge kind, if the target is
 /// in range, replace a indirect jump by plt stub with a direct jump to the
 /// target
-Error optimizeGOTAndStubAccesses(LinkGraph &G);
+LLVM_ABI Error optimizeGOTAndStubAccesses(LinkGraph &G);
 
 } // namespace x86_64
 } // end namespace jitlink

--- a/llvm/include/llvm/ExecutionEngine/JITSymbol.h
+++ b/llvm/include/llvm/ExecutionEngine/JITSymbol.h
@@ -220,7 +220,8 @@ public:
 
   operator JITSymbolFlags::TargetFlagsType&() { return Flags; }
 
-  LLVM_ABI static ARMJITSymbolFlags fromObjectSymbol(const object::SymbolRef &Symbol);
+  LLVM_ABI static ARMJITSymbolFlags
+  fromObjectSymbol(const object::SymbolRef &Symbol);
 
 private:
   JITSymbolFlags::TargetFlagsType Flags = 0;

--- a/llvm/include/llvm/ExecutionEngine/JITSymbol.h
+++ b/llvm/include/llvm/ExecutionEngine/JITSymbol.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITSYMBOL_H
 #define LLVM_EXECUTIONENGINE_JITSYMBOL_H
 
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -176,15 +177,15 @@ public:
 
   /// Construct a JITSymbolFlags value based on the flags of the given global
   /// value.
-  static JITSymbolFlags fromGlobalValue(const GlobalValue &GV);
+  LLVM_ABI static JITSymbolFlags fromGlobalValue(const GlobalValue &GV);
 
   /// Construct a JITSymbolFlags value based on the flags of the given global
   /// value summary.
-  static JITSymbolFlags fromSummary(GlobalValueSummary *S);
+  LLVM_ABI static JITSymbolFlags fromSummary(GlobalValueSummary *S);
 
   /// Construct a JITSymbolFlags value based on the flags of the given libobject
   /// symbol.
-  static Expected<JITSymbolFlags>
+  LLVM_ABI static Expected<JITSymbolFlags>
   fromObjectSymbol(const object::SymbolRef &Symbol);
 
 private:
@@ -219,7 +220,7 @@ public:
 
   operator JITSymbolFlags::TargetFlagsType&() { return Flags; }
 
-  static ARMJITSymbolFlags fromObjectSymbol(const object::SymbolRef &Symbol);
+  LLVM_ABI static ARMJITSymbolFlags fromObjectSymbol(const object::SymbolRef &Symbol);
 
 private:
   JITSymbolFlags::TargetFlagsType Flags = 0;
@@ -368,7 +369,7 @@ private:
 /// Symbol queries are done in bulk (i.e. you request resolution of a set of
 /// symbols, rather than a single one) to reduce IPC overhead in the case of
 /// remote JITing, and expose opportunities for parallel compilation.
-class JITSymbolResolver {
+class LLVM_ABI JITSymbolResolver {
 public:
   using LookupSet = std::set<StringRef>;
   using LookupResult = std::map<StringRef, JITEvaluatedSymbol>;
@@ -398,7 +399,7 @@ private:
 };
 
 /// Legacy symbol resolution interface.
-class LegacyJITSymbolResolver : public JITSymbolResolver {
+class LLVM_ABI LegacyJITSymbolResolver : public JITSymbolResolver {
 public:
   /// Performs lookup by, for each symbol, first calling
   ///        findSymbolInLogicalDylib and if that fails calling

--- a/llvm/include/llvm/ExecutionEngine/MCJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/MCJIT.h
@@ -15,9 +15,10 @@
 #define LLVM_EXECUTIONENGINE_MCJIT_H
 
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdlib>
 
-extern "C" void LLVMLinkInMCJIT();
+extern "C" LLVM_ABI void LLVMLinkInMCJIT();
 
 namespace {
   struct ForceMCJITLinking {

--- a/llvm/include/llvm/ExecutionEngine/ObjectCache.h
+++ b/llvm/include/llvm/ExecutionEngine/ObjectCache.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_EXECUTIONENGINE_OBJECTCACHE_H
 #define LLVM_EXECUTIONENGINE_OBJECTCACHE_H
 
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {
@@ -20,7 +21,7 @@ class Module;
 /// This is the base ObjectCache type which can be provided to an
 /// ExecutionEngine for the purpose of avoiding compilation for Modules that
 /// have already been compiled and an object file is available.
-class ObjectCache {
+class LLVM_ABI ObjectCache {
   virtual void anchor();
 
 public:

--- a/llvm/include/llvm/ExecutionEngine/Orc/AbsoluteSymbols.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/AbsoluteSymbols.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_ABSOLUTESYMBOLS_H
 #define LLVM_EXECUTIONENGINE_ORC_ABSOLUTESYMBOLS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/MaterializationUnit.h"
 
 namespace llvm::orc {
@@ -21,7 +22,7 @@ namespace llvm::orc {
 ///
 /// All symbols will be resolved and marked ready as soon as the unit is
 /// materialized.
-class AbsoluteSymbolsMaterializationUnit : public MaterializationUnit {
+class LLVM_ABI AbsoluteSymbolsMaterializationUnit : public MaterializationUnit {
 public:
   AbsoluteSymbolsMaterializationUnit(SymbolMap Symbols);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/AbsoluteSymbols.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/AbsoluteSymbols.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_ABSOLUTESYMBOLS_H
 #define LLVM_EXECUTIONENGINE_ORC_ABSOLUTESYMBOLS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/MaterializationUnit.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm::orc {
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/COFFPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFFPlatform.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COFFPLATFORM_H
 #define LLVM_EXECUTIONENGINE_ORC_COFFPLATFORM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/COFFVCRuntimeSupport.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
@@ -21,6 +20,7 @@
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 
 #include <future>
 #include <list>

--- a/llvm/include/llvm/ExecutionEngine/Orc/COFFPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFFPlatform.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COFFPLATFORM_H
 #define LLVM_EXECUTIONENGINE_ORC_COFFPLATFORM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/COFFVCRuntimeSupport.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
@@ -31,7 +32,7 @@ namespace llvm {
 namespace orc {
 
 /// Mediates between COFF initialization and ExecutionSession state.
-class COFFPlatform : public Platform {
+class LLVM_ABI COFFPlatform : public Platform {
 public:
   /// A function that will be called with the name of dll file that must be
   /// loaded.
@@ -90,7 +91,7 @@ private:
   // The COFFPlatformPlugin scans/modifies LinkGraphs to support COFF
   // platform features including initializers, exceptions, and language
   // runtime registration.
-  class COFFPlatformPlugin : public ObjectLinkingLayer::Plugin {
+  class LLVM_ABI COFFPlatformPlugin : public ObjectLinkingLayer::Plugin {
   public:
     COFFPlatformPlugin(COFFPlatform &CP) : CP(CP) {}
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/COFFVCRuntimeSupport.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFFVCRuntimeSupport.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COFFCRUNTIMESUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_COFFCRUNTIMESUPPORT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
@@ -45,12 +46,12 @@ public:
   ///
   /// More information is on:
   /// https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-library-features
-  static Expected<std::unique_ptr<COFFVCRuntimeBootstrapper>>
+  LLVM_ABI static Expected<std::unique_ptr<COFFVCRuntimeBootstrapper>>
   Create(ExecutionSession &ES, ObjectLinkingLayer &ObjLinkingLayer,
          const char *RuntimePath = nullptr);
 
   /// Adds symbol definitions of static version of msvc runtime libraries.
-  Expected<std::vector<std::string>>
+  LLVM_ABI Expected<std::vector<std::string>>
   loadStaticVCRuntime(JITDylib &JD, bool DebugVersion = false);
 
   /// Runs the initializer of static version of msvc runtime libraries.
@@ -58,10 +59,10 @@ public:
   /// printf) within the jit session. Note that proper initialization of vc
   /// runtime requires ability of running static initializers. Cosider setting
   /// up COFFPlatform.
-  Error initializeStaticVCRuntime(JITDylib &JD);
+  LLVM_ABI Error initializeStaticVCRuntime(JITDylib &JD);
 
   /// Adds symbol definitions of dynamic version of msvc runtime libraries.
-  Expected<std::vector<std::string>>
+  LLVM_ABI Expected<std::vector<std::string>>
   loadDynamicVCRuntime(JITDylib &JD, bool DebugVersion = false);
 
 private:

--- a/llvm/include/llvm/ExecutionEngine/Orc/COFFVCRuntimeSupport.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFFVCRuntimeSupport.h
@@ -13,12 +13,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COFFCRUNTIMESUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_COFFCRUNTIMESUPPORT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 
 #include <future>
 #include <memory>

--- a/llvm/include/llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COMPILEONDEMANDLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_COMPILEONDEMANDLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -38,6 +37,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
 #include <algorithm>

--- a/llvm/include/llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COMPILEONDEMANDLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_COMPILEONDEMANDLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -52,7 +53,7 @@
 namespace llvm {
 namespace orc {
 
-class CompileOnDemandLayer : public IRLayer {
+class LLVM_ABI CompileOnDemandLayer : public IRLayer {
 public:
   /// Builder for IndirectStubsManagers.
   using IndirectStubsManagerBuilder =

--- a/llvm/include/llvm/ExecutionEngine/Orc/CompileUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/CompileUtils.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COMPILEUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_COMPILEUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
@@ -27,13 +28,13 @@ class TargetMachine;
 
 namespace orc {
 
-IRSymbolMapper::ManglingOptions
+LLVM_ABI IRSymbolMapper::ManglingOptions
 irManglingOptionsFromTargetOptions(const TargetOptions &Opts);
 
 /// Simple compile functor: Takes a single IR module and returns an ObjectFile.
 /// This compiler supports a single compilation thread and LLVMContext only.
 /// For multithreaded compilation, use ConcurrentIRCompiler below.
-class SimpleCompiler : public IRCompileLayer::IRCompiler {
+class LLVM_ABI SimpleCompiler : public IRCompileLayer::IRCompiler {
 public:
   using CompileResult = std::unique_ptr<MemoryBuffer>;
 
@@ -79,7 +80,7 @@ private:
 ///
 /// This class creates a new TargetMachine and SimpleCompiler instance for each
 /// compile.
-class ConcurrentIRCompiler : public IRCompileLayer::IRCompiler {
+class LLVM_ABI ConcurrentIRCompiler : public IRCompileLayer::IRCompiler {
 public:
   ConcurrentIRCompiler(JITTargetMachineBuilder JTMB,
                        ObjectCache *ObjCache = nullptr);

--- a/llvm/include/llvm/ExecutionEngine/Orc/CompileUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/CompileUtils.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COMPILEUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_COMPILEUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {

--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_CORE_H
 #define LLVM_EXECUTIONENGINE_ORC_CORE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
@@ -27,6 +26,7 @@
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/ExecutionEngine/Orc/TaskDispatch.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ExtensibleRTTI.h"
 
@@ -423,7 +423,8 @@ using RegisterDependenciesFunction =
 /// are no dependants to register with.
 LLVM_ABI extern RegisterDependenciesFunction NoDependenciesToRegister;
 
-class LLVM_ABI ResourceTrackerDefunct : public ErrorInfo<ResourceTrackerDefunct> {
+class LLVM_ABI ResourceTrackerDefunct
+    : public ErrorInfo<ResourceTrackerDefunct> {
 public:
   static char ID;
 
@@ -493,7 +494,8 @@ private:
 };
 
 /// Used to notify clients that a set of symbols could not be removed.
-class LLVM_ABI SymbolsCouldNotBeRemoved : public ErrorInfo<SymbolsCouldNotBeRemoved> {
+class LLVM_ABI SymbolsCouldNotBeRemoved
+    : public ErrorInfo<SymbolsCouldNotBeRemoved> {
 public:
   static char ID;
 
@@ -513,7 +515,8 @@ private:
 /// definitions that are claimed by the module's associated
 /// MaterializationResponsibility. If this error is returned it is indicative of
 /// a broken transformation / compiler / object cache.
-class LLVM_ABI MissingSymbolDefinitions : public ErrorInfo<MissingSymbolDefinitions> {
+class LLVM_ABI MissingSymbolDefinitions
+    : public ErrorInfo<MissingSymbolDefinitions> {
 public:
   static char ID;
 
@@ -536,7 +539,8 @@ private:
 /// symbols that are not claimed by the module's associated
 /// MaterializationResponsibility. If this error is returned it is indicative of
 /// a broken transformation / compiler / object cache.
-class LLVM_ABI UnexpectedSymbolDefinitions : public ErrorInfo<UnexpectedSymbolDefinitions> {
+class LLVM_ABI UnexpectedSymbolDefinitions
+    : public ErrorInfo<UnexpectedSymbolDefinitions> {
 public:
   static char ID;
 
@@ -790,12 +794,12 @@ public:
   /// callback will be called once all queried symbols reach the given
   /// minimum state.
   LLVM_ABI AsynchronousSymbolQuery(const SymbolLookupSet &Symbols,
-                          SymbolState RequiredState,
-                          SymbolsResolvedCallback NotifyComplete);
+                                   SymbolState RequiredState,
+                                   SymbolsResolvedCallback NotifyComplete);
 
   /// Notify the query that a requested symbol has reached the required state.
   LLVM_ABI void notifySymbolMetRequiredState(const SymbolStringPtr &Name,
-                                    ExecutorSymbolDef Sym);
+                                             ExecutorSymbolDef Sym);
 
   /// Returns true if all symbols covered by this query have been
   ///        resolved.
@@ -988,7 +992,7 @@ public:
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
   LLVM_ABI void setLinkOrder(JITDylibSearchOrder NewSearchOrder,
-                    bool LinkAgainstThisJITDylibFirst = true);
+                             bool LinkAgainstThisJITDylibFirst = true);
 
   /// Append the given JITDylibSearchOrder to the link order for this
   /// JITDylib (discarding any elements already present in this JITDylib's
@@ -1000,18 +1004,20 @@ public:
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  LLVM_ABI void addToLinkOrder(JITDylib &JD,
-                      JITDylibLookupFlags JDLookupFlags =
-                          JITDylibLookupFlags::MatchExportedSymbolsOnly);
+  LLVM_ABI void
+  addToLinkOrder(JITDylib &JD,
+                 JITDylibLookupFlags JDLookupFlags =
+                     JITDylibLookupFlags::MatchExportedSymbolsOnly);
 
   /// Replace OldJD with NewJD in the link order if OldJD is present.
   /// Otherwise this operation is a no-op.
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  LLVM_ABI void replaceInLinkOrder(JITDylib &OldJD, JITDylib &NewJD,
-                          JITDylibLookupFlags JDLookupFlags =
-                              JITDylibLookupFlags::MatchExportedSymbolsOnly);
+  LLVM_ABI void
+  replaceInLinkOrder(JITDylib &OldJD, JITDylib &NewJD,
+                     JITDylibLookupFlags JDLookupFlags =
+                         JITDylibLookupFlags::MatchExportedSymbolsOnly);
 
   /// Remove the given JITDylib from the link order for this JITDylib if it is
   /// present. Otherwise this operation is a no-op.
@@ -1153,7 +1159,8 @@ private:
 
     LLVM_ABI void addQuery(std::shared_ptr<AsynchronousSymbolQuery> Q);
     LLVM_ABI void removeQuery(const AsynchronousSymbolQuery &Q);
-    LLVM_ABI AsynchronousSymbolQueryList takeQueriesMeeting(SymbolState RequiredState);
+    LLVM_ABI AsynchronousSymbolQueryList
+    takeQueriesMeeting(SymbolState RequiredState);
     AsynchronousSymbolQueryList takeAllPendingQueries() {
       return std::move(PendingQueries);
     }
@@ -1217,8 +1224,9 @@ private:
 
   LLVM_ABI Error defineImpl(MaterializationUnit &MU);
 
-  LLVM_ABI void installMaterializationUnit(std::unique_ptr<MaterializationUnit> MU,
-                                  ResourceTracker &RT);
+  LLVM_ABI void
+  installMaterializationUnit(std::unique_ptr<MaterializationUnit> MU,
+                             ResourceTracker &RT);
 
   void detachQueryHelper(AsynchronousSymbolQuery &Q,
                          const SymbolNameSet &QuerySymbols);
@@ -1311,7 +1319,8 @@ public:
 };
 
 /// A materialization task.
-class LLVM_ABI MaterializationTask : public RTTIExtends<MaterializationTask, Task> {
+class LLVM_ABI MaterializationTask
+    : public RTTIExtends<MaterializationTask, Task> {
 public:
   static char ID;
 
@@ -1482,14 +1491,15 @@ public:
 
   /// Search the given JITDylibs to find the flags associated with each of the
   /// given symbols.
-  LLVM_ABI void lookupFlags(LookupKind K, JITDylibSearchOrder SearchOrder,
-                   SymbolLookupSet Symbols,
-                   unique_function<void(Expected<SymbolFlagsMap>)> OnComplete);
+  LLVM_ABI void
+  lookupFlags(LookupKind K, JITDylibSearchOrder SearchOrder,
+              SymbolLookupSet Symbols,
+              unique_function<void(Expected<SymbolFlagsMap>)> OnComplete);
 
   /// Blocking version of lookupFlags.
   LLVM_ABI Expected<SymbolFlagsMap> lookupFlags(LookupKind K,
-                                       JITDylibSearchOrder SearchOrder,
-                                       SymbolLookupSet Symbols);
+                                                JITDylibSearchOrder SearchOrder,
+                                                SymbolLookupSet Symbols);
 
   /// Search the given JITDylibs for the given symbols.
   ///
@@ -1511,9 +1521,9 @@ public:
   /// client to get an address to call) then the value NoDependenciesToRegister
   /// can be used.
   LLVM_ABI void lookup(LookupKind K, const JITDylibSearchOrder &SearchOrder,
-              SymbolLookupSet Symbols, SymbolState RequiredState,
-              SymbolsResolvedCallback NotifyComplete,
-              RegisterDependenciesFunction RegisterDependencies);
+                       SymbolLookupSet Symbols, SymbolState RequiredState,
+                       SymbolsResolvedCallback NotifyComplete,
+                       RegisterDependenciesFunction RegisterDependencies);
 
   /// Blocking version of lookup above. Returns the resolved symbol map.
   /// If WaitUntilReady is true (the default), will not return until all
@@ -1522,12 +1532,12 @@ public:
   /// or an error occurs. If WaitUntilReady is false and an error occurs
   /// after resolution, the function will return a success value, but the
   /// error will be reported via reportErrors.
-  LLVM_ABI Expected<SymbolMap> lookup(const JITDylibSearchOrder &SearchOrder,
-                             SymbolLookupSet Symbols,
-                             LookupKind K = LookupKind::Static,
-                             SymbolState RequiredState = SymbolState::Ready,
-                             RegisterDependenciesFunction RegisterDependencies =
-                                 NoDependenciesToRegister);
+  LLVM_ABI Expected<SymbolMap>
+  lookup(const JITDylibSearchOrder &SearchOrder, SymbolLookupSet Symbols,
+         LookupKind K = LookupKind::Static,
+         SymbolState RequiredState = SymbolState::Ready,
+         RegisterDependenciesFunction RegisterDependencies =
+             NoDependenciesToRegister);
 
   /// Convenience version of blocking lookup.
   /// Searches each of the JITDylibs in the search order in turn for the given
@@ -1687,15 +1697,15 @@ public:
   /// JITDylibLookupFlags::MatchAllSymbols (hidden tags will be found), and
   /// LookupFlags::WeaklyReferencedSymbol. Missing tag definitions will not
   /// cause an error, the handler will simply be dropped.
-  LLVM_ABI Error registerJITDispatchHandlers(JITDylib &JD,
-                                    JITDispatchHandlerAssociationMap WFs);
+  LLVM_ABI Error registerJITDispatchHandlers(
+      JITDylib &JD, JITDispatchHandlerAssociationMap WFs);
 
   /// Run a registered jit-side wrapper function.
   /// This should be called by the ExecutorProcessControl instance in response
   /// to incoming jit-dispatch requests from the executor.
   LLVM_ABI void runJITDispatchHandler(SendResultFunction SendResult,
-                             ExecutorAddr HandlerFnTagAddr,
-                             ArrayRef<char> ArgBuffer);
+                                      ExecutorAddr HandlerFnTagAddr,
+                                      ArrayRef<char> ArgBuffer);
 
   /// Dump the state of all the JITDylibs in this session.
   LLVM_ABI void dump(raw_ostream &OS);
@@ -1761,11 +1771,12 @@ private:
       unique_function<void(Expected<SymbolFlagsMap>)> OnComplete);
 
   // State machine functions for MaterializationResponsibility.
-  LLVM_ABI void OL_destroyMaterializationResponsibility(
-      MaterializationResponsibility &MR);
-  LLVM_ABI SymbolNameSet OL_getRequestedSymbols(const MaterializationResponsibility &MR);
+  LLVM_ABI void
+  OL_destroyMaterializationResponsibility(MaterializationResponsibility &MR);
+  LLVM_ABI SymbolNameSet
+  OL_getRequestedSymbols(const MaterializationResponsibility &MR);
   LLVM_ABI Error OL_notifyResolved(MaterializationResponsibility &MR,
-                          const SymbolMap &Symbols);
+                                   const SymbolMap &Symbols);
 
   using EDUInfosMap =
       DenseMap<JITDylib::EmissionDepUnit *, JITDylib::EmissionDepUnitInfo>;
@@ -1792,17 +1803,17 @@ private:
   Expected<JITDylib::AsynchronousSymbolQuerySet>
   IL_emit(MaterializationResponsibility &MR, EDUInfosMap EDUInfos);
   LLVM_ABI Error OL_notifyEmitted(MaterializationResponsibility &MR,
-                         ArrayRef<SymbolDependenceGroup> EmittedDeps);
+                                  ArrayRef<SymbolDependenceGroup> EmittedDeps);
 
   LLVM_ABI Error OL_defineMaterializing(MaterializationResponsibility &MR,
-                               SymbolFlagsMap SymbolFlags);
+                                        SymbolFlagsMap SymbolFlags);
 
   std::pair<JITDylib::AsynchronousSymbolQuerySet,
             std::shared_ptr<SymbolDependenceMap>>
   IL_failSymbols(JITDylib &JD, const SymbolNameVector &SymbolsToFail);
   LLVM_ABI void OL_notifyFailed(MaterializationResponsibility &MR);
   LLVM_ABI Error OL_replace(MaterializationResponsibility &MR,
-                   std::unique_ptr<MaterializationUnit> MU);
+                            std::unique_ptr<MaterializationUnit> MU);
   LLVM_ABI Expected<std::unique_ptr<MaterializationResponsibility>>
   OL_delegate(MaterializationResponsibility &MR, const SymbolNameSet &Symbols);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_CORE_H
 #define LLVM_EXECUTIONENGINE_ORC_CORE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
@@ -64,7 +65,7 @@ public:
   const SymbolStringPtr &getName() const { return Name; }
 
   Expected<ExecutorSymbolDef> lookup() const;
-  void lookupAsync(LookupAsyncOnCompleteFn OnComplete) const;
+  LLVM_ABI void lookupAsync(LookupAsyncOnCompleteFn OnComplete) const;
 
 private:
   JITDylibSP JD;
@@ -86,7 +87,7 @@ public:
   ResourceTracker(ResourceTracker &&) = delete;
   ResourceTracker &operator=(ResourceTracker &&) = delete;
 
-  ~ResourceTracker();
+  LLVM_ABI ~ResourceTracker();
 
   /// Return the JITDylib targeted by this tracker.
   JITDylib &getJITDylib() const {
@@ -99,11 +100,11 @@ public:
   template <typename Func> Error withResourceKeyDo(Func &&F);
 
   /// Remove all resources associated with this key.
-  Error remove();
+  LLVM_ABI Error remove();
 
   /// Transfer all resources associated with this key to the given
   /// tracker, which must target the same JITDylib as this one.
-  void transferTo(ResourceTracker &DstRT);
+  LLVM_ABI void transferTo(ResourceTracker &DstRT);
 
   /// Return true if this tracker has become defunct.
   bool isDefunct() const { return JDAndFlag.load() & 0x1; }
@@ -122,7 +123,7 @@ private:
 };
 
 /// Listens for ResourceTracker operations.
-class ResourceManager {
+class LLVM_ABI ResourceManager {
 public:
   virtual ~ResourceManager();
 
@@ -420,9 +421,9 @@ using RegisterDependenciesFunction =
 
 /// This can be used as the value for a RegisterDependenciesFunction if there
 /// are no dependants to register with.
-extern RegisterDependenciesFunction NoDependenciesToRegister;
+LLVM_ABI extern RegisterDependenciesFunction NoDependenciesToRegister;
 
-class ResourceTrackerDefunct : public ErrorInfo<ResourceTrackerDefunct> {
+class LLVM_ABI ResourceTrackerDefunct : public ErrorInfo<ResourceTrackerDefunct> {
 public:
   static char ID;
 
@@ -436,7 +437,7 @@ private:
 
 /// Used to notify a JITDylib that the given set of symbols failed to
 /// materialize.
-class FailedToMaterialize : public ErrorInfo<FailedToMaterialize> {
+class LLVM_ABI FailedToMaterialize : public ErrorInfo<FailedToMaterialize> {
 public:
   static char ID;
 
@@ -453,7 +454,7 @@ private:
 };
 
 /// Used to report failure due to unsatisfiable symbol dependencies.
-class UnsatisfiedSymbolDependencies
+class LLVM_ABI UnsatisfiedSymbolDependencies
     : public ErrorInfo<UnsatisfiedSymbolDependencies> {
 public:
   static char ID;
@@ -474,7 +475,7 @@ private:
 };
 
 /// Used to notify clients when symbols can not be found during a lookup.
-class SymbolsNotFound : public ErrorInfo<SymbolsNotFound> {
+class LLVM_ABI SymbolsNotFound : public ErrorInfo<SymbolsNotFound> {
 public:
   static char ID;
 
@@ -492,7 +493,7 @@ private:
 };
 
 /// Used to notify clients that a set of symbols could not be removed.
-class SymbolsCouldNotBeRemoved : public ErrorInfo<SymbolsCouldNotBeRemoved> {
+class LLVM_ABI SymbolsCouldNotBeRemoved : public ErrorInfo<SymbolsCouldNotBeRemoved> {
 public:
   static char ID;
 
@@ -512,7 +513,7 @@ private:
 /// definitions that are claimed by the module's associated
 /// MaterializationResponsibility. If this error is returned it is indicative of
 /// a broken transformation / compiler / object cache.
-class MissingSymbolDefinitions : public ErrorInfo<MissingSymbolDefinitions> {
+class LLVM_ABI MissingSymbolDefinitions : public ErrorInfo<MissingSymbolDefinitions> {
 public:
   static char ID;
 
@@ -535,7 +536,7 @@ private:
 /// symbols that are not claimed by the module's associated
 /// MaterializationResponsibility. If this error is returned it is indicative of
 /// a broken transformation / compiler / object cache.
-class UnexpectedSymbolDefinitions : public ErrorInfo<UnexpectedSymbolDefinitions> {
+class LLVM_ABI UnexpectedSymbolDefinitions : public ErrorInfo<UnexpectedSymbolDefinitions> {
 public:
   static char ID;
 
@@ -703,7 +704,7 @@ private:
 
 /// A materialization unit for symbol aliases. Allows existing symbols to be
 /// aliased with alternate flags.
-class ReExportsMaterializationUnit : public MaterializationUnit {
+class LLVM_ABI ReExportsMaterializationUnit : public MaterializationUnit {
 public:
   /// SourceJD is allowed to be nullptr, in which case the source JITDylib is
   /// taken to be whatever JITDylib these definitions are materialized in (and
@@ -760,7 +761,7 @@ reexports(JITDylib &SourceJD, SymbolAliasMap Aliases,
 
 /// Build a SymbolAliasMap for the common case where you want to re-export
 /// symbols from another JITDylib with the same linkage/flags.
-Expected<SymbolAliasMap>
+LLVM_ABI Expected<SymbolAliasMap>
 buildSimpleReexportsAliasMap(JITDylib &SourceJD, const SymbolNameSet &Symbols);
 
 /// Represents the state that a symbol has reached during materialization.
@@ -788,12 +789,12 @@ public:
   /// Create a query for the given symbols. The NotifyComplete
   /// callback will be called once all queried symbols reach the given
   /// minimum state.
-  AsynchronousSymbolQuery(const SymbolLookupSet &Symbols,
+  LLVM_ABI AsynchronousSymbolQuery(const SymbolLookupSet &Symbols,
                           SymbolState RequiredState,
                           SymbolsResolvedCallback NotifyComplete);
 
   /// Notify the query that a requested symbol has reached the required state.
-  void notifySymbolMetRequiredState(const SymbolStringPtr &Name,
+  LLVM_ABI void notifySymbolMetRequiredState(const SymbolStringPtr &Name,
                                     ExecutorSymbolDef Sym);
 
   /// Returns true if all symbols covered by this query have been
@@ -831,14 +832,14 @@ class LookupState {
   friend class ExecutionSession;
 
 public:
-  LookupState();
-  LookupState(LookupState &&);
-  LookupState &operator=(LookupState &&);
-  ~LookupState();
+  LLVM_ABI LookupState();
+  LLVM_ABI LookupState(LookupState &&);
+  LLVM_ABI LookupState &operator=(LookupState &&);
+  LLVM_ABI ~LookupState();
 
   /// Continue the lookup. This can be called by DefinitionGenerators
   /// to re-start a captured query-application operation.
-  void continueLookup(Error Err);
+  LLVM_ABI void continueLookup(Error Err);
 
 private:
   LookupState(std::unique_ptr<InProgressLookupState> IPLS);
@@ -851,7 +852,7 @@ private:
 
 /// Definition generators can be attached to JITDylibs to generate new
 /// definitions for otherwise unresolved symbols during lookup.
-class DefinitionGenerator {
+class LLVM_ABI DefinitionGenerator {
   friend class ExecutionSession;
 
 public:
@@ -905,7 +906,7 @@ public:
   JITDylib &operator=(const JITDylib &) = delete;
   JITDylib(JITDylib &&) = delete;
   JITDylib &operator=(JITDylib &&) = delete;
-  ~JITDylib();
+  LLVM_ABI ~JITDylib();
 
   /// Get a reference to the ExecutionSession for this JITDylib.
   ///
@@ -918,7 +919,7 @@ public:
   /// Dump current JITDylib state to OS.
   ///
   /// It is legal to call this method on a defunct JITDylib.
-  void dump(raw_ostream &OS);
+  LLVM_ABI void dump(raw_ostream &OS);
 
   /// Calls remove on all trackers currently associated with this JITDylib.
   /// Does not run static deinits.
@@ -930,19 +931,19 @@ public:
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  Error clear();
+  LLVM_ABI Error clear();
 
   /// Get the default resource tracker for this JITDylib.
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  ResourceTrackerSP getDefaultResourceTracker();
+  LLVM_ABI ResourceTrackerSP getDefaultResourceTracker();
 
   /// Create a resource tracker for this JITDylib.
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  ResourceTrackerSP createResourceTracker();
+  LLVM_ABI ResourceTrackerSP createResourceTracker();
 
   /// Adds a definition generator to this JITDylib and returns a referenece to
   /// it.
@@ -963,7 +964,7 @@ public:
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  void removeGenerator(DefinitionGenerator &G);
+  LLVM_ABI void removeGenerator(DefinitionGenerator &G);
 
   /// Set the link order to be used when fixing up definitions in JITDylib.
   /// This will replace the previous link order, and apply to any symbol
@@ -986,20 +987,20 @@ public:
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  void setLinkOrder(JITDylibSearchOrder NewSearchOrder,
+  LLVM_ABI void setLinkOrder(JITDylibSearchOrder NewSearchOrder,
                     bool LinkAgainstThisJITDylibFirst = true);
 
   /// Append the given JITDylibSearchOrder to the link order for this
   /// JITDylib (discarding any elements already present in this JITDylib's
   /// link order).
-  void addToLinkOrder(const JITDylibSearchOrder &NewLinks);
+  LLVM_ABI void addToLinkOrder(const JITDylibSearchOrder &NewLinks);
 
   /// Add the given JITDylib to the link order for definitions in this
   /// JITDylib.
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  void addToLinkOrder(JITDylib &JD,
+  LLVM_ABI void addToLinkOrder(JITDylib &JD,
                       JITDylibLookupFlags JDLookupFlags =
                           JITDylibLookupFlags::MatchExportedSymbolsOnly);
 
@@ -1008,7 +1009,7 @@ public:
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  void replaceInLinkOrder(JITDylib &OldJD, JITDylib &NewJD,
+  LLVM_ABI void replaceInLinkOrder(JITDylib &OldJD, JITDylib &NewJD,
                           JITDylibLookupFlags JDLookupFlags =
                               JITDylibLookupFlags::MatchExportedSymbolsOnly);
 
@@ -1017,7 +1018,7 @@ public:
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  void removeFromLinkOrder(JITDylib &JD);
+  LLVM_ABI void removeFromLinkOrder(JITDylib &JD);
 
   /// Do something with the link order (run under the session lock).
   ///
@@ -1068,7 +1069,7 @@ public:
   ///
   /// It is illegal to call this method on a defunct JITDylib and the client
   /// is responsible for ensuring that they do not do so.
-  Error remove(const SymbolNameSet &Names);
+  LLVM_ABI Error remove(const SymbolNameSet &Names);
 
   /// Returns the given JITDylibs and all of their transitive dependencies in
   /// DFS order (based on linkage relationships). Each JITDylib will appear
@@ -1076,7 +1077,7 @@ public:
   ///
   /// If any JITDylib in the order is defunct then this method will return an
   /// error, otherwise returns the order.
-  static Expected<std::vector<JITDylibSP>>
+  LLVM_ABI static Expected<std::vector<JITDylibSP>>
   getDFSLinkOrder(ArrayRef<JITDylibSP> JDs);
 
   /// Returns the given JITDylibs and all of their transitive dependencies in
@@ -1085,7 +1086,7 @@ public:
   ///
   /// If any JITDylib in the order is defunct then this method will return an
   /// error, otherwise returns the order.
-  static Expected<std::vector<JITDylibSP>>
+  LLVM_ABI static Expected<std::vector<JITDylibSP>>
   getReverseDFSLinkOrder(ArrayRef<JITDylibSP> JDs);
 
   /// Return this JITDylib and its transitive dependencies in DFS order
@@ -1093,14 +1094,14 @@ public:
   ///
   /// If any JITDylib in the order is defunct then this method will return an
   /// error, otherwise returns the order.
-  Expected<std::vector<JITDylibSP>> getDFSLinkOrder();
+  LLVM_ABI Expected<std::vector<JITDylibSP>> getDFSLinkOrder();
 
   /// Rteurn this JITDylib and its transitive dependencies in reverse DFS order
   /// based on linkage relationships.
   ///
   /// If any JITDylib in the order is defunct then this method will return an
   /// error, otherwise returns the order.
-  Expected<std::vector<JITDylibSP>> getReverseDFSLinkOrder();
+  LLVM_ABI Expected<std::vector<JITDylibSP>> getReverseDFSLinkOrder();
 
 private:
   using AsynchronousSymbolQuerySet =
@@ -1150,9 +1151,9 @@ private:
     std::shared_ptr<EmissionDepUnit> DefiningEDU;
     DenseSet<EmissionDepUnit *> DependantEDUs;
 
-    void addQuery(std::shared_ptr<AsynchronousSymbolQuery> Q);
-    void removeQuery(const AsynchronousSymbolQuery &Q);
-    AsynchronousSymbolQueryList takeQueriesMeeting(SymbolState RequiredState);
+    LLVM_ABI void addQuery(std::shared_ptr<AsynchronousSymbolQuery> Q);
+    LLVM_ABI void removeQuery(const AsynchronousSymbolQuery &Q);
+    LLVM_ABI AsynchronousSymbolQueryList takeQueriesMeeting(SymbolState RequiredState);
     AsynchronousSymbolQueryList takeAllPendingQueries() {
       return std::move(PendingQueries);
     }
@@ -1214,9 +1215,9 @@ private:
 
   void transferTracker(ResourceTracker &DstRT, ResourceTracker &SrcRT);
 
-  Error defineImpl(MaterializationUnit &MU);
+  LLVM_ABI Error defineImpl(MaterializationUnit &MU);
 
-  void installMaterializationUnit(std::unique_ptr<MaterializationUnit> MU,
+  LLVM_ABI void installMaterializationUnit(std::unique_ptr<MaterializationUnit> MU,
                                   ResourceTracker &RT);
 
   void detachQueryHelper(AsynchronousSymbolQuery &Q,
@@ -1270,7 +1271,7 @@ private:
 /// initializers (e.g. C++ static constructors) and ExecutionSession state.
 /// Note that Platforms do not automatically run initializers: clients are still
 /// responsible for doing this.
-class Platform {
+class LLVM_ABI Platform {
 public:
   virtual ~Platform();
 
@@ -1310,7 +1311,7 @@ public:
 };
 
 /// A materialization task.
-class MaterializationTask : public RTTIExtends<MaterializationTask, Task> {
+class LLVM_ABI MaterializationTask : public RTTIExtends<MaterializationTask, Task> {
 public:
   static char ID;
 
@@ -1329,7 +1330,7 @@ private:
 /// Lookups are usually run on the current thread, but in some cases they may
 /// be run as tasks, e.g. if the lookup has been continued from a suspended
 /// state.
-class LookupTask : public RTTIExtends<LookupTask, Task> {
+class LLVM_ABI LookupTask : public RTTIExtends<LookupTask, Task> {
 public:
   static char ID;
 
@@ -1370,15 +1371,15 @@ public:
 
   /// Construct an ExecutionSession with the given ExecutorProcessControl
   /// object.
-  ExecutionSession(std::unique_ptr<ExecutorProcessControl> EPC);
+  LLVM_ABI ExecutionSession(std::unique_ptr<ExecutorProcessControl> EPC);
 
   /// Destroy an ExecutionSession. Verifies that endSession was called prior to
   /// destruction.
-  ~ExecutionSession();
+  LLVM_ABI ~ExecutionSession();
 
   /// End the session. Closes all JITDylibs and disconnects from the
   /// executor. Clients must call this method before destroying the session.
-  Error endSession();
+  LLVM_ABI Error endSession();
 
   /// Get the ExecutorProcessControl object associated with this
   /// ExecutionSession.
@@ -1413,15 +1414,15 @@ public:
 
   /// Register the given ResourceManager with this ExecutionSession.
   /// Managers will be notified of events in reverse order of registration.
-  void registerResourceManager(ResourceManager &RM);
+  LLVM_ABI void registerResourceManager(ResourceManager &RM);
 
   /// Deregister the given ResourceManager with this ExecutionSession.
   /// Manager must have been previously registered.
-  void deregisterResourceManager(ResourceManager &RM);
+  LLVM_ABI void deregisterResourceManager(ResourceManager &RM);
 
   /// Return a pointer to the "name" JITDylib.
   /// Ownership of JITDylib remains within Execution Session
-  JITDylib *getJITDylibByName(StringRef Name);
+  LLVM_ABI JITDylib *getJITDylibByName(StringRef Name);
 
   /// Add a new bare JITDylib to this ExecutionSession.
   ///
@@ -1431,7 +1432,7 @@ public:
   ///
   /// This call does not install any library code or symbols into the newly
   /// created JITDylib. The client is responsible for all configuration.
-  JITDylib &createBareJITDylib(std::string Name);
+  LLVM_ABI JITDylib &createBareJITDylib(std::string Name);
 
   /// Add a new JITDylib to this ExecutionSession.
   ///
@@ -1442,7 +1443,7 @@ public:
   /// If a Platform is attached then Platform::setupJITDylib will be called to
   /// install standard platform symbols (e.g. standard library interposes).
   /// If no Platform is attached this call is equivalent to createBareJITDylib.
-  Expected<JITDylib &> createJITDylib(std::string Name);
+  LLVM_ABI Expected<JITDylib &> createJITDylib(std::string Name);
 
   /// Removes the given JITDylibs from the ExecutionSession.
   ///
@@ -1461,7 +1462,7 @@ public:
   /// depend on it, so the JITDylib containing the ORC runtime must be removed
   /// last. If the client has introduced any other dependencies they should be
   /// accounted for in the removal order too.
-  Error removeJITDylibs(std::vector<JITDylibSP> JDsToRemove);
+  LLVM_ABI Error removeJITDylibs(std::vector<JITDylibSP> JDsToRemove);
 
   /// Calls removeJTIDylibs on the gives JITDylib.
   Error removeJITDylib(JITDylib &JD) {
@@ -1481,12 +1482,12 @@ public:
 
   /// Search the given JITDylibs to find the flags associated with each of the
   /// given symbols.
-  void lookupFlags(LookupKind K, JITDylibSearchOrder SearchOrder,
+  LLVM_ABI void lookupFlags(LookupKind K, JITDylibSearchOrder SearchOrder,
                    SymbolLookupSet Symbols,
                    unique_function<void(Expected<SymbolFlagsMap>)> OnComplete);
 
   /// Blocking version of lookupFlags.
-  Expected<SymbolFlagsMap> lookupFlags(LookupKind K,
+  LLVM_ABI Expected<SymbolFlagsMap> lookupFlags(LookupKind K,
                                        JITDylibSearchOrder SearchOrder,
                                        SymbolLookupSet Symbols);
 
@@ -1509,7 +1510,7 @@ public:
   /// dependenant symbols for this query (e.g. it is being made by a top level
   /// client to get an address to call) then the value NoDependenciesToRegister
   /// can be used.
-  void lookup(LookupKind K, const JITDylibSearchOrder &SearchOrder,
+  LLVM_ABI void lookup(LookupKind K, const JITDylibSearchOrder &SearchOrder,
               SymbolLookupSet Symbols, SymbolState RequiredState,
               SymbolsResolvedCallback NotifyComplete,
               RegisterDependenciesFunction RegisterDependencies);
@@ -1521,7 +1522,7 @@ public:
   /// or an error occurs. If WaitUntilReady is false and an error occurs
   /// after resolution, the function will return a success value, but the
   /// error will be reported via reportErrors.
-  Expected<SymbolMap> lookup(const JITDylibSearchOrder &SearchOrder,
+  LLVM_ABI Expected<SymbolMap> lookup(const JITDylibSearchOrder &SearchOrder,
                              SymbolLookupSet Symbols,
                              LookupKind K = LookupKind::Static,
                              SymbolState RequiredState = SymbolState::Ready,
@@ -1531,21 +1532,21 @@ public:
   /// Convenience version of blocking lookup.
   /// Searches each of the JITDylibs in the search order in turn for the given
   /// symbol.
-  Expected<ExecutorSymbolDef>
+  LLVM_ABI Expected<ExecutorSymbolDef>
   lookup(const JITDylibSearchOrder &SearchOrder, SymbolStringPtr Symbol,
          SymbolState RequiredState = SymbolState::Ready);
 
   /// Convenience version of blocking lookup.
   /// Searches each of the JITDylibs in the search order in turn for the given
   /// symbol. The search will not find non-exported symbols.
-  Expected<ExecutorSymbolDef>
+  LLVM_ABI Expected<ExecutorSymbolDef>
   lookup(ArrayRef<JITDylib *> SearchOrder, SymbolStringPtr Symbol,
          SymbolState RequiredState = SymbolState::Ready);
 
   /// Convenience version of blocking lookup.
   /// Searches each of the JITDylibs in the search order in turn for the given
   /// symbol. The search will not find non-exported symbols.
-  Expected<ExecutorSymbolDef>
+  LLVM_ABI Expected<ExecutorSymbolDef>
   lookup(ArrayRef<JITDylib *> SearchOrder, StringRef Symbol,
          SymbolState RequiredState = SymbolState::Ready);
 
@@ -1686,18 +1687,18 @@ public:
   /// JITDylibLookupFlags::MatchAllSymbols (hidden tags will be found), and
   /// LookupFlags::WeaklyReferencedSymbol. Missing tag definitions will not
   /// cause an error, the handler will simply be dropped.
-  Error registerJITDispatchHandlers(JITDylib &JD,
+  LLVM_ABI Error registerJITDispatchHandlers(JITDylib &JD,
                                     JITDispatchHandlerAssociationMap WFs);
 
   /// Run a registered jit-side wrapper function.
   /// This should be called by the ExecutorProcessControl instance in response
   /// to incoming jit-dispatch requests from the executor.
-  void runJITDispatchHandler(SendResultFunction SendResult,
+  LLVM_ABI void runJITDispatchHandler(SendResultFunction SendResult,
                              ExecutorAddr HandlerFnTagAddr,
                              ArrayRef<char> ArgBuffer);
 
   /// Dump the state of all the JITDylibs in this session.
-  void dump(raw_ostream &OS);
+  LLVM_ABI void dump(raw_ostream &OS);
 
   /// Check the internal consistency of ExecutionSession data structures.
 #ifdef EXPENSIVE_CHECKS
@@ -1760,10 +1761,10 @@ private:
       unique_function<void(Expected<SymbolFlagsMap>)> OnComplete);
 
   // State machine functions for MaterializationResponsibility.
-  void OL_destroyMaterializationResponsibility(
+  LLVM_ABI void OL_destroyMaterializationResponsibility(
       MaterializationResponsibility &MR);
-  SymbolNameSet OL_getRequestedSymbols(const MaterializationResponsibility &MR);
-  Error OL_notifyResolved(MaterializationResponsibility &MR,
+  LLVM_ABI SymbolNameSet OL_getRequestedSymbols(const MaterializationResponsibility &MR);
+  LLVM_ABI Error OL_notifyResolved(MaterializationResponsibility &MR,
                           const SymbolMap &Symbols);
 
   using EDUInfosMap =
@@ -1790,19 +1791,19 @@ private:
 
   Expected<JITDylib::AsynchronousSymbolQuerySet>
   IL_emit(MaterializationResponsibility &MR, EDUInfosMap EDUInfos);
-  Error OL_notifyEmitted(MaterializationResponsibility &MR,
+  LLVM_ABI Error OL_notifyEmitted(MaterializationResponsibility &MR,
                          ArrayRef<SymbolDependenceGroup> EmittedDeps);
 
-  Error OL_defineMaterializing(MaterializationResponsibility &MR,
+  LLVM_ABI Error OL_defineMaterializing(MaterializationResponsibility &MR,
                                SymbolFlagsMap SymbolFlags);
 
   std::pair<JITDylib::AsynchronousSymbolQuerySet,
             std::shared_ptr<SymbolDependenceMap>>
   IL_failSymbols(JITDylib &JD, const SymbolNameVector &SymbolsToFail);
-  void OL_notifyFailed(MaterializationResponsibility &MR);
-  Error OL_replace(MaterializationResponsibility &MR,
+  LLVM_ABI void OL_notifyFailed(MaterializationResponsibility &MR);
+  LLVM_ABI Error OL_replace(MaterializationResponsibility &MR,
                    std::unique_ptr<MaterializationUnit> MU);
-  Expected<std::unique_ptr<MaterializationResponsibility>>
+  LLVM_ABI Expected<std::unique_ptr<MaterializationResponsibility>>
   OL_delegate(MaterializationResponsibility &MR, const SymbolNameSet &Symbols);
 
 #ifndef NDEBUG
@@ -1954,7 +1955,7 @@ Error JITDylib::define(std::unique_ptr<MaterializationUnitType> &MU,
 
 /// ReexportsGenerator can be used with JITDylib::addGenerator to automatically
 /// re-export a subset of the source JITDylib's symbols in the target.
-class ReexportsGenerator : public DefinitionGenerator {
+class LLVM_ABI ReexportsGenerator : public DefinitionGenerator {
 public:
   using SymbolPredicate = std::function<bool(SymbolStringPtr)>;
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGOBJECTMANAGERPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGOBJECTMANAGERPLUGIN_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h"
@@ -45,7 +46,7 @@ class DebugObject;
 /// DebugObjectRegistrar is notified. Ownership of DebugObjects remains with the
 /// plugin.
 ///
-class DebugObjectManagerPlugin : public ObjectLinkingLayer::Plugin {
+class LLVM_ABI DebugObjectManagerPlugin : public ObjectLinkingLayer::Plugin {
 public:
   // DEPRECATED - Please specify options explicitly
   DebugObjectManagerPlugin(ExecutionSession &ES,

--- a/llvm/include/llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGOBJECTMANAGERPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGOBJECTMANAGERPLUGIN_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Memory.h"
 #include "llvm/Support/MemoryBufferRef.h"

--- a/llvm/include/llvm/ExecutionEngine/Orc/DebugUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/DebugUtils.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
@@ -30,67 +31,67 @@ namespace orc {
 // --raw_ostream operators for ORC types--
 
 /// Render a SymbolNameSet.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolNameSet &Symbols);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolNameSet &Symbols);
 
 /// Render a SymbolNameVector.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolNameVector &Symbols);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolNameVector &Symbols);
 
 /// Render an array of SymbolStringPtrs.
-raw_ostream &operator<<(raw_ostream &OS, ArrayRef<SymbolStringPtr> Symbols);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, ArrayRef<SymbolStringPtr> Symbols);
 
 /// Render JITSymbolFlags.
-raw_ostream &operator<<(raw_ostream &OS, const JITSymbolFlags &Flags);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const JITSymbolFlags &Flags);
 
 /// Render a SymbolFlagsMap entry.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolFlagsMap::value_type &KV);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolFlagsMap::value_type &KV);
 
 /// Render a SymbolMap entry.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolMap::value_type &KV);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolMap::value_type &KV);
 
 /// Render a SymbolFlagsMap.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolFlagsMap &SymbolFlags);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolFlagsMap &SymbolFlags);
 
 /// Render a SymbolMap.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolMap &Symbols);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolMap &Symbols);
 
 /// Render a SymbolDependenceMap entry.
-raw_ostream &operator<<(raw_ostream &OS,
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                         const SymbolDependenceMap::value_type &KV);
 
 /// Render a SymbolDependendeMap.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolDependenceMap &Deps);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolDependenceMap &Deps);
 
 /// Render a MaterializationUnit.
-raw_ostream &operator<<(raw_ostream &OS, const MaterializationUnit &MU);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const MaterializationUnit &MU);
 
 //// Render a JITDylibLookupFlags instance.
-raw_ostream &operator<<(raw_ostream &OS,
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                         const JITDylibLookupFlags &JDLookupFlags);
 
 /// Render a SymbolLookupFlags instance.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupFlags &LookupFlags);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupFlags &LookupFlags);
 
 /// Render a SymbolLookupSet entry.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupSet::value_type &KV);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupSet::value_type &KV);
 
 /// Render a SymbolLookupSet.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupSet &LookupSet);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupSet &LookupSet);
 
 /// Render a JITDylibSearchOrder.
-raw_ostream &operator<<(raw_ostream &OS,
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                         const JITDylibSearchOrder &SearchOrder);
 
 /// Render a SymbolAliasMap.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolAliasMap &Aliases);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolAliasMap &Aliases);
 
 /// Render a SymbolState.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolState &S);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolState &S);
 
 /// Render a LookupKind.
-raw_ostream &operator<<(raw_ostream &OS, const LookupKind &K);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const LookupKind &K);
 
 /// Dump a SymbolStringPool. Useful for debugging dangling-pointer crashes.
-raw_ostream &operator<<(raw_ostream &OS, const SymbolStringPool &SSP);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolStringPool &SSP);
 
 /// A function object that can be used as an ObjectTransformLayer transform
 /// to dump object files to disk at a specified path.
@@ -109,10 +110,10 @@ public:
   /// identifier, the resulting files will be named <ident>.o, <ident>.2.o,
   /// <ident>.3.o, and so on). IdentifierOverride should not contain an
   /// extension, as a .o suffix will be added by DumpObjects.
-  DumpObjects(std::string DumpDir = "", std::string IdentifierOverride = "");
+  LLVM_ABI DumpObjects(std::string DumpDir = "", std::string IdentifierOverride = "");
 
   /// Dumps the given buffer to disk.
-  Expected<std::unique_ptr<MemoryBuffer>>
+  LLVM_ABI Expected<std::unique_ptr<MemoryBuffer>>
   operator()(std::unique_ptr<MemoryBuffer> Obj);
 
 private:

--- a/llvm/include/llvm/ExecutionEngine/Orc/DebugUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/DebugUtils.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
@@ -34,55 +34,66 @@ namespace orc {
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolNameSet &Symbols);
 
 /// Render a SymbolNameVector.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolNameVector &Symbols);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolNameVector &Symbols);
 
 /// Render an array of SymbolStringPtrs.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, ArrayRef<SymbolStringPtr> Symbols);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 ArrayRef<SymbolStringPtr> Symbols);
 
 /// Render JITSymbolFlags.
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const JITSymbolFlags &Flags);
 
 /// Render a SymbolFlagsMap entry.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolFlagsMap::value_type &KV);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolFlagsMap::value_type &KV);
 
 /// Render a SymbolMap entry.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolMap::value_type &KV);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolMap::value_type &KV);
 
 /// Render a SymbolFlagsMap.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolFlagsMap &SymbolFlags);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolFlagsMap &SymbolFlags);
 
 /// Render a SymbolMap.
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolMap &Symbols);
 
 /// Render a SymbolDependenceMap entry.
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
-                        const SymbolDependenceMap::value_type &KV);
+                                 const SymbolDependenceMap::value_type &KV);
 
 /// Render a SymbolDependendeMap.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolDependenceMap &Deps);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolDependenceMap &Deps);
 
 /// Render a MaterializationUnit.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const MaterializationUnit &MU);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const MaterializationUnit &MU);
 
 //// Render a JITDylibLookupFlags instance.
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
-                        const JITDylibLookupFlags &JDLookupFlags);
+                                 const JITDylibLookupFlags &JDLookupFlags);
 
 /// Render a SymbolLookupFlags instance.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupFlags &LookupFlags);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolLookupFlags &LookupFlags);
 
 /// Render a SymbolLookupSet entry.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupSet::value_type &KV);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolLookupSet::value_type &KV);
 
 /// Render a SymbolLookupSet.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolLookupSet &LookupSet);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolLookupSet &LookupSet);
 
 /// Render a JITDylibSearchOrder.
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
-                        const JITDylibSearchOrder &SearchOrder);
+                                 const JITDylibSearchOrder &SearchOrder);
 
 /// Render a SymbolAliasMap.
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolAliasMap &Aliases);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolAliasMap &Aliases);
 
 /// Render a SymbolState.
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolState &S);
@@ -110,7 +121,8 @@ public:
   /// identifier, the resulting files will be named <ident>.o, <ident>.2.o,
   /// <ident>.3.o, and so on). IdentifierOverride should not contain an
   /// extension, as a .o suffix will be added by DumpObjects.
-  LLVM_ABI DumpObjects(std::string DumpDir = "", std::string IdentifierOverride = "");
+  LLVM_ABI DumpObjects(std::string DumpDir = "",
+                       std::string IdentifierOverride = "");
 
   /// Dumps the given buffer to disk.
   LLVM_ABI Expected<std::unique_ptr<MemoryBuffer>>

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebugInfoSupport.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebugInfoSupport.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGINFOSUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGINFOSUPPORT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#include "llvm/Support/Compiler.h"
 
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 
@@ -26,7 +26,7 @@ namespace orc {
 LLVM_ABI Error preserveDebugSections(jitlink::LinkGraph &G);
 // The backing stringmap is also returned, for memory liftime management.
 LLVM_ABI Expected<std::pair<std::unique_ptr<DWARFContext>,
-                   StringMap<std::unique_ptr<MemoryBuffer>>>>
+                            StringMap<std::unique_ptr<MemoryBuffer>>>>
 createDWARFContext(jitlink::LinkGraph &G);
 
 // Thin wrapper around preserveDebugSections to be used as a standalone plugin.

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebugInfoSupport.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebugInfoSupport.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGINFOSUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGINFOSUPPORT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 
@@ -22,9 +23,9 @@ namespace llvm {
 
 namespace orc {
 
-Error preserveDebugSections(jitlink::LinkGraph &G);
+LLVM_ABI Error preserveDebugSections(jitlink::LinkGraph &G);
 // The backing stringmap is also returned, for memory liftime management.
-Expected<std::pair<std::unique_ptr<DWARFContext>,
+LLVM_ABI Expected<std::pair<std::unique_ptr<DWARFContext>,
                    StringMap<std::unique_ptr<MemoryBuffer>>>>
 createDWARFContext(jitlink::LinkGraph &G);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGGERSUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGGERSUPPORT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -20,7 +21,7 @@ namespace orc {
 
 class LLJIT;
 
-Error enableDebuggerSupport(LLJIT &J);
+LLVM_ABI Error enableDebuggerSupport(LLJIT &J);
 
 } // namespace orc
 } // namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGGERSUPPORTPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGGERSUPPORTPLUGIN_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
@@ -25,7 +26,7 @@ namespace orc {
 ///
 /// Currently MachO only. For ELF use DebugObjectManagerPlugin. These two
 /// plugins will be merged in the near future.
-class GDBJITDebugInfoRegistrationPlugin : public ObjectLinkingLayer::Plugin {
+class LLVM_ABI GDBJITDebugInfoRegistrationPlugin : public ObjectLinkingLayer::Plugin {
 public:
   class DebugSectionSynthesizer {
   public:

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGGERSUPPORTPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGGERSUPPORTPLUGIN_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {
@@ -26,7 +26,8 @@ namespace orc {
 ///
 /// Currently MachO only. For ELF use DebugObjectManagerPlugin. These two
 /// plugins will be merged in the near future.
-class LLVM_ABI GDBJITDebugInfoRegistrationPlugin : public ObjectLinkingLayer::Plugin {
+class LLVM_ABI GDBJITDebugInfoRegistrationPlugin
+    : public ObjectLinkingLayer::Plugin {
 public:
   class DebugSectionSynthesizer {
   public:

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_PERFSUPPORTPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_PERFSUPPORTPLUGIN_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/PerfSharedStructs.h"
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
@@ -24,7 +25,7 @@ namespace orc {
 /// Log perf jitdump events for each object (see
 /// https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jitdump-specification.txt).
 /// Currently has support for dumping code load records and unwind info records.
-class PerfSupportPlugin : public ObjectLinkingLayer::Plugin {
+class LLVM_ABI PerfSupportPlugin : public ObjectLinkingLayer::Plugin {
 public:
   PerfSupportPlugin(ExecutorProcessControl &EPC,
                     ExecutorAddr RegisterPerfStartAddr,

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_PERFSUPPORTPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_PERFSUPPORTPLUGIN_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/PerfSharedStructs.h"
+#include "llvm/Support/Compiler.h"
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGGING_VTUNESUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGGING_VTUNESUPPORT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
@@ -24,7 +25,7 @@ namespace llvm {
 
 namespace orc {
 
-class VTuneSupportPlugin : public ObjectLinkingLayer::Plugin {
+class LLVM_ABI VTuneSupportPlugin : public ObjectLinkingLayer::Plugin {
 public:
   VTuneSupportPlugin(ExecutorProcessControl &EPC, ExecutorAddr RegisterImplAddr,
                      ExecutorAddr UnregisterImplAddr, bool EmitDebugInfo)

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.h
@@ -13,13 +13,13 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGGING_VTUNESUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_DEBUGGING_VTUNESUPPORT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimplePackedSerialization.h"
 #include "llvm/ExecutionEngine/Orc/Shared/VTuneSharedStructs.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/DylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/DylibManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DYLIBMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_DYLIBMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
@@ -25,7 +26,7 @@ namespace llvm::orc {
 
 class SymbolLookupSet;
 
-class DylibManager {
+class LLVM_ABI DylibManager {
 public:
   /// A pair of a dylib and a set of symbols to be looked up.
   struct LookupRequest {

--- a/llvm/include/llvm/ExecutionEngine/Orc/DylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/DylibManager.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_DYLIBMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_DYLIBMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/EHFrameRegistrationPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EHFrameRegistrationPlugin.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EHFRAMEREGISTRATIONPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_EHFRAMEREGISTRATIONPLUGIN_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
 
 #include <memory>
@@ -23,7 +24,7 @@ namespace llvm::orc {
 
 /// Adds AllocationActions to register and deregister eh-frame sections in the
 /// absence of native Platform support.
-class EHFrameRegistrationPlugin : public LinkGraphLinkingLayer::Plugin {
+class LLVM_ABI EHFrameRegistrationPlugin : public LinkGraphLinkingLayer::Plugin {
 public:
   static Expected<std::unique_ptr<EHFrameRegistrationPlugin>>
   Create(ExecutionSession &ES);

--- a/llvm/include/llvm/ExecutionEngine/Orc/EHFrameRegistrationPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EHFrameRegistrationPlugin.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EHFRAMEREGISTRATIONPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_EHFRAMEREGISTRATIONPLUGIN_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
+#include "llvm/Support/Compiler.h"
 
 #include <memory>
 #include <mutex>
@@ -24,7 +24,8 @@ namespace llvm::orc {
 
 /// Adds AllocationActions to register and deregister eh-frame sections in the
 /// absence of native Platform support.
-class LLVM_ABI EHFrameRegistrationPlugin : public LinkGraphLinkingLayer::Plugin {
+class LLVM_ABI EHFrameRegistrationPlugin
+    : public LinkGraphLinkingLayer::Plugin {
 public:
   static Expected<std::unique_ptr<EHFrameRegistrationPlugin>>
   Create(ExecutionSession &ES);

--- a/llvm/include/llvm/ExecutionEngine/Orc/ELFNixPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ELFNixPlatform.h
@@ -13,12 +13,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_ELFNIXPLATFORM_H
 #define LLVM_EXECUTIONENGINE_ORC_ELFNIXPLATFORM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 
 #include <future>
 #include <thread>

--- a/llvm/include/llvm/ExecutionEngine/Orc/ELFNixPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ELFNixPlatform.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_ELFNIXPLATFORM_H
 #define LLVM_EXECUTIONENGINE_ORC_ELFNIXPLATFORM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
@@ -65,7 +66,7 @@ using DeferredRuntimeFnMap = std::unordered_map<
     FunctionPairKeyHash, FunctionPairKeyEqual>;
 
 /// Mediates between ELFNix initialization and ExecutionSession state.
-class ELFNixPlatform : public Platform {
+class LLVM_ABI ELFNixPlatform : public Platform {
 public:
   /// Try to create a ELFNixPlatform instance, adding the ORC runtime to the
   /// given JITDylib.
@@ -165,7 +166,7 @@ private:
   // The ELFNixPlatformPlugin scans/modifies LinkGraphs to support ELF
   // platform features including initializers, exceptions, TLV, and language
   // runtime registration.
-  class ELFNixPlatformPlugin : public ObjectLinkingLayer::Plugin {
+  class LLVM_ABI ELFNixPlatformPlugin : public ObjectLinkingLayer::Plugin {
   public:
     ELFNixPlatformPlugin(ELFNixPlatform &MP) : MP(MP) {}
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCDEBUGOBJECTREGISTRAR_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCDEBUGOBJECTREGISTRAR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
@@ -37,7 +38,7 @@ public:
 
 /// Use ExecutorProcessControl to register debug objects locally or in a remote
 /// executor process.
-class EPCDebugObjectRegistrar : public DebugObjectRegistrar {
+class LLVM_ABI EPCDebugObjectRegistrar : public DebugObjectRegistrar {
 public:
   EPCDebugObjectRegistrar(ExecutionSession &ES, ExecutorAddr RegisterFn)
       : ES(ES), RegisterFn(RegisterFn) {}
@@ -57,7 +58,7 @@ private:
 /// If RegistrationFunctionsDylib is non-None then it will be searched to find
 /// the registration functions. If it is None then the process dylib will be
 /// loaded to find the registration functions.
-Expected<std::unique_ptr<EPCDebugObjectRegistrar>> createJITLoaderGDBRegistrar(
+LLVM_ABI Expected<std::unique_ptr<EPCDebugObjectRegistrar>> createJITLoaderGDBRegistrar(
     ExecutionSession &ES,
     std::optional<ExecutorAddr> RegistrationFunctionDylib = std::nullopt);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCDEBUGOBJECTREGISTRAR_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCDEBUGOBJECTREGISTRAR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Memory.h"
 
@@ -58,7 +58,8 @@ private:
 /// If RegistrationFunctionsDylib is non-None then it will be searched to find
 /// the registration functions. If it is None then the process dylib will be
 /// loaded to find the registration functions.
-LLVM_ABI Expected<std::unique_ptr<EPCDebugObjectRegistrar>> createJITLoaderGDBRegistrar(
+LLVM_ABI Expected<std::unique_ptr<EPCDebugObjectRegistrar>>
+createJITLoaderGDBRegistrar(
     ExecutionSession &ES,
     std::optional<ExecutorAddr> RegistrationFunctionDylib = std::nullopt);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCDYNAMICLIBRARYSEARCHGENERATOR_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCDYNAMICLIBRARYSEARCHGENERATOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCDYNAMICLIBRARYSEARCHGENERATOR_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCDYNAMICLIBRARYSEARCHGENERATOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 
@@ -22,7 +23,7 @@ namespace orc {
 
 class ExecutorProcessControl;
 
-class EPCDynamicLibrarySearchGenerator : public DefinitionGenerator {
+class LLVM_ABI EPCDynamicLibrarySearchGenerator : public DefinitionGenerator {
 public:
   using SymbolPredicate = unique_function<bool(const SymbolStringPtr &)>;
   using AddAbsoluteSymbolsFn = unique_function<Error(JITDylib &, SymbolMap)>;

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
@@ -18,10 +18,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCGENERICDYLIBMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCGENERICDYLIBMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {
@@ -72,12 +72,14 @@ public:
       unique_function<void(Expected<std::vector<ExecutorSymbolDef>>)>;
 
   /// Looks up symbols within the given dylib.
-  LLVM_ABI void lookupAsync(tpctypes::DylibHandle H, const SymbolLookupSet &Lookup,
-                   SymbolLookupCompleteFn Complete);
+  LLVM_ABI void lookupAsync(tpctypes::DylibHandle H,
+                            const SymbolLookupSet &Lookup,
+                            SymbolLookupCompleteFn Complete);
 
   /// Looks up symbols within the given dylib.
-  LLVM_ABI void lookupAsync(tpctypes::DylibHandle H, const RemoteSymbolLookupSet &Lookup,
-                   SymbolLookupCompleteFn Complete);
+  LLVM_ABI void lookupAsync(tpctypes::DylibHandle H,
+                            const RemoteSymbolLookupSet &Lookup,
+                            SymbolLookupCompleteFn Complete);
 
 private:
   ExecutorProcessControl &EPC;

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCGENERICDYLIBMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCGENERICDYLIBMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
@@ -38,7 +39,7 @@ public:
 
   /// Create an EPCGenericMemoryAccess instance from a given set of
   /// function addrs.
-  static Expected<EPCGenericDylibManager>
+  LLVM_ABI static Expected<EPCGenericDylibManager>
   CreateWithDefaultBootstrapSymbols(ExecutorProcessControl &EPC);
 
   /// Create an EPCGenericMemoryAccess instance from a given set of
@@ -47,7 +48,7 @@ public:
       : EPC(EPC), SAs(SAs) {}
 
   /// Loads the dylib with the given name.
-  Expected<tpctypes::DylibHandle> open(StringRef Path, uint64_t Mode);
+  LLVM_ABI Expected<tpctypes::DylibHandle> open(StringRef Path, uint64_t Mode);
 
   /// Looks up symbols within the given dylib.
   Expected<std::vector<ExecutorSymbolDef>>
@@ -71,11 +72,11 @@ public:
       unique_function<void(Expected<std::vector<ExecutorSymbolDef>>)>;
 
   /// Looks up symbols within the given dylib.
-  void lookupAsync(tpctypes::DylibHandle H, const SymbolLookupSet &Lookup,
+  LLVM_ABI void lookupAsync(tpctypes::DylibHandle H, const SymbolLookupSet &Lookup,
                    SymbolLookupCompleteFn Complete);
 
   /// Looks up symbols within the given dylib.
-  void lookupAsync(tpctypes::DylibHandle H, const RemoteSymbolLookupSet &Lookup,
+  LLVM_ABI void lookupAsync(tpctypes::DylibHandle H, const RemoteSymbolLookupSet &Lookup,
                    SymbolLookupCompleteFn Complete);
 
 private:

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
@@ -18,13 +18,14 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCGENERICJITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCGENERICJITLINKMEMORYMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 
 namespace llvm {
 namespace orc {
 
-class EPCGenericJITLinkMemoryManager : public jitlink::JITLinkMemoryManager {
+class LLVM_ABI EPCGenericJITLinkMemoryManager : public jitlink::JITLinkMemoryManager {
 public:
   /// Function addresses for memory access.
   struct SymbolAddrs {

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
@@ -18,14 +18,15 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCGENERICJITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCGENERICJITLINKMEMORYMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {
 
-class LLVM_ABI EPCGenericJITLinkMemoryManager : public jitlink::JITLinkMemoryManager {
+class LLVM_ABI EPCGenericJITLinkMemoryManager
+    : public jitlink::JITLinkMemoryManager {
 public:
   /// Function addresses for memory access.
   struct SymbolAddrs {

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericRTDyldMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericRTDyldMemoryManager.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCGENERICRTDYLDMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCGENERICRTDYLDMEMORYMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
 
@@ -23,7 +24,7 @@ namespace llvm {
 namespace orc {
 
 /// Remote-mapped RuntimeDyld-compatible memory manager.
-class EPCGenericRTDyldMemoryManager : public RuntimeDyld::MemoryManager {
+class LLVM_ABI EPCGenericRTDyldMemoryManager : public RuntimeDyld::MemoryManager {
 public:
   /// Symbol addresses for memory access.
   struct SymbolAddrs {

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericRTDyldMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericRTDyldMemoryManager.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCGENERICRTDYLDMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCGENERICRTDYLDMEMORYMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
+#include "llvm/Support/Compiler.h"
 
 #define DEBUG_TYPE "orc"
 
@@ -24,7 +24,8 @@ namespace llvm {
 namespace orc {
 
 /// Remote-mapped RuntimeDyld-compatible memory manager.
-class LLVM_ABI EPCGenericRTDyldMemoryManager : public RuntimeDyld::MemoryManager {
+class LLVM_ABI EPCGenericRTDyldMemoryManager
+    : public RuntimeDyld::MemoryManager {
 public:
   /// Symbol addresses for memory access.
   struct SymbolAddrs {

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutionUtils.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EXECUTIONUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_EXECUTIONUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
@@ -65,23 +66,23 @@ public:
 
   /// Construct an iterator instance. If End is true then this iterator
   ///        acts as the end of the range, otherwise it is the beginning.
-  CtorDtorIterator(const GlobalVariable *GV, bool End);
+  LLVM_ABI CtorDtorIterator(const GlobalVariable *GV, bool End);
 
   /// Test iterators for equality.
-  bool operator==(const CtorDtorIterator &Other) const;
+  LLVM_ABI bool operator==(const CtorDtorIterator &Other) const;
 
   /// Test iterators for inequality.
-  bool operator!=(const CtorDtorIterator &Other) const;
+  LLVM_ABI bool operator!=(const CtorDtorIterator &Other) const;
 
   /// Pre-increment iterator.
-  CtorDtorIterator& operator++();
+  LLVM_ABI CtorDtorIterator& operator++();
 
   /// Post-increment iterator.
-  CtorDtorIterator operator++(int);
+  LLVM_ABI CtorDtorIterator operator++(int);
 
   /// Dereference iterator. The resulting value provides a read-only view
   ///        of this element of the global_ctors/global_dtors list.
-  Element operator*() const;
+  LLVM_ABI Element operator*() const;
 
 private:
   const ConstantArray *InitList;
@@ -90,11 +91,11 @@ private:
 
 /// Create an iterator range over the entries of the llvm.global_ctors
 ///        array.
-iterator_range<CtorDtorIterator> getConstructors(const Module &M);
+LLVM_ABI iterator_range<CtorDtorIterator> getConstructors(const Module &M);
 
 /// Create an iterator range over the entries of the llvm.global_ctors
 ///        array.
-iterator_range<CtorDtorIterator> getDestructors(const Module &M);
+LLVM_ABI iterator_range<CtorDtorIterator> getDestructors(const Module &M);
 
 /// This iterator provides a convenient way to iterate over GlobalValues that
 /// have initialization effects.
@@ -124,7 +125,7 @@ public:
   GlobalValue &operator*() { return *I; }
 
 private:
-  bool isStaticInitGlobal(GlobalValue &GV);
+  LLVM_ABI bool isStaticInitGlobal(GlobalValue &GV);
   void moveToNextStaticInitGlobal() {
     ++I;
     while (I != E && !isStaticInitGlobal(*I))
@@ -146,8 +147,8 @@ inline iterator_range<StaticInitGVIterator> getStaticInitGVs(Module &M) {
 class CtorDtorRunner {
 public:
   CtorDtorRunner(JITDylib &JD) : JD(JD) {}
-  void add(iterator_range<CtorDtorIterator> CtorDtors);
-  Error run();
+  LLVM_ABI void add(iterator_range<CtorDtorIterator> CtorDtors);
+  LLVM_ABI Error run();
 
 private:
   using CtorDtorList = std::vector<SymbolStringPtr>;
@@ -176,20 +177,20 @@ class LocalCXXRuntimeOverridesBase {
 public:
   /// Run any destructors recorded by the overriden __cxa_atexit function
   /// (CXAAtExitOverride).
-  void runDestructors();
+  LLVM_ABI void runDestructors();
 
 protected:
   using DestructorPtr = void (*)(void *);
   using CXXDestructorDataPair = std::pair<DestructorPtr, void *>;
   using CXXDestructorDataPairList = std::vector<CXXDestructorDataPair>;
   CXXDestructorDataPairList DSOHandleOverride;
-  static int CXAAtExitOverride(DestructorPtr Destructor, void *Arg,
+  LLVM_ABI static int CXAAtExitOverride(DestructorPtr Destructor, void *Arg,
                                void *DSOHandle);
 };
 
 class LocalCXXRuntimeOverrides : public LocalCXXRuntimeOverridesBase {
 public:
-  Error enable(JITDylib &JD, MangleAndInterner &Mangler);
+  LLVM_ABI Error enable(JITDylib &JD, MangleAndInterner &Mangler);
 };
 
 /// An interface for Itanium __cxa_atexit interposer implementations.
@@ -200,8 +201,8 @@ public:
     void *Ctx;
   };
 
-  void registerAtExit(void (*F)(void *), void *Ctx, void *DSOHandle);
-  void runAtExits(void *DSOHandle);
+  LLVM_ABI void registerAtExit(void (*F)(void *), void *Ctx, void *DSOHandle);
+  LLVM_ABI void runAtExits(void *DSOHandle);
 
 private:
   std::mutex AtExitsMutex;
@@ -213,7 +214,7 @@ private:
 /// If an instance of this class is attached to a JITDylib as a fallback
 /// definition generator, then any symbol found in the given DynamicLibrary that
 /// passes the 'Allow' predicate will be added to the JITDylib.
-class DynamicLibrarySearchGenerator : public DefinitionGenerator {
+class LLVM_ABI DynamicLibrarySearchGenerator : public DefinitionGenerator {
 public:
   using SymbolPredicate = std::function<bool(const SymbolStringPtr &)>;
   using AddAbsoluteSymbolsFn = unique_function<Error(JITDylib &, SymbolMap)>;
@@ -266,7 +267,7 @@ private:
 /// If an instance of this class is attached to a JITDylib as a fallback
 /// definition generator, then any symbol found in the archive will result in
 /// the containing object being added to the JITDylib.
-class StaticLibraryDefinitionGenerator : public DefinitionGenerator {
+class LLVM_ABI StaticLibraryDefinitionGenerator : public DefinitionGenerator {
 public:
   /// Interface builder function for objects loaded from this archive.
   using GetObjectFileInterface =
@@ -355,7 +356,7 @@ private:
 /// definition generator, PLT stubs and dllimport __imp_ symbols will be
 /// generated for external symbols found outside the given jitdylib. Currently
 /// only supports x86_64 architecture.
-class DLLImportDefinitionGenerator : public DefinitionGenerator {
+class LLVM_ABI DLLImportDefinitionGenerator : public DefinitionGenerator {
 public:
   /// Creates a DLLImportDefinitionGenerator instance.
   static std::unique_ptr<DLLImportDefinitionGenerator>

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutionUtils.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EXECUTIONUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_EXECUTIONUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
@@ -22,6 +21,7 @@
 #include "llvm/ExecutionEngine/Orc/Shared/OrcError.h"
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
 #include "llvm/Object/Archive.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include <algorithm>
 #include <cstdint>
@@ -75,7 +75,7 @@ public:
   LLVM_ABI bool operator!=(const CtorDtorIterator &Other) const;
 
   /// Pre-increment iterator.
-  LLVM_ABI CtorDtorIterator& operator++();
+  LLVM_ABI CtorDtorIterator &operator++();
 
   /// Post-increment iterator.
   LLVM_ABI CtorDtorIterator operator++(int);
@@ -185,7 +185,7 @@ protected:
   using CXXDestructorDataPairList = std::vector<CXXDestructorDataPair>;
   CXXDestructorDataPairList DSOHandleOverride;
   LLVM_ABI static int CXAAtExitOverride(DestructorPtr Destructor, void *Arg,
-                               void *DSOHandle);
+                                        void *DSOHandle);
 };
 
 class LocalCXXRuntimeOverrides : public LocalCXXRuntimeOverridesBase {

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EXECUTORPROCESSCONTROL_H
 #define LLVM_EXECUTIONENGINE_ORC_EXECUTORPROCESSCONTROL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/DylibManager.h"
@@ -36,7 +37,7 @@ namespace orc {
 class ExecutionSession;
 
 /// ExecutorProcessControl supports interaction with a JIT target process.
-class ExecutorProcessControl {
+class LLVM_ABI ExecutorProcessControl {
   friend class ExecutionSession;
 public:
 
@@ -99,7 +100,7 @@ public:
   };
 
   /// APIs for manipulating memory in the target process.
-  class MemoryAccess {
+  class LLVM_ABI MemoryAccess {
   public:
     /// Callback function for asynchronous writes.
     using WriteResultFn = unique_function<void(Error)>;
@@ -398,7 +399,7 @@ protected:
   StringMap<ExecutorAddr> BootstrapSymbols;
 };
 
-class InProcessMemoryAccess : public ExecutorProcessControl::MemoryAccess {
+class LLVM_ABI InProcessMemoryAccess : public ExecutorProcessControl::MemoryAccess {
 public:
   InProcessMemoryAccess(bool IsArch64Bit) : IsArch64Bit(IsArch64Bit) {}
   void writeUInt8sAsync(ArrayRef<tpctypes::UInt8Write> Ws,
@@ -465,7 +466,7 @@ public:
 };
 
 /// A ExecutorProcessControl implementation targeting the current process.
-class SelfExecutorProcessControl : public ExecutorProcessControl,
+class LLVM_ABI SelfExecutorProcessControl : public ExecutorProcessControl,
                                    private InProcessMemoryAccess,
                                    private DylibManager {
 public:

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EXECUTORPROCESSCONTROL_H
 #define LLVM_EXECUTIONENGINE_ORC_EXECUTORPROCESSCONTROL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/DylibManager.h"
@@ -23,6 +22,7 @@
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h"
 #include "llvm/ExecutionEngine/Orc/TaskDispatch.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
 #include "llvm/TargetParser/Triple.h"
@@ -399,7 +399,8 @@ protected:
   StringMap<ExecutorAddr> BootstrapSymbols;
 };
 
-class LLVM_ABI InProcessMemoryAccess : public ExecutorProcessControl::MemoryAccess {
+class LLVM_ABI InProcessMemoryAccess
+    : public ExecutorProcessControl::MemoryAccess {
 public:
   InProcessMemoryAccess(bool IsArch64Bit) : IsArch64Bit(IsArch64Bit) {}
   void writeUInt8sAsync(ArrayRef<tpctypes::UInt8Write> Ws,
@@ -467,8 +468,8 @@ public:
 
 /// A ExecutorProcessControl implementation targeting the current process.
 class LLVM_ABI SelfExecutorProcessControl : public ExecutorProcessControl,
-                                   private InProcessMemoryAccess,
-                                   private DylibManager {
+                                            private InProcessMemoryAccess,
+                                            private DylibManager {
 public:
   SelfExecutorProcessControl(
       std::shared_ptr<SymbolStringPool> SSP, std::unique_ptr<TaskDispatcher> D,

--- a/llvm/include/llvm/ExecutionEngine/Orc/GetDylibInterface.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/GetDylibInterface.h
@@ -15,25 +15,26 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_GETDYLIBINTERFACE_H
 #define LLVM_EXECUTIONENGINE_ORC_GETDYLIBINTERFACE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm::orc {
 
 /// Returns a SymbolNameSet containing the exported symbols defined in the
 /// given dylib.
-LLVM_ABI Expected<SymbolNameSet> getDylibInterfaceFromDylib(ExecutionSession &ES,
-                                                   Twine Path);
+LLVM_ABI Expected<SymbolNameSet>
+getDylibInterfaceFromDylib(ExecutionSession &ES, Twine Path);
 
 /// Returns a SymbolNameSet containing the exported symbols defined in the
 /// relevant slice of the TapiUniversal file.
-LLVM_ABI Expected<SymbolNameSet> getDylibInterfaceFromTapiFile(ExecutionSession &ES,
-                                                      Twine Path);
+LLVM_ABI Expected<SymbolNameSet>
+getDylibInterfaceFromTapiFile(ExecutionSession &ES, Twine Path);
 
 /// Returns a SymbolNameSet containing the exported symbols defined in the
 /// relevant slice of the given file, which may be either a dylib or a tapi
 /// file.
-LLVM_ABI Expected<SymbolNameSet> getDylibInterface(ExecutionSession &ES, Twine Path);
+LLVM_ABI Expected<SymbolNameSet> getDylibInterface(ExecutionSession &ES,
+                                                   Twine Path);
 
 } // namespace llvm::orc
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/GetDylibInterface.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/GetDylibInterface.h
@@ -15,24 +15,25 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_GETDYLIBINTERFACE_H
 #define LLVM_EXECUTIONENGINE_ORC_GETDYLIBINTERFACE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 
 namespace llvm::orc {
 
 /// Returns a SymbolNameSet containing the exported symbols defined in the
 /// given dylib.
-Expected<SymbolNameSet> getDylibInterfaceFromDylib(ExecutionSession &ES,
+LLVM_ABI Expected<SymbolNameSet> getDylibInterfaceFromDylib(ExecutionSession &ES,
                                                    Twine Path);
 
 /// Returns a SymbolNameSet containing the exported symbols defined in the
 /// relevant slice of the TapiUniversal file.
-Expected<SymbolNameSet> getDylibInterfaceFromTapiFile(ExecutionSession &ES,
+LLVM_ABI Expected<SymbolNameSet> getDylibInterfaceFromTapiFile(ExecutionSession &ES,
                                                       Twine Path);
 
 /// Returns a SymbolNameSet containing the exported symbols defined in the
 /// relevant slice of the given file, which may be either a dylib or a tapi
 /// file.
-Expected<SymbolNameSet> getDylibInterface(ExecutionSession &ES, Twine Path);
+LLVM_ABI Expected<SymbolNameSet> getDylibInterface(ExecutionSession &ES, Twine Path);
 
 } // namespace llvm::orc
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_IRCOMPILELAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_IRCOMPILELAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
@@ -28,9 +29,9 @@ class Module;
 
 namespace orc {
 
-class IRCompileLayer : public IRLayer {
+class LLVM_ABI IRCompileLayer : public IRLayer {
 public:
-  class IRCompiler {
+  class LLVM_ABI IRCompiler {
   public:
     IRCompiler(IRSymbolMapper::ManglingOptions MO) : MO(std::move(MO)) {}
     virtual ~IRCompiler();

--- a/llvm/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_IRCOMPILELAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_IRCOMPILELAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <functional>

--- a/llvm/include/llvm/ExecutionEngine/Orc/IRPartitionLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IRPartitionLayer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_IRPARTITIONLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_IRPARTITIONLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/IndirectionUtils.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include "llvm/IR/Attributes.h"
@@ -34,7 +35,7 @@ namespace orc {
 
 /// A layer that breaks up IR modules into smaller submodules that only contains
 /// looked up symbols.
-class IRPartitionLayer : public IRLayer {
+class LLVM_ABI IRPartitionLayer : public IRLayer {
   friend class PartitioningIRMaterializationUnit;
 
 public:

--- a/llvm/include/llvm/ExecutionEngine/Orc/IRPartitionLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IRPartitionLayer.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_IRPARTITIONLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_IRPARTITIONLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/IndirectionUtils.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include "llvm/IR/Attributes.h"
@@ -29,6 +28,7 @@
 #include "llvm/IR/Mangler.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {

--- a/llvm/include/llvm/ExecutionEngine/Orc/IRTransformLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IRTransformLayer.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_IRTRANSFORMLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_IRTRANSFORMLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {

--- a/llvm/include/llvm/ExecutionEngine/Orc/IRTransformLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IRTransformLayer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_IRTRANSFORMLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_IRTRANSFORMLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
@@ -24,7 +25,7 @@ namespace orc {
 /// A layer that applies a transform to emitted modules.
 /// The transform function is responsible for locking the ThreadSafeContext
 /// before operating on the module.
-class IRTransformLayer : public IRLayer {
+class LLVM_ABI IRTransformLayer : public IRLayer {
 public:
   using TransformFunction = unique_function<Expected<ThreadSafeModule>(
       ThreadSafeModule, MaterializationResponsibility &R)>;

--- a/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_INDIRECTIONUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_INDIRECTIONUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
@@ -61,7 +62,7 @@ namespace orc {
 /// before calling a supplied function to return the trampoline landing
 /// address, then restore all state before jumping to that address. They
 /// are used by various ORC APIs to support lazy compilation
-class TrampolinePool {
+class LLVM_ABI TrampolinePool {
 public:
   using NotifyLandingResolvedFunction =
       unique_function<void(ExecutorAddr) const>;
@@ -208,11 +209,11 @@ public:
   virtual ~JITCompileCallbackManager() = default;
 
   /// Reserve a compile callback.
-  Expected<ExecutorAddr> getCompileCallback(CompileFunction Compile);
+  LLVM_ABI Expected<ExecutorAddr> getCompileCallback(CompileFunction Compile);
 
   /// Execute the callback for the given trampoline id. Called by the JIT
   ///        to compile functions on demand.
-  ExecutorAddr executeCompileCallback(ExecutorAddr TrampolineAddr);
+  LLVM_ABI ExecutorAddr executeCompileCallback(ExecutorAddr TrampolineAddr);
 
 protected:
   /// Construct a JITCompileCallbackManager.
@@ -279,7 +280,7 @@ private:
 };
 
 /// Base class for managing collections of named indirect stubs.
-class IndirectStubsManager : public RedirectableSymbolManager {
+class LLVM_ABI IndirectStubsManager : public RedirectableSymbolManager {
 public:
   /// Map type for initializing the manager. See init.
   using StubInitsMap = StringMap<std::pair<ExecutorAddr, JITSymbolFlags>>;
@@ -479,14 +480,14 @@ private:
 /// The given target triple will determine the ABI, and the given
 /// ErrorHandlerAddress will be used by the resulting compile callback
 /// manager if a compile callback fails.
-Expected<std::unique_ptr<JITCompileCallbackManager>>
+LLVM_ABI Expected<std::unique_ptr<JITCompileCallbackManager>>
 createLocalCompileCallbackManager(const Triple &T, ExecutionSession &ES,
                                   ExecutorAddr ErrorHandlerAddress);
 
 /// Create a local indirect stubs manager builder.
 ///
 /// The given target triple will determine the ABI.
-std::function<std::unique_ptr<IndirectStubsManager>()>
+LLVM_ABI std::function<std::unique_ptr<IndirectStubsManager>()>
 createLocalIndirectStubsManagerBuilder(const Triple &T);
 
 /// Build a function pointer of FunctionType with the given constant
@@ -494,16 +495,16 @@ createLocalIndirectStubsManagerBuilder(const Triple &T);
 ///
 ///   Usage example: Turn a trampoline address into a function pointer constant
 /// for use in a stub.
-Constant *createIRTypedAddress(FunctionType &FT, ExecutorAddr Addr);
+LLVM_ABI Constant *createIRTypedAddress(FunctionType &FT, ExecutorAddr Addr);
 
 /// Create a function pointer with the given type, name, and initializer
 ///        in the given Module.
-GlobalVariable *createImplPointer(PointerType &PT, Module &M, const Twine &Name,
+LLVM_ABI GlobalVariable *createImplPointer(PointerType &PT, Module &M, const Twine &Name,
                                   Constant *Initializer);
 
 /// Turn a function declaration into a stub function that makes an
 ///        indirect call using the given function pointer.
-void makeStub(Function &F, Value &ImplPointer);
+LLVM_ABI void makeStub(Function &F, Value &ImplPointer);
 
 /// Promotes private symbols to global hidden, and renames to prevent clashes
 /// with other promoted symbols. The same SymbolPromoter instance should be
@@ -512,7 +513,7 @@ class SymbolLinkagePromoter {
 public:
   /// Promote symbols in the given module. Returns the set of global values
   /// that have been renamed/promoted.
-  std::vector<GlobalValue *> operator()(Module &M);
+  LLVM_ABI std::vector<GlobalValue *> operator()(Module &M);
 
 private:
   unsigned NextId = 0;
@@ -530,15 +531,15 @@ private:
 /// modules with these utilities, all decls should be cloned (and added to a
 /// single VMap) before any bodies are moved. This will ensure that references
 /// between functions all refer to the versions in the new module.
-Function *cloneFunctionDecl(Module &Dst, const Function &F,
+LLVM_ABI Function *cloneFunctionDecl(Module &Dst, const Function &F,
                             ValueToValueMapTy *VMap = nullptr);
 
 /// Clone a global variable declaration into a new module.
-GlobalVariable *cloneGlobalVariableDecl(Module &Dst, const GlobalVariable &GV,
+LLVM_ABI GlobalVariable *cloneGlobalVariableDecl(Module &Dst, const GlobalVariable &GV,
                                         ValueToValueMapTy *VMap = nullptr);
 
 /// Clone a global alias declaration into a new module.
-GlobalAlias *cloneGlobalAliasDecl(Module &Dst, const GlobalAlias &OrigA,
+LLVM_ABI GlobalAlias *cloneGlobalAliasDecl(Module &Dst, const GlobalAlias &OrigA,
                                   ValueToValueMapTy &VMap);
 
 /// Introduce relocations to \p Sym in its own definition if there are any
@@ -563,7 +564,7 @@ GlobalAlias *cloneGlobalAliasDecl(Module &Dst, const GlobalAlias &OrigA,
 ///
 /// This is based on disassembly and should be considered "best effort". It may
 /// silently fail to add relocations.
-Error addFunctionPointerRelocationsToCurrentSymbol(jitlink::Symbol &Sym,
+LLVM_ABI Error addFunctionPointerRelocationsToCurrentSymbol(jitlink::Symbol &Sym,
                                                    jitlink::LinkGraph &G,
                                                    MCDisassembler &Disassembler,
                                                    MCInstrAnalysis &MIA);

--- a/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
@@ -13,13 +13,13 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_INDIRECTIONUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_INDIRECTIONUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/OrcABISupport.h"
 #include "llvm/ExecutionEngine/Orc/RedirectionManager.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Memory.h"
 #include "llvm/Support/Process.h"
@@ -499,8 +499,9 @@ LLVM_ABI Constant *createIRTypedAddress(FunctionType &FT, ExecutorAddr Addr);
 
 /// Create a function pointer with the given type, name, and initializer
 ///        in the given Module.
-LLVM_ABI GlobalVariable *createImplPointer(PointerType &PT, Module &M, const Twine &Name,
-                                  Constant *Initializer);
+LLVM_ABI GlobalVariable *createImplPointer(PointerType &PT, Module &M,
+                                           const Twine &Name,
+                                           Constant *Initializer);
 
 /// Turn a function declaration into a stub function that makes an
 ///        indirect call using the given function pointer.
@@ -532,15 +533,17 @@ private:
 /// single VMap) before any bodies are moved. This will ensure that references
 /// between functions all refer to the versions in the new module.
 LLVM_ABI Function *cloneFunctionDecl(Module &Dst, const Function &F,
-                            ValueToValueMapTy *VMap = nullptr);
+                                     ValueToValueMapTy *VMap = nullptr);
 
 /// Clone a global variable declaration into a new module.
-LLVM_ABI GlobalVariable *cloneGlobalVariableDecl(Module &Dst, const GlobalVariable &GV,
-                                        ValueToValueMapTy *VMap = nullptr);
+LLVM_ABI GlobalVariable *
+cloneGlobalVariableDecl(Module &Dst, const GlobalVariable &GV,
+                        ValueToValueMapTy *VMap = nullptr);
 
 /// Clone a global alias declaration into a new module.
-LLVM_ABI GlobalAlias *cloneGlobalAliasDecl(Module &Dst, const GlobalAlias &OrigA,
-                                  ValueToValueMapTy &VMap);
+LLVM_ABI GlobalAlias *cloneGlobalAliasDecl(Module &Dst,
+                                           const GlobalAlias &OrigA,
+                                           ValueToValueMapTy &VMap);
 
 /// Introduce relocations to \p Sym in its own definition if there are any
 /// pointers formed via PC-relative address that do not already have a
@@ -564,10 +567,9 @@ LLVM_ABI GlobalAlias *cloneGlobalAliasDecl(Module &Dst, const GlobalAlias &OrigA
 ///
 /// This is based on disassembly and should be considered "best effort". It may
 /// silently fail to add relocations.
-LLVM_ABI Error addFunctionPointerRelocationsToCurrentSymbol(jitlink::Symbol &Sym,
-                                                   jitlink::LinkGraph &G,
-                                                   MCDisassembler &Disassembler,
-                                                   MCInstrAnalysis &MIA);
+LLVM_ABI Error addFunctionPointerRelocationsToCurrentSymbol(
+    jitlink::Symbol &Sym, jitlink::LinkGraph &G, MCDisassembler &Disassembler,
+    MCInstrAnalysis &MIA);
 
 } // end namespace orc
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_JITLINKREDIRECABLESYMBOLMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_JITLINKREDIRECABLESYMBOLMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/RedirectionManager.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/StringSaver.h"
 
 #include <atomic>
@@ -23,7 +23,8 @@
 namespace llvm {
 namespace orc {
 
-class LLVM_ABI JITLinkRedirectableSymbolManager : public RedirectableSymbolManager {
+class LLVM_ABI JITLinkRedirectableSymbolManager
+    : public RedirectableSymbolManager {
 public:
   /// Create redirection manager that uses JITLink based implementaion.
   static Expected<std::unique_ptr<RedirectableSymbolManager>>

--- a/llvm/include/llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_JITLINKREDIRECABLESYMBOLMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_JITLINKREDIRECABLESYMBOLMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/RedirectionManager.h"
 #include "llvm/Support/StringSaver.h"
@@ -22,7 +23,7 @@
 namespace llvm {
 namespace orc {
 
-class JITLinkRedirectableSymbolManager : public RedirectableSymbolManager {
+class LLVM_ABI JITLinkRedirectableSymbolManager : public RedirectableSymbolManager {
 public:
   /// Create redirection manager that uses JITLink based implementaion.
   static Expected<std::unique_ptr<RedirectableSymbolManager>>

--- a/llvm/include/llvm/ExecutionEngine/Orc/JITLinkReentryTrampolines.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITLinkReentryTrampolines.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_JITLINKREENTRYTRAMPOLINES_H
 #define LLVM_EXECUTIONENGINE_ORC_JITLINKREENTRYTRAMPOLINES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/LazyReexports.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm::jitlink {
@@ -47,12 +47,12 @@ public:
   Create(ObjectLinkingLayer &ObjLinkingLayer);
 
   LLVM_ABI JITLinkReentryTrampolines(ObjectLinkingLayer &ObjLinkingLayer,
-                            EmitTrampolineFn EmitTrampoline);
+                                     EmitTrampolineFn EmitTrampoline);
   JITLinkReentryTrampolines(JITLinkReentryTrampolines &&) = delete;
   JITLinkReentryTrampolines &operator=(JITLinkReentryTrampolines &&) = delete;
 
   LLVM_ABI void emit(ResourceTrackerSP RT, size_t NumTrampolines,
-            OnTrampolinesReadyFn OnTrampolinesReady);
+                     OnTrampolinesReadyFn OnTrampolinesReady);
 
 private:
   class TrampolineAddrScraperPlugin;

--- a/llvm/include/llvm/ExecutionEngine/Orc/JITLinkReentryTrampolines.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITLinkReentryTrampolines.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_JITLINKREENTRYTRAMPOLINES_H
 #define LLVM_EXECUTIONENGINE_ORC_JITLINKREENTRYTRAMPOLINES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/LazyReexports.h"
@@ -42,15 +43,15 @@ public:
 
   /// Create trampolines using the default reentry trampoline function for
   /// the session triple.
-  static Expected<std::unique_ptr<JITLinkReentryTrampolines>>
+  LLVM_ABI static Expected<std::unique_ptr<JITLinkReentryTrampolines>>
   Create(ObjectLinkingLayer &ObjLinkingLayer);
 
-  JITLinkReentryTrampolines(ObjectLinkingLayer &ObjLinkingLayer,
+  LLVM_ABI JITLinkReentryTrampolines(ObjectLinkingLayer &ObjLinkingLayer,
                             EmitTrampolineFn EmitTrampoline);
   JITLinkReentryTrampolines(JITLinkReentryTrampolines &&) = delete;
   JITLinkReentryTrampolines &operator=(JITLinkReentryTrampolines &&) = delete;
 
-  void emit(ResourceTrackerSP RT, size_t NumTrampolines,
+  LLVM_ABI void emit(ResourceTrackerSP RT, size_t NumTrampolines,
             OnTrampolinesReadyFn OnTrampolinesReady);
 
 private:
@@ -62,7 +63,7 @@ private:
   std::atomic<size_t> ReentryGraphIdx{0};
 };
 
-Expected<std::unique_ptr<LazyReexportsManager>>
+LLVM_ABI Expected<std::unique_ptr<LazyReexportsManager>>
 createJITLinkLazyReexportsManager(ObjectLinkingLayer &ObjLinkingLayer,
                                   RedirectableSymbolManager &RSMgr,
                                   JITDylib &PlatformJD,

--- a/llvm/include/llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_JITTARGETMACHINEBUILDER_H
 #define LLVM_EXECUTIONENGINE_ORC_JITTARGETMACHINEBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Target/TargetMachine.h"
@@ -41,14 +42,14 @@ public:
   /// Note: TargetOptions is default-constructed, then EmulatedTLS is set to
   /// true. If EmulatedTLS is not required, these values should be reset before
   /// calling createTargetMachine.
-  JITTargetMachineBuilder(Triple TT);
+  LLVM_ABI JITTargetMachineBuilder(Triple TT);
 
   /// Create a JITTargetMachineBuilder for the host system.
   ///
   /// Note: TargetOptions is default-constructed, then EmulatedTLS is set to
   /// true. If EmulatedTLS is not required, these values should be reset before
   /// calling createTargetMachine.
-  static Expected<JITTargetMachineBuilder> detectHost();
+  LLVM_ABI static Expected<JITTargetMachineBuilder> detectHost();
 
   /// Create a TargetMachine.
   ///
@@ -57,7 +58,7 @@ public:
   /// the target's AsmPrinter must both be registered. To JIT assembly
   /// (including inline and module level assembly) the target's AsmParser must
   /// also be registered.
-  Expected<std::unique_ptr<TargetMachine>> createTargetMachine();
+  LLVM_ABI Expected<std::unique_ptr<TargetMachine>> createTargetMachine();
 
   /// Get the default DataLayout for the target.
   ///
@@ -111,7 +112,7 @@ public:
   }
 
   /// Add subtarget features.
-  JITTargetMachineBuilder &
+  LLVM_ABI JITTargetMachineBuilder &
   addFeatures(const std::vector<std::string> &FeatureVec);
 
   /// Access subtarget features.

--- a/llvm/include/llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_JITTARGETMACHINEBUILDER_H
 #define LLVM_EXECUTIONENGINE_ORC_JITTARGETMACHINEBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"

--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -42,7 +42,7 @@ class ExecutorProcessControl;
 class LLVM_ABI LLJIT {
   template <typename, typename, typename> friend class LLJITBuilderSetters;
 
-  friend Expected<JITDylibSP> setUpGenericLLVMIRPlatform(LLJIT &J);
+  LLVM_ABI_FRIEND friend Expected<JITDylibSP> setUpGenericLLVMIRPlatform(LLJIT &J);
 
 public:
   /// Initializer support for LLJIT.
@@ -290,7 +290,7 @@ public:
 private:
 
   // Create a single-threaded LLLazyJIT instance.
-  LLLazyJIT(LLLazyJITBuilderState &S, Error &Err);
+  LLVM_ABI LLLazyJIT(LLLazyJITBuilderState &S, Error &Err);
 
   std::unique_ptr<LazyCallThroughManager> LCTMgr;
   std::unique_ptr<IRPartitionLayer> IPLayer;

--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LLJIT_H
 #define LLVM_EXECUTIONENGINE_ORC_LLJIT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h"
@@ -38,14 +39,14 @@ class ExecutorProcessControl;
 /// A pre-fabricated ORC JIT stack that can serve as an alternative to MCJIT.
 ///
 /// Create instances using LLJITBuilder.
-class LLJIT {
+class LLVM_ABI LLJIT {
   template <typename, typename, typename> friend class LLJITBuilderSetters;
 
   friend Expected<JITDylibSP> setUpGenericLLVMIRPlatform(LLJIT &J);
 
 public:
   /// Initializer support for LLJIT.
-  class PlatformSupport {
+  class LLVM_ABI PlatformSupport {
   public:
     virtual ~PlatformSupport();
 
@@ -279,7 +280,7 @@ public:
   CompileOnDemandLayer &getCompileOnDemandLayer() { return *CODLayer; }
 
   /// Add a module to be lazily compiled to JITDylib JD.
-  Error addLazyIRModule(JITDylib &JD, ThreadSafeModule M);
+  LLVM_ABI Error addLazyIRModule(JITDylib &JD, ThreadSafeModule M);
 
   /// Add a module to be lazily compiled to the main JITDylib.
   Error addLazyIRModule(ThreadSafeModule M) {
@@ -327,7 +328,7 @@ public:
   std::optional<bool> SupportConcurrentCompilation;
 
   /// Called prior to JIT class construcion to fix up defaults.
-  Error prepareForConstruction();
+  LLVM_ABI Error prepareForConstruction();
 };
 
 template <typename JITType, typename SetterImpl, typename State>
@@ -523,7 +524,7 @@ public:
   std::unique_ptr<LazyCallThroughManager> LCTMgr;
   IndirectStubsManagerBuilderFunction ISMBuilder;
 
-  Error prepareForConstruction();
+  LLVM_ABI Error prepareForConstruction();
 };
 
 template <typename JITType, typename SetterImpl, typename State>
@@ -567,7 +568,7 @@ class LLLazyJITBuilder
 
 /// Configure the LLJIT instance to use orc runtime support. This overload
 /// assumes that the client has manually configured a Platform object.
-Error setUpOrcPlatformManually(LLJIT &J);
+LLVM_ABI Error setUpOrcPlatformManually(LLJIT &J);
 
 /// Configure the LLJIT instance to use the ORC runtime and the detected
 /// native target for the executor.
@@ -590,7 +591,7 @@ public:
     return *this;
   }
 
-  Expected<JITDylibSP> operator()(LLJIT &J);
+  LLVM_ABI Expected<JITDylibSP> operator()(LLJIT &J);
 
 private:
   std::variant<std::string, std::unique_ptr<MemoryBuffer>> OrcRuntime;
@@ -601,17 +602,17 @@ private:
 /// llvm.global_dtors variables and (if present) build initialization and
 /// deinitialization functions. Platform specific initialization configurations
 /// should be preferred where available.
-Expected<JITDylibSP> setUpGenericLLVMIRPlatform(LLJIT &J);
+LLVM_ABI Expected<JITDylibSP> setUpGenericLLVMIRPlatform(LLJIT &J);
 
 /// Configure the LLJIT instance to disable platform support explicitly. This is
 /// useful in two cases: for platforms that don't have such requirements and for
 /// platforms, that we have no explicit support yet and that don't work well
 /// with the generic IR platform.
-Expected<JITDylibSP> setUpInactivePlatform(LLJIT &J);
+LLVM_ABI Expected<JITDylibSP> setUpInactivePlatform(LLJIT &J);
 
 /// A Platform-support class that implements initialize / deinitialize by
 /// forwarding to ORC runtime dlopen / dlclose operations.
-class ORCPlatformSupport : public LLJIT::PlatformSupport {
+class LLVM_ABI ORCPlatformSupport : public LLJIT::PlatformSupport {
 public:
   ORCPlatformSupport(orc::LLJIT &J) : J(J) {}
   Error initialize(orc::JITDylib &JD) override;

--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LLJIT_H
 #define LLVM_EXECUTIONENGINE_ORC_LLJIT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h"
@@ -24,6 +23,7 @@
 #include "llvm/ExecutionEngine/Orc/IRTransformLayer.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ThreadPool.h"
 #include <variant>
@@ -42,7 +42,8 @@ class ExecutorProcessControl;
 class LLVM_ABI LLJIT {
   template <typename, typename, typename> friend class LLJITBuilderSetters;
 
-  LLVM_ABI_FRIEND friend Expected<JITDylibSP> setUpGenericLLVMIRPlatform(LLJIT &J);
+  LLVM_ABI_FRIEND friend Expected<JITDylibSP>
+  setUpGenericLLVMIRPlatform(LLJIT &J);
 
 public:
   /// Initializer support for LLJIT.

--- a/llvm/include/llvm/ExecutionEngine/Orc/Layer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Layer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_LAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Mangling.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
@@ -28,7 +29,7 @@ namespace orc {
 /// wrapping LLVM IR. Represents materialization responsibility for all symbols
 /// in the given module. If symbols are overridden by other definitions, then
 /// their linkage is changed to available-externally.
-class IRMaterializationUnit : public MaterializationUnit {
+class LLVM_ABI IRMaterializationUnit : public MaterializationUnit {
 public:
   using SymbolNameToDefinitionMap = std::map<SymbolStringPtr, GlobalValue *>;
 
@@ -64,7 +65,7 @@ private:
 };
 
 /// Interface for layers that accept LLVM IR.
-class IRLayer {
+class LLVM_ABI IRLayer {
 public:
   IRLayer(ExecutionSession &ES, const IRSymbolMapper::ManglingOptions *&MO)
       : ES(ES), MO(MO) {}
@@ -117,7 +118,7 @@ private:
 
 /// MaterializationUnit that materializes modules by calling the 'emit' method
 /// on the given IRLayer.
-class BasicIRLayerMaterializationUnit : public IRMaterializationUnit {
+class LLVM_ABI BasicIRLayerMaterializationUnit : public IRMaterializationUnit {
 public:
   BasicIRLayerMaterializationUnit(IRLayer &L,
                                   const IRSymbolMapper::ManglingOptions &MO,
@@ -130,7 +131,7 @@ private:
 };
 
 /// Interface for Layers that accept object files.
-class ObjectLayer : public RTTIExtends<ObjectLayer, RTTIRoot> {
+class LLVM_ABI ObjectLayer : public RTTIExtends<ObjectLayer, RTTIRoot> {
 public:
   static char ID;
 
@@ -172,7 +173,7 @@ private:
 
 /// Materializes the given object file (represented by a MemoryBuffer
 /// instance) by calling 'emit' on the given ObjectLayer.
-class BasicObjectLayerMaterializationUnit : public MaterializationUnit {
+class LLVM_ABI BasicObjectLayerMaterializationUnit : public MaterializationUnit {
 public:
   /// Create using the default object interface builder function.
   static Expected<std::unique_ptr<BasicObjectLayerMaterializationUnit>>

--- a/llvm/include/llvm/ExecutionEngine/Orc/Layer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Layer.h
@@ -13,12 +13,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_LAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Mangling.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ExtensibleRTTI.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -173,7 +173,8 @@ private:
 
 /// Materializes the given object file (represented by a MemoryBuffer
 /// instance) by calling 'emit' on the given ObjectLayer.
-class LLVM_ABI BasicObjectLayerMaterializationUnit : public MaterializationUnit {
+class LLVM_ABI BasicObjectLayerMaterializationUnit
+    : public MaterializationUnit {
 public:
   /// Create using the default object interface builder function.
   static Expected<std::unique_ptr<BasicObjectLayerMaterializationUnit>>

--- a/llvm/include/llvm/ExecutionEngine/Orc/LazyObjectLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LazyObjectLinkingLayer.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LAZYOBJECTLINKINGLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_LAZYOBJECTLINKINGLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 
@@ -33,7 +34,7 @@ class RedirectableSymbolManager;
 ///
 /// References to data symbols are not lazy and will trigger immediate linking
 /// (same os ObjectlinkingLayer).
-class LazyObjectLinkingLayer : public ObjectLayer {
+class LLVM_ABI LazyObjectLinkingLayer : public ObjectLayer {
 public:
   LazyObjectLinkingLayer(ObjectLinkingLayer &BaseLayer,
                          LazyReexportsManager &LRMgr);

--- a/llvm/include/llvm/ExecutionEngine/Orc/LazyObjectLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LazyObjectLinkingLayer.h
@@ -12,9 +12,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LAZYOBJECTLINKINGLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_LAZYOBJECTLINKINGLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm::orc {
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/LazyReexports.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LazyReexports.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LAZYREEXPORTS_H
 #define LLVM_EXECUTIONENGINE_ORC_LAZYREEXPORTS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/IndirectionUtils.h"
@@ -41,16 +42,16 @@ public:
   using NotifyResolvedFunction =
       unique_function<Error(ExecutorAddr ResolvedAddr)>;
 
-  LazyCallThroughManager(ExecutionSession &ES, ExecutorAddr ErrorHandlerAddr,
+  LLVM_ABI LazyCallThroughManager(ExecutionSession &ES, ExecutorAddr ErrorHandlerAddr,
                          TrampolinePool *TP);
 
   // Return a free call-through trampoline and bind it to look up and call
   // through to the given symbol.
-  Expected<ExecutorAddr>
+  LLVM_ABI Expected<ExecutorAddr>
   getCallThroughTrampoline(JITDylib &SourceJD, SymbolStringPtr SymbolName,
                            NotifyResolvedFunction NotifyResolved);
 
-  void resolveTrampolineLandingAddress(
+  LLVM_ABI void resolveTrampolineLandingAddress(
       ExecutorAddr TrampolineAddr,
       TrampolinePool::NotifyLandingResolvedFunction NotifyLandingResolved);
 
@@ -65,9 +66,9 @@ protected:
     SymbolStringPtr SymbolName;
   };
 
-  ExecutorAddr reportCallThroughError(Error Err);
-  Expected<ReexportsEntry> findReexport(ExecutorAddr TrampolineAddr);
-  Error notifyResolved(ExecutorAddr TrampolineAddr, ExecutorAddr ResolvedAddr);
+  LLVM_ABI ExecutorAddr reportCallThroughError(Error Err);
+  LLVM_ABI Expected<ReexportsEntry> findReexport(ExecutorAddr TrampolineAddr);
+  LLVM_ABI Error notifyResolved(ExecutorAddr TrampolineAddr, ExecutorAddr ResolvedAddr);
   void setTrampolinePool(TrampolinePool &TP) { this->TP = &TP; }
 
 private:
@@ -129,7 +130,7 @@ public:
 
 /// Create a LocalLazyCallThroughManager from the given triple and execution
 /// session.
-Expected<std::unique_ptr<LazyCallThroughManager>>
+LLVM_ABI Expected<std::unique_ptr<LazyCallThroughManager>>
 createLocalLazyCallThroughManager(const Triple &T, ExecutionSession &ES,
                                   ExecutorAddr ErrorHandlerAddr);
 
@@ -138,7 +139,7 @@ createLocalLazyCallThroughManager(const Triple &T, ExecutionSession &ES,
 /// Unlike a 'true' re-export, the address of the lazy re-export will not
 /// match the address of the re-exported symbol, but calling it will behave
 /// the same as calling the re-exported symbol.
-class LazyReexportsMaterializationUnit : public MaterializationUnit {
+class LLVM_ABI LazyReexportsMaterializationUnit : public MaterializationUnit {
 public:
   LazyReexportsMaterializationUnit(LazyCallThroughManager &LCTManager,
                                    RedirectableSymbolManager &RSManager,
@@ -173,7 +174,7 @@ lazyReexports(LazyCallThroughManager &LCTManager,
       LCTManager, RSManager, SourceJD, std::move(CallableAliases), SrcJDLoc);
 }
 
-class LazyReexportsManager : public ResourceManager {
+class LLVM_ABI LazyReexportsManager : public ResourceManager {
 
   friend std::unique_ptr<MaterializationUnit>
   lazyReexports(LazyReexportsManager &, SymbolAliasMap);
@@ -185,7 +186,7 @@ public:
     SymbolStringPtr BodyName;
   };
 
-  class Listener {
+  class LLVM_ABI Listener {
   public:
     using CallThroughInfo = LazyReexportsManager::CallThroughInfo;
 
@@ -268,7 +269,7 @@ lazyReexports(LazyReexportsManager &LRM, SymbolAliasMap Reexports) {
   return LRM.createLazyReexports(std::move(Reexports));
 }
 
-class SimpleLazyReexportsSpeculator : public LazyReexportsManager::Listener {
+class LLVM_ABI SimpleLazyReexportsSpeculator : public LazyReexportsManager::Listener {
 public:
   using RecordExecutionFunction =
       unique_function<void(const CallThroughInfo &CTI)>;

--- a/llvm/include/llvm/ExecutionEngine/Orc/LazyReexports.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LazyReexports.h
@@ -16,12 +16,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LAZYREEXPORTS_H
 #define LLVM_EXECUTIONENGINE_ORC_LAZYREEXPORTS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/IndirectionUtils.h"
 #include "llvm/ExecutionEngine/Orc/RedirectionManager.h"
 #include "llvm/ExecutionEngine/Orc/Speculation.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -42,8 +42,9 @@ public:
   using NotifyResolvedFunction =
       unique_function<Error(ExecutorAddr ResolvedAddr)>;
 
-  LLVM_ABI LazyCallThroughManager(ExecutionSession &ES, ExecutorAddr ErrorHandlerAddr,
-                         TrampolinePool *TP);
+  LLVM_ABI LazyCallThroughManager(ExecutionSession &ES,
+                                  ExecutorAddr ErrorHandlerAddr,
+                                  TrampolinePool *TP);
 
   // Return a free call-through trampoline and bind it to look up and call
   // through to the given symbol.
@@ -68,7 +69,8 @@ protected:
 
   LLVM_ABI ExecutorAddr reportCallThroughError(Error Err);
   LLVM_ABI Expected<ReexportsEntry> findReexport(ExecutorAddr TrampolineAddr);
-  LLVM_ABI Error notifyResolved(ExecutorAddr TrampolineAddr, ExecutorAddr ResolvedAddr);
+  LLVM_ABI Error notifyResolved(ExecutorAddr TrampolineAddr,
+                                ExecutorAddr ResolvedAddr);
   void setTrampolinePool(TrampolinePool &TP) { this->TP = &TP; }
 
 private:
@@ -269,7 +271,8 @@ lazyReexports(LazyReexportsManager &LRM, SymbolAliasMap Reexports) {
   return LRM.createLazyReexports(std::move(Reexports));
 }
 
-class LLVM_ABI SimpleLazyReexportsSpeculator : public LazyReexportsManager::Listener {
+class LLVM_ABI SimpleLazyReexportsSpeculator
+    : public LazyReexportsManager::Listener {
 public:
   using RecordExecutionFunction =
       unique_function<void(const CallThroughInfo &CTI)>;

--- a/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLayer.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LINKGRAPHLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_LINKGRAPHLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLayer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LINKGRAPHLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_LINKGRAPHLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/Support/Error.h"
@@ -23,7 +24,7 @@
 
 namespace llvm::orc {
 
-class LinkGraphLayer {
+class LLVM_ABI LinkGraphLayer {
 public:
   LinkGraphLayer(ExecutionSession &ES) : ES(ES) {}
 
@@ -70,7 +71,7 @@ private:
 };
 
 /// MaterializationUnit for wrapping LinkGraphs.
-class LinkGraphMaterializationUnit : public MaterializationUnit {
+class LLVM_ABI LinkGraphMaterializationUnit : public MaterializationUnit {
 public:
   LinkGraphMaterializationUnit(LinkGraphLayer &LGLayer,
                                std::unique_ptr<jitlink::LinkGraph> G,

--- a/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h
@@ -13,13 +13,13 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LINKGRAPHLINKINGLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_LINKGRAPHLINKINGLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include "llvm/ExecutionEngine/Orc/LinkGraphLayer.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <algorithm>
 #include <cassert>
@@ -41,7 +41,8 @@ namespace orc {
 ///
 /// Clients can use this class to add LinkGraphs to an ExecutionSession, and it
 /// serves as a base for the ObjectLinkingLayer that can link object files.
-class LLVM_ABI LinkGraphLinkingLayer : public LinkGraphLayer, private ResourceManager {
+class LLVM_ABI LinkGraphLinkingLayer : public LinkGraphLayer,
+                                       private ResourceManager {
   class JITLinkCtx;
 
 public:

--- a/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LINKGRAPHLINKINGLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_LINKGRAPHLINKINGLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
@@ -40,14 +41,14 @@ namespace orc {
 ///
 /// Clients can use this class to add LinkGraphs to an ExecutionSession, and it
 /// serves as a base for the ObjectLinkingLayer that can link object files.
-class LinkGraphLinkingLayer : public LinkGraphLayer, private ResourceManager {
+class LLVM_ABI LinkGraphLinkingLayer : public LinkGraphLayer, private ResourceManager {
   class JITLinkCtx;
 
 public:
   /// Plugin instances can be added to the ObjectLinkingLayer to receive
   /// callbacks when code is loaded or emitted, and when JITLink is being
   /// configured.
-  class Plugin {
+  class LLVM_ABI Plugin {
   public:
     virtual ~Plugin();
     virtual void modifyPassConfig(MaterializationResponsibility &MR,

--- a/llvm/include/llvm/ExecutionEngine/Orc/LoadLinkableFile.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LoadLinkableFile.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LOADLINKABLEFILE_H
 #define LLVM_EXECUTIONENGINE_ORC_LOADLINKABLEFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/TargetParser/Triple.h"
@@ -54,7 +55,7 @@ enum class LoadArchives {
 ///
 /// If IdentifierOverride is provided then it will be used as the name of the
 /// resulting buffer, rather than Path.
-Expected<std::pair<std::unique_ptr<MemoryBuffer>, LinkableFileKind>>
+LLVM_ABI Expected<std::pair<std::unique_ptr<MemoryBuffer>, LinkableFileKind>>
 loadLinkableFile(StringRef Path, const Triple &TT, LoadArchives LA,
                  std::optional<StringRef> IdentifierOverride = std::nullopt);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LOOKUPANDRECORDADDRS_H
 #define LLVM_EXECUTIONENGINE_ORC_LOOKUPANDRECORDADDRS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
@@ -41,7 +42,7 @@ namespace orc {
 /// addresses before using them).
 ///
 /// Asynchronous version.
-void lookupAndRecordAddrs(
+LLVM_ABI void lookupAndRecordAddrs(
     unique_function<void(Error)> OnRecorded, ExecutionSession &ES, LookupKind K,
     const JITDylibSearchOrder &SearchOrder,
     std::vector<std::pair<SymbolStringPtr, ExecutorAddr *>> Pairs,
@@ -50,7 +51,7 @@ void lookupAndRecordAddrs(
 /// Record addresses of the given symbols in the given ExecutorAddrs.
 ///
 /// Blocking version.
-Error lookupAndRecordAddrs(
+LLVM_ABI Error lookupAndRecordAddrs(
     ExecutionSession &ES, LookupKind K, const JITDylibSearchOrder &SearchOrder,
     std::vector<std::pair<SymbolStringPtr, ExecutorAddr *>> Pairs,
     SymbolLookupFlags LookupFlags = SymbolLookupFlags::RequiredSymbol);
@@ -59,7 +60,7 @@ Error lookupAndRecordAddrs(
 ///
 /// ExecutorProcessControl lookup version. Lookups are always implicitly
 /// weak.
-Error lookupAndRecordAddrs(
+LLVM_ABI Error lookupAndRecordAddrs(
     ExecutorProcessControl &EPC, tpctypes::DylibHandle H,
     std::vector<std::pair<SymbolStringPtr, ExecutorAddr *>> Pairs,
     SymbolLookupFlags LookupFlags = SymbolLookupFlags::RequiredSymbol);

--- a/llvm/include/llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h
@@ -16,10 +16,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_LOOKUPANDRECORDADDRS_H
 #define LLVM_EXECUTIONENGINE_ORC_LOOKUPANDRECORDADDRS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 
 #include <vector>
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/MachO.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MachO.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MACHO_H
 #define LLVM_EXECUTIONENGINE_ORC_MACHO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/LoadLinkableFile.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Support/Error.h"
@@ -37,21 +38,21 @@ class ObjectLayer;
 /// given triple.
 /// ObjIsSlice should be set to true if Obj is a slice of a universal binary
 /// (that fact will then be reported in the error messages).
-Error checkMachORelocatableObject(MemoryBufferRef Obj, const Triple &TT,
+LLVM_ABI Error checkMachORelocatableObject(MemoryBufferRef Obj, const Triple &TT,
                                   bool ObjIsSlice);
 
 /// Check that the given buffer contains a MachO object file compatible with the
 /// given triple.
 /// This convenience overload returns the buffer if it passes all checks,
 /// otherwise it returns an error.
-Expected<std::unique_ptr<MemoryBuffer>>
+LLVM_ABI Expected<std::unique_ptr<MemoryBuffer>>
 checkMachORelocatableObject(std::unique_ptr<MemoryBuffer> Obj, const Triple &TT,
                             bool ObjIsSlice);
 
 /// Load a relocatable object compatible with TT from Path.
 /// If Path is a universal binary, this function will return a buffer for the
 /// slice compatible with Triple (if one is present).
-Expected<std::pair<std::unique_ptr<MemoryBuffer>, LinkableFileKind>>
+LLVM_ABI Expected<std::pair<std::unique_ptr<MemoryBuffer>, LinkableFileKind>>
 loadMachOLinkableFile(
     StringRef Path, const Triple &TT, LoadArchives LA,
     std::optional<StringRef> IdentifierOverride = std::nullopt);
@@ -60,7 +61,7 @@ loadMachOLinkableFile(
 /// binary.
 /// Path is only used for error reporting. Identifier will be used to name the
 /// resulting buffer.
-Expected<std::pair<std::unique_ptr<MemoryBuffer>, LinkableFileKind>>
+LLVM_ABI Expected<std::pair<std::unique_ptr<MemoryBuffer>, LinkableFileKind>>
 loadLinkableSliceFromMachOUniversalBinary(sys::fs::file_t FD,
                                           std::unique_ptr<MemoryBuffer> UBBuf,
                                           const Triple &TT, LoadArchives LA,
@@ -69,12 +70,12 @@ loadLinkableSliceFromMachOUniversalBinary(sys::fs::file_t FD,
 
 /// Utility for identifying the file-slice compatible with TT in a universal
 /// binary.
-Expected<std::pair<size_t, size_t>>
+LLVM_ABI Expected<std::pair<size_t, size_t>>
 getMachOSliceRangeForTriple(object::MachOUniversalBinary &UB, const Triple &TT);
 
 /// Utility for identifying the file-slice compatible with TT in a universal
 /// binary.
-Expected<std::pair<size_t, size_t>>
+LLVM_ABI Expected<std::pair<size_t, size_t>>
 getMachOSliceRangeForTriple(MemoryBufferRef UBBuf, const Triple &TT);
 
 /// For use with StaticLibraryDefinitionGenerators.
@@ -83,7 +84,7 @@ public:
   ForceLoadMachOArchiveMembers(ObjectLayer &L, JITDylib &JD, bool ObjCOnly)
       : L(L), JD(JD), ObjCOnly(ObjCOnly) {}
 
-  Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
+  LLVM_ABI Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
                             size_t Index);
 
 private:

--- a/llvm/include/llvm/ExecutionEngine/Orc/MachO.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MachO.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MACHO_H
 #define LLVM_EXECUTIONENGINE_ORC_MACHO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/LoadLinkableFile.h"
 #include "llvm/Object/Archive.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/TargetParser/Triple.h"
@@ -38,8 +38,8 @@ class ObjectLayer;
 /// given triple.
 /// ObjIsSlice should be set to true if Obj is a slice of a universal binary
 /// (that fact will then be reported in the error messages).
-LLVM_ABI Error checkMachORelocatableObject(MemoryBufferRef Obj, const Triple &TT,
-                                  bool ObjIsSlice);
+LLVM_ABI Error checkMachORelocatableObject(MemoryBufferRef Obj,
+                                           const Triple &TT, bool ObjIsSlice);
 
 /// Check that the given buffer contains a MachO object file compatible with the
 /// given triple.
@@ -84,8 +84,8 @@ public:
   ForceLoadMachOArchiveMembers(ObjectLayer &L, JITDylib &JD, bool ObjCOnly)
       : L(L), JD(JD), ObjCOnly(ObjCOnly) {}
 
-  LLVM_ABI Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
-                            size_t Index);
+  LLVM_ABI Expected<bool> operator()(object::Archive &A,
+                                     MemoryBufferRef MemberBuf, size_t Index);
 
 private:
   ObjectLayer &L;

--- a/llvm/include/llvm/ExecutionEngine/Orc/MachOPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MachOPlatform.h
@@ -13,12 +13,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MACHOPLATFORM_H
 #define LLVM_EXECUTIONENGINE_ORC_MACHOPLATFORM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 
 #include <future>
 #include <thread>

--- a/llvm/include/llvm/ExecutionEngine/Orc/MachOPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MachOPlatform.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MACHOPLATFORM_H
 #define LLVM_EXECUTIONENGINE_ORC_MACHOPLATFORM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
@@ -27,7 +28,7 @@ namespace llvm {
 namespace orc {
 
 /// Mediates between MachO initialization and ExecutionSession state.
-class MachOPlatform : public Platform {
+class LLVM_ABI MachOPlatform : public Platform {
 public:
   // Used internally by MachOPlatform, but made public to enable serialization.
   struct MachOJITDylibDepInfo {
@@ -68,7 +69,7 @@ public:
     struct BuildVersionOpts {
 
       // Derive platform from triple if possible.
-      static std::optional<BuildVersionOpts>
+      LLVM_ABI static std::optional<BuildVersionOpts>
       fromTriple(const Triple &TT, uint32_t MinOS, uint32_t SDK);
 
       uint32_t Platform; // Platform.
@@ -205,7 +206,7 @@ private:
   // The MachOPlatformPlugin scans/modifies LinkGraphs to support MachO
   // platform features including initializers, exceptions, TLV, and language
   // runtime registration.
-  class MachOPlatformPlugin : public ObjectLinkingLayer::Plugin {
+  class LLVM_ABI MachOPlatformPlugin : public ObjectLinkingLayer::Plugin {
   public:
     MachOPlatformPlugin(MachOPlatform &MP) : MP(MP) {}
 
@@ -383,7 +384,7 @@ private:
 };
 
 // Generates a MachO header.
-class SimpleMachOHeaderMU : public MaterializationUnit {
+class LLVM_ABI SimpleMachOHeaderMU : public MaterializationUnit {
 public:
   SimpleMachOHeaderMU(MachOPlatform &MOP, SymbolStringPtr HeaderStartSymbol,
                       MachOPlatform::HeaderOptions Opts);
@@ -427,7 +428,7 @@ struct MachOHeaderInfo {
   uint32_t CPUType = 0;
   uint32_t CPUSubType = 0;
 };
-MachOHeaderInfo getMachOHeaderInfoFromTriple(const Triple &TT);
+LLVM_ABI MachOHeaderInfo getMachOHeaderInfoFromTriple(const Triple &TT);
 
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/Mangling.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Mangling.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MANGLING_H
 #define LLVM_EXECUTIONENGINE_ORC_MANGLING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 namespace llvm {
@@ -51,9 +51,10 @@ public:
   /// necessarily one-to-one: thread-local GlobalValues, for example, may
   /// produce more than one symbol, in which case the map will contain duplicate
   /// values.
-  LLVM_ABI static void add(ExecutionSession &ES, const ManglingOptions &MO,
-                  ArrayRef<GlobalValue *> GVs, SymbolFlagsMap &SymbolFlags,
-                  SymbolNameToDefinitionMap *SymbolToDefinition = nullptr);
+  LLVM_ABI static void
+  add(ExecutionSession &ES, const ManglingOptions &MO,
+      ArrayRef<GlobalValue *> GVs, SymbolFlagsMap &SymbolFlags,
+      SymbolNameToDefinitionMap *SymbolToDefinition = nullptr);
 };
 
 } // End namespace orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/Mangling.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Mangling.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MANGLING_H
 #define LLVM_EXECUTIONENGINE_ORC_MANGLING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
 #include "llvm/IR/Module.h"
@@ -25,8 +26,8 @@ namespace orc {
 /// ExecutionSession.
 class MangleAndInterner {
 public:
-  MangleAndInterner(ExecutionSession &ES, const DataLayout &DL);
-  SymbolStringPtr operator()(StringRef Name);
+  LLVM_ABI MangleAndInterner(ExecutionSession &ES, const DataLayout &DL);
+  LLVM_ABI SymbolStringPtr operator()(StringRef Name);
 
 private:
   ExecutionSession &ES;
@@ -50,7 +51,7 @@ public:
   /// necessarily one-to-one: thread-local GlobalValues, for example, may
   /// produce more than one symbol, in which case the map will contain duplicate
   /// values.
-  static void add(ExecutionSession &ES, const ManglingOptions &MO,
+  LLVM_ABI static void add(ExecutionSession &ES, const ManglingOptions &MO,
                   ArrayRef<GlobalValue *> GVs, SymbolFlagsMap &SymbolFlags,
                   SymbolNameToDefinitionMap *SymbolToDefinition = nullptr);
 };

--- a/llvm/include/llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MAPPERJITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_MAPPERJITLINKMEMORYMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/MemoryMapper.h"
@@ -20,7 +21,7 @@
 namespace llvm {
 namespace orc {
 
-class MapperJITLinkMemoryManager : public jitlink::JITLinkMemoryManager {
+class LLVM_ABI MapperJITLinkMemoryManager : public jitlink::JITLinkMemoryManager {
 public:
   MapperJITLinkMemoryManager(size_t ReservationGranularity,
                              std::unique_ptr<MemoryMapper> Mapper);

--- a/llvm/include/llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h
@@ -13,15 +13,16 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MAPPERJITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_MAPPERJITLINKMEMORYMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/MemoryMapper.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {
 
-class LLVM_ABI MapperJITLinkMemoryManager : public jitlink::JITLinkMemoryManager {
+class LLVM_ABI MapperJITLinkMemoryManager
+    : public jitlink::JITLinkMemoryManager {
 public:
   MapperJITLinkMemoryManager(size_t ReservationGranularity,
                              std::unique_ptr<MemoryMapper> Mapper);

--- a/llvm/include/llvm/ExecutionEngine/Orc/MaterializationUnit.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MaterializationUnit.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MATERIALIZATIONUNIT_H
 #define LLVM_EXECUTIONENGINE_ORC_MATERIALIZATIONUNIT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/CoreContainers.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm::orc {
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/MaterializationUnit.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MaterializationUnit.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MATERIALIZATIONUNIT_H
 #define LLVM_EXECUTIONENGINE_ORC_MATERIALIZATIONUNIT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/CoreContainers.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
@@ -29,7 +30,7 @@ class MaterializationResponsibility;
 /// JITDylibs. The JITDylib will call materialize when the address of a symbol
 /// is requested via the lookup method. The JITDylib will call discard if a
 /// stronger definition is added or already present.
-class MaterializationUnit {
+class LLVM_ABI MaterializationUnit {
   friend class ExecutionSession;
   friend class JITDylib;
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/MemoryMapper.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MemoryMapper.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MEMORYMAPPER_H
 #define LLVM_EXECUTIONENGINE_ORC_MEMORYMAPPER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
 #include "llvm/Support/Process.h"
@@ -23,7 +24,7 @@ namespace llvm {
 namespace orc {
 
 /// Manages mapping, content transfer and protections for JIT memory
-class MemoryMapper {
+class LLVM_ABI MemoryMapper {
 public:
   /// Represents a single allocation containing multiple segments and
   /// initialization and deinitialization actions
@@ -79,7 +80,7 @@ public:
   virtual ~MemoryMapper();
 };
 
-class InProcessMemoryMapper : public MemoryMapper {
+class LLVM_ABI InProcessMemoryMapper : public MemoryMapper {
 public:
   InProcessMemoryMapper(size_t PageSize);
 
@@ -121,7 +122,7 @@ private:
   size_t PageSize;
 };
 
-class SharedMemoryMapper final : public MemoryMapper {
+class LLVM_ABI SharedMemoryMapper final : public MemoryMapper {
 public:
   struct SymbolAddrs {
     ExecutorAddr Instance;

--- a/llvm/include/llvm/ExecutionEngine/Orc/MemoryMapper.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MemoryMapper.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MEMORYMAPPER_H
 #define LLVM_EXECUTIONENGINE_ORC_MEMORYMAPPER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Process.h"
 
 #include <mutex>

--- a/llvm/include/llvm/ExecutionEngine/Orc/ObjectFileInterface.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ObjectFileInterface.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_OBJECTFILEINTERFACE_H
 #define LLVM_EXECUTIONENGINE_ORC_OBJECTFILEINTERFACE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -23,13 +24,13 @@ namespace orc {
 /// Adds an initializer symbol to the given MU interface.
 /// The init symbol's name is guaranteed to be unique within I, and will be of
 /// the form $.<ObjFileName>.__inits.<N>, where N is some integer.
-void addInitSymbol(MaterializationUnit::Interface &I, ExecutionSession &ES,
+LLVM_ABI void addInitSymbol(MaterializationUnit::Interface &I, ExecutionSession &ES,
                    StringRef ObjFileName);
 
 /// Returns a MaterializationUnit::Interface for the object file contained in
 /// the given buffer, or an error if the buffer does not contain a valid object
 /// file.
-Expected<MaterializationUnit::Interface>
+LLVM_ABI Expected<MaterializationUnit::Interface>
 getObjectFileInterface(ExecutionSession &ES, MemoryBufferRef ObjBuffer);
 
 } // End namespace orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/ObjectFileInterface.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ObjectFileInterface.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_OBJECTFILEINTERFACE_H
 #define LLVM_EXECUTIONENGINE_ORC_OBJECTFILEINTERFACE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 namespace llvm {
@@ -24,8 +24,8 @@ namespace orc {
 /// Adds an initializer symbol to the given MU interface.
 /// The init symbol's name is guaranteed to be unique within I, and will be of
 /// the form $.<ObjFileName>.__inits.<N>, where N is some integer.
-LLVM_ABI void addInitSymbol(MaterializationUnit::Interface &I, ExecutionSession &ES,
-                   StringRef ObjFileName);
+LLVM_ABI void addInitSymbol(MaterializationUnit::Interface &I,
+                            ExecutionSession &ES, StringRef ObjFileName);
 
 /// Returns a MaterializationUnit::Interface for the object file contained in
 /// the given buffer, or an error if the buffer does not contain a valid object

--- a/llvm/include/llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h
@@ -14,12 +14,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_OBJECTLINKINGLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_OBJECTLINKINGLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <memory>
@@ -39,8 +39,9 @@ namespace orc {
 /// Clients can use this class to add relocatable object files to an
 /// ExecutionSession, and it typically serves as the base layer (underneath
 /// a compiling layer like IRCompileLayer) for the rest of the JIT.
-class LLVM_ABI ObjectLinkingLayer : public LinkGraphLinkingLayer,
-                           public RTTIExtends<ObjectLinkingLayer, ObjectLayer> {
+class LLVM_ABI ObjectLinkingLayer
+    : public LinkGraphLinkingLayer,
+      public RTTIExtends<ObjectLinkingLayer, ObjectLayer> {
 private:
   using BaseObjectLayer = RTTIExtends<ObjectLinkingLayer, ObjectLayer>;
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_OBJECTLINKINGLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_OBJECTLINKINGLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
@@ -38,7 +39,7 @@ namespace orc {
 /// Clients can use this class to add relocatable object files to an
 /// ExecutionSession, and it typically serves as the base layer (underneath
 /// a compiling layer like IRCompileLayer) for the rest of the JIT.
-class ObjectLinkingLayer : public LinkGraphLinkingLayer,
+class LLVM_ABI ObjectLinkingLayer : public LinkGraphLinkingLayer,
                            public RTTIExtends<ObjectLinkingLayer, ObjectLayer> {
 private:
   using BaseObjectLayer = RTTIExtends<ObjectLinkingLayer, ObjectLayer>;

--- a/llvm/include/llvm/ExecutionEngine/Orc/ObjectTransformLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ObjectTransformLayer.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_OBJECTTRANSFORMLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_OBJECTTRANSFORMLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <memory>
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/ObjectTransformLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ObjectTransformLayer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_OBJECTTRANSFORMLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_OBJECTTRANSFORMLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include <algorithm>
@@ -21,7 +22,7 @@
 namespace llvm {
 namespace orc {
 
-class ObjectTransformLayer
+class LLVM_ABI ObjectTransformLayer
     : public RTTIExtends<ObjectTransformLayer, ObjectLayer> {
 public:
   static char ID;

--- a/llvm/include/llvm/ExecutionEngine/Orc/OrcABISupport.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/OrcABISupport.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_ORCABISUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_ORCABISUPPORT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -101,7 +102,7 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  static void writeResolverCode(char *ResolverWorkingMem,
+  LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
                                 ExecutorAddr ResolverTargetAddress,
                                 ExecutorAddr ReentryFnAddr,
                                 ExecutorAddr RentryCtxAddr);
@@ -109,7 +110,7 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  static void writeTrampolines(char *TrampolineBlockWorkingMem,
+  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
                                ExecutorAddr TrampolineBlockTargetAddress,
                                ExecutorAddr ResolverAddr,
                                unsigned NumTrampolines);
@@ -118,7 +119,7 @@ public:
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
+  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
                                       ExecutorAddr StubsBlockTargetAddress,
                                       ExecutorAddr PointersBlockTargetAddress,
                                       unsigned MinStubs);
@@ -137,7 +138,7 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  static void writeTrampolines(char *TrampolineBlockWorkingMem,
+  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
                                ExecutorAddr TrampolineBlockTargetAddress,
                                ExecutorAddr ResolverAddr,
                                unsigned NumTrampolines);
@@ -146,7 +147,7 @@ public:
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
+  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
                                       ExecutorAddr StubsBlockTargetAddress,
                                       ExecutorAddr PointersBlockTargetAddress,
                                       unsigned NumStubs);
@@ -166,7 +167,7 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  static void writeResolverCode(char *ResolverWorkingMem,
+  LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
                                 ExecutorAddr ResolverTargetAddress,
                                 ExecutorAddr ReentryFnAddr,
                                 ExecutorAddr ReentryCtxAddr);
@@ -186,7 +187,7 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  static void writeResolverCode(char *ResolverWorkingMem,
+  LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
                                 ExecutorAddr ResolverTargetAddress,
                                 ExecutorAddr ReentryFnAddr,
                                 ExecutorAddr ReentryCtxAddr);
@@ -210,7 +211,7 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  static void writeResolverCode(char *ResolverWorkingMem,
+  LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
                                 ExecutorAddr ResolverTargetAddress,
                                 ExecutorAddr ReentryFnAddr,
                                 ExecutorAddr ReentryCtxAddr);
@@ -218,7 +219,7 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  static void writeTrampolines(char *TrampolineBlockWorkingMem,
+  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
                                ExecutorAddr TrampolineBlockTargetAddress,
                                ExecutorAddr ResolverAddr,
                                unsigned NumTrampolines);
@@ -227,7 +228,7 @@ public:
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
+  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
                                       ExecutorAddr StubsBlockTargetAddress,
                                       ExecutorAddr PointersBlockTargetAddress,
                                       unsigned NumStubs);
@@ -247,7 +248,7 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  static void writeTrampolines(char *TrampolineBlockWorkingMem,
+  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
                                ExecutorAddr TrampolineBlockTargetAddress,
                                ExecutorAddr ResolverAddr,
                                unsigned NumTrampolines);
@@ -259,7 +260,7 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  static void writeResolverCode(char *ResolverBlockWorkingMem,
+  LLVM_ABI static void writeResolverCode(char *ResolverBlockWorkingMem,
                                 ExecutorAddr ResolverBlockTargetAddress,
                                 ExecutorAddr ReentryFnAddr,
                                 ExecutorAddr ReentryCtxAddr, bool isBigEndian);
@@ -267,7 +268,7 @@ public:
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
+  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
                                       ExecutorAddr StubsBlockTargetAddress,
                                       ExecutorAddr PointersBlockTargetAddress,
                                       unsigned NumStubs);
@@ -313,7 +314,7 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  static void writeResolverCode(char *ResolverWorkingMem,
+  LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
                                 ExecutorAddr ResolverTargetAddress,
                                 ExecutorAddr ReentryFnAddr,
                                 ExecutorAddr ReentryCtxAddr);
@@ -321,7 +322,7 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  static void writeTrampolines(char *TrampolineBlockWorkingMem,
+  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
                                ExecutorAddr TrampolineBlockTargetAddress,
                                ExecutorAddr ResolverFnAddr,
                                unsigned NumTrampolines);
@@ -329,7 +330,7 @@ public:
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
+  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
                                       ExecutorAddr StubsBlockTargetAddress,
                                       ExecutorAddr PointersBlockTargetAddress,
                                       unsigned NumStubs);
@@ -353,7 +354,7 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  static void writeResolverCode(char *ResolverWorkingMem,
+  LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
                                 ExecutorAddr ResolverTargetAddress,
                                 ExecutorAddr ReentryFnAddr,
                                 ExecutorAddr ReentryCtxAddr);
@@ -361,7 +362,7 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  static void writeTrampolines(char *TrampolineBlockWorkingMem,
+  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
                                ExecutorAddr TrampolineBlockTargetAddress,
                                ExecutorAddr ResolverFnAddr,
                                unsigned NumTrampolines);
@@ -369,7 +370,7 @@ public:
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
+  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
                                       ExecutorAddr StubsBlockTargetAddress,
                                       ExecutorAddr PointersBlockTargetAddress,
                                       unsigned NumStubs);
@@ -393,7 +394,7 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  static void writeResolverCode(char *ResolverWorkingMem,
+  LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
                                 ExecutorAddr ResolverTargetAddress,
                                 ExecutorAddr ReentryFnAddr,
                                 ExecutorAddr ReentryCtxAddr);
@@ -401,7 +402,7 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  static void writeTrampolines(char *TrampolineBlockWorkingMem,
+  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
                                ExecutorAddr TrampolineBlockTargetAddress,
                                ExecutorAddr ResolverFnAddr,
                                unsigned NumTrampolines);
@@ -410,7 +411,7 @@ public:
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
+  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
                                       ExecutorAddr StubsBlockTargetAddress,
                                       ExecutorAddr PointersBlockTargetAddress,
                                       unsigned NumStubs);

--- a/llvm/include/llvm/ExecutionEngine/Orc/OrcABISupport.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/OrcABISupport.h
@@ -17,8 +17,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_ORCABISUPPORT_H
 #define LLVM_EXECUTIONENGINE_ORC_ORCABISUPPORT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
@@ -103,26 +103,25 @@ public:
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
   LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
-                                ExecutorAddr ResolverTargetAddress,
-                                ExecutorAddr ReentryFnAddr,
-                                ExecutorAddr RentryCtxAddr);
+                                         ExecutorAddr ResolverTargetAddress,
+                                         ExecutorAddr ReentryFnAddr,
+                                         ExecutorAddr RentryCtxAddr);
 
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
-                               ExecutorAddr TrampolineBlockTargetAddress,
-                               ExecutorAddr ResolverAddr,
-                               unsigned NumTrampolines);
+  LLVM_ABI static void
+  writeTrampolines(char *TrampolineBlockWorkingMem,
+                   ExecutorAddr TrampolineBlockTargetAddress,
+                   ExecutorAddr ResolverAddr, unsigned NumTrampolines);
 
   /// Write NumStubs indirect stubs to working memory at StubsBlockWorkingMem.
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
-                                      ExecutorAddr StubsBlockTargetAddress,
-                                      ExecutorAddr PointersBlockTargetAddress,
-                                      unsigned MinStubs);
+  LLVM_ABI static void writeIndirectStubsBlock(
+      char *StubsBlockWorkingMem, ExecutorAddr StubsBlockTargetAddress,
+      ExecutorAddr PointersBlockTargetAddress, unsigned MinStubs);
 };
 
 /// X86_64 code that's common to all ABIs.
@@ -138,19 +137,18 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
-                               ExecutorAddr TrampolineBlockTargetAddress,
-                               ExecutorAddr ResolverAddr,
-                               unsigned NumTrampolines);
+  LLVM_ABI static void
+  writeTrampolines(char *TrampolineBlockWorkingMem,
+                   ExecutorAddr TrampolineBlockTargetAddress,
+                   ExecutorAddr ResolverAddr, unsigned NumTrampolines);
 
   /// Write NumStubs indirect stubs to working memory at StubsBlockWorkingMem.
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
-                                      ExecutorAddr StubsBlockTargetAddress,
-                                      ExecutorAddr PointersBlockTargetAddress,
-                                      unsigned NumStubs);
+  LLVM_ABI static void writeIndirectStubsBlock(
+      char *StubsBlockWorkingMem, ExecutorAddr StubsBlockTargetAddress,
+      ExecutorAddr PointersBlockTargetAddress, unsigned NumStubs);
 };
 
 /// X86_64 support for SysV ABI (Linux, MacOSX).
@@ -168,9 +166,9 @@ public:
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
   LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
-                                ExecutorAddr ResolverTargetAddress,
-                                ExecutorAddr ReentryFnAddr,
-                                ExecutorAddr ReentryCtxAddr);
+                                         ExecutorAddr ResolverTargetAddress,
+                                         ExecutorAddr ReentryFnAddr,
+                                         ExecutorAddr ReentryCtxAddr);
 };
 
 /// X86_64 support for Win32.
@@ -188,9 +186,9 @@ public:
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
   LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
-                                ExecutorAddr ResolverTargetAddress,
-                                ExecutorAddr ReentryFnAddr,
-                                ExecutorAddr ReentryCtxAddr);
+                                         ExecutorAddr ResolverTargetAddress,
+                                         ExecutorAddr ReentryFnAddr,
+                                         ExecutorAddr ReentryCtxAddr);
 };
 
 /// I386 support.
@@ -212,26 +210,25 @@ public:
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
   LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
-                                ExecutorAddr ResolverTargetAddress,
-                                ExecutorAddr ReentryFnAddr,
-                                ExecutorAddr ReentryCtxAddr);
+                                         ExecutorAddr ResolverTargetAddress,
+                                         ExecutorAddr ReentryFnAddr,
+                                         ExecutorAddr ReentryCtxAddr);
 
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
-                               ExecutorAddr TrampolineBlockTargetAddress,
-                               ExecutorAddr ResolverAddr,
-                               unsigned NumTrampolines);
+  LLVM_ABI static void
+  writeTrampolines(char *TrampolineBlockWorkingMem,
+                   ExecutorAddr TrampolineBlockTargetAddress,
+                   ExecutorAddr ResolverAddr, unsigned NumTrampolines);
 
   /// Write NumStubs indirect stubs to working memory at StubsBlockWorkingMem.
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
-                                      ExecutorAddr StubsBlockTargetAddress,
-                                      ExecutorAddr PointersBlockTargetAddress,
-                                      unsigned NumStubs);
+  LLVM_ABI static void writeIndirectStubsBlock(
+      char *StubsBlockWorkingMem, ExecutorAddr StubsBlockTargetAddress,
+      ExecutorAddr PointersBlockTargetAddress, unsigned NumStubs);
 };
 
 // @brief Mips32 support.
@@ -248,10 +245,10 @@ public:
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
-                               ExecutorAddr TrampolineBlockTargetAddress,
-                               ExecutorAddr ResolverAddr,
-                               unsigned NumTrampolines);
+  LLVM_ABI static void
+  writeTrampolines(char *TrampolineBlockWorkingMem,
+                   ExecutorAddr TrampolineBlockTargetAddress,
+                   ExecutorAddr ResolverAddr, unsigned NumTrampolines);
 
   /// Write the resolver code into the given memory. The user is
   /// responsible for allocating the memory and setting permissions.
@@ -260,18 +257,18 @@ public:
   /// void* (*)(void *TrampolineAddr, void *ReentryCtxAddr). The ReentryCtxAddr
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
-  LLVM_ABI static void writeResolverCode(char *ResolverBlockWorkingMem,
-                                ExecutorAddr ResolverBlockTargetAddress,
-                                ExecutorAddr ReentryFnAddr,
-                                ExecutorAddr ReentryCtxAddr, bool isBigEndian);
+  LLVM_ABI static void
+  writeResolverCode(char *ResolverBlockWorkingMem,
+                    ExecutorAddr ResolverBlockTargetAddress,
+                    ExecutorAddr ReentryFnAddr, ExecutorAddr ReentryCtxAddr,
+                    bool isBigEndian);
   /// Write NumStubs indirect stubs to working memory at StubsBlockWorkingMem.
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
-                                      ExecutorAddr StubsBlockTargetAddress,
-                                      ExecutorAddr PointersBlockTargetAddress,
-                                      unsigned NumStubs);
+  LLVM_ABI static void writeIndirectStubsBlock(
+      char *StubsBlockWorkingMem, ExecutorAddr StubsBlockTargetAddress,
+      ExecutorAddr PointersBlockTargetAddress, unsigned NumStubs);
 };
 
 class OrcMips32Le : public OrcMips32_Base {
@@ -315,25 +312,24 @@ public:
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
   LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
-                                ExecutorAddr ResolverTargetAddress,
-                                ExecutorAddr ReentryFnAddr,
-                                ExecutorAddr ReentryCtxAddr);
+                                         ExecutorAddr ResolverTargetAddress,
+                                         ExecutorAddr ReentryFnAddr,
+                                         ExecutorAddr ReentryCtxAddr);
 
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
-                               ExecutorAddr TrampolineBlockTargetAddress,
-                               ExecutorAddr ResolverFnAddr,
-                               unsigned NumTrampolines);
+  LLVM_ABI static void
+  writeTrampolines(char *TrampolineBlockWorkingMem,
+                   ExecutorAddr TrampolineBlockTargetAddress,
+                   ExecutorAddr ResolverFnAddr, unsigned NumTrampolines);
   /// Write NumStubs indirect stubs to working memory at StubsBlockWorkingMem.
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
-                                      ExecutorAddr StubsBlockTargetAddress,
-                                      ExecutorAddr PointersBlockTargetAddress,
-                                      unsigned NumStubs);
+  LLVM_ABI static void writeIndirectStubsBlock(
+      char *StubsBlockWorkingMem, ExecutorAddr StubsBlockTargetAddress,
+      ExecutorAddr PointersBlockTargetAddress, unsigned NumStubs);
 };
 
 // @brief riscv64 support.
@@ -355,25 +351,24 @@ public:
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
   LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
-                                ExecutorAddr ResolverTargetAddress,
-                                ExecutorAddr ReentryFnAddr,
-                                ExecutorAddr ReentryCtxAddr);
+                                         ExecutorAddr ResolverTargetAddress,
+                                         ExecutorAddr ReentryFnAddr,
+                                         ExecutorAddr ReentryCtxAddr);
 
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
-                               ExecutorAddr TrampolineBlockTargetAddress,
-                               ExecutorAddr ResolverFnAddr,
-                               unsigned NumTrampolines);
+  LLVM_ABI static void
+  writeTrampolines(char *TrampolineBlockWorkingMem,
+                   ExecutorAddr TrampolineBlockTargetAddress,
+                   ExecutorAddr ResolverFnAddr, unsigned NumTrampolines);
   /// Write NumStubs indirect stubs to working memory at StubsBlockWorkingMem.
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
-                                      ExecutorAddr StubsBlockTargetAddress,
-                                      ExecutorAddr PointersBlockTargetAddress,
-                                      unsigned NumStubs);
+  LLVM_ABI static void writeIndirectStubsBlock(
+      char *StubsBlockWorkingMem, ExecutorAddr StubsBlockTargetAddress,
+      ExecutorAddr PointersBlockTargetAddress, unsigned NumStubs);
 };
 
 // @brief loongarch64 support.
@@ -395,26 +390,25 @@ public:
   /// argument of writeResolverCode will be passed as the second argument to
   /// the function at ReentryFnAddr.
   LLVM_ABI static void writeResolverCode(char *ResolverWorkingMem,
-                                ExecutorAddr ResolverTargetAddress,
-                                ExecutorAddr ReentryFnAddr,
-                                ExecutorAddr ReentryCtxAddr);
+                                         ExecutorAddr ResolverTargetAddress,
+                                         ExecutorAddr ReentryFnAddr,
+                                         ExecutorAddr ReentryCtxAddr);
 
   /// Write the requested number of trampolines into the given memory,
   /// which must be big enough to hold 1 pointer, plus NumTrampolines
   /// trampolines.
-  LLVM_ABI static void writeTrampolines(char *TrampolineBlockWorkingMem,
-                               ExecutorAddr TrampolineBlockTargetAddress,
-                               ExecutorAddr ResolverFnAddr,
-                               unsigned NumTrampolines);
+  LLVM_ABI static void
+  writeTrampolines(char *TrampolineBlockWorkingMem,
+                   ExecutorAddr TrampolineBlockTargetAddress,
+                   ExecutorAddr ResolverFnAddr, unsigned NumTrampolines);
 
   /// Write NumStubs indirect stubs to working memory at StubsBlockWorkingMem.
   /// Stubs will be written as if linked at StubsBlockTargetAddress, with the
   /// Nth stub using the Nth pointer in memory starting at
   /// PointersBlockTargetAddress.
-  LLVM_ABI static void writeIndirectStubsBlock(char *StubsBlockWorkingMem,
-                                      ExecutorAddr StubsBlockTargetAddress,
-                                      ExecutorAddr PointersBlockTargetAddress,
-                                      unsigned NumStubs);
+  LLVM_ABI static void writeIndirectStubsBlock(
+      char *StubsBlockWorkingMem, ExecutorAddr StubsBlockTargetAddress,
+      ExecutorAddr PointersBlockTargetAddress, unsigned NumStubs);
 };
 
 } // end namespace orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_RTDYLDOBJECTLINKINGLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_RTDYLDOBJECTLINKINGLAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/JITEventListener.h"
@@ -22,6 +21,7 @@
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <algorithm>
 #include <cassert>

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_RTDYLDOBJECTLINKINGLAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_RTDYLDOBJECTLINKINGLAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/JITEventListener.h"
@@ -33,7 +34,7 @@
 namespace llvm {
 namespace orc {
 
-class RTDyldObjectLinkingLayer
+class LLVM_ABI RTDyldObjectLinkingLayer
     : public RTTIExtends<RTDyldObjectLinkingLayer, ObjectLayer>,
       private ResourceManager {
 public:

--- a/llvm/include/llvm/ExecutionEngine/Orc/ReOptimizeLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ReOptimizeLayer.h
@@ -12,13 +12,13 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_REOPTIMIZELAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_REOPTIMIZELAYER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include "llvm/ExecutionEngine/Orc/Mangling.h"
 #include "llvm/ExecutionEngine/Orc/RedirectionManager.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/ReOptimizeLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ReOptimizeLayer.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_REOPTIMIZELAYER_H
 #define LLVM_EXECUTIONENGINE_ORC_REOPTIMIZELAYER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include "llvm/ExecutionEngine/Orc/Mangling.h"
@@ -24,7 +25,7 @@
 namespace llvm {
 namespace orc {
 
-class ReOptimizeLayer : public IRLayer, public ResourceManager {
+class LLVM_ABI ReOptimizeLayer : public IRLayer, public ResourceManager {
 public:
   using ReOptMaterializationUnitID = uint64_t;
 
@@ -123,9 +124,9 @@ private:
       return CurVersion;
     }
 
-    bool tryStartReoptimize();
-    void reoptimizeSucceeded();
-    void reoptimizeFailed();
+    LLVM_ABI bool tryStartReoptimize();
+    LLVM_ABI void reoptimizeSucceeded();
+    LLVM_ABI void reoptimizeFailed();
 
   private:
     std::mutex Mutex;

--- a/llvm/include/llvm/ExecutionEngine/Orc/RedirectionManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RedirectionManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_REDIRECTIONMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_REDIRECTIONMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 
 namespace llvm {
@@ -20,7 +21,7 @@ namespace orc {
 
 /// Base class for performing redirection of call to symbol to another symbol in
 /// runtime.
-class RedirectionManager {
+class LLVM_ABI RedirectionManager {
 public:
   virtual ~RedirectionManager() = default;
 
@@ -45,7 +46,7 @@ class RedirectableSymbolManager : public RedirectionManager {
 public:
   /// Create redirectable symbols with given symbol names and initial
   /// desitnation symbol addresses.
-  Error createRedirectableSymbols(ResourceTrackerSP RT, SymbolMap InitialDests);
+  LLVM_ABI Error createRedirectableSymbols(ResourceTrackerSP RT, SymbolMap InitialDests);
 
   /// Create a single redirectable symbol with given symbol name and initial
   /// desitnation symbol address.

--- a/llvm/include/llvm/ExecutionEngine/Orc/RedirectionManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RedirectionManager.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_REDIRECTIONMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_REDIRECTIONMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {
@@ -46,7 +46,8 @@ class RedirectableSymbolManager : public RedirectionManager {
 public:
   /// Create redirectable symbols with given symbol names and initial
   /// desitnation symbol addresses.
-  LLVM_ABI Error createRedirectableSymbols(ResourceTrackerSP RT, SymbolMap InitialDests);
+  LLVM_ABI Error createRedirectableSymbols(ResourceTrackerSP RT,
+                                           SymbolMap InitialDests);
 
   /// Create a single redirectable symbol with given symbol name and initial
   /// desitnation symbol address.

--- a/llvm/include/llvm/ExecutionEngine/Orc/SectCreate.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SectCreate.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SECTCREATE_H
 #define LLVM_EXECUTIONENGINE_ORC_SECTCREATE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 
@@ -21,7 +22,7 @@
 
 namespace llvm::orc {
 
-class SectCreateMaterializationUnit : public MaterializationUnit {
+class LLVM_ABI SectCreateMaterializationUnit : public MaterializationUnit {
 public:
   struct ExtraSymbolInfo {
     JITSymbolFlags Flags;

--- a/llvm/include/llvm/ExecutionEngine/Orc/SectCreate.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SectCreate.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SECTCREATE_H
 #define LLVM_EXECUTIONENGINE_ORC_SECTCREATE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#include "llvm/Support/Compiler.h"
 
 #include <utility>
 #include <vector>

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/AllocationActions.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/AllocationActions.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_ALLOCATIONACTIONS_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_ALLOCATIONACTIONS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
@@ -66,7 +67,7 @@ using OnRunFinalizeActionsCompleteFn =
 /// be returned. The dealloc actions should be run by calling
 /// runDeallocationActions. If this function succeeds then the AA argument will
 /// be cleared before the function returns.
-void runFinalizeActions(AllocActions &AAs,
+LLVM_ABI void runFinalizeActions(AllocActions &AAs,
                         OnRunFinalizeActionsCompleteFn OnComplete);
 
 using OnRunDeallocActionsComeleteFn = unique_function<void(Error)>;
@@ -74,7 +75,7 @@ using OnRunDeallocActionsComeleteFn = unique_function<void(Error)>;
 /// Run deallocation actions.
 /// Dealloc actions will be run in reverse order (from last element of DAs to
 /// first).
-void runDeallocActions(ArrayRef<WrapperFunctionCall> DAs,
+LLVM_ABI void runDeallocActions(ArrayRef<WrapperFunctionCall> DAs,
                        OnRunDeallocActionsComeleteFn OnComplete);
 
 using SPSAllocActionCallPair =

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/AllocationActions.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/AllocationActions.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_ALLOCATIONACTIONS_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_ALLOCATIONACTIONS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Memory.h"
 
 #include <vector>
@@ -68,7 +68,7 @@ using OnRunFinalizeActionsCompleteFn =
 /// runDeallocationActions. If this function succeeds then the AA argument will
 /// be cleared before the function returns.
 LLVM_ABI void runFinalizeActions(AllocActions &AAs,
-                        OnRunFinalizeActionsCompleteFn OnComplete);
+                                 OnRunFinalizeActionsCompleteFn OnComplete);
 
 using OnRunDeallocActionsComeleteFn = unique_function<void(Error)>;
 
@@ -76,7 +76,7 @@ using OnRunDeallocActionsComeleteFn = unique_function<void(Error)>;
 /// Dealloc actions will be run in reverse order (from last element of DAs to
 /// first).
 LLVM_ABI void runDeallocActions(ArrayRef<WrapperFunctionCall> DAs,
-                       OnRunDeallocActionsComeleteFn OnComplete);
+                                OnRunDeallocActionsComeleteFn OnComplete);
 
 using SPSAllocActionCallPair =
     SPSTuple<SPSWrapperFunctionCall, SPSWrapperFunctionCall>;

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/MachOObjectFormat.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/MachOObjectFormat.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_MACHOOBJECTFORMAT_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_MACHOOBJECTFORMAT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm {
@@ -22,43 +23,43 @@ namespace orc {
 
 // MachO section names.
 
-extern StringRef MachODataCommonSectionName;
-extern StringRef MachODataDataSectionName;
-extern StringRef MachOEHFrameSectionName;
-extern StringRef MachOCompactUnwindSectionName;
-extern StringRef MachOCStringSectionName;
-extern StringRef MachOModInitFuncSectionName;
-extern StringRef MachOObjCCatListSectionName;
-extern StringRef MachOObjCCatList2SectionName;
-extern StringRef MachOObjCClassListSectionName;
-extern StringRef MachOObjCClassNameSectionName;
-extern StringRef MachOObjCClassRefsSectionName;
-extern StringRef MachOObjCConstSectionName;
-extern StringRef MachOObjCDataSectionName;
-extern StringRef MachOObjCImageInfoSectionName;
-extern StringRef MachOObjCMethNameSectionName;
-extern StringRef MachOObjCMethTypeSectionName;
-extern StringRef MachOObjCNLCatListSectionName;
-extern StringRef MachOObjCNLClassListSectionName;
-extern StringRef MachOObjCProtoListSectionName;
-extern StringRef MachOObjCProtoRefsSectionName;
-extern StringRef MachOObjCSelRefsSectionName;
-extern StringRef MachOSwift5ProtoSectionName;
-extern StringRef MachOSwift5ProtosSectionName;
-extern StringRef MachOSwift5TypesSectionName;
-extern StringRef MachOSwift5TypeRefSectionName;
-extern StringRef MachOSwift5FieldMetadataSectionName;
-extern StringRef MachOSwift5EntrySectionName;
-extern StringRef MachOTextTextSectionName;
-extern StringRef MachOThreadBSSSectionName;
-extern StringRef MachOThreadDataSectionName;
-extern StringRef MachOThreadVarsSectionName;
-extern StringRef MachOUnwindInfoSectionName;
+LLVM_ABI extern StringRef MachODataCommonSectionName;
+LLVM_ABI extern StringRef MachODataDataSectionName;
+LLVM_ABI extern StringRef MachOEHFrameSectionName;
+LLVM_ABI extern StringRef MachOCompactUnwindSectionName;
+LLVM_ABI extern StringRef MachOCStringSectionName;
+LLVM_ABI extern StringRef MachOModInitFuncSectionName;
+LLVM_ABI extern StringRef MachOObjCCatListSectionName;
+LLVM_ABI extern StringRef MachOObjCCatList2SectionName;
+LLVM_ABI extern StringRef MachOObjCClassListSectionName;
+LLVM_ABI extern StringRef MachOObjCClassNameSectionName;
+LLVM_ABI extern StringRef MachOObjCClassRefsSectionName;
+LLVM_ABI extern StringRef MachOObjCConstSectionName;
+LLVM_ABI extern StringRef MachOObjCDataSectionName;
+LLVM_ABI extern StringRef MachOObjCImageInfoSectionName;
+LLVM_ABI extern StringRef MachOObjCMethNameSectionName;
+LLVM_ABI extern StringRef MachOObjCMethTypeSectionName;
+LLVM_ABI extern StringRef MachOObjCNLCatListSectionName;
+LLVM_ABI extern StringRef MachOObjCNLClassListSectionName;
+LLVM_ABI extern StringRef MachOObjCProtoListSectionName;
+LLVM_ABI extern StringRef MachOObjCProtoRefsSectionName;
+LLVM_ABI extern StringRef MachOObjCSelRefsSectionName;
+LLVM_ABI extern StringRef MachOSwift5ProtoSectionName;
+LLVM_ABI extern StringRef MachOSwift5ProtosSectionName;
+LLVM_ABI extern StringRef MachOSwift5TypesSectionName;
+LLVM_ABI extern StringRef MachOSwift5TypeRefSectionName;
+LLVM_ABI extern StringRef MachOSwift5FieldMetadataSectionName;
+LLVM_ABI extern StringRef MachOSwift5EntrySectionName;
+LLVM_ABI extern StringRef MachOTextTextSectionName;
+LLVM_ABI extern StringRef MachOThreadBSSSectionName;
+LLVM_ABI extern StringRef MachOThreadDataSectionName;
+LLVM_ABI extern StringRef MachOThreadVarsSectionName;
+LLVM_ABI extern StringRef MachOUnwindInfoSectionName;
 
-extern StringRef MachOInitSectionNames[22];
+LLVM_ABI extern StringRef MachOInitSectionNames[22];
 
-bool isMachOInitializerSection(StringRef SegName, StringRef SecName);
-bool isMachOInitializerSection(StringRef QualifiedName);
+LLVM_ABI bool isMachOInitializerSection(StringRef SegName, StringRef SecName);
+LLVM_ABI bool isMachOInitializerSection(StringRef QualifiedName);
 
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/MachOObjectFormat.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/MachOObjectFormat.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_MACHOOBJECTFORMAT_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_MACHOOBJECTFORMAT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/ObjectFormats.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/ObjectFormats.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_OBJECTFORMATS_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_OBJECTFORMATS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MachOObjectFormat.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/ObjectFormats.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/ObjectFormats.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_OBJECTFORMATS_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_OBJECTFORMATS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MachOObjectFormat.h"
 
@@ -20,23 +21,23 @@ namespace llvm {
 namespace orc {
 
 // ELF section names.
-extern StringRef ELFEHFrameSectionName;
+LLVM_ABI extern StringRef ELFEHFrameSectionName;
 
-extern StringRef ELFInitArrayFuncSectionName;
-extern StringRef ELFInitFuncSectionName;
-extern StringRef ELFFiniArrayFuncSectionName;
-extern StringRef ELFFiniFuncSectionName;
-extern StringRef ELFCtorArrayFuncSectionName;
-extern StringRef ELFDtorArrayFuncSectionName;
+LLVM_ABI extern StringRef ELFInitArrayFuncSectionName;
+LLVM_ABI extern StringRef ELFInitFuncSectionName;
+LLVM_ABI extern StringRef ELFFiniArrayFuncSectionName;
+LLVM_ABI extern StringRef ELFFiniFuncSectionName;
+LLVM_ABI extern StringRef ELFCtorArrayFuncSectionName;
+LLVM_ABI extern StringRef ELFDtorArrayFuncSectionName;
 
-extern StringRef ELFInitSectionNames[3];
+LLVM_ABI extern StringRef ELFInitSectionNames[3];
 
-extern StringRef ELFThreadBSSSectionName;
-extern StringRef ELFThreadDataSectionName;
+LLVM_ABI extern StringRef ELFThreadBSSSectionName;
+LLVM_ABI extern StringRef ELFThreadDataSectionName;
 
-bool isELFInitializerSection(StringRef SecName);
+LLVM_ABI bool isELFInitializerSection(StringRef SecName);
 
-bool isCOFFInitializerSection(StringRef Name);
+LLVM_ABI bool isCOFFInitializerSection(StringRef Name);
 
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcError.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcError.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_ORCERROR_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_ORCERROR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include <string>
@@ -42,9 +43,9 @@ enum class OrcErrorCode : int {
   UnexpectedSymbolDefinitions,
 };
 
-std::error_code orcError(OrcErrorCode ErrCode);
+LLVM_ABI std::error_code orcError(OrcErrorCode ErrCode);
 
-class DuplicateDefinition : public ErrorInfo<DuplicateDefinition> {
+class LLVM_ABI DuplicateDefinition : public ErrorInfo<DuplicateDefinition> {
 public:
   static char ID;
 
@@ -56,7 +57,7 @@ private:
   std::string SymbolName;
 };
 
-class JITSymbolNotFound : public ErrorInfo<JITSymbolNotFound> {
+class LLVM_ABI JITSymbolNotFound : public ErrorInfo<JITSymbolNotFound> {
 public:
   static char ID;
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_ORCRTBRIDGE_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_ORCRTBRIDGE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
@@ -22,34 +23,34 @@ namespace llvm {
 namespace orc {
 namespace rt {
 
-extern const char *SimpleExecutorDylibManagerInstanceName;
-extern const char *SimpleExecutorDylibManagerOpenWrapperName;
-extern const char *SimpleExecutorDylibManagerLookupWrapperName;
+LLVM_ABI extern const char *SimpleExecutorDylibManagerInstanceName;
+LLVM_ABI extern const char *SimpleExecutorDylibManagerOpenWrapperName;
+LLVM_ABI extern const char *SimpleExecutorDylibManagerLookupWrapperName;
 
-extern const char *SimpleExecutorMemoryManagerInstanceName;
-extern const char *SimpleExecutorMemoryManagerReserveWrapperName;
-extern const char *SimpleExecutorMemoryManagerFinalizeWrapperName;
-extern const char *SimpleExecutorMemoryManagerDeallocateWrapperName;
+LLVM_ABI extern const char *SimpleExecutorMemoryManagerInstanceName;
+LLVM_ABI extern const char *SimpleExecutorMemoryManagerReserveWrapperName;
+LLVM_ABI extern const char *SimpleExecutorMemoryManagerFinalizeWrapperName;
+LLVM_ABI extern const char *SimpleExecutorMemoryManagerDeallocateWrapperName;
 
-extern const char *ExecutorSharedMemoryMapperServiceInstanceName;
-extern const char *ExecutorSharedMemoryMapperServiceReserveWrapperName;
-extern const char *ExecutorSharedMemoryMapperServiceInitializeWrapperName;
-extern const char *ExecutorSharedMemoryMapperServiceDeinitializeWrapperName;
-extern const char *ExecutorSharedMemoryMapperServiceReleaseWrapperName;
+LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceInstanceName;
+LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceReserveWrapperName;
+LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceInitializeWrapperName;
+LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceDeinitializeWrapperName;
+LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceReleaseWrapperName;
 
-extern const char *MemoryWriteUInt8sWrapperName;
-extern const char *MemoryWriteUInt16sWrapperName;
-extern const char *MemoryWriteUInt32sWrapperName;
-extern const char *MemoryWriteUInt64sWrapperName;
-extern const char *MemoryWriteBuffersWrapperName;
-extern const char *MemoryWritePointersWrapperName;
+LLVM_ABI extern const char *MemoryWriteUInt8sWrapperName;
+LLVM_ABI extern const char *MemoryWriteUInt16sWrapperName;
+LLVM_ABI extern const char *MemoryWriteUInt32sWrapperName;
+LLVM_ABI extern const char *MemoryWriteUInt64sWrapperName;
+LLVM_ABI extern const char *MemoryWriteBuffersWrapperName;
+LLVM_ABI extern const char *MemoryWritePointersWrapperName;
 
-extern const char *RegisterEHFrameSectionAllocActionName;
-extern const char *DeregisterEHFrameSectionAllocActionName;
+LLVM_ABI extern const char *RegisterEHFrameSectionAllocActionName;
+LLVM_ABI extern const char *DeregisterEHFrameSectionAllocActionName;
 
-extern const char *RunAsMainWrapperName;
-extern const char *RunAsVoidFunctionWrapperName;
-extern const char *RunAsIntFunctionWrapperName;
+LLVM_ABI extern const char *RunAsMainWrapperName;
+LLVM_ABI extern const char *RunAsVoidFunctionWrapperName;
+LLVM_ABI extern const char *RunAsIntFunctionWrapperName;
 
 using SPSSimpleExecutorDylibManagerOpenSignature =
     shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,
@@ -90,8 +91,8 @@ using SPSRunAsIntFunctionSignature = int32_t(shared::SPSExecutorAddr, int32_t);
 } // end namespace rt
 
 namespace rt_alt {
-extern const char *UnwindInfoManagerRegisterActionName;
-extern const char *UnwindInfoManagerDeregisterActionName;
+LLVM_ABI extern const char *UnwindInfoManagerRegisterActionName;
+LLVM_ABI extern const char *UnwindInfoManagerDeregisterActionName;
 } // end namespace rt_alt
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_ORCRTBRIDGE_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_ORCRTBRIDGE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {
@@ -34,8 +34,10 @@ LLVM_ABI extern const char *SimpleExecutorMemoryManagerDeallocateWrapperName;
 
 LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceInstanceName;
 LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceReserveWrapperName;
-LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceInitializeWrapperName;
-LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceDeinitializeWrapperName;
+LLVM_ABI extern const char
+    *ExecutorSharedMemoryMapperServiceInitializeWrapperName;
+LLVM_ABI extern const char
+    *ExecutorSharedMemoryMapperServiceDeinitializeWrapperName;
 LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceReleaseWrapperName;
 
 LLVM_ABI extern const char *MemoryWriteUInt8sWrapperName;

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h
@@ -14,12 +14,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_SIMPLEREMOTEEPCUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_SIMPLEREMOTEEPCUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimplePackedSerialization.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <atomic>

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_SIMPLEREMOTEEPCUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_SHARED_SIMPLEREMOTEEPCUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
@@ -30,8 +31,8 @@ namespace llvm {
 namespace orc {
 
 namespace SimpleRemoteEPCDefaultBootstrapSymbolNames {
-extern const char *ExecutorSessionObjectName;
-extern const char *DispatchFnName;
+LLVM_ABI extern const char *ExecutorSessionObjectName;
+LLVM_ABI extern const char *DispatchFnName;
 } // end namespace SimpleRemoteEPCDefaultBootstrapSymbolNames
 
 enum class SimpleRemoteEPCOpcode : uint8_t {
@@ -51,7 +52,7 @@ struct SimpleRemoteEPCExecutorInfo {
 
 using SimpleRemoteEPCArgBytesVector = SmallVector<char, 128>;
 
-class SimpleRemoteEPCTransportClient {
+class LLVM_ABI SimpleRemoteEPCTransportClient {
 public:
   enum HandleMessageAction { ContinueSession, EndSession };
 
@@ -75,7 +76,7 @@ public:
   virtual void handleDisconnect(Error Err) = 0;
 };
 
-class SimpleRemoteEPCTransport {
+class LLVM_ABI SimpleRemoteEPCTransport {
 public:
   virtual ~SimpleRemoteEPCTransport();
 
@@ -100,7 +101,7 @@ public:
 };
 
 /// Uses read/write on FileDescriptors for transport.
-class FDSimpleRemoteEPCTransport : public SimpleRemoteEPCTransport {
+class LLVM_ABI FDSimpleRemoteEPCTransport : public SimpleRemoteEPCTransport {
 public:
   /// Create a FDSimpleRemoteEPCTransport using the given FDs for
   /// reading (InFD) and writing (OutFD).

--- a/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SIMPLEREMOTEEPC_H
 #define LLVM_EXECUTIONENGINE_ORC_SIMPLEREMOTEEPC_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h"
@@ -21,6 +20,7 @@
 #include "llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
 
@@ -30,8 +30,8 @@ namespace llvm {
 namespace orc {
 
 class LLVM_ABI SimpleRemoteEPC : public ExecutorProcessControl,
-                        public SimpleRemoteEPCTransportClient,
-                        private DylibManager {
+                                 public SimpleRemoteEPCTransportClient,
+                                 private DylibManager {
 public:
   /// A setup object containing callbacks to construct a memory manager and
   /// memory access object. Both are optional. If not specified,

--- a/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SIMPLEREMOTEEPC_H
 #define LLVM_EXECUTIONENGINE_ORC_SIMPLEREMOTEEPC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h"
@@ -28,7 +29,7 @@
 namespace llvm {
 namespace orc {
 
-class SimpleRemoteEPC : public ExecutorProcessControl,
+class LLVM_ABI SimpleRemoteEPC : public ExecutorProcessControl,
                         public SimpleRemoteEPCTransportClient,
                         private DylibManager {
 public:

--- a/llvm/include/llvm/ExecutionEngine/Orc/Speculation.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Speculation.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SPECULATION_H
 #define LLVM_EXECUTIONENGINE_ORC_SPECULATION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/DebugUtils.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include <mutex>
 #include <type_traits>

--- a/llvm/include/llvm/ExecutionEngine/Orc/Speculation.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Speculation.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SPECULATION_H
 #define LLVM_EXECUTIONENGINE_ORC_SPECULATION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/DebugUtils.h"
@@ -38,7 +39,7 @@ public:
   using AliaseeDetails = std::pair<SymbolStringPtr, JITDylib *>;
   using Alias = SymbolStringPtr;
   using ImapTy = DenseMap<Alias, AliaseeDetails>;
-  void trackImpls(SymbolAliasMap ImplMaps, JITDylib *SrcJD);
+  LLVM_ABI void trackImpls(SymbolAliasMap ImplMaps, JITDylib *SrcJD);
 
 private:
   // FIX ME: find a right way to distinguish the pre-compile Symbols, and update
@@ -129,7 +130,7 @@ public:
   /// Define symbols for this Speculator object (__orc_speculator) and the
   /// speculation runtime entry point symbol (__orc_speculate_for) in the
   /// given JITDylib.
-  Error addSpeculationRuntime(JITDylib &JD, MangleAndInterner &Mangle);
+  LLVM_ABI Error addSpeculationRuntime(JITDylib &JD, MangleAndInterner &Mangle);
 
   // Speculatively compile likely functions for the given Stub Address.
   // destination of __orc_speculate_for jump
@@ -168,7 +169,7 @@ private:
   StubAddrLikelies GlobalSpecMap;
 };
 
-class IRSpeculationLayer : public IRLayer {
+class LLVM_ABI IRSpeculationLayer : public IRLayer {
 public:
   using IRlikiesStrRef =
       std::optional<DenseMap<StringRef, DenseSet<StringRef>>>;

--- a/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Compiler.h"
 #include <atomic>
 #include <mutex>
 
@@ -35,7 +36,7 @@ class SymbolStringPool {
   friend class SymbolStringPoolEntryUnsafe;
 
   // Implemented in DebugUtils.h.
-  friend raw_ostream &operator<<(raw_ostream &OS, const SymbolStringPool &SSP);
+  LLVM_ABI_FRIEND friend raw_ostream &operator<<(raw_ostream &OS, const SymbolStringPool &SSP);
 
 public:
   /// Destroy a SymbolStringPool.
@@ -92,7 +93,7 @@ public:
     return LHS.S < RHS.S;
   }
 
-  friend raw_ostream &operator<<(raw_ostream &OS,
+  LLVM_ABI_FRIEND friend raw_ostream &operator<<(raw_ostream &OS,
                                  const SymbolStringPtrBase &Sym);
 
 #ifndef NDEBUG
@@ -312,6 +313,8 @@ inline size_t
 SymbolStringPool::getRefCount(const SymbolStringPtrBase &S) const {
   return S.getRefCount();
 }
+
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolStringPtrBase &Sym);
 
 } // end namespace orc
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
@@ -36,7 +36,8 @@ class SymbolStringPool {
   friend class SymbolStringPoolEntryUnsafe;
 
   // Implemented in DebugUtils.h.
-  LLVM_ABI_FRIEND friend raw_ostream &operator<<(raw_ostream &OS, const SymbolStringPool &SSP);
+  LLVM_ABI_FRIEND friend raw_ostream &operator<<(raw_ostream &OS,
+                                                 const SymbolStringPool &SSP);
 
 public:
   /// Destroy a SymbolStringPool.
@@ -93,8 +94,8 @@ public:
     return LHS.S < RHS.S;
   }
 
-  LLVM_ABI_FRIEND friend raw_ostream &operator<<(raw_ostream &OS,
-                                 const SymbolStringPtrBase &Sym);
+  LLVM_ABI_FRIEND friend raw_ostream &
+  operator<<(raw_ostream &OS, const SymbolStringPtrBase &Sym);
 
 #ifndef NDEBUG
   // Returns true if the pool entry's ref count is above zero (or if the entry
@@ -314,7 +315,8 @@ SymbolStringPool::getRefCount(const SymbolStringPtrBase &S) const {
   return S.getRefCount();
 }
 
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SymbolStringPtrBase &Sym);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const SymbolStringPtrBase &Sym);
 
 } // end namespace orc
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/DefaultHostBootstrapValues.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/DefaultHostBootstrapValues.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_DEFAULTHOSTBOOTSTRAPVALUES_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_DEFAULTHOSTBOOTSTRAPVALUES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 #include <vector>
 
 namespace llvm::orc {

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/DefaultHostBootstrapValues.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/DefaultHostBootstrapValues.h
@@ -13,13 +13,14 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_DEFAULTHOSTBOOTSTRAPVALUES_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_DEFAULTHOSTBOOTSTRAPVALUES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include <vector>
 
 namespace llvm::orc {
 
-void addDefaultBootstrapValuesForHostProcess(
+LLVM_ABI void addDefaultBootstrapValuesForHostProcess(
     StringMap<std::vector<char>> &BootstrapMap,
     StringMap<ExecutorAddr> &BootstrapSymbols);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h
@@ -15,13 +15,14 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_EXECUTORBOOTSTRAPSERVICE_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_EXECUTORBOOTSTRAPSERVICE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 
 namespace llvm {
 namespace orc {
 
-class ExecutorBootstrapService {
+class LLVM_ABI ExecutorBootstrapService {
 public:
   virtual ~ExecutorBootstrapService();
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h
@@ -15,9 +15,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_EXECUTORBOOTSTRAPSERVICE_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_EXECUTORBOOTSTRAPSERVICE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace orc {

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_EXECUTORSHAREDMEMORYMAPPERSERVICE_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_EXECUTORSHAREDMEMORYMAPPERSERVICE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
@@ -25,7 +26,7 @@ namespace llvm {
 namespace orc {
 namespace rt_bootstrap {
 
-class ExecutorSharedMemoryMapperService final
+class LLVM_ABI ExecutorSharedMemoryMapperService final
     : public ExecutorBootstrapService {
 public:
   ~ExecutorSharedMemoryMapperService(){};

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_EXECUTORSHAREDMEMORYMAPPERSERVICE_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_EXECUTORSHAREDMEMORYMAPPERSERVICE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h"
+#include "llvm/Support/Compiler.h"
 
 #include <atomic>
 #include <mutex>

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h
@@ -25,11 +25,11 @@ namespace orc {
 
 /// Register frames in the given eh-frame section with libunwind.
 LLVM_ABI Error registerEHFrameSection(const void *EHFrameSectionAddr,
-                             size_t EHFrameSectionSize);
+                                      size_t EHFrameSectionSize);
 
 /// Unregister frames in the given eh-frame section with libunwind.
 LLVM_ABI Error deregisterEHFrameSection(const void *EHFrameSectionAddr,
-                               size_t EHFrameSectionSize);
+                                        size_t EHFrameSectionSize);
 
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h
@@ -24,11 +24,11 @@ namespace llvm {
 namespace orc {
 
 /// Register frames in the given eh-frame section with libunwind.
-Error registerEHFrameSection(const void *EHFrameSectionAddr,
+LLVM_ABI Error registerEHFrameSection(const void *EHFrameSectionAddr,
                              size_t EHFrameSectionSize);
 
 /// Unregister frames in the given eh-frame section with libunwind.
-Error deregisterEHFrameSection(const void *EHFrameSectionAddr,
+LLVM_ABI Error deregisterEHFrameSection(const void *EHFrameSectionAddr,
                                size_t EHFrameSectionSize);
 
 } // end namespace orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h
@@ -16,7 +16,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEEXECUTORDYLIBMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEEXECUTORDYLIBMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
@@ -24,6 +23,7 @@
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEEXECUTORDYLIBMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEEXECUTORDYLIBMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
@@ -33,7 +34,7 @@ namespace orc {
 namespace rt_bootstrap {
 
 /// Simple page-based allocator.
-class SimpleExecutorDylibManager : public ExecutorBootstrapService {
+class LLVM_ABI SimpleExecutorDylibManager : public ExecutorBootstrapService {
 public:
   virtual ~SimpleExecutorDylibManager();
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h
@@ -15,12 +15,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEEXECUTORMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEEXECUTORMEMORYMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <mutex>

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEEXECUTORMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEEXECUTORMEMORYMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
@@ -29,7 +30,7 @@ namespace orc {
 namespace rt_bootstrap {
 
 /// Simple page-based allocator.
-class SimpleExecutorMemoryManager : public ExecutorBootstrapService {
+class LLVM_ABI SimpleExecutorMemoryManager : public ExecutorBootstrapService {
 public:
   virtual ~SimpleExecutorMemoryManager();
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEREMOTEEPCSERVER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEREMOTEEPCSERVER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/Config/llvm-config.h"
@@ -22,6 +21,7 @@
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEREMOTEEPCSERVER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_SIMPLEREMOTEEPCSERVER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/Config/llvm-config.h"
@@ -33,12 +34,12 @@ namespace llvm {
 namespace orc {
 
 /// A simple EPC server implementation.
-class SimpleRemoteEPCServer : public SimpleRemoteEPCTransportClient {
+class LLVM_ABI SimpleRemoteEPCServer : public SimpleRemoteEPCTransportClient {
 public:
   using ReportErrorFunction = unique_function<void(Error)>;
 
   /// Dispatches calls to runWrapper.
-  class Dispatcher {
+  class LLVM_ABI Dispatcher {
   public:
     virtual ~Dispatcher();
     virtual void dispatch(unique_function<void()> Work) = 0;
@@ -46,7 +47,7 @@ public:
   };
 
 #if LLVM_ENABLE_THREADS
-  class ThreadDispatcher : public Dispatcher {
+  class LLVM_ABI ThreadDispatcher : public Dispatcher {
   public:
     void dispatch(unique_function<void()> Work) override;
     void shutdown() override;

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_TARGETEXECUTIONUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_TARGETEXECUTIONUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include <string>
@@ -28,11 +29,11 @@ namespace orc {
 /// It is legal to have an empty argument list and no program name, however
 /// many main functions will expect a name argument at least, and will fail
 /// if none is provided.
-int runAsMain(int (*Main)(int, char *[]), ArrayRef<std::string> Args,
+LLVM_ABI int runAsMain(int (*Main)(int, char *[]), ArrayRef<std::string> Args,
               std::optional<StringRef> ProgramName = std::nullopt);
 
-int runAsVoidFunction(int (*Func)(void));
-int runAsIntFunction(int (*Func)(int), int Arg);
+LLVM_ABI int runAsVoidFunction(int (*Func)(void));
+LLVM_ABI int runAsIntFunction(int (*Func)(int), int Arg);
 
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_TARGETEXECUTIONUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_TARGETEXECUTIONUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <string>
 
 namespace llvm {
@@ -30,7 +30,7 @@ namespace orc {
 /// many main functions will expect a name argument at least, and will fail
 /// if none is provided.
 LLVM_ABI int runAsMain(int (*Main)(int, char *[]), ArrayRef<std::string> Args,
-              std::optional<StringRef> ProgramName = std::nullopt);
+                       std::optional<StringRef> ProgramName = std::nullopt);
 
 LLVM_ABI int runAsVoidFunction(int (*Func)(void));
 LLVM_ABI int runAsIntFunction(int (*Func)(int), int Arg);

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_UNWINDINFOMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_UNWINDINFOMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <map>
 #include <mutex>
@@ -46,12 +46,14 @@ public:
 
   LLVM_ABI static void addBootstrapSymbols(StringMap<ExecutorAddr> &M);
 
-  LLVM_ABI static Error registerSections(ArrayRef<orc::ExecutorAddrRange> CodeRanges,
-                                orc::ExecutorAddr DSOBase,
-                                orc::ExecutorAddrRange DWARFEHFrame,
-                                orc::ExecutorAddrRange CompactUnwind);
+  LLVM_ABI static Error
+  registerSections(ArrayRef<orc::ExecutorAddrRange> CodeRanges,
+                   orc::ExecutorAddr DSOBase,
+                   orc::ExecutorAddrRange DWARFEHFrame,
+                   orc::ExecutorAddrRange CompactUnwind);
 
-  LLVM_ABI static Error deregisterSections(ArrayRef<orc::ExecutorAddrRange> CodeRanges);
+  LLVM_ABI static Error
+  deregisterSections(ArrayRef<orc::ExecutorAddrRange> CodeRanges);
 
 private:
   UnwindInfoManager() = default;

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_UNWINDINFOMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_UNWINDINFOMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/Error.h"
 #include <map>
@@ -35,22 +36,22 @@ public:
 
   UnwindInfoManager(UnwindInfoManager &&) = delete;
   UnwindInfoManager &operator=(UnwindInfoManager &&) = delete;
-  ~UnwindInfoManager();
+  LLVM_ABI ~UnwindInfoManager();
 
   /// If the libunwind find-dynamic-unwind-info callback registration APIs are
   /// available then this method will instantiate a global UnwindInfoManager
   /// instance suitable for the process and return true. Otherwise it will
   /// return false.
-  static bool TryEnable();
+  LLVM_ABI static bool TryEnable();
 
-  static void addBootstrapSymbols(StringMap<ExecutorAddr> &M);
+  LLVM_ABI static void addBootstrapSymbols(StringMap<ExecutorAddr> &M);
 
-  static Error registerSections(ArrayRef<orc::ExecutorAddrRange> CodeRanges,
+  LLVM_ABI static Error registerSections(ArrayRef<orc::ExecutorAddrRange> CodeRanges,
                                 orc::ExecutorAddr DSOBase,
                                 orc::ExecutorAddrRange DWARFEHFrame,
                                 orc::ExecutorAddrRange CompactUnwind);
 
-  static Error deregisterSections(ArrayRef<orc::ExecutorAddrRange> CodeRanges);
+  LLVM_ABI static Error deregisterSections(ArrayRef<orc::ExecutorAddrRange> CodeRanges);
 
 private:
   UnwindInfoManager() = default;

--- a/llvm/include/llvm/ExecutionEngine/Orc/TaskDispatch.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TaskDispatch.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TASKDISPATCH_H
 #define LLVM_EXECUTIONENGINE_ORC_TASKDISPATCH_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ExtensibleRTTI.h"
 #include "llvm/Support/raw_ostream.h"

--- a/llvm/include/llvm/ExecutionEngine/Orc/TaskDispatch.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TaskDispatch.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TASKDISPATCH_H
 #define LLVM_EXECUTIONENGINE_ORC_TASKDISPATCH_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ExtensibleRTTI.h"
@@ -32,7 +33,7 @@ namespace llvm {
 namespace orc {
 
 /// Represents an abstract task for ORC to run.
-class Task : public RTTIExtends<Task, RTTIRoot> {
+class LLVM_ABI Task : public RTTIExtends<Task, RTTIRoot> {
 public:
   static char ID;
 
@@ -51,8 +52,8 @@ private:
 /// Base class for generic tasks.
 class GenericNamedTask : public RTTIExtends<GenericNamedTask, Task> {
 public:
-  static char ID;
-  static const char *DefaultDescription;
+  LLVM_ABI static char ID;
+  LLVM_ABI static const char *DefaultDescription;
 };
 
 /// Generic task implementation.
@@ -94,7 +95,7 @@ makeGenericNamedTask(FnT &&Fn, const char *Desc = nullptr) {
 
 /// IdleTask can be used as the basis for low-priority tasks, e.g. speculative
 /// lookup.
-class IdleTask : public RTTIExtends<IdleTask, Task> {
+class LLVM_ABI IdleTask : public RTTIExtends<IdleTask, Task> {
 public:
   static char ID;
 
@@ -103,7 +104,7 @@ private:
 };
 
 /// Abstract base for classes that dispatch ORC Tasks.
-class TaskDispatcher {
+class LLVM_ABI TaskDispatcher {
 public:
   virtual ~TaskDispatcher();
 
@@ -115,7 +116,7 @@ public:
 };
 
 /// Runs all tasks on the current thread.
-class InPlaceTaskDispatcher : public TaskDispatcher {
+class LLVM_ABI InPlaceTaskDispatcher : public TaskDispatcher {
 public:
   void dispatch(std::unique_ptr<Task> T) override;
   void shutdown() override;
@@ -123,7 +124,7 @@ public:
 
 #if LLVM_ENABLE_THREADS
 
-class DynamicThreadPoolTaskDispatcher : public TaskDispatcher {
+class LLVM_ABI DynamicThreadPoolTaskDispatcher : public TaskDispatcher {
 public:
   DynamicThreadPoolTaskDispatcher(
       std::optional<size_t> MaxMaterializationThreads)

--- a/llvm/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h
@@ -170,7 +170,7 @@ using GVPredicate = std::function<bool(const GlobalValue &)>;
 using GVModifier = std::function<void(GlobalValue &)>;
 
 /// Clones the given module on to a new context.
-ThreadSafeModule
+LLVM_ABI ThreadSafeModule
 cloneToNewContext(const ThreadSafeModule &TSMW,
                   GVPredicate ShouldCloneDef = GVPredicate(),
                   GVModifier UpdateClonedDefSource = GVModifier());

--- a/llvm/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h
@@ -170,10 +170,9 @@ using GVPredicate = std::function<bool(const GlobalValue &)>;
 using GVModifier = std::function<void(GlobalValue &)>;
 
 /// Clones the given module on to a new context.
-LLVM_ABI ThreadSafeModule
-cloneToNewContext(const ThreadSafeModule &TSMW,
-                  GVPredicate ShouldCloneDef = GVPredicate(),
-                  GVModifier UpdateClonedDefSource = GVModifier());
+LLVM_ABI ThreadSafeModule cloneToNewContext(
+    const ThreadSafeModule &TSMW, GVPredicate ShouldCloneDef = GVPredicate(),
+    GVModifier UpdateClonedDefSource = GVModifier());
 
 } // End namespace orc
 } // End namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.h
@@ -13,12 +13,13 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_UNWINDINFOREGISTRATIONPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_UNWINDINFOREGISTRATIONPLUGIN_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm::orc {
 
-class LLVM_ABI UnwindInfoRegistrationPlugin : public LinkGraphLinkingLayer::Plugin {
+class LLVM_ABI UnwindInfoRegistrationPlugin
+    : public LinkGraphLinkingLayer::Plugin {
 public:
   UnwindInfoRegistrationPlugin(ExecutionSession &ES, ExecutorAddr Register,
                                ExecutorAddr Deregister)

--- a/llvm/include/llvm/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.h
@@ -13,11 +13,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_UNWINDINFOREGISTRATIONPLUGIN_H
 #define LLVM_EXECUTIONENGINE_ORC_UNWINDINFOREGISTRATIONPLUGIN_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
 
 namespace llvm::orc {
 
-class UnwindInfoRegistrationPlugin : public LinkGraphLinkingLayer::Plugin {
+class LLVM_ABI UnwindInfoRegistrationPlugin : public LinkGraphLinkingLayer::Plugin {
 public:
   UnwindInfoRegistrationPlugin(ExecutionSession &ES, ExecutorAddr Register,
                                ExecutorAddr Deregister)

--- a/llvm/include/llvm/ExecutionEngine/RTDyldMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/RTDyldMemoryManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_RTDYLDMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_RTDYLDMEMORYMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/ExecutionEngine.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
@@ -29,7 +30,7 @@ namespace object {
   class ObjectFile;
 } // end namespace object
 
-class MCJITMemoryManager : public RuntimeDyld::MemoryManager {
+class LLVM_ABI MCJITMemoryManager : public RuntimeDyld::MemoryManager {
 public:
   // Don't hide the notifyObjectLoaded method from RuntimeDyld::MemoryManager.
   using RuntimeDyld::MemoryManager::notifyObjectLoaded;
@@ -57,7 +58,7 @@ private:
 //
 // FIXME: As the RuntimeDyld fills out, additional routines will be needed
 //        for the varying types of objects to be allocated.
-class RTDyldMemoryManager : public MCJITMemoryManager,
+class LLVM_ABI RTDyldMemoryManager : public MCJITMemoryManager,
                             public LegacyJITSymbolResolver {
 public:
   RTDyldMemoryManager() = default;

--- a/llvm/include/llvm/ExecutionEngine/RTDyldMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/RTDyldMemoryManager.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_EXECUTIONENGINE_RTDYLDMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_RTDYLDMEMORYMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/ExecutionEngine.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
 #include "llvm/Support/CBindingWrapping.h"
+#include "llvm/Support/Compiler.h"
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -59,7 +59,7 @@ private:
 // FIXME: As the RuntimeDyld fills out, additional routines will be needed
 //        for the varying types of objects to be allocated.
 class LLVM_ABI RTDyldMemoryManager : public MCJITMemoryManager,
-                            public LegacyJITSymbolResolver {
+                                     public LegacyJITSymbolResolver {
 public:
   RTDyldMemoryManager() = default;
   RTDyldMemoryManager(const RTDyldMemoryManager&) = delete;

--- a/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
+++ b/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
@@ -13,13 +13,13 @@
 #ifndef LLVM_EXECUTIONENGINE_RUNTIMEDYLD_H
 #define LLVM_EXECUTIONENGINE_RUNTIMEDYLD_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <algorithm>
 #include <cassert>
@@ -197,7 +197,8 @@ public:
 
   /// Add the referenced object file to the list of objects to be loaded and
   /// relocated.
-  LLVM_ABI std::unique_ptr<LoadedObjectInfo> loadObject(const object::ObjectFile &O);
+  LLVM_ABI std::unique_ptr<LoadedObjectInfo>
+  loadObject(const object::ObjectFile &O);
 
   /// Get the address of our local copy of the symbol. This may or may not
   /// be the address used for relocation (clients can copy the data around
@@ -225,7 +226,8 @@ public:
   /// Map the address of a JIT section as returned from the memory manager
   /// to the address in the target process as the running code will see it.
   /// This is the address which will be used for relocation resolution.
-  LLVM_ABI void mapSectionAddress(const void *LocalAddress, uint64_t TargetAddress);
+  LLVM_ABI void mapSectionAddress(const void *LocalAddress,
+                                  uint64_t TargetAddress);
 
   /// Returns the section's working memory.
   LLVM_ABI StringRef getSectionContent(unsigned SectionID) const;

--- a/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
+++ b/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_RUNTIMEDYLD_H
 #define LLVM_EXECUTIONENGINE_RUNTIMEDYLD_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -39,7 +40,7 @@ template <typename T> class OwningBinary;
 
 /// Base class for errors originating in RuntimeDyld, e.g. missing relocation
 /// support.
-class RuntimeDyldError : public ErrorInfo<RuntimeDyldError> {
+class LLVM_ABI RuntimeDyldError : public ErrorInfo<RuntimeDyldError> {
 public:
   static char ID;
 
@@ -59,14 +60,14 @@ class RuntimeDyld {
 public:
   // Change the address associated with a section when resolving relocations.
   // Any relocations already associated with the symbol will be re-resolved.
-  void reassignSectionAddress(unsigned SectionID, uint64_t Addr);
+  LLVM_ABI void reassignSectionAddress(unsigned SectionID, uint64_t Addr);
 
   using NotifyStubEmittedFunction = std::function<void(
       StringRef FileName, StringRef SectionName, StringRef SymbolName,
       unsigned SectionID, uint32_t StubOffset)>;
 
   /// Information about the loaded object.
-  class LoadedObjectInfo : public llvm::LoadedObjectInfo {
+  class LLVM_ABI LoadedObjectInfo : public llvm::LoadedObjectInfo {
     friend class RuntimeDyldImpl;
 
   public:
@@ -89,7 +90,7 @@ public:
   };
 
   /// Memory Management.
-  class MemoryManager {
+  class LLVM_ABI MemoryManager {
     friend class RuntimeDyld;
 
   public:
@@ -189,49 +190,49 @@ public:
   };
 
   /// Construct a RuntimeDyld instance.
-  RuntimeDyld(MemoryManager &MemMgr, JITSymbolResolver &Resolver);
+  LLVM_ABI RuntimeDyld(MemoryManager &MemMgr, JITSymbolResolver &Resolver);
   RuntimeDyld(const RuntimeDyld &) = delete;
   RuntimeDyld &operator=(const RuntimeDyld &) = delete;
-  ~RuntimeDyld();
+  LLVM_ABI ~RuntimeDyld();
 
   /// Add the referenced object file to the list of objects to be loaded and
   /// relocated.
-  std::unique_ptr<LoadedObjectInfo> loadObject(const object::ObjectFile &O);
+  LLVM_ABI std::unique_ptr<LoadedObjectInfo> loadObject(const object::ObjectFile &O);
 
   /// Get the address of our local copy of the symbol. This may or may not
   /// be the address used for relocation (clients can copy the data around
   /// and resolve relocatons based on where they put it).
-  void *getSymbolLocalAddress(StringRef Name) const;
+  LLVM_ABI void *getSymbolLocalAddress(StringRef Name) const;
 
   /// Get the section ID for the section containing the given symbol.
-  unsigned getSymbolSectionID(StringRef Name) const;
+  LLVM_ABI unsigned getSymbolSectionID(StringRef Name) const;
 
   /// Get the target address and flags for the named symbol.
   /// This address is the one used for relocation.
-  JITEvaluatedSymbol getSymbol(StringRef Name) const;
+  LLVM_ABI JITEvaluatedSymbol getSymbol(StringRef Name) const;
 
   /// Returns a copy of the symbol table. This can be used by on-finalized
   /// callbacks to extract the symbol table before throwing away the
   /// RuntimeDyld instance. Because the map keys (StringRefs) are backed by
   /// strings inside the RuntimeDyld instance, the map should be processed
   /// before the RuntimeDyld instance is discarded.
-  std::map<StringRef, JITEvaluatedSymbol> getSymbolTable() const;
+  LLVM_ABI std::map<StringRef, JITEvaluatedSymbol> getSymbolTable() const;
 
   /// Resolve the relocations for all symbols we currently know about.
-  void resolveRelocations();
+  LLVM_ABI void resolveRelocations();
 
   /// Map a section to its target address space value.
   /// Map the address of a JIT section as returned from the memory manager
   /// to the address in the target process as the running code will see it.
   /// This is the address which will be used for relocation resolution.
-  void mapSectionAddress(const void *LocalAddress, uint64_t TargetAddress);
+  LLVM_ABI void mapSectionAddress(const void *LocalAddress, uint64_t TargetAddress);
 
   /// Returns the section's working memory.
-  StringRef getSectionContent(unsigned SectionID) const;
+  LLVM_ABI StringRef getSectionContent(unsigned SectionID) const;
 
   /// If the section was loaded, return the section's load address,
   /// otherwise return std::nullopt.
-  uint64_t getSectionLoadAddress(unsigned SectionID) const;
+  LLVM_ABI uint64_t getSectionLoadAddress(unsigned SectionID) const;
 
   /// Set the NotifyStubEmitted callback. This is used for debugging
   /// purposes. A callback is made for each stub that is generated.
@@ -244,12 +245,12 @@ public:
   /// for identifying the EH frame and calling the memory manager with the
   /// EH frame section data.  However, the memory manager itself will handle
   /// the actual target-specific EH frame registration.
-  void registerEHFrames();
+  LLVM_ABI void registerEHFrames();
 
-  void deregisterEHFrames();
+  LLVM_ABI void deregisterEHFrames();
 
-  bool hasError();
-  StringRef getErrorString();
+  LLVM_ABI bool hasError();
+  LLVM_ABI StringRef getErrorString();
 
   /// By default, only sections that are "required for execution" are passed to
   /// the RTDyldMemoryManager, and other sections are discarded. Passing 'true'
@@ -281,7 +282,7 @@ public:
   ///   address of a symbol owned by some other instance in order to apply
   ///   relocations.
   ///
-  void finalizeWithMemoryManagerLocking();
+  LLVM_ABI void finalizeWithMemoryManagerLocking();
 
 private:
   friend void jitLinkForORC(
@@ -310,7 +311,7 @@ private:
 // but ORC's RTDyldObjectLinkingLayer2. Internally it constructs a RuntimeDyld
 // instance and uses continuation passing to perform the fix-up and finalize
 // steps asynchronously.
-void jitLinkForORC(
+LLVM_ABI void jitLinkForORC(
     object::OwningBinary<object::ObjectFile> O,
     RuntimeDyld::MemoryManager &MemMgr, JITSymbolResolver &Resolver,
     bool ProcessAllSections,

--- a/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
+++ b/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
@@ -285,7 +285,7 @@ public:
   LLVM_ABI void finalizeWithMemoryManagerLocking();
 
 private:
-  friend void jitLinkForORC(
+  LLVM_ABI_FRIEND friend void jitLinkForORC(
       object::OwningBinary<object::ObjectFile> O,
       RuntimeDyld::MemoryManager &MemMgr, JITSymbolResolver &Resolver,
       bool ProcessAllSections,

--- a/llvm/include/llvm/ExecutionEngine/RuntimeDyldChecker.h
+++ b/llvm/include/llvm/ExecutionEngine/RuntimeDyldChecker.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_EXECUTIONENGINE_RUNTIMEDYLDCHECKER_H
 #define LLVM_EXECUTIONENGINE_RUNTIMEDYLDCHECKER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
 #include "llvm/Support/Endian.h"
@@ -159,23 +160,23 @@ public:
   using GetGOTInfoFunction = std::function<Expected<MemoryRegionInfo>(
       StringRef GOTContainer, StringRef TargetName)>;
 
-  RuntimeDyldChecker(IsSymbolValidFunction IsSymbolValid,
+  LLVM_ABI RuntimeDyldChecker(IsSymbolValidFunction IsSymbolValid,
                      GetSymbolInfoFunction GetSymbolInfo,
                      GetSectionInfoFunction GetSectionInfo,
                      GetStubInfoFunction GetStubInfo,
                      GetGOTInfoFunction GetGOTInfo, llvm::endianness Endianness,
                      Triple TT, StringRef CPU, SubtargetFeatures TF,
                      raw_ostream &ErrStream);
-  ~RuntimeDyldChecker();
+  LLVM_ABI ~RuntimeDyldChecker();
 
   /// Check a single expression against the attached RuntimeDyld
   ///        instance.
-  bool check(StringRef CheckExpr) const;
+  LLVM_ABI bool check(StringRef CheckExpr) const;
 
   /// Scan the given memory buffer for lines beginning with the string
   ///        in RulePrefix. The remainder of the line is passed to the check
   ///        method to be evaluated as an expression.
-  bool checkAllRulesInBuffer(StringRef RulePrefix, MemoryBuffer *MemBuf) const;
+  LLVM_ABI bool checkAllRulesInBuffer(StringRef RulePrefix, MemoryBuffer *MemBuf) const;
 
   /// Returns the address of the requested section (or an error message
   ///        in the second element of the pair if the address cannot be found).
@@ -183,13 +184,13 @@ public:
   /// if 'LocalAddress' is true, this returns the address of the section
   /// within the linker's memory. If 'LocalAddress' is false it returns the
   /// address within the target process (i.e. the load address).
-  std::pair<uint64_t, std::string> getSectionAddr(StringRef FileName,
+  LLVM_ABI std::pair<uint64_t, std::string> getSectionAddr(StringRef FileName,
                                                   StringRef SectionName,
                                                   bool LocalAddress);
 
   /// If there is a section at the given local address, return its load
   /// address, otherwise return std::nullopt.
-  std::optional<uint64_t> getSectionLoadAddress(void *LocalAddress) const;
+  LLVM_ABI std::optional<uint64_t> getSectionLoadAddress(void *LocalAddress) const;
 
 private:
   std::unique_ptr<RuntimeDyldCheckerImpl> Impl;

--- a/llvm/include/llvm/ExecutionEngine/RuntimeDyldChecker.h
+++ b/llvm/include/llvm/ExecutionEngine/RuntimeDyldChecker.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_EXECUTIONENGINE_RUNTIMEDYLDCHECKER_H
 #define LLVM_EXECUTIONENGINE_RUNTIMEDYLDCHECKER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/TargetParser/SubtargetFeature.h"
 #include "llvm/TargetParser/Triple.h"
@@ -160,13 +160,11 @@ public:
   using GetGOTInfoFunction = std::function<Expected<MemoryRegionInfo>(
       StringRef GOTContainer, StringRef TargetName)>;
 
-  LLVM_ABI RuntimeDyldChecker(IsSymbolValidFunction IsSymbolValid,
-                     GetSymbolInfoFunction GetSymbolInfo,
-                     GetSectionInfoFunction GetSectionInfo,
-                     GetStubInfoFunction GetStubInfo,
-                     GetGOTInfoFunction GetGOTInfo, llvm::endianness Endianness,
-                     Triple TT, StringRef CPU, SubtargetFeatures TF,
-                     raw_ostream &ErrStream);
+  LLVM_ABI RuntimeDyldChecker(
+      IsSymbolValidFunction IsSymbolValid, GetSymbolInfoFunction GetSymbolInfo,
+      GetSectionInfoFunction GetSectionInfo, GetStubInfoFunction GetStubInfo,
+      GetGOTInfoFunction GetGOTInfo, llvm::endianness Endianness, Triple TT,
+      StringRef CPU, SubtargetFeatures TF, raw_ostream &ErrStream);
   LLVM_ABI ~RuntimeDyldChecker();
 
   /// Check a single expression against the attached RuntimeDyld
@@ -176,7 +174,8 @@ public:
   /// Scan the given memory buffer for lines beginning with the string
   ///        in RulePrefix. The remainder of the line is passed to the check
   ///        method to be evaluated as an expression.
-  LLVM_ABI bool checkAllRulesInBuffer(StringRef RulePrefix, MemoryBuffer *MemBuf) const;
+  LLVM_ABI bool checkAllRulesInBuffer(StringRef RulePrefix,
+                                      MemoryBuffer *MemBuf) const;
 
   /// Returns the address of the requested section (or an error message
   ///        in the second element of the pair if the address cannot be found).
@@ -184,13 +183,13 @@ public:
   /// if 'LocalAddress' is true, this returns the address of the section
   /// within the linker's memory. If 'LocalAddress' is false it returns the
   /// address within the target process (i.e. the load address).
-  LLVM_ABI std::pair<uint64_t, std::string> getSectionAddr(StringRef FileName,
-                                                  StringRef SectionName,
-                                                  bool LocalAddress);
+  LLVM_ABI std::pair<uint64_t, std::string>
+  getSectionAddr(StringRef FileName, StringRef SectionName, bool LocalAddress);
 
   /// If there is a section at the given local address, return its load
   /// address, otherwise return std::nullopt.
-  LLVM_ABI std::optional<uint64_t> getSectionLoadAddress(void *LocalAddress) const;
+  LLVM_ABI std::optional<uint64_t>
+  getSectionLoadAddress(void *LocalAddress) const;
 
 private:
   std::unique_ptr<RuntimeDyldCheckerImpl> Impl;

--- a/llvm/include/llvm/ExecutionEngine/SectionMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/SectionMemoryManager.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_SECTIONMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_SECTIONMEMORYMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
 #include "llvm/Support/Memory.h"
@@ -36,7 +37,7 @@ namespace llvm {
 /// in the JITed object.  Permissions can be applied either by calling
 /// MCJIT::finalizeObject or by calling SectionMemoryManager::finalizeMemory
 /// directly.  Clients of MCJIT should call MCJIT::finalizeObject.
-class SectionMemoryManager : public RTDyldMemoryManager {
+class LLVM_ABI SectionMemoryManager : public RTDyldMemoryManager {
 public:
   /// This enum describes the various reasons to allocate pages from
   /// allocateMappedMemory.
@@ -48,7 +49,7 @@ public:
 
   /// Implementations of this interface are used by SectionMemoryManager to
   /// request pages from the operating system.
-  class MemoryMapper {
+  class LLVM_ABI MemoryMapper {
   public:
     /// This method attempts to allocate \p NumBytes bytes of virtual memory for
     /// \p Purpose.  \p NearBlock may point to an existing allocation, in which

--- a/llvm/include/llvm/ExecutionEngine/SectionMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/SectionMemoryManager.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_EXECUTIONENGINE_SECTIONMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_SECTIONMEMORYMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Memory.h"
 #include <cstdint>
 #include <string>

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ExecutionEngine/JITLink/aarch32.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/TargetParser/ARMTargetParser.h"
 
@@ -31,7 +32,7 @@ namespace llvm {
 namespace jitlink {
 
 /// Translate from ELF relocation type to JITLink-internal edge kind.
-Expected<aarch32::EdgeKind_aarch32>
+LLVM_ABI Expected<aarch32::EdgeKind_aarch32>
 getJITLinkEdgeKind(uint32_t ELFType, const aarch32::ArmConfig &ArmCfg) {
   switch (ELFType) {
   case ELF::R_ARM_ABS32:
@@ -75,7 +76,7 @@ getJITLinkEdgeKind(uint32_t ELFType, const aarch32::ArmConfig &ArmCfg) {
 }
 
 /// Translate from JITLink-internal edge kind back to ELF relocation type.
-Expected<uint32_t> getELFRelocationType(Edge::Kind Kind) {
+LLVM_ABI Expected<uint32_t> getELFRelocationType(Edge::Kind Kind) {
   switch (static_cast<aarch32::EdgeKind_aarch32>(Kind)) {
   case aarch32::Data_Delta32:
     return ELF::R_ARM_REL32;

--- a/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MathExtras.h"
@@ -60,7 +61,7 @@ int64_t decodeImmBT4BlT1BlxT2(uint32_t Hi, uint32_t Lo) {
 ///
 ///   S:I1:I2:Imm10:Imm11:0 -> [ 00000:S:Imm10, 00:J1:0:J2:Imm11 ]
 ///
-HalfWords encodeImmBT4BlT1BlxT2_J1J2(int64_t Value) {
+LLVM_ABI HalfWords encodeImmBT4BlT1BlxT2_J1J2(int64_t Value) {
   uint32_t S = (Value >> 14) & 0x0400;
   uint32_t J1 = (((~(Value >> 10)) ^ (Value >> 11)) & 0x2000);
   uint32_t J2 = (((~(Value >> 11)) ^ (Value >> 13)) & 0x0800);
@@ -74,7 +75,7 @@ HalfWords encodeImmBT4BlT1BlxT2_J1J2(int64_t Value) {
 ///
 ///   [ 00000:S:Imm10, 00:J1:0:J2:Imm11] -> S:I1:I2:Imm10:Imm11:0
 ///
-int64_t decodeImmBT4BlT1BlxT2_J1J2(uint32_t Hi, uint32_t Lo) {
+LLVM_ABI int64_t decodeImmBT4BlT1BlxT2_J1J2(uint32_t Hi, uint32_t Lo) {
   uint32_t S = Hi & 0x0400;
   uint32_t I1 = ~((Lo ^ (Hi << 3)) << 10) & 0x00800000;
   uint32_t I2 = ~((Lo ^ (Hi << 1)) << 11) & 0x00400000;
@@ -88,7 +89,7 @@ int64_t decodeImmBT4BlT1BlxT2_J1J2(uint32_t Hi, uint32_t Lo) {
 ///
 ///   Imm24:00 ->  00000000:Imm24
 ///
-uint32_t encodeImmBA1BlA1BlxA2(int64_t Value) {
+LLVM_ABI uint32_t encodeImmBA1BlA1BlxA2(int64_t Value) {
   return (Value >> 2) & 0x00ffffff;
 }
 
@@ -97,7 +98,7 @@ uint32_t encodeImmBA1BlA1BlxA2(int64_t Value) {
 ///
 ///   00000000:Imm24 ->  Imm24:00
 ///
-int64_t decodeImmBA1BlA1BlxA2(int64_t Value) {
+LLVM_ABI int64_t decodeImmBA1BlA1BlxA2(int64_t Value) {
   return SignExtend64<26>((Value & 0x00ffffff) << 2);
 }
 
@@ -106,7 +107,7 @@ int64_t decodeImmBA1BlA1BlxA2(int64_t Value) {
 ///
 ///   Imm4:Imm1:Imm3:Imm8 -> [ 00000:i:000000:Imm4, 0:Imm3:0000:Imm8 ]
 ///
-HalfWords encodeImmMovtT1MovwT3(uint16_t Value) {
+LLVM_ABI HalfWords encodeImmMovtT1MovwT3(uint16_t Value) {
   uint32_t Imm4 = (Value >> 12) & 0x0f;
   uint32_t Imm1 = (Value >> 11) & 0x01;
   uint32_t Imm3 = (Value >> 8) & 0x07;
@@ -119,7 +120,7 @@ HalfWords encodeImmMovtT1MovwT3(uint16_t Value) {
 ///
 ///   [ 00000:i:000000:Imm4, 0:Imm3:0000:Imm8 ] -> Imm4:Imm1:Imm3:Imm8
 ///
-uint16_t decodeImmMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
+LLVM_ABI uint16_t decodeImmMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
   uint32_t Imm4 = Hi & 0x0f;
   uint32_t Imm1 = (Hi >> 10) & 0x01;
   uint32_t Imm3 = (Lo >> 12) & 0x07;
@@ -133,7 +134,7 @@ uint16_t decodeImmMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
 ///
 ///   Rd4 -> [0000000000000000, 0000:Rd4:00000000]
 ///
-HalfWords encodeRegMovtT1MovwT3(int64_t Value) {
+LLVM_ABI HalfWords encodeRegMovtT1MovwT3(int64_t Value) {
   uint32_t Rd4 = (Value & 0x0f) << 8;
   return HalfWords{0, Rd4};
 }
@@ -142,7 +143,7 @@ HalfWords encodeRegMovtT1MovwT3(int64_t Value) {
 ///
 ///   [0000000000000000, 0000:Rd4:00000000] -> Rd4
 ///
-int64_t decodeRegMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
+LLVM_ABI int64_t decodeRegMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
   uint32_t Rd4 = (Lo >> 8) & 0x0f;
   return Rd4;
 }
@@ -152,7 +153,7 @@ int64_t decodeRegMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
 ///
 ///   Imm4:Imm12 -> 000000000000:Imm4:0000:Imm12
 ///
-uint32_t encodeImmMovtA1MovwA2(uint16_t Value) {
+LLVM_ABI uint32_t encodeImmMovtA1MovwA2(uint16_t Value) {
   uint32_t Imm4 = (Value >> 12) & 0x0f;
   uint32_t Imm12 = Value & 0x0fff;
   return (Imm4 << 16) | Imm12;
@@ -163,7 +164,7 @@ uint32_t encodeImmMovtA1MovwA2(uint16_t Value) {
 ///
 ///   000000000000:Imm4:0000:Imm12 -> Imm4:Imm12
 ///
-uint16_t decodeImmMovtA1MovwA2(uint64_t Value) {
+LLVM_ABI uint16_t decodeImmMovtA1MovwA2(uint64_t Value) {
   uint32_t Imm4 = (Value >> 16) & 0x0f;
   uint32_t Imm12 = Value & 0x0fff;
   return (Imm4 << 12) | Imm12;
@@ -174,7 +175,7 @@ uint16_t decodeImmMovtA1MovwA2(uint64_t Value) {
 ///
 ///   Rd4 -> 0000000000000000:Rd4:000000000000
 ///
-uint32_t encodeRegMovtA1MovwA2(int64_t Value) {
+LLVM_ABI uint32_t encodeRegMovtA1MovwA2(int64_t Value) {
   uint32_t Rd4 = (Value & 0x00000f) << 12;
   return Rd4;
 }
@@ -184,7 +185,7 @@ uint32_t encodeRegMovtA1MovwA2(int64_t Value) {
 ///
 ///   0000000000000000:Rd4:000000000000 -> Rd4
 ///
-int64_t decodeRegMovtA1MovwA2(uint64_t Value) {
+LLVM_ABI int64_t decodeRegMovtA1MovwA2(uint64_t Value) {
   uint32_t Rd4 = (Value >> 12) & 0x00000f;
   return Rd4;
 }

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
@@ -24,14 +24,13 @@ extern "C" {
 // We put information about the JITed function in this global, which the
 // debugger reads.  Make sure to specify the version statically, because the
 // debugger checks the version before we can set it during runtime.
-LLVM_ABI LLVM_ALWAYS_EXPORT
-struct jit_descriptor __jit_debug_descriptor = {JitDescriptorVersion, 0,
-                                                nullptr, nullptr};
+LLVM_ABI LLVM_ALWAYS_EXPORT struct jit_descriptor __jit_debug_descriptor = {
+    JitDescriptorVersion, 0, nullptr, nullptr};
 
 // Debuggers that implement the GDB JIT interface put a special breakpoint in
 // this function.
-LLVM_ABI LLVM_ALWAYS_EXPORT
-LLVM_ATTRIBUTE_NOINLINE void __jit_debug_register_code() {
+LLVM_ABI LLVM_ALWAYS_EXPORT LLVM_ATTRIBUTE_NOINLINE void
+__jit_debug_register_code() {
   // The noinline and the asm prevent calls to this function from being
   // optimized out.
 #if !defined(_MSC_VER)

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
@@ -24,13 +24,13 @@ extern "C" {
 // We put information about the JITed function in this global, which the
 // debugger reads.  Make sure to specify the version statically, because the
 // debugger checks the version before we can set it during runtime.
-LLVM_ALWAYS_EXPORT
+LLVM_ABI LLVM_ALWAYS_EXPORT
 struct jit_descriptor __jit_debug_descriptor = {JitDescriptorVersion, 0,
                                                 nullptr, nullptr};
 
 // Debuggers that implement the GDB JIT interface put a special breakpoint in
 // this function.
-LLVM_ALWAYS_EXPORT
+LLVM_ABI LLVM_ALWAYS_EXPORT
 LLVM_ATTRIBUTE_NOINLINE void __jit_debug_register_code() {
   // The noinline and the asm prevent calls to this function from being
   // optimized out.

--- a/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
@@ -533,7 +533,7 @@ TEST_F(OrcCAPITestBase, AddObjectBuffer) {
 
 // JITLink debug support plugins put information about JITed code in this GDB
 // JIT Interface global from OrcTargetProcess.
-extern "C" struct jit_descriptor __jit_debug_descriptor;
+extern "C" LLVM_ABI struct jit_descriptor __jit_debug_descriptor;
 
 static void *findLastDebugDescriptorEntryPtr() {
   struct jit_code_entry *Last = __jit_debug_descriptor.first_entry;


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/ExecutionEngine` library. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS on Linux:
- Add `LLVM_ABI_FRIEND` to friend member functions declared with `LLVM_ABI`
- Add `LLVM_ABI` to a subset of private class methods and fields that require export
- Add `LLVM_ABI` to a small number of symbols that require export but are not declared in headers
- Add `LLVM_ABI` to a number of `extern "C"` methods that IDS missed because they're implicitly exported

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang