### PR TITLE
[lldb] Use if-with-initializer pattern in SBTarget (NFC)

### DIFF
--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -166,8 +166,7 @@ SBProcess SBTarget::GetProcess() {
 
   SBProcess sb_process;
   ProcessSP process_sp;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     process_sp = target_sp->GetProcessSP();
     sb_process.SetSP(process_sp);
   }
@@ -178,22 +177,19 @@ SBProcess SBTarget::GetProcess() {
 SBPlatform SBTarget::GetPlatform() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return SBPlatform();
-
-  SBPlatform platform;
-  platform.m_opaque_sp = target_sp->GetPlatform();
-
-  return platform;
+  if (TargetSP target_sp = GetSP()) {
+    SBPlatform platform;
+    platform.m_opaque_sp = target_sp->GetPlatform();
+    return platform;
+  }
+  return SBPlatform();
 }
 
 SBDebugger SBTarget::GetDebugger() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBDebugger debugger;
-  TargetSP target_sp(GetSP());
-  if (target_sp)
+  if (TargetSP target_sp = GetSP())
     debugger.reset(target_sp->GetDebugger().shared_from_this());
   return debugger;
 }
@@ -208,41 +204,38 @@ SBStructuredData SBTarget::GetStatistics(SBStatisticsOptions options) {
   LLDB_INSTRUMENT_VA(this);
 
   SBStructuredData data;
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
+  if (TargetSP target_sp = GetSP()) {
+    std::string json_str =
+        llvm::formatv("{0:2}", DebuggerStats::ReportStatistics(
+                                   target_sp->GetDebugger(), target_sp.get(),
+                                   options.ref()))
+            .str();
+    data.m_impl_up->SetObjectSP(StructuredData::ParseJSON(json_str));
     return data;
-  std::string json_str =
-      llvm::formatv("{0:2}", DebuggerStats::ReportStatistics(
-                                 target_sp->GetDebugger(), target_sp.get(),
-                                 options.ref()))
-          .str();
-  data.m_impl_up->SetObjectSP(StructuredData::ParseJSON(json_str));
+  }
   return data;
 }
 
 void SBTarget::ResetStatistics() {
   LLDB_INSTRUMENT_VA(this);
-  TargetSP target_sp(GetSP());
-  if (target_sp)
+
+  if (TargetSP target_sp = GetSP())
     DebuggerStats::ResetStatistics(target_sp->GetDebugger(), target_sp.get());
 }
 
 void SBTarget::SetCollectingStats(bool v) {
   LLDB_INSTRUMENT_VA(this, v);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return;
-  return DebuggerStats::SetCollectingStats(v);
+  if (TargetSP target_sp = GetSP())
+    DebuggerStats::SetCollectingStats(v);
 }
 
 bool SBTarget::GetCollectingStats() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return false;
