### PR TITLE
[lldb][headers] Create script to fix up versioning

### DIFF
--- a/lldb/scripts/framework-header-fix.sh
+++ b/lldb/scripts/framework-header-fix.sh
@@ -7,11 +7,5 @@ for file in `find $1 -name "*.h"`
 do
   /usr/bin/sed -i.bak 's/\(#include\)[ ]*"lldb\/\(API\/\)\{0,1\}\(.*\)"/\1 <LLDB\/\3>/1' "$file"
   /usr/bin/sed -i.bak 's|<LLDB/Utility|<LLDB|' "$file"
-  LLDB_VERSION=`echo $2 | /usr/bin/sed -E 's/^([0-9]+).([0-9]+).([0-9]+)(.[0-9]+)?$/\\1/g'`
-  LLDB_REVISION=`echo $2 | /usr/bin/sed -E 's/^([0-9]+).([0-9]+).([0-9]+)(.[0-9]+)?$/\\3/g'`
-  LLDB_VERSION_STRING=`echo $2`
-  /usr/bin/sed -i.bak "s|//#define LLDB_VERSION$|#define LLDB_VERSION $LLDB_VERSION |" "$file"
-  /usr/bin/sed -i.bak "s|//#define LLDB_REVISION|#define LLDB_REVISION $LLDB_REVISION |" "$file"
-  /usr/bin/sed -i.bak "s|//#define LLDB_VERSION_STRING|#define LLDB_VERSION_STRING \"$LLDB_VERSION_STRING\" |" "$file"
   rm -f "$file.bak"
 done

