### PR TITLE
[lldb][lldb-dap] Support breakpoint info bytes

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1042,12 +1042,12 @@ class DebugCommunication(object):
         return self.send_recv(command_dict)
 
     def request_dataBreakpointInfo(
-            self,
-            name: str,
-            variablesReference: int = None,
-            frameIndex: int = 0,
-            bytes_: int = None,
-            asAddress: bool = None,
+        self,
+        name: str,
+        variablesReference: int = None,
+        frameIndex: int = 0,
+        bytes_: int = None,
+        asAddress: bool = None,
     ):
 
         args_dict = {}

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1044,10 +1044,10 @@ class DebugCommunication(object):
     def request_dataBreakpointInfo(
         self,
         name: str,
-        variablesReference: int = None,
-        frameIndex: int = 0,
-        bytes_: int = None,
-        asAddress: bool = None,
+            variablesReference: Optional[int] | None = None,
+            frameIndex: Optional[int] = 0,
+            bytes_: Optional[int] = None,
+            asAddress: Optional[bool] = None,
     ):
         args_dict = {}
         if asAddress is not None:
@@ -1057,9 +1057,12 @@ class DebugCommunication(object):
                 "bytes": bytes_,
             }
         else:
-            stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=None)
+            thread_id = self.get_thread_id()
+            stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=thread_id)
             if stackFrame is None:
