### PR TITLE
Fix a bug where using "thread backtrace unique" would switch you to

### DIFF
--- a/lldb/source/Commands/CommandObjectThreadUtil.cpp
+++ b/lldb/source/Commands/CommandObjectThreadUtil.cpp
@@ -37,6 +37,8 @@ void CommandObjectIterateOverThreads::DoExecute(Args &command,
   result.SetStatus(m_success_return);
 
   bool all_threads = false;
+  m_unique_stacks = false;
+
   if (command.GetArgumentCount() == 0) {
     Thread *thread = m_exe_ctx.GetThreadPtr();
     if (thread)

--- a/lldb/test/API/functionalities/thread/num_threads/TestNumThreads.py
+++ b/lldb/test/API/functionalities/thread/num_threads/TestNumThreads.py
@@ -139,13 +139,19 @@ class NumberOfThreadsTestCase(TestBase):
         setting_data = self.dbg.GetSetting("frame-format-unique")
         setting_str = setting_data.GetStringValue(1000)
         setting_str = "UNIQUE: " + setting_str
-        lldb.SBDebugger.SetInternalVariable("frame-format-unique", setting_str, self.dbg.GetInstanceName())
+        lldb.SBDebugger.SetInternalVariable(
+            "frame-format-unique", setting_str, self.dbg.GetInstanceName()
+        )
         # Now that we are stopped, we should have 10 threads waiting in the
         # thread3 function. All of these threads should show as one stack.
         self.expect(
             "thread backtrace unique",
             "Backtrace with unique stack shown correctly",
-            substrs=[expect_string, "UNIQUE:", "main.cpp:%d" % self.thread3_before_lock_line],
+            substrs=[
+                expect_string,
+                "UNIQUE:",
+                "main.cpp:%d" % self.thread3_before_lock_line,
+            ],
         )
         # Make sure setting the unique flag in the command isn't
         # persistent:
@@ -153,5 +159,5 @@ class NumberOfThreadsTestCase(TestBase):
             "thread backtrace",
             "Backtrace unique is not sticky",
             substrs=["UNIQUE:"],
-            matching=False
+            matching=False,
         )

--- a/lldb/test/API/functionalities/thread/num_threads/TestNumThreads.py
+++ b/lldb/test/API/functionalities/thread/num_threads/TestNumThreads.py
@@ -132,10 +132,26 @@ class NumberOfThreadsTestCase(TestBase):
         # Construct our expected back trace string
         expect_string = "10 thread(s)%s" % (expect_threads)
 
+        # There was a bug where if you used 'thread backtrace unique'
+        # we would switch all future backtraces to use the
+        # "frame-format-unique" not the "frame-format".  Make
+        # sure we don't do that...
+        setting_data = self.dbg.GetSetting("frame-format-unique")
+        setting_str = setting_data.GetStringValue(1000)
+        setting_str = "UNIQUE: " + setting_str
+        lldb.SBDebugger.SetInternalVariable("frame-format-unique", setting_str, self.dbg.GetInstanceName())
         # Now that we are stopped, we should have 10 threads waiting in the
         # thread3 function. All of these threads should show as one stack.
         self.expect(
             "thread backtrace unique",
             "Backtrace with unique stack shown correctly",
-            substrs=[expect_string, "main.cpp:%d" % self.thread3_before_lock_line],
+            substrs=[expect_string, "UNIQUE:", "main.cpp:%d" % self.thread3_before_lock_line],
+        )
+        # Make sure setting the unique flag in the command isn't
+        # persistent:
+        self.expect(
+            "thread backtrace",
+            "Backtrace unique is not sticky",
+            substrs=["UNIQUE:"],
+            matching=False
         )


### PR DESCRIPTION
always using the "frame-format-unique" even when you weren't doing the unique backtrace mode.