### PR TITLE
[libclc] Move step to the CLC library; add missing half variants

### DIFF
--- a/libclc/clc/include/clc/clcmacro.h
+++ b/libclc/clc/include/clc/clcmacro.h
@@ -73,39 +73,6 @@
         FUNCTION(x.sf, y.sf));                                                 \
   }
 
-#define _CLC_V_S_V_VECTORIZE(DECLSPEC, RET_TYPE, FUNCTION, ARG1_TYPE,          \
-                             ARG2_TYPE)                                        \
-  DECLSPEC RET_TYPE##2 FUNCTION(ARG1_TYPE x, ARG2_TYPE##2 y) {                 \
-    return (RET_TYPE##2)(FUNCTION(x, y.s0), FUNCTION(x, y.s1));                \
-  }                                                                            \
-                                                                               \
-  DECLSPEC RET_TYPE##3 FUNCTION(ARG1_TYPE x, ARG2_TYPE##3 y) {                 \
-    return (RET_TYPE##3)(FUNCTION(x, y.s0), FUNCTION(x, y.s1),                 \
-                         FUNCTION(x, y.s2));                                   \
-  }                                                                            \
-                                                                               \
-  DECLSPEC RET_TYPE##4 FUNCTION(ARG1_TYPE x, ARG2_TYPE##4 y) {                 \
-    return (RET_TYPE##4)(FUNCTION(x, y.s0), FUNCTION(x, y.s1),                 \
-                         FUNCTION(x, y.s2), FUNCTION(x, y.s3));                \
-  }                                                                            \
-                                                                               \
-  DECLSPEC RET_TYPE##8 FUNCTION(ARG1_TYPE x, ARG2_TYPE##8 y) {                 \
-    return (RET_TYPE##8)(FUNCTION(x, y.s0), FUNCTION(x, y.s1),                 \
-                         FUNCTION(x, y.s2), FUNCTION(x, y.s3),                 \
-                         FUNCTION(x, y.s4), FUNCTION(x, y.s5),                 \
-                         FUNCTION(x, y.s6), FUNCTION(x, y.s7));                \
-  }                                                                            \
-                                                                               \
-  DECLSPEC RET_TYPE##16 FUNCTION(ARG1_TYPE x, ARG2_TYPE##16 y) {               \
-    return (RET_TYPE##16)(                                                     \
-        FUNCTION(x, y.s0), FUNCTION(x, y.s1), FUNCTION(x, y.s2),               \
-        FUNCTION(x, y.s3), FUNCTION(x, y.s4), FUNCTION(x, y.s5),               \
-        FUNCTION(x, y.s6), FUNCTION(x, y.s7), FUNCTION(x, y.s8),               \
-        FUNCTION(x, y.s9), FUNCTION(x, y.sa), FUNCTION(x, y.sb),               \
-        FUNCTION(x, y.sc), FUNCTION(x, y.sd), FUNCTION(x, y.se),               \
-        FUNCTION(x, y.sf));                                                    \
-  }
-
 #define _CLC_TERNARY_VECTORIZE(DECLSPEC, RET_TYPE, FUNCTION, ARG1_TYPE,        \
                                ARG2_TYPE, ARG3_TYPE)                           \
   DECLSPEC RET_TYPE##2 FUNCTION(ARG1_TYPE##2 x, ARG2_TYPE##2 y,                \

--- a/libclc/clc/include/clc/common/clc_step.h
+++ b/libclc/clc/include/clc/common/clc_step.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE step(__CLC_GENTYPE edge, __CLC_GENTYPE x);
+#ifndef __CLC_COMMON_CLC_STEP_H__
+#define __CLC_COMMON_CLC_STEP_H__
 
