### PR TITLE
[libc++] Work around namespace visibility annotations bleeding into user code

### DIFF
--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -517,9 +517,6 @@ struct __enum_hash<_Tp, false> {
   __enum_hash& operator=(__enum_hash const&) = delete;
 };
 
-template <class _Tp>
-struct hash : public __enum_hash<_Tp> {};
-
 #if _LIBCPP_STD_VER >= 17
 
 template <>
@@ -554,5 +551,14 @@ using __enable_hash_helper _LIBCPP_NODEBUG = _Type;
 #endif // !_LIBCPP_CXX03_LANG
 
 _LIBCPP_END_NAMESPACE_STD
+
+// Work around the visibility on a namespace bleed into user specializations.
+// TODO: Remove this workaround once all supported compilers are fixed
+namespace std {
+inline namespace _LIBCPP_ABI_NAMESPACE {
+template <class _Tp>
+struct hash : public __enum_hash<_Tp> {};
+} // namespace _LIBCPP_ABI_NAMESPACE
+} // namespace std
 
 #endif // _LIBCPP___FUNCTIONAL_HASH_H

--- a/libcxx/include/__fwd/functional.h
+++ b/libcxx/include/__fwd/functional.h
@@ -15,6 +15,15 @@
 #  pragma GCC system_header
 #endif
 
+// Work around the visibility on a namespace bleed into user specializations.
+// TODO: Remove this workaround once all supported compilers are fixed
+namespace std {
+inline namespace _LIBCPP_ABI_NAMESPACE {
+template <class>
+struct hash;
+} // namespace _LIBCPP_ABI_NAMESPACE
+} // namespace std
+
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 14
@@ -23,9 +32,6 @@ template <class _Tp = void>
 template <class _Tp>
 #endif
 struct less;
-
-template <class>
-struct hash;
 
 template <class>
 class reference_wrapper;

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -642,11 +642,6 @@ inline _LIBCPP_CONSTEXPR __bitset<0, 0>::__bitset() _NOEXCEPT {}
 inline _LIBCPP_CONSTEXPR __bitset<0, 0>::__bitset(unsigned long long) _NOEXCEPT {}
 
 template <size_t _Size>
-class bitset;
-template <size_t _Size>
-struct hash<bitset<_Size> >;
-
-template <size_t _Size>
 class bitset : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1, _Size> {
 public:
   static const unsigned __n_words = _Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1;

--- a/libcxx/include/typeindex
+++ b/libcxx/include/typeindex
@@ -50,6 +50,7 @@ struct hash<type_index>
 #else
 #  include <__config>
 #  include <__functional/unary_function.h>
+#  include <__fwd/functional.h>
 #  include <typeinfo>
 #  include <version>
 
@@ -89,9 +90,6 @@ public:
   _LIBCPP_HIDE_FROM_ABI size_t hash_code() const _NOEXCEPT { return __t_->hash_code(); }
   _LIBCPP_HIDE_FROM_ABI const char* name() const _NOEXCEPT { return __t_->name(); }
 };
-
-template <class _Tp>
-struct hash;
 
 template <>
 struct hash<type_index> : public __unary_function<type_index, size_t> {

--- a/libcxx/test/libcxx/utilities/function.objects/unord.hash/default_visibility.defined.sh.cpp
+++ b/libcxx/test/libcxx/utilities/function.objects/unord.hash/default_visibility.defined.sh.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Ensure that user specializations of std::hash have default visibility
+
+// RUN: %{cxx} %s %{flags} %{compile_flags} %{link_flags} -DSHARED -fPIC -shared -o %t.shared_lib
+// RUN: %{build} %t.shared_lib
+// RUN: %{run}
+
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
+#include <__functional/hash.h>
+
+struct S {};
+
+template <>
+struct std::hash<S> {
+  void operator()();
+};
+
+#ifdef SHARED
+void std::hash<S>::operator()() {}
+#else
+int main(int, char**) {
+  std::hash<S>()();
+  return 0;
+}
+#endif

--- a/libcxx/test/libcxx/utilities/function.objects/unord.hash/default_visibility.fwd.sh.cpp
+++ b/libcxx/test/libcxx/utilities/function.objects/unord.hash/default_visibility.fwd.sh.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Ensure that user specializations of std::hash have default visibility
+
+// RUN: %{cxx} %s %{flags} %{compile_flags} %{link_flags} -DSHARED -fPIC -shared -o %t.shared_lib
+// RUN: %{build} %t.shared_lib
+// RUN: %{run}
+
+#include <__fwd/functional.h>
+
+struct S {};
+
+template <>
+struct std::hash<S> {
+  void operator()();
+};
+
+#ifdef SHARED
+void std::hash<S>::operator()() {}
+#else
+int main(int, char**) {
+  std::hash<S>()();
+  return 0;
+}
+#endif


### PR DESCRIPTION
`[[gnu::visibility("hidden")]]` applied to the namespace scope can bleed into user-defined specializations of `std::hash` in some cases. This works around the issue until all of our supported compilers are fixed.
