### PR TITLE
[Clang] Add missing macro undefs in AttributeSpellingList emitter

### DIFF
--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -233,13 +233,11 @@ unsigned AttributeCommonInfo::calculateAttributeSpellingListIndex() const {
 static constexpr const char *AttrSpellingList[] = {
 #include "clang/Basic/AttributeSpellingList.inc"
 };
-#undef ATTR_NAME
 
-#define ATTR_SCOPE_SCOPE(SCOPE_NAME) SCOPE_NAME,
+#define ATTR_SCOPE_NAME(SCOPE_NAME) SCOPE_NAME,
 static constexpr const char *AttrScopeSpellingList[] = {
 #include "clang/Basic/AttributeSpellingList.inc"
 };
-#undef ATTR_SCOPE_SCOPE
 
 std::optional<std::string>
 AttributeCommonInfo::getCorrectedFullName(const TargetInfo &Target,

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -4146,13 +4146,17 @@ void EmitAttributeSpellingList(const RecordKeeper &Records, raw_ostream &OS) {
     OS << "ATTR_NAME(\"" << AttrName << "\")\n";
   }
   OS << "\n";
+  OS << "#undef ATTR_NAME" << "\n";
+  OS << "\n";
 
-  OS << "#ifndef ATTR_SCOPE_SCOPE" << "\n";
-  OS << "#define ATTR_SCOPE_SCOPE(SCOPE_NAME) SCOPE_NAME" << "\n";
+  OS << "#ifndef ATTR_SCOPE_NAME" << "\n";
+  OS << "#define ATTR_SCOPE_NAME(SCOPE_NAME) SCOPE_NAME" << "\n";
   OS << "#endif" << "\n" << "\n";
   for (const auto &AttrScopeName : AttrScopeSpellingList) {
-    OS << "ATTR_SCOPE_SCOPE(\"" << AttrScopeName << "\")\n";
+    OS << "ATTR_SCOPE_NAME(\"" << AttrScopeName << "\")\n";
   }
+  OS << "\n";
+  OS << "#undef ATTR_SCOPE_NAME" << "\n";
   OS << "\n";
 }
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/140629#issuecomment-2901568992

---

This patch adds `#undef ATTR_NAME` and `#undef ATTR_SCOPE_NAME` to the
end of the generated `AttributeSpellingList.inc` file to prevent macro
redefinition warnings