### PR TITLE
[lldb] Disable some unwind plans for discontinuous functions

### DIFF
--- a/lldb/include/lldb/Symbol/CallFrameInfo.h
+++ b/lldb/include/lldb/Symbol/CallFrameInfo.h
@@ -19,8 +19,10 @@ public:
 
   virtual bool GetAddressRange(Address addr, AddressRange &range) = 0;
 
-  virtual bool GetUnwindPlan(const Address &addr, UnwindPlan &unwind_plan) = 0;
-  virtual bool GetUnwindPlan(const AddressRange &range, UnwindPlan &unwind_plan) = 0;
+  virtual std::unique_ptr<UnwindPlan>
+  GetUnwindPlan(llvm::ArrayRef<AddressRange> ranges, const Address &addr) = 0;
+
+  virtual std::unique_ptr<UnwindPlan> GetUnwindPlan(const Address &addr) = 0;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Symbol/FuncUnwinders.h
+++ b/lldb/include/lldb/Symbol/FuncUnwinders.h
@@ -51,8 +51,6 @@ public:
   std::shared_ptr<const UnwindPlan>
   GetUnwindPlanArchitectureDefaultAtFunctionEntry(lldb_private::Thread &thread);
 
-  Address &GetFirstNonPrologueInsn(Target &target);
-
   const Address &GetFunctionStartAddress() const;
 
   bool ContainsAddress(const Address &addr) const {
@@ -113,10 +111,6 @@ private:
 
   /// The address ranges of the function.
   AddressRanges m_ranges;
-
-  /// The smallest address range covering the entire function.
-  /// DEPRECATED: Use m_ranges instead.
-  AddressRange m_range;
 
   std::recursive_mutex m_mutex;
 

--- a/lldb/source/Plugins/ObjectFile/PECOFF/PECallFrameInfo.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/PECallFrameInfo.h
@@ -9,7 +9,9 @@
 #ifndef LLDB_SOURCE_PLUGINS_OBJECTFILE_PECOFF_PECALLFRAMEINFO_H
 #define LLDB_SOURCE_PLUGINS_OBJECTFILE_PECOFF_PECALLFRAMEINFO_H
 
+#include "lldb/Core/AddressRange.h"
 #include "lldb/Symbol/CallFrameInfo.h"
+#include "lldb/Symbol/UnwindPlan.h"
 #include "lldb/Utility/DataExtractor.h"
 
 class ObjectFilePECOFF;
@@ -31,10 +33,14 @@ public:
   bool GetAddressRange(lldb_private::Address addr,
                        lldb_private::AddressRange &range) override;
 
-  bool GetUnwindPlan(const lldb_private::Address &addr,
-                     lldb_private::UnwindPlan &unwind_plan) override;
-  bool GetUnwindPlan(const lldb_private::AddressRange &range,
-                     lldb_private::UnwindPlan &unwind_plan) override;
+  std::unique_ptr<lldb_private::UnwindPlan>
+  GetUnwindPlan(const lldb_private::Address &addr) override {
+    return GetUnwindPlan({lldb_private::AddressRange(addr, 1)}, addr);
+  }
+
+  std::unique_ptr<lldb_private::UnwindPlan>
+  GetUnwindPlan(llvm::ArrayRef<lldb_private::AddressRange> ranges,
+                const lldb_private::Address &addr) override;
 
 private:
   const llvm::Win64EH::RuntimeFunction *FindRuntimeFunctionIntersectsWithRange(

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -880,10 +880,9 @@ RegisterContextUnwind::GetFullUnwindPlanForFrame() {
     CallFrameInfo *object_file_unwind =
         pc_module_sp->GetUnwindTable().GetObjectFileUnwindInfo();
     if (object_file_unwind) {
-      auto unwind_plan_sp =
-          std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
-      if (object_file_unwind->GetUnwindPlan(m_current_pc, *unwind_plan_sp))
-        return unwind_plan_sp;
+      if (std::unique_ptr<UnwindPlan> plan_up =
+              object_file_unwind->GetUnwindPlan(m_current_pc))
+        return plan_up;
     }
 
     return arch_default_unwind_plan_sp;


### PR DESCRIPTION
Basically, disable everything except the eh_frame unwind plan, as that's the only one which supports this right now. The other plans are working with now trying the interpret everything in between the function parts as a part of the function, which is more likely to produce wrong results than correct ones.

I changed the interface for object file plans, to give the implementations a chance to implement this correctly, but I haven't actually converted PECallFrameInfo (its only implementation) to handle that. (from the looks of things, it should be relatively easy to do, if it becomes necessary)

I'm also deleting UnwindPlan::GetFirstNonPrologueInsn, as it's not used, and it doesn't work for discontinuous functions.