### PR TITLE
Use ::llvm:LogicalResult instead of LogicalResult in FunctionInterfaces.td

### DIFF
--- a/mlir/include/mlir/Interfaces/FunctionInterfaces.td
+++ b/mlir/include/mlir/Interfaces/FunctionInterfaces.td
@@ -332,7 +332,7 @@ def FunctionOpInterface : OpInterface<"FunctionOpInterface", [
 
     /// Erase a single result at `resultIndex`. Returns failure if the function
     /// cannot be updated to have the new signature.
-    LogicalResult eraseResult(unsigned resultIndex) {
+    ::llvm::LogicalResult eraseResult(unsigned resultIndex) {
       ::llvm::BitVector resultsToErase($_op.getNumResults());
       resultsToErase.set(resultIndex);
       return eraseResults(resultsToErase);


### PR DESCRIPTION
Fixed a minor typo, which can cause compile error:

error C3646: 'eraseResult': unknown override specifier