### PR TITLE
replace the extension with the right functions

### DIFF
--- a/clang/lib/Driver/ToolChains/ZOS.cpp
+++ b/clang/lib/Driver/ToolChains/ZOS.cpp
@@ -153,11 +153,10 @@ void zos::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     StringRef OutputName = Output.getFilename();
     // Strip away the last file suffix in presence from output name and add
     // a new .x suffix.
-    size_t Suffix = OutputName.find_last_of('.');
-    const char *SideDeckName =
-        Args.MakeArgString(OutputName.substr(0, Suffix) + ".x");
+    SmallString<128> SideDeckName = OutputName;
+    llvm::sys::path::replace_extension(SideDeckName, "x");
     CmdArgs.push_back("-x");
-    CmdArgs.push_back(SideDeckName);
+    CmdArgs.push_back(Args.MakeArgString(SideDeckName));
   } else {
     // We need to direct side file to /dev/null to suppress linker warning when
     // the object file contains exported symbols, and -shared or

--- a/clang/test/Driver/zos-ld-sidedeck.c
+++ b/clang/test/Driver/zos-ld-sidedeck.c
@@ -1,0 +1,19 @@
+// Try using various forms of output file name to see what side deck file name looks like
+// RUN: %clang -### --shared --target=s390x-ibm-zos %s -o foo.out 2>&1 \
+// RUN:   | FileCheck --check-prefix=SD-BASE %s
+// RUN: %clang -### --shared --target=s390x-ibm-zos %s -o foo 2>&1 \
+// RUN:   | FileCheck --check-prefix=SD-BASE %s
+// SD-BASE: "-x" "foo.x"
+
+// RUN: %clang -### --shared --target=s390x-ibm-zos %s -o lib/foo.out 2>&1 \
+// RUN:   | FileCheck --check-prefix=SD-SUBDIR %s
+// RUN: %clang -### --shared --target=s390x-ibm-zos %s -o lib/foo 2>&1 \
+// RUN:   | FileCheck --check-prefix=SD-SUBDIR %s
+// SD-SUBDIR: "-x" "lib/foo.x"
+
+
+// RUN: %clang -### --shared --target=s390x-ibm-zos %s -o ../lib/foo.out 2>&1 \
+// RUN:   | FileCheck --check-prefix=SD-REL %s
+// RUN: %clang -### --shared --target=s390x-ibm-zos %s -o ../lib/foo 2>&1 \
+// RUN:   | FileCheck --check-prefix=SD-REL %s
+// SD-REL: "-x" "../lib/foo.x"


### PR DESCRIPTION
Using a relative path name for the shared library name was causing the side deck name to be incorrect.  Fixed the code by using the `replace_exentsion()` function.