### PR TITLE
[libc][bazel] Add bazel targets for libc/include/... tests.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -72,6 +72,9 @@ libc_test_library(
         "//libc:llvm_libc_macros_stdfix_macros",
         "//llvm:Support",
     ],
+    # Force linking in this library's `main()` to surface
+    # a duplicate symbol error if a test defines its own main.
+    alwayslink = True,
 )
 
 libc_test_library(

--- a/utils/bazel/llvm-project-overlay/libc/test/include/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/include/BUILD.bazel
@@ -11,12 +11,374 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 libc_test(
+    name = "assert_test",
+    srcs = ["assert_test.cpp"],
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "complex_test",
+    srcs = ["complex_test.cpp"],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "fpclassify_test",
+    srcs = [
+        "FpClassifyTest.h",
+        "fpclassify_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "fpclassifyf_test",
+    srcs = [
+        "FpClassifyTest.h",
+        "fpclassifyf_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "fpclassifyl_test",
+    srcs = [
+        "FpClassifyTest.h",
+        "fpclassifyl_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "fpclassify_c_test",
+    srcs = ["fpclassify_test.c"],
+    use_test_framework = False,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "isfinite_test",
+    srcs = [
+        "IsFiniteTest.h",
+        "isfinite_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isfinitef_test",
+    srcs = [
+        "IsFiniteTest.h",
+        "isfinitef_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isfinitel_test",
+    srcs = [
+        "IsFiniteTest.h",
+        "isfinitel_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isfinite_c_test",
+    srcs = ["isfinite_test.c"],
+    use_test_framework = False,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "isinf_test",
+    srcs = [
+        "IsInfTest.h",
+        "isinf_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isinff_test",
+    srcs = [
+        "IsInfTest.h",
+        "isinff_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isinfl_test",
+    srcs = [
+        "IsInfTest.h",
+        "isinfl_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isinf_c_test",
+    srcs = ["isinf_test.c"],
+    use_test_framework = False,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "isnan_test",
+    srcs = [
+        "IsNanTest.h",
+        "isnan_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isnanf_test",
+    srcs = [
+        "IsNanTest.h",
+        "isnanf_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isnanl_test",
+    srcs = [
+        "IsNanTest.h",
+        "isnanl_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isnan_c_test",
+    srcs = ["isnan_test.c"],
+    use_test_framework = False,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "isnormal_test",
+    srcs = [
+        "IsNormalTest.h",
+        "isnormal_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isnormalf_test",
+    srcs = [
+        "IsNormalTest.h",
+        "isnormalf_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isnormall_test",
+    srcs = [
+        "IsNormalTest.h",
+        "isnormall_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "isnormal_c_test",
+    srcs = ["isnormal_test.c"],
+    use_test_framework = False,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "issubnormal_c_test",
+    srcs = ["issubnormal_test.c"],
+    use_test_framework = False,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "iszero_test",
+    srcs = [
+        "IsZeroTest.h",
+        "iszero_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "iszerof_test",
+    srcs = [
+        "IsZeroTest.h",
+        "iszerof_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "iszerol_test",
+    srcs = [
+        "IsZeroTest.h",
+        "iszerol_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "iszero_c_test",
+    srcs = ["iszero_test.c"],
+    use_test_framework = False,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "signbit_test",
+    srcs = [
+        "SignbitTest.h",
+        "signbit_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "signbitf_test",
+    srcs = [
+        "SignbitTest.h",
+        "signbitf_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "signbitl_test",
+    srcs = [
+        "SignbitTest.h",
+        "signbitl_test.cpp",
+    ],
+    full_build = True,
+    deps = [
+        "//libc:public_headers_deps",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
     name = "stdbit_test",
     srcs = [
         "stdbit_stub.h",
         "stdbit_test.cpp",
     ],
+    full_build = True,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "signbit_c_test",
+    srcs = ["signbit_test.c"],
+    use_test_framework = False,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "stdckdint_test",
+    srcs = ["stdckdint_test.cpp"],
+    full_build = True,
+    deps = ["//libc:public_headers_deps"],
+)
+
+libc_test(
+    name = "sys_queue_test",
+    srcs = ["sys/queue_test.cpp"],
+    full_build = True,
     deps = [
+        "//libc:__support_char_vector",
+        "//libc:__support_cpp_string",
         "//libc:public_headers_deps",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -15,7 +15,21 @@ When performing tests we make sure to always use the internal version.
 load("//libc:libc_build_rules.bzl", "libc_common_copts")
 load("//libc:libc_configure_options.bzl", "LIBC_CONFIGURE_OPTIONS")
 
-def libc_test(name, copts = [], deps = [], local_defines = [], **kwargs):
+_FULL_BUILD_COPTS = [
+    "-nostdlib++",
+    "-nostdlib",
+    "-DLIBC_FULL_BUILD",
+    "-DLIBC_COPT_USE_C_ASSERT",
+]
+
+def libc_test(
+        name,
+        copts = [],
+        deps = [],
+        local_defines = [],
+        use_test_framework = True,
+        full_build = False,
+        **kwargs):
     """Add target for a libc test.
 
     Args:
@@ -23,21 +37,31 @@ def libc_test(name, copts = [], deps = [], local_defines = [], **kwargs):
       copts: The list of options to add to the C++ compilation command.
       deps: The list of libc functions and libraries to be linked in.
       local_defines: The list of target local_defines if any.
+      use_test_framework: Whether to use the libc unit test `main` function.
+      full_build: Whether to compile with LIBC_FULL_BUILD and disallow
+          use of system headers. This is useful for tests that include both
+          LLVM libc headers and proxy headers to avoid conflicting definitions.
       **kwargs: Attributes relevant for a cc_test.
     """
+    deps = deps + [
+        "//libc:__support_macros_config",
+        "//libc:__support_libc_errno",
+        "//libc:errno",
+        "//libc:func_aligned_alloc",
+        "//libc:func_free",
+        "//libc:func_malloc",
+        "//libc:func_realloc",
+    ]
+    if use_test_framework:
+        deps = deps + ["//libc/test/UnitTest:LibcUnitTest"]
+
+    if full_build:
+        copts = copts + _FULL_BUILD_COPTS
+
     native.cc_test(
         name = name,
         local_defines = local_defines + LIBC_CONFIGURE_OPTIONS,
-        deps = [
-            "//libc/test/UnitTest:LibcUnitTest",
-            "//libc:__support_macros_config",
-            "//libc:__support_libc_errno",
-            "//libc:errno",
-            "//libc:func_aligned_alloc",
-            "//libc:func_free",
-            "//libc:func_malloc",
-            "//libc:func_realloc",
-        ] + deps,
+        deps = deps,
         copts = copts + libc_common_copts(),
         linkstatic = 1,
         **kwargs


### PR DESCRIPTION
This PR also sets `alwayslink=True` for `//libc/test:LibcUnitTest`. This ensures that the `main` function provided always gets linked into a test target. While not strictly necessary, it makes it so tests like https://github.com/llvm/llvm-project/blob/45d8759cbed0f216786729718608a8be72a505c6/libc/test/include/signbit_test.c will give a duplicate symbol error if they incorrectly depend on `//libc/test:LibcUnitTest`.

This PR is missing tests for generated header includes since the current Bazel setup lacks generated headers or a mechanism to run hermetic tests. CMake version of the header include tests: https://github.com/llvm/llvm-project/blob/a2ce5647200ad40ae356affd44db7d054de444d2/libc/test/include/CMakeLists.txt#L515

See issue https://github.com/llvm/llvm-project/issues/134780