### PR TITLE
[TableGen] Warn on redundant intrinsic properties

### DIFF
--- a/llvm/test/TableGen/warn-default-property.td
+++ b/llvm/test/TableGen/warn-default-property.td
@@ -1,0 +1,7 @@
+// RUN: llvm-tblgen -gen-intrinsic-impl -I %p/../../include %s -DTEST_INTRINSICS_SUPPRESS_DEFS -o /dev/null 2>&1 | FileCheck %s
+
+include "llvm/IR/Intrinsics.td"
+
+// CHECK: warning: property 'IntrWillReturn' is already enabled by default
+// CHECK: warning: property 'IntrNoCallback' is already enabled by default
+def int_foo : DefaultAttrsIntrinsic<[], [], [IntrWillReturn, IntrNoMem, IntrNoCallback]>;

--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
@@ -154,10 +154,6 @@ struct CodeGenIntrinsic {
 
   bool hasProperty(enum SDNP Prop) const { return Properties & (1 << Prop); }
 
-  /// Goes through all IntrProperties that have IsDefault value set and sets
-  /// the property.
-  void setDefaultProperties(ArrayRef<const Record *> DefaultProperties);
-
   /// Helper function to set property \p Name to true.
   void setProperty(const Record *R);
 


### PR DESCRIPTION
Warn on explicit intrinsic properties that are already implied by the
use of DefaultAttrsIntrinsic.
