### PR TITLE
[DirectX] change makedouble return type to overloadTy

### DIFF
--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -965,7 +965,8 @@ def MakeDouble : DXILOp<101, makeDouble> {
   let Doc = "creates a double value";
   let intrinsics = [IntrinSelect<int_dx_asdouble>];
   let arguments = [Int32Ty, Int32Ty];
-  let result = DoubleTy;
+  let result = OverloadTy;
+  let overloads = [Overloads<DXIL1_0, [DoubleTy]>];
   let stages = [Stages<DXIL1_0, [all_stages]>];
   let attributes = [Attributes<DXIL1_0, [ReadNone]>];
 }

--- a/llvm/test/CodeGen/DirectX/asdouble.ll
+++ b/llvm/test/CodeGen/DirectX/asdouble.ll
@@ -4,7 +4,7 @@
 ; DirectX op
 
 define noundef double @asdouble_scalar(i32 noundef %low, i32 noundef %high) {
-; CHECK: call double @dx.op.makeDouble(i32 101, i32 %low, i32 %high)
+; CHECK: call double @dx.op.makeDouble.f64(i32 101, i32 %low, i32 %high)
   %ret = call double @llvm.dx.asdouble.i32(i32 %low, i32 %high)
   ret double %ret
 }
@@ -12,9 +12,9 @@ define noundef double @asdouble_scalar(i32 noundef %low, i32 noundef %high) {
 declare double @llvm.dx.asdouble.i32(i32, i32)
 
 define noundef <3 x double> @asdouble_vec(<3 x i32> noundef %low, <3 x i32> noundef %high) {
-; CHECK: call double @dx.op.makeDouble(i32 101, i32 %low.i0, i32 %high.i0)
-; CHECK: call double @dx.op.makeDouble(i32 101, i32 %low.i1, i32 %high.i1)
-; CHECK: call double @dx.op.makeDouble(i32 101, i32 %low.i2, i32 %high.i2)
+; CHECK: call double @dx.op.makeDouble.f64(i32 101, i32 %low.i0, i32 %high.i0)
+; CHECK: call double @dx.op.makeDouble.f64(i32 101, i32 %low.i1, i32 %high.i1)
+; CHECK: call double @dx.op.makeDouble.f64(i32 101, i32 %low.i2, i32 %high.i2)
   %ret = call <3 x double> @llvm.dx.asdouble.v3i32(<3 x i32> %low, <3 x i32> %high)
   ret <3 x double> %ret
 }


### PR DESCRIPTION
Change makedouble return type to overloadTy so makedouble will match validator expectations
Closes #140998 