### PR TITLE
[Clang] Fix a regression introduced by #140576

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -17777,15 +17777,13 @@ void Sema::PushExpressionEvaluationContextForFunction(
     Current.InImmediateEscalatingFunctionContext =
         getLangOpts().CPlusPlus20 && FD->isImmediateEscalating();
 
-    if (isLambdaMethod(FD)) {
-      Current.InDiscardedStatement = Parent.isDiscardedStatementContext();
+    if (isLambdaMethod(FD))
       Current.InImmediateFunctionContext =
           FD->isConsteval() ||
           (isLambdaMethod(FD) && (Parent.isConstantEvaluated() ||
                                   Parent.isImmediateFunctionContext()));
-    } else {
+    else
       Current.InImmediateFunctionContext = FD->isConsteval();
-    }
   }
 }
 

--- a/clang/test/CXX/stmt.stmt/stmt.select/stmt.if/p2.cpp
+++ b/clang/test/CXX/stmt.stmt/stmt.select/stmt.if/p2.cpp
@@ -208,6 +208,14 @@ void test() {
 
     }
 }
+
+void regression() {
+  if constexpr (false) {
+    auto lam = []() { return 0; };
+    1 | lam(); // expected-warning {{unused}}
+  }
+}
+
 }
 
 #endif


### PR DESCRIPTION
Lambda bodies should not be treated as subexpressions of the enclosing scope.

Fixes #140934.