### PR TITLE
[XRay] Fix argument parsing with offloading (#140748)

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -179,7 +179,6 @@ private:
   Tool *getLinkerWrapper() const;
 
   mutable bool SanitizerArgsChecked = false;
-  mutable std::unique_ptr<XRayArgs> XRayArguments;
 
   /// The effective clang triple for the current Job.
   mutable llvm::Triple EffectiveTriple;
@@ -323,7 +322,7 @@ public:
 
   SanitizerArgs getSanitizerArgs(const llvm::opt::ArgList &JobArgs) const;
 
-  const XRayArgs& getXRayArgs() const;
+  const XRayArgs getXRayArgs(const llvm::opt::ArgList &) const;
 
   // Returns the Arg * that explicitly turned on/off rtti, or nullptr.
   const llvm::opt::Arg *getRTTIArg() const { return CachedRTTIArg; }

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -389,10 +389,9 @@ ToolChain::getSanitizerArgs(const llvm::opt::ArgList &JobArgs) const {
   return SanArgs;
 }
 
-const XRayArgs& ToolChain::getXRayArgs() const {
-  if (!XRayArguments)
-    XRayArguments.reset(new XRayArgs(*this, Args));
-  return *XRayArguments;
+const XRayArgs ToolChain::getXRayArgs(const llvm::opt::ArgList &JobArgs) const {
+  XRayArgs XRayArguments(*this, JobArgs);
+  return XRayArguments;
 }
 
 namespace {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6913,7 +6913,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("--offload-new-driver");
   }
 
-  const XRayArgs &XRay = TC.getXRayArgs();
+  const XRayArgs &XRay = TC.getXRayArgs(Args);
   XRay.addArgs(TC, Args, CmdArgs, InputType);
 
   for (const auto &Filename :

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1647,17 +1647,18 @@ bool tools::addSanitizerRuntimes(const ToolChain &TC, const ArgList &Args,
 }
 
 bool tools::addXRayRuntime(const ToolChain&TC, const ArgList &Args, ArgStringList &CmdArgs) {
+  const XRayArgs &XRay = TC.getXRayArgs(Args);
   if (Args.hasArg(options::OPT_shared)) {
-    if (TC.getXRayArgs().needsXRayDSORt()) {
+    if (XRay.needsXRayDSORt()) {
       CmdArgs.push_back("--whole-archive");
       CmdArgs.push_back(TC.getCompilerRTArgString(Args, "xray-dso"));
       CmdArgs.push_back("--no-whole-archive");
       return true;
     }
-  } else if (TC.getXRayArgs().needsXRayRt()) {
+  } else if (XRay.needsXRayRt()) {
     CmdArgs.push_back("--whole-archive");
     CmdArgs.push_back(TC.getCompilerRTArgString(Args, "xray"));
-    for (const auto &Mode : TC.getXRayArgs().modeList())
+    for (const auto &Mode : XRay.modeList())
       CmdArgs.push_back(TC.getCompilerRTArgString(Args, Mode));
     CmdArgs.push_back("--no-whole-archive");
     return true;

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1627,7 +1627,7 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
           CmdArgs,
           llvm::memprof::getMemprofOptionsSymbolDarwinLinkageName().data());
 
-  const XRayArgs &XRay = getXRayArgs();
+  const XRayArgs &XRay = getXRayArgs(Args);
   if (XRay.needsXRayRt()) {
     AddLinkRuntimeLib(Args, CmdArgs, "xray");
     AddLinkRuntimeLib(Args, CmdArgs, "xray-basic");

--- a/clang/test/Driver/XRay/xray-instrument.c
+++ b/clang/test/Driver/XRay/xray-instrument.c
@@ -3,6 +3,11 @@
 // RUN: %clang -### --target=x86_64-apple-darwin -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s
 // RUN: not %clang -### --target=x86_64-pc-windows -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
 
+/// Checking -fxray-instrument with offloading and -Xarch_host
+// RUN: %clang -### -Xarch_host -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: not %clang -### -x hip --offload-arch=gfx906 -nogpulib -nogpuinc -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
+// RUN: %clang -### -x hip --offload-arch=gfx906 -nogpulib -nogpuinc -Xarch_host -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s
+
 // CHECK: "-cc1" {{.*}}"-fxray-instrument"
 // ERR:   error: unsupported option '-fxray-instrument' for target
 

--- a/clang/test/Driver/XRay/xray-instrument.c
+++ b/clang/test/Driver/XRay/xray-instrument.c
@@ -4,9 +4,9 @@
 // RUN: not %clang -### --target=x86_64-pc-windows -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
 
 /// Checking -fxray-instrument with offloading and -Xarch_host
-// RUN: %clang -### -Xarch_host -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s
-// RUN: not %clang -### -x hip --offload-arch=gfx906 -nogpulib -nogpuinc -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
-// RUN: %clang -### -x hip --offload-arch=gfx906 -nogpulib -nogpuinc -Xarch_host -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -Xarch_host -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: not %clang -### --target=x86_64-unknown-linux-gnu -x hip --offload-arch=gfx906 -nogpulib -nogpuinc -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -x hip --offload-arch=gfx906 -nogpulib -nogpuinc -Xarch_host -fxray-instrument -c %s -o /dev/null 2>&1 | FileCheck %s
 
 // CHECK: "-cc1" {{.*}}"-fxray-instrument"
 // ERR:   error: unsupported option '-fxray-instrument' for target


### PR DESCRIPTION
This PR addressed issue #140748 to support XRay instrumentation on the host side when using offloading. 

It makes the following changes:
- Initializes `XRayArgs` using the processed toolchain arguments instead of the raw input.
- Removes the current caching mechanism of `XRayArgs` in the `ToolChain` class, as this is error-prone and potential benefits are questionable. For reference, `SanitizierArgs`, which is constructed in a similar manner but is much more complex, does not use any caching.
- Adds driver tests to verify that XRay flags are set correctly with offloading and `-Xarch_host`.