### PR TITLE
[libc++] Revert removal of <movable_box.h> to fix lldb test failure

### DIFF
--- a/libcxx/include/__algorithm/for_each.h
+++ b/libcxx/include/__algorithm/for_each.h
@@ -13,6 +13,7 @@
 #include <__algorithm/for_each_segment.h>
 #include <__config>
 #include <__iterator/segmented_iterator.h>
+#include <__ranges/movable_box.h> // Re-included as a temporary fix for lldb test failure (https://github.com/llvm/llvm-project/issues/137046)
 #include <__type_traits/enable_if.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)


### PR DESCRIPTION
The removal of `<__ranges/movable_box.h>` from `<__algorithm/for_each.h>` (#134960) caused lldb test failures (#137046) due to an implicit dependency in clang's AST processing. After [discussion](https://github.com/llvm/llvm-project/issues/137046#issuecomment-2899127701) with @dmpots, we confirmed that re-adding this header represents the simplest fix for now. 

This is a temporary fix for #137046. A long-term resolution may require deeper investigation into lldb and clang behavior.