### PR TITLE
[mlir] explicitly delete copy ctor for DialectRegistry and OperationState

### DIFF
--- a/mlir/include/mlir/IR/DialectRegistry.h
+++ b/mlir/include/mlir/IR/DialectRegistry.h
@@ -143,6 +143,8 @@ class DialectRegistry {
 
 public:
   explicit DialectRegistry();
+  DialectRegistry(const DialectRegistry &) = delete;
+  DialectRegistry &operator=(const DialectRegistry &other) = delete;
 
   template <typename ConcreteDialect>
   void insert() {

--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -985,9 +985,9 @@ public:
                  BlockRange successors = {},
                  MutableArrayRef<std::unique_ptr<Region>> regions = {});
   OperationState(OperationState &&other) = default;
-  OperationState(const OperationState &other) = default;
   OperationState &operator=(OperationState &&other) = default;
-  OperationState &operator=(const OperationState &other) = default;
+  OperationState(const OperationState &other) = delete;
+  OperationState &operator=(const OperationState &other) = delete;
   ~OperationState();
 
   /// Get (or create) a properties of the provided type to be set on the


### PR DESCRIPTION
Both of these classes have fields involving `unique_ptr`s and thus can't be copied.
Holding a unique_ptr should trigger implicit deletion of the copy/assignment constructors, however
not when held through a container:

```
struct Foo {  
  explicit Foo();
  std::vector<std::unique_ptr<Bar>> ptr; // Does not implicitly delete its cpy/assign ctors
};
```

This results in a complicated diagnostics when attempting to copy such a class (it'll point to the
inner implementation of the container), instead of a nicer error message about `Foo` not being able
to be copied/assigned. Explicitly deleting the ctors provides an immediate diagnostic about the issue.

Fixes https://github.com/llvm/llvm-project/issues/118388