### PR TITLE
[clang][AIX] Strip unknown environment component for per target runtime directory

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -937,7 +937,8 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
 
   // On AIX, the environment component is not used in the target sub dir name.
   if (T.isOSAIX() && T.hasEnvironment()) {
-    llvm::Triple AIXTriple(T.getArchName(), T.getVendorName(), llvm::Triple::getOSTypeName(T.getOS()));
+    llvm::Triple AIXTriple(T.getArchName(), T.getVendorName(),
+                           llvm::Triple::getOSTypeName(T.getOS()));
     if (auto Path = getPathForTriple(AIXTriple))
       return *Path;
   }

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -935,6 +935,13 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
   if (auto Path = getPathForTriple(T))
     return *Path;
 
+  // On AIX, the environment component is not used in the target sub dir name.
+  if (T.isOSAIX() && T.hasEnvironment()) {
+    llvm::Triple AIXTriple(T.getArchName(), T.getVendorName(), llvm::Triple::getOSTypeName(T.getOS()));
+    if (auto Path = getPathForTriple(AIXTriple))
+      return *Path;
+  }
+
   if (T.isOSzOS() &&
       (!T.getOSVersion().empty() || !T.getEnvironmentVersion().empty())) {
     // Build the triple without version information

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -937,8 +937,9 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
 
   if (T.isOSAIX() && T.getEnvironment() == Triple::UnknownEnvironment) {
     // Strip unknown environment from the triple.
-    const llvm::Triple AIXTriple(llvm::Triple(T.getArchName(), T.getVendorName(),
-                                 llvm::Triple::getOSTypeName(T.getOS())));
+    const llvm::Triple AIXTriple(
+        llvm::Triple(T.getArchName(), T.getVendorName(),
+                     llvm::Triple::getOSTypeName(T.getOS())));
     if (auto Path = getPathForTriple(AIXTriple))
       return *Path;
   }

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -935,10 +935,10 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
   if (auto Path = getPathForTriple(T))
     return *Path;
 
-  // On AIX, the environment component is not used in the target sub dir name.
-  if (T.isOSAIX() && T.hasEnvironment()) {
-    llvm::Triple AIXTriple(T.getArchName(), T.getVendorName(),
-                           llvm::Triple::getOSTypeName(T.getOS()));
+  if (T.isOSAIX() && T.getEnvironment() == Triple::UnknownEnvironment) {
+    // Strip unknown environment from the triple.
+    const llvm::Triple AIXTriple(llvm::Triple(T.getArchName(), T.getVendorName(),
+                                 llvm::Triple::getOSTypeName(T.getOS())));
     if (auto Path = getPathForTriple(AIXTriple))
       return *Path;
   }

--- a/clang/test/Driver/aix-print-runtime-dir.c
+++ b/clang/test/Driver/aix-print-runtime-dir.c
@@ -16,6 +16,10 @@
 // RUN:        -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir\
 // RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR64-PER-TARGET %s
 
+// RUN: %clang -print-runtime-dir --target=powerpc-ibm-aix-unknown \
+// RUN:        -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir\
+// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR32-PER-TARGET %s
+
 // PRINT-RUNTIME-DIR: lib{{/|\\}}aix{{$}}
 // PRINT-RUNTIME-DIR32-PER-TARGET: lib{{/|\\}}powerpc-ibm-aix{{$}}
 // PRINT-RUNTIME-DIR64-PER-TARGET: lib{{/|\\}}powerpc64-ibm-aix{{$}}

--- a/clang/test/Driver/aix-print-runtime-dir.c
+++ b/clang/test/Driver/aix-print-runtime-dir.c
@@ -17,10 +17,15 @@
 // RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR64-PER-TARGET %s
 
 // RUN: %clang -print-runtime-dir --target=powerpc-ibm-aix-unknown \
-// RUN:        -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir\
-// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR-UNKNOWN-ENV %s
+// RUN:        -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir \
+// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR32-UNKNOWN-ENV %s
+
+// RUN: %clang -print-runtime-dir --target=powerpc64-ibm-aix-unknown \
+// RUN:        -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir \
+// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR64-UNKNOWN-ENV %s 
 
 // PRINT-RUNTIME-DIR: lib{{/|\\}}aix{{$}}
 // PRINT-RUNTIME-DIR32-PER-TARGET: lib{{/|\\}}powerpc-ibm-aix{{$}}
 // PRINT-RUNTIME-DIR64-PER-TARGET: lib{{/|\\}}powerpc64-ibm-aix{{$}}
-// PRINT-RUNTIME-DIR-UNKNOWN-ENV: lib{{/|\\}}powerpc-ibm-aix
+// PRINT-RUNTIME-DIR32-UNKNOWN-ENV: lib{{/|\\}}powerpc-ibm-aix
+// PRINT-RUNTIME-DIR64-UNKNOWN-ENV: lib{{/|\\}}powerpc64-ibm-aix

--- a/clang/test/Driver/aix-print-runtime-dir.c
+++ b/clang/test/Driver/aix-print-runtime-dir.c
@@ -18,8 +18,9 @@
 
 // RUN: %clang -print-runtime-dir --target=powerpc-ibm-aix-unknown \
 // RUN:        -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir\
-// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR32-PER-TARGET %s
+// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR-UNKNOWN-ENV %s
 
 // PRINT-RUNTIME-DIR: lib{{/|\\}}aix{{$}}
 // PRINT-RUNTIME-DIR32-PER-TARGET: lib{{/|\\}}powerpc-ibm-aix{{$}}
 // PRINT-RUNTIME-DIR64-PER-TARGET: lib{{/|\\}}powerpc64-ibm-aix{{$}}
+// PRINT-RUNTIME-DIR-UNKNOWN-ENV: lib{{/|\\}}powerpc-ibm-aix


### PR DESCRIPTION
Previously, when the triple is `powerpc-ibm-aix-unknown`, the driver fails to find subdirectory `lib/powerpc-ibm-aix`.

This ensures the correct runtime path is found if the triple has the -unknown environment component attached.