### PR TITLE
[compiler-rt] Hardcode uptr/sptr typedefs on Mips/Linux

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -139,7 +139,7 @@
 namespace __sanitizer {
 
 #if defined(__UINTPTR_TYPE__)
-#  if defined(__arm__) && defined(__linux__)
+#  if (defined(__arm__) || _ABIO32 == 1) && defined(__linux__)
 // Linux Arm headers redefine __UINTPTR_TYPE__ and disagree with clang/gcc.
 typedef unsigned int uptr;
 typedef int sptr;


### PR DESCRIPTION
Sanitizer build on Mips/Linux faills to build due to assertion errors mismatched definitions. This is due to inconsistent definitions of `uptr` of either `unsigned long` or `unsigned int` in compiler-rt. This is caused by clang defining

__UINTPTR_TYPE__ long unsigned int where as gcc defines it as unsigned int

As a workaround, this hardcodes `uptr`/`sptr` in compiler-rt to `unsigned int`/`int` on Linux Mips, matching gcc.