### PR TITLE
[llvm-remarkutil] Make invalid states un-representable in the count tool

### DIFF
--- a/llvm/test/tools/llvm-remarkutil/instruction-count.test
+++ b/llvm/test/tools/llvm-remarkutil/instruction-count.test
@@ -2,6 +2,9 @@ RUN: llvm-remarkutil instruction-count --parser=yaml %p/Inputs/instruction-count
 RUN: llvm-remarkutil yaml2bitstream %p/Inputs/instruction-count.yaml | llvm-remarkutil instruction-count --parser=bitstream | FileCheck %s
 RUN: llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --remark-name="InstructionCount" %p/Inputs/instruction-count.yaml | FileCheck %s --check-prefix=COUNT-CHECK
 RUN: llvm-remarkutil yaml2bitstream %p/Inputs/instruction-count.yaml  | llvm-remarkutil count --parser=bitstream --count-by=arg --group-by=function --remark-name="InstructionCount" | FileCheck %s --check-prefix=COUNT-CHECK
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rremark-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-REMARK-NAME
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rpass-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-PASS-NAME
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rfilter-arg-by=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-FILTER-ARG-BY
 
 ; CHECK-LABEL: Function,InstructionCount
 ; CHECK: func1,1
@@ -12,3 +15,7 @@ RUN: llvm-remarkutil yaml2bitstream %p/Inputs/instruction-count.yaml  | llvm-rem
 ; COUNT-CHECK: func1,1
 ; COUNT-CHECK: func2,2
 ; COUNT-CHECK: func3,3
+
+; ERROR-REMARK-NAME: error: invalid argument '--rremark-name=*': repetition-operator operand invalid
+; ERROR-PASS-NAME: error: invalid argument '--rpass-name=*': repetition-operator operand invalid
+; ERROR-FILTER-ARG-BY: error: invalid argument '--rfilter-arg-by=*': repetition-operator operand invalid

--- a/llvm/test/tools/llvm-remarkutil/instruction-count.test
+++ b/llvm/test/tools/llvm-remarkutil/instruction-count.test
@@ -2,9 +2,9 @@ RUN: llvm-remarkutil instruction-count --parser=yaml %p/Inputs/instruction-count
 RUN: llvm-remarkutil yaml2bitstream %p/Inputs/instruction-count.yaml | llvm-remarkutil instruction-count --parser=bitstream | FileCheck %s
 RUN: llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --remark-name="InstructionCount" %p/Inputs/instruction-count.yaml | FileCheck %s --check-prefix=COUNT-CHECK
 RUN: llvm-remarkutil yaml2bitstream %p/Inputs/instruction-count.yaml  | llvm-remarkutil count --parser=bitstream --count-by=arg --group-by=function --remark-name="InstructionCount" | FileCheck %s --check-prefix=COUNT-CHECK
-RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rremark-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-REMARK-NAME
-RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rpass-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-PASS-NAME
-RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rfilter-arg-by=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-FILTER-ARG-BY
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rremark-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR -DARG=rremark-name
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rpass-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR -DARG=rpass-name
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rfilter-arg-by=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR -DARG=rfilter-arg-by
 
 ; CHECK-LABEL: Function,InstructionCount
 ; CHECK: func1,1
@@ -16,6 +16,4 @@ RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function 
 ; COUNT-CHECK: func2,2
 ; COUNT-CHECK: func3,3
 
-; ERROR-REMARK-NAME: error: invalid argument '--rremark-name=*': repetition-operator operand invalid
-; ERROR-PASS-NAME: error: invalid argument '--rpass-name=*': repetition-operator operand invalid
-; ERROR-FILTER-ARG-BY: error: invalid argument '--rfilter-arg-by=*': repetition-operator operand invalid
+; ERROR: error: invalid argument '--[[ARG]]=*': repetition-operator operand invalid

