### PR TITLE
ClangFormat: Insert braces & newline for Chromium

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1892,6 +1892,9 @@ FormatStyle getChromiumStyle(FormatStyle::LanguageKind Language) {
   ChromiumStyle.IncludeStyle.IncludeBlocks =
       tooling::IncludeStyle::IBS_Preserve;
 
+  ChromiumStyle.InsertBraces = true;
+  ChromiumStyle.InsertNewlineAtEOF = true;
+
   if (Language == FormatStyle::LK_Java) {
     ChromiumStyle.AllowShortIfStatementsOnASingleLine =
         FormatStyle::SIS_WithoutElse;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -5407,7 +5407,7 @@ TEST_F(FormatTest, DoesntRemoveUnknownTokens) {
 }
 
 TEST_F(FormatTest, IndentsPPDirectiveWithPPIndentWidth) {
-  FormatStyle style = getChromiumStyle(FormatStyle::LK_Cpp);
+  FormatStyle style = getChromiumStyle();
   style.IndentWidth = 4;
   style.PPIndentWidth = 1;
 
@@ -5905,7 +5905,7 @@ TEST_F(FormatTest, MacrosWithoutTrailingSemicolon) {
 
   verifyFormat("VISIT_GL_CALL(GenBuffers, void, (GLsizei n, GLuint* buffers), "
                "(n, buffers))",
-               getChromiumStyle(FormatStyle::LK_Cpp));
+               getChromiumStyle());
 
   // See PR41483
   verifyNoChange("/**/ FOO(a)\n"
@@ -11605,7 +11605,7 @@ TEST_F(FormatTest, UnderstandsTemplateParameters) {
   verifyFormat("auto x = [] { A<A<A<A>>> a; };", "auto x=[]{A<A<A<A> >> a;};",
                getGoogleStyle());
 
-  verifyFormat("A<A<int>> a;", getChromiumStyle(FormatStyle::LK_Cpp));
+  verifyFormat("A<A<int>> a;", getChromiumStyle());
 
   // template closer followed by a token that starts with > or =
   verifyFormat("bool b = a<1> > 1;");
@@ -12814,7 +12814,7 @@ TEST_F(FormatTest, UnderstandsSquareAttributes) {
 }
 
 TEST_F(FormatTest, AttributeClass) {
-  FormatStyle Style = getChromiumStyle(FormatStyle::LK_Cpp);
+  FormatStyle Style = getChromiumStyle();
   verifyFormat("class S {\n"
                "  S(S&&) = default;\n"
                "};",
@@ -15732,7 +15732,7 @@ TEST_F(FormatTest, MergeHandlingInTheFaceOfPreprocessorDirectives) {
                "#define a \\\n"
                "  if      \\\n"
                "  0",
-               getChromiumStyle(FormatStyle::LK_Cpp));
+               getChromiumStyle());
 }
 
 TEST_F(FormatTest, FormatStarDependingOnContext) {
@@ -22542,7 +22542,7 @@ TEST_F(FormatTest, UnderstandsPragmas) {
                "#pragma comment(linker,      \\\n"
                "                 \"argument\" \\\n"
                "                 \"argument\"",
-               getStyleWithColumns(getChromiumStyle(FormatStyle::LK_Cpp), 32));
+               getStyleWithColumns(getChromiumStyle(), 32));
 }
 
 TEST_F(FormatTest, UnderstandsPragmaOmpTarget) {
@@ -26157,7 +26157,7 @@ TEST_F(FormatTest, GoogleDefaultStyle) {
                Style);
 }
 TEST_F(FormatTest, ChromiumDefaultStyle) {
-  FormatStyle Style = getChromiumStyle(FormatStyle::LK_Cpp);
+  FormatStyle Style = getChromiumStyle();
   verifyFormat("extern \"C\" {\n"
                "int foo();\n"
                "}",

--- a/clang/unittests/Format/FormatTestJS.cpp
+++ b/clang/unittests/Format/FormatTestJS.cpp
@@ -562,7 +562,7 @@ TEST_F(FormatTestJS, SpacesInContainerLiterals) {
                "  b: 'bbbbbbbbbbbbbbbbbb'\n"
                "};");
 
-  verifyFormat("f({a: 1, b: 2, c: 3});",
+  verifyFormat("f({a: 1, b: 2, c: 3});\n",
                getChromiumStyle(FormatStyle::LK_JavaScript));
   verifyFormat("f({'a': [{}]});");
 }

--- a/clang/unittests/Format/FormatTestJava.cpp
+++ b/clang/unittests/Format/FormatTestJava.cpp
@@ -60,7 +60,7 @@ TEST_F(FormatTestJava, Chromium) {
                "        for (;;) f();\n"
                "        if (true) f();\n"
                "    }\n"
-               "}",
+               "}\n",
                getChromiumStyle(FormatStyle::LK_Java));
 }
 
@@ -280,7 +280,7 @@ TEST_F(FormatTestJava, Annotations) {
   verifyFormat("@Partial @Mock DataLoader loader;");
   verifyFormat("@Partial\n"
                "@Mock\n"
-               "DataLoader loader;",
+               "DataLoader loader;\n",
                getChromiumStyle(FormatStyle::LK_Java));
   verifyFormat("@SuppressWarnings(value = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\")\n"
                "public static int iiiiiiiiiiiiiiiiiiiiiiii;");

--- a/clang/unittests/Format/FormatTestObjC.cpp
+++ b/clang/unittests/Format/FormatTestObjC.cpp
@@ -951,7 +951,7 @@ TEST_F(FormatTestObjC, FormatObjCMethodExpr) {
       "                styleMask:NSBorderlessWindowMask\n"
       "                  backing:NSBackingStoreBuffered\n"
       "                    defer:NO]);\n"
-      "}");
+      "}\n");
 
   // Respect continuation indent and colon alignment (e.g. when object name is
   // short, and first selector is the longest one)

--- a/clang/unittests/Format/FormatTestUtils.h
+++ b/clang/unittests/Format/FormatTestUtils.h
@@ -24,6 +24,12 @@ inline FormatStyle getGoogleStyle() {
   return getGoogleStyle(FormatStyle::LK_Cpp);
 }
 
+inline FormatStyle getChromiumStyle() {
+  auto Style = getChromiumStyle(FormatStyle::LK_Cpp);
+  Style.InsertNewlineAtEOF = false;
+  return Style;
+}
+
 // When HandleHash is false, preprocessor directives starting with hash will not
 // be on separate lines.  This is needed because Verilog uses hash for other
 // purposes.


### PR DESCRIPTION
This addresses an old TODO in the Chromium codebase to upstream a change to the Chromium format style.
https://source.chromium.org/chromium/chromium/src/+/main:.clang-format;l=10;drc=b9d8d6aeeef9feacf6eb4838cdccca4c2da2a0eb

Bug: crbug.com/40247920