### PR TITLE
[clang][bytecode] Diagnose placement-new'ing to a temporary

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1702,6 +1702,8 @@ bool CheckNewTypeMismatch(InterpState &S, CodePtr OpPC, const Expr *E,
                           std::optional<uint64_t> ArraySize) {
   const Pointer &Ptr = S.Stk.peek<Pointer>();
 
+  if (!CheckTemporary(S, OpPC, Ptr, AK_Construct))
+    return false;
   if (!CheckStore(S, OpPC, Ptr))
     return false;
 

--- a/clang/test/AST/ByteCode/placement-new.cpp
+++ b/clang/test/AST/ByteCode/placement-new.cpp
@@ -15,7 +15,8 @@ namespace std {
   constexpr void construct_at(void *p, Args &&...args) {
     new (p) T((Args&&)args...); // both-note {{in call to}} \
                                 // both-note {{placement new would change type of storage from 'int' to 'float'}} \
-                                // both-note {{construction of subobject of member 'x' of union with active member 'a' is not allowed in a constant expression}}
+                                // both-note {{construction of subobject of member 'x' of union with active member 'a' is not allowed in a constant expression}} \
+                                // both-note {{construction of temporary is not allowed}}
 
   }
 }
@@ -390,4 +391,10 @@ namespace MemMove {
   }
 
   static_assert(foo() == 123);
+}
+
+namespace Temp {
+  constexpr int &&temporary = 0; // both-note {{created here}}
+  static_assert((std::construct_at<int>(&temporary, 1), true)); // both-error{{not an integral constant expression}} \
+                                                                // both-note {{in call}}
 }


### PR DESCRIPTION
... that's been created in a different evaluation.