### PR TITLE
[clang-tidy] readability-redundant-smartptr-get: disable for smart pointers to arrays

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantSmartptrGetCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantSmartptrGetCheck.cpp
@@ -49,29 +49,41 @@ internal::Matcher<Decl> knownSmartptr() {
 
 void registerMatchersForGetArrowStart(MatchFinder *Finder,
                                       MatchFinder::MatchCallback *Callback) {
-  const auto QuacksLikeASmartptr = recordDecl(
-      recordDecl().bind("duck_typing"),
-      has(cxxMethodDecl(hasName("operator->"),
-                        returns(qualType(pointsTo(type().bind("op->Type")))))),
-      has(cxxMethodDecl(hasName("operator*"), returns(qualType(references(
-                                                  type().bind("op*Type")))))));
+  const auto MatchesOpArrow =
+      allOf(hasName("operator->"),
+            returns(qualType(pointsTo(type().bind("op->Type")))));
+  const auto MatchesOpStar =
+      allOf(hasName("operator*"),
+            returns(qualType(references(type().bind("op*Type")))));
+  const auto HasRelevantOps =
+      allOf(anyOf(hasMethod(MatchesOpArrow),
+                  has(functionTemplateDecl(has(functionDecl(MatchesOpArrow))))),
+            anyOf(hasMethod(MatchesOpStar),
+                  has(functionTemplateDecl(has(functionDecl(MatchesOpStar))))));
+
+  const auto QuacksLikeASmartptr =
+      cxxRecordDecl(cxxRecordDecl().bind("duck_typing"), HasRelevantOps);
 
   // Make sure we are not missing the known standard types.
-  const auto Smartptr = anyOf(knownSmartptr(), QuacksLikeASmartptr);
+  const auto SmartptrAny = anyOf(knownSmartptr(), QuacksLikeASmartptr);
+  const auto SmartptrWithDeref =
+      anyOf(cxxRecordDecl(knownSmartptr(), HasRelevantOps), QuacksLikeASmartptr);
 
   // Catch 'ptr.get()->Foo()'
-  Finder->addMatcher(memberExpr(expr().bind("memberExpr"), isArrow(),
-                                hasObjectExpression(callToGet(Smartptr))),
-                     Callback);
+  Finder->addMatcher(
+      memberExpr(expr().bind("memberExpr"), isArrow(),
+                 hasObjectExpression(callToGet(SmartptrWithDeref))),
+      Callback);
 
   // Catch '*ptr.get()' or '*ptr->get()'
   Finder->addMatcher(
-      unaryOperator(hasOperatorName("*"), hasUnaryOperand(callToGet(Smartptr))),
+      unaryOperator(hasOperatorName("*"),
+                    hasUnaryOperand(callToGet(SmartptrWithDeref))),
       Callback);
 
   // Catch '!ptr.get()'
   const auto CallToGetAsBool = callToGet(
-      recordDecl(Smartptr, has(cxxConversionDecl(returns(booleanType())))));
+      recordDecl(SmartptrAny, has(cxxConversionDecl(returns(booleanType())))));
   Finder->addMatcher(
       unaryOperator(hasOperatorName("!"), hasUnaryOperand(CallToGetAsBool)),
       Callback);
@@ -84,7 +96,7 @@ void registerMatchersForGetArrowStart(MatchFinder *Finder,
                      Callback);
 
   Finder->addMatcher(cxxDependentScopeMemberExpr(hasObjectExpression(
-                         callExpr(has(callToGet(Smartptr))).bind("obj"))),
+                         callExpr(has(callToGet(SmartptrAny))))),
                      Callback);
 }
 


### PR DESCRIPTION
Currently we generate an incorrect suggestion for shared/unique pointers to arrays; for instance ([Godbolt](https://godbolt.org/z/Tens1reGP)):
```c++
#include <memory>

void test_shared_ptr_to_array() {
  std::shared_ptr<int[]> i;
  auto s = sizeof(*i.get());
}
```
```
<source>:5:20: warning: redundant get() call on smart pointer [readability-redundant-smartptr-get]
    5 |   auto s = sizeof(*i.get());
      |                    ^~~~~~~
      |                    i
1 warning generated.
```
`sizeof(*i)` is incorrect, though, because the array specialization of `std::shared/unique_ptr` does not have an `operator*()`. Therefore I have disabled this check for smart pointers to arrays for now; future work could, of course, improve on this by suggesting, say, `sizeof(i[0])` in the above example.