### PR TITLE
[clang-doc] fix names of conversions for template parameters

### DIFF
--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -525,7 +525,13 @@ template <typename T>
 static void populateInfo(Info &I, const T *D, const FullComment *C,
                          bool &IsInAnonymousNamespace) {
   I.USR = getUSRForDecl(D);
-  I.Name = D->getNameAsString();
+  if (auto ConversionDecl = dyn_cast_or_null<CXXConversionDecl>(D);
+      ConversionDecl && ConversionDecl->getConversionType()
+                            .getTypePtr()
+                            ->isTemplateTypeParmType())
+    I.Name = "operator " + ConversionDecl->getConversionType().getAsString();
+  else
+    I.Name = D->getNameAsString();
   populateParentNamespaces(I.Namespace, D, IsInAnonymousNamespace);
   if (C) {
     I.Description.emplace_back();

--- a/clang-tools-extra/test/clang-doc/conversion_function.cpp
+++ b/clang-tools-extra/test/clang-doc/conversion_function.cpp
@@ -11,9 +11,8 @@ struct MyStruct {
   operator T();
 };
 
-// Output incorrect conversion names.
-// CHECK-YAML:         Name:            'operator type-parameter-0-0'
-// CHECK-YAML-NOT:     Name:            'operator T'
+// Output correct conversion names.
+// CHECK-YAML:         Name:            'operator T'
 
-// CHECK-HTML-NOT: <h3 id='{{[0-9A-F]*}}'>operator T</h3>
-// CHECK-HTML-NOT: <p>public T operator T()</p>
+// CHECK-HTML: <h3 id='{{[0-9A-F]*}}'>operator T</h3>
+// CHECK-HTML: <p>public T operator T()</p>


### PR DESCRIPTION
Fixes #59812

The names of conversion functions of template type parameters were being emitted as "type-parameter-N-M". Now we check if the conversion type is a TemplateTypeParmType and reconstruct the source name.