### PR TITLE
[MC] Fix HIP buildbot errors after 68472a3

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
@@ -18,6 +18,7 @@
 #include "llvm/MC/MCFixupKindInfo.h"
 #include "llvm/MC/MCObjectWriter.h"
 #include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/MCValue.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/EndianStream.h"
 #include "llvm/TargetParser/TargetParser.h"
@@ -51,6 +52,8 @@ public:
 
   std::optional<MCFixupKind> getFixupKind(StringRef Name) const override;
   MCFixupKindInfo getFixupKindInfo(MCFixupKind Kind) const override;
+  bool shouldForceRelocation(const MCAssembler &, const MCFixup &,
+                             const MCValue &, const MCSubtargetInfo *) override;
 };
 
 } //End anonymous namespace
@@ -187,6 +190,13 @@ MCFixupKindInfo AMDGPUAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
   assert(unsigned(Kind - FirstTargetFixupKind) < AMDGPU::NumTargetFixupKinds &&
          "Invalid kind!");
   return Infos[Kind - FirstTargetFixupKind];
+}
+
+bool AMDGPUAsmBackend::shouldForceRelocation(const MCAssembler &,
+                                             const MCFixup &,
+                                             const MCValue &Target,
+                                             const MCSubtargetInfo *) {
+  return Target.getSpecifier();
 }
 
 unsigned AMDGPUAsmBackend::getMinimumNopSize() const {


### PR DESCRIPTION
This fixes the errors on our HIP-Kokkos buildbot after 68472a39a0fbf38f5da7bb4ebe43e2ca87ff8308.

I do not know if this is the actually right fix, but afaict it restores the behavior for AMDGPU before the mentioned patch.