### PR TITLE
[clang-tidy] Use std:::string::find with std::string_view (NFC)

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/HeaderGuardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/HeaderGuardCheck.cpp
@@ -40,7 +40,7 @@ std::string LLVMHeaderGuardCheck::getHeaderGuard(StringRef Filename,
   // Unlike LLVM svn, LLVM git monorepo is named llvm-project, so we replace
   // "/llvm-project/" with the canonical "/llvm/".
   const static StringRef LLVMProject = "/llvm-project/";
-  size_t PosLLVMProject = Guard.rfind(std::string(LLVMProject));
+  size_t PosLLVMProject = Guard.rfind(LLVMProject);
   if (PosLLVMProject != StringRef::npos)
     Guard = Guard.replace(PosLLVMProject, LLVMProject.size(), "/llvm/");
 


### PR DESCRIPTION
std::string::rfind accepts anything that can be converted to
std::string_view starting in C++17.  Since StringRef can be converted
to std::string_view, we do not need to create a temporary instance of
std::string here.
