### PR TITLE
[clang][bytecode] Change diagnostics for self-initialization

### DIFF
--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -23,6 +23,16 @@ int array2[recurse2]; // both-warning {{variable length arrays in C++}} \
                       // expected-error {{variable length array declaration not allowed at file scope}} \
                       // ref-warning {{variable length array folded to constant array as an extension}}
 
+constexpr int b = b; // both-error {{must be initialized by a constant expression}} \
+                     // both-note {{read of object outside its lifetime is not allowed in a constant expression}}
+
+
+[[clang::require_constant_initialization]] int c = c; // both-error {{variable does not have a constant initializer}} \
+                                                      // both-note {{attribute here}} \
+                                                      // both-note {{read of non-const variable}} \
+                                                      // both-note {{declared here}}
+
+
 struct S {
   int m;
 };

--- a/clang/test/AST/ByteCode/cxx17.cpp
+++ b/clang/test/AST/ByteCode/cxx17.cpp
@@ -1,5 +1,10 @@
-// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -std=c++17 -verify=expected,both %s
-// RUN: %clang_cc1 -std=c++17 -verify=ref,both %s
+// RUN: %clang_cc1 -std=c++17 -verify=expected,both %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++17 -verify=ref,both      %s
+
+[[clang::require_constant_initialization]] int cc = cc; // both-error {{variable does not have a constant initializer}} \
+                                                        // both-note {{attribute here}} \
+                                                        // both-note {{ead of object outside its lifetime}}
+
 
 struct F { int a; int b;};
 constexpr F getF() {


### PR DESCRIPTION
Change the diagnostics when reading from the variable we're currently initializing do be the same as the one the current interpreter emits.