### PR TITLE
[clang] Fixed an assertion failure triggered when instantiating a template with an expr that references an invalid decl

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -579,6 +579,8 @@ Bug Fixes in This Version
   ``#include`` directive. (#GH138094)
 - Fixed a crash during constant evaluation involving invalid lambda captures
   (#GH138832)
+- Fixed an assertion failure triggered when instantiating a template with an
+  expression that references an invalid declaration (#GH140898)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -4552,6 +4552,9 @@ LocalInstantiationScope::findInstantiationOf(const Decl *D) {
       isa<CXXDeductionGuideDecl>(D->getDeclContext()))
     return nullptr;
 
+  if (D->isInvalidDecl())
+    return nullptr;
+
   // If we didn't find the decl, then we either have a sema bug, or we have a
   // forward reference to a label declaration.  Return null to indicate that
   // we have an uninstantiated label.

--- a/clang/test/SemaCXX/gh140898.cpp
+++ b/clang/test/SemaCXX/gh140898.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+template <typename T>
+void s() {
+  switch (Unknown tr = 1) // expected-error {{unknown type name 'Unknown'}}
+    tr;
+}
+
+void abc() {
+  s<int>();
+}


### PR DESCRIPTION
Fixes #140898 