### PR TITLE
[TableGen] !subst on a dag should retain name of operator

### DIFF
--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1688,7 +1688,7 @@ static const Init *ForeachDagApply(const Init *LHS, const DagInit *MHSd,
   }
 
   if (Change)
-    return DagInit::get(Val, NewArgs);
+    return DagInit::get(Val, MHSd->getName(), NewArgs);
   return MHSd;
 }
 

--- a/llvm/test/TableGen/dag-subst.td
+++ b/llvm/test/TableGen/dag-subst.td
@@ -1,0 +1,18 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+
+// Operator name "frg" in one_frag:$frg was not retained during !subst.
+
+def one_frag;
+def FPR32;
+def ops;
+def node;
+def GPR;
+def cond;
+def set;
+def FPR32_NEW;
+def a {
+  dag d = (set FPR32:$dst, (one_frag:$frg FPR32:$a, FPR32:$b));
+  dag n = !foreach(i, d, !subst(FPR32, FPR32_NEW, i));
+}
+
+// CHECK: dag n = (set FPR32_NEW:$dst, (one_frag:$frg FPR32_NEW:$a, FPR32_NEW:$b));


### PR DESCRIPTION
Without this patch the !subst in the test drops the name "$frag" from (one_frag:$frag ...) and returns:

```
(set FPR32_NEW:$dst, (one_frag FPR32_NEW:$a, FPR32_NEW:$b))
```