### PR TITLE
[llvm] Use *Map::try_emplace (NFC)

### DIFF
--- a/llvm/lib/Analysis/MLInlineAdvisor.cpp
+++ b/llvm/lib/Analysis/MLInlineAdvisor.cpp
@@ -330,8 +330,7 @@ int64_t MLInlineAdvisor::getModuleIRSize() const {
 }
 
 FunctionPropertiesInfo &MLInlineAdvisor::getCachedFPI(Function &F) const {
-  auto InsertPair =
-      FPICache.insert(std::make_pair(&F, FunctionPropertiesInfo()));
+  auto InsertPair = FPICache.try_emplace(&F);
   if (!InsertPair.second)
     return InsertPair.first->second;
   InsertPair.first->second = FAM.getResult<FunctionPropertiesAnalysis>(F);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfStringPool.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfStringPool.cpp
@@ -24,7 +24,7 @@ DwarfStringPool::DwarfStringPool(BumpPtrAllocator &A, AsmPrinter &Asm,
 
 StringMapEntry<DwarfStringPool::EntryTy> &
 DwarfStringPool::getEntryImpl(AsmPrinter &Asm, StringRef Str) {
-  auto I = Pool.insert(std::make_pair(Str, EntryTy()));
+  auto I = Pool.try_emplace(Str);
   auto &Entry = I.first->second;
   if (I.second) {
     Entry.Index = EntryTy::NotIndexed;

--- a/llvm/lib/LTO/LTOModule.cpp
+++ b/llvm/lib/LTO/LTOModule.cpp
@@ -271,8 +271,7 @@ void LTOModule::addObjCClass(const GlobalVariable *clgv) {
   // second slot in __OBJC,__class is pointer to superclass name
   std::string superclassName;
   if (objcClassNameFromExpression(c->getOperand(1), superclassName)) {
-    auto IterBool =
-        _undefines.insert(std::make_pair(superclassName, NameAndAttributes()));
+    auto IterBool = _undefines.try_emplace(superclassName);
     if (IterBool.second) {
       NameAndAttributes &info = IterBool.first->second;
       info.name = IterBool.first->first();
@@ -307,8 +306,7 @@ void LTOModule::addObjCCategory(const GlobalVariable *clgv) {
   if (!objcClassNameFromExpression(c->getOperand(1), targetclassName))
     return;
 
-  auto IterBool =
-      _undefines.insert(std::make_pair(targetclassName, NameAndAttributes()));
+  auto IterBool = _undefines.try_emplace(targetclassName);
 
   if (!IterBool.second)
     return;
@@ -326,8 +324,7 @@ void LTOModule::addObjCClassRef(const GlobalVariable *clgv) {
   if (!objcClassNameFromExpression(clgv->getInitializer(), targetclassName))
     return;
 
-  auto IterBool =
-      _undefines.insert(std::make_pair(targetclassName, NameAndAttributes()));
+  auto IterBool = _undefines.try_emplace(targetclassName);
 
   if (!IterBool.second)
     return;
@@ -522,7 +519,7 @@ void LTOModule::addAsmGlobalSymbol(StringRef name,
 /// addAsmGlobalSymbolUndef - Add a global symbol from module-level ASM to the
 /// undefined list.
 void LTOModule::addAsmGlobalSymbolUndef(StringRef name) {
-  auto IterBool = _undefines.insert(std::make_pair(name, NameAndAttributes()));
+  auto IterBool = _undefines.try_emplace(name);
 
   _asm_undefines.push_back(IterBool.first->first());
 
@@ -549,8 +546,7 @@ void LTOModule::addPotentialUndefinedSymbol(ModuleSymbolTable::Symbol Sym,
     name.c_str();
   }
 
-  auto IterBool =
-      _undefines.insert(std::make_pair(name.str(), NameAndAttributes()));
+  auto IterBool = _undefines.try_emplace(name.str());
 
   // we already have the symbol
   if (!IterBool.second)

--- a/llvm/lib/Target/Hexagon/HexagonGenMux.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonGenMux.cpp
@@ -245,8 +245,7 @@ bool HexagonGenMux::genMuxInBlock(MachineBasicBlock &B) {
       F = CM.end();
     }
     if (F == CM.end()) {
-      auto It = CM.insert(std::make_pair(DR, CondsetInfo()));
-      F = It.first;
+      F = CM.try_emplace(DR).first;
       F->second.PredR = PR;
     }
     CondsetInfo &CI = F->second;

--- a/llvm/lib/Transforms/AggressiveInstCombine/TruncInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/TruncInstCombine.cpp
@@ -110,7 +110,7 @@ bool TruncInstCombine::buildTruncExpressionGraph() {
       Worklist.pop_back();
       Stack.pop_back();
       // Insert I to the Info map.
-      InstInfoMap.insert(std::make_pair(I, Info()));
+      InstInfoMap.try_emplace(I);
       continue;
     }
 

--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -413,8 +413,7 @@ public:
 
 void
 RegUseTracker::countRegister(const SCEV *Reg, size_t LUIdx) {
-  std::pair<RegUsesTy::iterator, bool> Pair =
-    RegUsesMap.insert(std::make_pair(Reg, RegSortData()));
+  std::pair<RegUsesTy::iterator, bool> Pair = RegUsesMap.try_emplace(Reg);
   RegSortData &RSD = Pair.first->second;
   if (Pair.second)
     RegSequence.push_back(Reg);
@@ -4478,7 +4477,7 @@ void LSRInstance::GenerateCrossUseConstantOffsets() {
   for (const SCEV *Use : RegUses) {
     const SCEV *Reg = Use; // Make a copy for ExtractImmediate to modify.
     Immediate Imm = ExtractImmediate(Reg, SE);
-    auto Pair = Map.insert(std::make_pair(Reg, ImmMapTy()));
+    auto Pair = Map.try_emplace(Reg);
     if (Pair.second)
       Sequence.push_back(Reg);
     Pair.first->second.insert(std::make_pair(Imm, Use));

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -524,7 +524,7 @@ private:
   ValueLatticeElement &getValueState(Value *V) {
     assert(!V->getType()->isStructTy() && "Should use getStructValueState");
 
-    auto I = ValueState.insert(std::make_pair(V, ValueLatticeElement()));
+    auto I = ValueState.try_emplace(V);
     ValueLatticeElement &LV = I.first->second;
 
     if (!I.second)
@@ -765,10 +765,9 @@ public:
     if (auto *STy = dyn_cast<StructType>(F->getReturnType())) {
       MRVFunctionsTracked.insert(F);
       for (unsigned i = 0, e = STy->getNumElements(); i != e; ++i)
-        TrackedMultipleRetVals.insert(
-            std::make_pair(std::make_pair(F, i), ValueLatticeElement()));
+        TrackedMultipleRetVals.try_emplace(std::make_pair(F, i));
     } else if (!F->getReturnType()->isVoidTy())
-      TrackedRetVals.insert(std::make_pair(F, ValueLatticeElement()));
+      TrackedRetVals.try_emplace(F);
   }
 
   void addToMustPreserveReturnsInFunctions(Function *F) {

--- a/llvm/lib/Transforms/Utils/ValueMapper.cpp
+++ b/llvm/lib/Transforms/Utils/ValueMapper.cpp
@@ -773,7 +773,7 @@ MDNode *MDNodeMapper::visitOperands(UniquedGraph &G, MDNode::op_iterator &I,
     MDNode &OpN = *cast<MDNode>(Op);
     assert(OpN.isUniqued() &&
            "Only uniqued operands cannot be mapped immediately");
-    if (G.Info.insert(std::make_pair(&OpN, Data())).second)
+    if (G.Info.try_emplace(&OpN).second)
       return &OpN; // This is a new one.  Return it.
   }
   return nullptr;

--- a/llvm/tools/llvm-mca/Views/BottleneckAnalysis.cpp
+++ b/llvm/tools/llvm-mca/Views/BottleneckAnalysis.cpp
@@ -58,7 +58,7 @@ void PressureTracker::getResourceUsers(uint64_t ResourceMask,
 }
 
 void PressureTracker::onInstructionDispatched(unsigned IID) {
-  IPI.insert(std::make_pair(IID, InstructionPressureInfo()));
+  IPI.try_emplace(IID);
 }
 
 void PressureTracker::onInstructionExecuted(unsigned IID) { IPI.erase(IID); }


### PR DESCRIPTION
try_emplace can default-construct values, so we do not need to do so
on our own.  Plus, try_emplace(Key) is much shorter than
insert(std::make_pair(Key, Value()).
