### PR TITLE
[Clang] Add resource_dir_EQ flag to CC1Option group

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5897,7 +5897,7 @@ def resource_dir : Separate<["-"], "resource-dir">,
   HelpText<"The directory which holds the compiler resource files">,
   MarshallingInfoString<HeaderSearchOpts<"ResourceDir">>;
 def resource_dir_EQ : Joined<["-"], "resource-dir=">, Flags<[NoXarchOption]>,
-  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
+  Visibility<[ClangOption, CC1Option, CLOption, DXCOption, FlangOption]>,
   Alias<resource_dir>;
 def rpath : Separate<["-"], "rpath">, Flags<[LinkerInput]>, Group<Link_Group>,
   Visibility<[ClangOption, FlangOption]>;

--- a/clang/lib/Tooling/Tooling.cpp
+++ b/clang/lib/Tooling/Tooling.cpp
@@ -510,9 +510,11 @@ static void injectResourceDir(CommandLineArguments &Args, const char *Argv0,
       return;
 
   // If there's no override in place add our resource dir.
-  Args = getInsertArgumentAdjuster(
-      ("-resource-dir=" + CompilerInvocation::GetResourcesPath(Argv0, MainAddr))
-          .c_str())(Args, "");
+  CommandLineArguments Extra = {
+      "-resource-dir", CompilerInvocation::GetResourcesPath(Argv0, MainAddr)};
+
+  Args =
+      getInsertArgumentAdjuster(Extra, ArgumentInsertPosition::END)(Args, "");
 }
 
 int ClangTool::run(ToolAction *Action) {

--- a/clang/lib/Tooling/Tooling.cpp
+++ b/clang/lib/Tooling/Tooling.cpp
@@ -510,11 +510,9 @@ static void injectResourceDir(CommandLineArguments &Args, const char *Argv0,
       return;
 
   // If there's no override in place add our resource dir.
-  CommandLineArguments Extra = {
-      "-resource-dir", CompilerInvocation::GetResourcesPath(Argv0, MainAddr)};
-
-  Args =
-      getInsertArgumentAdjuster(Extra, ArgumentInsertPosition::END)(Args, "");
+  Args = getInsertArgumentAdjuster(
+      ("-resource-dir=" + CompilerInvocation::GetResourcesPath(Argv0, MainAddr))
+          .c_str())(Args, "");
 }
 
 int ClangTool::run(ToolAction *Action) {

--- a/clang/unittests/Tooling/ToolingTest.cpp
+++ b/clang/unittests/Tooling/ToolingTest.cpp
@@ -771,6 +771,25 @@ TEST(ClangToolTest, BaseVirtualFileSystemUsage) {
   EXPECT_EQ(0, Tool.run(Action.get()));
 }
 
+// Check -cc1 command doesn't crash.
+TEST(ClangToolTest, CC1Arg) {
+  FixedCompilationDatabase Compilations("/", {"-cc1"});
+  llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFileSystem(
+      new llvm::vfs::OverlayFileSystem(llvm::vfs::getRealFileSystem()));
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> InMemoryFileSystem(
+      new llvm::vfs::InMemoryFileSystem);
+  OverlayFileSystem->pushOverlay(InMemoryFileSystem);
+
+  InMemoryFileSystem->addFile(
+      "a.cpp", 0, llvm::MemoryBuffer::getMemBuffer("int main() {}"));
+
+  ClangTool Tool(Compilations, std::vector<std::string>(1, "a.cpp"),
+                 std::make_shared<PCHContainerOperations>(), OverlayFileSystem);
+  std::unique_ptr<FrontendActionFactory> Action(
+      newFrontendActionFactory<SyntaxOnlyAction>());
+  EXPECT_EQ(0, Tool.run(Action.get()));
+}
+
 // Check getClangStripDependencyFileAdjuster doesn't strip args after -MD/-MMD.
 TEST(ClangToolTest, StripDependencyFileAdjuster) {
   FixedCompilationDatabase Compilations("/", {"-MD", "-c", "-MMD", "-w"});

--- a/clang/unittests/Tooling/ToolingTest.cpp
+++ b/clang/unittests/Tooling/ToolingTest.cpp
@@ -771,7 +771,7 @@ TEST(ClangToolTest, BaseVirtualFileSystemUsage) {
   EXPECT_EQ(0, Tool.run(Action.get()));
 }
 
-// Check -cc1 command doesn't crash.
+// Check -cc1 command doesn't fail.
 TEST(ClangToolTest, CC1Arg) {
   FixedCompilationDatabase Compilations("/", {"-cc1"});
   llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFileSystem(


### PR DESCRIPTION
This PR fixes ClangTool error in -cc1 mode in function injectResourceDir:
error: unknown argument: '-resource-dir=