-  return DebuggerStats::GetCollectingStats();
+  if (TargetSP target_sp = GetSP())
+    return DebuggerStats::GetCollectingStats();
+  return false;
 }
 
 SBProcess SBTarget::LoadCore(const char *core_file) {
@@ -256,8 +249,7 @@ SBProcess SBTarget::LoadCore(const char *core_file, lldb::SBError &error) {
   LLDB_INSTRUMENT_VA(this, core_file, error);
 
   SBProcess sb_process;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     FileSpec filespec(core_file);
     FileSystem::Instance().Resolve(filespec);
     ProcessSP process_sp(target_sp->CreateProcess(
@@ -303,8 +295,7 @@ SBError SBTarget::Install() {
   LLDB_INSTRUMENT_VA(this);
 
   SBError sb_error;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     sb_error.ref() = target_sp->Install(nullptr);
   }
@@ -323,9 +314,7 @@ SBProcess SBTarget::Launch(SBListener &listener, char const **argv,
 
   SBProcess sb_process;
   ProcessSP process_sp;
-  TargetSP target_sp(GetSP());
-
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
 
     if (stop_at_entry)
@@ -400,9 +389,7 @@ SBProcess SBTarget::Launch(SBLaunchInfo &sb_launch_info, SBError &error) {
   LLDB_INSTRUMENT_VA(this, sb_launch_info, error);
 
   SBProcess sb_process;
-  TargetSP target_sp(GetSP());
-
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     StateType state = eStateInvalid;
     {
@@ -446,9 +433,7 @@ lldb::SBProcess SBTarget::Attach(SBAttachInfo &sb_attach_info, SBError &error) {
   LLDB_INSTRUMENT_VA(this, sb_attach_info, error);
 
   SBProcess sb_process;
-  TargetSP target_sp(GetSP());
-
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     ProcessAttachInfo &attach_info = sb_attach_info.ref();
     if (attach_info.ProcessIDIsValid() && !attach_info.UserIDIsValid() &&
         !attach_info.IsScriptedProcess()) {
@@ -484,9 +469,7 @@ lldb::SBProcess SBTarget::AttachToProcessWithID(
   LLDB_INSTRUMENT_VA(this, listener, pid, error);
 
   SBProcess sb_process;
-  TargetSP target_sp(GetSP());
-
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     ProcessAttachInfo attach_info;
     attach_info.SetProcessID(pid);
     if (listener.IsValid())
@@ -514,9 +497,13 @@ lldb::SBProcess SBTarget::AttachToProcessWithName(
   LLDB_INSTRUMENT_VA(this, listener, name, wait_for, error);
 
   SBProcess sb_process;
-  TargetSP target_sp(GetSP());
 
-  if (name && target_sp) {
+  if (!name) {
+    error.SetErrorString("invalid name");
+    return sb_process;
+  }
+
+  if (TargetSP target_sp = GetSP()) {
     ProcessAttachInfo attach_info;
     attach_info.GetExecutableFile().SetFile(name, FileSpec::Style::native);
     attach_info.SetWaitForLaunch(wait_for);
@@ -526,8 +513,9 @@ lldb::SBProcess SBTarget::AttachToProcessWithName(
     error.SetError(AttachToProcess(attach_info, *target_sp));
     if (error.Success())
       sb_process.SetSP(target_sp->GetProcessSP());
-  } else
+  } else {
     error.SetErrorString("SBTarget is invalid");
+  }
 
   return sb_process;
 }
@@ -539,9 +527,7 @@ lldb::SBProcess SBTarget::ConnectRemote(SBListener &listener, const char *url,
 
   SBProcess sb_process;
   ProcessSP process_sp;
-  TargetSP target_sp(GetSP());
-
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     if (listener.IsValid())
       process_sp =
@@ -568,8 +554,7 @@ SBFileSpec SBTarget::GetExecutable() {
   LLDB_INSTRUMENT_VA(this);
 
   SBFileSpec exe_file_spec;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     Module *exe_module = target_sp->GetExecutableModulePointer();
     if (exe_module)
       exe_file_spec.SetFileSpec(exe_module->GetFileSpec());
@@ -601,8 +586,7 @@ lldb::SBAddress SBTarget::ResolveLoadAddress(lldb::addr_t vm_addr) {
 
   lldb::SBAddress sb_addr;
   Address &addr = sb_addr.ref();
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     if (target_sp->ResolveLoadAddress(vm_addr, addr))
       return sb_addr;
@@ -619,8 +603,7 @@ lldb::SBAddress SBTarget::ResolveFileAddress(lldb::addr_t file_addr) {
 
   lldb::SBAddress sb_addr;
   Address &addr = sb_addr.ref();
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     if (target_sp->ResolveFileAddress(file_addr, addr))
       return sb_addr;
@@ -636,8 +619,7 @@ lldb::SBAddress SBTarget::ResolvePastLoadAddress(uint32_t stop_id,
 
   lldb::SBAddress sb_addr;
   Address &addr = sb_addr.ref();
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     if (target_sp->ResolveLoadAddress(vm_addr, addr))
       return sb_addr;
@@ -657,8 +639,7 @@ SBTarget::ResolveSymbolContextForAddress(const SBAddress &addr,
   SBSymbolContext sc;
   SymbolContextItem scope = static_cast<SymbolContextItem>(resolve_scope);
   if (addr.IsValid()) {
-    TargetSP target_sp(GetSP());
-    if (target_sp)
+    if (TargetSP target_sp = GetSP())
       target_sp->GetImages().ResolveSymbolContextForAddress(addr.ref(), scope,
                                                             sc.ref());
   }
@@ -670,8 +651,7 @@ size_t SBTarget::ReadMemory(const SBAddress addr, void *buf, size_t size,
   LLDB_INSTRUMENT_VA(this, addr, buf, size, error);
 
   size_t bytes_read = 0;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     bytes_read =
         target_sp->ReadMemory(addr.ref(), buf, size, error.ref(), true);
@@ -723,8 +703,7 @@ SBBreakpoint SBTarget::BreakpointCreateByLocation(
   LLDB_INSTRUMENT_VA(this, sb_file_spec, line, column, offset, sb_module_list);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp && line != 0) {
+  if (TargetSP target_sp = GetSP(); target_sp && line != 0) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
 
     const LazyBool check_inlines = eLazyBoolCalculate;
@@ -752,8 +731,7 @@ SBBreakpoint SBTarget::BreakpointCreateByLocation(
                      move_to_nearest_code);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp && line != 0) {
+  if (TargetSP target_sp = GetSP(); target_sp && line != 0) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
 
     const LazyBool check_inlines = eLazyBoolCalculate;
@@ -778,8 +756,7 @@ SBBreakpoint SBTarget::BreakpointCreateByName(const char *symbol_name,
   LLDB_INSTRUMENT_VA(this, symbol_name, module_name);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp.get()) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
 
     const bool internal = false;
@@ -833,8 +810,8 @@ lldb::SBBreakpoint SBTarget::BreakpointCreateByName(
                      module_list, comp_unit_list);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp && symbol_name && symbol_name[0]) {
+  if (TargetSP target_sp = GetSP();
+      target_sp && symbol_name && symbol_name[0]) {
     const bool internal = false;
     const bool hardware = false;
     const LazyBool skip_prologue = eLazyBoolCalculate;
@@ -879,8 +856,7 @@ lldb::SBBreakpoint SBTarget::BreakpointCreateByNames(
                      symbol_language, offset, module_list, comp_unit_list);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp && num_names > 0) {
+  if (TargetSP target_sp = GetSP(); target_sp && num_names > 0) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     const bool internal = false;
     const bool hardware = false;
@@ -924,8 +900,8 @@ lldb::SBBreakpoint SBTarget::BreakpointCreateByRegex(
                      comp_unit_list);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp && symbol_name_regex && symbol_name_regex[0]) {
+  if (TargetSP target_sp = GetSP();
+      target_sp && symbol_name_regex && symbol_name_regex[0]) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     RegularExpression regexp((llvm::StringRef(symbol_name_regex)));
     const bool internal = false;
@@ -944,8 +920,7 @@ SBBreakpoint SBTarget::BreakpointCreateByAddress(addr_t address) {
   LLDB_INSTRUMENT_VA(this, address);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     const bool hardware = false;
     sb_bp = target_sp->CreateBreakpoint(address, false, hardware);
@@ -958,12 +933,11 @@ SBBreakpoint SBTarget::BreakpointCreateBySBAddress(SBAddress &sb_address) {
   LLDB_INSTRUMENT_VA(this, sb_address);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
   if (!sb_address.IsValid()) {
     return sb_bp;
   }
 
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     const bool hardware = false;
     sb_bp = target_sp->CreateBreakpoint(sb_address.ref(), false, hardware);
@@ -1010,8 +984,8 @@ lldb::SBBreakpoint SBTarget::BreakpointCreateBySourceRegex(
                      func_names);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp && source_regex && source_regex[0]) {
+  if (TargetSP target_sp = GetSP();
+      target_sp && source_regex && source_regex[0]) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     const bool hardware = false;
     const LazyBool move_to_nearest_code = eLazyBoolCalculate;
@@ -1035,8 +1009,7 @@ SBTarget::BreakpointCreateForException(lldb::LanguageType language,
   LLDB_INSTRUMENT_VA(this, language, catch_bp, throw_bp);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     const bool hardware = false;
     sb_bp = target_sp->CreateExceptionBreakpoint(language, catch_bp, throw_bp,
@@ -1054,8 +1027,7 @@ lldb::SBBreakpoint SBTarget::BreakpointCreateFromScript(
                      request_hardware);
 
   SBBreakpoint sb_bp;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     Status error;
 
@@ -1076,8 +1048,7 @@ lldb::SBBreakpoint SBTarget::BreakpointCreateFromScript(
 uint32_t SBTarget::GetNumBreakpoints() const {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     // The breakpoint list is thread safe, no need to lock
     return target_sp->GetBreakpointList().GetSize();
   }
@@ -1088,8 +1059,7 @@ SBBreakpoint SBTarget::GetBreakpointAtIndex(uint32_t idx) const {
   LLDB_INSTRUMENT_VA(this, idx);
 
   SBBreakpoint sb_breakpoint;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     // The breakpoint list is thread safe, no need to lock
     sb_breakpoint = target_sp->GetBreakpointList().GetBreakpointAtIndex(idx);
   }
@@ -1100,8 +1070,7 @@ bool SBTarget::BreakpointDelete(break_id_t bp_id) {
   LLDB_INSTRUMENT_VA(this, bp_id);
 
   bool result = false;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     result = target_sp->RemoveBreakpointByID(bp_id);
   }
@@ -1113,10 +1082,11 @@ SBBreakpoint SBTarget::FindBreakpointByID(break_id_t bp_id) {
   LLDB_INSTRUMENT_VA(this, bp_id);
 
   SBBreakpoint sb_breakpoint;
-  TargetSP target_sp(GetSP());
-  if (target_sp && bp_id != LLDB_INVALID_BREAK_ID) {
-    std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
-    sb_breakpoint = target_sp->GetBreakpointByID(bp_id);
+  if (TargetSP target_sp = GetSP()) {
+    if (bp_id != LLDB_INVALID_BREAK_ID) {
+      std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
+      sb_breakpoint = target_sp->GetBreakpointByID(bp_id);
+    }
   }
 
   return sb_breakpoint;
@@ -1126,8 +1096,7 @@ bool SBTarget::FindBreakpointsByName(const char *name,
                                      SBBreakpointList &bkpts) {
   LLDB_INSTRUMENT_VA(this, name, bkpts);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     llvm::Expected<std::vector<BreakpointSP>> expected_vector =
         target_sp->GetBreakpointList().FindBreakpointsByName(name);
@@ -1148,8 +1117,7 @@ void SBTarget::GetBreakpointNames(SBStringList &names) {
 
   names.Clear();
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
 
     std::vector<std::string> name_vec;
@@ -1162,8 +1130,7 @@ void SBTarget::GetBreakpointNames(SBStringList &names) {
 void SBTarget::DeleteBreakpointName(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     target_sp->DeleteBreakpointName(ConstString(name));
   }
@@ -1172,8 +1139,7 @@ void SBTarget::DeleteBreakpointName(const char *name) {
 bool SBTarget::EnableAllBreakpoints() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     target_sp->EnableAllowedBreakpoints();
     return true;
@@ -1184,8 +1150,7 @@ bool SBTarget::EnableAllBreakpoints() {
 bool SBTarget::DisableAllBreakpoints() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     target_sp->DisableAllowedBreakpoints();
     return true;
@@ -1196,8 +1161,7 @@ bool SBTarget::DisableAllBreakpoints() {
 bool SBTarget::DeleteAllBreakpoints() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     target_sp->RemoveAllowedBreakpoints();
     return true;
@@ -1219,30 +1183,29 @@ lldb::SBError SBTarget::BreakpointsCreateFromFile(SBFileSpec &source_file,
   LLDB_INSTRUMENT_VA(this, source_file, matching_names, new_bps);
 
   SBError sberr;
-  TargetSP target_sp(GetSP());
-  if (!target_sp) {
+  if (TargetSP target_sp = GetSP()) {
+    std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
+
+    BreakpointIDList bp_ids;
+
+    std::vector<std::string> name_vector;
+    size_t num_names = matching_names.GetSize();
+    for (size_t i = 0; i < num_names; i++)
+      name_vector.push_back(matching_names.GetStringAtIndex(i));
+
+    sberr.ref() = target_sp->CreateBreakpointsFromFile(source_file.ref(),
+                                                       name_vector, bp_ids);
+    if (sberr.Fail())
+      return sberr;
+
+    size_t num_bkpts = bp_ids.GetSize();
+    for (size_t i = 0; i < num_bkpts; i++) {
+      BreakpointID bp_id = bp_ids.GetBreakpointIDAtIndex(i);
+      new_bps.AppendByID(bp_id.GetBreakpointID());
+    }
+  } else {
     sberr.SetErrorString(
         "BreakpointCreateFromFile called with invalid target.");
-    return sberr;
-  }
-  std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
-
-  BreakpointIDList bp_ids;
-
-  std::vector<std::string> name_vector;
-  size_t num_names = matching_names.GetSize();
-  for (size_t i = 0; i < num_names; i++)
-    name_vector.push_back(matching_names.GetStringAtIndex(i));
-
-  sberr.ref() = target_sp->CreateBreakpointsFromFile(source_file.ref(),
-                                                     name_vector, bp_ids);
-  if (sberr.Fail())
-    return sberr;
-
-  size_t num_bkpts = bp_ids.GetSize();
-  for (size_t i = 0; i < num_bkpts; i++) {
-    BreakpointID bp_id = bp_ids.GetBreakpointIDAtIndex(i);
-    new_bps.AppendByID(bp_id.GetBreakpointID());
   }
   return sberr;
 }
@@ -1251,13 +1214,12 @@ lldb::SBError SBTarget::BreakpointsWriteToFile(SBFileSpec &dest_file) {
   LLDB_INSTRUMENT_VA(this, dest_file);
 
   SBError sberr;
-  TargetSP target_sp(GetSP());
-  if (!target_sp) {
-    sberr.SetErrorString("BreakpointWriteToFile called with invalid target.");
-    return sberr;
+  if (TargetSP target_sp = GetSP()) {
+    SBBreakpointList bkpt_list(*this);
+    return BreakpointsWriteToFile(dest_file, bkpt_list);
   }
-  SBBreakpointList bkpt_list(*this);
-  return BreakpointsWriteToFile(dest_file, bkpt_list);
+  sberr.SetErrorString("BreakpointWriteToFile called with invalid target.");
+  return sberr;
 }
 
 lldb::SBError SBTarget::BreakpointsWriteToFile(SBFileSpec &dest_file,
@@ -1266,25 +1228,22 @@ lldb::SBError SBTarget::BreakpointsWriteToFile(SBFileSpec &dest_file,
   LLDB_INSTRUMENT_VA(this, dest_file, bkpt_list, append);
 
   SBError sberr;
-  TargetSP target_sp(GetSP());
-  if (!target_sp) {
+  if (TargetSP target_sp = GetSP()) {
+    std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
+    BreakpointIDList bp_id_list;
+    bkpt_list.CopyToBreakpointIDList(bp_id_list);
+    sberr.ref() = target_sp->SerializeBreakpointsToFile(dest_file.ref(),
+                                                        bp_id_list, append);
+  } else {
     sberr.SetErrorString("BreakpointWriteToFile called with invalid target.");
-    return sberr;
   }
-
-  std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
-  BreakpointIDList bp_id_list;
-  bkpt_list.CopyToBreakpointIDList(bp_id_list);
-  sberr.ref() = target_sp->SerializeBreakpointsToFile(dest_file.ref(),
-                                                      bp_id_list, append);
   return sberr;
 }
 
 uint32_t SBTarget::GetNumWatchpoints() const {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     // The watchpoint list is thread safe, no need to lock
     return target_sp->GetWatchpointList().GetSize();
   }
@@ -1295,8 +1254,7 @@ SBWatchpoint SBTarget::GetWatchpointAtIndex(uint32_t idx) const {
   LLDB_INSTRUMENT_VA(this, idx);
 
   SBWatchpoint sb_watchpoint;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     // The watchpoint list is thread safe, no need to lock
     sb_watchpoint.SetSP(target_sp->GetWatchpointList().GetByIndex(idx));
   }
@@ -1307,8 +1265,7 @@ bool SBTarget::DeleteWatchpoint(watch_id_t wp_id) {
   LLDB_INSTRUMENT_VA(this, wp_id);
 
   bool result = false;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     std::unique_lock<std::recursive_mutex> lock;
     target_sp->GetWatchpointList().GetListMutex(lock);
@@ -1323,8 +1280,8 @@ SBWatchpoint SBTarget::FindWatchpointByID(lldb::watch_id_t wp_id) {
 
   SBWatchpoint sb_watchpoint;
   lldb::WatchpointSP watchpoint_sp;
-  TargetSP target_sp(GetSP());
-  if (target_sp && wp_id != LLDB_INVALID_WATCH_ID) {
+  if (TargetSP target_sp = GetSP();
+      target_sp && wp_id != LLDB_INVALID_WATCH_ID) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     std::unique_lock<std::recursive_mutex> lock;
     target_sp->GetWatchpointList().GetListMutex(lock);
@@ -1355,29 +1312,30 @@ SBTarget::WatchpointCreateByAddress(lldb::addr_t addr, size_t size,
 
   SBWatchpoint sb_watchpoint;
   lldb::WatchpointSP watchpoint_sp;
-  TargetSP target_sp(GetSP());
-  uint32_t watch_type = 0;
-  if (options.GetWatchpointTypeRead())
-    watch_type |= LLDB_WATCH_TYPE_READ;
-  if (options.GetWatchpointTypeWrite() == eWatchpointWriteTypeAlways)
-    watch_type |= LLDB_WATCH_TYPE_WRITE;
-  if (options.GetWatchpointTypeWrite() == eWatchpointWriteTypeOnModify)
-    watch_type |= LLDB_WATCH_TYPE_MODIFY;
-  if (watch_type == 0) {
-    error.SetErrorString("Can't create a watchpoint that is neither read nor "
-                         "write nor modify.");
-    return sb_watchpoint;
-  }
-  if (target_sp && addr != LLDB_INVALID_ADDRESS && size > 0) {
-    std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
-    // Target::CreateWatchpoint() is thread safe.
-    Status cw_error;
-    // This API doesn't take in a type, so we can't figure out what it is.
-    CompilerType *type = nullptr;
-    watchpoint_sp =
-        target_sp->CreateWatchpoint(addr, size, type, watch_type, cw_error);
-    error.SetError(std::move(cw_error));
-    sb_watchpoint.SetSP(watchpoint_sp);
+  if (TargetSP target_sp = GetSP()) {
+    uint32_t watch_type = 0;
+    if (options.GetWatchpointTypeRead())
+      watch_type |= LLDB_WATCH_TYPE_READ;
+    if (options.GetWatchpointTypeWrite() == eWatchpointWriteTypeAlways)
+      watch_type |= LLDB_WATCH_TYPE_WRITE;
+    if (options.GetWatchpointTypeWrite() == eWatchpointWriteTypeOnModify)
+      watch_type |= LLDB_WATCH_TYPE_MODIFY;
+    if (watch_type == 0) {
+      error.SetErrorString("Can't create a watchpoint that is neither read nor "
+                           "write nor modify.");
+      return sb_watchpoint;
+    }
+    if (addr != LLDB_INVALID_ADDRESS && size > 0) {
+      std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
+      // Target::CreateWatchpoint() is thread safe.
+      Status cw_error;
+      // This API doesn't take in a type, so we can't figure out what it is.
+      CompilerType *type = nullptr;
+      watchpoint_sp =
+          target_sp->CreateWatchpoint(addr, size, type, watch_type, cw_error);
+      error.SetError(std::move(cw_error));
+      sb_watchpoint.SetSP(watchpoint_sp);
+    }
   }
 
   return sb_watchpoint;
@@ -1386,8 +1344,7 @@ SBTarget::WatchpointCreateByAddress(lldb::addr_t addr, size_t size,
 bool SBTarget::EnableAllWatchpoints() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     std::unique_lock<std::recursive_mutex> lock;
     target_sp->GetWatchpointList().GetListMutex(lock);
@@ -1400,8 +1357,7 @@ bool SBTarget::EnableAllWatchpoints() {
 bool SBTarget::DisableAllWatchpoints() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     std::unique_lock<std::recursive_mutex> lock;
     target_sp->GetWatchpointList().GetListMutex(lock);
@@ -1466,8 +1422,7 @@ lldb::SBValue SBTarget::CreateValueFromExpression(const char *name,
 bool SBTarget::DeleteAllWatchpoints() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     std::unique_lock<std::recursive_mutex> lock;
     target_sp->GetWatchpointList().GetListMutex(lock);
@@ -1481,17 +1436,17 @@ void SBTarget::AppendImageSearchPath(const char *from, const char *to,
                                      lldb::SBError &error) {
   LLDB_INSTRUMENT_VA(this, from, to, error);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return error.SetErrorString("invalid target");
+  if (TargetSP target_sp = GetSP()) {
+    llvm::StringRef srFrom = from, srTo = to;
+    if (srFrom.empty())
+      return error.SetErrorString("<from> path can't be empty");
+    if (srTo.empty())
+      return error.SetErrorString("<to> path can't be empty");
 
-  llvm::StringRef srFrom = from, srTo = to;
-  if (srFrom.empty())
-    return error.SetErrorString("<from> path can't be empty");
-  if (srTo.empty())
-    return error.SetErrorString("<to> path can't be empty");
-
-  target_sp->GetImageSearchPathList().Append(srFrom, srTo, true);
+    target_sp->GetImageSearchPathList().Append(srFrom, srTo, true);
+  } else {
+    error.SetErrorString("invalid target");
+  }
 }
 
 lldb::SBModule SBTarget::AddModule(const char *path, const char *triple,
@@ -1505,37 +1460,35 @@ lldb::SBModule SBTarget::AddModule(const char *path, const char *triple,
                                    const char *uuid_cstr, const char *symfile) {
   LLDB_INSTRUMENT_VA(this, path, triple, uuid_cstr, symfile);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return {};
+  if (TargetSP target_sp = GetSP()) {
+    ModuleSpec module_spec;
+    if (path)
+      module_spec.GetFileSpec().SetFile(path, FileSpec::Style::native);
 
-  ModuleSpec module_spec;
-  if (path)
-    module_spec.GetFileSpec().SetFile(path, FileSpec::Style::native);
+    if (uuid_cstr)
+      module_spec.GetUUID().SetFromStringRef(uuid_cstr);
 
-  if (uuid_cstr)
-    module_spec.GetUUID().SetFromStringRef(uuid_cstr);
+    if (triple)
+      module_spec.GetArchitecture() = Platform::GetAugmentedArchSpec(
+          target_sp->GetPlatform().get(), triple);
+    else
+      module_spec.GetArchitecture() = target_sp->GetArchitecture();
 
-  if (triple)
-    module_spec.GetArchitecture() =
-        Platform::GetAugmentedArchSpec(target_sp->GetPlatform().get(), triple);
-  else
-    module_spec.GetArchitecture() = target_sp->GetArchitecture();
+    if (symfile)
+      module_spec.GetSymbolFileSpec().SetFile(symfile, FileSpec::Style::native);
 
-  if (symfile)
-    module_spec.GetSymbolFileSpec().SetFile(symfile, FileSpec::Style::native);
+    SBModuleSpec sb_modulespec(module_spec);
 
-  SBModuleSpec sb_modulespec(module_spec);
-
-  return AddModule(sb_modulespec);
+    return AddModule(sb_modulespec);
+  }
+  return SBModule();
 }
 
 lldb::SBModule SBTarget::AddModule(const SBModuleSpec &module_spec) {
   LLDB_INSTRUMENT_VA(this, module_spec);
 
   lldb::SBModule sb_module;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     sb_module.SetSP(target_sp->GetOrCreateModule(*module_spec.m_opaque_up,
                                                  true /* notify */));
     if (!sb_module.IsValid() && module_spec.m_opaque_up->GetUUID().IsValid()) {
@@ -1550,20 +1503,20 @@ lldb::SBModule SBTarget::AddModule(const SBModuleSpec &module_spec) {
         }
       }
     }
+
+    // If the target hasn't initialized any architecture yet, use the
+    // binary's architecture.
+    if (sb_module.IsValid() && !target_sp->GetArchitecture().IsValid() &&
+        sb_module.GetSP()->GetArchitecture().IsValid())
+      target_sp->SetArchitecture(sb_module.GetSP()->GetArchitecture());
   }
-  // If the target hasn't initialized any architecture yet, use the
-  // binary's architecture.
-  if (sb_module.IsValid() && !target_sp->GetArchitecture().IsValid() &&
-      sb_module.GetSP()->GetArchitecture().IsValid())
-    target_sp->SetArchitecture(sb_module.GetSP()->GetArchitecture());
   return sb_module;
 }
 
 bool SBTarget::AddModule(lldb::SBModule &module) {
   LLDB_INSTRUMENT_VA(this, module);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     target_sp->GetImages().AppendIfNeeded(module.GetSP());
     return true;
   }
@@ -1574,8 +1527,7 @@ uint32_t SBTarget::GetNumModules() const {
   LLDB_INSTRUMENT_VA(this);
 
   uint32_t num = 0;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     // The module list is thread safe, no need to lock
     num = target_sp->GetImages().GetSize();
   }
@@ -1593,11 +1545,12 @@ SBModule SBTarget::FindModule(const SBFileSpec &sb_file_spec) {
   LLDB_INSTRUMENT_VA(this, sb_file_spec);
 
   SBModule sb_module;
-  TargetSP target_sp(GetSP());
-  if (target_sp && sb_file_spec.IsValid()) {
-    ModuleSpec module_spec(*sb_file_spec);
-    // The module list is thread safe, no need to lock
-    sb_module.SetSP(target_sp->GetImages().FindFirstModule(module_spec));
+  if (TargetSP target_sp = GetSP()) {
+    if (sb_file_spec.IsValid()) {
+      ModuleSpec module_spec(*sb_file_spec);
+      // The module list is thread safe, no need to lock
+      sb_module.SetSP(target_sp->GetImages().FindFirstModule(module_spec));
+    }
   }
   return sb_module;
 }
@@ -1606,17 +1559,17 @@ SBSymbolContextList SBTarget::FindCompileUnits(const SBFileSpec &sb_file_spec) {
   LLDB_INSTRUMENT_VA(this, sb_file_spec);
 
   SBSymbolContextList sb_sc_list;
-  const TargetSP target_sp(GetSP());
-  if (target_sp && sb_file_spec.IsValid())
-    target_sp->GetImages().FindCompileUnits(*sb_file_spec, *sb_sc_list);
+  if (TargetSP target_sp = GetSP()) {
+    if (sb_file_spec.IsValid())
+      target_sp->GetImages().FindCompileUnits(*sb_file_spec, *sb_sc_list);
+  }
   return sb_sc_list;
 }
 
 lldb::ByteOrder SBTarget::GetByteOrder() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp)
+  if (TargetSP target_sp = GetSP())
     return target_sp->GetArchitecture().GetByteOrder();
   return eByteOrderInvalid;
 }
@@ -1624,48 +1577,42 @@ lldb::ByteOrder SBTarget::GetByteOrder() {
 const char *SBTarget::GetTriple() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return nullptr;
-
-  std::string triple(target_sp->GetArchitecture().GetTriple().str());
-  // Unique the string so we don't run into ownership issues since the const
-  // strings put the string into the string pool once and the strings never
-  // comes out
-  ConstString const_triple(triple.c_str());
-  return const_triple.GetCString();
+  if (TargetSP target_sp = GetSP()) {
+    std::string triple(target_sp->GetArchitecture().GetTriple().str());
+    // Unique the string so we don't run into ownership issues since the const
+    // strings put the string into the string pool once and the strings never
+    // comes out
+    ConstString const_triple(triple.c_str());
+    return const_triple.GetCString();
+  }
+  return nullptr;
 }
 
 const char *SBTarget::GetABIName() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return nullptr;
-
-  std::string abi_name(target_sp->GetABIName().str());
-  ConstString const_name(abi_name.c_str());
-  return const_name.GetCString();
+  if (TargetSP target_sp = GetSP()) {
+    std::string abi_name(target_sp->GetABIName().str());
+    ConstString const_name(abi_name.c_str());
+    return const_name.GetCString();
+  }
+  return nullptr;
 }
 
 const char *SBTarget::GetLabel() const {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return nullptr;
-
-  return ConstString(target_sp->GetLabel().data()).AsCString();
+  if (TargetSP target_sp = GetSP())
+    return ConstString(target_sp->GetLabel().data()).AsCString();
+  return nullptr;
 }
 
 SBError SBTarget::SetLabel(const char *label) {
   LLDB_INSTRUMENT_VA(this, label);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return Status::FromErrorString("Couldn't get internal target object.");
-
-  return Status::FromError(target_sp->SetLabel(label));
+  if (TargetSP target_sp = GetSP())
+    return Status::FromError(target_sp->SetLabel(label));
+  return Status::FromErrorString("Couldn't get internal target object.");
 }
 
 uint32_t SBTarget::GetMinimumOpcodeByteSize() const {
@@ -1691,38 +1638,31 @@ uint32_t SBTarget::GetMaximumOpcodeByteSize() const {
 uint32_t SBTarget::GetDataByteSize() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP())
     return target_sp->GetArchitecture().GetDataByteSize();
-  }
   return 0;
 }
 
 uint32_t SBTarget::GetCodeByteSize() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP())
     return target_sp->GetArchitecture().GetCodeByteSize();
-  }
   return 0;
 }
 
 uint32_t SBTarget::GetMaximumNumberOfChildrenToDisplay() const {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if(target_sp){
-     return target_sp->GetMaximumNumberOfChildrenToDisplay();
-  }
+  if (TargetSP target_sp = GetSP())
+    return target_sp->GetMaximumNumberOfChildrenToDisplay();
   return 0;
 }
 
 uint32_t SBTarget::GetAddressByteSize() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp)
+  if (TargetSP target_sp = GetSP())
     return target_sp->GetArchitecture().GetAddressByteSize();
   return sizeof(void *);
 }
@@ -1732,8 +1672,7 @@ SBModule SBTarget::GetModuleAtIndex(uint32_t idx) {
 
   SBModule sb_module;
   ModuleSP module_sp;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     // The module list is thread safe, no need to lock
     module_sp = target_sp->GetImages().GetModuleAtIndex(idx);
     sb_module.SetSP(module_sp);
@@ -1745,8 +1684,7 @@ SBModule SBTarget::GetModuleAtIndex(uint32_t idx) {
 bool SBTarget::RemoveModule(lldb::SBModule module) {
   LLDB_INSTRUMENT_VA(this, module);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp)
+  if (TargetSP target_sp = GetSP())
     return target_sp->GetImages().Remove(module.GetSP());
   return false;
 }
@@ -1754,10 +1692,11 @@ bool SBTarget::RemoveModule(lldb::SBModule module) {
 SBBroadcaster SBTarget::GetBroadcaster() const {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  SBBroadcaster broadcaster(target_sp.get(), false);
-
-  return broadcaster;
+  if (TargetSP target_sp = GetSP()) {
+    SBBroadcaster broadcaster(target_sp.get(), false);
+    return broadcaster;
+  }
+  return SBBroadcaster();
 }
 
 bool SBTarget::GetDescription(SBStream &description,
@@ -1766,8 +1705,7 @@ bool SBTarget::GetDescription(SBStream &description,
 
   Stream &strm = description.ref();
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     target_sp->Dump(&strm, description_level);
   } else
     strm.PutCString("No value");
@@ -1783,17 +1721,15 @@ lldb::SBSymbolContextList SBTarget::FindFunctions(const char *name,
   if (!name || !name[0])
     return sb_sc_list;
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return sb_sc_list;
+  if (TargetSP target_sp = GetSP()) {
+    ModuleFunctionSearchOptions function_options;
+    function_options.include_symbols = true;
+    function_options.include_inlines = true;
 
-  ModuleFunctionSearchOptions function_options;
-  function_options.include_symbols = true;
-  function_options.include_inlines = true;
-
-  FunctionNameType mask = static_cast<FunctionNameType>(name_type_mask);
-  target_sp->GetImages().FindFunctions(ConstString(name), mask,
-                                       function_options, *sb_sc_list);
+    FunctionNameType mask = static_cast<FunctionNameType>(name_type_mask);
+    target_sp->GetImages().FindFunctions(ConstString(name), mask,
+                                         function_options, *sb_sc_list);
+  }
   return sb_sc_list;
 }
 
@@ -1805,8 +1741,7 @@ lldb::SBSymbolContextList SBTarget::FindGlobalFunctions(const char *name,
   lldb::SBSymbolContextList sb_sc_list;
   if (name && name[0]) {
     llvm::StringRef name_ref(name);
-    TargetSP target_sp(GetSP());
-    if (target_sp) {
+    if (TargetSP target_sp = GetSP()) {
       ModuleFunctionSearchOptions function_options;
       function_options.include_symbols = true;
       function_options.include_inlines = true;
@@ -1841,31 +1776,33 @@ lldb::SBSymbolContextList SBTarget::FindGlobalFunctions(const char *name,
 lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
   LLDB_INSTRUMENT_VA(this, typename_cstr);
 
-  TargetSP target_sp(GetSP());
-  if (typename_cstr && typename_cstr[0] && target_sp) {
-    ConstString const_typename(typename_cstr);
-    TypeQuery query(const_typename.GetStringRef(),
-                    TypeQueryOptions::e_find_one);
-    TypeResults results;
-    target_sp->GetImages().FindTypes(/*search_first=*/nullptr, query, results);
-    TypeSP type_sp = results.GetFirstType();
-    if (type_sp)
-      return SBType(type_sp);
-    // Didn't find the type in the symbols; Try the loaded language runtimes.
-    if (auto process_sp = target_sp->GetProcessSP()) {
-      for (auto *runtime : process_sp->GetLanguageRuntimes()) {
-        if (auto vendor = runtime->GetDeclVendor()) {
-          auto types = vendor->FindTypes(const_typename, /*max_matches*/ 1);
-          if (!types.empty())
-            return SBType(types.front());
+  if (TargetSP target_sp = GetSP()) {
+    if (typename_cstr && typename_cstr[0]) {
+      ConstString const_typename(typename_cstr);
+      TypeQuery query(const_typename.GetStringRef(),
+                      TypeQueryOptions::e_find_one);
+      TypeResults results;
+      target_sp->GetImages().FindTypes(/*search_first=*/nullptr, query,
+                                       results);
+      TypeSP type_sp = results.GetFirstType();
+      if (type_sp)
+        return SBType(type_sp);
+      // Didn't find the type in the symbols; Try the loaded language runtimes.
+      if (auto process_sp = target_sp->GetProcessSP()) {
+        for (auto *runtime : process_sp->GetLanguageRuntimes()) {
+          if (auto vendor = runtime->GetDeclVendor()) {
+            auto types = vendor->FindTypes(const_typename, /*max_matches*/ 1);
+            if (!types.empty())
+              return SBType(types.front());
+          }
         }
       }
-    }
 
-    // No matches, search for basic typename matches.
-    for (auto type_system_sp : target_sp->GetScratchTypeSystems())
-      if (auto type = type_system_sp->GetBuiltinTypeByName(const_typename))
-        return SBType(type);
+      // No matches, search for basic typename matches.
+      for (auto type_system_sp : target_sp->GetScratchTypeSystems())
+        if (auto type = type_system_sp->GetBuiltinTypeByName(const_typename))
+          return SBType(type);
+    }
   }
 
   return SBType();
@@ -1874,8 +1811,7 @@ lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
 SBType SBTarget::GetBasicType(lldb::BasicType type) {
   LLDB_INSTRUMENT_VA(this, type);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     for (auto type_system_sp : target_sp->GetScratchTypeSystems())
       if (auto compiler_type = type_system_sp->GetBasicTypeFromAST(type))
         return SBType(compiler_type);
@@ -1887,34 +1823,35 @@ lldb::SBTypeList SBTarget::FindTypes(const char *typename_cstr) {
   LLDB_INSTRUMENT_VA(this, typename_cstr);
 
   SBTypeList sb_type_list;
-  TargetSP target_sp(GetSP());
-  if (typename_cstr && typename_cstr[0] && target_sp) {
-    ModuleList &images = target_sp->GetImages();
-    ConstString const_typename(typename_cstr);
-    TypeQuery query(typename_cstr);
-    TypeResults results;
-    images.FindTypes(nullptr, query, results);
-    for (const TypeSP &type_sp : results.GetTypeMap().Types())
-      sb_type_list.Append(SBType(type_sp));
+  if (TargetSP target_sp = GetSP()) {
+    if (typename_cstr && typename_cstr[0]) {
+      ModuleList &images = target_sp->GetImages();
+      ConstString const_typename(typename_cstr);
+      TypeQuery query(typename_cstr);
+      TypeResults results;
+      images.FindTypes(nullptr, query, results);
+      for (const TypeSP &type_sp : results.GetTypeMap().Types())
+        sb_type_list.Append(SBType(type_sp));
 
-    // Try the loaded language runtimes
-    if (auto process_sp = target_sp->GetProcessSP()) {
-      for (auto *runtime : process_sp->GetLanguageRuntimes()) {
-        if (auto *vendor = runtime->GetDeclVendor()) {
-          auto types =
-              vendor->FindTypes(const_typename, /*max_matches*/ UINT32_MAX);
-          for (auto type : types)
-            sb_type_list.Append(SBType(type));
+      // Try the loaded language runtimes
+      if (auto process_sp = target_sp->GetProcessSP()) {
+        for (auto *runtime : process_sp->GetLanguageRuntimes()) {
+          if (auto *vendor = runtime->GetDeclVendor()) {
+            auto types =
+                vendor->FindTypes(const_typename, /*max_matches*/ UINT32_MAX);
+            for (auto type : types)
+              sb_type_list.Append(SBType(type));
+          }
         }
       }
-    }
 
-    if (sb_type_list.GetSize() == 0) {
-      // No matches, search for basic typename matches
-      for (auto type_system_sp : target_sp->GetScratchTypeSystems())
-        if (auto compiler_type =
-                type_system_sp->GetBuiltinTypeByName(const_typename))
-          sb_type_list.Append(SBType(compiler_type));
+      if (sb_type_list.GetSize() == 0) {
+        // No matches, search for basic typename matches
+        for (auto type_system_sp : target_sp->GetScratchTypeSystems())
+          if (auto compiler_type =
+                  type_system_sp->GetBuiltinTypeByName(const_typename))
+            sb_type_list.Append(SBType(compiler_type));
+      }
     }
   }
   return sb_type_list;
@@ -1926,20 +1863,21 @@ SBValueList SBTarget::FindGlobalVariables(const char *name,
 
   SBValueList sb_value_list;
 
-  TargetSP target_sp(GetSP());
-  if (name && target_sp) {
-    VariableList variable_list;
-    target_sp->GetImages().FindGlobalVariables(ConstString(name), max_matches,
-                                               variable_list);
-    if (!variable_list.Empty()) {
-      ExecutionContextScope *exe_scope = target_sp->GetProcessSP().get();
-      if (exe_scope == nullptr)
-        exe_scope = target_sp.get();
-      for (const VariableSP &var_sp : variable_list) {
-        lldb::ValueObjectSP valobj_sp(
-            ValueObjectVariable::Create(exe_scope, var_sp));
-        if (valobj_sp)
-          sb_value_list.Append(SBValue(valobj_sp));
+  if (TargetSP target_sp = GetSP()) {
+    if (name) {
+      VariableList variable_list;
+      target_sp->GetImages().FindGlobalVariables(ConstString(name), max_matches,
+                                                 variable_list);
+      if (!variable_list.Empty()) {
+        ExecutionContextScope *exe_scope = target_sp->GetProcessSP().get();
+        if (exe_scope == nullptr)
+          exe_scope = target_sp.get();
+        for (const VariableSP &var_sp : variable_list) {
+          lldb::ValueObjectSP valobj_sp(
+              ValueObjectVariable::Create(exe_scope, var_sp));
+          if (valobj_sp)
+            sb_value_list.Append(SBValue(valobj_sp));
+        }
       }
     }
   }
@@ -1954,41 +1892,42 @@ SBValueList SBTarget::FindGlobalVariables(const char *name,
 
   SBValueList sb_value_list;
 
-  TargetSP target_sp(GetSP());
-  if (name && target_sp) {
-    llvm::StringRef name_ref(name);
-    VariableList variable_list;
+  if (TargetSP target_sp = GetSP()) {
+    if (name) {
+      llvm::StringRef name_ref(name);
+      VariableList variable_list;
 
-    std::string regexstr;
-    switch (matchtype) {
-    case eMatchTypeNormal:
-      target_sp->GetImages().FindGlobalVariables(ConstString(name), max_matches,
-                                                 variable_list);
-      break;
-    case eMatchTypeRegex:
-      target_sp->GetImages().FindGlobalVariables(RegularExpression(name_ref),
-                                                 max_matches, variable_list);
-      break;
-    case eMatchTypeRegexInsensitive:
-      target_sp->GetImages().FindGlobalVariables(
-          RegularExpression(name_ref, llvm::Regex::IgnoreCase), max_matches,
-          variable_list);
-      break;
-    case eMatchTypeStartsWith:
-      regexstr = "^" + llvm::Regex::escape(name) + ".*";
-      target_sp->GetImages().FindGlobalVariables(RegularExpression(regexstr),
-                                                 max_matches, variable_list);
-      break;
-    }
-    if (!variable_list.Empty()) {
-      ExecutionContextScope *exe_scope = target_sp->GetProcessSP().get();
-      if (exe_scope == nullptr)
-        exe_scope = target_sp.get();
-      for (const VariableSP &var_sp : variable_list) {
-        lldb::ValueObjectSP valobj_sp(
-            ValueObjectVariable::Create(exe_scope, var_sp));
-        if (valobj_sp)
-          sb_value_list.Append(SBValue(valobj_sp));
+      std::string regexstr;
+      switch (matchtype) {
+      case eMatchTypeNormal:
+        target_sp->GetImages().FindGlobalVariables(ConstString(name),
+                                                   max_matches, variable_list);
+        break;
+      case eMatchTypeRegex:
+        target_sp->GetImages().FindGlobalVariables(RegularExpression(name_ref),
+                                                   max_matches, variable_list);
+        break;
+      case eMatchTypeRegexInsensitive:
+        target_sp->GetImages().FindGlobalVariables(
+            RegularExpression(name_ref, llvm::Regex::IgnoreCase), max_matches,
+            variable_list);
+        break;
+      case eMatchTypeStartsWith:
+        regexstr = "^" + llvm::Regex::escape(name) + ".*";
+        target_sp->GetImages().FindGlobalVariables(RegularExpression(regexstr),
+                                                   max_matches, variable_list);
+        break;
+      }
+      if (!variable_list.Empty()) {
+        ExecutionContextScope *exe_scope = target_sp->GetProcessSP().get();
+        if (exe_scope == nullptr)
+          exe_scope = target_sp.get();
+        for (const VariableSP &var_sp : variable_list) {
+          lldb::ValueObjectSP valobj_sp(
+              ValueObjectVariable::Create(exe_scope, var_sp));
+          if (valobj_sp)
+            sb_value_list.Append(SBValue(valobj_sp));
+        }
       }
     }
   }
@@ -2026,8 +1965,7 @@ lldb::SBInstructionList SBTarget::ReadInstructions(lldb::SBAddress base_addr,
 
   SBInstructionList sb_instructions;
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     Address *addr_ptr = base_addr.get();
 
     if (addr_ptr) {
@@ -2057,8 +1995,7 @@ lldb::SBInstructionList SBTarget::ReadInstructions(lldb::SBAddress start_addr,
 
   SBInstructionList sb_instructions;
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     lldb::addr_t start_load_addr = start_addr.GetLoadAddress(*this);
     lldb::addr_t end_load_addr = end_addr.GetLoadAddress(*this);
     if (end_load_addr > start_load_addr) {
@@ -2091,8 +2028,7 @@ SBTarget::GetInstructionsWithFlavor(lldb::SBAddress base_addr,
 
   SBInstructionList sb_instructions;
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     Address addr;
 
     if (base_addr.get())
@@ -2133,8 +2069,7 @@ SBError SBTarget::SetSectionLoadAddress(lldb::SBSection section,
   LLDB_INSTRUMENT_VA(this, section, section_base_addr);
 
   SBError sb_error;
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     if (!section.IsValid()) {
       sb_error.SetErrorStringWithFormat("invalid section");
     } else {
@@ -2170,8 +2105,7 @@ SBError SBTarget::ClearSectionLoadAddress(lldb::SBSection section) {
 
   SBError sb_error;
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     if (!section.IsValid()) {
       sb_error.SetErrorStringWithFormat("invalid section");
     } else {
@@ -2217,8 +2151,7 @@ SBError SBTarget::SetModuleLoadAddress(lldb::SBModule module,
 
   SBError sb_error;
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     ModuleSP module_sp(module.GetSP());
     if (module_sp) {
       bool changed = false;
@@ -2251,8 +2184,7 @@ SBError SBTarget::ClearModuleLoadAddress(lldb::SBModule module) {
   SBError sb_error;
 
   char path[PATH_MAX];
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     ModuleSP module_sp(module.GetSP());
     if (module_sp) {
       ObjectFile *objfile = module_sp->GetObjectFile();
@@ -2302,10 +2234,10 @@ lldb::SBSymbolContextList SBTarget::FindSymbols(const char *name,
 
   SBSymbolContextList sb_sc_list;
   if (name && name[0]) {
-    TargetSP target_sp(GetSP());
-    if (target_sp)
+    if (TargetSP target_sp = GetSP()) {
       target_sp->GetImages().FindSymbolsWithNameAndType(
           ConstString(name), symbol_type, *sb_sc_list);
+    }
   }
   return sb_sc_list;
 }
@@ -2313,16 +2245,15 @@ lldb::SBSymbolContextList SBTarget::FindSymbols(const char *name,
 lldb::SBValue SBTarget::EvaluateExpression(const char *expr) {
   LLDB_INSTRUMENT_VA(this, expr);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return SBValue();
-
-  SBExpressionOptions options;
-  lldb::DynamicValueType fetch_dynamic_value =
-      target_sp->GetPreferDynamicValue();
-  options.SetFetchDynamicValue(fetch_dynamic_value);
-  options.SetUnwindOnError(true);
-  return EvaluateExpression(expr, options);
+  if (TargetSP target_sp = GetSP()) {
+    SBExpressionOptions options;
+    lldb::DynamicValueType fetch_dynamic_value =
+        target_sp->GetPreferDynamicValue();
+    options.SetFetchDynamicValue(fetch_dynamic_value);
+    options.SetUnwindOnError(true);
+    return EvaluateExpression(expr, options);
+  }
+  return SBValue();
 }
 
 lldb::SBValue SBTarget::EvaluateExpression(const char *expr,
@@ -2332,12 +2263,10 @@ lldb::SBValue SBTarget::EvaluateExpression(const char *expr,
   Log *expr_log = GetLog(LLDBLog::Expressions);
   SBValue expr_result;
   ValueObjectSP expr_value_sp;
-  TargetSP target_sp(GetSP());
-  StackFrame *frame = nullptr;
-  if (target_sp) {
-    if (expr == nullptr || expr[0] == '\0') {
+  if (TargetSP target_sp = GetSP()) {
+    StackFrame *frame = nullptr;
+    if (expr == nullptr || expr[0] == '\0')
       return expr_result;
-    }
 
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     ExecutionContext exe_ctx(m_opaque_sp.get());
@@ -2376,8 +2305,7 @@ lldb::SBValue SBTarget::EvaluateExpression(const char *expr,
 lldb::addr_t SBTarget::GetStackRedZoneSize() {
   LLDB_INSTRUMENT_VA(this);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP()) {
     ABISP abi_sp;
     ProcessSP process_sp(target_sp->GetProcessSP());
     if (process_sp)
@@ -2393,23 +2321,19 @@ lldb::addr_t SBTarget::GetStackRedZoneSize() {
 bool SBTarget::IsLoaded(const SBModule &module) const {
   LLDB_INSTRUMENT_VA(this, module);
 
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return false;
-
-  ModuleSP module_sp(module.GetSP());
-  if (!module_sp)
-    return false;
-
-  return module_sp->IsLoadedInTarget(target_sp.get());
+  if (TargetSP target_sp = GetSP()) {
+    ModuleSP module_sp(module.GetSP());
+    if (module_sp)
+      return module_sp->IsLoadedInTarget(target_sp.get());
+  }
+  return false;
 }
 
 lldb::SBLaunchInfo SBTarget::GetLaunchInfo() const {
   LLDB_INSTRUMENT_VA(this);
 
   lldb::SBLaunchInfo launch_info(nullptr);
-  TargetSP target_sp(GetSP());
-  if (target_sp)
+  if (TargetSP target_sp = GetSP())
     launch_info.set_ref(m_opaque_sp->GetProcessLaunchInfo());
   return launch_info;
 }
@@ -2417,27 +2341,23 @@ lldb::SBLaunchInfo SBTarget::GetLaunchInfo() const {
 void SBTarget::SetLaunchInfo(const lldb::SBLaunchInfo &launch_info) {
   LLDB_INSTRUMENT_VA(this, launch_info);
 
-  TargetSP target_sp(GetSP());
-  if (target_sp)
+  if (TargetSP target_sp = GetSP())
     m_opaque_sp->SetProcessLaunchInfo(launch_info.ref());
 }
 
 SBEnvironment SBTarget::GetEnvironment() {
   LLDB_INSTRUMENT_VA(this);
-  TargetSP target_sp(GetSP());
 
-  if (target_sp) {
+  if (TargetSP target_sp = GetSP())
     return SBEnvironment(target_sp->GetEnvironment());
-  }
 
   return SBEnvironment();
 }
 
 lldb::SBTrace SBTarget::GetTrace() {
   LLDB_INSTRUMENT_VA(this);
-  TargetSP target_sp(GetSP());
 
-  if (target_sp)
+  if (TargetSP target_sp = GetSP())
     return SBTrace(target_sp->GetTrace());
 
   return SBTrace();
@@ -2445,10 +2365,9 @@ lldb::SBTrace SBTarget::GetTrace() {
 
 lldb::SBTrace SBTarget::CreateTrace(lldb::SBError &error) {
   LLDB_INSTRUMENT_VA(this, error);
-  TargetSP target_sp(GetSP());
-  error.Clear();
 
-  if (target_sp) {
+  error.Clear();
+  if (TargetSP target_sp = GetSP()) {
     if (llvm::Expected<lldb::TraceSP> trace_sp = target_sp->CreateTrace()) {
       return SBTrace(*trace_sp);
     } else {


### PR DESCRIPTION
Use the if statement with an initializer pattern that's very common in LLVM in SBTarget. Every time someone adds a new method to SBTarget, I want to encourage using this pattern, but I don't because it would be inconsistent with the rest of the file. This solves that problem by switching over the whole file.