### PR TITLE
[RISCV] Use print-enabled-extensions to check the extensions of Andes n45/nx45/a45/ax45 cpus. NFC.

### DIFF
--- a/clang/test/Driver/print-enabled-extensions/riscv-andes-a45.c
+++ b/clang/test/Driver/print-enabled-extensions/riscv-andes-a45.c
@@ -1,0 +1,28 @@
+// RUN: %clang --target=riscv32 -mcpu=andes-a45 --print-enabled-extensions | FileCheck %s
+// REQUIRES: riscv-registered-target
+
+// CHECK: Extensions enabled for the given RISC-V target
+// CHECK-EMPTY:
+// CHECK-NEXT:     Name                 Version   Description
+// CHECK-NEXT:     i                    2.1       'I' (Base Integer Instruction Set)
+// CHECK-NEXT:     m                    2.0       'M' (Integer Multiplication and Division)
+// CHECK-NEXT:     a                    2.1       'A' (Atomic Instructions)
+// CHECK-NEXT:     f                    2.2       'F' (Single-Precision Floating-Point)
+// CHECK-NEXT:     d                    2.2       'D' (Double-Precision Floating-Point)
+// CHECK-NEXT:     c                    2.0       'C' (Compressed Instructions)
+// CHECK-NEXT:     b                    1.0       'B' (the collection of the Zba, Zbb, Zbs extensions)
+// CHECK-NEXT:     zicsr                2.0       'Zicsr' (CSRs)
+// CHECK-NEXT:     zifencei             2.0       'Zifencei' (fence.i)
+// CHECK-NEXT:     zmmul                1.0       'Zmmul' (Integer Multiplication)
+// CHECK-NEXT:     zaamo                1.0       'Zaamo' (Atomic Memory Operations)
+// CHECK-NEXT:     zalrsc               1.0       'Zalrsc' (Load-Reserved/Store-Conditional)
+// CHECK-NEXT:     zca                  1.0       'Zca' (part of the C extension, excluding compressed floating point loads/stores)
+// CHECK-NEXT:     zcd                  1.0       'Zcd' (Compressed Double-Precision Floating-Point Instructions)
+// CHECK-NEXT:     zcf                  1.0       'Zcf' (Compressed Single-Precision Floating-Point Instructions)
+// CHECK-NEXT:     zba                  1.0       'Zba' (Address Generation Instructions)
+// CHECK-NEXT:     zbb                  1.0       'Zbb' (Basic Bit-Manipulation)
+// CHECK-NEXT:     zbs                  1.0       'Zbs' (Single-Bit Instructions)
+// CHECK-EMPTY:
+// CHECK-NEXT: Experimental extensions
+// CHECK-EMPTY:
+// CHECK-NEXT: ISA String: rv32i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_b1p0_zicsr2p0_zifencei2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0_zcf1p0_zba1p0_zbb1p0_zbs1p0

--- a/clang/test/Driver/print-enabled-extensions/riscv-andes-ax45.c
+++ b/clang/test/Driver/print-enabled-extensions/riscv-andes-ax45.c
@@ -1,0 +1,27 @@
+// RUN: %clang --target=riscv64 -mcpu=andes-ax45 --print-enabled-extensions | FileCheck %s
+// REQUIRES: riscv-registered-target
+
+// CHECK: Extensions enabled for the given RISC-V target
+// CHECK-EMPTY:
+// CHECK-NEXT:     Name                 Version   Description
+// CHECK-NEXT:     i                    2.1       'I' (Base Integer Instruction Set)
+// CHECK-NEXT:     m                    2.0       'M' (Integer Multiplication and Division)
+// CHECK-NEXT:     a                    2.1       'A' (Atomic Instructions)
+// CHECK-NEXT:     f                    2.2       'F' (Single-Precision Floating-Point)
+// CHECK-NEXT:     d                    2.2       'D' (Double-Precision Floating-Point)
+// CHECK-NEXT:     c                    2.0       'C' (Compressed Instructions)
+// CHECK-NEXT:     b                    1.0       'B' (the collection of the Zba, Zbb, Zbs extensions)
+// CHECK-NEXT:     zicsr                2.0       'Zicsr' (CSRs)
+// CHECK-NEXT:     zifencei             2.0       'Zifencei' (fence.i)
+// CHECK-NEXT:     zmmul                1.0       'Zmmul' (Integer Multiplication)
+// CHECK-NEXT:     zaamo                1.0       'Zaamo' (Atomic Memory Operations)
+// CHECK-NEXT:     zalrsc               1.0       'Zalrsc' (Load-Reserved/Store-Conditional)
+// CHECK-NEXT:     zca                  1.0       'Zca' (part of the C extension, excluding compressed floating point loads/stores)
+// CHECK-NEXT:     zcd                  1.0       'Zcd' (Compressed Double-Precision Floating-Point Instructions)
+// CHECK-NEXT:     zba                  1.0       'Zba' (Address Generation Instructions)
+// CHECK-NEXT:     zbb                  1.0       'Zbb' (Basic Bit-Manipulation)
+// CHECK-NEXT:     zbs                  1.0       'Zbs' (Single-Bit Instructions)
+// CHECK-EMPTY:
+// CHECK-NEXT: Experimental extensions
+// CHECK-EMPTY:
+// CHECK-NEXT: ISA String: rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_b1p0_zicsr2p0_zifencei2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0_zba1p0_zbb1p0_zbs1p0

