### PR TITLE
[clang][TableGen] Fix Duplicate Entries in TableGen

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -628,6 +628,7 @@ Bug Fixes in This Version
 - Fix crash due to unknown references and pointer implementation and handling of
   base classes. (GH139452)
 - Fixed an assertion failure in serialization of constexpr structs containing unions. (#GH140130)
+- Fixed duplicate entries in TableGen that caused the wrong attribute to be selected. (GH#140701)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/AST/ast-dump-riscv-attributes.cpp
+++ b/clang/test/AST/ast-dump-riscv-attributes.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -triple riscv64 -ast-dump -ast-dump-filter c23 -std=c23 -x c %s | FileCheck --strict-whitespace %s
+
+// CHECK:       FunctionDecl{{.*}}pre_c23
+// CHECK-NEXT:    |-CompoundStmt
+// CHECK-NEXT:    `-RISCVInterruptAttr{{.*}}supervisor
+__attribute__((interrupt("supervisor"))) void pre_c23(){}
+
+// CHECK:       FunctionDecl{{.*}}in_c23
+// CHECK-NEXT:    |-CompoundStmt
+// CHECK-NEXT:    `-RISCVInterruptAttr{{.*}}supervisor
+// CHECK-NOT:     `-RISCVInterruptAttr{{.*}}machine
+[[gnu::interrupt("supervisor")]] void in_c23(){}

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3669,8 +3669,8 @@ static void GenerateHasAttrSpellingStringSwitch(
     ArrayRef<std::pair<const Record *, FlattenedSpelling>> Attrs,
     raw_ostream &OS, StringRef Variety, StringRef Scope = "") {
 
-  // It turns out that duplicate records for a given spelling. This map combines
-  // matching test strings using '||'. For example, if there are three
+  // It turns out that there are duplicate records for a given spelling. This map
+  // combines matching test strings using '||'. For example, if there are three
   // conditions A, B, and C, the final result will be: A || B || C.
   llvm::StringMap<std::string> TestStringMap;
 

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3739,18 +3739,17 @@ static void GenerateHasAttrSpellingStringSwitch(
                       : '(' + itostr(Version) + ')';
 
     if (Scope.empty() || Scope == Spelling.nameSpace()) {
-      if (TestStringMap.contains(Spelling.name())) {
+      if (TestStringMap.contains(Spelling.name()))
         TestStringMap[Spelling.name()] += " || " + TestStr;
-      } else {
+      else
         TestStringMap[Spelling.name()] = TestStr;
-      }
     }
   }
 
   // Create the actual string switch statement after all the attributes have
-  // been parsed
-  for (auto &entry : TestStringMap) {
-    OS << "    .Case(\"" << entry.getKey() << "\", " << entry.getValue()
+  // been parsed.
+  for (auto &Entry : TestStringMap) {
+    OS << "    .Case(\"" << Entry.getKey() << "\", " << Entry.getValue()
        << ")\n";
   }
 

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3669,9 +3669,9 @@ static void GenerateHasAttrSpellingStringSwitch(
     ArrayRef<std::pair<const Record *, FlattenedSpelling>> Attrs,
     raw_ostream &OS, StringRef Variety, StringRef Scope = "") {
 
-  // It turns out that there are duplicate records for a given spelling. This map
-  // combines matching test strings using '||'. For example, if there are three
-  // conditions A, B, and C, the final result will be: A || B || C.
+  // It turns out that there are duplicate records for a given spelling. This
+  // map combines matching test strings using '||'. For example, if there are
+  // three conditions A, B, and C, the final result will be: A || B || C.
   llvm::StringMap<std::string> TestStringMap;
 
   for (const auto &[Attr, Spelling] : Attrs) {

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -3667,6 +3668,12 @@ static bool GenerateTargetSpecificAttrChecks(const Record *R,
 static void GenerateHasAttrSpellingStringSwitch(
     ArrayRef<std::pair<const Record *, FlattenedSpelling>> Attrs,
     raw_ostream &OS, StringRef Variety, StringRef Scope = "") {
+
+  // It turns out that duplicate records for a given spelling. This map combines
+  // matching test strings using '||'. For example, if there are three
+  // conditions A, B, and C, the final result will be: A || B || C.
+  llvm::StringMap<std::string> TestStringMap;
+
   for (const auto &[Attr, Spelling] : Attrs) {
     // C++11-style attributes have specific version information associated with
     // them. If the attribute has no scope, the version information must not
@@ -3727,12 +3734,26 @@ static void GenerateHasAttrSpellingStringSwitch(
       }
     }
 
-    std::string TestStr = !Test.empty()
-                              ? Test + " ? " + itostr(Version) + " : 0"
-                              : itostr(Version);
-    if (Scope.empty() || Scope == Spelling.nameSpace())
-      OS << "    .Case(\"" << Spelling.name() << "\", " << TestStr << ")\n";
+    std::string TestStr =
+        !Test.empty() ? '(' + Test + " ? " + itostr(Version) + " : 0" + ')'
+                      : '(' + itostr(Version) + ')';
+
+    if (Scope.empty() || Scope == Spelling.nameSpace()) {
+      if (TestStringMap.contains(Spelling.name())) {
+        TestStringMap[Spelling.name()] += " || " + TestStr;
+      } else {
+        TestStringMap[Spelling.name()] = TestStr;
+      }
+    }
   }
+
+  // Create the actual string switch statement after all the attributes have
+  // been parsed
+  for (auto &entry : TestStringMap) {
+    OS << "    .Case(\"" << entry.getKey() << "\", " << entry.getValue()
+       << ")\n";
+  }
+
   OS << "    .Default(0);\n";
 }
 


### PR DESCRIPTION
Fixed TableGen duplicate issues that causes the wrong interrupt attribute from being selected.

resolves #140701