### PR TITLE
[compiler-rt] [test] Don't apply the "arm" or "armhf" patterns for targets starting with "arm64"

### DIFF
--- a/compiler-rt/test/lit.common.configured.in
+++ b/compiler-rt/test/lit.common.configured.in
@@ -69,7 +69,7 @@ elif config.android:
   else:
     set_default("target_suffix", "-%s-android" % config.target_arch)
 else:
-  if config.target_arch.startswith("arm"):
+  if config.target_arch.startswith("arm") and not config.target_arch.startswith("arm64"):
     if config.target_arch.endswith("hf"):
       set_default("target_suffix", "-armhf")
     else:


### PR DESCRIPTION
This fixes finding the builtins library for arm64ec.

This matches a corresponding condition added in cmake in 3764ba23484afda683eea390407103e609ef4354.