### PR TITLE
[NFC][HLSL][RootSignature] Use `operator<<` overload instead of dump method

### DIFF
--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -97,9 +97,9 @@ struct DescriptorTable {
   // Denotes that the previous NumClauses in the RootElement array
   // are the clauses in the table.
   uint32_t NumClauses = 0;
-
-  void dump(raw_ostream &OS) const;
 };
+
+raw_ostream &operator<<(raw_ostream &OS, const DescriptorTable &Table);
 
 static const uint32_t NumDescriptorsUnbounded = 0xffffffff;
 static const uint32_t DescriptorTableOffsetAppend = 0xffffffff;
@@ -127,9 +127,9 @@ struct DescriptorTableClause {
       break;
     }
   }
-
-  void dump(raw_ostream &OS) const;
 };
+
+raw_ostream &operator<<(raw_ostream &OS, const DescriptorTableClause &Clause);
 
 /// Models RootElement : RootFlags | RootConstants | RootDescriptor
 ///  | DescriptorTable | DescriptorTableClause

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -71,11 +71,6 @@ static raw_ostream &operator<<(raw_ostream &OS,
   return OS;
 }
 
-void DescriptorTable::dump(raw_ostream &OS) const {
-  OS << "DescriptorTable(numClauses = " << NumClauses
-     << ", visibility = " << Visibility << ")";
-}
-
 static raw_ostream &operator<<(raw_ostream &OS, const ClauseType &Type) {
   switch (Type) {
   case ClauseType::CBuffer:
@@ -137,14 +132,24 @@ static raw_ostream &operator<<(raw_ostream &OS,
   return OS;
 }
 
-void DescriptorTableClause::dump(raw_ostream &OS) const {
-  OS << Type << "(" << Reg << ", numDescriptors = " << NumDescriptors
-     << ", space = " << Space << ", offset = ";
-  if (Offset == DescriptorTableOffsetAppend)
+raw_ostream &operator<<(raw_ostream &OS, const DescriptorTable &Table) {
+  OS << "DescriptorTable(numClauses = " << Table.NumClauses
+     << ", visibility = " << Table.Visibility << ")";
+
+  return OS;
+}
+
+raw_ostream &operator<<(raw_ostream &OS, const DescriptorTableClause &Clause) {
+  OS << Clause.Type << "(" << Clause.Reg
+     << ", numDescriptors = " << Clause.NumDescriptors
+     << ", space = " << Clause.Space << ", offset = ";
+  if (Clause.Offset == DescriptorTableOffsetAppend)
     OS << "DescriptorTableOffsetAppend";
   else
-    OS << Offset;
-  OS << ", flags = " << Flags << ")";
+    OS << Clause.Offset;
+  OS << ", flags = " << Clause.Flags << ")";
+
+  return OS;
 }
 
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
@@ -154,11 +159,11 @@ void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
     if (!First)
       OS << ",";
     OS << " ";
-    First = false;
     if (const auto &Clause = std::get_if<DescriptorTableClause>(&Element))
-      Clause->dump(OS);
+      OS << *Clause;
     if (const auto &Table = std::get_if<DescriptorTable>(&Element))
-      Table->dump(OS);
+      OS << *Table;
+    First = false;
   }
   OS << "}";
 }

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -21,7 +21,7 @@ TEST(HLSLRootSignatureTest, DescriptorCBVClauseDump) {
 
   std::string Out;
   llvm::raw_string_ostream OS(Out);
-  Clause.dump(OS);
+  OS << Clause;
   OS.flush();
 
   std::string Expected = "CBV(b0, numDescriptors = 1, space = 0, "
@@ -41,7 +41,7 @@ TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
 
   std::string Out;
   llvm::raw_string_ostream OS(Out);
-  Clause.dump(OS);
+  OS << Clause;
   OS.flush();
 
   std::string Expected =
@@ -60,7 +60,7 @@ TEST(HLSLRootSignatureTest, DescriptorUAVClauseDump) {
 
   std::string Out;
   llvm::raw_string_ostream OS(Out);
-  Clause.dump(OS);
+  OS << Clause;
   OS.flush();
 
   std::string Expected =
@@ -84,7 +84,7 @@ TEST(HLSLRootSignatureTest, DescriptorSamplerClauseDump) {
 
   std::string Out;
   llvm::raw_string_ostream OS(Out);
-  Clause.dump(OS);
+  OS << Clause;
   OS.flush();
 
   std::string Expected = "Sampler(s0, numDescriptors = 2, space = 42, offset = "
@@ -100,7 +100,7 @@ TEST(HLSLRootSignatureTest, DescriptorTableDump) {
 
   std::string Out;
   llvm::raw_string_ostream OS(Out);
-  Table.dump(OS);
+  OS << Table;
   OS.flush();
 
   std::string Expected =


### PR DESCRIPTION
- we will need to provide a way to dump `RootFlags` for serialization and by using operator overloads we can maintain a consistent interface

This is an NFC to allow for https://github.com/llvm/llvm-project/issues/138192 to be more straightforwardly implemented.