### PR TITLE
Update security group affiliation

### DIFF
--- a/llvm/docs/Security.rst
+++ b/llvm/docs/Security.rst
@@ -51,7 +51,7 @@ username for an individual isn't available, the brackets will be empty.
 * Nikhil Gupta (Nvidia) []
 * Oliver Hunt (Apple) [@ojhunt]
 * Peter Smith (ARM) [@smithp35]
-* Pietro Albini (Ferrous Systems; Rust) [@pietroalbini]
+* Pietro Albini (individual; Rust) [@pietroalbini]
 * Serge Guelton (Mozilla) [@serge-sans-paille]
 * Sergey Zverev (Intel) [@offsake]
 * Shayne Hiet-Block (Microsoft) [@GreatKeeper]


### PR DESCRIPTION
I recently left Ferrous Systems, updating my affiliation to "individual".