### PR TITLE
[lldb] Adding a new decorator for CMAKE_BUILD_TYPE.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -137,6 +137,9 @@ libcxx_library_dir = None
 # A plugin whose tests will be enabled, like intel-pt.
 enabled_plugins = []
 
+# the build type of lldb
+# Typical values include Debug, Release, RelWithDebInfo and MinSizeRel
+cmake_build_type = None
 
 def shouldSkipBecauseOfCategories(test_categories):
     if use_categories:

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1102,3 +1102,15 @@ def skipUnlessFeature(feature):
                 return "%s is not supported on this system." % feature
 
     return skipTestIfFn(is_feature_enabled)
+
+
+def skipIfBuildType(types: list[str]):
+    """Skip tests if built in a specific CMAKE_BUILD_TYPE.
+
+    Supported types include 'Release', 'RelWithDebInfo', 'Debug', 'MinSizeRel'.
+    """
+    types = [name.lower() for name in types]
+    return unittest.skipIf(
+        configuration.cmake_build_type.lower() in types,
+        "skip on {} build type(s)".format(", ".join(types)),
+    )

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -297,6 +297,7 @@ def parseOptionsAndInitTestdirs():
     configuration.libcxx_include_dir = args.libcxx_include_dir
     configuration.libcxx_include_target_dir = args.libcxx_include_target_dir
     configuration.libcxx_library_dir = args.libcxx_library_dir
+    configuration.cmake_build_type = args.cmake_build_type.lower()
 
     if args.channels:
         lldbtest_config.channels = args.channels

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -300,6 +300,12 @@ def create_parser():
         metavar="platform-available-ports",
         help="Ports available for connection to a lldb server on the remote platform",
     )
+    group.add_argument(
+        "--cmake-build-type",
+        dest="cmake_build_type",
+        metavar="cmake-build-type",
+        help="Specifies the build type on single-configuration",
+    )
 
     # Test-suite behaviour
     group = parser.add_argument_group("Runtime behaviour options")

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -271,6 +271,9 @@ if is_configured("lldb_libs_dir"):
 if is_configured("lldb_framework_dir"):
     dotest_cmd += ["--framework", config.lldb_framework_dir]
 
+if is_configured("cmake_build_type"):
+    dotest_cmd += ["--cmake-build-type", config.cmake_build_type]
+
 if "lldb-simulator-ios" in config.available_features:
     dotest_cmd += ["--apple-sdk", "iphonesimulator", "--platform-name", "ios-simulator"]
 elif "lldb-simulator-watchos" in config.available_features:

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -27,6 +27,7 @@ config.dotest_common_args_str = lit_config.substitute("@LLDB_TEST_COMMON_ARGS@")
 config.dotest_user_args_str = lit_config.substitute("@LLDB_TEST_USER_ARGS@")
 config.lldb_platform_url = lit_config.substitute("@LLDB_TEST_PLATFORM_URL@")
 config.lldb_platform_working_dir = lit_config.substitute("@LLDB_TEST_PLATFORM_WORKING_DIR@")
+config.cmake_build_type = "@CMAKE_BUILD_TYPE@"
 config.cmake_sysroot = lit_config.substitute("@LLDB_TEST_SYSROOT@" or "@DEFAULT_SYSROOT@")
 config.lldb_enable_python = @LLDB_ENABLE_PYTHON@
 config.dotest_lit_args_str = None


### PR DESCRIPTION
In lldb-dap, we have existing tests that are known to be unstable when lldb and lldb-dap are built in the Debug configuration.

This decorator lets us skip those tests in CI jobs that are to slow with those configurations.

This was split out from #140777 to make the patches smaller.