### PR TITLE
[clang][bytecode] Fix AccessKinds in placement new CheckStore() call

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1703,9 +1703,25 @@ bool CheckNewTypeMismatch(InterpState &S, CodePtr OpPC, const Expr *E,
                           std::optional<uint64_t> ArraySize) {
   const Pointer &Ptr = S.Stk.peek<Pointer>();
 
+  // Similar to CheckStore(), but with the additional CheckTemporary() call and
+  // the AccessKinds are different.
   if (!CheckTemporary(S, OpPC, Ptr, AK_Construct))
     return false;
-  if (!CheckStore(S, OpPC, Ptr))
+  if (!CheckLive(S, OpPC, Ptr, AK_Construct))
+    return false;
+  if (!CheckDummy(S, OpPC, Ptr, AK_Construct))
+    return false;
+  if (!CheckLifetime(S, OpPC, Ptr, AK_Construct))
+    return false;
+  if (!CheckExtern(S, OpPC, Ptr))
+    return false;
+  if (!CheckRange(S, OpPC, Ptr, AK_Construct))
+    return false;
+  if (!CheckGlobal(S, OpPC, Ptr))
+    return false;
+  if (!CheckConst(S, OpPC, Ptr))
+    return false;
+  if (!S.inConstantContext() && isConstexprUnknown(Ptr))
     return false;
 
   if (!InvalidNewDeleteExpr(S, OpPC, E))

--- a/clang/test/AST/ByteCode/placement-new.cpp
+++ b/clang/test/AST/ByteCode/placement-new.cpp
@@ -16,8 +16,8 @@ namespace std {
     new (p) T((Args&&)args...); // both-note {{in call to}} \
                                 // both-note {{placement new would change type of storage from 'int' to 'float'}} \
                                 // both-note {{construction of subobject of member 'x' of union with active member 'a' is not allowed in a constant expression}} \
-                                // both-note {{construction of temporary is not allowed}}
-
+                                // both-note {{construction of temporary is not allowed}} \
+                                // both-note {{construction of heap allocated object that has been deleted}}
   }
 }
 
@@ -397,4 +397,15 @@ namespace Temp {
   constexpr int &&temporary = 0; // both-note {{created here}}
   static_assert((std::construct_at<int>(&temporary, 1), true)); // both-error{{not an integral constant expression}} \
                                                                 // both-note {{in call}}
+}
+
+namespace PlacementNewAfterDelete {
+  constexpr bool construct_after_lifetime() {
+    int *p = new int;
+    delete p;
+    std::construct_at<int>(p); // both-note {{in call}}
+    return true;
+  }
+  static_assert(construct_after_lifetime()); // both-error {{}} \
+                                             // both-note {{in call}}
 }


### PR DESCRIPTION
CheckStore is for assignments, but we're constructing something here, so pass AK_Construct instead. We already diagnosed the test case, but as an assignment.