### PR TITLE
[WebKit checkers] Add an annotation for pointer conversion.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -468,6 +468,18 @@ bool isPtrConversion(const FunctionDecl *F) {
       FunctionName == "checked_objc_cast")
     return true;
 
+  auto ReturnType = F->getReturnType();
+  if (auto *Type = ReturnType.getTypePtrOrNull()) {
+    if (auto *AttrType = dyn_cast<AttributedType>(Type)) {
+      if (auto *Attr = AttrType->getAttr()) {
+        if (auto *AnnotateType = dyn_cast<AnnotateTypeAttr>(Attr)) {
+          if (AnnotateType->getAnnotation() == "webkit.pointerconversion")
+            return true;
+        }
+      }
+    }
+  }
+
   return false;
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args-safe-functions.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-safe-functions.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
-// expected-no-diagnostics
 
 class Base {
 public:
@@ -44,6 +43,12 @@ inline Target* uncheckedDowncast(Source* source)
     return static_cast<Target*>(source);
 }
 
+template<typename Target, typename Source>
+Target* [[clang::annotate_type("webkit.pointerconversion")]] newCastFunction(Source*);
+
+template<typename Target, typename Source>
+Target* [[clang::annotate_type("unrelated-annotation")]] badCastFunction(Source*);
+
 template<typename... Types>
 String toString(const Types&... values);
 
@@ -52,5 +57,8 @@ void foo(OtherObject* other)
     dynamicDowncast<SubDerived>(other->obj());
     checkedDowncast<SubDerived>(other->obj());
     uncheckedDowncast<SubDerived>(other->obj());
+    newCastFunction<SubDerived>(other->obj());
+    badCastFunction<SubDerived>(other->obj());
+    // expected-warning@-1{{Call argument is uncounted and unsafe}}
     toString(other->obj());
 }


### PR DESCRIPTION
This PR adds the WebKit checker support for [[clang::annotate_type("webkit.pointerconversion")]].

When this attribute is set on the return value of a function, the function is treated as safe to call anywhere and the return value's pointer origin is the argument.`