### PR TITLE
[CIR][NFC] Fix failing OpenACC NYI test

### DIFF
--- a/clang/test/CIR/CodeGenOpenACC/openacc-not-implemented.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/openacc-not-implemented.cpp
@@ -3,7 +3,7 @@
 void HelloWorld(int *A, int *B, int *C, int N) {
 
 // expected-error@+2{{ClangIR code gen Not Yet Implemented: OpenACC Atomic Construct}}
-// expected-error@+1{{ClangIR code gen Not Yet Implemented: statement}}
+// expected-error@+1{{ClangIR code gen Not Yet Implemented: emitCompoundStmtWithoutScope: OpenACCAtomicConstruct}}
 #pragma acc atomic
   N = N + 1;
 


### PR DESCRIPTION
A recent change to the error message produced for unhandled compound statements without scope introduced a failure in an OpenACC test that was checking for the old error message. This change updates the test to check for the new message.