### PR TITLE
[Offload] Allow allocations to be freed without knowing their type

### DIFF
--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -89,7 +89,6 @@ namespace offload {
 
 struct AllocInfo {
   ol_device_handle_t Device;
-  ol_alloc_type_t Type;
 };
 
 using AllocInfoMapT = DenseMap<void *, AllocInfo>;
@@ -314,7 +313,7 @@ ol_impl_result_t olMemAlloc_impl(ol_device_handle_t Device,
     return ol_impl_result_t::fromError(Alloc.takeError());
 
   *AllocationOut = *Alloc;
-  allocInfoMap().insert_or_assign(*Alloc, AllocInfo{Device, Type});
+  allocInfoMap().insert_or_assign(*Alloc, AllocInfo{Device});
   return OL_SUCCESS;
 }
 
@@ -324,10 +323,8 @@ ol_impl_result_t olMemFree_impl(void *Address) {
 
   auto AllocInfo = allocInfoMap().at(Address);
   auto Device = AllocInfo.Device;
-  auto Type = AllocInfo.Type;
 
-  auto Res =
-      Device->Device->dataDelete(Address, convertOlToPluginAllocTy(Type));
+  auto Res = Device->Device->dataDelete(Address);
   if (Res)
     return ol_impl_result_t::fromError(std::move(Res));
 

--- a/offload/plugins-nextgen/common/include/MemoryManager.h
+++ b/offload/plugins-nextgen/common/include/MemoryManager.h
@@ -36,7 +36,11 @@ public:
                          TargetAllocTy Kind = TARGET_ALLOC_DEFAULT) = 0;
 
   /// Delete the pointer \p TgtPtr on the device
-  virtual int free(void *TgtPtr, TargetAllocTy Kind = TARGET_ALLOC_DEFAULT) = 0;
+  virtual int free(void *TgtPtr) = 0;
+
+  /// Delete the pointer \p TgtPtr, of type TARGET_ALLOC_DEVICE_NON_BLOCKING,
+  /// on the device.
+  virtual int free_non_blocking(void *TgtPtr) = 0;
 };
 
 /// Class of memory manager. The memory manager is per-device by using

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -771,6 +771,10 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
   /// Deallocate data from the device or involving the device.
   Error dataDelete(void *TgtPtr, TargetAllocTy Kind);
 
+  /// Deallocate data from the device or involving the device, where the
+  /// allocation type is unknown.
+  Error dataDelete(void *TgtPtr);
+
   /// Pin host memory to optimize transfers and return the device accessible
   /// pointer that devices should use for memory transfers involving the host
   /// pinned allocation.

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -35,8 +35,7 @@ rpc::Status handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
   }
   case LIBC_FREE: {
     Port.recv([&](rpc::Buffer *Buffer, uint32_t) {
-      Device.free(reinterpret_cast<void *>(Buffer->data[0]),
-                  TARGET_ALLOC_DEVICE_NON_BLOCKING);
+      Device.free_non_blocking(reinterpret_cast<void *>(Buffer->data[0]));
     });
     break;
   }
@@ -198,7 +197,7 @@ Error RPCServerTy::initDevice(plugin::GenericDeviceTy &Device,
 
 Error RPCServerTy::deinitDevice(plugin::GenericDeviceTy &Device) {
   std::lock_guard<decltype(BufferMutex)> Lock(BufferMutex);
-  Device.free(Buffers[Device.getDeviceId()], TARGET_ALLOC_HOST);
+  Device.free(Buffers[Device.getDeviceId()]);
   Buffers[Device.getDeviceId()] = nullptr;
   Devices[Device.getDeviceId()] = nullptr;
   return Error::success();

--- a/offload/plugins-nextgen/cuda/dynamic_cuda/cuda.cpp
+++ b/offload/plugins-nextgen/cuda/dynamic_cuda/cuda.cpp
@@ -84,6 +84,7 @@ DLWRAP(cuEventRecord, 2)
 DLWRAP(cuStreamWaitEvent, 3)
 DLWRAP(cuEventSynchronize, 1)
 DLWRAP(cuEventDestroy, 1)
+DLWRAP(cuPointerGetAttributes, 4)
 
 DLWRAP_FINALIZE()
 

--- a/offload/plugins-nextgen/cuda/dynamic_cuda/cuda.h
+++ b/offload/plugins-nextgen/cuda/dynamic_cuda/cuda.h
@@ -256,6 +256,11 @@ typedef enum CUdevice_attribute_enum {
   CU_DEVICE_ATTRIBUTE_MAX,
 } CUdevice_attribute;
 
+typedef enum CUpointer_attribute_enum {
+  CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2,
+  CU_POINTER_ATTRIBUTE_IS_MANAGED = 8,
+} CUpointer_attribute;
+
 typedef enum CUfunction_attribute_enum {
   CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 0,
 } CUfunction_attribute;
@@ -283,6 +288,13 @@ typedef enum CUevent_flags_enum {
   CU_EVENT_DISABLE_TIMING = 0x2,
   CU_EVENT_INTERPROCESS = 0x4
 } CUevent_flags;
+
+typedef enum CUmemorytype_enum {
+  CU_MEMORYTYPE_HOST = 0x01,
+  CU_MEMORYTYPE_DEVICE = 0x02,
+  CU_MEMORYTYPE_ARRAY = 0x03,
+  CU_MEMORYTYPE_UNIFIED = 0x04
+} CUmemorytype;
 
 static inline void *CU_LAUNCH_PARAM_END = (void *)0x00;
 static inline void *CU_LAUNCH_PARAM_BUFFER_POINTER = (void *)0x01;
@@ -370,5 +382,8 @@ CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size,
 CUresult cuMemGetAllocationGranularity(size_t *granularity,
                                        const CUmemAllocationProp *prop,
                                        CUmemAllocationGranularity_flags option);
+CUresult cuPointerGetAttributes(unsigned int numAttributes,
+                                CUpointer_attribute *attributes, void **data,
+                                CUdeviceptr ptr);
 
 #endif

--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -239,10 +239,12 @@ struct GenELF64DeviceTy : public GenericDeviceTy {
   }
 
   /// Free the memory. Use std::free in all cases.
-  int free(void *TgtPtr, TargetAllocTy Kind) override {
+  int free(void *TgtPtr) override {
     std::free(TgtPtr);
     return OFFLOAD_SUCCESS;
   }
+
+  int free_non_blocking(void *TgtPtr) override { return free(TgtPtr); }
 
   /// This plugin does nothing to lock buffers. Do not return an error, just
   /// return the same pointer as the device pointer.


### PR DESCRIPTION
In liboffload we want users to be able to free memory with `olMemFree` without knowing the allocation's type. Currently we track every allocation's associated device and type in a map, and we'd like to remove that workaround. This removes the allocation type from the tracked info.

- Add an overload of `GenericDeviceTy::dataDelete` that doesn't take a `TargetAllocTy`
- Remove the kind argument from `DeviceAllocatorTy::free`
- In the AMDGPU plugin, we can free allocations like this already. Make the relevant method static and remove the code to determine the memory pool as it never actually mattered
- In the CUDA plugin, determine what type of memory an allocation is with `cuPointerGetAttributes`
- Split out `free_non_blocking` from `free` in `DeviceAllocatorTy` so non-blocking device allocations can still be freed