--- a/llvm/test/tools/llvm-remarkutil/instruction-count.test
+++ b/llvm/test/tools/llvm-remarkutil/instruction-count.test
@@ -2,9 +2,10 @@ RUN: llvm-remarkutil instruction-count --parser=yaml %p/Inputs/instruction-count
 RUN: llvm-remarkutil yaml2bitstream %p/Inputs/instruction-count.yaml | llvm-remarkutil instruction-count --parser=bitstream | FileCheck %s
 RUN: llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --remark-name="InstructionCount" %p/Inputs/instruction-count.yaml | FileCheck %s --check-prefix=COUNT-CHECK
 RUN: llvm-remarkutil yaml2bitstream %p/Inputs/instruction-count.yaml  | llvm-remarkutil count --parser=bitstream --count-by=arg --group-by=function --remark-name="InstructionCount" | FileCheck %s --check-prefix=COUNT-CHECK
-RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rremark-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR -DARG=rremark-name
-RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rpass-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR -DARG=rpass-name
-RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rfilter-arg-by=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR -DARG=rfilter-arg-by
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rremark-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-REPOPERATOR -DARG=rremark-name
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rpass-name=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-REPOPERATOR -DARG=rpass-name
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rfilter-arg-by=* %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-REPOPERATOR -DARG=rfilter-arg-by
+RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function --rremark-name=InstCombine --remark-name=InstCombine %p/Inputs/instruction-count.yaml 2>&1 | FileCheck %s --check-prefix=ERROR-BOTHFILTERS -DARG=rremark-name
 
 ; CHECK-LABEL: Function,InstructionCount
 ; CHECK: func1,1
@@ -16,4 +17,5 @@ RUN: not llvm-remarkutil count --parser=yaml --count-by=arg --group-by=function 
 ; COUNT-CHECK: func2,2
 ; COUNT-CHECK: func3,3
 
-; ERROR: error: invalid argument '--[[ARG]]=*': repetition-operator operand invalid
+; ERROR-REPOPERATOR: error: invalid argument '--[[ARG]]=*': repetition-operator operand invalid
+; ERROR-BOTHFILTERS: error: conflicting arguments: --remark-name and --rremark-name

