### PR TITLE
[lldb-dap] Minor change to stdio client name.

### DIFF
--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -542,7 +542,7 @@ int main(int argc, char *argv[]) {
   lldb::IOObjectSP output = std::make_shared<NativeFile>(
       stdout_fd, File::eOpenOptionWriteOnly, NativeFile::Unowned);
 
-  constexpr llvm::StringLiteral client_name = "stdin/stdout";
+  constexpr llvm::StringLiteral client_name = "stdio";
   Transport transport(client_name, log.get(), input, output);
   DAP dap(log.get(), default_repl_mode, pre_init_commands, transport);
 


### PR DESCRIPTION
Update the stdin <-> stdout client name to `stdio`. I noticed on macOS if I get a crash report from lldb-dap the `/` in the client name causes some thread names to be reported without the full name. For example `Thread 6 Crashed:: */stdout.event_handler`. Switching to `stdio` I think is still clear and not truncated in the macOS crash reports.