--- a/clang/test/Driver/print-enabled-extensions/riscv-andes-n45.c
+++ b/clang/test/Driver/print-enabled-extensions/riscv-andes-n45.c
@@ -1,0 +1,28 @@
+// RUN: %clang --target=riscv32 -mcpu=andes-n45 --print-enabled-extensions | FileCheck %s
+// REQUIRES: riscv-registered-target
+
+// CHECK: Extensions enabled for the given RISC-V target
+// CHECK-EMPTY:
+// CHECK-NEXT:     Name                 Version   Description
+// CHECK-NEXT:     i                    2.1       'I' (Base Integer Instruction Set)
+// CHECK-NEXT:     m                    2.0       'M' (Integer Multiplication and Division)
+// CHECK-NEXT:     a                    2.1       'A' (Atomic Instructions)
+// CHECK-NEXT:     f                    2.2       'F' (Single-Precision Floating-Point)
+// CHECK-NEXT:     d                    2.2       'D' (Double-Precision Floating-Point)
+// CHECK-NEXT:     c                    2.0       'C' (Compressed Instructions)
+// CHECK-NEXT:     b                    1.0       'B' (the collection of the Zba, Zbb, Zbs extensions)
+// CHECK-NEXT:     zicsr                2.0       'Zicsr' (CSRs)
+// CHECK-NEXT:     zifencei             2.0       'Zifencei' (fence.i)
+// CHECK-NEXT:     zmmul                1.0       'Zmmul' (Integer Multiplication)
+// CHECK-NEXT:     zaamo                1.0       'Zaamo' (Atomic Memory Operations)
+// CHECK-NEXT:     zalrsc               1.0       'Zalrsc' (Load-Reserved/Store-Conditional)
+// CHECK-NEXT:     zca                  1.0       'Zca' (part of the C extension, excluding compressed floating point loads/stores)
+// CHECK-NEXT:     zcd                  1.0       'Zcd' (Compressed Double-Precision Floating-Point Instructions)
+// CHECK-NEXT:     zcf                  1.0       'Zcf' (Compressed Single-Precision Floating-Point Instructions)
+// CHECK-NEXT:     zba                  1.0       'Zba' (Address Generation Instructions)
+// CHECK-NEXT:     zbb                  1.0       'Zbb' (Basic Bit-Manipulation)
+// CHECK-NEXT:     zbs                  1.0       'Zbs' (Single-Bit Instructions)
+// CHECK-EMPTY:
+// CHECK-NEXT: Experimental extensions
+// CHECK-EMPTY:
+// CHECK-NEXT: ISA String: rv32i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_b1p0_zicsr2p0_zifencei2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0_zcf1p0_zba1p0_zbb1p0_zbs1p0

--- a/clang/test/Driver/print-enabled-extensions/riscv-andes-nx45.c
+++ b/clang/test/Driver/print-enabled-extensions/riscv-andes-nx45.c
@@ -1,0 +1,27 @@
+// RUN: %clang --target=riscv64 -mcpu=andes-nx45 --print-enabled-extensions | FileCheck %s
+// REQUIRES: riscv-registered-target
+
+// CHECK: Extensions enabled for the given RISC-V target
+// CHECK-EMPTY:
+// CHECK-NEXT:     Name                 Version   Description
+// CHECK-NEXT:     i                    2.1       'I' (Base Integer Instruction Set)
+// CHECK-NEXT:     m                    2.0       'M' (Integer Multiplication and Division)
+// CHECK-NEXT:     a                    2.1       'A' (Atomic Instructions)
+// CHECK-NEXT:     f                    2.2       'F' (Single-Precision Floating-Point)
+// CHECK-NEXT:     d                    2.2       'D' (Double-Precision Floating-Point)
+// CHECK-NEXT:     c                    2.0       'C' (Compressed Instructions)
+// CHECK-NEXT:     b                    1.0       'B' (the collection of the Zba, Zbb, Zbs extensions)
+// CHECK-NEXT:     zicsr                2.0       'Zicsr' (CSRs)
+// CHECK-NEXT:     zifencei             2.0       'Zifencei' (fence.i)
+// CHECK-NEXT:     zmmul                1.0       'Zmmul' (Integer Multiplication)
+// CHECK-NEXT:     zaamo                1.0       'Zaamo' (Atomic Memory Operations)
+// CHECK-NEXT:     zalrsc               1.0       'Zalrsc' (Load-Reserved/Store-Conditional)
+// CHECK-NEXT:     zca                  1.0       'Zca' (part of the C extension, excluding compressed floating point loads/stores)
+// CHECK-NEXT:     zcd                  1.0       'Zcd' (Compressed Double-Precision Floating-Point Instructions)
+// CHECK-NEXT:     zba                  1.0       'Zba' (Address Generation Instructions)
+// CHECK-NEXT:     zbb                  1.0       'Zbb' (Basic Bit-Manipulation)
+// CHECK-NEXT:     zbs                  1.0       'Zbs' (Single-Bit Instructions)
+// CHECK-EMPTY:
+// CHECK-NEXT: Experimental extensions
+// CHECK-EMPTY:
+// CHECK-NEXT: ISA String: rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_b1p0_zicsr2p0_zifencei2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0_zba1p0_zbb1p0_zbs1p0

