### PR TITLE
[libc++] Temporarily disable the lldb tests

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -406,8 +406,8 @@ bootstrapping-build)
     ${NINJA} -vC "${BUILD_DIR}" install-runtimes
 
     step "Running the LLDB libc++ data formatter tests"
-    ${NINJA} -vC "${BUILD_DIR}" lldb-api-test-deps
-    ${BUILD_DIR}/bin/llvm-lit -sv --param dotest-args='--category libc++' "${MONOREPO_ROOT}/lldb/test/API"
+    # ${NINJA} -vC "${BUILD_DIR}" lldb-api-test-deps
+    # ${BUILD_DIR}/bin/llvm-lit -sv --param dotest-args='--category libc++' "${MONOREPO_ROOT}/lldb/test/API"
 
     ccache -s
 ;;


### PR DESCRIPTION
The lldb tests are currently failing for reasons unrelated to libc++. This disables the tests to make sure we run our own tests on all the supported platforms.
