### PR TITLE
[RISCV][test] Improve test robustness. [NFCI]

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert-zve64f.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert-zve64f.mir
@@ -24,8 +24,7 @@ body:             |
     ; CHECK-NEXT: renamable $v8 = PseudoVLE64_V_M1 undef renamable $v8, [[COPY1]], 1, 6 /* e64 */, 2 /* tu, ma */, implicit $vl, implicit $vtype :: (load unknown-size, align 8)
     ; CHECK-NEXT: dead $x0 = PseudoVSETIVLI 8, 208 /* e32, m1, ta, ma */, implicit-def $vl, implicit-def $vtype
     ; CHECK-NEXT: renamable $v9 = PseudoVLE32_V_M1 undef renamable $v9, [[COPY]], 8, 5 /* e32 */, 2 /* tu, ma */, implicit $vl, implicit $vtype :: (load unknown-size, align 4)
-    ; CHECK-NEXT: INLINEASM &"# use $0 $1 $2 $3", 1 /* sideeffect attdialect */, 4194313 /* reguse:VR */, killed renamable $v10, 4194313 /* reguse:VR */, killed renamable $v11, 4194313 /* reguse:VR */, killed renamable $v8, 4194313 /* reguse:VR */, killed renamable $v9
-    ; CHECK-NEXT: PseudoRET
+    ; CHECK-NEXT: PseudoRET implicit $v8, implicit $v9, implicit $v10, implicit $v11
     %3:gpr = COPY $x12
     %2:gpr = COPY $x11
     %1:gpr = COPY $x10
@@ -34,7 +33,5 @@ body:             |
     renamable $v11 = PseudoVMV_S_X undef renamable $v11, %1, 8, 5 /* e32 */
     renamable $v8 = PseudoVLE64_V_M1 undef renamable $v8, %2, 1, 6 /* e64 */, 2 /* tu, ma */ :: (load unknown-size, align 8)
     renamable $v9 = PseudoVLE32_V_M1 undef renamable $v9, %3, 8, 5 /* e32 */, 2 /* tu, ma */ :: (load unknown-size, align 4)
-    INLINEASM &"# use $0 $1 $2 $3", 1 /* sideeffect attdialect */, 4194313 /* reguse:VR */, killed renamable $v10, 4194313 /* reguse:VR */, killed renamable $v11, 4194313 /* reguse:VR */, killed renamable $v8, 4194313 /* reguse:VR */, killed renamable $v9
-    PseudoRET
-
+    PseudoRET implicit $v8, implicit $v9, implicit $v10, implicit $v11
 ...


### PR DESCRIPTION
In a0b6cfd9752742ff599364545ca9996cee67ef9b the literal in the test needed to be updated because of the changes in the enums generated by tablegen.

We can achieve the same "reguse" constraint with a PseudoRET instruction.