### PR TITLE
Revert "[Clang] Fix missed initializer instantiation bug for variable templates"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -743,7 +743,6 @@ Bug Fixes to C++ Support
   in a ``constexpr`` function. (#GH131432)
 - Fixed an incorrect TreeTransform for calls to ``consteval`` functions if a conversion template is present. (#GH137885)
 - Clang now emits a warning when class template argument deduction for alias templates is used in C++17. (#GH133806)
-- Fix missed initializer instantiation bug for variable templates. (#GH138122)
 - Fix a crash when checking the template template parameters of a dependent lambda appearing in an alias declaration.
   (#GH136432), (#GH137014), (#GH138018)
 - Fixed an assertion when trying to constant-fold various builtins when the argument

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -6032,11 +6032,11 @@ void Sema::BuildVariableInstantiation(
   Context.setStaticLocalNumber(NewVar, Context.getStaticLocalNumber(OldVar));
 
   // Figure out whether to eagerly instantiate the initializer.
-  if (NewVar->getType()->isUndeducedType()) {
+  if (InstantiatingVarTemplate || InstantiatingVarTemplatePartialSpec) {
+    // We're producing a template. Don't instantiate the initializer yet.
+  } else if (NewVar->getType()->isUndeducedType()) {
     // We need the type to complete the declaration of the variable.
     InstantiateVariableInitializer(NewVar, OldVar, TemplateArgs);
-  } else if (InstantiatingVarTemplate || InstantiatingVarTemplatePartialSpec) {
-    // We're producing a template. Don't instantiate the initializer yet.
   } else if (InstantiatingSpecFromTemplate ||
              (OldVar->isInline() && OldVar->isThisDeclarationADefinition() &&
               !NewVar->isThisDeclarationADefinition())) {

--- a/clang/test/CodeGenCXX/cxx1z-inline-variables.cpp
+++ b/clang/test/CodeGenCXX/cxx1z-inline-variables.cpp
@@ -1,19 +1,5 @@
 // RUN: %clang_cc1 -std=c++1z %s -emit-llvm -o - -triple x86_64-linux-gnu | FileCheck %s
 
-template <typename T> struct InlineAuto {
-  template <typename G> inline static auto var = 5;
-};
-int inlineauto = InlineAuto<int>::var<int>;
-// CHECK: @_ZN10InlineAutoIiE3varIiEE = {{.*}}i32 5{{.*}}comdat
-//
-template <typename> struct PartialInlineAuto {
-  template <typename, typename> inline static auto var = 6;
-  template <typename T> inline static auto var<int, T> = 7;
-};
-
-int partialinlineauto = PartialInlineAuto<int>::var<int, int>;
-// CHECK: @_ZN17PartialInlineAutoIiE3varIiiEE = {{.*}}i32 7{{.*}}comdat
-
 struct Q {
   // CHECK: @_ZN1Q1kE = linkonce_odr constant i32 5, comdat
   static constexpr int k = 5;

--- a/clang/test/SemaTemplate/cxx17-inline-variables.cpp
+++ b/clang/test/SemaTemplate/cxx17-inline-variables.cpp
@@ -27,15 +27,3 @@ template <typename T> constexpr int A<T>::n = sizeof(A) + sizeof(T);
 template <typename T> inline constexpr int A<T>::m = sizeof(A) + sizeof(T);
 static_assert(A<int>().f() == 5);
 static_assert(A<int>().g() == 5);
-
-template <typename T> struct InlineAuto {
-  template <typename G> inline static auto var = 5;
-};
-
-template <typename> struct PartialInlineAuto {
-  template <typename, typename> inline static auto var = 6;
-  template <typename T> inline static auto var<int, T> = 7;
-};
-
-int inlineauto = InlineAuto<int>::var<int>;
-int partialinlineauto = PartialInlineAuto<int>::var<int, int>;


### PR DESCRIPTION
Reverts llvm/llvm-project#138122

The patch causes a regression and prevents compiling valid C++ code. 
The code was accepted by earlier versions of clang and GCC. 
See https://github.com/llvm/llvm-project/issues/140773 for details.