### PR TITLE
[Clang] Set the final date for workaround for libstdc++'s `format_kind`

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -4370,7 +4370,15 @@ static bool IsLibstdcxxStdFormatKind(Preprocessor &PP, VarDecl *Var) {
   const Token &RevisionDateTok = MacroGLIBCXX->getReplacementToken(0);
   bool Invalid = false;
   std::string RevisionDate = PP.getSpelling(RevisionDateTok, &Invalid);
-  StringRef FixDate = "30251231";
+
+  // We can use 20250520 as the final date, see the following commits.
+  // GCC releases/gcc-15 branch:
+  // https://gcc.gnu.org/g:fedf81ef7b98e5c9ac899b8641bb670746c51205
+  // https://gcc.gnu.org/g:53680c1aa92d9f78e8255fbf696c0ed36f160650
+  // GCC master branch:
+  // https://gcc.gnu.org/g:9361966d80f625c5accc25cbb439f0278dd8b278
+  // https://gcc.gnu.org/g:c65725eccbabf3b9b5965f27fff2d3b9f6c75930
+  StringRef FixDate = "20250520";
 
   if (Invalid)
     return false;
@@ -4381,9 +4389,7 @@ static bool IsLibstdcxxStdFormatKind(Preprocessor &PP, VarDecl *Var) {
   //
   // Checking old versions of libstdc++ is not needed because 15.1 is the first
   // release in which users can access std::format_kind.
-  //
-  // FIXME: Correct FixDate once the issue is fixed.
-  return RevisionDate.size() == 8 && RevisionDate <= FixDate;
+  return RevisionDate.size() == 8 && RevisionDate < FixDate;
 }
 } // end anonymous namespace
 


### PR DESCRIPTION
We can use 20250520 as the final date, see the following commits.
- GCC releases/gcc-15 branch:
  - https://gcc.gnu.org/g:fedf81ef7b98e5c9ac899b8641bb670746c51205
  - https://gcc.gnu.org/g:53680c1aa92d9f78e8255fbf696c0ed36f160650
- GCC master branch:
  - https://gcc.gnu.org/g:9361966d80f625c5accc25cbb439f0278dd8b278
  - https://gcc.gnu.org/g:c65725eccbabf3b9b5965f27fff2d3b9f6c75930

Follows-up #139560.