### PR TITLE
[MLIR][ODS] Fix properties tablegen wrapper to allow ADL lookup for hash_value

### DIFF
--- a/mlir/include/mlir/IR/Properties.td
+++ b/mlir/include/mlir/IR/Properties.td
@@ -548,7 +548,7 @@ class ArrayProp<Property elem = Property<>, string newSummary = ""> :
   // In the non-trivial case, we define a mapped range to get internal hash
   // codes.
   let hashProperty = !if(!empty(elem.hashProperty),
-    [{::llvm::hash_value(::llvm::ArrayRef<}] # elem.storageType # [{>{$_storage})}],
+    [{hash_value(::llvm::ArrayRef<}] # elem.storageType # [{>{$_storage})}],
     [{[&]() -> ::llvm::hash_code {
         auto getElemHash = [](const auto& propStorage) -> ::llvm::hash_code {
           return }] # !subst("$_storage", "propStorage", elem.hashProperty) # [{;
@@ -762,7 +762,7 @@ class OptionalProp<Property p, bit canDelegateParsing = 1>
   }] # !subst("$_storage", "(*($_storage))", p.writeToMlirBytecode);
 
   let hashProperty = !if(!empty(p.hashProperty), p.hashProperty,
-    [{ ::llvm::hash_value($_storage.has_value() ? std::optional<::llvm::hash_code>{}] #
+    [{ hash_value($_storage.has_value() ? std::optional<::llvm::hash_code>{}] #
       !subst("$_storage", "(*($_storage))", p.hashProperty) #[{} : std::nullopt) }]);
   assert !or(!not(delegatesParsing), !eq(defaultValue, "std::nullopt")),
     "For delegated parsing to be used, the default value must be nullopt. " #

--- a/mlir/test/lib/Dialect/Test/TestOps.h
+++ b/mlir/test/lib/Dialect/Test/TestOps.h
@@ -86,7 +86,7 @@ mlir::ParseResult customParseProperties(mlir::OpAsmParser &parser,
 //===----------------------------------------------------------------------===//
 // MyPropStruct
 //===----------------------------------------------------------------------===//
-
+namespace test_properties {
 class MyPropStruct {
 public:
   std::string content;
@@ -101,6 +101,9 @@ public:
     return content == rhs.content;
   }
 };
+inline llvm::hash_code hash_value(const MyPropStruct &S) { return S.hash(); }
+} // namespace test_properties
+using test_properties::MyPropStruct;
 
 llvm::LogicalResult readFromMlirBytecode(mlir::DialectBytecodeReader &reader,
                                          MyPropStruct &prop);

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3197,6 +3197,20 @@ def TestOpWithWrappedProperties : TEST_Op<"with_wrapped_properties"> {
   );
 }
 
+// Same as above, but without a custom `hashProperty` field, checking
+// that ADL is correctly working.
+def MyStructProperty2 : Property<"MyPropStruct"> {
+  let convertToAttribute = "return $_storage.asAttribute($_ctxt);";
+  let convertFromAttribute = "return MyPropStruct::setFromAttr($_storage, $_attr, $_diag);";
+}
+
+def TestOpWithWrappedProperties2 : TEST_Op<"with_wrapped_properties2"> {
+  let assemblyFormat = "prop-dict attr-dict";
+  let arguments = (ins
+    MyStructProperty2:$prop
+  );
+}
+
 def TestOpWithEmptyProperties : TEST_Op<"empty_properties"> {
   let assemblyFormat = "prop-dict attr-dict";
   let arguments = (ins);

--- a/mlir/test/mlir-tblgen/op-properties.td
+++ b/mlir/test/mlir-tblgen/op-properties.td
@@ -115,8 +115,9 @@ def OpWithOptionalPropsAndAttrs :
 
 // DEFS-LABEL: OpWithProps::computePropertiesHash
 // DEFS: hash_intArray
-// DEFS-NEXT: return ::llvm::hash_value(::llvm::ArrayRef<int64_t>{propStorage})
-// DEFS: ::llvm::hash_value(prop.optional)
+// DEFS: using ::llvm::hash_value;
+// DEFS-NEXT: return hash_value(::llvm::ArrayRef<int64_t>{propStorage})
+// DEFS: hash_value(prop.optional)
 // DEFS: hash_intArray(prop.intArray)
 
 // -----

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -1588,6 +1588,7 @@ void OpEmitter::genPropertiesSupport() {
 
   const char *propHashFmt = R"decl(
   auto hash_{0} = [] (const auto &propStorage) -> llvm::hash_code {
+    using ::llvm::hash_value;
     return {1};
   };
 )decl";
@@ -1605,6 +1606,7 @@ void OpEmitter::genPropertiesSupport() {
       }
     }
   }
+  hashMethod << "  using llvm::hash_value;\n";
   hashMethod << "  return llvm::hash_combine(";
   llvm::interleaveComma(
       attrOrProperties, hashMethod, [&](const ConstArgument &attrOrProp) {
@@ -1614,8 +1616,8 @@ void OpEmitter::genPropertiesSupport() {
             hashMethod << "\n    hash_" << namedProperty->name << "(prop."
                        << namedProperty->name << ")";
           } else {
-            hashMethod << "\n    ::llvm::hash_value(prop."
-                       << namedProperty->name << ")";
+            hashMethod << "\n    hash_value(prop." << namedProperty->name
+                       << ")";
           }
           return;
         }


### PR DESCRIPTION
llvm::hash_value() is meant to be redefined in the relevant namespace and looked up through ADL. However this can't work with a fully qualified call.