### PR TITLE
[flang-rt] Fix usage of kNoAsyncId in assign.cpp

### DIFF
--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -591,7 +591,7 @@ void RTDEF(CopyInAssign)(Descriptor &temp, const Descriptor &var,
   temp = var;
   temp.set_base_addr(nullptr);
   temp.raw().attribute = CFI_attribute_allocatable;
-  temp.Allocate(kNoAsyncId);
+  temp.Allocate(kNoAsyncObject);
   ShallowCopy(temp, var);
 }
 


### PR DESCRIPTION
Fix a leftover old variable name causing build bot errors.