--- a/lldb/scripts/version-header-fix.py
+++ b/lldb/scripts/version-header-fix.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Usage: <path/to/input-header.h> <path/to/output-header.h> LLDB_MAJOR_VERSION LLDB_MINOR_VERSION LLDB_PATCH_VERSION
+
+This script uncomments and populates the versioning information in lldb-defines.h
+"""
+
+import argparse
+import os
+import re
+
+LLDB_VERSION_REGEX = re.compile(r"//\s*#define LLDB_VERSION\s*$", re.M)
+LLDB_REVISION_REGEX = re.compile(r"//\s*#define LLDB_REVISION\s*$", re.M)
+LLDB_VERSION_STRING_REGEX = re.compile(r"//\s*#define LLDB_VERSION_STRING\s*$", re.M)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_path")
+    parser.add_argument("output_path")
+    parser.add_argument("lldb_version_major")
+    parser.add_argument("lldb_version_minor")
+    parser.add_argument("lldb_version_patch")
+    args = parser.parse_args()
+    input_path = str(args.input_path)
+    output_path = str(args.output_path)
+    lldb_version_major = args.lldb_version_major
+    lldb_version_minor = args.lldb_version_minor
+    lldb_version_patch = args.lldb_version_patch
+
+    with open(input_path, "r") as input_file:
+        lines = input_file.readlines()
+        file_buffer = "".join(lines)
+
+    with open(output_path, "w") as output_file:
+        # For the defines in lldb-defines.h that define the major, minor and version string
+        # uncomment each define and populate its value using the arguments passed in.
+        # e.g. //#define LLDB_VERSION -> #define LLDB_VERSION <LLDB_MAJOR_VERSION>
+        file_buffer = re.sub(
+            LLDB_VERSION_REGEX,
+            r"#define LLDB_VERSION " + lldb_version_major,
+            file_buffer,
+        )
+
+        file_buffer = re.sub(
+            LLDB_REVISION_REGEX,
+            r"#define LLDB_REVISION " + lldb_version_patch,
+            file_buffer,
+        )
+        file_buffer = re.sub(
+            LLDB_VERSION_STRING_REGEX,
+            r'#define LLDB_VERSION_STRING "{0}.{1}.{2}"'.format(
+                lldb_version_major, lldb_version_minor, lldb_version_patch
+            ),
+            file_buffer,
+        )
+        output_file.write(file_buffer)
+
+
+if __name__ == "__main__":
+    main()

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -290,6 +290,45 @@ else()
   endif()
 endif()
 
+# Stage all headers in the include directory in the build dir.
+file(GLOB public_headers ${LLDB_SOURCE_DIR}/include/lldb/API/*.h)
+set(lldb_header_staging_dir ${CMAKE_BINARY_DIR}/include/lldb)
+file(GLOB root_public_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-*.h)
+file(GLOB root_private_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-private*.h)
+list(REMOVE_ITEM root_public_headers ${root_private_headers})
+
+find_program(unifdef_EXECUTABLE unifdef)
+
+foreach(header
+    ${public_headers}
+    ${generated_public_headers}
+    ${root_public_headers})
+  get_filename_component(basename ${header} NAME)
+  set(staged_header ${lldb_header_staging_dir}/${basename})
+
+  if(unifdef_EXECUTABLE)
+    # unifdef returns 0 when the file is unchanged and 1 if something was changed.
+    # That means if we successfully remove SWIG code, the build system believes
+    # that the command has failed and stops. This is undesirable.
+    set(copy_command ${unifdef_EXECUTABLE} -USWIG -o ${staged_header} ${header} || (exit 0))
+  else()
+    set(copy_command ${CMAKE_COMMAND} -E copy ${header} ${staged_header})
+  endif()
+
+  add_custom_command(
+    DEPENDS ${header} OUTPUT ${staged_header}
+    COMMAND ${copy_command}
+    COMMENT "LLDB headers: stage LLDB headers in include directory")
+
+  list(APPEND lldb_staged_headers ${staged_header})
+endforeach()
+
+add_custom_command(TARGET liblldb POST_BUILD
+  COMMAND ${LLDB_SOURCE_DIR}/scripts/version-header-fix.py ${LLDB_SOURCE_DIR}/include/lldb/lldb-defines.h ${lldb_header_staging_dir}/lldb-defines.h ${LLDB_VERSION_MAJOR} ${LLDB_VERSION_MINOR} ${LLDB_VERSION_PATCH}
+)
+add_custom_target(liblldb-header-staging DEPENDS ${lldb_staged_headers})
+add_dependencies(liblldb liblldb-header-staging)
+
 if(LLDB_BUILD_FRAMEWORK)
   include(LLDBFramework)
 

--- a/lldb/test/Shell/Scripts/Inputs/lldb-defines.h
+++ b/lldb/test/Shell/Scripts/Inputs/lldb-defines.h
@@ -1,0 +1,7 @@
+// This is a truncated version of lldb-defines.h used to test the script
+// that fixes up its versioning info.
+
+// The script needs to uncomment these lines and populate the info for versioning.
+// #define LLDB_VERSION
+// #define LLDB_REVISION
+// #define LLDB_VERSION_STRING

--- a/lldb/test/Shell/Scripts/TestVersionFixScript.test
+++ b/lldb/test/Shell/Scripts/TestVersionFixScript.test
@@ -1,0 +1,11 @@
+# Create a temp dir for output and run the version fix script on the truncated version of lldb-defines.h in the inputs dir.
+RUN: mkdir -p %t/Outputs
+RUN: %python %p/../../../scripts/version-header-fix.py %p/Inputs/lldb-defines.h %t/Outputs/lldb-defines.h 21 0 12
+
+# Check the output
+RUN: cat %t/Outputs/lldb-defines.h | FileCheck %s
+
+# The LLDB version defines must be uncommented and filled in with the values passed into the script.
+CHECK: {{^}}#define LLDB_VERSION 21
+CHECK: {{^}}#define LLDB_REVISION 12
+CHECK: {{^}}#define LLDB_VERSION_STRING "21.0.12"


### PR DESCRIPTION
This commit creates a Python script that fixes up the versioning information in lldb-defines.h. It also moves the build logic for fixing up the lldb headers from being in the framework only to being in the same location that we create the liblldb target.