### PR TITLE
[lldb-dap] Fix address comparison in DisassembleRequestHandler

### DIFF
--- a/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
+++ b/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
@@ -20,6 +20,7 @@ class TestDAP_disassemble(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         source = "main.c"
+        self.source_path = os.path.join(os.getcwd(), source)
         self.set_source_breakpoints(source, [line_number(source, "// breakpoint 1")])
         self.continue_to_next_stop()
 

--- a/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
+++ b/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
@@ -20,7 +20,6 @@ class TestDAP_disassemble(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         source = "main.c"
-        self.source_path = os.path.join(os.getcwd(), source)
         self.set_source_breakpoints(source, [line_number(source, "// breakpoint 1")])
         self.continue_to_next_stop()
 

--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -87,6 +87,13 @@ static DisassembledInstruction ConvertSBInstructionToDisassembledInstruction(
 
   auto addr = inst.GetAddress();
   const auto inst_addr = addr.GetLoadAddress(target);
+  
+  // FIXME: This is a workaround - this address might come from
+  // disassembly that started in a different section, and thus
+  // comparisons between this object and other address objects with the
+  // same load address will return false.
+  addr = lldb::SBAddress(inst_addr, target);
+
   const char *m = inst.GetMnemonic(target);
   const char *o = inst.GetOperands(target);
   const char *c = inst.GetComment(target);

--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -87,7 +87,7 @@ static DisassembledInstruction ConvertSBInstructionToDisassembledInstruction(
 
   auto addr = inst.GetAddress();
   const auto inst_addr = addr.GetLoadAddress(target);
-  
+
   // FIXME: This is a workaround - this address might come from
   // disassembly that started in a different section, and thus
   // comparisons between this object and other address objects with the


### PR DESCRIPTION
Fix comparisons between addresses with the same load address that can unexpectedly return false in `DisassembleRequestHandler`