--- a/clang/test/Driver/riscv-cpus.c
+++ b/clang/test/Driver/riscv-cpus.c
@@ -700,68 +700,32 @@
 // MTUNE-SYNTACORE-SCR7: "-tune-cpu" "syntacore-scr7"
 
 // RUN: %clang --target=riscv32 -### -c %s 2>&1 -mcpu=andes-n45 | FileCheck -check-prefix=MCPU-ANDES-N45 %s
+// COM: The list of extensions are tested in `test/Driver/print-enabled-extensions/riscv-andes-n45.c`
 // MCPU-ANDES-N45: "-target-cpu" "andes-n45"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+m"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+a"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+f"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+d"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+c"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+zicsr"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+zifencei"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+zba"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+zbb"
-// MCPU-ANDES-N45-SAME: "-target-feature" "+zbs"
 // MCPU-ANDES-N45-SAME: "-target-abi" "ilp32d"
 
 // RUN: %clang --target=riscv32 -### -c %s 2>&1 -mtune=andes-n45 | FileCheck -check-prefix=MTUNE-ANDES-N45 %s
 // MTUNE-ANDES-N45: "-tune-cpu" "andes-n45"
 
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mcpu=andes-nx45 | FileCheck -check-prefix=MCPU-ANDES-NX45 %s
+// COM: The list of extensions are tested in `test/Driver/print-enabled-extensions/riscv-andes-nx45.c`
 // MCPU-ANDES-NX45: "-target-cpu" "andes-nx45"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+m"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+a"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+f"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+d"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+c"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+zicsr"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+zifencei"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+zba"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+zbb"
-// MCPU-ANDES-NX45-SAME: "-target-feature" "+zbs"
 // MCPU-ANDES-NX45-SAME: "-target-abi" "lp64d"
 
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mtune=andes-nx45 | FileCheck -check-prefix=MTUNE-ANDES-NX45 %s
 // MTUNE-ANDES-NX45: "-tune-cpu" "andes-nx45"
 
 // RUN: %clang --target=riscv32 -### -c %s 2>&1 -mcpu=andes-a45 | FileCheck -check-prefix=MCPU-ANDES-A45 %s
+// COM: The list of extensions are tested in `test/Driver/print-enabled-extensions/riscv-andes-a45.c`
 // MCPU-ANDES-A45: "-target-cpu" "andes-a45"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+m"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+a"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+f"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+d"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+c"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+zicsr"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+zifencei"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+zba"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+zbb"
-// MCPU-ANDES-A45-SAME: "-target-feature" "+zbs"
 // MCPU-ANDES-A45-SAME: "-target-abi" "ilp32d"
 
 // RUN: %clang --target=riscv32 -### -c %s 2>&1 -mtune=andes-a45 | FileCheck -check-prefix=MTUNE-ANDES-A45 %s
 // MTUNE-ANDES-A45: "-tune-cpu" "andes-a45"
 
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mcpu=andes-ax45 | FileCheck -check-prefix=MCPU-ANDES-AX45 %s
+// COM: The list of extensions are tested in `test/Driver/print-enabled-extensions/riscv-andes-ax45.c`
 // MCPU-ANDES-AX45: "-target-cpu" "andes-ax45"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+m"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+a"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+f"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+d"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+c"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+zicsr"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+zifencei"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+zba"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+zbb"
-// MCPU-ANDES-AX45-SAME: "-target-feature" "+zbs"
 // MCPU-ANDES-AX45-SAME: "-target-abi" "lp64d"
 
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mtune=andes-ax45 | FileCheck -check-prefix=MTUNE-ANDES-AX45 %s


### PR DESCRIPTION
Similarly to what #137725 did for the SiFive P870.