### PR TITLE
[libc][bazel] Support generating public libc headers in Bazel builds.

### DIFF
--- a/utils/bazel/WORKSPACE
+++ b/utils/bazel/WORKSPACE
@@ -182,6 +182,15 @@ maybe(
     url = "https://github.com/wjakob/nanobind/archive/refs/tags/v2.4.0.tar.gz",
 )
 
+maybe(
+    http_archive,
+    name = "pyyaml",
+    build_file = "@llvm-raw//utils/bazel/third_party_build:pyyaml.BUILD",
+    sha256 = "f0a35d7f282a6d6b1a4f3f3965ef5c124e30ed27a0088efb97c0977268fd671f",
+    strip_prefix = "pyyaml-5.1/lib3",
+    url = "https://github.com/yaml/pyyaml/archive/refs/tags/5.1.zip",
+)
+
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 
 py_repositories()

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -9,6 +9,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load(
     ":libc_build_rules.bzl",
     "libc_function",
+    "libc_generated_header",
     "libc_header_library",
     "libc_math_function",
     "libc_support_library",
@@ -88,6 +89,14 @@ py_binary(
     srcs = glob(["utils/hdrgen/hdrgen/**/*.py"]),
     imports = ["utils/hdrgen"],
     main = "utils/hdrgen/hdrgen/main.py",
+    deps = ["@pyyaml//:yaml"],
+)
+
+libc_generated_header(
+    name = "include_stdbit_h",
+    hdr = "include/stdbit.h",
+    other_srcs = ["include/stdbit.h.def"],
+    yaml_template = "include/stdbit.yaml",
 )
 
 # Library containing all headers that can be transitively included by generated llvm-libc

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -248,6 +248,29 @@ def libc_header_library(name, hdrs, deps = [], **kwargs):
         **kwargs
     )
 
+def libc_generated_header(name, hdr, yaml_template, other_srcs = []):
+    """Generates a libc header file from YAML template.
+
+    Args:
+      name: Name of the genrule target.
+      hdr: Path of the header file to generate.
+      yaml_template: Path of the YAML template file.
+      other_srcs: Other files required to generate the header, if any.
+    """
+    hdrgen = "//libc:hdrgen"
+    cmd = "$(location {hdrgen}) $(location {yaml}) -o $@".format(
+        hdrgen = hdrgen,
+        yaml = yaml_template,
+    )
+
+    native.genrule(
+        name = name,
+        outs = [hdr],
+        srcs = [yaml_template] + other_srcs,
+        cmd = cmd,
+        tools = [hdrgen],
+    )
+
 def libc_math_function(
         name,
         additional_deps = None):

--- a/utils/bazel/third_party_build/pyyaml.BUILD
+++ b/utils/bazel/third_party_build/pyyaml.BUILD
@@ -1,0 +1,16 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    # BSD/MIT-like license (for PyYAML)
+    licenses = ["notice"],
+)
+
+py_library(
+    name = "yaml",
+    srcs = glob(["yaml/*.py"]),
+)


### PR DESCRIPTION
This requires adding a new dependency on PyYAML so that Bazel is able to run the `hdrgen` tool hermetically. This PR uses PyYAML version 5.1 due to keep in line with the docs: https://github.com/llvm/llvm-project/blob/b878e0d11874a898bbaa1daf58007dfd232005f2/libc/docs/dev/header_generation.rst?plain=1#L22

See https://github.com/llvm/llvm-project/issues/134780.