### PR TITLE
[CIR] Improve NYI message for emitCompoundStmtWithoutScope

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -26,7 +26,9 @@ using namespace cir;
 void CIRGenFunction::emitCompoundStmtWithoutScope(const CompoundStmt &s) {
   for (auto *curStmt : s.body()) {
     if (emitStmt(curStmt, /*useCurrentScope=*/false).failed())
-      getCIRGenModule().errorNYI(curStmt->getSourceRange(), "statement");
+      getCIRGenModule().errorNYI(curStmt->getSourceRange(),
+                                 std::string("emitCompoundStmtWithoutScope: ") +
+                                     curStmt->getStmtClassName());
   }
 }
 


### PR DESCRIPTION
This improves the error emitting for unhandled compound statements without scope by reporting the statement class that wasn't handled.