### PR TITLE
[LLVM] Add color to SDNode ID's when dumping

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
@@ -606,7 +606,14 @@ const char *SDNode::getIndexedModeName(ISD::MemIndexedMode AM) {
 static Printable PrintNodeId(const SDNode &Node) {
   return Printable([&Node](raw_ostream &OS) {
 #ifndef NDEBUG
+    static const raw_ostream::Colors Color[] = {
+        raw_ostream::BLACK,  raw_ostream::RED,  raw_ostream::GREEN,
+        raw_ostream::YELLOW, raw_ostream::BLUE, raw_ostream::MAGENTA,
+        raw_ostream::CYAN,
+    };
+    OS.changeColor(Color[Node.PersistentId % std::size(Color)]);
     OS << 't' << Node.PersistentId;
+    OS.resetColor();
 #else
     OS << (const void*)&Node;
 #endif

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -4415,6 +4415,8 @@ void SelectionDAGISel::CannotYetSelect(SDNode *N) {
   raw_string_ostream Msg(msg);
   Msg << "Cannot select: ";
 
+  Msg.enable_colors(errs().has_colors());
+
   if (N->getOpcode() != ISD::INTRINSIC_W_CHAIN &&
       N->getOpcode() != ISD::INTRINSIC_WO_CHAIN &&
       N->getOpcode() != ISD::INTRINSIC_VOID) {


### PR DESCRIPTION
This is especially helpful for the recursive 'Cannot select:' dumps, where colors help distinguish nodes at a quick glance.