### PR TITLE
[TableGen] Add missing $ before the dag operator name

### DIFF
--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -2786,7 +2786,7 @@ bool DagInit::isConcrete() const {
 std::string DagInit::getAsString() const {
   std::string Result = "(" + Val->getAsString();
   if (ValName)
-    Result += ":" + ValName->getAsUnquotedString();
+    Result += ":$" + ValName->getAsUnquotedString();
   if (!arg_empty()) {
     Result += " ";
     ListSeparator LS;

--- a/llvm/test/TableGen/usevalname.td
+++ b/llvm/test/TableGen/usevalname.td
@@ -20,5 +20,5 @@ multiclass shuffle<Reg RC> {
                                        RC:$src1, RC:$src2))]>;
 }
 
-// CHECK: shufp:src3
+// CHECK: shufp:$src3
 defm ADD : shuffle<VR128>;


### PR DESCRIPTION
This way the dump output is roundtripable.