### PR TITLE
[test] Fix dissassemble-entry-point.s for #140187

### DIFF
--- a/lldb/test/Shell/SymbolFile/dissassemble-entry-point.s
+++ b/lldb/test/Shell/SymbolFile/dissassemble-entry-point.s
@@ -1,7 +1,7 @@
 # REQUIRES: lld, arm
 
 # RUN: llvm-mc -triple=thumbv7-eabi %s -filetype=obj -o %t.o
-# RUN: ld.lld %t.o -o %t --section-start=.text=0x8074 -e 0x8075 -s
+# RUN: ld.lld %t.o -o %t --image-base=0x8074 --section-start=.text=0x8074 -e 0x8075 -s
 # RUN: %lldb -x -b -o 'dis -s 0x8074 -e 0x8080' -- %t | FileCheck %s
 # CHECK:      {{.*}}[0x8074] <+0>: movs   r0, #0x2a
 # CHECK-NEXT: {{.*}}[0x8076] <+2>: movs   r7, #0x1

--- a/lldb/test/Shell/SymbolFile/dissassemble-entry-point.s
+++ b/lldb/test/Shell/SymbolFile/dissassemble-entry-point.s
@@ -1,7 +1,7 @@
 # REQUIRES: lld, arm
 
 # RUN: llvm-mc -triple=thumbv7-eabi %s -filetype=obj -o %t.o
-# RUN: ld.lld %t.o -o %t --image-base=0x8074 --section-start=.text=0x8074 -e 0x8075 -s
+# RUN: ld.lld %t.o -o %t --image-base=0x8000 --section-start=.text=0x8074 -e 0x8075 -s
 # RUN: %lldb -x -b -o 'dis -s 0x8074 -e 0x8080' -- %t | FileCheck %s
 # CHECK:      {{.*}}[0x8074] <+0>: movs   r0, #0x2a
 # CHECK-NEXT: {{.*}}[0x8076] <+2>: movs   r7, #0x1


### PR DESCRIPTION
similar to #140570

getting this error:

exit status 1
ld.lld: error: section '.text' address (0x8074) is smaller than image base (0x10000); specify --image-base