### PR TITLE
[lldb-dap] Avoid double 'new' events for dyld on Darwin

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1292,15 +1292,7 @@ void DAP::EventThread() {
 
             llvm::StringRef reason;
             bool id_only = false;
-            if (event_mask & lldb::SBTarget::eBroadcastBitModulesLoaded) {
-              modules.insert(module_id);
-              reason = "new";
-            } else {
-              // If this is a module we've never told the client about, don't
-              // send an event.
-              if (!modules.contains(module_id))
-                continue;
-
+            if (modules.contains(module_id)) {
               if (event_mask & lldb::SBTarget::eBroadcastBitModulesUnloaded) {
                 modules.erase(module_id);
                 reason = "removed";
@@ -1308,6 +1300,9 @@ void DAP::EventThread() {
               } else {
                 reason = "changed";
               }
+            } else {
+              modules.insert(module_id);
+              reason = "new";
             }
 
             llvm::json::Object body;


### PR DESCRIPTION
I got a bug report where a pedantic DAP client complains about getting two "new" module events for the same UUID. This is caused by the dyld transition from the on-disk dyld to the shared cache dyld, which share the same UUID. The transition is not generating an unloaded event (because we're not really unloading dyld) but we do get a loaded event (because the load address changed). This PR fixes the issue by relying on the modules set as the source of truth instead of relying on the event type.