### PR TITLE
[mlir] Add missing add_mlir_library_install() to tool libraries

### DIFF
--- a/mlir/lib/Tools/PDLL/Parser/CMakeLists.txt
+++ b/mlir/lib/Tools/PDLL/Parser/CMakeLists.txt
@@ -15,3 +15,5 @@ llvm_add_library(MLIRPDLLParser STATIC
   MLIRSupport
   MLIRTableGen
   )
+
+add_mlir_library_install(MLIRPDLLParser)

--- a/mlir/lib/Tools/mlir-pdll-lsp-server/CMakeLists.txt
+++ b/mlir/lib/Tools/mlir-pdll-lsp-server/CMakeLists.txt
@@ -12,3 +12,5 @@ llvm_add_library(MLIRPdllLspServerLib
   MLIRPDLLParser
   MLIRLspServerSupportLib
   )
+
+add_mlir_library_install(MLIRPdllLspServerLib)

--- a/mlir/lib/Tools/tblgen-lsp-server/CMakeLists.txt
+++ b/mlir/lib/Tools/tblgen-lsp-server/CMakeLists.txt
@@ -18,3 +18,5 @@ llvm_add_library(TableGenLspServerLib
   MLIRLspServerSupportLib
   MLIRSupport
   )
+
+add_mlir_library_install(TableGenLspServerLib)


### PR DESCRIPTION
The corresponding tools can only be run when the libraries are built as static currently due to this. I'm assuming this was not intentional.

`TableGenLspServerLib` already had the install command and the others are added with `add_mlir_library()`, which handles `install()` automatically.