### PR TITLE
[mlir][vector] Move hidden function to op definition

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1114,6 +1114,8 @@ def Vector_InsertStridedSliceOp :
         return ::llvm::cast<IntegerAttr>(attr).getInt() != 1;
       });
     }
+    // \return The indices in dest that the values are inserted to.
+    FailureOr<SmallVector<int64_t>> getLinearIndices();
   }];
 
   let hasFolder = 1;
@@ -1254,6 +1256,8 @@ def Vector_ExtractStridedSliceOp :
         return ::llvm::cast<IntegerAttr>(attr).getInt() != 1;
       });
     }
+    // \return The indices in source that the values are taken from.
+    FailureOr<SmallVector<int64_t>> getLinearIndices();
   }];
   let hasCanonicalizer = 1;
   let hasFolder = 1;

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1114,7 +1114,7 @@ def Vector_InsertStridedSliceOp :
         return ::llvm::cast<IntegerAttr>(attr).getInt() != 1;
       });
     }
-    // \return The indices in dest that the values are inserted to.
+    // \return The indices in `dest` where values are stored.
     FailureOr<SmallVector<int64_t>> getLinearIndices();
   }];
 
@@ -1256,7 +1256,7 @@ def Vector_ExtractStridedSliceOp :
         return ::llvm::cast<IntegerAttr>(attr).getInt() != 1;
       });
     }
-    // \return The indices in source that the values are taken from.
+    // \return The indices in `source` where values are extracted.
     FailureOr<SmallVector<int64_t>> getLinearIndices();
   }];
   let hasCanonicalizer = 1;


### PR DESCRIPTION
This non-functional change moves the function `getStridedSliceInsertionIndices` introduced in https://github.com/llvm/llvm-project/pull/138725 to the tablegen class definitions of `vector.insert_strided_slice` and `vector.extract_strided_slice`. Alternatives considered: 
1) duplicate in .cpp where I need it currently 
2) make a non-class method exposed in VectorUtils.h

It's quite a large function so (1) doesn't seem good. My concern with (2) is that it'll get 'lost' - having it on the class makes it more likely to be reused IMO. 

Question: is the testing sufficient? It's indirectly lit tested by https://github.com/llvm/llvm-project/pull/138725