### PR TITLE
[SCCPSolver] Make getMRVFunctionsTracked return a reference (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/SCCPSolver.h
+++ b/llvm/include/llvm/Transforms/Utils/SCCPSolver.h
@@ -147,7 +147,7 @@ public:
 
   /// getMRVFunctionsTracked - Get the set of functions which return multiple
   /// values tracked by the pass.
-  const SmallPtrSet<Function *, 16> getMRVFunctionsTracked();
+  const SmallPtrSet<Function *, 16> &getMRVFunctionsTracked();
 
   /// markOverdefined - Mark the specified value overdefined.  This
   /// works with both scalars and structs.

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -848,7 +848,7 @@ public:
     return TrackedGlobals;
   }
 
-  const SmallPtrSet<Function *, 16> getMRVFunctionsTracked() {
+  const SmallPtrSet<Function *, 16> &getMRVFunctionsTracked() {
     return MRVFunctionsTracked;
   }
 
@@ -2231,7 +2231,7 @@ SCCPSolver::getTrackedGlobals() {
   return Visitor->getTrackedGlobals();
 }
 
-const SmallPtrSet<Function *, 16> SCCPSolver::getMRVFunctionsTracked() {
+const SmallPtrSet<Function *, 16> &SCCPSolver::getMRVFunctionsTracked() {
   return Visitor->getMRVFunctionsTracked();
 }
 


### PR DESCRIPTION
This patch makes getMRVFunctionsTracked return a reference.
runIPSCCP, the sole user of getMRVFunctionsTracked, just needs a
read-access to the map.

The missing "&" is most likely an oversight as two "sibling" functions
getTrackedRetVals and getTrackedGlobals return maps by const
reference.
