### PR TITLE
[clang-tidy] Add option to disable bugprone-multi-level-pointer-conversion in C code

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.cpp
@@ -57,6 +57,17 @@ AST_MATCHER(QualType, isPointerType) {
 
 } // namespace
 
+MultiLevelImplicitPointerConversionCheck::
+    MultiLevelImplicitPointerConversionCheck(StringRef Name,
+                                             ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context), EnableInC(Options.get("EnableInC", true)) {
+}
+
+void MultiLevelImplicitPointerConversionCheck::storeOptions(
+    ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "EnableInC", EnableInC);
+}
+
 void MultiLevelImplicitPointerConversionCheck::registerMatchers(
     MatchFinder *Finder) {
   Finder->addMatcher(

--- a/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.h
@@ -21,11 +21,17 @@ namespace clang::tidy::bugprone {
 class MultiLevelImplicitPointerConversionCheck : public ClangTidyCheck {
 public:
   MultiLevelImplicitPointerConversionCheck(StringRef Name,
-                                           ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+                                           ClangTidyContext *Context);
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   std::optional<TraversalKind> getCheckTraversalKind() const override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return EnableInC ? true : LangOpts.CPlusPlus;
+  }
+
+private:
+  bool const EnableInC;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -159,6 +159,10 @@ Changes in existing checks
   false positives on deleted constructors that cannot be used to construct
   objects, even if they have public or protected access.
 
+- Added an option to :doc:`bugprone-multi-level-implicit-pointer-conversion
+  <clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion>` to
+  choose whether to enable the check in C code or not.
+
 - Improved :doc:`bugprone-optional-value-conversion
   <clang-tidy/checks/bugprone/optional-value-conversion>` check to detect
   conversion in argument of ``std::make_optional``.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion.rst
@@ -42,3 +42,11 @@ Additionally, it is recommended that developers thoroughly check and verify the
 safety of the conversion before using an explicit cast. This extra level of
 caution can help catch potential issues early on in the development process,
 improving the overall reliability and maintainability of the code.
+
+Options
+-------
+
+.. option:: EnableInC
+
+   If `true`, enables the check in C code (it is always enabled in C++ code).
+   Default is `true`.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/multi-level-implicit-pointer-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/multi-level-implicit-pointer-conversion.c
@@ -1,0 +1,11 @@
+// RUN: %check_clang_tidy -check-suffixes=ENABLE-IN-C %s bugprone-multi-level-implicit-pointer-conversion %t -- -config="{CheckOptions: {bugprone-multi-level-implicit-pointer-conversion.EnableInC: true}}"
+// RUN: %check_clang_tidy -check-suffixes=DISABLE-IN-C %s bugprone-multi-level-implicit-pointer-conversion %t -- -config="{CheckOptions: {bugprone-multi-level-implicit-pointer-conversion.EnableInC: false}}"
+
+void free(void*);
+
+void test() {
+  char **p;
+  free(p);
+  // CHECK-MESSAGES-ENABLE-IN-C: :[[@LINE-1]]:8: warning: multilevel pointer conversion from 'char **' to 'void *', please use explicit cast [bugprone-multi-level-implicit-pointer-conversion]
+  free((void *)p);
+}


### PR DESCRIPTION
Sometimes a project may want to enable this check only in C++, and
disable it in C, since the patterns the check warns about are quite
common and idiomatic in C, and there are no better alternatives.
    
Fixes #140659