### PR TITLE
[NFCI] Avoid adding duplicated SpecialCaseList::Sections.

### DIFF
--- a/llvm/include/llvm/Support/SpecialCaseList.h
+++ b/llvm/include/llvm/Support/SpecialCaseList.h
@@ -138,7 +138,6 @@ protected:
     std::unique_ptr<Matcher> SectionMatcher;
     SectionEntries Entries;
     std::string SectionStr;
-    unsigned LineNo;
   };
 
   std::vector<Section> Sections;

--- a/llvm/lib/Support/SpecialCaseList.cpp
+++ b/llvm/lib/Support/SpecialCaseList.cpp
@@ -139,13 +139,12 @@ SpecialCaseList::addSection(StringRef SectionStr, unsigned LineNo,
                             bool UseGlobs) {
   auto it =
       std::find_if(Sections.begin(), Sections.end(), [&](const Section &s) {
-        return s.SectionStr == SectionStr && s.LineNo == LineNo;
+        return s.SectionStr == SectionStr;
       });
   if (it == Sections.end()) {
     Sections.emplace_back();
     auto &sec = Sections.back();
     sec.SectionStr = SectionStr;
-    sec.LineNo = LineNo;
     it = std::prev(Sections.end());
   }
   if (auto Err = it->SectionMatcher->insert(SectionStr, LineNo, UseGlobs)) {

--- a/llvm/unittests/Support/SpecialCaseListTest.cpp
+++ b/llvm/unittests/Support/SpecialCaseListTest.cpp
@@ -216,8 +216,9 @@ TEST_F(SpecialCaseListTest, NoTrigramsInARule) {
 }
 
 TEST_F(SpecialCaseListTest, RepetitiveRule) {
-  std::unique_ptr<SpecialCaseList> SCL = makeSpecialCaseList("fun:*bar*bar*bar*bar*\n"
-                                                             "fun:bar*\n");
+  std::unique_ptr<SpecialCaseList> SCL =
+      makeSpecialCaseList("fun:*bar*bar*bar*bar*\n"
+                          "fun:bar*\n");
   EXPECT_TRUE(SCL->inSection("", "fun", "bara"));
   EXPECT_FALSE(SCL->inSection("", "fun", "abara"));
   EXPECT_TRUE(SCL->inSection("", "fun", "barbarbarbar"));
@@ -226,7 +227,8 @@ TEST_F(SpecialCaseListTest, RepetitiveRule) {
 }
 
 TEST_F(SpecialCaseListTest, SpecialSymbolRule) {
-  std::unique_ptr<SpecialCaseList> SCL = makeSpecialCaseList("src:*c\\+\\+abi*\n");
+  std::unique_ptr<SpecialCaseList> SCL =
+      makeSpecialCaseList("src:*c\\+\\+abi*\n");
   EXPECT_TRUE(SCL->inSection("", "src", "c++abi"));
   EXPECT_FALSE(SCL->inSection("", "src", "c\\+\\+abi"));
 }
@@ -242,8 +244,9 @@ TEST_F(SpecialCaseListTest, PopularTrigram) {
 }
 
 TEST_F(SpecialCaseListTest, EscapedSymbols) {
-  std::unique_ptr<SpecialCaseList> SCL = makeSpecialCaseList("src:*c\\+\\+abi*\n"
-                                                             "src:*hello\\\\world*\n");
+  std::unique_ptr<SpecialCaseList> SCL =
+      makeSpecialCaseList("src:*c\\+\\+abi*\n"
+                          "src:*hello\\\\world*\n");
   EXPECT_TRUE(SCL->inSection("", "src", "dir/c++abi"));
   EXPECT_FALSE(SCL->inSection("", "src", "dir/c\\+\\+abi"));
   EXPECT_FALSE(SCL->inSection("", "src", "c\\+\\+abi"));
@@ -315,7 +318,9 @@ TEST_F(SpecialCaseListTest, Version3) {
                                                              "src:def\n"
                                                              "[sect2]\n"
                                                              "src:def\n"
-                                                             "src:def\n");
+                                                             "src:def\n"
+                                                             "[sect1]\n"
+                                                             "src:foo*\n");
   EXPECT_TRUE(SCL->inSection("sect1", "src", "fooz"));
   EXPECT_TRUE(SCL->inSection("sect1", "src", "barz"));
   EXPECT_FALSE(SCL->inSection("sect2", "src", "fooz"));
@@ -323,9 +328,9 @@ TEST_F(SpecialCaseListTest, Version3) {
   EXPECT_TRUE(SCL->inSection("sect2", "src", "def"));
   EXPECT_TRUE(SCL->inSection("sect1", "src", "def"));
 
-  EXPECT_EQ(2u, SCL->inSectionBlame("sect1", "src", "fooz"));
   EXPECT_EQ(4u, SCL->inSectionBlame("sect1", "src", "barz"));
   EXPECT_EQ(5u, SCL->inSectionBlame("sect1", "src", "def"));
   EXPECT_EQ(8u, SCL->inSectionBlame("sect2", "src", "def"));
+  EXPECT_EQ(10u, SCL->inSectionBlame("sect1", "src", "fooz"));
 }
-}
+} // namespace


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/140127 converts SpecialCaseList::Sections
from StringMap to vector. However, the previous StringMap ensures that only a new
section is created when the SectionStr is different. We should keep the same behavior.
