### PR TITLE
[lldb/cmake] Remove a no-op statement

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -93,13 +93,6 @@ function(add_lldb_library name)
     set(libkind STATIC)
   endif()
 
-  #PIC not needed on Win
-  # FIXME: Setting CMAKE_CXX_FLAGS here is a no-op, use target_compile_options
-  # or omit this logic instead.
-  if (NOT WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-  endif()
-
   if (PARAM_OBJECT)
     add_library(${name} ${libkind} ${srcs})
   else()


### PR DESCRIPTION
Like the comment says, this really is a no-op and has no effect on the generated build commands.