### PR TITLE
[bazel][mlir] Add missing dep for 747620d

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -3419,6 +3419,7 @@ cc_library(
     deps = [
         ":AffineUtils",
         ":Analysis",
+        ":ArithUtils",
         ":DialectUtils",
         ":FunctionInterfaces",
         ":GPUDialect",

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -3424,6 +3424,7 @@ cc_library(
         ":GPUDialect",
         ":GPUUtils",
         ":IR",
+        ":IndexDialect",
         ":InliningUtils",
         ":MemRefDialect",
         ":Pass",


### PR DESCRIPTION
fixes the following errors:

ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/6a1efeb401da192d3572f00e2f11245b/external/llvm-project/mlir/BUILD.bazel:3410:11: Compiling mlir/lib/Dialect/XeGPU/Transforms/XeGPUWgToSgDistribute.cpp failed: (Exit 1): clang failed: error executing CppCompile command (from target @@llvm-project//mlir:XeGPUTransforms) /usr/lib/llvm-18/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer ... (remaining 130 arguments skipped)
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/llvm-project/mlir/lib/Dialect/XeGPU/Transforms/XeGPUWgToSgDistribute.cpp:11:10: error: module llvm-project//mlir:XeGPUTransforms does not depend on a module exporting 'mlir/Dialect/Arith/Utils/Utils.h'
   11 | #include "mlir/Dialect/Arith/Utils/Utils.h"
      |          ^
external/llvm-project/mlir/lib/Dialect/XeGPU/Transforms/XeGPUWgToSgDistribute.cpp:13:10: fatal error: 'mlir/Dialect/Index/IR/IndexDialect.h' file not found
   13 | #include "mlir/Dialect/Index/IR/IndexDialect.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.