### PR TITLE
[lldb][Modules] Fix error handling of parseAndLoadModuleMapFile

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -330,7 +330,7 @@ bool ClangModulesDeclVendorImpl::AddModule(const SourceModule &module,
       auto file = HS.lookupModuleMapFile(*dir, is_framework);
       if (!file)
         return error();
-      if (!HS.parseAndLoadModuleMapFile(*file, is_system))
+      if (HS.parseAndLoadModuleMapFile(*file, is_system))
         return error();
     }
   }


### PR DESCRIPTION
`parseAndLoadModuleMapFile` returns `true` on error. This seems to have always been an issue? This is now preventing me from fixing a different modules related issue. So this patch checks the return value correctly.