### PR TITLE
[LLVM] Use `reportFatalUsageError` for LTO usage errors

### DIFF
--- a/lld/test/COFF/lto-cache-errors.ll
+++ b/lld/test/COFF/lto-cache-errors.ll
@@ -7,8 +7,8 @@
 ; RUN: rm -Rf %t.cache && mkdir %t.cache
 ; RUN: chmod 444 %t.cache
 
-;; Check emit warnings when we can't create the cache dir
-; RUN: not --crash lld-link /lldltocache:%t.cache/nonexistant/ /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
+;; Check fatal usage error emitted when the cache dir can't be created.
+; RUN: not lld-link /lldltocache:%t.cache/nonexistant/ /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
 ; CHECK: LLVM ERROR: can't create cache directory {{.*}}/nonexistant/: Permission denied
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"

--- a/lld/test/ELF/lto/ltopasses-custom.ll
+++ b/lld/test/ELF/lto/ltopasses-custom.ll
@@ -24,13 +24,13 @@ define void @barrier() {
 ; ATOMIC-NEXT: ret void
 
 ; Check that invalid passes are rejected gracefully.
-; RUN: env LLD_IN_TEST=1 not --crash ld.lld -m elf_x86_64 %t.o -o /dev/null \
+; RUN: env LLD_IN_TEST=1 not ld.lld -m elf_x86_64 %t.o -o /dev/null \
 ; RUN:   --lto-newpm-passes=iamnotapass -shared 2>&1 | \
 ; RUN:   FileCheck %s --check-prefix=INVALID
 ; INVALID: unable to parse pass pipeline description 'iamnotapass': unknown pass name 'iamnotapass'
 
 ; Check that invalid AA pipelines are rejected gracefully.
-; RUN: env LLD_IN_TEST=1 not --crash ld.lld -m elf_x86_64 %t.o -o /dev/null \
+; RUN: env LLD_IN_TEST=1 not ld.lld -m elf_x86_64 %t.o -o /dev/null \
 ; RUN:   --lto-newpm-passes=globaldce --lto-aa-pipeline=patatino \
 ; RUN:   -shared 2>&1 | \
 ; RUN:   FileCheck %s --check-prefix=INVALIDAA

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -290,7 +290,7 @@ static void runNewPMPasses(const Config &Conf, Module &Mod, TargetMachine *TM,
   if (!Conf.AAPipeline.empty()) {
     AAManager AA;
     if (auto Err = PB.parseAAPipeline(AA, Conf.AAPipeline)) {
-      report_fatal_error(Twine("unable to parse AA pipeline description '") +
+      reportFatalUsageError(Twine("unable to parse AA pipeline description '") +
                          Conf.AAPipeline + "': " + toString(std::move(Err)));
     }
     // Register the AA manager first so that our version is the one used.
@@ -331,7 +331,7 @@ static void runNewPMPasses(const Config &Conf, Module &Mod, TargetMachine *TM,
   // Parse a custom pipeline if asked to.
   if (!Conf.OptPipeline.empty()) {
     if (auto Err = PB.parsePassPipeline(MPM, Conf.OptPipeline)) {
-      report_fatal_error(Twine("unable to parse pass pipeline description '") +
+      reportFatalUsageError(Twine("unable to parse pass pipeline description '") +
                          Conf.OptPipeline + "': " + toString(std::move(Err)));
     }
   } else if (IsThinLTO) {
@@ -415,7 +415,7 @@ static void codegen(const Config &Conf, TargetMachine *TM,
   if (!Conf.DwoDir.empty()) {
     std::error_code EC;
     if (auto EC = llvm::sys::fs::create_directories(Conf.DwoDir))
-      report_fatal_error(Twine("Failed to create directory ") + Conf.DwoDir +
+      reportFatalUsageError(Twine("Failed to create directory ") + Conf.DwoDir +
                          ": " + EC.message());
 
     DwoFile = Conf.DwoDir;
@@ -428,14 +428,14 @@ static void codegen(const Config &Conf, TargetMachine *TM,
     std::error_code EC;
     DwoOut = std::make_unique<ToolOutputFile>(DwoFile, EC, sys::fs::OF_None);
     if (EC)
-      report_fatal_error(Twine("Failed to open ") + DwoFile + ": " +
+      reportFatalUsageError(Twine("Failed to open ") + DwoFile + ": " +
                          EC.message());
   }
 
   Expected<std::unique_ptr<CachedFileStream>> StreamOrErr =
       AddStream(Task, Mod.getModuleIdentifier());
   if (Error Err = StreamOrErr.takeError())
-    report_fatal_error(std::move(Err));
+    reportFatalUsageError(std::move(Err));
   std::unique_ptr<CachedFileStream> &Stream = *StreamOrErr;
   TM->Options.ObjectFilenameForDebug = Stream->ObjectPathName;
 

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -291,7 +291,7 @@ static void runNewPMPasses(const Config &Conf, Module &Mod, TargetMachine *TM,
     AAManager AA;
     if (auto Err = PB.parseAAPipeline(AA, Conf.AAPipeline)) {
       reportFatalUsageError(Twine("unable to parse AA pipeline description '") +
-                         Conf.AAPipeline + "': " + toString(std::move(Err)));
+                            Conf.AAPipeline + "': " + toString(std::move(Err)));
     }
     // Register the AA manager first so that our version is the one used.
     FAM.registerPass([&] { return std::move(AA); });
@@ -331,8 +331,9 @@ static void runNewPMPasses(const Config &Conf, Module &Mod, TargetMachine *TM,
   // Parse a custom pipeline if asked to.
   if (!Conf.OptPipeline.empty()) {
     if (auto Err = PB.parsePassPipeline(MPM, Conf.OptPipeline)) {
-      reportFatalUsageError(Twine("unable to parse pass pipeline description '") +
-                         Conf.OptPipeline + "': " + toString(std::move(Err)));
+      reportFatalUsageError(
+          Twine("unable to parse pass pipeline description '") +
+          Conf.OptPipeline + "': " + toString(std::move(Err)));
     }
   } else if (IsThinLTO) {
     MPM.addPass(PB.buildThinLTODefaultPipeline(OL, ImportSummary));
@@ -416,7 +417,7 @@ static void codegen(const Config &Conf, TargetMachine *TM,
     std::error_code EC;
     if (auto EC = llvm::sys::fs::create_directories(Conf.DwoDir))
       reportFatalUsageError(Twine("Failed to create directory ") + Conf.DwoDir +
-                         ": " + EC.message());
+                            ": " + EC.message());
 
     DwoFile = Conf.DwoDir;
     sys::path::append(DwoFile, std::to_string(Task) + ".dwo");
@@ -429,7 +430,7 @@ static void codegen(const Config &Conf, TargetMachine *TM,
     DwoOut = std::make_unique<ToolOutputFile>(DwoFile, EC, sys::fs::OF_None);
     if (EC)
       reportFatalUsageError(Twine("Failed to open ") + DwoFile + ": " +
-                         EC.message());
+                            EC.message());
   }
 
   Expected<std::unique_ptr<CachedFileStream>> StreamOrErr =

--- a/llvm/test/tools/llvm-lto2/X86/pipeline.ll
+++ b/llvm/test/tools/llvm-lto2/X86/pipeline.ll
@@ -28,13 +28,13 @@ define void @patatino() {
 ; CUSTOM-NEXT: }
 
 ; Check that invalid pipelines are caught as errors.
-; RUN: not --crash llvm-lto2 run %t1.bc -o %t.o \
+; RUN: not llvm-lto2 run %t1.bc -o %t.o \
 ; RUN:  -r %t1.bc,patatino,px -opt-pipeline foogoo 2>&1 | \
 ; RUN:  FileCheck %s --check-prefix=ERR
 
 ; ERR: LLVM ERROR: unable to parse pass pipeline description 'foogoo': unknown pass name 'foogoo'
 
-; RUN: not --crash llvm-lto2 run %t1.bc -o %t.o \
+; RUN: not llvm-lto2 run %t1.bc -o %t.o \
 ; RUN:  -r %t1.bc,patatino,px -aa-pipeline patatino \
 ; RUN:  -opt-pipeline lower-atomic 2>&1 | \
 ; RUN:  FileCheck %s --check-prefix=AAERR


### PR DESCRIPTION
Usage errors in `LTOBackend.cpp` were previously, misleadingly, reported as internal crashes.

This PR updates `LTOBackend.cpp` to use `reportFatalUsageError` for reporting usage-related issues.

LLVM Issue: https://github.com/llvm/llvm-project/issues/140953
Internal Tracker: TOOLCHAIN-17744