-#ifndef __CLC_SCALAR
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE step(__CLC_SCALAR_GENTYPE edge,
-                                           __CLC_GENTYPE x);
-#endif
+#define __CLC_FUNCTION __clc_step
+#define __CLC_BODY <clc/shared/binary_decl.inc>
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_FUNCTION
+
+#endif // __CLC_COMMON_CLC_STEP_H__

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -2,6 +2,7 @@ common/clc_degrees.cl
 common/clc_radians.cl
 common/clc_sign.cl
 common/clc_smoothstep.cl
+common/clc_step.cl
 geometric/clc_cross.cl
 geometric/clc_distance.cl
 geometric/clc_dot.cl

--- a/libclc/clc/lib/generic/common/clc_step.cl
+++ b/libclc/clc/lib/generic/common/clc_step.cl
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE step(__CLC_GENTYPE edge, __CLC_GENTYPE x);
+#include <clc/clcmacro.h>
 
-#ifndef __CLC_SCALAR
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE step(__CLC_SCALAR_GENTYPE edge,
-                                           __CLC_GENTYPE x);
-#endif
+#define __CLC_BODY <clc_step.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/common/clc_step.inc
+++ b/libclc/clc/lib/generic/common/clc_step.inc
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE step(__CLC_GENTYPE edge, __CLC_GENTYPE x);
-
-#ifndef __CLC_SCALAR
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE step(__CLC_SCALAR_GENTYPE edge,
-                                           __CLC_GENTYPE x);
-#endif
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_step(__CLC_GENTYPE edge,
+                                                __CLC_GENTYPE x) {
+  return x < edge ? __CLC_FP_LIT(0.0) : __CLC_FP_LIT(1.0);
+}

--- a/libclc/opencl/lib/generic/common/step.cl
+++ b/libclc/opencl/lib/generic/common/step.cl
@@ -6,36 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clcmacro.h>
+#include <clc/common/clc_step.h>
 #include <clc/opencl/clc.h>
 
-_CLC_OVERLOAD _CLC_DEF float step(float edge, float x) {
-  return x < edge ? 0.0f : 1.0f;
-}
-
-_CLC_BINARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, step, float, float);
-
-_CLC_V_S_V_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, step, float, float);
-
-#ifdef cl_khr_fp64
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-
-#define STEP_DEF(edge_type, x_type)                                            \
-  _CLC_OVERLOAD _CLC_DEF x_type step(edge_type edge, x_type x) {               \
-    return x < edge ? 0.0 : 1.0;                                               \
-  }
-
-STEP_DEF(double, double);
-
-_CLC_BINARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, step, double, double);
-_CLC_V_S_V_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, step, double, double);
-
-#if !defined(CLC_SPIRV)
-STEP_DEF(float, double);
-STEP_DEF(double, float);
-
-_CLC_V_S_V_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, step, float, double);
-_CLC_V_S_V_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, step, double, float);
-#endif
-
-#endif
+#define __CLC_BODY <step.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/opencl/lib/generic/common/step.inc
+++ b/libclc/opencl/lib/generic/common/step.inc
@@ -6,9 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE step(__CLC_GENTYPE edge, __CLC_GENTYPE x);
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE step(__CLC_GENTYPE edge, __CLC_GENTYPE x) {
+  return __clc_step(edge, x);
+}
 
-#ifndef __CLC_SCALAR
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE step(__CLC_SCALAR_GENTYPE edge,
-                                           __CLC_GENTYPE x);
+#if !defined(__CLC_SCALAR)
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE step(__CLC_SCALAR_GENTYPE edge,
+                                          __CLC_GENTYPE x) {
+  return __clc_step((__CLC_GENTYPE)edge, x);
+}
+
 #endif


### PR DESCRIPTION
The half variants were missing but are trivial to implement. There were some incorrect mixed type overloads (step(float, double)) which aren't in the OpenCL specification and so have been removed.

Like certain other builtins the CLC step function only deals with identical types. The OpenCL layer is responsible for casting the scalar argument to a vector.

This commit also trivially vectorizes the CLC function, generating better bytecode.