### PR TITLE
[asan][test] Disable asan_lsan_deadlock test

### DIFF
--- a/compiler-rt/test/asan/TestCases/asan_lsan_deadlock.cpp
+++ b/compiler-rt/test/asan/TestCases/asan_lsan_deadlock.cpp
@@ -4,8 +4,9 @@
 // RUN: %clangxx_asan -O0 %s -o %t
 // RUN: %env_asan_opts=detect_leaks=1 not %run %t 2>&1 | FileCheck %s
 
-// Hangs for unknown reasons.
-// UNSUPPORTED: darwin
+// FIXME: Hangs for unknown reasons on all platforms. We can re-enable it when
+// its either deterministic, or we solve the deadlock between asan and lsan.
+// UNSUPPORTED: true
 
 /*
  * Purpose: Verify deadlock prevention between ASan error reporting and LSan leak checking.


### PR DESCRIPTION
While the current test exercised the deadlock behavior prior to #131756,
deadlock still can occur intermittently. Since this results in test
flakes in CI, we disable this test until the locking behavior can be
fixed in the runtime. See #140646 for details.
