### PR TITLE
[flang] Fix prescanner bug w/ empty macros in line continuation

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -1473,7 +1473,7 @@ const char *Prescanner::FreeFormContinuationLine(bool ampersand) {
             GetProvenanceRange(p, p + 1),
             "Character literal continuation line should have been preceded by '&'"_port_en_US);
       }
-    } else if (p > lineStart) {
+    } else if (p > lineStart && IsSpaceOrTab(p - 1)) {
       --p;
     } else {
       insertASpace_ = true;

--- a/flang/test/Preprocessing/bug890.F90
+++ b/flang/test/Preprocessing/bug890.F90
@@ -1,0 +1,6 @@
+! RUN: %flang -E %s 2>&1 | FileCheck %s
+!CHECK: subroutine sub()
+#define empty
+subroutine sub ( &
+  empty)
+end


### PR DESCRIPTION
When processing free form source line continuation, the prescanner treats empty keyword macros as if they were spaces or tabs.  After skipping over them, however, there's code that only works if the skipped characters ended with an actual space or tab.  If the last skipped item was an empty keyword macro's name, the last character of that name would end up being the first character of the continuation line.  Fix.