### PR TITLE
[LLVM][IR] Replace `unsigned >= ConstantDataFirstVal` with static_assert

### DIFF
--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -74,8 +74,9 @@ public:
 
   /// Methods to support type inquiry through isa, cast, and dyn_cast.
   static bool classof(const Value *V) {
-    return V->getValueID() >= ConstantDataFirstVal &&
-           V->getValueID() <= ConstantDataLastVal;
+    static_assert(Value::ConstantDataFirstVal == 0,
+                  "V->getValueID() >= Value::ConstantDataFirstVal");
+    return V->getValueID() <= ConstantDataLastVal;
   }
 };
 

--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -987,15 +987,17 @@ template <class Compare> void Value::sortUseList(Compare Cmp) {
 //
 template <> struct isa_impl<Constant, Value> {
   static inline bool doit(const Value &Val) {
-    static_assert(Value::ConstantFirstVal == 0, "Val.getValueID() >= Value::ConstantFirstVal");
+    static_assert(Value::ConstantFirstVal == 0,
+                  "Val.getValueID() >= Value::ConstantFirstVal");
     return Val.getValueID() <= Value::ConstantLastVal;
   }
 };
 
 template <> struct isa_impl<ConstantData, Value> {
   static inline bool doit(const Value &Val) {
-    return Val.getValueID() >= Value::ConstantDataFirstVal &&
-           Val.getValueID() <= Value::ConstantDataLastVal;
+    static_assert(Value::ConstantDataFirstVal == 0,
+                  "Val.getValueID() >= Value::ConstantDataFirstVal");
+    return Val.getValueID() <= Value::ConstantDataLastVal;
   }
 };
 


### PR DESCRIPTION
`ConstantDataFirstVal` is 0, so `getValueID() >= ConstantDataFirstVal` leads to a compiler warning that the expression is always true. Replace such comparisons with a static_assert() to verify that `ConstantDataFirstVal` is 0, similar to the existing code in Value.h