### PR TITLE
[LOH] Emit hints for LDP/STP instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CollectLOH.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CollectLOH.cpp
@@ -192,6 +192,7 @@ static bool isCandidateStore(const MachineInstr &MI, const MachineOperand &MO) {
   switch (MI.getOpcode()) {
   default:
     return false;
+  // STR
   case AArch64::STRBBui:
   case AArch64::STRHHui:
   case AArch64::STRBui:
@@ -201,12 +202,37 @@ static bool isCandidateStore(const MachineInstr &MI, const MachineOperand &MO) {
   case AArch64::STRSui:
   case AArch64::STRDui:
   case AArch64::STRQui:
+  // STUR
+  case AArch64::STURBi:
+  case AArch64::STURBBi:
+  case AArch64::STURHi:
+  case AArch64::STURHHi:
+  case AArch64::STURWi:
+  case AArch64::STURXi:
+  case AArch64::STURSi:
+  case AArch64::STURDi:
+  case AArch64::STURQi:
     // We can only optimize the index operand.
     // In case we have str xA, [xA, #imm], this is two different uses
     // of xA and we cannot fold, otherwise the xA stored may be wrong,
     // even if #imm == 0.
     return MO.getOperandNo() == 1 &&
            MI.getOperand(0).getReg() != MI.getOperand(1).getReg();
+  // STP
+  case AArch64::STPWi:
+  case AArch64::STPXi:
+  case AArch64::STPSi:
+  case AArch64::STPDi:
+  case AArch64::STPQi:
+  // STNP
+  case AArch64::STNPWi:
+  case AArch64::STNPXi:
+  case AArch64::STNPSi:
+  case AArch64::STNPDi:
+  case AArch64::STNPQi:
+    return MO.getOperandNo() == 2 &&
+           MI.getOperand(0).getReg() != MI.getOperand(2).getReg() &&
+           MI.getOperand(1).getReg() != MI.getOperand(2).getReg();
   }
 }
 
@@ -216,6 +242,7 @@ static bool isCandidateLoad(const MachineInstr &MI) {
   switch (MI.getOpcode()) {
   default:
     return false;
+  // LDR
   case AArch64::LDRSBWui:
   case AArch64::LDRSBXui:
   case AArch64::LDRSHWui:
@@ -228,11 +255,40 @@ static bool isCandidateLoad(const MachineInstr &MI) {
   case AArch64::LDRSui:
   case AArch64::LDRDui:
   case AArch64::LDRQui:
+  // LDUR
+  case AArch64::LDURBBi:
+  case AArch64::LDURBi:
+  case AArch64::LDURDi:
+  case AArch64::LDURHHi:
+  case AArch64::LDURHi:
+  case AArch64::LDURQi:
+  case AArch64::LDURSBWi:
+  case AArch64::LDURSBXi:
+  case AArch64::LDURSHWi:
+  case AArch64::LDURSHXi:
+  case AArch64::LDURSWi:
+  case AArch64::LDURSi:
+  case AArch64::LDURWi:
+  case AArch64::LDURXi:
     return !(MI.getOperand(2).getTargetFlags() & AArch64II::MO_GOT);
+  // LDP
+  case AArch64::LDPSi:
+  case AArch64::LDPSWi:
+  case AArch64::LDPDi:
+  case AArch64::LDPQi:
+  case AArch64::LDPWi:
+  case AArch64::LDPXi:
+  // LDNP
+  case AArch64::LDNPSi:
+  case AArch64::LDNPDi:
+  case AArch64::LDNPQi:
+  case AArch64::LDNPWi:
+  case AArch64::LDNPXi:
+    return !(MI.getOperand(3).getTargetFlags() & AArch64II::MO_GOT);
   }
 }
 
-/// Check whether the given instruction can load a litteral.
+/// Check whether the given instruction can load a literal.
 static bool supportLoadFromLiteral(const MachineInstr &MI) {
   switch (MI.getOpcode()) {
   default:

--- a/llvm/lib/Target/AArch64/AArch64CollectLOH.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CollectLOH.cpp
@@ -230,6 +230,10 @@ static bool isCandidateStore(const MachineInstr &MI, const MachineOperand &MO) {
   case AArch64::STNPSi:
   case AArch64::STNPDi:
   case AArch64::STNPQi:
+    // We can only optimize the index operand.
+    // In case we have str xA, xB, [xA, #imm] or str xA, xB [xB, #imm], this is
+    // two different uses of xA or xB and we cannot fold, otherwise the xA or xB
+    // stored may be wrong, even if #imm == 0.
     return MO.getOperandNo() == 2 &&
            MI.getOperand(0).getReg() != MI.getOperand(2).getReg() &&
            MI.getOperand(1).getReg() != MI.getOperand(2).getReg();

--- a/llvm/test/CodeGen/AArch64/arm64-collect-loh-str.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-collect-loh-str.ll
@@ -1,5 +1,5 @@
-; RUN: llc -o - %s -mtriple=arm64-apple-ios -O2 | FileCheck %s
-; RUN: llc -o - %s -mtriple=arm64_32-apple-ios -O2 | FileCheck %s
+; RUN: llc -o - %s -mtriple=arm64-apple-ios -O2 | FileCheck %s --implicit-check-not=AdrpAddStr
+; RUN: llc -o - %s -mtriple=arm64_32-apple-ios -O2 | FileCheck %s --implicit-check-not=AdrpAddStr
 ; Test case for <rdar://problem/15942912>.
 ; AdrpAddStr cannot be used when the store uses same
 ; register as address and value. Indeed, the related
@@ -7,18 +7,26 @@
 ; at least provide a wrong one (with the offset folded
 ; into the definition).
 
-%struct.anon = type { ptr, ptr }
+@A = internal global i32 0, align 4
 
-@pptp_wan_head = internal global %struct.anon zeroinitializer, align 8
-
-; CHECK-LABEL: _pptp_wan_init
-; CHECK: ret
-; CHECK-NOT: AdrpAddStr
-define i32 @pptp_wan_init() {
+define void @str() {
 entry:
-  store ptr null, ptr @pptp_wan_head, align 8
-  store ptr @pptp_wan_head, ptr getelementptr inbounds (%struct.anon, ptr @pptp_wan_head, i64 0, i32 1), align 8
-  ret i32 0
+  store ptr @A, ptr @A, align 4
+  ret void
 }
 
+define void @stp0(i64 %t) {
+entry:
+  %addr = getelementptr inbounds i64, ptr @A, i32 1
+  store ptr @A, ptr @A, align 4
+  store i64 %t, ptr %addr, align 4
+  ret void
+}
 
+define void @stp1(i64 %t) {
+entry:
+  %addr = getelementptr inbounds i64, ptr @A, i32 1
+  store i64 %t, ptr @A, align 4
+  store ptr @A, ptr %addr, align 4
+  ret void
+}


### PR DESCRIPTION
Support more load/store instructions for `.loh` directives. Note that these new instructions are not supported in LLD yet, so they will be skipped for now.
https://github.com/llvm/llvm-project/blob/1695e8b3d1080cea089baa74b2c3c7fd469c62c8/lld/MachO/Arch/ARM64.cpp#L283-L314

In a large binary, we saw `NumADDToLDR` increase from 3587 to 4511. I believe this shows the potential for improvement.