### PR TITLE
[ARM] Remove unused class member in ARMConstantIslandPass

### DIFF
--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -183,9 +183,6 @@ namespace {
     /// base address.
     DenseMap<int, int> JumpTableUserIndices;
 
-    // Maps a MachineBasicBlock to the number of jump tables entries.
-    DenseMap<const MachineBasicBlock *, int> BlockJumpTableRefCount;
-
     /// ImmBranch - One per immediate branch, keeping the machine instruction
     /// pointer, conditional or unconditional, the max displacement,
     /// and (if isCond is true) the corresponding unconditional branch
@@ -523,7 +520,6 @@ bool ARMConstantIslands::runOnMachineFunction(MachineFunction &mf) {
   CPEntries.clear();
   JumpTableEntryIndices.clear();
   JumpTableUserIndices.clear();
-  BlockJumpTableRefCount.clear();
   ImmBranches.clear();
   PushPopMIs.clear();
   T2JumpTables.clear();
@@ -736,14 +732,6 @@ Align ARMConstantIslands::getCPEAlign(const MachineInstr *CPEMI) {
   return MCP->getConstants()[CPI].getAlign();
 }
 
-// Exception landing pads, blocks that has their adress taken, and function
-// entry blocks will always be (potential) indirect jump targets, regardless of
-// whether they are referenced by or not by jump tables.
-static bool isAlwaysIndirectTarget(const MachineBasicBlock &MBB) {
-  return MBB.isEHPad() || MBB.hasAddressTaken() ||
-         &MBB == &MBB.getParent()->front();
-}
-
 /// scanFunctionJumpTables - Do a scan of the function, building up
 /// information about the sizes of each block and the locations of all
 /// the jump tables.
@@ -754,20 +742,6 @@ void ARMConstantIslands::scanFunctionJumpTables() {
           (I.getOpcode() == ARM::t2BR_JT || I.getOpcode() == ARM::tBR_JTr))
         T2JumpTables.push_back(&I);
   }
-
-  if (!MF->getInfo<ARMFunctionInfo>()->branchTargetEnforcement())
-    return;
-
-  if (const MachineJumpTableInfo *JTI = MF->getJumpTableInfo())
-    for (const MachineJumpTableEntry &JTE : JTI->getJumpTables())
-      for (const MachineBasicBlock *MBB : JTE.MBBs) {
-        if (isAlwaysIndirectTarget(*MBB))
-          // Set the reference count essentially to infinity, it will never
-          // reach zero and the BTI Instruction will never be removed.
-          BlockJumpTableRefCount[MBB] = std::numeric_limits<int>::max();
-        else
-          ++BlockJumpTableRefCount[MBB];
-      }
 }
 
 /// initializeFunctionInfo - Do the initial scan of the function, building up


### PR DESCRIPTION
The map variable `BlockJumpTableRefCount` was added in commit f5f28d5b0ce76af8f6944774aa73bad9e328b020 to track whether a basic block was the target of any jump table entries. This was used in the function `fixupBTI` to insert and remove BTIs after jump tables had been modified.

Commit 3b742242a53ed0c2a2e1b6bb2352cace43c22030 removed `fixupBTI` on the grounds that the work was now being done elsewhere. That left `BlockJumpTableRefCount` still being created, but now nothing is using it. So we can garbage-collect that variable and all the code that populates it.