### PR TITLE
[Clang] Remap paths in OpenMP runtime calls (#82541)

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1353,8 +1353,8 @@ static StringRef getIdentStringFromSourceLocation(CodeGenFunction &CGF,
   // Build debug location
   PresumedLoc PLoc = CGF.getContext().getSourceManager().getPresumedLoc(Loc);
   OS << ";";
-  if (CGF.getDebugInfo())
-    OS << CGF.getDebugInfo()->remapDIPath(PLoc.getFilename());
+  if (auto *DbgInfo = CGF.getDebugInfo())
+    OS << DbgInfo->remapDIPath(PLoc.getFilename());
   else
     OS << PLoc.getFilename();
   OS << ";";
@@ -1379,8 +1379,8 @@ llvm::Value *CGOpenMPRuntime::emitUpdateLocation(CodeGenFunction &CGF,
     if (const auto *FD = dyn_cast_or_null<FunctionDecl>(CGF.CurFuncDecl))
       FunctionName = FD->getQualifiedNameAsString();
     PresumedLoc PLoc = CGF.getContext().getSourceManager().getPresumedLoc(Loc);
-    if (CGF.getDebugInfo())
-      FileName = CGF.getDebugInfo()->remapDIPath(PLoc.getFilename());
+    if (auto *DbgInfo = CGF.getDebugInfo())
+      FileName = DbgInfo->remapDIPath(PLoc.getFilename());
     else
       FileName = PLoc.getFilename();
     unsigned Line = PLoc.getLine();
@@ -8851,8 +8851,8 @@ emitMappingInformation(CodeGenFunction &CGF, llvm::OpenMPIRBuilder &OMPBuilder,
 
   std::string FileName;
   PresumedLoc PLoc = CGF.getContext().getSourceManager().getPresumedLoc(Loc);
-  if (CGF.getDebugInfo())
-    FileName = CGF.getDebugInfo()->remapDIPath(PLoc.getFilename());
+  if (auto *DbgInfo = CGF.getDebugInfo())
+    FileName = DbgInfo->remapDIPath(PLoc.getFilename());
   else
     FileName = PLoc.getFilename();
   return OMPBuilder.getOrCreateSrcLocStr(FileName, ExprName, PLoc.getLine(),

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1352,7 +1352,12 @@ static StringRef getIdentStringFromSourceLocation(CodeGenFunction &CGF,
   llvm::raw_svector_ostream OS(Buffer);
   // Build debug location
   PresumedLoc PLoc = CGF.getContext().getSourceManager().getPresumedLoc(Loc);
-  OS << ";" << PLoc.getFilename() << ";";
+  OS << ";";
+  if (CGF.getDebugInfo())
+    OS << CGF.getDebugInfo()->remapDIPath(PLoc.getFilename());
+  else
+    OS << PLoc.getFilename();
+  OS << ";";
   if (const auto *FD = dyn_cast_or_null<FunctionDecl>(CGF.CurFuncDecl))
     OS << FD->getQualifiedNameAsString();
   OS << ";" << PLoc.getLine() << ";" << PLoc.getColumn() << ";;";
@@ -1370,10 +1375,14 @@ llvm::Value *CGOpenMPRuntime::emitUpdateLocation(CodeGenFunction &CGF,
     SrcLocStr = OMPBuilder.getOrCreateDefaultSrcLocStr(SrcLocStrSize);
   } else {
     std::string FunctionName;
+    std::string FileName;
     if (const auto *FD = dyn_cast_or_null<FunctionDecl>(CGF.CurFuncDecl))
       FunctionName = FD->getQualifiedNameAsString();
     PresumedLoc PLoc = CGF.getContext().getSourceManager().getPresumedLoc(Loc);
-    const char *FileName = PLoc.getFilename();
+    if (CGF.getDebugInfo())
+      FileName = CGF.getDebugInfo()->remapDIPath(PLoc.getFilename());
+    else
+      FileName = PLoc.getFilename();
     unsigned Line = PLoc.getLine();
     unsigned Column = PLoc.getColumn();
     SrcLocStr = OMPBuilder.getOrCreateSrcLocStr(FunctionName, FileName, Line,
@@ -8840,10 +8849,14 @@ emitMappingInformation(CodeGenFunction &CGF, llvm::OpenMPIRBuilder &OMPBuilder,
     ExprName = MapExprs.getMapDecl()->getNameAsString();
   }
 
+  std::string FileName;
   PresumedLoc PLoc = CGF.getContext().getSourceManager().getPresumedLoc(Loc);
-  return OMPBuilder.getOrCreateSrcLocStr(PLoc.getFilename(), ExprName,
-                                         PLoc.getLine(), PLoc.getColumn(),
-                                         SrcLocStrSize);
+  if (CGF.getDebugInfo())
+    FileName = CGF.getDebugInfo()->remapDIPath(PLoc.getFilename());
+  else
+    FileName = PLoc.getFilename();
+  return OMPBuilder.getOrCreateSrcLocStr(FileName, ExprName, PLoc.getLine(),
+                                         PLoc.getColumn(), SrcLocStrSize);
 }
 /// Emit the arrays used to pass the captures and map information to the
 /// offloading runtime library. If there is no map or capture information,

--- a/clang/test/CodeGen/openmp-prefix-map.c
+++ b/clang/test/CodeGen/openmp-prefix-map.c
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -triple i386-unknown-unknown -debug-info-kind=standalone -fopenmp %s -emit-llvm -o - -disable-llvm-optzns -fdebug-prefix-map=%S=.| FileCheck -DPREFIX=%S %s
+
+// CHECK-NOT: @{{[0-9]+}} = private unnamed_addr constant [{{[0-9]+}} x i8] c";[[PREFIX]]{{.*}}.c;foo;{{[0-9]+}};{{[0-9]+}};;\00"
+
+void work1(int, int);
+void work2(int, int);
+void work12(int, int);
+
+void foo(int q) {
+  int p = 2;
+
+  #pragma omp parallel firstprivate(q, p)
+  work1(p, q);
+
+  #pragma omp parallel for firstprivate(p, q)
+  for (int i = 0; i < q; i++)
+    work2(i, p);
+
+  #pragma omp target teams firstprivate(p)
+  work12(p, p);
+}


### PR DESCRIPTION
Apply the debug prefix mapping to the OpenMP location strings.

Fixes https://github.com/llvm/llvm-project/issues/82541