### PR TITLE
[TSan][Test] Disable signal_recursive.cpp test on Darwin

### DIFF
--- a/compiler-rt/test/tsan/signal_recursive.cpp
+++ b/compiler-rt/test/tsan/signal_recursive.cpp
@@ -3,6 +3,8 @@
 // Test case for recursive signal handlers, adopted from:
 // https://github.com/google/sanitizers/issues/478
 
+// UNSUPPORTED: darwin
+
 #include "test.h"
 #include <semaphore.h>
 #include <signal.h>


### PR DESCRIPTION
Mark signal_recursive.cpp test as unsupported on Darwin due to deprecated API `sem_init` and test receives error:

`sem_init failed (errno=78)`