--- a/llvm/tools/llvm-remarkutil/RemarkCounter.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkCounter.cpp
@@ -240,7 +240,7 @@ Expected<Filters> getRemarkFilter() {
   if (!RemarkNameOpt.empty())
     RemarkNameFilter = FilterMatcher::createExact(RemarkNameOpt);
   else if (!RemarkNameOptRE.empty()) {
-    auto FM = FilterMatcher::createRE(RemarkNameOptRE, "rremark-name");
+    auto FM = FilterMatcher::createRE(RemarkNameOptRE);
     if (!FM)
       return FM.takeError();
     RemarkNameFilter = std::move(*FM);
@@ -250,7 +250,7 @@ Expected<Filters> getRemarkFilter() {
   if (!PassNameOpt.empty())
     PassNameFilter = FilterMatcher::createExact(PassNameOpt);
   else if (!PassNameOptRE.empty()) {
-    auto FM = FilterMatcher::createRE(PassNameOptRE, "rpass-name");
+    auto FM = FilterMatcher::createRE(PassNameOptRE);
     if (!FM)
       return FM.takeError();
     PassNameFilter = std::move(*FM);
@@ -260,7 +260,7 @@ Expected<Filters> getRemarkFilter() {
   if (!RemarkFilterArgByOpt.empty())
     RemarkArgFilter = FilterMatcher::createExact(RemarkFilterArgByOpt);
   else if (!RemarkArgFilterOptRE.empty()) {
-    auto FM = FilterMatcher::createRE(RemarkArgFilterOptRE, "rfilter-arg-by");
+    auto FM = FilterMatcher::createRE(RemarkArgFilterOptRE);
     if (!FM)
       return FM.takeError();
     RemarkArgFilter = std::move(*FM);
@@ -318,14 +318,13 @@ static Error collectRemarks() {
         ArgumentsVector.push_back(FilterMatcher::createExact(Key));
     } else if (!RKeys.empty())
       for (auto Key : RKeys) {
-        auto FM = FilterMatcher::createRE(Key, "count-by");
+        auto FM = FilterMatcher::createRE(Key, RKeys);
         if (!FM)
           return FM.takeError();
         ArgumentsVector.push_back(std::move(*FM));
       }
     else
-      ArgumentsVector.push_back(
-          cantFail(FilterMatcher::createRE(".*", "count-by")));
+      ArgumentsVector.push_back(FilterMatcher::createAny());
 
     Expected<ArgumentCounter> AC = ArgumentCounter::createArgumentCounter(
         GroupByOpt, ArgumentsVector, Buffer, Filter);

--- a/llvm/tools/llvm-remarkutil/RemarkCounter.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkCounter.cpp
@@ -236,43 +236,25 @@ Error RemarkCounter::print(StringRef OutputFileName) {
 
 Expected<Filters> getRemarkFilter() {
   // Create Filter properties.
-  std::optional<FilterMatcher> RemarkNameFilter;
-  if (!RemarkNameOpt.empty())
-    RemarkNameFilter = FilterMatcher::createExact(RemarkNameOpt);
-  else if (!RemarkNameOptRE.empty()) {
-    auto FM = FilterMatcher::createRE(RemarkNameOptRE);
-    if (!FM)
-      return FM.takeError();
-    RemarkNameFilter = std::move(*FM);
-  }
+  auto MaybeRemarkNameFilter = FilterMatcher::createExactOrRE(RemarkNameOpt, RemarkNameOptRE);
+  if (!MaybeRemarkNameFilter)
+    return MaybeRemarkNameFilter.takeError();
 
-  std::optional<FilterMatcher> PassNameFilter;
-  if (!PassNameOpt.empty())
-    PassNameFilter = FilterMatcher::createExact(PassNameOpt);
-  else if (!PassNameOptRE.empty()) {
-    auto FM = FilterMatcher::createRE(PassNameOptRE);
-    if (!FM)
-      return FM.takeError();
-    PassNameFilter = std::move(*FM);
-  }
+  auto MaybePassNameFilter = FilterMatcher::createExactOrRE(PassNameOpt, PassNameOptRE);
+  if (!MaybePassNameFilter)
+    return MaybePassNameFilter.takeError();
 
-  std::optional<FilterMatcher> RemarkArgFilter;
-  if (!RemarkFilterArgByOpt.empty())
-    RemarkArgFilter = FilterMatcher::createExact(RemarkFilterArgByOpt);
-  else if (!RemarkArgFilterOptRE.empty()) {
-    auto FM = FilterMatcher::createRE(RemarkArgFilterOptRE);
-    if (!FM)
-      return FM.takeError();
-    RemarkArgFilter = std::move(*FM);
-  }
+  auto MaybeRemarkArgFilter = FilterMatcher::createExactOrRE(RemarkFilterArgByOpt, RemarkArgFilterOptRE);
+  if (!MaybeRemarkArgFilter)
+    return MaybeRemarkArgFilter.takeError();
 
   std::optional<Type> RemarkType;
   if (RemarkTypeOpt != Type::Failure)
     RemarkType = RemarkTypeOpt;
 
   // Create RemarkFilter.
-  return Filters{std::move(RemarkNameFilter), std::move(PassNameFilter),
-                 std::move(RemarkArgFilter), RemarkType};
+  return Filters{std::move(*MaybeRemarkNameFilter), std::move(*MaybePassNameFilter),
+                 std::move(*MaybeRemarkArgFilter), RemarkType};
 }
 
 Error useCollectRemark(StringRef Buffer, Counter &Counter, Filters &Filter) {

--- a/llvm/tools/llvm-remarkutil/RemarkCounter.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkCounter.cpp
@@ -236,15 +236,18 @@ Error RemarkCounter::print(StringRef OutputFileName) {
 
 Expected<Filters> getRemarkFilter() {
   // Create Filter properties.
-  auto MaybeRemarkNameFilter = FilterMatcher::createExactOrRE(RemarkNameOpt, RemarkNameOptRE);
+  auto MaybeRemarkNameFilter =
+      FilterMatcher::createExactOrRE(RemarkNameOpt, RemarkNameOptRE);
   if (!MaybeRemarkNameFilter)
     return MaybeRemarkNameFilter.takeError();
 
-  auto MaybePassNameFilter = FilterMatcher::createExactOrRE(PassNameOpt, PassNameOptRE);
+  auto MaybePassNameFilter =
+      FilterMatcher::createExactOrRE(PassNameOpt, PassNameOptRE);
   if (!MaybePassNameFilter)
     return MaybePassNameFilter.takeError();
 
-  auto MaybeRemarkArgFilter = FilterMatcher::createExactOrRE(RemarkFilterArgByOpt, RemarkArgFilterOptRE);
+  auto MaybeRemarkArgFilter = FilterMatcher::createExactOrRE(
+      RemarkFilterArgByOpt, RemarkArgFilterOptRE);
   if (!MaybeRemarkArgFilter)
     return MaybeRemarkArgFilter.takeError();
 
@@ -253,7 +256,8 @@ Expected<Filters> getRemarkFilter() {
     RemarkType = RemarkTypeOpt;
 
   // Create RemarkFilter.
-  return Filters{std::move(*MaybeRemarkNameFilter), std::move(*MaybePassNameFilter),
+  return Filters{std::move(*MaybeRemarkNameFilter),
+                 std::move(*MaybePassNameFilter),
                  std::move(*MaybeRemarkArgFilter), RemarkType};
 }
 

--- a/llvm/tools/llvm-remarkutil/RemarkCounter.h
+++ b/llvm/tools/llvm-remarkutil/RemarkCounter.h
@@ -45,26 +45,6 @@ inline std::string groupByToStr(GroupBy GroupBy) {
   }
 }
 
-/// Filter object which can be either a string or a regex to match with the
-/// remark properties.
-struct FilterMatcher {
-  Regex FilterRE;
-  std::string FilterStr;
-  bool IsRegex;
-  FilterMatcher(std::string Filter, bool IsRegex) : IsRegex(IsRegex) {
-    if (IsRegex)
-      FilterRE = Regex(Filter);
-    else
-      FilterStr = Filter;
-  }
-
-  bool match(StringRef StringToMatch) const {
-    if (IsRegex)
-      return FilterRE.match(StringToMatch);
-    return FilterStr == StringToMatch.trim().str();
-  }
-};
-
 /// Filter out remarks based on remark properties based on name, pass name,
 /// argument and type.
 struct Filters {
@@ -72,38 +52,10 @@ struct Filters {
   std::optional<FilterMatcher> PassNameFilter;
   std::optional<FilterMatcher> ArgFilter;
   std::optional<Type> RemarkTypeFilter;
-  /// Returns a filter object if all the arguments provided are valid regex
-  /// types otherwise return an error.
-  static Expected<Filters>
-  createRemarkFilter(std::optional<FilterMatcher> RemarkNameFilter,
-                     std::optional<FilterMatcher> PassNameFilter,
-                     std::optional<FilterMatcher> ArgFilter,
-                     std::optional<Type> RemarkTypeFilter) {
-    Filters Filter;
-    Filter.RemarkNameFilter = std::move(RemarkNameFilter);
-    Filter.PassNameFilter = std::move(PassNameFilter);
-    Filter.ArgFilter = std::move(ArgFilter);
-    Filter.RemarkTypeFilter = std::move(RemarkTypeFilter);
-    if (auto E = Filter.regexArgumentsValid())
-      return std::move(E);
-    return std::move(Filter);
-  }
+
   /// Returns true if \p Remark satisfies all the provided filters.
   bool filterRemark(const Remark &Remark);
-
-private:
-  /// Check if arguments can be parsed as valid regex types.
-  Error regexArgumentsValid();
 };
-
-/// Convert Regex string error to an error object.
-inline Error checkRegex(const Regex &Regex) {
-  std::string Error;
-  if (!Regex.isValid(Error))
-    return createStringError(make_error_code(std::errc::invalid_argument),
-                             Twine("Regex: ", Error));
-  return Error::success();
-}
 
 /// Abstract counter class used to define the general required methods for
 /// counting a remark.
@@ -160,12 +112,6 @@ struct ArgumentCounter : Counter {
                         StringRef Buffer, Filters &Filter) {
     ArgumentCounter AC;
     AC.Group = Group;
-    for (auto &Arg : Arguments) {
-      if (Arg.IsRegex) {
-        if (auto E = checkRegex(Arg.FilterRE))
-          return std::move(E);
-      }
-    }
     if (auto E = AC.getAllMatchingArgumentsInRemark(Buffer, Arguments, Filter))
       return std::move(E);
     return AC;

--- a/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.cpp
@@ -53,5 +53,28 @@ getOutputFileForRemarks(StringRef OutputFileName, Format OutputFormat) {
                                                     ? sys::fs::OF_TextWithCRLF
                                                     : sys::fs::OF_None);
 }
+
+Expected<FilterMatcher>
+FilterMatcher::createRE(const llvm::cl::opt<std::string> &Arg) {
+  return createRE(Arg.ArgStr, Arg);
+}
+
+
+Expected<FilterMatcher>
+FilterMatcher::createRE(StringRef Filter, const cl::list<std::string> &Arg) {
+  return createRE(Arg.ArgStr, Filter);
+}
+
+Expected<FilterMatcher> FilterMatcher::createRE(StringRef Arg,
+                                                StringRef Value) {
+  FilterMatcher FM(Value, true);
+  std::string Error;
+  if (!FM.FilterRE.isValid(Error))
+    return createStringError(make_error_code(std::errc::invalid_argument),
+                             "invalid argument '--" + Arg + "=" + Value +
+                                 "': " + Error);
+  return std::move(FM);
+}
+
 } // namespace remarks
 } // namespace llvm

--- a/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.cpp
@@ -59,7 +59,6 @@ FilterMatcher::createRE(const llvm::cl::opt<std::string> &Arg) {
   return createRE(Arg.ArgStr, Arg);
 }
 
-
 Expected<FilterMatcher>
 FilterMatcher::createRE(StringRef Filter, const cl::list<std::string> &Arg) {
   return createRE(Arg.ArgStr, Filter);

--- a/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.cpp
@@ -75,10 +75,13 @@ Expected<FilterMatcher> FilterMatcher::createRE(StringRef Arg,
   return std::move(FM);
 }
 
-Expected<std::optional<FilterMatcher>> FilterMatcher::createExactOrRE(const llvm::cl::opt<std::string> &ExactArg,
-  const llvm::cl::opt<std::string> &REArg) {
+Expected<std::optional<FilterMatcher>>
+FilterMatcher::createExactOrRE(const llvm::cl::opt<std::string> &ExactArg,
+                               const llvm::cl::opt<std::string> &REArg) {
   if (!ExactArg.empty() && !REArg.empty())
-    return createStringError(make_error_code(std::errc::invalid_argument), "conflicting arguments: --" + ExactArg.ArgStr + " and --" + REArg.ArgStr);
+    return createStringError(make_error_code(std::errc::invalid_argument),
+                             "conflicting arguments: --" + ExactArg.ArgStr +
+                                 " and --" + REArg.ArgStr);
 
   if (!ExactArg.empty())
     return createExact(ExactArg);

--- a/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.cpp
@@ -75,5 +75,19 @@ Expected<FilterMatcher> FilterMatcher::createRE(StringRef Arg,
   return std::move(FM);
 }
 
+Expected<std::optional<FilterMatcher>> FilterMatcher::createExactOrRE(const llvm::cl::opt<std::string> &ExactArg,
+  const llvm::cl::opt<std::string> &REArg) {
+  if (!ExactArg.empty() && !REArg.empty())
+    return createStringError(make_error_code(std::errc::invalid_argument), "conflicting arguments: --" + ExactArg.ArgStr + " and --" + REArg.ArgStr);
+
+  if (!ExactArg.empty())
+    return createExact(ExactArg);
+
+  if (!REArg.empty())
+    return createRE(REArg);
+
+  return std::nullopt;
+}
+
 } // namespace remarks
 } // namespace llvm

--- a/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.h
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.h
@@ -18,6 +18,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Regex.h"
 #include "llvm/Support/ToolOutputFile.h"
 
 // Keep input + output help + names consistent across the various modes via a
@@ -55,5 +56,37 @@ Expected<std::unique_ptr<ToolOutputFile>>
 getOutputFileWithFlags(StringRef OutputFileName, sys::fs::OpenFlags Flags);
 Expected<std::unique_ptr<ToolOutputFile>>
 getOutputFileForRemarks(StringRef OutputFileName, Format OutputFormat);
+
+/// Filter object which can be either a string or a regex to match with the
+/// remark properties.
+class FilterMatcher {
+  Regex FilterRE;
+  std::string FilterStr;
+  bool IsRegex;
+
+  FilterMatcher(StringRef Filter, bool IsRegex)
+      : FilterRE(Filter), FilterStr(Filter), IsRegex(IsRegex) {}
+
+public:
+  static FilterMatcher createExact(StringRef Filter) { return {Filter, false}; }
+
+  static Expected<FilterMatcher> createRE(StringRef Filter,
+                                          StringRef Argument) {
+    FilterMatcher FM(Filter, true);
+    std::string Error;
+    if (!FM.FilterRE.isValid(Error))
+      return createStringError(make_error_code(std::errc::invalid_argument),
+                               "invalid argument '--" + Argument + "=" +
+                                   Filter + "': " + Error);
+    return std::move(FM);
+  }
+
+  bool match(StringRef StringToMatch) const {
+    if (IsRegex)
+      return FilterRE.match(StringToMatch);
+    return FilterStr == StringToMatch.trim().str();
+  }
+};
+
 } // namespace remarks
 } // namespace llvm

--- a/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.h
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.h
@@ -76,8 +76,8 @@ public:
   static Expected<FilterMatcher>
   createRE(const llvm::cl::opt<std::string> &Arg);
 
-  static Expected<FilterMatcher>
-  createRE(StringRef Filter, const cl::list<std::string> &Arg);
+  static Expected<FilterMatcher> createRE(StringRef Filter,
+                                          const cl::list<std::string> &Arg);
 
   static FilterMatcher createAny() { return {".*", true}; }
 

--- a/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.h
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.h
@@ -79,8 +79,9 @@ public:
   static Expected<FilterMatcher> createRE(StringRef Filter,
                                           const cl::list<std::string> &Arg);
 
-  static Expected<std::optional<FilterMatcher>> createExactOrRE(const llvm::cl::opt<std::string> &ExactArg,
-                                                 const llvm::cl::opt<std::string> &REArg);
+  static Expected<std::optional<FilterMatcher>>
+  createExactOrRE(const llvm::cl::opt<std::string> &ExactArg,
+                  const llvm::cl::opt<std::string> &REArg);
 
   static FilterMatcher createAny() { return {".*", true}; }
 

--- a/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.h
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilHelpers.h
@@ -79,6 +79,9 @@ public:
   static Expected<FilterMatcher> createRE(StringRef Filter,
                                           const cl::list<std::string> &Arg);
 
+  static Expected<std::optional<FilterMatcher>> createExactOrRE(const llvm::cl::opt<std::string> &ExactArg,
+                                                 const llvm::cl::opt<std::string> &REArg);
+
   static FilterMatcher createAny() { return {".*", true}; }
 
   bool match(StringRef StringToMatch) const {


### PR DESCRIPTION
This consolidates some of the error handling around regex arguments to the tool, and sets up the APIs such that errors must be handled before their usage.