### PR TITLE
[llvm] annotate interfaces in llvm/CGData and llvm/CodeGen for DLL export

### DIFF
--- a/llvm/include/llvm/CGData/CodeGenData.h
+++ b/llvm/include/llvm/CGData/CodeGenData.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CGDATA_CODEGENDATA_H
 #define LLVM_CGDATA_CODEGENDATA_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/Bitcode/BitcodeReader.h"
@@ -24,6 +23,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Caching.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/TargetParser/Triple.h"
 #include <mutex>
@@ -36,8 +36,8 @@ enum CGDataSectKind {
 };
 
 LLVM_ABI std::string getCodeGenDataSectionName(CGDataSectKind CGSK,
-                                      Triple::ObjectFormatType OF,
-                                      bool AddSegmentInfo = true);
+                                               Triple::ObjectFormatType OF,
+                                               bool AddSegmentInfo = true);
 
 enum class CGDataKind {
   Unknown = 0x0,
@@ -247,7 +247,7 @@ struct StreamCacheData {
 /// process. \p AddStream is the callback used to add the serialized module to
 /// the stream.
 LLVM_ABI void saveModuleForTwoRounds(const Module &TheModule, unsigned Task,
-                            AddStreamFn AddStream);
+                                     AddStreamFn AddStream);
 
 /// Load the optimized bitcode module for the second codegen round.
 /// \p OrigModule is the original bitcode module.
@@ -255,15 +255,15 @@ LLVM_ABI void saveModuleForTwoRounds(const Module &TheModule, unsigned Task,
 /// process. \p Context provides the environment settings for module operations.
 /// \p IRFiles contains optimized bitcode module files needed for loading.
 /// \return A unique_ptr to the loaded Module, or nullptr if loading fails.
-LLVM_ABI std::unique_ptr<Module> loadModuleForTwoRounds(BitcodeModule &OrigModule,
-                                               unsigned Task,
-                                               LLVMContext &Context,
-                                               ArrayRef<StringRef> IRFiles);
+LLVM_ABI std::unique_ptr<Module>
+loadModuleForTwoRounds(BitcodeModule &OrigModule, unsigned Task,
+                       LLVMContext &Context, ArrayRef<StringRef> IRFiles);
 
 /// Merge the codegen data from the scratch objects \p ObjectFiles from the
 /// first codegen round.
 /// \return the combined hash of the merged codegen data.
-LLVM_ABI Expected<stable_hash> mergeCodeGenData(ArrayRef<StringRef> ObjectFiles);
+LLVM_ABI Expected<stable_hash>
+mergeCodeGenData(ArrayRef<StringRef> ObjectFiles);
 
 LLVM_ABI void warn(Error E, StringRef Whence = "");
 LLVM_ABI void warn(Twine Message, StringRef Whence = "", StringRef Hint = "");

--- a/llvm/include/llvm/CGData/CodeGenData.h
+++ b/llvm/include/llvm/CGData/CodeGenData.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CGDATA_CODEGENDATA_H
 #define LLVM_CGDATA_CODEGENDATA_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/Bitcode/BitcodeReader.h"
@@ -34,7 +35,7 @@ enum CGDataSectKind {
 #include "llvm/CGData/CodeGenData.inc"
 };
 
-std::string getCodeGenDataSectionName(CGDataSectKind CGSK,
+LLVM_ABI std::string getCodeGenDataSectionName(CGDataSectKind CGSK,
                                       Triple::ObjectFormatType OF,
                                       bool AddSegmentInfo = true);
 
@@ -47,7 +48,7 @@ enum class CGDataKind {
   LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/StableFunctionMergingMap)
 };
 
-const std::error_category &cgdata_category();
+LLVM_ABI const std::error_category &cgdata_category();
 
 enum class cgdata_error {
   success = 0,
@@ -63,7 +64,7 @@ inline std::error_code make_error_code(cgdata_error E) {
   return std::error_code(static_cast<int>(E), cgdata_category());
 }
 
-class CGDataError : public ErrorInfo<CGDataError> {
+class LLVM_ABI CGDataError : public ErrorInfo<CGDataError> {
 public:
   CGDataError(cgdata_error Err, const Twine &ErrStr = Twine())
       : Err(Err), Msg(ErrStr.str()) {
@@ -130,7 +131,7 @@ class CodeGenData {
 public:
   ~CodeGenData() = default;
 
-  static CodeGenData &getInstance();
+  LLVM_ABI static CodeGenData &getInstance();
 
   /// Returns true if we have a valid outlined hash tree.
   bool hasOutlinedHashTree() {
@@ -245,7 +246,7 @@ struct StreamCacheData {
 /// \p Task represents the partition number in the parallel code generation
 /// process. \p AddStream is the callback used to add the serialized module to
 /// the stream.
-void saveModuleForTwoRounds(const Module &TheModule, unsigned Task,
+LLVM_ABI void saveModuleForTwoRounds(const Module &TheModule, unsigned Task,
                             AddStreamFn AddStream);
 
 /// Load the optimized bitcode module for the second codegen round.
@@ -254,7 +255,7 @@ void saveModuleForTwoRounds(const Module &TheModule, unsigned Task,
 /// process. \p Context provides the environment settings for module operations.
 /// \p IRFiles contains optimized bitcode module files needed for loading.
 /// \return A unique_ptr to the loaded Module, or nullptr if loading fails.
-std::unique_ptr<Module> loadModuleForTwoRounds(BitcodeModule &OrigModule,
+LLVM_ABI std::unique_ptr<Module> loadModuleForTwoRounds(BitcodeModule &OrigModule,
                                                unsigned Task,
                                                LLVMContext &Context,
                                                ArrayRef<StringRef> IRFiles);
@@ -262,10 +263,10 @@ std::unique_ptr<Module> loadModuleForTwoRounds(BitcodeModule &OrigModule,
 /// Merge the codegen data from the scratch objects \p ObjectFiles from the
 /// first codegen round.
 /// \return the combined hash of the merged codegen data.
-Expected<stable_hash> mergeCodeGenData(ArrayRef<StringRef> ObjectFiles);
+LLVM_ABI Expected<stable_hash> mergeCodeGenData(ArrayRef<StringRef> ObjectFiles);
 
-void warn(Error E, StringRef Whence = "");
-void warn(Twine Message, StringRef Whence = "", StringRef Hint = "");
+LLVM_ABI void warn(Error E, StringRef Whence = "");
+LLVM_ABI void warn(Twine Message, StringRef Whence = "", StringRef Hint = "");
 
 } // end namespace cgdata
 
@@ -297,7 +298,7 @@ struct Header {
   // the new field is read correctly.
 
   // Reads a header struct from the buffer.
-  static Expected<Header> readFromBuffer(const unsigned char *Curr);
+  LLVM_ABI static Expected<Header> readFromBuffer(const unsigned char *Curr);
 };
 
 } // end namespace IndexedCGData

--- a/llvm/include/llvm/CGData/CodeGenDataReader.h
+++ b/llvm/include/llvm/CGData/CodeGenDataReader.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CGDATA_CODEGENDATAREADER_H
 #define LLVM_CGDATA_CODEGENDATAREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CGData/CodeGenData.h"
 #include "llvm/CGData/OutlinedHashTreeRecord.h"
 #include "llvm/CGData/StableFunctionMapRecord.h"
@@ -49,12 +50,12 @@ public:
 
   /// Factory method to create an appropriately typed reader for the given
   /// codegen data file path and file system.
-  static Expected<std::unique_ptr<CodeGenDataReader>>
+  LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
   create(const Twine &Path, vfs::FileSystem &FS);
 
   /// Factory method to create an appropriately typed reader for the given
   /// memory buffer.
-  static Expected<std::unique_ptr<CodeGenDataReader>>
+  LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
   create(std::unique_ptr<MemoryBuffer> Buffer);
 
   /// Extract the cgdata embedded in sections from the given object file and
@@ -62,7 +63,7 @@ public:
   /// is used by `llvm-cgdata --merge` or ThinLTO's two-codegen rounds.
   /// Optionally, \p CombinedHash can be used to compuate the combined hash of
   /// the merged data.
-  static Error
+  LLVM_ABI static Error
   mergeFromObjectFile(const object::ObjectFile *Obj,
                       OutlinedHashTreeRecord &GlobalOutlineRecord,
                       StableFunctionMapRecord &GlobalFunctionMapRecord,
@@ -98,7 +99,7 @@ protected:
   Error success() { return error(cgdata_error::success); }
 };
 
-class IndexedCodeGenDataReader : public CodeGenDataReader {
+class LLVM_ABI IndexedCodeGenDataReader : public CodeGenDataReader {
   /// The codegen data file contents.
   std::unique_ptr<MemoryBuffer> DataBuffer;
   /// The header
@@ -139,7 +140,7 @@ public:
 /// codegen data is recorded. `#` is used to indicate a comment.
 /// The subsequent data is a YAML format per each codegen data in order.
 /// Currently, it only has a function outlined hash tree.
-class TextCodeGenDataReader : public CodeGenDataReader {
+class LLVM_ABI TextCodeGenDataReader : public CodeGenDataReader {
   /// The codegen data file contents.
   std::unique_ptr<MemoryBuffer> DataBuffer;
   /// Iterator over the profile data.

--- a/llvm/include/llvm/CGData/CodeGenDataReader.h
+++ b/llvm/include/llvm/CGData/CodeGenDataReader.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_CGDATA_CODEGENDATAREADER_H
 #define LLVM_CGDATA_CODEGENDATAREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CGData/CodeGenData.h"
 #include "llvm/CGData/OutlinedHashTreeRecord.h"
 #include "llvm/CGData/StableFunctionMapRecord.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/LineIterator.h"
 #include "llvm/Support/VirtualFileSystem.h"
 

--- a/llvm/include/llvm/CGData/CodeGenDataWriter.h
+++ b/llvm/include/llvm/CGData/CodeGenDataWriter.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CGDATA_CODEGENDATAWRITER_H
 #define LLVM_CGDATA_CODEGENDATAWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CGData/CodeGenData.h"
 #include "llvm/CGData/OutlinedHashTreeRecord.h"
 #include "llvm/CGData/StableFunctionMapRecord.h"
@@ -45,7 +46,7 @@ public:
   // \c patch can only be called when all data is written and flushed.
   // For raw_string_ostream, the patch is done on the target string
   // directly and it won't be reflected in the stream's internal buffer.
-  void patch(ArrayRef<CGDataPatchItem> P);
+  LLVM_ABI void patch(ArrayRef<CGDataPatchItem> P);
 
   // If \c OS is an instance of \c raw_fd_ostream, this field will be
   // true. Otherwise, \c OS will be an raw_string_ostream.
@@ -69,16 +70,16 @@ public:
   ~CodeGenDataWriter() = default;
 
   /// Add the outlined hash tree record. The input hash tree is released.
-  void addRecord(OutlinedHashTreeRecord &Record);
+  LLVM_ABI void addRecord(OutlinedHashTreeRecord &Record);
 
   /// Add the stable function map record. The input function map is released.
-  void addRecord(StableFunctionMapRecord &Record);
+  LLVM_ABI void addRecord(StableFunctionMapRecord &Record);
 
   /// Write the codegen data to \c OS
-  Error write(raw_fd_ostream &OS);
+  LLVM_ABI Error write(raw_fd_ostream &OS);
 
   /// Write the codegen data in text format to \c OS
-  Error writeText(raw_fd_ostream &OS);
+  LLVM_ABI Error writeText(raw_fd_ostream &OS);
 
   /// Return the attributes of the current CGData.
   CGDataKind getCGDataKind() const { return DataKind; }

--- a/llvm/include/llvm/CGData/CodeGenDataWriter.h
+++ b/llvm/include/llvm/CGData/CodeGenDataWriter.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_CGDATA_CODEGENDATAWRITER_H
 #define LLVM_CGDATA_CODEGENDATAWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CGData/CodeGenData.h"
 #include "llvm/CGData/OutlinedHashTreeRecord.h"
 #include "llvm/CGData/StableFunctionMapRecord.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/CGData/OutlinedHashTree.h
+++ b/llvm/include/llvm/CGData/OutlinedHashTree.h
@@ -15,10 +15,10 @@
 #ifndef LLVM_CGDATA_OUTLINEDHASHTREE_H
 #define LLVM_CGDATA_OUTLINEDHASHTREE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/ObjectYAML/YAML.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <unordered_map>
@@ -56,8 +56,8 @@ public:
   /// callbacks can be used to traverse a OutlinedHashTree for the purpose of
   /// print debugging or serializing it.
   LLVM_ABI void walkGraph(NodeCallbackFn CallbackNode,
-                 EdgeCallbackFn CallbackEdge = nullptr,
-                 bool SortedWalk = false) const;
+                          EdgeCallbackFn CallbackEdge = nullptr,
+                          bool SortedWalk = false) const;
 
   /// Release all hash nodes except the root hash node.
   void clear() {

--- a/llvm/include/llvm/CGData/OutlinedHashTree.h
+++ b/llvm/include/llvm/CGData/OutlinedHashTree.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CGDATA_OUTLINEDHASHTREE_H
 #define LLVM_CGDATA_OUTLINEDHASHTREE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/ObjectYAML/YAML.h"
@@ -54,7 +55,7 @@ public:
   /// the source and the stable_hash of the sink for an edge. These generic
   /// callbacks can be used to traverse a OutlinedHashTree for the purpose of
   /// print debugging or serializing it.
-  void walkGraph(NodeCallbackFn CallbackNode,
+  LLVM_ABI void walkGraph(NodeCallbackFn CallbackNode,
                  EdgeCallbackFn CallbackEdge = nullptr,
                  bool SortedWalk = false) const;
 
@@ -71,10 +72,10 @@ public:
   /// \p GetTerminalCountOnly is true, it only counts the terminal nodes
   /// (meaning it returns the the number of hash sequences in the
   /// OutlinedHashTree).
-  size_t size(bool GetTerminalCountOnly = false) const;
+  LLVM_ABI size_t size(bool GetTerminalCountOnly = false) const;
 
   /// \returns the depth of a OutlinedHashTree by traversing it.
-  size_t depth() const;
+  LLVM_ABI size_t depth() const;
 
   /// \returns the root hash node of a OutlinedHashTree.
   const HashNode *getRoot() const { return &Root; }
@@ -82,13 +83,13 @@ public:
 
   /// Inserts a \p Sequence into the this tree. The last node in the sequence
   /// will increase Terminals.
-  void insert(const HashSequencePair &SequencePair);
+  LLVM_ABI void insert(const HashSequencePair &SequencePair);
 
   /// Merge a \p OtherTree into this Tree.
-  void merge(const OutlinedHashTree *OtherTree);
+  LLVM_ABI void merge(const OutlinedHashTree *OtherTree);
 
   /// \returns the matching count if \p Sequence exists in the OutlinedHashTree.
-  std::optional<unsigned> find(const HashSequence &Sequence) const;
+  LLVM_ABI std::optional<unsigned> find(const HashSequence &Sequence) const;
 
 private:
   HashNode Root;

--- a/llvm/include/llvm/CGData/OutlinedHashTreeRecord.h
+++ b/llvm/include/llvm/CGData/OutlinedHashTreeRecord.h
@@ -16,8 +16,8 @@
 #ifndef LLVM_CGDATA_OUTLINEDHASHTREERECORD_H
 #define LLVM_CGDATA_OUTLINEDHASHTREERECORD_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CGData/OutlinedHashTree.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CGData/OutlinedHashTreeRecord.h
+++ b/llvm/include/llvm/CGData/OutlinedHashTreeRecord.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CGDATA_OUTLINEDHASHTREERECORD_H
 #define LLVM_CGDATA_OUTLINEDHASHTREERECORD_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CGData/OutlinedHashTree.h"
 
 namespace llvm {
@@ -40,13 +41,13 @@ struct OutlinedHashTreeRecord {
       : HashTree(std::move(HashTree)) {};
 
   /// Serialize the outlined hash tree to a raw_ostream.
-  void serialize(raw_ostream &OS) const;
+  LLVM_ABI void serialize(raw_ostream &OS) const;
   /// Deserialize the outlined hash tree from a raw_ostream.
-  void deserialize(const unsigned char *&Ptr);
+  LLVM_ABI void deserialize(const unsigned char *&Ptr);
   /// Serialize the outlined hash tree to a YAML stream.
-  void serializeYAML(yaml::Output &YOS) const;
+  LLVM_ABI void serializeYAML(yaml::Output &YOS) const;
   /// Deserialize the outlined hash tree from a YAML stream.
-  void deserializeYAML(yaml::Input &YIS);
+  LLVM_ABI void deserializeYAML(yaml::Input &YIS);
 
   /// Merge the other outlined hash tree into this one.
   void merge(const OutlinedHashTreeRecord &Other) {

--- a/llvm/include/llvm/CGData/StableFunctionMap.h
+++ b/llvm/include/llvm/CGData/StableFunctionMap.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CGDATA_STABLEFUNCTIONMAP_H
 #define LLVM_CGDATA_STABLEFUNCTIONMAP_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/IR/StructuralHash.h"
@@ -82,18 +83,18 @@ struct StableFunctionMap {
 
   /// Get an existing ID associated with the given name or create a new ID if it
   /// doesn't exist.
-  unsigned getIdOrCreateForName(StringRef Name);
+  LLVM_ABI unsigned getIdOrCreateForName(StringRef Name);
 
   /// Get the name associated with a given ID
-  std::optional<std::string> getNameForId(unsigned Id) const;
+  LLVM_ABI std::optional<std::string> getNameForId(unsigned Id) const;
 
   /// Insert a `StableFunction` object into the function map. This method
   /// handles the uniquing of string names and create a `StableFunctionEntry`
   /// for insertion.
-  void insert(const StableFunction &Func);
+  LLVM_ABI void insert(const StableFunction &Func);
 
   /// Merge a \p OtherMap into this function map.
-  void merge(const StableFunctionMap &OtherMap);
+  LLVM_ABI void merge(const StableFunctionMap &OtherMap);
 
   /// \returns true if there is no stable function entry.
   bool empty() const { return size() == 0; }
@@ -107,10 +108,10 @@ struct StableFunctionMap {
 
   /// \returns the size of StableFunctionMap.
   /// \p Type is the type of size to return.
-  size_t size(SizeType Type = UniqueHashCount) const;
+  LLVM_ABI size_t size(SizeType Type = UniqueHashCount) const;
 
   /// Finalize the stable function map by trimming content.
-  void finalize(bool SkipTrim = false);
+  LLVM_ABI void finalize(bool SkipTrim = false);
 
 private:
   /// Insert a `StableFunctionEntry` into the function map directly. This

--- a/llvm/include/llvm/CGData/StableFunctionMap.h
+++ b/llvm/include/llvm/CGData/StableFunctionMap.h
@@ -16,10 +16,10 @@
 #ifndef LLVM_CGDATA_STABLEFUNCTIONMAP_H
 #define LLVM_CGDATA_STABLEFUNCTIONMAP_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/IR/StructuralHash.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CGData/StableFunctionMapRecord.h
+++ b/llvm/include/llvm/CGData/StableFunctionMapRecord.h
@@ -16,9 +16,9 @@
 #ifndef LLVM_CGDATA_STABLEFUNCTIONMAPRECORD_H
 #define LLVM_CGDATA_STABLEFUNCTIONMAPRECORD_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CGData/StableFunctionMap.h"
 #include "llvm/ObjectYAML/YAML.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -35,7 +35,8 @@ struct StableFunctionMapRecord {
 
   /// A static helper function to serialize the stable function map without
   /// owning the stable function map.
-  LLVM_ABI static void serialize(raw_ostream &OS, const StableFunctionMap *FunctionMap);
+  LLVM_ABI static void serialize(raw_ostream &OS,
+                                 const StableFunctionMap *FunctionMap);
 
   /// Serialize the stable function map to a raw_ostream.
   LLVM_ABI void serialize(raw_ostream &OS) const;

--- a/llvm/include/llvm/CGData/StableFunctionMapRecord.h
+++ b/llvm/include/llvm/CGData/StableFunctionMapRecord.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CGDATA_STABLEFUNCTIONMAPRECORD_H
 #define LLVM_CGDATA_STABLEFUNCTIONMAPRECORD_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CGData/StableFunctionMap.h"
 #include "llvm/ObjectYAML/YAML.h"
 #include "llvm/Support/raw_ostream.h"
@@ -34,19 +35,19 @@ struct StableFunctionMapRecord {
 
   /// A static helper function to serialize the stable function map without
   /// owning the stable function map.
-  static void serialize(raw_ostream &OS, const StableFunctionMap *FunctionMap);
+  LLVM_ABI static void serialize(raw_ostream &OS, const StableFunctionMap *FunctionMap);
 
   /// Serialize the stable function map to a raw_ostream.
-  void serialize(raw_ostream &OS) const;
+  LLVM_ABI void serialize(raw_ostream &OS) const;
 
   /// Deserialize the stable function map from a raw_ostream.
-  void deserialize(const unsigned char *&Ptr);
+  LLVM_ABI void deserialize(const unsigned char *&Ptr);
 
   /// Serialize the stable function map to a YAML stream.
-  void serializeYAML(yaml::Output &YOS) const;
+  LLVM_ABI void serializeYAML(yaml::Output &YOS) const;
 
   /// Deserialize the stable function map from a YAML stream.
-  void deserializeYAML(yaml::Input &YIS);
+  LLVM_ABI void deserializeYAML(yaml::Input &YIS);
 
   /// Finalize the stable function map by trimming content.
   void finalize(bool SkipTrim = false) { FunctionMap->finalize(SkipTrim); }

--- a/llvm/include/llvm/CodeGen/AccelTable.h
+++ b/llvm/include/llvm/CodeGen/AccelTable.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CODEGEN_ACCELTABLE_H
 #define LLVM_CODEGEN_ACCELTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
@@ -22,6 +21,7 @@
 #include "llvm/CodeGen/DIE.h"
 #include "llvm/CodeGen/DwarfStringPoolEntry.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DJB.h"
 #include "llvm/Support/Debug.h"
 #include <cstdint>
@@ -294,7 +294,8 @@ class DWARF5AccelTableData : public AccelTableData {
 public:
   static uint32_t hash(StringRef Name) { return caseFoldingDjbHash(Name); }
 
-  LLVM_ABI DWARF5AccelTableData(const DIE &Die, const uint32_t UnitID, const bool IsTU);
+  LLVM_ABI DWARF5AccelTableData(const DIE &Die, const uint32_t UnitID,
+                                const bool IsTU);
   DWARF5AccelTableData(const uint64_t DieOffset,
                        const std::optional<uint64_t> DefiningParentOffset,
                        const unsigned DieTag, const unsigned UnitID,
@@ -349,7 +350,8 @@ public:
 
   /// If `Die` has a non-null parent and the parent is not a declaration,
   /// return its offset.
-  LLVM_ABI static std::optional<uint64_t> getDefiningParentDieOffset(const DIE &Die);
+  LLVM_ABI static std::optional<uint64_t>
+  getDefiningParentDieOffset(const DIE &Die);
 
 protected:
   std::variant<const DIE *, uint64_t> OffsetVal;
@@ -438,9 +440,10 @@ public:
   }
 };
 
-LLVM_ABI void emitAppleAccelTableImpl(AsmPrinter *Asm, AccelTableBase &Contents,
-                             StringRef Prefix, const MCSymbol *SecBegin,
-                             ArrayRef<AppleAccelTableData::Atom> Atoms);
+LLVM_ABI void
+emitAppleAccelTableImpl(AsmPrinter *Asm, AccelTableBase &Contents,
+                        StringRef Prefix, const MCSymbol *SecBegin,
+                        ArrayRef<AppleAccelTableData::Atom> Atoms);
 
 /// Emit an Apple Accelerator Table consisting of entries in the specified
 /// AccelTable. The DataT template parameter should be derived from
@@ -452,9 +455,10 @@ void emitAppleAccelTable(AsmPrinter *Asm, AccelTable<DataT> &Contents,
   emitAppleAccelTableImpl(Asm, Contents, Prefix, SecBegin, DataT::Atoms);
 }
 
-LLVM_ABI void emitDWARF5AccelTable(AsmPrinter *Asm, DWARF5AccelTable &Contents,
-                          const DwarfDebug &DD,
-                          ArrayRef<std::unique_ptr<DwarfCompileUnit>> CUs);
+LLVM_ABI void
+emitDWARF5AccelTable(AsmPrinter *Asm, DWARF5AccelTable &Contents,
+                     const DwarfDebug &DD,
+                     ArrayRef<std::unique_ptr<DwarfCompileUnit>> CUs);
 
 /// Emit a DWARFv5 Accelerator Table consisting of entries in the specified
 /// AccelTable. The \p CUs contains either symbols keeping offsets to the
@@ -526,7 +530,8 @@ protected:
 
 /// Accelerator table data implementation for type accelerator tables with
 /// a DIE offset but no actual DIE pointer.
-class LLVM_ABI AppleAccelTableStaticTypeData : public AppleAccelTableStaticOffsetData {
+class LLVM_ABI AppleAccelTableStaticTypeData
+    : public AppleAccelTableStaticOffsetData {
 public:
   AppleAccelTableStaticTypeData(uint32_t Offset, uint16_t Tag,
                                 bool ObjCClassIsImplementation,

--- a/llvm/include/llvm/CodeGen/AccelTable.h
+++ b/llvm/include/llvm/CodeGen/AccelTable.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_ACCELTABLE_H
 #define LLVM_CODEGEN_ACCELTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
@@ -174,12 +175,12 @@ protected:
   HashList Hashes;
   BucketList Buckets;
 
-  void computeBucketCount();
+  LLVM_ABI void computeBucketCount();
 
   AccelTableBase(HashFn *Hash) : Hash(Hash) {}
 
 public:
-  void finalize(AsmPrinter *Asm, StringRef Prefix);
+  LLVM_ABI void finalize(AsmPrinter *Asm, StringRef Prefix);
   ArrayRef<HashList> getBuckets() const { return Buckets; }
   uint32_t getBucketCount() const { return BucketCount; }
   uint32_t getUniqueHashCount() const { return UniqueHashCount; }
@@ -293,7 +294,7 @@ class DWARF5AccelTableData : public AccelTableData {
 public:
   static uint32_t hash(StringRef Name) { return caseFoldingDjbHash(Name); }
 
-  DWARF5AccelTableData(const DIE &Die, const uint32_t UnitID, const bool IsTU);
+  LLVM_ABI DWARF5AccelTableData(const DIE &Die, const uint32_t UnitID, const bool IsTU);
   DWARF5AccelTableData(const uint64_t DieOffset,
                        const std::optional<uint64_t> DefiningParentOffset,
                        const unsigned DieTag, const unsigned UnitID,
@@ -348,7 +349,7 @@ public:
 
   /// If `Die` has a non-null parent and the parent is not a declaration,
   /// return its offset.
-  static std::optional<uint64_t> getDefiningParentDieOffset(const DIE &Die);
+  LLVM_ABI static std::optional<uint64_t> getDefiningParentDieOffset(const DIE &Die);
 
 protected:
   std::variant<const DIE *, uint64_t> OffsetVal;
@@ -380,7 +381,7 @@ public:
   /// Get DIE Tag.
   uint32_t getDieTag() const { return DieTag; }
   /// Used to gather unique data for the abbreviation folding set.
-  void Profile(FoldingSetNodeID &ID) const;
+  LLVM_ABI void Profile(FoldingSetNodeID &ID) const;
   /// Returns attributes for an abbreviation.
   const SmallVector<AttributeEncoding, 1> &getAttributes() const {
     return AttrVect;
@@ -409,9 +410,9 @@ public:
   /// Returns type units that were constructed.
   const TUVectorTy &getTypeUnitsSymbols() { return TUSymbolsOrHashes; }
   /// Add a type unit start symbol.
-  void addTypeUnitSymbol(DwarfTypeUnit &U);
+  LLVM_ABI void addTypeUnitSymbol(DwarfTypeUnit &U);
   /// Add a type unit Signature.
-  void addTypeUnitSignature(DwarfTypeUnit &U);
+  LLVM_ABI void addTypeUnitSignature(DwarfTypeUnit &U);
   /// Convert DIE entries to explicit offset.
   /// Needs to be called after DIE offsets are computed.
   void convertDieToOffset() {
@@ -437,7 +438,7 @@ public:
   }
 };
 
-void emitAppleAccelTableImpl(AsmPrinter *Asm, AccelTableBase &Contents,
+LLVM_ABI void emitAppleAccelTableImpl(AsmPrinter *Asm, AccelTableBase &Contents,
                              StringRef Prefix, const MCSymbol *SecBegin,
                              ArrayRef<AppleAccelTableData::Atom> Atoms);
 
@@ -451,7 +452,7 @@ void emitAppleAccelTable(AsmPrinter *Asm, AccelTable<DataT> &Contents,
   emitAppleAccelTableImpl(Asm, Contents, Prefix, SecBegin, DataT::Atoms);
 }
 
-void emitDWARF5AccelTable(AsmPrinter *Asm, DWARF5AccelTable &Contents,
+LLVM_ABI void emitDWARF5AccelTable(AsmPrinter *Asm, DWARF5AccelTable &Contents,
                           const DwarfDebug &DD,
                           ArrayRef<std::unique_ptr<DwarfCompileUnit>> CUs);
 
@@ -459,7 +460,7 @@ void emitDWARF5AccelTable(AsmPrinter *Asm, DWARF5AccelTable &Contents,
 /// AccelTable. The \p CUs contains either symbols keeping offsets to the
 /// start of compilation unit, either offsets to the start of compilation
 /// unit themselves.
-void emitDWARF5AccelTable(
+LLVM_ABI void emitDWARF5AccelTable(
     AsmPrinter *Asm, DWARF5AccelTable &Contents,
     ArrayRef<std::variant<MCSymbol *, uint64_t>> CUs,
     llvm::function_ref<std::optional<DWARF5AccelTable::UnitIndexAndEncoding>(
@@ -468,7 +469,7 @@ void emitDWARF5AccelTable(
 
 /// Accelerator table data implementation for simple Apple accelerator tables
 /// with just a DIE reference.
-class AppleAccelTableOffsetData : public AppleAccelTableData {
+class LLVM_ABI AppleAccelTableOffsetData : public AppleAccelTableData {
 public:
   AppleAccelTableOffsetData(const DIE &D) : Die(D) {}
 
@@ -487,7 +488,7 @@ protected:
 };
 
 /// Accelerator table data implementation for Apple type accelerator tables.
-class AppleAccelTableTypeData : public AppleAccelTableOffsetData {
+class LLVM_ABI AppleAccelTableTypeData : public AppleAccelTableOffsetData {
 public:
   AppleAccelTableTypeData(const DIE &D) : AppleAccelTableOffsetData(D) {}
 
@@ -505,7 +506,7 @@ public:
 
 /// Accelerator table data implementation for simple Apple accelerator tables
 /// with a DIE offset but no actual DIE pointer.
-class AppleAccelTableStaticOffsetData : public AppleAccelTableData {
+class LLVM_ABI AppleAccelTableStaticOffsetData : public AppleAccelTableData {
 public:
   AppleAccelTableStaticOffsetData(uint32_t Offset) : Offset(Offset) {}
 
@@ -525,7 +526,7 @@ protected:
 
 /// Accelerator table data implementation for type accelerator tables with
 /// a DIE offset but no actual DIE pointer.
-class AppleAccelTableStaticTypeData : public AppleAccelTableStaticOffsetData {
+class LLVM_ABI AppleAccelTableStaticTypeData : public AppleAccelTableStaticOffsetData {
 public:
   AppleAccelTableStaticTypeData(uint32_t Offset, uint16_t Tag,
                                 bool ObjCClassIsImplementation,

--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_ASMPRINTER_H
 #define LLVM_CODEGEN_ASMPRINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -86,7 +87,7 @@ class RemarkStreamer;
 }
 
 /// This class is intended to be used as a driving class for all asm writers.
-class AsmPrinter : public MachineFunctionPass {
+class LLVM_ABI AsmPrinter : public MachineFunctionPass {
 public:
   /// Target machine description.
   TargetMachine &TM;
@@ -369,7 +370,7 @@ public:
     const class Function *Fn;
     uint8_t Version;
 
-    void emit(int, MCStreamer *) const;
+    LLVM_ABI void emit(int, MCStreamer *) const;
   };
 
   // All the sleds to be emitted.

--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -15,7 +15,6 @@
 #ifndef LLVM_CODEGEN_ASMPRINTER_H
 #define LLVM_CODEGEN_ASMPRINTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -27,6 +26,7 @@
 #include "llvm/CodeGen/StackMaps.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/IR/InlineAsm.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cstdint>
 #include <memory>

--- a/llvm/include/llvm/CodeGen/AsmPrinterHandler.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinterHandler.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_ASMPRINTERHANDLER_H
 #define LLVM_CODEGEN_ASMPRINTERHANDLER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 
 namespace llvm {
@@ -30,7 +31,7 @@ typedef MCSymbol *ExceptionSymbolProvider(AsmPrinter *Asm,
 
 /// Collects and handles AsmPrinter objects required to build debug
 /// or EH information.
-class AsmPrinterHandler {
+class LLVM_ABI AsmPrinterHandler {
 public:
   virtual ~AsmPrinterHandler();
 

--- a/llvm/include/llvm/CodeGen/CallingConvLower.h
+++ b/llvm/include/llvm/CodeGen/CallingConvLower.h
@@ -14,13 +14,13 @@
 #ifndef LLVM_CODEGEN_CALLINGCONVLOWER_H
 #define LLVM_CODEGEN_CALLINGCONVLOWER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/CodeGen/TargetCallingConv.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/Support/Alignment.h"
+#include "llvm/Support/Compiler.h"
 #include <variant>
 
 namespace llvm {
@@ -230,8 +230,8 @@ private:
 
 public:
   LLVM_ABI CCState(CallingConv::ID CC, bool IsVarArg, MachineFunction &MF,
-          SmallVectorImpl<CCValAssign> &Locs, LLVMContext &Context,
-          bool NegativeOffsets = false);
+                   SmallVectorImpl<CCValAssign> &Locs, LLVMContext &Context,
+                   bool NegativeOffsets = false);
 
   void addLoc(const CCValAssign &V) {
     Locs.push_back(V);
@@ -260,8 +260,9 @@ public:
 
   /// AnalyzeFormalArguments - Analyze an array of argument values,
   /// incorporating info about the formals into this state.
-  LLVM_ABI void AnalyzeFormalArguments(const SmallVectorImpl<ISD::InputArg> &Ins,
-                              CCAssignFn Fn);
+  LLVM_ABI void
+  AnalyzeFormalArguments(const SmallVectorImpl<ISD::InputArg> &Ins,
+                         CCAssignFn Fn);
 
   /// The function will invoke AnalyzeFormalArguments.
   void AnalyzeArguments(const SmallVectorImpl<ISD::InputArg> &Ins,
@@ -272,24 +273,24 @@ public:
   /// AnalyzeReturn - Analyze the returned values of a return,
   /// incorporating info about the result values into this state.
   LLVM_ABI void AnalyzeReturn(const SmallVectorImpl<ISD::OutputArg> &Outs,
-                     CCAssignFn Fn);
+                              CCAssignFn Fn);
 
   /// CheckReturn - Analyze the return values of a function, returning
   /// true if the return can be performed without sret-demotion, and
   /// false otherwise.
   LLVM_ABI bool CheckReturn(const SmallVectorImpl<ISD::OutputArg> &Outs,
-                   CCAssignFn Fn);
+                            CCAssignFn Fn);
 
   /// AnalyzeCallOperands - Analyze the outgoing arguments to a call,
   /// incorporating info about the passed values into this state.
   LLVM_ABI void AnalyzeCallOperands(const SmallVectorImpl<ISD::OutputArg> &Outs,
-                           CCAssignFn Fn);
+                                    CCAssignFn Fn);
 
   /// AnalyzeCallOperands - Same as above except it takes vectors of types
   /// and argument flags.
   LLVM_ABI void AnalyzeCallOperands(SmallVectorImpl<MVT> &ArgVTs,
-                           SmallVectorImpl<ISD::ArgFlagsTy> &Flags,
-                           CCAssignFn Fn);
+                                    SmallVectorImpl<ISD::ArgFlagsTy> &Flags,
+                                    CCAssignFn Fn);
 
   /// The function will invoke AnalyzeCallOperands.
   void AnalyzeArguments(const SmallVectorImpl<ISD::OutputArg> &Outs,
@@ -300,7 +301,7 @@ public:
   /// AnalyzeCallResult - Analyze the return values of a call,
   /// incorporating info about the passed values into this state.
   LLVM_ABI void AnalyzeCallResult(const SmallVectorImpl<ISD::InputArg> &Ins,
-                         CCAssignFn Fn);
+                                  CCAssignFn Fn);
 
   /// A shadow allocated register is a register that was allocated
   /// but wasn't added to the location list (Locs).
@@ -432,8 +433,8 @@ public:
   // value. The size and alignment information of the argument is encoded in its
   // parameter attribute.
   LLVM_ABI void HandleByVal(unsigned ValNo, MVT ValVT, MVT LocVT,
-                   CCValAssign::LocInfo LocInfo, int MinSize, Align MinAlign,
-                   ISD::ArgFlagsTy ArgFlags);
+                            CCValAssign::LocInfo LocInfo, int MinSize,
+                            Align MinAlign, ISD::ArgFlagsTy ArgFlags);
 
   // Returns count of byval arguments that are to be stored (even partly)
   // in registers.
@@ -494,8 +495,8 @@ public:
   /// the given value type. This is useful when varargs are passed in the
   /// registers that normal prototyped parameters would be passed in, or for
   /// implementing perfect forwarding.
-  LLVM_ABI void getRemainingRegParmsForType(SmallVectorImpl<MCRegister> &Regs, MVT VT,
-                                   CCAssignFn Fn);
+  LLVM_ABI void getRemainingRegParmsForType(SmallVectorImpl<MCRegister> &Regs,
+                                            MVT VT, CCAssignFn Fn);
 
   /// Compute the set of registers that need to be preserved and forwarded to
   /// any musttail calls.
@@ -505,11 +506,11 @@ public:
 
   /// Returns true if the results of the two calling conventions are compatible.
   /// This is usually part of the check for tailcall eligibility.
-  LLVM_ABI static bool resultsCompatible(CallingConv::ID CalleeCC,
-                                CallingConv::ID CallerCC, MachineFunction &MF,
-                                LLVMContext &C,
-                                const SmallVectorImpl<ISD::InputArg> &Ins,
-                                CCAssignFn CalleeFn, CCAssignFn CallerFn);
+  LLVM_ABI static bool
+  resultsCompatible(CallingConv::ID CalleeCC, CallingConv::ID CallerCC,
+                    MachineFunction &MF, LLVMContext &C,
+                    const SmallVectorImpl<ISD::InputArg> &Ins,
+                    CCAssignFn CalleeFn, CCAssignFn CallerFn);
 
   /// The function runs an additional analysis pass over function arguments.
   /// It will mark each argument with the attribute flag SecArgPass.

--- a/llvm/include/llvm/CodeGen/CallingConvLower.h
+++ b/llvm/include/llvm/CodeGen/CallingConvLower.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_CALLINGCONVLOWER_H
 #define LLVM_CODEGEN_CALLINGCONVLOWER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/Register.h"
@@ -228,7 +229,7 @@ private:
   unsigned InRegsParamsProcessed;
 
 public:
-  CCState(CallingConv::ID CC, bool IsVarArg, MachineFunction &MF,
+  LLVM_ABI CCState(CallingConv::ID CC, bool IsVarArg, MachineFunction &MF,
           SmallVectorImpl<CCValAssign> &Locs, LLVMContext &Context,
           bool NegativeOffsets = false);
 
@@ -259,7 +260,7 @@ public:
 
   /// AnalyzeFormalArguments - Analyze an array of argument values,
   /// incorporating info about the formals into this state.
-  void AnalyzeFormalArguments(const SmallVectorImpl<ISD::InputArg> &Ins,
+  LLVM_ABI void AnalyzeFormalArguments(const SmallVectorImpl<ISD::InputArg> &Ins,
                               CCAssignFn Fn);
 
   /// The function will invoke AnalyzeFormalArguments.
@@ -270,23 +271,23 @@ public:
 
   /// AnalyzeReturn - Analyze the returned values of a return,
   /// incorporating info about the result values into this state.
-  void AnalyzeReturn(const SmallVectorImpl<ISD::OutputArg> &Outs,
+  LLVM_ABI void AnalyzeReturn(const SmallVectorImpl<ISD::OutputArg> &Outs,
                      CCAssignFn Fn);
 
   /// CheckReturn - Analyze the return values of a function, returning
   /// true if the return can be performed without sret-demotion, and
   /// false otherwise.
-  bool CheckReturn(const SmallVectorImpl<ISD::OutputArg> &Outs,
+  LLVM_ABI bool CheckReturn(const SmallVectorImpl<ISD::OutputArg> &Outs,
                    CCAssignFn Fn);
 
   /// AnalyzeCallOperands - Analyze the outgoing arguments to a call,
   /// incorporating info about the passed values into this state.
-  void AnalyzeCallOperands(const SmallVectorImpl<ISD::OutputArg> &Outs,
+  LLVM_ABI void AnalyzeCallOperands(const SmallVectorImpl<ISD::OutputArg> &Outs,
                            CCAssignFn Fn);
 
   /// AnalyzeCallOperands - Same as above except it takes vectors of types
   /// and argument flags.
-  void AnalyzeCallOperands(SmallVectorImpl<MVT> &ArgVTs,
+  LLVM_ABI void AnalyzeCallOperands(SmallVectorImpl<MVT> &ArgVTs,
                            SmallVectorImpl<ISD::ArgFlagsTy> &Flags,
                            CCAssignFn Fn);
 
@@ -298,17 +299,17 @@ public:
 
   /// AnalyzeCallResult - Analyze the return values of a call,
   /// incorporating info about the passed values into this state.
-  void AnalyzeCallResult(const SmallVectorImpl<ISD::InputArg> &Ins,
+  LLVM_ABI void AnalyzeCallResult(const SmallVectorImpl<ISD::InputArg> &Ins,
                          CCAssignFn Fn);
 
   /// A shadow allocated register is a register that was allocated
   /// but wasn't added to the location list (Locs).
   /// \returns true if the register was allocated as shadow or false otherwise.
-  bool IsShadowAllocatedReg(MCRegister Reg) const;
+  LLVM_ABI bool IsShadowAllocatedReg(MCRegister Reg) const;
 
   /// AnalyzeCallResult - Same as above except it's specialized for calls which
   /// produce a single value.
-  void AnalyzeCallResult(MVT VT, CCAssignFn Fn);
+  LLVM_ABI void AnalyzeCallResult(MVT VT, CCAssignFn Fn);
 
   /// getFirstUnallocated - Return the index of the first unallocated register
   /// in the set, or Regs.size() if they are all allocated.
@@ -416,7 +417,7 @@ public:
     return Offset;
   }
 
-  void ensureMaxAlignment(Align Alignment);
+  LLVM_ABI void ensureMaxAlignment(Align Alignment);
 
   /// Version of AllocateStack with list of extra registers to be shadowed.
   /// Note that, unlike AllocateReg, this shadows ALL of the shadow registers.
@@ -430,7 +431,7 @@ public:
   // HandleByVal - Allocate a stack slot large enough to pass an argument by
   // value. The size and alignment information of the argument is encoded in its
   // parameter attribute.
-  void HandleByVal(unsigned ValNo, MVT ValVT, MVT LocVT,
+  LLVM_ABI void HandleByVal(unsigned ValNo, MVT ValVT, MVT LocVT,
                    CCValAssign::LocInfo LocInfo, int MinSize, Align MinAlign,
                    ISD::ArgFlagsTy ArgFlags);
 
@@ -493,18 +494,18 @@ public:
   /// the given value type. This is useful when varargs are passed in the
   /// registers that normal prototyped parameters would be passed in, or for
   /// implementing perfect forwarding.
-  void getRemainingRegParmsForType(SmallVectorImpl<MCRegister> &Regs, MVT VT,
+  LLVM_ABI void getRemainingRegParmsForType(SmallVectorImpl<MCRegister> &Regs, MVT VT,
                                    CCAssignFn Fn);
 
   /// Compute the set of registers that need to be preserved and forwarded to
   /// any musttail calls.
-  void analyzeMustTailForwardedRegisters(
+  LLVM_ABI void analyzeMustTailForwardedRegisters(
       SmallVectorImpl<ForwardedRegister> &Forwards, ArrayRef<MVT> RegParmTypes,
       CCAssignFn Fn);
 
   /// Returns true if the results of the two calling conventions are compatible.
   /// This is usually part of the check for tailcall eligibility.
-  static bool resultsCompatible(CallingConv::ID CalleeCC,
+  LLVM_ABI static bool resultsCompatible(CallingConv::ID CalleeCC,
                                 CallingConv::ID CallerCC, MachineFunction &MF,
                                 LLVMContext &C,
                                 const SmallVectorImpl<ISD::InputArg> &Ins,
@@ -543,9 +544,9 @@ public:
 
 private:
   /// MarkAllocated - Mark a register and all of its aliases as allocated.
-  void MarkAllocated(MCPhysReg Reg);
+  LLVM_ABI void MarkAllocated(MCPhysReg Reg);
 
-  void MarkUnallocated(MCPhysReg Reg);
+  LLVM_ABI void MarkUnallocated(MCPhysReg Reg);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/CodeGenTargetMachineImpl.h
+++ b/llvm/include/llvm/CodeGen/CodeGenTargetMachineImpl.h
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 #ifndef LLVM_CODEGEN_CODEGENTARGETMACHINEIMPL_H
 #define LLVM_CODEGEN_CODEGENTARGETMACHINEIMPL_H
+#include "llvm/Support/Compiler.h"
 #include "llvm/Target/TargetMachine.h"
 
 namespace llvm {
@@ -20,7 +21,7 @@ namespace llvm {
 /// for targets that make use of the independent code generator (CodeGen)
 /// library. Must not be used directly in code unless to inherit its
 /// implementation.
-class CodeGenTargetMachineImpl : public TargetMachine {
+class LLVM_ABI CodeGenTargetMachineImpl : public TargetMachine {
 protected: // Can only create subclasses.
   CodeGenTargetMachineImpl(const Target &T, StringRef DataLayoutString,
                            const Triple &TT, StringRef CPU, StringRef FS,

--- a/llvm/include/llvm/CodeGen/CommandFlags.h
+++ b/llvm/include/llvm/CodeGen/CommandFlags.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_COMMANDFLAGS_H
 #define LLVM_CODEGEN_COMMANDFLAGS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Target/TargetOptions.h"
@@ -32,138 +33,138 @@ class TargetMachine;
 
 namespace codegen {
 
-std::string getMArch();
+LLVM_ABI std::string getMArch();
 
-std::string getMCPU();
+LLVM_ABI std::string getMCPU();
 
-std::vector<std::string> getMAttrs();
+LLVM_ABI std::vector<std::string> getMAttrs();
 
-Reloc::Model getRelocModel();
-std::optional<Reloc::Model> getExplicitRelocModel();
+LLVM_ABI Reloc::Model getRelocModel();
+LLVM_ABI std::optional<Reloc::Model> getExplicitRelocModel();
 
-ThreadModel::Model getThreadModel();
+LLVM_ABI ThreadModel::Model getThreadModel();
 
-CodeModel::Model getCodeModel();
-std::optional<CodeModel::Model> getExplicitCodeModel();
+LLVM_ABI CodeModel::Model getCodeModel();
+LLVM_ABI std::optional<CodeModel::Model> getExplicitCodeModel();
 
-uint64_t getLargeDataThreshold();
-std::optional<uint64_t> getExplicitLargeDataThreshold();
+LLVM_ABI uint64_t getLargeDataThreshold();
+LLVM_ABI std::optional<uint64_t> getExplicitLargeDataThreshold();
 
-llvm::ExceptionHandling getExceptionModel();
+LLVM_ABI llvm::ExceptionHandling getExceptionModel();
 
-std::optional<CodeGenFileType> getExplicitFileType();
+LLVM_ABI std::optional<CodeGenFileType> getExplicitFileType();
 
-CodeGenFileType getFileType();
+LLVM_ABI CodeGenFileType getFileType();
 
-FramePointerKind getFramePointerUsage();
+LLVM_ABI FramePointerKind getFramePointerUsage();
 
-bool getEnableUnsafeFPMath();
+LLVM_ABI bool getEnableUnsafeFPMath();
 
-bool getEnableNoInfsFPMath();
+LLVM_ABI bool getEnableNoInfsFPMath();
 
-bool getEnableNoNaNsFPMath();
+LLVM_ABI bool getEnableNoNaNsFPMath();
 
-bool getEnableNoSignedZerosFPMath();
+LLVM_ABI bool getEnableNoSignedZerosFPMath();
 
-bool getEnableApproxFuncFPMath();
+LLVM_ABI bool getEnableApproxFuncFPMath();
 
-bool getEnableNoTrappingFPMath();
+LLVM_ABI bool getEnableNoTrappingFPMath();
 
-DenormalMode::DenormalModeKind getDenormalFPMath();
-DenormalMode::DenormalModeKind getDenormalFP32Math();
+LLVM_ABI DenormalMode::DenormalModeKind getDenormalFPMath();
+LLVM_ABI DenormalMode::DenormalModeKind getDenormalFP32Math();
 
-bool getEnableHonorSignDependentRoundingFPMath();
+LLVM_ABI bool getEnableHonorSignDependentRoundingFPMath();
 
-llvm::FloatABI::ABIType getFloatABIForCalls();
+LLVM_ABI llvm::FloatABI::ABIType getFloatABIForCalls();
 
-llvm::FPOpFusion::FPOpFusionMode getFuseFPOps();
+LLVM_ABI llvm::FPOpFusion::FPOpFusionMode getFuseFPOps();
 
-SwiftAsyncFramePointerMode getSwiftAsyncFramePointer();
+LLVM_ABI SwiftAsyncFramePointerMode getSwiftAsyncFramePointer();
 
-bool getDontPlaceZerosInBSS();
+LLVM_ABI bool getDontPlaceZerosInBSS();
 
-bool getEnableGuaranteedTailCallOpt();
+LLVM_ABI bool getEnableGuaranteedTailCallOpt();
 
-bool getEnableAIXExtendedAltivecABI();
+LLVM_ABI bool getEnableAIXExtendedAltivecABI();
 
-bool getDisableTailCalls();
+LLVM_ABI bool getDisableTailCalls();
 
-bool getStackSymbolOrdering();
+LLVM_ABI bool getStackSymbolOrdering();
 
-bool getStackRealign();
+LLVM_ABI bool getStackRealign();
 
-std::string getTrapFuncName();
+LLVM_ABI std::string getTrapFuncName();
 
-bool getUseCtors();
+LLVM_ABI bool getUseCtors();
 
-bool getDisableIntegratedAS();
+LLVM_ABI bool getDisableIntegratedAS();
 
-bool getDataSections();
-std::optional<bool> getExplicitDataSections();
+LLVM_ABI bool getDataSections();
+LLVM_ABI std::optional<bool> getExplicitDataSections();
 
-bool getFunctionSections();
-std::optional<bool> getExplicitFunctionSections();
+LLVM_ABI bool getFunctionSections();
+LLVM_ABI std::optional<bool> getExplicitFunctionSections();
 
-bool getIgnoreXCOFFVisibility();
+LLVM_ABI bool getIgnoreXCOFFVisibility();
 
-bool getXCOFFTracebackTable();
+LLVM_ABI bool getXCOFFTracebackTable();
 
-std::string getBBSections();
+LLVM_ABI std::string getBBSections();
 
-unsigned getTLSSize();
+LLVM_ABI unsigned getTLSSize();
 
-bool getEmulatedTLS();
-std::optional<bool> getExplicitEmulatedTLS();
+LLVM_ABI bool getEmulatedTLS();
+LLVM_ABI std::optional<bool> getExplicitEmulatedTLS();
 
-bool getEnableTLSDESC();
-std::optional<bool> getExplicitEnableTLSDESC();
+LLVM_ABI bool getEnableTLSDESC();
+LLVM_ABI std::optional<bool> getExplicitEnableTLSDESC();
 
-bool getUniqueSectionNames();
+LLVM_ABI bool getUniqueSectionNames();
 
-bool getUniqueBasicBlockSectionNames();
+LLVM_ABI bool getUniqueBasicBlockSectionNames();
 
-bool getSeparateNamedSections();
+LLVM_ABI bool getSeparateNamedSections();
 
-llvm::EABI getEABIVersion();
+LLVM_ABI llvm::EABI getEABIVersion();
 
-llvm::DebuggerKind getDebuggerTuningOpt();
+LLVM_ABI llvm::DebuggerKind getDebuggerTuningOpt();
 
-bool getEnableStackSizeSection();
+LLVM_ABI bool getEnableStackSizeSection();
 
-bool getEnableAddrsig();
+LLVM_ABI bool getEnableAddrsig();
 
-bool getEmitCallSiteInfo();
+LLVM_ABI bool getEmitCallSiteInfo();
 
-bool getEnableMachineFunctionSplitter();
+LLVM_ABI bool getEnableMachineFunctionSplitter();
 
-bool getEnableStaticDataPartitioning();
+LLVM_ABI bool getEnableStaticDataPartitioning();
 
-bool getEnableDebugEntryValues();
+LLVM_ABI bool getEnableDebugEntryValues();
 
-bool getValueTrackingVariableLocations();
-std::optional<bool> getExplicitValueTrackingVariableLocations();
+LLVM_ABI bool getValueTrackingVariableLocations();
+LLVM_ABI std::optional<bool> getExplicitValueTrackingVariableLocations();
 
-bool getForceDwarfFrameSection();
+LLVM_ABI bool getForceDwarfFrameSection();
 
-bool getXRayFunctionIndex();
+LLVM_ABI bool getXRayFunctionIndex();
 
-bool getDebugStrictDwarf();
+LLVM_ABI bool getDebugStrictDwarf();
 
-unsigned getAlignLoops();
+LLVM_ABI unsigned getAlignLoops();
 
-bool getJMCInstrument();
+LLVM_ABI bool getJMCInstrument();
 
-bool getXCOFFReadOnlyPointers();
+LLVM_ABI bool getXCOFFReadOnlyPointers();
 
 /// Create this object with static storage to register codegen-related command
 /// line options.
 struct RegisterCodeGenFlags {
-  RegisterCodeGenFlags();
+  LLVM_ABI RegisterCodeGenFlags();
 };
 
-bool getEnableBBAddrMap();
+LLVM_ABI bool getEnableBBAddrMap();
 
-llvm::BasicBlockSection getBBSectionsMode(llvm::TargetOptions &Options);
+LLVM_ABI llvm::BasicBlockSection getBBSectionsMode(llvm::TargetOptions &Options);
 
 /// Common utility function tightly tied to the options listed here. Initializes
 /// a TargetOptions object with CodeGen flags and returns it.
@@ -171,32 +172,32 @@ llvm::BasicBlockSection getBBSectionsMode(llvm::TargetOptions &Options);
 ///    options are not explicitly specified. If those triple dependant options
 ///    value do not have effect for your component, a default Triple() could be
 ///    passed in.
-TargetOptions InitTargetOptionsFromCodeGenFlags(const llvm::Triple &TheTriple);
+LLVM_ABI TargetOptions InitTargetOptionsFromCodeGenFlags(const llvm::Triple &TheTriple);
 
-std::string getCPUStr();
+LLVM_ABI std::string getCPUStr();
 
-std::string getFeaturesStr();
+LLVM_ABI std::string getFeaturesStr();
 
-std::vector<std::string> getFeatureList();
+LLVM_ABI std::vector<std::string> getFeatureList();
 
-void renderBoolStringAttr(AttrBuilder &B, StringRef Name, bool Val);
+LLVM_ABI void renderBoolStringAttr(AttrBuilder &B, StringRef Name, bool Val);
 
 /// Set function attributes of function \p F based on CPU, Features, and command
 /// line flags.
-void setFunctionAttributes(StringRef CPU, StringRef Features, Function &F);
+LLVM_ABI void setFunctionAttributes(StringRef CPU, StringRef Features, Function &F);
 
 /// Set function attributes of functions in Module M based on CPU,
 /// Features, and command line flags.
-void setFunctionAttributes(StringRef CPU, StringRef Features, Module &M);
+LLVM_ABI void setFunctionAttributes(StringRef CPU, StringRef Features, Module &M);
 
 /// Should value-tracking variable locations / instruction referencing be
 /// enabled by default for this triple?
-bool getDefaultValueTrackingVariableLocations(const llvm::Triple &T);
+LLVM_ABI bool getDefaultValueTrackingVariableLocations(const llvm::Triple &T);
 
 /// Creates a TargetMachine instance with the options defined on the command
 /// line. This can be used for tools that do not need further customization of
 /// the TargetOptions.
-Expected<std::unique_ptr<TargetMachine>> createTargetMachineForTriple(
+LLVM_ABI Expected<std::unique_ptr<TargetMachine>> createTargetMachineForTriple(
     StringRef TargetTriple,
     CodeGenOptLevel OptLevel = CodeGenOptLevel::Default);
 

--- a/llvm/include/llvm/CodeGen/CommandFlags.h
+++ b/llvm/include/llvm/CodeGen/CommandFlags.h
@@ -15,9 +15,9 @@
 #ifndef LLVM_CODEGEN_COMMANDFLAGS_H
 #define LLVM_CODEGEN_COMMANDFLAGS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Target/TargetOptions.h"
 #include <optional>
 #include <string>
@@ -164,7 +164,8 @@ struct RegisterCodeGenFlags {
 
 LLVM_ABI bool getEnableBBAddrMap();
 
-LLVM_ABI llvm::BasicBlockSection getBBSectionsMode(llvm::TargetOptions &Options);
+LLVM_ABI llvm::BasicBlockSection
+getBBSectionsMode(llvm::TargetOptions &Options);
 
 /// Common utility function tightly tied to the options listed here. Initializes
 /// a TargetOptions object with CodeGen flags and returns it.
@@ -172,7 +173,8 @@ LLVM_ABI llvm::BasicBlockSection getBBSectionsMode(llvm::TargetOptions &Options)
 ///    options are not explicitly specified. If those triple dependant options
 ///    value do not have effect for your component, a default Triple() could be
 ///    passed in.
-LLVM_ABI TargetOptions InitTargetOptionsFromCodeGenFlags(const llvm::Triple &TheTriple);
+LLVM_ABI TargetOptions
+InitTargetOptionsFromCodeGenFlags(const llvm::Triple &TheTriple);
 
 LLVM_ABI std::string getCPUStr();
 
@@ -184,11 +186,13 @@ LLVM_ABI void renderBoolStringAttr(AttrBuilder &B, StringRef Name, bool Val);
 
 /// Set function attributes of function \p F based on CPU, Features, and command
 /// line flags.
-LLVM_ABI void setFunctionAttributes(StringRef CPU, StringRef Features, Function &F);
+LLVM_ABI void setFunctionAttributes(StringRef CPU, StringRef Features,
+                                    Function &F);
 
 /// Set function attributes of functions in Module M based on CPU,
 /// Features, and command line flags.
-LLVM_ABI void setFunctionAttributes(StringRef CPU, StringRef Features, Module &M);
+LLVM_ABI void setFunctionAttributes(StringRef CPU, StringRef Features,
+                                    Module &M);
 
 /// Should value-tracking variable locations / instruction referencing be
 /// enabled by default for this triple?

--- a/llvm/include/llvm/CodeGen/DIE.h
+++ b/llvm/include/llvm/CodeGen/DIE.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_DIE_H
 #define LLVM_CODEGEN_DIE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -70,7 +71,7 @@ public:
   /// @}
 
   /// Used to gather unique data for the abbreviation folding set.
-  void Profile(FoldingSetNodeID &ID) const;
+  LLVM_ABI void Profile(FoldingSetNodeID &ID) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -121,13 +122,13 @@ public:
   }
 
   /// Used to gather unique data for the abbreviation folding set.
-  void Profile(FoldingSetNodeID &ID) const;
+  LLVM_ABI void Profile(FoldingSetNodeID &ID) const;
 
   /// Print the abbreviation using the specified asm printer.
-  void Emit(const AsmPrinter *AP) const;
+  LLVM_ABI void Emit(const AsmPrinter *AP) const;
 
-  void print(raw_ostream &O) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &O) const;
+  LLVM_ABI void dump() const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -148,7 +149,7 @@ class DIEAbbrevSet {
 
 public:
   DIEAbbrevSet(BumpPtrAllocator &A) : Alloc(A) {}
-  ~DIEAbbrevSet();
+  LLVM_ABI ~DIEAbbrevSet();
 
   /// Generate the abbreviation declaration for a DIE and return a pointer to
   /// the generated abbreviation.
@@ -156,10 +157,10 @@ public:
   /// \param Die the debug info entry to generate the abbreviation for.
   /// \returns A reference to the uniqued abbreviation declaration that is
   /// owned by this class.
-  DIEAbbrev &uniqueAbbreviation(DIE &Die);
+  LLVM_ABI DIEAbbrev &uniqueAbbreviation(DIE &Die);
 
   /// Print all abbreviations using the specified asm printer.
-  void Emit(const AsmPrinter *AP, MCSection *Section) const;
+  LLVM_ABI void Emit(const AsmPrinter *AP, MCSection *Section) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -195,10 +196,10 @@ public:
   uint64_t getValue() const { return Integer; }
   void setValue(uint64_t Val) { Integer = Val; }
 
-  void emitValue(const AsmPrinter *Asm, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *Asm, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -212,10 +213,10 @@ public:
   /// Get MCExpr.
   const MCExpr *getValue() const { return Expr; }
 
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -229,10 +230,10 @@ public:
   /// Get MCSymbol.
   const MCSymbol *getValue() const { return Label; }
 
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -247,11 +248,11 @@ public:
     : CU(TheCU), Index(Idx) {}
 
   /// EmitValue - Emit base type reference.
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
   /// sizeOf - Determine size of the base type reference in bytes.
-  unsigned sizeOf(const dwarf::FormParams &, dwarf::Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &, dwarf::Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
   uint64_t getIndex() const { return Index; }
 };
 
@@ -265,10 +266,10 @@ class DIEDelta {
 public:
   DIEDelta(const MCSymbol *Hi, const MCSymbol *Lo) : LabelHi(Hi), LabelLo(Lo) {}
 
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -284,10 +285,10 @@ public:
   /// Grab the string out of the object.
   StringRef getString() const { return S.getString(); }
 
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -306,10 +307,10 @@ public:
   /// Grab the string out of the object.
   StringRef getString() const { return S; }
 
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &, dwarf::Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &, dwarf::Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -325,10 +326,10 @@ public:
 
   DIE &getEntry() const { return *Entry; }
 
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -344,10 +345,10 @@ public:
   /// Grab the current index out.
   size_t getValue() const { return Index; }
 
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -360,10 +361,10 @@ public:
   explicit DIEAddrOffset(uint64_t Idx, const MCSymbol *Hi, const MCSymbol *Lo)
       : Addr(Idx), Offset(Hi, Lo) {}
 
-  void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -510,13 +511,13 @@ public:
 #include "llvm/CodeGen/DIEValue.def"
 
   /// Emit value via the Dwarf writer.
-  void emitValue(const AsmPrinter *AP) const;
+  LLVM_ABI void emitValue(const AsmPrinter *AP) const;
 
   /// Return the size of a value in bytes.
-  unsigned sizeOf(const dwarf::FormParams &FormParams) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams) const;
 
-  void print(raw_ostream &O) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &O) const;
+  LLVM_ABI void dump() const;
 };
 
 struct IntrusiveBackListNode {
@@ -879,20 +880,20 @@ public:
     return make_range(Children.begin(), Children.end());
   }
 
-  DIE *getParent() const;
+  LLVM_ABI DIE *getParent() const;
 
   /// Generate the abbreviation for this DIE.
   ///
   /// Calculate the abbreviation for this, which should be uniqued and
   /// eventually used to call \a setAbbrevNumber().
-  DIEAbbrev generateAbbrev() const;
+  LLVM_ABI DIEAbbrev generateAbbrev() const;
 
   /// Set the abbreviation number for this DIE.
   void setAbbrevNumber(unsigned I) { AbbrevNumber = I; }
 
   /// Get the absolute offset within the .debug_info or .debug_types section
   /// for this DIE.
-  uint64_t getDebugSectionOffset() const;
+  LLVM_ABI uint64_t getDebugSectionOffset() const;
 
   /// Compute the offset of this DIE and all its children.
   ///
@@ -910,7 +911,7 @@ public:
   /// \param CUOffset the compile/type unit relative offset in bytes.
   /// \returns the offset for the DIE that follows this DIE within the
   /// current compile/type unit.
-  unsigned computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
+  LLVM_ABI unsigned computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
                                     DIEAbbrevSet &AbbrevSet, unsigned CUOffset);
 
   /// Climb up the parent chain to get the compile unit or type unit DIE that
@@ -918,14 +919,14 @@ public:
   ///
   /// \returns the compile or type unit DIE that owns this DIE, or NULL if
   /// this DIE hasn't been added to a unit DIE.
-  const DIE *getUnitDie() const;
+  LLVM_ABI const DIE *getUnitDie() const;
 
   /// Climb up the parent chain to get the compile unit or type unit that this
   /// DIE belongs to.
   ///
   /// \returns the DIEUnit that represents the compile or type unit that owns
   /// this DIE, or NULL if this DIE hasn't been added to a unit DIE.
-  DIEUnit *getUnit() const;
+  LLVM_ABI DIEUnit *getUnit() const;
 
   void setOffset(unsigned O) { Offset = O; }
   void setSize(unsigned S) { Size = S; }
@@ -949,10 +950,10 @@ public:
   ///
   /// Returns a default-constructed DIEValue (where \a DIEValue::getType()
   /// gives \a DIEValue::isNone) if no such attribute exists.
-  DIEValue findAttribute(dwarf::Attribute Attribute) const;
+  LLVM_ABI DIEValue findAttribute(dwarf::Attribute Attribute) const;
 
-  void print(raw_ostream &O, unsigned IndentCount = 0) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &O, unsigned IndentCount = 0) const;
+  LLVM_ABI void dump() const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -972,7 +973,7 @@ protected:
   virtual ~DIEUnit() = default;
 
 public:
-  explicit DIEUnit(dwarf::Tag UnitTag);
+  LLVM_ABI explicit DIEUnit(dwarf::Tag UnitTag);
   DIEUnit(const DIEUnit &RHS) = delete;
   DIEUnit(DIEUnit &&RHS) = delete;
   void operator=(const DIEUnit &RHS) = delete;
@@ -1014,7 +1015,7 @@ public:
   DIELoc() = default;
 
   /// Calculate the size of the location expression.
-  unsigned computeSize(const dwarf::FormParams &FormParams) const;
+  LLVM_ABI unsigned computeSize(const dwarf::FormParams &FormParams) const;
 
   // TODO: move setSize() and Size to DIEValueList.
   void setSize(unsigned size) { Size = size; }
@@ -1034,10 +1035,10 @@ public:
     return dwarf::DW_FORM_block;
   }
 
-  void emitValue(const AsmPrinter *Asm, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *Asm, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 //===--------------------------------------------------------------------===//
@@ -1050,7 +1051,7 @@ public:
   DIEBlock() = default;
 
   /// Calculate the size of the location expression.
-  unsigned computeSize(const dwarf::FormParams &FormParams) const;
+  LLVM_ABI unsigned computeSize(const dwarf::FormParams &FormParams) const;
 
   // TODO: move setSize() and Size to DIEValueList.
   void setSize(unsigned size) { Size = size; }
@@ -1067,10 +1068,10 @@ public:
     return dwarf::DW_FORM_block;
   }
 
-  void emitValue(const AsmPrinter *Asm, dwarf::Form Form) const;
-  unsigned sizeOf(const dwarf::FormParams &, dwarf::Form Form) const;
+  LLVM_ABI void emitValue(const AsmPrinter *Asm, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &, dwarf::Form Form) const;
 
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/DIE.h
+++ b/llvm/include/llvm/CodeGen/DIE.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CODEGEN_DIE_H
 #define LLVM_CODEGEN_DIE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -25,6 +24,7 @@
 #include "llvm/CodeGen/DwarfStringPoolEntry.h"
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -197,7 +197,8 @@ public:
   void setValue(uint64_t Val) { Integer = Val; }
 
   LLVM_ABI void emitValue(const AsmPrinter *Asm, dwarf::Form Form) const;
-  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams,
+                           dwarf::Form Form) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
 };
@@ -214,7 +215,8 @@ public:
   const MCExpr *getValue() const { return Expr; }
 
   LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams,
+                           dwarf::Form Form) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
 };
@@ -231,7 +233,8 @@ public:
   const MCSymbol *getValue() const { return Label; }
 
   LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams,
+                           dwarf::Form Form) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
 };
@@ -267,7 +270,8 @@ public:
   DIEDelta(const MCSymbol *Hi, const MCSymbol *Lo) : LabelHi(Hi), LabelLo(Lo) {}
 
   LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams,
+                           dwarf::Form Form) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
 };
@@ -286,7 +290,8 @@ public:
   StringRef getString() const { return S.getString(); }
 
   LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams,
+                           dwarf::Form Form) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
 };
@@ -327,7 +332,8 @@ public:
   DIE &getEntry() const { return *Entry; }
 
   LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams,
+                           dwarf::Form Form) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
 };
@@ -346,7 +352,8 @@ public:
   size_t getValue() const { return Index; }
 
   LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams,
+                           dwarf::Form Form) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
 };
@@ -362,7 +369,8 @@ public:
       : Addr(Idx), Offset(Hi, Lo) {}
 
   LLVM_ABI void emitValue(const AsmPrinter *AP, dwarf::Form Form) const;
-  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams, dwarf::Form Form) const;
+  LLVM_ABI unsigned sizeOf(const dwarf::FormParams &FormParams,
+                           dwarf::Form Form) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
 };
@@ -911,8 +919,9 @@ public:
   /// \param CUOffset the compile/type unit relative offset in bytes.
   /// \returns the offset for the DIE that follows this DIE within the
   /// current compile/type unit.
-  LLVM_ABI unsigned computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
-                                    DIEAbbrevSet &AbbrevSet, unsigned CUOffset);
+  LLVM_ABI unsigned
+  computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
+                           DIEAbbrevSet &AbbrevSet, unsigned CUOffset);
 
   /// Climb up the parent chain to get the compile unit or type unit DIE that
   /// this DIE belongs to.

--- a/llvm/include/llvm/CodeGen/DroppedVariableStatsMIR.h
+++ b/llvm/include/llvm/CodeGen/DroppedVariableStatsMIR.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_DROPPEDVARIABLESTATSMIR_H
 #define LLVM_CODEGEN_DROPPEDVARIABLESTATSMIR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/IR/DroppedVariableStats.h"
 
@@ -22,7 +23,7 @@ namespace llvm {
 /// A class to collect and print dropped debug information due to MIR
 /// optimization passes. After every MIR pass is run, it will print how many
 /// #DBG_VALUEs were dropped due to that pass.
-class DroppedVariableStatsMIR : public DroppedVariableStats {
+class LLVM_ABI DroppedVariableStatsMIR : public DroppedVariableStats {
 public:
   DroppedVariableStatsMIR() : DroppedVariableStats(false) {}
 

--- a/llvm/include/llvm/CodeGen/DroppedVariableStatsMIR.h
+++ b/llvm/include/llvm/CodeGen/DroppedVariableStatsMIR.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_CODEGEN_DROPPEDVARIABLESTATSMIR_H
 #define LLVM_CODEGEN_DROPPEDVARIABLESTATSMIR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/IR/DroppedVariableStats.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/GCMetadata.h
+++ b/llvm/include/llvm/CodeGen/GCMetadata.h
@@ -41,6 +41,7 @@
 #include "llvm/IR/GCStrategy.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -200,7 +201,7 @@ public:
 class CollectorMetadataAnalysis
     : public AnalysisInfoMixin<CollectorMetadataAnalysis> {
   friend struct AnalysisInfoMixin<CollectorMetadataAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = GCStrategyMap;
@@ -212,7 +213,7 @@ public:
 /// This pass depends on `CollectorMetadataAnalysis`.
 class GCFunctionAnalysis : public AnalysisInfoMixin<GCFunctionAnalysis> {
   friend struct AnalysisInfoMixin<GCFunctionAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = GCFunctionInfo;

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_CSEINFO_H
 #define LLVM_CODEGEN_GLOBALISEL_CSEINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/CodeGen/CSEConfigBase.h"
 #include "llvm/CodeGen/GlobalISel/GISelChangeObserver.h"
@@ -33,18 +34,18 @@ class UniqueMachineInstr : public FoldingSetNode {
   explicit UniqueMachineInstr(const MachineInstr *MI) : MI(MI) {}
 
 public:
-  void Profile(FoldingSetNodeID &ID);
+  LLVM_ABI void Profile(FoldingSetNodeID &ID);
 };
 
 // A CSE config for fully optimized builds.
-class CSEConfigFull : public CSEConfigBase {
+class LLVM_ABI CSEConfigFull : public CSEConfigBase {
 public:
   virtual ~CSEConfigFull() = default;
   bool shouldCSEOpc(unsigned Opc) override;
 };
 
 // Commonly used for O0 config.
-class CSEConfigConstantOnly : public CSEConfigBase {
+class LLVM_ABI CSEConfigConstantOnly : public CSEConfigBase {
 public:
   virtual ~CSEConfigConstantOnly() = default;
   bool shouldCSEOpc(unsigned Opc) override;
@@ -54,7 +55,7 @@ public:
 // We have this logic here so targets can make use of it from their derived
 // TargetPassConfig, but can't put this logic into TargetPassConfig directly
 // because the CodeGen library can't depend on GlobalISel.
-std::unique_ptr<CSEConfigBase>
+LLVM_ABI std::unique_ptr<CSEConfigBase>
 getStandardCSEConfigForOpt(CodeGenOptLevel Level);
 
 /// The CSE Analysis object.
@@ -67,7 +68,7 @@ getStandardCSEConfigForOpt(CodeGenOptLevel Level);
 /// CSEInfo should assert when trying to enter an incomplete instruction into
 /// the CSEMap. There is Opcode level granularity on which instructions can be
 /// CSE'd and for now, only Generic instructions are CSEable.
-class GISelCSEInfo : public GISelChangeObserver {
+class LLVM_ABI GISelCSEInfo : public GISelChangeObserver {
   // Make it accessible only to CSEMIRBuilder.
   friend class CSEMIRBuilder;
 
@@ -175,29 +176,29 @@ public:
   GISelInstProfileBuilder(FoldingSetNodeID &ID, const MachineRegisterInfo &MRI)
       : ID(ID), MRI(MRI) {}
   // Profiling methods.
-  const GISelInstProfileBuilder &addNodeIDOpcode(unsigned Opc) const;
-  const GISelInstProfileBuilder &addNodeIDRegType(const LLT Ty) const;
-  const GISelInstProfileBuilder &addNodeIDRegType(const Register) const;
-  const GISelInstProfileBuilder &
+  LLVM_ABI const GISelInstProfileBuilder &addNodeIDOpcode(unsigned Opc) const;
+  LLVM_ABI const GISelInstProfileBuilder &addNodeIDRegType(const LLT Ty) const;
+  LLVM_ABI const GISelInstProfileBuilder &addNodeIDRegType(const Register) const;
+  LLVM_ABI const GISelInstProfileBuilder &
       addNodeIDRegType(MachineRegisterInfo::VRegAttrs) const;
 
-  const GISelInstProfileBuilder &
+  LLVM_ABI const GISelInstProfileBuilder &
   addNodeIDRegType(const TargetRegisterClass *RC) const;
-  const GISelInstProfileBuilder &addNodeIDRegType(const RegisterBank *RB) const;
+  LLVM_ABI const GISelInstProfileBuilder &addNodeIDRegType(const RegisterBank *RB) const;
 
-  const GISelInstProfileBuilder &addNodeIDRegNum(Register Reg) const;
+  LLVM_ABI const GISelInstProfileBuilder &addNodeIDRegNum(Register Reg) const;
 
-  const GISelInstProfileBuilder &addNodeIDReg(Register Reg) const;
+  LLVM_ABI const GISelInstProfileBuilder &addNodeIDReg(Register Reg) const;
 
-  const GISelInstProfileBuilder &addNodeIDImmediate(int64_t Imm) const;
-  const GISelInstProfileBuilder &
+  LLVM_ABI const GISelInstProfileBuilder &addNodeIDImmediate(int64_t Imm) const;
+  LLVM_ABI const GISelInstProfileBuilder &
   addNodeIDMBB(const MachineBasicBlock *MBB) const;
 
-  const GISelInstProfileBuilder &
+  LLVM_ABI const GISelInstProfileBuilder &
   addNodeIDMachineOperand(const MachineOperand &MO) const;
 
-  const GISelInstProfileBuilder &addNodeIDFlag(unsigned Flag) const;
-  const GISelInstProfileBuilder &addNodeID(const MachineInstr *MI) const;
+  LLVM_ABI const GISelInstProfileBuilder &addNodeIDFlag(unsigned Flag) const;
+  LLVM_ABI const GISelInstProfileBuilder &addNodeID(const MachineInstr *MI) const;
 };
 
 /// Simple wrapper that does the following.
@@ -214,7 +215,7 @@ public:
   /// If CSEConfig is already set, and the CSE Analysis has been preserved,
   /// it will not use the new CSEOpt(use Recompute to force using the new
   /// CSEOpt).
-  GISelCSEInfo &get(std::unique_ptr<CSEConfigBase> CSEOpt,
+  LLVM_ABI GISelCSEInfo &get(std::unique_ptr<CSEConfigBase> CSEOpt,
                     bool ReCompute = false);
   void setMF(MachineFunction &MFunc) { MF = &MFunc; }
   void setComputed(bool Computed) { AlreadyComputed = Computed; }
@@ -222,7 +223,7 @@ public:
 };
 
 /// The actual analysis pass wrapper.
-class GISelCSEAnalysisWrapperPass : public MachineFunctionPass {
+class LLVM_ABI GISelCSEAnalysisWrapperPass : public MachineFunctionPass {
   GISelCSEAnalysisWrapper Wrapper;
 
 public:

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
@@ -12,7 +12,6 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_CSEINFO_H
 #define LLVM_CODEGEN_GLOBALISEL_CSEINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/CodeGen/CSEConfigBase.h"
 #include "llvm/CodeGen/GlobalISel/GISelChangeObserver.h"
@@ -21,6 +20,7 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class MachineBasicBlock;
@@ -178,13 +178,15 @@ public:
   // Profiling methods.
   LLVM_ABI const GISelInstProfileBuilder &addNodeIDOpcode(unsigned Opc) const;
   LLVM_ABI const GISelInstProfileBuilder &addNodeIDRegType(const LLT Ty) const;
-  LLVM_ABI const GISelInstProfileBuilder &addNodeIDRegType(const Register) const;
+  LLVM_ABI const GISelInstProfileBuilder &
+  addNodeIDRegType(const Register) const;
   LLVM_ABI const GISelInstProfileBuilder &
       addNodeIDRegType(MachineRegisterInfo::VRegAttrs) const;
 
   LLVM_ABI const GISelInstProfileBuilder &
   addNodeIDRegType(const TargetRegisterClass *RC) const;
-  LLVM_ABI const GISelInstProfileBuilder &addNodeIDRegType(const RegisterBank *RB) const;
+  LLVM_ABI const GISelInstProfileBuilder &
+  addNodeIDRegType(const RegisterBank *RB) const;
 
   LLVM_ABI const GISelInstProfileBuilder &addNodeIDRegNum(Register Reg) const;
 
@@ -198,7 +200,8 @@ public:
   addNodeIDMachineOperand(const MachineOperand &MO) const;
 
   LLVM_ABI const GISelInstProfileBuilder &addNodeIDFlag(unsigned Flag) const;
-  LLVM_ABI const GISelInstProfileBuilder &addNodeID(const MachineInstr *MI) const;
+  LLVM_ABI const GISelInstProfileBuilder &
+  addNodeID(const MachineInstr *MI) const;
 };
 
 /// Simple wrapper that does the following.
@@ -216,7 +219,7 @@ public:
   /// it will not use the new CSEOpt(use Recompute to force using the new
   /// CSEOpt).
   LLVM_ABI GISelCSEInfo &get(std::unique_ptr<CSEConfigBase> CSEOpt,
-                    bool ReCompute = false);
+                             bool ReCompute = false);
   void setMF(MachineFunction &MFunc) { MF = &MFunc; }
   void setComputed(bool Computed) { AlreadyComputed = Computed; }
   void releaseMemory() { Info.releaseMemory(); }

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEMIRBuilder.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEMIRBuilder.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_CSEMIRBUILDER_H
 #define LLVM_CODEGEN_GLOBALISEL_CSEMIRBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 
 namespace llvm {
@@ -35,7 +36,7 @@ class GISelInstProfileBuilder;
 ///
 /// Explicitly passing in a register would materialize a copy if possible.
 /// CSEMIRBuilder also does trivial constant folding for binary ops.
-class CSEMIRBuilder : public MachineIRBuilder {
+class LLVM_ABI CSEMIRBuilder : public MachineIRBuilder {
 
   /// Returns true if A dominates B (within the same basic block).
   /// Both iterators must be in the same basic block.

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEMIRBuilder.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEMIRBuilder.h
@@ -12,8 +12,8 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_CSEMIRBUILDER_H
 #define LLVM_CODEGEN_GLOBALISEL_CSEMIRBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_CALLLOWERING_H
 #define LLVM_CODEGEN_GLOBALISEL_CALLLOWERING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/CallingConvLower.h"
@@ -25,6 +24,7 @@
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cstdint>
 #include <functional>

--- a/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_CALLLOWERING_H
 #define LLVM_CODEGEN_GLOBALISEL_CALLLOWERING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/CallingConvLower.h"
@@ -41,7 +42,7 @@ struct MachinePointerInfo;
 class MachineRegisterInfo;
 class TargetLowering;
 
-class CallLowering {
+class LLVM_ABI CallLowering {
   const TargetLowering *TLI;
 
   virtual void anchor();
@@ -172,7 +173,7 @@ public:
   ///
   /// ValueAssigner should not depend on any specific function state, and
   /// only determine the types and locations for arguments.
-  struct ValueAssigner {
+  struct LLVM_ABI ValueAssigner {
     ValueAssigner(bool IsIncoming, CCAssignFn *AssignFn_,
                   CCAssignFn *AssignFnVarArg_ = nullptr)
         : AssignFn(AssignFn_), AssignFnVarArg(AssignFnVarArg_),
@@ -239,7 +240,7 @@ public:
         : ValueAssigner(false, AssignFn_, AssignFnVarArg_) {}
   };
 
-  struct ValueHandler {
+  struct LLVM_ABI ValueHandler {
     MachineIRBuilder &MIRBuilder;
     MachineRegisterInfo &MRI;
     const bool IsIncomingArgumentHandler;
@@ -328,7 +329,7 @@ public:
 
   /// Base class for ValueHandlers used for arguments coming into the current
   /// function, or for return values received from a call.
-  struct IncomingValueHandler : public ValueHandler {
+  struct LLVM_ABI IncomingValueHandler : public ValueHandler {
     IncomingValueHandler(MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI)
         : ValueHandler(/*IsIncoming*/ true, MIRBuilder, MRI) {}
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutor.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutor.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_GIMATCHTABLEEXECUTOR_H
 #define LLVM_CODEGEN_GLOBALISEL_GIMATCHTABLEEXECUTOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Bitset.h"
 #include "llvm/ADT/DenseMap.h"
@@ -631,7 +632,7 @@ protected:
     /// Whenever a type index is negative, we look here instead.
     SmallVector<LLT, 4> RecordedTypes;
 
-    MatcherState(unsigned MaxRenderers);
+    LLVM_ABI MatcherState(unsigned MaxRenderers);
   };
 
   bool shouldOptForSize(const MachineFunction *MF) const {
@@ -668,7 +669,7 @@ public:
   };
 
 protected:
-  GIMatchTableExecutor();
+  LLVM_ABI GIMatchTableExecutor();
 
   /// Execute a given matcher table and return true if the match was successful
   /// and false otherwise.
@@ -715,20 +716,20 @@ protected:
     llvm_unreachable("Subclass does not implement runCustomAction!");
   }
 
-  bool isOperandImmEqual(const MachineOperand &MO, int64_t Value,
+  LLVM_ABI bool isOperandImmEqual(const MachineOperand &MO, int64_t Value,
                          const MachineRegisterInfo &MRI,
                          bool Splat = false) const;
 
   /// Return true if the specified operand is a G_PTR_ADD with a G_CONSTANT on
   /// the right-hand side. GlobalISel's separation of pointer and integer types
   /// means that we don't need to worry about G_OR with equivalent semantics.
-  bool isBaseWithConstantOffset(const MachineOperand &Root,
+  LLVM_ABI bool isBaseWithConstantOffset(const MachineOperand &Root,
                                 const MachineRegisterInfo &MRI) const;
 
   /// Return true if MI can obviously be folded into IntoMI.
   /// MI and IntoMI do not need to be in the same basic blocks, but MI must
   /// preceed IntoMI.
-  bool isObviouslySafeToFold(MachineInstr &MI, MachineInstr &IntoMI) const;
+  LLVM_ABI bool isObviouslySafeToFold(MachineInstr &MI, MachineInstr &IntoMI) const;
 
   template <typename Ty> static Ty readBytesAs(const uint8_t *MatchTable) {
     Ty Ret;

--- a/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutor.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutor.h
@@ -15,7 +15,6 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_GIMATCHTABLEEXECUTOR_H
 #define LLVM_CODEGEN_GLOBALISEL_GIMATCHTABLEEXECUTOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Bitset.h"
 #include "llvm/ADT/DenseMap.h"
@@ -25,6 +24,7 @@
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGenTypes/LowLevelType.h"
 #include "llvm/IR/Function.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Transforms/Utils/SizeOpts.h"
 #include <bitset>
 #include <cstddef>
@@ -717,19 +717,20 @@ protected:
   }
 
   LLVM_ABI bool isOperandImmEqual(const MachineOperand &MO, int64_t Value,
-                         const MachineRegisterInfo &MRI,
-                         bool Splat = false) const;
+                                  const MachineRegisterInfo &MRI,
+                                  bool Splat = false) const;
 
   /// Return true if the specified operand is a G_PTR_ADD with a G_CONSTANT on
   /// the right-hand side. GlobalISel's separation of pointer and integer types
   /// means that we don't need to worry about G_OR with equivalent semantics.
   LLVM_ABI bool isBaseWithConstantOffset(const MachineOperand &Root,
-                                const MachineRegisterInfo &MRI) const;
+                                         const MachineRegisterInfo &MRI) const;
 
   /// Return true if MI can obviously be folded into IntoMI.
   /// MI and IntoMI do not need to be in the same basic blocks, but MI must
   /// preceed IntoMI.
-  LLVM_ABI bool isObviouslySafeToFold(MachineInstr &MI, MachineInstr &IntoMI) const;
+  LLVM_ABI bool isObviouslySafeToFold(MachineInstr &MI,
+                                      MachineInstr &IntoMI) const;
 
   template <typename Ty> static Ty readBytesAs(const uint8_t *MatchTable) {
     Ty Ret;

--- a/llvm/include/llvm/CodeGen/GlobalISel/GISelChangeObserver.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GISelChangeObserver.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_GISELCHANGEOBSERVER_H
 #define LLVM_CODEGEN_GLOBALISEL_GISELCHANGEOBSERVER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/CodeGen/MachineFunction.h"
 
@@ -52,10 +53,10 @@ public:
   /// For convenience, finishedChangingAllUsesOfReg() will report the completion
   /// of the changes. The use list may change between this call and
   /// finishedChangingAllUsesOfReg().
-  void changingAllUsesOfReg(const MachineRegisterInfo &MRI, Register Reg);
+  LLVM_ABI void changingAllUsesOfReg(const MachineRegisterInfo &MRI, Register Reg);
   /// All instructions reported as changing by changingAllUsesOfReg() have
   /// finished being changed.
-  void finishedChangingAllUsesOfReg();
+  LLVM_ABI void finishedChangingAllUsesOfReg();
 
 };
 
@@ -112,8 +113,8 @@ class RAIIDelegateInstaller {
   MachineFunction::Delegate *Delegate;
 
 public:
-  RAIIDelegateInstaller(MachineFunction &MF, MachineFunction::Delegate *Del);
-  ~RAIIDelegateInstaller();
+  LLVM_ABI RAIIDelegateInstaller(MachineFunction &MF, MachineFunction::Delegate *Del);
+  LLVM_ABI ~RAIIDelegateInstaller();
 };
 
 /// A simple RAII based Observer installer.
@@ -123,8 +124,8 @@ class RAIIMFObserverInstaller {
   MachineFunction &MF;
 
 public:
-  RAIIMFObserverInstaller(MachineFunction &MF, GISelChangeObserver &Observer);
-  ~RAIIMFObserverInstaller();
+  LLVM_ABI RAIIMFObserverInstaller(MachineFunction &MF, GISelChangeObserver &Observer);
+  LLVM_ABI ~RAIIMFObserverInstaller();
 };
 
 /// Class to install both of the above.
@@ -143,9 +144,9 @@ public:
 /// it at the end of the scope.
 class RAIITemporaryObserverInstaller {
 public:
-  RAIITemporaryObserverInstaller(GISelObserverWrapper &Observers,
+  LLVM_ABI RAIITemporaryObserverInstaller(GISelObserverWrapper &Observers,
                                  GISelChangeObserver &TemporaryObserver);
-  ~RAIITemporaryObserverInstaller();
+  LLVM_ABI ~RAIITemporaryObserverInstaller();
 
 private:
   GISelObserverWrapper &Observers;

--- a/llvm/include/llvm/CodeGen/GlobalISel/GISelChangeObserver.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GISelChangeObserver.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_GISELCHANGEOBSERVER_H
 #define LLVM_CODEGEN_GLOBALISEL_GISELCHANGEOBSERVER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class MachineInstr;
@@ -53,11 +53,11 @@ public:
   /// For convenience, finishedChangingAllUsesOfReg() will report the completion
   /// of the changes. The use list may change between this call and
   /// finishedChangingAllUsesOfReg().
-  LLVM_ABI void changingAllUsesOfReg(const MachineRegisterInfo &MRI, Register Reg);
+  LLVM_ABI void changingAllUsesOfReg(const MachineRegisterInfo &MRI,
+                                     Register Reg);
   /// All instructions reported as changing by changingAllUsesOfReg() have
   /// finished being changed.
   LLVM_ABI void finishedChangingAllUsesOfReg();
-
 };
 
 /// Simple wrapper observer that takes several observers, and calls
@@ -113,7 +113,8 @@ class RAIIDelegateInstaller {
   MachineFunction::Delegate *Delegate;
 
 public:
-  LLVM_ABI RAIIDelegateInstaller(MachineFunction &MF, MachineFunction::Delegate *Del);
+  LLVM_ABI RAIIDelegateInstaller(MachineFunction &MF,
+                                 MachineFunction::Delegate *Del);
   LLVM_ABI ~RAIIDelegateInstaller();
 };
 
@@ -124,7 +125,8 @@ class RAIIMFObserverInstaller {
   MachineFunction &MF;
 
 public:
-  LLVM_ABI RAIIMFObserverInstaller(MachineFunction &MF, GISelChangeObserver &Observer);
+  LLVM_ABI RAIIMFObserverInstaller(MachineFunction &MF,
+                                   GISelChangeObserver &Observer);
   LLVM_ABI ~RAIIMFObserverInstaller();
 };
 
@@ -144,7 +146,8 @@ public:
 /// it at the end of the scope.
 class RAIITemporaryObserverInstaller {
 public:
-  LLVM_ABI RAIITemporaryObserverInstaller(GISelObserverWrapper &Observers,
+  LLVM_ABI
+  RAIITemporaryObserverInstaller(GISelObserverWrapper &Observers,
                                  GISelChangeObserver &TemporaryObserver);
   LLVM_ABI ~RAIITemporaryObserverInstaller();
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
@@ -167,7 +167,7 @@ public:
 class GISelValueTrackingAnalysis
     : public AnalysisInfoMixin<GISelValueTrackingAnalysis> {
   friend AnalysisInfoMixin<GISelValueTrackingAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = GISelValueTracking;

--- a/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_GISELVALUETRACKING_H
 #define LLVM_CODEGEN_GLOBALISEL_GISELVALUETRACKING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/CodeGen/GlobalISel/GISelChangeObserver.h"
@@ -23,6 +22,7 @@
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/InitializePasses.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/KnownFPClass.h"
 
@@ -172,7 +172,8 @@ class GISelValueTrackingAnalysis
 public:
   using Result = GISelValueTracking;
 
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
 };
 
 class GISelValueTrackingPrinterPass
@@ -183,7 +184,7 @@ public:
   GISelValueTrackingPrinterPass(raw_ostream &OS) : OS(OS) {}
 
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_GISELVALUETRACKING_H
 #define LLVM_CODEGEN_GLOBALISEL_GISELVALUETRACKING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/CodeGen/GlobalISel/GISelChangeObserver.h"
@@ -30,7 +31,7 @@ namespace llvm {
 class TargetLowering;
 class DataLayout;
 
-class GISelValueTracking : public GISelChangeObserver {
+class LLVM_ABI GISelValueTracking : public GISelChangeObserver {
   MachineFunction &MF;
   MachineRegisterInfo &MRI;
   const TargetLowering &TL;
@@ -148,7 +149,7 @@ protected:
 /// Eventually add other features such as caching/ser/deserializing
 /// to MIR etc. Those implementations can derive from GISelValueTracking
 /// and override computeKnownBitsImpl.
-class GISelValueTrackingAnalysisLegacy : public MachineFunctionPass {
+class LLVM_ABI GISelValueTrackingAnalysisLegacy : public MachineFunctionPass {
   std::unique_ptr<GISelValueTracking> Info;
 
 public:
@@ -171,7 +172,7 @@ class GISelValueTrackingAnalysis
 public:
   using Result = GISelValueTracking;
 
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
 };
 
 class GISelValueTrackingPrinterPass
@@ -181,7 +182,7 @@ class GISelValueTrackingPrinterPass
 public:
   GISelValueTrackingPrinterPass(raw_ostream &OS) : OS(OS) {}
 
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 };
 } // namespace llvm

--- a/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelect.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelect.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_INSTRUCTIONSELECT_H
 #define LLVM_CODEGEN_GLOBALISEL_INSTRUCTIONSELECT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelect.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelect.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_INSTRUCTIONSELECT_H
 #define LLVM_CODEGEN_GLOBALISEL_INSTRUCTIONSELECT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
@@ -32,7 +33,7 @@ class ProfileSummaryInfo;
 /// reverse order.
 ///
 /// \post for all inst in MF: not isPreISelGenericOpcode(inst.opcode)
-class InstructionSelect : public MachineFunctionPass {
+class LLVM_ABI InstructionSelect : public MachineFunctionPass {
 public:
   static char ID;
   StringRef getPassName() const override { return "InstructionSelect"; }

--- a/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelector.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelector.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_INSTRUCTIONSELECTOR_H
 #define LLVM_CODEGEN_GLOBALISEL_INSTRUCTIONSELECTOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/GlobalISel/GIMatchTableExecutor.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class GISelObserverWrapper;

--- a/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelector.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelector.h
@@ -13,12 +13,13 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_INSTRUCTIONSELECTOR_H
 #define LLVM_CODEGEN_GLOBALISEL_INSTRUCTIONSELECTOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/GlobalISel/GIMatchTableExecutor.h"
 
 namespace llvm {
 class GISelObserverWrapper;
 
-class InstructionSelector : public GIMatchTableExecutor {
+class LLVM_ABI InstructionSelector : public GIMatchTableExecutor {
 public:
   virtual ~InstructionSelector();
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegacyLegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegacyLegalizerInfo.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LEGACYLEGALIZERINFO_H
 #define LLVM_CODEGEN_GLOBALISEL_LEGACYLEGALIZERINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/CodeGenTypes/LowLevelType.h"
@@ -75,7 +76,7 @@ enum LegacyLegalizeAction : std::uint8_t {
   NotFound,
 };
 } // end namespace LegacyLegalizeActions
-raw_ostream &operator<<(raw_ostream &OS,
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                         LegacyLegalizeActions::LegacyLegalizeAction Action);
 
 /// Legalization is decided based on an instruction's opcode, which type slot
@@ -125,7 +126,7 @@ public:
   using SizeChangeStrategy =
       std::function<SizeAndActionsVec(const SizeAndActionsVec &v)>;
 
-  LegacyLegalizerInfo();
+  LLVM_ABI LegacyLegalizerInfo();
 
   static bool needsLegalizingToDifferentSize(
       const LegacyLegalizeActions::LegacyLegalizeAction Action) {
@@ -145,7 +146,7 @@ public:
   /// Compute any ancillary tables needed to quickly decide how an operation
   /// should be handled. This must be called after all "set*Action"methods but
   /// before any query is made or incorrect results may be returned.
-  void computeTables();
+  LLVM_ABI void computeTables();
 
   /// More friendly way to set an action for common types that have an LLT
   /// representation.
@@ -267,19 +268,19 @@ public:
   }
 
   /// Helper function to implement many typical SizeChangeStrategy functions.
-  static SizeAndActionsVec increaseToLargerTypesAndDecreaseToLargest(
+  LLVM_ABI static SizeAndActionsVec increaseToLargerTypesAndDecreaseToLargest(
       const SizeAndActionsVec &v,
       LegacyLegalizeActions::LegacyLegalizeAction IncreaseAction,
       LegacyLegalizeActions::LegacyLegalizeAction DecreaseAction);
   /// Helper function to implement many typical SizeChangeStrategy functions.
-  static SizeAndActionsVec decreaseToSmallerTypesAndIncreaseToSmallest(
+  LLVM_ABI static SizeAndActionsVec decreaseToSmallerTypesAndIncreaseToSmallest(
       const SizeAndActionsVec &v,
       LegacyLegalizeActions::LegacyLegalizeAction DecreaseAction,
       LegacyLegalizeActions::LegacyLegalizeAction IncreaseAction);
 
-  LegacyLegalizeActionStep getAction(const LegalityQuery &Query) const;
+  LLVM_ABI LegacyLegalizeActionStep getAction(const LegalityQuery &Query) const;
 
-  unsigned getOpcodeIdxForOpcode(unsigned Opcode) const;
+  LLVM_ABI unsigned getOpcodeIdxForOpcode(unsigned Opcode) const;
 
 private:
   /// Determine what action should be taken to legalize the given generic

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegacyLegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegacyLegalizerInfo.h
@@ -15,10 +15,10 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LEGACYLEGALIZERINFO_H
 #define LLVM_CODEGEN_GLOBALISEL_LEGACYLEGALIZERINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/CodeGenTypes/LowLevelType.h"
+#include "llvm/Support/Compiler.h"
 #include <unordered_map>
 #include <vector>
 
@@ -76,8 +76,8 @@ enum LegacyLegalizeAction : std::uint8_t {
   NotFound,
 };
 } // end namespace LegacyLegalizeActions
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
-                        LegacyLegalizeActions::LegacyLegalizeAction Action);
+LLVM_ABI raw_ostream &
+operator<<(raw_ostream &OS, LegacyLegalizeActions::LegacyLegalizeAction Action);
 
 /// Legalization is decided based on an instruction's opcode, which type slot
 /// we're considering, and what the existing type is. These aspects are gathered

--- a/llvm/include/llvm/CodeGen/GlobalISel/Legalizer.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/Legalizer.h
@@ -20,6 +20,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LEGALIZER_H
 #define LLVM_CODEGEN_GLOBALISEL_LEGALIZER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/GlobalISel/GISelValueTracking.h"
@@ -34,7 +35,7 @@ class MachineInstr;
 class GISelChangeObserver;
 class LostDebugLocObserver;
 
-class Legalizer : public MachineFunctionPass {
+class LLVM_ABI Legalizer : public MachineFunctionPass {
 public:
   static char ID;
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/Legalizer.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/Legalizer.h
@@ -20,12 +20,12 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LEGALIZER_H
 #define LLVM_CODEGEN_GLOBALISEL_LEGALIZER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/GlobalISel/GISelValueTracking.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
@@ -20,12 +20,12 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LEGALIZERHELPER_H
 #define LLVM_CODEGEN_GLOBALISEL_LEGALIZERHELPER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/GISelValueTracking.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/RuntimeLibcallUtil.h"
 #include "llvm/CodeGen/TargetOpcodes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 // Forward declarations.
@@ -81,10 +81,10 @@ public:
   GISelValueTracking *getValueTracking() const { return VT; }
 
   LLVM_ABI LegalizerHelper(MachineFunction &MF, GISelChangeObserver &Observer,
-                  MachineIRBuilder &B);
+                           MachineIRBuilder &B);
   LLVM_ABI LegalizerHelper(MachineFunction &MF, const LegalizerInfo &LI,
-                  GISelChangeObserver &Observer, MachineIRBuilder &B,
-                  GISelValueTracking *VT = nullptr);
+                           GISelChangeObserver &Observer, MachineIRBuilder &B,
+                           GISelValueTracking *VT = nullptr);
 
   /// Replace \p MI by a sequence of legal instructions that can implement the
   /// same operation. Note that this means \p MI may be deleted, so any iterator
@@ -94,19 +94,22 @@ public:
   /// Considered as an opaque blob, the legal code will use and define the same
   /// registers as \p MI.
   LLVM_ABI LegalizeResult legalizeInstrStep(MachineInstr &MI,
-                                   LostDebugLocObserver &LocObserver);
+                                            LostDebugLocObserver &LocObserver);
 
   /// Legalize an instruction by emiting a runtime library call instead.
-  LLVM_ABI LegalizeResult libcall(MachineInstr &MI, LostDebugLocObserver &LocObserver);
+  LLVM_ABI LegalizeResult libcall(MachineInstr &MI,
+                                  LostDebugLocObserver &LocObserver);
 
   /// Legalize an instruction by reducing the width of the underlying scalar
   /// type.
-  LLVM_ABI LegalizeResult narrowScalar(MachineInstr &MI, unsigned TypeIdx, LLT NarrowTy);
+  LLVM_ABI LegalizeResult narrowScalar(MachineInstr &MI, unsigned TypeIdx,
+                                       LLT NarrowTy);
 
   /// Legalize an instruction by performing the operation on a wider scalar type
   /// (for example a 16-bit addition can be safely performed at 32-bits
   /// precision, ignoring the unused bits).
-  LLVM_ABI LegalizeResult widenScalar(MachineInstr &MI, unsigned TypeIdx, LLT WideTy);
+  LLVM_ABI LegalizeResult widenScalar(MachineInstr &MI, unsigned TypeIdx,
+                                      LLT WideTy);
 
   /// Legalize an instruction by replacing the value type
   LLVM_ABI LegalizeResult bitcast(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
@@ -117,13 +120,13 @@ public:
 
   /// Legalize a vector instruction by splitting into multiple components, each
   /// acting on the same scalar type as the original but with fewer elements.
-  LLVM_ABI LegalizeResult fewerElementsVector(MachineInstr &MI, unsigned TypeIdx,
-                                     LLT NarrowTy);
+  LLVM_ABI LegalizeResult fewerElementsVector(MachineInstr &MI,
+                                              unsigned TypeIdx, LLT NarrowTy);
 
   /// Legalize a vector instruction by increasing the number of vector elements
   /// involved and ignoring the added elements later.
   LLVM_ABI LegalizeResult moreElementsVector(MachineInstr &MI, unsigned TypeIdx,
-                                    LLT MoreTy);
+                                             LLT MoreTy);
 
   /// Cast the given value to an LLT::scalar with an equivalent size. Returns
   /// the register to use if an instruction was inserted. Returns the original
@@ -137,7 +140,7 @@ public:
   /// ExtOpcode for the extension instruction, and replacing the vreg of the
   /// operand in place.
   LLVM_ABI void widenScalarSrc(MachineInstr &MI, LLT WideTy, unsigned OpIdx,
-                      unsigned ExtOpcode);
+                               unsigned ExtOpcode);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// Use by truncating the operand's type to \p NarrowTy using G_TRUNC, and
@@ -148,22 +151,24 @@ public:
   /// Def by extending the operand's type to \p WideTy and truncating it back
   /// with the \p TruncOpcode, and replacing the vreg of the operand in place.
   LLVM_ABI void widenScalarDst(MachineInstr &MI, LLT WideTy, unsigned OpIdx = 0,
-                      unsigned TruncOpcode = TargetOpcode::G_TRUNC);
+                               unsigned TruncOpcode = TargetOpcode::G_TRUNC);
 
   // Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   // Def by truncating the operand's type to \p NarrowTy, replacing in place and
   // extending back with \p ExtOpcode.
   LLVM_ABI void narrowScalarDst(MachineInstr &MI, LLT NarrowTy, unsigned OpIdx,
-                       unsigned ExtOpcode);
+                                unsigned ExtOpcode);
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// Def by performing it with additional vector elements and extracting the
   /// result elements, and replacing the vreg of the operand in place.
-  LLVM_ABI void moreElementsVectorDst(MachineInstr &MI, LLT MoreTy, unsigned OpIdx);
+  LLVM_ABI void moreElementsVectorDst(MachineInstr &MI, LLT MoreTy,
+                                      unsigned OpIdx);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// Use by producing a vector with undefined high elements, extracting the
   /// original vector type, and replacing the vreg of the operand in place.
-  LLVM_ABI void moreElementsVectorSrc(MachineInstr &MI, LLT MoreTy, unsigned OpIdx);
+  LLVM_ABI void moreElementsVectorSrc(MachineInstr &MI, LLT MoreTy,
+                                      unsigned OpIdx);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// use by inserting a G_BITCAST to \p CastTy
@@ -293,15 +298,17 @@ private:
 public:
   /// Return the alignment to use for a stack temporary object with the given
   /// type.
-  LLVM_ABI Align getStackTemporaryAlignment(LLT Type, Align MinAlign = Align()) const;
+  LLVM_ABI Align getStackTemporaryAlignment(LLT Type,
+                                            Align MinAlign = Align()) const;
 
   /// Create a stack temporary based on the size in bytes and the alignment
-  LLVM_ABI MachineInstrBuilder createStackTemporary(TypeSize Bytes, Align Alignment,
-                                           MachinePointerInfo &PtrInfo);
+  LLVM_ABI MachineInstrBuilder createStackTemporary(
+      TypeSize Bytes, Align Alignment, MachinePointerInfo &PtrInfo);
 
   /// Create a store of \p Val to a stack temporary and return a load as the
   /// same type as \p Res.
-  LLVM_ABI MachineInstrBuilder createStackStoreLoad(const DstOp &Res, const SrcOp &Val);
+  LLVM_ABI MachineInstrBuilder createStackStoreLoad(const DstOp &Res,
+                                                    const SrcOp &Val);
 
   /// Given a store of a boolean vector, scalarize it.
   LLVM_ABI LegalizeResult scalarizeVectorBooleanStore(GStore &MI);
@@ -310,7 +317,8 @@ public:
   /// type \p VecTy starting at a base address of \p VecPtr. If \p Index is out
   /// of bounds the returned pointer is unspecified, but will be within the
   /// vector bounds.
-  LLVM_ABI Register getVectorElementPointer(Register VecPtr, LLT VecTy, Register Index);
+  LLVM_ABI Register getVectorElementPointer(Register VecPtr, LLT VecTy,
+                                            Register Index);
 
   /// Handles most opcodes. Split \p MI into same instruction on sub-vectors or
   /// scalars with \p NumElts elements (1 for scalar). Supports uneven splits:
@@ -323,76 +331,92 @@ public:
       std::initializer_list<unsigned> NonVecOpIndices = {});
 
   LLVM_ABI LegalizeResult fewerElementsVectorPhi(GenericMachineInstr &MI,
-                                        unsigned NumElts);
+                                                 unsigned NumElts);
 
-  LLVM_ABI LegalizeResult moreElementsVectorPhi(MachineInstr &MI, unsigned TypeIdx,
-                                       LLT MoreTy);
-  LLVM_ABI LegalizeResult moreElementsVectorShuffle(MachineInstr &MI, unsigned TypeIdx,
-                                           LLT MoreTy);
+  LLVM_ABI LegalizeResult moreElementsVectorPhi(MachineInstr &MI,
+                                                unsigned TypeIdx, LLT MoreTy);
+  LLVM_ABI LegalizeResult moreElementsVectorShuffle(MachineInstr &MI,
+                                                    unsigned TypeIdx,
+                                                    LLT MoreTy);
 
   LLVM_ABI LegalizeResult fewerElementsVectorUnmergeValues(MachineInstr &MI,
-                                                  unsigned TypeIdx,
-                                                  LLT NarrowTy);
-  LLVM_ABI LegalizeResult fewerElementsVectorMerge(MachineInstr &MI, unsigned TypeIdx,
-                                          LLT NarrowTy);
-  LLVM_ABI LegalizeResult fewerElementsVectorExtractInsertVectorElt(MachineInstr &MI,
                                                            unsigned TypeIdx,
                                                            LLT NarrowTy);
+  LLVM_ABI LegalizeResult fewerElementsVectorMerge(MachineInstr &MI,
+                                                   unsigned TypeIdx,
+                                                   LLT NarrowTy);
+  LLVM_ABI LegalizeResult fewerElementsVectorExtractInsertVectorElt(
+      MachineInstr &MI, unsigned TypeIdx, LLT NarrowTy);
 
   /// Equalize source and destination vector sizes of G_SHUFFLE_VECTOR.
   LLVM_ABI LegalizeResult equalizeVectorShuffleLengths(MachineInstr &MI);
 
   LLVM_ABI LegalizeResult reduceLoadStoreWidth(GLoadStore &MI, unsigned TypeIdx,
-                                      LLT NarrowTy);
+                                               LLT NarrowTy);
 
-  LLVM_ABI LegalizeResult narrowScalarShiftByConstant(MachineInstr &MI, const APInt &Amt,
-                                             LLT HalfTy, LLT ShiftAmtTy);
+  LLVM_ABI LegalizeResult narrowScalarShiftByConstant(MachineInstr &MI,
+                                                      const APInt &Amt,
+                                                      LLT HalfTy,
+                                                      LLT ShiftAmtTy);
 
   LLVM_ABI LegalizeResult fewerElementsVectorReductions(MachineInstr &MI,
-                                               unsigned TypeIdx, LLT NarrowTy);
+                                                        unsigned TypeIdx,
+                                                        LLT NarrowTy);
   LLVM_ABI LegalizeResult fewerElementsVectorSeqReductions(MachineInstr &MI,
-                                                  unsigned TypeIdx,
-                                                  LLT NarrowTy);
+                                                           unsigned TypeIdx,
+                                                           LLT NarrowTy);
 
   // Fewer Elements for bitcast, ensuring that the size of the Src and Dst
   // registers will be the same
-  LLVM_ABI LegalizeResult fewerElementsBitcast(MachineInstr &MI, unsigned TypeIdx,
-                                      LLT NarrowTy);
+  LLVM_ABI LegalizeResult fewerElementsBitcast(MachineInstr &MI,
+                                               unsigned TypeIdx, LLT NarrowTy);
 
-  LLVM_ABI LegalizeResult fewerElementsVectorShuffle(MachineInstr &MI, unsigned TypeIdx,
-                                            LLT NarrowTy);
+  LLVM_ABI LegalizeResult fewerElementsVectorShuffle(MachineInstr &MI,
+                                                     unsigned TypeIdx,
+                                                     LLT NarrowTy);
 
-  LLVM_ABI LegalizeResult narrowScalarShift(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarShift(MachineInstr &MI, unsigned TypeIdx,
+                                            LLT Ty);
   LLVM_ABI LegalizeResult narrowScalarAddSub(MachineInstr &MI, unsigned TypeIdx,
-                                    LLT NarrowTy);
+                                             LLT NarrowTy);
   LLVM_ABI LegalizeResult narrowScalarMul(MachineInstr &MI, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarFPTOI(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarExtract(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarInsert(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarFPTOI(MachineInstr &MI, unsigned TypeIdx,
+                                            LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarExtract(MachineInstr &MI,
+                                              unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarInsert(MachineInstr &MI, unsigned TypeIdx,
+                                             LLT Ty);
 
-  LLVM_ABI LegalizeResult narrowScalarBasic(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarExt(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarSelect(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarCTLZ(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarCTTZ(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarCTPOP(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LLVM_ABI LegalizeResult narrowScalarFLDEXP(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarBasic(MachineInstr &MI, unsigned TypeIdx,
+                                            LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarExt(MachineInstr &MI, unsigned TypeIdx,
+                                          LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarSelect(MachineInstr &MI, unsigned TypeIdx,
+                                             LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarCTLZ(MachineInstr &MI, unsigned TypeIdx,
+                                           LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarCTTZ(MachineInstr &MI, unsigned TypeIdx,
+                                           LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarCTPOP(MachineInstr &MI, unsigned TypeIdx,
+                                            LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarFLDEXP(MachineInstr &MI, unsigned TypeIdx,
+                                             LLT Ty);
 
   /// Perform Bitcast legalize action on G_EXTRACT_VECTOR_ELT.
-  LLVM_ABI LegalizeResult bitcastExtractVectorElt(MachineInstr &MI, unsigned TypeIdx,
-                                         LLT CastTy);
+  LLVM_ABI LegalizeResult bitcastExtractVectorElt(MachineInstr &MI,
+                                                  unsigned TypeIdx, LLT CastTy);
 
   /// Perform Bitcast legalize action on G_INSERT_VECTOR_ELT.
-  LLVM_ABI LegalizeResult bitcastInsertVectorElt(MachineInstr &MI, unsigned TypeIdx,
-                                        LLT CastTy);
-  LLVM_ABI LegalizeResult bitcastConcatVector(MachineInstr &MI, unsigned TypeIdx,
-                                     LLT CastTy);
-  LLVM_ABI LegalizeResult bitcastShuffleVector(MachineInstr &MI, unsigned TypeIdx,
-                                      LLT CastTy);
-  LLVM_ABI LegalizeResult bitcastExtractSubvector(MachineInstr &MI, unsigned TypeIdx,
-                                         LLT CastTy);
-  LLVM_ABI LegalizeResult bitcastInsertSubvector(MachineInstr &MI, unsigned TypeIdx,
-                                        LLT CastTy);
+  LLVM_ABI LegalizeResult bitcastInsertVectorElt(MachineInstr &MI,
+                                                 unsigned TypeIdx, LLT CastTy);
+  LLVM_ABI LegalizeResult bitcastConcatVector(MachineInstr &MI,
+                                              unsigned TypeIdx, LLT CastTy);
+  LLVM_ABI LegalizeResult bitcastShuffleVector(MachineInstr &MI,
+                                               unsigned TypeIdx, LLT CastTy);
+  LLVM_ABI LegalizeResult bitcastExtractSubvector(MachineInstr &MI,
+                                                  unsigned TypeIdx, LLT CastTy);
+  LLVM_ABI LegalizeResult bitcastInsertSubvector(MachineInstr &MI,
+                                                 unsigned TypeIdx, LLT CastTy);
 
   LLVM_ABI LegalizeResult lowerConstant(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerFConstant(MachineInstr &MI);
@@ -435,8 +459,9 @@ public:
   LLVM_ABI LegalizeResult lowerExtractInsertVectorElt(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerShuffleVector(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerVECTOR_COMPRESS(MachineInstr &MI);
-  LLVM_ABI Register getDynStackAllocTargetPtr(Register SPReg, Register AllocSize,
-                                     Align Alignment, LLT PtrTy);
+  LLVM_ABI Register getDynStackAllocTargetPtr(Register SPReg,
+                                              Register AllocSize,
+                                              Align Alignment, LLT PtrTy);
   LLVM_ABI LegalizeResult lowerDynStackAlloc(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerStackSave(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerStackRestore(MachineInstr &MI);
@@ -458,7 +483,8 @@ public:
   LLVM_ABI LegalizeResult lowerFAbs(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerVectorReduction(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerMemcpyInline(MachineInstr &MI);
-  LLVM_ABI LegalizeResult lowerMemCpyFamily(MachineInstr &MI, unsigned MaxLen = 0);
+  LLVM_ABI LegalizeResult lowerMemCpyFamily(MachineInstr &MI,
+                                            unsigned MaxLen = 0);
   LLVM_ABI LegalizeResult lowerVAArg(MachineInstr &MI);
 };
 
@@ -481,7 +507,6 @@ createLibcall(MachineIRBuilder &MIRBuilder, RTLIB::Libcall Libcall,
 LLVM_ABI LegalizerHelper::LegalizeResult
 createMemLibcall(MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI,
                  MachineInstr &MI, LostDebugLocObserver &LocObserver);
-
 
 } // End namespace llvm.
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
@@ -20,6 +20,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LEGALIZERHELPER_H
 #define LLVM_CODEGEN_GLOBALISEL_LEGALIZERHELPER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/GISelValueTracking.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
@@ -79,9 +80,9 @@ public:
   const TargetLowering &getTargetLowering() const { return TLI; }
   GISelValueTracking *getValueTracking() const { return VT; }
 
-  LegalizerHelper(MachineFunction &MF, GISelChangeObserver &Observer,
+  LLVM_ABI LegalizerHelper(MachineFunction &MF, GISelChangeObserver &Observer,
                   MachineIRBuilder &B);
-  LegalizerHelper(MachineFunction &MF, const LegalizerInfo &LI,
+  LLVM_ABI LegalizerHelper(MachineFunction &MF, const LegalizerInfo &LI,
                   GISelChangeObserver &Observer, MachineIRBuilder &B,
                   GISelValueTracking *VT = nullptr);
 
@@ -92,36 +93,36 @@ public:
   ///
   /// Considered as an opaque blob, the legal code will use and define the same
   /// registers as \p MI.
-  LegalizeResult legalizeInstrStep(MachineInstr &MI,
+  LLVM_ABI LegalizeResult legalizeInstrStep(MachineInstr &MI,
                                    LostDebugLocObserver &LocObserver);
 
   /// Legalize an instruction by emiting a runtime library call instead.
-  LegalizeResult libcall(MachineInstr &MI, LostDebugLocObserver &LocObserver);
+  LLVM_ABI LegalizeResult libcall(MachineInstr &MI, LostDebugLocObserver &LocObserver);
 
   /// Legalize an instruction by reducing the width of the underlying scalar
   /// type.
-  LegalizeResult narrowScalar(MachineInstr &MI, unsigned TypeIdx, LLT NarrowTy);
+  LLVM_ABI LegalizeResult narrowScalar(MachineInstr &MI, unsigned TypeIdx, LLT NarrowTy);
 
   /// Legalize an instruction by performing the operation on a wider scalar type
   /// (for example a 16-bit addition can be safely performed at 32-bits
   /// precision, ignoring the unused bits).
-  LegalizeResult widenScalar(MachineInstr &MI, unsigned TypeIdx, LLT WideTy);
+  LLVM_ABI LegalizeResult widenScalar(MachineInstr &MI, unsigned TypeIdx, LLT WideTy);
 
   /// Legalize an instruction by replacing the value type
-  LegalizeResult bitcast(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult bitcast(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
 
   /// Legalize an instruction by splitting it into simpler parts, hopefully
   /// understood by the target.
-  LegalizeResult lower(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult lower(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
 
   /// Legalize a vector instruction by splitting into multiple components, each
   /// acting on the same scalar type as the original but with fewer elements.
-  LegalizeResult fewerElementsVector(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult fewerElementsVector(MachineInstr &MI, unsigned TypeIdx,
                                      LLT NarrowTy);
 
   /// Legalize a vector instruction by increasing the number of vector elements
   /// involved and ignoring the added elements later.
-  LegalizeResult moreElementsVector(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult moreElementsVector(MachineInstr &MI, unsigned TypeIdx,
                                     LLT MoreTy);
 
   /// Cast the given value to an LLT::scalar with an equivalent size. Returns
@@ -129,48 +130,48 @@ public:
   /// register if no coercion was necessary.
   //
   // This may also fail and return Register() if there is no legal way to cast.
-  Register coerceToScalar(Register Val);
+  LLVM_ABI Register coerceToScalar(Register Val);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// Use by extending the operand's type to \p WideTy using the specified \p
   /// ExtOpcode for the extension instruction, and replacing the vreg of the
   /// operand in place.
-  void widenScalarSrc(MachineInstr &MI, LLT WideTy, unsigned OpIdx,
+  LLVM_ABI void widenScalarSrc(MachineInstr &MI, LLT WideTy, unsigned OpIdx,
                       unsigned ExtOpcode);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// Use by truncating the operand's type to \p NarrowTy using G_TRUNC, and
   /// replacing the vreg of the operand in place.
-  void narrowScalarSrc(MachineInstr &MI, LLT NarrowTy, unsigned OpIdx);
+  LLVM_ABI void narrowScalarSrc(MachineInstr &MI, LLT NarrowTy, unsigned OpIdx);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// Def by extending the operand's type to \p WideTy and truncating it back
   /// with the \p TruncOpcode, and replacing the vreg of the operand in place.
-  void widenScalarDst(MachineInstr &MI, LLT WideTy, unsigned OpIdx = 0,
+  LLVM_ABI void widenScalarDst(MachineInstr &MI, LLT WideTy, unsigned OpIdx = 0,
                       unsigned TruncOpcode = TargetOpcode::G_TRUNC);
 
   // Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   // Def by truncating the operand's type to \p NarrowTy, replacing in place and
   // extending back with \p ExtOpcode.
-  void narrowScalarDst(MachineInstr &MI, LLT NarrowTy, unsigned OpIdx,
+  LLVM_ABI void narrowScalarDst(MachineInstr &MI, LLT NarrowTy, unsigned OpIdx,
                        unsigned ExtOpcode);
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// Def by performing it with additional vector elements and extracting the
   /// result elements, and replacing the vreg of the operand in place.
-  void moreElementsVectorDst(MachineInstr &MI, LLT MoreTy, unsigned OpIdx);
+  LLVM_ABI void moreElementsVectorDst(MachineInstr &MI, LLT MoreTy, unsigned OpIdx);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// Use by producing a vector with undefined high elements, extracting the
   /// original vector type, and replacing the vreg of the operand in place.
-  void moreElementsVectorSrc(MachineInstr &MI, LLT MoreTy, unsigned OpIdx);
+  LLVM_ABI void moreElementsVectorSrc(MachineInstr &MI, LLT MoreTy, unsigned OpIdx);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// use by inserting a G_BITCAST to \p CastTy
-  void bitcastSrc(MachineInstr &MI, LLT CastTy, unsigned OpIdx);
+  LLVM_ABI void bitcastSrc(MachineInstr &MI, LLT CastTy, unsigned OpIdx);
 
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// def by inserting a G_BITCAST from \p CastTy
-  void bitcastDst(MachineInstr &MI, LLT CastTy, unsigned OpIdx);
+  LLVM_ABI void bitcastDst(MachineInstr &MI, LLT CastTy, unsigned OpIdx);
 
 private:
   LegalizeResult
@@ -292,24 +293,24 @@ private:
 public:
   /// Return the alignment to use for a stack temporary object with the given
   /// type.
-  Align getStackTemporaryAlignment(LLT Type, Align MinAlign = Align()) const;
+  LLVM_ABI Align getStackTemporaryAlignment(LLT Type, Align MinAlign = Align()) const;
 
   /// Create a stack temporary based on the size in bytes and the alignment
-  MachineInstrBuilder createStackTemporary(TypeSize Bytes, Align Alignment,
+  LLVM_ABI MachineInstrBuilder createStackTemporary(TypeSize Bytes, Align Alignment,
                                            MachinePointerInfo &PtrInfo);
 
   /// Create a store of \p Val to a stack temporary and return a load as the
   /// same type as \p Res.
-  MachineInstrBuilder createStackStoreLoad(const DstOp &Res, const SrcOp &Val);
+  LLVM_ABI MachineInstrBuilder createStackStoreLoad(const DstOp &Res, const SrcOp &Val);
 
   /// Given a store of a boolean vector, scalarize it.
-  LegalizeResult scalarizeVectorBooleanStore(GStore &MI);
+  LLVM_ABI LegalizeResult scalarizeVectorBooleanStore(GStore &MI);
 
   /// Get a pointer to vector element \p Index located in memory for a vector of
   /// type \p VecTy starting at a base address of \p VecPtr. If \p Index is out
   /// of bounds the returned pointer is unspecified, but will be within the
   /// vector bounds.
-  Register getVectorElementPointer(Register VecPtr, LLT VecTy, Register Index);
+  LLVM_ABI Register getVectorElementPointer(Register VecPtr, LLT VecTy, Register Index);
 
   /// Handles most opcodes. Split \p MI into same instruction on sub-vectors or
   /// scalars with \p NumElts elements (1 for scalar). Supports uneven splits:
@@ -317,167 +318,167 @@ public:
   /// scalar. To avoid this use moreElements first and set MI number of elements
   /// to multiple of \p NumElts. Non-vector operands that should be used on all
   /// sub-instructions without split are listed in \p NonVecOpIndices.
-  LegalizeResult fewerElementsVectorMultiEltType(
+  LLVM_ABI LegalizeResult fewerElementsVectorMultiEltType(
       GenericMachineInstr &MI, unsigned NumElts,
       std::initializer_list<unsigned> NonVecOpIndices = {});
 
-  LegalizeResult fewerElementsVectorPhi(GenericMachineInstr &MI,
+  LLVM_ABI LegalizeResult fewerElementsVectorPhi(GenericMachineInstr &MI,
                                         unsigned NumElts);
 
-  LegalizeResult moreElementsVectorPhi(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult moreElementsVectorPhi(MachineInstr &MI, unsigned TypeIdx,
                                        LLT MoreTy);
-  LegalizeResult moreElementsVectorShuffle(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult moreElementsVectorShuffle(MachineInstr &MI, unsigned TypeIdx,
                                            LLT MoreTy);
 
-  LegalizeResult fewerElementsVectorUnmergeValues(MachineInstr &MI,
+  LLVM_ABI LegalizeResult fewerElementsVectorUnmergeValues(MachineInstr &MI,
                                                   unsigned TypeIdx,
                                                   LLT NarrowTy);
-  LegalizeResult fewerElementsVectorMerge(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult fewerElementsVectorMerge(MachineInstr &MI, unsigned TypeIdx,
                                           LLT NarrowTy);
-  LegalizeResult fewerElementsVectorExtractInsertVectorElt(MachineInstr &MI,
+  LLVM_ABI LegalizeResult fewerElementsVectorExtractInsertVectorElt(MachineInstr &MI,
                                                            unsigned TypeIdx,
                                                            LLT NarrowTy);
 
   /// Equalize source and destination vector sizes of G_SHUFFLE_VECTOR.
-  LegalizeResult equalizeVectorShuffleLengths(MachineInstr &MI);
+  LLVM_ABI LegalizeResult equalizeVectorShuffleLengths(MachineInstr &MI);
 
-  LegalizeResult reduceLoadStoreWidth(GLoadStore &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult reduceLoadStoreWidth(GLoadStore &MI, unsigned TypeIdx,
                                       LLT NarrowTy);
 
-  LegalizeResult narrowScalarShiftByConstant(MachineInstr &MI, const APInt &Amt,
+  LLVM_ABI LegalizeResult narrowScalarShiftByConstant(MachineInstr &MI, const APInt &Amt,
                                              LLT HalfTy, LLT ShiftAmtTy);
 
-  LegalizeResult fewerElementsVectorReductions(MachineInstr &MI,
+  LLVM_ABI LegalizeResult fewerElementsVectorReductions(MachineInstr &MI,
                                                unsigned TypeIdx, LLT NarrowTy);
-  LegalizeResult fewerElementsVectorSeqReductions(MachineInstr &MI,
+  LLVM_ABI LegalizeResult fewerElementsVectorSeqReductions(MachineInstr &MI,
                                                   unsigned TypeIdx,
                                                   LLT NarrowTy);
 
   // Fewer Elements for bitcast, ensuring that the size of the Src and Dst
   // registers will be the same
-  LegalizeResult fewerElementsBitcast(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult fewerElementsBitcast(MachineInstr &MI, unsigned TypeIdx,
                                       LLT NarrowTy);
 
-  LegalizeResult fewerElementsVectorShuffle(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult fewerElementsVectorShuffle(MachineInstr &MI, unsigned TypeIdx,
                                             LLT NarrowTy);
 
-  LegalizeResult narrowScalarShift(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarAddSub(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult narrowScalarShift(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarAddSub(MachineInstr &MI, unsigned TypeIdx,
                                     LLT NarrowTy);
-  LegalizeResult narrowScalarMul(MachineInstr &MI, LLT Ty);
-  LegalizeResult narrowScalarFPTOI(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarExtract(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarInsert(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarMul(MachineInstr &MI, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarFPTOI(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarExtract(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarInsert(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
 
-  LegalizeResult narrowScalarBasic(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarExt(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarSelect(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarCTLZ(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarCTTZ(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarCTPOP(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
-  LegalizeResult narrowScalarFLDEXP(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarBasic(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarExt(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarSelect(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarCTLZ(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarCTTZ(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarCTPOP(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
+  LLVM_ABI LegalizeResult narrowScalarFLDEXP(MachineInstr &MI, unsigned TypeIdx, LLT Ty);
 
   /// Perform Bitcast legalize action on G_EXTRACT_VECTOR_ELT.
-  LegalizeResult bitcastExtractVectorElt(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult bitcastExtractVectorElt(MachineInstr &MI, unsigned TypeIdx,
                                          LLT CastTy);
 
   /// Perform Bitcast legalize action on G_INSERT_VECTOR_ELT.
-  LegalizeResult bitcastInsertVectorElt(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult bitcastInsertVectorElt(MachineInstr &MI, unsigned TypeIdx,
                                         LLT CastTy);
-  LegalizeResult bitcastConcatVector(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult bitcastConcatVector(MachineInstr &MI, unsigned TypeIdx,
                                      LLT CastTy);
-  LegalizeResult bitcastShuffleVector(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult bitcastShuffleVector(MachineInstr &MI, unsigned TypeIdx,
                                       LLT CastTy);
-  LegalizeResult bitcastExtractSubvector(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult bitcastExtractSubvector(MachineInstr &MI, unsigned TypeIdx,
                                          LLT CastTy);
-  LegalizeResult bitcastInsertSubvector(MachineInstr &MI, unsigned TypeIdx,
+  LLVM_ABI LegalizeResult bitcastInsertSubvector(MachineInstr &MI, unsigned TypeIdx,
                                         LLT CastTy);
 
-  LegalizeResult lowerConstant(MachineInstr &MI);
-  LegalizeResult lowerFConstant(MachineInstr &MI);
-  LegalizeResult lowerBitcast(MachineInstr &MI);
-  LegalizeResult lowerLoad(GAnyLoad &MI);
-  LegalizeResult lowerStore(GStore &MI);
-  LegalizeResult lowerBitCount(MachineInstr &MI);
-  LegalizeResult lowerFunnelShiftWithInverse(MachineInstr &MI);
-  LegalizeResult lowerFunnelShiftAsShifts(MachineInstr &MI);
-  LegalizeResult lowerFunnelShift(MachineInstr &MI);
-  LegalizeResult lowerEXT(MachineInstr &MI);
-  LegalizeResult lowerTRUNC(MachineInstr &MI);
-  LegalizeResult lowerRotateWithReverseRotate(MachineInstr &MI);
-  LegalizeResult lowerRotate(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerConstant(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFConstant(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerBitcast(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerLoad(GAnyLoad &MI);
+  LLVM_ABI LegalizeResult lowerStore(GStore &MI);
+  LLVM_ABI LegalizeResult lowerBitCount(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFunnelShiftWithInverse(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFunnelShiftAsShifts(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFunnelShift(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerEXT(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerTRUNC(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerRotateWithReverseRotate(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerRotate(MachineInstr &MI);
 
-  LegalizeResult lowerU64ToF32BitOps(MachineInstr &MI);
-  LegalizeResult lowerU64ToF32WithSITOFP(MachineInstr &MI);
-  LegalizeResult lowerU64ToF64BitFloatOps(MachineInstr &MI);
-  LegalizeResult lowerUITOFP(MachineInstr &MI);
-  LegalizeResult lowerSITOFP(MachineInstr &MI);
-  LegalizeResult lowerFPTOUI(MachineInstr &MI);
-  LegalizeResult lowerFPTOSI(MachineInstr &MI);
-  LegalizeResult lowerFPTOINT_SAT(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerU64ToF32BitOps(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerU64ToF32WithSITOFP(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerU64ToF64BitFloatOps(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerUITOFP(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerSITOFP(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFPTOUI(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFPTOSI(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFPTOINT_SAT(MachineInstr &MI);
 
-  LegalizeResult lowerFPTRUNC_F64_TO_F16(MachineInstr &MI);
-  LegalizeResult lowerFPTRUNC(MachineInstr &MI);
-  LegalizeResult lowerFPOWI(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFPTRUNC_F64_TO_F16(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFPTRUNC(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFPOWI(MachineInstr &MI);
 
-  LegalizeResult lowerISFPCLASS(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerISFPCLASS(MachineInstr &MI);
 
-  LegalizeResult lowerThreewayCompare(MachineInstr &MI);
-  LegalizeResult lowerMinMax(MachineInstr &MI);
-  LegalizeResult lowerFCopySign(MachineInstr &MI);
-  LegalizeResult lowerFMinNumMaxNum(MachineInstr &MI);
-  LegalizeResult lowerFMad(MachineInstr &MI);
-  LegalizeResult lowerIntrinsicRound(MachineInstr &MI);
-  LegalizeResult lowerFFloor(MachineInstr &MI);
-  LegalizeResult lowerMergeValues(MachineInstr &MI);
-  LegalizeResult lowerUnmergeValues(MachineInstr &MI);
-  LegalizeResult lowerExtractInsertVectorElt(MachineInstr &MI);
-  LegalizeResult lowerShuffleVector(MachineInstr &MI);
-  LegalizeResult lowerVECTOR_COMPRESS(MachineInstr &MI);
-  Register getDynStackAllocTargetPtr(Register SPReg, Register AllocSize,
+  LLVM_ABI LegalizeResult lowerThreewayCompare(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerMinMax(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFCopySign(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFMinNumMaxNum(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFMad(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerIntrinsicRound(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFFloor(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerMergeValues(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerUnmergeValues(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerExtractInsertVectorElt(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerShuffleVector(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerVECTOR_COMPRESS(MachineInstr &MI);
+  LLVM_ABI Register getDynStackAllocTargetPtr(Register SPReg, Register AllocSize,
                                      Align Alignment, LLT PtrTy);
-  LegalizeResult lowerDynStackAlloc(MachineInstr &MI);
-  LegalizeResult lowerStackSave(MachineInstr &MI);
-  LegalizeResult lowerStackRestore(MachineInstr &MI);
-  LegalizeResult lowerExtract(MachineInstr &MI);
-  LegalizeResult lowerInsert(MachineInstr &MI);
-  LegalizeResult lowerSADDO_SSUBO(MachineInstr &MI);
-  LegalizeResult lowerAddSubSatToMinMax(MachineInstr &MI);
-  LegalizeResult lowerAddSubSatToAddoSubo(MachineInstr &MI);
-  LegalizeResult lowerShlSat(MachineInstr &MI);
-  LegalizeResult lowerBswap(MachineInstr &MI);
-  LegalizeResult lowerBitreverse(MachineInstr &MI);
-  LegalizeResult lowerReadWriteRegister(MachineInstr &MI);
-  LegalizeResult lowerSMULH_UMULH(MachineInstr &MI);
-  LegalizeResult lowerSelect(MachineInstr &MI);
-  LegalizeResult lowerDIVREM(MachineInstr &MI);
-  LegalizeResult lowerAbsToAddXor(MachineInstr &MI);
-  LegalizeResult lowerAbsToMaxNeg(MachineInstr &MI);
-  LegalizeResult lowerAbsToCNeg(MachineInstr &MI);
-  LegalizeResult lowerFAbs(MachineInstr &MI);
-  LegalizeResult lowerVectorReduction(MachineInstr &MI);
-  LegalizeResult lowerMemcpyInline(MachineInstr &MI);
-  LegalizeResult lowerMemCpyFamily(MachineInstr &MI, unsigned MaxLen = 0);
-  LegalizeResult lowerVAArg(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerDynStackAlloc(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerStackSave(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerStackRestore(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerExtract(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerInsert(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerSADDO_SSUBO(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerAddSubSatToMinMax(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerAddSubSatToAddoSubo(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerShlSat(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerBswap(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerBitreverse(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerReadWriteRegister(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerSMULH_UMULH(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerSelect(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerDIVREM(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerAbsToAddXor(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerAbsToMaxNeg(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerAbsToCNeg(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerFAbs(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerVectorReduction(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerMemcpyInline(MachineInstr &MI);
+  LLVM_ABI LegalizeResult lowerMemCpyFamily(MachineInstr &MI, unsigned MaxLen = 0);
+  LLVM_ABI LegalizeResult lowerVAArg(MachineInstr &MI);
 };
 
 /// Helper function that creates a libcall to the given \p Name using the given
 /// calling convention \p CC.
-LegalizerHelper::LegalizeResult
+LLVM_ABI LegalizerHelper::LegalizeResult
 createLibcall(MachineIRBuilder &MIRBuilder, const char *Name,
               const CallLowering::ArgInfo &Result,
               ArrayRef<CallLowering::ArgInfo> Args, CallingConv::ID CC,
               LostDebugLocObserver &LocObserver, MachineInstr *MI = nullptr);
 
 /// Helper function that creates the given libcall.
-LegalizerHelper::LegalizeResult
+LLVM_ABI LegalizerHelper::LegalizeResult
 createLibcall(MachineIRBuilder &MIRBuilder, RTLIB::Libcall Libcall,
               const CallLowering::ArgInfo &Result,
               ArrayRef<CallLowering::ArgInfo> Args,
               LostDebugLocObserver &LocObserver, MachineInstr *MI = nullptr);
 
 /// Create a libcall to memcpy et al.
-LegalizerHelper::LegalizeResult
+LLVM_ABI LegalizerHelper::LegalizeResult
 createMemLibcall(MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI,
                  MachineInstr &MI, LostDebugLocObserver &LocObserver);
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LEGALIZERINFO_H
 #define LLVM_CODEGEN_GLOBALISEL_LEGALIZERINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/GlobalISel/LegacyLegalizerInfo.h"
@@ -24,6 +23,7 @@
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/Support/AtomicOrdering.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <tuple>
@@ -99,7 +99,8 @@ enum LegalizeAction : std::uint8_t {
   UseLegacyRules,
 };
 } // end namespace LegalizeActions
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, LegalizeActions::LegalizeAction Action);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 LegalizeActions::LegalizeAction Action);
 
 using LegalizeActions::LegalizeAction;
 
@@ -257,7 +258,7 @@ Predicate any(Predicate P0, Predicate P1, Args... args) {
 LLVM_ABI LegalityPredicate typeIs(unsigned TypeIdx, LLT TypesInit);
 /// True iff the given type index is one of the specified types.
 LLVM_ABI LegalityPredicate typeInSet(unsigned TypeIdx,
-                            std::initializer_list<LLT> TypesInit);
+                                     std::initializer_list<LLT> TypesInit);
 
 /// True iff the given type index is not the specified type.
 inline LegalityPredicate typeIsNot(unsigned TypeIdx, LLT Type) {
@@ -307,11 +308,13 @@ LLVM_ABI LegalityPredicate scalarWiderThan(unsigned TypeIdx, unsigned Size);
 
 /// True iff the specified type index is a scalar or vector with an element type
 /// that's narrower than the given size.
-LLVM_ABI LegalityPredicate scalarOrEltNarrowerThan(unsigned TypeIdx, unsigned Size);
+LLVM_ABI LegalityPredicate scalarOrEltNarrowerThan(unsigned TypeIdx,
+                                                   unsigned Size);
 
 /// True iff the specified type index is a scalar or a vector with an element
 /// type that's wider than the given size.
-LLVM_ABI LegalityPredicate scalarOrEltWiderThan(unsigned TypeIdx, unsigned Size);
+LLVM_ABI LegalityPredicate scalarOrEltWiderThan(unsigned TypeIdx,
+                                                unsigned Size);
 
 /// True iff the specified type index is a scalar whose size is not a multiple
 /// of Size.
@@ -352,8 +355,8 @@ LLVM_ABI LegalityPredicate memSizeNotByteSizePow2(unsigned MMOIdx);
 LLVM_ABI LegalityPredicate numElementsNotPow2(unsigned TypeIdx);
 /// True iff the specified MMO index has at an atomic ordering of at Ordering or
 /// stronger.
-LLVM_ABI LegalityPredicate atomicOrderingAtLeastOrStrongerThan(unsigned MMOIdx,
-                                                      AtomicOrdering Ordering);
+LLVM_ABI LegalityPredicate
+atomicOrderingAtLeastOrStrongerThan(unsigned MMOIdx, AtomicOrdering Ordering);
 } // end namespace LegalityPredicates
 
 namespace LegalizeMutations {
@@ -364,14 +367,16 @@ LLVM_ABI LegalizeMutation changeTo(unsigned TypeIdx, LLT Ty);
 LLVM_ABI LegalizeMutation changeTo(unsigned TypeIdx, unsigned FromTypeIdx);
 
 /// Keep the same scalar or element type as the given type index.
-LLVM_ABI LegalizeMutation changeElementTo(unsigned TypeIdx, unsigned FromTypeIdx);
+LLVM_ABI LegalizeMutation changeElementTo(unsigned TypeIdx,
+                                          unsigned FromTypeIdx);
 
 /// Keep the same scalar or element type as the given type.
 LLVM_ABI LegalizeMutation changeElementTo(unsigned TypeIdx, LLT Ty);
 
 /// Keep the same scalar or element type as \p TypeIdx, but take the number of
 /// elements from \p FromTypeIdx.
-LLVM_ABI LegalizeMutation changeElementCountTo(unsigned TypeIdx, unsigned FromTypeIdx);
+LLVM_ABI LegalizeMutation changeElementCountTo(unsigned TypeIdx,
+                                               unsigned FromTypeIdx);
 
 /// Keep the same scalar or element type as \p TypeIdx, but take the number of
 /// elements from \p Ty.
@@ -380,20 +385,23 @@ LLVM_ABI LegalizeMutation changeElementCountTo(unsigned TypeIdx, LLT Ty);
 /// Change the scalar size or element size to have the same scalar size as type
 /// index \p FromIndex. Unlike changeElementTo, this discards pointer types and
 /// only changes the size.
-LLVM_ABI LegalizeMutation changeElementSizeTo(unsigned TypeIdx, unsigned FromTypeIdx);
+LLVM_ABI LegalizeMutation changeElementSizeTo(unsigned TypeIdx,
+                                              unsigned FromTypeIdx);
 
 /// Widen the scalar type or vector element type for the given type index to the
 /// next power of 2.
-LLVM_ABI LegalizeMutation widenScalarOrEltToNextPow2(unsigned TypeIdx, unsigned Min = 0);
+LLVM_ABI LegalizeMutation widenScalarOrEltToNextPow2(unsigned TypeIdx,
+                                                     unsigned Min = 0);
 
 /// Widen the scalar type or vector element type for the given type index to
 /// next multiple of \p Size.
 LLVM_ABI LegalizeMutation widenScalarOrEltToNextMultipleOf(unsigned TypeIdx,
-                                                  unsigned Size);
+                                                           unsigned Size);
 
 /// Add more elements to the type for the given type index to the next power of
 /// 2.
-LLVM_ABI LegalizeMutation moreElementsToNextPow2(unsigned TypeIdx, unsigned Min = 0);
+LLVM_ABI LegalizeMutation moreElementsToNextPow2(unsigned TypeIdx,
+                                                 unsigned Min = 0);
 /// Break up the vector type for the given type index into the element type.
 LLVM_ABI LegalizeMutation scalarize(unsigned TypeIdx);
 } // end namespace LegalizeMutations

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LEGALIZERINFO_H
 #define LLVM_CODEGEN_GLOBALISEL_LEGALIZERINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/GlobalISel/LegacyLegalizerInfo.h"
@@ -30,7 +31,7 @@
 
 namespace llvm {
 
-extern cl::opt<bool> DisableGISelLegalityCheck;
+LLVM_ABI extern cl::opt<bool> DisableGISelLegalityCheck;
 
 class MachineFunction;
 class raw_ostream;
@@ -98,7 +99,7 @@ enum LegalizeAction : std::uint8_t {
   UseLegacyRules,
 };
 } // end namespace LegalizeActions
-raw_ostream &operator<<(raw_ostream &OS, LegalizeActions::LegalizeAction Action);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, LegalizeActions::LegalizeAction Action);
 
 using LegalizeActions::LegalizeAction;
 
@@ -131,7 +132,7 @@ struct LegalityQuery {
                           ArrayRef<MemDesc> MMODescrs = {})
       : Opcode(Opcode), Types(Types), MMODescrs(MMODescrs) {}
 
-  raw_ostream &print(raw_ostream &OS) const;
+  LLVM_ABI raw_ostream &print(raw_ostream &OS) const;
 };
 
 /// The result of a query. It either indicates a final answer of Legal or
@@ -253,9 +254,9 @@ Predicate any(Predicate P0, Predicate P1, Args... args) {
 }
 
 /// True iff the given type index is the specified type.
-LegalityPredicate typeIs(unsigned TypeIdx, LLT TypesInit);
+LLVM_ABI LegalityPredicate typeIs(unsigned TypeIdx, LLT TypesInit);
 /// True iff the given type index is one of the specified types.
-LegalityPredicate typeInSet(unsigned TypeIdx,
+LLVM_ABI LegalityPredicate typeInSet(unsigned TypeIdx,
                             std::initializer_list<LLT> TypesInit);
 
 /// True iff the given type index is not the specified type.
@@ -267,134 +268,134 @@ inline LegalityPredicate typeIsNot(unsigned TypeIdx, LLT Type) {
 
 /// True iff the given types for the given pair of type indexes is one of the
 /// specified type pairs.
-LegalityPredicate
+LLVM_ABI LegalityPredicate
 typePairInSet(unsigned TypeIdx0, unsigned TypeIdx1,
               std::initializer_list<std::pair<LLT, LLT>> TypesInit);
 /// True iff the given types for the given tuple of type indexes is one of the
 /// specified type tuple.
-LegalityPredicate
+LLVM_ABI LegalityPredicate
 typeTupleInSet(unsigned TypeIdx0, unsigned TypeIdx1, unsigned Type2,
                std::initializer_list<std::tuple<LLT, LLT, LLT>> TypesInit);
 /// True iff the given types for the given pair of type indexes is one of the
 /// specified type pairs.
-LegalityPredicate typePairAndMemDescInSet(
+LLVM_ABI LegalityPredicate typePairAndMemDescInSet(
     unsigned TypeIdx0, unsigned TypeIdx1, unsigned MMOIdx,
     std::initializer_list<TypePairAndMemDesc> TypesAndMemDescInit);
 /// True iff the specified type index is a scalar.
-LegalityPredicate isScalar(unsigned TypeIdx);
+LLVM_ABI LegalityPredicate isScalar(unsigned TypeIdx);
 /// True iff the specified type index is a vector.
-LegalityPredicate isVector(unsigned TypeIdx);
+LLVM_ABI LegalityPredicate isVector(unsigned TypeIdx);
 /// True iff the specified type index is a pointer (with any address space).
-LegalityPredicate isPointer(unsigned TypeIdx);
+LLVM_ABI LegalityPredicate isPointer(unsigned TypeIdx);
 /// True iff the specified type index is a pointer with the specified address
 /// space.
-LegalityPredicate isPointer(unsigned TypeIdx, unsigned AddrSpace);
+LLVM_ABI LegalityPredicate isPointer(unsigned TypeIdx, unsigned AddrSpace);
 /// True iff the specified type index is a vector of pointers (with any address
 /// space).
-LegalityPredicate isPointerVector(unsigned TypeIdx);
+LLVM_ABI LegalityPredicate isPointerVector(unsigned TypeIdx);
 
 /// True if the type index is a vector with element type \p EltTy
-LegalityPredicate elementTypeIs(unsigned TypeIdx, LLT EltTy);
+LLVM_ABI LegalityPredicate elementTypeIs(unsigned TypeIdx, LLT EltTy);
 
 /// True iff the specified type index is a scalar that's narrower than the given
 /// size.
-LegalityPredicate scalarNarrowerThan(unsigned TypeIdx, unsigned Size);
+LLVM_ABI LegalityPredicate scalarNarrowerThan(unsigned TypeIdx, unsigned Size);
 
 /// True iff the specified type index is a scalar that's wider than the given
 /// size.
-LegalityPredicate scalarWiderThan(unsigned TypeIdx, unsigned Size);
+LLVM_ABI LegalityPredicate scalarWiderThan(unsigned TypeIdx, unsigned Size);
 
 /// True iff the specified type index is a scalar or vector with an element type
 /// that's narrower than the given size.
-LegalityPredicate scalarOrEltNarrowerThan(unsigned TypeIdx, unsigned Size);
+LLVM_ABI LegalityPredicate scalarOrEltNarrowerThan(unsigned TypeIdx, unsigned Size);
 
 /// True iff the specified type index is a scalar or a vector with an element
 /// type that's wider than the given size.
-LegalityPredicate scalarOrEltWiderThan(unsigned TypeIdx, unsigned Size);
+LLVM_ABI LegalityPredicate scalarOrEltWiderThan(unsigned TypeIdx, unsigned Size);
 
 /// True iff the specified type index is a scalar whose size is not a multiple
 /// of Size.
-LegalityPredicate sizeNotMultipleOf(unsigned TypeIdx, unsigned Size);
+LLVM_ABI LegalityPredicate sizeNotMultipleOf(unsigned TypeIdx, unsigned Size);
 
 /// True iff the specified type index is a scalar whose size is not a power of
 /// 2.
-LegalityPredicate sizeNotPow2(unsigned TypeIdx);
+LLVM_ABI LegalityPredicate sizeNotPow2(unsigned TypeIdx);
 
 /// True iff the specified type index is a scalar or vector whose element size
 /// is not a power of 2.
-LegalityPredicate scalarOrEltSizeNotPow2(unsigned TypeIdx);
+LLVM_ABI LegalityPredicate scalarOrEltSizeNotPow2(unsigned TypeIdx);
 
 /// True if the total bitwidth of the specified type index is \p Size bits.
-LegalityPredicate sizeIs(unsigned TypeIdx, unsigned Size);
+LLVM_ABI LegalityPredicate sizeIs(unsigned TypeIdx, unsigned Size);
 
 /// True iff the specified type indices are both the same bit size.
-LegalityPredicate sameSize(unsigned TypeIdx0, unsigned TypeIdx1);
+LLVM_ABI LegalityPredicate sameSize(unsigned TypeIdx0, unsigned TypeIdx1);
 
 /// True iff the first type index has a larger total bit size than second type
 /// index.
-LegalityPredicate largerThan(unsigned TypeIdx0, unsigned TypeIdx1);
+LLVM_ABI LegalityPredicate largerThan(unsigned TypeIdx0, unsigned TypeIdx1);
 
 /// True iff the first type index has a smaller total bit size than second type
 /// index.
-LegalityPredicate smallerThan(unsigned TypeIdx0, unsigned TypeIdx1);
+LLVM_ABI LegalityPredicate smallerThan(unsigned TypeIdx0, unsigned TypeIdx1);
 
 /// True iff the specified MMO index has a size (rounded to bytes) that is not a
 /// power of 2.
-LegalityPredicate memSizeInBytesNotPow2(unsigned MMOIdx);
+LLVM_ABI LegalityPredicate memSizeInBytesNotPow2(unsigned MMOIdx);
 
 /// True iff the specified MMO index has a size that is not an even byte size,
 /// or that even byte size is not a power of 2.
-LegalityPredicate memSizeNotByteSizePow2(unsigned MMOIdx);
+LLVM_ABI LegalityPredicate memSizeNotByteSizePow2(unsigned MMOIdx);
 
 /// True iff the specified type index is a vector whose element count is not a
 /// power of 2.
-LegalityPredicate numElementsNotPow2(unsigned TypeIdx);
+LLVM_ABI LegalityPredicate numElementsNotPow2(unsigned TypeIdx);
 /// True iff the specified MMO index has at an atomic ordering of at Ordering or
 /// stronger.
-LegalityPredicate atomicOrderingAtLeastOrStrongerThan(unsigned MMOIdx,
+LLVM_ABI LegalityPredicate atomicOrderingAtLeastOrStrongerThan(unsigned MMOIdx,
                                                       AtomicOrdering Ordering);
 } // end namespace LegalityPredicates
 
 namespace LegalizeMutations {
 /// Select this specific type for the given type index.
-LegalizeMutation changeTo(unsigned TypeIdx, LLT Ty);
+LLVM_ABI LegalizeMutation changeTo(unsigned TypeIdx, LLT Ty);
 
 /// Keep the same type as the given type index.
-LegalizeMutation changeTo(unsigned TypeIdx, unsigned FromTypeIdx);
+LLVM_ABI LegalizeMutation changeTo(unsigned TypeIdx, unsigned FromTypeIdx);
 
 /// Keep the same scalar or element type as the given type index.
-LegalizeMutation changeElementTo(unsigned TypeIdx, unsigned FromTypeIdx);
+LLVM_ABI LegalizeMutation changeElementTo(unsigned TypeIdx, unsigned FromTypeIdx);
 
 /// Keep the same scalar or element type as the given type.
-LegalizeMutation changeElementTo(unsigned TypeIdx, LLT Ty);
+LLVM_ABI LegalizeMutation changeElementTo(unsigned TypeIdx, LLT Ty);
 
 /// Keep the same scalar or element type as \p TypeIdx, but take the number of
 /// elements from \p FromTypeIdx.
-LegalizeMutation changeElementCountTo(unsigned TypeIdx, unsigned FromTypeIdx);
+LLVM_ABI LegalizeMutation changeElementCountTo(unsigned TypeIdx, unsigned FromTypeIdx);
 
 /// Keep the same scalar or element type as \p TypeIdx, but take the number of
 /// elements from \p Ty.
-LegalizeMutation changeElementCountTo(unsigned TypeIdx, LLT Ty);
+LLVM_ABI LegalizeMutation changeElementCountTo(unsigned TypeIdx, LLT Ty);
 
 /// Change the scalar size or element size to have the same scalar size as type
 /// index \p FromIndex. Unlike changeElementTo, this discards pointer types and
 /// only changes the size.
-LegalizeMutation changeElementSizeTo(unsigned TypeIdx, unsigned FromTypeIdx);
+LLVM_ABI LegalizeMutation changeElementSizeTo(unsigned TypeIdx, unsigned FromTypeIdx);
 
 /// Widen the scalar type or vector element type for the given type index to the
 /// next power of 2.
-LegalizeMutation widenScalarOrEltToNextPow2(unsigned TypeIdx, unsigned Min = 0);
+LLVM_ABI LegalizeMutation widenScalarOrEltToNextPow2(unsigned TypeIdx, unsigned Min = 0);
 
 /// Widen the scalar type or vector element type for the given type index to
 /// next multiple of \p Size.
-LegalizeMutation widenScalarOrEltToNextMultipleOf(unsigned TypeIdx,
+LLVM_ABI LegalizeMutation widenScalarOrEltToNextMultipleOf(unsigned TypeIdx,
                                                   unsigned Size);
 
 /// Add more elements to the type for the given type index to the next power of
 /// 2.
-LegalizeMutation moreElementsToNextPow2(unsigned TypeIdx, unsigned Min = 0);
+LLVM_ABI LegalizeMutation moreElementsToNextPow2(unsigned TypeIdx, unsigned Min = 0);
 /// Break up the vector type for the given type index into the element type.
-LegalizeMutation scalarize(unsigned TypeIdx);
+LLVM_ABI LegalizeMutation scalarize(unsigned TypeIdx);
 } // end namespace LegalizeMutations
 
 /// A single rule in a legalizer info ruleset.
@@ -1295,17 +1296,17 @@ public:
   /// Check if there is no type index which is obviously not handled by the
   /// LegalizeRuleSet in any way at all.
   /// \pre Type indices of the opcode form a dense [0, \p NumTypeIdxs) set.
-  bool verifyTypeIdxsCoverage(unsigned NumTypeIdxs) const;
+  LLVM_ABI bool verifyTypeIdxsCoverage(unsigned NumTypeIdxs) const;
   /// Check if there is no imm index which is obviously not handled by the
   /// LegalizeRuleSet in any way at all.
   /// \pre Type indices of the opcode form a dense [0, \p NumTypeIdxs) set.
-  bool verifyImmIdxsCoverage(unsigned NumImmIdxs) const;
+  LLVM_ABI bool verifyImmIdxsCoverage(unsigned NumImmIdxs) const;
 
   /// Apply the ruleset to the given LegalityQuery.
-  LegalizeActionStep apply(const LegalityQuery &Query) const;
+  LLVM_ABI LegalizeActionStep apply(const LegalityQuery &Query) const;
 };
 
-class LegalizerInfo {
+class LLVM_ABI LegalizerInfo {
 public:
   virtual ~LegalizerInfo() = default;
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/LoadStoreOpt.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LoadStoreOpt.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LOADSTOREOPT_H
 #define LLVM_CODEGEN_GLOBALISEL_LOADSTOREOPT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
@@ -23,6 +22,7 @@
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 // Forward declarations.
@@ -61,15 +61,16 @@ LLVM_ABI BaseIndexOffset getPointerInfo(Register Ptr, MachineRegisterInfo &MRI);
 /// Compute whether or not a memory access at \p MI1 aliases with an access at
 /// \p MI2 \returns true if either alias/no-alias is known. Sets \p IsAlias
 /// accordingly.
-LLVM_ABI bool aliasIsKnownForLoadStore(const MachineInstr &MI1, const MachineInstr &MI2,
-                              bool &IsAlias, MachineRegisterInfo &MRI);
+LLVM_ABI bool aliasIsKnownForLoadStore(const MachineInstr &MI1,
+                                       const MachineInstr &MI2, bool &IsAlias,
+                                       MachineRegisterInfo &MRI);
 
 /// Returns true if the instruction \p MI may alias \p Other.
 /// This function uses multiple strategies to detect aliasing, whereas
 /// aliasIsKnownForLoadStore just looks at the addresses of load/stores and is
 /// tries to reason about base/index/offsets.
 LLVM_ABI bool instMayAlias(const MachineInstr &MI, const MachineInstr &Other,
-                  MachineRegisterInfo &MRI, AliasAnalysis *AA);
+                           MachineRegisterInfo &MRI, AliasAnalysis *AA);
 } // namespace GISelAddressing
 
 using namespace GISelAddressing;

--- a/llvm/include/llvm/CodeGen/GlobalISel/LoadStoreOpt.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LoadStoreOpt.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LOADSTOREOPT_H
 #define LLVM_CODEGEN_GLOBALISEL_LOADSTOREOPT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
@@ -55,25 +56,25 @@ public:
 };
 
 /// Returns a BaseIndexOffset which describes the pointer in \p Ptr.
-BaseIndexOffset getPointerInfo(Register Ptr, MachineRegisterInfo &MRI);
+LLVM_ABI BaseIndexOffset getPointerInfo(Register Ptr, MachineRegisterInfo &MRI);
 
 /// Compute whether or not a memory access at \p MI1 aliases with an access at
 /// \p MI2 \returns true if either alias/no-alias is known. Sets \p IsAlias
 /// accordingly.
-bool aliasIsKnownForLoadStore(const MachineInstr &MI1, const MachineInstr &MI2,
+LLVM_ABI bool aliasIsKnownForLoadStore(const MachineInstr &MI1, const MachineInstr &MI2,
                               bool &IsAlias, MachineRegisterInfo &MRI);
 
 /// Returns true if the instruction \p MI may alias \p Other.
 /// This function uses multiple strategies to detect aliasing, whereas
 /// aliasIsKnownForLoadStore just looks at the addresses of load/stores and is
 /// tries to reason about base/index/offsets.
-bool instMayAlias(const MachineInstr &MI, const MachineInstr &Other,
+LLVM_ABI bool instMayAlias(const MachineInstr &MI, const MachineInstr &Other,
                   MachineRegisterInfo &MRI, AliasAnalysis *AA);
 } // namespace GISelAddressing
 
 using namespace GISelAddressing;
 
-class LoadStoreOpt : public MachineFunctionPass {
+class LLVM_ABI LoadStoreOpt : public MachineFunctionPass {
 public:
   static char ID;
 
@@ -112,7 +113,7 @@ private:
     // after the potential alias is recorded.
     SmallVector<std::pair<MachineInstr *, unsigned>> PotentialAliases;
 
-    void addPotentialAlias(MachineInstr &MI);
+    LLVM_ABI void addPotentialAlias(MachineInstr &MI);
 
     /// Reset this candidate back to an empty one.
     void reset() {

--- a/llvm/include/llvm/CodeGen/GlobalISel/LostDebugLocObserver.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LostDebugLocObserver.h
@@ -12,11 +12,12 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LOSTDEBUGLOCOBSERVER_H
 #define LLVM_CODEGEN_GLOBALISEL_LOSTDEBUGLOCOBSERVER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/CodeGen/GlobalISel/GISelChangeObserver.h"
 
 namespace llvm {
-class LostDebugLocObserver : public GISelChangeObserver {
+class LLVM_ABI LostDebugLocObserver : public GISelChangeObserver {
   StringRef DebugType;
   SmallSet<DebugLoc, 4> LostDebugLocs;
   SmallPtrSet<MachineInstr *, 4> PotentialMIsForDebugLocs;

--- a/llvm/include/llvm/CodeGen/GlobalISel/LostDebugLocObserver.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LostDebugLocObserver.h
@@ -12,9 +12,9 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_LOSTDEBUGLOCOBSERVER_H
 #define LLVM_CODEGEN_GLOBALISEL_LOSTDEBUGLOCOBSERVER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/CodeGen/GlobalISel/GISelChangeObserver.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class LLVM_ABI LostDebugLocObserver : public GISelChangeObserver {

--- a/llvm/include/llvm/CodeGen/GlobalISel/MachineIRBuilder.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MachineIRBuilder.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_MACHINEIRBUILDER_H
 #define LLVM_CODEGEN_GLOBALISEL_MACHINEIRBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/GlobalISel/GISelChangeObserver.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
@@ -232,7 +233,7 @@ private:
 /// It keeps internally the insertion point and debug location for all
 /// the new instructions we want to create.
 /// This information can be modified via the related setters.
-class MachineIRBuilder {
+class LLVM_ABI MachineIRBuilder {
 
   MachineIRBuilderState State;
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/MachineIRBuilder.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MachineIRBuilder.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_MACHINEIRBUILDER_H
 #define LLVM_CODEGEN_GLOBALISEL_MACHINEIRBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/GlobalISel/GISelChangeObserver.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
@@ -22,6 +21,7 @@
 #include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_UTILS_H
 #define LLVM_CODEGEN_GLOBALISEL_UTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "GISelWorkList.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/StringRef.h"
@@ -23,6 +22,7 @@
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 
 #include <cstdint>
 
@@ -94,9 +94,9 @@ class APFloat;
 ///
 /// \return The virtual register constrained to the right register class.
 LLVM_ABI Register constrainRegToClass(MachineRegisterInfo &MRI,
-                             const TargetInstrInfo &TII,
-                             const RegisterBankInfo &RBI, Register Reg,
-                             const TargetRegisterClass &RegClass);
+                                      const TargetInstrInfo &TII,
+                                      const RegisterBankInfo &RBI, Register Reg,
+                                      const TargetRegisterClass &RegClass);
 
 /// Constrain the Register operand OpIdx, so that it is now constrained to the
 /// TargetRegisterClass passed as an argument (RegClass).
@@ -106,14 +106,11 @@ LLVM_ABI Register constrainRegToClass(MachineRegisterInfo &MRI,
 /// location of \p InsertPt is used for the new copy.
 ///
 /// \return The virtual register constrained to the right register class.
-LLVM_ABI Register constrainOperandRegClass(const MachineFunction &MF,
-                                  const TargetRegisterInfo &TRI,
-                                  MachineRegisterInfo &MRI,
-                                  const TargetInstrInfo &TII,
-                                  const RegisterBankInfo &RBI,
-                                  MachineInstr &InsertPt,
-                                  const TargetRegisterClass &RegClass,
-                                  MachineOperand &RegMO);
+LLVM_ABI Register constrainOperandRegClass(
+    const MachineFunction &MF, const TargetRegisterInfo &TRI,
+    MachineRegisterInfo &MRI, const TargetInstrInfo &TII,
+    const RegisterBankInfo &RBI, MachineInstr &InsertPt,
+    const TargetRegisterClass &RegClass, MachineOperand &RegMO);
 
 /// Try to constrain Reg so that it is usable by argument OpIdx of the provided
 /// MCInstrDesc \p II. If this fails, create a new virtual register in the
@@ -125,13 +122,11 @@ LLVM_ABI Register constrainOperandRegClass(const MachineFunction &MF,
 /// InsertPt is used for the new copy.
 ///
 /// \return The virtual register constrained to the right register class.
-LLVM_ABI Register constrainOperandRegClass(const MachineFunction &MF,
-                                  const TargetRegisterInfo &TRI,
-                                  MachineRegisterInfo &MRI,
-                                  const TargetInstrInfo &TII,
-                                  const RegisterBankInfo &RBI,
-                                  MachineInstr &InsertPt, const MCInstrDesc &II,
-                                  MachineOperand &RegMO, unsigned OpIdx);
+LLVM_ABI Register constrainOperandRegClass(
+    const MachineFunction &MF, const TargetRegisterInfo &TRI,
+    MachineRegisterInfo &MRI, const TargetInstrInfo &TII,
+    const RegisterBankInfo &RBI, MachineInstr &InsertPt, const MCInstrDesc &II,
+    MachineOperand &RegMO, unsigned OpIdx);
 
 /// Mutate the newly-selected instruction \p I to constrain its (possibly
 /// generic) virtual register operands to the instruction's register class.
@@ -143,49 +138,55 @@ LLVM_ABI Register constrainOperandRegClass(const MachineFunction &MF,
 // probably expose a constrain helper per operand and let the target selector
 // constrain individual registers, like fast-isel.
 LLVM_ABI bool constrainSelectedInstRegOperands(MachineInstr &I,
-                                      const TargetInstrInfo &TII,
-                                      const TargetRegisterInfo &TRI,
-                                      const RegisterBankInfo &RBI);
+                                               const TargetInstrInfo &TII,
+                                               const TargetRegisterInfo &TRI,
+                                               const RegisterBankInfo &RBI);
 
 /// Check if DstReg can be replaced with SrcReg depending on the register
 /// constraints.
-LLVM_ABI bool canReplaceReg(Register DstReg, Register SrcReg, MachineRegisterInfo &MRI);
+LLVM_ABI bool canReplaceReg(Register DstReg, Register SrcReg,
+                            MachineRegisterInfo &MRI);
 
 /// Check whether an instruction \p MI is dead: it only defines dead virtual
 /// registers, and doesn't have other side effects.
-LLVM_ABI bool isTriviallyDead(const MachineInstr &MI, const MachineRegisterInfo &MRI);
+LLVM_ABI bool isTriviallyDead(const MachineInstr &MI,
+                              const MachineRegisterInfo &MRI);
 
 /// Report an ISel error as a missed optimization remark to the LLVMContext's
 /// diagnostic stream.  Set the FailedISel MachineFunction property.
-LLVM_ABI void reportGISelFailure(MachineFunction &MF, const TargetPassConfig &TPC,
-                        MachineOptimizationRemarkEmitter &MORE,
-                        MachineOptimizationRemarkMissed &R);
+LLVM_ABI void reportGISelFailure(MachineFunction &MF,
+                                 const TargetPassConfig &TPC,
+                                 MachineOptimizationRemarkEmitter &MORE,
+                                 MachineOptimizationRemarkMissed &R);
 
-LLVM_ABI void reportGISelFailure(MachineFunction &MF, const TargetPassConfig &TPC,
-                        MachineOptimizationRemarkEmitter &MORE,
-                        const char *PassName, StringRef Msg,
-                        const MachineInstr &MI);
+LLVM_ABI void reportGISelFailure(MachineFunction &MF,
+                                 const TargetPassConfig &TPC,
+                                 MachineOptimizationRemarkEmitter &MORE,
+                                 const char *PassName, StringRef Msg,
+                                 const MachineInstr &MI);
 
 /// Report an ISel warning as a missed optimization remark to the LLVMContext's
 /// diagnostic stream.
-LLVM_ABI void reportGISelWarning(MachineFunction &MF, const TargetPassConfig &TPC,
-                        MachineOptimizationRemarkEmitter &MORE,
-                        MachineOptimizationRemarkMissed &R);
+LLVM_ABI void reportGISelWarning(MachineFunction &MF,
+                                 const TargetPassConfig &TPC,
+                                 MachineOptimizationRemarkEmitter &MORE,
+                                 MachineOptimizationRemarkMissed &R);
 
 /// Returns the inverse opcode of \p MinMaxOpc, which is a generic min/max
 /// opcode like G_SMIN.
 LLVM_ABI unsigned getInverseGMinMaxOpcode(unsigned MinMaxOpc);
 
 /// If \p VReg is defined by a G_CONSTANT, return the corresponding value.
-LLVM_ABI std::optional<APInt> getIConstantVRegVal(Register VReg,
-                                         const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<APInt>
+getIConstantVRegVal(Register VReg, const MachineRegisterInfo &MRI);
 
 /// If \p VReg is defined by a G_CONSTANT fits in int64_t returns it.
-LLVM_ABI std::optional<int64_t> getIConstantVRegSExtVal(Register VReg,
-                                               const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<int64_t>
+getIConstantVRegSExtVal(Register VReg, const MachineRegisterInfo &MRI);
 
 /// \p VReg is defined by a G_CONSTANT, return the corresponding value.
-LLVM_ABI const APInt &getIConstantFromReg(Register VReg, const MachineRegisterInfo &MRI);
+LLVM_ABI const APInt &getIConstantFromReg(Register VReg,
+                                          const MachineRegisterInfo &MRI);
 
 /// Simple struct used to hold a constant integer value and a virtual
 /// register.
@@ -219,14 +220,14 @@ getFConstantVRegValWithLookThrough(Register VReg,
                                    const MachineRegisterInfo &MRI,
                                    bool LookThroughInstrs = true);
 
-LLVM_ABI const ConstantFP* getConstantFPVRegVal(Register VReg,
-                                       const MachineRegisterInfo &MRI);
+LLVM_ABI const ConstantFP *getConstantFPVRegVal(Register VReg,
+                                                const MachineRegisterInfo &MRI);
 
 /// See if Reg is defined by an single def instruction that is
 /// Opcode. Also try to do trivial folding if it's a COPY with
 /// same types. Returns null otherwise.
 LLVM_ABI MachineInstr *getOpcodeDef(unsigned Opcode, Register Reg,
-                           const MachineRegisterInfo &MRI);
+                                    const MachineRegisterInfo &MRI);
 
 /// Simple struct used to hold a Register value and the instruction which
 /// defines it.
@@ -247,7 +248,7 @@ getDefSrcRegIgnoringCopies(Register Reg, const MachineRegisterInfo &MRI);
 ///
 /// Also walks through hints such as G_ASSERT_ZEXT.
 LLVM_ABI MachineInstr *getDefIgnoringCopies(Register Reg,
-                                   const MachineRegisterInfo &MRI);
+                                            const MachineRegisterInfo &MRI);
 
 /// Find the source register for \p Reg, folding away any trivial copies. It
 /// will be an output register of the instruction that getDefIgnoringCopies
@@ -255,25 +256,29 @@ LLVM_ABI MachineInstr *getDefIgnoringCopies(Register Reg,
 /// register.
 ///
 /// Also walks through hints such as G_ASSERT_ZEXT.
-LLVM_ABI Register getSrcRegIgnoringCopies(Register Reg, const MachineRegisterInfo &MRI);
+LLVM_ABI Register getSrcRegIgnoringCopies(Register Reg,
+                                          const MachineRegisterInfo &MRI);
 
 /// Helper function to split a wide generic register into bitwise blocks with
 /// the given Type (which implies the number of blocks needed). The generic
 /// registers created are appended to Ops, starting at bit 0 of Reg.
 LLVM_ABI void extractParts(Register Reg, LLT Ty, int NumParts,
-                  SmallVectorImpl<Register> &VRegs,
-                  MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI);
+                           SmallVectorImpl<Register> &VRegs,
+                           MachineIRBuilder &MIRBuilder,
+                           MachineRegisterInfo &MRI);
 
 /// Version which handles irregular splits.
 LLVM_ABI bool extractParts(Register Reg, LLT RegTy, LLT MainTy, LLT &LeftoverTy,
-                  SmallVectorImpl<Register> &VRegs,
-                  SmallVectorImpl<Register> &LeftoverVRegs,
-                  MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI);
+                           SmallVectorImpl<Register> &VRegs,
+                           SmallVectorImpl<Register> &LeftoverVRegs,
+                           MachineIRBuilder &MIRBuilder,
+                           MachineRegisterInfo &MRI);
 
 /// Version which handles irregular sub-vector splits.
 LLVM_ABI void extractVectorParts(Register Reg, unsigned NumElts,
-                        SmallVectorImpl<Register> &VRegs,
-                        MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI);
+                                 SmallVectorImpl<Register> &VRegs,
+                                 MachineIRBuilder &MIRBuilder,
+                                 MachineRegisterInfo &MRI);
 
 // Templated variant of getOpcodeDef returning a MachineInstr derived T.
 /// See if Reg is defined by an single def instruction of type T
@@ -292,30 +297,32 @@ LLVM_ABI APFloat getAPFloatFromSize(double Val, unsigned Size);
 /// fallback.
 LLVM_ABI void getSelectionDAGFallbackAnalysisUsage(AnalysisUsage &AU);
 
-LLVM_ABI std::optional<APInt> ConstantFoldBinOp(unsigned Opcode, const Register Op1,
-                                       const Register Op2,
-                                       const MachineRegisterInfo &MRI);
-LLVM_ABI std::optional<APFloat> ConstantFoldFPBinOp(unsigned Opcode, const Register Op1,
-                                           const Register Op2,
-                                           const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<APInt> ConstantFoldBinOp(unsigned Opcode,
+                                                const Register Op1,
+                                                const Register Op2,
+                                                const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<APFloat>
+ConstantFoldFPBinOp(unsigned Opcode, const Register Op1, const Register Op2,
+                    const MachineRegisterInfo &MRI);
 
 /// Tries to constant fold a vector binop with sources \p Op1 and \p Op2.
 /// Returns an empty vector on failure.
-LLVM_ABI SmallVector<APInt> ConstantFoldVectorBinop(unsigned Opcode, const Register Op1,
-                                           const Register Op2,
-                                           const MachineRegisterInfo &MRI);
+LLVM_ABI SmallVector<APInt>
+ConstantFoldVectorBinop(unsigned Opcode, const Register Op1, const Register Op2,
+                        const MachineRegisterInfo &MRI);
 
-LLVM_ABI std::optional<APInt> ConstantFoldCastOp(unsigned Opcode, LLT DstTy,
-                                        const Register Op0,
-                                        const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<APInt>
+ConstantFoldCastOp(unsigned Opcode, LLT DstTy, const Register Op0,
+                   const MachineRegisterInfo &MRI);
 
-LLVM_ABI std::optional<APInt> ConstantFoldExtOp(unsigned Opcode, const Register Op1,
-                                       uint64_t Imm,
-                                       const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<APInt> ConstantFoldExtOp(unsigned Opcode,
+                                                const Register Op1,
+                                                uint64_t Imm,
+                                                const MachineRegisterInfo &MRI);
 
-LLVM_ABI std::optional<APFloat> ConstantFoldIntToFloat(unsigned Opcode, LLT DstTy,
-                                              Register Src,
-                                              const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<APFloat>
+ConstantFoldIntToFloat(unsigned Opcode, LLT DstTy, Register Src,
+                       const MachineRegisterInfo &MRI);
 
 /// Tries to constant fold a counting-zero operation (G_CTLZ or G_CTTZ) on \p
 /// Src. If \p Src is a vector then it tries to do an element-wise constant
@@ -332,20 +339,22 @@ ConstantFoldICmp(unsigned Pred, const Register Op1, const Register Op2,
 /// Test if the given value is known to have exactly one bit set. This differs
 /// from computeKnownBits in that it doesn't necessarily determine which bit is
 /// set.
-LLVM_ABI bool isKnownToBeAPowerOfTwo(Register Val, const MachineRegisterInfo &MRI,
-                            GISelValueTracking *ValueTracking = nullptr);
+LLVM_ABI bool
+isKnownToBeAPowerOfTwo(Register Val, const MachineRegisterInfo &MRI,
+                       GISelValueTracking *ValueTracking = nullptr);
 
 /// Returns true if \p Val can be assumed to never be a NaN. If \p SNaN is true,
 /// this returns if \p Val can be assumed to never be a signaling NaN.
 LLVM_ABI bool isKnownNeverNaN(Register Val, const MachineRegisterInfo &MRI,
-                     bool SNaN = false);
+                              bool SNaN = false);
 
 /// Returns true if \p Val can be assumed to never be a signaling NaN.
 inline bool isKnownNeverSNaN(Register Val, const MachineRegisterInfo &MRI) {
   return isKnownNeverNaN(Val, MRI, true);
 }
 
-LLVM_ABI Align inferAlignFromPtrInfo(MachineFunction &MF, const MachinePointerInfo &MPO);
+LLVM_ABI Align inferAlignFromPtrInfo(MachineFunction &MF,
+                                     const MachinePointerInfo &MPO);
 
 /// Return a virtual register corresponding to the incoming argument register \p
 /// PhysReg. This register is expected to have class \p RC, and optional type \p
@@ -353,11 +362,9 @@ LLVM_ABI Align inferAlignFromPtrInfo(MachineFunction &MF, const MachinePointerIn
 ///
 /// If there is an existing live-in argument register, it will be returned.
 /// This will also ensure there is a valid copy
-LLVM_ABI Register getFunctionLiveInPhysReg(MachineFunction &MF,
-                                  const TargetInstrInfo &TII,
-                                  MCRegister PhysReg,
-                                  const TargetRegisterClass &RC,
-                                  const DebugLoc &DL, LLT RegTy = LLT());
+LLVM_ABI Register getFunctionLiveInPhysReg(
+    MachineFunction &MF, const TargetInstrInfo &TII, MCRegister PhysReg,
+    const TargetRegisterClass &RC, const DebugLoc &DL, LLT RegTy = LLT());
 
 /// Return the least common multiple type of \p OrigTy and \p TargetTy, by
 /// changing the number of vector elements or scalar bitwidth. The intent is a
@@ -366,13 +373,13 @@ LLVM_ABI Register getFunctionLiveInPhysReg(MachineFunction &MF,
 /// this function where one argument is a fixed vector and the other is a
 /// scalable vector, since it is illegal to build a G_{MERGE|UNMERGE}_VALUES
 /// between fixed and scalable vectors.
-LLVM_ABI LLVM_READNONE
-LLT getLCMType(LLT OrigTy, LLT TargetTy);
+LLVM_ABI LLVM_READNONE LLT getLCMType(LLT OrigTy, LLT TargetTy);
 
 LLVM_ABI LLVM_READNONE
-/// Return smallest type that covers both \p OrigTy and \p TargetTy and is
-/// multiple of TargetTy.
-LLT getCoverTy(LLT OrigTy, LLT TargetTy);
+    /// Return smallest type that covers both \p OrigTy and \p TargetTy and is
+    /// multiple of TargetTy.
+    LLT
+    getCoverTy(LLT OrigTy, LLT TargetTy);
 
 /// Return a type where the total size is the greatest common divisor of \p
 /// OrigTy and \p TargetTy. This will try to either change the number of vector
@@ -390,8 +397,7 @@ LLT getCoverTy(LLT OrigTy, LLT TargetTy);
 /// vectors.
 ///
 /// In the worst case, this returns LLT::scalar(1)
-LLVM_ABI LLVM_READNONE
-LLT getGCDType(LLT OrigTy, LLT TargetTy);
+LLVM_ABI LLVM_READNONE LLT getGCDType(LLT OrigTy, LLT TargetTy);
 
 /// Represents a value which can be a Register or a constant.
 ///
@@ -423,52 +429,53 @@ public:
 LLVM_ABI std::optional<int> getSplatIndex(MachineInstr &MI);
 
 /// \returns the scalar integral splat value of \p Reg if possible.
-LLVM_ABI std::optional<APInt> getIConstantSplatVal(const Register Reg,
-                                          const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<APInt>
+getIConstantSplatVal(const Register Reg, const MachineRegisterInfo &MRI);
 
 /// \returns the scalar integral splat value defined by \p MI if possible.
-LLVM_ABI std::optional<APInt> getIConstantSplatVal(const MachineInstr &MI,
-                                          const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<APInt>
+getIConstantSplatVal(const MachineInstr &MI, const MachineRegisterInfo &MRI);
 
 /// \returns the scalar sign extended integral splat value of \p Reg if
 /// possible.
-LLVM_ABI std::optional<int64_t> getIConstantSplatSExtVal(const Register Reg,
-                                                const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<int64_t>
+getIConstantSplatSExtVal(const Register Reg, const MachineRegisterInfo &MRI);
 
 /// \returns the scalar sign extended integral splat value defined by \p MI if
 /// possible.
-LLVM_ABI std::optional<int64_t> getIConstantSplatSExtVal(const MachineInstr &MI,
-                                                const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<int64_t>
+getIConstantSplatSExtVal(const MachineInstr &MI,
+                         const MachineRegisterInfo &MRI);
 
 /// Returns a floating point scalar constant of a build vector splat if it
 /// exists. When \p AllowUndef == true some elements can be undef but not all.
-LLVM_ABI std::optional<FPValueAndVReg> getFConstantSplat(Register VReg,
-                                                const MachineRegisterInfo &MRI,
-                                                bool AllowUndef = true);
+LLVM_ABI std::optional<FPValueAndVReg>
+getFConstantSplat(Register VReg, const MachineRegisterInfo &MRI,
+                  bool AllowUndef = true);
 
 /// Return true if the specified register is defined by G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are \p SplatValue or undef.
 LLVM_ABI bool isBuildVectorConstantSplat(const Register Reg,
-                                const MachineRegisterInfo &MRI,
-                                int64_t SplatValue, bool AllowUndef);
+                                         const MachineRegisterInfo &MRI,
+                                         int64_t SplatValue, bool AllowUndef);
 
 /// Return true if the specified instruction is a G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are \p SplatValue or undef.
 LLVM_ABI bool isBuildVectorConstantSplat(const MachineInstr &MI,
-                                const MachineRegisterInfo &MRI,
-                                int64_t SplatValue, bool AllowUndef);
+                                         const MachineRegisterInfo &MRI,
+                                         int64_t SplatValue, bool AllowUndef);
 
 /// Return true if the specified instruction is a G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are 0 or undef.
 LLVM_ABI bool isBuildVectorAllZeros(const MachineInstr &MI,
-                           const MachineRegisterInfo &MRI,
-                           bool AllowUndef = false);
+                                    const MachineRegisterInfo &MRI,
+                                    bool AllowUndef = false);
 
 /// Return true if the specified instruction is a G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are ~0 or undef.
 LLVM_ABI bool isBuildVectorAllOnes(const MachineInstr &MI,
-                          const MachineRegisterInfo &MRI,
-                          bool AllowUndef = false);
+                                   const MachineRegisterInfo &MRI,
+                                   bool AllowUndef = false);
 
 /// Return true if the specified instruction is known to be a constant, or a
 /// vector of constants.
@@ -477,22 +484,23 @@ LLVM_ABI bool isBuildVectorAllOnes(const MachineInstr &MI,
 /// G_CONSTANT. If \p AllowOpaqueConstants is true, constant-like instructions
 /// such as G_GLOBAL_VALUE will also be considered.
 LLVM_ABI bool isConstantOrConstantVector(const MachineInstr &MI,
-                                const MachineRegisterInfo &MRI,
-                                bool AllowFP = true,
-                                bool AllowOpaqueConstants = true);
+                                         const MachineRegisterInfo &MRI,
+                                         bool AllowFP = true,
+                                         bool AllowOpaqueConstants = true);
 
 /// Return true if the value is a constant 0 integer or a splatted vector of a
 /// constant 0 integer (with no undefs if \p AllowUndefs is false). This will
 /// handle G_BUILD_VECTOR and G_BUILD_VECTOR_TRUNC as truncation is not an issue
 /// for null values.
-LLVM_ABI bool isNullOrNullSplat(const MachineInstr &MI, const MachineRegisterInfo &MRI,
-                       bool AllowUndefs = false);
+LLVM_ABI bool isNullOrNullSplat(const MachineInstr &MI,
+                                const MachineRegisterInfo &MRI,
+                                bool AllowUndefs = false);
 
 /// Return true if the value is a constant -1 integer or a splatted vector of a
 /// constant -1 integer (with no undefs if \p AllowUndefs is false).
 LLVM_ABI bool isAllOnesOrAllOnesSplat(const MachineInstr &MI,
-                             const MachineRegisterInfo &MRI,
-                             bool AllowUndefs = false);
+                                      const MachineRegisterInfo &MRI,
+                                      bool AllowUndefs = false);
 
 /// \returns a value when \p MI is a vector splat. The splat can be either a
 /// Register or a constant.
@@ -513,13 +521,13 @@ LLVM_ABI bool isAllOnesOrAllOnesSplat(const MachineInstr &MI,
 /// \endcode
 ///
 /// In the above case, this will return a RegOrConstant containing 4.
-LLVM_ABI std::optional<RegOrConstant> getVectorSplat(const MachineInstr &MI,
-                                            const MachineRegisterInfo &MRI);
+LLVM_ABI std::optional<RegOrConstant>
+getVectorSplat(const MachineInstr &MI, const MachineRegisterInfo &MRI);
 
 /// Determines if \p MI defines a constant integer or a build vector of
 /// constant integers. Treats undef values as constants.
 LLVM_ABI bool isConstantOrConstantVector(MachineInstr &MI,
-                                const MachineRegisterInfo &MRI);
+                                         const MachineRegisterInfo &MRI);
 
 /// Determines if \p MI defines a constant integer or a splat vector of
 /// constant integers.
@@ -538,35 +546,39 @@ isConstantOrConstantSplatVectorFP(MachineInstr &MI,
 /// Attempt to match a unary predicate against a scalar/splat constant or every
 /// element of a constant G_BUILD_VECTOR. If \p ConstVal is null, the source
 /// value was undef.
-LLVM_ABI bool matchUnaryPredicate(const MachineRegisterInfo &MRI, Register Reg,
-                         std::function<bool(const Constant *ConstVal)> Match,
-                         bool AllowUndefs = false);
+LLVM_ABI bool
+matchUnaryPredicate(const MachineRegisterInfo &MRI, Register Reg,
+                    std::function<bool(const Constant *ConstVal)> Match,
+                    bool AllowUndefs = false);
 
 /// Returns true if given the TargetLowering's boolean contents information,
 /// the value \p Val contains a true value.
-LLVM_ABI bool isConstTrueVal(const TargetLowering &TLI, int64_t Val, bool IsVector,
-                    bool IsFP);
+LLVM_ABI bool isConstTrueVal(const TargetLowering &TLI, int64_t Val,
+                             bool IsVector, bool IsFP);
 /// \returns true if given the TargetLowering's boolean contents information,
 /// the value \p Val contains a false value.
-LLVM_ABI bool isConstFalseVal(const TargetLowering &TLI, int64_t Val, bool IsVector,
-                    bool IsFP);
+LLVM_ABI bool isConstFalseVal(const TargetLowering &TLI, int64_t Val,
+                              bool IsVector, bool IsFP);
 
 /// Returns an integer representing true, as defined by the
 /// TargetBooleanContents.
-LLVM_ABI int64_t getICmpTrueVal(const TargetLowering &TLI, bool IsVector, bool IsFP);
+LLVM_ABI int64_t getICmpTrueVal(const TargetLowering &TLI, bool IsVector,
+                                bool IsFP);
 
 using SmallInstListTy = GISelWorkList<4>;
 LLVM_ABI void saveUsesAndErase(MachineInstr &MI, MachineRegisterInfo &MRI,
-                      LostDebugLocObserver *LocObserver,
-                      SmallInstListTy &DeadInstChain);
-LLVM_ABI void eraseInstrs(ArrayRef<MachineInstr *> DeadInstrs, MachineRegisterInfo &MRI,
-                 LostDebugLocObserver *LocObserver = nullptr);
+                               LostDebugLocObserver *LocObserver,
+                               SmallInstListTy &DeadInstChain);
+LLVM_ABI void eraseInstrs(ArrayRef<MachineInstr *> DeadInstrs,
+                          MachineRegisterInfo &MRI,
+                          LostDebugLocObserver *LocObserver = nullptr);
 LLVM_ABI void eraseInstr(MachineInstr &MI, MachineRegisterInfo &MRI,
-                LostDebugLocObserver *LocObserver = nullptr);
+                         LostDebugLocObserver *LocObserver = nullptr);
 
 /// Assuming the instruction \p MI is going to be deleted, attempt to salvage
 /// debug users of \p MI by writing the effect of \p MI in a DIExpression.
-LLVM_ABI void salvageDebugInfo(const MachineRegisterInfo &MRI, MachineInstr &MI);
+LLVM_ABI void salvageDebugInfo(const MachineRegisterInfo &MRI,
+                               MachineInstr &MI);
 
 /// Returns whether opcode \p Opc is a pre-isel generic floating-point opcode,
 /// having only floating-point operands.
@@ -578,25 +590,28 @@ LLVM_ABI bool isPreISelGenericFloatingPointOpcode(unsigned Opc);
 /// used to see if the instruction could still introduce undef or poison even
 /// without poison generating flags and metadata which might be on the
 /// instruction.
-LLVM_ABI bool canCreateUndefOrPoison(Register Reg, const MachineRegisterInfo &MRI,
-                            bool ConsiderFlagsAndMetadata = true);
+LLVM_ABI bool canCreateUndefOrPoison(Register Reg,
+                                     const MachineRegisterInfo &MRI,
+                                     bool ConsiderFlagsAndMetadata = true);
 
 /// Returns true if \p Reg can create poison from non-poison operands.
 LLVM_ABI bool canCreatePoison(Register Reg, const MachineRegisterInfo &MRI,
-                     bool ConsiderFlagsAndMetadata = true);
+                              bool ConsiderFlagsAndMetadata = true);
 
 /// Returns true if \p Reg cannot be poison and undef.
 LLVM_ABI bool isGuaranteedNotToBeUndefOrPoison(Register Reg,
-                                      const MachineRegisterInfo &MRI,
-                                      unsigned Depth = 0);
+                                               const MachineRegisterInfo &MRI,
+                                               unsigned Depth = 0);
 
 /// Returns true if \p Reg cannot be poison, but may be undef.
-LLVM_ABI bool isGuaranteedNotToBePoison(Register Reg, const MachineRegisterInfo &MRI,
-                               unsigned Depth = 0);
+LLVM_ABI bool isGuaranteedNotToBePoison(Register Reg,
+                                        const MachineRegisterInfo &MRI,
+                                        unsigned Depth = 0);
 
 /// Returns true if \p Reg cannot be undef, but may be poison.
-LLVM_ABI bool isGuaranteedNotToBeUndef(Register Reg, const MachineRegisterInfo &MRI,
-                              unsigned Depth = 0);
+LLVM_ABI bool isGuaranteedNotToBeUndef(Register Reg,
+                                       const MachineRegisterInfo &MRI,
+                                       unsigned Depth = 0);
 
 /// Get the type back from LLT. It won't be 100 percent accurate but returns an
 /// estimate of the type.
@@ -637,8 +652,8 @@ public:
   /// Returns the value, if this constant is a scalar.
   LLVM_ABI APInt getScalarValue() const;
 
-  LLVM_ABI static std::optional<GIConstant> getConstant(Register Const,
-                                               const MachineRegisterInfo &MRI);
+  LLVM_ABI static std::optional<GIConstant>
+  getConstant(Register Const, const MachineRegisterInfo &MRI);
 };
 
 /// An floating-point-like constant.
@@ -696,8 +711,8 @@ public:
   /// Returns the value, if this constant is a scalar.
   LLVM_ABI APFloat getScalarValue() const;
 
-  LLVM_ABI static std::optional<GFConstant> getConstant(Register Const,
-                                               const MachineRegisterInfo &MRI);
+  LLVM_ABI static std::optional<GFConstant>
+  getConstant(Register Const, const MachineRegisterInfo &MRI);
 };
 
 } // End namespace llvm.

--- a/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_GLOBALISEL_UTILS_H
 #define LLVM_CODEGEN_GLOBALISEL_UTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "GISelWorkList.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/StringRef.h"
@@ -92,7 +93,7 @@ class APFloat;
 /// create a new virtual register in the correct class.
 ///
 /// \return The virtual register constrained to the right register class.
-Register constrainRegToClass(MachineRegisterInfo &MRI,
+LLVM_ABI Register constrainRegToClass(MachineRegisterInfo &MRI,
                              const TargetInstrInfo &TII,
                              const RegisterBankInfo &RBI, Register Reg,
                              const TargetRegisterClass &RegClass);
@@ -105,7 +106,7 @@ Register constrainRegToClass(MachineRegisterInfo &MRI,
 /// location of \p InsertPt is used for the new copy.
 ///
 /// \return The virtual register constrained to the right register class.
-Register constrainOperandRegClass(const MachineFunction &MF,
+LLVM_ABI Register constrainOperandRegClass(const MachineFunction &MF,
                                   const TargetRegisterInfo &TRI,
                                   MachineRegisterInfo &MRI,
                                   const TargetInstrInfo &TII,
@@ -124,7 +125,7 @@ Register constrainOperandRegClass(const MachineFunction &MF,
 /// InsertPt is used for the new copy.
 ///
 /// \return The virtual register constrained to the right register class.
-Register constrainOperandRegClass(const MachineFunction &MF,
+LLVM_ABI Register constrainOperandRegClass(const MachineFunction &MF,
                                   const TargetRegisterInfo &TRI,
                                   MachineRegisterInfo &MRI,
                                   const TargetInstrInfo &TII,
@@ -141,50 +142,50 @@ Register constrainOperandRegClass(const MachineFunction &MF,
 // FIXME: Not all instructions have the same number of operands. We should
 // probably expose a constrain helper per operand and let the target selector
 // constrain individual registers, like fast-isel.
-bool constrainSelectedInstRegOperands(MachineInstr &I,
+LLVM_ABI bool constrainSelectedInstRegOperands(MachineInstr &I,
                                       const TargetInstrInfo &TII,
                                       const TargetRegisterInfo &TRI,
                                       const RegisterBankInfo &RBI);
 
 /// Check if DstReg can be replaced with SrcReg depending on the register
 /// constraints.
-bool canReplaceReg(Register DstReg, Register SrcReg, MachineRegisterInfo &MRI);
+LLVM_ABI bool canReplaceReg(Register DstReg, Register SrcReg, MachineRegisterInfo &MRI);
 
 /// Check whether an instruction \p MI is dead: it only defines dead virtual
 /// registers, and doesn't have other side effects.
-bool isTriviallyDead(const MachineInstr &MI, const MachineRegisterInfo &MRI);
+LLVM_ABI bool isTriviallyDead(const MachineInstr &MI, const MachineRegisterInfo &MRI);
 
 /// Report an ISel error as a missed optimization remark to the LLVMContext's
 /// diagnostic stream.  Set the FailedISel MachineFunction property.
-void reportGISelFailure(MachineFunction &MF, const TargetPassConfig &TPC,
+LLVM_ABI void reportGISelFailure(MachineFunction &MF, const TargetPassConfig &TPC,
                         MachineOptimizationRemarkEmitter &MORE,
                         MachineOptimizationRemarkMissed &R);
 
-void reportGISelFailure(MachineFunction &MF, const TargetPassConfig &TPC,
+LLVM_ABI void reportGISelFailure(MachineFunction &MF, const TargetPassConfig &TPC,
                         MachineOptimizationRemarkEmitter &MORE,
                         const char *PassName, StringRef Msg,
                         const MachineInstr &MI);
 
 /// Report an ISel warning as a missed optimization remark to the LLVMContext's
 /// diagnostic stream.
-void reportGISelWarning(MachineFunction &MF, const TargetPassConfig &TPC,
+LLVM_ABI void reportGISelWarning(MachineFunction &MF, const TargetPassConfig &TPC,
                         MachineOptimizationRemarkEmitter &MORE,
                         MachineOptimizationRemarkMissed &R);
 
 /// Returns the inverse opcode of \p MinMaxOpc, which is a generic min/max
 /// opcode like G_SMIN.
-unsigned getInverseGMinMaxOpcode(unsigned MinMaxOpc);
+LLVM_ABI unsigned getInverseGMinMaxOpcode(unsigned MinMaxOpc);
 
 /// If \p VReg is defined by a G_CONSTANT, return the corresponding value.
-std::optional<APInt> getIConstantVRegVal(Register VReg,
+LLVM_ABI std::optional<APInt> getIConstantVRegVal(Register VReg,
                                          const MachineRegisterInfo &MRI);
 
 /// If \p VReg is defined by a G_CONSTANT fits in int64_t returns it.
-std::optional<int64_t> getIConstantVRegSExtVal(Register VReg,
+LLVM_ABI std::optional<int64_t> getIConstantVRegSExtVal(Register VReg,
                                                const MachineRegisterInfo &MRI);
 
 /// \p VReg is defined by a G_CONSTANT, return the corresponding value.
-const APInt &getIConstantFromReg(Register VReg, const MachineRegisterInfo &MRI);
+LLVM_ABI const APInt &getIConstantFromReg(Register VReg, const MachineRegisterInfo &MRI);
 
 /// Simple struct used to hold a constant integer value and a virtual
 /// register.
@@ -195,14 +196,14 @@ struct ValueAndVReg {
 
 /// If \p VReg is defined by a statically evaluable chain of instructions rooted
 /// on a G_CONSTANT returns its APInt value and def register.
-std::optional<ValueAndVReg>
+LLVM_ABI std::optional<ValueAndVReg>
 getIConstantVRegValWithLookThrough(Register VReg,
                                    const MachineRegisterInfo &MRI,
                                    bool LookThroughInstrs = true);
 
 /// If \p VReg is defined by a statically evaluable chain of instructions rooted
 /// on a G_CONSTANT or G_FCONSTANT returns its value as APInt and def register.
-std::optional<ValueAndVReg> getAnyConstantVRegValWithLookThrough(
+LLVM_ABI std::optional<ValueAndVReg> getAnyConstantVRegValWithLookThrough(
     Register VReg, const MachineRegisterInfo &MRI,
     bool LookThroughInstrs = true, bool LookThroughAnyExt = false);
 
@@ -213,18 +214,18 @@ struct FPValueAndVReg {
 
 /// If \p VReg is defined by a statically evaluable chain of instructions rooted
 /// on a G_FCONSTANT returns its APFloat value and def register.
-std::optional<FPValueAndVReg>
+LLVM_ABI std::optional<FPValueAndVReg>
 getFConstantVRegValWithLookThrough(Register VReg,
                                    const MachineRegisterInfo &MRI,
                                    bool LookThroughInstrs = true);
 
-const ConstantFP* getConstantFPVRegVal(Register VReg,
+LLVM_ABI const ConstantFP* getConstantFPVRegVal(Register VReg,
                                        const MachineRegisterInfo &MRI);
 
 /// See if Reg is defined by an single def instruction that is
 /// Opcode. Also try to do trivial folding if it's a COPY with
 /// same types. Returns null otherwise.
-MachineInstr *getOpcodeDef(unsigned Opcode, Register Reg,
+LLVM_ABI MachineInstr *getOpcodeDef(unsigned Opcode, Register Reg,
                            const MachineRegisterInfo &MRI);
 
 /// Simple struct used to hold a Register value and the instruction which
@@ -238,14 +239,14 @@ struct DefinitionAndSourceRegister {
 /// away any copies.
 ///
 /// Also walks through hints such as G_ASSERT_ZEXT.
-std::optional<DefinitionAndSourceRegister>
+LLVM_ABI std::optional<DefinitionAndSourceRegister>
 getDefSrcRegIgnoringCopies(Register Reg, const MachineRegisterInfo &MRI);
 
 /// Find the def instruction for \p Reg, folding away any trivial copies. May
 /// return nullptr if \p Reg is not a generic virtual register.
 ///
 /// Also walks through hints such as G_ASSERT_ZEXT.
-MachineInstr *getDefIgnoringCopies(Register Reg,
+LLVM_ABI MachineInstr *getDefIgnoringCopies(Register Reg,
                                    const MachineRegisterInfo &MRI);
 
 /// Find the source register for \p Reg, folding away any trivial copies. It
@@ -254,23 +255,23 @@ MachineInstr *getDefIgnoringCopies(Register Reg,
 /// register.
 ///
 /// Also walks through hints such as G_ASSERT_ZEXT.
-Register getSrcRegIgnoringCopies(Register Reg, const MachineRegisterInfo &MRI);
+LLVM_ABI Register getSrcRegIgnoringCopies(Register Reg, const MachineRegisterInfo &MRI);
 
 /// Helper function to split a wide generic register into bitwise blocks with
 /// the given Type (which implies the number of blocks needed). The generic
 /// registers created are appended to Ops, starting at bit 0 of Reg.
-void extractParts(Register Reg, LLT Ty, int NumParts,
+LLVM_ABI void extractParts(Register Reg, LLT Ty, int NumParts,
                   SmallVectorImpl<Register> &VRegs,
                   MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI);
 
 /// Version which handles irregular splits.
-bool extractParts(Register Reg, LLT RegTy, LLT MainTy, LLT &LeftoverTy,
+LLVM_ABI bool extractParts(Register Reg, LLT RegTy, LLT MainTy, LLT &LeftoverTy,
                   SmallVectorImpl<Register> &VRegs,
                   SmallVectorImpl<Register> &LeftoverVRegs,
                   MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI);
 
 /// Version which handles irregular sub-vector splits.
-void extractVectorParts(Register Reg, unsigned NumElts,
+LLVM_ABI void extractVectorParts(Register Reg, unsigned NumElts,
                         SmallVectorImpl<Register> &VRegs,
                         MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI);
 
@@ -285,45 +286,45 @@ T *getOpcodeDef(Register Reg, const MachineRegisterInfo &MRI) {
 }
 
 /// Returns an APFloat from Val converted to the appropriate size.
-APFloat getAPFloatFromSize(double Val, unsigned Size);
+LLVM_ABI APFloat getAPFloatFromSize(double Val, unsigned Size);
 
 /// Modify analysis usage so it preserves passes required for the SelectionDAG
 /// fallback.
-void getSelectionDAGFallbackAnalysisUsage(AnalysisUsage &AU);
+LLVM_ABI void getSelectionDAGFallbackAnalysisUsage(AnalysisUsage &AU);
 
-std::optional<APInt> ConstantFoldBinOp(unsigned Opcode, const Register Op1,
+LLVM_ABI std::optional<APInt> ConstantFoldBinOp(unsigned Opcode, const Register Op1,
                                        const Register Op2,
                                        const MachineRegisterInfo &MRI);
-std::optional<APFloat> ConstantFoldFPBinOp(unsigned Opcode, const Register Op1,
+LLVM_ABI std::optional<APFloat> ConstantFoldFPBinOp(unsigned Opcode, const Register Op1,
                                            const Register Op2,
                                            const MachineRegisterInfo &MRI);
 
 /// Tries to constant fold a vector binop with sources \p Op1 and \p Op2.
 /// Returns an empty vector on failure.
-SmallVector<APInt> ConstantFoldVectorBinop(unsigned Opcode, const Register Op1,
+LLVM_ABI SmallVector<APInt> ConstantFoldVectorBinop(unsigned Opcode, const Register Op1,
                                            const Register Op2,
                                            const MachineRegisterInfo &MRI);
 
-std::optional<APInt> ConstantFoldCastOp(unsigned Opcode, LLT DstTy,
+LLVM_ABI std::optional<APInt> ConstantFoldCastOp(unsigned Opcode, LLT DstTy,
                                         const Register Op0,
                                         const MachineRegisterInfo &MRI);
 
-std::optional<APInt> ConstantFoldExtOp(unsigned Opcode, const Register Op1,
+LLVM_ABI std::optional<APInt> ConstantFoldExtOp(unsigned Opcode, const Register Op1,
                                        uint64_t Imm,
                                        const MachineRegisterInfo &MRI);
 
-std::optional<APFloat> ConstantFoldIntToFloat(unsigned Opcode, LLT DstTy,
+LLVM_ABI std::optional<APFloat> ConstantFoldIntToFloat(unsigned Opcode, LLT DstTy,
                                               Register Src,
                                               const MachineRegisterInfo &MRI);
 
 /// Tries to constant fold a counting-zero operation (G_CTLZ or G_CTTZ) on \p
 /// Src. If \p Src is a vector then it tries to do an element-wise constant
 /// fold.
-std::optional<SmallVector<unsigned>>
+LLVM_ABI std::optional<SmallVector<unsigned>>
 ConstantFoldCountZeros(Register Src, const MachineRegisterInfo &MRI,
                        std::function<unsigned(APInt)> CB);
 
-std::optional<SmallVector<APInt>>
+LLVM_ABI std::optional<SmallVector<APInt>>
 ConstantFoldICmp(unsigned Pred, const Register Op1, const Register Op2,
                  unsigned DstScalarSizeInBits, unsigned ExtOp,
                  const MachineRegisterInfo &MRI);
@@ -331,12 +332,12 @@ ConstantFoldICmp(unsigned Pred, const Register Op1, const Register Op2,
 /// Test if the given value is known to have exactly one bit set. This differs
 /// from computeKnownBits in that it doesn't necessarily determine which bit is
 /// set.
-bool isKnownToBeAPowerOfTwo(Register Val, const MachineRegisterInfo &MRI,
+LLVM_ABI bool isKnownToBeAPowerOfTwo(Register Val, const MachineRegisterInfo &MRI,
                             GISelValueTracking *ValueTracking = nullptr);
 
 /// Returns true if \p Val can be assumed to never be a NaN. If \p SNaN is true,
 /// this returns if \p Val can be assumed to never be a signaling NaN.
-bool isKnownNeverNaN(Register Val, const MachineRegisterInfo &MRI,
+LLVM_ABI bool isKnownNeverNaN(Register Val, const MachineRegisterInfo &MRI,
                      bool SNaN = false);
 
 /// Returns true if \p Val can be assumed to never be a signaling NaN.
@@ -344,7 +345,7 @@ inline bool isKnownNeverSNaN(Register Val, const MachineRegisterInfo &MRI) {
   return isKnownNeverNaN(Val, MRI, true);
 }
 
-Align inferAlignFromPtrInfo(MachineFunction &MF, const MachinePointerInfo &MPO);
+LLVM_ABI Align inferAlignFromPtrInfo(MachineFunction &MF, const MachinePointerInfo &MPO);
 
 /// Return a virtual register corresponding to the incoming argument register \p
 /// PhysReg. This register is expected to have class \p RC, and optional type \p
@@ -352,7 +353,7 @@ Align inferAlignFromPtrInfo(MachineFunction &MF, const MachinePointerInfo &MPO);
 ///
 /// If there is an existing live-in argument register, it will be returned.
 /// This will also ensure there is a valid copy
-Register getFunctionLiveInPhysReg(MachineFunction &MF,
+LLVM_ABI Register getFunctionLiveInPhysReg(MachineFunction &MF,
                                   const TargetInstrInfo &TII,
                                   MCRegister PhysReg,
                                   const TargetRegisterClass &RC,
@@ -365,10 +366,10 @@ Register getFunctionLiveInPhysReg(MachineFunction &MF,
 /// this function where one argument is a fixed vector and the other is a
 /// scalable vector, since it is illegal to build a G_{MERGE|UNMERGE}_VALUES
 /// between fixed and scalable vectors.
-LLVM_READNONE
+LLVM_ABI LLVM_READNONE
 LLT getLCMType(LLT OrigTy, LLT TargetTy);
 
-LLVM_READNONE
+LLVM_ABI LLVM_READNONE
 /// Return smallest type that covers both \p OrigTy and \p TargetTy and is
 /// multiple of TargetTy.
 LLT getCoverTy(LLT OrigTy, LLT TargetTy);
@@ -389,7 +390,7 @@ LLT getCoverTy(LLT OrigTy, LLT TargetTy);
 /// vectors.
 ///
 /// In the worst case, this returns LLT::scalar(1)
-LLVM_READNONE
+LLVM_ABI LLVM_READNONE
 LLT getGCDType(LLT OrigTy, LLT TargetTy);
 
 /// Represents a value which can be a Register or a constant.
@@ -419,53 +420,53 @@ public:
 
 /// \returns The splat index of a G_SHUFFLE_VECTOR \p MI when \p MI is a splat.
 /// If \p MI is not a splat, returns std::nullopt.
-std::optional<int> getSplatIndex(MachineInstr &MI);
+LLVM_ABI std::optional<int> getSplatIndex(MachineInstr &MI);
 
 /// \returns the scalar integral splat value of \p Reg if possible.
-std::optional<APInt> getIConstantSplatVal(const Register Reg,
+LLVM_ABI std::optional<APInt> getIConstantSplatVal(const Register Reg,
                                           const MachineRegisterInfo &MRI);
 
 /// \returns the scalar integral splat value defined by \p MI if possible.
-std::optional<APInt> getIConstantSplatVal(const MachineInstr &MI,
+LLVM_ABI std::optional<APInt> getIConstantSplatVal(const MachineInstr &MI,
                                           const MachineRegisterInfo &MRI);
 
 /// \returns the scalar sign extended integral splat value of \p Reg if
 /// possible.
-std::optional<int64_t> getIConstantSplatSExtVal(const Register Reg,
+LLVM_ABI std::optional<int64_t> getIConstantSplatSExtVal(const Register Reg,
                                                 const MachineRegisterInfo &MRI);
 
 /// \returns the scalar sign extended integral splat value defined by \p MI if
 /// possible.
-std::optional<int64_t> getIConstantSplatSExtVal(const MachineInstr &MI,
+LLVM_ABI std::optional<int64_t> getIConstantSplatSExtVal(const MachineInstr &MI,
                                                 const MachineRegisterInfo &MRI);
 
 /// Returns a floating point scalar constant of a build vector splat if it
 /// exists. When \p AllowUndef == true some elements can be undef but not all.
-std::optional<FPValueAndVReg> getFConstantSplat(Register VReg,
+LLVM_ABI std::optional<FPValueAndVReg> getFConstantSplat(Register VReg,
                                                 const MachineRegisterInfo &MRI,
                                                 bool AllowUndef = true);
 
 /// Return true if the specified register is defined by G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are \p SplatValue or undef.
-bool isBuildVectorConstantSplat(const Register Reg,
+LLVM_ABI bool isBuildVectorConstantSplat(const Register Reg,
                                 const MachineRegisterInfo &MRI,
                                 int64_t SplatValue, bool AllowUndef);
 
 /// Return true if the specified instruction is a G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are \p SplatValue or undef.
-bool isBuildVectorConstantSplat(const MachineInstr &MI,
+LLVM_ABI bool isBuildVectorConstantSplat(const MachineInstr &MI,
                                 const MachineRegisterInfo &MRI,
                                 int64_t SplatValue, bool AllowUndef);
 
 /// Return true if the specified instruction is a G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are 0 or undef.
-bool isBuildVectorAllZeros(const MachineInstr &MI,
+LLVM_ABI bool isBuildVectorAllZeros(const MachineInstr &MI,
                            const MachineRegisterInfo &MRI,
                            bool AllowUndef = false);
 
 /// Return true if the specified instruction is a G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are ~0 or undef.
-bool isBuildVectorAllOnes(const MachineInstr &MI,
+LLVM_ABI bool isBuildVectorAllOnes(const MachineInstr &MI,
                           const MachineRegisterInfo &MRI,
                           bool AllowUndef = false);
 
@@ -475,7 +476,7 @@ bool isBuildVectorAllOnes(const MachineInstr &MI,
 /// If \p AllowFP is true, this will consider G_FCONSTANT in addition to
 /// G_CONSTANT. If \p AllowOpaqueConstants is true, constant-like instructions
 /// such as G_GLOBAL_VALUE will also be considered.
-bool isConstantOrConstantVector(const MachineInstr &MI,
+LLVM_ABI bool isConstantOrConstantVector(const MachineInstr &MI,
                                 const MachineRegisterInfo &MRI,
                                 bool AllowFP = true,
                                 bool AllowOpaqueConstants = true);
@@ -484,12 +485,12 @@ bool isConstantOrConstantVector(const MachineInstr &MI,
 /// constant 0 integer (with no undefs if \p AllowUndefs is false). This will
 /// handle G_BUILD_VECTOR and G_BUILD_VECTOR_TRUNC as truncation is not an issue
 /// for null values.
-bool isNullOrNullSplat(const MachineInstr &MI, const MachineRegisterInfo &MRI,
+LLVM_ABI bool isNullOrNullSplat(const MachineInstr &MI, const MachineRegisterInfo &MRI,
                        bool AllowUndefs = false);
 
 /// Return true if the value is a constant -1 integer or a splatted vector of a
 /// constant -1 integer (with no undefs if \p AllowUndefs is false).
-bool isAllOnesOrAllOnesSplat(const MachineInstr &MI,
+LLVM_ABI bool isAllOnesOrAllOnesSplat(const MachineInstr &MI,
                              const MachineRegisterInfo &MRI,
                              bool AllowUndefs = false);
 
@@ -512,64 +513,64 @@ bool isAllOnesOrAllOnesSplat(const MachineInstr &MI,
 /// \endcode
 ///
 /// In the above case, this will return a RegOrConstant containing 4.
-std::optional<RegOrConstant> getVectorSplat(const MachineInstr &MI,
+LLVM_ABI std::optional<RegOrConstant> getVectorSplat(const MachineInstr &MI,
                                             const MachineRegisterInfo &MRI);
 
 /// Determines if \p MI defines a constant integer or a build vector of
 /// constant integers. Treats undef values as constants.
-bool isConstantOrConstantVector(MachineInstr &MI,
+LLVM_ABI bool isConstantOrConstantVector(MachineInstr &MI,
                                 const MachineRegisterInfo &MRI);
 
 /// Determines if \p MI defines a constant integer or a splat vector of
 /// constant integers.
 /// \returns the scalar constant or std::nullopt.
-std::optional<APInt>
+LLVM_ABI std::optional<APInt>
 isConstantOrConstantSplatVector(MachineInstr &MI,
                                 const MachineRegisterInfo &MRI);
 
 /// Determines if \p MI defines a float constant integer or a splat vector of
 /// float constant integers.
 /// \returns the float constant or std::nullopt.
-std::optional<APFloat>
+LLVM_ABI std::optional<APFloat>
 isConstantOrConstantSplatVectorFP(MachineInstr &MI,
                                   const MachineRegisterInfo &MRI);
 
 /// Attempt to match a unary predicate against a scalar/splat constant or every
 /// element of a constant G_BUILD_VECTOR. If \p ConstVal is null, the source
 /// value was undef.
-bool matchUnaryPredicate(const MachineRegisterInfo &MRI, Register Reg,
+LLVM_ABI bool matchUnaryPredicate(const MachineRegisterInfo &MRI, Register Reg,
                          std::function<bool(const Constant *ConstVal)> Match,
                          bool AllowUndefs = false);
 
 /// Returns true if given the TargetLowering's boolean contents information,
 /// the value \p Val contains a true value.
-bool isConstTrueVal(const TargetLowering &TLI, int64_t Val, bool IsVector,
+LLVM_ABI bool isConstTrueVal(const TargetLowering &TLI, int64_t Val, bool IsVector,
                     bool IsFP);
 /// \returns true if given the TargetLowering's boolean contents information,
 /// the value \p Val contains a false value.
-bool isConstFalseVal(const TargetLowering &TLI, int64_t Val, bool IsVector,
+LLVM_ABI bool isConstFalseVal(const TargetLowering &TLI, int64_t Val, bool IsVector,
                     bool IsFP);
 
 /// Returns an integer representing true, as defined by the
 /// TargetBooleanContents.
-int64_t getICmpTrueVal(const TargetLowering &TLI, bool IsVector, bool IsFP);
+LLVM_ABI int64_t getICmpTrueVal(const TargetLowering &TLI, bool IsVector, bool IsFP);
 
 using SmallInstListTy = GISelWorkList<4>;
-void saveUsesAndErase(MachineInstr &MI, MachineRegisterInfo &MRI,
+LLVM_ABI void saveUsesAndErase(MachineInstr &MI, MachineRegisterInfo &MRI,
                       LostDebugLocObserver *LocObserver,
                       SmallInstListTy &DeadInstChain);
-void eraseInstrs(ArrayRef<MachineInstr *> DeadInstrs, MachineRegisterInfo &MRI,
+LLVM_ABI void eraseInstrs(ArrayRef<MachineInstr *> DeadInstrs, MachineRegisterInfo &MRI,
                  LostDebugLocObserver *LocObserver = nullptr);
-void eraseInstr(MachineInstr &MI, MachineRegisterInfo &MRI,
+LLVM_ABI void eraseInstr(MachineInstr &MI, MachineRegisterInfo &MRI,
                 LostDebugLocObserver *LocObserver = nullptr);
 
 /// Assuming the instruction \p MI is going to be deleted, attempt to salvage
 /// debug users of \p MI by writing the effect of \p MI in a DIExpression.
-void salvageDebugInfo(const MachineRegisterInfo &MRI, MachineInstr &MI);
+LLVM_ABI void salvageDebugInfo(const MachineRegisterInfo &MRI, MachineInstr &MI);
 
 /// Returns whether opcode \p Opc is a pre-isel generic floating-point opcode,
 /// having only floating-point operands.
-bool isPreISelGenericFloatingPointOpcode(unsigned Opc);
+LLVM_ABI bool isPreISelGenericFloatingPointOpcode(unsigned Opc);
 
 /// Returns true if \p Reg can create undef or poison from non-undef &
 /// non-poison operands. \p ConsiderFlagsAndMetadata controls whether poison
@@ -577,29 +578,29 @@ bool isPreISelGenericFloatingPointOpcode(unsigned Opc);
 /// used to see if the instruction could still introduce undef or poison even
 /// without poison generating flags and metadata which might be on the
 /// instruction.
-bool canCreateUndefOrPoison(Register Reg, const MachineRegisterInfo &MRI,
+LLVM_ABI bool canCreateUndefOrPoison(Register Reg, const MachineRegisterInfo &MRI,
                             bool ConsiderFlagsAndMetadata = true);
 
 /// Returns true if \p Reg can create poison from non-poison operands.
-bool canCreatePoison(Register Reg, const MachineRegisterInfo &MRI,
+LLVM_ABI bool canCreatePoison(Register Reg, const MachineRegisterInfo &MRI,
                      bool ConsiderFlagsAndMetadata = true);
 
 /// Returns true if \p Reg cannot be poison and undef.
-bool isGuaranteedNotToBeUndefOrPoison(Register Reg,
+LLVM_ABI bool isGuaranteedNotToBeUndefOrPoison(Register Reg,
                                       const MachineRegisterInfo &MRI,
                                       unsigned Depth = 0);
 
 /// Returns true if \p Reg cannot be poison, but may be undef.
-bool isGuaranteedNotToBePoison(Register Reg, const MachineRegisterInfo &MRI,
+LLVM_ABI bool isGuaranteedNotToBePoison(Register Reg, const MachineRegisterInfo &MRI,
                                unsigned Depth = 0);
 
 /// Returns true if \p Reg cannot be undef, but may be poison.
-bool isGuaranteedNotToBeUndef(Register Reg, const MachineRegisterInfo &MRI,
+LLVM_ABI bool isGuaranteedNotToBeUndef(Register Reg, const MachineRegisterInfo &MRI,
                               unsigned Depth = 0);
 
 /// Get the type back from LLT. It won't be 100 percent accurate but returns an
 /// estimate of the type.
-Type *getTypeForLLT(LLT Ty, LLVMContext &C);
+LLVM_ABI Type *getTypeForLLT(LLT Ty, LLVMContext &C);
 
 /// An integer-like constant.
 ///
@@ -634,9 +635,9 @@ public:
   GIConstantKind getKind() const { return Kind; }
 
   /// Returns the value, if this constant is a scalar.
-  APInt getScalarValue() const;
+  LLVM_ABI APInt getScalarValue() const;
 
-  static std::optional<GIConstant> getConstant(Register Const,
+  LLVM_ABI static std::optional<GIConstant> getConstant(Register Const,
                                                const MachineRegisterInfo &MRI);
 };
 
@@ -693,9 +694,9 @@ public:
   }
 
   /// Returns the value, if this constant is a scalar.
-  APFloat getScalarValue() const;
+  LLVM_ABI APFloat getScalarValue() const;
 
-  static std::optional<GFConstant> getConstant(Register Const,
+  LLVM_ABI static std::optional<GFConstant> getConstant(Register Const,
                                                const MachineRegisterInfo &MRI);
 };
 

--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_CODEGEN_ISDOPCODES_H
 #define LLVM_CODEGEN_ISDOPCODES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/ValueTypes.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -1582,7 +1582,8 @@ LLVM_ABI std::optional<unsigned> getVPMaskIdx(unsigned Opcode);
 LLVM_ABI std::optional<unsigned> getVPExplicitVectorLengthIdx(unsigned Opcode);
 
 /// Translate this VP Opcode to its corresponding non-VP Opcode.
-LLVM_ABI std::optional<unsigned> getBaseOpcodeForVP(unsigned Opcode, bool hasFPExcept);
+LLVM_ABI std::optional<unsigned> getBaseOpcodeForVP(unsigned Opcode,
+                                                    bool hasFPExcept);
 
 /// Translate this non-VP Opcode to its corresponding VP Opcode.
 LLVM_ABI std::optional<unsigned> getVPForBaseOpcode(unsigned Opcode);

--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_ISDOPCODES_H
 #define LLVM_CODEGEN_ISDOPCODES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/ValueTypes.h"
 
 namespace llvm {
@@ -1559,32 +1560,32 @@ inline bool isBitwiseLogicOp(unsigned Opcode) {
 
 /// Given a \p MinMaxOpc of ISD::(U|S)MIN or ISD::(U|S)MAX, returns
 /// ISD::(U|S)MAX and ISD::(U|S)MIN, respectively.
-NodeType getInverseMinMaxOpcode(unsigned MinMaxOpc);
+LLVM_ABI NodeType getInverseMinMaxOpcode(unsigned MinMaxOpc);
 
 /// Get underlying scalar opcode for VECREDUCE opcode.
 /// For example ISD::AND for ISD::VECREDUCE_AND.
-NodeType getVecReduceBaseOpcode(unsigned VecReduceOpcode);
+LLVM_ABI NodeType getVecReduceBaseOpcode(unsigned VecReduceOpcode);
 
 /// Whether this is a vector-predicated Opcode.
-bool isVPOpcode(unsigned Opcode);
+LLVM_ABI bool isVPOpcode(unsigned Opcode);
 
 /// Whether this is a vector-predicated binary operation opcode.
-bool isVPBinaryOp(unsigned Opcode);
+LLVM_ABI bool isVPBinaryOp(unsigned Opcode);
 
 /// Whether this is a vector-predicated reduction opcode.
-bool isVPReduction(unsigned Opcode);
+LLVM_ABI bool isVPReduction(unsigned Opcode);
 
 /// The operand position of the vector mask.
-std::optional<unsigned> getVPMaskIdx(unsigned Opcode);
+LLVM_ABI std::optional<unsigned> getVPMaskIdx(unsigned Opcode);
 
 /// The operand position of the explicit vector length parameter.
-std::optional<unsigned> getVPExplicitVectorLengthIdx(unsigned Opcode);
+LLVM_ABI std::optional<unsigned> getVPExplicitVectorLengthIdx(unsigned Opcode);
 
 /// Translate this VP Opcode to its corresponding non-VP Opcode.
-std::optional<unsigned> getBaseOpcodeForVP(unsigned Opcode, bool hasFPExcept);
+LLVM_ABI std::optional<unsigned> getBaseOpcodeForVP(unsigned Opcode, bool hasFPExcept);
 
 /// Translate this non-VP Opcode to its corresponding VP Opcode.
-std::optional<unsigned> getVPForBaseOpcode(unsigned Opcode);
+LLVM_ABI std::optional<unsigned> getVPForBaseOpcode(unsigned Opcode);
 
 //===--------------------------------------------------------------------===//
 /// MemIndexedMode enum - This enum defines the load / store indexed
@@ -1649,7 +1650,7 @@ enum LoadExtType { NON_EXTLOAD = 0, EXTLOAD, SEXTLOAD, ZEXTLOAD };
 
 static const int LAST_LOADEXT_TYPE = ZEXTLOAD + 1;
 
-NodeType getExtForLoadExtType(bool IsFP, LoadExtType);
+LLVM_ABI NodeType getExtForLoadExtType(bool IsFP, LoadExtType);
 
 //===--------------------------------------------------------------------===//
 /// ISD::CondCode enum - These are ordered carefully to make the bitfields
@@ -1734,7 +1735,7 @@ inline unsigned getUnorderedFlavor(CondCode Cond) {
 
 /// Return the operation corresponding to !(X op Y), where 'op' is a valid
 /// SetCC operation.
-CondCode getSetCCInverse(CondCode Operation, EVT Type);
+LLVM_ABI CondCode getSetCCInverse(CondCode Operation, EVT Type);
 
 inline bool isExtOpcode(unsigned Opcode) {
   return Opcode == ISD::ANY_EXTEND || Opcode == ISD::ZERO_EXTEND ||
@@ -1754,22 +1755,22 @@ namespace GlobalISel {
 /// this distinction. As such we need to be told whether the comparison is
 /// floating point or integer-like. Pointers should use integer-like
 /// comparisons.
-CondCode getSetCCInverse(CondCode Operation, bool isIntegerLike);
+LLVM_ABI CondCode getSetCCInverse(CondCode Operation, bool isIntegerLike);
 } // end namespace GlobalISel
 
 /// Return the operation corresponding to (Y op X) when given the operation
 /// for (X op Y).
-CondCode getSetCCSwappedOperands(CondCode Operation);
+LLVM_ABI CondCode getSetCCSwappedOperands(CondCode Operation);
 
 /// Return the result of a logical OR between different comparisons of
 /// identical values: ((X op1 Y) | (X op2 Y)). This function returns
 /// SETCC_INVALID if it is not possible to represent the resultant comparison.
-CondCode getSetCCOrOperation(CondCode Op1, CondCode Op2, EVT Type);
+LLVM_ABI CondCode getSetCCOrOperation(CondCode Op1, CondCode Op2, EVT Type);
 
 /// Return the result of a logical AND between different comparisons of
 /// identical values: ((X op1 Y) & (X op2 Y)). This function returns
 /// SETCC_INVALID if it is not possible to represent the resultant comparison.
-CondCode getSetCCAndOperation(CondCode Op1, CondCode Op2, EVT Type);
+LLVM_ABI CondCode getSetCCAndOperation(CondCode Op1, CondCode Op2, EVT Type);
 
 } // namespace ISD
 

--- a/llvm/include/llvm/CodeGen/LexicalScopes.h
+++ b/llvm/include/llvm/CodeGen/LexicalScopes.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CODEGEN_LEXICALSCOPES_H
 #define LLVM_CODEGEN_LEXICALSCOPES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -116,7 +117,7 @@ public:
   void setDFSIn(unsigned I) { DFSIn = I; }
 
   /// dump - print lexical scope.
-  void dump(unsigned Indent = 0) const;
+  LLVM_ABI void dump(unsigned Indent = 0) const;
 
 private:
   LexicalScope *Parent;                        // Parent to this scope.
@@ -144,10 +145,10 @@ public:
 
   /// initialize - Scan machine function and constuct lexical scope nest, resets
   /// the instance if necessary.
-  void initialize(const MachineFunction &);
+  LLVM_ABI void initialize(const MachineFunction &);
 
   /// releaseMemory - release memory.
-  void reset();
+  LLVM_ABI void reset();
 
   /// empty - Return true if there is any lexical scope information available.
   bool empty() { return CurrentFnLexicalScope == nullptr; }
@@ -160,16 +161,16 @@ public:
   /// getMachineBasicBlocks - Populate given set using machine basic blocks
   /// which have machine instructions that belong to lexical scope identified by
   /// DebugLoc.
-  void getMachineBasicBlocks(const DILocation *DL,
+  LLVM_ABI void getMachineBasicBlocks(const DILocation *DL,
                              SmallPtrSetImpl<const MachineBasicBlock *> &MBBs);
 
   /// Return true if DebugLoc's lexical scope dominates at least one machine
   /// instruction's lexical scope in a given machine basic block.
-  bool dominates(const DILocation *DL, MachineBasicBlock *MBB);
+  LLVM_ABI bool dominates(const DILocation *DL, MachineBasicBlock *MBB);
 
   /// findLexicalScope - Find lexical scope, either regular or inlined, for the
   /// given DebugLoc. Return NULL if not found.
-  LexicalScope *findLexicalScope(const DILocation *DL);
+  LLVM_ABI LexicalScope *findLexicalScope(const DILocation *DL);
 
   /// getAbstractScopesList - Return a reference to list of abstract scopes.
   ArrayRef<LexicalScope *> getAbstractScopesList() const {
@@ -195,12 +196,12 @@ public:
   }
 
   /// getOrCreateAbstractScope - Find or create an abstract lexical scope.
-  LexicalScope *getOrCreateAbstractScope(const DILocalScope *Scope);
+  LLVM_ABI LexicalScope *getOrCreateAbstractScope(const DILocalScope *Scope);
 
 private:
   /// getOrCreateLexicalScope - Find lexical scope for the given Scope/IA. If
   /// not available then create new lexical scope.
-  LexicalScope *getOrCreateLexicalScope(const DILocalScope *Scope,
+  LLVM_ABI LexicalScope *getOrCreateLexicalScope(const DILocalScope *Scope,
                                         const DILocation *IA = nullptr);
   LexicalScope *getOrCreateLexicalScope(const DILocation *DL) {
     return DL ? getOrCreateLexicalScope(DL->getScope(), DL->getInlinedAt())

--- a/llvm/include/llvm/CodeGen/LexicalScopes.h
+++ b/llvm/include/llvm/CodeGen/LexicalScopes.h
@@ -16,12 +16,12 @@
 #ifndef LLVM_CODEGEN_LEXICALSCOPES_H
 #define LLVM_CODEGEN_LEXICALSCOPES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <unordered_map>
 #include <utility>
@@ -161,8 +161,9 @@ public:
   /// getMachineBasicBlocks - Populate given set using machine basic blocks
   /// which have machine instructions that belong to lexical scope identified by
   /// DebugLoc.
-  LLVM_ABI void getMachineBasicBlocks(const DILocation *DL,
-                             SmallPtrSetImpl<const MachineBasicBlock *> &MBBs);
+  LLVM_ABI void
+  getMachineBasicBlocks(const DILocation *DL,
+                        SmallPtrSetImpl<const MachineBasicBlock *> &MBBs);
 
   /// Return true if DebugLoc's lexical scope dominates at least one machine
   /// instruction's lexical scope in a given machine basic block.
@@ -201,8 +202,9 @@ public:
 private:
   /// getOrCreateLexicalScope - Find lexical scope for the given Scope/IA. If
   /// not available then create new lexical scope.
-  LLVM_ABI LexicalScope *getOrCreateLexicalScope(const DILocalScope *Scope,
-                                        const DILocation *IA = nullptr);
+  LLVM_ABI LexicalScope *
+  getOrCreateLexicalScope(const DILocalScope *Scope,
+                          const DILocation *IA = nullptr);
   LexicalScope *getOrCreateLexicalScope(const DILocation *DL) {
     return DL ? getOrCreateLexicalScope(DL->getScope(), DL->getInlinedAt())
               : nullptr;

--- a/llvm/include/llvm/CodeGen/LiveInterval.h
+++ b/llvm/include/llvm/CodeGen/LiveInterval.h
@@ -20,6 +20,7 @@
 #ifndef LLVM_CODEGEN_LIVEINTERVAL_H
 #define LLVM_CODEGEN_LIVEINTERVAL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntEqClasses.h"
 #include "llvm/ADT/STLExtras.h"
@@ -194,7 +195,7 @@ namespace llvm {
         return !(*this == Other);
       }
 
-      void dump() const;
+      LLVM_ABI void dump() const;
     };
 
     using Segments = SmallVector<Segment, 2>;
@@ -291,7 +292,7 @@ namespace llvm {
     /// If Pos is contained in a Segment, that segment is returned.
     /// If Pos is in a hole, the following Segment is returned.
     /// If Pos is beyond endIndex, end() is returned.
-    iterator find(SlotIndex Pos);
+    LLVM_ABI iterator find(SlotIndex Pos);
 
     const_iterator find(SlotIndex Pos) const {
       return const_cast<LiveRange*>(this)->find(Pos);
@@ -338,11 +339,11 @@ namespace llvm {
     /// createDeadDef - Make sure the range has a value defined at Def.
     /// If one already exists, return it. Otherwise allocate a new value and
     /// add liveness for a dead def.
-    VNInfo *createDeadDef(SlotIndex Def, VNInfo::Allocator &VNIAlloc);
+    LLVM_ABI VNInfo *createDeadDef(SlotIndex Def, VNInfo::Allocator &VNIAlloc);
 
     /// Create a def of value @p VNI. Return @p VNI. If there already exists
     /// a definition at VNI->def, the value defined there must be @p VNI.
-    VNInfo *createDeadDef(VNInfo *VNI);
+    LLVM_ABI VNInfo *createDeadDef(VNInfo *VNI);
 
     /// Create a copy of the given value. The new value will be identical except
     /// for the Value number.
@@ -356,27 +357,27 @@ namespace llvm {
 
     /// RenumberValues - Renumber all values in order of appearance and remove
     /// unused values.
-    void RenumberValues();
+    LLVM_ABI void RenumberValues();
 
     /// MergeValueNumberInto - This method is called when two value numbers
     /// are found to be equivalent.  This eliminates V1, replacing all
     /// segments with the V1 value number with the V2 value number.  This can
     /// cause merging of V1/V2 values numbers and compaction of the value space.
-    VNInfo* MergeValueNumberInto(VNInfo *V1, VNInfo *V2);
+    LLVM_ABI VNInfo* MergeValueNumberInto(VNInfo *V1, VNInfo *V2);
 
     /// Merge all of the live segments of a specific val# in RHS into this live
     /// range as the specified value number. The segments in RHS are allowed
     /// to overlap with segments in the current range, it will replace the
     /// value numbers of the overlaped live segments with the specified value
     /// number.
-    void MergeSegmentsInAsValue(const LiveRange &RHS, VNInfo *LHSValNo);
+    LLVM_ABI void MergeSegmentsInAsValue(const LiveRange &RHS, VNInfo *LHSValNo);
 
     /// MergeValueInAsValue - Merge all of the segments of a specific val#
     /// in RHS into this live range as the specified value number.
     /// The segments in RHS are allowed to overlap with segments in the
     /// current range, but only if the overlapping segments have the
     /// specified value number.
-    void MergeValueInAsValue(const LiveRange &RHS,
+    LLVM_ABI void MergeValueInAsValue(const LiveRange &RHS,
                              const VNInfo *RHSValNo, VNInfo *LHSValNo);
 
     bool empty() const { return segments.empty(); }
@@ -456,28 +457,28 @@ namespace llvm {
     ///
     /// Overlapping segments where one range is defined by a coalescable
     /// copy are allowed.
-    bool overlaps(const LiveRange &Other, const CoalescerPair &CP,
+    LLVM_ABI bool overlaps(const LiveRange &Other, const CoalescerPair &CP,
                   const SlotIndexes&) const;
 
     /// overlaps - Return true if the live range overlaps an interval specified
     /// by [Start, End).
-    bool overlaps(SlotIndex Start, SlotIndex End) const;
+    LLVM_ABI bool overlaps(SlotIndex Start, SlotIndex End) const;
 
     /// overlapsFrom - Return true if the intersection of the two live ranges
     /// is not empty.  The specified iterator is a hint that we can begin
     /// scanning the Other range starting at I.
-    bool overlapsFrom(const LiveRange &Other, const_iterator StartPos) const;
+    LLVM_ABI bool overlapsFrom(const LiveRange &Other, const_iterator StartPos) const;
 
     /// Returns true if all segments of the @p Other live range are completely
     /// covered by this live range.
     /// Adjacent live ranges do not affect the covering:the liverange
     /// [1,5](5,10] covers (3,7].
-    bool covers(const LiveRange &Other) const;
+    LLVM_ABI bool covers(const LiveRange &Other) const;
 
     /// Add the specified Segment to this range, merging segments as
     /// appropriate.  This returns an iterator to the inserted segment (which
     /// may have grown since it was inserted).
-    iterator addSegment(Segment S);
+    LLVM_ABI iterator addSegment(Segment S);
 
     /// Attempt to extend a value defined after @p StartIdx to include @p Use.
     /// Both @p StartIdx and @p Use should be in the same basic block. In case
@@ -493,7 +494,7 @@ namespace llvm {
     /// segment before @p Use and there is no "undef" between @p StartIdx and
     /// @p Use, return {nullptr, false}. If there is an "undef" before @p Use,
     /// return {nullptr, true}.
-    std::pair<VNInfo*,bool> extendInBlock(ArrayRef<SlotIndex> Undefs,
+    LLVM_ABI std::pair<VNInfo*,bool> extendInBlock(ArrayRef<SlotIndex> Undefs,
         SlotIndex StartIdx, SlotIndex Kill);
 
     /// Simplified version of the above "extendInBlock", which assumes that
@@ -501,12 +502,12 @@ namespace llvm {
     /// If this range is live before @p Use in the basic block that starts
     /// at @p StartIdx, extend it to be live up to @p Use, and return the
     /// value. If there is no segment before @p Use, return nullptr.
-    VNInfo *extendInBlock(SlotIndex StartIdx, SlotIndex Kill);
+    LLVM_ABI VNInfo *extendInBlock(SlotIndex StartIdx, SlotIndex Kill);
 
     /// join - Join two live ranges (this, and other) together.  This applies
     /// mappings to the value numbers in the LHS/RHS ranges as specified.  If
     /// the ranges are not joinable, this aborts.
-    void join(LiveRange &Other,
+    LLVM_ABI void join(LiveRange &Other,
               const int *ValNoAssignments,
               const int *RHSValNoAssignments,
               SmallVectorImpl<VNInfo *> &NewVNInfo);
@@ -523,7 +524,7 @@ namespace llvm {
     /// Remove the specified interval from this live range.
     /// Does nothing if interval is not part of this live range.
     /// Note that the interval must be within a single Segment in its entirety.
-    void removeSegment(SlotIndex Start, SlotIndex End,
+    LLVM_ABI void removeSegment(SlotIndex Start, SlotIndex End,
                        bool RemoveDeadValNo = false);
 
     void removeSegment(Segment S, bool RemoveDeadValNo = false) {
@@ -531,10 +532,10 @@ namespace llvm {
     }
 
     /// Remove segment pointed to by iterator @p I from this range.
-    iterator removeSegment(iterator I, bool RemoveDeadValNo = false);
+    LLVM_ABI iterator removeSegment(iterator I, bool RemoveDeadValNo = false);
 
     /// Mark \p ValNo for deletion if no segments in this range use it.
-    void removeValNoIfDead(VNInfo *ValNo);
+    LLVM_ABI void removeValNoIfDead(VNInfo *ValNo);
 
     /// Query Liveness at Idx.
     /// The sub-instruction slot of Idx doesn't matter, only the instruction
@@ -580,7 +581,7 @@ namespace llvm {
 
     /// removeValNo - Remove all the segments defined by the specified value#.
     /// Also remove the value# from value# list.
-    void removeValNo(VNInfo *ValNo);
+    LLVM_ABI void removeValNo(VNInfo *ValNo);
 
     /// Returns true if the live range is zero length, i.e. no live segments
     /// span instructions. It doesn't pay to spill such a range.
@@ -595,7 +596,7 @@ namespace llvm {
     // Returns true if any segment in the live range contains any of the
     // provided slot indexes.  Slots which occur in holes between
     // segments will not cause the function to return true.
-    bool isLiveAtIndexes(ArrayRef<SlotIndex> Slots) const;
+    LLVM_ABI bool isLiveAtIndexes(ArrayRef<SlotIndex> Slots) const;
 
     bool operator<(const LiveRange& other) const {
       const SlotIndex &thisIndex = beginIndex();
@@ -616,7 +617,7 @@ namespace llvm {
     /// The method is to be called after the live range
     /// has been created, if use of the segment set was
     /// activated in the constructor of the live range.
-    void flushSegmentSet();
+    LLVM_ABI void flushSegmentSet();
 
     /// Stores indexes from the input index sequence R at which this LiveRange
     /// is live to the output O iterator.
@@ -655,8 +656,8 @@ namespace llvm {
       return Found;
     }
 
-    void print(raw_ostream &OS) const;
-    void dump() const;
+    LLVM_ABI void print(raw_ostream &OS) const;
+    LLVM_ABI void dump() const;
 
     /// Walk the range and assert if any invariants fail to hold.
     ///
@@ -669,7 +670,7 @@ namespace llvm {
 
   protected:
     /// Append a segment to the list of segments.
-    void append(const LiveRange::Segment S);
+    LLVM_ABI void append(const LiveRange::Segment S);
 
   private:
     friend class LiveRangeUpdater;
@@ -704,8 +705,8 @@ namespace llvm {
                BumpPtrAllocator &Allocator)
         : LiveRange(Other, Allocator), LaneMask(LaneMask) {}
 
-      void print(raw_ostream &OS) const;
-      void dump() const;
+      LLVM_ABI void print(raw_ostream &OS) const;
+      LLVM_ABI void dump() const;
     };
 
   private:
@@ -812,15 +813,15 @@ namespace llvm {
     }
 
     /// Removes all subregister liveness information.
-    void clearSubRanges();
+    LLVM_ABI void clearSubRanges();
 
     /// Removes all subranges without any segments (subranges without segments
     /// are not considered valid and should only exist temporarily).
-    void removeEmptySubRanges();
+    LLVM_ABI void removeEmptySubRanges();
 
     /// getSize - Returns the sum of sizes of all the LiveRange's.
     ///
-    unsigned getSize() const;
+    LLVM_ABI unsigned getSize() const;
 
     /// isSpillable - Can this interval be spilled?
     bool isSpillable() const { return Weight != huge_valf; }
@@ -830,7 +831,7 @@ namespace llvm {
 
     /// For a given lane mask @p LaneMask, compute indexes at which the
     /// lane is marked undefined by subregister <def,read-undef> definitions.
-    void computeSubRangeUndefs(SmallVectorImpl<SlotIndex> &Undefs,
+    LLVM_ABI void computeSubRangeUndefs(SmallVectorImpl<SlotIndex> &Undefs,
                                LaneBitmask LaneMask,
                                const MachineRegisterInfo &MRI,
                                const SlotIndexes &Indexes) const;
@@ -874,7 +875,7 @@ namespace llvm {
     /// still having the old IR around because updating the IR on-the-fly
     /// would actually clobber some information on how the live-ranges that
     /// are being updated look like.
-    void refineSubRanges(BumpPtrAllocator &Allocator, LaneBitmask LaneMask,
+    LLVM_ABI void refineSubRanges(BumpPtrAllocator &Allocator, LaneBitmask LaneMask,
                          std::function<void(LiveInterval::SubRange &)> Apply,
                          const SlotIndexes &Indexes,
                          const TargetRegisterInfo &TRI,
@@ -886,8 +887,8 @@ namespace llvm {
       return std::tie(thisIndex, Reg) < std::tie(otherIndex, other.Reg);
     }
 
-    void print(raw_ostream &OS) const;
-    void dump() const;
+    LLVM_ABI void print(raw_ostream &OS) const;
+    LLVM_ABI void dump() const;
 
     /// Walks the interval and assert if any invariants fail to hold.
     ///
@@ -922,7 +923,7 @@ namespace llvm {
     return OS;
   }
 
-  raw_ostream &operator<<(raw_ostream &OS, const LiveRange::Segment &S);
+  LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const LiveRange::Segment &S);
 
   inline bool operator<(SlotIndex V, const LiveRange::Segment &S) {
     return V < S.start;
@@ -958,7 +959,7 @@ namespace llvm {
     /// Add a segment to LR and coalesce when possible, just like
     /// LR.addSegment(). Segments should be added in increasing start order for
     /// best performance.
-    void add(LiveRange::Segment);
+    LLVM_ABI void add(LiveRange::Segment);
 
     void add(SlotIndex Start, SlotIndex End, VNInfo *VNI) {
       add(LiveRange::Segment(Start, End, VNI));
@@ -970,7 +971,7 @@ namespace llvm {
 
     /// Flush the updater state to LR so it is valid and contains all added
     /// segments.
-    void flush();
+    LLVM_ABI void flush();
 
     /// Select a different destination live range.
     void setDest(LiveRange *lr) {
@@ -982,8 +983,8 @@ namespace llvm {
     /// Get the current destination live range.
     LiveRange *getDest() const { return LR; }
 
-    void dump() const;
-    void print(raw_ostream&) const;
+    LLVM_ABI void dump() const;
+    LLVM_ABI void print(raw_ostream&) const;
   };
 
   inline raw_ostream &operator<<(raw_ostream &OS, const LiveRangeUpdater &X) {
@@ -1013,7 +1014,7 @@ namespace llvm {
 
     /// Classify the values in \p LR into connected components.
     /// Returns the number of connected components.
-    unsigned Classify(const LiveRange &LR);
+    LLVM_ABI unsigned Classify(const LiveRange &LR);
 
     /// getEqClass - Classify creates equivalence classes numbered 0..N. Return
     /// the equivalence class assigned the VNI.
@@ -1023,7 +1024,7 @@ namespace llvm {
     /// for each connected component. LIV must have an empty LiveInterval for
     /// each additional connected component. The first connected component is
     /// left in \p LI.
-    void Distribute(LiveInterval &LI, LiveInterval *LIV[],
+    LLVM_ABI void Distribute(LiveInterval &LI, LiveInterval *LIV[],
                     MachineRegisterInfo &MRI);
   };
 

--- a/llvm/include/llvm/CodeGen/LiveInterval.h
+++ b/llvm/include/llvm/CodeGen/LiveInterval.h
@@ -20,7 +20,6 @@
 #ifndef LLVM_CODEGEN_LIVEINTERVAL_H
 #define LLVM_CODEGEN_LIVEINTERVAL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntEqClasses.h"
 #include "llvm/ADT/STLExtras.h"
@@ -30,6 +29,7 @@
 #include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/MC/LaneBitmask.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 #include <algorithm>
 #include <cassert>
@@ -363,14 +363,15 @@ namespace llvm {
     /// are found to be equivalent.  This eliminates V1, replacing all
     /// segments with the V1 value number with the V2 value number.  This can
     /// cause merging of V1/V2 values numbers and compaction of the value space.
-    LLVM_ABI VNInfo* MergeValueNumberInto(VNInfo *V1, VNInfo *V2);
+    LLVM_ABI VNInfo *MergeValueNumberInto(VNInfo *V1, VNInfo *V2);
 
     /// Merge all of the live segments of a specific val# in RHS into this live
     /// range as the specified value number. The segments in RHS are allowed
     /// to overlap with segments in the current range, it will replace the
     /// value numbers of the overlaped live segments with the specified value
     /// number.
-    LLVM_ABI void MergeSegmentsInAsValue(const LiveRange &RHS, VNInfo *LHSValNo);
+    LLVM_ABI void MergeSegmentsInAsValue(const LiveRange &RHS,
+                                         VNInfo *LHSValNo);
 
     /// MergeValueInAsValue - Merge all of the segments of a specific val#
     /// in RHS into this live range as the specified value number.
@@ -378,7 +379,7 @@ namespace llvm {
     /// current range, but only if the overlapping segments have the
     /// specified value number.
     LLVM_ABI void MergeValueInAsValue(const LiveRange &RHS,
-                             const VNInfo *RHSValNo, VNInfo *LHSValNo);
+                                      const VNInfo *RHSValNo, VNInfo *LHSValNo);
 
     bool empty() const { return segments.empty(); }
 
@@ -458,7 +459,7 @@ namespace llvm {
     /// Overlapping segments where one range is defined by a coalescable
     /// copy are allowed.
     LLVM_ABI bool overlaps(const LiveRange &Other, const CoalescerPair &CP,
-                  const SlotIndexes&) const;
+                           const SlotIndexes &) const;
 
     /// overlaps - Return true if the live range overlaps an interval specified
     /// by [Start, End).
@@ -467,7 +468,8 @@ namespace llvm {
     /// overlapsFrom - Return true if the intersection of the two live ranges
     /// is not empty.  The specified iterator is a hint that we can begin
     /// scanning the Other range starting at I.
-    LLVM_ABI bool overlapsFrom(const LiveRange &Other, const_iterator StartPos) const;
+    LLVM_ABI bool overlapsFrom(const LiveRange &Other,
+                               const_iterator StartPos) const;
 
     /// Returns true if all segments of the @p Other live range are completely
     /// covered by this live range.
@@ -494,8 +496,9 @@ namespace llvm {
     /// segment before @p Use and there is no "undef" between @p StartIdx and
     /// @p Use, return {nullptr, false}. If there is an "undef" before @p Use,
     /// return {nullptr, true}.
-    LLVM_ABI std::pair<VNInfo*,bool> extendInBlock(ArrayRef<SlotIndex> Undefs,
-        SlotIndex StartIdx, SlotIndex Kill);
+    LLVM_ABI std::pair<VNInfo *, bool> extendInBlock(ArrayRef<SlotIndex> Undefs,
+                                                     SlotIndex StartIdx,
+                                                     SlotIndex Kill);
 
     /// Simplified version of the above "extendInBlock", which assumes that
     /// no register lanes are undefined by <def,read-undef> operands.
@@ -507,10 +510,9 @@ namespace llvm {
     /// join - Join two live ranges (this, and other) together.  This applies
     /// mappings to the value numbers in the LHS/RHS ranges as specified.  If
     /// the ranges are not joinable, this aborts.
-    LLVM_ABI void join(LiveRange &Other,
-              const int *ValNoAssignments,
-              const int *RHSValNoAssignments,
-              SmallVectorImpl<VNInfo *> &NewVNInfo);
+    LLVM_ABI void join(LiveRange &Other, const int *ValNoAssignments,
+                       const int *RHSValNoAssignments,
+                       SmallVectorImpl<VNInfo *> &NewVNInfo);
 
     /// True iff this segment is a single segment that lies between the
     /// specified boundaries, exclusively. Vregs live across a backedge are not
@@ -525,7 +527,7 @@ namespace llvm {
     /// Does nothing if interval is not part of this live range.
     /// Note that the interval must be within a single Segment in its entirety.
     LLVM_ABI void removeSegment(SlotIndex Start, SlotIndex End,
-                       bool RemoveDeadValNo = false);
+                                bool RemoveDeadValNo = false);
 
     void removeSegment(Segment S, bool RemoveDeadValNo = false) {
       removeSegment(S.start, S.end, RemoveDeadValNo);
@@ -832,9 +834,9 @@ namespace llvm {
     /// For a given lane mask @p LaneMask, compute indexes at which the
     /// lane is marked undefined by subregister <def,read-undef> definitions.
     LLVM_ABI void computeSubRangeUndefs(SmallVectorImpl<SlotIndex> &Undefs,
-                               LaneBitmask LaneMask,
-                               const MachineRegisterInfo &MRI,
-                               const SlotIndexes &Indexes) const;
+                                        LaneBitmask LaneMask,
+                                        const MachineRegisterInfo &MRI,
+                                        const SlotIndexes &Indexes) const;
 
     /// Refines the subranges to support \p LaneMask. This may only be called
     /// for LI.hasSubrange()==true. Subregister ranges are split or created
@@ -875,11 +877,11 @@ namespace llvm {
     /// still having the old IR around because updating the IR on-the-fly
     /// would actually clobber some information on how the live-ranges that
     /// are being updated look like.
-    LLVM_ABI void refineSubRanges(BumpPtrAllocator &Allocator, LaneBitmask LaneMask,
-                         std::function<void(LiveInterval::SubRange &)> Apply,
-                         const SlotIndexes &Indexes,
-                         const TargetRegisterInfo &TRI,
-                         unsigned ComposeSubRegIdx = 0);
+    LLVM_ABI void
+    refineSubRanges(BumpPtrAllocator &Allocator, LaneBitmask LaneMask,
+                    std::function<void(LiveInterval::SubRange &)> Apply,
+                    const SlotIndexes &Indexes, const TargetRegisterInfo &TRI,
+                    unsigned ComposeSubRegIdx = 0);
 
     bool operator<(const LiveInterval& other) const {
       const SlotIndex &thisIndex = beginIndex();
@@ -923,7 +925,8 @@ namespace llvm {
     return OS;
   }
 
-  LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const LiveRange::Segment &S);
+  LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                   const LiveRange::Segment &S);
 
   inline bool operator<(SlotIndex V, const LiveRange::Segment &S) {
     return V < S.start;
@@ -984,7 +987,7 @@ namespace llvm {
     LiveRange *getDest() const { return LR; }
 
     LLVM_ABI void dump() const;
-    LLVM_ABI void print(raw_ostream&) const;
+    LLVM_ABI void print(raw_ostream &) const;
   };
 
   inline raw_ostream &operator<<(raw_ostream &OS, const LiveRangeUpdater &X) {
@@ -1025,7 +1028,7 @@ namespace llvm {
     /// each additional connected component. The first connected component is
     /// left in \p LI.
     LLVM_ABI void Distribute(LiveInterval &LI, LiveInterval *LIV[],
-                    MachineRegisterInfo &MRI);
+                             MachineRegisterInfo &MRI);
   };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/LiveIntervalCalc.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervalCalc.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_CODEGEN_LIVEINTERVALCALC_H
 #define LLVM_CODEGEN_LIVEINTERVALCALC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/LiveRangeCalc.h"
 
 namespace llvm {
@@ -36,7 +37,7 @@ class LiveIntervalCalc : public LiveRangeCalc {
   /// (via <def,read-undef> operands).
   /// If @p LR is a main range, the @p LaneMask should be set to ~0, i.e.
   /// LaneBitmask::getAll().
-  void extendToUses(LiveRange &LR, Register Reg, LaneBitmask LaneMask,
+  LLVM_ABI void extendToUses(LiveRange &LR, Register Reg, LaneBitmask LaneMask,
                     LiveInterval *LI = nullptr);
 
 public:
@@ -45,7 +46,7 @@ public:
   /// createDeadDefs - Create a dead def in LI for every def operand of Reg.
   /// Each instruction defining Reg gets a new VNInfo with a corresponding
   /// minimal live range.
-  void createDeadDefs(LiveRange &LR, Register Reg);
+  LLVM_ABI void createDeadDefs(LiveRange &LR, Register Reg);
 
   /// Extend the live range of @p LR to reach all uses of Reg.
   ///
@@ -58,12 +59,12 @@ public:
   /// Calculates liveness for the register specified in live interval @p LI.
   /// Creates subregister live ranges as needed if subreg liveness tracking is
   /// enabled.
-  void calculate(LiveInterval &LI, bool TrackSubRegs);
+  LLVM_ABI void calculate(LiveInterval &LI, bool TrackSubRegs);
 
   /// For live interval \p LI with correct SubRanges construct matching
   /// information for the main live range. Expects the main live range to not
   /// have any segments or value numbers.
-  void constructMainRangeFromSubranges(LiveInterval &LI);
+  LLVM_ABI void constructMainRangeFromSubranges(LiveInterval &LI);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/LiveIntervalCalc.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervalCalc.h
@@ -17,8 +17,8 @@
 #ifndef LLVM_CODEGEN_LIVEINTERVALCALC_H
 #define LLVM_CODEGEN_LIVEINTERVALCALC_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/LiveRangeCalc.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -38,7 +38,7 @@ class LiveIntervalCalc : public LiveRangeCalc {
   /// If @p LR is a main range, the @p LaneMask should be set to ~0, i.e.
   /// LaneBitmask::getAll().
   LLVM_ABI void extendToUses(LiveRange &LR, Register Reg, LaneBitmask LaneMask,
-                    LiveInterval *LI = nullptr);
+                             LiveInterval *LI = nullptr);
 
 public:
   LiveIntervalCalc() = default;

--- a/llvm/include/llvm/CodeGen/LiveIntervals.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervals.h
@@ -39,7 +39,7 @@
 
 namespace llvm {
 
-extern cl::opt<bool> UseSegmentSetForPhysRegs;
+LLVM_ABI extern cl::opt<bool> UseSegmentSetForPhysRegs;
 
 class BitVector;
 class MachineBlockFrequencyInfo;
@@ -105,27 +105,27 @@ class LiveIntervals {
     analyze(MF);
   }
 
-  void analyze(MachineFunction &MF);
+  LLVM_ABI void analyze(MachineFunction &MF);
 
-  void clear();
+  LLVM_ABI void clear();
 
 public:
   LiveIntervals(LiveIntervals &&) = default;
-  ~LiveIntervals();
+  LLVM_ABI ~LiveIntervals();
 
-  bool invalidate(MachineFunction &MF, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(MachineFunction &MF, const PreservedAnalyses &PA,
                   MachineFunctionAnalysisManager::Invalidator &Inv);
 
   /// Calculate the spill weight to assign to a single instruction.
   /// If \p PSI is provided the calculation is altered for optsize functions.
-  static float getSpillWeight(bool isDef, bool isUse,
+  LLVM_ABI static float getSpillWeight(bool isDef, bool isUse,
                               const MachineBlockFrequencyInfo *MBFI,
                               const MachineInstr &MI,
                               ProfileSummaryInfo *PSI = nullptr);
 
   /// Calculate the spill weight to assign to a single instruction.
   /// If \p PSI is provided the calculation is altered for optsize functions.
-  static float getSpillWeight(bool isDef, bool isUse,
+  LLVM_ABI static float getSpillWeight(bool isDef, bool isUse,
                               const MachineBlockFrequencyInfo *MBFI,
                               const MachineBasicBlock *MBB,
                               ProfileSummaryInfo *PSI = nullptr);
@@ -176,7 +176,7 @@ public:
 
   /// Given a register and an instruction, adds a live segment from that
   /// instruction to the end of its MBB.
-  LiveInterval::Segment addSegmentToEndOfBlock(Register Reg,
+  LLVM_ABI LiveInterval::Segment addSegmentToEndOfBlock(Register Reg,
                                                MachineInstr &startInst);
 
   /// After removing some uses of a register, shrink its live range to just
@@ -185,7 +185,7 @@ public:
   /// Dead PHIDef values are marked as unused. New dead machine instructions
   /// are added to the dead vector. Returns true if the interval may have been
   /// separated into multiple connected components.
-  bool shrinkToUses(LiveInterval *li,
+  LLVM_ABI bool shrinkToUses(LiveInterval *li,
                     SmallVectorImpl<MachineInstr *> *dead = nullptr);
 
   /// Specialized version of
@@ -194,7 +194,7 @@ public:
   /// the lane mask of the subregister range.
   /// This may leave the subrange empty which needs to be cleaned up with
   /// LiveInterval::removeEmptySubranges() afterwards.
-  void shrinkToUses(LiveInterval::SubRange &SR, Register Reg);
+  LLVM_ABI void shrinkToUses(LiveInterval::SubRange &SR, Register Reg);
 
   /// Extend the live range \p LR to reach all points in \p Indices. The
   /// points in the \p Indices array must be jointly dominated by the union
@@ -208,7 +208,7 @@ public:
   /// \p Undefs, the live range will not be extended to that point.
   ///
   /// See also LiveRangeCalc::extend().
-  void extendToIndices(LiveRange &LR, ArrayRef<SlotIndex> Indices,
+  LLVM_ABI void extendToIndices(LiveRange &LR, ArrayRef<SlotIndex> Indices,
                        ArrayRef<SlotIndex> Undefs);
 
   void extendToIndices(LiveRange &LR, ArrayRef<SlotIndex> Indices) {
@@ -222,7 +222,7 @@ public:
   ///
   /// Calling pruneValue() and extendToIndices() can be used to reconstruct
   /// SSA form after adding defs to a virtual register.
-  void pruneValue(LiveRange &LR, SlotIndex Kill,
+  LLVM_ABI void pruneValue(LiveRange &LR, SlotIndex Kill,
                   SmallVectorImpl<SlotIndex> *EndPoints);
 
   /// This function should not be used. Its intent is to tell you that you are
@@ -303,8 +303,8 @@ public:
   VNInfo::Allocator &getVNInfoAllocator() { return VNInfoAllocator; }
 
   /// Implement the dump method.
-  void print(raw_ostream &O) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &O) const;
+  LLVM_ABI void dump() const;
 
   // For legacy pass to recompute liveness.
   void reanalyze(MachineFunction &MF) {
@@ -316,21 +316,21 @@ public:
 
   /// If LI is confined to a single basic block, return a pointer to that
   /// block.  If LI is live in to or out of any block, return NULL.
-  MachineBasicBlock *intervalIsInOneMBB(const LiveInterval &LI) const;
+  LLVM_ABI MachineBasicBlock *intervalIsInOneMBB(const LiveInterval &LI) const;
 
   /// Returns true if VNI is killed by any PHI-def values in LI.
   /// This may conservatively return true to avoid expensive computations.
-  bool hasPHIKill(const LiveInterval &LI, const VNInfo *VNI) const;
+  LLVM_ABI bool hasPHIKill(const LiveInterval &LI, const VNInfo *VNI) const;
 
   /// Add kill flags to any instruction that kills a virtual register.
-  void addKillFlags(const VirtRegMap *);
+  LLVM_ABI void addKillFlags(const VirtRegMap *);
 
   /// Call this method to notify LiveIntervals that instruction \p MI has been
   /// moved within a basic block. This will update the live intervals for all
   /// operands of \p MI. Moves between basic blocks are not supported.
   ///
   /// \param UpdateFlags Update live intervals for nonallocatable physregs.
-  void handleMove(MachineInstr &MI, bool UpdateFlags = false);
+  LLVM_ABI void handleMove(MachineInstr &MI, bool UpdateFlags = false);
 
   /// Update intervals of operands of all instructions in the newly
   /// created bundle specified by \p BundleStart.
@@ -340,7 +340,7 @@ public:
   /// Assumes existing liveness is accurate.
   /// \pre BundleStart should be the first instruction in the Bundle.
   /// \pre BundleStart should not have a have SlotIndex as one will be assigned.
-  void handleMoveIntoNewBundle(MachineInstr &BundleStart,
+  LLVM_ABI void handleMoveIntoNewBundle(MachineInstr &BundleStart,
                                bool UpdateFlags = false);
 
   /// Update live intervals for instructions in a range of iterators. It is
@@ -352,7 +352,7 @@ public:
   ///
   /// Currently, the only changes that are supported are simple removal
   /// and addition of uses.
-  void repairIntervalsInRange(MachineBasicBlock *MBB,
+  LLVM_ABI void repairIntervalsInRange(MachineBasicBlock *MBB,
                               MachineBasicBlock::iterator Begin,
                               MachineBasicBlock::iterator End,
                               ArrayRef<Register> OrigRegs);
@@ -396,7 +396,7 @@ public:
   ///
   /// Returns false if \p LI doesn't cross any register mask instructions. In
   /// that case, the bit vector is not filled in.
-  bool checkRegMaskInterference(const LiveInterval &LI, BitVector &UsableRegs);
+  LLVM_ABI bool checkRegMaskInterference(const LiveInterval &LI, BitVector &UsableRegs);
 
   // Register unit functions.
   //
@@ -449,20 +449,20 @@ public:
   /// Remove value numbers and related live segments starting at position
   /// \p Pos that are part of any liverange of physical register \p Reg or one
   /// of its subregisters.
-  void removePhysRegDefAt(MCRegister Reg, SlotIndex Pos);
+  LLVM_ABI void removePhysRegDefAt(MCRegister Reg, SlotIndex Pos);
 
   /// Remove value number and related live segments of \p LI and its subranges
   /// that start at position \p Pos.
-  void removeVRegDefAt(LiveInterval &LI, SlotIndex Pos);
+  LLVM_ABI void removeVRegDefAt(LiveInterval &LI, SlotIndex Pos);
 
   /// Split separate components in LiveInterval \p LI into separate intervals.
-  void splitSeparateComponents(LiveInterval &LI,
+  LLVM_ABI void splitSeparateComponents(LiveInterval &LI,
                                SmallVectorImpl<LiveInterval *> &SplitLIs);
 
   /// For live interval \p LI with correct SubRanges construct matching
   /// information for the main live range. Expects the main live range to not
   /// have any segments or value numbers.
-  void constructMainRangeFromSubranges(LiveInterval &LI);
+  LLVM_ABI void constructMainRangeFromSubranges(LiveInterval &LI);
 
 private:
   /// Compute live intervals for all virtual registers.
@@ -481,14 +481,14 @@ private:
   bool computeDeadValues(LiveInterval &LI,
                          SmallVectorImpl<MachineInstr *> *dead);
 
-  static LiveInterval *createInterval(Register Reg);
+  LLVM_ABI static LiveInterval *createInterval(Register Reg);
 
   void printInstrs(raw_ostream &O) const;
   void dumpInstrs() const;
 
   void computeLiveInRegUnits();
-  void computeRegUnitRange(LiveRange &, unsigned Unit);
-  bool computeVirtRegInterval(LiveInterval &);
+  LLVM_ABI void computeRegUnitRange(LiveRange &, unsigned Unit);
+  LLVM_ABI bool computeVirtRegInterval(LiveInterval &);
 
   using ShrinkToUsesWorkList = SmallVector<std::pair<SlotIndex, VNInfo *>, 16>;
   void extendSegmentsToUses(LiveRange &Segments, ShrinkToUsesWorkList &WorkList,
@@ -512,7 +512,7 @@ class LiveIntervalsAnalysis : public AnalysisInfoMixin<LiveIntervalsAnalysis> {
 
 public:
   using Result = LiveIntervals;
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
 };
 
 class LiveIntervalsPrinterPass
@@ -521,12 +521,12 @@ class LiveIntervalsPrinterPass
 
 public:
   explicit LiveIntervalsPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
-class LiveIntervalsWrapperPass : public MachineFunctionPass {
+class LLVM_ABI LiveIntervalsWrapperPass : public MachineFunctionPass {
   LiveIntervals LIS;
 
 public:

--- a/llvm/include/llvm/CodeGen/LiveIntervals.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervals.h
@@ -508,7 +508,7 @@ private:
 
 class LiveIntervalsAnalysis : public AnalysisInfoMixin<LiveIntervalsAnalysis> {
   friend AnalysisInfoMixin<LiveIntervalsAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = LiveIntervals;

--- a/llvm/include/llvm/CodeGen/LiveIntervals.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervals.h
@@ -114,21 +114,21 @@ public:
   LLVM_ABI ~LiveIntervals();
 
   LLVM_ABI bool invalidate(MachineFunction &MF, const PreservedAnalyses &PA,
-                  MachineFunctionAnalysisManager::Invalidator &Inv);
+                           MachineFunctionAnalysisManager::Invalidator &Inv);
 
   /// Calculate the spill weight to assign to a single instruction.
   /// If \p PSI is provided the calculation is altered for optsize functions.
   LLVM_ABI static float getSpillWeight(bool isDef, bool isUse,
-                              const MachineBlockFrequencyInfo *MBFI,
-                              const MachineInstr &MI,
-                              ProfileSummaryInfo *PSI = nullptr);
+                                       const MachineBlockFrequencyInfo *MBFI,
+                                       const MachineInstr &MI,
+                                       ProfileSummaryInfo *PSI = nullptr);
 
   /// Calculate the spill weight to assign to a single instruction.
   /// If \p PSI is provided the calculation is altered for optsize functions.
   LLVM_ABI static float getSpillWeight(bool isDef, bool isUse,
-                              const MachineBlockFrequencyInfo *MBFI,
-                              const MachineBasicBlock *MBB,
-                              ProfileSummaryInfo *PSI = nullptr);
+                                       const MachineBlockFrequencyInfo *MBFI,
+                                       const MachineBasicBlock *MBB,
+                                       ProfileSummaryInfo *PSI = nullptr);
 
   LiveInterval &getInterval(Register Reg) {
     if (hasInterval(Reg))
@@ -176,8 +176,8 @@ public:
 
   /// Given a register and an instruction, adds a live segment from that
   /// instruction to the end of its MBB.
-  LLVM_ABI LiveInterval::Segment addSegmentToEndOfBlock(Register Reg,
-                                               MachineInstr &startInst);
+  LLVM_ABI LiveInterval::Segment
+  addSegmentToEndOfBlock(Register Reg, MachineInstr &startInst);
 
   /// After removing some uses of a register, shrink its live range to just
   /// the remaining uses. This method does not compute reaching defs for new
@@ -186,7 +186,7 @@ public:
   /// are added to the dead vector. Returns true if the interval may have been
   /// separated into multiple connected components.
   LLVM_ABI bool shrinkToUses(LiveInterval *li,
-                    SmallVectorImpl<MachineInstr *> *dead = nullptr);
+                             SmallVectorImpl<MachineInstr *> *dead = nullptr);
 
   /// Specialized version of
   /// shrinkToUses(LiveInterval *li, SmallVectorImpl<MachineInstr*> *dead)
@@ -209,7 +209,7 @@ public:
   ///
   /// See also LiveRangeCalc::extend().
   LLVM_ABI void extendToIndices(LiveRange &LR, ArrayRef<SlotIndex> Indices,
-                       ArrayRef<SlotIndex> Undefs);
+                                ArrayRef<SlotIndex> Undefs);
 
   void extendToIndices(LiveRange &LR, ArrayRef<SlotIndex> Indices) {
     extendToIndices(LR, Indices, /*Undefs=*/{});
@@ -223,7 +223,7 @@ public:
   /// Calling pruneValue() and extendToIndices() can be used to reconstruct
   /// SSA form after adding defs to a virtual register.
   LLVM_ABI void pruneValue(LiveRange &LR, SlotIndex Kill,
-                  SmallVectorImpl<SlotIndex> *EndPoints);
+                           SmallVectorImpl<SlotIndex> *EndPoints);
 
   /// This function should not be used. Its intent is to tell you that you are
   /// doing something wrong if you call pruneValue directly on a
@@ -341,7 +341,7 @@ public:
   /// \pre BundleStart should be the first instruction in the Bundle.
   /// \pre BundleStart should not have a have SlotIndex as one will be assigned.
   LLVM_ABI void handleMoveIntoNewBundle(MachineInstr &BundleStart,
-                               bool UpdateFlags = false);
+                                        bool UpdateFlags = false);
 
   /// Update live intervals for instructions in a range of iterators. It is
   /// intended for use after target hooks that may insert or remove
@@ -353,9 +353,9 @@ public:
   /// Currently, the only changes that are supported are simple removal
   /// and addition of uses.
   LLVM_ABI void repairIntervalsInRange(MachineBasicBlock *MBB,
-                              MachineBasicBlock::iterator Begin,
-                              MachineBasicBlock::iterator End,
-                              ArrayRef<Register> OrigRegs);
+                                       MachineBasicBlock::iterator Begin,
+                                       MachineBasicBlock::iterator End,
+                                       ArrayRef<Register> OrigRegs);
 
   // Register mask functions.
   //
@@ -396,7 +396,8 @@ public:
   ///
   /// Returns false if \p LI doesn't cross any register mask instructions. In
   /// that case, the bit vector is not filled in.
-  LLVM_ABI bool checkRegMaskInterference(const LiveInterval &LI, BitVector &UsableRegs);
+  LLVM_ABI bool checkRegMaskInterference(const LiveInterval &LI,
+                                         BitVector &UsableRegs);
 
   // Register unit functions.
   //
@@ -456,8 +457,9 @@ public:
   LLVM_ABI void removeVRegDefAt(LiveInterval &LI, SlotIndex Pos);
 
   /// Split separate components in LiveInterval \p LI into separate intervals.
-  LLVM_ABI void splitSeparateComponents(LiveInterval &LI,
-                               SmallVectorImpl<LiveInterval *> &SplitLIs);
+  LLVM_ABI void
+  splitSeparateComponents(LiveInterval &LI,
+                          SmallVectorImpl<LiveInterval *> &SplitLIs);
 
   /// For live interval \p LI with correct SubRanges construct matching
   /// information for the main live range. Expects the main live range to not
@@ -512,7 +514,8 @@ class LiveIntervalsAnalysis : public AnalysisInfoMixin<LiveIntervalsAnalysis> {
 
 public:
   using Result = LiveIntervals;
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
 };
 
 class LiveIntervalsPrinterPass
@@ -522,7 +525,7 @@ class LiveIntervalsPrinterPass
 public:
   explicit LiveIntervalsPrinterPass(raw_ostream &OS) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 

--- a/llvm/include/llvm/CodeGen/LiveRangeCalc.h
+++ b/llvm/include/llvm/CodeGen/LiveRangeCalc.h
@@ -23,6 +23,7 @@
 #ifndef LLVM_CODEGEN_LIVERANGECALC_H
 #define LLVM_CODEGEN_LIVERANGECALC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
@@ -170,7 +171,7 @@ protected:
   VNInfo::Allocator *getVNAlloc() { return Alloc; }
 
   /// Reset Map and Seen fields.
-  void resetLiveOutMap();
+  LLVM_ABI void resetLiveOutMap();
 
 public:
   LiveRangeCalc() = default;
@@ -187,7 +188,7 @@ public:
   /// that may overlap a previously computed live range, and before the first
   /// live range in a function.  If live ranges are not known to be
   /// non-overlapping, call reset before each.
-  void reset(const MachineFunction *mf, SlotIndexes *SI,
+  LLVM_ABI void reset(const MachineFunction *mf, SlotIndexes *SI,
              MachineDominatorTree *MDT, VNInfo::Allocator *VNIA);
 
   //===--------------------------------------------------------------------===//
@@ -204,7 +205,7 @@ public:
   /// inserted as required to preserve SSA form.
   ///
   /// PhysReg, when set, is used to verify live-in lists on basic blocks.
-  void extend(LiveRange &LR, SlotIndex Use, Register PhysReg,
+  LLVM_ABI void extend(LiveRange &LR, SlotIndex Use, Register PhysReg,
               ArrayRef<SlotIndex> Undefs);
 
   //===--------------------------------------------------------------------===//
@@ -252,13 +253,13 @@ public:
   ///
   /// Every predecessor of a live-in block must have been given a value with
   /// setLiveOutValue, the value may be null for live-trough blocks.
-  void calculateValues();
+  LLVM_ABI void calculateValues();
 
   /// A diagnostic function to check if the end of the block @p MBB is
   /// jointly dominated by the blocks corresponding to the slot indices
   /// in @p Defs. This function is mainly for use in self-verification
   /// checks.
-  LLVM_ATTRIBUTE_UNUSED
+  LLVM_ABI LLVM_ATTRIBUTE_UNUSED
   static bool isJointlyDominated(const MachineBasicBlock *MBB,
                                  ArrayRef<SlotIndex> Defs,
                                  const SlotIndexes &Indexes);

--- a/llvm/include/llvm/CodeGen/LiveRangeCalc.h
+++ b/llvm/include/llvm/CodeGen/LiveRangeCalc.h
@@ -23,7 +23,6 @@
 #ifndef LLVM_CODEGEN_LIVERANGECALC_H
 #define LLVM_CODEGEN_LIVERANGECALC_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
@@ -32,6 +31,7 @@
 #include "llvm/CodeGen/LiveInterval.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/SlotIndexes.h"
+#include "llvm/Support/Compiler.h"
 #include <utility>
 
 namespace llvm {
@@ -189,7 +189,7 @@ public:
   /// live range in a function.  If live ranges are not known to be
   /// non-overlapping, call reset before each.
   LLVM_ABI void reset(const MachineFunction *mf, SlotIndexes *SI,
-             MachineDominatorTree *MDT, VNInfo::Allocator *VNIA);
+                      MachineDominatorTree *MDT, VNInfo::Allocator *VNIA);
 
   //===--------------------------------------------------------------------===//
   // Mid-level interface.
@@ -206,7 +206,7 @@ public:
   ///
   /// PhysReg, when set, is used to verify live-in lists on basic blocks.
   LLVM_ABI void extend(LiveRange &LR, SlotIndex Use, Register PhysReg,
-              ArrayRef<SlotIndex> Undefs);
+                       ArrayRef<SlotIndex> Undefs);
 
   //===--------------------------------------------------------------------===//
   // Low-level interface.
@@ -259,10 +259,9 @@ public:
   /// jointly dominated by the blocks corresponding to the slot indices
   /// in @p Defs. This function is mainly for use in self-verification
   /// checks.
-  LLVM_ABI LLVM_ATTRIBUTE_UNUSED
-  static bool isJointlyDominated(const MachineBasicBlock *MBB,
-                                 ArrayRef<SlotIndex> Defs,
-                                 const SlotIndexes &Indexes);
+  LLVM_ABI LLVM_ATTRIBUTE_UNUSED static bool
+  isJointlyDominated(const MachineBasicBlock *MBB, ArrayRef<SlotIndex> Defs,
+                     const SlotIndexes &Indexes);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/LiveRegUnits.h
+++ b/llvm/include/llvm/CodeGen/LiveRegUnits.h
@@ -14,12 +14,12 @@
 #ifndef LLVM_CODEGEN_LIVEREGUNITS_H
 #define LLVM_CODEGEN_LIVEREGUNITS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/CodeGen/MachineInstrBundle.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/MC/LaneBitmask.h"
 #include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {

--- a/llvm/include/llvm/CodeGen/LiveRegUnits.h
+++ b/llvm/include/llvm/CodeGen/LiveRegUnits.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_LIVEREGUNITS_H
 #define LLVM_CODEGEN_LIVEREGUNITS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/CodeGen/MachineInstrBundle.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
@@ -106,11 +107,11 @@ public:
 
   /// Removes register units not preserved by the regmask \p RegMask.
   /// The regmask has the same format as the one in the RegMask machine operand.
-  void removeRegsNotPreserved(const uint32_t *RegMask);
+  LLVM_ABI void removeRegsNotPreserved(const uint32_t *RegMask);
 
   /// Adds register units not preserved by the regmask \p RegMask.
   /// The regmask has the same format as the one in the RegMask machine operand.
-  void addRegsInMask(const uint32_t *RegMask);
+  LLVM_ABI void addRegsInMask(const uint32_t *RegMask);
 
   /// Returns true if no part of physical register \p Reg is live.
   bool available(MCRegister Reg) const {
@@ -124,21 +125,21 @@ public:
   /// Updates liveness when stepping backwards over the instruction \p MI.
   /// This removes all register units defined or clobbered in \p MI and then
   /// adds the units used (as in use operands) in \p MI.
-  void stepBackward(const MachineInstr &MI);
+  LLVM_ABI void stepBackward(const MachineInstr &MI);
 
   /// Adds all register units used, defined or clobbered in \p MI.
   /// This is useful when walking over a range of instruction to find registers
   /// unused over the whole range.
-  void accumulate(const MachineInstr &MI);
+  LLVM_ABI void accumulate(const MachineInstr &MI);
 
   /// Adds registers living out of block \p MBB.
   /// Live out registers are the union of the live-in registers of the successor
   /// blocks and pristine registers. Live out registers of the end block are the
   /// callee saved registers.
-  void addLiveOuts(const MachineBasicBlock &MBB);
+  LLVM_ABI void addLiveOuts(const MachineBasicBlock &MBB);
 
   /// Adds registers living into block \p MBB.
-  void addLiveIns(const MachineBasicBlock &MBB);
+  LLVM_ABI void addLiveIns(const MachineBasicBlock &MBB);
 
   /// Adds all register units marked in the bitvector \p RegUnits.
   void addUnits(const BitVector &RegUnits) {

--- a/llvm/include/llvm/CodeGen/LiveVariables.h
+++ b/llvm/include/llvm/CodeGen/LiveVariables.h
@@ -304,7 +304,7 @@ public:
 
 class LiveVariablesAnalysis : public AnalysisInfoMixin<LiveVariablesAnalysis> {
   friend AnalysisInfoMixin<LiveVariablesAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = LiveVariables;

--- a/llvm/include/llvm/CodeGen/LiveVariables.h
+++ b/llvm/include/llvm/CodeGen/LiveVariables.h
@@ -28,6 +28,7 @@
 #ifndef LLVM_CODEGEN_LIVEVARIABLES_H
 #define LLVM_CODEGEN_LIVEVARIABLES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/ADT/SmallSet.h"
@@ -99,17 +100,17 @@ public:
     }
 
     /// findKill - Find a kill instruction in MBB. Return NULL if none is found.
-    MachineInstr *findKill(const MachineBasicBlock *MBB) const;
+    LLVM_ABI MachineInstr *findKill(const MachineBasicBlock *MBB) const;
 
     /// isLiveIn - Is Reg live in to MBB? This means that Reg is live through
     /// MBB, or it is killed in MBB. If Reg is only used by PHI instructions in
     /// MBB, it is not considered live in.
-    bool isLiveIn(const MachineBasicBlock &MBB, Register Reg,
+    LLVM_ABI bool isLiveIn(const MachineBasicBlock &MBB, Register Reg,
                   MachineRegisterInfo &MRI);
 
-    void print(raw_ostream &OS) const;
+    LLVM_ABI void print(raw_ostream &OS) const;
 
-    void dump() const;
+    LLVM_ABI void dump() const;
   };
 
 private:
@@ -144,7 +145,7 @@ private:   // Intermediate data structures
   // For legacy pass.
   LiveVariables() = default;
 
-  void analyze(MachineFunction &MF);
+  LLVM_ABI void analyze(MachineFunction &MF);
 
   /// HandlePhysRegKill - Add kills of Reg and its sub-registers to the
   /// uses. Pay special attention to the sub-register uses which may come below
@@ -181,9 +182,9 @@ private:   // Intermediate data structures
   void runOnBlock(MachineBasicBlock *MBB, unsigned NumRegs);
 
 public:
-  LiveVariables(MachineFunction &MF);
+  LLVM_ABI LiveVariables(MachineFunction &MF);
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
   //===--------------------------------------------------------------------===//
   //  API to update live variable information
@@ -192,11 +193,11 @@ public:
   /// known to have a single def that dominates all uses. This can be useful
   /// after removing some uses of \p Reg. It is not necessary for the whole
   /// machine function to be in SSA form.
-  void recomputeForSingleDefVirtReg(Register Reg);
+  LLVM_ABI void recomputeForSingleDefVirtReg(Register Reg);
 
   /// replaceKillInstruction - Update register kill info by replacing a kill
   /// instruction with a new one.
-  void replaceKillInstruction(Register Reg, MachineInstr &OldMI,
+  LLVM_ABI void replaceKillInstruction(Register Reg, MachineInstr &OldMI,
                               MachineInstr &NewMI);
 
   /// addVirtualRegisterKilled - Add information about the fact that the
@@ -233,7 +234,7 @@ public:
 
   /// removeVirtualRegistersKilled - Remove all killed info for the specified
   /// instruction.
-  void removeVirtualRegistersKilled(MachineInstr &MI);
+  LLVM_ABI void removeVirtualRegistersKilled(MachineInstr &MI);
 
   /// addVirtualRegisterDead - Add information about the fact that the specified
   /// register is dead after being used by the specified instruction. If
@@ -267,16 +268,16 @@ public:
 
   /// getVarInfo - Return the VarInfo structure for the specified VIRTUAL
   /// register.
-  VarInfo &getVarInfo(Register Reg);
+  LLVM_ABI VarInfo &getVarInfo(Register Reg);
 
-  void MarkVirtRegAliveInBlock(VarInfo& VRInfo, MachineBasicBlock* DefBlock,
+  LLVM_ABI void MarkVirtRegAliveInBlock(VarInfo& VRInfo, MachineBasicBlock* DefBlock,
                                MachineBasicBlock *BB);
-  void MarkVirtRegAliveInBlock(VarInfo &VRInfo, MachineBasicBlock *DefBlock,
+  LLVM_ABI void MarkVirtRegAliveInBlock(VarInfo &VRInfo, MachineBasicBlock *DefBlock,
                                MachineBasicBlock *BB,
                                SmallVectorImpl<MachineBasicBlock *> &WorkList);
 
-  void HandleVirtRegDef(Register reg, MachineInstr &MI);
-  void HandleVirtRegUse(Register reg, MachineBasicBlock *MBB, MachineInstr &MI);
+  LLVM_ABI void HandleVirtRegDef(Register reg, MachineInstr &MI);
+  LLVM_ABI void HandleVirtRegUse(Register reg, MachineBasicBlock *MBB, MachineInstr &MI);
 
   bool isLiveIn(Register Reg, const MachineBasicBlock &MBB) {
     return getVarInfo(Reg).isLiveIn(MBB, Reg, *MRI);
@@ -285,17 +286,17 @@ public:
   /// isLiveOut - Determine if Reg is live out from MBB, when not considering
   /// PHI nodes. This means that Reg is either killed by a successor block or
   /// passed through one.
-  bool isLiveOut(Register Reg, const MachineBasicBlock &MBB);
+  LLVM_ABI bool isLiveOut(Register Reg, const MachineBasicBlock &MBB);
 
   /// addNewBlock - Add a new basic block BB between DomBB and SuccBB. All
   /// variables that are live out of DomBB and live into SuccBB will be marked
   /// as passing live through BB. This method assumes that the machine code is
   /// still in SSA form.
-  void addNewBlock(MachineBasicBlock *BB,
+  LLVM_ABI void addNewBlock(MachineBasicBlock *BB,
                    MachineBasicBlock *DomBB,
                    MachineBasicBlock *SuccBB);
 
-  void addNewBlock(MachineBasicBlock *BB,
+  LLVM_ABI void addNewBlock(MachineBasicBlock *BB,
                    MachineBasicBlock *DomBB,
                    MachineBasicBlock *SuccBB,
                    std::vector<SparseBitVector<>> &LiveInSets);
@@ -307,7 +308,7 @@ class LiveVariablesAnalysis : public AnalysisInfoMixin<LiveVariablesAnalysis> {
 
 public:
   using Result = LiveVariables;
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
 };
 
 class LiveVariablesPrinterPass
@@ -316,12 +317,12 @@ class LiveVariablesPrinterPass
 
 public:
   explicit LiveVariablesPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
-class LiveVariablesWrapperPass : public MachineFunctionPass {
+class LLVM_ABI LiveVariablesWrapperPass : public MachineFunctionPass {
   LiveVariables LV;
 
 public:

--- a/llvm/include/llvm/CodeGen/LiveVariables.h
+++ b/llvm/include/llvm/CodeGen/LiveVariables.h
@@ -28,7 +28,6 @@
 #ifndef LLVM_CODEGEN_LIVEVARIABLES_H
 #define LLVM_CODEGEN_LIVEVARIABLES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/ADT/SmallSet.h"
@@ -40,6 +39,7 @@
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/PassRegistry.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -106,7 +106,7 @@ public:
     /// MBB, or it is killed in MBB. If Reg is only used by PHI instructions in
     /// MBB, it is not considered live in.
     LLVM_ABI bool isLiveIn(const MachineBasicBlock &MBB, Register Reg,
-                  MachineRegisterInfo &MRI);
+                           MachineRegisterInfo &MRI);
 
     LLVM_ABI void print(raw_ostream &OS) const;
 
@@ -198,7 +198,7 @@ public:
   /// replaceKillInstruction - Update register kill info by replacing a kill
   /// instruction with a new one.
   LLVM_ABI void replaceKillInstruction(Register Reg, MachineInstr &OldMI,
-                              MachineInstr &NewMI);
+                                       MachineInstr &NewMI);
 
   /// addVirtualRegisterKilled - Add information about the fact that the
   /// specified register is killed after being used by the specified
@@ -270,14 +270,17 @@ public:
   /// register.
   LLVM_ABI VarInfo &getVarInfo(Register Reg);
 
-  LLVM_ABI void MarkVirtRegAliveInBlock(VarInfo& VRInfo, MachineBasicBlock* DefBlock,
-                               MachineBasicBlock *BB);
-  LLVM_ABI void MarkVirtRegAliveInBlock(VarInfo &VRInfo, MachineBasicBlock *DefBlock,
-                               MachineBasicBlock *BB,
-                               SmallVectorImpl<MachineBasicBlock *> &WorkList);
+  LLVM_ABI void MarkVirtRegAliveInBlock(VarInfo &VRInfo,
+                                        MachineBasicBlock *DefBlock,
+                                        MachineBasicBlock *BB);
+  LLVM_ABI void
+  MarkVirtRegAliveInBlock(VarInfo &VRInfo, MachineBasicBlock *DefBlock,
+                          MachineBasicBlock *BB,
+                          SmallVectorImpl<MachineBasicBlock *> &WorkList);
 
   LLVM_ABI void HandleVirtRegDef(Register reg, MachineInstr &MI);
-  LLVM_ABI void HandleVirtRegUse(Register reg, MachineBasicBlock *MBB, MachineInstr &MI);
+  LLVM_ABI void HandleVirtRegUse(Register reg, MachineBasicBlock *MBB,
+                                 MachineInstr &MI);
 
   bool isLiveIn(Register Reg, const MachineBasicBlock &MBB) {
     return getVarInfo(Reg).isLiveIn(MBB, Reg, *MRI);
@@ -292,14 +295,12 @@ public:
   /// variables that are live out of DomBB and live into SuccBB will be marked
   /// as passing live through BB. This method assumes that the machine code is
   /// still in SSA form.
-  LLVM_ABI void addNewBlock(MachineBasicBlock *BB,
-                   MachineBasicBlock *DomBB,
-                   MachineBasicBlock *SuccBB);
+  LLVM_ABI void addNewBlock(MachineBasicBlock *BB, MachineBasicBlock *DomBB,
+                            MachineBasicBlock *SuccBB);
 
-  LLVM_ABI void addNewBlock(MachineBasicBlock *BB,
-                   MachineBasicBlock *DomBB,
-                   MachineBasicBlock *SuccBB,
-                   std::vector<SparseBitVector<>> &LiveInSets);
+  LLVM_ABI void addNewBlock(MachineBasicBlock *BB, MachineBasicBlock *DomBB,
+                            MachineBasicBlock *SuccBB,
+                            std::vector<SparseBitVector<>> &LiveInSets);
 };
 
 class LiveVariablesAnalysis : public AnalysisInfoMixin<LiveVariablesAnalysis> {
@@ -318,7 +319,7 @@ class LiveVariablesPrinterPass
 public:
   explicit LiveVariablesPrinterPass(raw_ostream &OS) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 

--- a/llvm/include/llvm/CodeGen/LowLevelTypeUtils.h
+++ b/llvm/include/llvm/CodeGen/LowLevelTypeUtils.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CODEGEN_LOWLEVELTYPEUTILS_H
 #define LLVM_CODEGEN_LOWLEVELTYPEUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/ValueTypes.h"
 #include "llvm/CodeGenTypes/LowLevelType.h"
 
@@ -26,20 +27,20 @@ class Type;
 struct fltSemantics;
 
 /// Construct a low-level type based on an LLVM type.
-LLT getLLTForType(Type &Ty, const DataLayout &DL);
+LLVM_ABI LLT getLLTForType(Type &Ty, const DataLayout &DL);
 
 /// Get a rough equivalent of an MVT for a given LLT. MVT can't distinguish
 /// pointers, so these will convert to a plain integer.
-MVT getMVTForLLT(LLT Ty);
-EVT getApproximateEVTForLLT(LLT Ty, LLVMContext &Ctx);
+LLVM_ABI MVT getMVTForLLT(LLT Ty);
+LLVM_ABI EVT getApproximateEVTForLLT(LLT Ty, LLVMContext &Ctx);
 
 /// Get a rough equivalent of an LLT for a given MVT. LLT does not yet support
 /// scalarable vector types, and will assert if used.
-LLT getLLTForMVT(MVT Ty);
+LLVM_ABI LLT getLLTForMVT(MVT Ty);
 
 /// Get the appropriate floating point arithmetic semantic based on the bit size
 /// of the given scalar LLT.
-const llvm::fltSemantics &getFltSemanticForLLT(LLT Ty);
+LLVM_ABI const llvm::fltSemantics &getFltSemanticForLLT(LLT Ty);
 }
 
 #endif // LLVM_CODEGEN_LOWLEVELTYPEUTILS_H

--- a/llvm/include/llvm/CodeGen/LowLevelTypeUtils.h
+++ b/llvm/include/llvm/CodeGen/LowLevelTypeUtils.h
@@ -16,9 +16,9 @@
 #ifndef LLVM_CODEGEN_LOWLEVELTYPEUTILS_H
 #define LLVM_CODEGEN_LOWLEVELTYPEUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/ValueTypes.h"
 #include "llvm/CodeGenTypes/LowLevelType.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/MIRFormatter.h
+++ b/llvm/include/llvm/CodeGen/MIRFormatter.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_CODEGEN_MIRFORMATTER_H
 #define LLVM_CODEGEN_MIRFORMATTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/PseudoSourceValue.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
@@ -75,14 +75,15 @@ public:
   /// be useful for target specific printer, e.g. for printing IR value in
   /// custom pseudo source value.
   LLVM_ABI static void printIRValue(raw_ostream &OS, const Value &V,
-                           ModuleSlotTracker &MST);
+                                    ModuleSlotTracker &MST);
 
   /// Helper functions to parse IR value from MIR serialization format which
   /// will be useful for target specific parser, e.g. for parsing IR value for
   /// custom pseudo source value.
   LLVM_ABI static bool parseIRValue(StringRef Src, MachineFunction &MF,
-                           PerFunctionMIParsingState &PFS, const Value *&V,
-                           ErrorCallbackType ErrorCallback);
+                                    PerFunctionMIParsingState &PFS,
+                                    const Value *&V,
+                                    ErrorCallbackType ErrorCallback);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/MIRFormatter.h
+++ b/llvm/include/llvm/CodeGen/MIRFormatter.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MIRFORMATTER_H
 #define LLVM_CODEGEN_MIRFORMATTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/PseudoSourceValue.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
@@ -73,13 +74,13 @@ public:
   /// Helper functions to print IR value as MIR serialization format which will
   /// be useful for target specific printer, e.g. for printing IR value in
   /// custom pseudo source value.
-  static void printIRValue(raw_ostream &OS, const Value &V,
+  LLVM_ABI static void printIRValue(raw_ostream &OS, const Value &V,
                            ModuleSlotTracker &MST);
 
   /// Helper functions to parse IR value from MIR serialization format which
   /// will be useful for target specific parser, e.g. for parsing IR value for
   /// custom pseudo source value.
-  static bool parseIRValue(StringRef Src, MachineFunction &MF,
+  LLVM_ABI static bool parseIRValue(StringRef Src, MachineFunction &MF,
                            PerFunctionMIParsingState &PFS, const Value *&V,
                            ErrorCallbackType ErrorCallback);
 };

--- a/llvm/include/llvm/CodeGen/MIRParser/MIRParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIRParser.h
@@ -17,9 +17,9 @@
 #ifndef LLVM_CODEGEN_MIRPARSER_MIRPARSER_H
 #define LLVM_CODEGEN_MIRPARSER_MIRPARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <functional>
 #include <memory>
 #include <optional>

--- a/llvm/include/llvm/CodeGen/MIRParser/MIRParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIRParser.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_CODEGEN_MIRPARSER_MIRPARSER_H
 #define LLVM_CODEGEN_MIRPARSER_MIRPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include <functional>
@@ -46,15 +47,15 @@ class MIRParser {
   std::unique_ptr<MIRParserImpl> Impl;
 
 public:
-  MIRParser(std::unique_ptr<MIRParserImpl> Impl);
+  LLVM_ABI MIRParser(std::unique_ptr<MIRParserImpl> Impl);
   MIRParser(const MIRParser &) = delete;
-  ~MIRParser();
+  LLVM_ABI ~MIRParser();
 
   /// Parses the optional LLVM IR module in the MIR file.
   ///
   /// A new, empty module is created if the LLVM IR isn't present.
   /// \returns nullptr if a parsing error occurred.
-  std::unique_ptr<Module>
+  LLVM_ABI std::unique_ptr<Module>
   parseIRModule(DataLayoutCallbackTy DataLayoutCallback =
                     [](StringRef, StringRef) { return std::nullopt; });
 
@@ -62,7 +63,7 @@ public:
   /// MachineModuleInfo \p MMI.
   ///
   /// \returns true if an error occurred.
-  bool parseMachineFunctions(Module &M, MachineModuleInfo &MMI);
+  LLVM_ABI bool parseMachineFunctions(Module &M, MachineModuleInfo &MMI);
 
   /// Parses MachineFunctions in the MIR file and add them as the result
   /// of MachineFunctionAnalysis in ModulePassManager \p MAM.
@@ -71,7 +72,7 @@ public:
   /// PassInstrumentationAnalysis in \p MAM before parsing MIR.
   ///
   /// \returns true if an error occurred.
-  bool parseMachineFunctions(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI bool parseMachineFunctions(Module &M, ModuleAnalysisManager &MAM);
 };
 
 /// This function is the main interface to the MIR serialization format parser.
@@ -85,7 +86,7 @@ public:
 /// \param Context - Context which will be used for the parsed LLVM IR module.
 /// \param ProcessIRFunction - function to run on every IR function or stub
 /// loaded from the MIR file.
-std::unique_ptr<MIRParser> createMIRParserFromFile(
+LLVM_ABI std::unique_ptr<MIRParser> createMIRParserFromFile(
     StringRef Filename, SMDiagnostic &Error, LLVMContext &Context,
     std::function<void(Function &)> ProcessIRFunction = nullptr);
 
@@ -97,7 +98,7 @@ std::unique_ptr<MIRParser> createMIRParserFromFile(
 ///
 /// \param Contents - The MemoryBuffer containing the machine level IR.
 /// \param Context - Context which will be used for the parsed LLVM IR module.
-std::unique_ptr<MIRParser>
+LLVM_ABI std::unique_ptr<MIRParser>
 createMIRParser(std::unique_ptr<MemoryBuffer> Contents, LLVMContext &Context,
                 std::function<void(Function &)> ProcessIRFunction = nullptr);
 

--- a/llvm/include/llvm/CodeGen/MIRPrinter.h
+++ b/llvm/include/llvm/CodeGen/MIRPrinter.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_CODEGEN_MIRPRINTER_H
 #define LLVM_CODEGEN_MIRPRINTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -41,7 +41,7 @@ class PrintMIRPass : public PassInfoMixin<PrintMIRPass> {
 public:
   PrintMIRPass(raw_ostream &OS = errs()) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
@@ -51,7 +51,7 @@ LLVM_ABI void printMIR(raw_ostream &OS, const Module &M);
 /// Print a machine function using the MIR serialization format to the given
 /// output stream.
 LLVM_ABI void printMIR(raw_ostream &OS, const MachineModuleInfo &MMI,
-              const MachineFunction &MF);
+                       const MachineFunction &MF);
 
 /// Determine a possible list of successors of a basic block based on the
 /// basic block machine operand being used inside the block. This should give
@@ -61,8 +61,8 @@ LLVM_ABI void printMIR(raw_ostream &OS, const MachineModuleInfo &MMI,
 /// this function and the parser will use this function to construct a list if
 /// it is missing.
 LLVM_ABI void guessSuccessors(const MachineBasicBlock &MBB,
-                     SmallVectorImpl<MachineBasicBlock*> &Result,
-                     bool &IsFallthrough);
+                              SmallVectorImpl<MachineBasicBlock *> &Result,
+                              bool &IsFallthrough);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/MIRPrinter.h
+++ b/llvm/include/llvm/CodeGen/MIRPrinter.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MIRPRINTER_H
 #define LLVM_CODEGEN_MIRPRINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -30,7 +31,7 @@ class PrintMIRPreparePass : public PassInfoMixin<PrintMIRPreparePass> {
 
 public:
   PrintMIRPreparePass(raw_ostream &OS = errs()) : OS(OS) {}
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MFAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
@@ -39,17 +40,17 @@ class PrintMIRPass : public PassInfoMixin<PrintMIRPass> {
 
 public:
   PrintMIRPass(raw_ostream &OS = errs()) : OS(OS) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
 /// Print LLVM IR using the MIR serialization format to the given output stream.
-void printMIR(raw_ostream &OS, const Module &M);
+LLVM_ABI void printMIR(raw_ostream &OS, const Module &M);
 
 /// Print a machine function using the MIR serialization format to the given
 /// output stream.
-void printMIR(raw_ostream &OS, const MachineModuleInfo &MMI,
+LLVM_ABI void printMIR(raw_ostream &OS, const MachineModuleInfo &MMI,
               const MachineFunction &MF);
 
 /// Determine a possible list of successors of a basic block based on the
@@ -59,7 +60,7 @@ void printMIR(raw_ostream &OS, const MachineModuleInfo &MMI,
 /// The MIRPRinter will skip printing successors if they match the result of
 /// this function and the parser will use this function to construct a list if
 /// it is missing.
-void guessSuccessors(const MachineBasicBlock &MBB,
+LLVM_ABI void guessSuccessors(const MachineBasicBlock &MBB,
                      SmallVectorImpl<MachineBasicBlock*> &Result,
                      bool &IsFallthrough);
 

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CODEGEN_MACHINEBASICBLOCK_H
 #define LLVM_CODEGEN_MACHINEBASICBLOCK_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/SparseBitVector.h"
@@ -25,6 +24,7 @@
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/MC/LaneBitmask.h"
 #include "llvm/Support/BranchProbability.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <iterator>
@@ -118,8 +118,9 @@ private:
 public:
   LLVM_ABI void addNodeToList(MachineInstr *N);
   LLVM_ABI void removeNodeFromList(MachineInstr *N);
-  LLVM_ABI void transferNodesFromList(ilist_traits &FromList, instr_iterator First,
-                             instr_iterator Last);
+  LLVM_ABI void transferNodesFromList(ilist_traits &FromList,
+                                      instr_iterator First,
+                                      instr_iterator Last);
   LLVM_ABI void deleteNode(MachineInstr *MI);
 };
 
@@ -487,15 +488,16 @@ public:
   /// Add PhysReg as live in to this block, and ensure that there is a copy of
   /// PhysReg to a virtual register of class RC. Return the virtual register
   /// that is a copy of the live in PhysReg.
-  LLVM_ABI Register addLiveIn(MCRegister PhysReg, const TargetRegisterClass *RC);
+  LLVM_ABI Register addLiveIn(MCRegister PhysReg,
+                              const TargetRegisterClass *RC);
 
   /// Remove the specified register from the live in set.
   LLVM_ABI void removeLiveIn(MCRegister Reg,
-                    LaneBitmask LaneMask = LaneBitmask::getAll());
+                             LaneBitmask LaneMask = LaneBitmask::getAll());
 
   /// Return true if the specified register is in the live in set.
   LLVM_ABI bool isLiveIn(MCRegister Reg,
-                LaneBitmask LaneMask = LaneBitmask::getAll()) const;
+                         LaneBitmask LaneMask = LaneBitmask::getAll()) const;
 
   // Iteration support for live in sets.  These sets are kept in sorted
   // order by their register number.
@@ -615,11 +617,13 @@ public:
 
   /// Get the clobber mask for the start of this basic block. Funclets use this
   /// to prevent register allocation across funclet transitions.
-  LLVM_ABI const uint32_t *getBeginClobberMask(const TargetRegisterInfo *TRI) const;
+  LLVM_ABI const uint32_t *
+  getBeginClobberMask(const TargetRegisterInfo *TRI) const;
 
   /// Get the clobber mask for the end of the basic block.
   /// \see getBeginClobberMask()
-  LLVM_ABI const uint32_t *getEndClobberMask(const TargetRegisterInfo *TRI) const;
+  LLVM_ABI const uint32_t *
+  getEndClobberMask(const TargetRegisterInfo *TRI) const;
 
   /// Return alignment of the basic block.
   Align getAlignment() const { return Alignment; }
@@ -755,8 +759,9 @@ public:
   /// probability for each successor, where N is the number of successors.
   ///
   /// Note that duplicate Machine CFG edges are not allowed.
-  LLVM_ABI void addSuccessor(MachineBasicBlock *Succ,
-                    BranchProbability Prob = BranchProbability::getUnknown());
+  LLVM_ABI void
+  addSuccessor(MachineBasicBlock *Succ,
+               BranchProbability Prob = BranchProbability::getUnknown());
 
   /// Add Succ as a successor of this MachineBasicBlock.  The Predecessors list
   /// of Succ is automatically updated. The probability is not provided because
@@ -785,7 +790,7 @@ public:
   /// If NormalizeSuccProbs is true, then normalize successors' probabilities
   /// after the successor is removed.
   LLVM_ABI void removeSuccessor(MachineBasicBlock *Succ,
-                       bool NormalizeSuccProbs = false);
+                                bool NormalizeSuccProbs = false);
 
   /// Remove specified successor from the successors list of this
   /// MachineBasicBlock. The Predecessors list of Succ is automatically updated.
@@ -793,10 +798,11 @@ public:
   /// after the successor is removed.
   /// Return the iterator to the element after the one removed.
   LLVM_ABI succ_iterator removeSuccessor(succ_iterator I,
-                                bool NormalizeSuccProbs = false);
+                                         bool NormalizeSuccProbs = false);
 
   /// Replace successor OLD with NEW and update probability info.
-  LLVM_ABI void replaceSuccessor(MachineBasicBlock *Old, MachineBasicBlock *New);
+  LLVM_ABI void replaceSuccessor(MachineBasicBlock *Old,
+                                 MachineBasicBlock *New);
 
   /// Copy a successor (and any probability info) from original block to this
   /// block's. Uses an iterator into the original blocks successors.
@@ -808,7 +814,7 @@ public:
   /// Split the old successor into old plus new and updates the probability
   /// info.
   LLVM_ABI void splitSuccessor(MachineBasicBlock *Old, MachineBasicBlock *New,
-                      bool NormalizeSuccProbs = false);
+                               bool NormalizeSuccProbs = false);
 
   /// Transfers all the successors from MBB to this machine basic block (i.e.,
   /// copies all the successors FromMBB and remove all the successors from
@@ -891,8 +897,9 @@ public:
   /// debug.  This is the correct point to insert copies at the beginning of a
   /// basic block. \p Reg is the register being used by a spill or defined for a
   /// restore/split during register allocation.
-  LLVM_ABI iterator SkipPHIsLabelsAndDebug(iterator I, Register Reg = Register(),
-                                  bool SkipPseudoOp = true);
+  LLVM_ABI iterator SkipPHIsLabelsAndDebug(iterator I,
+                                           Register Reg = Register(),
+                                           bool SkipPseudoOp = true);
 
   /// Returns an iterator to the first terminator instruction of this basic
   /// block. If a terminator does not exist, it returns end().
@@ -974,8 +981,9 @@ public:
   ///
   /// If \p UpdateLiveIns is true, this will ensure the live ins list is
   /// accurate, including for physreg uses/defs in the original block.
-  LLVM_ABI MachineBasicBlock *splitAt(MachineInstr &SplitInst, bool UpdateLiveIns = true,
-                             LiveIntervals *LIS = nullptr);
+  LLVM_ABI MachineBasicBlock *splitAt(MachineInstr &SplitInst,
+                                      bool UpdateLiveIns = true,
+                                      LiveIntervals *LIS = nullptr);
 
   /// Split the critical edge from this block to the given successor block, and
   /// return the newly created block, or null if splitting is not possible.
@@ -1154,11 +1162,13 @@ public:
 
   /// Given a machine basic block that branched to 'Old', change the code and
   /// CFG so that it branches to 'New' instead.
-  LLVM_ABI void ReplaceUsesOfBlockWith(MachineBasicBlock *Old, MachineBasicBlock *New);
+  LLVM_ABI void ReplaceUsesOfBlockWith(MachineBasicBlock *Old,
+                                       MachineBasicBlock *New);
 
   /// Update all phi nodes in this basic block to refer to basic block \p New
   /// instead of basic block \p Old.
-  LLVM_ABI void replacePhiUsesWith(MachineBasicBlock *Old, MachineBasicBlock *New);
+  LLVM_ABI void replacePhiUsesWith(MachineBasicBlock *Old,
+                                   MachineBasicBlock *New);
 
   /// Find the next valid DebugLoc starting at MBBI, skipping any debug
   /// instructions.  Return UnknownLoc if there is none.
@@ -1211,25 +1221,26 @@ public:
   /// after (searching just for defs) \p Before.
   ///
   /// \p Reg must be a physical register.
-  LLVM_ABI LivenessQueryResult computeRegisterLiveness(const TargetRegisterInfo *TRI,
-                                              MCRegister Reg,
-                                              const_iterator Before,
-                                              unsigned Neighborhood = 10) const;
+  LLVM_ABI LivenessQueryResult computeRegisterLiveness(
+      const TargetRegisterInfo *TRI, MCRegister Reg, const_iterator Before,
+      unsigned Neighborhood = 10) const;
 
   // Debugging methods.
   LLVM_ABI void dump() const;
   LLVM_ABI void print(raw_ostream &OS, const SlotIndexes * = nullptr,
-             bool IsStandalone = true) const;
+                      bool IsStandalone = true) const;
   LLVM_ABI void print(raw_ostream &OS, ModuleSlotTracker &MST,
-             const SlotIndexes * = nullptr, bool IsStandalone = true) const;
+                      const SlotIndexes * = nullptr,
+                      bool IsStandalone = true) const;
 
   enum PrintNameFlag {
     PrintNameIr = (1 << 0), ///< Add IR name where available
     PrintNameAttributes = (1 << 1), ///< Print attributes
   };
 
-  LLVM_ABI void printName(raw_ostream &os, unsigned printNameFlags = PrintNameIr,
-                 ModuleSlotTracker *moduleSlotTracker = nullptr) const;
+  LLVM_ABI void printName(raw_ostream &os,
+                          unsigned printNameFlags = PrintNameIr,
+                          ModuleSlotTracker *moduleSlotTracker = nullptr) const;
 
   // Printing method used by LoopInfo.
   LLVM_ABI void printAsOperand(raw_ostream &OS, bool PrintType = true) const;
@@ -1290,7 +1301,7 @@ private:
   void removePredecessor(MachineBasicBlock *Pred);
 };
 
-LLVM_ABI raw_ostream& operator<<(raw_ostream &OS, const MachineBasicBlock &MBB);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const MachineBasicBlock &MBB);
 
 /// Prints a machine basic block reference.
 ///

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MACHINEBASICBLOCK_H
 #define LLVM_CODEGEN_MACHINEBASICBLOCK_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/SparseBitVector.h"
@@ -65,8 +66,8 @@ struct MBBSectionID {
   MBBSectionID(unsigned N) : Type(Default), Number(N) {}
 
   // Special unique sections for cold and exception blocks.
-  const static MBBSectionID ColdSectionID;
-  const static MBBSectionID ExceptionSectionID;
+  LLVM_ABI const static MBBSectionID ColdSectionID;
+  LLVM_ABI const static MBBSectionID ExceptionSectionID;
 
   bool operator==(const MBBSectionID &Other) const {
     return Type == Other.Type && Number == Other.Number;
@@ -115,11 +116,11 @@ private:
       simple_ilist<MachineInstr, ilist_sentinel_tracking<true>>::iterator;
 
 public:
-  void addNodeToList(MachineInstr *N);
-  void removeNodeFromList(MachineInstr *N);
-  void transferNodesFromList(ilist_traits &FromList, instr_iterator First,
+  LLVM_ABI void addNodeToList(MachineInstr *N);
+  LLVM_ABI void removeNodeFromList(MachineInstr *N);
+  LLVM_ABI void transferNodesFromList(ilist_traits &FromList, instr_iterator First,
                              instr_iterator Last);
-  void deleteNode(MachineInstr *MI);
+  LLVM_ABI void deleteNode(MachineInstr *MI);
 };
 
 class MachineBasicBlock
@@ -263,13 +264,13 @@ public:
   }
 
   /// Check if there is a name of corresponding LLVM basic block.
-  bool hasName() const;
+  LLVM_ABI bool hasName() const;
 
   /// Return the name of the corresponding LLVM basic block, or an empty string.
-  StringRef getName() const;
+  LLVM_ABI StringRef getName() const;
 
   /// Return a formatted string to identify this block and its parent function.
-  std::string getFullName() const;
+  LLVM_ABI std::string getFullName() const;
 
   /// Test whether this block is used as something other than the target
   /// of a terminator, exception-handling target, or jump table. This is
@@ -333,7 +334,7 @@ public:
       MachineInstrBundleIterator<const MachineInstr, true>;
 
   unsigned size() const { return (unsigned)Insts.size(); }
-  bool sizeWithoutDebugLargerThan(unsigned Limit) const;
+  LLVM_ABI bool sizeWithoutDebugLargerThan(unsigned Limit) const;
   bool empty() const { return Insts.empty(); }
 
   MachineInstr       &instr_front()       { return Insts.front(); }
@@ -474,26 +475,26 @@ public:
   /// Sorts and uniques the LiveIns vector. It can be significantly faster to do
   /// this than repeatedly calling isLiveIn before calling addLiveIn for every
   /// LiveIn insertion.
-  void sortUniqueLiveIns();
+  LLVM_ABI void sortUniqueLiveIns();
 
   /// Clear live in list.
-  void clearLiveIns();
+  LLVM_ABI void clearLiveIns();
 
   /// Clear the live in list, and return the removed live in's in \p OldLiveIns.
   /// Requires that the vector \p OldLiveIns is empty.
-  void clearLiveIns(std::vector<RegisterMaskPair> &OldLiveIns);
+  LLVM_ABI void clearLiveIns(std::vector<RegisterMaskPair> &OldLiveIns);
 
   /// Add PhysReg as live in to this block, and ensure that there is a copy of
   /// PhysReg to a virtual register of class RC. Return the virtual register
   /// that is a copy of the live in PhysReg.
-  Register addLiveIn(MCRegister PhysReg, const TargetRegisterClass *RC);
+  LLVM_ABI Register addLiveIn(MCRegister PhysReg, const TargetRegisterClass *RC);
 
   /// Remove the specified register from the live in set.
-  void removeLiveIn(MCRegister Reg,
+  LLVM_ABI void removeLiveIn(MCRegister Reg,
                     LaneBitmask LaneMask = LaneBitmask::getAll());
 
   /// Return true if the specified register is in the live in set.
-  bool isLiveIn(MCRegister Reg,
+  LLVM_ABI bool isLiveIn(MCRegister Reg,
                 LaneBitmask LaneMask = LaneBitmask::getAll()) const;
 
   // Iteration support for live in sets.  These sets are kept in sorted
@@ -509,7 +510,7 @@ public:
     return make_range(livein_begin_dbg(), livein_end());
   }
 
-  livein_iterator livein_begin() const;
+  LLVM_ABI livein_iterator livein_begin() const;
   livein_iterator livein_end()   const { return LiveIns.end(); }
   bool            livein_empty() const { return LiveIns.empty(); }
   iterator_range<livein_iterator> liveins() const {
@@ -517,7 +518,7 @@ public:
   }
 
   /// Remove entry from the livein set and return iterator to the next.
-  livein_iterator removeLiveIn(livein_iterator I);
+  LLVM_ABI livein_iterator removeLiveIn(livein_iterator I);
 
   const std::vector<RegisterMaskPair> &getLiveIns() const { return LiveIns; }
 
@@ -604,7 +605,7 @@ public:
   /// Iterator scanning successor basic blocks' liveins to determine the
   /// registers potentially live at the end of this block. There may be
   /// duplicates or overlapping registers in the list returned.
-  liveout_iterator liveout_begin() const;
+  LLVM_ABI liveout_iterator liveout_begin() const;
   liveout_iterator liveout_end() const {
     return liveout_iterator(*this, 0, 0, true);
   }
@@ -614,11 +615,11 @@ public:
 
   /// Get the clobber mask for the start of this basic block. Funclets use this
   /// to prevent register allocation across funclet transitions.
-  const uint32_t *getBeginClobberMask(const TargetRegisterInfo *TRI) const;
+  LLVM_ABI const uint32_t *getBeginClobberMask(const TargetRegisterInfo *TRI) const;
 
   /// Get the clobber mask for the end of the basic block.
   /// \see getBeginClobberMask()
-  const uint32_t *getEndClobberMask(const TargetRegisterInfo *TRI) const;
+  LLVM_ABI const uint32_t *getEndClobberMask(const TargetRegisterInfo *TRI) const;
 
   /// Return alignment of the basic block.
   Align getAlignment() const { return Alignment; }
@@ -647,10 +648,10 @@ public:
   /// via an exception handler.
   void setIsEHPad(bool V = true) { IsEHPad = V; }
 
-  bool hasEHPadSuccessor() const;
+  LLVM_ABI bool hasEHPadSuccessor() const;
 
   /// Returns true if this is the entry block of the function.
-  bool isEntryBlock() const;
+  LLVM_ABI bool isEntryBlock() const;
 
   /// Returns true if this is the entry block of an EH scope, i.e., the block
   /// that used to have a catchpad or cleanuppad instruction in the LLVM IR.
@@ -703,12 +704,12 @@ public:
   void setSectionID(MBBSectionID V) { SectionID = V; }
 
   /// Returns the MCSymbol marking the end of this basic block.
-  MCSymbol *getEndSymbol() const;
+  LLVM_ABI MCSymbol *getEndSymbol() const;
 
   /// Returns true if this block may have an INLINEASM_BR (overestimate, by
   /// checking if any of the successors are indirect targets of any inlineasm_br
   /// in the function).
-  bool mayHaveInlineAsmBr() const;
+  LLVM_ABI bool mayHaveInlineAsmBr() const;
 
   /// Returns true if this is the indirect dest of an INLINEASM_BR.
   bool isInlineAsmBrIndirectTarget() const {
@@ -721,15 +722,15 @@ public:
   }
 
   /// Returns true if it is legal to hoist instructions into this block.
-  bool isLegalToHoistInto() const;
+  LLVM_ABI bool isLegalToHoistInto() const;
 
   // Code Layout methods.
 
   /// Move 'this' block before or after the specified block.  This only moves
   /// the block, it does not modify the CFG or adjust potential fall-throughs at
   /// the end of the block.
-  void moveBefore(MachineBasicBlock *NewAfter);
-  void moveAfter(MachineBasicBlock *NewBefore);
+  LLVM_ABI void moveBefore(MachineBasicBlock *NewAfter);
+  LLVM_ABI void moveAfter(MachineBasicBlock *NewBefore);
 
   /// Returns true if this and MBB belong to the same section.
   bool sameSection(const MachineBasicBlock *MBB) const {
@@ -742,7 +743,7 @@ public:
   /// layout was modified.  If the block previously fell through to that block,
   /// it may now need a branch. If it previously branched to another block, it
   /// may now be able to fallthrough to the current layout successor.
-  void updateTerminator(MachineBasicBlock *PreviousLayoutSuccessor);
+  LLVM_ABI void updateTerminator(MachineBasicBlock *PreviousLayoutSuccessor);
 
   // Machine-CFG mutators
 
@@ -754,17 +755,17 @@ public:
   /// probability for each successor, where N is the number of successors.
   ///
   /// Note that duplicate Machine CFG edges are not allowed.
-  void addSuccessor(MachineBasicBlock *Succ,
+  LLVM_ABI void addSuccessor(MachineBasicBlock *Succ,
                     BranchProbability Prob = BranchProbability::getUnknown());
 
   /// Add Succ as a successor of this MachineBasicBlock.  The Predecessors list
   /// of Succ is automatically updated. The probability is not provided because
   /// BPI is not available (e.g. -O0 is used), in which case edge probabilities
   /// won't be used. Using this interface can save some space.
-  void addSuccessorWithoutProb(MachineBasicBlock *Succ);
+  LLVM_ABI void addSuccessorWithoutProb(MachineBasicBlock *Succ);
 
   /// Set successor probability of a given iterator.
-  void setSuccProbability(succ_iterator I, BranchProbability Prob);
+  LLVM_ABI void setSuccProbability(succ_iterator I, BranchProbability Prob);
 
   /// Normalize probabilities of all successors so that the sum of them becomes
   /// one. This is usually done when the current update on this MBB is done, and
@@ -777,13 +778,13 @@ public:
 
   /// Validate successors' probabilities and check if the sum of them is
   /// approximate one. This only works in DEBUG mode.
-  void validateSuccProbs() const;
+  LLVM_ABI void validateSuccProbs() const;
 
   /// Remove successor from the successors list of this MachineBasicBlock. The
   /// Predecessors list of Succ is automatically updated.
   /// If NormalizeSuccProbs is true, then normalize successors' probabilities
   /// after the successor is removed.
-  void removeSuccessor(MachineBasicBlock *Succ,
+  LLVM_ABI void removeSuccessor(MachineBasicBlock *Succ,
                        bool NormalizeSuccProbs = false);
 
   /// Remove specified successor from the successors list of this
@@ -791,53 +792,53 @@ public:
   /// If NormalizeSuccProbs is true, then normalize successors' probabilities
   /// after the successor is removed.
   /// Return the iterator to the element after the one removed.
-  succ_iterator removeSuccessor(succ_iterator I,
+  LLVM_ABI succ_iterator removeSuccessor(succ_iterator I,
                                 bool NormalizeSuccProbs = false);
 
   /// Replace successor OLD with NEW and update probability info.
-  void replaceSuccessor(MachineBasicBlock *Old, MachineBasicBlock *New);
+  LLVM_ABI void replaceSuccessor(MachineBasicBlock *Old, MachineBasicBlock *New);
 
   /// Copy a successor (and any probability info) from original block to this
   /// block's. Uses an iterator into the original blocks successors.
   ///
   /// This is useful when doing a partial clone of successors. Afterward, the
   /// probabilities may need to be normalized.
-  void copySuccessor(const MachineBasicBlock *Orig, succ_iterator I);
+  LLVM_ABI void copySuccessor(const MachineBasicBlock *Orig, succ_iterator I);
 
   /// Split the old successor into old plus new and updates the probability
   /// info.
-  void splitSuccessor(MachineBasicBlock *Old, MachineBasicBlock *New,
+  LLVM_ABI void splitSuccessor(MachineBasicBlock *Old, MachineBasicBlock *New,
                       bool NormalizeSuccProbs = false);
 
   /// Transfers all the successors from MBB to this machine basic block (i.e.,
   /// copies all the successors FromMBB and remove all the successors from
   /// FromMBB).
-  void transferSuccessors(MachineBasicBlock *FromMBB);
+  LLVM_ABI void transferSuccessors(MachineBasicBlock *FromMBB);
 
   /// Transfers all the successors, as in transferSuccessors, and update PHI
   /// operands in the successor blocks which refer to FromMBB to refer to this.
-  void transferSuccessorsAndUpdatePHIs(MachineBasicBlock *FromMBB);
+  LLVM_ABI void transferSuccessorsAndUpdatePHIs(MachineBasicBlock *FromMBB);
 
   /// Return true if any of the successors have probabilities attached to them.
   bool hasSuccessorProbabilities() const { return !Probs.empty(); }
 
   /// Return true if the specified MBB is a predecessor of this block.
-  bool isPredecessor(const MachineBasicBlock *MBB) const;
+  LLVM_ABI bool isPredecessor(const MachineBasicBlock *MBB) const;
 
   /// Return true if the specified MBB is a successor of this block.
-  bool isSuccessor(const MachineBasicBlock *MBB) const;
+  LLVM_ABI bool isSuccessor(const MachineBasicBlock *MBB) const;
 
   /// Return true if the specified MBB will be emitted immediately after this
   /// block, such that if this block exits by falling through, control will
   /// transfer to the specified MBB. Note that MBB need not be a successor at
   /// all, for example if this block ends with an unconditional branch to some
   /// other block.
-  bool isLayoutSuccessor(const MachineBasicBlock *MBB) const;
+  LLVM_ABI bool isLayoutSuccessor(const MachineBasicBlock *MBB) const;
 
   /// Return the successor of this block if it has a single successor.
   /// Otherwise return a null pointer.
   ///
-  const MachineBasicBlock *getSingleSuccessor() const;
+  LLVM_ABI const MachineBasicBlock *getSingleSuccessor() const;
   MachineBasicBlock *getSingleSuccessor() {
     return const_cast<MachineBasicBlock *>(
         static_cast<const MachineBasicBlock *>(this)->getSingleSuccessor());
@@ -846,7 +847,7 @@ public:
   /// Return the predecessor of this block if it has a single predecessor.
   /// Otherwise return a null pointer.
   ///
-  const MachineBasicBlock *getSinglePredecessor() const;
+  LLVM_ABI const MachineBasicBlock *getSinglePredecessor() const;
   MachineBasicBlock *getSinglePredecessor() {
     return const_cast<MachineBasicBlock *>(
         static_cast<const MachineBasicBlock *>(this)->getSinglePredecessor());
@@ -857,7 +858,7 @@ public:
   /// it. If an explicit branch to the fallthrough block is not allowed,
   /// set JumpToFallThrough to be false. Non-null return is a conservative
   /// answer.
-  MachineBasicBlock *getFallThrough(bool JumpToFallThrough = true);
+  LLVM_ABI MachineBasicBlock *getFallThrough(bool JumpToFallThrough = true);
 
   /// Return the fallthrough block if the block can implicitly
   /// transfer control to it's successor, whether by a branch or
@@ -869,14 +870,14 @@ public:
   /// false if it can reach the block after it, but it uses an
   /// explicit branch to do so (e.g., a table jump).  True is a
   /// conservative answer.
-  bool canFallThrough();
+  LLVM_ABI bool canFallThrough();
 
   /// Returns a pointer to the first instruction in this block that is not a
   /// PHINode instruction. When adding instructions to the beginning of the
   /// basic block, they should be added before the returned value, not before
   /// the first instruction, which might be PHI.
   /// Returns end() is there's no non-PHI instruction.
-  iterator getFirstNonPHI();
+  LLVM_ABI iterator getFirstNonPHI();
   const_iterator getFirstNonPHI() const {
     return const_cast<MachineBasicBlock *>(this)->getFirstNonPHI();
   }
@@ -884,30 +885,30 @@ public:
   /// Return the first instruction in MBB after I that is not a PHI or a label.
   /// This is the correct point to insert lowered copies at the beginning of a
   /// basic block that must be before any debugging information.
-  iterator SkipPHIsAndLabels(iterator I);
+  LLVM_ABI iterator SkipPHIsAndLabels(iterator I);
 
   /// Return the first instruction in MBB after I that is not a PHI, label or
   /// debug.  This is the correct point to insert copies at the beginning of a
   /// basic block. \p Reg is the register being used by a spill or defined for a
   /// restore/split during register allocation.
-  iterator SkipPHIsLabelsAndDebug(iterator I, Register Reg = Register(),
+  LLVM_ABI iterator SkipPHIsLabelsAndDebug(iterator I, Register Reg = Register(),
                                   bool SkipPseudoOp = true);
 
   /// Returns an iterator to the first terminator instruction of this basic
   /// block. If a terminator does not exist, it returns end().
-  iterator getFirstTerminator();
+  LLVM_ABI iterator getFirstTerminator();
   const_iterator getFirstTerminator() const {
     return const_cast<MachineBasicBlock *>(this)->getFirstTerminator();
   }
 
   /// Same getFirstTerminator but it ignores bundles and return an
   /// instr_iterator instead.
-  instr_iterator getFirstInstrTerminator();
+  LLVM_ABI instr_iterator getFirstInstrTerminator();
 
   /// Finds the first terminator in a block by scanning forward. This can handle
   /// cases in GlobalISel where there may be non-terminator instructions between
   /// terminators, for which getFirstTerminator() will not work correctly.
-  iterator getFirstTerminatorForward();
+  LLVM_ABI iterator getFirstTerminatorForward();
 
   /// Returns an iterator to the first non-debug instruction in the basic block,
   /// or end(). Skip any pseudo probe operation if \c SkipPseudoOp is true.
@@ -925,7 +926,7 @@ public:
   /// value of \c SkipPseudoOp is set to true to maximize code quality in
   /// general, with an explict false value passed in in a few places like branch
   /// folding and if-conversion to favor profile quality.
-  iterator getFirstNonDebugInstr(bool SkipPseudoOp = true);
+  LLVM_ABI iterator getFirstNonDebugInstr(bool SkipPseudoOp = true);
   const_iterator getFirstNonDebugInstr(bool SkipPseudoOp = true) const {
     return const_cast<MachineBasicBlock *>(this)->getFirstNonDebugInstr(
         SkipPseudoOp);
@@ -947,7 +948,7 @@ public:
   /// value of \c SkipPseudoOp is set to true to maximize code quality in
   /// general, with an explict false value passed in in a few places like branch
   /// folding and if-conversion to favor profile quality.
-  iterator getLastNonDebugInstr(bool SkipPseudoOp = true);
+  LLVM_ABI iterator getLastNonDebugInstr(bool SkipPseudoOp = true);
   const_iterator getLastNonDebugInstr(bool SkipPseudoOp = true) const {
     return const_cast<MachineBasicBlock *>(this)->getLastNonDebugInstr(
         SkipPseudoOp);
@@ -973,7 +974,7 @@ public:
   ///
   /// If \p UpdateLiveIns is true, this will ensure the live ins list is
   /// accurate, including for physreg uses/defs in the original block.
-  MachineBasicBlock *splitAt(MachineInstr &SplitInst, bool UpdateLiveIns = true,
+  LLVM_ABI MachineBasicBlock *splitAt(MachineInstr &SplitInst, bool UpdateLiveIns = true,
                              LiveIntervals *LIS = nullptr);
 
   /// Split the critical edge from this block to the given successor block, and
@@ -1004,11 +1005,11 @@ public:
   }
 
   // Helper method for new pass manager migration.
-  MachineBasicBlock *SplitCriticalEdge(
+  LLVM_ABI MachineBasicBlock *SplitCriticalEdge(
       MachineBasicBlock *Succ, const SplitCriticalEdgeAnalyses &Analyses,
       std::vector<SparseBitVector<>> *LiveInSets, MachineDomTreeUpdater *MDTU);
 
-  MachineBasicBlock *SplitCriticalEdge(
+  LLVM_ABI MachineBasicBlock *SplitCriticalEdge(
       MachineBasicBlock *Succ, Pass *P, MachineFunctionAnalysisManager *MFAM,
       std::vector<SparseBitVector<>> *LiveInSets, MachineDomTreeUpdater *MDTU);
 
@@ -1016,7 +1017,7 @@ public:
   /// Succ, can be split. If this returns true a subsequent call to
   /// SplitCriticalEdge is guaranteed to return a valid basic block if
   /// no changes occurred in the meantime.
-  bool canSplitCriticalEdge(const MachineBasicBlock *Succ) const;
+  LLVM_ABI bool canSplitCriticalEdge(const MachineBasicBlock *Succ) const;
 
   void pop_front() { Insts.pop_front(); }
   void pop_back() { Insts.pop_back(); }
@@ -1028,7 +1029,7 @@ public:
   /// otherwise MI will not be added to any bundle. That means this function
   /// alone can't be used to prepend or append instructions to bundles. See
   /// MIBundleBuilder::insert() for a more reliable way of doing that.
-  instr_iterator insert(instr_iterator I, MachineInstr *M);
+  LLVM_ABI instr_iterator insert(instr_iterator I, MachineInstr *M);
 
   /// Insert a range of instructions into the instruction list before I.
   template<typename IT>
@@ -1072,7 +1073,7 @@ public:
   ///
   /// If the instruction is part of a bundle, the other instructions in the
   /// bundle will still be bundled after removing the single instruction.
-  instr_iterator erase(instr_iterator I);
+  LLVM_ABI instr_iterator erase(instr_iterator I);
 
   /// Remove an instruction from the instruction list and delete it.
   ///
@@ -1117,7 +1118,7 @@ public:
   ///
   /// If the instruction is part of a bundle, the other instructions in the
   /// bundle will still be bundled after removing the single instruction.
-  MachineInstr *remove_instr(MachineInstr *I);
+  LLVM_ABI MachineInstr *remove_instr(MachineInstr *I);
 
   void clear() {
     Insts.clear();
@@ -1146,22 +1147,22 @@ public:
 
   /// This method unlinks 'this' from the containing function, and returns it,
   /// but does not delete it.
-  MachineBasicBlock *removeFromParent();
+  LLVM_ABI MachineBasicBlock *removeFromParent();
 
   /// This method unlinks 'this' from the containing function and deletes it.
-  void eraseFromParent();
+  LLVM_ABI void eraseFromParent();
 
   /// Given a machine basic block that branched to 'Old', change the code and
   /// CFG so that it branches to 'New' instead.
-  void ReplaceUsesOfBlockWith(MachineBasicBlock *Old, MachineBasicBlock *New);
+  LLVM_ABI void ReplaceUsesOfBlockWith(MachineBasicBlock *Old, MachineBasicBlock *New);
 
   /// Update all phi nodes in this basic block to refer to basic block \p New
   /// instead of basic block \p Old.
-  void replacePhiUsesWith(MachineBasicBlock *Old, MachineBasicBlock *New);
+  LLVM_ABI void replacePhiUsesWith(MachineBasicBlock *Old, MachineBasicBlock *New);
 
   /// Find the next valid DebugLoc starting at MBBI, skipping any debug
   /// instructions.  Return UnknownLoc if there is none.
-  DebugLoc findDebugLoc(instr_iterator MBBI);
+  LLVM_ABI DebugLoc findDebugLoc(instr_iterator MBBI);
   DebugLoc findDebugLoc(iterator MBBI) {
     return findDebugLoc(MBBI.getInstrIterator());
   }
@@ -1169,7 +1170,7 @@ public:
   /// Has exact same behavior as @ref findDebugLoc (it also searches towards the
   /// end of this MBB) except that this function takes a reverse iterator to
   /// identify the starting MI.
-  DebugLoc rfindDebugLoc(reverse_instr_iterator MBBI);
+  LLVM_ABI DebugLoc rfindDebugLoc(reverse_instr_iterator MBBI);
   DebugLoc rfindDebugLoc(reverse_iterator MBBI) {
     return rfindDebugLoc(MBBI.getInstrIterator());
   }
@@ -1177,7 +1178,7 @@ public:
   /// Find the previous valid DebugLoc preceding MBBI, skipping any debug
   /// instructions. It is possible to find the last DebugLoc in the MBB using
   /// findPrevDebugLoc(instr_end()).  Return UnknownLoc if there is none.
-  DebugLoc findPrevDebugLoc(instr_iterator MBBI);
+  LLVM_ABI DebugLoc findPrevDebugLoc(instr_iterator MBBI);
   DebugLoc findPrevDebugLoc(iterator MBBI) {
     return findPrevDebugLoc(MBBI.getInstrIterator());
   }
@@ -1186,14 +1187,14 @@ public:
   /// the beginning of this MBB) except that this function takes reverse
   /// iterator to identify the starting MI. A minor difference compared to
   /// findPrevDebugLoc is that we can't start scanning at "instr_end".
-  DebugLoc rfindPrevDebugLoc(reverse_instr_iterator MBBI);
+  LLVM_ABI DebugLoc rfindPrevDebugLoc(reverse_instr_iterator MBBI);
   DebugLoc rfindPrevDebugLoc(reverse_iterator MBBI) {
     return rfindPrevDebugLoc(MBBI.getInstrIterator());
   }
 
   /// Find and return the merged DebugLoc of the branch instructions of the
   /// block. Return UnknownLoc if there is none.
-  DebugLoc findBranchDebugLoc();
+  LLVM_ABI DebugLoc findBranchDebugLoc();
 
   /// Possible outcome of a register liveness query to computeRegisterLiveness()
   enum LivenessQueryResult {
@@ -1210,16 +1211,16 @@ public:
   /// after (searching just for defs) \p Before.
   ///
   /// \p Reg must be a physical register.
-  LivenessQueryResult computeRegisterLiveness(const TargetRegisterInfo *TRI,
+  LLVM_ABI LivenessQueryResult computeRegisterLiveness(const TargetRegisterInfo *TRI,
                                               MCRegister Reg,
                                               const_iterator Before,
                                               unsigned Neighborhood = 10) const;
 
   // Debugging methods.
-  void dump() const;
-  void print(raw_ostream &OS, const SlotIndexes * = nullptr,
+  LLVM_ABI void dump() const;
+  LLVM_ABI void print(raw_ostream &OS, const SlotIndexes * = nullptr,
              bool IsStandalone = true) const;
-  void print(raw_ostream &OS, ModuleSlotTracker &MST,
+  LLVM_ABI void print(raw_ostream &OS, ModuleSlotTracker &MST,
              const SlotIndexes * = nullptr, bool IsStandalone = true) const;
 
   enum PrintNameFlag {
@@ -1227,11 +1228,11 @@ public:
     PrintNameAttributes = (1 << 1), ///< Print attributes
   };
 
-  void printName(raw_ostream &os, unsigned printNameFlags = PrintNameIr,
+  LLVM_ABI void printName(raw_ostream &os, unsigned printNameFlags = PrintNameIr,
                  ModuleSlotTracker *moduleSlotTracker = nullptr) const;
 
   // Printing method used by LoopInfo.
-  void printAsOperand(raw_ostream &OS, bool PrintType = true) const;
+  LLVM_ABI void printAsOperand(raw_ostream &OS, bool PrintType = true) const;
 
   /// MachineBasicBlocks are uniquely numbered at the function level, unless
   /// they're not in a MachineFunction yet, in which case this will return -1.
@@ -1244,10 +1245,10 @@ public:
   void setCallFrameSize(unsigned N) { CallFrameSize = N; }
 
   /// Return the MCSymbol for this basic block.
-  MCSymbol *getSymbol() const;
+  LLVM_ABI MCSymbol *getSymbol() const;
 
   /// Return the Windows EH Continuation Symbol for this basic block.
-  MCSymbol *getEHContSymbol() const;
+  LLVM_ABI MCSymbol *getEHContSymbol() const;
 
   std::optional<uint64_t> getIrrLoopHeaderWeight() const {
     return IrrLoopHeaderWeight;
@@ -1260,10 +1261,10 @@ public:
   /// Return probability of the edge from this block to MBB. This method should
   /// NOT be called directly, but by using getEdgeProbability method from
   /// MachineBranchProbabilityInfo class.
-  BranchProbability getSuccProbability(const_succ_iterator Succ) const;
+  LLVM_ABI BranchProbability getSuccProbability(const_succ_iterator Succ) const;
 
   // Helper function for MIRPrinter.
-  bool canPredictBranchProbabilities() const;
+  LLVM_ABI bool canPredictBranchProbabilities() const;
 
 private:
   /// Return probability iterator corresponding to the I successor iterator.
@@ -1289,7 +1290,7 @@ private:
   void removePredecessor(MachineBasicBlock *Pred);
 };
 
-raw_ostream& operator<<(raw_ostream &OS, const MachineBasicBlock &MBB);
+LLVM_ABI raw_ostream& operator<<(raw_ostream &OS, const MachineBasicBlock &MBB);
 
 /// Prints a machine basic block reference.
 ///
@@ -1297,7 +1298,7 @@ raw_ostream& operator<<(raw_ostream &OS, const MachineBasicBlock &MBB);
 ///   %bb.5           - a machine basic block with MBB.getNumber() == 5.
 ///
 /// Usage: OS << printMBBReference(MBB) << '\n';
-Printable printMBBReference(const MachineBasicBlock &MBB);
+LLVM_ABI Printable printMBBReference(const MachineBasicBlock &MBB);
 
 // This is useful when building IndexedMaps keyed on basic block pointers.
 struct MBB2NumberFunctor {

--- a/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_CODEGEN_MACHINEBLOCKFREQUENCYINFO_H
 #define LLVM_CODEGEN_MACHINEBLOCKFREQUENCYINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/Support/BlockFrequency.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -38,20 +38,20 @@ class MachineBlockFrequencyInfo {
 
 public:
   LLVM_ABI MachineBlockFrequencyInfo(); // Legacy pass manager only.
-  LLVM_ABI explicit MachineBlockFrequencyInfo(MachineFunction &F,
-                                     MachineBranchProbabilityInfo &MBPI,
-                                     MachineLoopInfo &MLI);
+  LLVM_ABI explicit MachineBlockFrequencyInfo(
+      MachineFunction &F, MachineBranchProbabilityInfo &MBPI,
+      MachineLoopInfo &MLI);
   LLVM_ABI MachineBlockFrequencyInfo(MachineBlockFrequencyInfo &&);
   LLVM_ABI ~MachineBlockFrequencyInfo();
 
   /// Handle invalidation explicitly.
   LLVM_ABI bool invalidate(MachineFunction &F, const PreservedAnalyses &PA,
-                  MachineFunctionAnalysisManager::Invalidator &);
+                           MachineFunctionAnalysisManager::Invalidator &);
 
   /// calculate - compute block frequency info for the given function.
   LLVM_ABI void calculate(const MachineFunction &F,
-                 const MachineBranchProbabilityInfo &MBPI,
-                 const MachineLoopInfo &MLI);
+                          const MachineBranchProbabilityInfo &MBPI,
+                          const MachineLoopInfo &MLI);
 
   LLVM_ABI void print(raw_ostream &OS);
 
@@ -77,15 +77,16 @@ public:
 
   LLVM_ABI std::optional<uint64_t>
   getBlockProfileCount(const MachineBasicBlock *MBB) const;
-  LLVM_ABI std::optional<uint64_t> getProfileCountFromFreq(BlockFrequency Freq) const;
+  LLVM_ABI std::optional<uint64_t>
+  getProfileCountFromFreq(BlockFrequency Freq) const;
 
   LLVM_ABI bool isIrrLoopHeader(const MachineBasicBlock *MBB) const;
 
   /// incrementally calculate block frequencies when we split edges, to avoid
   /// full CFG traversal.
   LLVM_ABI void onEdgeSplit(const MachineBasicBlock &NewPredecessor,
-                   const MachineBasicBlock &NewSuccessor,
-                   const MachineBranchProbabilityInfo &MBPI);
+                            const MachineBasicBlock &NewSuccessor,
+                            const MachineBranchProbabilityInfo &MBPI);
 
   LLVM_ABI const MachineFunction *getFunction() const;
   LLVM_ABI const MachineBranchProbabilityInfo *getMBPI() const;
@@ -103,12 +104,12 @@ public:
 /// frequency. Returns a Printable object that can be piped via `<<` to a
 /// `raw_ostream`.
 LLVM_ABI Printable printBlockFreq(const MachineBlockFrequencyInfo &MBFI,
-                         BlockFrequency Freq);
+                                  BlockFrequency Freq);
 
 /// Convenience function equivalent to calling
 /// `printBlockFreq(MBFI, MBFI.getBlockFreq(&MBB))`.
 LLVM_ABI Printable printBlockFreq(const MachineBlockFrequencyInfo &MBFI,
-                         const MachineBasicBlock &MBB);
+                                  const MachineBasicBlock &MBB);
 
 class MachineBlockFrequencyAnalysis
     : public AnalysisInfoMixin<MachineBlockFrequencyAnalysis> {
@@ -118,7 +119,8 @@ class MachineBlockFrequencyAnalysis
 public:
   using Result = MachineBlockFrequencyInfo;
 
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
 };
 
 /// Printer pass for the \c MachineBlockFrequencyInfo results.
@@ -130,12 +132,13 @@ public:
   explicit MachineBlockFrequencyPrinterPass(raw_ostream &OS) : OS(OS) {}
 
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
 
   static bool isRequired() { return true; }
 };
 
-class LLVM_ABI MachineBlockFrequencyInfoWrapperPass : public MachineFunctionPass {
+class LLVM_ABI MachineBlockFrequencyInfoWrapperPass
+    : public MachineFunctionPass {
   MachineBlockFrequencyInfo MBFI;
 
 public:

--- a/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MACHINEBLOCKFREQUENCYINFO_H
 #define LLVM_CODEGEN_MACHINEBLOCKFREQUENCYINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/Support/BlockFrequency.h"
@@ -36,25 +37,25 @@ class MachineBlockFrequencyInfo {
   std::unique_ptr<ImplType> MBFI;
 
 public:
-  MachineBlockFrequencyInfo(); // Legacy pass manager only.
-  explicit MachineBlockFrequencyInfo(MachineFunction &F,
+  LLVM_ABI MachineBlockFrequencyInfo(); // Legacy pass manager only.
+  LLVM_ABI explicit MachineBlockFrequencyInfo(MachineFunction &F,
                                      MachineBranchProbabilityInfo &MBPI,
                                      MachineLoopInfo &MLI);
-  MachineBlockFrequencyInfo(MachineBlockFrequencyInfo &&);
-  ~MachineBlockFrequencyInfo();
+  LLVM_ABI MachineBlockFrequencyInfo(MachineBlockFrequencyInfo &&);
+  LLVM_ABI ~MachineBlockFrequencyInfo();
 
   /// Handle invalidation explicitly.
-  bool invalidate(MachineFunction &F, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(MachineFunction &F, const PreservedAnalyses &PA,
                   MachineFunctionAnalysisManager::Invalidator &);
 
   /// calculate - compute block frequency info for the given function.
-  void calculate(const MachineFunction &F,
+  LLVM_ABI void calculate(const MachineFunction &F,
                  const MachineBranchProbabilityInfo &MBPI,
                  const MachineLoopInfo &MLI);
 
-  void print(raw_ostream &OS);
+  LLVM_ABI void print(raw_ostream &OS);
 
-  void releaseMemory();
+  LLVM_ABI void releaseMemory();
 
   /// getblockFreq - Return block frequency. Return 0 if we don't have the
   /// information. Please note that initial frequency is equal to 1024. It means
@@ -63,7 +64,7 @@ public:
   /// For example, to get the frequency of a block relative to the entry block,
   /// divide the integral value returned by this function (the
   /// BlockFrequency::getFrequency() value) by getEntryFreq().
-  BlockFrequency getBlockFreq(const MachineBasicBlock *MBB) const;
+  LLVM_ABI BlockFrequency getBlockFreq(const MachineBasicBlock *MBB) const;
 
   /// Compute the frequency of the block, relative to the entry block.
   /// This API assumes getEntryFreq() is non-zero.
@@ -74,39 +75,39 @@ public:
            static_cast<double>(getEntryFreq().getFrequency());
   }
 
-  std::optional<uint64_t>
+  LLVM_ABI std::optional<uint64_t>
   getBlockProfileCount(const MachineBasicBlock *MBB) const;
-  std::optional<uint64_t> getProfileCountFromFreq(BlockFrequency Freq) const;
+  LLVM_ABI std::optional<uint64_t> getProfileCountFromFreq(BlockFrequency Freq) const;
 
-  bool isIrrLoopHeader(const MachineBasicBlock *MBB) const;
+  LLVM_ABI bool isIrrLoopHeader(const MachineBasicBlock *MBB) const;
 
   /// incrementally calculate block frequencies when we split edges, to avoid
   /// full CFG traversal.
-  void onEdgeSplit(const MachineBasicBlock &NewPredecessor,
+  LLVM_ABI void onEdgeSplit(const MachineBasicBlock &NewPredecessor,
                    const MachineBasicBlock &NewSuccessor,
                    const MachineBranchProbabilityInfo &MBPI);
 
-  const MachineFunction *getFunction() const;
-  const MachineBranchProbabilityInfo *getMBPI() const;
+  LLVM_ABI const MachineFunction *getFunction() const;
+  LLVM_ABI const MachineBranchProbabilityInfo *getMBPI() const;
 
   /// Pop up a ghostview window with the current block frequency propagation
   /// rendered using dot.
-  void view(const Twine &Name, bool isSimple = true) const;
+  LLVM_ABI void view(const Twine &Name, bool isSimple = true) const;
 
   /// Divide a block's BlockFrequency::getFrequency() value by this value to
   /// obtain the entry block - relative frequency of said block.
-  BlockFrequency getEntryFreq() const;
+  LLVM_ABI BlockFrequency getEntryFreq() const;
 };
 
 /// Print the block frequency @p Freq relative to the current functions entry
 /// frequency. Returns a Printable object that can be piped via `<<` to a
 /// `raw_ostream`.
-Printable printBlockFreq(const MachineBlockFrequencyInfo &MBFI,
+LLVM_ABI Printable printBlockFreq(const MachineBlockFrequencyInfo &MBFI,
                          BlockFrequency Freq);
 
 /// Convenience function equivalent to calling
 /// `printBlockFreq(MBFI, MBFI.getBlockFreq(&MBB))`.
-Printable printBlockFreq(const MachineBlockFrequencyInfo &MBFI,
+LLVM_ABI Printable printBlockFreq(const MachineBlockFrequencyInfo &MBFI,
                          const MachineBasicBlock &MBB);
 
 class MachineBlockFrequencyAnalysis
@@ -117,7 +118,7 @@ class MachineBlockFrequencyAnalysis
 public:
   using Result = MachineBlockFrequencyInfo;
 
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
 };
 
 /// Printer pass for the \c MachineBlockFrequencyInfo results.
@@ -128,13 +129,13 @@ class MachineBlockFrequencyPrinterPass
 public:
   explicit MachineBlockFrequencyPrinterPass(raw_ostream &OS) : OS(OS) {}
 
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 
   static bool isRequired() { return true; }
 };
 
-class MachineBlockFrequencyInfoWrapperPass : public MachineFunctionPass {
+class LLVM_ABI MachineBlockFrequencyInfoWrapperPass : public MachineFunctionPass {
   MachineBlockFrequencyInfo MBFI;
 
 public:

--- a/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
@@ -113,7 +113,7 @@ LLVM_ABI Printable printBlockFreq(const MachineBlockFrequencyInfo &MBFI,
 class MachineBlockFrequencyAnalysis
     : public AnalysisInfoMixin<MachineBlockFrequencyAnalysis> {
   friend AnalysisInfoMixin<MachineBlockFrequencyAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = MachineBlockFrequencyInfo;

--- a/llvm/include/llvm/CodeGen/MachineCycleAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineCycleAnalysis.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MACHINECYCLEANALYSIS_H
 #define LLVM_CODEGEN_MACHINECYCLEANALYSIS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/GenericCycleInfo.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachinePassManager.h"
@@ -25,7 +26,7 @@ using MachineCycleInfo = GenericCycleInfo<MachineSSAContext>;
 using MachineCycle = MachineCycleInfo::CycleT;
 
 /// Legacy analysis pass which computes a \ref MachineCycleInfo.
-class MachineCycleInfoWrapperPass : public MachineFunctionPass {
+class LLVM_ABI MachineCycleInfoWrapperPass : public MachineFunctionPass {
   MachineFunction *F = nullptr;
   MachineCycleInfo CI;
 
@@ -45,7 +46,7 @@ public:
 
 // TODO: add this function to GenericCycle template after implementing IR
 //       version.
-bool isCycleInvariant(const MachineCycle *Cycle, MachineInstr &I);
+LLVM_ABI bool isCycleInvariant(const MachineCycle *Cycle, MachineInstr &I);
 
 class MachineCycleAnalysis : public AnalysisInfoMixin<MachineCycleAnalysis> {
   friend AnalysisInfoMixin<MachineCycleAnalysis>;
@@ -54,7 +55,7 @@ class MachineCycleAnalysis : public AnalysisInfoMixin<MachineCycleAnalysis> {
 public:
   using Result = MachineCycleInfo;
 
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
 };
 
 class MachineCycleInfoPrinterPass
@@ -63,7 +64,7 @@ class MachineCycleInfoPrinterPass
 
 public:
   explicit MachineCycleInfoPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };

--- a/llvm/include/llvm/CodeGen/MachineCycleAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineCycleAnalysis.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_CODEGEN_MACHINECYCLEANALYSIS_H
 #define LLVM_CODEGEN_MACHINECYCLEANALYSIS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/GenericCycleInfo.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/CodeGen/MachineSSAContext.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -55,7 +55,8 @@ class MachineCycleAnalysis : public AnalysisInfoMixin<MachineCycleAnalysis> {
 public:
   using Result = MachineCycleInfo;
 
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
 };
 
 class MachineCycleInfoPrinterPass
@@ -65,7 +66,7 @@ class MachineCycleInfoPrinterPass
 public:
   explicit MachineCycleInfoPrinterPass(raw_ostream &OS) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 

--- a/llvm/include/llvm/CodeGen/MachineCycleAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineCycleAnalysis.h
@@ -50,7 +50,7 @@ LLVM_ABI bool isCycleInvariant(const MachineCycle *Cycle, MachineInstr &I);
 
 class MachineCycleAnalysis : public AnalysisInfoMixin<MachineCycleAnalysis> {
   friend AnalysisInfoMixin<MachineCycleAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = MachineCycleInfo;

--- a/llvm/include/llvm/CodeGen/MachineDomTreeUpdater.h
+++ b/llvm/include/llvm/CodeGen/MachineDomTreeUpdater.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_CODEGEN_MACHINEDOMTREEUPDATER_H
 #define LLVM_CODEGEN_MACHINEDOMTREEUPDATER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Analysis/GenericDomTreeUpdater.h"
 #include "llvm/CodeGen/MachineDominators.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/MachineDomTreeUpdater.h
+++ b/llvm/include/llvm/CodeGen/MachineDomTreeUpdater.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MACHINEDOMTREEUPDATER_H
 #define LLVM_CODEGEN_MACHINEDOMTREEUPDATER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Analysis/GenericDomTreeUpdater.h"
 #include "llvm/CodeGen/MachineDominators.h"
 
@@ -62,7 +63,7 @@ public:
   /// all available trees are up-to-date. Assert if any instruction of DelBB is
   /// modified while awaiting deletion. When both DT and PDT are nullptrs, DelBB
   /// will be queued until flush() is called.
-  void deleteBB(MachineBasicBlock *DelBB);
+  LLVM_ABI void deleteBB(MachineBasicBlock *DelBB);
 
   ///@}
 

--- a/llvm/include/llvm/CodeGen/MachineDomTreeUpdater.h
+++ b/llvm/include/llvm/CodeGen/MachineDomTreeUpdater.h
@@ -23,18 +23,18 @@ namespace llvm {
 class MachinePostDominatorTree;
 class MachineDomTreeUpdater;
 
-extern template class GenericDomTreeUpdater<
+extern template class LLVM_TEMPLATE_ABI GenericDomTreeUpdater<
     MachineDomTreeUpdater, MachineDominatorTree, MachinePostDominatorTree>;
 
-extern template void
+extern template LLVM_TEMPLATE_ABI void
 GenericDomTreeUpdater<MachineDomTreeUpdater, MachineDominatorTree,
                       MachinePostDominatorTree>::recalculate(MachineFunction
                                                                  &MF);
 
-extern template void GenericDomTreeUpdater<
+extern template LLVM_TEMPLATE_ABI void GenericDomTreeUpdater<
     MachineDomTreeUpdater, MachineDominatorTree,
     MachinePostDominatorTree>::applyUpdatesImpl</*IsForward=*/true>();
-extern template void GenericDomTreeUpdater<
+extern template LLVM_TEMPLATE_ABI void GenericDomTreeUpdater<
     MachineDomTreeUpdater, MachineDominatorTree,
     MachinePostDominatorTree>::applyUpdatesImpl</*IsForward=*/false>();
 

--- a/llvm/include/llvm/CodeGen/MachineDominators.h
+++ b/llvm/include/llvm/CodeGen/MachineDominators.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_MACHINEDOMINATORS_H
 #define LLVM_CODEGEN_MACHINEDOMINATORS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
@@ -22,6 +21,7 @@
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGen/MachineInstrBundleIterator.h"
 #include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/GenericDomTree.h"
 #include <cassert>
 #include <memory>
@@ -34,7 +34,8 @@ class Module;
 class raw_ostream;
 
 extern template class LLVM_TEMPLATE_ABI DomTreeNodeBase<MachineBasicBlock>;
-extern template class LLVM_TEMPLATE_ABI DominatorTreeBase<MachineBasicBlock, false>; // DomTree
+extern template class LLVM_TEMPLATE_ABI
+    DominatorTreeBase<MachineBasicBlock, false>; // DomTree
 
 using MachineDomTreeNode = DomTreeNodeBase<MachineBasicBlock>;
 
@@ -44,23 +45,23 @@ using MBBUpdates = ArrayRef<llvm::cfg::Update<MachineBasicBlock *>>;
 using MBBDomTreeGraphDiff = GraphDiff<MachineBasicBlock *, false>;
 
 extern template LLVM_TEMPLATE_ABI void Calculate<MBBDomTree>(MBBDomTree &DT);
-extern template LLVM_TEMPLATE_ABI void CalculateWithUpdates<MBBDomTree>(MBBDomTree &DT,
-                                                      MBBUpdates U);
+extern template LLVM_TEMPLATE_ABI void
+CalculateWithUpdates<MBBDomTree>(MBBDomTree &DT, MBBUpdates U);
 
-extern template LLVM_TEMPLATE_ABI void InsertEdge<MBBDomTree>(MBBDomTree &DT,
-                                            MachineBasicBlock *From,
-                                            MachineBasicBlock *To);
+extern template LLVM_TEMPLATE_ABI void
+InsertEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
+                       MachineBasicBlock *To);
 
-extern template LLVM_TEMPLATE_ABI void DeleteEdge<MBBDomTree>(MBBDomTree &DT,
-                                            MachineBasicBlock *From,
-                                            MachineBasicBlock *To);
+extern template LLVM_TEMPLATE_ABI void
+DeleteEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
+                       MachineBasicBlock *To);
 
-extern template LLVM_TEMPLATE_ABI void ApplyUpdates<MBBDomTree>(MBBDomTree &DT,
-                                              MBBDomTreeGraphDiff &,
-                                              MBBDomTreeGraphDiff *);
+extern template LLVM_TEMPLATE_ABI void
+ApplyUpdates<MBBDomTree>(MBBDomTree &DT, MBBDomTreeGraphDiff &,
+                         MBBDomTreeGraphDiff *);
 
-extern template LLVM_TEMPLATE_ABI bool Verify<MBBDomTree>(const MBBDomTree &DT,
-                                        MBBDomTree::VerificationLevel VL);
+extern template LLVM_TEMPLATE_ABI bool
+Verify<MBBDomTree>(const MBBDomTree &DT, MBBDomTree::VerificationLevel VL);
 } // namespace DomTreeBuilder
 
 //===-------------------------------------
@@ -77,7 +78,7 @@ public:
 
   /// Handle invalidation explicitly.
   LLVM_ABI bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
-                  MachineFunctionAnalysisManager::Invalidator &);
+                           MachineFunctionAnalysisManager::Invalidator &);
 
   using Base::dominates;
 
@@ -118,7 +119,7 @@ class MachineDominatorTreePrinterPass
 public:
   explicit MachineDominatorTreePrinterPass(raw_ostream &OS) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 

--- a/llvm/include/llvm/CodeGen/MachineDominators.h
+++ b/llvm/include/llvm/CodeGen/MachineDominators.h
@@ -33,8 +33,8 @@ class MachineFunction;
 class Module;
 class raw_ostream;
 
-extern template class DomTreeNodeBase<MachineBasicBlock>;
-extern template class DominatorTreeBase<MachineBasicBlock, false>; // DomTree
+extern template class LLVM_TEMPLATE_ABI DomTreeNodeBase<MachineBasicBlock>;
+extern template class LLVM_TEMPLATE_ABI DominatorTreeBase<MachineBasicBlock, false>; // DomTree
 
 using MachineDomTreeNode = DomTreeNodeBase<MachineBasicBlock>;
 
@@ -43,23 +43,23 @@ using MBBDomTree = DomTreeBase<MachineBasicBlock>;
 using MBBUpdates = ArrayRef<llvm::cfg::Update<MachineBasicBlock *>>;
 using MBBDomTreeGraphDiff = GraphDiff<MachineBasicBlock *, false>;
 
-extern template void Calculate<MBBDomTree>(MBBDomTree &DT);
-extern template void CalculateWithUpdates<MBBDomTree>(MBBDomTree &DT,
+extern template LLVM_TEMPLATE_ABI void Calculate<MBBDomTree>(MBBDomTree &DT);
+extern template LLVM_TEMPLATE_ABI void CalculateWithUpdates<MBBDomTree>(MBBDomTree &DT,
                                                       MBBUpdates U);
 
-extern template void InsertEdge<MBBDomTree>(MBBDomTree &DT,
+extern template LLVM_TEMPLATE_ABI void InsertEdge<MBBDomTree>(MBBDomTree &DT,
                                             MachineBasicBlock *From,
                                             MachineBasicBlock *To);
 
-extern template void DeleteEdge<MBBDomTree>(MBBDomTree &DT,
+extern template LLVM_TEMPLATE_ABI void DeleteEdge<MBBDomTree>(MBBDomTree &DT,
                                             MachineBasicBlock *From,
                                             MachineBasicBlock *To);
 
-extern template void ApplyUpdates<MBBDomTree>(MBBDomTree &DT,
+extern template LLVM_TEMPLATE_ABI void ApplyUpdates<MBBDomTree>(MBBDomTree &DT,
                                               MBBDomTreeGraphDiff &,
                                               MBBDomTreeGraphDiff *);
 
-extern template bool Verify<MBBDomTree>(const MBBDomTree &DT,
+extern template LLVM_TEMPLATE_ABI bool Verify<MBBDomTree>(const MBBDomTree &DT,
                                         MBBDomTree::VerificationLevel VL);
 } // namespace DomTreeBuilder
 
@@ -102,7 +102,7 @@ class MachineDominatorTreeAnalysis
     : public AnalysisInfoMixin<MachineDominatorTreeAnalysis> {
   friend AnalysisInfoMixin<MachineDominatorTreeAnalysis>;
 
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = MachineDominatorTree;

--- a/llvm/include/llvm/CodeGen/MachineDominators.h
+++ b/llvm/include/llvm/CodeGen/MachineDominators.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MACHINEDOMINATORS_H
 #define LLVM_CODEGEN_MACHINEDOMINATORS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
@@ -75,7 +76,7 @@ public:
   explicit MachineDominatorTree(MachineFunction &MF) { recalculate(MF); }
 
   /// Handle invalidation explicitly.
-  bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
                   MachineFunctionAnalysisManager::Invalidator &);
 
   using Base::dominates;
@@ -106,7 +107,7 @@ class MachineDominatorTreeAnalysis
 public:
   using Result = MachineDominatorTree;
 
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
 };
 
 /// \brief Machine function pass which print \c MachineDominatorTree.
@@ -116,13 +117,13 @@ class MachineDominatorTreePrinterPass
 
 public:
   explicit MachineDominatorTreePrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
 /// \brief Analysis pass which computes a \c MachineDominatorTree.
-class MachineDominatorTreeWrapperPass : public MachineFunctionPass {
+class LLVM_ABI MachineDominatorTreeWrapperPass : public MachineFunctionPass {
   // MachineFunctionPass may verify the analysis result without running pass,
   // e.g. when `F.hasAvailableExternallyLinkage` is true.
   std::optional<MachineDominatorTree> DT;

--- a/llvm/include/llvm/CodeGen/MachineFrameInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineFrameInfo.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MACHINEFRAMEINFO_H
 #define LLVM_CODEGEN_MACHINEFRAMEINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/CodeGen/TargetFrameLowering.h"
@@ -591,7 +592,7 @@ public:
   void setStackSize(uint64_t Size) { StackSize = Size; }
 
   /// Estimate and return the size of the stack frame.
-  uint64_t estimateStackSize(const MachineFunction &MF) const;
+  LLVM_ABI uint64_t estimateStackSize(const MachineFunction &MF) const;
 
   /// Return the correction for frame offsets.
   int64_t getOffsetAdjustment() const { return OffsetAdjustment; }
@@ -604,7 +605,7 @@ public:
   Align getMaxAlign() const { return MaxAlignment; }
 
   /// Make sure the function is at least Align bytes aligned.
-  void ensureMaxAlignment(Align Alignment);
+  LLVM_ABI void ensureMaxAlignment(Align Alignment);
 
   /// Return true if stack realignment is forced by function attributes or if
   /// the stack alignment.
@@ -655,7 +656,7 @@ public:
   /// targets may call this to compute it earlier.
   /// If FrameSDOps is passed, the frame instructions in the MF will be
   /// inserted into it.
-  void computeMaxCallFrameSize(
+  LLVM_ABI void computeMaxCallFrameSize(
       MachineFunction &MF,
       std::vector<MachineBasicBlock::iterator> *FrameSDOps = nullptr);
 
@@ -689,12 +690,12 @@ public:
   /// All fixed objects should be created before other objects are created for
   /// efficiency. By default, fixed objects are not pointed to by LLVM IR
   /// values. This returns an index with a negative value.
-  int CreateFixedObject(uint64_t Size, int64_t SPOffset, bool IsImmutable,
+  LLVM_ABI int CreateFixedObject(uint64_t Size, int64_t SPOffset, bool IsImmutable,
                         bool isAliased = false);
 
   /// Create a spill slot at a fixed location on the stack.
   /// Returns an index with a negative value.
-  int CreateFixedSpillStackObject(uint64_t Size, int64_t SPOffset,
+  LLVM_ABI int CreateFixedSpillStackObject(uint64_t Size, int64_t SPOffset,
                                   bool IsImmutable = false);
 
   /// Returns true if the specified index corresponds to a fixed stack object.
@@ -785,12 +786,12 @@ public:
 
   /// Create a new statically sized stack object, returning
   /// a nonnegative identifier to represent it.
-  int CreateStackObject(uint64_t Size, Align Alignment, bool isSpillSlot,
+  LLVM_ABI int CreateStackObject(uint64_t Size, Align Alignment, bool isSpillSlot,
                         const AllocaInst *Alloca = nullptr, uint8_t ID = 0);
 
   /// Create a new statically sized stack object that represents a spill slot,
   /// returning a nonnegative identifier to represent it.
-  int CreateSpillStackObject(uint64_t Size, Align Alignment);
+  LLVM_ABI int CreateSpillStackObject(uint64_t Size, Align Alignment);
 
   /// Remove or mark dead a statically sized stack object.
   void RemoveStackObject(int ObjectIdx) {
@@ -801,7 +802,7 @@ public:
   /// Notify the MachineFrameInfo object that a variable sized object has been
   /// created.  This must be created whenever a variable sized object is
   /// created, whether or not the index returned is actually used.
-  int CreateVariableSizedObject(Align Alignment, const AllocaInst *Alloca);
+  LLVM_ABI int CreateVariableSizedObject(Align Alignment, const AllocaInst *Alloca);
 
   /// Returns a reference to call saved info vector for the current function.
   const std::vector<CalleeSavedInfo> &getCalleeSavedInfo() const {
@@ -837,14 +838,14 @@ public:
   ///
   /// Before the PrologueEpilogueInserter has placed the CSR spill code, this
   /// method always returns an empty set.
-  BitVector getPristineRegs(const MachineFunction &MF) const;
+  LLVM_ABI BitVector getPristineRegs(const MachineFunction &MF) const;
 
   /// Used by the MachineFunction printer to print information about
   /// stack objects. Implemented in MachineFunction.cpp.
-  void print(const MachineFunction &MF, raw_ostream &OS) const;
+  LLVM_ABI void print(const MachineFunction &MF, raw_ostream &OS) const;
 
   /// dump - Print the function to stderr.
-  void dump(const MachineFunction &MF) const;
+  LLVM_ABI void dump(const MachineFunction &MF) const;
 };
 
 } // End llvm namespace

--- a/llvm/include/llvm/CodeGen/MachineFrameInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineFrameInfo.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_CODEGEN_MACHINEFRAMEINFO_H
 #define LLVM_CODEGEN_MACHINEFRAMEINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/CodeGen/TargetFrameLowering.h"
 #include "llvm/Support/Alignment.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <vector>
 
@@ -690,13 +690,13 @@ public:
   /// All fixed objects should be created before other objects are created for
   /// efficiency. By default, fixed objects are not pointed to by LLVM IR
   /// values. This returns an index with a negative value.
-  LLVM_ABI int CreateFixedObject(uint64_t Size, int64_t SPOffset, bool IsImmutable,
-                        bool isAliased = false);
+  LLVM_ABI int CreateFixedObject(uint64_t Size, int64_t SPOffset,
+                                 bool IsImmutable, bool isAliased = false);
 
   /// Create a spill slot at a fixed location on the stack.
   /// Returns an index with a negative value.
   LLVM_ABI int CreateFixedSpillStackObject(uint64_t Size, int64_t SPOffset,
-                                  bool IsImmutable = false);
+                                           bool IsImmutable = false);
 
   /// Returns true if the specified index corresponds to a fixed stack object.
   bool isFixedObjectIndex(int ObjectIdx) const {
@@ -786,8 +786,10 @@ public:
 
   /// Create a new statically sized stack object, returning
   /// a nonnegative identifier to represent it.
-  LLVM_ABI int CreateStackObject(uint64_t Size, Align Alignment, bool isSpillSlot,
-                        const AllocaInst *Alloca = nullptr, uint8_t ID = 0);
+  LLVM_ABI int CreateStackObject(uint64_t Size, Align Alignment,
+                                 bool isSpillSlot,
+                                 const AllocaInst *Alloca = nullptr,
+                                 uint8_t ID = 0);
 
   /// Create a new statically sized stack object that represents a spill slot,
   /// returning a nonnegative identifier to represent it.
@@ -802,7 +804,8 @@ public:
   /// Notify the MachineFrameInfo object that a variable sized object has been
   /// created.  This must be created whenever a variable sized object is
   /// created, whether or not the index returned is actually used.
-  LLVM_ABI int CreateVariableSizedObject(Align Alignment, const AllocaInst *Alloca);
+  LLVM_ABI int CreateVariableSizedObject(Align Alignment,
+                                         const AllocaInst *Alloca);
 
   /// Returns a reference to call saved info vector for the current function.
   const std::vector<CalleeSavedInfo> &getCalleeSavedInfo() const {

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -79,8 +79,8 @@ template <> struct ilist_alloc_traits<MachineBasicBlock> {
 };
 
 template <> struct ilist_callback_traits<MachineBasicBlock> {
-  LLVM_ABI void addNodeToList(MachineBasicBlock* N);
-  LLVM_ABI void removeNodeFromList(MachineBasicBlock* N);
+  LLVM_ABI void addNodeToList(MachineBasicBlock *N);
+  LLVM_ABI void removeNodeFromList(MachineBasicBlock *N);
 
   template <class Iterator>
   void transferNodesFromList(ilist_callback_traits &OldList, Iterator, Iterator) {
@@ -1564,7 +1564,7 @@ template <> struct GraphTraits<Inverse<const MachineFunction*>> :
 };
 
 LLVM_ABI void verifyMachineFunction(const std::string &Banner,
-                           const MachineFunction &MF);
+                                    const MachineFunction &MF);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -75,12 +75,12 @@ struct WasmEHFuncInfo;
 struct WinEHFuncInfo;
 
 template <> struct ilist_alloc_traits<MachineBasicBlock> {
-  void deleteNode(MachineBasicBlock *MBB);
+  LLVM_ABI void deleteNode(MachineBasicBlock *MBB);
 };
 
 template <> struct ilist_callback_traits<MachineBasicBlock> {
-  void addNodeToList(MachineBasicBlock* N);
-  void removeNodeFromList(MachineBasicBlock* N);
+  LLVM_ABI void addNodeToList(MachineBasicBlock* N);
+  LLVM_ABI void removeNodeFromList(MachineBasicBlock* N);
 
   template <class Iterator>
   void transferNodesFromList(ilist_callback_traits &OldList, Iterator, Iterator) {
@@ -101,7 +101,7 @@ enum class MachineFunctionDataHotness {
 /// hold private target-specific information for each MachineFunction.  Objects
 /// of type are accessed/created with MF::getInfo and destroyed when the
 /// MachineFunction is destroyed.
-struct MachineFunctionInfo {
+struct LLVM_ABI MachineFunctionInfo {
   virtual ~MachineFunctionInfo();
 
   /// Factory function: default behavior is to call new using the
@@ -256,7 +256,7 @@ public:
   }
 
   /// Print the MachineFunctionProperties in human-readable form.
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 private:
   std::bitset<static_cast<unsigned>(Property::LastProperty) + 1> Properties;
@@ -485,7 +485,7 @@ public:
     }
   };
 
-  class Delegate {
+  class LLVM_ABI Delegate {
     virtual void anchor();
 
   public:
@@ -1563,7 +1563,7 @@ template <> struct GraphTraits<Inverse<const MachineFunction*>> :
   }
 };
 
-void verifyMachineFunction(const std::string &Banner,
+LLVM_ABI void verifyMachineFunction(const std::string &Banner,
                            const MachineFunction &MF);
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MACHINEFUNCTIONANALYSIS
 #define LLVM_CODEGEN_MACHINEFUNCTIONANALYSIS
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/IR/PassManager.h"
 
 namespace llvm {
@@ -37,12 +38,12 @@ public:
   public:
     Result(std::unique_ptr<MachineFunction> MF) : MF(std::move(MF)) {}
     MachineFunction &getMF() { return *MF; };
-    bool invalidate(Function &, const PreservedAnalyses &PA,
+    LLVM_ABI bool invalidate(Function &, const PreservedAnalyses &PA,
                     FunctionAnalysisManager::Invalidator &);
   };
 
   MachineFunctionAnalysis(const TargetMachine *TM) : TM(TM) {};
-  Result run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI Result run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
@@ -27,7 +27,7 @@ class MachineFunctionAnalysis
     : public AnalysisInfoMixin<MachineFunctionAnalysis> {
   friend AnalysisInfoMixin<MachineFunctionAnalysis>;
 
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
   const TargetMachine *TM;
 

--- a/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_CODEGEN_MACHINEFUNCTIONANALYSIS
 #define LLVM_CODEGEN_MACHINEFUNCTIONANALYSIS
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -39,7 +39,7 @@ public:
     Result(std::unique_ptr<MachineFunction> MF) : MF(std::move(MF)) {}
     MachineFunction &getMF() { return *MF; };
     LLVM_ABI bool invalidate(Function &, const PreservedAnalyses &PA,
-                    FunctionAnalysisManager::Invalidator &);
+                             FunctionAnalysisManager::Invalidator &);
   };
 
   MachineFunctionAnalysis(const TargetMachine *TM) : TM(TM) {};

--- a/llvm/include/llvm/CodeGen/MachineFunctionAnalysisManager.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionAnalysisManager.h
@@ -14,12 +14,13 @@
 #define LLVM_CODEGEN_MACHINEFUNCTIONANALYSISMANAGER
 
 #include "llvm/IR/PassManager.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
 class MachineFunction;
 
-extern template class AnalysisManager<MachineFunction>;
+extern template class LLVM_TEMPLATE_ABI AnalysisManager<MachineFunction>;
 using MachineFunctionAnalysisManager = AnalysisManager<MachineFunction>;
 
 } // namespace llvm

--- a/llvm/include/llvm/CodeGen/MachineFunctionPass.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionPass.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_CODEGEN_MACHINEFUNCTIONPASS_H
 #define LLVM_CODEGEN_MACHINEFUNCTIONPASS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/Pass.h"
 
@@ -27,7 +28,7 @@ namespace llvm {
 /// allow convenient creation of passes that operate on the MachineFunction
 /// representation. Instead of overriding runOnFunction, subclasses
 /// override runOnMachineFunction.
-class MachineFunctionPass : public FunctionPass {
+class LLVM_ABI MachineFunctionPass : public FunctionPass {
 public:
   bool doInitialization(Module&) override {
     // Cache the properties info at module-init time so we don't have to

--- a/llvm/include/llvm/CodeGen/MachineFunctionPass.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionPass.h
@@ -18,9 +18,9 @@
 #ifndef LLVM_CODEGEN_MACHINEFUNCTIONPASS_H
 #define LLVM_CODEGEN_MACHINEFUNCTIONPASS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -15,7 +15,6 @@
 #ifndef LLVM_CODEGEN_MACHINEINSTR_H
 #define LLVM_CODEGEN_MACHINEINSTR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/PointerSumType.h"
@@ -31,6 +30,7 @@
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/Support/ArrayRecycler.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/TrailingObjects.h"
 #include <algorithm>
@@ -614,10 +614,11 @@ public:
 
   /// Returns a range of all of the operands that correspond to a debug use of
   /// \p Reg.
-  LLVM_ABI iterator_range<filter_iterator<const MachineOperand *,
-                                 std::function<bool(const MachineOperand &Op)>>>
+  LLVM_ABI iterator_range<filter_iterator<
+      const MachineOperand *, std::function<bool(const MachineOperand &Op)>>>
   getDebugOperandsForReg(Register Reg) const;
-  LLVM_ABI iterator_range<filter_iterator<MachineOperand *,
+  LLVM_ABI
+  iterator_range<filter_iterator<MachineOperand *,
                                  std::function<bool(MachineOperand &Op)>>>
   getDebugOperandsForReg(Register Reg);
 
@@ -948,7 +949,8 @@ public:
 
   /// Return true if this is a call instruction that may have an additional
   /// information associated with it.
-  LLVM_ABI bool isCandidateForAdditionalCallInfo(QueryType Type = IgnoreBundle) const;
+  LLVM_ABI bool
+  isCandidateForAdditionalCallInfo(QueryType Type = IgnoreBundle) const;
 
   /// Return true if copying, moving, or erasing this instruction requires
   /// updating additional call info (see \ref copyCallInfo, \ref moveCallInfo,
@@ -1277,7 +1279,7 @@ public:
   /// Note that this means liveness related flags (dead, undef, kill) do not
   /// affect the notion of identical.
   LLVM_ABI bool isIdenticalTo(const MachineInstr &Other,
-                     MICheckType Check = CheckDefs) const;
+                              MICheckType Check = CheckDefs) const;
 
   /// Returns true if this instruction is a debug instruction that represents an
   /// identical debug value to \p Other.
@@ -1494,8 +1496,9 @@ public:
   /// Return a pair of bools (reads, writes) indicating if this instruction
   /// reads or writes Reg. This also considers partial defines.
   /// If Ops is not null, all operand indices for Reg are added.
-  LLVM_ABI std::pair<bool,bool> readsWritesVirtualRegister(Register Reg,
-                                SmallVectorImpl<unsigned> *Ops = nullptr) const;
+  LLVM_ABI std::pair<bool, bool>
+  readsWritesVirtualRegister(Register Reg,
+                             SmallVectorImpl<unsigned> *Ops = nullptr) const;
 
   /// Return true if the MachineInstr kills the specified register.
   /// If TargetRegisterInfo is non-null, then it also checks if there is
@@ -1533,8 +1536,9 @@ public:
   /// Returns the operand index that is a use of the specific register or -1
   /// if it is not found. It further tightens the search criteria to a use
   /// that kills the register if isKill is true.
-  LLVM_ABI int findRegisterUseOperandIdx(Register Reg, const TargetRegisterInfo *TRI,
-                                bool isKill = false) const;
+  LLVM_ABI int findRegisterUseOperandIdx(Register Reg,
+                                         const TargetRegisterInfo *TRI,
+                                         bool isKill = false) const;
 
   /// Wrapper for findRegisterUseOperandIdx, it returns
   /// a pointer to the MachineOperand rather than an index.
@@ -1558,9 +1562,10 @@ public:
   /// overlap the specified register. If TargetRegisterInfo is non-null,
   /// then it also checks if there is a def of a super-register.
   /// This may also return a register mask operand when Overlap is true.
-  LLVM_ABI int findRegisterDefOperandIdx(Register Reg, const TargetRegisterInfo *TRI,
-                                bool isDead = false,
-                                bool Overlap = false) const;
+  LLVM_ABI int findRegisterDefOperandIdx(Register Reg,
+                                         const TargetRegisterInfo *TRI,
+                                         bool isDead = false,
+                                         bool Overlap = false) const;
 
   /// Wrapper for findRegisterDefOperandIdx, it returns
   /// a pointer to the MachineOperand rather than an index.
@@ -1591,7 +1596,8 @@ public:
   ///
   /// If GroupNo is not NULL, it will receive the number of the operand group
   /// containing OpIdx.
-  LLVM_ABI int findInlineAsmFlagIdx(unsigned OpIdx, unsigned *GroupNo = nullptr) const;
+  LLVM_ABI int findInlineAsmFlagIdx(unsigned OpIdx,
+                                    unsigned *GroupNo = nullptr) const;
 
   /// Compute the static register class constraint for operand OpIdx.
   /// For normal instructions, this is derived from the MCInstrDesc.
@@ -1599,9 +1605,8 @@ public:
   ///
   /// Returns NULL if the static register class constraint cannot be
   /// determined.
-  LLVM_ABI const TargetRegisterClass*
-  getRegClassConstraint(unsigned OpIdx,
-                        const TargetInstrInfo *TII,
+  LLVM_ABI const TargetRegisterClass *
+  getRegClassConstraint(unsigned OpIdx, const TargetInstrInfo *TII,
                         const TargetRegisterInfo *TRI) const;
 
   /// Applies the constraints (def/use) implied by this MI on \p Reg to
@@ -1680,27 +1685,29 @@ public:
 
   /// Replace all occurrences of FromReg with ToReg:SubIdx,
   /// properly composing subreg indices where necessary.
-  LLVM_ABI void substituteRegister(Register FromReg, Register ToReg, unsigned SubIdx,
-                          const TargetRegisterInfo &RegInfo);
+  LLVM_ABI void substituteRegister(Register FromReg, Register ToReg,
+                                   unsigned SubIdx,
+                                   const TargetRegisterInfo &RegInfo);
 
   /// We have determined MI kills a register. Look for the
   /// operand that uses it and mark it as IsKill. If AddIfNotFound is true,
   /// add a implicit operand if it's not found. Returns true if the operand
   /// exists / is added.
   LLVM_ABI bool addRegisterKilled(Register IncomingReg,
-                         const TargetRegisterInfo *RegInfo,
-                         bool AddIfNotFound = false);
+                                  const TargetRegisterInfo *RegInfo,
+                                  bool AddIfNotFound = false);
 
   /// Clear all kill flags affecting Reg.  If RegInfo is provided, this includes
   /// all aliasing registers.
-  LLVM_ABI void clearRegisterKills(Register Reg, const TargetRegisterInfo *RegInfo);
+  LLVM_ABI void clearRegisterKills(Register Reg,
+                                   const TargetRegisterInfo *RegInfo);
 
   /// We have determined MI defined a register without a use.
   /// Look for the operand that defines it and mark it as IsDead. If
   /// AddIfNotFound is true, add a implicit operand if it's not found. Returns
   /// true if the operand exists / is added.
   LLVM_ABI bool addRegisterDead(Register Reg, const TargetRegisterInfo *RegInfo,
-                       bool AddIfNotFound = false);
+                                bool AddIfNotFound = false);
 
   /// Clear all dead flags on operands defining register @p Reg.
   LLVM_ABI void clearRegisterDeads(Register Reg);
@@ -1713,7 +1720,7 @@ public:
   /// We have determined MI defines a register. Make sure there is an operand
   /// defining Reg.
   LLVM_ABI void addRegisterDefined(Register Reg,
-                          const TargetRegisterInfo *RegInfo = nullptr);
+                                   const TargetRegisterInfo *RegInfo = nullptr);
 
   /// Mark every physreg used by this instruction as
   /// dead except those in the UsedRegs list.
@@ -1721,7 +1728,7 @@ public:
   /// On instructions with register mask operands, also add implicit-def
   /// operands for all registers in UsedRegs.
   LLVM_ABI void setPhysRegsDeadExcept(ArrayRef<Register> UsedRegs,
-                             const TargetRegisterInfo &TRI);
+                                      const TargetRegisterInfo &TRI);
 
   /// Return true if it is safe to move this instruction. If
   /// SawStore is set to true, it means that there is a store (or call) between
@@ -1742,7 +1749,7 @@ public:
   /// either have dead flags or have no uses, then the instruction is said to be
   /// dead.
   LLVM_ABI bool isDead(const MachineRegisterInfo &MRI,
-              LiveRegUnits *LivePhysRegs = nullptr) const;
+                       LiveRegUnits *LivePhysRegs = nullptr) const;
 
   /// Returns true if this instruction's memory access aliases the memory
   /// access of Other.
@@ -1755,8 +1762,9 @@ public:
   /// @param Other MachineInstr to check aliasing against.
   /// @param UseTBAA Whether to pass TBAA information to alias analysis.
   LLVM_ABI bool mayAlias(BatchAAResults *AA, const MachineInstr &Other,
-                bool UseTBAA) const;
-  LLVM_ABI bool mayAlias(AAResults *AA, const MachineInstr &Other, bool UseTBAA) const;
+                         bool UseTBAA) const;
+  LLVM_ABI bool mayAlias(AAResults *AA, const MachineInstr &Other,
+                         bool UseTBAA) const;
 
   /// Return true if this instruction may have an ordered
   /// or volatile memory reference, or if the information describing the memory
@@ -1796,14 +1804,16 @@ public:
   LLVM_ABI bool allImplicitDefsAreDead() const;
 
   /// Return a valid size if the instruction is a spill instruction.
-  LLVM_ABI std::optional<LocationSize> getSpillSize(const TargetInstrInfo *TII) const;
+  LLVM_ABI std::optional<LocationSize>
+  getSpillSize(const TargetInstrInfo *TII) const;
 
   /// Return a valid size if the instruction is a folded spill instruction.
   LLVM_ABI std::optional<LocationSize>
   getFoldedSpillSize(const TargetInstrInfo *TII) const;
 
   /// Return a valid size if the instruction is a restore instruction.
-  LLVM_ABI std::optional<LocationSize> getRestoreSize(const TargetInstrInfo *TII) const;
+  LLVM_ABI std::optional<LocationSize>
+  getRestoreSize(const TargetInstrInfo *TII) const;
 
   /// Return a valid size if the instruction is a folded restore instruction.
   LLVM_ABI std::optional<LocationSize>
@@ -1817,7 +1827,7 @@ public:
   /// @{
   /// Determine the generic type to be printed (if needed) on uses and defs.
   LLVM_ABI LLT getTypeToPrint(unsigned OpIdx, SmallBitVector &PrintedTypes,
-                     const MachineRegisterInfo &MRI) const;
+                              const MachineRegisterInfo &MRI) const;
 
   /// Return true when an instruction has tied register that can't be determined
   /// by the instruction's descriptor. This is useful for MIR printing, to
@@ -1833,18 +1843,19 @@ public:
   /// Otherwise, also print the debug loc, with a terminating newline.
   /// \p TII is used to print the opcode name.  If it's not present, but the
   /// MI is in a function, the opcode will be printed using the function's TII.
-  LLVM_ABI void print(raw_ostream &OS, bool IsStandalone = true, bool SkipOpers = false,
-             bool SkipDebugLoc = false, bool AddNewLine = true,
-             const TargetInstrInfo *TII = nullptr) const;
-  LLVM_ABI void print(raw_ostream &OS, ModuleSlotTracker &MST, bool IsStandalone = true,
-             bool SkipOpers = false, bool SkipDebugLoc = false,
-             bool AddNewLine = true,
-             const TargetInstrInfo *TII = nullptr) const;
+  LLVM_ABI void print(raw_ostream &OS, bool IsStandalone = true,
+                      bool SkipOpers = false, bool SkipDebugLoc = false,
+                      bool AddNewLine = true,
+                      const TargetInstrInfo *TII = nullptr) const;
+  LLVM_ABI void print(raw_ostream &OS, ModuleSlotTracker &MST,
+                      bool IsStandalone = true, bool SkipOpers = false,
+                      bool SkipDebugLoc = false, bool AddNewLine = true,
+                      const TargetInstrInfo *TII = nullptr) const;
   LLVM_ABI void dump() const;
   /// Print on dbgs() the current instruction and the instructions defining its
   /// operands and so on until we reach \p MaxDepth.
   LLVM_ABI void dumpr(const MachineRegisterInfo &MRI,
-             unsigned MaxDepth = UINT_MAX) const;
+                      unsigned MaxDepth = UINT_MAX) const;
   /// @}
 
   //===--------------------------------------------------------------------===//
@@ -1897,7 +1908,8 @@ public:
   ///
   /// Unlike other methods, this *will* allocate them into a new array
   /// associated with the provided `MachineFunction`.
-  LLVM_ABI void setMemRefs(MachineFunction &MF, ArrayRef<MachineMemOperand *> MemRefs);
+  LLVM_ABI void setMemRefs(MachineFunction &MF,
+                           ArrayRef<MachineMemOperand *> MemRefs);
 
   /// Add a MachineMemOperand to the machine instruction.
   /// This function should be used only occasionally. The setMemRefs function
@@ -1921,7 +1933,7 @@ public:
   /// Prefer this API whenever possible as it can avoid allocations in common
   /// cases.
   LLVM_ABI void cloneMergedMemRefs(MachineFunction &MF,
-                          ArrayRef<const MachineInstr *> MIs);
+                                   ArrayRef<const MachineInstr *> MIs);
 
   /// Set a symbol that will be emitted just prior to the instruction itself.
   ///
@@ -1959,7 +1971,7 @@ public:
   /// Return the MIFlags which represent both MachineInstrs. This
   /// should be used when merging two MachineInstrs into one. This routine does
   /// not modify the MIFlags of this MachineInstr.
-  LLVM_ABI uint32_t mergeFlagsWith(const MachineInstr& Other) const;
+  LLVM_ABI uint32_t mergeFlagsWith(const MachineInstr &Other) const;
 
   LLVM_ABI static uint32_t copyFlagsFromInstruction(const Instruction &I);
 
@@ -2027,10 +2039,11 @@ public:
   LLVM_ABI std::tuple<Register, LLT, Register, LLT> getFirst2RegLLTs() const;
   LLVM_ABI std::tuple<Register, LLT, Register, LLT, Register, LLT>
   getFirst3RegLLTs() const;
-  LLVM_ABI std::tuple<Register, LLT, Register, LLT, Register, LLT, Register, LLT>
+  LLVM_ABI
+  std::tuple<Register, LLT, Register, LLT, Register, LLT, Register, LLT>
   getFirst4RegLLTs() const;
-  LLVM_ABI std::tuple<Register, LLT, Register, LLT, Register, LLT, Register, LLT,
-             Register, LLT>
+  LLVM_ABI std::tuple<Register, LLT, Register, LLT, Register, LLT, Register,
+                      LLT, Register, LLT>
   getFirst5RegLLTs() const;
 
 private:
@@ -2081,7 +2094,7 @@ struct MachineInstrExpressionTrait : DenseMapInfo<MachineInstr*> {
     return reinterpret_cast<MachineInstr*>(-1);
   }
 
-  LLVM_ABI static unsigned getHashValue(const MachineInstr* const &MI);
+  LLVM_ABI static unsigned getHashValue(const MachineInstr *const &MI);
 
   static bool isEqual(const MachineInstr* const &LHS,
                       const MachineInstr* const &RHS) {

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_MACHINEINSTR_H
 #define LLVM_CODEGEN_MACHINEINSTR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/PointerSumType.h"
@@ -357,14 +358,14 @@ public:
   MachineBasicBlock* getParent() { return Parent; }
 
   /// Move the instruction before \p MovePos.
-  void moveBefore(MachineInstr *MovePos);
+  LLVM_ABI void moveBefore(MachineInstr *MovePos);
 
   /// Return the function that contains the basic block that this instruction
   /// belongs to.
   ///
   /// Note: this is undefined behaviour if the instruction does not have a
   /// parent.
-  const MachineFunction *getMF() const;
+  LLVM_ABI const MachineFunction *getMF() const;
   MachineFunction *getMF() {
     return const_cast<MachineFunction *>(
         static_cast<const MachineInstr *>(this)->getMF());
@@ -492,17 +493,17 @@ public:
 
   /// Bundle this instruction with its predecessor. This can be an unbundled
   /// instruction, or it can be the first instruction in a bundle.
-  void bundleWithPred();
+  LLVM_ABI void bundleWithPred();
 
   /// Bundle this instruction with its successor. This can be an unbundled
   /// instruction, or it can be the last instruction in a bundle.
-  void bundleWithSucc();
+  LLVM_ABI void bundleWithSucc();
 
   /// Break bundle above this instruction.
-  void unbundleFromPred();
+  LLVM_ABI void unbundleFromPred();
 
   /// Break bundle below this instruction.
-  void unbundleFromSucc();
+  LLVM_ABI void unbundleFromSucc();
 
   /// Returns the debug location id of this MachineInstr.
   const DebugLoc &getDebugLoc() const { return DbgLoc; }
@@ -521,34 +522,34 @@ public:
 
   /// Return the operand for the debug variable referenced by
   /// this DBG_VALUE instruction.
-  const MachineOperand &getDebugVariableOp() const;
-  MachineOperand &getDebugVariableOp();
+  LLVM_ABI const MachineOperand &getDebugVariableOp() const;
+  LLVM_ABI MachineOperand &getDebugVariableOp();
 
   /// Return the debug variable referenced by
   /// this DBG_VALUE instruction.
-  const DILocalVariable *getDebugVariable() const;
+  LLVM_ABI const DILocalVariable *getDebugVariable() const;
 
   /// Return the operand for the complex address expression referenced by
   /// this DBG_VALUE instruction.
-  const MachineOperand &getDebugExpressionOp() const;
-  MachineOperand &getDebugExpressionOp();
+  LLVM_ABI const MachineOperand &getDebugExpressionOp() const;
+  LLVM_ABI MachineOperand &getDebugExpressionOp();
 
   /// Return the complex address expression referenced by
   /// this DBG_VALUE instruction.
-  const DIExpression *getDebugExpression() const;
+  LLVM_ABI const DIExpression *getDebugExpression() const;
 
   /// Return the debug label referenced by
   /// this DBG_LABEL instruction.
-  const DILabel *getDebugLabel() const;
+  LLVM_ABI const DILabel *getDebugLabel() const;
 
   /// Fetch the instruction number of this MachineInstr. If it does not have
   /// one already, a new and unique number will be assigned.
-  unsigned getDebugInstrNum();
+  LLVM_ABI unsigned getDebugInstrNum();
 
   /// Fetch instruction number of this MachineInstr -- but before it's inserted
   /// into \p MF. Needed for transformations that create an instruction but
   /// don't immediately insert them.
-  unsigned getDebugInstrNum(MachineFunction &MF);
+  LLVM_ABI unsigned getDebugInstrNum(MachineFunction &MF);
 
   /// Examine the instruction number of this MachineInstr. May be zero if
   /// it hasn't been assigned a number yet.
@@ -566,16 +567,16 @@ public:
 
   /// For inline asm, get the !srcloc metadata node if we have it, and decode
   /// the loc cookie from it.
-  const MDNode *getLocCookieMD() const;
+  LLVM_ABI const MDNode *getLocCookieMD() const;
 
   /// Emit an error referring to the source location of this instruction. This
   /// should only be used for inline assembly that is somehow impossible to
   /// compile. Other errors should have been handled much earlier.
-  void emitInlineAsmError(const Twine &ErrMsg) const;
+  LLVM_ABI void emitInlineAsmError(const Twine &ErrMsg) const;
 
   // Emit an error in the LLVMContext referring to the source location of this
   // instruction, if available.
-  void emitGenericError(const Twine &ErrMsg) const;
+  LLVM_ABI void emitGenericError(const Twine &ErrMsg) const;
 
   /// Returns the target instruction descriptor of this MachineInstr.
   const MCInstrDesc &getDesc() const { return *MCID; }
@@ -613,10 +614,10 @@ public:
 
   /// Returns a range of all of the operands that correspond to a debug use of
   /// \p Reg.
-  iterator_range<filter_iterator<const MachineOperand *,
+  LLVM_ABI iterator_range<filter_iterator<const MachineOperand *,
                                  std::function<bool(const MachineOperand &Op)>>>
   getDebugOperandsForReg(Register Reg) const;
-  iterator_range<filter_iterator<MachineOperand *,
+  LLVM_ABI iterator_range<filter_iterator<MachineOperand *,
                                  std::function<bool(MachineOperand &Op)>>>
   getDebugOperandsForReg(Register Reg);
 
@@ -662,10 +663,10 @@ public:
   }
 
   /// Returns the number of non-implicit operands.
-  unsigned getNumExplicitOperands() const;
+  LLVM_ABI unsigned getNumExplicitOperands() const;
 
   /// Returns the number of non-implicit definitions.
-  unsigned getNumExplicitDefs() const;
+  LLVM_ABI unsigned getNumExplicitDefs() const;
 
   /// iterator/begin/end - Iterate over all operands of a machine instruction.
 
@@ -947,12 +948,12 @@ public:
 
   /// Return true if this is a call instruction that may have an additional
   /// information associated with it.
-  bool isCandidateForAdditionalCallInfo(QueryType Type = IgnoreBundle) const;
+  LLVM_ABI bool isCandidateForAdditionalCallInfo(QueryType Type = IgnoreBundle) const;
 
   /// Return true if copying, moving, or erasing this instruction requires
   /// updating additional call info (see \ref copyCallInfo, \ref moveCallInfo,
   /// \ref eraseCallInfo).
-  bool shouldUpdateAdditionalCallInfo() const;
+  LLVM_ABI bool shouldUpdateAdditionalCallInfo() const;
 
   /// Returns true if the specified instruction stops control flow
   /// from executing the instruction immediately following it.  Examples include
@@ -1275,7 +1276,7 @@ public:
   /// operands are identical (with respect to MachineOperand::isIdenticalTo()).
   /// Note that this means liveness related flags (dead, undef, kill) do not
   /// affect the notion of identical.
-  bool isIdenticalTo(const MachineInstr &Other,
+  LLVM_ABI bool isIdenticalTo(const MachineInstr &Other,
                      MICheckType Check = CheckDefs) const;
 
   /// Returns true if this instruction is a debug instruction that represents an
@@ -1283,34 +1284,34 @@ public:
   /// This function considers these debug instructions equivalent if they have
   /// identical variables, debug locations, and debug operands, and if the
   /// DIExpressions combined with the directness flags are equivalent.
-  bool isEquivalentDbgInstr(const MachineInstr &Other) const;
+  LLVM_ABI bool isEquivalentDbgInstr(const MachineInstr &Other) const;
 
   /// Unlink 'this' from the containing basic block, and return it without
   /// deleting it.
   ///
   /// This function can not be used on bundled instructions, use
   /// removeFromBundle() to remove individual instructions from a bundle.
-  MachineInstr *removeFromParent();
+  LLVM_ABI MachineInstr *removeFromParent();
 
   /// Unlink this instruction from its basic block and return it without
   /// deleting it.
   ///
   /// If the instruction is part of a bundle, the other instructions in the
   /// bundle remain bundled.
-  MachineInstr *removeFromBundle();
+  LLVM_ABI MachineInstr *removeFromBundle();
 
   /// Unlink 'this' from the containing basic block and delete it.
   ///
   /// If this instruction is the header of a bundle, the whole bundle is erased.
   /// This function can not be used for instructions inside a bundle, use
   /// eraseFromBundle() to erase individual bundled instructions.
-  void eraseFromParent();
+  LLVM_ABI void eraseFromParent();
 
   /// Unlink 'this' from its basic block and delete it.
   ///
   /// If the instruction is part of a bundle, the other instructions in the
   /// bundle remain bundled.
-  void eraseFromBundle();
+  LLVM_ABI void eraseFromBundle();
 
   bool isEHLabel() const { return getOpcode() == TargetOpcode::EH_LABEL; }
   bool isGCLabel() const { return getOpcode() == TargetOpcode::GC_LABEL; }
@@ -1371,7 +1372,7 @@ public:
 
   /// A DBG_VALUE is an entry value iff its debug expression contains the
   /// DW_OP_LLVM_entry_value operation.
-  bool isDebugEntryValue() const;
+  LLVM_ABI bool isDebugEntryValue() const;
 
   /// Return true if the instruction is a debug value which describes a part of
   /// a variable as unavailable.
@@ -1402,10 +1403,10 @@ public:
   /// Returns true if the register operand can be folded with a load or store
   /// into a frame index. Does so by checking the InlineAsm::Flag immediate
   /// operand at OpId - 1.
-  bool mayFoldInlineAsmRegOp(unsigned OpId) const;
+  LLVM_ABI bool mayFoldInlineAsmRegOp(unsigned OpId) const;
 
-  bool isStackAligningInlineAsm() const;
-  InlineAsm::AsmDialect getInlineAsmDialect() const;
+  LLVM_ABI bool isStackAligningInlineAsm() const;
+  LLVM_ABI InlineAsm::AsmDialect getInlineAsmDialect() const;
 
   bool isInsertSubreg() const {
     return getOpcode() == TargetOpcode::INSERT_SUBREG;
@@ -1472,7 +1473,7 @@ public:
   ///
   /// This is the number of instructions that MachineBasicBlock::iterator
   /// skips, 0 for unbundled instructions.
-  unsigned getBundleSize() const;
+  LLVM_ABI unsigned getBundleSize() const;
 
   /// Return true if the MachineInstr reads the specified register.
   /// If TargetRegisterInfo is non-null, then it also checks if there
@@ -1493,7 +1494,7 @@ public:
   /// Return a pair of bools (reads, writes) indicating if this instruction
   /// reads or writes Reg. This also considers partial defines.
   /// If Ops is not null, all operand indices for Reg are added.
-  std::pair<bool,bool> readsWritesVirtualRegister(Register Reg,
+  LLVM_ABI std::pair<bool,bool> readsWritesVirtualRegister(Register Reg,
                                 SmallVectorImpl<unsigned> *Ops = nullptr) const;
 
   /// Return true if the MachineInstr kills the specified register.
@@ -1527,12 +1528,12 @@ public:
 
   /// Returns true if the MachineInstr has an implicit-use operand of exactly
   /// the given register (not considering sub/super-registers).
-  bool hasRegisterImplicitUseOperand(Register Reg) const;
+  LLVM_ABI bool hasRegisterImplicitUseOperand(Register Reg) const;
 
   /// Returns the operand index that is a use of the specific register or -1
   /// if it is not found. It further tightens the search criteria to a use
   /// that kills the register if isKill is true.
-  int findRegisterUseOperandIdx(Register Reg, const TargetRegisterInfo *TRI,
+  LLVM_ABI int findRegisterUseOperandIdx(Register Reg, const TargetRegisterInfo *TRI,
                                 bool isKill = false) const;
 
   /// Wrapper for findRegisterUseOperandIdx, it returns
@@ -1557,7 +1558,7 @@ public:
   /// overlap the specified register. If TargetRegisterInfo is non-null,
   /// then it also checks if there is a def of a super-register.
   /// This may also return a register mask operand when Overlap is true.
-  int findRegisterDefOperandIdx(Register Reg, const TargetRegisterInfo *TRI,
+  LLVM_ABI int findRegisterDefOperandIdx(Register Reg, const TargetRegisterInfo *TRI,
                                 bool isDead = false,
                                 bool Overlap = false) const;
 
@@ -1582,7 +1583,7 @@ public:
   /// Find the index of the first operand in the
   /// operand list that is used to represent the predicate. It returns -1 if
   /// none is found.
-  int findFirstPredOperandIdx() const;
+  LLVM_ABI int findFirstPredOperandIdx() const;
 
   /// Find the index of the flag word operand that
   /// corresponds to operand OpIdx on an inline asm instruction.  Returns -1 if
@@ -1590,7 +1591,7 @@ public:
   ///
   /// If GroupNo is not NULL, it will receive the number of the operand group
   /// containing OpIdx.
-  int findInlineAsmFlagIdx(unsigned OpIdx, unsigned *GroupNo = nullptr) const;
+  LLVM_ABI int findInlineAsmFlagIdx(unsigned OpIdx, unsigned *GroupNo = nullptr) const;
 
   /// Compute the static register class constraint for operand OpIdx.
   /// For normal instructions, this is derived from the MCInstrDesc.
@@ -1598,7 +1599,7 @@ public:
   ///
   /// Returns NULL if the static register class constraint cannot be
   /// determined.
-  const TargetRegisterClass*
+  LLVM_ABI const TargetRegisterClass*
   getRegClassConstraint(unsigned OpIdx,
                         const TargetInstrInfo *TII,
                         const TargetRegisterInfo *TRI) const;
@@ -1615,7 +1616,7 @@ public:
   /// exist.
   ///
   /// \pre CurRC must not be NULL.
-  const TargetRegisterClass *getRegClassConstraintEffectForVReg(
+  LLVM_ABI const TargetRegisterClass *getRegClassConstraintEffectForVReg(
       Register Reg, const TargetRegisterClass *CurRC,
       const TargetInstrInfo *TII, const TargetRegisterInfo *TRI,
       bool ExploreBundle = false) const;
@@ -1629,7 +1630,7 @@ public:
   ///
   /// \pre CurRC must not be NULL.
   /// \pre The operand at \p OpIdx must be a register.
-  const TargetRegisterClass *
+  LLVM_ABI const TargetRegisterClass *
   getRegClassConstraintEffect(unsigned OpIdx, const TargetRegisterClass *CurRC,
                               const TargetInstrInfo *TII,
                               const TargetRegisterInfo *TRI) const;
@@ -1640,12 +1641,12 @@ public:
   ///
   /// Tied operands are managed automatically for explicit operands in the
   /// MCInstrDesc. This method is for exceptional cases like inline asm.
-  void tieOperands(unsigned DefIdx, unsigned UseIdx);
+  LLVM_ABI void tieOperands(unsigned DefIdx, unsigned UseIdx);
 
   /// Given the index of a tied register operand, find the
   /// operand it is tied to. Defs are tied to uses and vice versa. Returns the
   /// index of the tied operand which must exist.
-  unsigned findTiedOperandIdx(unsigned OpIdx) const;
+  LLVM_ABI unsigned findTiedOperandIdx(unsigned OpIdx) const;
 
   /// Given the index of a register def operand,
   /// check if the register def is tied to a source operand, due to either
@@ -1675,43 +1676,43 @@ public:
   }
 
   /// Clears kill flags on all operands.
-  void clearKillInfo();
+  LLVM_ABI void clearKillInfo();
 
   /// Replace all occurrences of FromReg with ToReg:SubIdx,
   /// properly composing subreg indices where necessary.
-  void substituteRegister(Register FromReg, Register ToReg, unsigned SubIdx,
+  LLVM_ABI void substituteRegister(Register FromReg, Register ToReg, unsigned SubIdx,
                           const TargetRegisterInfo &RegInfo);
 
   /// We have determined MI kills a register. Look for the
   /// operand that uses it and mark it as IsKill. If AddIfNotFound is true,
   /// add a implicit operand if it's not found. Returns true if the operand
   /// exists / is added.
-  bool addRegisterKilled(Register IncomingReg,
+  LLVM_ABI bool addRegisterKilled(Register IncomingReg,
                          const TargetRegisterInfo *RegInfo,
                          bool AddIfNotFound = false);
 
   /// Clear all kill flags affecting Reg.  If RegInfo is provided, this includes
   /// all aliasing registers.
-  void clearRegisterKills(Register Reg, const TargetRegisterInfo *RegInfo);
+  LLVM_ABI void clearRegisterKills(Register Reg, const TargetRegisterInfo *RegInfo);
 
   /// We have determined MI defined a register without a use.
   /// Look for the operand that defines it and mark it as IsDead. If
   /// AddIfNotFound is true, add a implicit operand if it's not found. Returns
   /// true if the operand exists / is added.
-  bool addRegisterDead(Register Reg, const TargetRegisterInfo *RegInfo,
+  LLVM_ABI bool addRegisterDead(Register Reg, const TargetRegisterInfo *RegInfo,
                        bool AddIfNotFound = false);
 
   /// Clear all dead flags on operands defining register @p Reg.
-  void clearRegisterDeads(Register Reg);
+  LLVM_ABI void clearRegisterDeads(Register Reg);
 
   /// Mark all subregister defs of register @p Reg with the undef flag.
   /// This function is used when we determined to have a subregister def in an
   /// otherwise undefined super register.
-  void setRegisterDefReadUndef(Register Reg, bool IsUndef = true);
+  LLVM_ABI void setRegisterDefReadUndef(Register Reg, bool IsUndef = true);
 
   /// We have determined MI defines a register. Make sure there is an operand
   /// defining Reg.
-  void addRegisterDefined(Register Reg,
+  LLVM_ABI void addRegisterDefined(Register Reg,
                           const TargetRegisterInfo *RegInfo = nullptr);
 
   /// Mark every physreg used by this instruction as
@@ -1719,17 +1720,17 @@ public:
   ///
   /// On instructions with register mask operands, also add implicit-def
   /// operands for all registers in UsedRegs.
-  void setPhysRegsDeadExcept(ArrayRef<Register> UsedRegs,
+  LLVM_ABI void setPhysRegsDeadExcept(ArrayRef<Register> UsedRegs,
                              const TargetRegisterInfo &TRI);
 
   /// Return true if it is safe to move this instruction. If
   /// SawStore is set to true, it means that there is a store (or call) between
   /// the instruction's location and its intended destination.
-  bool isSafeToMove(bool &SawStore) const;
+  LLVM_ABI bool isSafeToMove(bool &SawStore) const;
 
   /// Return true if this instruction would be trivially dead if all of its
   /// defined registers were dead.
-  bool wouldBeTriviallyDead() const;
+  LLVM_ABI bool wouldBeTriviallyDead() const;
 
   /// Check whether an MI is dead. If \p LivePhysRegs is provided, it is assumed
   /// to be at the position of MI and will be used to check the Liveness of
@@ -1740,7 +1741,7 @@ public:
   /// MachineInstr. If the instruction wouldBeTriviallyDead, and  all the defs
   /// either have dead flags or have no uses, then the instruction is said to be
   /// dead.
-  bool isDead(const MachineRegisterInfo &MRI,
+  LLVM_ABI bool isDead(const MachineRegisterInfo &MRI,
               LiveRegUnits *LivePhysRegs = nullptr) const;
 
   /// Returns true if this instruction's memory access aliases the memory
@@ -1753,15 +1754,15 @@ public:
   /// @param AA Optional alias analysis, used to compare memory operands.
   /// @param Other MachineInstr to check aliasing against.
   /// @param UseTBAA Whether to pass TBAA information to alias analysis.
-  bool mayAlias(BatchAAResults *AA, const MachineInstr &Other,
+  LLVM_ABI bool mayAlias(BatchAAResults *AA, const MachineInstr &Other,
                 bool UseTBAA) const;
-  bool mayAlias(AAResults *AA, const MachineInstr &Other, bool UseTBAA) const;
+  LLVM_ABI bool mayAlias(AAResults *AA, const MachineInstr &Other, bool UseTBAA) const;
 
   /// Return true if this instruction may have an ordered
   /// or volatile memory reference, or if the information describing the memory
   /// reference is not available. Return false if it is known to have no
   /// ordered or volatile memory references.
-  bool hasOrderedMemoryRef() const;
+  LLVM_ABI bool hasOrderedMemoryRef() const;
 
   /// Return true if this load instruction never traps and points to a memory
   /// location whose value doesn't change during the execution of this function.
@@ -1770,11 +1771,11 @@ public:
   /// argument area of a function (if it does not change).  If the instruction
   /// does multiple loads, this returns true only if all of the loads are
   /// dereferenceable and invariant.
-  bool isDereferenceableInvariantLoad() const;
+  LLVM_ABI bool isDereferenceableInvariantLoad() const;
 
   /// If the specified instruction is a PHI that always merges together the
   /// same virtual register, return the register, otherwise return Register().
-  Register isConstantValuePHI() const;
+  LLVM_ABI Register isConstantValuePHI() const;
 
   /// Return true if this instruction has side effects that are not modeled
   /// by mayLoad / mayStore, etc.
@@ -1783,45 +1784,45 @@ public:
   /// INLINEASM instruction, in which case the side effect property is encoded
   /// in one of its operands (see InlineAsm::Extra_HasSideEffect).
   ///
-  bool hasUnmodeledSideEffects() const;
+  LLVM_ABI bool hasUnmodeledSideEffects() const;
 
   /// Returns true if it is illegal to fold a load across this instruction.
-  bool isLoadFoldBarrier() const;
+  LLVM_ABI bool isLoadFoldBarrier() const;
 
   /// Return true if all the defs of this instruction are dead.
-  bool allDefsAreDead() const;
+  LLVM_ABI bool allDefsAreDead() const;
 
   /// Return true if all the implicit defs of this instruction are dead.
-  bool allImplicitDefsAreDead() const;
+  LLVM_ABI bool allImplicitDefsAreDead() const;
 
   /// Return a valid size if the instruction is a spill instruction.
-  std::optional<LocationSize> getSpillSize(const TargetInstrInfo *TII) const;
+  LLVM_ABI std::optional<LocationSize> getSpillSize(const TargetInstrInfo *TII) const;
 
   /// Return a valid size if the instruction is a folded spill instruction.
-  std::optional<LocationSize>
+  LLVM_ABI std::optional<LocationSize>
   getFoldedSpillSize(const TargetInstrInfo *TII) const;
 
   /// Return a valid size if the instruction is a restore instruction.
-  std::optional<LocationSize> getRestoreSize(const TargetInstrInfo *TII) const;
+  LLVM_ABI std::optional<LocationSize> getRestoreSize(const TargetInstrInfo *TII) const;
 
   /// Return a valid size if the instruction is a folded restore instruction.
-  std::optional<LocationSize>
+  LLVM_ABI std::optional<LocationSize>
   getFoldedRestoreSize(const TargetInstrInfo *TII) const;
 
   /// Copy implicit register operands from specified
   /// instruction to this instruction.
-  void copyImplicitOps(MachineFunction &MF, const MachineInstr &MI);
+  LLVM_ABI void copyImplicitOps(MachineFunction &MF, const MachineInstr &MI);
 
   /// Debugging support
   /// @{
   /// Determine the generic type to be printed (if needed) on uses and defs.
-  LLT getTypeToPrint(unsigned OpIdx, SmallBitVector &PrintedTypes,
+  LLVM_ABI LLT getTypeToPrint(unsigned OpIdx, SmallBitVector &PrintedTypes,
                      const MachineRegisterInfo &MRI) const;
 
   /// Return true when an instruction has tied register that can't be determined
   /// by the instruction's descriptor. This is useful for MIR printing, to
   /// determine whether we need to print the ties or not.
-  bool hasComplexRegisterTies() const;
+  LLVM_ABI bool hasComplexRegisterTies() const;
 
   /// Print this MI to \p OS.
   /// Don't print information that can be inferred from other instructions if
@@ -1832,17 +1833,17 @@ public:
   /// Otherwise, also print the debug loc, with a terminating newline.
   /// \p TII is used to print the opcode name.  If it's not present, but the
   /// MI is in a function, the opcode will be printed using the function's TII.
-  void print(raw_ostream &OS, bool IsStandalone = true, bool SkipOpers = false,
+  LLVM_ABI void print(raw_ostream &OS, bool IsStandalone = true, bool SkipOpers = false,
              bool SkipDebugLoc = false, bool AddNewLine = true,
              const TargetInstrInfo *TII = nullptr) const;
-  void print(raw_ostream &OS, ModuleSlotTracker &MST, bool IsStandalone = true,
+  LLVM_ABI void print(raw_ostream &OS, ModuleSlotTracker &MST, bool IsStandalone = true,
              bool SkipOpers = false, bool SkipDebugLoc = false,
              bool AddNewLine = true,
              const TargetInstrInfo *TII = nullptr) const;
-  void dump() const;
+  LLVM_ABI void dump() const;
   /// Print on dbgs() the current instruction and the instructions defining its
   /// operands and so on until we reach \p MaxDepth.
-  void dumpr(const MachineRegisterInfo &MRI,
+  LLVM_ABI void dumpr(const MachineRegisterInfo &MRI,
              unsigned MaxDepth = UINT_MAX) const;
   /// @}
 
@@ -1859,21 +1860,21 @@ public:
   ///
   /// MachineInstrBuilder provides a more convenient interface for creating
   /// instructions and adding operands.
-  void addOperand(MachineFunction &MF, const MachineOperand &Op);
+  LLVM_ABI void addOperand(MachineFunction &MF, const MachineOperand &Op);
 
   /// Add an operand without providing an MF reference. This only works for
   /// instructions that are inserted in a basic block.
   ///
   /// MachineInstrBuilder and the two-argument addOperand(MF, MO) should be
   /// preferred.
-  void addOperand(const MachineOperand &Op);
+  LLVM_ABI void addOperand(const MachineOperand &Op);
 
   /// Inserts Ops BEFORE It. Can untie/retie tied operands.
-  void insert(mop_iterator InsertBefore, ArrayRef<MachineOperand> Ops);
+  LLVM_ABI void insert(mop_iterator InsertBefore, ArrayRef<MachineOperand> Ops);
 
   /// Replace the instruction descriptor (thus opcode) of
   /// the current instruction with a new one.
-  void setDesc(const MCInstrDesc &TID);
+  LLVM_ABI void setDesc(const MCInstrDesc &TID);
 
   /// Replace current source information with new such.
   /// Avoid using this, the constructor argument is preferable.
@@ -1884,24 +1885,24 @@ public:
 
   /// Erase an operand from an instruction, leaving it with one
   /// fewer operand than it started with.
-  void removeOperand(unsigned OpNo);
+  LLVM_ABI void removeOperand(unsigned OpNo);
 
   /// Clear this MachineInstr's memory reference descriptor list.  This resets
   /// the memrefs to their most conservative state.  This should be used only
   /// as a last resort since it greatly pessimizes our knowledge of the memory
   /// access performed by the instruction.
-  void dropMemRefs(MachineFunction &MF);
+  LLVM_ABI void dropMemRefs(MachineFunction &MF);
 
   /// Assign this MachineInstr's memory reference descriptor list.
   ///
   /// Unlike other methods, this *will* allocate them into a new array
   /// associated with the provided `MachineFunction`.
-  void setMemRefs(MachineFunction &MF, ArrayRef<MachineMemOperand *> MemRefs);
+  LLVM_ABI void setMemRefs(MachineFunction &MF, ArrayRef<MachineMemOperand *> MemRefs);
 
   /// Add a MachineMemOperand to the machine instruction.
   /// This function should be used only occasionally. The setMemRefs function
   /// is the primary method for setting up a MachineInstr's MemRefs list.
-  void addMemOperand(MachineFunction &MF, MachineMemOperand *MO);
+  LLVM_ABI void addMemOperand(MachineFunction &MF, MachineMemOperand *MO);
 
   /// Clone another MachineInstr's memory reference descriptor list and replace
   /// ours with it.
@@ -1910,7 +1911,7 @@ public:
   ///
   /// Prefer this API whenever possible as it can avoid allocations in common
   /// cases.
-  void cloneMemRefs(MachineFunction &MF, const MachineInstr &MI);
+  LLVM_ABI void cloneMemRefs(MachineFunction &MF, const MachineInstr &MI);
 
   /// Clone the merge of multiple MachineInstrs' memory reference descriptors
   /// list and replace ours with it.
@@ -1919,7 +1920,7 @@ public:
   ///
   /// Prefer this API whenever possible as it can avoid allocations in common
   /// cases.
-  void cloneMergedMemRefs(MachineFunction &MF,
+  LLVM_ABI void cloneMergedMemRefs(MachineFunction &MF,
                           ArrayRef<const MachineInstr *> MIs);
 
   /// Set a symbol that will be emitted just prior to the instruction itself.
@@ -1927,43 +1928,43 @@ public:
   /// Setting this to a null pointer will remove any such symbol.
   ///
   /// FIXME: This is not fully implemented yet.
-  void setPreInstrSymbol(MachineFunction &MF, MCSymbol *Symbol);
+  LLVM_ABI void setPreInstrSymbol(MachineFunction &MF, MCSymbol *Symbol);
 
   /// Set a symbol that will be emitted just after the instruction itself.
   ///
   /// Setting this to a null pointer will remove any such symbol.
   ///
   /// FIXME: This is not fully implemented yet.
-  void setPostInstrSymbol(MachineFunction &MF, MCSymbol *Symbol);
+  LLVM_ABI void setPostInstrSymbol(MachineFunction &MF, MCSymbol *Symbol);
 
   /// Clone another MachineInstr's pre- and post- instruction symbols and
   /// replace ours with it.
-  void cloneInstrSymbols(MachineFunction &MF, const MachineInstr &MI);
+  LLVM_ABI void cloneInstrSymbols(MachineFunction &MF, const MachineInstr &MI);
 
   /// Set a marker on instructions that denotes where we should create and emit
   /// heap alloc site labels. This waits until after instruction selection and
   /// optimizations to create the label, so it should still work if the
   /// instruction is removed or duplicated.
-  void setHeapAllocMarker(MachineFunction &MF, MDNode *MD);
+  LLVM_ABI void setHeapAllocMarker(MachineFunction &MF, MDNode *MD);
 
   // Set metadata on instructions that say which sections to emit instruction
   // addresses into.
-  void setPCSections(MachineFunction &MF, MDNode *MD);
+  LLVM_ABI void setPCSections(MachineFunction &MF, MDNode *MD);
 
-  void setMMRAMetadata(MachineFunction &MF, MDNode *MMRAs);
+  LLVM_ABI void setMMRAMetadata(MachineFunction &MF, MDNode *MMRAs);
 
   /// Set the CFI type for the instruction.
-  void setCFIType(MachineFunction &MF, uint32_t Type);
+  LLVM_ABI void setCFIType(MachineFunction &MF, uint32_t Type);
 
   /// Return the MIFlags which represent both MachineInstrs. This
   /// should be used when merging two MachineInstrs into one. This routine does
   /// not modify the MIFlags of this MachineInstr.
-  uint32_t mergeFlagsWith(const MachineInstr& Other) const;
+  LLVM_ABI uint32_t mergeFlagsWith(const MachineInstr& Other) const;
 
-  static uint32_t copyFlagsFromInstruction(const Instruction &I);
+  LLVM_ABI static uint32_t copyFlagsFromInstruction(const Instruction &I);
 
   /// Copy all flags to MachineInst MIFlags
-  void copyIRFlags(const Instruction &I);
+  LLVM_ABI void copyIRFlags(const Instruction &I);
 
   /// Break any tie involving OpIdx.
   void untieRegOperand(unsigned OpIdx) {
@@ -1975,15 +1976,15 @@ public:
   }
 
   /// Add all implicit def and use operands to this instruction.
-  void addImplicitDefUseOperands(MachineFunction &MF);
+  LLVM_ABI void addImplicitDefUseOperands(MachineFunction &MF);
 
   /// Scan instructions immediately following MI and collect any matching
   /// DBG_VALUEs.
-  void collectDebugValues(SmallVectorImpl<MachineInstr *> &DbgValues);
+  LLVM_ABI void collectDebugValues(SmallVectorImpl<MachineInstr *> &DbgValues);
 
   /// Find all DBG_VALUEs that point to the register def in this instruction
   /// and point them to \p Reg instead.
-  void changeDebugValuesDefReg(Register Reg);
+  LLVM_ABI void changeDebugValuesDefReg(Register Reg);
 
   /// Sets all register debug operands in this debug value instruction to be
   /// undef.
@@ -2018,17 +2019,17 @@ public:
                       getOperand(4).getReg());
   }
 
-  std::tuple<LLT, LLT> getFirst2LLTs() const;
-  std::tuple<LLT, LLT, LLT> getFirst3LLTs() const;
-  std::tuple<LLT, LLT, LLT, LLT> getFirst4LLTs() const;
-  std::tuple<LLT, LLT, LLT, LLT, LLT> getFirst5LLTs() const;
+  LLVM_ABI std::tuple<LLT, LLT> getFirst2LLTs() const;
+  LLVM_ABI std::tuple<LLT, LLT, LLT> getFirst3LLTs() const;
+  LLVM_ABI std::tuple<LLT, LLT, LLT, LLT> getFirst4LLTs() const;
+  LLVM_ABI std::tuple<LLT, LLT, LLT, LLT, LLT> getFirst5LLTs() const;
 
-  std::tuple<Register, LLT, Register, LLT> getFirst2RegLLTs() const;
-  std::tuple<Register, LLT, Register, LLT, Register, LLT>
+  LLVM_ABI std::tuple<Register, LLT, Register, LLT> getFirst2RegLLTs() const;
+  LLVM_ABI std::tuple<Register, LLT, Register, LLT, Register, LLT>
   getFirst3RegLLTs() const;
-  std::tuple<Register, LLT, Register, LLT, Register, LLT, Register, LLT>
+  LLVM_ABI std::tuple<Register, LLT, Register, LLT, Register, LLT, Register, LLT>
   getFirst4RegLLTs() const;
-  std::tuple<Register, LLT, Register, LLT, Register, LLT, Register, LLT,
+  LLVM_ABI std::tuple<Register, LLT, Register, LLT, Register, LLT, Register, LLT,
              Register, LLT>
   getFirst5RegLLTs() const;
 
@@ -2050,7 +2051,7 @@ private:
   void addRegOperandsToUseLists(MachineRegisterInfo&);
 
   /// Slow path for hasProperty when we're dealing with a bundle.
-  bool hasPropertyInBundle(uint64_t Mask, QueryType Type) const;
+  LLVM_ABI bool hasPropertyInBundle(uint64_t Mask, QueryType Type) const;
 
   /// Implements the logic of getRegClassConstraintEffectForVReg for the
   /// this MI and the given operand index \p OpIdx.
@@ -2080,7 +2081,7 @@ struct MachineInstrExpressionTrait : DenseMapInfo<MachineInstr*> {
     return reinterpret_cast<MachineInstr*>(-1);
   }
 
-  static unsigned getHashValue(const MachineInstr* const &MI);
+  LLVM_ABI static unsigned getHashValue(const MachineInstr* const &MI);
 
   static bool isEqual(const MachineInstr* const &LHS,
                       const MachineInstr* const &RHS) {

--- a/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -19,7 +19,6 @@
 #ifndef LLVM_CODEGEN_MACHINEINSTRBUILDER_H
 #define LLVM_CODEGEN_MACHINEINSTRBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/CodeGen/GlobalISel/Utils.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
@@ -30,6 +29,7 @@
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <cstdint>
@@ -504,39 +504,40 @@ inline MachineInstrBuilder BuildMI(MachineBasicBlock *BB,
 /// address.  The convention is that a DBG_VALUE is indirect iff the
 /// second operand is an immediate.
 LLVM_ABI MachineInstrBuilder BuildMI(MachineFunction &MF, const DebugLoc &DL,
-                            const MCInstrDesc &MCID, bool IsIndirect,
-                            Register Reg, const MDNode *Variable,
-                            const MDNode *Expr);
+                                     const MCInstrDesc &MCID, bool IsIndirect,
+                                     Register Reg, const MDNode *Variable,
+                                     const MDNode *Expr);
 
 /// This version of the builder builds a DBG_VALUE or DBG_VALUE_LIST intrinsic
 /// for a MachineOperand.
 LLVM_ABI MachineInstrBuilder BuildMI(MachineFunction &MF, const DebugLoc &DL,
-                            const MCInstrDesc &MCID, bool IsIndirect,
-                            ArrayRef<MachineOperand> MOs,
-                            const MDNode *Variable, const MDNode *Expr);
+                                     const MCInstrDesc &MCID, bool IsIndirect,
+                                     ArrayRef<MachineOperand> MOs,
+                                     const MDNode *Variable,
+                                     const MDNode *Expr);
 
 /// This version of the builder builds a DBG_VALUE intrinsic
 /// for either a value in a register or a register-indirect
 /// address and inserts it at position I.
 LLVM_ABI MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
-                            MachineBasicBlock::iterator I, const DebugLoc &DL,
-                            const MCInstrDesc &MCID, bool IsIndirect,
-                            Register Reg, const MDNode *Variable,
-                            const MDNode *Expr);
+                                     MachineBasicBlock::iterator I,
+                                     const DebugLoc &DL,
+                                     const MCInstrDesc &MCID, bool IsIndirect,
+                                     Register Reg, const MDNode *Variable,
+                                     const MDNode *Expr);
 
 /// This version of the builder builds a DBG_VALUE, DBG_INSTR_REF, or
 /// DBG_VALUE_LIST intrinsic for a machine operand and inserts it at position I.
-LLVM_ABI MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
-                            MachineBasicBlock::iterator I, const DebugLoc &DL,
-                            const MCInstrDesc &MCID, bool IsIndirect,
-                            ArrayRef<MachineOperand> MOs,
-                            const MDNode *Variable, const MDNode *Expr);
+LLVM_ABI MachineInstrBuilder BuildMI(
+    MachineBasicBlock &BB, MachineBasicBlock::iterator I, const DebugLoc &DL,
+    const MCInstrDesc &MCID, bool IsIndirect, ArrayRef<MachineOperand> MOs,
+    const MDNode *Variable, const MDNode *Expr);
 
 /// Clone a DBG_VALUE whose value has been spilled to FrameIndex.
 LLVM_ABI MachineInstr *buildDbgValueForSpill(MachineBasicBlock &BB,
-                                    MachineBasicBlock::iterator I,
-                                    const MachineInstr &Orig, int FrameIndex,
-                                    Register SpillReg);
+                                             MachineBasicBlock::iterator I,
+                                             const MachineInstr &Orig,
+                                             int FrameIndex, Register SpillReg);
 LLVM_ABI MachineInstr *buildDbgValueForSpill(
     MachineBasicBlock &BB, MachineBasicBlock::iterator I,
     const MachineInstr &Orig, int FrameIndex,
@@ -544,7 +545,8 @@ LLVM_ABI MachineInstr *buildDbgValueForSpill(
 
 /// Update a DBG_VALUE whose value has been spilled to FrameIndex. Useful when
 /// modifying an instruction in place while iterating over a basic block.
-LLVM_ABI void updateDbgValueForSpill(MachineInstr &Orig, int FrameIndex, Register Reg);
+LLVM_ABI void updateDbgValueForSpill(MachineInstr &Orig, int FrameIndex,
+                                     Register Reg);
 
 inline unsigned getDefRegState(bool B) {
   return B ? RegState::Define : 0;

--- a/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -19,6 +19,7 @@
 #ifndef LLVM_CODEGEN_MACHINEINSTRBUILDER_H
 #define LLVM_CODEGEN_MACHINEINSTRBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/CodeGen/GlobalISel/Utils.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
@@ -502,14 +503,14 @@ inline MachineInstrBuilder BuildMI(MachineBasicBlock *BB,
 /// for either a value in a register or a register-indirect
 /// address.  The convention is that a DBG_VALUE is indirect iff the
 /// second operand is an immediate.
-MachineInstrBuilder BuildMI(MachineFunction &MF, const DebugLoc &DL,
+LLVM_ABI MachineInstrBuilder BuildMI(MachineFunction &MF, const DebugLoc &DL,
                             const MCInstrDesc &MCID, bool IsIndirect,
                             Register Reg, const MDNode *Variable,
                             const MDNode *Expr);
 
 /// This version of the builder builds a DBG_VALUE or DBG_VALUE_LIST intrinsic
 /// for a MachineOperand.
-MachineInstrBuilder BuildMI(MachineFunction &MF, const DebugLoc &DL,
+LLVM_ABI MachineInstrBuilder BuildMI(MachineFunction &MF, const DebugLoc &DL,
                             const MCInstrDesc &MCID, bool IsIndirect,
                             ArrayRef<MachineOperand> MOs,
                             const MDNode *Variable, const MDNode *Expr);
@@ -517,7 +518,7 @@ MachineInstrBuilder BuildMI(MachineFunction &MF, const DebugLoc &DL,
 /// This version of the builder builds a DBG_VALUE intrinsic
 /// for either a value in a register or a register-indirect
 /// address and inserts it at position I.
-MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
+LLVM_ABI MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
                             MachineBasicBlock::iterator I, const DebugLoc &DL,
                             const MCInstrDesc &MCID, bool IsIndirect,
                             Register Reg, const MDNode *Variable,
@@ -525,25 +526,25 @@ MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
 
 /// This version of the builder builds a DBG_VALUE, DBG_INSTR_REF, or
 /// DBG_VALUE_LIST intrinsic for a machine operand and inserts it at position I.
-MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
+LLVM_ABI MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
                             MachineBasicBlock::iterator I, const DebugLoc &DL,
                             const MCInstrDesc &MCID, bool IsIndirect,
                             ArrayRef<MachineOperand> MOs,
                             const MDNode *Variable, const MDNode *Expr);
 
 /// Clone a DBG_VALUE whose value has been spilled to FrameIndex.
-MachineInstr *buildDbgValueForSpill(MachineBasicBlock &BB,
+LLVM_ABI MachineInstr *buildDbgValueForSpill(MachineBasicBlock &BB,
                                     MachineBasicBlock::iterator I,
                                     const MachineInstr &Orig, int FrameIndex,
                                     Register SpillReg);
-MachineInstr *buildDbgValueForSpill(
+LLVM_ABI MachineInstr *buildDbgValueForSpill(
     MachineBasicBlock &BB, MachineBasicBlock::iterator I,
     const MachineInstr &Orig, int FrameIndex,
     const SmallVectorImpl<const MachineOperand *> &SpilledOperands);
 
 /// Update a DBG_VALUE whose value has been spilled to FrameIndex. Useful when
 /// modifying an instruction in place while iterating over a basic block.
-void updateDbgValueForSpill(MachineInstr &Orig, int FrameIndex, Register Reg);
+LLVM_ABI void updateDbgValueForSpill(MachineInstr &Orig, int FrameIndex, Register Reg);
 
 inline unsigned getDefRegState(bool B) {
   return B ? RegState::Define : 0;

--- a/llvm/include/llvm/CodeGen/MachineInstrBundle.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBundle.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MACHINEINSTRBUNDLE_H
 #define LLVM_CODEGEN_MACHINEINSTRBUNDLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 
 namespace llvm {
@@ -24,7 +25,7 @@ namespace llvm {
 /// IsInternalRead markers to MachineOperands which are defined inside the
 /// bundle, and it copies externally visible defs and uses to the BUNDLE
 /// instruction.
-void finalizeBundle(MachineBasicBlock &MBB,
+LLVM_ABI void finalizeBundle(MachineBasicBlock &MBB,
                     MachineBasicBlock::instr_iterator FirstMI,
                     MachineBasicBlock::instr_iterator LastMI);
 
@@ -33,12 +34,12 @@ void finalizeBundle(MachineBasicBlock &MBB,
 /// used in cases where bundles are pre-determined by marking instructions
 /// with 'InsideBundle' marker. It returns the MBB instruction iterator that
 /// points to the end of the bundle.
-MachineBasicBlock::instr_iterator finalizeBundle(MachineBasicBlock &MBB,
+LLVM_ABI MachineBasicBlock::instr_iterator finalizeBundle(MachineBasicBlock &MBB,
                     MachineBasicBlock::instr_iterator FirstMI);
 
 /// finalizeBundles - Finalize instruction bundles in the specified
 /// MachineFunction. Return true if any bundles are finalized.
-bool finalizeBundles(MachineFunction &MF);
+LLVM_ABI bool finalizeBundles(MachineFunction &MF);
 
 /// Returns an iterator to the first instruction in the bundle containing \p I.
 inline MachineBasicBlock::instr_iterator getBundleStart(
@@ -237,13 +238,13 @@ struct VirtRegInfo {
 /// @param Ops When set, this vector will receive an (MI, OpNum) entry for
 ///            each operand referring to Reg.
 /// @returns A filled-in RegInfo struct.
-VirtRegInfo AnalyzeVirtRegInBundle(
+LLVM_ABI VirtRegInfo AnalyzeVirtRegInBundle(
     MachineInstr &MI, Register Reg,
     SmallVectorImpl<std::pair<MachineInstr *, unsigned>> *Ops = nullptr);
 
 /// Return a pair of lane masks (reads, writes) indicating which lanes this
 /// instruction uses with Reg.
-std::pair<LaneBitmask, LaneBitmask>
+LLVM_ABI std::pair<LaneBitmask, LaneBitmask>
 AnalyzeVirtRegLanesInBundle(const MachineInstr &MI, Register Reg,
                             const MachineRegisterInfo &MRI,
                             const TargetRegisterInfo &TRI);
@@ -288,7 +289,7 @@ struct PhysRegInfo {
 ///
 /// @param Reg The physical register to analyze.
 /// @returns A filled-in PhysRegInfo struct.
-PhysRegInfo AnalyzePhysRegInBundle(const MachineInstr &MI, Register Reg,
+LLVM_ABI PhysRegInfo AnalyzePhysRegInBundle(const MachineInstr &MI, Register Reg,
                                    const TargetRegisterInfo *TRI);
 
 } // End llvm namespace

--- a/llvm/include/llvm/CodeGen/MachineInstrBundle.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBundle.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_CODEGEN_MACHINEINSTRBUNDLE_H
 #define LLVM_CODEGEN_MACHINEINSTRBUNDLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -26,16 +26,17 @@ namespace llvm {
 /// bundle, and it copies externally visible defs and uses to the BUNDLE
 /// instruction.
 LLVM_ABI void finalizeBundle(MachineBasicBlock &MBB,
-                    MachineBasicBlock::instr_iterator FirstMI,
-                    MachineBasicBlock::instr_iterator LastMI);
+                             MachineBasicBlock::instr_iterator FirstMI,
+                             MachineBasicBlock::instr_iterator LastMI);
 
 /// finalizeBundle - Same functionality as the previous finalizeBundle except
 /// the last instruction in the bundle is not provided as an input. This is
 /// used in cases where bundles are pre-determined by marking instructions
 /// with 'InsideBundle' marker. It returns the MBB instruction iterator that
 /// points to the end of the bundle.
-LLVM_ABI MachineBasicBlock::instr_iterator finalizeBundle(MachineBasicBlock &MBB,
-                    MachineBasicBlock::instr_iterator FirstMI);
+LLVM_ABI MachineBasicBlock::instr_iterator
+finalizeBundle(MachineBasicBlock &MBB,
+               MachineBasicBlock::instr_iterator FirstMI);
 
 /// finalizeBundles - Finalize instruction bundles in the specified
 /// MachineFunction. Return true if any bundles are finalized.
@@ -289,8 +290,9 @@ struct PhysRegInfo {
 ///
 /// @param Reg The physical register to analyze.
 /// @returns A filled-in PhysRegInfo struct.
-LLVM_ABI PhysRegInfo AnalyzePhysRegInBundle(const MachineInstr &MI, Register Reg,
-                                   const TargetRegisterInfo *TRI);
+LLVM_ABI PhysRegInfo AnalyzePhysRegInBundle(const MachineInstr &MI,
+                                            Register Reg,
+                                            const TargetRegisterInfo *TRI);
 
 } // End llvm namespace
 

--- a/llvm/include/llvm/CodeGen/MachineJumpTableInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineJumpTableInfo.h
@@ -41,7 +41,8 @@ struct MachineJumpTableEntry {
   /// block(s) that reference it.
   MachineFunctionDataHotness Hotness;
 
-  LLVM_ABI explicit MachineJumpTableEntry(const std::vector<MachineBasicBlock *> &M);
+  LLVM_ABI explicit MachineJumpTableEntry(
+      const std::vector<MachineBasicBlock *> &M);
 };
 
 class MachineJumpTableInfo {
@@ -102,7 +103,8 @@ public:
 
   /// createJumpTableIndex - Create a new jump table.
   ///
-  LLVM_ABI unsigned createJumpTableIndex(const std::vector<MachineBasicBlock*> &DestBBs);
+  LLVM_ABI unsigned
+  createJumpTableIndex(const std::vector<MachineBasicBlock *> &DestBBs);
 
   /// isEmpty - Return true if there are no jump tables.
   ///
@@ -115,7 +117,7 @@ public:
   // Update machine jump table entry's hotness. Return true if the hotness is
   // updated.
   LLVM_ABI bool updateJumpTableEntryHotness(size_t JTI,
-                                   MachineFunctionDataHotness Hotness);
+                                            MachineFunctionDataHotness Hotness);
 
   /// RemoveJumpTable - Mark the specific index as being dead.  This will
   /// prevent it from being emitted.
@@ -128,12 +130,13 @@ public:
 
   /// ReplaceMBBInJumpTables - If Old is the target of any jump tables, update
   /// the jump tables to branch to New instead.
-  LLVM_ABI bool ReplaceMBBInJumpTables(MachineBasicBlock *Old, MachineBasicBlock *New);
+  LLVM_ABI bool ReplaceMBBInJumpTables(MachineBasicBlock *Old,
+                                       MachineBasicBlock *New);
 
   /// ReplaceMBBInJumpTable - If Old is a target of the jump tables, update
   /// the jump table to branch to New instead.
   LLVM_ABI bool ReplaceMBBInJumpTable(unsigned Idx, MachineBasicBlock *Old,
-                             MachineBasicBlock *New);
+                                      MachineBasicBlock *New);
 
   /// print - Used by the MachineFunction printer to print information about
   /// jump tables.  Implemented in MachineFunction.cpp

--- a/llvm/include/llvm/CodeGen/MachineJumpTableInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineJumpTableInfo.h
@@ -19,6 +19,7 @@
 #ifndef LLVM_CODEGEN_MACHINEJUMPTABLEINFO_H
 #define LLVM_CODEGEN_MACHINEJUMPTABLEINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Printable.h"
 #include <cassert>
 #include <vector>
@@ -40,7 +41,7 @@ struct MachineJumpTableEntry {
   /// block(s) that reference it.
   MachineFunctionDataHotness Hotness;
 
-  explicit MachineJumpTableEntry(const std::vector<MachineBasicBlock *> &M);
+  LLVM_ABI explicit MachineJumpTableEntry(const std::vector<MachineBasicBlock *> &M);
 };
 
 class MachineJumpTableInfo {
@@ -95,13 +96,13 @@ public:
   JTEntryKind getEntryKind() const { return EntryKind; }
 
   /// getEntrySize - Return the size of each entry in the jump table.
-  unsigned getEntrySize(const DataLayout &TD) const;
+  LLVM_ABI unsigned getEntrySize(const DataLayout &TD) const;
   /// getEntryAlignment - Return the alignment of each entry in the jump table.
-  unsigned getEntryAlignment(const DataLayout &TD) const;
+  LLVM_ABI unsigned getEntryAlignment(const DataLayout &TD) const;
 
   /// createJumpTableIndex - Create a new jump table.
   ///
-  unsigned createJumpTableIndex(const std::vector<MachineBasicBlock*> &DestBBs);
+  LLVM_ABI unsigned createJumpTableIndex(const std::vector<MachineBasicBlock*> &DestBBs);
 
   /// isEmpty - Return true if there are no jump tables.
   ///
@@ -113,7 +114,7 @@ public:
 
   // Update machine jump table entry's hotness. Return true if the hotness is
   // updated.
-  bool updateJumpTableEntryHotness(size_t JTI,
+  LLVM_ABI bool updateJumpTableEntryHotness(size_t JTI,
                                    MachineFunctionDataHotness Hotness);
 
   /// RemoveJumpTable - Mark the specific index as being dead.  This will
@@ -123,25 +124,25 @@ public:
   }
 
   /// RemoveMBBFromJumpTables - If MBB is present in any jump tables, remove it.
-  bool RemoveMBBFromJumpTables(MachineBasicBlock *MBB);
+  LLVM_ABI bool RemoveMBBFromJumpTables(MachineBasicBlock *MBB);
 
   /// ReplaceMBBInJumpTables - If Old is the target of any jump tables, update
   /// the jump tables to branch to New instead.
-  bool ReplaceMBBInJumpTables(MachineBasicBlock *Old, MachineBasicBlock *New);
+  LLVM_ABI bool ReplaceMBBInJumpTables(MachineBasicBlock *Old, MachineBasicBlock *New);
 
   /// ReplaceMBBInJumpTable - If Old is a target of the jump tables, update
   /// the jump table to branch to New instead.
-  bool ReplaceMBBInJumpTable(unsigned Idx, MachineBasicBlock *Old,
+  LLVM_ABI bool ReplaceMBBInJumpTable(unsigned Idx, MachineBasicBlock *Old,
                              MachineBasicBlock *New);
 
   /// print - Used by the MachineFunction printer to print information about
   /// jump tables.  Implemented in MachineFunction.cpp
   ///
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
   /// dump - Call to stderr.
   ///
-  void dump() const;
+  LLVM_ABI void dump() const;
 };
 
 
@@ -151,7 +152,7 @@ public:
 ///   %jump-table.5       - a jump table entry with index == 5.
 ///
 /// Usage: OS << printJumpTableEntryReference(Idx) << '\n';
-Printable printJumpTableEntryReference(unsigned Idx);
+LLVM_ABI Printable printJumpTableEntryReference(unsigned Idx);
 
 } // End llvm namespace
 

--- a/llvm/include/llvm/CodeGen/MachineLoopInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineLoopInfo.h
@@ -29,12 +29,12 @@
 #ifndef LLVM_CODEGEN_MACHINELOOPINFO_H
 #define LLVM_CODEGEN_MACHINELOOPINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/DebugLoc.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/GenericLoopInfo.h"
 
 namespace llvm {
@@ -84,7 +84,8 @@ public:
   /// ExcludeReg can be used to exclude the given register from the check
   /// i.e. when we're considering hoisting it's definition but not hoisted it
   /// yet
-  LLVM_ABI bool isLoopInvariant(MachineInstr &I, const Register ExcludeReg = 0) const;
+  LLVM_ABI bool isLoopInvariant(MachineInstr &I,
+                                const Register ExcludeReg = 0) const;
 
   LLVM_ABI void dump() const;
 
@@ -101,7 +102,8 @@ private:
 };
 
 // Implementation in LoopInfoImpl.h
-extern template class LLVM_TEMPLATE_ABI LoopInfoBase<MachineBasicBlock, MachineLoop>;
+extern template class LLVM_TEMPLATE_ABI
+    LoopInfoBase<MachineBasicBlock, MachineLoop>;
 
 class MachineLoopInfo : public LoopInfoBase<MachineBasicBlock, MachineLoop> {
   friend class LoopBase<MachineBasicBlock, MachineLoop>;
@@ -116,7 +118,7 @@ public:
 
   /// Handle invalidation explicitly.
   LLVM_ABI bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
-                  MachineFunctionAnalysisManager::Invalidator &);
+                           MachineFunctionAnalysisManager::Invalidator &);
 
   /// Find the block that either is the loop preheader, or could
   /// speculatively be used as the preheader. This is e.g. useful to place
@@ -140,7 +142,8 @@ class MachineLoopAnalysis : public AnalysisInfoMixin<MachineLoopAnalysis> {
 
 public:
   using Result = MachineLoopInfo;
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
 };
 
 /// Printer pass for the \c LoopAnalysis results.
@@ -150,7 +153,7 @@ class MachineLoopPrinterPass : public PassInfoMixin<MachineLoopPrinterPass> {
 public:
   explicit MachineLoopPrinterPass(raw_ostream &OS) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 

--- a/llvm/include/llvm/CodeGen/MachineLoopInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineLoopInfo.h
@@ -101,7 +101,7 @@ private:
 };
 
 // Implementation in LoopInfoImpl.h
-extern template class LoopInfoBase<MachineBasicBlock, MachineLoop>;
+extern template class LLVM_TEMPLATE_ABI LoopInfoBase<MachineBasicBlock, MachineLoop>;
 
 class MachineLoopInfo : public LoopInfoBase<MachineBasicBlock, MachineLoop> {
   friend class LoopBase<MachineBasicBlock, MachineLoop>;
@@ -136,7 +136,7 @@ public:
 /// Analysis pass that exposes the \c MachineLoopInfo for a machine function.
 class MachineLoopAnalysis : public AnalysisInfoMixin<MachineLoopAnalysis> {
   friend AnalysisInfoMixin<MachineLoopAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = MachineLoopInfo;

--- a/llvm/include/llvm/CodeGen/MachineLoopInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineLoopInfo.h
@@ -29,6 +29,7 @@
 #ifndef LLVM_CODEGEN_MACHINELOOPINFO_H
 #define LLVM_CODEGEN_MACHINELOOPINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachinePassManager.h"
@@ -48,25 +49,25 @@ public:
   /// Return the "top" block in the loop, which is the first block in the linear
   /// layout, ignoring any parts of the loop not contiguous with the part that
   /// contains the header.
-  MachineBasicBlock *getTopBlock();
+  LLVM_ABI MachineBasicBlock *getTopBlock();
 
   /// Return the "bottom" block in the loop, which is the last block in the
   /// linear layout, ignoring any parts of the loop not contiguous with the part
   /// that contains the header.
-  MachineBasicBlock *getBottomBlock();
+  LLVM_ABI MachineBasicBlock *getBottomBlock();
 
   /// Find the block that contains the loop control variable and the
   /// loop test. This will return the latch block if it's one of the exiting
   /// blocks. Otherwise, return the exiting block. Return 'null' when
   /// multiple exiting blocks are present.
-  MachineBasicBlock *findLoopControlBlock() const;
+  LLVM_ABI MachineBasicBlock *findLoopControlBlock() const;
 
   /// Return the debug location of the start of this loop.
   /// This looks for a BB terminating instruction with a known debug
   /// location by looking at the preheader and header blocks. If it
   /// cannot find a terminating instruction with location information,
   /// it returns an unknown location.
-  DebugLoc getStartLoc() const;
+  LLVM_ABI DebugLoc getStartLoc() const;
 
   /// Find the llvm.loop metadata for this loop.
   /// If each branch to the header of this loop contains the same llvm.loop
@@ -74,7 +75,7 @@ public:
   /// latch instruction does not contain the llvm.loop metadata or
   /// multiple latch instructions contain different llvm.loop metadata nodes,
   /// then null is returned.
-  MDNode *getLoopID() const;
+  LLVM_ABI MDNode *getLoopID() const;
 
   /// Returns true if the instruction is loop invariant.
   /// I.e., all virtual register operands are defined outside of the loop,
@@ -83,9 +84,9 @@ public:
   /// ExcludeReg can be used to exclude the given register from the check
   /// i.e. when we're considering hoisting it's definition but not hoisted it
   /// yet
-  bool isLoopInvariant(MachineInstr &I, const Register ExcludeReg = 0) const;
+  LLVM_ABI bool isLoopInvariant(MachineInstr &I, const Register ExcludeReg = 0) const;
 
-  void dump() const;
+  LLVM_ABI void dump() const;
 
 private:
   friend class LoopInfoBase<MachineBasicBlock, MachineLoop>;
@@ -114,7 +115,7 @@ public:
   MachineLoopInfo &operator=(const MachineLoopInfo &) = delete;
 
   /// Handle invalidation explicitly.
-  bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
                   MachineFunctionAnalysisManager::Invalidator &);
 
   /// Find the block that either is the loop preheader, or could
@@ -124,12 +125,12 @@ public:
   /// find the speculative preheader if the regular preheader is not present.
   /// With FindMultiLoopPreheader = false, nullptr will be returned if the found
   /// preheader is the preheader of multiple loops.
-  MachineBasicBlock *
+  LLVM_ABI MachineBasicBlock *
   findLoopPreheader(MachineLoop *L, bool SpeculativePreheader = false,
                     bool FindMultiLoopPreheader = false) const;
 
   /// Calculate the natural loop information.
-  void calculate(MachineDominatorTree &MDT);
+  LLVM_ABI void calculate(MachineDominatorTree &MDT);
 };
 
 /// Analysis pass that exposes the \c MachineLoopInfo for a machine function.
@@ -139,7 +140,7 @@ class MachineLoopAnalysis : public AnalysisInfoMixin<MachineLoopAnalysis> {
 
 public:
   using Result = MachineLoopInfo;
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
 };
 
 /// Printer pass for the \c LoopAnalysis results.
@@ -148,12 +149,12 @@ class MachineLoopPrinterPass : public PassInfoMixin<MachineLoopPrinterPass> {
 
 public:
   explicit MachineLoopPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
-class MachineLoopInfoWrapperPass : public MachineFunctionPass {
+class LLVM_ABI MachineLoopInfoWrapperPass : public MachineFunctionPass {
   MachineLoopInfo LI;
 
 public:

--- a/llvm/include/llvm/CodeGen/MachineMemOperand.h
+++ b/llvm/include/llvm/CodeGen/MachineMemOperand.h
@@ -15,7 +15,6 @@
 #ifndef LLVM_CODEGEN_MACHINEMEMOPERAND_H
 #define LLVM_CODEGEN_MACHINEMEMOPERAND_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Analysis/MemoryLocation.h"
@@ -26,6 +25,7 @@
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Value.h" // PointerLikeTypeTraits<Value*>
 #include "llvm/Support/AtomicOrdering.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 
 namespace llvm {
@@ -91,7 +91,7 @@ struct MachinePointerInfo {
   /// Return true if memory region [V, V+Offset+Size) is known to be
   /// dereferenceable.
   LLVM_ABI bool isDereferenceable(unsigned Size, LLVMContext &C,
-                         const DataLayout &DL) const;
+                                  const DataLayout &DL) const;
 
   /// Return the LLVM IR address space number that this pointer points into.
   LLVM_ABI unsigned getAddrSpace() const;
@@ -102,7 +102,7 @@ struct MachinePointerInfo {
   /// Return a MachinePointerInfo record that refers to the specified
   /// FrameIndex.
   LLVM_ABI static MachinePointerInfo getFixedStack(MachineFunction &MF, int FI,
-                                          int64_t Offset = 0);
+                                                   int64_t Offset = 0);
 
   /// Return a MachinePointerInfo record that refers to a jump table entry.
   LLVM_ABI static MachinePointerInfo getJumpTable(MachineFunction &MF);
@@ -111,8 +111,8 @@ struct MachinePointerInfo {
   LLVM_ABI static MachinePointerInfo getGOT(MachineFunction &MF);
 
   /// Stack pointer relative access.
-  LLVM_ABI static MachinePointerInfo getStack(MachineFunction &MF, int64_t Offset,
-                                     uint8_t ID = 0);
+  LLVM_ABI static MachinePointerInfo getStack(MachineFunction &MF,
+                                              int64_t Offset, uint8_t ID = 0);
 
   /// Stack memory without other information.
   LLVM_ABI static MachinePointerInfo getUnknownStack(MachineFunction &MF);
@@ -189,13 +189,15 @@ public:
   /// and atomic ordering requirements must also be specified. For cmpxchg
   /// atomic operations the atomic ordering requirements when store does not
   /// occur must also be specified.
-  LLVM_ABI MachineMemOperand(MachinePointerInfo PtrInfo, Flags flags, LocationSize TS,
+  LLVM_ABI
+  MachineMemOperand(MachinePointerInfo PtrInfo, Flags flags, LocationSize TS,
                     Align a, const AAMDNodes &AAInfo = AAMDNodes(),
                     const MDNode *Ranges = nullptr,
                     SyncScope::ID SSID = SyncScope::System,
                     AtomicOrdering Ordering = AtomicOrdering::NotAtomic,
                     AtomicOrdering FailureOrdering = AtomicOrdering::NotAtomic);
-  LLVM_ABI MachineMemOperand(MachinePointerInfo PtrInfo, Flags flags, LLT type, Align a,
+  LLVM_ABI
+  MachineMemOperand(MachinePointerInfo PtrInfo, Flags flags, LLT type, Align a,
                     const AAMDNodes &AAInfo = AAMDNodes(),
                     const MDNode *Ranges = nullptr,
                     SyncScope::ID SSID = SyncScope::System,
@@ -339,8 +341,9 @@ public:
   /// Support for operator<<.
   /// @{
   LLVM_ABI void print(raw_ostream &OS, ModuleSlotTracker &MST,
-             SmallVectorImpl<StringRef> &SSNs, const LLVMContext &Context,
-             const MachineFrameInfo *MFI, const TargetInstrInfo *TII) const;
+                      SmallVectorImpl<StringRef> &SSNs,
+                      const LLVMContext &Context, const MachineFrameInfo *MFI,
+                      const TargetInstrInfo *TII) const;
   /// @}
 
   friend bool operator==(const MachineMemOperand &LHS,

--- a/llvm/include/llvm/CodeGen/MachineMemOperand.h
+++ b/llvm/include/llvm/CodeGen/MachineMemOperand.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_MACHINEMEMOPERAND_H
 #define LLVM_CODEGEN_MACHINEMEMOPERAND_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Analysis/MemoryLocation.h"
@@ -89,32 +90,32 @@ struct MachinePointerInfo {
 
   /// Return true if memory region [V, V+Offset+Size) is known to be
   /// dereferenceable.
-  bool isDereferenceable(unsigned Size, LLVMContext &C,
+  LLVM_ABI bool isDereferenceable(unsigned Size, LLVMContext &C,
                          const DataLayout &DL) const;
 
   /// Return the LLVM IR address space number that this pointer points into.
-  unsigned getAddrSpace() const;
+  LLVM_ABI unsigned getAddrSpace() const;
 
   /// Return a MachinePointerInfo record that refers to the constant pool.
-  static MachinePointerInfo getConstantPool(MachineFunction &MF);
+  LLVM_ABI static MachinePointerInfo getConstantPool(MachineFunction &MF);
 
   /// Return a MachinePointerInfo record that refers to the specified
   /// FrameIndex.
-  static MachinePointerInfo getFixedStack(MachineFunction &MF, int FI,
+  LLVM_ABI static MachinePointerInfo getFixedStack(MachineFunction &MF, int FI,
                                           int64_t Offset = 0);
 
   /// Return a MachinePointerInfo record that refers to a jump table entry.
-  static MachinePointerInfo getJumpTable(MachineFunction &MF);
+  LLVM_ABI static MachinePointerInfo getJumpTable(MachineFunction &MF);
 
   /// Return a MachinePointerInfo record that refers to a GOT entry.
-  static MachinePointerInfo getGOT(MachineFunction &MF);
+  LLVM_ABI static MachinePointerInfo getGOT(MachineFunction &MF);
 
   /// Stack pointer relative access.
-  static MachinePointerInfo getStack(MachineFunction &MF, int64_t Offset,
+  LLVM_ABI static MachinePointerInfo getStack(MachineFunction &MF, int64_t Offset,
                                      uint8_t ID = 0);
 
   /// Stack memory without other information.
-  static MachinePointerInfo getUnknownStack(MachineFunction &MF);
+  LLVM_ABI static MachinePointerInfo getUnknownStack(MachineFunction &MF);
 };
 
 
@@ -188,13 +189,13 @@ public:
   /// and atomic ordering requirements must also be specified. For cmpxchg
   /// atomic operations the atomic ordering requirements when store does not
   /// occur must also be specified.
-  MachineMemOperand(MachinePointerInfo PtrInfo, Flags flags, LocationSize TS,
+  LLVM_ABI MachineMemOperand(MachinePointerInfo PtrInfo, Flags flags, LocationSize TS,
                     Align a, const AAMDNodes &AAInfo = AAMDNodes(),
                     const MDNode *Ranges = nullptr,
                     SyncScope::ID SSID = SyncScope::System,
                     AtomicOrdering Ordering = AtomicOrdering::NotAtomic,
                     AtomicOrdering FailureOrdering = AtomicOrdering::NotAtomic);
-  MachineMemOperand(MachinePointerInfo PtrInfo, Flags flags, LLT type, Align a,
+  LLVM_ABI MachineMemOperand(MachinePointerInfo PtrInfo, Flags flags, LLT type, Align a,
                     const AAMDNodes &AAInfo = AAMDNodes(),
                     const MDNode *Ranges = nullptr,
                     SyncScope::ID SSID = SyncScope::System,
@@ -256,7 +257,7 @@ public:
 
   /// Return the minimum known alignment in bytes of the actual memory
   /// reference.
-  Align getAlign() const;
+  LLVM_ABI Align getAlign() const;
 
   /// Return the minimum known alignment in bytes of the base address, without
   /// the offset.
@@ -318,7 +319,7 @@ public:
   /// Update this MachineMemOperand to reflect the alignment of MMO, if it has a
   /// greater alignment. This must only be used when the new alignment applies
   /// to all users of this MachineMemOperand.
-  void refineAlignment(const MachineMemOperand *MMO);
+  LLVM_ABI void refineAlignment(const MachineMemOperand *MMO);
 
   /// Change the SourceValue for this MachineMemOperand. This should only be
   /// used when an object is being relocated and all references to it are being
@@ -337,7 +338,7 @@ public:
 
   /// Support for operator<<.
   /// @{
-  void print(raw_ostream &OS, ModuleSlotTracker &MST,
+  LLVM_ABI void print(raw_ostream &OS, ModuleSlotTracker &MST,
              SmallVectorImpl<StringRef> &SSNs, const LLVMContext &Context,
              const MachineFrameInfo *MFI, const TargetInstrInfo *TII) const;
   /// @}

--- a/llvm/include/llvm/CodeGen/MachineModuleInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineModuleInfo.h
@@ -193,7 +193,7 @@ public:
 /// infrastructure must own the MachineModuleInfo.
 class MachineModuleAnalysis : public AnalysisInfoMixin<MachineModuleAnalysis> {
   friend AnalysisInfoMixin<MachineModuleAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
   MachineModuleInfo &MMI;
 

--- a/llvm/include/llvm/CodeGen/MachineModuleInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineModuleInfo.h
@@ -30,13 +30,13 @@
 #ifndef LLVM_CODEGEN_MACHINEMODULEINFO_H
 #define LLVM_CODEGEN_MACHINEMODULEINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 #include <utility>
 #include <vector>
@@ -112,7 +112,8 @@ class MachineModuleInfo {
 public:
   LLVM_ABI explicit MachineModuleInfo(const TargetMachine *TM = nullptr);
 
-  LLVM_ABI explicit MachineModuleInfo(const TargetMachine *TM, MCContext *ExtContext);
+  LLVM_ABI explicit MachineModuleInfo(const TargetMachine *TM,
+                                      MCContext *ExtContext);
 
   LLVM_ABI MachineModuleInfo(MachineModuleInfo &&MMII);
 
@@ -149,7 +150,8 @@ public:
   LLVM_ABI void deleteMachineFunctionFor(Function &F);
 
   /// Add an externally created MachineFunction \p MF for \p F.
-  LLVM_ABI void insertFunction(const Function &F, std::unique_ptr<MachineFunction> &&MF);
+  LLVM_ABI void insertFunction(const Function &F,
+                               std::unique_ptr<MachineFunction> &&MF);
 
   /// Keep track of various per-module pieces of information for backends
   /// that would like to do so.

--- a/llvm/include/llvm/CodeGen/MachineModuleInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineModuleInfo.h
@@ -30,6 +30,7 @@
 #ifndef LLVM_CODEGEN_MACHINEMODULEINFO_H
 #define LLVM_CODEGEN_MACHINEMODULEINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/IR/PassManager.h"
@@ -53,7 +54,7 @@ class Module;
 /// accessed/created with MachineModuleInfo::getObjFileInfo and destroyed when
 /// the MachineModuleInfo is destroyed.
 ///
-class MachineModuleInfoImpl {
+class LLVM_ABI MachineModuleInfoImpl {
 public:
   using StubValueTy = PointerIntPair<MCSymbol *, 1, bool>;
   using SymbolListTy = std::vector<std::pair<MCSymbol *, StubValueTy>>;
@@ -109,16 +110,16 @@ class MachineModuleInfo {
   MachineModuleInfo &operator=(MachineModuleInfo &&MMII) = delete;
 
 public:
-  explicit MachineModuleInfo(const TargetMachine *TM = nullptr);
+  LLVM_ABI explicit MachineModuleInfo(const TargetMachine *TM = nullptr);
 
-  explicit MachineModuleInfo(const TargetMachine *TM, MCContext *ExtContext);
+  LLVM_ABI explicit MachineModuleInfo(const TargetMachine *TM, MCContext *ExtContext);
 
-  MachineModuleInfo(MachineModuleInfo &&MMII);
+  LLVM_ABI MachineModuleInfo(MachineModuleInfo &&MMII);
 
-  ~MachineModuleInfo();
+  LLVM_ABI ~MachineModuleInfo();
 
-  void initialize();
-  void finalize();
+  LLVM_ABI void initialize();
+  LLVM_ABI void finalize();
 
   const TargetMachine &getTarget() const { return TM; }
 
@@ -135,20 +136,20 @@ public:
   /// Creates a new MachineFunction if none exists yet.
   /// NOTE: New pass manager clients shall not use this method to get
   /// the `MachineFunction`, use `MachineFunctionAnalysis` instead.
-  MachineFunction &getOrCreateMachineFunction(Function &F);
+  LLVM_ABI MachineFunction &getOrCreateMachineFunction(Function &F);
 
   /// \brief Returns the MachineFunction associated to IR function \p F if there
   /// is one, otherwise nullptr.
   /// NOTE: New pass manager clients shall not use this method to get
   /// the `MachineFunction`, use `MachineFunctionAnalysis` instead.
-  MachineFunction *getMachineFunction(const Function &F) const;
+  LLVM_ABI MachineFunction *getMachineFunction(const Function &F) const;
 
   /// Delete the MachineFunction \p MF and reset the link in the IR Function to
   /// Machine Function map.
-  void deleteMachineFunctionFor(Function &F);
+  LLVM_ABI void deleteMachineFunctionFor(Function &F);
 
   /// Add an externally created MachineFunction \p MF for \p F.
-  void insertFunction(const Function &F, std::unique_ptr<MachineFunction> &&MF);
+  LLVM_ABI void insertFunction(const Function &F, std::unique_ptr<MachineFunction> &&MF);
 
   /// Keep track of various per-module pieces of information for backends
   /// that would like to do so.
@@ -167,7 +168,7 @@ public:
   /// \}
 }; // End class MachineModuleInfo
 
-class MachineModuleInfoWrapperPass : public ImmutablePass {
+class LLVM_ABI MachineModuleInfoWrapperPass : public ImmutablePass {
   MachineModuleInfo MMI;
 
 public:
@@ -215,7 +216,7 @@ public:
   MachineModuleAnalysis(MachineModuleInfo &MMI) : MMI(MMI) {}
 
   /// Run the analysis pass and produce machine module information.
-  Result run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI Result run(Module &M, ModuleAnalysisManager &);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/MachineModuleSlotTracker.h
+++ b/llvm/include/llvm/CodeGen/MachineModuleSlotTracker.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_CODEGEN_MACHINEMODULESLOTTRACKER_H
 #define LLVM_CODEGEN_MACHINEMODULESLOTTRACKER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/IR/ModuleSlotTracker.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/CodeGen/MachineModuleSlotTracker.h
+++ b/llvm/include/llvm/CodeGen/MachineModuleSlotTracker.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CODEGEN_MACHINEMODULESLOTTRACKER_H
 #define LLVM_CODEGEN_MACHINEMODULESLOTTRACKER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/IR/ModuleSlotTracker.h"
 
 namespace llvm {
@@ -19,7 +20,7 @@ class MachineModuleInfo;
 class MachineFunction;
 class Module;
 
-class MachineModuleSlotTracker : public ModuleSlotTracker {
+class LLVM_ABI MachineModuleSlotTracker : public ModuleSlotTracker {
   const Function &TheFunction;
   const MachineModuleInfo &TheMMI;
   unsigned MDNStartSlot = 0, MDNEndSlot = 0;

--- a/llvm/include/llvm/CodeGen/MachineOperand.h
+++ b/llvm/include/llvm/CodeGen/MachineOperand.h
@@ -759,7 +759,7 @@ public:
   /// isIdenticalTo uses for comparison. It is thus suited for use in hash
   /// tables which use that function for equality comparisons only. This must
   /// stay exactly in sync with isIdenticalTo above.
-  friend hash_code hash_value(const MachineOperand &MO);
+  LLVM_ABI_FRIEND friend hash_code hash_value(const MachineOperand &MO);
 
   /// ChangeToImmediate - Replace this operand with a new immediate operand of
   /// the specified value.  If an operand is known to be an immediate already,

--- a/llvm/include/llvm/CodeGen/MachineOperand.h
+++ b/llvm/include/llvm/CodeGen/MachineOperand.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MACHINEOPERAND_H
 #define LLVM_CODEGEN_MACHINEOPERAND_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/IR/Intrinsics.h"
@@ -253,35 +254,35 @@ public:
   void clearParent() { ParentMI = nullptr; }
 
   /// Returns the index of this operand in the instruction that it belongs to.
-  unsigned getOperandNo() const;
+  LLVM_ABI unsigned getOperandNo() const;
 
   /// Print a subreg index operand.
   /// MO_Immediate operands can also be subreg idices. If it's the case, the
   /// subreg index name will be printed. MachineInstr::isOperandSubregIdx can be
   /// called to check this.
-  static void printSubRegIdx(raw_ostream &OS, uint64_t Index,
+  LLVM_ABI static void printSubRegIdx(raw_ostream &OS, uint64_t Index,
                              const TargetRegisterInfo *TRI);
 
   /// Print operand target flags.
-  static void printTargetFlags(raw_ostream& OS, const MachineOperand &Op);
+  LLVM_ABI static void printTargetFlags(raw_ostream& OS, const MachineOperand &Op);
 
   /// Print a MCSymbol as an operand.
-  static void printSymbol(raw_ostream &OS, MCSymbol &Sym);
+  LLVM_ABI static void printSymbol(raw_ostream &OS, MCSymbol &Sym);
 
   /// Print a stack object reference.
-  static void printStackObjectReference(raw_ostream &OS, unsigned FrameIndex,
+  LLVM_ABI static void printStackObjectReference(raw_ostream &OS, unsigned FrameIndex,
                                         bool IsFixed, StringRef Name);
 
   /// Print the offset with explicit +/- signs.
-  static void printOperandOffset(raw_ostream &OS, int64_t Offset);
+  LLVM_ABI static void printOperandOffset(raw_ostream &OS, int64_t Offset);
 
   /// Print an IRSlotNumber.
-  static void printIRSlotNumber(raw_ostream &OS, int Slot);
+  LLVM_ABI static void printIRSlotNumber(raw_ostream &OS, int Slot);
 
   /// Print the MachineOperand to \p os.
   /// Providing a valid \p TRI results in a more target-specific printing. If
   /// \p TRI is null, the function will try to pick it up from the parent.
-  void print(raw_ostream &os, const TargetRegisterInfo *TRI = nullptr) const;
+  LLVM_ABI void print(raw_ostream &os, const TargetRegisterInfo *TRI = nullptr) const;
 
   /// More complex way of printing a MachineOperand.
   /// \param TypeToPrint specifies the generic type to be printed on uses and
@@ -303,17 +304,17 @@ public:
   /// \param TRI - provide more target-specific information to the printer.
   /// Unlike the previous function, this one will not try and get the
   /// information from it's parent.
-  void print(raw_ostream &os, ModuleSlotTracker &MST, LLT TypeToPrint,
+  LLVM_ABI void print(raw_ostream &os, ModuleSlotTracker &MST, LLT TypeToPrint,
              std::optional<unsigned> OpIdx, bool PrintDef, bool IsStandalone,
              bool ShouldPrintRegisterTies, unsigned TiedOperandIdx,
              const TargetRegisterInfo *TRI) const;
 
   /// Same as print(os, TRI), but allows to specify the low-level type to be
   /// printed the same way the full version of print(...) does it.
-  void print(raw_ostream &os, LLT TypeToPrint,
+  LLVM_ABI void print(raw_ostream &os, LLT TypeToPrint,
              const TargetRegisterInfo *TRI = nullptr) const;
 
-  void dump() const;
+  LLVM_ABI void dump() const;
 
   //===--------------------------------------------------------------------===//
   // Accessors that tell you what kind of MachineOperand you're looking at.
@@ -429,7 +430,7 @@ public:
   ///   prevents any operands from being marked renamable for targets that don't
   ///   have detailed opcode hasExtraSrcRegAllocReq/hasExtraDstRegAllocReq
   ///   values.
-  bool isRenamable() const;
+  LLVM_ABI bool isRenamable() const;
 
   bool isInternalRead() const {
     assert(isReg() && "Wrong MachineOperand accessor");
@@ -479,7 +480,7 @@ public:
 
   /// Change the register this operand corresponds to.
   ///
-  void setReg(Register Reg);
+  LLVM_ABI void setReg(Register Reg);
 
   void setSubReg(unsigned subReg) {
     assert(isReg() && "Wrong MachineOperand mutator");
@@ -492,18 +493,18 @@ public:
   /// using TargetRegisterInfo to compose the subreg indices if necessary.
   /// Reg must be a virtual register, SubIdx can be 0.
   ///
-  void substVirtReg(Register Reg, unsigned SubIdx, const TargetRegisterInfo&);
+  LLVM_ABI void substVirtReg(Register Reg, unsigned SubIdx, const TargetRegisterInfo&);
 
   /// substPhysReg - Substitute the current register with the physical register
   /// Reg, taking any existing SubReg into account. For instance,
   /// substPhysReg(%eax) will change %reg1024:sub_8bit to %al.
   ///
-  void substPhysReg(MCRegister Reg, const TargetRegisterInfo&);
+  LLVM_ABI void substPhysReg(MCRegister Reg, const TargetRegisterInfo&);
 
   void setIsUse(bool Val = true) { setIsDef(!Val); }
 
   /// Change a def to a use, or a use to a def.
-  void setIsDef(bool Val = true);
+  LLVM_ABI void setIsDef(bool Val = true);
 
   void setImplicit(bool Val = true) {
     assert(isReg() && "Wrong MachineOperand mutator");
@@ -526,7 +527,7 @@ public:
     IsUndef = Val;
   }
 
-  void setIsRenamable(bool Val = true);
+  LLVM_ABI void setIsRenamable(bool Val = true);
 
   void setIsInternalRead(bool Val = true) {
     assert(isReg() && "Wrong MachineOperand mutator");
@@ -750,7 +751,7 @@ public:
   /// Returns true if this operand is identical to the specified operand except
   /// for liveness related flags (isKill, isUndef and isDead). Note that this
   /// should stay in sync with the hash_value overload below.
-  bool isIdenticalTo(const MachineOperand &Other) const;
+  LLVM_ABI bool isIdenticalTo(const MachineOperand &Other) const;
 
   /// MachineOperand hash_value overload.
   ///
@@ -763,49 +764,49 @@ public:
   /// ChangeToImmediate - Replace this operand with a new immediate operand of
   /// the specified value.  If an operand is known to be an immediate already,
   /// the setImm method should be used.
-  void ChangeToImmediate(int64_t ImmVal, unsigned TargetFlags = 0);
+  LLVM_ABI void ChangeToImmediate(int64_t ImmVal, unsigned TargetFlags = 0);
 
   /// ChangeToFPImmediate - Replace this operand with a new FP immediate operand
   /// of the specified value.  If an operand is known to be an FP immediate
   /// already, the setFPImm method should be used.
-  void ChangeToFPImmediate(const ConstantFP *FPImm, unsigned TargetFlags = 0);
+  LLVM_ABI void ChangeToFPImmediate(const ConstantFP *FPImm, unsigned TargetFlags = 0);
 
   /// ChangeToES - Replace this operand with a new external symbol operand.
-  void ChangeToES(const char *SymName, unsigned TargetFlags = 0);
+  LLVM_ABI void ChangeToES(const char *SymName, unsigned TargetFlags = 0);
 
   /// ChangeToGA - Replace this operand with a new global address operand.
-  void ChangeToGA(const GlobalValue *GV, int64_t Offset,
+  LLVM_ABI void ChangeToGA(const GlobalValue *GV, int64_t Offset,
                   unsigned TargetFlags = 0);
 
   /// ChangeToBA - Replace this operand with a new block address operand.
-  void ChangeToBA(const BlockAddress *BA, int64_t Offset,
+  LLVM_ABI void ChangeToBA(const BlockAddress *BA, int64_t Offset,
                   unsigned TargetFlags = 0);
 
   /// ChangeToMCSymbol - Replace this operand with a new MC symbol operand.
-  void ChangeToMCSymbol(MCSymbol *Sym, unsigned TargetFlags = 0);
+  LLVM_ABI void ChangeToMCSymbol(MCSymbol *Sym, unsigned TargetFlags = 0);
 
   /// Replace this operand with a frame index.
-  void ChangeToFrameIndex(int Idx, unsigned TargetFlags = 0);
+  LLVM_ABI void ChangeToFrameIndex(int Idx, unsigned TargetFlags = 0);
 
   /// Replace this operand with a target index.
-  void ChangeToTargetIndex(unsigned Idx, int64_t Offset,
+  LLVM_ABI void ChangeToTargetIndex(unsigned Idx, int64_t Offset,
                            unsigned TargetFlags = 0);
 
   /// Replace this operand with an Instruction Reference.
-  void ChangeToDbgInstrRef(unsigned InstrIdx, unsigned OpIdx,
+  LLVM_ABI void ChangeToDbgInstrRef(unsigned InstrIdx, unsigned OpIdx,
                            unsigned TargetFlags = 0);
 
   /// ChangeToRegister - Replace this operand with a new register operand of
   /// the specified value.  If an operand is known to be an register already,
   /// the setReg method should be used.
-  void ChangeToRegister(Register Reg, bool isDef, bool isImp = false,
+  LLVM_ABI void ChangeToRegister(Register Reg, bool isDef, bool isImp = false,
                         bool isKill = false, bool isDead = false,
                         bool isUndef = false, bool isDebug = false);
 
   /// getTargetIndexName - If this MachineOperand is a TargetIndex that has a
   /// name, attempt to get the name. Returns nullptr if the TargetIndex does not
   /// have a name. Asserts if MO is not a TargetIndex.
-  const char *getTargetIndexName() const;
+  LLVM_ABI const char *getTargetIndexName() const;
 
   //===--------------------------------------------------------------------===//
   // Construction methods.
@@ -1040,7 +1041,7 @@ inline raw_ostream &operator<<(raw_ostream &OS, const MachineOperand &MO) {
 
 // See friend declaration above. This additional declaration is required in
 // order to compile LLVM with IBM xlC compiler.
-hash_code hash_value(const MachineOperand &MO);
+LLVM_ABI hash_code hash_value(const MachineOperand &MO);
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/CodeGen/MachineOperand.h
+++ b/llvm/include/llvm/CodeGen/MachineOperand.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_CODEGEN_MACHINEOPERAND_H
 #define LLVM_CODEGEN_MACHINEOPERAND_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 
 namespace llvm {
@@ -261,17 +261,19 @@ public:
   /// subreg index name will be printed. MachineInstr::isOperandSubregIdx can be
   /// called to check this.
   LLVM_ABI static void printSubRegIdx(raw_ostream &OS, uint64_t Index,
-                             const TargetRegisterInfo *TRI);
+                                      const TargetRegisterInfo *TRI);
 
   /// Print operand target flags.
-  LLVM_ABI static void printTargetFlags(raw_ostream& OS, const MachineOperand &Op);
+  LLVM_ABI static void printTargetFlags(raw_ostream &OS,
+                                        const MachineOperand &Op);
 
   /// Print a MCSymbol as an operand.
   LLVM_ABI static void printSymbol(raw_ostream &OS, MCSymbol &Sym);
 
   /// Print a stack object reference.
-  LLVM_ABI static void printStackObjectReference(raw_ostream &OS, unsigned FrameIndex,
-                                        bool IsFixed, StringRef Name);
+  LLVM_ABI static void printStackObjectReference(raw_ostream &OS,
+                                                 unsigned FrameIndex,
+                                                 bool IsFixed, StringRef Name);
 
   /// Print the offset with explicit +/- signs.
   LLVM_ABI static void printOperandOffset(raw_ostream &OS, int64_t Offset);
@@ -282,7 +284,8 @@ public:
   /// Print the MachineOperand to \p os.
   /// Providing a valid \p TRI results in a more target-specific printing. If
   /// \p TRI is null, the function will try to pick it up from the parent.
-  LLVM_ABI void print(raw_ostream &os, const TargetRegisterInfo *TRI = nullptr) const;
+  LLVM_ABI void print(raw_ostream &os,
+                      const TargetRegisterInfo *TRI = nullptr) const;
 
   /// More complex way of printing a MachineOperand.
   /// \param TypeToPrint specifies the generic type to be printed on uses and
@@ -305,14 +308,15 @@ public:
   /// Unlike the previous function, this one will not try and get the
   /// information from it's parent.
   LLVM_ABI void print(raw_ostream &os, ModuleSlotTracker &MST, LLT TypeToPrint,
-             std::optional<unsigned> OpIdx, bool PrintDef, bool IsStandalone,
-             bool ShouldPrintRegisterTies, unsigned TiedOperandIdx,
-             const TargetRegisterInfo *TRI) const;
+                      std::optional<unsigned> OpIdx, bool PrintDef,
+                      bool IsStandalone, bool ShouldPrintRegisterTies,
+                      unsigned TiedOperandIdx,
+                      const TargetRegisterInfo *TRI) const;
 
   /// Same as print(os, TRI), but allows to specify the low-level type to be
   /// printed the same way the full version of print(...) does it.
   LLVM_ABI void print(raw_ostream &os, LLT TypeToPrint,
-             const TargetRegisterInfo *TRI = nullptr) const;
+                      const TargetRegisterInfo *TRI = nullptr) const;
 
   LLVM_ABI void dump() const;
 
@@ -493,13 +497,14 @@ public:
   /// using TargetRegisterInfo to compose the subreg indices if necessary.
   /// Reg must be a virtual register, SubIdx can be 0.
   ///
-  LLVM_ABI void substVirtReg(Register Reg, unsigned SubIdx, const TargetRegisterInfo&);
+  LLVM_ABI void substVirtReg(Register Reg, unsigned SubIdx,
+                             const TargetRegisterInfo &);
 
   /// substPhysReg - Substitute the current register with the physical register
   /// Reg, taking any existing SubReg into account. For instance,
   /// substPhysReg(%eax) will change %reg1024:sub_8bit to %al.
   ///
-  LLVM_ABI void substPhysReg(MCRegister Reg, const TargetRegisterInfo&);
+  LLVM_ABI void substPhysReg(MCRegister Reg, const TargetRegisterInfo &);
 
   void setIsUse(bool Val = true) { setIsDef(!Val); }
 
@@ -769,18 +774,19 @@ public:
   /// ChangeToFPImmediate - Replace this operand with a new FP immediate operand
   /// of the specified value.  If an operand is known to be an FP immediate
   /// already, the setFPImm method should be used.
-  LLVM_ABI void ChangeToFPImmediate(const ConstantFP *FPImm, unsigned TargetFlags = 0);
+  LLVM_ABI void ChangeToFPImmediate(const ConstantFP *FPImm,
+                                    unsigned TargetFlags = 0);
 
   /// ChangeToES - Replace this operand with a new external symbol operand.
   LLVM_ABI void ChangeToES(const char *SymName, unsigned TargetFlags = 0);
 
   /// ChangeToGA - Replace this operand with a new global address operand.
   LLVM_ABI void ChangeToGA(const GlobalValue *GV, int64_t Offset,
-                  unsigned TargetFlags = 0);
+                           unsigned TargetFlags = 0);
 
   /// ChangeToBA - Replace this operand with a new block address operand.
   LLVM_ABI void ChangeToBA(const BlockAddress *BA, int64_t Offset,
-                  unsigned TargetFlags = 0);
+                           unsigned TargetFlags = 0);
 
   /// ChangeToMCSymbol - Replace this operand with a new MC symbol operand.
   LLVM_ABI void ChangeToMCSymbol(MCSymbol *Sym, unsigned TargetFlags = 0);
@@ -790,18 +796,18 @@ public:
 
   /// Replace this operand with a target index.
   LLVM_ABI void ChangeToTargetIndex(unsigned Idx, int64_t Offset,
-                           unsigned TargetFlags = 0);
+                                    unsigned TargetFlags = 0);
 
   /// Replace this operand with an Instruction Reference.
   LLVM_ABI void ChangeToDbgInstrRef(unsigned InstrIdx, unsigned OpIdx,
-                           unsigned TargetFlags = 0);
+                                    unsigned TargetFlags = 0);
 
   /// ChangeToRegister - Replace this operand with a new register operand of
   /// the specified value.  If an operand is known to be an register already,
   /// the setReg method should be used.
   LLVM_ABI void ChangeToRegister(Register Reg, bool isDef, bool isImp = false,
-                        bool isKill = false, bool isDead = false,
-                        bool isUndef = false, bool isDebug = false);
+                                 bool isKill = false, bool isDead = false,
+                                 bool isUndef = false, bool isDebug = false);
 
   /// getTargetIndexName - If this MachineOperand is a TargetIndex that has a
   /// name, attempt to get the name. Returns nullptr if the TargetIndex does not

--- a/llvm/include/llvm/CodeGen/MachineOptimizationRemarkEmitter.h
+++ b/llvm/include/llvm/CodeGen/MachineOptimizationRemarkEmitter.h
@@ -15,11 +15,11 @@
 #ifndef LLVM_CODEGEN_MACHINEOPTIMIZATIONREMARKEMITTER_H
 #define LLVM_CODEGEN_MACHINEOPTIMIZATIONREMARKEMITTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Function.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {
@@ -162,7 +162,7 @@ public:
 
   /// Handle invalidation events in the new pass manager.
   LLVM_ABI bool invalidate(MachineFunction &MF, const PreservedAnalyses &PA,
-                  MachineFunctionAnalysisManager::Invalidator &Inv);
+                           MachineFunctionAnalysisManager::Invalidator &Inv);
 
   /// Emit an optimization remark.
   LLVM_ABI void emit(DiagnosticInfoOptimizationBase &OptDiag);
@@ -229,7 +229,8 @@ class MachineOptimizationRemarkEmitterAnalysis
 
 public:
   using Result = MachineOptimizationRemarkEmitter;
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
 };
 
 /// The analysis pass
@@ -237,7 +238,8 @@ public:
 /// Note that this pass shouldn't generally be marked as preserved by other
 /// passes.  It's holding onto BFI, so if the pass does not preserve BFI, BFI
 /// could be freed.
-class LLVM_ABI MachineOptimizationRemarkEmitterPass : public MachineFunctionPass {
+class LLVM_ABI MachineOptimizationRemarkEmitterPass
+    : public MachineFunctionPass {
   std::unique_ptr<MachineOptimizationRemarkEmitter> ORE;
 
 public:

--- a/llvm/include/llvm/CodeGen/MachineOptimizationRemarkEmitter.h
+++ b/llvm/include/llvm/CodeGen/MachineOptimizationRemarkEmitter.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_MACHINEOPTIMIZATIONREMARKEMITTER_H
 #define LLVM_CODEGEN_MACHINEOPTIMIZATIONREMARKEMITTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -41,7 +42,7 @@ public:
   /// MI-specific kinds of diagnostic Arguments.
   struct MachineArgument : public DiagnosticInfoOptimizationBase::Argument {
     /// Print an entire MachineInstr.
-    MachineArgument(StringRef Key, const MachineInstr &MI);
+    LLVM_ABI MachineArgument(StringRef Key, const MachineInstr &MI);
   };
 
   static bool classof(const DiagnosticInfo *DI) {
@@ -160,11 +161,11 @@ public:
       default;
 
   /// Handle invalidation events in the new pass manager.
-  bool invalidate(MachineFunction &MF, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(MachineFunction &MF, const PreservedAnalyses &PA,
                   MachineFunctionAnalysisManager::Invalidator &Inv);
 
   /// Emit an optimization remark.
-  void emit(DiagnosticInfoOptimizationBase &OptDiag);
+  LLVM_ABI void emit(DiagnosticInfoOptimizationBase &OptDiag);
 
   /// Whether we allow for extra compile-time budget to perform more
   /// analysis to be more informative.
@@ -228,7 +229,7 @@ class MachineOptimizationRemarkEmitterAnalysis
 
 public:
   using Result = MachineOptimizationRemarkEmitter;
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
 };
 
 /// The analysis pass
@@ -236,7 +237,7 @@ public:
 /// Note that this pass shouldn't generally be marked as preserved by other
 /// passes.  It's holding onto BFI, so if the pass does not preserve BFI, BFI
 /// could be freed.
-class MachineOptimizationRemarkEmitterPass : public MachineFunctionPass {
+class LLVM_ABI MachineOptimizationRemarkEmitterPass : public MachineFunctionPass {
   std::unique_ptr<MachineOptimizationRemarkEmitter> ORE;
 
 public:

--- a/llvm/include/llvm/CodeGen/MachineOptimizationRemarkEmitter.h
+++ b/llvm/include/llvm/CodeGen/MachineOptimizationRemarkEmitter.h
@@ -225,7 +225,7 @@ private:
 class MachineOptimizationRemarkEmitterAnalysis
     : public AnalysisInfoMixin<MachineOptimizationRemarkEmitterAnalysis> {
   friend AnalysisInfoMixin<MachineOptimizationRemarkEmitterAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = MachineOptimizationRemarkEmitter;

--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -21,13 +21,13 @@
 #ifndef LLVM_CODEGEN_MACHINEPASSMANAGER_H
 #define LLVM_CODEGEN_MACHINEPASSMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/PassManagerInternal.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -120,8 +120,8 @@ LLVM_ABI bool MachineFunctionAnalysisManagerFunctionProxy::Result::invalidate(
 extern template class InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
                                                 Function>;
 
-extern template class LLVM_TEMPLATE_ABI OuterAnalysisManagerProxy<ModuleAnalysisManager,
-                                                MachineFunction>;
+extern template class LLVM_TEMPLATE_ABI
+    OuterAnalysisManagerProxy<ModuleAnalysisManager, MachineFunction>;
 /// Provide the \c ModuleAnalysisManager to \c Function proxy.
 using ModuleAnalysisManagerMachineFunctionProxy =
     OuterAnalysisManagerProxy<ModuleAnalysisManager, MachineFunction>;
@@ -163,7 +163,7 @@ public:
     /// the analyses in the inner analysis manager are potentially invalidated
     /// based on the set of preserved analyses.
     LLVM_ABI bool invalidate(MachineFunction &IR, const PreservedAnalyses &PA,
-                    MachineFunctionAnalysisManager::Invalidator &Inv);
+                             MachineFunctionAnalysisManager::Invalidator &Inv);
 
   private:
     FunctionAnalysisManager *FAM;
@@ -200,8 +200,9 @@ public:
 
   /// Runs the function pass across every function in the function.
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
-  LLVM_ABI void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 
   static bool isRequired() { return true; }
 
@@ -222,9 +223,8 @@ createFunctionToMachineFunctionPassAdaptor(MachineFunctionPassT &&Pass) {
 }
 
 template <>
-LLVM_ABI PreservedAnalyses
-PassManager<MachineFunction>::run(MachineFunction &,
-                                  AnalysisManager<MachineFunction> &);
+LLVM_ABI PreservedAnalyses PassManager<MachineFunction>::run(
+    MachineFunction &, AnalysisManager<MachineFunction> &);
 extern template class PassManager<MachineFunction>;
 
 /// Convenience typedef for a pass manager over functions.

--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -21,6 +21,7 @@
 #ifndef LLVM_CODEGEN_MACHINEPASSMANAGER_H
 #define LLVM_CODEGEN_MACHINEPASSMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -104,7 +105,7 @@ using MachineFunctionAnalysisManagerModuleProxy =
     InnerAnalysisManagerProxy<MachineFunctionAnalysisManager, Module>;
 
 template <>
-bool MachineFunctionAnalysisManagerModuleProxy::Result::invalidate(
+LLVM_ABI bool MachineFunctionAnalysisManagerModuleProxy::Result::invalidate(
     Module &M, const PreservedAnalyses &PA,
     ModuleAnalysisManager::Invalidator &Inv);
 extern template class InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
@@ -113,7 +114,7 @@ using MachineFunctionAnalysisManagerFunctionProxy =
     InnerAnalysisManagerProxy<MachineFunctionAnalysisManager, Function>;
 
 template <>
-bool MachineFunctionAnalysisManagerFunctionProxy::Result::invalidate(
+LLVM_ABI bool MachineFunctionAnalysisManagerFunctionProxy::Result::invalidate(
     Function &F, const PreservedAnalyses &PA,
     FunctionAnalysisManager::Invalidator &Inv);
 extern template class InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
@@ -161,7 +162,7 @@ public:
     /// Regardless of whether the proxy analysis is marked as preserved, all of
     /// the analyses in the inner analysis manager are potentially invalidated
     /// based on the set of preserved analyses.
-    bool invalidate(MachineFunction &IR, const PreservedAnalyses &PA,
+    LLVM_ABI bool invalidate(MachineFunction &IR, const PreservedAnalyses &PA,
                     MachineFunctionAnalysisManager::Invalidator &Inv);
 
   private:
@@ -181,7 +182,7 @@ public:
     return Result(*FAM);
   }
 
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 private:
   FunctionAnalysisManager *FAM;
@@ -198,8 +199,8 @@ public:
       : Pass(std::move(Pass)) {}
 
   /// Runs the function pass across every function in the function.
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
-  void printPipeline(raw_ostream &OS,
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI void printPipeline(raw_ostream &OS,
                      function_ref<StringRef(StringRef)> MapClassName2PassName);
 
   static bool isRequired() { return true; }
@@ -221,7 +222,7 @@ createFunctionToMachineFunctionPassAdaptor(MachineFunctionPassT &&Pass) {
 }
 
 template <>
-PreservedAnalyses
+LLVM_ABI PreservedAnalyses
 PassManager<MachineFunction>::run(MachineFunction &,
                                   AnalysisManager<MachineFunction> &);
 extern template class PassManager<MachineFunction>;
@@ -231,7 +232,7 @@ using MachineFunctionPassManager = PassManager<MachineFunction>;
 
 /// Returns the minimum set of Analyses that all machine function passes must
 /// preserve.
-PreservedAnalyses getMachineFunctionPassPreservedAnalyses();
+LLVM_ABI PreservedAnalyses getMachineFunctionPassPreservedAnalyses();
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -120,7 +120,7 @@ LLVM_ABI bool MachineFunctionAnalysisManagerFunctionProxy::Result::invalidate(
 extern template class InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
                                                 Function>;
 
-extern template class OuterAnalysisManagerProxy<ModuleAnalysisManager,
+extern template class LLVM_TEMPLATE_ABI OuterAnalysisManagerProxy<ModuleAnalysisManager,
                                                 MachineFunction>;
 /// Provide the \c ModuleAnalysisManager to \c Function proxy.
 using ModuleAnalysisManagerMachineFunctionProxy =

--- a/llvm/include/llvm/CodeGen/MachinePostDominators.h
+++ b/llvm/include/llvm/CodeGen/MachinePostDominators.h
@@ -14,27 +14,29 @@
 #ifndef LLVM_CODEGEN_MACHINEPOSTDOMINATORS_H
 #define LLVM_CODEGEN_MACHINEPOSTDOMINATORS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineDominators.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
-extern template class LLVM_TEMPLATE_ABI DominatorTreeBase<MachineBasicBlock, true>; // PostDomTree
+extern template class LLVM_TEMPLATE_ABI
+    DominatorTreeBase<MachineBasicBlock, true>; // PostDomTree
 
 namespace DomTreeBuilder {
 using MBBPostDomTree = PostDomTreeBase<MachineBasicBlock>;
 using MBBPostDomTreeGraphDiff = GraphDiff<MachineBasicBlock *, true>;
 
-extern template LLVM_TEMPLATE_ABI void Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
-extern template LLVM_TEMPLATE_ABI void InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT,
-                                                MachineBasicBlock *From,
-                                                MachineBasicBlock *To);
-extern template LLVM_TEMPLATE_ABI void DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT,
-                                                MachineBasicBlock *From,
-                                                MachineBasicBlock *To);
-extern template LLVM_TEMPLATE_ABI void ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT,
-                                                  MBBPostDomTreeGraphDiff &,
-                                                  MBBPostDomTreeGraphDiff *);
+extern template LLVM_TEMPLATE_ABI void
+Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
+extern template LLVM_TEMPLATE_ABI void
+InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT, MachineBasicBlock *From,
+                           MachineBasicBlock *To);
+extern template LLVM_TEMPLATE_ABI void
+DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT, MachineBasicBlock *From,
+                           MachineBasicBlock *To);
+extern template LLVM_TEMPLATE_ABI void
+ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT, MBBPostDomTreeGraphDiff &,
+                             MBBPostDomTreeGraphDiff *);
 extern template LLVM_TEMPLATE_ABI bool
 Verify<MBBPostDomTree>(const MBBPostDomTree &DT,
                        MBBPostDomTree::VerificationLevel VL);
@@ -54,7 +56,7 @@ public:
 
   /// Handle invalidation explicitly.
   LLVM_ABI bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
-                  MachineFunctionAnalysisManager::Invalidator &);
+                           MachineFunctionAnalysisManager::Invalidator &);
 
   /// Make findNearestCommonDominator(const NodeT *A, const NodeT *B) available.
   using Base::findNearestCommonDominator;
@@ -74,7 +76,8 @@ class MachinePostDominatorTreeAnalysis
 public:
   using Result = MachinePostDominatorTree;
 
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
 };
 
 class MachinePostDominatorTreePrinterPass
@@ -84,11 +87,12 @@ class MachinePostDominatorTreePrinterPass
 public:
   explicit MachinePostDominatorTreePrinterPass(raw_ostream &OS) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
-class LLVM_ABI MachinePostDominatorTreeWrapperPass : public MachineFunctionPass {
+class LLVM_ABI MachinePostDominatorTreeWrapperPass
+    : public MachineFunctionPass {
   std::optional<MachinePostDominatorTree> PDT;
 
 public:

--- a/llvm/include/llvm/CodeGen/MachinePostDominators.h
+++ b/llvm/include/llvm/CodeGen/MachinePostDominators.h
@@ -19,23 +19,23 @@
 
 namespace llvm {
 
-extern template class DominatorTreeBase<MachineBasicBlock, true>; // PostDomTree
+extern template class LLVM_TEMPLATE_ABI DominatorTreeBase<MachineBasicBlock, true>; // PostDomTree
 
 namespace DomTreeBuilder {
 using MBBPostDomTree = PostDomTreeBase<MachineBasicBlock>;
 using MBBPostDomTreeGraphDiff = GraphDiff<MachineBasicBlock *, true>;
 
-extern template void Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
-extern template void InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT,
+extern template LLVM_TEMPLATE_ABI void Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
+extern template LLVM_TEMPLATE_ABI void InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT,
                                                 MachineBasicBlock *From,
                                                 MachineBasicBlock *To);
-extern template void DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT,
+extern template LLVM_TEMPLATE_ABI void DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT,
                                                 MachineBasicBlock *From,
                                                 MachineBasicBlock *To);
-extern template void ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT,
+extern template LLVM_TEMPLATE_ABI void ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT,
                                                   MBBPostDomTreeGraphDiff &,
                                                   MBBPostDomTreeGraphDiff *);
-extern template bool
+extern template LLVM_TEMPLATE_ABI bool
 Verify<MBBPostDomTree>(const MBBPostDomTree &DT,
                        MBBPostDomTree::VerificationLevel VL);
 } // namespace DomTreeBuilder
@@ -69,7 +69,7 @@ class MachinePostDominatorTreeAnalysis
     : public AnalysisInfoMixin<MachinePostDominatorTreeAnalysis> {
   friend AnalysisInfoMixin<MachinePostDominatorTreeAnalysis>;
 
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = MachinePostDominatorTree;

--- a/llvm/include/llvm/CodeGen/MachinePostDominators.h
+++ b/llvm/include/llvm/CodeGen/MachinePostDominators.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MACHINEPOSTDOMINATORS_H
 #define LLVM_CODEGEN_MACHINEPOSTDOMINATORS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachineDominators.h"
 
 namespace llvm {
@@ -52,7 +53,7 @@ public:
   explicit MachinePostDominatorTree(MachineFunction &MF) { recalculate(MF); }
 
   /// Handle invalidation explicitly.
-  bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(MachineFunction &, const PreservedAnalyses &PA,
                   MachineFunctionAnalysisManager::Invalidator &);
 
   /// Make findNearestCommonDominator(const NodeT *A, const NodeT *B) available.
@@ -60,7 +61,7 @@ public:
 
   /// Returns the nearest common dominator of the given blocks.
   /// If that tree node is a virtual root, a nullptr will be returned.
-  MachineBasicBlock *
+  LLVM_ABI MachineBasicBlock *
   findNearestCommonDominator(ArrayRef<MachineBasicBlock *> Blocks) const;
 };
 
@@ -73,7 +74,7 @@ class MachinePostDominatorTreeAnalysis
 public:
   using Result = MachinePostDominatorTree;
 
-  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
 };
 
 class MachinePostDominatorTreePrinterPass
@@ -82,12 +83,12 @@ class MachinePostDominatorTreePrinterPass
 
 public:
   explicit MachinePostDominatorTreePrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
-class MachinePostDominatorTreeWrapperPass : public MachineFunctionPass {
+class LLVM_ABI MachinePostDominatorTreeWrapperPass : public MachineFunctionPass {
   std::optional<MachinePostDominatorTree> PDT;
 
 public:

--- a/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MACHINEREGISTERINFO_H
 #define LLVM_CODEGEN_MACHINEREGISTERINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/IndexedMap.h"
@@ -51,7 +52,7 @@ using RegClassOrRegBank =
 /// etc.
 class MachineRegisterInfo {
 public:
-  class Delegate {
+  class LLVM_ABI Delegate {
     virtual void anchor();
 
   public:
@@ -151,7 +152,7 @@ private:
   std::vector<std::pair<MCRegister, Register>> LiveIns;
 
 public:
-  explicit MachineRegisterInfo(MachineFunction *MF);
+  LLVM_ABI explicit MachineRegisterInfo(MachineFunction *MF);
   MachineRegisterInfo(const MachineRegisterInfo &) = delete;
   MachineRegisterInfo &operator=(const MachineRegisterInfo &) = delete;
 
@@ -240,31 +241,31 @@ public:
   /// Disables the register from the list of CSRs.
   /// I.e. the register will not appear as part of the CSR mask.
   /// \see UpdatedCalleeSavedRegs.
-  void disableCalleeSavedRegister(MCRegister Reg);
+  LLVM_ABI void disableCalleeSavedRegister(MCRegister Reg);
 
   /// Returns list of callee saved registers.
   /// The function returns the updated CSR list (after taking into account
   /// registers that are disabled from the CSR list).
-  const MCPhysReg *getCalleeSavedRegs() const;
+  LLVM_ABI const MCPhysReg *getCalleeSavedRegs() const;
 
   /// Sets the updated Callee Saved Registers list.
   /// Notice that it will override ant previously disabled/saved CSRs.
-  void setCalleeSavedRegs(ArrayRef<MCPhysReg> CSRs);
+  LLVM_ABI void setCalleeSavedRegs(ArrayRef<MCPhysReg> CSRs);
 
   // Strictly for use by MachineInstr.cpp.
-  void addRegOperandToUseList(MachineOperand *MO);
+  LLVM_ABI void addRegOperandToUseList(MachineOperand *MO);
 
   // Strictly for use by MachineInstr.cpp.
-  void removeRegOperandFromUseList(MachineOperand *MO);
+  LLVM_ABI void removeRegOperandFromUseList(MachineOperand *MO);
 
   // Strictly for use by MachineInstr.cpp.
-  void moveOperands(MachineOperand *Dst, MachineOperand *Src, unsigned NumOps);
+  LLVM_ABI void moveOperands(MachineOperand *Dst, MachineOperand *Src, unsigned NumOps);
 
   /// Verify the sanity of the use list for Reg.
-  void verifyUseList(Register Reg) const;
+  LLVM_ABI void verifyUseList(Register Reg) const;
 
   /// Verify the use list of all registers.
-  void verifyUseLists() const;
+  LLVM_ABI void verifyUseLists() const;
 
   /// reg_begin/reg_end - Provide iteration support to walk over all definitions
   /// and uses of a register within the MachineFunction that corresponds to this
@@ -570,20 +571,20 @@ public:
 
   /// hasOneNonDBGUse - Return true if there is exactly one non-Debug
   /// use of the specified register.
-  bool hasOneNonDBGUse(Register RegNo) const;
+  LLVM_ABI bool hasOneNonDBGUse(Register RegNo) const;
 
   /// hasOneNonDBGUse - Return true if there is exactly one non-Debug
   /// instruction using the specified register. Said instruction may have
   /// multiple uses.
-  bool hasOneNonDBGUser(Register RegNo) const;
+  LLVM_ABI bool hasOneNonDBGUser(Register RegNo) const;
 
   /// If the register has a single non-Debug instruction using the specified
   /// register, returns it; otherwise returns nullptr.
-  MachineInstr *getOneNonDBGUser(Register RegNo) const;
+  LLVM_ABI MachineInstr *getOneNonDBGUser(Register RegNo) const;
 
   /// hasAtMostUses - Return true if the given register has at most \p MaxUsers
   /// non-debug user instructions.
-  bool hasAtMostUserInstrs(Register Reg, unsigned MaxUsers) const;
+  LLVM_ABI bool hasAtMostUserInstrs(Register Reg, unsigned MaxUsers) const;
 
   /// replaceRegWith - Replace all instances of FromReg with ToReg in the
   /// machine function.  This is like llvm-level X->replaceAllUsesWith(Y),
@@ -604,29 +605,29 @@ public:
   /// Note that if ToReg is a physical register the function will replace and
   /// apply sub registers to ToReg in order to obtain a final/proper physical
   /// register.
-  void replaceRegWith(Register FromReg, Register ToReg);
+  LLVM_ABI void replaceRegWith(Register FromReg, Register ToReg);
 
   /// getVRegDef - Return the machine instr that defines the specified virtual
   /// register or null if none is found.  This assumes that the code is in SSA
   /// form, so there should only be one definition.
-  MachineInstr *getVRegDef(Register Reg) const;
+  LLVM_ABI MachineInstr *getVRegDef(Register Reg) const;
 
   /// getUniqueVRegDef - Return the unique machine instr that defines the
   /// specified virtual register or null if none is found.  If there are
   /// multiple definitions or no definition, return null.
-  MachineInstr *getUniqueVRegDef(Register Reg) const;
+  LLVM_ABI MachineInstr *getUniqueVRegDef(Register Reg) const;
 
   /// clearKillFlags - Iterate over all the uses of the given register and
   /// clear the kill flag from the MachineOperand. This function is used by
   /// optimization passes which extend register lifetimes and need only
   /// preserve conservative kill flag information.
-  void clearKillFlags(Register Reg) const;
+  LLVM_ABI void clearKillFlags(Register Reg) const;
 
-  void dumpUses(Register RegNo) const;
+  LLVM_ABI void dumpUses(Register RegNo) const;
 
   /// Returns true if PhysReg is unallocatable and constant throughout the
   /// function. Writing to a constant register has no effect.
-  bool isConstantPhysReg(MCRegister PhysReg) const;
+  LLVM_ABI bool isConstantPhysReg(MCRegister PhysReg) const;
 
   /// Get an iterator over the pressure sets affected by the given physical or
   /// virtual register. If RegUnit is physical, it must be a register unit (from
@@ -685,10 +686,10 @@ public:
   }
 
   /// setRegClass - Set the register class of the specified virtual register.
-  void setRegClass(Register Reg, const TargetRegisterClass *RC);
+  LLVM_ABI void setRegClass(Register Reg, const TargetRegisterClass *RC);
 
   /// Set the register bank to \p RegBank for \p Reg.
-  void setRegBank(Register Reg, const RegisterBank &RegBank);
+  LLVM_ABI void setRegBank(Register Reg, const RegisterBank &RegBank);
 
   void setRegClassOrRegBank(Register Reg,
                             const RegClassOrRegBank &RCOrRB){
@@ -706,7 +707,7 @@ public:
   /// Use RegisterBankInfo::constrainGenericRegister in GlobalISel's
   /// InstructionSelect pass and constrainRegAttrs in every other pass,
   /// including non-select passes of GlobalISel, instead.
-  const TargetRegisterClass *constrainRegClass(Register Reg,
+  LLVM_ABI const TargetRegisterClass *constrainRegClass(Register Reg,
                                                const TargetRegisterClass *RC,
                                                unsigned MinNumRegs = 0);
 
@@ -721,7 +722,7 @@ public:
   /// \note Use this method instead of constrainRegClass and
   /// RegisterBankInfo::constrainGenericRegister everywhere but SelectionDAG
   /// ISel / FastISel and GlobalISel's InstructionSelect pass respectively.
-  bool constrainRegAttrs(Register Reg, Register ConstrainingReg,
+  LLVM_ABI bool constrainRegAttrs(Register Reg, Register ConstrainingReg,
                          unsigned MinNumRegs = 0);
 
   /// recomputeRegClass - Try to find a legal super-class of Reg's register
@@ -731,11 +732,11 @@ public:
   /// This method can be used after constraints have been removed from a
   /// virtual register, for example after removing instructions or splitting
   /// the live range.
-  bool recomputeRegClass(Register Reg);
+  LLVM_ABI bool recomputeRegClass(Register Reg);
 
   /// createVirtualRegister - Create and return a new virtual register in the
   /// function with the specified register class.
-  Register createVirtualRegister(const TargetRegisterClass *RegClass,
+  LLVM_ABI Register createVirtualRegister(const TargetRegisterClass *RegClass,
                                  StringRef Name = "");
 
   /// All attributes(register class or bank and low-level type) a virtual
@@ -754,11 +755,11 @@ public:
 
   /// Create and return a new virtual register in the function with the
   /// specified register attributes(register class or bank and low level type).
-  Register createVirtualRegister(VRegAttrs RegAttr, StringRef Name = "");
+  LLVM_ABI Register createVirtualRegister(VRegAttrs RegAttr, StringRef Name = "");
 
   /// Create and return a new virtual register in the function with the same
   /// attributes as the given register.
-  Register cloneVirtualRegister(Register VReg, StringRef Name = "");
+  LLVM_ABI Register cloneVirtualRegister(Register VReg, StringRef Name = "");
 
   /// Get the low-level type of \p Reg or LLT{} if Reg is not a generic
   /// (target independent) virtual register.
@@ -769,28 +770,28 @@ public:
   }
 
   /// Set the low-level type of \p VReg to \p Ty.
-  void setType(Register VReg, LLT Ty);
+  LLVM_ABI void setType(Register VReg, LLT Ty);
 
   /// Create and return a new generic virtual register with low-level
   /// type \p Ty.
-  Register createGenericVirtualRegister(LLT Ty, StringRef Name = "");
+  LLVM_ABI Register createGenericVirtualRegister(LLT Ty, StringRef Name = "");
 
   /// Remove all types associated to virtual registers (after instruction
   /// selection and constraining of all generic virtual registers).
-  void clearVirtRegTypes();
+  LLVM_ABI void clearVirtRegTypes();
 
   /// Creates a new virtual register that has no register class, register bank
   /// or size assigned yet. This is only allowed to be used
   /// temporarily while constructing machine instructions. Most operations are
   /// undefined on an incomplete register until one of setRegClass(),
   /// setRegBank() or setSize() has been called on it.
-  Register createIncompleteVirtualRegister(StringRef Name = "");
+  LLVM_ABI Register createIncompleteVirtualRegister(StringRef Name = "");
 
   /// getNumVirtRegs - Return the number of virtual registers created.
   unsigned getNumVirtRegs() const { return VRegInfo.size(); }
 
   /// clearVirtRegs - Remove all virtual registers (after physreg assignment).
-  void clearVirtRegs();
+  LLVM_ABI void clearVirtRegs();
 
   /// setRegAllocationHint - Specify a register allocation hint for the
   /// specified virtual register. This is typically used by target, and in case
@@ -856,7 +857,7 @@ public:
   /// markUsesInDebugValueAsUndef - Mark every DBG_VALUE referencing the
   /// specified register as undefined which causes the DBG_VALUE to be
   /// deleted during LiveDebugVariables analysis.
-  void markUsesInDebugValueAsUndef(Register Reg) const;
+  LLVM_ABI void markUsesInDebugValueAsUndef(Register Reg) const;
 
   /// updateDbgUsersToReg - Update a collection of debug instructions
   /// to refer to the designated register.
@@ -892,13 +893,13 @@ public:
   /// ignored, to consider them pass 'true' for optional parameter
   /// SkipNoReturnDef. The register is also considered modified when it is set
   /// in the UsedPhysRegMask.
-  bool isPhysRegModified(MCRegister PhysReg, bool SkipNoReturnDef = false) const;
+  LLVM_ABI bool isPhysRegModified(MCRegister PhysReg, bool SkipNoReturnDef = false) const;
 
   /// Return true if the specified register is modified or read in this
   /// function. This checks that no machine operands exist for the register or
   /// any of its aliases. If SkipRegMaskTest is false, the register is
   /// considered used when it is set in the UsedPhysRegMask.
-  bool isPhysRegUsed(MCRegister PhysReg, bool SkipRegMaskTest = false) const;
+  LLVM_ABI bool isPhysRegUsed(MCRegister PhysReg, bool SkipRegMaskTest = false) const;
 
   /// addPhysRegsUsedFromRegMask - Mark any registers not in RegMask as used.
   /// This corresponds to the bit mask attached to register mask operands.
@@ -922,7 +923,7 @@ public:
 
   /// freezeReservedRegs - Called by the register allocator to freeze the set
   /// of reserved registers before allocation begins.
-  void freezeReservedRegs();
+  LLVM_ABI void freezeReservedRegs();
 
   /// reserveReg -- Mark a register as reserved so checks like isAllocatable
   /// will not suggest using it. This should not be used during the middle
@@ -973,7 +974,7 @@ public:
   /// root registers, the root register and all super registers are reserved.
   /// This currently iterates the register hierarchy and may be slower than
   /// expected.
-  bool isReservedRegUnit(unsigned Unit) const;
+  LLVM_ABI bool isReservedRegUnit(unsigned Unit) const;
 
   /// isAllocatable - Returns true when PhysReg belongs to an allocatable
   /// register class and it hasn't been reserved.
@@ -1008,25 +1009,25 @@ public:
     return LiveIns;
   }
 
-  bool isLiveIn(Register Reg) const;
+  LLVM_ABI bool isLiveIn(Register Reg) const;
 
   /// getLiveInPhysReg - If VReg is a live-in virtual register, return the
   /// corresponding live-in physical register.
-  MCRegister getLiveInPhysReg(Register VReg) const;
+  LLVM_ABI MCRegister getLiveInPhysReg(Register VReg) const;
 
   /// getLiveInVirtReg - If PReg is a live-in physical register, return the
   /// corresponding live-in virtual register.
-  Register getLiveInVirtReg(MCRegister PReg) const;
+  LLVM_ABI Register getLiveInVirtReg(MCRegister PReg) const;
 
   /// EmitLiveInCopies - Emit copies to initialize livein virtual registers
   /// into the given entry block.
-  void EmitLiveInCopies(MachineBasicBlock *EntryMBB,
+  LLVM_ABI void EmitLiveInCopies(MachineBasicBlock *EntryMBB,
                         const TargetRegisterInfo &TRI,
                         const TargetInstrInfo &TII);
 
   /// Returns a mask covering all bits that can appear in lane masks of
   /// subregisters of the virtual register @p Reg.
-  LaneBitmask getMaxLaneMaskForVReg(Register Reg) const;
+  LLVM_ABI LaneBitmask getMaxLaneMaskForVReg(Register Reg) const;
 
   /// defusechain_iterator - This class provides iterator support for machine
   /// operands in the function that use or define a specific register.  If

--- a/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CODEGEN_MACHINEREGISTERINFO_H
 #define LLVM_CODEGEN_MACHINEREGISTERINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/IndexedMap.h"
@@ -31,6 +30,7 @@
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/MC/LaneBitmask.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -259,7 +259,8 @@ public:
   LLVM_ABI void removeRegOperandFromUseList(MachineOperand *MO);
 
   // Strictly for use by MachineInstr.cpp.
-  LLVM_ABI void moveOperands(MachineOperand *Dst, MachineOperand *Src, unsigned NumOps);
+  LLVM_ABI void moveOperands(MachineOperand *Dst, MachineOperand *Src,
+                             unsigned NumOps);
 
   /// Verify the sanity of the use list for Reg.
   LLVM_ABI void verifyUseList(Register Reg) const;
@@ -707,9 +708,9 @@ public:
   /// Use RegisterBankInfo::constrainGenericRegister in GlobalISel's
   /// InstructionSelect pass and constrainRegAttrs in every other pass,
   /// including non-select passes of GlobalISel, instead.
-  LLVM_ABI const TargetRegisterClass *constrainRegClass(Register Reg,
-                                               const TargetRegisterClass *RC,
-                                               unsigned MinNumRegs = 0);
+  LLVM_ABI const TargetRegisterClass *
+  constrainRegClass(Register Reg, const TargetRegisterClass *RC,
+                    unsigned MinNumRegs = 0);
 
   /// Constrain the register class or the register bank of the virtual register
   /// \p Reg (and low-level type) to be a common subclass or a common bank of
@@ -723,7 +724,7 @@ public:
   /// RegisterBankInfo::constrainGenericRegister everywhere but SelectionDAG
   /// ISel / FastISel and GlobalISel's InstructionSelect pass respectively.
   LLVM_ABI bool constrainRegAttrs(Register Reg, Register ConstrainingReg,
-                         unsigned MinNumRegs = 0);
+                                  unsigned MinNumRegs = 0);
 
   /// recomputeRegClass - Try to find a legal super-class of Reg's register
   /// class that still satisfies the constraints from the instructions using
@@ -737,7 +738,7 @@ public:
   /// createVirtualRegister - Create and return a new virtual register in the
   /// function with the specified register class.
   LLVM_ABI Register createVirtualRegister(const TargetRegisterClass *RegClass,
-                                 StringRef Name = "");
+                                          StringRef Name = "");
 
   /// All attributes(register class or bank and low-level type) a virtual
   /// register can have.
@@ -755,7 +756,8 @@ public:
 
   /// Create and return a new virtual register in the function with the
   /// specified register attributes(register class or bank and low level type).
-  LLVM_ABI Register createVirtualRegister(VRegAttrs RegAttr, StringRef Name = "");
+  LLVM_ABI Register createVirtualRegister(VRegAttrs RegAttr,
+                                          StringRef Name = "");
 
   /// Create and return a new virtual register in the function with the same
   /// attributes as the given register.
@@ -893,13 +895,15 @@ public:
   /// ignored, to consider them pass 'true' for optional parameter
   /// SkipNoReturnDef. The register is also considered modified when it is set
   /// in the UsedPhysRegMask.
-  LLVM_ABI bool isPhysRegModified(MCRegister PhysReg, bool SkipNoReturnDef = false) const;
+  LLVM_ABI bool isPhysRegModified(MCRegister PhysReg,
+                                  bool SkipNoReturnDef = false) const;
 
   /// Return true if the specified register is modified or read in this
   /// function. This checks that no machine operands exist for the register or
   /// any of its aliases. If SkipRegMaskTest is false, the register is
   /// considered used when it is set in the UsedPhysRegMask.
-  LLVM_ABI bool isPhysRegUsed(MCRegister PhysReg, bool SkipRegMaskTest = false) const;
+  LLVM_ABI bool isPhysRegUsed(MCRegister PhysReg,
+                              bool SkipRegMaskTest = false) const;
 
   /// addPhysRegsUsedFromRegMask - Mark any registers not in RegMask as used.
   /// This corresponds to the bit mask attached to register mask operands.
@@ -1022,8 +1026,8 @@ public:
   /// EmitLiveInCopies - Emit copies to initialize livein virtual registers
   /// into the given entry block.
   LLVM_ABI void EmitLiveInCopies(MachineBasicBlock *EntryMBB,
-                        const TargetRegisterInfo &TRI,
-                        const TargetInstrInfo &TII);
+                                 const TargetRegisterInfo &TRI,
+                                 const TargetInstrInfo &TII);
 
   /// Returns a mask covering all bits that can appear in lane masks of
   /// subregisters of the virtual register @p Reg.

--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -74,6 +74,7 @@
 #ifndef LLVM_CODEGEN_MACHINESCHEDULER_H
 #define LLVM_CODEGEN_MACHINESCHEDULER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
@@ -114,14 +115,14 @@ enum Direction {
 };
 } // namespace MISched
 
-extern cl::opt<MISched::Direction> PreRADirection;
-extern cl::opt<bool> VerifyScheduling;
+LLVM_ABI extern cl::opt<MISched::Direction> PreRADirection;
+LLVM_ABI extern cl::opt<bool> VerifyScheduling;
 #ifndef NDEBUG
 extern cl::opt<bool> ViewMISchedDAGs;
 extern cl::opt<bool> PrintDAGs;
 #else
-extern const bool ViewMISchedDAGs;
-extern const bool PrintDAGs;
+LLVM_ABI extern const bool ViewMISchedDAGs;
+LLVM_ABI extern const bool PrintDAGs;
 #endif
 
 class AAResults;
@@ -139,7 +140,7 @@ class TargetRegisterInfo;
 
 /// MachineSchedContext provides enough context from the MachineScheduler pass
 /// for the target to instantiate a scheduler.
-struct MachineSchedContext {
+struct LLVM_ABI MachineSchedContext {
   MachineFunction *MF = nullptr;
   const MachineLoopInfo *MLI = nullptr;
   const MachineDominatorTree *MDT = nullptr;
@@ -166,7 +167,7 @@ public:
   // RegisterPassParser requires a (misnamed) FunctionPassCtor type.
   using FunctionPassCtor = ScheduleDAGCtor;
 
-  static MachinePassRegistry<ScheduleDAGCtor> Registry;
+  LLVM_ABI static MachinePassRegistry<ScheduleDAGCtor> Registry;
 
   MachineSchedRegistry(const char *N, const char *D, ScheduleDAGCtor C)
       : MachinePassRegistryNode(N, D, C) {
@@ -222,7 +223,7 @@ struct MachineSchedPolicy {
 ///
 /// Initialization sequence:
 ///   initPolicy -> shouldTrackPressure -> initialize(DAG) -> registerRoots
-class MachineSchedStrategy {
+class LLVM_ABI MachineSchedStrategy {
   virtual void anchor();
 
 public:
@@ -288,7 +289,7 @@ public:
 /// schedules machine instructions according to the given MachineSchedStrategy
 /// without much extra book-keeping. This is the common functionality between
 /// PreRA and PostRA MachineScheduler.
-class ScheduleDAGMI : public ScheduleDAGInstrs {
+class LLVM_ABI ScheduleDAGMI : public ScheduleDAGInstrs {
 protected:
   AAResults *AA;
   LiveIntervals *LIS;
@@ -410,7 +411,7 @@ protected:
 
 /// ScheduleDAGMILive is an implementation of ScheduleDAGInstrs that schedules
 /// machine instructions while updating LiveIntervals and tracking regpressure.
-class ScheduleDAGMILive : public ScheduleDAGMI {
+class LLVM_ABI ScheduleDAGMILive : public ScheduleDAGMI {
 protected:
   RegisterClassInfo *RegClassInfo;
 
@@ -596,7 +597,7 @@ public:
     return Queue.begin() + idx;
   }
 
-  void dump() const;
+  LLVM_ABI void dump() const;
 };
 
 /// Summarize the unscheduled region.
@@ -623,7 +624,7 @@ struct SchedRemainder {
     RemainingCounts.clear();
   }
 
-  void init(ScheduleDAGMI *DAG, const TargetSchedModel *SchedModel);
+  LLVM_ABI void init(ScheduleDAGMI *DAG, const TargetSchedModel *SchedModel);
 };
 
 /// ResourceSegments are a collection of intervals closed on the
@@ -660,11 +661,11 @@ public:
   /// overlaps any of the intervals in the collection. We can
   /// require this because by definition a \ref ResourceSegments is
   /// attached only to an individual resource instance.
-  void add(IntervalTy A, const unsigned CutOff = 10);
+  LLVM_ABI void add(IntervalTy A, const unsigned CutOff = 10);
 
 public:
   /// Checks whether intervals intersect.
-  static bool intersects(IntervalTy A, IntervalTy B);
+  LLVM_ABI static bool intersects(IntervalTy A, IntervalTy B);
 
   /// These function return the interval used by a resource in bottom and top
   /// scheduling.
@@ -787,7 +788,7 @@ private:
   /// [*] See \ref `getResourceIntervalTop` and
   /// \ref `getResourceIntervalBottom` to see how such resource intervals
   /// are built.
-  unsigned getFirstAvailableAt(
+  LLVM_ABI unsigned getFirstAvailableAt(
       unsigned CurrCycle, unsigned AcquireAtCycle, unsigned ReleaseAtCycle,
       std::function<IntervalTy(unsigned, unsigned, unsigned)> IntervalBuilder)
       const;
@@ -816,7 +817,7 @@ private:
   ///
   /// Before performing the merge operation, the intervals are
   /// sorted with \ref sort_predicate.
-  void sortAndMerge();
+  LLVM_ABI void sortAndMerge();
 
 public:
   // constructor for empty set
@@ -961,11 +962,11 @@ public:
   }
   SchedBoundary &operator=(const SchedBoundary &other) = delete;
   SchedBoundary(const SchedBoundary &other) = delete;
-  ~SchedBoundary();
+  LLVM_ABI ~SchedBoundary();
 
-  void reset();
+  LLVM_ABI void reset();
 
-  void init(ScheduleDAGMI *dag, const TargetSchedModel *smodel,
+  LLVM_ABI void init(ScheduleDAGMI *dag, const TargetSchedModel *smodel,
             SchedRemainder *rem);
 
   bool isTop() const {
@@ -1019,13 +1020,13 @@ public:
 
   /// Get the difference between the given SUnit's ready time and the current
   /// cycle.
-  unsigned getLatencyStallCycles(SUnit *SU);
+  LLVM_ABI unsigned getLatencyStallCycles(SUnit *SU);
 
-  unsigned getNextResourceCycleByInstance(unsigned InstanceIndex,
+  LLVM_ABI unsigned getNextResourceCycleByInstance(unsigned InstanceIndex,
                                           unsigned ReleaseAtCycle,
                                           unsigned AcquireAtCycle);
 
-  std::pair<unsigned, unsigned> getNextResourceCycle(const MCSchedClassDesc *SC,
+  LLVM_ABI std::pair<unsigned, unsigned> getNextResourceCycle(const MCSchedClassDesc *SC,
                                                      unsigned PIdx,
                                                      unsigned ReleaseAtCycle,
                                                      unsigned AcquireAtCycle);
@@ -1035,11 +1036,11 @@ public:
            !SchedModel->getProcResource(PIdx)->BufferSize;
   }
 
-  bool checkHazard(SUnit *SU);
+  LLVM_ABI bool checkHazard(SUnit *SU);
 
-  unsigned findMaxLatency(ArrayRef<SUnit*> ReadySUs);
+  LLVM_ABI unsigned findMaxLatency(ArrayRef<SUnit*> ReadySUs);
 
-  unsigned getOtherResourceCount(unsigned &OtherCritIdx);
+  LLVM_ABI unsigned getOtherResourceCount(unsigned &OtherCritIdx);
 
   /// Release SU to make it ready. If it's not in hazard, remove it from
   /// pending queue (if already in) and push into available queue.
@@ -1049,31 +1050,31 @@ public:
   /// @param ReadyCycle Until which cycle the unit is ready.
   /// @param InPQueue Whether SU is already in pending queue.
   /// @param Idx Position offset in pending queue (if in it).
-  void releaseNode(SUnit *SU, unsigned ReadyCycle, bool InPQueue,
+  LLVM_ABI void releaseNode(SUnit *SU, unsigned ReadyCycle, bool InPQueue,
                    unsigned Idx = 0);
 
-  void bumpCycle(unsigned NextCycle);
+  LLVM_ABI void bumpCycle(unsigned NextCycle);
 
-  void incExecutedResources(unsigned PIdx, unsigned Count);
+  LLVM_ABI void incExecutedResources(unsigned PIdx, unsigned Count);
 
-  unsigned countResource(const MCSchedClassDesc *SC, unsigned PIdx,
+  LLVM_ABI unsigned countResource(const MCSchedClassDesc *SC, unsigned PIdx,
                          unsigned Cycles, unsigned ReadyCycle,
                          unsigned StartAtCycle);
 
-  void bumpNode(SUnit *SU);
+  LLVM_ABI void bumpNode(SUnit *SU);
 
-  void releasePending();
+  LLVM_ABI void releasePending();
 
-  void removeReady(SUnit *SU);
+  LLVM_ABI void removeReady(SUnit *SU);
 
   /// Call this before applying any other heuristics to the Available queue.
   /// Updates the Available/Pending Q's if necessary and returns the single
   /// available instruction, or NULL if there are multiple candidates.
-  SUnit *pickOnlyChoice();
+  LLVM_ABI SUnit *pickOnlyChoice();
 
   /// Dump the state of the information that tracks resource usage.
-  void dumpReservedCycles() const;
-  void dumpScheduledState() const;
+  LLVM_ABI void dumpReservedCycles() const;
+  LLVM_ABI void dumpScheduledState() const;
 };
 
 /// Base class for GenericScheduler. This class maintains information about
@@ -1188,7 +1189,7 @@ public:
       ResDelta = Best.ResDelta;
     }
 
-    void initResourceDelta(const ScheduleDAGMI *DAG,
+    LLVM_ABI void initResourceDelta(const ScheduleDAGMI *DAG,
                            const TargetSchedModel *SchedModel);
   };
 
@@ -1206,7 +1207,7 @@ protected:
 
   GenericSchedulerBase(const MachineSchedContext *C) : Context(C) {}
 
-  void setPolicy(CandPolicy &Policy, bool IsPostRA, SchedBoundary &CurrZone,
+  LLVM_ABI void setPolicy(CandPolicy &Policy, bool IsPostRA, SchedBoundary &CurrZone,
                  SchedBoundary *OtherZone);
 
   MachineSchedPolicy getPolicy() const override { return RegionPolicy; }
@@ -1221,30 +1222,30 @@ private:
 };
 
 // Utility functions used by heuristics in tryCandidate().
-bool tryLess(int TryVal, int CandVal,
+LLVM_ABI bool tryLess(int TryVal, int CandVal,
              GenericSchedulerBase::SchedCandidate &TryCand,
              GenericSchedulerBase::SchedCandidate &Cand,
              GenericSchedulerBase::CandReason Reason);
-bool tryGreater(int TryVal, int CandVal,
+LLVM_ABI bool tryGreater(int TryVal, int CandVal,
                 GenericSchedulerBase::SchedCandidate &TryCand,
                 GenericSchedulerBase::SchedCandidate &Cand,
                 GenericSchedulerBase::CandReason Reason);
-bool tryLatency(GenericSchedulerBase::SchedCandidate &TryCand,
+LLVM_ABI bool tryLatency(GenericSchedulerBase::SchedCandidate &TryCand,
                 GenericSchedulerBase::SchedCandidate &Cand,
                 SchedBoundary &Zone);
-bool tryPressure(const PressureChange &TryP,
+LLVM_ABI bool tryPressure(const PressureChange &TryP,
                  const PressureChange &CandP,
                  GenericSchedulerBase::SchedCandidate &TryCand,
                  GenericSchedulerBase::SchedCandidate &Cand,
                  GenericSchedulerBase::CandReason Reason,
                  const TargetRegisterInfo *TRI,
                  const MachineFunction &MF);
-unsigned getWeakLeft(const SUnit *SU, bool isTop);
-int biasPhysReg(const SUnit *SU, bool isTop);
+LLVM_ABI unsigned getWeakLeft(const SUnit *SU, bool isTop);
+LLVM_ABI int biasPhysReg(const SUnit *SU, bool isTop);
 
 /// GenericScheduler shrinks the unscheduled zone using heuristics to balance
 /// the schedule.
-class GenericScheduler : public GenericSchedulerBase {
+class LLVM_ABI GenericScheduler : public GenericSchedulerBase {
 public:
   GenericScheduler(const MachineSchedContext *C):
     GenericSchedulerBase(C), Top(SchedBoundary::TopQID, "TopQ"),
@@ -1324,7 +1325,7 @@ protected:
 ///
 /// Callbacks from ScheduleDAGMI:
 ///   initPolicy -> initialize(DAG) -> registerRoots -> pickNode ...
-class PostGenericScheduler : public GenericSchedulerBase {
+class LLVM_ABI PostGenericScheduler : public GenericSchedulerBase {
 protected:
   ScheduleDAGMI *DAG = nullptr;
   SchedBoundary Top;
@@ -1386,26 +1387,26 @@ protected:
 /// Create the standard converging machine scheduler. This will be used as the
 /// default scheduler if the target does not set a default.
 /// Adds default DAG mutations.
-ScheduleDAGMILive *createGenericSchedLive(MachineSchedContext *C);
+LLVM_ABI ScheduleDAGMILive *createGenericSchedLive(MachineSchedContext *C);
 
 /// Create a generic scheduler with no vreg liveness or DAG mutation passes.
-ScheduleDAGMI *createGenericSchedPostRA(MachineSchedContext *C);
+LLVM_ABI ScheduleDAGMI *createGenericSchedPostRA(MachineSchedContext *C);
 
 /// If ReorderWhileClustering is set to true, no attempt will be made to
 /// reduce reordering due to store clustering.
-std::unique_ptr<ScheduleDAGMutation>
+LLVM_ABI std::unique_ptr<ScheduleDAGMutation>
 createLoadClusterDAGMutation(const TargetInstrInfo *TII,
                              const TargetRegisterInfo *TRI,
                              bool ReorderWhileClustering = false);
 
 /// If ReorderWhileClustering is set to true, no attempt will be made to
 /// reduce reordering due to store clustering.
-std::unique_ptr<ScheduleDAGMutation>
+LLVM_ABI std::unique_ptr<ScheduleDAGMutation>
 createStoreClusterDAGMutation(const TargetInstrInfo *TII,
                               const TargetRegisterInfo *TRI,
                               bool ReorderWhileClustering = false);
 
-std::unique_ptr<ScheduleDAGMutation>
+LLVM_ABI std::unique_ptr<ScheduleDAGMutation>
 createCopyConstrainDAGMutation(const TargetInstrInfo *TII,
                                const TargetRegisterInfo *TRI);
 
@@ -1416,10 +1417,10 @@ class MachineSchedulerPass : public PassInfoMixin<MachineSchedulerPass> {
   const TargetMachine *TM;
 
 public:
-  MachineSchedulerPass(const TargetMachine *TM);
-  MachineSchedulerPass(MachineSchedulerPass &&Other);
-  ~MachineSchedulerPass();
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI MachineSchedulerPass(const TargetMachine *TM);
+  LLVM_ABI MachineSchedulerPass(MachineSchedulerPass &&Other);
+  LLVM_ABI ~MachineSchedulerPass();
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 };
 
@@ -1431,10 +1432,10 @@ class PostMachineSchedulerPass
   const TargetMachine *TM;
 
 public:
-  PostMachineSchedulerPass(const TargetMachine *TM);
-  PostMachineSchedulerPass(PostMachineSchedulerPass &&Other);
-  ~PostMachineSchedulerPass();
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PostMachineSchedulerPass(const TargetMachine *TM);
+  LLVM_ABI PostMachineSchedulerPass(PostMachineSchedulerPass &&Other);
+  LLVM_ABI ~PostMachineSchedulerPass();
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 };
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -74,7 +74,6 @@
 #ifndef LLVM_CODEGEN_MACHINESCHEDULER_H
 #define LLVM_CODEGEN_MACHINESCHEDULER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
@@ -90,6 +89,7 @@
 #include "llvm/CodeGen/ScheduleDAGMutation.h"
 #include "llvm/CodeGen/TargetSchedule.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
 #include <cassert>
@@ -967,7 +967,7 @@ public:
   LLVM_ABI void reset();
 
   LLVM_ABI void init(ScheduleDAGMI *dag, const TargetSchedModel *smodel,
-            SchedRemainder *rem);
+                     SchedRemainder *rem);
 
   bool isTop() const {
     return Available.getID() == TopQID;
@@ -1023,13 +1023,12 @@ public:
   LLVM_ABI unsigned getLatencyStallCycles(SUnit *SU);
 
   LLVM_ABI unsigned getNextResourceCycleByInstance(unsigned InstanceIndex,
-                                          unsigned ReleaseAtCycle,
-                                          unsigned AcquireAtCycle);
+                                                   unsigned ReleaseAtCycle,
+                                                   unsigned AcquireAtCycle);
 
-  LLVM_ABI std::pair<unsigned, unsigned> getNextResourceCycle(const MCSchedClassDesc *SC,
-                                                     unsigned PIdx,
-                                                     unsigned ReleaseAtCycle,
-                                                     unsigned AcquireAtCycle);
+  LLVM_ABI std::pair<unsigned, unsigned>
+  getNextResourceCycle(const MCSchedClassDesc *SC, unsigned PIdx,
+                       unsigned ReleaseAtCycle, unsigned AcquireAtCycle);
 
   bool isUnbufferedGroup(unsigned PIdx) const {
     return SchedModel->getProcResource(PIdx)->SubUnitsIdxBegin &&
@@ -1038,7 +1037,7 @@ public:
 
   LLVM_ABI bool checkHazard(SUnit *SU);
 
-  LLVM_ABI unsigned findMaxLatency(ArrayRef<SUnit*> ReadySUs);
+  LLVM_ABI unsigned findMaxLatency(ArrayRef<SUnit *> ReadySUs);
 
   LLVM_ABI unsigned getOtherResourceCount(unsigned &OtherCritIdx);
 
@@ -1051,15 +1050,15 @@ public:
   /// @param InPQueue Whether SU is already in pending queue.
   /// @param Idx Position offset in pending queue (if in it).
   LLVM_ABI void releaseNode(SUnit *SU, unsigned ReadyCycle, bool InPQueue,
-                   unsigned Idx = 0);
+                            unsigned Idx = 0);
 
   LLVM_ABI void bumpCycle(unsigned NextCycle);
 
   LLVM_ABI void incExecutedResources(unsigned PIdx, unsigned Count);
 
   LLVM_ABI unsigned countResource(const MCSchedClassDesc *SC, unsigned PIdx,
-                         unsigned Cycles, unsigned ReadyCycle,
-                         unsigned StartAtCycle);
+                                  unsigned Cycles, unsigned ReadyCycle,
+                                  unsigned StartAtCycle);
 
   LLVM_ABI void bumpNode(SUnit *SU);
 
@@ -1190,7 +1189,7 @@ public:
     }
 
     LLVM_ABI void initResourceDelta(const ScheduleDAGMI *DAG,
-                           const TargetSchedModel *SchedModel);
+                                    const TargetSchedModel *SchedModel);
   };
 
 protected:
@@ -1207,8 +1206,8 @@ protected:
 
   GenericSchedulerBase(const MachineSchedContext *C) : Context(C) {}
 
-  LLVM_ABI void setPolicy(CandPolicy &Policy, bool IsPostRA, SchedBoundary &CurrZone,
-                 SchedBoundary *OtherZone);
+  LLVM_ABI void setPolicy(CandPolicy &Policy, bool IsPostRA,
+                          SchedBoundary &CurrZone, SchedBoundary *OtherZone);
 
   MachineSchedPolicy getPolicy() const override { return RegionPolicy; }
 
@@ -1223,23 +1222,23 @@ private:
 
 // Utility functions used by heuristics in tryCandidate().
 LLVM_ABI bool tryLess(int TryVal, int CandVal,
-             GenericSchedulerBase::SchedCandidate &TryCand,
-             GenericSchedulerBase::SchedCandidate &Cand,
-             GenericSchedulerBase::CandReason Reason);
+                      GenericSchedulerBase::SchedCandidate &TryCand,
+                      GenericSchedulerBase::SchedCandidate &Cand,
+                      GenericSchedulerBase::CandReason Reason);
 LLVM_ABI bool tryGreater(int TryVal, int CandVal,
-                GenericSchedulerBase::SchedCandidate &TryCand,
-                GenericSchedulerBase::SchedCandidate &Cand,
-                GenericSchedulerBase::CandReason Reason);
+                         GenericSchedulerBase::SchedCandidate &TryCand,
+                         GenericSchedulerBase::SchedCandidate &Cand,
+                         GenericSchedulerBase::CandReason Reason);
 LLVM_ABI bool tryLatency(GenericSchedulerBase::SchedCandidate &TryCand,
-                GenericSchedulerBase::SchedCandidate &Cand,
-                SchedBoundary &Zone);
+                         GenericSchedulerBase::SchedCandidate &Cand,
+                         SchedBoundary &Zone);
 LLVM_ABI bool tryPressure(const PressureChange &TryP,
-                 const PressureChange &CandP,
-                 GenericSchedulerBase::SchedCandidate &TryCand,
-                 GenericSchedulerBase::SchedCandidate &Cand,
-                 GenericSchedulerBase::CandReason Reason,
-                 const TargetRegisterInfo *TRI,
-                 const MachineFunction &MF);
+                          const PressureChange &CandP,
+                          GenericSchedulerBase::SchedCandidate &TryCand,
+                          GenericSchedulerBase::SchedCandidate &Cand,
+                          GenericSchedulerBase::CandReason Reason,
+                          const TargetRegisterInfo *TRI,
+                          const MachineFunction &MF);
 LLVM_ABI unsigned getWeakLeft(const SUnit *SU, bool isTop);
 LLVM_ABI int biasPhysReg(const SUnit *SU, bool isTop);
 
@@ -1421,7 +1420,7 @@ public:
   LLVM_ABI MachineSchedulerPass(MachineSchedulerPass &&Other);
   LLVM_ABI ~MachineSchedulerPass();
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
 };
 
 class PostMachineSchedulerPass
@@ -1436,7 +1435,7 @@ public:
   LLVM_ABI PostMachineSchedulerPass(PostMachineSchedulerPass &&Other);
   LLVM_ABI ~PostMachineSchedulerPass();
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/MachineSizeOpts.h
+++ b/llvm/include/llvm/CodeGen/MachineSizeOpts.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MACHINESIZEOPTS_H
 #define LLVM_CODEGEN_MACHINESIZEOPTS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Transforms/Utils/SizeOpts.h"
 
 namespace llvm {
@@ -25,18 +26,18 @@ class MBFIWrapper;
 
 /// Returns true if machine function \p MF is suggested to be size-optimized
 /// based on the profile.
-bool shouldOptimizeForSize(const MachineFunction *MF, ProfileSummaryInfo *PSI,
+LLVM_ABI bool shouldOptimizeForSize(const MachineFunction *MF, ProfileSummaryInfo *PSI,
                            const MachineBlockFrequencyInfo *BFI,
                            PGSOQueryType QueryType = PGSOQueryType::Other);
 /// Returns true if machine basic block \p MBB is suggested to be size-optimized
 /// based on the profile.
-bool shouldOptimizeForSize(const MachineBasicBlock *MBB,
+LLVM_ABI bool shouldOptimizeForSize(const MachineBasicBlock *MBB,
                            ProfileSummaryInfo *PSI,
                            const MachineBlockFrequencyInfo *MBFI,
                            PGSOQueryType QueryType = PGSOQueryType::Other);
 /// Returns true if machine basic block \p MBB is suggested to be size-optimized
 /// based on the profile.
-bool shouldOptimizeForSize(const MachineBasicBlock *MBB,
+LLVM_ABI bool shouldOptimizeForSize(const MachineBasicBlock *MBB,
                            ProfileSummaryInfo *PSI,
                            MBFIWrapper *MBFIWrapper,
                            PGSOQueryType QueryType = PGSOQueryType::Other);

--- a/llvm/include/llvm/CodeGen/MachineSizeOpts.h
+++ b/llvm/include/llvm/CodeGen/MachineSizeOpts.h
@@ -26,21 +26,22 @@ class MBFIWrapper;
 
 /// Returns true if machine function \p MF is suggested to be size-optimized
 /// based on the profile.
-LLVM_ABI bool shouldOptimizeForSize(const MachineFunction *MF, ProfileSummaryInfo *PSI,
-                           const MachineBlockFrequencyInfo *BFI,
-                           PGSOQueryType QueryType = PGSOQueryType::Other);
+LLVM_ABI bool
+shouldOptimizeForSize(const MachineFunction *MF, ProfileSummaryInfo *PSI,
+                      const MachineBlockFrequencyInfo *BFI,
+                      PGSOQueryType QueryType = PGSOQueryType::Other);
 /// Returns true if machine basic block \p MBB is suggested to be size-optimized
 /// based on the profile.
-LLVM_ABI bool shouldOptimizeForSize(const MachineBasicBlock *MBB,
-                           ProfileSummaryInfo *PSI,
-                           const MachineBlockFrequencyInfo *MBFI,
-                           PGSOQueryType QueryType = PGSOQueryType::Other);
+LLVM_ABI bool
+shouldOptimizeForSize(const MachineBasicBlock *MBB, ProfileSummaryInfo *PSI,
+                      const MachineBlockFrequencyInfo *MBFI,
+                      PGSOQueryType QueryType = PGSOQueryType::Other);
 /// Returns true if machine basic block \p MBB is suggested to be size-optimized
 /// based on the profile.
-LLVM_ABI bool shouldOptimizeForSize(const MachineBasicBlock *MBB,
-                           ProfileSummaryInfo *PSI,
-                           MBFIWrapper *MBFIWrapper,
-                           PGSOQueryType QueryType = PGSOQueryType::Other);
+LLVM_ABI bool
+shouldOptimizeForSize(const MachineBasicBlock *MBB, ProfileSummaryInfo *PSI,
+                      MBFIWrapper *MBFIWrapper,
+                      PGSOQueryType QueryType = PGSOQueryType::Other);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/MachineStableHash.h
+++ b/llvm/include/llvm/CodeGen/MachineStableHash.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MACHINESTABLEHASH_H
 #define LLVM_CODEGEN_MACHINESTABLEHASH_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StableHashing.h"
 
 namespace llvm {
@@ -22,12 +23,12 @@ class MachineFunction;
 class MachineInstr;
 class MachineOperand;
 
-stable_hash stableHashValue(const MachineOperand &MO);
-stable_hash stableHashValue(const MachineInstr &MI, bool HashVRegs = false,
+LLVM_ABI stable_hash stableHashValue(const MachineOperand &MO);
+LLVM_ABI stable_hash stableHashValue(const MachineInstr &MI, bool HashVRegs = false,
                             bool HashConstantPoolIndices = false,
                             bool HashMemOperands = false);
-stable_hash stableHashValue(const MachineBasicBlock &MBB);
-stable_hash stableHashValue(const MachineFunction &MF);
+LLVM_ABI stable_hash stableHashValue(const MachineBasicBlock &MBB);
+LLVM_ABI stable_hash stableHashValue(const MachineFunction &MF);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/CodeGen/MachineStableHash.h
+++ b/llvm/include/llvm/CodeGen/MachineStableHash.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_CODEGEN_MACHINESTABLEHASH_H
 #define LLVM_CODEGEN_MACHINESTABLEHASH_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StableHashing.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class MachineBasicBlock;
@@ -24,9 +24,10 @@ class MachineInstr;
 class MachineOperand;
 
 LLVM_ABI stable_hash stableHashValue(const MachineOperand &MO);
-LLVM_ABI stable_hash stableHashValue(const MachineInstr &MI, bool HashVRegs = false,
-                            bool HashConstantPoolIndices = false,
-                            bool HashMemOperands = false);
+LLVM_ABI stable_hash stableHashValue(const MachineInstr &MI,
+                                     bool HashVRegs = false,
+                                     bool HashConstantPoolIndices = false,
+                                     bool HashMemOperands = false);
 LLVM_ABI stable_hash stableHashValue(const MachineBasicBlock &MBB);
 LLVM_ABI stable_hash stableHashValue(const MachineFunction &MF);
 

--- a/llvm/include/llvm/CodeGen/MachineVerifier.h
+++ b/llvm/include/llvm/CodeGen/MachineVerifier.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_CODEGEN_MACHINEVERIFIER_H
 #define LLVM_CODEGEN_MACHINEVERIFIER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/Support/Compiler.h"
 #include <string>
 
 namespace llvm {
@@ -21,7 +21,7 @@ public:
   MachineVerifierPass(const std::string &Banner = std::string())
       : Banner(Banner) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 

--- a/llvm/include/llvm/CodeGen/MachineVerifier.h
+++ b/llvm/include/llvm/CodeGen/MachineVerifier.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CODEGEN_MACHINEVERIFIER_H
 #define LLVM_CODEGEN_MACHINEVERIFIER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include <string>
 
@@ -19,7 +20,7 @@ class MachineVerifierPass : public PassInfoMixin<MachineVerifierPass> {
 public:
   MachineVerifierPass(const std::string &Banner = std::string())
       : Banner(Banner) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };

--- a/llvm/include/llvm/CodeGen/MacroFusion.h
+++ b/llvm/include/llvm/CodeGen/MacroFusion.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MACROFUSION_H
 #define LLVM_CODEGEN_MACROFUSION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <memory>
 
@@ -36,14 +37,14 @@ using MacroFusionPredTy = bool (*)(const TargetInstrInfo &TII,
 
 /// Checks if the number of cluster edges between SU and its predecessors is
 /// less than FuseLimit
-bool hasLessThanNumFused(const SUnit &SU, unsigned FuseLimit);
+LLVM_ABI bool hasLessThanNumFused(const SUnit &SU, unsigned FuseLimit);
 
 /// Create an artificial edge between FirstSU and SecondSU.
 /// Make data dependencies from the FirstSU also dependent on the SecondSU to
 /// prevent them from being scheduled between the FirstSU and the SecondSU
 /// and vice-versa.
 /// Fusing more than 2 instructions is not currently supported.
-bool fuseInstructionPair(ScheduleDAGInstrs &DAG, SUnit &FirstSU,
+LLVM_ABI bool fuseInstructionPair(ScheduleDAGInstrs &DAG, SUnit &FirstSU,
                          SUnit &SecondSU);
 
 /// Create a DAG scheduling mutation to pair instructions back to back
@@ -52,7 +53,7 @@ bool fuseInstructionPair(ScheduleDAGInstrs &DAG, SUnit &FirstSU,
 /// provided predicates are true.
 /// If BranchOnly is true, only branch instructions with one of their
 /// predecessors will be fused.
-std::unique_ptr<ScheduleDAGMutation>
+LLVM_ABI std::unique_ptr<ScheduleDAGMutation>
 createMacroFusionDAGMutation(ArrayRef<MacroFusionPredTy> Predicates,
                              bool BranchOnly = false);
 

--- a/llvm/include/llvm/CodeGen/MacroFusion.h
+++ b/llvm/include/llvm/CodeGen/MacroFusion.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_CODEGEN_MACROFUSION_H
 #define LLVM_CODEGEN_MACROFUSION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {
@@ -45,7 +45,7 @@ LLVM_ABI bool hasLessThanNumFused(const SUnit &SU, unsigned FuseLimit);
 /// and vice-versa.
 /// Fusing more than 2 instructions is not currently supported.
 LLVM_ABI bool fuseInstructionPair(ScheduleDAGInstrs &DAG, SUnit &FirstSU,
-                         SUnit &SecondSU);
+                                  SUnit &SecondSU);
 
 /// Create a DAG scheduling mutation to pair instructions back to back
 /// for instructions that benefit according to the target-specific

--- a/llvm/include/llvm/CodeGen/NonRelocatableStringpool.h
+++ b/llvm/include/llvm/CodeGen/NonRelocatableStringpool.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_CODEGEN_NONRELOCATABLESTRINGPOOL_H
 #define LLVM_CODEGEN_NONRELOCATABLESTRINGPOOL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/DwarfStringPoolEntry.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <vector>
 

--- a/llvm/include/llvm/CodeGen/NonRelocatableStringpool.h
+++ b/llvm/include/llvm/CodeGen/NonRelocatableStringpool.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CODEGEN_NONRELOCATABLESTRINGPOOL_H
 #define LLVM_CODEGEN_NONRELOCATABLESTRINGPOOL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/DwarfStringPoolEntry.h"
 #include "llvm/Support/Allocator.h"
 #include <cstdint>
@@ -32,7 +33,7 @@ public:
       getEntry("");
   }
 
-  DwarfStringPoolEntryRef getEntry(StringRef S);
+  LLVM_ABI DwarfStringPoolEntryRef getEntry(StringRef S);
 
   /// Get the offset of string \p S in the string table. This can insert a new
   /// element or return the offset of a pre-existing one.
@@ -44,13 +45,13 @@ public:
   ///
   /// \returns The StringRef that points to permanent storage to use
   /// in place of \p S.
-  StringRef internString(StringRef S);
+  LLVM_ABI StringRef internString(StringRef S);
 
   uint64_t getSize() { return CurrentEndOffset; }
 
   /// Return the list of strings to be emitted. This does not contain the
   /// strings which were added via internString only.
-  std::vector<DwarfStringPoolEntryRef> getEntriesForEmission() const;
+  LLVM_ABI std::vector<DwarfStringPoolEntryRef> getEntriesForEmission() const;
 
 private:
   MapTy Strings;

--- a/llvm/include/llvm/CodeGen/PBQPRAConstraint.h
+++ b/llvm/include/llvm/CodeGen/PBQPRAConstraint.h
@@ -52,8 +52,8 @@ class LLVM_ABI PBQPRAConstraintList : public PBQPRAConstraint {
 public:
   // Explicitly non-copyable.
   PBQPRAConstraintList() = default;
-  PBQPRAConstraintList& operator=(const PBQPRAConstraintList &) = delete;
-  PBQPRAConstraintList(const PBQPRAConstraintList&) = delete;
+  PBQPRAConstraintList &operator=(const PBQPRAConstraintList &) = delete;
+  PBQPRAConstraintList(const PBQPRAConstraintList &) = delete;
 
   void apply(PBQPRAGraph &G) override {
     for (auto &C : Constraints)
@@ -66,7 +66,6 @@ public:
   }
 
 private:
-
   std::vector<std::unique_ptr<PBQPRAConstraint>> Constraints;
 
   void anchor() override;

--- a/llvm/include/llvm/CodeGen/PBQPRAConstraint.h
+++ b/llvm/include/llvm/CodeGen/PBQPRAConstraint.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_PBQPRACONSTRAINT_H
 #define LLVM_CODEGEN_PBQPRACONSTRAINT_H
 
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <memory>
 #include <vector>
@@ -34,7 +35,7 @@ using PBQPRAGraph = PBQP::RegAlloc::PBQPRAGraph;
 
 /// Abstract base for classes implementing PBQP register allocation
 ///        constraints (e.g. Spill-costs, interference, coalescing).
-class PBQPRAConstraint {
+class LLVM_ABI PBQPRAConstraint {
 public:
   virtual ~PBQPRAConstraint() = 0;
   virtual void apply(PBQPRAGraph &G) = 0;
@@ -47,7 +48,7 @@ private:
 ///
 ///   Constraints added to this list will be applied, in the order that they are
 /// added, to the PBQP graph.
-class PBQPRAConstraintList : public PBQPRAConstraint {
+class LLVM_ABI PBQPRAConstraintList : public PBQPRAConstraint {
 public:
   void apply(PBQPRAGraph &G) override {
     for (auto &C : Constraints)

--- a/llvm/include/llvm/CodeGen/PBQPRAConstraint.h
+++ b/llvm/include/llvm/CodeGen/PBQPRAConstraint.h
@@ -50,6 +50,11 @@ private:
 /// added, to the PBQP graph.
 class LLVM_ABI PBQPRAConstraintList : public PBQPRAConstraint {
 public:
+  // Explicitly non-copyable.
+  PBQPRAConstraintList() = default;
+  PBQPRAConstraintList& operator=(const PBQPRAConstraintList &) = delete;
+  PBQPRAConstraintList(const PBQPRAConstraintList&) = delete;
+
   void apply(PBQPRAGraph &G) override {
     for (auto &C : Constraints)
       C->apply(G);
@@ -61,6 +66,7 @@ public:
   }
 
 private:
+
   std::vector<std::unique_ptr<PBQPRAConstraint>> Constraints;
 
   void anchor() override;

--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_CODEGEN_PASSES_H
 #define LLVM_CODEGEN_PASSES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/RegAllocCommon.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Discriminator.h"
 
 #include <functional>
@@ -100,8 +100,8 @@ LLVM_ABI MachineFunctionPass *createPrintMIRPass(raw_ostream &OS);
 /// If EmitFallbackDiag is true, the pass will emit a
 /// DiagnosticInfoISelFallback for every MachineFunction it resets.
 /// If AbortOnFailedISel is true, abort compilation instead of resetting.
-LLVM_ABI MachineFunctionPass *createResetMachineFunctionPass(bool EmitFallbackDiag,
-                                                    bool AbortOnFailedISel);
+LLVM_ABI MachineFunctionPass *
+createResetMachineFunctionPass(bool EmitFallbackDiag, bool AbortOnFailedISel);
 
 /// createCodeGenPrepareLegacyPass - Transform the code to expose more pattern
 /// matching during instruction selection.
@@ -216,7 +216,7 @@ LLVM_ABI extern char &InitUndefID;
 ///
 LLVM_ABI FunctionPass *createFastRegisterAllocator();
 LLVM_ABI FunctionPass *createFastRegisterAllocator(RegAllocFilterFunc F,
-                                          bool ClearVirtRegs);
+                                                   bool ClearVirtRegs);
 
 /// BasicRegisterAllocation Pass - This pass implements a degenerate global
 /// register allocator using the basic regalloc framework.
@@ -365,7 +365,8 @@ LLVM_ABI extern char &MachineSinkingLegacyID;
 /// machine instructions.
 LLVM_ABI extern char &MachineCopyPropagationID;
 
-LLVM_ABI MachineFunctionPass *createMachineCopyPropagationPass(bool UseCopyInstr);
+LLVM_ABI MachineFunctionPass *
+createMachineCopyPropagationPass(bool UseCopyInstr);
 
 /// MachineLateInstrsCleanup - This pass removes redundant identical
 /// instructions after register allocation and rematerialization.
@@ -487,11 +488,12 @@ LLVM_ABI ModulePass *createPreISelIntrinsicLoweringPass();
 /// to enable reuse of a base pointer by indexed addressing modes.
 /// It can also be configured to focus on size optimizations only.
 ///
-LLVM_ABI Pass *createGlobalMergePass(const TargetMachine *TM, unsigned MaximalOffset,
-                            bool OnlyOptimizeForSize = false,
-                            bool MergeExternalByDefault = false,
-                            bool MergeConstantByDefault = false,
-                            bool MergeConstAggressiveByDefault = false);
+LLVM_ABI Pass *
+createGlobalMergePass(const TargetMachine *TM, unsigned MaximalOffset,
+                      bool OnlyOptimizeForSize = false,
+                      bool MergeExternalByDefault = false,
+                      bool MergeConstantByDefault = false,
+                      bool MergeConstAggressiveByDefault = false);
 
 /// This pass splits the stack into a safe stack and an unsafe stack to
 /// protect against stack-based overflow vulnerabilities.

--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_PASSES_H
 #define LLVM_CODEGEN_PASSES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/RegAllocCommon.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Discriminator.h"
@@ -44,7 +45,7 @@ namespace llvm {
 /// AtomicExpandPass - At IR level this pass replace atomic instructions with
 /// __atomic_* library calls, or target specific instruction which implement the
 /// same semantics in a way which better fits the target backend.
-FunctionPass *createAtomicExpandLegacyPass();
+LLVM_ABI FunctionPass *createAtomicExpandLegacyPass();
 
 /// createUnreachableBlockEliminationPass - The LLVM code generator does not
 /// work well with unreachable basic blocks (what live ranges make sense for a
@@ -52,441 +53,441 @@ FunctionPass *createAtomicExpandLegacyPass();
 /// not instruction select unreachable blocks, or run this pass as its
 /// last LLVM modifying pass to clean up blocks that are not reachable from
 /// the entry block.
-FunctionPass *createUnreachableBlockEliminationPass();
+LLVM_ABI FunctionPass *createUnreachableBlockEliminationPass();
 
 /// createGCEmptyBasicblocksPass - Empty basic blocks (basic blocks without
 /// real code) appear as the result of optimization passes removing
 /// instructions. These blocks confuscate profile analysis (e.g., basic block
 /// sections) since they will share the address of their fallthrough blocks.
 /// This pass garbage-collects such basic blocks.
-MachineFunctionPass *createGCEmptyBasicBlocksPass();
+LLVM_ABI MachineFunctionPass *createGCEmptyBasicBlocksPass();
 
 /// createBasicBlockSections Pass - This pass assigns sections to machine
 /// basic blocks and is enabled with -fbasic-block-sections.
-MachineFunctionPass *createBasicBlockSectionsPass();
+LLVM_ABI MachineFunctionPass *createBasicBlockSectionsPass();
 
-MachineFunctionPass *createBasicBlockPathCloningPass();
+LLVM_ABI MachineFunctionPass *createBasicBlockPathCloningPass();
 
 /// createMachineFunctionSplitterPass - This pass splits machine functions
 /// using profile information.
-MachineFunctionPass *createMachineFunctionSplitterPass();
+LLVM_ABI MachineFunctionPass *createMachineFunctionSplitterPass();
 
 /// createStaticDataSplitterPass - This is a machine-function pass that
 /// categorizes static data hotness using profile information.
-MachineFunctionPass *createStaticDataSplitterPass();
+LLVM_ABI MachineFunctionPass *createStaticDataSplitterPass();
 
 /// createStaticDataAnnotatorPASS - This is a module pass that reads from
 /// StaticDataProfileInfoWrapperPass and annotates the section prefix of
 /// global variables.
-ModulePass *createStaticDataAnnotatorPass();
+LLVM_ABI ModulePass *createStaticDataAnnotatorPass();
 
 /// MachineFunctionPrinter pass - This pass prints out the machine function to
 /// the given stream as a debugging tool.
-MachineFunctionPass *
+LLVM_ABI MachineFunctionPass *
 createMachineFunctionPrinterPass(raw_ostream &OS,
                                  const std::string &Banner = "");
 
 /// StackFramePrinter pass - This pass prints out the machine function's
 /// stack frame to the given stream as a debugging tool.
-MachineFunctionPass *createStackFrameLayoutAnalysisPass();
+LLVM_ABI MachineFunctionPass *createStackFrameLayoutAnalysisPass();
 
 /// MIRPrinting pass - this pass prints out the LLVM IR into the given stream
 /// using the MIR serialization format.
-MachineFunctionPass *createPrintMIRPass(raw_ostream &OS);
+LLVM_ABI MachineFunctionPass *createPrintMIRPass(raw_ostream &OS);
 
 /// This pass resets a MachineFunction when it has the FailedISel property
 /// as if it was just created.
 /// If EmitFallbackDiag is true, the pass will emit a
 /// DiagnosticInfoISelFallback for every MachineFunction it resets.
 /// If AbortOnFailedISel is true, abort compilation instead of resetting.
-MachineFunctionPass *createResetMachineFunctionPass(bool EmitFallbackDiag,
+LLVM_ABI MachineFunctionPass *createResetMachineFunctionPass(bool EmitFallbackDiag,
                                                     bool AbortOnFailedISel);
 
 /// createCodeGenPrepareLegacyPass - Transform the code to expose more pattern
 /// matching during instruction selection.
-FunctionPass *createCodeGenPrepareLegacyPass();
+LLVM_ABI FunctionPass *createCodeGenPrepareLegacyPass();
 
 /// This pass implements generation of target-specific intrinsics to support
 /// handling of complex number arithmetic
-FunctionPass *createComplexDeinterleavingPass(const TargetMachine *TM);
+LLVM_ABI FunctionPass *createComplexDeinterleavingPass(const TargetMachine *TM);
 
 /// AtomicExpandID -- Lowers atomic operations in terms of either cmpxchg
 /// load-linked/store-conditional loops.
-extern char &AtomicExpandID;
+LLVM_ABI extern char &AtomicExpandID;
 
 /// MachineLoopInfo - This pass is a loop analysis pass.
-extern char &MachineLoopInfoID;
+LLVM_ABI extern char &MachineLoopInfoID;
 
 /// MachineDominators - This pass is a machine dominators analysis pass.
-extern char &MachineDominatorsID;
+LLVM_ABI extern char &MachineDominatorsID;
 
 /// MachineDominanaceFrontier - This pass is a machine dominators analysis.
-extern char &MachineDominanceFrontierID;
+LLVM_ABI extern char &MachineDominanceFrontierID;
 
 /// MachineRegionInfo - This pass computes SESE regions for machine functions.
-extern char &MachineRegionInfoPassID;
+LLVM_ABI extern char &MachineRegionInfoPassID;
 
 /// EdgeBundles analysis - Bundle machine CFG edges.
-extern char &EdgeBundlesWrapperLegacyID;
+LLVM_ABI extern char &EdgeBundlesWrapperLegacyID;
 
 /// LiveVariables pass - This pass computes the set of blocks in which each
 /// variable is life and sets machine operand kill flags.
-extern char &LiveVariablesID;
+LLVM_ABI extern char &LiveVariablesID;
 
 /// PHIElimination - This pass eliminates machine instruction PHI nodes
 /// by inserting copy instructions.  This destroys SSA information, but is the
 /// desired input for some register allocators.  This pass is "required" by
 /// these register allocator like this: AU.addRequiredID(PHIEliminationID);
-extern char &PHIEliminationID;
+LLVM_ABI extern char &PHIEliminationID;
 
 /// LiveIntervals - This analysis keeps track of the live ranges of virtual
 /// and physical registers.
-extern char &LiveIntervalsID;
+LLVM_ABI extern char &LiveIntervalsID;
 
 /// LiveStacks pass. An analysis keeping track of the liveness of stack slots.
-extern char &LiveStacksID;
+LLVM_ABI extern char &LiveStacksID;
 
 /// TwoAddressInstruction - This pass reduces two-address instructions to
 /// use two operands. This destroys SSA information but it is desired by
 /// register allocators.
-extern char &TwoAddressInstructionPassID;
+LLVM_ABI extern char &TwoAddressInstructionPassID;
 
 /// ProcessImpicitDefs pass - This pass removes IMPLICIT_DEFs.
-extern char &ProcessImplicitDefsID;
+LLVM_ABI extern char &ProcessImplicitDefsID;
 
 /// RegisterCoalescer - This pass merges live ranges to eliminate copies.
-extern char &RegisterCoalescerID;
+LLVM_ABI extern char &RegisterCoalescerID;
 
 /// MachineScheduler - This pass schedules machine instructions.
-extern char &MachineSchedulerID;
+LLVM_ABI extern char &MachineSchedulerID;
 
 /// PostMachineScheduler - This pass schedules machine instructions postRA.
-extern char &PostMachineSchedulerID;
+LLVM_ABI extern char &PostMachineSchedulerID;
 
 /// SpillPlacement analysis. Suggest optimal placement of spill code between
 /// basic blocks.
-extern char &SpillPlacementID;
+LLVM_ABI extern char &SpillPlacementID;
 
 /// ShrinkWrap pass. Look for the best place to insert save and restore
 // instruction and update the MachineFunctionInfo with that information.
-extern char &ShrinkWrapID;
+LLVM_ABI extern char &ShrinkWrapID;
 
 /// LiveRangeShrink pass. Move instruction close to its definition to shrink
 /// the definition's live range.
-extern char &LiveRangeShrinkID;
+LLVM_ABI extern char &LiveRangeShrinkID;
 
 /// Greedy register allocator.
-extern char &RAGreedyLegacyID;
+LLVM_ABI extern char &RAGreedyLegacyID;
 
 /// Basic register allocator.
-extern char &RABasicID;
+LLVM_ABI extern char &RABasicID;
 
 /// VirtRegRewriter pass. Rewrite virtual registers to physical registers as
 /// assigned in VirtRegMap.
-extern char &VirtRegRewriterID;
-FunctionPass *createVirtRegRewriter(bool ClearVirtRegs = true);
+LLVM_ABI extern char &VirtRegRewriterID;
+LLVM_ABI FunctionPass *createVirtRegRewriter(bool ClearVirtRegs = true);
 
 /// UnreachableMachineBlockElimination - This pass removes unreachable
 /// machine basic blocks.
-extern char &UnreachableMachineBlockElimID;
+LLVM_ABI extern char &UnreachableMachineBlockElimID;
 
 /// DeadMachineInstructionElim - This pass removes dead machine instructions.
-extern char &DeadMachineInstructionElimID;
+LLVM_ABI extern char &DeadMachineInstructionElimID;
 
 /// This pass adds dead/undef flags after analyzing subregister lanes.
-extern char &DetectDeadLanesID;
+LLVM_ABI extern char &DetectDeadLanesID;
 
 /// This pass perform post-ra machine sink for COPY instructions.
-extern char &PostRAMachineSinkingID;
+LLVM_ABI extern char &PostRAMachineSinkingID;
 
 /// This pass adds flow sensitive discriminators.
-extern char &MIRAddFSDiscriminatorsID;
+LLVM_ABI extern char &MIRAddFSDiscriminatorsID;
 
 /// This pass reads flow sensitive profile.
-extern char &MIRProfileLoaderPassID;
+LLVM_ABI extern char &MIRProfileLoaderPassID;
 
 // This pass gives undef values a Pseudo Instruction definition for
 // Instructions to ensure early-clobber is followed when using the greedy
 // register allocator.
-extern char &InitUndefID;
+LLVM_ABI extern char &InitUndefID;
 
 /// FastRegisterAllocation Pass - This pass register allocates as fast as
 /// possible. It is best suited for debug code where live ranges are short.
 ///
-FunctionPass *createFastRegisterAllocator();
-FunctionPass *createFastRegisterAllocator(RegAllocFilterFunc F,
+LLVM_ABI FunctionPass *createFastRegisterAllocator();
+LLVM_ABI FunctionPass *createFastRegisterAllocator(RegAllocFilterFunc F,
                                           bool ClearVirtRegs);
 
 /// BasicRegisterAllocation Pass - This pass implements a degenerate global
 /// register allocator using the basic regalloc framework.
 ///
-FunctionPass *createBasicRegisterAllocator();
-FunctionPass *createBasicRegisterAllocator(RegAllocFilterFunc F);
+LLVM_ABI FunctionPass *createBasicRegisterAllocator();
+LLVM_ABI FunctionPass *createBasicRegisterAllocator(RegAllocFilterFunc F);
 
 /// Greedy register allocation pass - This pass implements a global register
 /// allocator for optimized builds.
 ///
-FunctionPass *createGreedyRegisterAllocator();
-FunctionPass *createGreedyRegisterAllocator(RegAllocFilterFunc F);
+LLVM_ABI FunctionPass *createGreedyRegisterAllocator();
+LLVM_ABI FunctionPass *createGreedyRegisterAllocator(RegAllocFilterFunc F);
 
 /// PBQPRegisterAllocation Pass - This pass implements the Partitioned Boolean
 /// Quadratic Prograaming (PBQP) based register allocator.
 ///
-FunctionPass *createDefaultPBQPRegisterAllocator();
+LLVM_ABI FunctionPass *createDefaultPBQPRegisterAllocator();
 
 /// PrologEpilogCodeInserter - This pass inserts prolog and epilog code,
 /// and eliminates abstract frame references.
-extern char &PrologEpilogCodeInserterID;
-MachineFunctionPass *createPrologEpilogInserterPass();
+LLVM_ABI extern char &PrologEpilogCodeInserterID;
+LLVM_ABI MachineFunctionPass *createPrologEpilogInserterPass();
 
 /// ExpandPostRAPseudos - This pass expands pseudo instructions after
 /// register allocation.
-extern char &ExpandPostRAPseudosID;
+LLVM_ABI extern char &ExpandPostRAPseudosID;
 
 /// PostRAHazardRecognizer - This pass runs the post-ra hazard
 /// recognizer.
-extern char &PostRAHazardRecognizerID;
+LLVM_ABI extern char &PostRAHazardRecognizerID;
 
 /// PostRAScheduler - This pass performs post register allocation
 /// scheduling.
-extern char &PostRASchedulerID;
+LLVM_ABI extern char &PostRASchedulerID;
 
 /// BranchFolding - This pass performs machine code CFG based
 /// optimizations to delete branches to branches, eliminate branches to
 /// successor blocks (creating fall throughs), and eliminating branches over
 /// branches.
-extern char &BranchFolderPassID;
+LLVM_ABI extern char &BranchFolderPassID;
 
 /// BranchRelaxation - This pass replaces branches that need to jump further
 /// than is supported by a branch instruction.
-extern char &BranchRelaxationPassID;
+LLVM_ABI extern char &BranchRelaxationPassID;
 
 /// MachineFunctionPrinterPass - This pass prints out MachineInstr's.
-extern char &MachineFunctionPrinterPassID;
+LLVM_ABI extern char &MachineFunctionPrinterPassID;
 
 /// MIRPrintingPass - this pass prints out the LLVM IR using the MIR
 /// serialization format.
-extern char &MIRPrintingPassID;
+LLVM_ABI extern char &MIRPrintingPassID;
 
 /// TailDuplicate - Duplicate blocks with unconditional branches
 /// into tails of their predecessors.
-extern char &TailDuplicateLegacyID;
+LLVM_ABI extern char &TailDuplicateLegacyID;
 
 /// Duplicate blocks with unconditional branches into tails of their
 /// predecessors. Variant that works before register allocation.
-extern char &EarlyTailDuplicateLegacyID;
+LLVM_ABI extern char &EarlyTailDuplicateLegacyID;
 
 /// MachineTraceMetrics - This pass computes critical path and CPU resource
 /// usage in an ensemble of traces.
-extern char &MachineTraceMetricsID;
+LLVM_ABI extern char &MachineTraceMetricsID;
 
 /// EarlyIfConverter - This pass performs if-conversion on SSA form by
 /// inserting cmov instructions.
-extern char &EarlyIfConverterLegacyID;
+LLVM_ABI extern char &EarlyIfConverterLegacyID;
 
 /// EarlyIfPredicator - This pass performs if-conversion on SSA form by
 /// predicating if/else block and insert select at the join point.
-extern char &EarlyIfPredicatorID;
+LLVM_ABI extern char &EarlyIfPredicatorID;
 
 /// This pass performs instruction combining using trace metrics to estimate
 /// critical-path and resource depth.
-extern char &MachineCombinerID;
+LLVM_ABI extern char &MachineCombinerID;
 
 /// StackSlotColoring - This pass performs stack coloring and merging.
 /// It merges disjoint allocas to reduce the stack size.
-extern char &StackColoringLegacyID;
+LLVM_ABI extern char &StackColoringLegacyID;
 
 /// StackFramePrinter - This pass prints the stack frame layout and variable
 /// mappings.
-extern char &StackFrameLayoutAnalysisPassID;
+LLVM_ABI extern char &StackFrameLayoutAnalysisPassID;
 
 /// IfConverter - This pass performs machine code if conversion.
-extern char &IfConverterID;
+LLVM_ABI extern char &IfConverterID;
 
-FunctionPass *
+LLVM_ABI FunctionPass *
 createIfConverter(std::function<bool(const MachineFunction &)> Ftor);
 
 /// MachineBlockPlacement - This pass places basic blocks based on branch
 /// probabilities.
-extern char &MachineBlockPlacementID;
+LLVM_ABI extern char &MachineBlockPlacementID;
 
 /// MachineBlockPlacementStats - This pass collects statistics about the
 /// basic block placement using branch probabilities and block frequency
 /// information.
-extern char &MachineBlockPlacementStatsID;
+LLVM_ABI extern char &MachineBlockPlacementStatsID;
 
 /// GCLowering Pass - Used by gc.root to perform its default lowering
 /// operations.
-FunctionPass *createGCLoweringPass();
+LLVM_ABI FunctionPass *createGCLoweringPass();
 
 /// GCLowering Pass - Used by gc.root to perform its default lowering
 /// operations.
-extern char &GCLoweringID;
+LLVM_ABI extern char &GCLoweringID;
 
 /// ShadowStackGCLowering - Implements the custom lowering mechanism
 /// used by the shadow stack GC.  Only runs on functions which opt in to
 /// the shadow stack collector.
-FunctionPass *createShadowStackGCLoweringPass();
+LLVM_ABI FunctionPass *createShadowStackGCLoweringPass();
 
 /// ShadowStackGCLowering - Implements the custom lowering mechanism
 /// used by the shadow stack GC.
-extern char &ShadowStackGCLoweringID;
+LLVM_ABI extern char &ShadowStackGCLoweringID;
 
 /// GCMachineCodeAnalysis - Target-independent pass to mark safe points
 /// in machine code. Must be added very late during code generation, just
 /// prior to output, and importantly after all CFG transformations (such as
 /// branch folding).
-extern char &GCMachineCodeAnalysisID;
+LLVM_ABI extern char &GCMachineCodeAnalysisID;
 
 /// MachineCSE - This pass performs global CSE on machine instructions.
-extern char &MachineCSELegacyID;
+LLVM_ABI extern char &MachineCSELegacyID;
 
 /// MIRCanonicalizer - This pass canonicalizes MIR by renaming vregs
 /// according to the semantics of the instruction as well as hoists
 /// code.
-extern char &MIRCanonicalizerID;
+LLVM_ABI extern char &MIRCanonicalizerID;
 
 /// ImplicitNullChecks - This pass folds null pointer checks into nearby
 /// memory operations.
-extern char &ImplicitNullChecksID;
+LLVM_ABI extern char &ImplicitNullChecksID;
 
 /// This pass performs loop invariant code motion on machine instructions.
-extern char &MachineLICMID;
+LLVM_ABI extern char &MachineLICMID;
 
 /// This pass performs loop invariant code motion on machine instructions.
 /// This variant works before register allocation. \see MachineLICMID.
-extern char &EarlyMachineLICMID;
+LLVM_ABI extern char &EarlyMachineLICMID;
 
 /// MachineSinking - This pass performs sinking on machine instructions.
-extern char &MachineSinkingLegacyID;
+LLVM_ABI extern char &MachineSinkingLegacyID;
 
 /// MachineCopyPropagation - This pass performs copy propagation on
 /// machine instructions.
-extern char &MachineCopyPropagationID;
+LLVM_ABI extern char &MachineCopyPropagationID;
 
-MachineFunctionPass *createMachineCopyPropagationPass(bool UseCopyInstr);
+LLVM_ABI MachineFunctionPass *createMachineCopyPropagationPass(bool UseCopyInstr);
 
 /// MachineLateInstrsCleanup - This pass removes redundant identical
 /// instructions after register allocation and rematerialization.
-extern char &MachineLateInstrsCleanupID;
+LLVM_ABI extern char &MachineLateInstrsCleanupID;
 
 /// PeepholeOptimizer - This pass performs peephole optimizations -
 /// like extension and comparison eliminations.
-extern char &PeepholeOptimizerLegacyID;
+LLVM_ABI extern char &PeepholeOptimizerLegacyID;
 
 /// OptimizePHIs - This pass optimizes machine instruction PHIs
 /// to take advantage of opportunities created during DAG legalization.
-extern char &OptimizePHIsLegacyID;
+LLVM_ABI extern char &OptimizePHIsLegacyID;
 
 /// StackSlotColoring - This pass performs stack slot coloring.
-extern char &StackSlotColoringID;
+LLVM_ABI extern char &StackSlotColoringID;
 
 /// This pass lays out funclets contiguously.
-extern char &FuncletLayoutID;
+LLVM_ABI extern char &FuncletLayoutID;
 
 /// This pass inserts the XRay instrumentation sleds if they are supported by
 /// the target platform.
-extern char &XRayInstrumentationID;
+LLVM_ABI extern char &XRayInstrumentationID;
 
 /// This pass inserts FEntry calls
-extern char &FEntryInserterID;
+LLVM_ABI extern char &FEntryInserterID;
 
 /// This pass implements the "patchable-function" attribute.
-extern char &PatchableFunctionID;
+LLVM_ABI extern char &PatchableFunctionID;
 
 /// createStackProtectorPass - This pass adds stack protectors to functions.
 ///
-FunctionPass *createStackProtectorPass();
+LLVM_ABI FunctionPass *createStackProtectorPass();
 
 /// createMachineVerifierPass - This pass verifies cenerated machine code
 /// instructions for correctness.
 ///
-FunctionPass *createMachineVerifierPass(const std::string &Banner);
+LLVM_ABI FunctionPass *createMachineVerifierPass(const std::string &Banner);
 
 /// createDwarfEHPass - This pass mulches exception handling code into a form
 /// adapted to code generation.  Required if using dwarf exception handling.
-FunctionPass *createDwarfEHPass(CodeGenOptLevel OptLevel);
+LLVM_ABI FunctionPass *createDwarfEHPass(CodeGenOptLevel OptLevel);
 
 /// createWinEHPass - Prepares personality functions used by MSVC on Windows,
 /// in addition to the Itanium LSDA based personalities.
-FunctionPass *createWinEHPass(bool DemoteCatchSwitchPHIOnly = false);
+LLVM_ABI FunctionPass *createWinEHPass(bool DemoteCatchSwitchPHIOnly = false);
 
 /// createSjLjEHPreparePass - This pass adapts exception handling code to use
 /// the GCC-style builtin setjmp/longjmp (sjlj) to handling EH control flow.
 ///
-FunctionPass *createSjLjEHPreparePass(const TargetMachine *TM);
+LLVM_ABI FunctionPass *createSjLjEHPreparePass(const TargetMachine *TM);
 
 /// createWasmEHPass - This pass adapts exception handling code to use
 /// WebAssembly's exception handling scheme.
-FunctionPass *createWasmEHPass();
+LLVM_ABI FunctionPass *createWasmEHPass();
 
 /// LocalStackSlotAllocation - This pass assigns local frame indices to stack
 /// slots relative to one another and allocates base registers to access them
 /// when it is estimated by the target to be out of range of normal frame
 /// pointer or stack pointer index addressing.
-extern char &LocalStackSlotAllocationID;
+LLVM_ABI extern char &LocalStackSlotAllocationID;
 
 /// This pass expands pseudo-instructions, reserves registers and adjusts
 /// machine frame information.
-extern char &FinalizeISelID;
+LLVM_ABI extern char &FinalizeISelID;
 
 /// UnpackMachineBundles - This pass unpack machine instruction bundles.
-extern char &UnpackMachineBundlesID;
+LLVM_ABI extern char &UnpackMachineBundlesID;
 
-FunctionPass *
+LLVM_ABI FunctionPass *
 createUnpackMachineBundles(std::function<bool(const MachineFunction &)> Ftor);
 
 /// FinalizeMachineBundles - This pass finalize machine instruction
 /// bundles (created earlier, e.g. during pre-RA scheduling).
-extern char &FinalizeMachineBundlesID;
+LLVM_ABI extern char &FinalizeMachineBundlesID;
 
 /// StackMapLiveness - This pass analyses the register live-out set of
 /// stackmap/patchpoint intrinsics and attaches the calculated information to
 /// the intrinsic for later emission to the StackMap.
-extern char &StackMapLivenessID;
+LLVM_ABI extern char &StackMapLivenessID;
 
 // MachineSanitizerBinaryMetadata - appends/finalizes sanitizer binary
 // metadata after llvm SanitizerBinaryMetadata pass.
-extern char &MachineSanitizerBinaryMetadataID;
+LLVM_ABI extern char &MachineSanitizerBinaryMetadataID;
 
 /// RemoveLoadsIntoFakeUses pass.
-extern char &RemoveLoadsIntoFakeUsesID;
+LLVM_ABI extern char &RemoveLoadsIntoFakeUsesID;
 
 /// RemoveRedundantDebugValues pass.
-extern char &RemoveRedundantDebugValuesID;
+LLVM_ABI extern char &RemoveRedundantDebugValuesID;
 
 /// MachineCFGPrinter pass.
-extern char &MachineCFGPrinterID;
+LLVM_ABI extern char &MachineCFGPrinterID;
 
 /// LiveDebugValues pass
-extern char &LiveDebugValuesID;
+LLVM_ABI extern char &LiveDebugValuesID;
 
 /// InterleavedAccess Pass - This pass identifies and matches interleaved
 /// memory accesses to target specific intrinsics.
 ///
-FunctionPass *createInterleavedAccessPass();
+LLVM_ABI FunctionPass *createInterleavedAccessPass();
 
 /// InterleavedLoadCombines Pass - This pass identifies interleaved loads and
 /// combines them into wide loads detectable by InterleavedAccessPass
 ///
-FunctionPass *createInterleavedLoadCombinePass();
+LLVM_ABI FunctionPass *createInterleavedLoadCombinePass();
 
 /// LowerEmuTLS - This pass generates __emutls_[vt].xyz variables for all
 /// TLS variables for the emulated TLS model.
 ///
-ModulePass *createLowerEmuTLSPass();
+LLVM_ABI ModulePass *createLowerEmuTLSPass();
 
 /// This pass lowers the \@llvm.load.relative and \@llvm.objc.* intrinsics to
 /// instructions.  This is unsafe to do earlier because a pass may combine the
 /// constant initializer into the load, which may result in an overflowing
 /// evaluation.
-ModulePass *createPreISelIntrinsicLoweringPass();
+LLVM_ABI ModulePass *createPreISelIntrinsicLoweringPass();
 
 /// GlobalMerge - This pass merges internal (by default) globals into structs
 /// to enable reuse of a base pointer by indexed addressing modes.
 /// It can also be configured to focus on size optimizations only.
 ///
-Pass *createGlobalMergePass(const TargetMachine *TM, unsigned MaximalOffset,
+LLVM_ABI Pass *createGlobalMergePass(const TargetMachine *TM, unsigned MaximalOffset,
                             bool OnlyOptimizeForSize = false,
                             bool MergeExternalByDefault = false,
                             bool MergeConstantByDefault = false,
@@ -494,129 +495,129 @@ Pass *createGlobalMergePass(const TargetMachine *TM, unsigned MaximalOffset,
 
 /// This pass splits the stack into a safe stack and an unsafe stack to
 /// protect against stack-based overflow vulnerabilities.
-FunctionPass *createSafeStackPass();
+LLVM_ABI FunctionPass *createSafeStackPass();
 
 /// This pass detects subregister lanes in a virtual register that are used
 /// independently of other lanes and splits them into separate virtual
 /// registers.
-extern char &RenameIndependentSubregsID;
+LLVM_ABI extern char &RenameIndependentSubregsID;
 
 /// This pass is executed POST-RA to collect which physical registers are
 /// preserved by given machine function.
-FunctionPass *createRegUsageInfoCollector();
+LLVM_ABI FunctionPass *createRegUsageInfoCollector();
 
 /// Return a MachineFunction pass that identifies call sites
 /// and propagates register usage information of callee to caller
 /// if available with PysicalRegisterUsageInfo pass.
-FunctionPass *createRegUsageInfoPropPass();
+LLVM_ABI FunctionPass *createRegUsageInfoPropPass();
 
 /// This pass performs software pipelining on machine instructions.
-extern char &MachinePipelinerID;
+LLVM_ABI extern char &MachinePipelinerID;
 
 /// This pass frees the memory occupied by the MachineFunction.
-FunctionPass *createFreeMachineFunctionPass();
+LLVM_ABI FunctionPass *createFreeMachineFunctionPass();
 
 /// This pass performs merging similar functions globally.
-ModulePass *createGlobalMergeFuncPass();
+LLVM_ABI ModulePass *createGlobalMergeFuncPass();
 
 /// This pass performs outlining on machine instructions directly before
 /// printing assembly.
-ModulePass *createMachineOutlinerPass(bool RunOnAllFunctions = true);
+LLVM_ABI ModulePass *createMachineOutlinerPass(bool RunOnAllFunctions = true);
 
 /// This pass expands the reduction intrinsics into sequences of shuffles.
-FunctionPass *createExpandReductionsPass();
+LLVM_ABI FunctionPass *createExpandReductionsPass();
 
 // This pass replaces intrinsics operating on vector operands with calls to
 // the corresponding function in a vector library (e.g., SVML, libmvec).
-FunctionPass *createReplaceWithVeclibLegacyPass();
+LLVM_ABI FunctionPass *createReplaceWithVeclibLegacyPass();
 
 // Expands large div/rem instructions.
-FunctionPass *createExpandLargeDivRemPass();
+LLVM_ABI FunctionPass *createExpandLargeDivRemPass();
 
 // Expands large div/rem instructions.
-FunctionPass *createExpandFpPass();
+LLVM_ABI FunctionPass *createExpandFpPass();
 
 // This pass expands memcmp() to load/stores.
-FunctionPass *createExpandMemCmpLegacyPass();
+LLVM_ABI FunctionPass *createExpandMemCmpLegacyPass();
 
 /// Creates Break False Dependencies pass. \see BreakFalseDeps.cpp
-FunctionPass *createBreakFalseDeps();
+LLVM_ABI FunctionPass *createBreakFalseDeps();
 
 // This pass expands indirectbr instructions.
-FunctionPass *createIndirectBrExpandPass();
+LLVM_ABI FunctionPass *createIndirectBrExpandPass();
 
 /// Creates CFI Fixup pass. \see CFIFixup.cpp
-FunctionPass *createCFIFixup();
+LLVM_ABI FunctionPass *createCFIFixup();
 
 /// Creates CFI Instruction Inserter pass. \see CFIInstrInserter.cpp
-FunctionPass *createCFIInstrInserter();
+LLVM_ABI FunctionPass *createCFIInstrInserter();
 
 /// Creates CFGuard longjmp target identification pass.
 /// \see CFGuardLongjmp.cpp
-FunctionPass *createCFGuardLongjmpPass();
+LLVM_ABI FunctionPass *createCFGuardLongjmpPass();
 
 /// Creates Windows EH Continuation Guard target identification pass.
 /// \see EHContGuardTargets.cpp
-FunctionPass *createEHContGuardTargetsPass();
+LLVM_ABI FunctionPass *createEHContGuardTargetsPass();
 
 /// Create Hardware Loop pass. \see HardwareLoops.cpp
-FunctionPass *createHardwareLoopsLegacyPass();
+LLVM_ABI FunctionPass *createHardwareLoopsLegacyPass();
 
 /// This pass inserts pseudo probe annotation for callsite profiling.
-FunctionPass *createPseudoProbeInserter();
+LLVM_ABI FunctionPass *createPseudoProbeInserter();
 
 /// Create IR Type Promotion pass. \see TypePromotion.cpp
-FunctionPass *createTypePromotionLegacyPass();
+LLVM_ABI FunctionPass *createTypePromotionLegacyPass();
 
 /// Add Flow Sensitive Discriminators. PassNum specifies the
 /// sequence number of this pass (starting from 1).
-FunctionPass *
+LLVM_ABI FunctionPass *
 createMIRAddFSDiscriminatorsPass(sampleprof::FSDiscriminatorPass P);
 
 /// Read Flow Sensitive Profile.
-FunctionPass *
+LLVM_ABI FunctionPass *
 createMIRProfileLoaderPass(std::string File, std::string RemappingFile,
                            sampleprof::FSDiscriminatorPass P,
                            IntrusiveRefCntPtr<vfs::FileSystem> FS);
 
 /// Creates MIR Debugify pass. \see MachineDebugify.cpp
-ModulePass *createDebugifyMachineModulePass();
+LLVM_ABI ModulePass *createDebugifyMachineModulePass();
 
 /// Creates MIR Strip Debug pass. \see MachineStripDebug.cpp
 /// If OnlyDebugified is true then it will only strip debug info if it was
 /// added by a Debugify pass. The module will be left unchanged if the debug
 /// info was generated by another source such as clang.
-ModulePass *createStripDebugMachineModulePass(bool OnlyDebugified);
+LLVM_ABI ModulePass *createStripDebugMachineModulePass(bool OnlyDebugified);
 
 /// Creates MIR Check Debug pass. \see MachineCheckDebugify.cpp
-ModulePass *createCheckDebugMachineModulePass();
+LLVM_ABI ModulePass *createCheckDebugMachineModulePass();
 
 /// The pass fixups statepoint machine instruction to replace usage of
 /// caller saved registers with stack slots.
-extern char &FixupStatepointCallerSavedID;
+LLVM_ABI extern char &FixupStatepointCallerSavedID;
 
 /// The pass transforms load/store <256 x i32> to AMX load/store intrinsics
 /// or split the data to two <128 x i32>.
-FunctionPass *createX86LowerAMXTypePass();
+LLVM_ABI FunctionPass *createX86LowerAMXTypePass();
 
 /// The pass transforms amx intrinsics to scalar operation if the function has
 /// optnone attribute or it is O0.
-FunctionPass *createX86LowerAMXIntrinsicsPass();
+LLVM_ABI FunctionPass *createX86LowerAMXIntrinsicsPass();
 
 /// When learning an eviction policy, extract score(reward) information,
 /// otherwise this does nothing
-FunctionPass *createRegAllocScoringPass();
+LLVM_ABI FunctionPass *createRegAllocScoringPass();
 
 /// JMC instrument pass.
-ModulePass *createJMCInstrumenterPass();
+LLVM_ABI ModulePass *createJMCInstrumenterPass();
 
 /// This pass converts conditional moves to conditional jumps when profitable.
-FunctionPass *createSelectOptimizePass();
+LLVM_ABI FunctionPass *createSelectOptimizePass();
 
-FunctionPass *createCallBrPass();
+LLVM_ABI FunctionPass *createCallBrPass();
 
 /// Lowers KCFI operand bundles for indirect calls.
-FunctionPass *createKCFIPass();
+LLVM_ABI FunctionPass *createKCFIPass();
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/CodeGen/PseudoSourceValue.h
+++ b/llvm/include/llvm/CodeGen/PseudoSourceValue.h
@@ -23,12 +23,12 @@ class PseudoSourceValue;
 class raw_ostream;
 class TargetMachine;
 
-raw_ostream &operator<<(raw_ostream &OS, const PseudoSourceValue* PSV);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PseudoSourceValue* PSV);
 
 /// Special value supplied for machine level alias analysis. It indicates that
 /// a memory access references the functions stack frame (e.g., a spill slot),
 /// below the stack frame (e.g., argument space), or constant pool.
-class PseudoSourceValue {
+class LLVM_ABI PseudoSourceValue {
 public:
   enum PSVKind : unsigned {
     Stack,
@@ -87,7 +87,7 @@ public:
 
 /// A specialized PseudoSourceValue for holding FixedStack values, which must
 /// include a frame index.
-class FixedStackPseudoSourceValue : public PseudoSourceValue {
+class LLVM_ABI FixedStackPseudoSourceValue : public PseudoSourceValue {
   const int FI;
 
 public:
@@ -109,7 +109,7 @@ public:
   int getFrameIndex() const { return FI; }
 };
 
-class CallEntryPseudoSourceValue : public PseudoSourceValue {
+class LLVM_ABI CallEntryPseudoSourceValue : public PseudoSourceValue {
 protected:
   CallEntryPseudoSourceValue(unsigned Kind, const TargetMachine &TM);
 
@@ -124,7 +124,7 @@ class GlobalValuePseudoSourceValue : public CallEntryPseudoSourceValue {
   const GlobalValue *GV;
 
 public:
-  GlobalValuePseudoSourceValue(const GlobalValue *GV, const TargetMachine &TM);
+  LLVM_ABI GlobalValuePseudoSourceValue(const GlobalValue *GV, const TargetMachine &TM);
 
   static bool classof(const PseudoSourceValue *V) {
     return V->kind() == GlobalValueCallEntry;
@@ -138,7 +138,7 @@ class ExternalSymbolPseudoSourceValue : public CallEntryPseudoSourceValue {
   const char *ES;
 
 public:
-  ExternalSymbolPseudoSourceValue(const char *ES, const TargetMachine &TM);
+  LLVM_ABI ExternalSymbolPseudoSourceValue(const char *ES, const TargetMachine &TM);
 
   static bool classof(const PseudoSourceValue *V) {
     return V->kind() == ExternalSymbolCallEntry;

--- a/llvm/include/llvm/CodeGen/PseudoSourceValue.h
+++ b/llvm/include/llvm/CodeGen/PseudoSourceValue.h
@@ -13,6 +13,8 @@
 #ifndef LLVM_CODEGEN_PSEUDOSOURCEVALUE_H
 #define LLVM_CODEGEN_PSEUDOSOURCEVALUE_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class GlobalValue;
@@ -44,7 +46,7 @@ public:
 private:
   unsigned Kind;
   unsigned AddressSpace;
-  friend raw_ostream &llvm::operator<<(raw_ostream &OS,
+  LLVM_ABI_FRIEND friend raw_ostream &llvm::operator<<(raw_ostream &OS,
                                        const PseudoSourceValue* PSV);
 
   friend class MachineMemOperand; // For printCustom().

--- a/llvm/include/llvm/CodeGen/PseudoSourceValue.h
+++ b/llvm/include/llvm/CodeGen/PseudoSourceValue.h
@@ -25,7 +25,7 @@ class PseudoSourceValue;
 class raw_ostream;
 class TargetMachine;
 
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PseudoSourceValue* PSV);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const PseudoSourceValue *PSV);
 
 /// Special value supplied for machine level alias analysis. It indicates that
 /// a memory access references the functions stack frame (e.g., a spill slot),
@@ -46,8 +46,8 @@ public:
 private:
   unsigned Kind;
   unsigned AddressSpace;
-  LLVM_ABI_FRIEND friend raw_ostream &llvm::operator<<(raw_ostream &OS,
-                                       const PseudoSourceValue* PSV);
+  LLVM_ABI_FRIEND friend raw_ostream &
+  llvm::operator<<(raw_ostream &OS, const PseudoSourceValue *PSV);
 
   friend class MachineMemOperand; // For printCustom().
   friend class MIRFormatter;      // For printCustom().
@@ -126,7 +126,8 @@ class GlobalValuePseudoSourceValue : public CallEntryPseudoSourceValue {
   const GlobalValue *GV;
 
 public:
-  LLVM_ABI GlobalValuePseudoSourceValue(const GlobalValue *GV, const TargetMachine &TM);
+  LLVM_ABI GlobalValuePseudoSourceValue(const GlobalValue *GV,
+                                        const TargetMachine &TM);
 
   static bool classof(const PseudoSourceValue *V) {
     return V->kind() == GlobalValueCallEntry;
@@ -140,7 +141,8 @@ class ExternalSymbolPseudoSourceValue : public CallEntryPseudoSourceValue {
   const char *ES;
 
 public:
-  LLVM_ABI ExternalSymbolPseudoSourceValue(const char *ES, const TargetMachine &TM);
+  LLVM_ABI ExternalSymbolPseudoSourceValue(const char *ES,
+                                           const TargetMachine &TM);
 
   static bool classof(const PseudoSourceValue *V) {
     return V->kind() == ExternalSymbolCallEntry;

--- a/llvm/include/llvm/CodeGen/PseudoSourceValueManager.h
+++ b/llvm/include/llvm/CodeGen/PseudoSourceValueManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_PSEUDOSOURCEVALUEMANAGER_H
 #define LLVM_CODEGEN_PSEUDOSOURCEVALUEMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CodeGen/PseudoSourceValue.h"
@@ -35,32 +36,32 @@ class PseudoSourceValueManager {
       GlobalCallEntries;
 
 public:
-  PseudoSourceValueManager(const TargetMachine &TM);
+  LLVM_ABI PseudoSourceValueManager(const TargetMachine &TM);
 
   /// Return a pseudo source value referencing the area below the stack frame of
   /// a function, e.g., the argument space.
-  const PseudoSourceValue *getStack();
+  LLVM_ABI const PseudoSourceValue *getStack();
 
   /// Return a pseudo source value referencing the global offset table
   /// (or something the like).
-  const PseudoSourceValue *getGOT();
+  LLVM_ABI const PseudoSourceValue *getGOT();
 
   /// Return a pseudo source value referencing the constant pool. Since constant
   /// pools are constant, this doesn't need to identify a specific constant
   /// pool entry.
-  const PseudoSourceValue *getConstantPool();
+  LLVM_ABI const PseudoSourceValue *getConstantPool();
 
   /// Return a pseudo source value referencing a jump table. Since jump tables
   /// are constant, this doesn't need to identify a specific jump table.
-  const PseudoSourceValue *getJumpTable();
+  LLVM_ABI const PseudoSourceValue *getJumpTable();
 
   /// Return a pseudo source value referencing a fixed stack frame entry,
   /// e.g., a spill slot.
-  const PseudoSourceValue *getFixedStack(int FI);
+  LLVM_ABI const PseudoSourceValue *getFixedStack(int FI);
 
-  const PseudoSourceValue *getGlobalValueCallEntry(const GlobalValue *GV);
+  LLVM_ABI const PseudoSourceValue *getGlobalValueCallEntry(const GlobalValue *GV);
 
-  const PseudoSourceValue *getExternalSymbolCallEntry(const char *ES);
+  LLVM_ABI const PseudoSourceValue *getExternalSymbolCallEntry(const char *ES);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/PseudoSourceValueManager.h
+++ b/llvm/include/llvm/CodeGen/PseudoSourceValueManager.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_CODEGEN_PSEUDOSOURCEVALUEMANAGER_H
 #define LLVM_CODEGEN_PSEUDOSOURCEVALUEMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CodeGen/PseudoSourceValue.h"
 #include "llvm/IR/ValueMap.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -59,7 +59,8 @@ public:
   /// e.g., a spill slot.
   LLVM_ABI const PseudoSourceValue *getFixedStack(int FI);
 
-  LLVM_ABI const PseudoSourceValue *getGlobalValueCallEntry(const GlobalValue *GV);
+  LLVM_ABI const PseudoSourceValue *
+  getGlobalValueCallEntry(const GlobalValue *GV);
 
   LLVM_ABI const PseudoSourceValue *getExternalSymbolCallEntry(const char *ES);
 };

--- a/llvm/include/llvm/CodeGen/RegisterBank.h
+++ b/llvm/include/llvm/CodeGen/RegisterBank.h
@@ -55,7 +55,8 @@ public:
   /// \note This method does not check anything when assertions are disabled.
   ///
   /// \return True is the check was successful.
-  LLVM_ABI bool verify(const RegisterBankInfo &RBI, const TargetRegisterInfo &TRI) const;
+  LLVM_ABI bool verify(const RegisterBankInfo &RBI,
+                       const TargetRegisterInfo &TRI) const;
 
   /// Check whether this register bank covers \p RC.
   /// In other words, check if this register bank fully covers
@@ -78,7 +79,7 @@ public:
   /// TRI is then used to print the name of the register classes that
   /// this register bank covers.
   LLVM_ABI void print(raw_ostream &OS, bool IsForDebug = false,
-             const TargetRegisterInfo *TRI = nullptr) const;
+                      const TargetRegisterInfo *TRI = nullptr) const;
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const RegisterBank &RegBank) {

--- a/llvm/include/llvm/CodeGen/RegisterBank.h
+++ b/llvm/include/llvm/CodeGen/RegisterBank.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_REGISTERBANK_H
 #define LLVM_CODEGEN_REGISTERBANK_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -54,29 +55,29 @@ public:
   /// \note This method does not check anything when assertions are disabled.
   ///
   /// \return True is the check was successful.
-  bool verify(const RegisterBankInfo &RBI, const TargetRegisterInfo &TRI) const;
+  LLVM_ABI bool verify(const RegisterBankInfo &RBI, const TargetRegisterInfo &TRI) const;
 
   /// Check whether this register bank covers \p RC.
   /// In other words, check if this register bank fully covers
   /// the registers that \p RC contains.
-  bool covers(const TargetRegisterClass &RC) const;
+  LLVM_ABI bool covers(const TargetRegisterClass &RC) const;
 
   /// Check whether \p OtherRB is the same as this.
-  bool operator==(const RegisterBank &OtherRB) const;
+  LLVM_ABI bool operator==(const RegisterBank &OtherRB) const;
   bool operator!=(const RegisterBank &OtherRB) const {
     return !this->operator==(OtherRB);
   }
 
   /// Dump the register mask on dbgs() stream.
   /// The dump is verbose.
-  void dump(const TargetRegisterInfo *TRI = nullptr) const;
+  LLVM_ABI void dump(const TargetRegisterInfo *TRI = nullptr) const;
 
   /// Print the register mask on OS.
   /// If IsForDebug is false, then only the name of the register bank
   /// is printed. Otherwise, all the fields are printing.
   /// TRI is then used to print the name of the register classes that
   /// this register bank covers.
-  void print(raw_ostream &OS, bool IsForDebug = false,
+  LLVM_ABI void print(raw_ostream &OS, bool IsForDebug = false,
              const TargetRegisterInfo *TRI = nullptr) const;
 };
 

--- a/llvm/include/llvm/CodeGen/RegisterClassInfo.h
+++ b/llvm/include/llvm/CodeGen/RegisterClassInfo.h
@@ -16,12 +16,12 @@
 #ifndef LLVM_CODEGEN_REGISTERCLASSINFO_H
 #define LLVM_CODEGEN_REGISTERCLASSINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/MC/MCRegister.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <memory>
 

--- a/llvm/include/llvm/CodeGen/RegisterClassInfo.h
+++ b/llvm/include/llvm/CodeGen/RegisterClassInfo.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CODEGEN_REGISTERCLASSINFO_H
 #define LLVM_CODEGEN_REGISTERCLASSINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -72,7 +73,7 @@ class RegisterClassInfo {
   ArrayRef<uint8_t> RegCosts;
 
   // Compute all information about RC.
-  void compute(const TargetRegisterClass *RC) const;
+  LLVM_ABI void compute(const TargetRegisterClass *RC) const;
 
   // Return an up-to-date RCInfo for RC.
   const RCInfo &get(const TargetRegisterClass *RC) const {
@@ -83,11 +84,11 @@ class RegisterClassInfo {
   }
 
 public:
-  RegisterClassInfo();
+  LLVM_ABI RegisterClassInfo();
 
   /// runOnFunction - Prepare to answer questions about MF. This must be called
   /// before any other methods are used.
-  void runOnMachineFunction(const MachineFunction &MF);
+  LLVM_ABI void runOnMachineFunction(const MachineFunction &MF);
 
   /// getNumAllocatableRegs - Returns the number of actually allocatable
   /// registers in RC in the current function.
@@ -150,7 +151,7 @@ public:
   }
 
 protected:
-  unsigned computePSetLimit(unsigned Idx) const;
+  LLVM_ABI unsigned computePSetLimit(unsigned Idx) const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/RegisterPressure.h
+++ b/llvm/include/llvm/CodeGen/RegisterPressure.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_REGISTERPRESSURE_H
 #define LLVM_CODEGEN_REGISTERPRESSURE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SparseSet.h"
@@ -22,6 +21,7 @@
 #include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/MC/LaneBitmask.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
@@ -158,7 +158,7 @@ public:
   const_iterator end() const { return &PressureChanges[MaxPSets]; }
 
   LLVM_ABI void addPressureChange(Register RegUnit, bool IsDec,
-                         const MachineRegisterInfo *MRI);
+                                  const MachineRegisterInfo *MRI);
 
   LLVM_ABI void dump(const TargetRegisterInfo &TRI) const;
 };
@@ -178,20 +178,22 @@ public:
   /// Analyze the given instruction \p MI and fill in the Uses, Defs and
   /// DeadDefs list based on the MachineOperand flags.
   LLVM_ABI void collect(const MachineInstr &MI, const TargetRegisterInfo &TRI,
-               const MachineRegisterInfo &MRI, bool TrackLaneMasks,
-               bool IgnoreDead);
+                        const MachineRegisterInfo &MRI, bool TrackLaneMasks,
+                        bool IgnoreDead);
 
   /// Use liveness information to find dead defs not marked with a dead flag
   /// and move them to the DeadDefs vector.
-  LLVM_ABI void detectDeadDefs(const MachineInstr &MI, const LiveIntervals &LIS);
+  LLVM_ABI void detectDeadDefs(const MachineInstr &MI,
+                               const LiveIntervals &LIS);
 
   /// Use liveness information to find out which uses/defs are partially
   /// undefined/dead and adjust the VRegMaskOrUnits accordingly.
   /// If \p AddFlagsMI is given then missing read-undef and dead flags will be
   /// added to the instruction.
   LLVM_ABI void adjustLaneLiveness(const LiveIntervals &LIS,
-                          const MachineRegisterInfo &MRI, SlotIndex Pos,
-                          MachineInstr *AddFlagsMI = nullptr);
+                                   const MachineRegisterInfo &MRI,
+                                   SlotIndex Pos,
+                                   MachineInstr *AddFlagsMI = nullptr);
 };
 
 /// Array of PressureDiffs.
@@ -221,7 +223,7 @@ public:
   /// Record pressure difference induced by the given operand list to
   /// node with index \p Idx.
   LLVM_ABI void addInstruction(unsigned Idx, const RegisterOperands &RegOpers,
-                      const MachineRegisterInfo &MRI);
+                               const MachineRegisterInfo &MRI);
 };
 
 /// Store the effects of a change in pressure on things that MI scheduler cares
@@ -402,9 +404,9 @@ public:
   LLVM_ABI void reset();
 
   LLVM_ABI void init(const MachineFunction *mf, const RegisterClassInfo *rci,
-            const LiveIntervals *lis, const MachineBasicBlock *mbb,
-            MachineBasicBlock::const_iterator pos,
-            bool TrackLaneMasks, bool TrackUntiedDefs);
+                     const LiveIntervals *lis, const MachineBasicBlock *mbb,
+                     MachineBasicBlock::const_iterator pos, bool TrackLaneMasks,
+                     bool TrackUntiedDefs);
 
   /// Force liveness of virtual registers or physical register
   /// units. Particularly useful to initialize the livein/out state of the
@@ -428,7 +430,7 @@ public:
   /// called previously and takes precomputed RegisterOperands for the
   /// instruction.
   LLVM_ABI void recede(const RegisterOperands &RegOpers,
-              SmallVectorImpl<VRegMaskOrUnit> *LiveUses = nullptr);
+                       SmallVectorImpl<VRegMaskOrUnit> *LiveUses = nullptr);
 
   /// Recede until we find an instruction which is not a DebugValue.
   LLVM_ABI void recedeSkipDebugValues();
@@ -476,26 +478,26 @@ public:
   /// bottom-up. Find the pressure set with the most change beyond its pressure
   /// limit based on the tracker's current pressure, and record the number of
   /// excess register units of that pressure set introduced by this instruction.
-  LLVM_ABI void getMaxUpwardPressureDelta(const MachineInstr *MI,
-                                 PressureDiff *PDiff,
-                                 RegPressureDelta &Delta,
-                                 ArrayRef<PressureChange> CriticalPSets,
-                                 ArrayRef<unsigned> MaxPressureLimit);
+  LLVM_ABI void
+  getMaxUpwardPressureDelta(const MachineInstr *MI, PressureDiff *PDiff,
+                            RegPressureDelta &Delta,
+                            ArrayRef<PressureChange> CriticalPSets,
+                            ArrayRef<unsigned> MaxPressureLimit);
 
-  LLVM_ABI void getUpwardPressureDelta(const MachineInstr *MI,
-                              /*const*/ PressureDiff &PDiff,
-                              RegPressureDelta &Delta,
-                              ArrayRef<PressureChange> CriticalPSets,
-                              ArrayRef<unsigned> MaxPressureLimit) const;
+  LLVM_ABI void
+  getUpwardPressureDelta(const MachineInstr *MI,
+                         /*const*/ PressureDiff &PDiff, RegPressureDelta &Delta,
+                         ArrayRef<PressureChange> CriticalPSets,
+                         ArrayRef<unsigned> MaxPressureLimit) const;
 
   /// Consider the pressure increase caused by traversing this instruction
   /// top-down. Find the pressure set with the most change beyond its pressure
   /// limit based on the tracker's current pressure, and record the number of
   /// excess register units of that pressure set introduced by this instruction.
-  LLVM_ABI void getMaxDownwardPressureDelta(const MachineInstr *MI,
-                                   RegPressureDelta &Delta,
-                                   ArrayRef<PressureChange> CriticalPSets,
-                                   ArrayRef<unsigned> MaxPressureLimit);
+  LLVM_ABI void
+  getMaxDownwardPressureDelta(const MachineInstr *MI, RegPressureDelta &Delta,
+                              ArrayRef<PressureChange> CriticalPSets,
+                              ArrayRef<unsigned> MaxPressureLimit);
 
   /// Find the pressure set with the most change beyond its pressure limit after
   /// traversing this instruction either upward or downward depending on the
@@ -515,13 +517,13 @@ public:
 
   /// Get the pressure of each PSet after traversing this instruction bottom-up.
   LLVM_ABI void getUpwardPressure(const MachineInstr *MI,
-                         std::vector<unsigned> &PressureResult,
-                         std::vector<unsigned> &MaxPressureResult);
+                                  std::vector<unsigned> &PressureResult,
+                                  std::vector<unsigned> &MaxPressureResult);
 
   /// Get the pressure of each PSet after traversing this instruction top-down.
   LLVM_ABI void getDownwardPressure(const MachineInstr *MI,
-                           std::vector<unsigned> &PressureResult,
-                           std::vector<unsigned> &MaxPressureResult);
+                                    std::vector<unsigned> &PressureResult,
+                                    std::vector<unsigned> &MaxPressureResult);
 
   void getPressureAfterInst(const MachineInstr *MI,
                             std::vector<unsigned> &PressureResult,
@@ -540,9 +542,9 @@ public:
   LLVM_ABI void dump() const;
 
   LLVM_ABI void increaseRegPressure(Register RegUnit, LaneBitmask PreviousMask,
-                           LaneBitmask NewMask);
+                                    LaneBitmask NewMask);
   LLVM_ABI void decreaseRegPressure(Register RegUnit, LaneBitmask PreviousMask,
-                           LaneBitmask NewMask);
+                                    LaneBitmask NewMask);
 
 protected:
   /// Add Reg to the live out set and increase max pressure.
@@ -559,8 +561,9 @@ protected:
   LLVM_ABI void bumpUpwardPressure(const MachineInstr *MI);
   LLVM_ABI void bumpDownwardPressure(const MachineInstr *MI);
 
-  LLVM_ABI void discoverLiveInOrOut(VRegMaskOrUnit Pair,
-                           SmallVectorImpl<VRegMaskOrUnit> &LiveInOrOut);
+  LLVM_ABI void
+  discoverLiveInOrOut(VRegMaskOrUnit Pair,
+                      SmallVectorImpl<VRegMaskOrUnit> &LiveInOrOut);
 
   LLVM_ABI LaneBitmask getLastUsedLanes(Register RegUnit, SlotIndex Pos) const;
   LLVM_ABI LaneBitmask getLiveLanesAt(Register RegUnit, SlotIndex Pos) const;
@@ -568,7 +571,7 @@ protected:
 };
 
 LLVM_ABI void dumpRegSetPressure(ArrayRef<unsigned> SetPressure,
-                        const TargetRegisterInfo *TRI);
+                                 const TargetRegisterInfo *TRI);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/RegisterPressure.h
+++ b/llvm/include/llvm/CodeGen/RegisterPressure.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_REGISTERPRESSURE_H
 #define LLVM_CODEGEN_REGISTERPRESSURE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SparseSet.h"
@@ -52,7 +53,7 @@ struct RegisterPressure {
   SmallVector<VRegMaskOrUnit, 8> LiveInRegs;
   SmallVector<VRegMaskOrUnit, 8> LiveOutRegs;
 
-  void dump(const TargetRegisterInfo *TRI) const;
+  LLVM_ABI void dump(const TargetRegisterInfo *TRI) const;
 };
 
 /// RegisterPressure computed within a region of instructions delimited by
@@ -69,11 +70,11 @@ struct IntervalPressure : RegisterPressure {
   SlotIndex TopIdx;
   SlotIndex BottomIdx;
 
-  void reset();
+  LLVM_ABI void reset();
 
-  void openTop(SlotIndex NextTop);
+  LLVM_ABI void openTop(SlotIndex NextTop);
 
-  void openBottom(SlotIndex PrevBottom);
+  LLVM_ABI void openBottom(SlotIndex PrevBottom);
 };
 
 /// RegisterPressure computed within a region of instructions delimited by
@@ -84,11 +85,11 @@ struct RegionPressure : RegisterPressure {
   MachineBasicBlock::const_iterator TopPos;
   MachineBasicBlock::const_iterator BottomPos;
 
-  void reset();
+  LLVM_ABI void reset();
 
-  void openTop(MachineBasicBlock::const_iterator PrevTop);
+  LLVM_ABI void openTop(MachineBasicBlock::const_iterator PrevTop);
 
-  void openBottom(MachineBasicBlock::const_iterator PrevBottom);
+  LLVM_ABI void openBottom(MachineBasicBlock::const_iterator PrevBottom);
 };
 
 /// Capture a change in pressure for a single pressure set. UnitInc may be
@@ -129,7 +130,7 @@ public:
     return PSetID == RHS.PSetID && UnitInc == RHS.UnitInc;
   }
 
-  void dump() const;
+  LLVM_ABI void dump() const;
 };
 
 /// List of PressureChanges in order of increasing, unique PSetID.
@@ -156,10 +157,10 @@ public:
   const_iterator begin() const { return &PressureChanges[0]; }
   const_iterator end() const { return &PressureChanges[MaxPSets]; }
 
-  void addPressureChange(Register RegUnit, bool IsDec,
+  LLVM_ABI void addPressureChange(Register RegUnit, bool IsDec,
                          const MachineRegisterInfo *MRI);
 
-  void dump(const TargetRegisterInfo &TRI) const;
+  LLVM_ABI void dump(const TargetRegisterInfo &TRI) const;
 };
 
 /// List of registers defined and used by a machine instruction.
@@ -176,19 +177,19 @@ public:
 
   /// Analyze the given instruction \p MI and fill in the Uses, Defs and
   /// DeadDefs list based on the MachineOperand flags.
-  void collect(const MachineInstr &MI, const TargetRegisterInfo &TRI,
+  LLVM_ABI void collect(const MachineInstr &MI, const TargetRegisterInfo &TRI,
                const MachineRegisterInfo &MRI, bool TrackLaneMasks,
                bool IgnoreDead);
 
   /// Use liveness information to find dead defs not marked with a dead flag
   /// and move them to the DeadDefs vector.
-  void detectDeadDefs(const MachineInstr &MI, const LiveIntervals &LIS);
+  LLVM_ABI void detectDeadDefs(const MachineInstr &MI, const LiveIntervals &LIS);
 
   /// Use liveness information to find out which uses/defs are partially
   /// undefined/dead and adjust the VRegMaskOrUnits accordingly.
   /// If \p AddFlagsMI is given then missing read-undef and dead flags will be
   /// added to the instruction.
-  void adjustLaneLiveness(const LiveIntervals &LIS,
+  LLVM_ABI void adjustLaneLiveness(const LiveIntervals &LIS,
                           const MachineRegisterInfo &MRI, SlotIndex Pos,
                           MachineInstr *AddFlagsMI = nullptr);
 };
@@ -207,7 +208,7 @@ public:
 
   void clear() { Size = 0; }
 
-  void init(unsigned N);
+  LLVM_ABI void init(unsigned N);
 
   PressureDiff &operator[](unsigned Idx) {
     assert(Idx < Size && "PressureDiff index out of bounds");
@@ -219,7 +220,7 @@ public:
 
   /// Record pressure difference induced by the given operand list to
   /// node with index \p Idx.
-  void addInstruction(unsigned Idx, const RegisterOperands &RegOpers,
+  LLVM_ABI void addInstruction(unsigned Idx, const RegisterOperands &RegOpers,
                       const MachineRegisterInfo &MRI);
 };
 
@@ -251,7 +252,7 @@ struct RegPressureDelta {
   bool operator!=(const RegPressureDelta &RHS) const {
     return !operator==(RHS);
   }
-  void dump() const;
+  LLVM_ABI void dump() const;
 };
 
 /// A set of live virtual registers and physical register units.
@@ -290,8 +291,8 @@ private:
   }
 
 public:
-  void clear();
-  void init(const MachineRegisterInfo &MRI);
+  LLVM_ABI void clear();
+  LLVM_ABI void init(const MachineRegisterInfo &MRI);
 
   LaneBitmask contains(Register Reg) const {
     unsigned SparseIndex = getSparseIndexFromReg(Reg);
@@ -398,9 +399,9 @@ public:
   RegPressureTracker(IntervalPressure &rp) : P(rp), RequireIntervals(true) {}
   RegPressureTracker(RegionPressure &rp) : P(rp), RequireIntervals(false) {}
 
-  void reset();
+  LLVM_ABI void reset();
 
-  void init(const MachineFunction *mf, const RegisterClassInfo *rci,
+  LLVM_ABI void init(const MachineFunction *mf, const RegisterClassInfo *rci,
             const LiveIntervals *lis, const MachineBasicBlock *mbb,
             MachineBasicBlock::const_iterator pos,
             bool TrackLaneMasks, bool TrackUntiedDefs);
@@ -408,7 +409,7 @@ public:
   /// Force liveness of virtual registers or physical register
   /// units. Particularly useful to initialize the livein/out state of the
   /// tracker before the first call to advance/recede.
-  void addLiveRegs(ArrayRef<VRegMaskOrUnit> Regs);
+  LLVM_ABI void addLiveRegs(ArrayRef<VRegMaskOrUnit> Regs);
 
   /// Get the MI position corresponding to this register pressure.
   MachineBasicBlock::const_iterator getPos() const { return CurrPos; }
@@ -420,32 +421,32 @@ public:
   void setPos(MachineBasicBlock::const_iterator Pos) { CurrPos = Pos; }
 
   /// Recede across the previous instruction.
-  void recede(SmallVectorImpl<VRegMaskOrUnit> *LiveUses = nullptr);
+  LLVM_ABI void recede(SmallVectorImpl<VRegMaskOrUnit> *LiveUses = nullptr);
 
   /// Recede across the previous instruction.
   /// This "low-level" variant assumes that recedeSkipDebugValues() was
   /// called previously and takes precomputed RegisterOperands for the
   /// instruction.
-  void recede(const RegisterOperands &RegOpers,
+  LLVM_ABI void recede(const RegisterOperands &RegOpers,
               SmallVectorImpl<VRegMaskOrUnit> *LiveUses = nullptr);
 
   /// Recede until we find an instruction which is not a DebugValue.
-  void recedeSkipDebugValues();
+  LLVM_ABI void recedeSkipDebugValues();
 
   /// Advance across the current instruction.
-  void advance();
+  LLVM_ABI void advance();
 
   /// Advance across the current instruction.
   /// This is a "low-level" variant of advance() which takes precomputed
   /// RegisterOperands of the instruction.
-  void advance(const RegisterOperands &RegOpers);
+  LLVM_ABI void advance(const RegisterOperands &RegOpers);
 
   /// Finalize the region boundaries and recored live ins and live outs.
-  void closeRegion();
+  LLVM_ABI void closeRegion();
 
   /// Initialize the LiveThru pressure set based on the untied defs found in
   /// RPTracker.
-  void initLiveThru(const RegPressureTracker &RPTracker);
+  LLVM_ABI void initLiveThru(const RegPressureTracker &RPTracker);
 
   /// Copy an existing live thru pressure result.
   void initLiveThru(ArrayRef<unsigned> PressureSet) {
@@ -465,23 +466,23 @@ public:
     return CurrSetPressure;
   }
 
-  bool isTopClosed() const;
-  bool isBottomClosed() const;
+  LLVM_ABI bool isTopClosed() const;
+  LLVM_ABI bool isBottomClosed() const;
 
-  void closeTop();
-  void closeBottom();
+  LLVM_ABI void closeTop();
+  LLVM_ABI void closeBottom();
 
   /// Consider the pressure increase caused by traversing this instruction
   /// bottom-up. Find the pressure set with the most change beyond its pressure
   /// limit based on the tracker's current pressure, and record the number of
   /// excess register units of that pressure set introduced by this instruction.
-  void getMaxUpwardPressureDelta(const MachineInstr *MI,
+  LLVM_ABI void getMaxUpwardPressureDelta(const MachineInstr *MI,
                                  PressureDiff *PDiff,
                                  RegPressureDelta &Delta,
                                  ArrayRef<PressureChange> CriticalPSets,
                                  ArrayRef<unsigned> MaxPressureLimit);
 
-  void getUpwardPressureDelta(const MachineInstr *MI,
+  LLVM_ABI void getUpwardPressureDelta(const MachineInstr *MI,
                               /*const*/ PressureDiff &PDiff,
                               RegPressureDelta &Delta,
                               ArrayRef<PressureChange> CriticalPSets,
@@ -491,7 +492,7 @@ public:
   /// top-down. Find the pressure set with the most change beyond its pressure
   /// limit based on the tracker's current pressure, and record the number of
   /// excess register units of that pressure set introduced by this instruction.
-  void getMaxDownwardPressureDelta(const MachineInstr *MI,
+  LLVM_ABI void getMaxDownwardPressureDelta(const MachineInstr *MI,
                                    RegPressureDelta &Delta,
                                    ArrayRef<PressureChange> CriticalPSets,
                                    ArrayRef<unsigned> MaxPressureLimit);
@@ -513,12 +514,12 @@ public:
   }
 
   /// Get the pressure of each PSet after traversing this instruction bottom-up.
-  void getUpwardPressure(const MachineInstr *MI,
+  LLVM_ABI void getUpwardPressure(const MachineInstr *MI,
                          std::vector<unsigned> &PressureResult,
                          std::vector<unsigned> &MaxPressureResult);
 
   /// Get the pressure of each PSet after traversing this instruction top-down.
-  void getDownwardPressure(const MachineInstr *MI,
+  LLVM_ABI void getDownwardPressure(const MachineInstr *MI,
                            std::vector<unsigned> &PressureResult,
                            std::vector<unsigned> &MaxPressureResult);
 
@@ -536,37 +537,37 @@ public:
     return UntiedDefs.count(VirtReg);
   }
 
-  void dump() const;
+  LLVM_ABI void dump() const;
 
-  void increaseRegPressure(Register RegUnit, LaneBitmask PreviousMask,
+  LLVM_ABI void increaseRegPressure(Register RegUnit, LaneBitmask PreviousMask,
                            LaneBitmask NewMask);
-  void decreaseRegPressure(Register RegUnit, LaneBitmask PreviousMask,
+  LLVM_ABI void decreaseRegPressure(Register RegUnit, LaneBitmask PreviousMask,
                            LaneBitmask NewMask);
 
 protected:
   /// Add Reg to the live out set and increase max pressure.
-  void discoverLiveOut(VRegMaskOrUnit Pair);
+  LLVM_ABI void discoverLiveOut(VRegMaskOrUnit Pair);
   /// Add Reg to the live in set and increase max pressure.
-  void discoverLiveIn(VRegMaskOrUnit Pair);
+  LLVM_ABI void discoverLiveIn(VRegMaskOrUnit Pair);
 
   /// Get the SlotIndex for the first nondebug instruction including or
   /// after the current position.
-  SlotIndex getCurrSlot() const;
+  LLVM_ABI SlotIndex getCurrSlot() const;
 
-  void bumpDeadDefs(ArrayRef<VRegMaskOrUnit> DeadDefs);
+  LLVM_ABI void bumpDeadDefs(ArrayRef<VRegMaskOrUnit> DeadDefs);
 
-  void bumpUpwardPressure(const MachineInstr *MI);
-  void bumpDownwardPressure(const MachineInstr *MI);
+  LLVM_ABI void bumpUpwardPressure(const MachineInstr *MI);
+  LLVM_ABI void bumpDownwardPressure(const MachineInstr *MI);
 
-  void discoverLiveInOrOut(VRegMaskOrUnit Pair,
+  LLVM_ABI void discoverLiveInOrOut(VRegMaskOrUnit Pair,
                            SmallVectorImpl<VRegMaskOrUnit> &LiveInOrOut);
 
-  LaneBitmask getLastUsedLanes(Register RegUnit, SlotIndex Pos) const;
-  LaneBitmask getLiveLanesAt(Register RegUnit, SlotIndex Pos) const;
-  LaneBitmask getLiveThroughAt(Register RegUnit, SlotIndex Pos) const;
+  LLVM_ABI LaneBitmask getLastUsedLanes(Register RegUnit, SlotIndex Pos) const;
+  LLVM_ABI LaneBitmask getLiveLanesAt(Register RegUnit, SlotIndex Pos) const;
+  LLVM_ABI LaneBitmask getLiveThroughAt(Register RegUnit, SlotIndex Pos) const;
 };
 
-void dumpRegSetPressure(ArrayRef<unsigned> SetPressure,
+LLVM_ABI void dumpRegSetPressure(ArrayRef<unsigned> SetPressure,
                         const TargetRegisterInfo *TRI);
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/ReplaceWithVeclib.h
+++ b/llvm/include/llvm/CodeGen/ReplaceWithVeclib.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_CODEGEN_REPLACEWITHVECLIB_H
 #define LLVM_CODEGEN_REPLACEWITHVECLIB_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/PassRegistry.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class Function;

--- a/llvm/include/llvm/CodeGen/ReplaceWithVeclib.h
+++ b/llvm/include/llvm/CodeGen/ReplaceWithVeclib.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_REPLACEWITHVECLIB_H
 #define LLVM_CODEGEN_REPLACEWITHVECLIB_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
@@ -22,11 +23,11 @@
 namespace llvm {
 class Function;
 struct ReplaceWithVeclib : public PassInfoMixin<ReplaceWithVeclib> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 // Legacy pass
-struct ReplaceWithVeclibLegacy : public FunctionPass {
+struct LLVM_ABI ReplaceWithVeclibLegacy : public FunctionPass {
   static char ID;
   ReplaceWithVeclibLegacy() : FunctionPass(ID) {
     initializeReplaceWithVeclibLegacyPass(*PassRegistry::getPassRegistry());

--- a/llvm/include/llvm/CodeGen/RuntimeLibcallUtil.h
+++ b/llvm/include/llvm/CodeGen/RuntimeLibcallUtil.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_RUNTIMELIBCALLS_H
 #define LLVM_CODEGEN_RUNTIMELIBCALLS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/ISDOpcodes.h"
 #include "llvm/CodeGen/ValueTypes.h"
 #include "llvm/IR/RuntimeLibcalls.h"
@@ -23,88 +24,88 @@ namespace RTLIB {
 
 /// GetFPLibCall - Helper to return the right libcall for the given floating
 /// point type, or UNKNOWN_LIBCALL if there is none.
-Libcall getFPLibCall(EVT VT, Libcall Call_F32, Libcall Call_F64,
+LLVM_ABI Libcall getFPLibCall(EVT VT, Libcall Call_F32, Libcall Call_F64,
                      Libcall Call_F80, Libcall Call_F128, Libcall Call_PPCF128);
 
 /// getFPEXT - Return the FPEXT_*_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getFPEXT(EVT OpVT, EVT RetVT);
+LLVM_ABI Libcall getFPEXT(EVT OpVT, EVT RetVT);
 
 /// getFPROUND - Return the FPROUND_*_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getFPROUND(EVT OpVT, EVT RetVT);
+LLVM_ABI Libcall getFPROUND(EVT OpVT, EVT RetVT);
 
 /// getFPTOSINT - Return the FPTOSINT_*_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getFPTOSINT(EVT OpVT, EVT RetVT);
+LLVM_ABI Libcall getFPTOSINT(EVT OpVT, EVT RetVT);
 
 /// getFPTOUINT - Return the FPTOUINT_*_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getFPTOUINT(EVT OpVT, EVT RetVT);
+LLVM_ABI Libcall getFPTOUINT(EVT OpVT, EVT RetVT);
 
 /// getSINTTOFP - Return the SINTTOFP_*_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getSINTTOFP(EVT OpVT, EVT RetVT);
+LLVM_ABI Libcall getSINTTOFP(EVT OpVT, EVT RetVT);
 
 /// getUINTTOFP - Return the UINTTOFP_*_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getUINTTOFP(EVT OpVT, EVT RetVT);
+LLVM_ABI Libcall getUINTTOFP(EVT OpVT, EVT RetVT);
 
 /// getPOWI - Return the POWI_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getPOWI(EVT RetVT);
+LLVM_ABI Libcall getPOWI(EVT RetVT);
 
 /// getLDEXP - Return the LDEXP_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getLDEXP(EVT RetVT);
+LLVM_ABI Libcall getLDEXP(EVT RetVT);
 
 /// getFREXP - Return the FREXP_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getFREXP(EVT RetVT);
+LLVM_ABI Libcall getFREXP(EVT RetVT);
 
 /// getSINCOS - Return the SINCOS_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getSINCOS(EVT RetVT);
+LLVM_ABI Libcall getSINCOS(EVT RetVT);
 
 /// getSINCOSPI - Return the SINCOSPI_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getSINCOSPI(EVT RetVT);
+LLVM_ABI Libcall getSINCOSPI(EVT RetVT);
 
 /// getMODF - Return the MODF_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getMODF(EVT RetVT);
+LLVM_ABI Libcall getMODF(EVT RetVT);
 
 /// Return the SYNC_FETCH_AND_* value for the given opcode and type, or
 /// UNKNOWN_LIBCALL if there is none.
-Libcall getSYNC(unsigned Opc, MVT VT);
+LLVM_ABI Libcall getSYNC(unsigned Opc, MVT VT);
 
 /// Return the outline atomics value for the given atomic ordering, access
 /// size and set of libcalls for a given atomic, or UNKNOWN_LIBCALL if there
 /// is none.
-Libcall getOutlineAtomicHelper(const Libcall (&LC)[5][4], AtomicOrdering Order,
+LLVM_ABI Libcall getOutlineAtomicHelper(const Libcall (&LC)[5][4], AtomicOrdering Order,
                                uint64_t MemSize);
 
 /// Return the outline atomics value for the given opcode, atomic ordering
 /// and type, or UNKNOWN_LIBCALL if there is none.
-Libcall getOUTLINE_ATOMIC(unsigned Opc, AtomicOrdering Order, MVT VT);
+LLVM_ABI Libcall getOUTLINE_ATOMIC(unsigned Opc, AtomicOrdering Order, MVT VT);
 
 /// getMEMCPY_ELEMENT_UNORDERED_ATOMIC - Return
 /// MEMCPY_ELEMENT_UNORDERED_ATOMIC_* value for the given element size or
 /// UNKNOW_LIBCALL if there is none.
-Libcall getMEMCPY_ELEMENT_UNORDERED_ATOMIC(uint64_t ElementSize);
+LLVM_ABI Libcall getMEMCPY_ELEMENT_UNORDERED_ATOMIC(uint64_t ElementSize);
 
 /// getMEMMOVE_ELEMENT_UNORDERED_ATOMIC - Return
 /// MEMMOVE_ELEMENT_UNORDERED_ATOMIC_* value for the given element size or
 /// UNKNOW_LIBCALL if there is none.
-Libcall getMEMMOVE_ELEMENT_UNORDERED_ATOMIC(uint64_t ElementSize);
+LLVM_ABI Libcall getMEMMOVE_ELEMENT_UNORDERED_ATOMIC(uint64_t ElementSize);
 
 /// getMEMSET_ELEMENT_UNORDERED_ATOMIC - Return
 /// MEMSET_ELEMENT_UNORDERED_ATOMIC_* value for the given element size or
 /// UNKNOW_LIBCALL if there is none.
-Libcall getMEMSET_ELEMENT_UNORDERED_ATOMIC(uint64_t ElementSize);
+LLVM_ABI Libcall getMEMSET_ELEMENT_UNORDERED_ATOMIC(uint64_t ElementSize);
 
 /// Initialize the default condition code on the libcalls.
-void initCmpLibcallCCs(ISD::CondCode *CmpLibcallCCs);
+LLVM_ABI void initCmpLibcallCCs(ISD::CondCode *CmpLibcallCCs);
 
 } // namespace RTLIB
 } // namespace llvm

--- a/llvm/include/llvm/CodeGen/RuntimeLibcallUtil.h
+++ b/llvm/include/llvm/CodeGen/RuntimeLibcallUtil.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_CODEGEN_RUNTIMELIBCALLS_H
 #define LLVM_CODEGEN_RUNTIMELIBCALLS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/ISDOpcodes.h"
 #include "llvm/CodeGen/ValueTypes.h"
 #include "llvm/IR/RuntimeLibcalls.h"
 #include "llvm/Support/AtomicOrdering.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace RTLIB {
@@ -25,7 +25,8 @@ namespace RTLIB {
 /// GetFPLibCall - Helper to return the right libcall for the given floating
 /// point type, or UNKNOWN_LIBCALL if there is none.
 LLVM_ABI Libcall getFPLibCall(EVT VT, Libcall Call_F32, Libcall Call_F64,
-                     Libcall Call_F80, Libcall Call_F128, Libcall Call_PPCF128);
+                              Libcall Call_F80, Libcall Call_F128,
+                              Libcall Call_PPCF128);
 
 /// getFPEXT - Return the FPEXT_*_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
@@ -82,8 +83,8 @@ LLVM_ABI Libcall getSYNC(unsigned Opc, MVT VT);
 /// Return the outline atomics value for the given atomic ordering, access
 /// size and set of libcalls for a given atomic, or UNKNOWN_LIBCALL if there
 /// is none.
-LLVM_ABI Libcall getOutlineAtomicHelper(const Libcall (&LC)[5][4], AtomicOrdering Order,
-                               uint64_t MemSize);
+LLVM_ABI Libcall getOutlineAtomicHelper(const Libcall (&LC)[5][4],
+                                        AtomicOrdering Order, uint64_t MemSize);
 
 /// Return the outline atomics value for the given opcode, atomic ordering
 /// and type, or UNKNOWN_LIBCALL if there is none.

--- a/llvm/include/llvm/CodeGen/ScheduleDAG.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAG.h
@@ -15,13 +15,13 @@
 #ifndef LLVM_CODEGEN_SCHEDULEDAG_H
 #define LLVM_CODEGEN_SCHEDULEDAG_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <cstddef>
@@ -750,7 +750,8 @@ class TargetRegisterInfo;
     void FixOrder();
 
   public:
-    LLVM_ABI ScheduleDAGTopologicalSort(std::vector<SUnit> &SUnits, SUnit *ExitSU);
+    LLVM_ABI ScheduleDAGTopologicalSort(std::vector<SUnit> &SUnits,
+                                        SUnit *ExitSU);
 
     /// Add a SUnit without predecessors to the end of the topological order. It
     /// also must be the first new node added to the DAG.
@@ -764,8 +765,8 @@ class TargetRegisterInfo;
     /// StartSU and TargetSU are not in the array.
     /// Success is false if TargetSU is not in the successor subtree of
     /// StartSU, else it is true.
-    LLVM_ABI std::vector<int> GetSubGraph(const SUnit &StartSU, const SUnit &TargetSU,
-                                 bool &Success);
+    LLVM_ABI std::vector<int> GetSubGraph(const SUnit &StartSU,
+                                          const SUnit &TargetSU, bool &Success);
 
     /// Checks if \p SU is reachable from \p TargetSU.
     LLVM_ABI bool IsReachable(const SUnit *SU, const SUnit *TargetSU);

--- a/llvm/include/llvm/CodeGen/ScheduleDAG.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAG.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_SCHEDULEDAG_H
 #define LLVM_CODEGEN_SCHEDULEDAG_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallVector.h"
@@ -231,7 +232,7 @@ class TargetRegisterInfo;
       Contents.Reg = Reg.id();
     }
 
-    void dump(const TargetRegisterInfo *TRI = nullptr) const;
+    LLVM_ABI void dump(const TargetRegisterInfo *TRI = nullptr) const;
   };
 
   /// Scheduling unit. This is a node in the scheduling DAG.
@@ -391,7 +392,7 @@ class TargetRegisterInfo;
 
     /// Adds the specified edge as a pred of the current node if not already.
     /// It also adds the current node as a successor of the specified node.
-    bool addPred(const SDep &D, bool Required = true);
+    LLVM_ABI bool addPred(const SDep &D, bool Required = true);
 
     /// Adds a barrier edge to SU by calling addPred(), with latency 0
     /// generally or latency 1 for a store followed by a load.
@@ -405,7 +406,7 @@ class TargetRegisterInfo;
 
     /// Removes the specified edge as a pred of the current node if it exists.
     /// It also removes the current node as a successor of the specified node.
-    void removePred(const SDep &D);
+    LLVM_ABI void removePred(const SDep &D);
 
     /// Returns the depth of this node, which is the length of the maximum path
     /// up to any node which has no predecessors.
@@ -426,20 +427,20 @@ class TargetRegisterInfo;
     /// If NewDepth is greater than this node's depth value, sets it to
     /// be the new depth value. This also recursively marks successor nodes
     /// dirty.
-    void setDepthToAtLeast(unsigned NewDepth);
+    LLVM_ABI void setDepthToAtLeast(unsigned NewDepth);
 
     /// If NewHeight is greater than this node's height value, set it to be
     /// the new height value. This also recursively marks predecessor nodes
     /// dirty.
-    void setHeightToAtLeast(unsigned NewHeight);
+    LLVM_ABI void setHeightToAtLeast(unsigned NewHeight);
 
     /// Sets a flag in this node to indicate that its stored Depth value
     /// will require recomputation the next time getDepth() is called.
-    void setDepthDirty();
+    LLVM_ABI void setDepthDirty();
 
     /// Sets a flag in this node to indicate that its stored Height value
     /// will require recomputation the next time getHeight() is called.
-    void setHeightDirty();
+    LLVM_ABI void setHeightDirty();
 
     /// Tests if node N is a predecessor of this node.
     bool isPred(const SUnit *N) const {
@@ -466,13 +467,13 @@ class TargetRegisterInfo;
 
     /// Orders this node's predecessor edges such that the critical path
     /// edge occurs first.
-    void biasCriticalPath();
+    LLVM_ABI void biasCriticalPath();
 
-    void dumpAttributes() const;
+    LLVM_ABI void dumpAttributes() const;
 
   private:
-    void ComputeDepth();
-    void ComputeHeight();
+    LLVM_ABI void ComputeDepth();
+    LLVM_ABI void ComputeHeight();
   };
 
   /// Returns true if the specified SDep is equivalent except for latency.
@@ -507,7 +508,7 @@ class TargetRegisterInfo;
   /// returned in priority order.  The computation of the priority and the
   /// representation of the queue are totally up to the implementation to
   /// decide.
-  class SchedulingPriorityQueue {
+  class LLVM_ABI SchedulingPriorityQueue {
     virtual void anchor();
 
     unsigned CurCycle = 0;
@@ -565,7 +566,7 @@ class TargetRegisterInfo;
     }
   };
 
-  class ScheduleDAG {
+  class LLVM_ABI ScheduleDAG {
   public:
     const TargetMachine &TM;            ///< Target processor
     const TargetInstrInfo *TII;         ///< Target instruction information
@@ -749,41 +750,41 @@ class TargetRegisterInfo;
     void FixOrder();
 
   public:
-    ScheduleDAGTopologicalSort(std::vector<SUnit> &SUnits, SUnit *ExitSU);
+    LLVM_ABI ScheduleDAGTopologicalSort(std::vector<SUnit> &SUnits, SUnit *ExitSU);
 
     /// Add a SUnit without predecessors to the end of the topological order. It
     /// also must be the first new node added to the DAG.
-    void AddSUnitWithoutPredecessors(const SUnit *SU);
+    LLVM_ABI void AddSUnitWithoutPredecessors(const SUnit *SU);
 
     /// Creates the initial topological ordering from the DAG to be scheduled.
-    void InitDAGTopologicalSorting();
+    LLVM_ABI void InitDAGTopologicalSorting();
 
     /// Returns an array of SUs that are both in the successor
     /// subtree of StartSU and in the predecessor subtree of TargetSU.
     /// StartSU and TargetSU are not in the array.
     /// Success is false if TargetSU is not in the successor subtree of
     /// StartSU, else it is true.
-    std::vector<int> GetSubGraph(const SUnit &StartSU, const SUnit &TargetSU,
+    LLVM_ABI std::vector<int> GetSubGraph(const SUnit &StartSU, const SUnit &TargetSU,
                                  bool &Success);
 
     /// Checks if \p SU is reachable from \p TargetSU.
-    bool IsReachable(const SUnit *SU, const SUnit *TargetSU);
+    LLVM_ABI bool IsReachable(const SUnit *SU, const SUnit *TargetSU);
 
     /// Returns true if addPred(TargetSU, SU) creates a cycle.
-    bool WillCreateCycle(SUnit *TargetSU, SUnit *SU);
+    LLVM_ABI bool WillCreateCycle(SUnit *TargetSU, SUnit *SU);
 
     /// Updates the topological ordering to accommodate an edge to be
     /// added from SUnit \p X to SUnit \p Y.
-    void AddPred(SUnit *Y, SUnit *X);
+    LLVM_ABI void AddPred(SUnit *Y, SUnit *X);
 
     /// Queues an update to the topological ordering to accommodate an edge to
     /// be added from SUnit \p X to SUnit \p Y.
-    void AddPredQueued(SUnit *Y, SUnit *X);
+    LLVM_ABI void AddPredQueued(SUnit *Y, SUnit *X);
 
     /// Updates the topological ordering to accommodate an edge to be
     /// removed from the specified node \p N from the predecessors of the
     /// current node \p M.
-    void RemovePred(SUnit *M, SUnit *N);
+    LLVM_ABI void RemovePred(SUnit *M, SUnit *N);
 
     /// Mark the ordering as temporarily broken, after a new node has been
     /// added.

--- a/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_SCHEDULEDAGINSTRS_H
 #define LLVM_CODEGEN_SCHEDULEDAGINSTRS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallVector.h"
@@ -112,7 +113,7 @@ namespace llvm {
   using UnderlyingObjectsVector = SmallVector<UnderlyingObject, 4>;
 
   /// A ScheduleDAG for scheduling lists of MachineInstr.
-  class ScheduleDAGInstrs : public ScheduleDAG {
+  class LLVM_ABI ScheduleDAGInstrs : public ScheduleDAG {
   protected:
     const MachineLoopInfo *MLI = nullptr;
     const MachineFrameInfo &MFI;

--- a/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_SCHEDULEDAGINSTRS_H
 #define LLVM_CODEGEN_SCHEDULEDAGINSTRS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallVector.h"
@@ -27,6 +26,7 @@
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/CodeGen/TargetSchedule.h"
 #include "llvm/MC/LaneBitmask.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <list>

--- a/llvm/include/llvm/CodeGen/ScheduleDAGMutation.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAGMutation.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_CODEGEN_SCHEDULEDAGMUTATION_H
 #define LLVM_CODEGEN_SCHEDULEDAGMUTATION_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class ScheduleDAGInstrs;

--- a/llvm/include/llvm/CodeGen/ScheduleDAGMutation.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAGMutation.h
@@ -19,7 +19,7 @@ namespace llvm {
 class ScheduleDAGInstrs;
 
 /// Mutate the DAG as a postpass after normal DAG building.
-class ScheduleDAGMutation {
+class LLVM_ABI ScheduleDAGMutation {
   virtual void anchor();
 
 public:

--- a/llvm/include/llvm/CodeGen/SchedulerRegistry.h
+++ b/llvm/include/llvm/CodeGen/SchedulerRegistry.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_SCHEDULERREGISTRY_H
 #define LLVM_CODEGEN_SCHEDULERREGISTRY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachinePassRegistry.h"
 #include "llvm/Support/CodeGen.h"
 
@@ -35,7 +36,7 @@ public:
   using FunctionPassCtor = ScheduleDAGSDNodes *(*)(SelectionDAGISel *,
                                                    CodeGenOptLevel);
 
-  static MachinePassRegistry<FunctionPassCtor> Registry;
+  LLVM_ABI static MachinePassRegistry<FunctionPassCtor> Registry;
 
   RegisterScheduler(const char *N, const char *D, FunctionPassCtor C)
       : MachinePassRegistryNode(N, D, C) {
@@ -60,46 +61,46 @@ public:
 
 /// createBURRListDAGScheduler - This creates a bottom up register usage
 /// reduction list scheduler.
-ScheduleDAGSDNodes *createBURRListDAGScheduler(SelectionDAGISel *IS,
+LLVM_ABI ScheduleDAGSDNodes *createBURRListDAGScheduler(SelectionDAGISel *IS,
                                                CodeGenOptLevel OptLevel);
 
 /// createSourceListDAGScheduler - This creates a bottom up list scheduler that
 /// schedules nodes in source code order when possible.
-ScheduleDAGSDNodes *createSourceListDAGScheduler(SelectionDAGISel *IS,
+LLVM_ABI ScheduleDAGSDNodes *createSourceListDAGScheduler(SelectionDAGISel *IS,
                                                  CodeGenOptLevel OptLevel);
 
 /// createHybridListDAGScheduler - This creates a bottom up register pressure
 /// aware list scheduler that make use of latency information to avoid stalls
 /// for long latency instructions in low register pressure mode. In high
 /// register pressure mode it schedules to reduce register pressure.
-ScheduleDAGSDNodes *createHybridListDAGScheduler(SelectionDAGISel *IS,
+LLVM_ABI ScheduleDAGSDNodes *createHybridListDAGScheduler(SelectionDAGISel *IS,
                                                  CodeGenOptLevel);
 
 /// createILPListDAGScheduler - This creates a bottom up register pressure
 /// aware list scheduler that tries to increase instruction level parallelism
 /// in low register pressure mode. In high register pressure mode it schedules
 /// to reduce register pressure.
-ScheduleDAGSDNodes *createILPListDAGScheduler(SelectionDAGISel *IS,
+LLVM_ABI ScheduleDAGSDNodes *createILPListDAGScheduler(SelectionDAGISel *IS,
                                               CodeGenOptLevel);
 
 /// createFastDAGScheduler - This creates a "fast" scheduler.
 ///
-ScheduleDAGSDNodes *createFastDAGScheduler(SelectionDAGISel *IS,
+LLVM_ABI ScheduleDAGSDNodes *createFastDAGScheduler(SelectionDAGISel *IS,
                                            CodeGenOptLevel OptLevel);
 
 /// createVLIWDAGScheduler - Scheduler for VLIW targets. This creates top down
 /// DFA driven list scheduler with clustering heuristic to control
 /// register pressure.
-ScheduleDAGSDNodes *createVLIWDAGScheduler(SelectionDAGISel *IS,
+LLVM_ABI ScheduleDAGSDNodes *createVLIWDAGScheduler(SelectionDAGISel *IS,
                                            CodeGenOptLevel OptLevel);
 /// createDefaultScheduler - This creates an instruction scheduler appropriate
 /// for the target.
-ScheduleDAGSDNodes *createDefaultScheduler(SelectionDAGISel *IS,
+LLVM_ABI ScheduleDAGSDNodes *createDefaultScheduler(SelectionDAGISel *IS,
                                            CodeGenOptLevel OptLevel);
 
 /// createDAGLinearizer - This creates a "no-scheduling" scheduler which
 /// linearize the DAG using topological order.
-ScheduleDAGSDNodes *createDAGLinearizer(SelectionDAGISel *IS,
+LLVM_ABI ScheduleDAGSDNodes *createDAGLinearizer(SelectionDAGISel *IS,
                                         CodeGenOptLevel OptLevel);
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/SchedulerRegistry.h
+++ b/llvm/include/llvm/CodeGen/SchedulerRegistry.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_CODEGEN_SCHEDULERREGISTRY_H
 #define LLVM_CODEGEN_SCHEDULERREGISTRY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/CodeGen/MachinePassRegistry.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -61,47 +61,47 @@ public:
 
 /// createBURRListDAGScheduler - This creates a bottom up register usage
 /// reduction list scheduler.
-LLVM_ABI ScheduleDAGSDNodes *createBURRListDAGScheduler(SelectionDAGISel *IS,
-                                               CodeGenOptLevel OptLevel);
+LLVM_ABI ScheduleDAGSDNodes *
+createBURRListDAGScheduler(SelectionDAGISel *IS, CodeGenOptLevel OptLevel);
 
 /// createSourceListDAGScheduler - This creates a bottom up list scheduler that
 /// schedules nodes in source code order when possible.
-LLVM_ABI ScheduleDAGSDNodes *createSourceListDAGScheduler(SelectionDAGISel *IS,
-                                                 CodeGenOptLevel OptLevel);
+LLVM_ABI ScheduleDAGSDNodes *
+createSourceListDAGScheduler(SelectionDAGISel *IS, CodeGenOptLevel OptLevel);
 
 /// createHybridListDAGScheduler - This creates a bottom up register pressure
 /// aware list scheduler that make use of latency information to avoid stalls
 /// for long latency instructions in low register pressure mode. In high
 /// register pressure mode it schedules to reduce register pressure.
 LLVM_ABI ScheduleDAGSDNodes *createHybridListDAGScheduler(SelectionDAGISel *IS,
-                                                 CodeGenOptLevel);
+                                                          CodeGenOptLevel);
 
 /// createILPListDAGScheduler - This creates a bottom up register pressure
 /// aware list scheduler that tries to increase instruction level parallelism
 /// in low register pressure mode. In high register pressure mode it schedules
 /// to reduce register pressure.
 LLVM_ABI ScheduleDAGSDNodes *createILPListDAGScheduler(SelectionDAGISel *IS,
-                                              CodeGenOptLevel);
+                                                       CodeGenOptLevel);
 
 /// createFastDAGScheduler - This creates a "fast" scheduler.
 ///
 LLVM_ABI ScheduleDAGSDNodes *createFastDAGScheduler(SelectionDAGISel *IS,
-                                           CodeGenOptLevel OptLevel);
+                                                    CodeGenOptLevel OptLevel);
 
 /// createVLIWDAGScheduler - Scheduler for VLIW targets. This creates top down
 /// DFA driven list scheduler with clustering heuristic to control
 /// register pressure.
 LLVM_ABI ScheduleDAGSDNodes *createVLIWDAGScheduler(SelectionDAGISel *IS,
-                                           CodeGenOptLevel OptLevel);
+                                                    CodeGenOptLevel OptLevel);
 /// createDefaultScheduler - This creates an instruction scheduler appropriate
 /// for the target.
 LLVM_ABI ScheduleDAGSDNodes *createDefaultScheduler(SelectionDAGISel *IS,
-                                           CodeGenOptLevel OptLevel);
+                                                    CodeGenOptLevel OptLevel);
 
 /// createDAGLinearizer - This creates a "no-scheduling" scheduler which
 /// linearize the DAG using topological order.
 LLVM_ABI ScheduleDAGSDNodes *createDAGLinearizer(SelectionDAGISel *IS,
-                                        CodeGenOptLevel OptLevel);
+                                                 CodeGenOptLevel OptLevel);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_SELECTIONDAG_H
 #define LLVM_CODEGEN_SELECTIONDAG_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
@@ -172,13 +173,13 @@ public:
   SDDbgInfo(const SDDbgInfo &) = delete;
   SDDbgInfo &operator=(const SDDbgInfo &) = delete;
 
-  void add(SDDbgValue *V, bool isParameter);
+  LLVM_ABI void add(SDDbgValue *V, bool isParameter);
 
   void add(SDDbgLabel *L) { DbgLabels.push_back(L); }
 
   /// Invalidate all DbgValues attached to the node and remove
   /// it from the Node-to-DbgValues map.
-  void erase(const SDNode *Node);
+  LLVM_ABI void erase(const SDNode *Node);
 
   void clear() {
     DbgValMap.clear();
@@ -212,7 +213,7 @@ public:
   DbgLabelIterator DbgLabelEnd()   { return DbgLabels.end(); }
 };
 
-void checkForCycles(const SelectionDAG *DAG, bool force = false);
+LLVM_ABI void checkForCycles(const SelectionDAG *DAG, bool force = false);
 
 /// This is used to represent a portion of an LLVM function in a low-level
 /// Data Dependence DAG representation suitable for instruction selection.
@@ -314,7 +315,7 @@ public:
   ///
   /// A DAGUpdateListener automatically registers itself with DAG when it is
   /// constructed, and removes itself when destroyed in RAII fashion.
-  struct DAGUpdateListener {
+  struct LLVM_ABI DAGUpdateListener {
     DAGUpdateListener *const Next;
     SelectionDAG &DAG;
 
@@ -340,7 +341,7 @@ public:
     virtual void NodeInserted(SDNode *N);
   };
 
-  struct DAGNodeDeletedListener : public DAGUpdateListener {
+  struct LLVM_ABI DAGNodeDeletedListener : public DAGUpdateListener {
     std::function<void(SDNode *, SDNode *)> Callback;
 
     DAGNodeDeletedListener(SelectionDAG &DAG,
@@ -353,7 +354,7 @@ public:
     virtual void anchor();
   };
 
-  struct DAGNodeInsertedListener : public DAGUpdateListener {
+  struct LLVM_ABI DAGNodeInsertedListener : public DAGUpdateListener {
     std::function<void(SDNode *)> Callback;
 
     DAGNodeInsertedListener(SelectionDAG &DAG,
@@ -458,15 +459,15 @@ public:
   static constexpr unsigned MaxRecursionDepth = 6;
 
   // Returns the maximum steps for SDNode->hasPredecessor() like searches.
-  static unsigned getHasPredecessorMaxSteps();
+  LLVM_ABI static unsigned getHasPredecessorMaxSteps();
 
-  explicit SelectionDAG(const TargetMachine &TM, CodeGenOptLevel);
+  LLVM_ABI explicit SelectionDAG(const TargetMachine &TM, CodeGenOptLevel);
   SelectionDAG(const SelectionDAG &) = delete;
   SelectionDAG &operator=(const SelectionDAG &) = delete;
-  ~SelectionDAG();
+  LLVM_ABI ~SelectionDAG();
 
   /// Prepare this SelectionDAG to process code in the given MachineFunction.
-  void init(MachineFunction &NewMF, OptimizationRemarkEmitter &NewORE,
+  LLVM_ABI void init(MachineFunction &NewMF, OptimizationRemarkEmitter &NewORE,
             Pass *PassPtr, const TargetLibraryInfo *LibraryInfo,
             UniformityInfo *UA, ProfileSummaryInfo *PSIin,
             BlockFrequencyInfo *BFIin, MachineModuleInfo &MMI,
@@ -487,7 +488,7 @@ public:
 
   /// Clear state and free memory necessary to make this
   /// SelectionDAG ready to process a new block.
-  void clear();
+  LLVM_ABI void clear();
 
   MachineFunction &getMachineFunction() const { return *MF; }
   const Pass *getPass() const { return SDAGISelPass; }
@@ -528,8 +529,8 @@ public:
 #endif
 
   /// Pop up a GraphViz/gv window with the DAG rendered using 'dot'.
-  void viewGraph(const std::string &Title);
-  void viewGraph();
+  LLVM_ABI void viewGraph(const std::string &Title);
+  LLVM_ABI void viewGraph();
 
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS
   std::map<const SDNode *, std::string> NodeGraphAttrs;
@@ -537,20 +538,20 @@ public:
 
   /// Clear all previously defined node graph attributes.
   /// Intended to be used from a debugging tool (eg. gdb).
-  void clearGraphAttrs();
+  LLVM_ABI void clearGraphAttrs();
 
   /// Set graph attributes for a node. (eg. "color=red".)
-  void setGraphAttrs(const SDNode *N, const char *Attrs);
+  LLVM_ABI void setGraphAttrs(const SDNode *N, const char *Attrs);
 
   /// Get graph attributes for a node. (eg. "color=red".)
   /// Used from getNodeAttributes.
-  std::string getGraphAttrs(const SDNode *N) const;
+  LLVM_ABI std::string getGraphAttrs(const SDNode *N) const;
 
   /// Convenience for setting node color attribute.
-  void setGraphColor(const SDNode *N, const char *Color);
+  LLVM_ABI void setGraphColor(const SDNode *N, const char *Color);
 
   /// Convenience for setting subgraph color attribute.
-  void setSubgraphColor(SDNode *N, const char *Color);
+  LLVM_ABI void setSubgraphColor(SDNode *N, const char *Color);
 
   using allnodes_const_iterator = ilist<SDNode>::const_iterator;
 
@@ -602,7 +603,7 @@ public:
   /// certain types of nodes together, or eliminating superfluous nodes.  The
   /// Level argument controls whether Combine is allowed to produce nodes and
   /// types that are illegal on the target.
-  void Combine(CombineLevel Level, BatchAAResults *BatchAA,
+  LLVM_ABI void Combine(CombineLevel Level, BatchAAResults *BatchAA,
                CodeGenOptLevel OptLevel);
 
   /// This transforms the SelectionDAG into a SelectionDAG that
@@ -611,7 +612,7 @@ public:
   ///
   /// Note that this is an involved process that may invalidate pointers into
   /// the graph.
-  bool LegalizeTypes();
+  LLVM_ABI bool LegalizeTypes();
 
   /// This transforms the SelectionDAG into a SelectionDAG that is
   /// compatible with the target instruction selector, as indicated by the
@@ -619,7 +620,7 @@ public:
   ///
   /// Note that this is an involved process that may invalidate pointers into
   /// the graph.
-  void Legalize();
+  LLVM_ABI void Legalize();
 
   /// Transforms a SelectionDAG node and any operands to it into a node
   /// that is compatible with the target instruction selector, as indicated by
@@ -640,7 +641,7 @@ public:
   /// N passed in is a legal node, and can be immediately processed as such.
   /// This may still have done some work on the DAG, and will still populate
   /// UpdatedNodes with any new nodes replacing those originally in the DAG.
-  bool LegalizeOp(SDNode *N, SmallSetVector<SDNode *, 16> &UpdatedNodes);
+  LLVM_ABI bool LegalizeOp(SDNode *N, SmallSetVector<SDNode *, 16> &UpdatedNodes);
 
   /// This transforms the SelectionDAG into a SelectionDAG
   /// that only uses vector math operations supported by the target.  This is
@@ -653,21 +654,21 @@ public:
   ///
   /// Note that this is an involved process that may invalidate pointers into
   /// the graph.
-  bool LegalizeVectors();
+  LLVM_ABI bool LegalizeVectors();
 
   /// This method deletes all unreachable nodes in the SelectionDAG.
-  void RemoveDeadNodes();
+  LLVM_ABI void RemoveDeadNodes();
 
   /// Remove the specified node from the system.  This node must
   /// have no referrers.
-  void DeleteNode(SDNode *N);
+  LLVM_ABI void DeleteNode(SDNode *N);
 
   /// Return an SDVTList that represents the list of values specified.
-  SDVTList getVTList(EVT VT);
-  SDVTList getVTList(EVT VT1, EVT VT2);
-  SDVTList getVTList(EVT VT1, EVT VT2, EVT VT3);
-  SDVTList getVTList(EVT VT1, EVT VT2, EVT VT3, EVT VT4);
-  SDVTList getVTList(ArrayRef<EVT> VTs);
+  LLVM_ABI SDVTList getVTList(EVT VT);
+  LLVM_ABI SDVTList getVTList(EVT VT1, EVT VT2);
+  LLVM_ABI SDVTList getVTList(EVT VT1, EVT VT2, EVT VT3);
+  LLVM_ABI SDVTList getVTList(EVT VT1, EVT VT2, EVT VT3, EVT VT4);
+  LLVM_ABI SDVTList getVTList(ArrayRef<EVT> VTs);
 
   //===--------------------------------------------------------------------===//
   // Node creation methods.
@@ -678,24 +679,24 @@ public:
   /// If only legal types can be produced, this does the necessary
   /// transformations (e.g., if the vector element type is illegal).
   /// @{
-  SDValue getConstant(uint64_t Val, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getConstant(uint64_t Val, const SDLoc &DL, EVT VT,
                       bool isTarget = false, bool isOpaque = false);
-  SDValue getConstant(const APInt &Val, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getConstant(const APInt &Val, const SDLoc &DL, EVT VT,
                       bool isTarget = false, bool isOpaque = false);
 
-  SDValue getSignedConstant(int64_t Val, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getSignedConstant(int64_t Val, const SDLoc &DL, EVT VT,
                             bool isTarget = false, bool isOpaque = false);
 
-  SDValue getAllOnesConstant(const SDLoc &DL, EVT VT, bool IsTarget = false,
+  LLVM_ABI SDValue getAllOnesConstant(const SDLoc &DL, EVT VT, bool IsTarget = false,
                              bool IsOpaque = false);
 
-  SDValue getConstant(const ConstantInt &Val, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getConstant(const ConstantInt &Val, const SDLoc &DL, EVT VT,
                       bool isTarget = false, bool isOpaque = false);
-  SDValue getIntPtrConstant(uint64_t Val, const SDLoc &DL,
+  LLVM_ABI SDValue getIntPtrConstant(uint64_t Val, const SDLoc &DL,
                             bool isTarget = false);
-  SDValue getShiftAmountConstant(uint64_t Val, EVT VT, const SDLoc &DL);
-  SDValue getShiftAmountConstant(const APInt &Val, EVT VT, const SDLoc &DL);
-  SDValue getVectorIdxConstant(uint64_t Val, const SDLoc &DL,
+  LLVM_ABI SDValue getShiftAmountConstant(uint64_t Val, EVT VT, const SDLoc &DL);
+  LLVM_ABI SDValue getShiftAmountConstant(const APInt &Val, EVT VT, const SDLoc &DL);
+  LLVM_ABI SDValue getVectorIdxConstant(uint64_t Val, const SDLoc &DL,
                                bool isTarget = false);
 
   SDValue getTargetConstant(uint64_t Val, const SDLoc &DL, EVT VT,
@@ -717,7 +718,7 @@ public:
 
   /// Create a true or false constant of type \p VT using the target's
   /// BooleanContent for type \p OpVT.
-  SDValue getBoolConstant(bool V, const SDLoc &DL, EVT VT, EVT OpVT);
+  LLVM_ABI SDValue getBoolConstant(bool V, const SDLoc &DL, EVT VT, EVT OpVT);
   /// @}
 
   /// Create a ConstantFPSDNode wrapping a constant value.
@@ -728,11 +729,11 @@ public:
   /// The forms that take a double should only be used for simple constants
   /// that can be exactly represented in VT.  No checks are made.
   /// @{
-  SDValue getConstantFP(double Val, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getConstantFP(double Val, const SDLoc &DL, EVT VT,
                         bool isTarget = false);
-  SDValue getConstantFP(const APFloat &Val, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getConstantFP(const APFloat &Val, const SDLoc &DL, EVT VT,
                         bool isTarget = false);
-  SDValue getConstantFP(const ConstantFP &V, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getConstantFP(const ConstantFP &V, const SDLoc &DL, EVT VT,
                         bool isTarget = false);
   SDValue getTargetConstantFP(double Val, const SDLoc &DL, EVT VT) {
     return getConstantFP(Val, DL, VT, true);
@@ -745,24 +746,24 @@ public:
   }
   /// @}
 
-  SDValue getGlobalAddress(const GlobalValue *GV, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getGlobalAddress(const GlobalValue *GV, const SDLoc &DL, EVT VT,
                            int64_t offset = 0, bool isTargetGA = false,
                            unsigned TargetFlags = 0);
   SDValue getTargetGlobalAddress(const GlobalValue *GV, const SDLoc &DL, EVT VT,
                                  int64_t offset = 0, unsigned TargetFlags = 0) {
     return getGlobalAddress(GV, DL, VT, offset, true, TargetFlags);
   }
-  SDValue getFrameIndex(int FI, EVT VT, bool isTarget = false);
+  LLVM_ABI SDValue getFrameIndex(int FI, EVT VT, bool isTarget = false);
   SDValue getTargetFrameIndex(int FI, EVT VT) {
     return getFrameIndex(FI, VT, true);
   }
-  SDValue getJumpTable(int JTI, EVT VT, bool isTarget = false,
+  LLVM_ABI SDValue getJumpTable(int JTI, EVT VT, bool isTarget = false,
                        unsigned TargetFlags = 0);
   SDValue getTargetJumpTable(int JTI, EVT VT, unsigned TargetFlags = 0) {
     return getJumpTable(JTI, VT, true, TargetFlags);
   }
-  SDValue getJumpTableDebugInfo(int JTI, SDValue Chain, const SDLoc &DL);
-  SDValue getConstantPool(const Constant *C, EVT VT,
+  LLVM_ABI SDValue getJumpTableDebugInfo(int JTI, SDValue Chain, const SDLoc &DL);
+  LLVM_ABI SDValue getConstantPool(const Constant *C, EVT VT,
                           MaybeAlign Align = std::nullopt, int Offs = 0,
                           bool isT = false, unsigned TargetFlags = 0);
   SDValue getTargetConstantPool(const Constant *C, EVT VT,
@@ -770,7 +771,7 @@ public:
                                 unsigned TargetFlags = 0) {
     return getConstantPool(C, VT, Align, Offset, true, TargetFlags);
   }
-  SDValue getConstantPool(MachineConstantPoolValue *C, EVT VT,
+  LLVM_ABI SDValue getConstantPool(MachineConstantPoolValue *C, EVT VT,
                           MaybeAlign Align = std::nullopt, int Offs = 0,
                           bool isT = false, unsigned TargetFlags = 0);
   SDValue getTargetConstantPool(MachineConstantPoolValue *C, EVT VT,
@@ -780,19 +781,19 @@ public:
   }
   // When generating a branch to a BB, we don't in general know enough
   // to provide debug info for the BB at that time, so keep this one around.
-  SDValue getBasicBlock(MachineBasicBlock *MBB);
-  SDValue getExternalSymbol(const char *Sym, EVT VT);
-  SDValue getTargetExternalSymbol(const char *Sym, EVT VT,
+  LLVM_ABI SDValue getBasicBlock(MachineBasicBlock *MBB);
+  LLVM_ABI SDValue getExternalSymbol(const char *Sym, EVT VT);
+  LLVM_ABI SDValue getTargetExternalSymbol(const char *Sym, EVT VT,
                                   unsigned TargetFlags = 0);
-  SDValue getMCSymbol(MCSymbol *Sym, EVT VT);
+  LLVM_ABI SDValue getMCSymbol(MCSymbol *Sym, EVT VT);
 
-  SDValue getValueType(EVT);
-  SDValue getRegister(Register Reg, EVT VT);
-  SDValue getRegisterMask(const uint32_t *RegMask);
-  SDValue getEHLabel(const SDLoc &dl, SDValue Root, MCSymbol *Label);
-  SDValue getLabelNode(unsigned Opcode, const SDLoc &dl, SDValue Root,
+  LLVM_ABI SDValue getValueType(EVT);
+  LLVM_ABI SDValue getRegister(Register Reg, EVT VT);
+  LLVM_ABI SDValue getRegisterMask(const uint32_t *RegMask);
+  LLVM_ABI SDValue getEHLabel(const SDLoc &dl, SDValue Root, MCSymbol *Label);
+  LLVM_ABI SDValue getLabelNode(unsigned Opcode, const SDLoc &dl, SDValue Root,
                        MCSymbol *Label);
-  SDValue getBlockAddress(const BlockAddress *BA, EVT VT, int64_t Offset = 0,
+  LLVM_ABI SDValue getBlockAddress(const BlockAddress *BA, EVT VT, int64_t Offset = 0,
                           bool isTarget = false, unsigned TargetFlags = 0);
   SDValue getTargetBlockAddress(const BlockAddress *BA, EVT VT,
                                 int64_t Offset = 0, unsigned TargetFlags = 0) {
@@ -842,12 +843,12 @@ public:
                    ArrayRef(Ops, Glue.getNode() ? 3 : 2));
   }
 
-  SDValue getCondCode(ISD::CondCode Cond);
+  LLVM_ABI SDValue getCondCode(ISD::CondCode Cond);
 
   /// Return an ISD::VECTOR_SHUFFLE node. The number of elements in VT,
   /// which must be a vector type, must match the number of mask elements
   /// NumElts. An integer mask element equal to -1 is treated as undefined.
-  SDValue getVectorShuffle(EVT VT, const SDLoc &dl, SDValue N1, SDValue N2,
+  LLVM_ABI SDValue getVectorShuffle(EVT VT, const SDLoc &dl, SDValue N1, SDValue N2,
                            ArrayRef<int> Mask);
 
   /// Return an ISD::BUILD_VECTOR node. The number of elements in VT,
@@ -912,17 +913,17 @@ public:
 
   /// Returns a vector of type ResVT whose elements contain the linear sequence
   ///   <0, Step, Step * 2, Step * 3, ...>
-  SDValue getStepVector(const SDLoc &DL, EVT ResVT, const APInt &StepVal);
+  LLVM_ABI SDValue getStepVector(const SDLoc &DL, EVT ResVT, const APInt &StepVal);
 
   /// Returns a vector of type ResVT whose elements contain the linear sequence
   ///   <0, 1, 2, 3, ...>
-  SDValue getStepVector(const SDLoc &DL, EVT ResVT);
+  LLVM_ABI SDValue getStepVector(const SDLoc &DL, EVT ResVT);
 
   /// Returns an ISD::VECTOR_SHUFFLE node semantically equivalent to
   /// the shuffle node in input but with swapped operands.
   ///
   /// Example: shuffle A, B, <0,5,2,7> -> shuffle B, A, <4,1,6,3>
-  SDValue getCommutedVectorShuffle(const ShuffleVectorSDNode &SV);
+  LLVM_ABI SDValue getCommutedVectorShuffle(const ShuffleVectorSDNode &SV);
 
   /// Extract element at \p Idx from \p Vec.  See EXTRACT_VECTOR_ELT
   /// description for result type handling.
@@ -956,11 +957,11 @@ public:
 
   /// Convert Op, which must be of float type, to the
   /// float type VT, by either extending or rounding (by truncation).
-  SDValue getFPExtendOrRound(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getFPExtendOrRound(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be a STRICT operation of float type, to the
   /// float type VT, by either extending or rounding (by truncation).
-  std::pair<SDValue, SDValue>
+  LLVM_ABI std::pair<SDValue, SDValue>
   getStrictFPExtendOrRound(SDValue Op, SDValue Chain, const SDLoc &DL, EVT VT);
 
   /// Convert *_EXTEND_VECTOR_INREG to *_EXTEND opcode.
@@ -997,15 +998,15 @@ public:
 
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by either any-extending or truncating it.
-  SDValue getAnyExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getAnyExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by either sign-extending or truncating it.
-  SDValue getSExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getSExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by either zero-extending or truncating it.
-  SDValue getZExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getZExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by either any/sign/zero-extending (depending on IsAny /
@@ -1033,61 +1034,61 @@ public:
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by first bitcasting (from potential vector) to
   /// corresponding scalar type then either any-extending or truncating it.
-  SDValue getBitcastedAnyExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getBitcastedAnyExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by first bitcasting (from potential vector) to
   /// corresponding scalar type then either sign-extending or truncating it.
-  SDValue getBitcastedSExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getBitcastedSExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by first bitcasting (from potential vector) to
   /// corresponding scalar type then either zero-extending or truncating it.
-  SDValue getBitcastedZExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getBitcastedZExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Return the expression required to zero extend the Op
   /// value assuming it was the smaller SrcTy value.
-  SDValue getZeroExtendInReg(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getZeroExtendInReg(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Return the expression required to zero extend the Op
   /// value assuming it was the smaller SrcTy value.
-  SDValue getVPZeroExtendInReg(SDValue Op, SDValue Mask, SDValue EVL,
+  LLVM_ABI SDValue getVPZeroExtendInReg(SDValue Op, SDValue Mask, SDValue EVL,
                                const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be of integer type, to the integer type VT, by
   /// either truncating it or performing either zero or sign extension as
   /// appropriate extension for the pointer's semantics.
-  SDValue getPtrExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getPtrExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Return the expression required to extend the Op as a pointer value
   /// assuming it was the smaller SrcTy value. This may be either a zero extend
   /// or a sign extend.
-  SDValue getPtrExtendInReg(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getPtrExtendInReg(SDValue Op, const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be of integer type, to the integer type VT,
   /// by using an extension appropriate for the target's
   /// BooleanContent for type OpVT or truncating it.
-  SDValue getBoolExtOrTrunc(SDValue Op, const SDLoc &SL, EVT VT, EVT OpVT);
+  LLVM_ABI SDValue getBoolExtOrTrunc(SDValue Op, const SDLoc &SL, EVT VT, EVT OpVT);
 
   /// Create negative operation as (SUB 0, Val).
-  SDValue getNegative(SDValue Val, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getNegative(SDValue Val, const SDLoc &DL, EVT VT);
 
   /// Create a bitwise NOT operation as (XOR Val, -1).
-  SDValue getNOT(const SDLoc &DL, SDValue Val, EVT VT);
+  LLVM_ABI SDValue getNOT(const SDLoc &DL, SDValue Val, EVT VT);
 
   /// Create a logical NOT operation as (XOR Val, BooleanOne).
-  SDValue getLogicalNOT(const SDLoc &DL, SDValue Val, EVT VT);
+  LLVM_ABI SDValue getLogicalNOT(const SDLoc &DL, SDValue Val, EVT VT);
 
   /// Create a vector-predicated logical NOT operation as (VP_XOR Val,
   /// BooleanOne, Mask, EVL).
-  SDValue getVPLogicalNOT(const SDLoc &DL, SDValue Val, SDValue Mask,
+  LLVM_ABI SDValue getVPLogicalNOT(const SDLoc &DL, SDValue Val, SDValue Mask,
                           SDValue EVL, EVT VT);
 
   /// Convert a vector-predicated Op, which must be an integer vector, to the
   /// vector-type VT, by performing either vector-predicated zext or truncating
   /// it. The Op will be returned as-is if Op and VT are vectors containing
   /// integer with same width.
-  SDValue getVPZExtOrTrunc(const SDLoc &DL, EVT VT, SDValue Op, SDValue Mask,
+  LLVM_ABI SDValue getVPZExtOrTrunc(const SDLoc &DL, EVT VT, SDValue Op, SDValue Mask,
                            SDValue EVL);
 
   /// Convert a vector-predicated Op, which must be of integer type, to the
@@ -1095,14 +1096,14 @@ public:
   /// vector-predicated zero or sign extension as appropriate extension for the
   /// pointer's semantics. This function just redirects to getVPZExtOrTrunc
   /// right now.
-  SDValue getVPPtrExtOrTrunc(const SDLoc &DL, EVT VT, SDValue Op, SDValue Mask,
+  LLVM_ABI SDValue getVPPtrExtOrTrunc(const SDLoc &DL, EVT VT, SDValue Op, SDValue Mask,
                              SDValue EVL);
 
   /// Returns sum of the base pointer and offset.
   /// Unlike getObjectPtrOffset this does not set NoUnsignedWrap by default.
-  SDValue getMemBasePlusOffset(SDValue Base, TypeSize Offset, const SDLoc &DL,
+  LLVM_ABI SDValue getMemBasePlusOffset(SDValue Base, TypeSize Offset, const SDLoc &DL,
                                const SDNodeFlags Flags = SDNodeFlags());
-  SDValue getMemBasePlusOffset(SDValue Base, SDValue Offset, const SDLoc &DL,
+  LLVM_ABI SDValue getMemBasePlusOffset(SDValue Base, SDValue Offset, const SDLoc &DL,
                                const SDNodeFlags Flags = SDNodeFlags());
 
   /// Create an add instruction with appropriate flags when used for
@@ -1153,7 +1154,7 @@ public:
   }
 
   /// Return true if the result of this operation is always undefined.
-  bool isUndef(unsigned Opcode, ArrayRef<SDValue> Ops);
+  LLVM_ABI bool isUndef(unsigned Opcode, ArrayRef<SDValue> Ops);
 
   /// Return an UNDEF node. UNDEF does not have a useful SDLoc.
   SDValue getUNDEF(EVT VT) {
@@ -1164,10 +1165,10 @@ public:
   SDValue getPOISON(EVT VT) { return getNode(ISD::POISON, SDLoc(), VT); }
 
   /// Return a node that represents the runtime scaling 'MulImm * RuntimeVL'.
-  SDValue getVScale(const SDLoc &DL, EVT VT, APInt MulImm,
+  LLVM_ABI SDValue getVScale(const SDLoc &DL, EVT VT, APInt MulImm,
                     bool ConstantFold = true);
 
-  SDValue getElementCount(const SDLoc &DL, EVT VT, ElementCount EC,
+  LLVM_ABI SDValue getElementCount(const SDLoc &DL, EVT VT, ElementCount EC,
                           bool ConstantFold = true);
 
   /// Return a GLOBAL_OFFSET_TABLE node. This does not have a useful SDLoc.
@@ -1177,66 +1178,66 @@ public:
 
   /// Gets or creates the specified node.
   ///
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
                   ArrayRef<SDUse> Ops);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
                   ArrayRef<SDValue> Ops, const SDNodeFlags Flags);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, ArrayRef<EVT> ResultTys,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, ArrayRef<EVT> ResultTys,
                   ArrayRef<SDValue> Ops);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
                   ArrayRef<SDValue> Ops, const SDNodeFlags Flags);
 
   // Use flags from current flag inserter.
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
                   ArrayRef<SDValue> Ops);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
                   ArrayRef<SDValue> Ops);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue Operand);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue Operand);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
                   SDValue N2);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
                   SDValue N2, SDValue N3);
 
   // Specialize based on number of operands.
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue Operand,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue Operand,
                   const SDNodeFlags Flags);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
                   SDValue N2, const SDNodeFlags Flags);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
                   SDValue N2, SDValue N3, const SDNodeFlags Flags);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
                   SDValue N2, SDValue N3, SDValue N4);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
                   SDValue N2, SDValue N3, SDValue N4, const SDNodeFlags Flags);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
                   SDValue N2, SDValue N3, SDValue N4, SDValue N5);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
                   SDValue N2, SDValue N3, SDValue N4, SDValue N5,
                   const SDNodeFlags Flags);
 
   // Specialize again based on number of operands for nodes with a VTList
   // rather than a single VT.
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
                   SDValue N2);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
                   SDValue N2, SDValue N3);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
                   SDValue N2, SDValue N3, SDValue N4);
-  SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
                   SDValue N2, SDValue N3, SDValue N4, SDValue N5);
 
   /// Compute a TokenFactor to force all the incoming stack arguments to be
   /// loaded from the stack. This is used in tail call lowering to protect
   /// stack arguments from being clobbered.
-  SDValue getStackArgumentTokenFactor(SDValue Chain);
+  LLVM_ABI SDValue getStackArgumentTokenFactor(SDValue Chain);
 
   /* \p CI if not null is the memset call being lowered.
    * \p OverrideTailCall is an optional parameter that can be used to override
    * the tail call optimization decision. */
-  SDValue getMemcpy(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
+  LLVM_ABI SDValue getMemcpy(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
                     SDValue Size, Align Alignment, bool isVol,
                     bool AlwaysInline, const CallInst *CI,
                     std::optional<bool> OverrideTailCall,
@@ -1248,7 +1249,7 @@ public:
   /* \p CI if not null is the memset call being lowered.
    * \p OverrideTailCall is an optional parameter that can be used to override
    * the tail call optimization decision. */
-  SDValue getMemmove(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
+  LLVM_ABI SDValue getMemmove(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
                      SDValue Size, Align Alignment, bool isVol,
                      const CallInst *CI, std::optional<bool> OverrideTailCall,
                      MachinePointerInfo DstPtrInfo,
@@ -1256,25 +1257,25 @@ public:
                      const AAMDNodes &AAInfo = AAMDNodes(),
                      BatchAAResults *BatchAA = nullptr);
 
-  SDValue getMemset(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
+  LLVM_ABI SDValue getMemset(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
                     SDValue Size, Align Alignment, bool isVol,
                     bool AlwaysInline, const CallInst *CI,
                     MachinePointerInfo DstPtrInfo,
                     const AAMDNodes &AAInfo = AAMDNodes());
 
-  SDValue getAtomicMemcpy(SDValue Chain, const SDLoc &dl, SDValue Dst,
+  LLVM_ABI SDValue getAtomicMemcpy(SDValue Chain, const SDLoc &dl, SDValue Dst,
                           SDValue Src, SDValue Size, Type *SizeTy,
                           unsigned ElemSz, bool isTailCall,
                           MachinePointerInfo DstPtrInfo,
                           MachinePointerInfo SrcPtrInfo);
 
-  SDValue getAtomicMemmove(SDValue Chain, const SDLoc &dl, SDValue Dst,
+  LLVM_ABI SDValue getAtomicMemmove(SDValue Chain, const SDLoc &dl, SDValue Dst,
                            SDValue Src, SDValue Size, Type *SizeTy,
                            unsigned ElemSz, bool isTailCall,
                            MachinePointerInfo DstPtrInfo,
                            MachinePointerInfo SrcPtrInfo);
 
-  SDValue getAtomicMemset(SDValue Chain, const SDLoc &dl, SDValue Dst,
+  LLVM_ABI SDValue getAtomicMemset(SDValue Chain, const SDLoc &dl, SDValue Dst,
                           SDValue Value, SDValue Size, Type *SizeTy,
                           unsigned ElemSz, bool isTailCall,
                           MachinePointerInfo DstPtrInfo);
@@ -1327,42 +1328,42 @@ public:
   }
 
   /// Try to simplify a select/vselect into 1 of its operands or a constant.
-  SDValue simplifySelect(SDValue Cond, SDValue TVal, SDValue FVal);
+  LLVM_ABI SDValue simplifySelect(SDValue Cond, SDValue TVal, SDValue FVal);
 
   /// Try to simplify a shift into 1 of its operands or a constant.
-  SDValue simplifyShift(SDValue X, SDValue Y);
+  LLVM_ABI SDValue simplifyShift(SDValue X, SDValue Y);
 
   /// Try to simplify a floating-point binary operation into 1 of its operands
   /// or a constant.
-  SDValue simplifyFPBinop(unsigned Opcode, SDValue X, SDValue Y,
+  LLVM_ABI SDValue simplifyFPBinop(unsigned Opcode, SDValue X, SDValue Y,
                           SDNodeFlags Flags);
 
   /// VAArg produces a result and token chain, and takes a pointer
   /// and a source value as input.
-  SDValue getVAArg(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
+  LLVM_ABI SDValue getVAArg(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
                    SDValue SV, unsigned Align);
 
   /// Gets a node for an atomic cmpxchg op. There are two
   /// valid Opcodes. ISD::ATOMIC_CMO_SWAP produces the value loaded and a
   /// chain result. ISD::ATOMIC_CMP_SWAP_WITH_SUCCESS produces the value loaded,
   /// a success flag (initially i1), and a chain.
-  SDValue getAtomicCmpSwap(unsigned Opcode, const SDLoc &dl, EVT MemVT,
+  LLVM_ABI SDValue getAtomicCmpSwap(unsigned Opcode, const SDLoc &dl, EVT MemVT,
                            SDVTList VTs, SDValue Chain, SDValue Ptr,
                            SDValue Cmp, SDValue Swp, MachineMemOperand *MMO);
 
   /// Gets a node for an atomic op, produces result (if relevant)
   /// and chain and takes 2 operands.
-  SDValue getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT, SDValue Chain,
+  LLVM_ABI SDValue getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT, SDValue Chain,
                     SDValue Ptr, SDValue Val, MachineMemOperand *MMO);
 
   /// Gets a node for an atomic op, produces result and chain and takes N
   /// operands.
-  SDValue getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT,
+  LLVM_ABI SDValue getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT,
                     SDVTList VTList, ArrayRef<SDValue> Ops,
                     MachineMemOperand *MMO,
                     ISD::LoadExtType ExtType = ISD::NON_EXTLOAD);
 
-  SDValue getAtomicLoad(ISD::LoadExtType ExtType, const SDLoc &dl, EVT MemVT,
+  LLVM_ABI SDValue getAtomicLoad(ISD::LoadExtType ExtType, const SDLoc &dl, EVT MemVT,
                         EVT VT, SDValue Chain, SDValue Ptr,
                         MachineMemOperand *MMO);
 
@@ -1370,7 +1371,7 @@ public:
   /// result and takes a list of operands. Opcode may be INTRINSIC_VOID,
   /// INTRINSIC_W_CHAIN, or a target-specific memory-referencing opcode
   // (see `SelectionDAGTargetInfo::isTargetMemoryOpcode`).
-  SDValue getMemIntrinsicNode(
+  LLVM_ABI SDValue getMemIntrinsicNode(
       unsigned Opcode, const SDLoc &dl, SDVTList VTList, ArrayRef<SDValue> Ops,
       EVT MemVT, MachinePointerInfo PtrInfo, Align Alignment,
       MachineMemOperand::Flags Flags = MachineMemOperand::MOLoad |
@@ -1392,50 +1393,50 @@ public:
                                Size, AAInfo);
   }
 
-  SDValue getMemIntrinsicNode(unsigned Opcode, const SDLoc &dl, SDVTList VTList,
+  LLVM_ABI SDValue getMemIntrinsicNode(unsigned Opcode, const SDLoc &dl, SDVTList VTList,
                               ArrayRef<SDValue> Ops, EVT MemVT,
                               MachineMemOperand *MMO);
 
   /// Creates a LifetimeSDNode that starts (`IsStart==true`) or ends
   /// (`IsStart==false`) the lifetime of the portion of `FrameIndex` between
   /// offsets `Offset` and `Offset + Size`.
-  SDValue getLifetimeNode(bool IsStart, const SDLoc &dl, SDValue Chain,
+  LLVM_ABI SDValue getLifetimeNode(bool IsStart, const SDLoc &dl, SDValue Chain,
                           int FrameIndex, int64_t Size, int64_t Offset = -1);
 
   /// Creates a PseudoProbeSDNode with function GUID `Guid` and
   /// the index of the block `Index` it is probing, as well as the attributes
   /// `attr` of the probe.
-  SDValue getPseudoProbeNode(const SDLoc &Dl, SDValue Chain, uint64_t Guid,
+  LLVM_ABI SDValue getPseudoProbeNode(const SDLoc &Dl, SDValue Chain, uint64_t Guid,
                              uint64_t Index, uint32_t Attr);
 
   /// Create a MERGE_VALUES node from the given operands.
-  SDValue getMergeValues(ArrayRef<SDValue> Ops, const SDLoc &dl);
+  LLVM_ABI SDValue getMergeValues(ArrayRef<SDValue> Ops, const SDLoc &dl);
 
   /// Loads are not normal binary operators: their result type is not
   /// determined by their operands, and they produce a value AND a token chain.
   ///
   /// This function will set the MOLoad flag on MMOFlags, but you can set it if
   /// you want.  The MOStore flag must not be set.
-  SDValue getLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
+  LLVM_ABI SDValue getLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
                   MachinePointerInfo PtrInfo,
                   MaybeAlign Alignment = MaybeAlign(),
                   MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
                   const AAMDNodes &AAInfo = AAMDNodes(),
                   const MDNode *Ranges = nullptr);
-  SDValue getLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
+  LLVM_ABI SDValue getLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
                   MachineMemOperand *MMO);
-  SDValue
+  LLVM_ABI SDValue
   getExtLoad(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT, SDValue Chain,
              SDValue Ptr, MachinePointerInfo PtrInfo, EVT MemVT,
              MaybeAlign Alignment = MaybeAlign(),
              MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
              const AAMDNodes &AAInfo = AAMDNodes());
-  SDValue getExtLoad(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
+  LLVM_ABI SDValue getExtLoad(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
                      SDValue Chain, SDValue Ptr, EVT MemVT,
                      MachineMemOperand *MMO);
-  SDValue getIndexedLoad(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
+  LLVM_ABI SDValue getIndexedLoad(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
                          SDValue Offset, ISD::MemIndexedMode AM);
-  SDValue getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
+  LLVM_ABI SDValue getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
                   const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
                   MachinePointerInfo PtrInfo, EVT MemVT, Align Alignment,
                   MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
@@ -1452,7 +1453,7 @@ public:
                    Alignment.value_or(getEVTAlign(MemVT)), MMOFlags, AAInfo,
                    Ranges);
   }
-  SDValue getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
+  LLVM_ABI SDValue getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
                   const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
                   EVT MemVT, MachineMemOperand *MMO);
 
@@ -1461,7 +1462,7 @@ public:
   /// This function will set the MOStore flag on MMOFlags, but you can set it if
   /// you want.  The MOLoad and MOInvariant flags must not be set.
 
-  SDValue
+  LLVM_ABI SDValue
   getStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
            MachinePointerInfo PtrInfo, Align Alignment,
            MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
@@ -1475,9 +1476,9 @@ public:
                     Alignment.value_or(getEVTAlign(Val.getValueType())),
                     MMOFlags, AAInfo);
   }
-  SDValue getStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
+  LLVM_ABI SDValue getStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
                    MachineMemOperand *MMO);
-  SDValue
+  LLVM_ABI SDValue
   getTruncStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
                 MachinePointerInfo PtrInfo, EVT SVT, Align Alignment,
                 MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
@@ -1492,15 +1493,15 @@ public:
                          Alignment.value_or(getEVTAlign(SVT)), MMOFlags,
                          AAInfo);
   }
-  SDValue getTruncStore(SDValue Chain, const SDLoc &dl, SDValue Val,
+  LLVM_ABI SDValue getTruncStore(SDValue Chain, const SDLoc &dl, SDValue Val,
                         SDValue Ptr, EVT SVT, MachineMemOperand *MMO);
-  SDValue getIndexedStore(SDValue OrigStore, const SDLoc &dl, SDValue Base,
+  LLVM_ABI SDValue getIndexedStore(SDValue OrigStore, const SDLoc &dl, SDValue Base,
                           SDValue Offset, ISD::MemIndexedMode AM);
-  SDValue getStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
+  LLVM_ABI SDValue getStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
                    SDValue Offset, EVT SVT, MachineMemOperand *MMO,
                    ISD::MemIndexedMode AM, bool IsTruncating = false);
 
-  SDValue getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
+  LLVM_ABI SDValue getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
                     const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
                     SDValue Mask, SDValue EVL, MachinePointerInfo PtrInfo,
                     EVT MemVT, Align Alignment,
@@ -1519,152 +1520,152 @@ public:
                      PtrInfo, MemVT, Alignment.value_or(getEVTAlign(MemVT)),
                      MMOFlags, AAInfo, Ranges, IsExpanding);
   }
-  SDValue getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
+  LLVM_ABI SDValue getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
                     const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
                     SDValue Mask, SDValue EVL, EVT MemVT,
                     MachineMemOperand *MMO, bool IsExpanding = false);
-  SDValue getLoadVP(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
+  LLVM_ABI SDValue getLoadVP(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
                     SDValue Mask, SDValue EVL, MachinePointerInfo PtrInfo,
                     MaybeAlign Alignment, MachineMemOperand::Flags MMOFlags,
                     const AAMDNodes &AAInfo, const MDNode *Ranges = nullptr,
                     bool IsExpanding = false);
-  SDValue getLoadVP(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
+  LLVM_ABI SDValue getLoadVP(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
                     SDValue Mask, SDValue EVL, MachineMemOperand *MMO,
                     bool IsExpanding = false);
-  SDValue getExtLoadVP(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
+  LLVM_ABI SDValue getExtLoadVP(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
                        SDValue Chain, SDValue Ptr, SDValue Mask, SDValue EVL,
                        MachinePointerInfo PtrInfo, EVT MemVT,
                        MaybeAlign Alignment, MachineMemOperand::Flags MMOFlags,
                        const AAMDNodes &AAInfo, bool IsExpanding = false);
-  SDValue getExtLoadVP(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
+  LLVM_ABI SDValue getExtLoadVP(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
                        SDValue Chain, SDValue Ptr, SDValue Mask, SDValue EVL,
                        EVT MemVT, MachineMemOperand *MMO,
                        bool IsExpanding = false);
-  SDValue getIndexedLoadVP(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
+  LLVM_ABI SDValue getIndexedLoadVP(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
                            SDValue Offset, ISD::MemIndexedMode AM);
-  SDValue getStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
+  LLVM_ABI SDValue getStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
                      SDValue Offset, SDValue Mask, SDValue EVL, EVT MemVT,
                      MachineMemOperand *MMO, ISD::MemIndexedMode AM,
                      bool IsTruncating = false, bool IsCompressing = false);
-  SDValue getTruncStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
+  LLVM_ABI SDValue getTruncStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
                           SDValue Ptr, SDValue Mask, SDValue EVL,
                           MachinePointerInfo PtrInfo, EVT SVT, Align Alignment,
                           MachineMemOperand::Flags MMOFlags,
                           const AAMDNodes &AAInfo, bool IsCompressing = false);
-  SDValue getTruncStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
+  LLVM_ABI SDValue getTruncStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
                           SDValue Ptr, SDValue Mask, SDValue EVL, EVT SVT,
                           MachineMemOperand *MMO, bool IsCompressing = false);
-  SDValue getIndexedStoreVP(SDValue OrigStore, const SDLoc &dl, SDValue Base,
+  LLVM_ABI SDValue getIndexedStoreVP(SDValue OrigStore, const SDLoc &dl, SDValue Base,
                             SDValue Offset, ISD::MemIndexedMode AM);
 
-  SDValue getStridedLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
+  LLVM_ABI SDValue getStridedLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
                            EVT VT, const SDLoc &DL, SDValue Chain, SDValue Ptr,
                            SDValue Offset, SDValue Stride, SDValue Mask,
                            SDValue EVL, EVT MemVT, MachineMemOperand *MMO,
                            bool IsExpanding = false);
-  SDValue getStridedLoadVP(EVT VT, const SDLoc &DL, SDValue Chain, SDValue Ptr,
+  LLVM_ABI SDValue getStridedLoadVP(EVT VT, const SDLoc &DL, SDValue Chain, SDValue Ptr,
                            SDValue Stride, SDValue Mask, SDValue EVL,
                            MachineMemOperand *MMO, bool IsExpanding = false);
-  SDValue getExtStridedLoadVP(ISD::LoadExtType ExtType, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getExtStridedLoadVP(ISD::LoadExtType ExtType, const SDLoc &DL, EVT VT,
                               SDValue Chain, SDValue Ptr, SDValue Stride,
                               SDValue Mask, SDValue EVL, EVT MemVT,
                               MachineMemOperand *MMO, bool IsExpanding = false);
-  SDValue getStridedStoreVP(SDValue Chain, const SDLoc &DL, SDValue Val,
+  LLVM_ABI SDValue getStridedStoreVP(SDValue Chain, const SDLoc &DL, SDValue Val,
                             SDValue Ptr, SDValue Offset, SDValue Stride,
                             SDValue Mask, SDValue EVL, EVT MemVT,
                             MachineMemOperand *MMO, ISD::MemIndexedMode AM,
                             bool IsTruncating = false,
                             bool IsCompressing = false);
-  SDValue getTruncStridedStoreVP(SDValue Chain, const SDLoc &DL, SDValue Val,
+  LLVM_ABI SDValue getTruncStridedStoreVP(SDValue Chain, const SDLoc &DL, SDValue Val,
                                  SDValue Ptr, SDValue Stride, SDValue Mask,
                                  SDValue EVL, EVT SVT, MachineMemOperand *MMO,
                                  bool IsCompressing = false);
 
-  SDValue getGatherVP(SDVTList VTs, EVT VT, const SDLoc &dl,
+  LLVM_ABI SDValue getGatherVP(SDVTList VTs, EVT VT, const SDLoc &dl,
                       ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
                       ISD::MemIndexType IndexType);
-  SDValue getScatterVP(SDVTList VTs, EVT VT, const SDLoc &dl,
+  LLVM_ABI SDValue getScatterVP(SDVTList VTs, EVT VT, const SDLoc &dl,
                        ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
                        ISD::MemIndexType IndexType);
 
-  SDValue getMaskedLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Base,
+  LLVM_ABI SDValue getMaskedLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Base,
                         SDValue Offset, SDValue Mask, SDValue Src0, EVT MemVT,
                         MachineMemOperand *MMO, ISD::MemIndexedMode AM,
                         ISD::LoadExtType, bool IsExpanding = false);
-  SDValue getIndexedMaskedLoad(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
+  LLVM_ABI SDValue getIndexedMaskedLoad(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
                                SDValue Offset, ISD::MemIndexedMode AM);
-  SDValue getMaskedStore(SDValue Chain, const SDLoc &dl, SDValue Val,
+  LLVM_ABI SDValue getMaskedStore(SDValue Chain, const SDLoc &dl, SDValue Val,
                          SDValue Base, SDValue Offset, SDValue Mask, EVT MemVT,
                          MachineMemOperand *MMO, ISD::MemIndexedMode AM,
                          bool IsTruncating = false, bool IsCompressing = false);
-  SDValue getIndexedMaskedStore(SDValue OrigStore, const SDLoc &dl,
+  LLVM_ABI SDValue getIndexedMaskedStore(SDValue OrigStore, const SDLoc &dl,
                                 SDValue Base, SDValue Offset,
                                 ISD::MemIndexedMode AM);
-  SDValue getMaskedGather(SDVTList VTs, EVT MemVT, const SDLoc &dl,
+  LLVM_ABI SDValue getMaskedGather(SDVTList VTs, EVT MemVT, const SDLoc &dl,
                           ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
                           ISD::MemIndexType IndexType, ISD::LoadExtType ExtTy);
-  SDValue getMaskedScatter(SDVTList VTs, EVT MemVT, const SDLoc &dl,
+  LLVM_ABI SDValue getMaskedScatter(SDVTList VTs, EVT MemVT, const SDLoc &dl,
                            ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
                            ISD::MemIndexType IndexType,
                            bool IsTruncating = false);
-  SDValue getMaskedHistogram(SDVTList VTs, EVT MemVT, const SDLoc &dl,
+  LLVM_ABI SDValue getMaskedHistogram(SDVTList VTs, EVT MemVT, const SDLoc &dl,
                              ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
                              ISD::MemIndexType IndexType);
 
-  SDValue getGetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr, EVT MemVT,
+  LLVM_ABI SDValue getGetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr, EVT MemVT,
                       MachineMemOperand *MMO);
-  SDValue getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr, EVT MemVT,
+  LLVM_ABI SDValue getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr, EVT MemVT,
                       MachineMemOperand *MMO);
 
   /// Construct a node to track a Value* through the backend.
-  SDValue getSrcValue(const Value *v);
+  LLVM_ABI SDValue getSrcValue(const Value *v);
 
   /// Return an MDNodeSDNode which holds an MDNode.
-  SDValue getMDNode(const MDNode *MD);
+  LLVM_ABI SDValue getMDNode(const MDNode *MD);
 
   /// Return a bitcast using the SDLoc of the value operand, and casting to the
   /// provided type. Use getNode to set a custom SDLoc.
-  SDValue getBitcast(EVT VT, SDValue V);
+  LLVM_ABI SDValue getBitcast(EVT VT, SDValue V);
 
   /// Return an AddrSpaceCastSDNode.
-  SDValue getAddrSpaceCast(const SDLoc &dl, EVT VT, SDValue Ptr, unsigned SrcAS,
+  LLVM_ABI SDValue getAddrSpaceCast(const SDLoc &dl, EVT VT, SDValue Ptr, unsigned SrcAS,
                            unsigned DestAS);
 
   /// Return a freeze using the SDLoc of the value operand.
-  SDValue getFreeze(SDValue V);
+  LLVM_ABI SDValue getFreeze(SDValue V);
 
   /// Return an AssertAlignSDNode.
-  SDValue getAssertAlign(const SDLoc &DL, SDValue V, Align A);
+  LLVM_ABI SDValue getAssertAlign(const SDLoc &DL, SDValue V, Align A);
 
   /// Swap N1 and N2 if Opcode is a commutative binary opcode
   /// and the canonical form expects the opposite order.
-  void canonicalizeCommutativeBinop(unsigned Opcode, SDValue &N1,
+  LLVM_ABI void canonicalizeCommutativeBinop(unsigned Opcode, SDValue &N1,
                                     SDValue &N2) const;
 
   /// Return the specified value casted to
   /// the target's desired shift amount type.
-  SDValue getShiftAmountOperand(EVT LHSTy, SDValue Op);
+  LLVM_ABI SDValue getShiftAmountOperand(EVT LHSTy, SDValue Op);
 
   /// Expands a node with multiple results to an FP or vector libcall. The
   /// libcall is expected to take all the operands of the \p Node followed by
   /// output pointers for each of the results. \p CallRetResNo can be optionally
   /// set to indicate that one of the results comes from the libcall's return
   /// value.
-  bool expandMultipleResultFPLibCall(RTLIB::Libcall LC, SDNode *Node,
+  LLVM_ABI bool expandMultipleResultFPLibCall(RTLIB::Libcall LC, SDNode *Node,
                                      SmallVectorImpl<SDValue> &Results,
                                      std::optional<unsigned> CallRetResNo = {});
 
   /// Expand the specified \c ISD::VAARG node as the Legalize pass would.
-  SDValue expandVAArg(SDNode *Node);
+  LLVM_ABI SDValue expandVAArg(SDNode *Node);
 
   /// Expand the specified \c ISD::VACOPY node as the Legalize pass would.
-  SDValue expandVACopy(SDNode *Node);
+  LLVM_ABI SDValue expandVACopy(SDNode *Node);
 
   /// Return a GlobalAddress of the function from the current module with
   /// name matching the given ExternalSymbol. Additionally can provide the
   /// matched function.
   /// Panic if the function doesn't exist.
-  SDValue getSymbolFunctionGlobalAddress(SDValue Op,
+  LLVM_ABI SDValue getSymbolFunctionGlobalAddress(SDValue Op,
                                          Function **TargetFunction = nullptr);
 
   /// *Mutate* the specified node in-place to have the
@@ -1673,63 +1674,63 @@ public:
   /// already exists.  If the resultant node does not exist in the DAG, the
   /// input node is returned.  As a degenerate case, if you specify the same
   /// input operands as the node already has, the input node is returned.
-  SDNode *UpdateNodeOperands(SDNode *N, SDValue Op);
-  SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2);
-  SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
+  LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op);
+  LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2);
+  LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
                                SDValue Op3);
-  SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
+  LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
                                SDValue Op3, SDValue Op4);
-  SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
+  LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
                                SDValue Op3, SDValue Op4, SDValue Op5);
-  SDNode *UpdateNodeOperands(SDNode *N, ArrayRef<SDValue> Ops);
+  LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, ArrayRef<SDValue> Ops);
 
   /// Creates a new TokenFactor containing \p Vals. If \p Vals contains 64k
   /// values or more, move values into new TokenFactors in 64k-1 blocks, until
   /// the final TokenFactor has less than 64k operands.
-  SDValue getTokenFactor(const SDLoc &DL, SmallVectorImpl<SDValue> &Vals);
+  LLVM_ABI SDValue getTokenFactor(const SDLoc &DL, SmallVectorImpl<SDValue> &Vals);
 
   /// *Mutate* the specified machine node's memory references to the provided
   /// list.
-  void setNodeMemRefs(MachineSDNode *N,
+  LLVM_ABI void setNodeMemRefs(MachineSDNode *N,
                       ArrayRef<MachineMemOperand *> NewMemRefs);
 
   // Calculate divergence of node \p N based on its operands.
-  bool calculateDivergence(SDNode *N);
+  LLVM_ABI bool calculateDivergence(SDNode *N);
 
   // Propagates the change in divergence to users
-  void updateDivergence(SDNode * N);
+  LLVM_ABI void updateDivergence(SDNode * N);
 
   /// These are used for target selectors to *mutate* the
   /// specified node to have the specified return type, Target opcode, and
   /// operands.  Note that target opcodes are stored as
   /// ~TargetOpcode in the node opcode field.  The resultant node is returned.
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT, SDValue Op1);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT);
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT, SDValue Op1);
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
                        SDValue Op1, SDValue Op2);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
                        SDValue Op1, SDValue Op2, SDValue Op3);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
                        ArrayRef<SDValue> Ops);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1, EVT VT2);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1, EVT VT2);
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
                        EVT VT2, ArrayRef<SDValue> Ops);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
                        EVT VT2, EVT VT3, ArrayRef<SDValue> Ops);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
                        EVT VT2, SDValue Op1, SDValue Op2);
-  SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, SDVTList VTs,
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, SDVTList VTs,
                        ArrayRef<SDValue> Ops);
 
   /// This *mutates* the specified node to have the specified
   /// return type, opcode, and operands.
-  SDNode *MorphNodeTo(SDNode *N, unsigned Opc, SDVTList VTs,
+  LLVM_ABI SDNode *MorphNodeTo(SDNode *N, unsigned Opc, SDVTList VTs,
                       ArrayRef<SDValue> Ops);
 
   /// Mutate the specified strict FP node to its non-strict equivalent,
   /// unlinking the node from its chain and dropping the metadata arguments.
   /// The node must be a strict FP node.
-  SDNode *mutateStrictFPToFP(SDNode *Node);
+  LLVM_ABI SDNode *mutateStrictFPToFP(SDNode *Node);
 
   /// These are used for target selectors to create a new node
   /// with specified return type(s), MachineInstr opcode, and operands.
@@ -1737,100 +1738,100 @@ public:
   /// Note that getMachineNode returns the resultant node.  If there is already
   /// a node of the specified opcode and operands, it returns that node instead
   /// of the current one.
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
                                 SDValue Op1);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
                                 SDValue Op1, SDValue Op2);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
                                 SDValue Op1, SDValue Op2, SDValue Op3);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
                                 ArrayRef<SDValue> Ops);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
                                 EVT VT2, SDValue Op1, SDValue Op2);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
                                 EVT VT2, SDValue Op1, SDValue Op2, SDValue Op3);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
                                 EVT VT2, ArrayRef<SDValue> Ops);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
                                 EVT VT2, EVT VT3, SDValue Op1, SDValue Op2);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
                                 EVT VT2, EVT VT3, SDValue Op1, SDValue Op2,
                                 SDValue Op3);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
                                 EVT VT2, EVT VT3, ArrayRef<SDValue> Ops);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
                                 ArrayRef<EVT> ResultTys, ArrayRef<SDValue> Ops);
-  MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, SDVTList VTs,
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, SDVTList VTs,
                                 ArrayRef<SDValue> Ops);
 
   /// A convenience function for creating TargetInstrInfo::EXTRACT_SUBREG nodes.
-  SDValue getTargetExtractSubreg(int SRIdx, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getTargetExtractSubreg(int SRIdx, const SDLoc &DL, EVT VT,
                                  SDValue Operand);
 
   /// A convenience function for creating TargetInstrInfo::INSERT_SUBREG nodes.
-  SDValue getTargetInsertSubreg(int SRIdx, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getTargetInsertSubreg(int SRIdx, const SDLoc &DL, EVT VT,
                                 SDValue Operand, SDValue Subreg);
 
   /// Get the specified node if it's already available, or else return NULL.
-  SDNode *getNodeIfExists(unsigned Opcode, SDVTList VTList,
+  LLVM_ABI SDNode *getNodeIfExists(unsigned Opcode, SDVTList VTList,
                           ArrayRef<SDValue> Ops, const SDNodeFlags Flags);
-  SDNode *getNodeIfExists(unsigned Opcode, SDVTList VTList,
+  LLVM_ABI SDNode *getNodeIfExists(unsigned Opcode, SDVTList VTList,
                           ArrayRef<SDValue> Ops);
 
   /// Check if a node exists without modifying its flags.
-  bool doesNodeExist(unsigned Opcode, SDVTList VTList, ArrayRef<SDValue> Ops);
+  LLVM_ABI bool doesNodeExist(unsigned Opcode, SDVTList VTList, ArrayRef<SDValue> Ops);
 
   /// Creates a SDDbgValue node.
-  SDDbgValue *getDbgValue(DIVariable *Var, DIExpression *Expr, SDNode *N,
+  LLVM_ABI SDDbgValue *getDbgValue(DIVariable *Var, DIExpression *Expr, SDNode *N,
                           unsigned R, bool IsIndirect, const DebugLoc &DL,
                           unsigned O);
 
   /// Creates a constant SDDbgValue node.
-  SDDbgValue *getConstantDbgValue(DIVariable *Var, DIExpression *Expr,
+  LLVM_ABI SDDbgValue *getConstantDbgValue(DIVariable *Var, DIExpression *Expr,
                                   const Value *C, const DebugLoc &DL,
                                   unsigned O);
 
   /// Creates a FrameIndex SDDbgValue node.
-  SDDbgValue *getFrameIndexDbgValue(DIVariable *Var, DIExpression *Expr,
+  LLVM_ABI SDDbgValue *getFrameIndexDbgValue(DIVariable *Var, DIExpression *Expr,
                                     unsigned FI, bool IsIndirect,
                                     const DebugLoc &DL, unsigned O);
 
   /// Creates a FrameIndex SDDbgValue node.
-  SDDbgValue *getFrameIndexDbgValue(DIVariable *Var, DIExpression *Expr,
+  LLVM_ABI SDDbgValue *getFrameIndexDbgValue(DIVariable *Var, DIExpression *Expr,
                                     unsigned FI,
                                     ArrayRef<SDNode *> Dependencies,
                                     bool IsIndirect, const DebugLoc &DL,
                                     unsigned O);
 
   /// Creates a VReg SDDbgValue node.
-  SDDbgValue *getVRegDbgValue(DIVariable *Var, DIExpression *Expr,
+  LLVM_ABI SDDbgValue *getVRegDbgValue(DIVariable *Var, DIExpression *Expr,
                               Register VReg, bool IsIndirect,
                               const DebugLoc &DL, unsigned O);
 
   /// Creates a SDDbgValue node from a list of locations.
-  SDDbgValue *getDbgValueList(DIVariable *Var, DIExpression *Expr,
+  LLVM_ABI SDDbgValue *getDbgValueList(DIVariable *Var, DIExpression *Expr,
                               ArrayRef<SDDbgOperand> Locs,
                               ArrayRef<SDNode *> Dependencies, bool IsIndirect,
                               const DebugLoc &DL, unsigned O, bool IsVariadic);
 
   /// Creates a SDDbgLabel node.
-  SDDbgLabel *getDbgLabel(DILabel *Label, const DebugLoc &DL, unsigned O);
+  LLVM_ABI SDDbgLabel *getDbgLabel(DILabel *Label, const DebugLoc &DL, unsigned O);
 
   /// Transfer debug values from one node to another, while optionally
   /// generating fragment expressions for split-up values. If \p InvalidateDbg
   /// is set, debug values are invalidated after they are transferred.
-  void transferDbgValues(SDValue From, SDValue To, unsigned OffsetInBits = 0,
+  LLVM_ABI void transferDbgValues(SDValue From, SDValue To, unsigned OffsetInBits = 0,
                          unsigned SizeInBits = 0, bool InvalidateDbg = true);
 
   /// Remove the specified node from the system. If any of its
   /// operands then becomes dead, remove them as well. Inform UpdateListener
   /// for each node deleted.
-  void RemoveDeadNode(SDNode *N);
+  LLVM_ABI void RemoveDeadNode(SDNode *N);
 
   /// This method deletes the unreachable nodes in the
   /// given list, and any nodes that become unreachable as a result.
-  void RemoveDeadNodes(SmallVectorImpl<SDNode *> &DeadNodes);
+  LLVM_ABI void RemoveDeadNodes(SmallVectorImpl<SDNode *> &DeadNodes);
 
   /// Modify anything using 'From' to use 'To' instead.
   /// This can cause recursive merging of nodes in the DAG.  Use the first
@@ -1847,18 +1848,18 @@ public:
   /// to be given new uses. These new uses of From are left in place, and
   /// not automatically transferred to To.
   ///
-  void ReplaceAllUsesWith(SDValue From, SDValue To);
-  void ReplaceAllUsesWith(SDNode *From, SDNode *To);
-  void ReplaceAllUsesWith(SDNode *From, const SDValue *To);
+  LLVM_ABI void ReplaceAllUsesWith(SDValue From, SDValue To);
+  LLVM_ABI void ReplaceAllUsesWith(SDNode *From, SDNode *To);
+  LLVM_ABI void ReplaceAllUsesWith(SDNode *From, const SDValue *To);
 
   /// Replace any uses of From with To, leaving
   /// uses of other values produced by From.getNode() alone.
-  void ReplaceAllUsesOfValueWith(SDValue From, SDValue To);
+  LLVM_ABI void ReplaceAllUsesOfValueWith(SDValue From, SDValue To);
 
   /// Like ReplaceAllUsesOfValueWith, but for multiple values at once.
   /// This correctly handles the case where
   /// there is an overlap between the From values and the To values.
-  void ReplaceAllUsesOfValuesWith(const SDValue *From, const SDValue *To,
+  LLVM_ABI void ReplaceAllUsesOfValuesWith(const SDValue *From, const SDValue *To,
                                   unsigned Num);
 
   /// If an existing load has uses of its chain, create a token factor node with
@@ -1866,19 +1867,19 @@ public:
   /// chain to the token factor. This ensures that the new memory node will have
   /// the same relative memory dependency position as the old load. Returns the
   /// new merged load chain.
-  SDValue makeEquivalentMemoryOrdering(SDValue OldChain, SDValue NewMemOpChain);
+  LLVM_ABI SDValue makeEquivalentMemoryOrdering(SDValue OldChain, SDValue NewMemOpChain);
 
   /// If an existing load has uses of its chain, create a token factor node with
   /// that chain and the new memory node's chain and update users of the old
   /// chain to the token factor. This ensures that the new memory node will have
   /// the same relative memory dependency position as the old load. Returns the
   /// new merged load chain.
-  SDValue makeEquivalentMemoryOrdering(LoadSDNode *OldLoad, SDValue NewMemOp);
+  LLVM_ABI SDValue makeEquivalentMemoryOrdering(LoadSDNode *OldLoad, SDValue NewMemOp);
 
   /// Topological-sort the AllNodes list and a
   /// assign a unique node id for each node in the DAG based on their
   /// topological order. Returns the number of nodes.
-  unsigned AssignTopologicalOrder();
+  LLVM_ABI unsigned AssignTopologicalOrder();
 
   /// Move node N in the AllNodes list to be immediately
   /// before the given iterator Position. This may be used to update the
@@ -1889,10 +1890,10 @@ public:
 
   /// Add a dbg_value SDNode. If SD is non-null that means the
   /// value is produced by SD.
-  void AddDbgValue(SDDbgValue *DB, bool isParameter);
+  LLVM_ABI void AddDbgValue(SDDbgValue *DB, bool isParameter);
 
   /// Add a dbg_label SDNode.
-  void AddDbgLabel(SDDbgLabel *DB);
+  LLVM_ABI void AddDbgLabel(SDDbgLabel *DB);
 
   /// Get the debug values which reference the given SDNode.
   ArrayRef<SDDbgValue*> GetDbgValues(const SDNode* SD) const {
@@ -1923,72 +1924,72 @@ public:
 
   /// To be invoked on an SDNode that is slated to be erased. This
   /// function mirrors \c llvm::salvageDebugInfo.
-  void salvageDebugInfo(SDNode &N);
+  LLVM_ABI void salvageDebugInfo(SDNode &N);
 
-  void dump() const;
+  LLVM_ABI void dump() const;
 
   /// In most cases this function returns the ABI alignment for a given type,
   /// except for illegal vector types where the alignment exceeds that of the
   /// stack. In such cases we attempt to break the vector down to a legal type
   /// and return the ABI alignment for that instead.
-  Align getReducedAlign(EVT VT, bool UseABI);
+  LLVM_ABI Align getReducedAlign(EVT VT, bool UseABI);
 
   /// Create a stack temporary based on the size in bytes and the alignment
-  SDValue CreateStackTemporary(TypeSize Bytes, Align Alignment);
+  LLVM_ABI SDValue CreateStackTemporary(TypeSize Bytes, Align Alignment);
 
   /// Create a stack temporary, suitable for holding the specified value type.
   /// If minAlign is specified, the slot size will have at least that alignment.
-  SDValue CreateStackTemporary(EVT VT, unsigned minAlign = 1);
+  LLVM_ABI SDValue CreateStackTemporary(EVT VT, unsigned minAlign = 1);
 
   /// Create a stack temporary suitable for holding either of the specified
   /// value types.
-  SDValue CreateStackTemporary(EVT VT1, EVT VT2);
+  LLVM_ABI SDValue CreateStackTemporary(EVT VT1, EVT VT2);
 
-  SDValue FoldSymbolOffset(unsigned Opcode, EVT VT,
+  LLVM_ABI SDValue FoldSymbolOffset(unsigned Opcode, EVT VT,
                            const GlobalAddressSDNode *GA,
                            const SDNode *N2);
 
-  SDValue FoldConstantArithmetic(unsigned Opcode, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue FoldConstantArithmetic(unsigned Opcode, const SDLoc &DL, EVT VT,
                                  ArrayRef<SDValue> Ops,
                                  SDNodeFlags Flags = SDNodeFlags());
 
   /// Fold floating-point operations when all operands are constants and/or
   /// undefined.
-  SDValue foldConstantFPMath(unsigned Opcode, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue foldConstantFPMath(unsigned Opcode, const SDLoc &DL, EVT VT,
                              ArrayRef<SDValue> Ops);
 
   /// Constant fold a setcc to true or false.
-  SDValue FoldSetCC(EVT VT, SDValue N1, SDValue N2, ISD::CondCode Cond,
+  LLVM_ABI SDValue FoldSetCC(EVT VT, SDValue N1, SDValue N2, ISD::CondCode Cond,
                     const SDLoc &dl);
 
   /// Return true if the sign bit of Op is known to be zero.
   /// We use this predicate to simplify operations downstream.
-  bool SignBitIsZero(SDValue Op, unsigned Depth = 0) const;
+  LLVM_ABI bool SignBitIsZero(SDValue Op, unsigned Depth = 0) const;
 
   /// Return true if 'Op & Mask' is known to be zero.  We
   /// use this predicate to simplify operations downstream.  Op and Mask are
   /// known to be the same type.
-  bool MaskedValueIsZero(SDValue Op, const APInt &Mask,
+  LLVM_ABI bool MaskedValueIsZero(SDValue Op, const APInt &Mask,
                          unsigned Depth = 0) const;
 
   /// Return true if 'Op & Mask' is known to be zero in DemandedElts.  We
   /// use this predicate to simplify operations downstream.  Op and Mask are
   /// known to be the same type.
-  bool MaskedValueIsZero(SDValue Op, const APInt &Mask,
+  LLVM_ABI bool MaskedValueIsZero(SDValue Op, const APInt &Mask,
                          const APInt &DemandedElts, unsigned Depth = 0) const;
 
   /// Return true if 'Op' is known to be zero in DemandedElts.  We
   /// use this predicate to simplify operations downstream.
-  bool MaskedVectorIsZero(SDValue Op, const APInt &DemandedElts,
+  LLVM_ABI bool MaskedVectorIsZero(SDValue Op, const APInt &DemandedElts,
                           unsigned Depth = 0) const;
 
   /// Return true if '(Op & Mask) == Mask'.
   /// Op and Mask are known to be the same type.
-  bool MaskedValueIsAllOnes(SDValue Op, const APInt &Mask,
+  LLVM_ABI bool MaskedValueIsAllOnes(SDValue Op, const APInt &Mask,
                             unsigned Depth = 0) const;
 
   /// For each demanded element of a vector, see if it is known to be zero.
-  APInt computeVectorKnownZeroElements(SDValue Op, const APInt &DemandedElts,
+  LLVM_ABI APInt computeVectorKnownZeroElements(SDValue Op, const APInt &DemandedElts,
                                        unsigned Depth = 0) const;
 
   /// Determine which bits of Op are known to be either zero or one and return
@@ -1996,14 +1997,14 @@ public:
   /// every vector element.
   /// Targets can implement the computeKnownBitsForTargetNode method in the
   /// TargetLowering class to allow target nodes to be understood.
-  KnownBits computeKnownBits(SDValue Op, unsigned Depth = 0) const;
+  LLVM_ABI KnownBits computeKnownBits(SDValue Op, unsigned Depth = 0) const;
 
   /// Determine which bits of Op are known to be either zero or one and return
   /// them in Known. The DemandedElts argument allows us to only collect the
   /// known bits that are shared by the requested vector elements.
   /// Targets can implement the computeKnownBitsForTargetNode method in the
   /// TargetLowering class to allow target nodes to be understood.
-  KnownBits computeKnownBits(SDValue Op, const APInt &DemandedElts,
+  LLVM_ABI KnownBits computeKnownBits(SDValue Op, const APInt &DemandedElts,
                              unsigned Depth = 0) const;
 
   /// Used to represent the possible overflow behavior of an operation.
@@ -2017,10 +2018,10 @@ public:
   };
 
   /// Determine if the result of the signed addition of 2 nodes can overflow.
-  OverflowKind computeOverflowForSignedAdd(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForSignedAdd(SDValue N0, SDValue N1) const;
 
   /// Determine if the result of the unsigned addition of 2 nodes can overflow.
-  OverflowKind computeOverflowForUnsignedAdd(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForUnsignedAdd(SDValue N0, SDValue N1) const;
 
   /// Determine if the result of the addition of 2 nodes can overflow.
   OverflowKind computeOverflowForAdd(bool IsSigned, SDValue N0,
@@ -2035,10 +2036,10 @@ public:
   }
 
   /// Determine if the result of the signed sub of 2 nodes can overflow.
-  OverflowKind computeOverflowForSignedSub(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForSignedSub(SDValue N0, SDValue N1) const;
 
   /// Determine if the result of the unsigned sub of 2 nodes can overflow.
-  OverflowKind computeOverflowForUnsignedSub(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForUnsignedSub(SDValue N0, SDValue N1) const;
 
   /// Determine if the result of the sub of 2 nodes can overflow.
   OverflowKind computeOverflowForSub(bool IsSigned, SDValue N0,
@@ -2053,10 +2054,10 @@ public:
   }
 
   /// Determine if the result of the signed mul of 2 nodes can overflow.
-  OverflowKind computeOverflowForSignedMul(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForSignedMul(SDValue N0, SDValue N1) const;
 
   /// Determine if the result of the unsigned mul of 2 nodes can overflow.
-  OverflowKind computeOverflowForUnsignedMul(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForUnsignedMul(SDValue N0, SDValue N1) const;
 
   /// Determine if the result of the mul of 2 nodes can overflow.
   OverflowKind computeOverflowForMul(bool IsSigned, SDValue N0,
@@ -2073,11 +2074,11 @@ public:
   /// Test if the given value is known to have exactly one bit set. This differs
   /// from computeKnownBits in that it doesn't necessarily determine which bit
   /// is set.
-  bool isKnownToBeAPowerOfTwo(SDValue Val, unsigned Depth = 0) const;
+  LLVM_ABI bool isKnownToBeAPowerOfTwo(SDValue Val, unsigned Depth = 0) const;
 
   /// Test if the given _fp_ value is known to be an integer power-of-2, either
   /// positive or negative.
-  bool isKnownToBeAPowerOfTwoFP(SDValue Val, unsigned Depth = 0) const;
+  LLVM_ABI bool isKnownToBeAPowerOfTwoFP(SDValue Val, unsigned Depth = 0) const;
 
   /// Return the number of times the sign bit of the register is replicated into
   /// the other bits. We know that at least 1 bit is always equal to the sign
@@ -2086,7 +2087,7 @@ public:
   /// to each other, so we return 3. Targets can implement the
   /// ComputeNumSignBitsForTarget method in the TargetLowering class to allow
   /// target nodes to be understood.
-  unsigned ComputeNumSignBits(SDValue Op, unsigned Depth = 0) const;
+  LLVM_ABI unsigned ComputeNumSignBits(SDValue Op, unsigned Depth = 0) const;
 
   /// Return the number of times the sign bit of the register is replicated into
   /// the other bits. We know that at least 1 bit is always equal to the sign
@@ -2096,31 +2097,31 @@ public:
   /// us to only collect the minimum sign bits of the requested vector elements.
   /// Targets can implement the ComputeNumSignBitsForTarget method in the
   /// TargetLowering class to allow target nodes to be understood.
-  unsigned ComputeNumSignBits(SDValue Op, const APInt &DemandedElts,
+  LLVM_ABI unsigned ComputeNumSignBits(SDValue Op, const APInt &DemandedElts,
                               unsigned Depth = 0) const;
 
   /// Get the upper bound on bit size for this Value \p Op as a signed integer.
   /// i.e.  x == sext(trunc(x to MaxSignedBits) to bitwidth(x)).
   /// Similar to the APInt::getSignificantBits function.
   /// Helper wrapper to ComputeNumSignBits.
-  unsigned ComputeMaxSignificantBits(SDValue Op, unsigned Depth = 0) const;
+  LLVM_ABI unsigned ComputeMaxSignificantBits(SDValue Op, unsigned Depth = 0) const;
 
   /// Get the upper bound on bit size for this Value \p Op as a signed integer.
   /// i.e.  x == sext(trunc(x to MaxSignedBits) to bitwidth(x)).
   /// Similar to the APInt::getSignificantBits function.
   /// Helper wrapper to ComputeNumSignBits.
-  unsigned ComputeMaxSignificantBits(SDValue Op, const APInt &DemandedElts,
+  LLVM_ABI unsigned ComputeMaxSignificantBits(SDValue Op, const APInt &DemandedElts,
                                      unsigned Depth = 0) const;
 
   /// Return true if this function can prove that \p Op is never poison
   /// and, if \p PoisonOnly is false, does not have undef bits.
-  bool isGuaranteedNotToBeUndefOrPoison(SDValue Op, bool PoisonOnly = false,
+  LLVM_ABI bool isGuaranteedNotToBeUndefOrPoison(SDValue Op, bool PoisonOnly = false,
                                         unsigned Depth = 0) const;
 
   /// Return true if this function can prove that \p Op is never poison
   /// and, if \p PoisonOnly is false, does not have undef bits. The DemandedElts
   /// argument limits the check to the requested vector elements.
-  bool isGuaranteedNotToBeUndefOrPoison(SDValue Op, const APInt &DemandedElts,
+  LLVM_ABI bool isGuaranteedNotToBeUndefOrPoison(SDValue Op, const APInt &DemandedElts,
                                         bool PoisonOnly = false,
                                         unsigned Depth = 0) const;
 
@@ -2146,7 +2147,7 @@ public:
   /// could still introduce undef or poison even without poison generating flags
   /// which might be on the instruction.  (i.e. could the result of
   /// Op->dropPoisonGeneratingFlags() still create poison or undef)
-  bool canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
+  LLVM_ABI bool canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
                               bool PoisonOnly = false,
                               bool ConsiderFlags = true,
                               unsigned Depth = 0) const;
@@ -2159,7 +2160,7 @@ public:
   /// could still introduce undef or poison even without poison generating flags
   /// which might be on the instruction.  (i.e. could the result of
   /// Op->dropPoisonGeneratingFlags() still create poison or undef)
-  bool canCreateUndefOrPoison(SDValue Op, bool PoisonOnly = false,
+  LLVM_ABI bool canCreateUndefOrPoison(SDValue Op, bool PoisonOnly = false,
                               bool ConsiderFlags = true,
                               unsigned Depth = 0) const;
 
@@ -2168,26 +2169,26 @@ public:
   /// or(x,y) == add(x,y) iff haveNoCommonBitsSet(x,y)
   /// xor(x,y) == add(x,y) iff isMinSignedConstant(y) && !NoWrap
   /// If \p NoWrap is true, this will not match ISD::XOR.
-  bool isADDLike(SDValue Op, bool NoWrap = false) const;
+  LLVM_ABI bool isADDLike(SDValue Op, bool NoWrap = false) const;
 
   /// Return true if the specified operand is an ISD::ADD with a ConstantSDNode
   /// on the right-hand side, or if it is an ISD::OR with a ConstantSDNode that
   /// is guaranteed to have the same semantics as an ADD. This handles the
   /// equivalence:
   ///     X|Cst == X+Cst iff X&Cst = 0.
-  bool isBaseWithConstantOffset(SDValue Op) const;
+  LLVM_ABI bool isBaseWithConstantOffset(SDValue Op) const;
 
   /// Test whether the given SDValue (or all elements of it, if it is a
   /// vector) is known to never be NaN in \p DemandedElts. If \p SNaN is true,
   /// returns if \p Op is known to never be a signaling NaN (it may still be a
   /// qNaN).
-  bool isKnownNeverNaN(SDValue Op, const APInt &DemandedElts, bool SNaN = false,
+  LLVM_ABI bool isKnownNeverNaN(SDValue Op, const APInt &DemandedElts, bool SNaN = false,
                        unsigned Depth = 0) const;
 
   /// Test whether the given SDValue (or all elements of it, if it is a
   /// vector) is known to never be NaN. If \p SNaN is true, returns if \p Op is
   /// known to never be a signaling NaN (it may still be a qNaN).
-  bool isKnownNeverNaN(SDValue Op, bool SNaN = false, unsigned Depth = 0) const;
+  LLVM_ABI bool isKnownNeverNaN(SDValue Op, bool SNaN = false, unsigned Depth = 0) const;
 
   /// \returns true if \p Op is known to never be a signaling NaN in \p
   /// DemandedElts.
@@ -2203,23 +2204,23 @@ public:
 
   /// Test whether the given floating point SDValue is known to never be
   /// positive or negative zero.
-  bool isKnownNeverZeroFloat(SDValue Op) const;
+  LLVM_ABI bool isKnownNeverZeroFloat(SDValue Op) const;
 
   /// Test whether the given SDValue is known to contain non-zero value(s).
-  bool isKnownNeverZero(SDValue Op, unsigned Depth = 0) const;
+  LLVM_ABI bool isKnownNeverZero(SDValue Op, unsigned Depth = 0) const;
 
   /// Test whether the given float value is known to be positive. +0.0, +inf and
   /// +nan are considered positive, -0.0, -inf and -nan are not.
-  bool cannotBeOrderedNegativeFP(SDValue Op) const;
+  LLVM_ABI bool cannotBeOrderedNegativeFP(SDValue Op) const;
 
   /// Test whether two SDValues are known to compare equal. This
   /// is true if they are the same value, or if one is negative zero and the
   /// other positive zero.
-  bool isEqualTo(SDValue A, SDValue B) const;
+  LLVM_ABI bool isEqualTo(SDValue A, SDValue B) const;
 
   /// Return true if A and B have no common bits set. As an example, this can
   /// allow an 'add' to be transformed into an 'or'.
-  bool haveNoCommonBitsSet(SDValue A, SDValue B) const;
+  LLVM_ABI bool haveNoCommonBitsSet(SDValue A, SDValue B) const;
 
   /// Test whether \p V has a splatted value for all the demanded elements.
   ///
@@ -2228,58 +2229,58 @@ public:
   /// for \p DemandedElts.
   ///
   /// NOTE: The function will return true for a demanded splat of UNDEF values.
-  bool isSplatValue(SDValue V, const APInt &DemandedElts, APInt &UndefElts,
+  LLVM_ABI bool isSplatValue(SDValue V, const APInt &DemandedElts, APInt &UndefElts,
                     unsigned Depth = 0) const;
 
   /// Test whether \p V has a splatted value.
-  bool isSplatValue(SDValue V, bool AllowUndefs = false) const;
+  LLVM_ABI bool isSplatValue(SDValue V, bool AllowUndefs = false) const;
 
   /// If V is a splatted value, return the source vector and its splat index.
-  SDValue getSplatSourceVector(SDValue V, int &SplatIndex);
+  LLVM_ABI SDValue getSplatSourceVector(SDValue V, int &SplatIndex);
 
   /// If V is a splat vector, return its scalar source operand by extracting
   /// that element from the source vector. If LegalTypes is true, this method
   /// may only return a legally-typed splat value. If it cannot legalize the
   /// splatted value it will return SDValue().
-  SDValue getSplatValue(SDValue V, bool LegalTypes = false);
+  LLVM_ABI SDValue getSplatValue(SDValue V, bool LegalTypes = false);
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the valid constant range.
-  std::optional<ConstantRange>
+  LLVM_ABI std::optional<ConstantRange>
   getValidShiftAmountRange(SDValue V, const APInt &DemandedElts,
                            unsigned Depth) const;
 
   /// If a SHL/SRA/SRL node \p V has a uniform shift amount
   /// that is less than the element bit-width of the shift node, return it.
-  std::optional<uint64_t> getValidShiftAmount(SDValue V,
+  LLVM_ABI std::optional<uint64_t> getValidShiftAmount(SDValue V,
                                               const APInt &DemandedElts,
                                               unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has a uniform shift amount
   /// that is less than the element bit-width of the shift node, return it.
-  std::optional<uint64_t> getValidShiftAmount(SDValue V,
+  LLVM_ABI std::optional<uint64_t> getValidShiftAmount(SDValue V,
                                               unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the minimum possible value.
-  std::optional<uint64_t> getValidMinimumShiftAmount(SDValue V,
+  LLVM_ABI std::optional<uint64_t> getValidMinimumShiftAmount(SDValue V,
                                                      const APInt &DemandedElts,
                                                      unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the minimum possible value.
-  std::optional<uint64_t> getValidMinimumShiftAmount(SDValue V,
+  LLVM_ABI std::optional<uint64_t> getValidMinimumShiftAmount(SDValue V,
                                                      unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the maximum possible value.
-  std::optional<uint64_t> getValidMaximumShiftAmount(SDValue V,
+  LLVM_ABI std::optional<uint64_t> getValidMaximumShiftAmount(SDValue V,
                                                      const APInt &DemandedElts,
                                                      unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the maximum possible value.
-  std::optional<uint64_t> getValidMaximumShiftAmount(SDValue V,
+  LLVM_ABI std::optional<uint64_t> getValidMaximumShiftAmount(SDValue V,
                                                      unsigned Depth = 0) const;
 
   /// Match a binop + shuffle pyramid that represents a horizontal reduction
@@ -2290,7 +2291,7 @@ public:
   /// was not matched. If \p AllowPartials is set then in the case of a
   /// reduction pattern that only matches the first few stages, the extracted
   /// subvector of the start of the reduction is returned.
-  SDValue matchBinOpReduction(SDNode *Extract, ISD::NodeType &BinOp,
+  LLVM_ABI SDValue matchBinOpReduction(SDNode *Extract, ISD::NodeType &BinOp,
                               ArrayRef<ISD::NodeType> CandidateBinOps,
                               bool AllowPartials = false);
 
@@ -2300,42 +2301,42 @@ public:
   /// op. If ResNE is less than the width of the vector op, unroll up to ResNE.
   /// If the  ResNE is greater than the width of the vector op, unroll the
   /// vector op and fill the end of the resulting vector with UNDEFS.
-  SDValue UnrollVectorOp(SDNode *N, unsigned ResNE = 0);
+  LLVM_ABI SDValue UnrollVectorOp(SDNode *N, unsigned ResNE = 0);
 
   /// Like UnrollVectorOp(), but for the [US](ADD|SUB|MUL)O family of opcodes.
   /// This is a separate function because those opcodes have two results.
-  std::pair<SDValue, SDValue> UnrollVectorOverflowOp(SDNode *N,
+  LLVM_ABI std::pair<SDValue, SDValue> UnrollVectorOverflowOp(SDNode *N,
                                                      unsigned ResNE = 0);
 
   /// Return true if loads are next to each other and can be
   /// merged. Check that both are nonvolatile and if LD is loading
   /// 'Bytes' bytes from a location that is 'Dist' units away from the
   /// location that the 'Base' load is loading from.
-  bool areNonVolatileConsecutiveLoads(LoadSDNode *LD, LoadSDNode *Base,
+  LLVM_ABI bool areNonVolatileConsecutiveLoads(LoadSDNode *LD, LoadSDNode *Base,
                                       unsigned Bytes, int Dist) const;
 
   /// Infer alignment of a load / store address. Return std::nullopt if it
   /// cannot be inferred.
-  MaybeAlign InferPtrAlign(SDValue Ptr) const;
+  LLVM_ABI MaybeAlign InferPtrAlign(SDValue Ptr) const;
 
   /// Split the scalar node with EXTRACT_ELEMENT using the provided VTs and
   /// return the low/high part.
-  std::pair<SDValue, SDValue> SplitScalar(const SDValue &N, const SDLoc &DL,
+  LLVM_ABI std::pair<SDValue, SDValue> SplitScalar(const SDValue &N, const SDLoc &DL,
                                           const EVT &LoVT, const EVT &HiVT);
 
   /// Compute the VTs needed for the low/hi parts of a type
   /// which is split (or expanded) into two not necessarily identical pieces.
-  std::pair<EVT, EVT> GetSplitDestVTs(const EVT &VT) const;
+  LLVM_ABI std::pair<EVT, EVT> GetSplitDestVTs(const EVT &VT) const;
 
   /// Compute the VTs needed for the low/hi parts of a type, dependent on an
   /// enveloping VT that has been split into two identical pieces. Sets the
   /// HisIsEmpty flag when hi type has zero storage size.
-  std::pair<EVT, EVT> GetDependentSplitDestVTs(const EVT &VT, const EVT &EnvVT,
+  LLVM_ABI std::pair<EVT, EVT> GetDependentSplitDestVTs(const EVT &VT, const EVT &EnvVT,
                                                bool *HiIsEmpty) const;
 
   /// Split the vector with EXTRACT_SUBVECTOR using the provided
   /// VTs and return the low/high part.
-  std::pair<SDValue, SDValue> SplitVector(const SDValue &N, const SDLoc &DL,
+  LLVM_ABI std::pair<SDValue, SDValue> SplitVector(const SDValue &N, const SDLoc &DL,
                                           const EVT &LoVT, const EVT &HiVT);
 
   /// Split the vector with EXTRACT_SUBVECTOR and return the low/high part.
@@ -2346,7 +2347,7 @@ public:
   }
 
   /// Split the explicit vector length parameter of a VP operation.
-  std::pair<SDValue, SDValue> SplitEVL(SDValue N, EVT VecVT, const SDLoc &DL);
+  LLVM_ABI std::pair<SDValue, SDValue> SplitEVL(SDValue N, EVT VecVT, const SDLoc &DL);
 
   /// Split the node's operand with EXTRACT_SUBVECTOR and
   /// return the low/high part.
@@ -2356,25 +2357,25 @@ public:
   }
 
   /// Widen the vector up to the next power of two using INSERT_SUBVECTOR.
-  SDValue WidenVector(const SDValue &N, const SDLoc &DL);
+  LLVM_ABI SDValue WidenVector(const SDValue &N, const SDLoc &DL);
 
   /// Append the extracted elements from Start to Count out of the vector Op in
   /// Args. If Count is 0, all of the elements will be extracted. The extracted
   /// elements will have type EVT if it is provided, and otherwise their type
   /// will be Op's element type.
-  void ExtractVectorElements(SDValue Op, SmallVectorImpl<SDValue> &Args,
+  LLVM_ABI void ExtractVectorElements(SDValue Op, SmallVectorImpl<SDValue> &Args,
                              unsigned Start = 0, unsigned Count = 0,
                              EVT EltVT = EVT());
 
   /// Compute the default alignment value for the given type.
-  Align getEVTAlign(EVT MemoryVT) const;
+  LLVM_ABI Align getEVTAlign(EVT MemoryVT) const;
 
   /// Test whether the given value is a constant int or similar node.
-  bool isConstantIntBuildVectorOrConstantInt(SDValue N,
+  LLVM_ABI bool isConstantIntBuildVectorOrConstantInt(SDValue N,
                                              bool AllowOpaques = true) const;
 
   /// Test whether the given value is a constant FP or similar node.
-  bool isConstantFPBuildVectorOrConstantFP(SDValue N) const;
+  LLVM_ABI bool isConstantFPBuildVectorOrConstantFP(SDValue N) const;
 
   /// \returns true if \p N is any kind of constant or build_vector of
   /// constants, int or float. If a vector, it may not necessarily be a splat.
@@ -2385,7 +2386,7 @@ public:
 
   /// Check if a value \op N is a constant using the target's BooleanContent for
   /// its type.
-  std::optional<bool> isBoolConstant(SDValue N,
+  LLVM_ABI std::optional<bool> isBoolConstant(SDValue N,
                                      bool AllowTruncation = false) const;
 
   /// Set CallSiteInfo to be associated with Node.
@@ -2449,7 +2450,7 @@ public:
   }
 
   /// Copy extra info associated with one node to another.
-  void copyExtraInfo(SDNode *From, SDNode *To);
+  LLVM_ABI void copyExtraInfo(SDNode *From, SDNode *To);
 
   /// Return the current function's default denormal handling kind for the given
   /// floating point type.
@@ -2457,10 +2458,10 @@ public:
     return MF->getDenormalMode(VT.getFltSemantics());
   }
 
-  bool shouldOptForSize() const;
+  LLVM_ABI bool shouldOptForSize() const;
 
   /// Get the (commutative) neutral element for the given opcode, if it exists.
-  SDValue getNeutralElement(unsigned Opcode, const SDLoc &DL, EVT VT,
+  LLVM_ABI SDValue getNeutralElement(unsigned Opcode, const SDLoc &DL, EVT VT,
                             SDNodeFlags Flags);
 
   /// Some opcodes may create immediate undefined behavior when used with some
@@ -2493,7 +2494,7 @@ public:
     }
   }
 
-  SDValue makeStateFunctionCall(unsigned LibFunc, SDValue Ptr, SDValue InChain,
+  LLVM_ABI SDValue makeStateFunctionCall(unsigned LibFunc, SDValue Ptr, SDValue InChain,
                                 const SDLoc &DLoc);
 
 private:

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CODEGEN_SELECTIONDAG_H
 #define LLVM_CODEGEN_SELECTIONDAG_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
@@ -39,6 +38,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/ArrayRecycler.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/RecyclingAllocator.h"
 #include <cassert>
@@ -468,10 +468,10 @@ public:
 
   /// Prepare this SelectionDAG to process code in the given MachineFunction.
   LLVM_ABI void init(MachineFunction &NewMF, OptimizationRemarkEmitter &NewORE,
-            Pass *PassPtr, const TargetLibraryInfo *LibraryInfo,
-            UniformityInfo *UA, ProfileSummaryInfo *PSIin,
-            BlockFrequencyInfo *BFIin, MachineModuleInfo &MMI,
-            FunctionVarLocs const *FnVarLocs);
+                     Pass *PassPtr, const TargetLibraryInfo *LibraryInfo,
+                     UniformityInfo *UA, ProfileSummaryInfo *PSIin,
+                     BlockFrequencyInfo *BFIin, MachineModuleInfo &MMI,
+                     FunctionVarLocs const *FnVarLocs);
 
   void init(MachineFunction &NewMF, OptimizationRemarkEmitter &NewORE,
             MachineFunctionAnalysisManager &AM,
@@ -604,7 +604,7 @@ public:
   /// Level argument controls whether Combine is allowed to produce nodes and
   /// types that are illegal on the target.
   LLVM_ABI void Combine(CombineLevel Level, BatchAAResults *BatchAA,
-               CodeGenOptLevel OptLevel);
+                        CodeGenOptLevel OptLevel);
 
   /// This transforms the SelectionDAG into a SelectionDAG that
   /// only uses types natively supported by the target.
@@ -641,7 +641,8 @@ public:
   /// N passed in is a legal node, and can be immediately processed as such.
   /// This may still have done some work on the DAG, and will still populate
   /// UpdatedNodes with any new nodes replacing those originally in the DAG.
-  LLVM_ABI bool LegalizeOp(SDNode *N, SmallSetVector<SDNode *, 16> &UpdatedNodes);
+  LLVM_ABI bool LegalizeOp(SDNode *N,
+                           SmallSetVector<SDNode *, 16> &UpdatedNodes);
 
   /// This transforms the SelectionDAG into a SelectionDAG
   /// that only uses vector math operations supported by the target.  This is
@@ -680,24 +681,28 @@ public:
   /// transformations (e.g., if the vector element type is illegal).
   /// @{
   LLVM_ABI SDValue getConstant(uint64_t Val, const SDLoc &DL, EVT VT,
-                      bool isTarget = false, bool isOpaque = false);
+                               bool isTarget = false, bool isOpaque = false);
   LLVM_ABI SDValue getConstant(const APInt &Val, const SDLoc &DL, EVT VT,
-                      bool isTarget = false, bool isOpaque = false);
+                               bool isTarget = false, bool isOpaque = false);
 
   LLVM_ABI SDValue getSignedConstant(int64_t Val, const SDLoc &DL, EVT VT,
-                            bool isTarget = false, bool isOpaque = false);
+                                     bool isTarget = false,
+                                     bool isOpaque = false);
 
-  LLVM_ABI SDValue getAllOnesConstant(const SDLoc &DL, EVT VT, bool IsTarget = false,
-                             bool IsOpaque = false);
+  LLVM_ABI SDValue getAllOnesConstant(const SDLoc &DL, EVT VT,
+                                      bool IsTarget = false,
+                                      bool IsOpaque = false);
 
   LLVM_ABI SDValue getConstant(const ConstantInt &Val, const SDLoc &DL, EVT VT,
-                      bool isTarget = false, bool isOpaque = false);
+                               bool isTarget = false, bool isOpaque = false);
   LLVM_ABI SDValue getIntPtrConstant(uint64_t Val, const SDLoc &DL,
-                            bool isTarget = false);
-  LLVM_ABI SDValue getShiftAmountConstant(uint64_t Val, EVT VT, const SDLoc &DL);
-  LLVM_ABI SDValue getShiftAmountConstant(const APInt &Val, EVT VT, const SDLoc &DL);
+                                     bool isTarget = false);
+  LLVM_ABI SDValue getShiftAmountConstant(uint64_t Val, EVT VT,
+                                          const SDLoc &DL);
+  LLVM_ABI SDValue getShiftAmountConstant(const APInt &Val, EVT VT,
+                                          const SDLoc &DL);
   LLVM_ABI SDValue getVectorIdxConstant(uint64_t Val, const SDLoc &DL,
-                               bool isTarget = false);
+                                        bool isTarget = false);
 
   SDValue getTargetConstant(uint64_t Val, const SDLoc &DL, EVT VT,
                             bool isOpaque = false) {
@@ -730,11 +735,11 @@ public:
   /// that can be exactly represented in VT.  No checks are made.
   /// @{
   LLVM_ABI SDValue getConstantFP(double Val, const SDLoc &DL, EVT VT,
-                        bool isTarget = false);
+                                 bool isTarget = false);
   LLVM_ABI SDValue getConstantFP(const APFloat &Val, const SDLoc &DL, EVT VT,
-                        bool isTarget = false);
+                                 bool isTarget = false);
   LLVM_ABI SDValue getConstantFP(const ConstantFP &V, const SDLoc &DL, EVT VT,
-                        bool isTarget = false);
+                                 bool isTarget = false);
   SDValue getTargetConstantFP(double Val, const SDLoc &DL, EVT VT) {
     return getConstantFP(Val, DL, VT, true);
   }
@@ -746,9 +751,10 @@ public:
   }
   /// @}
 
-  LLVM_ABI SDValue getGlobalAddress(const GlobalValue *GV, const SDLoc &DL, EVT VT,
-                           int64_t offset = 0, bool isTargetGA = false,
-                           unsigned TargetFlags = 0);
+  LLVM_ABI SDValue getGlobalAddress(const GlobalValue *GV, const SDLoc &DL,
+                                    EVT VT, int64_t offset = 0,
+                                    bool isTargetGA = false,
+                                    unsigned TargetFlags = 0);
   SDValue getTargetGlobalAddress(const GlobalValue *GV, const SDLoc &DL, EVT VT,
                                  int64_t offset = 0, unsigned TargetFlags = 0) {
     return getGlobalAddress(GV, DL, VT, offset, true, TargetFlags);
@@ -758,22 +764,25 @@ public:
     return getFrameIndex(FI, VT, true);
   }
   LLVM_ABI SDValue getJumpTable(int JTI, EVT VT, bool isTarget = false,
-                       unsigned TargetFlags = 0);
+                                unsigned TargetFlags = 0);
   SDValue getTargetJumpTable(int JTI, EVT VT, unsigned TargetFlags = 0) {
     return getJumpTable(JTI, VT, true, TargetFlags);
   }
-  LLVM_ABI SDValue getJumpTableDebugInfo(int JTI, SDValue Chain, const SDLoc &DL);
+  LLVM_ABI SDValue getJumpTableDebugInfo(int JTI, SDValue Chain,
+                                         const SDLoc &DL);
   LLVM_ABI SDValue getConstantPool(const Constant *C, EVT VT,
-                          MaybeAlign Align = std::nullopt, int Offs = 0,
-                          bool isT = false, unsigned TargetFlags = 0);
+                                   MaybeAlign Align = std::nullopt,
+                                   int Offs = 0, bool isT = false,
+                                   unsigned TargetFlags = 0);
   SDValue getTargetConstantPool(const Constant *C, EVT VT,
                                 MaybeAlign Align = std::nullopt, int Offset = 0,
                                 unsigned TargetFlags = 0) {
     return getConstantPool(C, VT, Align, Offset, true, TargetFlags);
   }
   LLVM_ABI SDValue getConstantPool(MachineConstantPoolValue *C, EVT VT,
-                          MaybeAlign Align = std::nullopt, int Offs = 0,
-                          bool isT = false, unsigned TargetFlags = 0);
+                                   MaybeAlign Align = std::nullopt,
+                                   int Offs = 0, bool isT = false,
+                                   unsigned TargetFlags = 0);
   SDValue getTargetConstantPool(MachineConstantPoolValue *C, EVT VT,
                                 MaybeAlign Align = std::nullopt, int Offset = 0,
                                 unsigned TargetFlags = 0) {
@@ -784,7 +793,7 @@ public:
   LLVM_ABI SDValue getBasicBlock(MachineBasicBlock *MBB);
   LLVM_ABI SDValue getExternalSymbol(const char *Sym, EVT VT);
   LLVM_ABI SDValue getTargetExternalSymbol(const char *Sym, EVT VT,
-                                  unsigned TargetFlags = 0);
+                                           unsigned TargetFlags = 0);
   LLVM_ABI SDValue getMCSymbol(MCSymbol *Sym, EVT VT);
 
   LLVM_ABI SDValue getValueType(EVT);
@@ -792,9 +801,10 @@ public:
   LLVM_ABI SDValue getRegisterMask(const uint32_t *RegMask);
   LLVM_ABI SDValue getEHLabel(const SDLoc &dl, SDValue Root, MCSymbol *Label);
   LLVM_ABI SDValue getLabelNode(unsigned Opcode, const SDLoc &dl, SDValue Root,
-                       MCSymbol *Label);
-  LLVM_ABI SDValue getBlockAddress(const BlockAddress *BA, EVT VT, int64_t Offset = 0,
-                          bool isTarget = false, unsigned TargetFlags = 0);
+                                MCSymbol *Label);
+  LLVM_ABI SDValue getBlockAddress(const BlockAddress *BA, EVT VT,
+                                   int64_t Offset = 0, bool isTarget = false,
+                                   unsigned TargetFlags = 0);
   SDValue getTargetBlockAddress(const BlockAddress *BA, EVT VT,
                                 int64_t Offset = 0, unsigned TargetFlags = 0) {
     return getBlockAddress(BA, VT, Offset, true, TargetFlags);
@@ -848,8 +858,8 @@ public:
   /// Return an ISD::VECTOR_SHUFFLE node. The number of elements in VT,
   /// which must be a vector type, must match the number of mask elements
   /// NumElts. An integer mask element equal to -1 is treated as undefined.
-  LLVM_ABI SDValue getVectorShuffle(EVT VT, const SDLoc &dl, SDValue N1, SDValue N2,
-                           ArrayRef<int> Mask);
+  LLVM_ABI SDValue getVectorShuffle(EVT VT, const SDLoc &dl, SDValue N1,
+                                    SDValue N2, ArrayRef<int> Mask);
 
   /// Return an ISD::BUILD_VECTOR node. The number of elements in VT,
   /// which must be a vector type, must match the number of operands in Ops.
@@ -913,7 +923,8 @@ public:
 
   /// Returns a vector of type ResVT whose elements contain the linear sequence
   ///   <0, Step, Step * 2, Step * 3, ...>
-  LLVM_ABI SDValue getStepVector(const SDLoc &DL, EVT ResVT, const APInt &StepVal);
+  LLVM_ABI SDValue getStepVector(const SDLoc &DL, EVT ResVT,
+                                 const APInt &StepVal);
 
   /// Returns a vector of type ResVT whose elements contain the linear sequence
   ///   <0, 1, 2, 3, ...>
@@ -1034,7 +1045,8 @@ public:
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by first bitcasting (from potential vector) to
   /// corresponding scalar type then either any-extending or truncating it.
-  LLVM_ABI SDValue getBitcastedAnyExtOrTrunc(SDValue Op, const SDLoc &DL, EVT VT);
+  LLVM_ABI SDValue getBitcastedAnyExtOrTrunc(SDValue Op, const SDLoc &DL,
+                                             EVT VT);
 
   /// Convert Op, which must be of integer type, to the
   /// integer type VT, by first bitcasting (from potential vector) to
@@ -1053,7 +1065,7 @@ public:
   /// Return the expression required to zero extend the Op
   /// value assuming it was the smaller SrcTy value.
   LLVM_ABI SDValue getVPZeroExtendInReg(SDValue Op, SDValue Mask, SDValue EVL,
-                               const SDLoc &DL, EVT VT);
+                                        const SDLoc &DL, EVT VT);
 
   /// Convert Op, which must be of integer type, to the integer type VT, by
   /// either truncating it or performing either zero or sign extension as
@@ -1068,7 +1080,8 @@ public:
   /// Convert Op, which must be of integer type, to the integer type VT,
   /// by using an extension appropriate for the target's
   /// BooleanContent for type OpVT or truncating it.
-  LLVM_ABI SDValue getBoolExtOrTrunc(SDValue Op, const SDLoc &SL, EVT VT, EVT OpVT);
+  LLVM_ABI SDValue getBoolExtOrTrunc(SDValue Op, const SDLoc &SL, EVT VT,
+                                     EVT OpVT);
 
   /// Create negative operation as (SUB 0, Val).
   LLVM_ABI SDValue getNegative(SDValue Val, const SDLoc &DL, EVT VT);
@@ -1082,29 +1095,31 @@ public:
   /// Create a vector-predicated logical NOT operation as (VP_XOR Val,
   /// BooleanOne, Mask, EVL).
   LLVM_ABI SDValue getVPLogicalNOT(const SDLoc &DL, SDValue Val, SDValue Mask,
-                          SDValue EVL, EVT VT);
+                                   SDValue EVL, EVT VT);
 
   /// Convert a vector-predicated Op, which must be an integer vector, to the
   /// vector-type VT, by performing either vector-predicated zext or truncating
   /// it. The Op will be returned as-is if Op and VT are vectors containing
   /// integer with same width.
-  LLVM_ABI SDValue getVPZExtOrTrunc(const SDLoc &DL, EVT VT, SDValue Op, SDValue Mask,
-                           SDValue EVL);
+  LLVM_ABI SDValue getVPZExtOrTrunc(const SDLoc &DL, EVT VT, SDValue Op,
+                                    SDValue Mask, SDValue EVL);
 
   /// Convert a vector-predicated Op, which must be of integer type, to the
   /// vector-type integer type VT, by either truncating it or performing either
   /// vector-predicated zero or sign extension as appropriate extension for the
   /// pointer's semantics. This function just redirects to getVPZExtOrTrunc
   /// right now.
-  LLVM_ABI SDValue getVPPtrExtOrTrunc(const SDLoc &DL, EVT VT, SDValue Op, SDValue Mask,
-                             SDValue EVL);
+  LLVM_ABI SDValue getVPPtrExtOrTrunc(const SDLoc &DL, EVT VT, SDValue Op,
+                                      SDValue Mask, SDValue EVL);
 
   /// Returns sum of the base pointer and offset.
   /// Unlike getObjectPtrOffset this does not set NoUnsignedWrap by default.
-  LLVM_ABI SDValue getMemBasePlusOffset(SDValue Base, TypeSize Offset, const SDLoc &DL,
-                               const SDNodeFlags Flags = SDNodeFlags());
-  LLVM_ABI SDValue getMemBasePlusOffset(SDValue Base, SDValue Offset, const SDLoc &DL,
-                               const SDNodeFlags Flags = SDNodeFlags());
+  LLVM_ABI SDValue
+  getMemBasePlusOffset(SDValue Base, TypeSize Offset, const SDLoc &DL,
+                       const SDNodeFlags Flags = SDNodeFlags());
+  LLVM_ABI SDValue
+  getMemBasePlusOffset(SDValue Base, SDValue Offset, const SDLoc &DL,
+                       const SDNodeFlags Flags = SDNodeFlags());
 
   /// Create an add instruction with appropriate flags when used for
   /// addressing some offset of an object. i.e. if a load is split into multiple
@@ -1166,10 +1181,10 @@ public:
 
   /// Return a node that represents the runtime scaling 'MulImm * RuntimeVL'.
   LLVM_ABI SDValue getVScale(const SDLoc &DL, EVT VT, APInt MulImm,
-                    bool ConstantFold = true);
+                             bool ConstantFold = true);
 
   LLVM_ABI SDValue getElementCount(const SDLoc &DL, EVT VT, ElementCount EC,
-                          bool ConstantFold = true);
+                                   bool ConstantFold = true);
 
   /// Return a GLOBAL_OFFSET_TABLE node. This does not have a useful SDLoc.
   SDValue getGLOBAL_OFFSET_TABLE(EVT VT) {
@@ -1179,55 +1194,59 @@ public:
   /// Gets or creates the specified node.
   ///
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
-                  ArrayRef<SDUse> Ops);
+                           ArrayRef<SDUse> Ops);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
-                  ArrayRef<SDValue> Ops, const SDNodeFlags Flags);
-  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, ArrayRef<EVT> ResultTys,
-                  ArrayRef<SDValue> Ops);
+                           ArrayRef<SDValue> Ops, const SDNodeFlags Flags);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL,
+                           ArrayRef<EVT> ResultTys, ArrayRef<SDValue> Ops);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
-                  ArrayRef<SDValue> Ops, const SDNodeFlags Flags);
+                           ArrayRef<SDValue> Ops, const SDNodeFlags Flags);
 
   // Use flags from current flag inserter.
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
-                  ArrayRef<SDValue> Ops);
+                           ArrayRef<SDValue> Ops);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
-                  ArrayRef<SDValue> Ops);
-  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue Operand);
+                           ArrayRef<SDValue> Ops);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
+                           SDValue Operand);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
-                  SDValue N2);
+                           SDValue N2);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
-                  SDValue N2, SDValue N3);
+                           SDValue N2, SDValue N3);
 
   // Specialize based on number of operands.
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT);
-  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue Operand,
-                  const SDNodeFlags Flags);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
+                           SDValue Operand, const SDNodeFlags Flags);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
-                  SDValue N2, const SDNodeFlags Flags);
+                           SDValue N2, const SDNodeFlags Flags);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
-                  SDValue N2, SDValue N3, const SDNodeFlags Flags);
+                           SDValue N2, SDValue N3, const SDNodeFlags Flags);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
-                  SDValue N2, SDValue N3, SDValue N4);
+                           SDValue N2, SDValue N3, SDValue N4);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
-                  SDValue N2, SDValue N3, SDValue N4, const SDNodeFlags Flags);
+                           SDValue N2, SDValue N3, SDValue N4,
+                           const SDNodeFlags Flags);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
-                  SDValue N2, SDValue N3, SDValue N4, SDValue N5);
+                           SDValue N2, SDValue N3, SDValue N4, SDValue N5);
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, EVT VT, SDValue N1,
-                  SDValue N2, SDValue N3, SDValue N4, SDValue N5,
-                  const SDNodeFlags Flags);
+                           SDValue N2, SDValue N3, SDValue N4, SDValue N5,
+                           const SDNodeFlags Flags);
 
   // Specialize again based on number of operands for nodes with a VTList
   // rather than a single VT.
   LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList);
-  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N);
-  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
-                  SDValue N2);
-  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
-                  SDValue N2, SDValue N3);
-  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
-                  SDValue N2, SDValue N3, SDValue N4);
-  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList, SDValue N1,
-                  SDValue N2, SDValue N3, SDValue N4, SDValue N5);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
+                           SDValue N);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
+                           SDValue N1, SDValue N2);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
+                           SDValue N1, SDValue N2, SDValue N3);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
+                           SDValue N1, SDValue N2, SDValue N3, SDValue N4);
+  LLVM_ABI SDValue getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
+                           SDValue N1, SDValue N2, SDValue N3, SDValue N4,
+                           SDValue N5);
 
   /// Compute a TokenFactor to force all the incoming stack arguments to be
   /// loaded from the stack. This is used in tail call lowering to protect
@@ -1237,48 +1256,49 @@ public:
   /* \p CI if not null is the memset call being lowered.
    * \p OverrideTailCall is an optional parameter that can be used to override
    * the tail call optimization decision. */
-  LLVM_ABI SDValue getMemcpy(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
-                    SDValue Size, Align Alignment, bool isVol,
-                    bool AlwaysInline, const CallInst *CI,
-                    std::optional<bool> OverrideTailCall,
-                    MachinePointerInfo DstPtrInfo,
-                    MachinePointerInfo SrcPtrInfo,
-                    const AAMDNodes &AAInfo = AAMDNodes(),
-                    BatchAAResults *BatchAA = nullptr);
+  LLVM_ABI SDValue getMemcpy(SDValue Chain, const SDLoc &dl, SDValue Dst,
+                             SDValue Src, SDValue Size, Align Alignment,
+                             bool isVol, bool AlwaysInline, const CallInst *CI,
+                             std::optional<bool> OverrideTailCall,
+                             MachinePointerInfo DstPtrInfo,
+                             MachinePointerInfo SrcPtrInfo,
+                             const AAMDNodes &AAInfo = AAMDNodes(),
+                             BatchAAResults *BatchAA = nullptr);
 
   /* \p CI if not null is the memset call being lowered.
    * \p OverrideTailCall is an optional parameter that can be used to override
    * the tail call optimization decision. */
-  LLVM_ABI SDValue getMemmove(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
-                     SDValue Size, Align Alignment, bool isVol,
-                     const CallInst *CI, std::optional<bool> OverrideTailCall,
-                     MachinePointerInfo DstPtrInfo,
-                     MachinePointerInfo SrcPtrInfo,
-                     const AAMDNodes &AAInfo = AAMDNodes(),
-                     BatchAAResults *BatchAA = nullptr);
+  LLVM_ABI SDValue getMemmove(SDValue Chain, const SDLoc &dl, SDValue Dst,
+                              SDValue Src, SDValue Size, Align Alignment,
+                              bool isVol, const CallInst *CI,
+                              std::optional<bool> OverrideTailCall,
+                              MachinePointerInfo DstPtrInfo,
+                              MachinePointerInfo SrcPtrInfo,
+                              const AAMDNodes &AAInfo = AAMDNodes(),
+                              BatchAAResults *BatchAA = nullptr);
 
-  LLVM_ABI SDValue getMemset(SDValue Chain, const SDLoc &dl, SDValue Dst, SDValue Src,
-                    SDValue Size, Align Alignment, bool isVol,
-                    bool AlwaysInline, const CallInst *CI,
-                    MachinePointerInfo DstPtrInfo,
-                    const AAMDNodes &AAInfo = AAMDNodes());
+  LLVM_ABI SDValue getMemset(SDValue Chain, const SDLoc &dl, SDValue Dst,
+                             SDValue Src, SDValue Size, Align Alignment,
+                             bool isVol, bool AlwaysInline, const CallInst *CI,
+                             MachinePointerInfo DstPtrInfo,
+                             const AAMDNodes &AAInfo = AAMDNodes());
 
   LLVM_ABI SDValue getAtomicMemcpy(SDValue Chain, const SDLoc &dl, SDValue Dst,
-                          SDValue Src, SDValue Size, Type *SizeTy,
-                          unsigned ElemSz, bool isTailCall,
-                          MachinePointerInfo DstPtrInfo,
-                          MachinePointerInfo SrcPtrInfo);
+                                   SDValue Src, SDValue Size, Type *SizeTy,
+                                   unsigned ElemSz, bool isTailCall,
+                                   MachinePointerInfo DstPtrInfo,
+                                   MachinePointerInfo SrcPtrInfo);
 
   LLVM_ABI SDValue getAtomicMemmove(SDValue Chain, const SDLoc &dl, SDValue Dst,
-                           SDValue Src, SDValue Size, Type *SizeTy,
-                           unsigned ElemSz, bool isTailCall,
-                           MachinePointerInfo DstPtrInfo,
-                           MachinePointerInfo SrcPtrInfo);
+                                    SDValue Src, SDValue Size, Type *SizeTy,
+                                    unsigned ElemSz, bool isTailCall,
+                                    MachinePointerInfo DstPtrInfo,
+                                    MachinePointerInfo SrcPtrInfo);
 
   LLVM_ABI SDValue getAtomicMemset(SDValue Chain, const SDLoc &dl, SDValue Dst,
-                          SDValue Value, SDValue Size, Type *SizeTy,
-                          unsigned ElemSz, bool isTailCall,
-                          MachinePointerInfo DstPtrInfo);
+                                   SDValue Value, SDValue Size, Type *SizeTy,
+                                   unsigned ElemSz, bool isTailCall,
+                                   MachinePointerInfo DstPtrInfo);
 
   /// Helper function to make it easier to build SetCC's if you just have an
   /// ISD::CondCode instead of an SDValue.
@@ -1336,36 +1356,38 @@ public:
   /// Try to simplify a floating-point binary operation into 1 of its operands
   /// or a constant.
   LLVM_ABI SDValue simplifyFPBinop(unsigned Opcode, SDValue X, SDValue Y,
-                          SDNodeFlags Flags);
+                                   SDNodeFlags Flags);
 
   /// VAArg produces a result and token chain, and takes a pointer
   /// and a source value as input.
   LLVM_ABI SDValue getVAArg(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
-                   SDValue SV, unsigned Align);
+                            SDValue SV, unsigned Align);
 
   /// Gets a node for an atomic cmpxchg op. There are two
   /// valid Opcodes. ISD::ATOMIC_CMO_SWAP produces the value loaded and a
   /// chain result. ISD::ATOMIC_CMP_SWAP_WITH_SUCCESS produces the value loaded,
   /// a success flag (initially i1), and a chain.
   LLVM_ABI SDValue getAtomicCmpSwap(unsigned Opcode, const SDLoc &dl, EVT MemVT,
-                           SDVTList VTs, SDValue Chain, SDValue Ptr,
-                           SDValue Cmp, SDValue Swp, MachineMemOperand *MMO);
+                                    SDVTList VTs, SDValue Chain, SDValue Ptr,
+                                    SDValue Cmp, SDValue Swp,
+                                    MachineMemOperand *MMO);
 
   /// Gets a node for an atomic op, produces result (if relevant)
   /// and chain and takes 2 operands.
-  LLVM_ABI SDValue getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT, SDValue Chain,
-                    SDValue Ptr, SDValue Val, MachineMemOperand *MMO);
+  LLVM_ABI SDValue getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT,
+                             SDValue Chain, SDValue Ptr, SDValue Val,
+                             MachineMemOperand *MMO);
 
   /// Gets a node for an atomic op, produces result and chain and takes N
   /// operands.
   LLVM_ABI SDValue getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT,
-                    SDVTList VTList, ArrayRef<SDValue> Ops,
-                    MachineMemOperand *MMO,
-                    ISD::LoadExtType ExtType = ISD::NON_EXTLOAD);
+                             SDVTList VTList, ArrayRef<SDValue> Ops,
+                             MachineMemOperand *MMO,
+                             ISD::LoadExtType ExtType = ISD::NON_EXTLOAD);
 
-  LLVM_ABI SDValue getAtomicLoad(ISD::LoadExtType ExtType, const SDLoc &dl, EVT MemVT,
-                        EVT VT, SDValue Chain, SDValue Ptr,
-                        MachineMemOperand *MMO);
+  LLVM_ABI SDValue getAtomicLoad(ISD::LoadExtType ExtType, const SDLoc &dl,
+                                 EVT MemVT, EVT VT, SDValue Chain, SDValue Ptr,
+                                 MachineMemOperand *MMO);
 
   /// Creates a MemIntrinsicNode that may produce a
   /// result and takes a list of operands. Opcode may be INTRINSIC_VOID,
@@ -1393,21 +1415,23 @@ public:
                                Size, AAInfo);
   }
 
-  LLVM_ABI SDValue getMemIntrinsicNode(unsigned Opcode, const SDLoc &dl, SDVTList VTList,
-                              ArrayRef<SDValue> Ops, EVT MemVT,
-                              MachineMemOperand *MMO);
+  LLVM_ABI SDValue getMemIntrinsicNode(unsigned Opcode, const SDLoc &dl,
+                                       SDVTList VTList, ArrayRef<SDValue> Ops,
+                                       EVT MemVT, MachineMemOperand *MMO);
 
   /// Creates a LifetimeSDNode that starts (`IsStart==true`) or ends
   /// (`IsStart==false`) the lifetime of the portion of `FrameIndex` between
   /// offsets `Offset` and `Offset + Size`.
   LLVM_ABI SDValue getLifetimeNode(bool IsStart, const SDLoc &dl, SDValue Chain,
-                          int FrameIndex, int64_t Size, int64_t Offset = -1);
+                                   int FrameIndex, int64_t Size,
+                                   int64_t Offset = -1);
 
   /// Creates a PseudoProbeSDNode with function GUID `Guid` and
   /// the index of the block `Index` it is probing, as well as the attributes
   /// `attr` of the probe.
-  LLVM_ABI SDValue getPseudoProbeNode(const SDLoc &Dl, SDValue Chain, uint64_t Guid,
-                             uint64_t Index, uint32_t Attr);
+  LLVM_ABI SDValue getPseudoProbeNode(const SDLoc &Dl, SDValue Chain,
+                                      uint64_t Guid, uint64_t Index,
+                                      uint32_t Attr);
 
   /// Create a MERGE_VALUES node from the given operands.
   LLVM_ABI SDValue getMergeValues(ArrayRef<SDValue> Ops, const SDLoc &dl);
@@ -1417,14 +1441,13 @@ public:
   ///
   /// This function will set the MOLoad flag on MMOFlags, but you can set it if
   /// you want.  The MOStore flag must not be set.
+  LLVM_ABI SDValue getLoad(
+      EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
+      MachinePointerInfo PtrInfo, MaybeAlign Alignment = MaybeAlign(),
+      MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
+      const AAMDNodes &AAInfo = AAMDNodes(), const MDNode *Ranges = nullptr);
   LLVM_ABI SDValue getLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
-                  MachinePointerInfo PtrInfo,
-                  MaybeAlign Alignment = MaybeAlign(),
-                  MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
-                  const AAMDNodes &AAInfo = AAMDNodes(),
-                  const MDNode *Ranges = nullptr);
-  LLVM_ABI SDValue getLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
-                  MachineMemOperand *MMO);
+                           MachineMemOperand *MMO);
   LLVM_ABI SDValue
   getExtLoad(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT, SDValue Chain,
              SDValue Ptr, MachinePointerInfo PtrInfo, EVT MemVT,
@@ -1432,16 +1455,17 @@ public:
              MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
              const AAMDNodes &AAInfo = AAMDNodes());
   LLVM_ABI SDValue getExtLoad(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
-                     SDValue Chain, SDValue Ptr, EVT MemVT,
-                     MachineMemOperand *MMO);
-  LLVM_ABI SDValue getIndexedLoad(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
-                         SDValue Offset, ISD::MemIndexedMode AM);
-  LLVM_ABI SDValue getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
-                  const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
-                  MachinePointerInfo PtrInfo, EVT MemVT, Align Alignment,
-                  MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
-                  const AAMDNodes &AAInfo = AAMDNodes(),
-                  const MDNode *Ranges = nullptr);
+                              SDValue Chain, SDValue Ptr, EVT MemVT,
+                              MachineMemOperand *MMO);
+  LLVM_ABI SDValue getIndexedLoad(SDValue OrigLoad, const SDLoc &dl,
+                                  SDValue Base, SDValue Offset,
+                                  ISD::MemIndexedMode AM);
+  LLVM_ABI SDValue getLoad(
+      ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT, const SDLoc &dl,
+      SDValue Chain, SDValue Ptr, SDValue Offset, MachinePointerInfo PtrInfo,
+      EVT MemVT, Align Alignment,
+      MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
+      const AAMDNodes &AAInfo = AAMDNodes(), const MDNode *Ranges = nullptr);
   inline SDValue getLoad(
       ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT, const SDLoc &dl,
       SDValue Chain, SDValue Ptr, SDValue Offset, MachinePointerInfo PtrInfo,
@@ -1453,9 +1477,9 @@ public:
                    Alignment.value_or(getEVTAlign(MemVT)), MMOFlags, AAInfo,
                    Ranges);
   }
-  LLVM_ABI SDValue getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
-                  const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
-                  EVT MemVT, MachineMemOperand *MMO);
+  LLVM_ABI SDValue getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
+                           EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
+                           SDValue Offset, EVT MemVT, MachineMemOperand *MMO);
 
   /// Helper function to build ISD::STORE nodes.
   ///
@@ -1476,8 +1500,8 @@ public:
                     Alignment.value_or(getEVTAlign(Val.getValueType())),
                     MMOFlags, AAInfo);
   }
-  LLVM_ABI SDValue getStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
-                   MachineMemOperand *MMO);
+  LLVM_ABI SDValue getStore(SDValue Chain, const SDLoc &dl, SDValue Val,
+                            SDValue Ptr, MachineMemOperand *MMO);
   LLVM_ABI SDValue
   getTruncStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
                 MachinePointerInfo PtrInfo, EVT SVT, Align Alignment,
@@ -1494,19 +1518,23 @@ public:
                          AAInfo);
   }
   LLVM_ABI SDValue getTruncStore(SDValue Chain, const SDLoc &dl, SDValue Val,
-                        SDValue Ptr, EVT SVT, MachineMemOperand *MMO);
-  LLVM_ABI SDValue getIndexedStore(SDValue OrigStore, const SDLoc &dl, SDValue Base,
-                          SDValue Offset, ISD::MemIndexedMode AM);
-  LLVM_ABI SDValue getStore(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
-                   SDValue Offset, EVT SVT, MachineMemOperand *MMO,
-                   ISD::MemIndexedMode AM, bool IsTruncating = false);
+                                 SDValue Ptr, EVT SVT, MachineMemOperand *MMO);
+  LLVM_ABI SDValue getIndexedStore(SDValue OrigStore, const SDLoc &dl,
+                                   SDValue Base, SDValue Offset,
+                                   ISD::MemIndexedMode AM);
+  LLVM_ABI SDValue getStore(SDValue Chain, const SDLoc &dl, SDValue Val,
+                            SDValue Ptr, SDValue Offset, EVT SVT,
+                            MachineMemOperand *MMO, ISD::MemIndexedMode AM,
+                            bool IsTruncating = false);
 
-  LLVM_ABI SDValue getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
-                    const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
-                    SDValue Mask, SDValue EVL, MachinePointerInfo PtrInfo,
-                    EVT MemVT, Align Alignment,
-                    MachineMemOperand::Flags MMOFlags, const AAMDNodes &AAInfo,
-                    const MDNode *Ranges = nullptr, bool IsExpanding = false);
+  LLVM_ABI SDValue getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
+                             EVT VT, const SDLoc &dl, SDValue Chain,
+                             SDValue Ptr, SDValue Offset, SDValue Mask,
+                             SDValue EVL, MachinePointerInfo PtrInfo, EVT MemVT,
+                             Align Alignment, MachineMemOperand::Flags MMOFlags,
+                             const AAMDNodes &AAInfo,
+                             const MDNode *Ranges = nullptr,
+                             bool IsExpanding = false);
   inline SDValue
   getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
             const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
@@ -1520,102 +1548,125 @@ public:
                      PtrInfo, MemVT, Alignment.value_or(getEVTAlign(MemVT)),
                      MMOFlags, AAInfo, Ranges, IsExpanding);
   }
-  LLVM_ABI SDValue getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT,
-                    const SDLoc &dl, SDValue Chain, SDValue Ptr, SDValue Offset,
-                    SDValue Mask, SDValue EVL, EVT MemVT,
-                    MachineMemOperand *MMO, bool IsExpanding = false);
-  LLVM_ABI SDValue getLoadVP(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
-                    SDValue Mask, SDValue EVL, MachinePointerInfo PtrInfo,
-                    MaybeAlign Alignment, MachineMemOperand::Flags MMOFlags,
-                    const AAMDNodes &AAInfo, const MDNode *Ranges = nullptr,
-                    bool IsExpanding = false);
-  LLVM_ABI SDValue getLoadVP(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Ptr,
-                    SDValue Mask, SDValue EVL, MachineMemOperand *MMO,
-                    bool IsExpanding = false);
-  LLVM_ABI SDValue getExtLoadVP(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
-                       SDValue Chain, SDValue Ptr, SDValue Mask, SDValue EVL,
-                       MachinePointerInfo PtrInfo, EVT MemVT,
-                       MaybeAlign Alignment, MachineMemOperand::Flags MMOFlags,
-                       const AAMDNodes &AAInfo, bool IsExpanding = false);
-  LLVM_ABI SDValue getExtLoadVP(ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT,
-                       SDValue Chain, SDValue Ptr, SDValue Mask, SDValue EVL,
-                       EVT MemVT, MachineMemOperand *MMO,
-                       bool IsExpanding = false);
-  LLVM_ABI SDValue getIndexedLoadVP(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
-                           SDValue Offset, ISD::MemIndexedMode AM);
-  LLVM_ABI SDValue getStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val, SDValue Ptr,
-                     SDValue Offset, SDValue Mask, SDValue EVL, EVT MemVT,
-                     MachineMemOperand *MMO, ISD::MemIndexedMode AM,
-                     bool IsTruncating = false, bool IsCompressing = false);
+  LLVM_ABI SDValue getLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
+                             EVT VT, const SDLoc &dl, SDValue Chain,
+                             SDValue Ptr, SDValue Offset, SDValue Mask,
+                             SDValue EVL, EVT MemVT, MachineMemOperand *MMO,
+                             bool IsExpanding = false);
+  LLVM_ABI SDValue getLoadVP(EVT VT, const SDLoc &dl, SDValue Chain,
+                             SDValue Ptr, SDValue Mask, SDValue EVL,
+                             MachinePointerInfo PtrInfo, MaybeAlign Alignment,
+                             MachineMemOperand::Flags MMOFlags,
+                             const AAMDNodes &AAInfo,
+                             const MDNode *Ranges = nullptr,
+                             bool IsExpanding = false);
+  LLVM_ABI SDValue getLoadVP(EVT VT, const SDLoc &dl, SDValue Chain,
+                             SDValue Ptr, SDValue Mask, SDValue EVL,
+                             MachineMemOperand *MMO, bool IsExpanding = false);
+  LLVM_ABI SDValue getExtLoadVP(
+      ISD::LoadExtType ExtType, const SDLoc &dl, EVT VT, SDValue Chain,
+      SDValue Ptr, SDValue Mask, SDValue EVL, MachinePointerInfo PtrInfo,
+      EVT MemVT, MaybeAlign Alignment, MachineMemOperand::Flags MMOFlags,
+      const AAMDNodes &AAInfo, bool IsExpanding = false);
+  LLVM_ABI SDValue getExtLoadVP(ISD::LoadExtType ExtType, const SDLoc &dl,
+                                EVT VT, SDValue Chain, SDValue Ptr,
+                                SDValue Mask, SDValue EVL, EVT MemVT,
+                                MachineMemOperand *MMO,
+                                bool IsExpanding = false);
+  LLVM_ABI SDValue getIndexedLoadVP(SDValue OrigLoad, const SDLoc &dl,
+                                    SDValue Base, SDValue Offset,
+                                    ISD::MemIndexedMode AM);
+  LLVM_ABI SDValue getStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
+                              SDValue Ptr, SDValue Offset, SDValue Mask,
+                              SDValue EVL, EVT MemVT, MachineMemOperand *MMO,
+                              ISD::MemIndexedMode AM, bool IsTruncating = false,
+                              bool IsCompressing = false);
   LLVM_ABI SDValue getTruncStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
-                          SDValue Ptr, SDValue Mask, SDValue EVL,
-                          MachinePointerInfo PtrInfo, EVT SVT, Align Alignment,
-                          MachineMemOperand::Flags MMOFlags,
-                          const AAMDNodes &AAInfo, bool IsCompressing = false);
+                                   SDValue Ptr, SDValue Mask, SDValue EVL,
+                                   MachinePointerInfo PtrInfo, EVT SVT,
+                                   Align Alignment,
+                                   MachineMemOperand::Flags MMOFlags,
+                                   const AAMDNodes &AAInfo,
+                                   bool IsCompressing = false);
   LLVM_ABI SDValue getTruncStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
-                          SDValue Ptr, SDValue Mask, SDValue EVL, EVT SVT,
-                          MachineMemOperand *MMO, bool IsCompressing = false);
-  LLVM_ABI SDValue getIndexedStoreVP(SDValue OrigStore, const SDLoc &dl, SDValue Base,
-                            SDValue Offset, ISD::MemIndexedMode AM);
+                                   SDValue Ptr, SDValue Mask, SDValue EVL,
+                                   EVT SVT, MachineMemOperand *MMO,
+                                   bool IsCompressing = false);
+  LLVM_ABI SDValue getIndexedStoreVP(SDValue OrigStore, const SDLoc &dl,
+                                     SDValue Base, SDValue Offset,
+                                     ISD::MemIndexedMode AM);
 
-  LLVM_ABI SDValue getStridedLoadVP(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
-                           EVT VT, const SDLoc &DL, SDValue Chain, SDValue Ptr,
-                           SDValue Offset, SDValue Stride, SDValue Mask,
-                           SDValue EVL, EVT MemVT, MachineMemOperand *MMO,
-                           bool IsExpanding = false);
-  LLVM_ABI SDValue getStridedLoadVP(EVT VT, const SDLoc &DL, SDValue Chain, SDValue Ptr,
-                           SDValue Stride, SDValue Mask, SDValue EVL,
-                           MachineMemOperand *MMO, bool IsExpanding = false);
-  LLVM_ABI SDValue getExtStridedLoadVP(ISD::LoadExtType ExtType, const SDLoc &DL, EVT VT,
-                              SDValue Chain, SDValue Ptr, SDValue Stride,
-                              SDValue Mask, SDValue EVL, EVT MemVT,
-                              MachineMemOperand *MMO, bool IsExpanding = false);
-  LLVM_ABI SDValue getStridedStoreVP(SDValue Chain, const SDLoc &DL, SDValue Val,
-                            SDValue Ptr, SDValue Offset, SDValue Stride,
-                            SDValue Mask, SDValue EVL, EVT MemVT,
-                            MachineMemOperand *MMO, ISD::MemIndexedMode AM,
-                            bool IsTruncating = false,
-                            bool IsCompressing = false);
-  LLVM_ABI SDValue getTruncStridedStoreVP(SDValue Chain, const SDLoc &DL, SDValue Val,
-                                 SDValue Ptr, SDValue Stride, SDValue Mask,
-                                 SDValue EVL, EVT SVT, MachineMemOperand *MMO,
-                                 bool IsCompressing = false);
+  LLVM_ABI SDValue getStridedLoadVP(
+      ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT, const SDLoc &DL,
+      SDValue Chain, SDValue Ptr, SDValue Offset, SDValue Stride, SDValue Mask,
+      SDValue EVL, EVT MemVT, MachineMemOperand *MMO, bool IsExpanding = false);
+  LLVM_ABI SDValue getStridedLoadVP(EVT VT, const SDLoc &DL, SDValue Chain,
+                                    SDValue Ptr, SDValue Stride, SDValue Mask,
+                                    SDValue EVL, MachineMemOperand *MMO,
+                                    bool IsExpanding = false);
+  LLVM_ABI SDValue getExtStridedLoadVP(ISD::LoadExtType ExtType,
+                                       const SDLoc &DL, EVT VT, SDValue Chain,
+                                       SDValue Ptr, SDValue Stride,
+                                       SDValue Mask, SDValue EVL, EVT MemVT,
+                                       MachineMemOperand *MMO,
+                                       bool IsExpanding = false);
+  LLVM_ABI SDValue getStridedStoreVP(SDValue Chain, const SDLoc &DL,
+                                     SDValue Val, SDValue Ptr, SDValue Offset,
+                                     SDValue Stride, SDValue Mask, SDValue EVL,
+                                     EVT MemVT, MachineMemOperand *MMO,
+                                     ISD::MemIndexedMode AM,
+                                     bool IsTruncating = false,
+                                     bool IsCompressing = false);
+  LLVM_ABI SDValue getTruncStridedStoreVP(SDValue Chain, const SDLoc &DL,
+                                          SDValue Val, SDValue Ptr,
+                                          SDValue Stride, SDValue Mask,
+                                          SDValue EVL, EVT SVT,
+                                          MachineMemOperand *MMO,
+                                          bool IsCompressing = false);
 
   LLVM_ABI SDValue getGatherVP(SDVTList VTs, EVT VT, const SDLoc &dl,
-                      ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
-                      ISD::MemIndexType IndexType);
+                               ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
+                               ISD::MemIndexType IndexType);
   LLVM_ABI SDValue getScatterVP(SDVTList VTs, EVT VT, const SDLoc &dl,
-                       ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
-                       ISD::MemIndexType IndexType);
+                                ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
+                                ISD::MemIndexType IndexType);
 
-  LLVM_ABI SDValue getMaskedLoad(EVT VT, const SDLoc &dl, SDValue Chain, SDValue Base,
-                        SDValue Offset, SDValue Mask, SDValue Src0, EVT MemVT,
-                        MachineMemOperand *MMO, ISD::MemIndexedMode AM,
-                        ISD::LoadExtType, bool IsExpanding = false);
-  LLVM_ABI SDValue getIndexedMaskedLoad(SDValue OrigLoad, const SDLoc &dl, SDValue Base,
-                               SDValue Offset, ISD::MemIndexedMode AM);
+  LLVM_ABI SDValue getMaskedLoad(EVT VT, const SDLoc &dl, SDValue Chain,
+                                 SDValue Base, SDValue Offset, SDValue Mask,
+                                 SDValue Src0, EVT MemVT,
+                                 MachineMemOperand *MMO, ISD::MemIndexedMode AM,
+                                 ISD::LoadExtType, bool IsExpanding = false);
+  LLVM_ABI SDValue getIndexedMaskedLoad(SDValue OrigLoad, const SDLoc &dl,
+                                        SDValue Base, SDValue Offset,
+                                        ISD::MemIndexedMode AM);
   LLVM_ABI SDValue getMaskedStore(SDValue Chain, const SDLoc &dl, SDValue Val,
-                         SDValue Base, SDValue Offset, SDValue Mask, EVT MemVT,
-                         MachineMemOperand *MMO, ISD::MemIndexedMode AM,
-                         bool IsTruncating = false, bool IsCompressing = false);
+                                  SDValue Base, SDValue Offset, SDValue Mask,
+                                  EVT MemVT, MachineMemOperand *MMO,
+                                  ISD::MemIndexedMode AM,
+                                  bool IsTruncating = false,
+                                  bool IsCompressing = false);
   LLVM_ABI SDValue getIndexedMaskedStore(SDValue OrigStore, const SDLoc &dl,
-                                SDValue Base, SDValue Offset,
-                                ISD::MemIndexedMode AM);
+                                         SDValue Base, SDValue Offset,
+                                         ISD::MemIndexedMode AM);
   LLVM_ABI SDValue getMaskedGather(SDVTList VTs, EVT MemVT, const SDLoc &dl,
-                          ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
-                          ISD::MemIndexType IndexType, ISD::LoadExtType ExtTy);
+                                   ArrayRef<SDValue> Ops,
+                                   MachineMemOperand *MMO,
+                                   ISD::MemIndexType IndexType,
+                                   ISD::LoadExtType ExtTy);
   LLVM_ABI SDValue getMaskedScatter(SDVTList VTs, EVT MemVT, const SDLoc &dl,
-                           ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
-                           ISD::MemIndexType IndexType,
-                           bool IsTruncating = false);
+                                    ArrayRef<SDValue> Ops,
+                                    MachineMemOperand *MMO,
+                                    ISD::MemIndexType IndexType,
+                                    bool IsTruncating = false);
   LLVM_ABI SDValue getMaskedHistogram(SDVTList VTs, EVT MemVT, const SDLoc &dl,
-                             ArrayRef<SDValue> Ops, MachineMemOperand *MMO,
-                             ISD::MemIndexType IndexType);
+                                      ArrayRef<SDValue> Ops,
+                                      MachineMemOperand *MMO,
+                                      ISD::MemIndexType IndexType);
 
-  LLVM_ABI SDValue getGetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr, EVT MemVT,
-                      MachineMemOperand *MMO);
-  LLVM_ABI SDValue getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr, EVT MemVT,
-                      MachineMemOperand *MMO);
+  LLVM_ABI SDValue getGetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
+                               EVT MemVT, MachineMemOperand *MMO);
+  LLVM_ABI SDValue getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
+                               EVT MemVT, MachineMemOperand *MMO);
 
   /// Construct a node to track a Value* through the backend.
   LLVM_ABI SDValue getSrcValue(const Value *v);
@@ -1628,8 +1679,8 @@ public:
   LLVM_ABI SDValue getBitcast(EVT VT, SDValue V);
 
   /// Return an AddrSpaceCastSDNode.
-  LLVM_ABI SDValue getAddrSpaceCast(const SDLoc &dl, EVT VT, SDValue Ptr, unsigned SrcAS,
-                           unsigned DestAS);
+  LLVM_ABI SDValue getAddrSpaceCast(const SDLoc &dl, EVT VT, SDValue Ptr,
+                                    unsigned SrcAS, unsigned DestAS);
 
   /// Return a freeze using the SDLoc of the value operand.
   LLVM_ABI SDValue getFreeze(SDValue V);
@@ -1640,7 +1691,7 @@ public:
   /// Swap N1 and N2 if Opcode is a commutative binary opcode
   /// and the canonical form expects the opposite order.
   LLVM_ABI void canonicalizeCommutativeBinop(unsigned Opcode, SDValue &N1,
-                                    SDValue &N2) const;
+                                             SDValue &N2) const;
 
   /// Return the specified value casted to
   /// the target's desired shift amount type.
@@ -1651,9 +1702,10 @@ public:
   /// output pointers for each of the results. \p CallRetResNo can be optionally
   /// set to indicate that one of the results comes from the libcall's return
   /// value.
-  LLVM_ABI bool expandMultipleResultFPLibCall(RTLIB::Libcall LC, SDNode *Node,
-                                     SmallVectorImpl<SDValue> &Results,
-                                     std::optional<unsigned> CallRetResNo = {});
+  LLVM_ABI bool
+  expandMultipleResultFPLibCall(RTLIB::Libcall LC, SDNode *Node,
+                                SmallVectorImpl<SDValue> &Results,
+                                std::optional<unsigned> CallRetResNo = {});
 
   /// Expand the specified \c ISD::VAARG node as the Legalize pass would.
   LLVM_ABI SDValue expandVAArg(SDNode *Node);
@@ -1665,8 +1717,8 @@ public:
   /// name matching the given ExternalSymbol. Additionally can provide the
   /// matched function.
   /// Panic if the function doesn't exist.
-  LLVM_ABI SDValue getSymbolFunctionGlobalAddress(SDValue Op,
-                                         Function **TargetFunction = nullptr);
+  LLVM_ABI SDValue getSymbolFunctionGlobalAddress(
+      SDValue Op, Function **TargetFunction = nullptr);
 
   /// *Mutate* the specified node in-place to have the
   /// specified operands.  If the resultant node already exists in the DAG,
@@ -1677,55 +1729,58 @@ public:
   LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op);
   LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2);
   LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
-                               SDValue Op3);
+                                      SDValue Op3);
   LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
-                               SDValue Op3, SDValue Op4);
+                                      SDValue Op3, SDValue Op4);
   LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2,
-                               SDValue Op3, SDValue Op4, SDValue Op5);
+                                      SDValue Op3, SDValue Op4, SDValue Op5);
   LLVM_ABI SDNode *UpdateNodeOperands(SDNode *N, ArrayRef<SDValue> Ops);
 
   /// Creates a new TokenFactor containing \p Vals. If \p Vals contains 64k
   /// values or more, move values into new TokenFactors in 64k-1 blocks, until
   /// the final TokenFactor has less than 64k operands.
-  LLVM_ABI SDValue getTokenFactor(const SDLoc &DL, SmallVectorImpl<SDValue> &Vals);
+  LLVM_ABI SDValue getTokenFactor(const SDLoc &DL,
+                                  SmallVectorImpl<SDValue> &Vals);
 
   /// *Mutate* the specified machine node's memory references to the provided
   /// list.
   LLVM_ABI void setNodeMemRefs(MachineSDNode *N,
-                      ArrayRef<MachineMemOperand *> NewMemRefs);
+                               ArrayRef<MachineMemOperand *> NewMemRefs);
 
   // Calculate divergence of node \p N based on its operands.
   LLVM_ABI bool calculateDivergence(SDNode *N);
 
   // Propagates the change in divergence to users
-  LLVM_ABI void updateDivergence(SDNode * N);
+  LLVM_ABI void updateDivergence(SDNode *N);
 
   /// These are used for target selectors to *mutate* the
   /// specified node to have the specified return type, Target opcode, and
   /// operands.  Note that target opcodes are stored as
   /// ~TargetOpcode in the node opcode field.  The resultant node is returned.
   LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT);
-  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT, SDValue Op1);
   LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
-                       SDValue Op1, SDValue Op2);
+                                SDValue Op1);
   LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
-                       SDValue Op1, SDValue Op2, SDValue Op3);
+                                SDValue Op1, SDValue Op2);
   LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
-                       ArrayRef<SDValue> Ops);
-  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1, EVT VT2);
+                                SDValue Op1, SDValue Op2, SDValue Op3);
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT,
+                                ArrayRef<SDValue> Ops);
   LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
-                       EVT VT2, ArrayRef<SDValue> Ops);
+                                EVT VT2);
   LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
-                       EVT VT2, EVT VT3, ArrayRef<SDValue> Ops);
+                                EVT VT2, ArrayRef<SDValue> Ops);
   LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
-                       EVT VT2, SDValue Op1, SDValue Op2);
+                                EVT VT2, EVT VT3, ArrayRef<SDValue> Ops);
+  LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, EVT VT1,
+                                EVT VT2, SDValue Op1, SDValue Op2);
   LLVM_ABI SDNode *SelectNodeTo(SDNode *N, unsigned MachineOpc, SDVTList VTs,
-                       ArrayRef<SDValue> Ops);
+                                ArrayRef<SDValue> Ops);
 
   /// This *mutates* the specified node to have the specified
   /// return type, opcode, and operands.
   LLVM_ABI SDNode *MorphNodeTo(SDNode *N, unsigned Opc, SDVTList VTs,
-                      ArrayRef<SDValue> Ops);
+                               ArrayRef<SDValue> Ops);
 
   /// Mutate the specified strict FP node to its non-strict equivalent,
   /// unlinking the node from its chain and dropping the metadata arguments.
@@ -1738,91 +1793,106 @@ public:
   /// Note that getMachineNode returns the resultant node.  If there is already
   /// a node of the specified opcode and operands, it returns that node instead
   /// of the current one.
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
-                                SDValue Op1);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
-                                SDValue Op1, SDValue Op2);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
-                                SDValue Op1, SDValue Op2, SDValue Op3);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT,
-                                ArrayRef<SDValue> Ops);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
-                                EVT VT2, SDValue Op1, SDValue Op2);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
-                                EVT VT2, SDValue Op1, SDValue Op2, SDValue Op3);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
-                                EVT VT2, ArrayRef<SDValue> Ops);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
-                                EVT VT2, EVT VT3, SDValue Op1, SDValue Op2);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
-                                EVT VT2, EVT VT3, SDValue Op1, SDValue Op2,
-                                SDValue Op3);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, EVT VT1,
-                                EVT VT2, EVT VT3, ArrayRef<SDValue> Ops);
   LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
-                                ArrayRef<EVT> ResultTys, ArrayRef<SDValue> Ops);
-  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl, SDVTList VTs,
-                                ArrayRef<SDValue> Ops);
+                                         EVT VT);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT, SDValue Op1);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT, SDValue Op1, SDValue Op2);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT, SDValue Op1, SDValue Op2,
+                                         SDValue Op3);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT, ArrayRef<SDValue> Ops);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT1, EVT VT2, SDValue Op1,
+                                         SDValue Op2);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT1, EVT VT2, SDValue Op1,
+                                         SDValue Op2, SDValue Op3);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT1, EVT VT2,
+                                         ArrayRef<SDValue> Ops);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT1, EVT VT2, EVT VT3, SDValue Op1,
+                                         SDValue Op2);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT1, EVT VT2, EVT VT3, SDValue Op1,
+                                         SDValue Op2, SDValue Op3);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         EVT VT1, EVT VT2, EVT VT3,
+                                         ArrayRef<SDValue> Ops);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         ArrayRef<EVT> ResultTys,
+                                         ArrayRef<SDValue> Ops);
+  LLVM_ABI MachineSDNode *getMachineNode(unsigned Opcode, const SDLoc &dl,
+                                         SDVTList VTs, ArrayRef<SDValue> Ops);
 
   /// A convenience function for creating TargetInstrInfo::EXTRACT_SUBREG nodes.
   LLVM_ABI SDValue getTargetExtractSubreg(int SRIdx, const SDLoc &DL, EVT VT,
-                                 SDValue Operand);
+                                          SDValue Operand);
 
   /// A convenience function for creating TargetInstrInfo::INSERT_SUBREG nodes.
   LLVM_ABI SDValue getTargetInsertSubreg(int SRIdx, const SDLoc &DL, EVT VT,
-                                SDValue Operand, SDValue Subreg);
+                                         SDValue Operand, SDValue Subreg);
 
   /// Get the specified node if it's already available, or else return NULL.
   LLVM_ABI SDNode *getNodeIfExists(unsigned Opcode, SDVTList VTList,
-                          ArrayRef<SDValue> Ops, const SDNodeFlags Flags);
+                                   ArrayRef<SDValue> Ops,
+                                   const SDNodeFlags Flags);
   LLVM_ABI SDNode *getNodeIfExists(unsigned Opcode, SDVTList VTList,
-                          ArrayRef<SDValue> Ops);
+                                   ArrayRef<SDValue> Ops);
 
   /// Check if a node exists without modifying its flags.
-  LLVM_ABI bool doesNodeExist(unsigned Opcode, SDVTList VTList, ArrayRef<SDValue> Ops);
+  LLVM_ABI bool doesNodeExist(unsigned Opcode, SDVTList VTList,
+                              ArrayRef<SDValue> Ops);
 
   /// Creates a SDDbgValue node.
-  LLVM_ABI SDDbgValue *getDbgValue(DIVariable *Var, DIExpression *Expr, SDNode *N,
-                          unsigned R, bool IsIndirect, const DebugLoc &DL,
-                          unsigned O);
+  LLVM_ABI SDDbgValue *getDbgValue(DIVariable *Var, DIExpression *Expr,
+                                   SDNode *N, unsigned R, bool IsIndirect,
+                                   const DebugLoc &DL, unsigned O);
 
   /// Creates a constant SDDbgValue node.
   LLVM_ABI SDDbgValue *getConstantDbgValue(DIVariable *Var, DIExpression *Expr,
-                                  const Value *C, const DebugLoc &DL,
-                                  unsigned O);
+                                           const Value *C, const DebugLoc &DL,
+                                           unsigned O);
 
   /// Creates a FrameIndex SDDbgValue node.
-  LLVM_ABI SDDbgValue *getFrameIndexDbgValue(DIVariable *Var, DIExpression *Expr,
-                                    unsigned FI, bool IsIndirect,
-                                    const DebugLoc &DL, unsigned O);
+  LLVM_ABI SDDbgValue *getFrameIndexDbgValue(DIVariable *Var,
+                                             DIExpression *Expr, unsigned FI,
+                                             bool IsIndirect,
+                                             const DebugLoc &DL, unsigned O);
 
   /// Creates a FrameIndex SDDbgValue node.
-  LLVM_ABI SDDbgValue *getFrameIndexDbgValue(DIVariable *Var, DIExpression *Expr,
-                                    unsigned FI,
-                                    ArrayRef<SDNode *> Dependencies,
-                                    bool IsIndirect, const DebugLoc &DL,
-                                    unsigned O);
+  LLVM_ABI SDDbgValue *getFrameIndexDbgValue(DIVariable *Var,
+                                             DIExpression *Expr, unsigned FI,
+                                             ArrayRef<SDNode *> Dependencies,
+                                             bool IsIndirect,
+                                             const DebugLoc &DL, unsigned O);
 
   /// Creates a VReg SDDbgValue node.
   LLVM_ABI SDDbgValue *getVRegDbgValue(DIVariable *Var, DIExpression *Expr,
-                              Register VReg, bool IsIndirect,
-                              const DebugLoc &DL, unsigned O);
+                                       Register VReg, bool IsIndirect,
+                                       const DebugLoc &DL, unsigned O);
 
   /// Creates a SDDbgValue node from a list of locations.
   LLVM_ABI SDDbgValue *getDbgValueList(DIVariable *Var, DIExpression *Expr,
-                              ArrayRef<SDDbgOperand> Locs,
-                              ArrayRef<SDNode *> Dependencies, bool IsIndirect,
-                              const DebugLoc &DL, unsigned O, bool IsVariadic);
+                                       ArrayRef<SDDbgOperand> Locs,
+                                       ArrayRef<SDNode *> Dependencies,
+                                       bool IsIndirect, const DebugLoc &DL,
+                                       unsigned O, bool IsVariadic);
 
   /// Creates a SDDbgLabel node.
-  LLVM_ABI SDDbgLabel *getDbgLabel(DILabel *Label, const DebugLoc &DL, unsigned O);
+  LLVM_ABI SDDbgLabel *getDbgLabel(DILabel *Label, const DebugLoc &DL,
+                                   unsigned O);
 
   /// Transfer debug values from one node to another, while optionally
   /// generating fragment expressions for split-up values. If \p InvalidateDbg
   /// is set, debug values are invalidated after they are transferred.
-  LLVM_ABI void transferDbgValues(SDValue From, SDValue To, unsigned OffsetInBits = 0,
-                         unsigned SizeInBits = 0, bool InvalidateDbg = true);
+  LLVM_ABI void transferDbgValues(SDValue From, SDValue To,
+                                  unsigned OffsetInBits = 0,
+                                  unsigned SizeInBits = 0,
+                                  bool InvalidateDbg = true);
 
   /// Remove the specified node from the system. If any of its
   /// operands then becomes dead, remove them as well. Inform UpdateListener
@@ -1859,22 +1929,24 @@ public:
   /// Like ReplaceAllUsesOfValueWith, but for multiple values at once.
   /// This correctly handles the case where
   /// there is an overlap between the From values and the To values.
-  LLVM_ABI void ReplaceAllUsesOfValuesWith(const SDValue *From, const SDValue *To,
-                                  unsigned Num);
+  LLVM_ABI void ReplaceAllUsesOfValuesWith(const SDValue *From,
+                                           const SDValue *To, unsigned Num);
 
   /// If an existing load has uses of its chain, create a token factor node with
   /// that chain and the new memory node's chain and update users of the old
   /// chain to the token factor. This ensures that the new memory node will have
   /// the same relative memory dependency position as the old load. Returns the
   /// new merged load chain.
-  LLVM_ABI SDValue makeEquivalentMemoryOrdering(SDValue OldChain, SDValue NewMemOpChain);
+  LLVM_ABI SDValue makeEquivalentMemoryOrdering(SDValue OldChain,
+                                                SDValue NewMemOpChain);
 
   /// If an existing load has uses of its chain, create a token factor node with
   /// that chain and the new memory node's chain and update users of the old
   /// chain to the token factor. This ensures that the new memory node will have
   /// the same relative memory dependency position as the old load. Returns the
   /// new merged load chain.
-  LLVM_ABI SDValue makeEquivalentMemoryOrdering(LoadSDNode *OldLoad, SDValue NewMemOp);
+  LLVM_ABI SDValue makeEquivalentMemoryOrdering(LoadSDNode *OldLoad,
+                                                SDValue NewMemOp);
 
   /// Topological-sort the AllNodes list and a
   /// assign a unique node id for each node in the DAG based on their
@@ -1946,21 +2018,21 @@ public:
   LLVM_ABI SDValue CreateStackTemporary(EVT VT1, EVT VT2);
 
   LLVM_ABI SDValue FoldSymbolOffset(unsigned Opcode, EVT VT,
-                           const GlobalAddressSDNode *GA,
-                           const SDNode *N2);
+                                    const GlobalAddressSDNode *GA,
+                                    const SDNode *N2);
 
-  LLVM_ABI SDValue FoldConstantArithmetic(unsigned Opcode, const SDLoc &DL, EVT VT,
-                                 ArrayRef<SDValue> Ops,
-                                 SDNodeFlags Flags = SDNodeFlags());
+  LLVM_ABI SDValue FoldConstantArithmetic(unsigned Opcode, const SDLoc &DL,
+                                          EVT VT, ArrayRef<SDValue> Ops,
+                                          SDNodeFlags Flags = SDNodeFlags());
 
   /// Fold floating-point operations when all operands are constants and/or
   /// undefined.
   LLVM_ABI SDValue foldConstantFPMath(unsigned Opcode, const SDLoc &DL, EVT VT,
-                             ArrayRef<SDValue> Ops);
+                                      ArrayRef<SDValue> Ops);
 
   /// Constant fold a setcc to true or false.
   LLVM_ABI SDValue FoldSetCC(EVT VT, SDValue N1, SDValue N2, ISD::CondCode Cond,
-                    const SDLoc &dl);
+                             const SDLoc &dl);
 
   /// Return true if the sign bit of Op is known to be zero.
   /// We use this predicate to simplify operations downstream.
@@ -1970,27 +2042,29 @@ public:
   /// use this predicate to simplify operations downstream.  Op and Mask are
   /// known to be the same type.
   LLVM_ABI bool MaskedValueIsZero(SDValue Op, const APInt &Mask,
-                         unsigned Depth = 0) const;
+                                  unsigned Depth = 0) const;
 
   /// Return true if 'Op & Mask' is known to be zero in DemandedElts.  We
   /// use this predicate to simplify operations downstream.  Op and Mask are
   /// known to be the same type.
   LLVM_ABI bool MaskedValueIsZero(SDValue Op, const APInt &Mask,
-                         const APInt &DemandedElts, unsigned Depth = 0) const;
+                                  const APInt &DemandedElts,
+                                  unsigned Depth = 0) const;
 
   /// Return true if 'Op' is known to be zero in DemandedElts.  We
   /// use this predicate to simplify operations downstream.
   LLVM_ABI bool MaskedVectorIsZero(SDValue Op, const APInt &DemandedElts,
-                          unsigned Depth = 0) const;
+                                   unsigned Depth = 0) const;
 
   /// Return true if '(Op & Mask) == Mask'.
   /// Op and Mask are known to be the same type.
   LLVM_ABI bool MaskedValueIsAllOnes(SDValue Op, const APInt &Mask,
-                            unsigned Depth = 0) const;
+                                     unsigned Depth = 0) const;
 
   /// For each demanded element of a vector, see if it is known to be zero.
-  LLVM_ABI APInt computeVectorKnownZeroElements(SDValue Op, const APInt &DemandedElts,
-                                       unsigned Depth = 0) const;
+  LLVM_ABI APInt computeVectorKnownZeroElements(SDValue Op,
+                                                const APInt &DemandedElts,
+                                                unsigned Depth = 0) const;
 
   /// Determine which bits of Op are known to be either zero or one and return
   /// them in Known. For vectors, the known bits are those that are shared by
@@ -2005,7 +2079,7 @@ public:
   /// Targets can implement the computeKnownBitsForTargetNode method in the
   /// TargetLowering class to allow target nodes to be understood.
   LLVM_ABI KnownBits computeKnownBits(SDValue Op, const APInt &DemandedElts,
-                             unsigned Depth = 0) const;
+                                      unsigned Depth = 0) const;
 
   /// Used to represent the possible overflow behavior of an operation.
   /// Never: the operation cannot overflow.
@@ -2018,10 +2092,12 @@ public:
   };
 
   /// Determine if the result of the signed addition of 2 nodes can overflow.
-  LLVM_ABI OverflowKind computeOverflowForSignedAdd(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForSignedAdd(SDValue N0,
+                                                    SDValue N1) const;
 
   /// Determine if the result of the unsigned addition of 2 nodes can overflow.
-  LLVM_ABI OverflowKind computeOverflowForUnsignedAdd(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForUnsignedAdd(SDValue N0,
+                                                      SDValue N1) const;
 
   /// Determine if the result of the addition of 2 nodes can overflow.
   OverflowKind computeOverflowForAdd(bool IsSigned, SDValue N0,
@@ -2036,10 +2112,12 @@ public:
   }
 
   /// Determine if the result of the signed sub of 2 nodes can overflow.
-  LLVM_ABI OverflowKind computeOverflowForSignedSub(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForSignedSub(SDValue N0,
+                                                    SDValue N1) const;
 
   /// Determine if the result of the unsigned sub of 2 nodes can overflow.
-  LLVM_ABI OverflowKind computeOverflowForUnsignedSub(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForUnsignedSub(SDValue N0,
+                                                      SDValue N1) const;
 
   /// Determine if the result of the sub of 2 nodes can overflow.
   OverflowKind computeOverflowForSub(bool IsSigned, SDValue N0,
@@ -2054,10 +2132,12 @@ public:
   }
 
   /// Determine if the result of the signed mul of 2 nodes can overflow.
-  LLVM_ABI OverflowKind computeOverflowForSignedMul(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForSignedMul(SDValue N0,
+                                                    SDValue N1) const;
 
   /// Determine if the result of the unsigned mul of 2 nodes can overflow.
-  LLVM_ABI OverflowKind computeOverflowForUnsignedMul(SDValue N0, SDValue N1) const;
+  LLVM_ABI OverflowKind computeOverflowForUnsignedMul(SDValue N0,
+                                                      SDValue N1) const;
 
   /// Determine if the result of the mul of 2 nodes can overflow.
   OverflowKind computeOverflowForMul(bool IsSigned, SDValue N0,
@@ -2098,32 +2178,36 @@ public:
   /// Targets can implement the ComputeNumSignBitsForTarget method in the
   /// TargetLowering class to allow target nodes to be understood.
   LLVM_ABI unsigned ComputeNumSignBits(SDValue Op, const APInt &DemandedElts,
-                              unsigned Depth = 0) const;
+                                       unsigned Depth = 0) const;
 
   /// Get the upper bound on bit size for this Value \p Op as a signed integer.
   /// i.e.  x == sext(trunc(x to MaxSignedBits) to bitwidth(x)).
   /// Similar to the APInt::getSignificantBits function.
   /// Helper wrapper to ComputeNumSignBits.
-  LLVM_ABI unsigned ComputeMaxSignificantBits(SDValue Op, unsigned Depth = 0) const;
+  LLVM_ABI unsigned ComputeMaxSignificantBits(SDValue Op,
+                                              unsigned Depth = 0) const;
 
   /// Get the upper bound on bit size for this Value \p Op as a signed integer.
   /// i.e.  x == sext(trunc(x to MaxSignedBits) to bitwidth(x)).
   /// Similar to the APInt::getSignificantBits function.
   /// Helper wrapper to ComputeNumSignBits.
-  LLVM_ABI unsigned ComputeMaxSignificantBits(SDValue Op, const APInt &DemandedElts,
-                                     unsigned Depth = 0) const;
+  LLVM_ABI unsigned ComputeMaxSignificantBits(SDValue Op,
+                                              const APInt &DemandedElts,
+                                              unsigned Depth = 0) const;
 
   /// Return true if this function can prove that \p Op is never poison
   /// and, if \p PoisonOnly is false, does not have undef bits.
-  LLVM_ABI bool isGuaranteedNotToBeUndefOrPoison(SDValue Op, bool PoisonOnly = false,
-                                        unsigned Depth = 0) const;
+  LLVM_ABI bool isGuaranteedNotToBeUndefOrPoison(SDValue Op,
+                                                 bool PoisonOnly = false,
+                                                 unsigned Depth = 0) const;
 
   /// Return true if this function can prove that \p Op is never poison
   /// and, if \p PoisonOnly is false, does not have undef bits. The DemandedElts
   /// argument limits the check to the requested vector elements.
-  LLVM_ABI bool isGuaranteedNotToBeUndefOrPoison(SDValue Op, const APInt &DemandedElts,
-                                        bool PoisonOnly = false,
-                                        unsigned Depth = 0) const;
+  LLVM_ABI bool isGuaranteedNotToBeUndefOrPoison(SDValue Op,
+                                                 const APInt &DemandedElts,
+                                                 bool PoisonOnly = false,
+                                                 unsigned Depth = 0) const;
 
   /// Return true if this function can prove that \p Op is never poison.
   bool isGuaranteedNotToBePoison(SDValue Op, unsigned Depth = 0) const {
@@ -2148,9 +2232,9 @@ public:
   /// which might be on the instruction.  (i.e. could the result of
   /// Op->dropPoisonGeneratingFlags() still create poison or undef)
   LLVM_ABI bool canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
-                              bool PoisonOnly = false,
-                              bool ConsiderFlags = true,
-                              unsigned Depth = 0) const;
+                                       bool PoisonOnly = false,
+                                       bool ConsiderFlags = true,
+                                       unsigned Depth = 0) const;
 
   /// Return true if Op can create undef or poison from non-undef & non-poison
   /// operands.
@@ -2161,8 +2245,8 @@ public:
   /// which might be on the instruction.  (i.e. could the result of
   /// Op->dropPoisonGeneratingFlags() still create poison or undef)
   LLVM_ABI bool canCreateUndefOrPoison(SDValue Op, bool PoisonOnly = false,
-                              bool ConsiderFlags = true,
-                              unsigned Depth = 0) const;
+                                       bool ConsiderFlags = true,
+                                       unsigned Depth = 0) const;
 
   /// Return true if the specified operand is an ISD::OR or ISD::XOR node
   /// that can be treated as an ISD::ADD node.
@@ -2182,13 +2266,14 @@ public:
   /// vector) is known to never be NaN in \p DemandedElts. If \p SNaN is true,
   /// returns if \p Op is known to never be a signaling NaN (it may still be a
   /// qNaN).
-  LLVM_ABI bool isKnownNeverNaN(SDValue Op, const APInt &DemandedElts, bool SNaN = false,
-                       unsigned Depth = 0) const;
+  LLVM_ABI bool isKnownNeverNaN(SDValue Op, const APInt &DemandedElts,
+                                bool SNaN = false, unsigned Depth = 0) const;
 
   /// Test whether the given SDValue (or all elements of it, if it is a
   /// vector) is known to never be NaN. If \p SNaN is true, returns if \p Op is
   /// known to never be a signaling NaN (it may still be a qNaN).
-  LLVM_ABI bool isKnownNeverNaN(SDValue Op, bool SNaN = false, unsigned Depth = 0) const;
+  LLVM_ABI bool isKnownNeverNaN(SDValue Op, bool SNaN = false,
+                                unsigned Depth = 0) const;
 
   /// \returns true if \p Op is known to never be a signaling NaN in \p
   /// DemandedElts.
@@ -2229,8 +2314,8 @@ public:
   /// for \p DemandedElts.
   ///
   /// NOTE: The function will return true for a demanded splat of UNDEF values.
-  LLVM_ABI bool isSplatValue(SDValue V, const APInt &DemandedElts, APInt &UndefElts,
-                    unsigned Depth = 0) const;
+  LLVM_ABI bool isSplatValue(SDValue V, const APInt &DemandedElts,
+                             APInt &UndefElts, unsigned Depth = 0) const;
 
   /// Test whether \p V has a splatted value.
   LLVM_ABI bool isSplatValue(SDValue V, bool AllowUndefs = false) const;
@@ -2252,36 +2337,36 @@ public:
 
   /// If a SHL/SRA/SRL node \p V has a uniform shift amount
   /// that is less than the element bit-width of the shift node, return it.
-  LLVM_ABI std::optional<uint64_t> getValidShiftAmount(SDValue V,
-                                              const APInt &DemandedElts,
-                                              unsigned Depth = 0) const;
+  LLVM_ABI std::optional<uint64_t>
+  getValidShiftAmount(SDValue V, const APInt &DemandedElts,
+                      unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has a uniform shift amount
   /// that is less than the element bit-width of the shift node, return it.
-  LLVM_ABI std::optional<uint64_t> getValidShiftAmount(SDValue V,
-                                              unsigned Depth = 0) const;
+  LLVM_ABI std::optional<uint64_t>
+  getValidShiftAmount(SDValue V, unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the minimum possible value.
-  LLVM_ABI std::optional<uint64_t> getValidMinimumShiftAmount(SDValue V,
-                                                     const APInt &DemandedElts,
-                                                     unsigned Depth = 0) const;
+  LLVM_ABI std::optional<uint64_t>
+  getValidMinimumShiftAmount(SDValue V, const APInt &DemandedElts,
+                             unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the minimum possible value.
-  LLVM_ABI std::optional<uint64_t> getValidMinimumShiftAmount(SDValue V,
-                                                     unsigned Depth = 0) const;
+  LLVM_ABI std::optional<uint64_t>
+  getValidMinimumShiftAmount(SDValue V, unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the maximum possible value.
-  LLVM_ABI std::optional<uint64_t> getValidMaximumShiftAmount(SDValue V,
-                                                     const APInt &DemandedElts,
-                                                     unsigned Depth = 0) const;
+  LLVM_ABI std::optional<uint64_t>
+  getValidMaximumShiftAmount(SDValue V, const APInt &DemandedElts,
+                             unsigned Depth = 0) const;
 
   /// If a SHL/SRA/SRL node \p V has shift amounts that are all less than the
   /// element bit-width of the shift node, return the maximum possible value.
-  LLVM_ABI std::optional<uint64_t> getValidMaximumShiftAmount(SDValue V,
-                                                     unsigned Depth = 0) const;
+  LLVM_ABI std::optional<uint64_t>
+  getValidMaximumShiftAmount(SDValue V, unsigned Depth = 0) const;
 
   /// Match a binop + shuffle pyramid that represents a horizontal reduction
   /// over the elements of a vector starting from the EXTRACT_VECTOR_ELT node /p
@@ -2292,8 +2377,8 @@ public:
   /// reduction pattern that only matches the first few stages, the extracted
   /// subvector of the start of the reduction is returned.
   LLVM_ABI SDValue matchBinOpReduction(SDNode *Extract, ISD::NodeType &BinOp,
-                              ArrayRef<ISD::NodeType> CandidateBinOps,
-                              bool AllowPartials = false);
+                                       ArrayRef<ISD::NodeType> CandidateBinOps,
+                                       bool AllowPartials = false);
 
   /// Utility function used by legalize and lowering to
   /// "unroll" a vector operation by splitting out the scalars and operating
@@ -2305,15 +2390,15 @@ public:
 
   /// Like UnrollVectorOp(), but for the [US](ADD|SUB|MUL)O family of opcodes.
   /// This is a separate function because those opcodes have two results.
-  LLVM_ABI std::pair<SDValue, SDValue> UnrollVectorOverflowOp(SDNode *N,
-                                                     unsigned ResNE = 0);
+  LLVM_ABI std::pair<SDValue, SDValue>
+  UnrollVectorOverflowOp(SDNode *N, unsigned ResNE = 0);
 
   /// Return true if loads are next to each other and can be
   /// merged. Check that both are nonvolatile and if LD is loading
   /// 'Bytes' bytes from a location that is 'Dist' units away from the
   /// location that the 'Base' load is loading from.
   LLVM_ABI bool areNonVolatileConsecutiveLoads(LoadSDNode *LD, LoadSDNode *Base,
-                                      unsigned Bytes, int Dist) const;
+                                               unsigned Bytes, int Dist) const;
 
   /// Infer alignment of a load / store address. Return std::nullopt if it
   /// cannot be inferred.
@@ -2321,8 +2406,10 @@ public:
 
   /// Split the scalar node with EXTRACT_ELEMENT using the provided VTs and
   /// return the low/high part.
-  LLVM_ABI std::pair<SDValue, SDValue> SplitScalar(const SDValue &N, const SDLoc &DL,
-                                          const EVT &LoVT, const EVT &HiVT);
+  LLVM_ABI std::pair<SDValue, SDValue> SplitScalar(const SDValue &N,
+                                                   const SDLoc &DL,
+                                                   const EVT &LoVT,
+                                                   const EVT &HiVT);
 
   /// Compute the VTs needed for the low/hi parts of a type
   /// which is split (or expanded) into two not necessarily identical pieces.
@@ -2331,13 +2418,16 @@ public:
   /// Compute the VTs needed for the low/hi parts of a type, dependent on an
   /// enveloping VT that has been split into two identical pieces. Sets the
   /// HisIsEmpty flag when hi type has zero storage size.
-  LLVM_ABI std::pair<EVT, EVT> GetDependentSplitDestVTs(const EVT &VT, const EVT &EnvVT,
-                                               bool *HiIsEmpty) const;
+  LLVM_ABI std::pair<EVT, EVT> GetDependentSplitDestVTs(const EVT &VT,
+                                                        const EVT &EnvVT,
+                                                        bool *HiIsEmpty) const;
 
   /// Split the vector with EXTRACT_SUBVECTOR using the provided
   /// VTs and return the low/high part.
-  LLVM_ABI std::pair<SDValue, SDValue> SplitVector(const SDValue &N, const SDLoc &DL,
-                                          const EVT &LoVT, const EVT &HiVT);
+  LLVM_ABI std::pair<SDValue, SDValue> SplitVector(const SDValue &N,
+                                                   const SDLoc &DL,
+                                                   const EVT &LoVT,
+                                                   const EVT &HiVT);
 
   /// Split the vector with EXTRACT_SUBVECTOR and return the low/high part.
   std::pair<SDValue, SDValue> SplitVector(const SDValue &N, const SDLoc &DL) {
@@ -2347,7 +2437,8 @@ public:
   }
 
   /// Split the explicit vector length parameter of a VP operation.
-  LLVM_ABI std::pair<SDValue, SDValue> SplitEVL(SDValue N, EVT VecVT, const SDLoc &DL);
+  LLVM_ABI std::pair<SDValue, SDValue> SplitEVL(SDValue N, EVT VecVT,
+                                                const SDLoc &DL);
 
   /// Split the node's operand with EXTRACT_SUBVECTOR and
   /// return the low/high part.
@@ -2363,16 +2454,18 @@ public:
   /// Args. If Count is 0, all of the elements will be extracted. The extracted
   /// elements will have type EVT if it is provided, and otherwise their type
   /// will be Op's element type.
-  LLVM_ABI void ExtractVectorElements(SDValue Op, SmallVectorImpl<SDValue> &Args,
-                             unsigned Start = 0, unsigned Count = 0,
-                             EVT EltVT = EVT());
+  LLVM_ABI void ExtractVectorElements(SDValue Op,
+                                      SmallVectorImpl<SDValue> &Args,
+                                      unsigned Start = 0, unsigned Count = 0,
+                                      EVT EltVT = EVT());
 
   /// Compute the default alignment value for the given type.
   LLVM_ABI Align getEVTAlign(EVT MemoryVT) const;
 
   /// Test whether the given value is a constant int or similar node.
-  LLVM_ABI bool isConstantIntBuildVectorOrConstantInt(SDValue N,
-                                             bool AllowOpaques = true) const;
+  LLVM_ABI bool
+  isConstantIntBuildVectorOrConstantInt(SDValue N,
+                                        bool AllowOpaques = true) const;
 
   /// Test whether the given value is a constant FP or similar node.
   LLVM_ABI bool isConstantFPBuildVectorOrConstantFP(SDValue N) const;
@@ -2386,8 +2479,8 @@ public:
 
   /// Check if a value \op N is a constant using the target's BooleanContent for
   /// its type.
-  LLVM_ABI std::optional<bool> isBoolConstant(SDValue N,
-                                     bool AllowTruncation = false) const;
+  LLVM_ABI std::optional<bool>
+  isBoolConstant(SDValue N, bool AllowTruncation = false) const;
 
   /// Set CallSiteInfo to be associated with Node.
   void addCallSiteInfo(const SDNode *Node, CallSiteInfo &&CallInfo) {
@@ -2462,7 +2555,7 @@ public:
 
   /// Get the (commutative) neutral element for the given opcode, if it exists.
   LLVM_ABI SDValue getNeutralElement(unsigned Opcode, const SDLoc &DL, EVT VT,
-                            SDNodeFlags Flags);
+                                     SDNodeFlags Flags);
 
   /// Some opcodes may create immediate undefined behavior when used with some
   /// values (integer division-by-zero for example). Therefore, these operations
@@ -2494,8 +2587,8 @@ public:
     }
   }
 
-  LLVM_ABI SDValue makeStateFunctionCall(unsigned LibFunc, SDValue Ptr, SDValue InChain,
-                                const SDLoc &DLoc);
+  LLVM_ABI SDValue makeStateFunctionCall(unsigned LibFunc, SDValue Ptr,
+                                         SDValue InChain, const SDLoc &DLoc);
 
 private:
 #ifndef NDEBUG

--- a/llvm/include/llvm/CodeGen/SelectionDAGAddressAnalysis.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGAddressAnalysis.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_CODEGEN_SELECTIONDAGADDRESSANALYSIS_H
 #define LLVM_CODEGEN_SELECTIONDAGADDRESSANALYSIS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Analysis/MemoryLocation.h"
 #include "llvm/CodeGen/SelectionDAGNodes.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -60,8 +60,8 @@ public:
   // Returns true if `Other` and `*this` are both some offset from the same base
   // pointer. In that case, `Off` is set to the offset between `*this` and
   // `Other` (negative if `Other` is before `*this`).
-  LLVM_ABI bool equalBaseIndex(const BaseIndexOffset &Other, const SelectionDAG &DAG,
-                      int64_t &Off) const;
+  LLVM_ABI bool equalBaseIndex(const BaseIndexOffset &Other,
+                               const SelectionDAG &DAG, int64_t &Off) const;
 
   bool equalBaseIndex(const BaseIndexOffset &Other,
                       const SelectionDAG &DAG) const {
@@ -72,8 +72,8 @@ public:
   // Returns true if `Other` (with size `OtherSize`) can be proven to be fully
   // contained in `*this` (with size `Size`).
   LLVM_ABI bool contains(const SelectionDAG &DAG, int64_t BitSize,
-                const BaseIndexOffset &Other, int64_t OtherBitSize,
-                int64_t &BitOffset) const;
+                         const BaseIndexOffset &Other, int64_t OtherBitSize,
+                         int64_t &BitOffset) const;
 
   bool contains(const SelectionDAG &DAG, int64_t BitSize,
                 const BaseIndexOffset &Other, int64_t OtherBitSize) const {
@@ -83,14 +83,17 @@ public:
 
   // Returns true `Op0` and `Op1` can be proven to alias/not alias, in
   // which case `IsAlias` is set to true/false.
-  LLVM_ABI static bool computeAliasing(const SDNode *Op0, const LocationSize NumBytes0,
-                              const SDNode *Op1, const LocationSize NumBytes1,
-                              const SelectionDAG &DAG, bool &IsAlias);
+  LLVM_ABI static bool computeAliasing(const SDNode *Op0,
+                                       const LocationSize NumBytes0,
+                                       const SDNode *Op1,
+                                       const LocationSize NumBytes1,
+                                       const SelectionDAG &DAG, bool &IsAlias);
 
   /// Parses tree in N for base, index, offset addresses.
-  LLVM_ABI static BaseIndexOffset match(const SDNode *N, const SelectionDAG &DAG);
+  LLVM_ABI static BaseIndexOffset match(const SDNode *N,
+                                        const SelectionDAG &DAG);
 
-  LLVM_ABI void print(raw_ostream& OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
   LLVM_ABI void dump() const;
 };
 

--- a/llvm/include/llvm/CodeGen/SelectionDAGAddressAnalysis.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGAddressAnalysis.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CODEGEN_SELECTIONDAGADDRESSANALYSIS_H
 #define LLVM_CODEGEN_SELECTIONDAGADDRESSANALYSIS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Analysis/MemoryLocation.h"
 #include "llvm/CodeGen/SelectionDAGNodes.h"
 #include <cstdint>
@@ -59,7 +60,7 @@ public:
   // Returns true if `Other` and `*this` are both some offset from the same base
   // pointer. In that case, `Off` is set to the offset between `*this` and
   // `Other` (negative if `Other` is before `*this`).
-  bool equalBaseIndex(const BaseIndexOffset &Other, const SelectionDAG &DAG,
+  LLVM_ABI bool equalBaseIndex(const BaseIndexOffset &Other, const SelectionDAG &DAG,
                       int64_t &Off) const;
 
   bool equalBaseIndex(const BaseIndexOffset &Other,
@@ -70,7 +71,7 @@ public:
 
   // Returns true if `Other` (with size `OtherSize`) can be proven to be fully
   // contained in `*this` (with size `Size`).
-  bool contains(const SelectionDAG &DAG, int64_t BitSize,
+  LLVM_ABI bool contains(const SelectionDAG &DAG, int64_t BitSize,
                 const BaseIndexOffset &Other, int64_t OtherBitSize,
                 int64_t &BitOffset) const;
 
@@ -82,15 +83,15 @@ public:
 
   // Returns true `Op0` and `Op1` can be proven to alias/not alias, in
   // which case `IsAlias` is set to true/false.
-  static bool computeAliasing(const SDNode *Op0, const LocationSize NumBytes0,
+  LLVM_ABI static bool computeAliasing(const SDNode *Op0, const LocationSize NumBytes0,
                               const SDNode *Op1, const LocationSize NumBytes1,
                               const SelectionDAG &DAG, bool &IsAlias);
 
   /// Parses tree in N for base, index, offset addresses.
-  static BaseIndexOffset match(const SDNode *N, const SelectionDAG &DAG);
+  LLVM_ABI static BaseIndexOffset match(const SDNode *N, const SelectionDAG &DAG);
 
-  void print(raw_ostream& OS) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream& OS) const;
+  LLVM_ABI void dump() const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_CODEGEN_SELECTIONDAGNODES_H
 #define LLVM_CODEGEN_SELECTIONDAGNODES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
@@ -69,7 +70,7 @@ class SelectionDAG;
 class Type;
 class Value;
 
-void checkForCycles(const SDNode *N, const SelectionDAG *DAG = nullptr,
+LLVM_ABI void checkForCycles(const SDNode *N, const SelectionDAG *DAG = nullptr,
                     bool force = false);
 
 /// This represents a list of ValueType's that has been intern'd by
@@ -88,46 +89,46 @@ namespace ISD {
 /// If N is a BUILD_VECTOR or SPLAT_VECTOR node whose elements are all the
 /// same constant or undefined, return true and return the constant value in
 /// \p SplatValue.
-bool isConstantSplatVector(const SDNode *N, APInt &SplatValue);
+LLVM_ABI bool isConstantSplatVector(const SDNode *N, APInt &SplatValue);
 
 /// Return true if the specified node is a BUILD_VECTOR or SPLAT_VECTOR where
 /// all of the elements are ~0 or undef. If \p BuildVectorOnly is set to
 /// true, it only checks BUILD_VECTOR.
-bool isConstantSplatVectorAllOnes(const SDNode *N,
+LLVM_ABI bool isConstantSplatVectorAllOnes(const SDNode *N,
                                   bool BuildVectorOnly = false);
 
 /// Return true if the specified node is a BUILD_VECTOR or SPLAT_VECTOR where
 /// all of the elements are 0 or undef. If \p BuildVectorOnly is set to true, it
 /// only checks BUILD_VECTOR.
-bool isConstantSplatVectorAllZeros(const SDNode *N,
+LLVM_ABI bool isConstantSplatVectorAllZeros(const SDNode *N,
                                    bool BuildVectorOnly = false);
 
 /// Return true if the specified node is a BUILD_VECTOR where all of the
 /// elements are ~0 or undef.
-bool isBuildVectorAllOnes(const SDNode *N);
+LLVM_ABI bool isBuildVectorAllOnes(const SDNode *N);
 
 /// Return true if the specified node is a BUILD_VECTOR where all of the
 /// elements are 0 or undef.
-bool isBuildVectorAllZeros(const SDNode *N);
+LLVM_ABI bool isBuildVectorAllZeros(const SDNode *N);
 
 /// Return true if the specified node is a BUILD_VECTOR node of all
 /// ConstantSDNode or undef.
-bool isBuildVectorOfConstantSDNodes(const SDNode *N);
+LLVM_ABI bool isBuildVectorOfConstantSDNodes(const SDNode *N);
 
 /// Return true if the specified node is a BUILD_VECTOR node of all
 /// ConstantFPSDNode or undef.
-bool isBuildVectorOfConstantFPSDNodes(const SDNode *N);
+LLVM_ABI bool isBuildVectorOfConstantFPSDNodes(const SDNode *N);
 
 /// Returns true if the specified node is a vector where all elements can
 /// be truncated to the specified element size without a loss in meaning.
-bool isVectorShrinkable(const SDNode *N, unsigned NewEltSize, bool Signed);
+LLVM_ABI bool isVectorShrinkable(const SDNode *N, unsigned NewEltSize, bool Signed);
 
 /// Return true if the node has at least one operand and all operands of the
 /// specified node are ISD::UNDEF.
-bool allOperandsUndef(const SDNode *N);
+LLVM_ABI bool allOperandsUndef(const SDNode *N);
 
 /// Return true if the specified node is FREEZE(UNDEF).
-bool isFreezeUndef(const SDNode *N);
+LLVM_ABI bool isFreezeUndef(const SDNode *N);
 
 } // end namespace ISD
 
@@ -181,7 +182,7 @@ public:
   }
 
   /// Return true if this node is an operand of N.
-  bool isOperandOf(const SDNode *N) const;
+  LLVM_ABI bool isOperandOf(const SDNode *N) const;
 
   /// Return the ValueType of the referenced return value.
   inline EVT getValueType() const;
@@ -225,7 +226,7 @@ public:
   /// In practice, this looks through token factors and non-volatile loads.
   /// In order to remain efficient, this only
   /// looks a couple of nodes in, it does not do an exhaustive search.
-  bool reachesChainWithoutSideEffects(SDValue Dest,
+  LLVM_ABI bool reachesChainWithoutSideEffects(SDValue Dest,
                                       unsigned Depth = 2) const;
 
   /// Return true if there are no nodes using value ResNo of Node.
@@ -668,7 +669,7 @@ private:
   DebugLoc debugLoc;
 
   /// Return a pointer to the specified value type.
-  static const EVT *getValueTypeList(MVT VT);
+  LLVM_ABI static const EVT *getValueTypeList(MVT VT);
 
   /// Index in worklist of DAGCombiner, or negative if the node is not in the
   /// worklist. -1 = not in worklist; -2 = not in worklist, but has already been
@@ -899,13 +900,13 @@ public:
 
   /// Return true if there are any use of the indicated value.
   /// This method ignores uses of other values defined by this operation.
-  bool hasAnyUseOfValue(unsigned Value) const;
+  LLVM_ABI bool hasAnyUseOfValue(unsigned Value) const;
 
   /// Return true if this node is the only use of N.
-  bool isOnlyUserOf(const SDNode *N) const;
+  LLVM_ABI bool isOnlyUserOf(const SDNode *N) const;
 
   /// Return true if this node is an operand of N.
-  bool isOperandOf(const SDNode *N) const;
+  LLVM_ABI bool isOperandOf(const SDNode *N) const;
 
   /// Return true if this node is a predecessor of N.
   /// NOTE: Implemented on top of hasPredecessor and every bit as
@@ -918,7 +919,7 @@ public:
   /// N is either an operand of this node, or can be reached by recursively
   /// traversing up the operands.
   /// NOTE: This is an expensive method. Use it carefully.
-  bool hasPredecessor(const SDNode *N) const;
+  LLVM_ABI bool hasPredecessor(const SDNode *N) const;
 
   /// Returns true if N is a predecessor of any node in Worklist. This
   /// helper keeps Visited and Worklist sets externally to allow unions
@@ -985,7 +986,7 @@ public:
 
   /// Return true if all the users of N are contained in Nodes.
   /// NOTE: Requires at least one match, but doesn't require them all.
-  static bool areOnlyUsersOf(ArrayRef<const SDNode *> Nodes, const SDNode *N);
+  LLVM_ABI static bool areOnlyUsersOf(ArrayRef<const SDNode *> Nodes, const SDNode *N);
 
   /// Return the number of values used by this operation.
   unsigned getNumOperands() const { return NumOperands; }
@@ -1066,7 +1067,7 @@ public:
 
   /// Clear any flags in this node that aren't also set in Flags.
   /// If Flags is not in a defined state then this has no effect.
-  void intersectFlagsWith(const SDNodeFlags Flags);
+  LLVM_ABI void intersectFlagsWith(const SDNodeFlags Flags);
 
   bool hasPoisonGeneratingFlags() const {
     return Flags.Flags & SDNodeFlags::PoisonGeneratingFlags;
@@ -1107,12 +1108,12 @@ public:
   }
 
   /// Return the opcode of this operation for printing.
-  std::string getOperationName(const SelectionDAG *G = nullptr) const;
-  static const char* getIndexedModeName(ISD::MemIndexedMode AM);
-  void print_types(raw_ostream &OS, const SelectionDAG *G) const;
-  void print_details(raw_ostream &OS, const SelectionDAG *G) const;
-  void print(raw_ostream &OS, const SelectionDAG *G = nullptr) const;
-  void printr(raw_ostream &OS, const SelectionDAG *G = nullptr) const;
+  LLVM_ABI std::string getOperationName(const SelectionDAG *G = nullptr) const;
+  LLVM_ABI static const char* getIndexedModeName(ISD::MemIndexedMode AM);
+  LLVM_ABI void print_types(raw_ostream &OS, const SelectionDAG *G) const;
+  LLVM_ABI void print_details(raw_ostream &OS, const SelectionDAG *G) const;
+  LLVM_ABI void print(raw_ostream &OS, const SelectionDAG *G = nullptr) const;
+  LLVM_ABI void printr(raw_ostream &OS, const SelectionDAG *G = nullptr) const;
 
   /// Print a SelectionDAG node and all children down to
   /// the leaves.  The given SelectionDAG allows target-specific nodes
@@ -1120,7 +1121,7 @@ public:
   /// print the whole DAG, including children that appear multiple
   /// times.
   ///
-  void printrFull(raw_ostream &O, const SelectionDAG *G = nullptr) const;
+  LLVM_ABI void printrFull(raw_ostream &O, const SelectionDAG *G = nullptr) const;
 
   /// Print a SelectionDAG node and children up to
   /// depth "depth."  The given SelectionDAG allows target-specific
@@ -1128,41 +1129,41 @@ public:
   /// will print children that appear multiple times wherever they are
   /// used.
   ///
-  void printrWithDepth(raw_ostream &O, const SelectionDAG *G = nullptr,
+  LLVM_ABI void printrWithDepth(raw_ostream &O, const SelectionDAG *G = nullptr,
                        unsigned depth = 100) const;
 
   /// Dump this node, for debugging.
-  void dump() const;
+  LLVM_ABI void dump() const;
 
   /// Dump (recursively) this node and its use-def subgraph.
-  void dumpr() const;
+  LLVM_ABI void dumpr() const;
 
   /// Dump this node, for debugging.
   /// The given SelectionDAG allows target-specific nodes to be printed
   /// in human-readable form.
-  void dump(const SelectionDAG *G) const;
+  LLVM_ABI void dump(const SelectionDAG *G) const;
 
   /// Dump (recursively) this node and its use-def subgraph.
   /// The given SelectionDAG allows target-specific nodes to be printed
   /// in human-readable form.
-  void dumpr(const SelectionDAG *G) const;
+  LLVM_ABI void dumpr(const SelectionDAG *G) const;
 
   /// printrFull to dbgs().  The given SelectionDAG allows
   /// target-specific nodes to be printed in human-readable form.
   /// Unlike dumpr, this will print the whole DAG, including children
   /// that appear multiple times.
-  void dumprFull(const SelectionDAG *G = nullptr) const;
+  LLVM_ABI void dumprFull(const SelectionDAG *G = nullptr) const;
 
   /// printrWithDepth to dbgs().  The given
   /// SelectionDAG allows target-specific nodes to be printed in
   /// human-readable form.  Unlike dumpr, this will print children
   /// that appear multiple times wherever they are used.
   ///
-  void dumprWithDepth(const SelectionDAG *G = nullptr,
+  LLVM_ABI void dumprWithDepth(const SelectionDAG *G = nullptr,
                       unsigned depth = 100) const;
 
   /// Gather unique data for the node.
-  void Profile(FoldingSetNodeID &ID) const;
+  LLVM_ABI void Profile(FoldingSetNodeID &ID) const;
 
   /// This method should only be used by the SDUse class.
   void addUse(SDUse &U) { U.addToList(&UseList); }
@@ -1187,7 +1188,7 @@ protected:
   }
 
   /// Release the operands and set this node to have zero operands.
-  void DropOperands();
+  LLVM_ABI void DropOperands();
 };
 
 /// Wrapper class for IR location info (IR ordering and DebugLoc) to be passed
@@ -1344,7 +1345,7 @@ public:
     NumOperands = 1;
     OperandList = &Op;
   }
-  ~HandleSDNode();
+  LLVM_ABI ~HandleSDNode();
 
   const SDValue &getValue() const { return Op; }
 };
@@ -1379,7 +1380,7 @@ protected:
   MachineMemOperand *MMO;
 
 public:
-  MemSDNode(unsigned Opc, unsigned Order, const DebugLoc &dl, SDVTList VTs,
+  LLVM_ABI MemSDNode(unsigned Opc, unsigned Order, const DebugLoc &dl, SDVTList VTs,
             EVT memvt, MachineMemOperand *MMO);
 
   bool readMem() const { return MMO->isLoad(); }
@@ -1671,7 +1672,7 @@ public:
 
   int getSplatIndex() const { return getSplatMaskIndex(getMask()); }
 
-  static bool isSplatMask(ArrayRef<int> Mask);
+  LLVM_ABI static bool isSplatMask(ArrayRef<int> Mask);
 
   static int getSplatMaskIndex(ArrayRef<int> Mask) {
     assert(isSplatMask(Mask) && "Cannot get splat index for non-splat!");
@@ -1798,9 +1799,9 @@ public:
   bool isExactlyValue(double V) const {
     return Value->getValueAPF().isExactlyValue(V);
   }
-  bool isExactlyValue(const APFloat& V) const;
+  LLVM_ABI bool isExactlyValue(const APFloat& V) const;
 
-  static bool isValueValidForType(EVT VT, const APFloat& Val);
+  LLVM_ABI static bool isValueValidForType(EVT VT, const APFloat& Val);
 
   static bool classof(const SDNode *N) {
     return N->getOpcode() == ISD::ConstantFP ||
@@ -1817,87 +1818,87 @@ std::optional<APInt> SDNode::bitcastToAPInt() const {
 }
 
 /// Returns true if \p V is a constant integer zero.
-bool isNullConstant(SDValue V);
+LLVM_ABI bool isNullConstant(SDValue V);
 
 /// Returns true if \p V is a constant integer zero or an UNDEF node.
-bool isNullConstantOrUndef(SDValue V);
+LLVM_ABI bool isNullConstantOrUndef(SDValue V);
 
 /// Returns true if \p V is an FP constant with a value of positive zero.
-bool isNullFPConstant(SDValue V);
+LLVM_ABI bool isNullFPConstant(SDValue V);
 
 /// Returns true if \p V is an integer constant with all bits set.
-bool isAllOnesConstant(SDValue V);
+LLVM_ABI bool isAllOnesConstant(SDValue V);
 
 /// Returns true if \p V is a constant integer one.
-bool isOneConstant(SDValue V);
+LLVM_ABI bool isOneConstant(SDValue V);
 
 /// Returns true if \p V is a constant min signed integer value.
-bool isMinSignedConstant(SDValue V);
+LLVM_ABI bool isMinSignedConstant(SDValue V);
 
 /// Returns true if \p V is a neutral element of Opc with Flags.
 /// When OperandNo is 0, it checks that V is a left identity. Otherwise, it
 /// checks that V is a right identity.
-bool isNeutralConstant(unsigned Opc, SDNodeFlags Flags, SDValue V,
+LLVM_ABI bool isNeutralConstant(unsigned Opc, SDNodeFlags Flags, SDValue V,
                        unsigned OperandNo);
 
 /// Return the non-bitcasted source operand of \p V if it exists.
 /// If \p V is not a bitcasted value, it is returned as-is.
-SDValue peekThroughBitcasts(SDValue V);
+LLVM_ABI SDValue peekThroughBitcasts(SDValue V);
 
 /// Return the non-bitcasted and one-use source operand of \p V if it exists.
 /// If \p V is not a bitcasted one-use value, it is returned as-is.
-SDValue peekThroughOneUseBitcasts(SDValue V);
+LLVM_ABI SDValue peekThroughOneUseBitcasts(SDValue V);
 
 /// Return the non-extracted vector source operand of \p V if it exists.
 /// If \p V is not an extracted subvector, it is returned as-is.
-SDValue peekThroughExtractSubvectors(SDValue V);
+LLVM_ABI SDValue peekThroughExtractSubvectors(SDValue V);
 
 /// Return the non-truncated source operand of \p V if it exists.
 /// If \p V is not a truncation, it is returned as-is.
-SDValue peekThroughTruncates(SDValue V);
+LLVM_ABI SDValue peekThroughTruncates(SDValue V);
 
 /// Returns true if \p V is a bitwise not operation. Assumes that an all ones
 /// constant is canonicalized to be operand 1.
-bool isBitwiseNot(SDValue V, bool AllowUndefs = false);
+LLVM_ABI bool isBitwiseNot(SDValue V, bool AllowUndefs = false);
 
 /// If \p V is a bitwise not, returns the inverted operand. Otherwise returns
 /// an empty SDValue. Only bits set in \p Mask are required to be inverted,
 /// other bits may be arbitrary.
-SDValue getBitwiseNotOperand(SDValue V, SDValue Mask, bool AllowUndefs);
+LLVM_ABI SDValue getBitwiseNotOperand(SDValue V, SDValue Mask, bool AllowUndefs);
 
 /// Returns the SDNode if it is a constant splat BuildVector or constant int.
-ConstantSDNode *isConstOrConstSplat(SDValue N, bool AllowUndefs = false,
+LLVM_ABI ConstantSDNode *isConstOrConstSplat(SDValue N, bool AllowUndefs = false,
                                     bool AllowTruncation = false);
 
 /// Returns the SDNode if it is a demanded constant splat BuildVector or
 /// constant int.
-ConstantSDNode *isConstOrConstSplat(SDValue N, const APInt &DemandedElts,
+LLVM_ABI ConstantSDNode *isConstOrConstSplat(SDValue N, const APInt &DemandedElts,
                                     bool AllowUndefs = false,
                                     bool AllowTruncation = false);
 
 /// Returns the SDNode if it is a constant splat BuildVector or constant float.
-ConstantFPSDNode *isConstOrConstSplatFP(SDValue N, bool AllowUndefs = false);
+LLVM_ABI ConstantFPSDNode *isConstOrConstSplatFP(SDValue N, bool AllowUndefs = false);
 
 /// Returns the SDNode if it is a demanded constant splat BuildVector or
 /// constant float.
-ConstantFPSDNode *isConstOrConstSplatFP(SDValue N, const APInt &DemandedElts,
+LLVM_ABI ConstantFPSDNode *isConstOrConstSplatFP(SDValue N, const APInt &DemandedElts,
                                         bool AllowUndefs = false);
 
 /// Return true if the value is a constant 0 integer or a splatted vector of
 /// a constant 0 integer (with no undefs by default).
 /// Build vector implicit truncation is not an issue for null values.
-bool isNullOrNullSplat(SDValue V, bool AllowUndefs = false);
+LLVM_ABI bool isNullOrNullSplat(SDValue V, bool AllowUndefs = false);
 
 /// Return true if the value is a constant 1 integer or a splatted vector of a
 /// constant 1 integer (with no undefs).
 /// Build vector implicit truncation is allowed, but the truncated bits need to
 /// be zero.
-bool isOneOrOneSplat(SDValue V, bool AllowUndefs = false);
+LLVM_ABI bool isOneOrOneSplat(SDValue V, bool AllowUndefs = false);
 
 /// Return true if the value is a constant -1 integer or a splatted vector of a
 /// constant -1 integer (with no undefs).
 /// Does not permit build vector implicit truncation.
-bool isAllOnesOrAllOnesSplat(SDValue V, bool AllowUndefs = false);
+LLVM_ABI bool isAllOnesOrAllOnesSplat(SDValue V, bool AllowUndefs = false);
 
 /// Return true if \p V is either a integer or FP constant.
 inline bool isIntOrFPConstant(SDValue V) {
@@ -1922,7 +1923,7 @@ public:
   int64_t getOffset() const { return Offset; }
   unsigned getTargetFlags() const { return TargetFlags; }
   // Return the address space this GlobalAddress belongs to.
-  unsigned getAddressSpace() const;
+  LLVM_ABI unsigned getAddressSpace() const;
 
   static bool classof(const SDNode *N) {
     return N->getOpcode() == ISD::GlobalAddress ||
@@ -2084,7 +2085,7 @@ public:
   Align getAlign() const { return Alignment; }
   unsigned getTargetFlags() const { return TargetFlags; }
 
-  Type *getType() const;
+  LLVM_ABI Type *getType() const;
 
   static bool classof(const SDNode *N) {
     return N->getOpcode() == ISD::ConstantPool ||
@@ -2149,7 +2150,7 @@ public:
   /// are set.  The SplatBitSize value is set to the splat element size in
   /// bits.  HasAnyUndefs is set to true if any bits in the vector are
   /// undefined.  isBigEndian describes the endianness of the target.
-  bool isConstantSplat(APInt &SplatValue, APInt &SplatUndef,
+  LLVM_ABI bool isConstantSplat(APInt &SplatValue, APInt &SplatUndef,
                        unsigned &SplatBitSize, bool &HasAnyUndefs,
                        unsigned MinSplatBits = 0,
                        bool isBigEndian = false) const;
@@ -2160,14 +2161,14 @@ public:
   /// The DemandedElts mask indicates the elements that must be in the splat.
   /// If passed a non-null UndefElements bitvector, it will resize it to match
   /// the vector width and set the bits where elements are undef.
-  SDValue getSplatValue(const APInt &DemandedElts,
+  LLVM_ABI SDValue getSplatValue(const APInt &DemandedElts,
                         BitVector *UndefElements = nullptr) const;
 
   /// Returns the splatted value or a null value if this is not a splat.
   ///
   /// If passed a non-null UndefElements bitvector, it will resize it to match
   /// the vector width and set the bits where elements are undef.
-  SDValue getSplatValue(BitVector *UndefElements = nullptr) const;
+  LLVM_ABI SDValue getSplatValue(BitVector *UndefElements = nullptr) const;
 
   /// Find the shortest repeating sequence of values in the build vector.
   ///
@@ -2180,7 +2181,7 @@ public:
   /// non-null UndefElements bitvector, it will resize it to match the original
   /// vector width and set the bits where elements are undef. If result is
   /// false, Sequence will be empty.
-  bool getRepeatedSequence(const APInt &DemandedElts,
+  LLVM_ABI bool getRepeatedSequence(const APInt &DemandedElts,
                            SmallVectorImpl<SDValue> &Sequence,
                            BitVector *UndefElements = nullptr) const;
 
@@ -2193,7 +2194,7 @@ public:
   /// If passed a non-null UndefElements bitvector, it will resize it to match
   /// the original vector width and set the bits where elements are undef.
   /// If result is false, Sequence will be empty.
-  bool getRepeatedSequence(SmallVectorImpl<SDValue> &Sequence,
+  LLVM_ABI bool getRepeatedSequence(SmallVectorImpl<SDValue> &Sequence,
                            BitVector *UndefElements = nullptr) const;
 
   /// Returns the demanded splatted constant or null if this is not a constant
@@ -2202,7 +2203,7 @@ public:
   /// The DemandedElts mask indicates the elements that must be in the splat.
   /// If passed a non-null UndefElements bitvector, it will resize it to match
   /// the vector width and set the bits where elements are undef.
-  ConstantSDNode *
+  LLVM_ABI ConstantSDNode *
   getConstantSplatNode(const APInt &DemandedElts,
                        BitVector *UndefElements = nullptr) const;
 
@@ -2211,7 +2212,7 @@ public:
   ///
   /// If passed a non-null UndefElements bitvector, it will resize it to match
   /// the vector width and set the bits where elements are undef.
-  ConstantSDNode *
+  LLVM_ABI ConstantSDNode *
   getConstantSplatNode(BitVector *UndefElements = nullptr) const;
 
   /// Returns the demanded splatted constant FP or null if this is not a
@@ -2220,7 +2221,7 @@ public:
   /// The DemandedElts mask indicates the elements that must be in the splat.
   /// If passed a non-null UndefElements bitvector, it will resize it to match
   /// the vector width and set the bits where elements are undef.
-  ConstantFPSDNode *
+  LLVM_ABI ConstantFPSDNode *
   getConstantFPSplatNode(const APInt &DemandedElts,
                          BitVector *UndefElements = nullptr) const;
 
@@ -2229,7 +2230,7 @@ public:
   ///
   /// If passed a non-null UndefElements bitvector, it will resize it to match
   /// the vector width and set the bits where elements are undef.
-  ConstantFPSDNode *
+  LLVM_ABI ConstantFPSDNode *
   getConstantFPSplatNode(BitVector *UndefElements = nullptr) const;
 
   /// If this is a constant FP splat and the splatted constant FP is an
@@ -2237,28 +2238,28 @@ public:
   /// return -1.
   ///
   /// The BitWidth specifies the necessary bit precision.
-  int32_t getConstantFPSplatPow2ToLog2Int(BitVector *UndefElements,
+  LLVM_ABI int32_t getConstantFPSplatPow2ToLog2Int(BitVector *UndefElements,
                                           uint32_t BitWidth) const;
 
   /// Extract the raw bit data from a build vector of Undef, Constant or
   /// ConstantFP node elements. Each raw bit element will be \p
   /// DstEltSizeInBits wide, undef elements are treated as zero, and entirely
   /// undefined elements are flagged in \p UndefElements.
-  bool getConstantRawBits(bool IsLittleEndian, unsigned DstEltSizeInBits,
+  LLVM_ABI bool getConstantRawBits(bool IsLittleEndian, unsigned DstEltSizeInBits,
                           SmallVectorImpl<APInt> &RawBitElements,
                           BitVector &UndefElements) const;
 
-  bool isConstant() const;
+  LLVM_ABI bool isConstant() const;
 
   /// If this BuildVector is constant and represents the numerical series
   /// "<a, a+n, a+2n, a+3n, ...>" where a is integer and n is a non-zero integer,
   /// the value "<a,n>" is returned.
-  std::optional<std::pair<APInt, APInt>> isConstantSequence() const;
+  LLVM_ABI std::optional<std::pair<APInt, APInt>> isConstantSequence() const;
 
   /// Recast bit data \p SrcBitElements to \p DstEltSizeInBits wide elements.
   /// Undef elements are treated as zero, and entirely undefined elements are
   /// flagged in \p DstUndefElements.
-  static void recastRawBits(bool IsLittleEndian, unsigned DstEltSizeInBits,
+  LLVM_ABI static void recastRawBits(bool IsLittleEndian, unsigned DstEltSizeInBits,
                             SmallVectorImpl<APInt> &DstBitElements,
                             ArrayRef<APInt> SrcBitElements,
                             BitVector &DstUndefElements,
@@ -3313,7 +3314,7 @@ namespace ISD {
   /// constants or every element of a pair of constant BUILD_VECTORs.
   /// If AllowUndef is true, then UNDEF elements will pass nullptr to Match.
   /// If AllowTypeMismatch is true then RetType + ArgTypes don't need to match.
-  bool matchBinaryPredicate(
+  LLVM_ABI bool matchBinaryPredicate(
       SDValue LHS, SDValue RHS,
       std::function<bool(ConstantSDNode *, ConstantSDNode *)> Match,
       bool AllowUndefs = false, bool AllowTypeMismatch = false);

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -18,7 +18,6 @@
 #ifndef LLVM_CODEGEN_SELECTIONDAGNODES_H
 #define LLVM_CODEGEN_SELECTIONDAGNODES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
@@ -43,6 +42,7 @@
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/AtomicOrdering.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TypeSize.h"
 #include <algorithm>
@@ -71,7 +71,7 @@ class Type;
 class Value;
 
 LLVM_ABI void checkForCycles(const SDNode *N, const SelectionDAG *DAG = nullptr,
-                    bool force = false);
+                             bool force = false);
 
 /// This represents a list of ValueType's that has been intern'd by
 /// a SelectionDAG.  Instances of this simple value class are returned by
@@ -95,13 +95,13 @@ LLVM_ABI bool isConstantSplatVector(const SDNode *N, APInt &SplatValue);
 /// all of the elements are ~0 or undef. If \p BuildVectorOnly is set to
 /// true, it only checks BUILD_VECTOR.
 LLVM_ABI bool isConstantSplatVectorAllOnes(const SDNode *N,
-                                  bool BuildVectorOnly = false);
+                                           bool BuildVectorOnly = false);
 
 /// Return true if the specified node is a BUILD_VECTOR or SPLAT_VECTOR where
 /// all of the elements are 0 or undef. If \p BuildVectorOnly is set to true, it
 /// only checks BUILD_VECTOR.
 LLVM_ABI bool isConstantSplatVectorAllZeros(const SDNode *N,
-                                   bool BuildVectorOnly = false);
+                                            bool BuildVectorOnly = false);
 
 /// Return true if the specified node is a BUILD_VECTOR where all of the
 /// elements are ~0 or undef.
@@ -121,7 +121,8 @@ LLVM_ABI bool isBuildVectorOfConstantFPSDNodes(const SDNode *N);
 
 /// Returns true if the specified node is a vector where all elements can
 /// be truncated to the specified element size without a loss in meaning.
-LLVM_ABI bool isVectorShrinkable(const SDNode *N, unsigned NewEltSize, bool Signed);
+LLVM_ABI bool isVectorShrinkable(const SDNode *N, unsigned NewEltSize,
+                                 bool Signed);
 
 /// Return true if the node has at least one operand and all operands of the
 /// specified node are ISD::UNDEF.
@@ -227,7 +228,7 @@ public:
   /// In order to remain efficient, this only
   /// looks a couple of nodes in, it does not do an exhaustive search.
   LLVM_ABI bool reachesChainWithoutSideEffects(SDValue Dest,
-                                      unsigned Depth = 2) const;
+                                               unsigned Depth = 2) const;
 
   /// Return true if there are no nodes using value ResNo of Node.
   inline bool use_empty() const;
@@ -986,7 +987,8 @@ public:
 
   /// Return true if all the users of N are contained in Nodes.
   /// NOTE: Requires at least one match, but doesn't require them all.
-  LLVM_ABI static bool areOnlyUsersOf(ArrayRef<const SDNode *> Nodes, const SDNode *N);
+  LLVM_ABI static bool areOnlyUsersOf(ArrayRef<const SDNode *> Nodes,
+                                      const SDNode *N);
 
   /// Return the number of values used by this operation.
   unsigned getNumOperands() const { return NumOperands; }
@@ -1109,7 +1111,7 @@ public:
 
   /// Return the opcode of this operation for printing.
   LLVM_ABI std::string getOperationName(const SelectionDAG *G = nullptr) const;
-  LLVM_ABI static const char* getIndexedModeName(ISD::MemIndexedMode AM);
+  LLVM_ABI static const char *getIndexedModeName(ISD::MemIndexedMode AM);
   LLVM_ABI void print_types(raw_ostream &OS, const SelectionDAG *G) const;
   LLVM_ABI void print_details(raw_ostream &OS, const SelectionDAG *G) const;
   LLVM_ABI void print(raw_ostream &OS, const SelectionDAG *G = nullptr) const;
@@ -1121,7 +1123,8 @@ public:
   /// print the whole DAG, including children that appear multiple
   /// times.
   ///
-  LLVM_ABI void printrFull(raw_ostream &O, const SelectionDAG *G = nullptr) const;
+  LLVM_ABI void printrFull(raw_ostream &O,
+                           const SelectionDAG *G = nullptr) const;
 
   /// Print a SelectionDAG node and children up to
   /// depth "depth."  The given SelectionDAG allows target-specific
@@ -1130,7 +1133,7 @@ public:
   /// used.
   ///
   LLVM_ABI void printrWithDepth(raw_ostream &O, const SelectionDAG *G = nullptr,
-                       unsigned depth = 100) const;
+                                unsigned depth = 100) const;
 
   /// Dump this node, for debugging.
   LLVM_ABI void dump() const;
@@ -1160,7 +1163,7 @@ public:
   /// that appear multiple times wherever they are used.
   ///
   LLVM_ABI void dumprWithDepth(const SelectionDAG *G = nullptr,
-                      unsigned depth = 100) const;
+                               unsigned depth = 100) const;
 
   /// Gather unique data for the node.
   LLVM_ABI void Profile(FoldingSetNodeID &ID) const;
@@ -1380,8 +1383,8 @@ protected:
   MachineMemOperand *MMO;
 
 public:
-  LLVM_ABI MemSDNode(unsigned Opc, unsigned Order, const DebugLoc &dl, SDVTList VTs,
-            EVT memvt, MachineMemOperand *MMO);
+  LLVM_ABI MemSDNode(unsigned Opc, unsigned Order, const DebugLoc &dl,
+                     SDVTList VTs, EVT memvt, MachineMemOperand *MMO);
 
   bool readMem() const { return MMO->isLoad(); }
   bool writeMem() const { return MMO->isStore(); }
@@ -1799,9 +1802,9 @@ public:
   bool isExactlyValue(double V) const {
     return Value->getValueAPF().isExactlyValue(V);
   }
-  LLVM_ABI bool isExactlyValue(const APFloat& V) const;
+  LLVM_ABI bool isExactlyValue(const APFloat &V) const;
 
-  LLVM_ABI static bool isValueValidForType(EVT VT, const APFloat& Val);
+  LLVM_ABI static bool isValueValidForType(EVT VT, const APFloat &Val);
 
   static bool classof(const SDNode *N) {
     return N->getOpcode() == ISD::ConstantFP ||
@@ -1839,7 +1842,7 @@ LLVM_ABI bool isMinSignedConstant(SDValue V);
 /// When OperandNo is 0, it checks that V is a left identity. Otherwise, it
 /// checks that V is a right identity.
 LLVM_ABI bool isNeutralConstant(unsigned Opc, SDNodeFlags Flags, SDValue V,
-                       unsigned OperandNo);
+                                unsigned OperandNo);
 
 /// Return the non-bitcasted source operand of \p V if it exists.
 /// If \p V is not a bitcasted value, it is returned as-is.
@@ -1864,25 +1867,30 @@ LLVM_ABI bool isBitwiseNot(SDValue V, bool AllowUndefs = false);
 /// If \p V is a bitwise not, returns the inverted operand. Otherwise returns
 /// an empty SDValue. Only bits set in \p Mask are required to be inverted,
 /// other bits may be arbitrary.
-LLVM_ABI SDValue getBitwiseNotOperand(SDValue V, SDValue Mask, bool AllowUndefs);
+LLVM_ABI SDValue getBitwiseNotOperand(SDValue V, SDValue Mask,
+                                      bool AllowUndefs);
 
 /// Returns the SDNode if it is a constant splat BuildVector or constant int.
-LLVM_ABI ConstantSDNode *isConstOrConstSplat(SDValue N, bool AllowUndefs = false,
-                                    bool AllowTruncation = false);
+LLVM_ABI ConstantSDNode *isConstOrConstSplat(SDValue N,
+                                             bool AllowUndefs = false,
+                                             bool AllowTruncation = false);
 
 /// Returns the SDNode if it is a demanded constant splat BuildVector or
 /// constant int.
-LLVM_ABI ConstantSDNode *isConstOrConstSplat(SDValue N, const APInt &DemandedElts,
-                                    bool AllowUndefs = false,
-                                    bool AllowTruncation = false);
+LLVM_ABI ConstantSDNode *isConstOrConstSplat(SDValue N,
+                                             const APInt &DemandedElts,
+                                             bool AllowUndefs = false,
+                                             bool AllowTruncation = false);
 
 /// Returns the SDNode if it is a constant splat BuildVector or constant float.
-LLVM_ABI ConstantFPSDNode *isConstOrConstSplatFP(SDValue N, bool AllowUndefs = false);
+LLVM_ABI ConstantFPSDNode *isConstOrConstSplatFP(SDValue N,
+                                                 bool AllowUndefs = false);
 
 /// Returns the SDNode if it is a demanded constant splat BuildVector or
 /// constant float.
-LLVM_ABI ConstantFPSDNode *isConstOrConstSplatFP(SDValue N, const APInt &DemandedElts,
-                                        bool AllowUndefs = false);
+LLVM_ABI ConstantFPSDNode *isConstOrConstSplatFP(SDValue N,
+                                                 const APInt &DemandedElts,
+                                                 bool AllowUndefs = false);
 
 /// Return true if the value is a constant 0 integer or a splatted vector of
 /// a constant 0 integer (with no undefs by default).
@@ -2151,9 +2159,9 @@ public:
   /// bits.  HasAnyUndefs is set to true if any bits in the vector are
   /// undefined.  isBigEndian describes the endianness of the target.
   LLVM_ABI bool isConstantSplat(APInt &SplatValue, APInt &SplatUndef,
-                       unsigned &SplatBitSize, bool &HasAnyUndefs,
-                       unsigned MinSplatBits = 0,
-                       bool isBigEndian = false) const;
+                                unsigned &SplatBitSize, bool &HasAnyUndefs,
+                                unsigned MinSplatBits = 0,
+                                bool isBigEndian = false) const;
 
   /// Returns the demanded splatted value or a null value if this is not a
   /// splat.
@@ -2162,7 +2170,7 @@ public:
   /// If passed a non-null UndefElements bitvector, it will resize it to match
   /// the vector width and set the bits where elements are undef.
   LLVM_ABI SDValue getSplatValue(const APInt &DemandedElts,
-                        BitVector *UndefElements = nullptr) const;
+                                 BitVector *UndefElements = nullptr) const;
 
   /// Returns the splatted value or a null value if this is not a splat.
   ///
@@ -2182,8 +2190,8 @@ public:
   /// vector width and set the bits where elements are undef. If result is
   /// false, Sequence will be empty.
   LLVM_ABI bool getRepeatedSequence(const APInt &DemandedElts,
-                           SmallVectorImpl<SDValue> &Sequence,
-                           BitVector *UndefElements = nullptr) const;
+                                    SmallVectorImpl<SDValue> &Sequence,
+                                    BitVector *UndefElements = nullptr) const;
 
   /// Find the shortest repeating sequence of values in the build vector.
   ///
@@ -2195,7 +2203,7 @@ public:
   /// the original vector width and set the bits where elements are undef.
   /// If result is false, Sequence will be empty.
   LLVM_ABI bool getRepeatedSequence(SmallVectorImpl<SDValue> &Sequence,
-                           BitVector *UndefElements = nullptr) const;
+                                    BitVector *UndefElements = nullptr) const;
 
   /// Returns the demanded splatted constant or null if this is not a constant
   /// splat.
@@ -2239,15 +2247,16 @@ public:
   ///
   /// The BitWidth specifies the necessary bit precision.
   LLVM_ABI int32_t getConstantFPSplatPow2ToLog2Int(BitVector *UndefElements,
-                                          uint32_t BitWidth) const;
+                                                   uint32_t BitWidth) const;
 
   /// Extract the raw bit data from a build vector of Undef, Constant or
   /// ConstantFP node elements. Each raw bit element will be \p
   /// DstEltSizeInBits wide, undef elements are treated as zero, and entirely
   /// undefined elements are flagged in \p UndefElements.
-  LLVM_ABI bool getConstantRawBits(bool IsLittleEndian, unsigned DstEltSizeInBits,
-                          SmallVectorImpl<APInt> &RawBitElements,
-                          BitVector &UndefElements) const;
+  LLVM_ABI bool getConstantRawBits(bool IsLittleEndian,
+                                   unsigned DstEltSizeInBits,
+                                   SmallVectorImpl<APInt> &RawBitElements,
+                                   BitVector &UndefElements) const;
 
   LLVM_ABI bool isConstant() const;
 
@@ -2259,11 +2268,12 @@ public:
   /// Recast bit data \p SrcBitElements to \p DstEltSizeInBits wide elements.
   /// Undef elements are treated as zero, and entirely undefined elements are
   /// flagged in \p DstUndefElements.
-  LLVM_ABI static void recastRawBits(bool IsLittleEndian, unsigned DstEltSizeInBits,
-                            SmallVectorImpl<APInt> &DstBitElements,
-                            ArrayRef<APInt> SrcBitElements,
-                            BitVector &DstUndefElements,
-                            const BitVector &SrcUndefElements);
+  LLVM_ABI static void recastRawBits(bool IsLittleEndian,
+                                     unsigned DstEltSizeInBits,
+                                     SmallVectorImpl<APInt> &DstBitElements,
+                                     ArrayRef<APInt> SrcBitElements,
+                                     BitVector &DstUndefElements,
+                                     const BitVector &SrcUndefElements);
 
   static bool classof(const SDNode *N) {
     return N->getOpcode() == ISD::BUILD_VECTOR;

--- a/llvm/include/llvm/CodeGen/SlotIndexes.h
+++ b/llvm/include/llvm/CodeGen/SlotIndexes.h
@@ -18,7 +18,6 @@
 #ifndef LLVM_CODEGEN_SLOTINDEXES_H
 #define LLVM_CODEGEN_SLOTINDEXES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ADT/PointerIntPair.h"
@@ -31,6 +30,7 @@
 #include "llvm/CodeGen/MachineInstrBundle.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <cassert>
 #include <iterator>
@@ -356,8 +356,8 @@ class raw_ostream;
 
     /// Repair indexes after adding and removing instructions.
     LLVM_ABI void repairIndexesInRange(MachineBasicBlock *MBB,
-                              MachineBasicBlock::iterator Begin,
-                              MachineBasicBlock::iterator End);
+                                       MachineBasicBlock::iterator Begin,
+                                       MachineBasicBlock::iterator End);
 
     /// Returns the zero index for this analysis.
     SlotIndex getZeroIndex() {
@@ -576,7 +576,7 @@ class raw_ostream;
     /// instruction; however, this exists to support handleMoveIntoBundle,
     /// and in general removeSingleMachineInstrFromMaps should be used instead.
     LLVM_ABI void removeMachineInstrFromMaps(MachineInstr &MI,
-                                    bool AllowBundled = false);
+                                             bool AllowBundled = false);
 
     /// Removes a single machine instruction \p MI from the mapping.
     /// This should be called before MachineInstr::eraseFromBundle() is used to
@@ -657,7 +657,7 @@ class raw_ostream;
   public:
     explicit SlotIndexesPrinterPass(raw_ostream &OS) : OS(OS) {}
     LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                          MachineFunctionAnalysisManager &MFAM);
+                                   MachineFunctionAnalysisManager &MFAM);
     static bool isRequired() { return true; }
   };
 

--- a/llvm/include/llvm/CodeGen/SlotIndexes.h
+++ b/llvm/include/llvm/CodeGen/SlotIndexes.h
@@ -644,7 +644,7 @@ class raw_ostream;
 
   class SlotIndexesAnalysis : public AnalysisInfoMixin<SlotIndexesAnalysis> {
     friend AnalysisInfoMixin<SlotIndexesAnalysis>;
-    static AnalysisKey Key;
+    LLVM_ABI static AnalysisKey Key;
 
   public:
     using Result = SlotIndexes;

--- a/llvm/include/llvm/CodeGen/SlotIndexes.h
+++ b/llvm/include/llvm/CodeGen/SlotIndexes.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_CODEGEN_SLOTINDEXES_H
 #define LLVM_CODEGEN_SLOTINDEXES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ADT/PointerIntPair.h"
@@ -135,10 +136,10 @@ class raw_ostream;
     explicit operator bool() const { return isValid(); }
 
     /// Print this index to the given raw_ostream.
-    void print(raw_ostream &os) const;
+    LLVM_ABI void print(raw_ostream &os) const;
 
     /// Dump this index to stderr.
-    void dump() const;
+    LLVM_ABI void dump() const;
 
     /// Compare two SlotIndex objects for equality.
     bool operator==(SlotIndex other) const {
@@ -319,9 +320,9 @@ class raw_ostream;
     // For legacy pass manager.
     SlotIndexes() = default;
 
-    void clear();
+    LLVM_ABI void clear();
 
-    void analyze(MachineFunction &MF);
+    LLVM_ABI void analyze(MachineFunction &MF);
 
     IndexListEntry* createEntry(MachineInstr *mi, unsigned index) {
       IndexListEntry *entry =
@@ -334,27 +335,27 @@ class raw_ostream;
     }
 
     /// Renumber locally after inserting curItr.
-    void renumberIndexes(IndexList::iterator curItr);
+    LLVM_ABI void renumberIndexes(IndexList::iterator curItr);
 
   public:
     SlotIndexes(SlotIndexes &&) = default;
 
     SlotIndexes(MachineFunction &MF) { analyze(MF); }
 
-    ~SlotIndexes();
+    LLVM_ABI ~SlotIndexes();
 
     void reanalyze(MachineFunction &MF) {
       clear();
       analyze(MF);
     }
 
-    void print(raw_ostream &OS) const;
+    LLVM_ABI void print(raw_ostream &OS) const;
 
     /// Dump the indexes.
-    void dump() const;
+    LLVM_ABI void dump() const;
 
     /// Repair indexes after adding and removing instructions.
-    void repairIndexesInRange(MachineBasicBlock *MBB,
+    LLVM_ABI void repairIndexesInRange(MachineBasicBlock *MBB,
                               MachineBasicBlock::iterator Begin,
                               MachineBasicBlock::iterator End);
 
@@ -574,13 +575,13 @@ class raw_ostream;
     /// If \p AllowBundled is set then this can be used on a bundled
     /// instruction; however, this exists to support handleMoveIntoBundle,
     /// and in general removeSingleMachineInstrFromMaps should be used instead.
-    void removeMachineInstrFromMaps(MachineInstr &MI,
+    LLVM_ABI void removeMachineInstrFromMaps(MachineInstr &MI,
                                     bool AllowBundled = false);
 
     /// Removes a single machine instruction \p MI from the mapping.
     /// This should be called before MachineInstr::eraseFromBundle() is used to
     /// remove a single instruction (out of a bundle).
-    void removeSingleMachineInstrFromMaps(MachineInstr &MI);
+    LLVM_ABI void removeSingleMachineInstrFromMaps(MachineInstr &MI);
 
     /// ReplaceMachineInstrInMaps - Replacing a machine instr with a new one in
     /// maps used by register allocator. \returns the index where the new
@@ -633,7 +634,7 @@ class raw_ostream;
     }
 
     /// Renumber all indexes using the default instruction distance.
-    void packIndexes();
+    LLVM_ABI void packIndexes();
   };
 
   // Specialize IntervalMapInfo for half-open slot index intervals.
@@ -647,7 +648,7 @@ class raw_ostream;
 
   public:
     using Result = SlotIndexes;
-    Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
+    LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
   };
 
   class SlotIndexesPrinterPass : public PassInfoMixin<SlotIndexesPrinterPass> {
@@ -655,12 +656,12 @@ class raw_ostream;
 
   public:
     explicit SlotIndexesPrinterPass(raw_ostream &OS) : OS(OS) {}
-    PreservedAnalyses run(MachineFunction &MF,
+    LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                           MachineFunctionAnalysisManager &MFAM);
     static bool isRequired() { return true; }
   };
 
-  class SlotIndexesWrapperPass : public MachineFunctionPass {
+  class LLVM_ABI SlotIndexesWrapperPass : public MachineFunctionPass {
     SlotIndexes SI;
 
   public:

--- a/llvm/include/llvm/CodeGen/StackMaps.h
+++ b/llvm/include/llvm/CodeGen/StackMaps.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_CODEGEN_STACKMAPS_H
 #define LLVM_CODEGEN_STACKMAPS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/IR/CallingConv.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include <algorithm>
 #include <cassert>
@@ -297,7 +297,8 @@ public:
 
   /// Get index of next meta operand.
   /// Similar to parseOperand, but does not actually parses operand meaning.
-  LLVM_ABI static unsigned getNextMetaArgIdx(const MachineInstr *MI, unsigned CurIdx);
+  LLVM_ABI static unsigned getNextMetaArgIdx(const MachineInstr *MI,
+                                             unsigned CurIdx);
 
   void reset() {
     CSInfos.clear();
@@ -336,16 +337,13 @@ public:
   /// Generate a stackmap record for a stackmap instruction.
   ///
   /// MI must be a raw STACKMAP, not a PATCHPOINT.
-  LLVM_ABI void recordStackMap(const MCSymbol &L,
-                      const MachineInstr &MI);
+  LLVM_ABI void recordStackMap(const MCSymbol &L, const MachineInstr &MI);
 
   /// Generate a stackmap record for a patchpoint instruction.
-  LLVM_ABI void recordPatchPoint(const MCSymbol &L,
-                        const MachineInstr &MI);
+  LLVM_ABI void recordPatchPoint(const MCSymbol &L, const MachineInstr &MI);
 
   /// Generate a stackmap record for a statepoint instruction.
-  LLVM_ABI void recordStatepoint(const MCSymbol &L,
-                        const MachineInstr &MI);
+  LLVM_ABI void recordStatepoint(const MCSymbol &L, const MachineInstr &MI);
 
   /// If there is any stack map data, create a stack map section and serialize
   /// the map info into it. This clears the stack map data structures

--- a/llvm/include/llvm/CodeGen/StackMaps.h
+++ b/llvm/include/llvm/CodeGen/StackMaps.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CODEGEN_STACKMAPS_H
 #define LLVM_CODEGEN_STACKMAPS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/MachineInstr.h"
@@ -41,7 +42,7 @@ private:
   const MachineInstr* MI;
 
 public:
-  explicit StackMapOpers(const MachineInstr *MI);
+  LLVM_ABI explicit StackMapOpers(const MachineInstr *MI);
 
   /// Return the ID for the given stackmap
   uint64_t getID() const { return MI->getOperand(IDPos).getImm(); }
@@ -92,7 +93,7 @@ private:
   }
 
 public:
-  explicit PatchPointOpers(const MachineInstr *MI);
+  LLVM_ABI explicit PatchPointOpers(const MachineInstr *MI);
 
   bool isAnyReg() const { return (getCallingConv() == CallingConv::AnyReg); }
   bool hasDef() const { return HasDef; }
@@ -137,7 +138,7 @@ public:
   }
 
   /// Get the next scratch register operand index.
-  unsigned getNextScratchIdx(unsigned StartIdx = 0) const;
+  LLVM_ABI unsigned getNextScratchIdx(unsigned StartIdx = 0) const;
 };
 
 /// MI-level Statepoint operands
@@ -226,30 +227,30 @@ public:
   }
 
   /// Get index of number of gc map entries.
-  unsigned getNumGcMapEntriesIdx();
+  LLVM_ABI unsigned getNumGcMapEntriesIdx();
 
   /// Get index of number of gc allocas.
-  unsigned getNumAllocaIdx();
+  LLVM_ABI unsigned getNumAllocaIdx();
 
   /// Get index of number of GC pointers.
-  unsigned getNumGCPtrIdx();
+  LLVM_ABI unsigned getNumGCPtrIdx();
 
   /// Get index of first GC pointer operand of -1 if there are none.
-  int getFirstGCPtrIdx();
+  LLVM_ABI int getFirstGCPtrIdx();
 
   /// Get vector of base/derived pairs from statepoint.
   /// Elements are indices into GC Pointer operand list (logical).
   /// Returns number of elements in GCMap.
-  unsigned
+  LLVM_ABI unsigned
   getGCPointerMap(SmallVectorImpl<std::pair<unsigned, unsigned>> &GCMap);
 
   /// Return true if Reg is used only in operands which can be folded to
   /// stack usage.
-  bool isFoldableReg(Register Reg) const;
+  LLVM_ABI bool isFoldableReg(Register Reg) const;
 
   /// Return true if Reg is used only in operands of MI which can be folded to
   /// stack usage and MI is a statepoint instruction.
-  static bool isFoldableReg(const MachineInstr *MI, Register Reg);
+  LLVM_ABI static bool isFoldableReg(const MachineInstr *MI, Register Reg);
 
 private:
   const MachineInstr *MI;
@@ -292,11 +293,11 @@ public:
   // OpParser.
   using OpType = enum { DirectMemRefOp, IndirectMemRefOp, ConstantOp };
 
-  StackMaps(AsmPrinter &AP);
+  LLVM_ABI StackMaps(AsmPrinter &AP);
 
   /// Get index of next meta operand.
   /// Similar to parseOperand, but does not actually parses operand meaning.
-  static unsigned getNextMetaArgIdx(const MachineInstr *MI, unsigned CurIdx);
+  LLVM_ABI static unsigned getNextMetaArgIdx(const MachineInstr *MI, unsigned CurIdx);
 
   void reset() {
     CSInfos.clear();
@@ -335,21 +336,21 @@ public:
   /// Generate a stackmap record for a stackmap instruction.
   ///
   /// MI must be a raw STACKMAP, not a PATCHPOINT.
-  void recordStackMap(const MCSymbol &L,
+  LLVM_ABI void recordStackMap(const MCSymbol &L,
                       const MachineInstr &MI);
 
   /// Generate a stackmap record for a patchpoint instruction.
-  void recordPatchPoint(const MCSymbol &L,
+  LLVM_ABI void recordPatchPoint(const MCSymbol &L,
                         const MachineInstr &MI);
 
   /// Generate a stackmap record for a statepoint instruction.
-  void recordStatepoint(const MCSymbol &L,
+  LLVM_ABI void recordStatepoint(const MCSymbol &L,
                         const MachineInstr &MI);
 
   /// If there is any stack map data, create a stack map section and serialize
   /// the map info into it. This clears the stack map data structures
   /// afterwards.
-  void serializeToStackMapSection();
+  LLVM_ABI void serializeToStackMapSection();
 
   /// Get call site info.
   CallsiteInfoList &getCSInfos() { return CSInfos; }
@@ -410,7 +411,7 @@ private:
   /// Emit the callsite info for each stackmap/patchpoint intrinsic call.
   void emitCallsiteEntries(MCStreamer &OS);
 
-  void print(raw_ostream &OS);
+  LLVM_ABI void print(raw_ostream &OS);
   void debug() { print(dbgs()); }
 };
 

--- a/llvm/include/llvm/CodeGen/TargetFrameLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetFrameLowering.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_CODEGEN_TARGETFRAMELOWERING_H
 #define LLVM_CODEGEN_TARGETFRAMELOWERING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/TypeSize.h"
 #include <vector>
 

--- a/llvm/include/llvm/CodeGen/TargetFrameLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetFrameLowering.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_TARGETFRAMELOWERING_H
 #define LLVM_CODEGEN_TARGETFRAMELOWERING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
@@ -42,7 +43,7 @@ enum Value {
 /// The offset to the local area is the offset from the stack pointer on
 /// function entry to the first location where function data (local variables,
 /// spill locations) can be stored.
-class TargetFrameLowering {
+class LLVM_ABI TargetFrameLowering {
 public:
   enum StackDirection {
     StackGrowsUp,        // Adding to the stack increases the stack address

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CODEGEN_TARGETINSTRINFO_H
 #define LLVM_CODEGEN_TARGETINSTRINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
@@ -31,6 +30,7 @@
 #include "llvm/CodeGen/VirtRegMap.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/Support/BranchProbability.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TypeSize.h"
 #include <array>

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_TARGETINSTRINFO_H
 #define LLVM_CODEGEN_TARGETINSTRINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
@@ -110,7 +111,7 @@ struct ExtAddrMode {
 ///
 /// TargetInstrInfo - Interface to description of machine instruction set
 ///
-class TargetInstrInfo : public MCInstrInfo {
+class LLVM_ABI TargetInstrInfo : public MCInstrInfo {
 public:
   TargetInstrInfo(unsigned CFSetupOpcode = ~0u, unsigned CFDestroyOpcode = ~0u,
                   unsigned CatchRetOpcode = ~0u, unsigned ReturnOpcode = ~0u)
@@ -759,7 +760,7 @@ public:
   /// Object returned by analyzeLoopForPipelining. Allows software pipelining
   /// implementations to query attributes of the loop being pipelined and to
   /// apply target-specific updates to the loop once pipelining is complete.
-  class PipelinerLoopInfo {
+  class LLVM_ABI PipelinerLoopInfo {
   public:
     virtual ~PipelinerLoopInfo();
     /// Return true if the given instruction should not be pipelined and should

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -22,7 +22,6 @@
 #ifndef LLVM_CODEGEN_TARGETLOWERING_H
 #define LLVM_CODEGEN_TARGETLOWERING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -51,6 +50,7 @@
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/AtomicOrdering.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/KnownFPClass.h"
 #include <algorithm>
@@ -4371,9 +4371,11 @@ public:
     bool isCalledByLegalizer() const { return CalledByLegalizer; }
 
     LLVM_ABI void AddToWorklist(SDNode *N);
-    LLVM_ABI SDValue CombineTo(SDNode *N, ArrayRef<SDValue> To, bool AddTo = true);
+    LLVM_ABI SDValue CombineTo(SDNode *N, ArrayRef<SDValue> To,
+                               bool AddTo = true);
     LLVM_ABI SDValue CombineTo(SDNode *N, SDValue Res, bool AddTo = true);
-    LLVM_ABI SDValue CombineTo(SDNode *N, SDValue Res0, SDValue Res1, bool AddTo = true);
+    LLVM_ABI SDValue CombineTo(SDNode *N, SDValue Res0, SDValue Res1,
+                               bool AddTo = true);
 
     LLVM_ABI bool recursivelyDeleteUnusedNodes(SDNode *N);
 
@@ -5809,9 +5811,10 @@ private:
 /// Given an LLVM IR type and return type attributes, compute the return value
 /// EVTs and flags, and optionally also the offsets, if the return value is
 /// being lowered to memory.
-LLVM_ABI void GetReturnInfo(CallingConv::ID CC, Type *ReturnType, AttributeList attr,
-                   SmallVectorImpl<ISD::OutputArg> &Outs,
-                   const TargetLowering &TLI, const DataLayout &DL);
+LLVM_ABI void GetReturnInfo(CallingConv::ID CC, Type *ReturnType,
+                            AttributeList attr,
+                            SmallVectorImpl<ISD::OutputArg> &Outs,
+                            const TargetLowering &TLI, const DataLayout &DL);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -22,6 +22,7 @@
 #ifndef LLVM_CODEGEN_TARGETLOWERING_H
 #define LLVM_CODEGEN_TARGETLOWERING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -194,7 +195,7 @@ public:
 
 /// This base class for TargetLowering contains the SelectionDAG-independent
 /// parts that can be used from the rest of CodeGen.
-class TargetLoweringBase {
+class LLVM_ABI TargetLoweringBase {
 public:
   /// This enum indicates whether operations are valid for a target, and if not,
   /// what action should be used to make them valid.
@@ -326,7 +327,7 @@ public:
           IsSwiftSelf(false), IsSwiftAsync(false), IsSwiftError(false),
           IsCFGuardTarget(false) {}
 
-    void setAttributes(const CallBase *Call, unsigned ArgIdx);
+    LLVM_ABI void setAttributes(const CallBase *Call, unsigned ArgIdx);
   };
   using ArgListTy = std::vector<ArgListEntry>;
 
@@ -3897,7 +3898,7 @@ protected:
 ///
 /// This class also defines callbacks that targets must implement to lower
 /// target-specific constructs to SelectionDAG operators.
-class TargetLowering : public TargetLoweringBase {
+class LLVM_ABI TargetLowering : public TargetLoweringBase {
 public:
   struct DAGCombinerInfo;
   struct MakeLibCallOptions;
@@ -4369,14 +4370,14 @@ public:
     CombineLevel getDAGCombineLevel() { return Level; }
     bool isCalledByLegalizer() const { return CalledByLegalizer; }
 
-    void AddToWorklist(SDNode *N);
-    SDValue CombineTo(SDNode *N, ArrayRef<SDValue> To, bool AddTo = true);
-    SDValue CombineTo(SDNode *N, SDValue Res, bool AddTo = true);
-    SDValue CombineTo(SDNode *N, SDValue Res0, SDValue Res1, bool AddTo = true);
+    LLVM_ABI void AddToWorklist(SDNode *N);
+    LLVM_ABI SDValue CombineTo(SDNode *N, ArrayRef<SDValue> To, bool AddTo = true);
+    LLVM_ABI SDValue CombineTo(SDNode *N, SDValue Res, bool AddTo = true);
+    LLVM_ABI SDValue CombineTo(SDNode *N, SDValue Res0, SDValue Res1, bool AddTo = true);
 
-    bool recursivelyDeleteUnusedNodes(SDNode *N);
+    LLVM_ABI bool recursivelyDeleteUnusedNodes(SDNode *N);
 
-    void CommitTargetLoweringOpt(const TargetLoweringOpt &TLO);
+    LLVM_ABI void CommitTargetLoweringOpt(const TargetLoweringOpt &TLO);
   };
 
   /// Return if the N is a constant or constant vector equal to the true value
@@ -5132,11 +5133,11 @@ public:
 
     /// Return true of this is an input operand that is a matching constraint
     /// like "4".
-    bool isMatchingInputConstraint() const;
+    LLVM_ABI bool isMatchingInputConstraint() const;
 
     /// If this is an input matching constraint, this method returns the output
     /// operand it matches.
-    unsigned getMatchedOperand() const;
+    LLVM_ABI unsigned getMatchedOperand() const;
   };
 
   using AsmOperandInfoVector = std::vector<AsmOperandInfo>;
@@ -5808,7 +5809,7 @@ private:
 /// Given an LLVM IR type and return type attributes, compute the return value
 /// EVTs and flags, and optionally also the offsets, if the return value is
 /// being lowered to memory.
-void GetReturnInfo(CallingConv::ID CC, Type *ReturnType, AttributeList attr,
+LLVM_ABI void GetReturnInfo(CallingConv::ID CC, Type *ReturnType, AttributeList attr,
                    SmallVectorImpl<ISD::OutputArg> &Outs,
                    const TargetLowering &TLI, const DataLayout &DL);
 

--- a/llvm/include/llvm/CodeGen/TargetPassConfig.h
+++ b/llvm/include/llvm/CodeGen/TargetPassConfig.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_TARGETPASSCONFIG_H
 #define LLVM_CODEGEN_TARGETPASSCONFIG_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Error.h"
@@ -80,7 +81,7 @@ public:
 ///
 /// This is an ImmutablePass solely for the purpose of exposing CodeGen options
 /// to the internals of other CodeGen passes.
-class TargetPassConfig : public ImmutablePass {
+class LLVM_ABI TargetPassConfig : public ImmutablePass {
 private:
   PassManagerBase *PM = nullptr;
   AnalysisID StartBefore = nullptr;
@@ -474,7 +475,7 @@ protected:
   virtual bool addRegAssignAndRewriteOptimized();
 };
 
-void registerCodeGenCallback(PassInstrumentationCallbacks &PIC,
+LLVM_ABI void registerCodeGenCallback(PassInstrumentationCallbacks &PIC,
                              TargetMachine &);
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/TargetPassConfig.h
+++ b/llvm/include/llvm/CodeGen/TargetPassConfig.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_CODEGEN_TARGETPASSCONFIG_H
 #define LLVM_CODEGEN_TARGETPASSCONFIG_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cassert>
 #include <string>
@@ -476,7 +476,7 @@ protected:
 };
 
 LLVM_ABI void registerCodeGenCallback(PassInstrumentationCallbacks &PIC,
-                             TargetMachine &);
+                                      TargetMachine &);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -15,7 +15,6 @@
 #ifndef LLVM_CODEGEN_TARGETREGISTERINFO_H
 #define LLVM_CODEGEN_TARGETREGISTERINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -25,6 +24,7 @@
 #include "llvm/IR/CallingConv.h"
 #include "llvm/MC/LaneBitmask.h"
 #include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Printable.h"
@@ -1405,9 +1405,10 @@ struct VirtReg2IndexFunctor {
 ///   %physreg17      - a physical register when no TRI instance given.
 ///
 /// Usage: OS << printReg(Reg, TRI, SubRegIdx) << '\n';
-LLVM_ABI Printable printReg(Register Reg, const TargetRegisterInfo *TRI = nullptr,
-                   unsigned SubIdx = 0,
-                   const MachineRegisterInfo *MRI = nullptr);
+LLVM_ABI Printable printReg(Register Reg,
+                            const TargetRegisterInfo *TRI = nullptr,
+                            unsigned SubIdx = 0,
+                            const MachineRegisterInfo *MRI = nullptr);
 
 /// Create Printable object to print register units on a \ref raw_ostream.
 ///
@@ -1421,12 +1422,14 @@ LLVM_ABI Printable printRegUnit(unsigned Unit, const TargetRegisterInfo *TRI);
 
 /// Create Printable object to print virtual registers and physical
 /// registers on a \ref raw_ostream.
-LLVM_ABI Printable printVRegOrUnit(unsigned VRegOrUnit, const TargetRegisterInfo *TRI);
+LLVM_ABI Printable printVRegOrUnit(unsigned VRegOrUnit,
+                                   const TargetRegisterInfo *TRI);
 
 /// Create Printable object to print register classes or register banks
 /// on a \ref raw_ostream.
-LLVM_ABI Printable printRegClassOrBank(Register Reg, const MachineRegisterInfo &RegInfo,
-                              const TargetRegisterInfo *TRI);
+LLVM_ABI Printable printRegClassOrBank(Register Reg,
+                                       const MachineRegisterInfo &RegInfo,
+                                       const TargetRegisterInfo *TRI);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_TARGETREGISTERINFO_H
 #define LLVM_CODEGEN_TARGETREGISTERINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -232,7 +233,7 @@ struct RegClassWeight {
 /// to this array so that we can turn register number into a register
 /// descriptor.
 ///
-class TargetRegisterInfo : public MCRegisterInfo {
+class LLVM_ABI TargetRegisterInfo : public MCRegisterInfo {
 public:
   using regclass_iterator = const TargetRegisterClass * const *;
   using vt_iterator = const MVT::SimpleValueType *;
@@ -1404,7 +1405,7 @@ struct VirtReg2IndexFunctor {
 ///   %physreg17      - a physical register when no TRI instance given.
 ///
 /// Usage: OS << printReg(Reg, TRI, SubRegIdx) << '\n';
-Printable printReg(Register Reg, const TargetRegisterInfo *TRI = nullptr,
+LLVM_ABI Printable printReg(Register Reg, const TargetRegisterInfo *TRI = nullptr,
                    unsigned SubIdx = 0,
                    const MachineRegisterInfo *MRI = nullptr);
 
@@ -1416,15 +1417,15 @@ Printable printReg(Register Reg, const TargetRegisterInfo *TRI = nullptr,
 ///   fp0~st7 - Dual roots.
 ///
 /// Usage: OS << printRegUnit(Unit, TRI) << '\n';
-Printable printRegUnit(unsigned Unit, const TargetRegisterInfo *TRI);
+LLVM_ABI Printable printRegUnit(unsigned Unit, const TargetRegisterInfo *TRI);
 
 /// Create Printable object to print virtual registers and physical
 /// registers on a \ref raw_ostream.
-Printable printVRegOrUnit(unsigned VRegOrUnit, const TargetRegisterInfo *TRI);
+LLVM_ABI Printable printVRegOrUnit(unsigned VRegOrUnit, const TargetRegisterInfo *TRI);
 
 /// Create Printable object to print register classes or register banks
 /// on a \ref raw_ostream.
-Printable printRegClassOrBank(Register Reg, const MachineRegisterInfo &RegInfo,
+LLVM_ABI Printable printRegClassOrBank(Register Reg, const MachineRegisterInfo &RegInfo,
                               const TargetRegisterInfo *TRI);
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/TargetSchedule.h
+++ b/llvm/include/llvm/CodeGen/TargetSchedule.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CODEGEN_TARGETSCHEDULE_H
 #define LLVM_CODEGEN_TARGETSCHEDULE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/Config/llvm-config.h"
@@ -63,11 +64,11 @@ public:
   /// The machine model API keeps a copy of the top-level MCSchedModel table
   /// indices and may query TargetSubtargetInfo and TargetInstrInfo to resolve
   /// dynamic properties.
-  void init(const TargetSubtargetInfo *TSInfo, bool EnableSModel = true,
+  LLVM_ABI void init(const TargetSubtargetInfo *TSInfo, bool EnableSModel = true,
             bool EnableSItins = true);
 
   /// Return the MCSchedClassDesc for this instruction.
-  const MCSchedClassDesc *resolveSchedClass(const MachineInstr *MI) const;
+  LLVM_ABI const MCSchedClassDesc *resolveSchedClass(const MachineInstr *MI) const;
 
   /// TargetSubtargetInfo getter.
   const TargetSubtargetInfo *getSubtargetInfo() const { return STI; }
@@ -80,7 +81,7 @@ public:
   ///
   /// This is more detailed than the course grain IssueWidth and default
   /// latency properties, but separate from the per-cycle itinerary data.
-  bool hasInstrSchedModel() const;
+  LLVM_ABI bool hasInstrSchedModel() const;
 
   const MCSchedModel *getMCSchedModel() const { return &SchedModel; }
 
@@ -88,7 +89,7 @@ public:
   /// data.
   ///
   /// This models scheduling at each stage in the processor pipeline.
-  bool hasInstrItineraries() const;
+  LLVM_ABI bool hasInstrItineraries() const;
 
   const InstrItineraryData *getInstrItineraries() const {
     if (hasInstrItineraries())
@@ -101,7 +102,7 @@ public:
   bool hasInstrSchedModelOrItineraries() const {
     return hasInstrSchedModel() || hasInstrItineraries();
   }
-  bool enableIntervals() const;
+  LLVM_ABI bool enableIntervals() const;
   /// Identify the processor corresponding to the current subtarget.
   unsigned getProcessorID() const { return SchedModel.getProcessorID(); }
 
@@ -109,14 +110,14 @@ public:
   unsigned getIssueWidth() const { return SchedModel.IssueWidth; }
 
   /// Return true if new group must begin.
-  bool mustBeginGroup(const MachineInstr *MI,
+  LLVM_ABI bool mustBeginGroup(const MachineInstr *MI,
                           const MCSchedClassDesc *SC = nullptr) const;
   /// Return true if current group must end.
-  bool mustEndGroup(const MachineInstr *MI,
+  LLVM_ABI bool mustEndGroup(const MachineInstr *MI,
                           const MCSchedClassDesc *SC = nullptr) const;
 
   /// Return the number of issue slots required for this MI.
-  unsigned getNumMicroOps(const MachineInstr *MI,
+  LLVM_ABI unsigned getNumMicroOps(const MachineInstr *MI,
                           const MCSchedClassDesc *SC = nullptr) const;
 
   /// Get the number of kinds of resources for this target.
@@ -181,7 +182,7 @@ public:
   /// Compute and return the latency of the given data dependent def and use
   /// when the operand indices are already known. UseMI may be NULL for an
   /// unknown user.
-  unsigned computeOperandLatency(const MachineInstr *DefMI, unsigned DefOperIdx,
+  LLVM_ABI unsigned computeOperandLatency(const MachineInstr *DefMI, unsigned DefOperIdx,
                                  const MachineInstr *UseMI, unsigned UseOperIdx)
     const;
 
@@ -196,22 +197,22 @@ public:
   /// present this method falls back to TII->getInstrLatency with an empty
   /// instruction itinerary (this is so we preserve the previous behavior of the
   /// if converter after moving it to TargetSchedModel).
-  unsigned computeInstrLatency(const MachineInstr *MI,
+  LLVM_ABI unsigned computeInstrLatency(const MachineInstr *MI,
                                bool UseDefaultDefLatency = true) const;
-  unsigned computeInstrLatency(const MCInst &Inst) const;
-  unsigned computeInstrLatency(unsigned Opcode) const;
+  LLVM_ABI unsigned computeInstrLatency(const MCInst &Inst) const;
+  LLVM_ABI unsigned computeInstrLatency(unsigned Opcode) const;
 
 
   /// Output dependency latency of a pair of defs of the same register.
   ///
   /// This is typically one cycle.
-  unsigned computeOutputLatency(const MachineInstr *DefMI, unsigned DefOperIdx,
+  LLVM_ABI unsigned computeOutputLatency(const MachineInstr *DefMI, unsigned DefOperIdx,
                                 const MachineInstr *DepMI) const;
 
   /// Compute the reciprocal throughput of the given instruction.
-  double computeReciprocalThroughput(const MachineInstr *MI) const;
-  double computeReciprocalThroughput(const MCInst &MI) const;
-  double computeReciprocalThroughput(unsigned Opcode) const;
+  LLVM_ABI double computeReciprocalThroughput(const MachineInstr *MI) const;
+  LLVM_ABI double computeReciprocalThroughput(const MCInst &MI) const;
+  LLVM_ABI double computeReciprocalThroughput(unsigned Opcode) const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/TargetSchedule.h
+++ b/llvm/include/llvm/CodeGen/TargetSchedule.h
@@ -15,12 +15,12 @@
 #ifndef LLVM_CODEGEN_TARGETSCHEDULE_H
 #define LLVM_CODEGEN_TARGETSCHEDULE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/MC/MCInstrItineraries.h"
 #include "llvm/MC/MCSchedule.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -64,11 +64,12 @@ public:
   /// The machine model API keeps a copy of the top-level MCSchedModel table
   /// indices and may query TargetSubtargetInfo and TargetInstrInfo to resolve
   /// dynamic properties.
-  LLVM_ABI void init(const TargetSubtargetInfo *TSInfo, bool EnableSModel = true,
-            bool EnableSItins = true);
+  LLVM_ABI void init(const TargetSubtargetInfo *TSInfo,
+                     bool EnableSModel = true, bool EnableSItins = true);
 
   /// Return the MCSchedClassDesc for this instruction.
-  LLVM_ABI const MCSchedClassDesc *resolveSchedClass(const MachineInstr *MI) const;
+  LLVM_ABI const MCSchedClassDesc *
+  resolveSchedClass(const MachineInstr *MI) const;
 
   /// TargetSubtargetInfo getter.
   const TargetSubtargetInfo *getSubtargetInfo() const { return STI; }
@@ -111,14 +112,14 @@ public:
 
   /// Return true if new group must begin.
   LLVM_ABI bool mustBeginGroup(const MachineInstr *MI,
-                          const MCSchedClassDesc *SC = nullptr) const;
+                               const MCSchedClassDesc *SC = nullptr) const;
   /// Return true if current group must end.
   LLVM_ABI bool mustEndGroup(const MachineInstr *MI,
-                          const MCSchedClassDesc *SC = nullptr) const;
+                             const MCSchedClassDesc *SC = nullptr) const;
 
   /// Return the number of issue slots required for this MI.
   LLVM_ABI unsigned getNumMicroOps(const MachineInstr *MI,
-                          const MCSchedClassDesc *SC = nullptr) const;
+                                   const MCSchedClassDesc *SC = nullptr) const;
 
   /// Get the number of kinds of resources for this target.
   unsigned getNumProcResourceKinds() const {
@@ -182,9 +183,10 @@ public:
   /// Compute and return the latency of the given data dependent def and use
   /// when the operand indices are already known. UseMI may be NULL for an
   /// unknown user.
-  LLVM_ABI unsigned computeOperandLatency(const MachineInstr *DefMI, unsigned DefOperIdx,
-                                 const MachineInstr *UseMI, unsigned UseOperIdx)
-    const;
+  LLVM_ABI unsigned computeOperandLatency(const MachineInstr *DefMI,
+                                          unsigned DefOperIdx,
+                                          const MachineInstr *UseMI,
+                                          unsigned UseOperIdx) const;
 
   /// Compute the instruction latency based on the available machine
   /// model.
@@ -198,16 +200,16 @@ public:
   /// instruction itinerary (this is so we preserve the previous behavior of the
   /// if converter after moving it to TargetSchedModel).
   LLVM_ABI unsigned computeInstrLatency(const MachineInstr *MI,
-                               bool UseDefaultDefLatency = true) const;
+                                        bool UseDefaultDefLatency = true) const;
   LLVM_ABI unsigned computeInstrLatency(const MCInst &Inst) const;
   LLVM_ABI unsigned computeInstrLatency(unsigned Opcode) const;
-
 
   /// Output dependency latency of a pair of defs of the same register.
   ///
   /// This is typically one cycle.
-  LLVM_ABI unsigned computeOutputLatency(const MachineInstr *DefMI, unsigned DefOperIdx,
-                                const MachineInstr *DepMI) const;
+  LLVM_ABI unsigned computeOutputLatency(const MachineInstr *DefMI,
+                                         unsigned DefOperIdx,
+                                         const MachineInstr *DepMI) const;
 
   /// Compute the reciprocal throughput of the given instruction.
   LLVM_ABI double computeReciprocalThroughput(const MachineInstr *MI) const;

--- a/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CODEGEN_TARGETSUBTARGETINFO_H
 #define LLVM_CODEGEN_TARGETSUBTARGETINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -23,6 +22,7 @@
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 #include <vector>
 

--- a/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_TARGETSUBTARGETINFO_H
 #define LLVM_CODEGEN_TARGETSUBTARGETINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -60,7 +61,7 @@ class Triple;
 /// Target-specific options that control code generation and printing should
 /// be exposed through a TargetSubtargetInfo-derived class.
 ///
-class TargetSubtargetInfo : public MCSubtargetInfo {
+class LLVM_ABI TargetSubtargetInfo : public MCSubtargetInfo {
 protected: // Can only create subclasses...
   TargetSubtargetInfo(const Triple &TT, StringRef CPU, StringRef TuneCPU,
                       StringRef FS, ArrayRef<StringRef> PN,

--- a/llvm/include/llvm/CodeGen/ValueTypes.h
+++ b/llvm/include/llvm/CodeGen/ValueTypes.h
@@ -534,10 +534,11 @@ namespace llvm {
     LLVM_ABI EVT changeExtendedVectorElementType(EVT EltVT) const;
     LLVM_ABI EVT changeExtendedVectorElementTypeToInteger() const;
     LLVM_ABI static EVT getExtendedIntegerVT(LLVMContext &C, unsigned BitWidth);
-    LLVM_ABI static EVT getExtendedVectorVT(LLVMContext &C, EVT VT, unsigned NumElements,
-                                   bool IsScalable);
+    LLVM_ABI static EVT getExtendedVectorVT(LLVMContext &C, EVT VT,
+                                            unsigned NumElements,
+                                            bool IsScalable);
     LLVM_ABI static EVT getExtendedVectorVT(LLVMContext &Context, EVT VT,
-                                   ElementCount EC);
+                                            ElementCount EC);
     LLVM_ABI bool isExtendedFloatingPoint() const LLVM_READONLY;
     LLVM_ABI bool isExtendedInteger() const LLVM_READONLY;
     LLVM_ABI bool isExtendedScalarInteger() const LLVM_READONLY;

--- a/llvm/include/llvm/CodeGen/ValueTypes.h
+++ b/llvm/include/llvm/CodeGen/ValueTypes.h
@@ -482,10 +482,10 @@ namespace llvm {
     }
 
     /// This function returns value type as a string, e.g. "i32".
-    std::string getEVTString() const;
+    LLVM_ABI std::string getEVTString() const;
 
     /// Support for debugging, callable in GDB: VT.dump()
-    void dump() const;
+    LLVM_ABI void dump() const;
 
     /// Implement operator<<.
     void print(raw_ostream &OS) const {
@@ -495,14 +495,14 @@ namespace llvm {
     /// This method returns an LLVM type corresponding to the specified EVT.
     /// For integer types, this returns an unsigned type. Note that this will
     /// abort for types that cannot be represented.
-    Type *getTypeForEVT(LLVMContext &Context) const;
+    LLVM_ABI Type *getTypeForEVT(LLVMContext &Context) const;
 
     /// Return the value type corresponding to the specified type.
     /// If HandleUnknown is true, unknown types are returned as Other,
     /// otherwise they are invalid.
     /// NB: This includes pointer types, which require a DataLayout to convert
     /// to a concrete value type.
-    static EVT getEVT(Type *Ty, bool HandleUnknown = false);
+    LLVM_ABI static EVT getEVT(Type *Ty, bool HandleUnknown = false);
 
     intptr_t getRawBits() const {
       if (isSimple())
@@ -524,38 +524,38 @@ namespace llvm {
 
     /// Returns an APFloat semantics tag appropriate for the value type. If this
     /// is a vector type, the element semantics are returned.
-    const fltSemantics &getFltSemantics() const;
+    LLVM_ABI const fltSemantics &getFltSemantics() const;
 
   private:
     // Methods for handling the Extended-type case in functions above.
     // These are all out-of-line to prevent users of this header file
     // from having a dependency on Type.h.
-    EVT changeExtendedTypeToInteger() const;
-    EVT changeExtendedVectorElementType(EVT EltVT) const;
-    EVT changeExtendedVectorElementTypeToInteger() const;
-    static EVT getExtendedIntegerVT(LLVMContext &C, unsigned BitWidth);
-    static EVT getExtendedVectorVT(LLVMContext &C, EVT VT, unsigned NumElements,
+    LLVM_ABI EVT changeExtendedTypeToInteger() const;
+    LLVM_ABI EVT changeExtendedVectorElementType(EVT EltVT) const;
+    LLVM_ABI EVT changeExtendedVectorElementTypeToInteger() const;
+    LLVM_ABI static EVT getExtendedIntegerVT(LLVMContext &C, unsigned BitWidth);
+    LLVM_ABI static EVT getExtendedVectorVT(LLVMContext &C, EVT VT, unsigned NumElements,
                                    bool IsScalable);
-    static EVT getExtendedVectorVT(LLVMContext &Context, EVT VT,
+    LLVM_ABI static EVT getExtendedVectorVT(LLVMContext &Context, EVT VT,
                                    ElementCount EC);
-    bool isExtendedFloatingPoint() const LLVM_READONLY;
-    bool isExtendedInteger() const LLVM_READONLY;
-    bool isExtendedScalarInteger() const LLVM_READONLY;
-    bool isExtendedVector() const LLVM_READONLY;
-    bool isExtended16BitVector() const LLVM_READONLY;
-    bool isExtended32BitVector() const LLVM_READONLY;
-    bool isExtended64BitVector() const LLVM_READONLY;
-    bool isExtended128BitVector() const LLVM_READONLY;
-    bool isExtended256BitVector() const LLVM_READONLY;
-    bool isExtended512BitVector() const LLVM_READONLY;
-    bool isExtended1024BitVector() const LLVM_READONLY;
-    bool isExtended2048BitVector() const LLVM_READONLY;
-    bool isExtendedFixedLengthVector() const LLVM_READONLY;
-    bool isExtendedScalableVector() const LLVM_READONLY;
-    EVT getExtendedVectorElementType() const;
-    unsigned getExtendedVectorNumElements() const LLVM_READONLY;
-    ElementCount getExtendedVectorElementCount() const LLVM_READONLY;
-    TypeSize getExtendedSizeInBits() const LLVM_READONLY;
+    LLVM_ABI bool isExtendedFloatingPoint() const LLVM_READONLY;
+    LLVM_ABI bool isExtendedInteger() const LLVM_READONLY;
+    LLVM_ABI bool isExtendedScalarInteger() const LLVM_READONLY;
+    LLVM_ABI bool isExtendedVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtended16BitVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtended32BitVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtended64BitVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtended128BitVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtended256BitVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtended512BitVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtended1024BitVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtended2048BitVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtendedFixedLengthVector() const LLVM_READONLY;
+    LLVM_ABI bool isExtendedScalableVector() const LLVM_READONLY;
+    LLVM_ABI EVT getExtendedVectorElementType() const;
+    LLVM_ABI unsigned getExtendedVectorNumElements() const LLVM_READONLY;
+    LLVM_ABI ElementCount getExtendedVectorElementCount() const LLVM_READONLY;
+    LLVM_ABI TypeSize getExtendedSizeInBits() const LLVM_READONLY;
   };
 
   inline raw_ostream &operator<<(raw_ostream &OS, const EVT &V) {

--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CODEGEN_VIRTREGMAP_H
 #define LLVM_CODEGEN_VIRTREGMAP_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
@@ -69,7 +70,7 @@ public:
   VirtRegMap &operator=(const VirtRegMap &) = delete;
   VirtRegMap(VirtRegMap &&) = default;
 
-  void init(MachineFunction &MF);
+  LLVM_ABI void init(MachineFunction &MF);
 
   MachineFunction &getMachineFunction() const {
     assert(MF && "getMachineFunction called before runOnMachineFunction");
@@ -79,7 +80,7 @@ public:
   MachineRegisterInfo &getRegInfo() const { return *MRI; }
   const TargetRegisterInfo &getTargetRegInfo() const { return *TRI; }
 
-  void grow();
+  LLVM_ABI void grow();
 
   /// returns true if the specified virtual register is
   /// mapped to a physical register
@@ -94,7 +95,7 @@ public:
 
   /// creates a mapping for the specified virtual register to
   /// the specified physical register
-  void assignVirt2Phys(Register virtReg, MCRegister physReg);
+  LLVM_ABI void assignVirt2Phys(Register virtReg, MCRegister physReg);
 
   bool isShapeMapEmpty() const { return Virt2ShapeMap.empty(); }
 
@@ -127,12 +128,12 @@ public:
   }
 
   /// returns true if VirtReg is assigned to its preferred physreg.
-  bool hasPreferredPhys(Register VirtReg) const;
+  LLVM_ABI bool hasPreferredPhys(Register VirtReg) const;
 
   /// returns true if VirtReg has a known preferred register.
   /// This returns false if VirtReg has a preference that is a virtual
   /// register that hasn't been assigned yet.
-  bool hasKnownPreference(Register VirtReg) const;
+  LLVM_ABI bool hasKnownPreference(Register VirtReg) const;
 
   /// records virtReg is a split live interval from SReg.
   void setIsSplitFromReg(Register virtReg, Register SReg) {
@@ -175,14 +176,14 @@ public:
 
   /// create a mapping for the specifed virtual register to
   /// the next available stack slot
-  int assignVirt2StackSlot(Register virtReg);
+  LLVM_ABI int assignVirt2StackSlot(Register virtReg);
 
   /// create a mapping for the specified virtual register to
   /// the specified stack slot
-  void assignVirt2StackSlot(Register virtReg, int SS);
+  LLVM_ABI void assignVirt2StackSlot(Register virtReg, int SS);
 
-  void print(raw_ostream &OS, const Module *M = nullptr) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &OS, const Module *M = nullptr) const;
+  LLVM_ABI void dump() const;
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const VirtRegMap &VRM) {
@@ -194,7 +195,7 @@ class VirtRegMapWrapperLegacy : public MachineFunctionPass {
   VirtRegMap VRM;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
 
   VirtRegMapWrapperLegacy() : MachineFunctionPass(ID) {}
 
@@ -223,7 +224,7 @@ class VirtRegMapAnalysis : public AnalysisInfoMixin<VirtRegMapAnalysis> {
 public:
   using Result = VirtRegMap;
 
-  VirtRegMap run(MachineFunction &MF, MachineFunctionAnalysisManager &MAM);
+  LLVM_ABI VirtRegMap run(MachineFunction &MF, MachineFunctionAnalysisManager &MAM);
 };
 
 class VirtRegMapPrinterPass : public PassInfoMixin<VirtRegMapPrinterPass> {
@@ -231,7 +232,7 @@ class VirtRegMapPrinterPass : public PassInfoMixin<VirtRegMapPrinterPass> {
 
 public:
   explicit VirtRegMapPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
@@ -242,12 +243,12 @@ class VirtRegRewriterPass : public PassInfoMixin<VirtRegRewriterPass> {
 public:
   VirtRegRewriterPass(bool ClearVirtRegs = true)
       : ClearVirtRegs(ClearVirtRegs) {}
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 
   static bool isRequired() { return true; }
 
-  void printPipeline(raw_ostream &OS, function_ref<StringRef(StringRef)>) const;
+  LLVM_ABI void printPipeline(raw_ostream &OS, function_ref<StringRef(StringRef)>) const;
 };
 
 } // end llvm namespace

--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -16,13 +16,13 @@
 #ifndef LLVM_CODEGEN_VIRTREGMAP_H
 #define LLVM_CODEGEN_VIRTREGMAP_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/CodeGen/TileShapeInfo.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 
 namespace llvm {
@@ -224,7 +224,8 @@ class VirtRegMapAnalysis : public AnalysisInfoMixin<VirtRegMapAnalysis> {
 public:
   using Result = VirtRegMap;
 
-  LLVM_ABI VirtRegMap run(MachineFunction &MF, MachineFunctionAnalysisManager &MAM);
+  LLVM_ABI VirtRegMap run(MachineFunction &MF,
+                          MachineFunctionAnalysisManager &MAM);
 };
 
 class VirtRegMapPrinterPass : public PassInfoMixin<VirtRegMapPrinterPass> {
@@ -233,7 +234,7 @@ class VirtRegMapPrinterPass : public PassInfoMixin<VirtRegMapPrinterPass> {
 public:
   explicit VirtRegMapPrinterPass(raw_ostream &OS) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
   static bool isRequired() { return true; }
 };
 
@@ -244,11 +245,12 @@ public:
   VirtRegRewriterPass(bool ClearVirtRegs = true)
       : ClearVirtRegs(ClearVirtRegs) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
 
   static bool isRequired() { return true; }
 
-  LLVM_ABI void printPipeline(raw_ostream &OS, function_ref<StringRef(StringRef)>) const;
+  LLVM_ABI void printPipeline(raw_ostream &OS,
+                              function_ref<StringRef(StringRef)>) const;
 };
 
 } // end llvm namespace

--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -219,7 +219,7 @@ public:
 
 class VirtRegMapAnalysis : public AnalysisInfoMixin<VirtRegMapAnalysis> {
   friend AnalysisInfoMixin<VirtRegMapAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
 public:
   using Result = VirtRegMap;

--- a/llvm/unittests/CodeGen/RegAllocScoreTest.cpp
+++ b/llvm/unittests/CodeGen/RegAllocScoreTest.cpp
@@ -24,17 +24,18 @@
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Triple.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
-extern cl::opt<double> CopyWeight;
-extern cl::opt<double> LoadWeight;
-extern cl::opt<double> StoreWeight;
-extern cl::opt<double> CheapRematWeight;
-extern cl::opt<double> ExpensiveRematWeight;
+LLVM_ABI extern cl::opt<double> CopyWeight;
+LLVM_ABI extern cl::opt<double> LoadWeight;
+LLVM_ABI extern cl::opt<double> StoreWeight;
+LLVM_ABI extern cl::opt<double> CheapRematWeight;
+LLVM_ABI extern cl::opt<double> ExpensiveRematWeight;
 
 namespace {
 // Include helper functions to ease the manipulation of MachineFunctions.


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/CGData` and `llvm/CodeGen` libraries. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS on Linux:
- Add `LLVM_ABI` to a subset of private class methods and fields that require export
- Add `LLVM_TEMPLATE_ABI` and `LLVM_EXPORT_TEMPLATE` to exported instantiated templates defined via X-macro
- Add `LLVM_ABI_FRIEND` to friend member functions declared with `LLVM_ABI`
- Explicitly make classes non-copyable where needed to due IDS adding LLVM_ABI at the class level
- Add `#include "llvm/Support/Compiler.h"` to files where it was not auto-added by IDS due to no pre-existing block of include statements.
- Add `LLVM_ABI` to a small number of symbols that require export but are not declared in headers

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang