### PR TITLE
release/20.x: [libclc] Include isnan implementation for SPIR-V targets

### DIFF
--- a/libclc/clc/lib/spirv/SOURCES
+++ b/libclc/clc/lib/spirv/SOURCES
@@ -10,5 +10,6 @@
 ../generic/math/clc_nextafter.cl
 ../generic/math/clc_rint.cl
 ../generic/math/clc_trunc.cl
+../generic/relational/clc_isnan.cl
 ../generic/relational/clc_select.cl
 ../generic/shared/clc_clamp.cl

--- a/libclc/clc/lib/spirv64/SOURCES
+++ b/libclc/clc/lib/spirv64/SOURCES
@@ -10,5 +10,6 @@
 ../generic/math/clc_nextafter.cl
 ../generic/math/clc_rint.cl
 ../generic/math/clc_trunc.cl
+../generic/relational/clc_isnan.cl
 ../generic/relational/clc_select.cl
 ../generic/shared/clc_clamp.cl


### PR DESCRIPTION
The fma software emulation requires it.

Similar to https://github.com/llvm/llvm-project/pull/124614

This change intentionally targets 20.x as things changed on main enough that it's not feasible to land a change in main first.