### PR TITLE
[lldb] Show more children of top level values

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -186,7 +186,7 @@ public:
 
   uint32_t GetMaxZeroPaddingInFloatFormat() const;
 
-  uint32_t GetMaximumNumberOfChildrenToDisplay() const;
+  std::pair<uint32_t, bool> GetMaximumNumberOfChildrenToDisplay() const;
 
   /// Get the max depth value, augmented with a bool to indicate whether the
   /// depth is the default.

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1648,7 +1648,7 @@ uint32_t SBTarget::GetMaximumNumberOfChildrenToDisplay() const {
   LLDB_INSTRUMENT_VA(this);
 
   if (TargetSP target_sp = GetSP())
-    return target_sp->GetMaximumNumberOfChildrenToDisplay();
+    return target_sp->GetMaximumNumberOfChildrenToDisplay().first;
   return 0;
 }
 

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -1027,7 +1027,7 @@ static bool DumpValue(Stream &s, const SymbolContext *sc,
     if (index_higher < 0)
       index_higher = valobj->GetNumChildrenIgnoringErrors() - 1;
 
-    uint32_t max_num_children =
+    auto [max_num_children, _] =
         target->GetTargetSP()->GetMaximumNumberOfChildrenToDisplay();
 
     bool success = true;

--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -466,7 +466,7 @@ bool FormatManager::ShouldPrintAsOneLiner(ValueObject &valobj) {
   if (valobj.GetSummaryFormat().get() != nullptr)
     return valobj.GetSummaryFormat()->IsOneLiner();
 
-  const size_t max_num_children =
+  const auto [max_num_children, _] =
       (target_sp ? *target_sp : Target::GetGlobalProperties())
           .GetMaximumNumberOfChildrenToDisplay();
   auto num_children = valobj.GetNumChildren(max_num_children);

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -633,6 +633,27 @@ void ValueObjectPrinter::PrintChild(
   }
 }
 
+static uint32_t determineMaxChildren(bool ignore_cap, uint32_t cur_depth,
+                                     TargetSP target_sp) {
+  if (ignore_cap)
+    return UINT32_MAX;
+
+  const auto [max_num_children, max_is_default] =
+      target_sp->GetMaximumNumberOfChildrenToDisplay();
+
+  // Special handling for printing values at the top level (such as variables).
+  // The original default value for target.max-children-count was 256. The
+  // default has since been reduced, to avoid printing too much data. However,
+  // users will naturally have expectations that all children are shown for top
+  // level values. The following code keeps 256 as the max count for top level
+  // values (unless customized).
+  const uint32_t top_level_max_num_childen = 256;
+  if (cur_depth == 0 && max_is_default)
+    return top_level_max_num_childen;
+
+  return max_num_children;
+}
+
 llvm::Expected<uint32_t>
 ValueObjectPrinter::GetMaxNumChildrenToPrint(bool &print_dotdotdot) {
   ValueObject &synth_valobj = GetValueObjectForChildrenGeneration();
@@ -641,10 +662,8 @@ ValueObjectPrinter::GetMaxNumChildrenToPrint(bool &print_dotdotdot) {
     return m_options.m_pointer_as_array.m_element_count;
 
   const uint32_t max_num_children =
-      m_options.m_ignore_cap ? UINT32_MAX
-                             : GetMostSpecializedValue()
-                                   .GetTargetSP()
-                                   ->GetMaximumNumberOfChildrenToDisplay();
+      determineMaxChildren(m_options.m_ignore_cap, m_curr_depth,
+                           GetMostSpecializedValue().GetTargetSP());
   // Ask for one more child than the maximum to see if we should print "...".
   auto num_children_or_err = synth_valobj.GetNumChildren(
       llvm::SaturatingAdd(max_num_children, uint32_t(1)));

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -176,7 +176,7 @@ lldb::ChildCacheState AbstractListFrontEnd::Update() {
 
   if (m_backend.GetTargetSP())
     m_list_capping_size =
-        m_backend.GetTargetSP()->GetMaximumNumberOfChildrenToDisplay();
+        m_backend.GetTargetSP()->GetMaximumNumberOfChildrenToDisplay().first;
   if (m_list_capping_size == 0)
     m_list_capping_size = 255;
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4814,10 +4814,13 @@ uint32_t TargetProperties::GetMaxZeroPaddingInFloatFormat() const {
       idx, g_target_properties[idx].default_uint_value);
 }
 
-uint32_t TargetProperties::GetMaximumNumberOfChildrenToDisplay() const {
+std::pair<uint32_t, bool>
+TargetProperties::GetMaximumNumberOfChildrenToDisplay() const {
   const uint32_t idx = ePropertyMaxChildrenCount;
-  return GetPropertyAtIndexAs<uint64_t>(
-      idx, g_target_properties[idx].default_uint_value);
+  auto *option_value =
+      m_collection_sp->GetPropertyAtIndexAsOptionValueUInt64(idx);
+  bool is_default = !option_value->OptionWasSet();
+  return {option_value->GetCurrentValue(), is_default};
 }
 
 std::pair<uint32_t, bool>

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -97,7 +97,7 @@ let Definition = "target" in {
     Desc<"The maximum number of zeroes to insert when displaying a very small float before falling back to scientific notation.">;
   def MaxChildrenCount: Property<"max-children-count", "UInt64">,
     DefaultUnsignedValue<24>,
-    Desc<"Maximum number of children to expand in any level of depth.">;
+    Desc<"Maximum number of children to show for nested values. Top level values show up to 256 children.">;
   def MaxChildrenDepth: Property<"max-children-depth", "UInt64">,
     DefaultUnsignedValue<0xFFFFFFFF>,
     Desc<"Maximum depth to expand children.">;

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -97,7 +97,7 @@ let Definition = "target" in {
     Desc<"The maximum number of zeroes to insert when displaying a very small float before falling back to scientific notation.">;
   def MaxChildrenCount: Property<"max-children-count", "UInt64">,
     DefaultUnsignedValue<24>,
-    Desc<"Maximum number of children to show for nested values. Top level values show up to 256 children.">;
+    Desc<"Maximum number of children to show. Note: The default behavior will show 256 children for top-level values, and 24 children for any nested value. A custom count applies to all values, at any nesting.">;
   def MaxChildrenDepth: Property<"max-children-depth", "UInt64">,
     DefaultUnsignedValue<0xFFFFFFFF>,
     Desc<"Maximum depth to expand children.">;


### PR DESCRIPTION
This changes printing values at the top level (such as variables). The original default
value for `target.max-children-count` was 256. The default has since been reduced, to
avoid printing too much data (ff127624be).

However, users will naturally have expectations that all (or significantly many)
children are shown for top level values. The following code keeps 256 as the max count
for top level values (unless customized). The value of `target.max-children-count` will
continue to apply to nested values (depth >= 1).
