### PR TITLE
[pdb] Provide a better error message when overflowing the public/global symbol record stream

### DIFF
--- a/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
@@ -322,9 +322,11 @@ Error GSIStreamBuilder::finalizeMsfLayout() {
 
   uint64_t RecordBytes = PSH->RecordByteSize + GSH->RecordByteSize;
   if (RecordBytes > UINT32_MAX)
-    return make_error<StringError>(formatv("the public ({0} bytes) and global "
-          "({1} bytes) symbols are too large to fit in a PDB file.",
-          PSH->RecordByteSize, GSH->RecordByteSize), inconvertibleErrorCode());
+    return make_error<StringError>(
+        formatv("the public ({0} bytes) and global ({1} bytes) "
+                "symbols are too large to fit in a PDB file.",
+                PSH->RecordByteSize, GSH->RecordByteSize),
+        inconvertibleErrorCode());
 
   Idx = Msf.addStream(RecordBytes);
   if (!Idx)

--- a/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
@@ -25,6 +25,7 @@
 #include "llvm/DebugInfo/PDB/Native/RawTypes.h"
 #include "llvm/Support/BinaryItemStream.h"
 #include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Parallel.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/xxhash.h"
@@ -39,7 +40,7 @@ using namespace llvm::codeview;
 // Helper class for building the public and global PDB hash table buckets.
 struct llvm::pdb::GSIHashStreamBuilder {
   // Sum of the size of all public or global records.
-  uint32_t RecordByteSize = 0;
+  uint64_t RecordByteSize = 0;
 
   std::vector<PSHashRecord> HashRecords;
 
@@ -319,7 +320,11 @@ Error GSIStreamBuilder::finalizeMsfLayout() {
     return Idx.takeError();
   PublicsStreamIndex = *Idx;
 
-  uint32_t RecordBytes = PSH->RecordByteSize + GSH->RecordByteSize;
+  uint64_t RecordBytes = PSH->RecordByteSize + GSH->RecordByteSize;
+  if (RecordBytes > UINT32_MAX)
+    return make_error<StringError>(formatv("the public ({0} bytes) and global "
+          "({1} bytes) symbols are too large to fit in a PDB file.",
+          PSH->RecordByteSize, GSH->RecordByteSize), inconvertibleErrorCode());
 
   Idx = Msf.addStream(RecordBytes);
   if (!Idx)

--- a/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
@@ -324,7 +324,8 @@ Error GSIStreamBuilder::finalizeMsfLayout() {
   if (RecordBytes > UINT32_MAX)
     return make_error<StringError>(
         formatv("the public ({0} bytes) and global ({1} bytes) "
-                "symbols are too large to fit in a PDB file.",
+                "symbols are too large to fit in a PDB file; ",
+                "the maximum total is 4294967295 bytes.
                 PSH->RecordByteSize, GSH->RecordByteSize),
         inconvertibleErrorCode());
 

--- a/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
@@ -324,9 +324,9 @@ Error GSIStreamBuilder::finalizeMsfLayout() {
   if (RecordBytes > UINT32_MAX)
     return make_error<StringError>(
         formatv("the public ({0} bytes) and global ({1} bytes) "
-                "symbols are too large to fit in a PDB file; ",
-                "the maximum total is 4294967295 bytes.
-                PSH->RecordByteSize, GSH->RecordByteSize),
+                "symbols are too large to fit in a PDB file; "
+                "the maximum total is {2} bytes.",
+                PSH->RecordByteSize, GSH->RecordByteSize, UINT32_MAX),
         inconvertibleErrorCode());
 
   Idx = Msf.addStream(RecordBytes);


### PR DESCRIPTION
Before:

  lld-link: error: Stream Error: The stream is too short to perform the requested operation.
  lld-link: error: failed to write PDB file ./unit_tests.exe.pdb

After:

  lld-link: error: the public (2127832912 bytes) and global (2200532960 bytes) symbols
  are too large to fit in a PDB file; the maximum total is 4294967295 bytes.
  lld-link: error: failed to write PDB file ./unit_tests.exe.pdb