-                return []
+                raise ValueError(
+                    f"could not get stackframe for frameIndex: {frameIndex} and threadId: {thread_id}"
+                )
             args_dict = {
                 "variablesReference": variablesReference,
                 "name": name,

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1044,10 +1044,10 @@ class DebugCommunication(object):
     def request_dataBreakpointInfo(
         self,
         name: str,
-            variablesReference: Optional[int] | None = None,
-            frameIndex: Optional[int] = 0,
-            bytes_: Optional[int] = None,
-            asAddress: Optional[bool] = None,
+        variablesReference: Optional[int] | None = None,
+        frameIndex: Optional[int] = 0,
+        bytes_: Optional[int] = None,
+        asAddress: Optional[bool] = None,
     ):
         args_dict = {}
         if asAddress is not None:

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1042,16 +1042,31 @@ class DebugCommunication(object):
         return self.send_recv(command_dict)
 
     def request_dataBreakpointInfo(
-        self, variablesReference, name, frameIndex=0, threadId=None
+            self,
+            name: str,
+            variablesReference: int = None,
+            frameIndex: int = 0,
+            bytes_: int = None,
+            asAddress: bool = None,
     ):
-        stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=threadId)
-        if stackFrame is None:
-            return []
-        args_dict = {
-            "variablesReference": variablesReference,
-            "name": name,
-            "frameId": stackFrame["id"],
-        }
+
+        args_dict = {}
+        if asAddress is not None:
+            args_dict = {
+                "name": name,
+                "asAddress": asAddress,
+                "bytes": bytes_,
+            }
+        else:
+            stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=None)
+            if stackFrame is None:
+                return []
+            args_dict = {
+                "variablesReference": variablesReference,
+                "name": name,
+                "frameId": stackFrame["id"],
+            }
+
         command_dict = {
             "command": "dataBreakpointInfo",
             "type": "request",

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1044,7 +1044,7 @@ class DebugCommunication(object):
     def request_dataBreakpointInfo(
         self,
         name: str,
-        variablesReference: Optional[int] | None = None,
+        variablesReference: Optional[int] = None,
         frameIndex: Optional[int] = 0,
         bytes_: Optional[int] = None,
         asAddress: Optional[bool] = None,

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1049,7 +1049,6 @@ class DebugCommunication(object):
         bytes_: int = None,
         asAddress: bool = None,
     ):
-
         args_dict = {}
         if asAddress is not None:
             args_dict = {

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -105,7 +105,7 @@ class DAPTestCaseBase(TestBase):
         return False
 
     def verify_breakpoint_hit(
-            self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
+        self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
     ):
         """Wait for the process we are debugging to stop, and verify we hit
         any breakpoint location in the "breakpoint_ids" array.
@@ -119,9 +119,9 @@ class DAPTestCaseBase(TestBase):
                 if "reason" not in body:
                     continue
                 if body["reason"] not in (
-                        "breakpoint",
-                        "instruction breakpoint",
-                        "data breakpoint",
+                    "breakpoint",
+                    "instruction breakpoint",
+                    "data breakpoint",
                 ):
                     continue
                 if "description" not in body:
@@ -334,12 +334,12 @@ class DAPTestCaseBase(TestBase):
         return self.dap_server.wait_for_stopped(timeout)
 
     def continue_to_breakpoint(
-            self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
+        self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
     ):
         self.continue_to_breakpoints([breakpoint_id], timeout, reason)
 
     def continue_to_breakpoints(
-            self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
+        self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
     ):
         self.do_continue()
         self.verify_breakpoint_hit(breakpoint_ids, timeout, reason)

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -105,7 +105,7 @@ class DAPTestCaseBase(TestBase):
         return False
 
     def verify_breakpoint_hit(
-            self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+        self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
     ):
         """Wait for the process we are debugging to stop, and verify we hit
         any breakpoint location in the "breakpoint_ids" array.
@@ -333,12 +333,12 @@ class DAPTestCaseBase(TestBase):
         return self.dap_server.wait_for_stopped(timeout)
 
     def continue_to_breakpoint(
-            self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+        self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
     ):
         self.continue_to_breakpoints([breakpoint_id], timeout, is_watchpoint)
 
     def continue_to_breakpoints(
-            self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+        self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
     ):
         self.do_continue()
         self.verify_breakpoint_hit(breakpoint_ids, timeout, is_watchpoint)

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -104,7 +104,9 @@ class DAPTestCaseBase(TestBase):
             time.sleep(0.5)
         return False
 
-    def verify_breakpoint_hit(self, breakpoint_ids, timeout=DEFAULT_TIMEOUT):
+    def verify_breakpoint_hit(
+            self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+    ):
         """Wait for the process we are debugging to stop, and verify we hit
         any breakpoint location in the "breakpoint_ids" array.
         "breakpoint_ids" should be a list of breakpoint ID strings
@@ -131,9 +133,10 @@ class DAPTestCaseBase(TestBase):
                 # So when looking at the description we just want to make sure
                 # the right breakpoint matches and not worry about the actual
                 # location.
+                type_name = "watchpoint" if is_watchpoint else "breakpoint"
                 description = body["description"]
                 for breakpoint_id in breakpoint_ids:
-                    match_desc = f"breakpoint {breakpoint_id}."
+                    match_desc = f"{type_name} {breakpoint_id}"
                     if match_desc in description:
                         return
         self.assertTrue(False, f"breakpoint not hit, stopped_events={stopped_events}")
@@ -329,12 +332,16 @@ class DAPTestCaseBase(TestBase):
         self.do_continue()
         return self.dap_server.wait_for_stopped(timeout)
 
-    def continue_to_breakpoint(self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT):
-        self.continue_to_breakpoints((breakpoint_id), timeout)
+    def continue_to_breakpoint(
+            self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+    ):
+        self.continue_to_breakpoints([breakpoint_id], timeout, is_watchpoint)
 
-    def continue_to_breakpoints(self, breakpoint_ids, timeout=DEFAULT_TIMEOUT):
+    def continue_to_breakpoints(
+            self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+    ):
         self.do_continue()
-        self.verify_breakpoint_hit(breakpoint_ids, timeout)
+        self.verify_breakpoint_hit(breakpoint_ids, timeout, is_watchpoint)
 
     def continue_to_exception_breakpoint(self, filter_label, timeout=DEFAULT_TIMEOUT):
         self.do_continue()

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -105,7 +105,7 @@ class DAPTestCaseBase(TestBase):
         return False
 
     def verify_breakpoint_hit(
-        self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+            self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
     ):
         """Wait for the process we are debugging to stop, and verify we hit
         any breakpoint location in the "breakpoint_ids" array.
@@ -118,9 +118,10 @@ class DAPTestCaseBase(TestBase):
                 body = stopped_event["body"]
                 if "reason" not in body:
                     continue
-                if (
-                    body["reason"] != "breakpoint"
-                    and body["reason"] != "instruction breakpoint"
+                if body["reason"] not in (
+                        "breakpoint",
+                        "instruction breakpoint",
+                        "data breakpoint",
                 ):
                     continue
                 if "description" not in body:
@@ -133,7 +134,7 @@ class DAPTestCaseBase(TestBase):
                 # So when looking at the description we just want to make sure
                 # the right breakpoint matches and not worry about the actual
                 # location.
-                type_name = "watchpoint" if is_watchpoint else "breakpoint"
+                type_name = reason or "breakpoint"
                 description = body["description"]
                 for breakpoint_id in breakpoint_ids:
                     match_desc = f"{type_name} {breakpoint_id}"
@@ -333,15 +334,15 @@ class DAPTestCaseBase(TestBase):
         return self.dap_server.wait_for_stopped(timeout)
 
     def continue_to_breakpoint(
-        self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+            self, breakpoint_id: str, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
     ):
-        self.continue_to_breakpoints([breakpoint_id], timeout, is_watchpoint)
+        self.continue_to_breakpoints([breakpoint_id], timeout, reason)
 
     def continue_to_breakpoints(
-        self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, is_watchpoint=False
+            self, breakpoint_ids, timeout=DEFAULT_TIMEOUT, reason: Optional[str] = None
     ):
         self.do_continue()
-        self.verify_breakpoint_hit(breakpoint_ids, timeout, is_watchpoint)
+        self.verify_breakpoint_hit(breakpoint_ids, timeout, reason)
 
     def continue_to_exception_breakpoint(self, filter_label, timeout=DEFAULT_TIMEOUT):
         self.do_continue()

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1725,6 +1725,8 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
     if (region_info.GetRange() == qXfer_region_info.GetRange()) {
       region_info.SetFlash(qXfer_region_info.GetFlash());
       region_info.SetBlocksize(qXfer_region_info.GetBlocksize());
+      region_info.SetReadable(qXfer_region_info.GetReadable());
+      region_info.SetWritable(qXfer_region_info.GetWritable());
     }
   }
   return error;

--- a/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
@@ -77,16 +77,16 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         bp_resp = self.dap_server.request_dataBreakpointInfo(
             var_address, asAddress=True, bytes_=var_byte_watch_size
         )
-        resp_data_id = bp_resp["body"]["dataId"]
         self.assertTrue(
             bp_resp["success"], f"dataBreakpointInfo request failed: {bp_resp}"
         )
+        resp_data_id = bp_resp["body"]["dataId"]
         self.assertEqual(resp_data_id.split("/")[1], str(var_byte_watch_size))
 
         data_breakpoints = [{"dataId": resp_data_id, "accessType": "write"}]
         self.dap_server.request_setDataBreakpoint(data_breakpoints)
 
-        self.continue_to_breakpoint(breakpoint_id=1, is_watchpoint=True)
+        self.continue_to_breakpoint(breakpoint_id=1, reason="data breakpoint")
         eval_response = self.dap_server.request_evaluate("var", context="watch")
         self.assertTrue(eval_response["success"])
         var_value = eval_response["body"]["result"]

--- a/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
@@ -23,8 +23,8 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_next_stop()
         self.dap_server.get_stackFrame()
         # Test setting write watchpoint using expressions: &x, arr+2
-        response_x = self.dap_server.request_dataBreakpointInfo(0, "&x")
-        response_arr_2 = self.dap_server.request_dataBreakpointInfo(0, "arr+2")
+        response_x = self.dap_server.request_dataBreakpointInfo("&x", 0)
+        response_arr_2 = self.dap_server.request_dataBreakpointInfo("arr+2", 0)
         # Test response from dataBreakpointInfo request.
         self.assertEqual(response_x["body"]["dataId"].split("/")[1], "4")
         self.assertEqual(response_x["body"]["accessTypes"], self.accessTypes)
@@ -57,6 +57,47 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(i_val, "2")
 
     @skipIfWindows
+    def test_breakpoint_info_bytes(self):
+        """Test supportBreakpointInfoBytes
+        Set the watchpoint on `var` variable address + 6 characters.
+        """
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+        source = "main.cpp"
+        first_loop_break_line = line_number(source, "// first loop breakpoint")
+        self.set_source_breakpoints(source, [first_loop_break_line])
+        self.continue_to_next_stop()
+
+        # get the address of `var` variable
+        eval_response = self.dap_server.request_evaluate("&var", context="watch")
+        self.assertTrue(eval_response["success"])
+        var_address = eval_response["body"]["result"]
+
+        var_byte_watch_size = 5
+        bp_resp = self.dap_server.request_dataBreakpointInfo(
+            var_address, asAddress=True, bytes_=var_byte_watch_size
+        )
+        resp_data_id = bp_resp["body"]["dataId"]
+        self.assertTrue(
+            bp_resp["success"], f"dataBreakpointInfo request failed: {bp_resp}"
+        )
+        self.assertEqual(resp_data_id.split("/")[1], str(var_byte_watch_size))
+
+        data_breakpoints = [{"dataId": resp_data_id, "accessType": "write"}]
+        self.dap_server.request_setDataBreakpoint(data_breakpoints)
+
+        self.continue_to_breakpoint(breakpoint_id=1, is_watchpoint=True)
+        eval_response = self.dap_server.request_evaluate("var", context="watch")
+        self.assertTrue(eval_response["success"])
+        var_value = eval_response["body"]["result"]
+        self.assertEqual(var_value, '"HALLO"')
+
+        # Remove the watchpoint because once it leaves this function scope, the address can be
+        # be used by another variable or register.
+        self.dap_server.request_setDataBreakpoint([])
+        self.continue_to_exit()
+
+    @skipIfWindows
     def test_expression(self):
         """Tests setting data breakpoints on expression."""
         program = self.getBuildArtifact("a.out")
@@ -67,8 +108,8 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_next_stop()
         self.dap_server.get_stackFrame()
         # Test setting write watchpoint using expressions: &x, arr+2
-        response_x = self.dap_server.request_dataBreakpointInfo(0, "&x")
-        response_arr_2 = self.dap_server.request_dataBreakpointInfo(0, "arr+2")
+        response_x = self.dap_server.request_dataBreakpointInfo("&x", 0)
+        response_arr_2 = self.dap_server.request_dataBreakpointInfo("arr+2", 0)
         # Test response from dataBreakpointInfo request.
         self.assertEqual(response_x["body"]["dataId"].split("/")[1], "4")
         self.assertEqual(response_x["body"]["accessTypes"], self.accessTypes)
@@ -107,10 +148,10 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_next_stop()
         self.dap_server.get_local_variables()
         # Test write watchpoints on x, arr[2]
-        response_x = self.dap_server.request_dataBreakpointInfo(1, "x")
+        response_x = self.dap_server.request_dataBreakpointInfo("x", 1)
         arr = self.dap_server.get_local_variable("arr")
         response_arr_2 = self.dap_server.request_dataBreakpointInfo(
-            arr["variablesReference"], "[2]"
+            "[2]", arr["variablesReference"]
         )
 
         # Test response from dataBreakpointInfo request.

--- a/lldb/test/API/tools/lldb-dap/databreakpoint/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/main.cpp
@@ -1,5 +1,6 @@
 int main(int argc, char const *argv[]) {
   // Test for data breakpoint
+  char var[6] = "HELLO";
   int x = 0;
   int arr[4] = {1, 2, 3, 4};
   for (int i = 0; i < 5; ++i) { // first loop breakpoint
@@ -9,6 +10,8 @@ int main(int argc, char const *argv[]) {
       arr[i] = 42;
     }
   }
+
+  var[1] = 'A';
 
   x = 1;
   for (int i = 0; i < 10; ++i) { // second loop breakpoint

--- a/lldb/tools/lldb-dap/Handler/DataBreakpointInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DataBreakpointInfoRequestHandler.cpp
@@ -18,16 +18,15 @@ namespace lldb_dap {
 static llvm::Expected<protocol::DataBreakpointInfoResponseBody>
 HandleDataBreakpointBytes(DAP &dap,
                           const protocol::DataBreakpointInfoArguments &args) {
-  llvm::StringRef address = args.name;
+  llvm::StringRef raw_address = args.name;
 
-  unsigned long long load_addr = LLDB_INVALID_ADDRESS;
-  if (llvm::getAsUnsignedInteger(address, 0, load_addr)) {
+  lldb::addr_t load_addr = LLDB_INVALID_ADDRESS;
+  if (raw_address.getAsInteger<lldb::addr_t>(0, load_addr)) {
     return llvm::make_error<DAPError>(llvm::formatv("invalid address"),
                                       llvm::inconvertibleErrorCode(), false);
   }
 
-  lldb::SBAddress sb_addr(load_addr, dap.target);
-  if (!sb_addr.IsValid()) {
+  if (lldb::SBAddress address(load_addr, dap.target); !address.IsValid()) {
     return llvm::make_error<DAPError>(
         llvm::formatv("address {:x} does not exist in the debuggee", load_addr),
         llvm::inconvertibleErrorCode(), false);

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -420,6 +420,9 @@ class DataBreakpointInfoRequestHandler
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral GetCommand() { return "dataBreakpointInfo"; }
+  FeatureSet GetSupportedFeatures() const override {
+    return {protocol::eAdapterFeatureDataBreakpointBytes};
+  }
   llvm::Expected<protocol::DataBreakpointInfoResponseBody>
   Run(const protocol::DataBreakpointInfoArguments &args) const override;
 };

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -893,7 +893,16 @@ llvm::json::Value CreateThreadStopped(DAP &dap, lldb::SBThread &thread,
       EmplaceSafeString(body, "description", desc_str);
     }
   } break;
-  case lldb::eStopReasonWatchpoint:
+  case lldb::eStopReasonWatchpoint: {
+    lldb::break_id_t bp_id = thread.GetStopReasonDataAtIndex(0);
+    lldb::break_id_t bp_loc_id = thread.GetStopReasonDataAtIndex(1);
+    std::string desc_str =
+        llvm::formatv("data breakpoint {0}.{1}", bp_id, bp_loc_id);
+    body.try_emplace("hitBreakpointIds",
+                     llvm::json::Array{llvm::json::Value(bp_id)});
+    body.try_emplace("reason", "data breakpoint");
+    EmplaceSafeString(body, "description", desc_str);
+  } break;
   case lldb::eStopReasonInstrumentation:
     body.try_emplace("reason", "breakpoint");
     break;

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -668,7 +668,7 @@ struct DataBreakpointInfoArguments {
   /// pause on data access anywhere within that range.
   /// Clients may set this property only if the `supportsDataBreakpointBytes`
   /// capability is true.
-  std::optional<int64_t> bytes;
+  std::optional<uint64_t> bytes;
 
   /// If `true`, the `name` is a memory address and the debugger should
   /// interpret it as a decimal value, or hex value if it is prefixed with `0x`.


### PR DESCRIPTION
This adds the support for `supportsBreakpointInfoBytes` to set watchpoint on a address range. 