### PR TITLE
[clang-tidy] properly handle private move constructors in `modernize-pass-by-value` check

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
@@ -20,8 +20,21 @@ using namespace llvm;
 
 namespace clang::tidy::modernize {
 
+static bool isFirstFriendOfSecond(const CXXRecordDecl *Friend,
+                                  const CXXRecordDecl *Class) {
+  return llvm::any_of(
+      Class->friends(), [Friend](FriendDecl *FriendDecl) -> bool {
+        if (TypeSourceInfo *FriendTypeSource = FriendDecl->getFriendType()) {
+          const QualType FriendType = FriendTypeSource->getType();
+          return FriendType->getAsCXXRecordDecl() == Friend;
+        }
+        return false;
+      });
+}
+
 namespace {
-/// Matches move-constructible classes.
+/// Matches move-constructible classes whose constructor can be called inside
+/// a CXXRecordDecl with a bound ID. 
 ///
 /// Given
 /// \code
@@ -32,29 +45,35 @@ namespace {
 ///     Bar(Bar &&) = deleted;
 ///     int a;
 ///   };
+///
+///   class Buz {
+///     Buz(Buz &&);
+///     int a;
+///     friend class Outer; 
+///   };
+///
+///   class Outer {
+///   };
 /// \endcode
-/// recordDecl(isMoveConstructible())
-///   matches "Foo".
-AST_MATCHER(CXXRecordDecl, isMoveConstructible) {
-  for (const CXXConstructorDecl *Ctor : Node.ctors()) {
-    if (Ctor->isMoveConstructor() && !Ctor->isDeleted())
-      return true;
-  }
-  return false;
-}
-} // namespace
-
-static bool isFriendOfClass(const CXXRecordDecl *Class,
-                            const CXXRecordDecl *Friend) {
-  return llvm::any_of(
-      Class->friends(), [Friend](FriendDecl *FriendDecl) -> bool {
-        if (TypeSourceInfo *FriendTypeSource = FriendDecl->getFriendType()) {
-          const QualType FriendType = FriendTypeSource->getType();
-          return FriendType->getAsCXXRecordDecl() == Friend;
+/// recordDecl(isMoveConstructibleInBoundCXXRecordDecl("Outer"))
+///   matches "Foo", "Buz".
+AST_MATCHER_P(CXXRecordDecl, isMoveConstructibleInBoundCXXRecordDecl, StringRef,
+              RecordDeclID) {
+  return Builder->removeBindings(
+      [this,
+       &Node](const ast_matchers::internal::BoundNodesMap &Nodes) -> bool {
+        const auto *BoundClass =
+            Nodes.getNode(this->RecordDeclID).get<CXXRecordDecl>();
+        for (const CXXConstructorDecl *Ctor : Node.ctors()) {
+          if (Ctor->isMoveConstructor() && !Ctor->isDeleted() &&
+              (Ctor->getAccess() == AS_public ||
+               (BoundClass && isFirstFriendOfSecond(BoundClass, &Node))))
+            return false;
         }
-        return false;
+        return true;
       });
 }
+} // namespace
 
 static TypeMatcher notTemplateSpecConstRefType() {
   return lValueReferenceType(
@@ -238,8 +257,9 @@ void PassByValueCheck::registerMatchers(MatchFinder *Finder) {
                                   .bind("Param"))))),
                           hasDeclaration(cxxConstructorDecl(
                               isCopyConstructor(), unless(isDeleted()),
-                              hasDeclContext(
-                                  cxxRecordDecl(isMoveConstructible())))))))
+                              hasDeclContext(cxxRecordDecl(
+                                  isMoveConstructibleInBoundCXXRecordDecl(
+                                      "outer"))))))))
                       .bind("Initializer")))
               .bind("Ctor")),
       this);

--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
@@ -214,6 +214,7 @@ void PassByValueCheck::registerMatchers(MatchFinder *Finder) {
       traverse(
           TK_AsIs,
           cxxConstructorDecl(
+              ofClass(cxxRecordDecl().bind("outer")),
               forEachConstructorInitializer(
                   cxxCtorInitializer(
                       unless(isBaseInitializer()),

--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
@@ -44,6 +44,18 @@ AST_MATCHER(CXXRecordDecl, isMoveConstructible) {
 }
 } // namespace
 
+static bool isFriendOfClass(const CXXRecordDecl *Class,
+                            const CXXRecordDecl *Friend) {
+  return llvm::any_of(
+      Class->friends(), [Friend](FriendDecl *FriendDecl) -> bool {
+        if (TypeSourceInfo *FriendTypeSource = FriendDecl->getFriendType()) {
+          const QualType FriendType = FriendTypeSource->getType();
+          return FriendType->getAsCXXRecordDecl() == Friend;
+        }
+        return false;
+      });
+}
+
 static TypeMatcher notTemplateSpecConstRefType() {
   return lValueReferenceType(
       pointee(unless(elaboratedType(namesType(templateSpecializationType()))),

--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
@@ -34,7 +34,7 @@ static bool isFirstFriendOfSecond(const CXXRecordDecl *Friend,
 
 namespace {
 /// Matches move-constructible classes whose constructor can be called inside
-/// a CXXRecordDecl with a bound ID. 
+/// a CXXRecordDecl with a bound ID.
 ///
 /// Given
 /// \code
@@ -49,7 +49,7 @@ namespace {
 ///   class Buz {
 ///     Buz(Buz &&);
 ///     int a;
-///     friend class Outer; 
+///     friend class Outer;
 ///   };
 ///
 ///   class Outer {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -281,6 +281,10 @@ Changes in existing checks
   excluding variables with ``thread_local`` storage class specifier from being
   matched.
 
+- Improved :doc:`modernize-pass-by-value
+  <clang-tidy/checks/modernize/pass-by-value>` check by fixing false positives
+  when class passed by const-reference had a private move constructor.
+
 - Improved :doc:`modernize-type-traits
   <clang-tidy/checks/modernize/type-traits>` check by detecting more type traits.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
@@ -283,13 +283,11 @@ struct InheritedPrivateMovable : PrivateMovable {
 
 struct X1 {
   X1(const ProtectedMovable &M) : M(M) {}
-  // CHECK-FIXES: X1(const ProtectedMovable &M) : M(M) {}
   ProtectedMovable M;
 };
 
 struct X2 {
   X2(const PrivateMovable &M) : M(M) {}
-  // CHECK-FIXES: X2(const PrivateMovable &M) : M(M) {}
   PrivateMovable M;
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
@@ -252,3 +252,64 @@ struct W3 {
   W3(W1 &&, Movable &&M);
   Movable M;
 };
+
+struct ProtectedMovable {
+  ProtectedMovable() = default;
+  ProtectedMovable(const ProtectedMovable &) {}
+protected:
+  ProtectedMovable(ProtectedMovable &&) {}
+};
+
+struct PrivateMovable {
+  PrivateMovable() = default;
+  PrivateMovable(const PrivateMovable &) {}
+private:
+  PrivateMovable(PrivateMovable &&) {}
+
+  friend struct X5;
+};
+
+struct InheritedProtectedMovable : ProtectedMovable {
+  InheritedProtectedMovable() = default;
+  InheritedProtectedMovable(const InheritedProtectedMovable &) {}
+  InheritedProtectedMovable(InheritedProtectedMovable &&) {}
+};
+
+struct InheritedPrivateMovable : PrivateMovable {
+  InheritedPrivateMovable() = default;
+  InheritedPrivateMovable(const InheritedPrivateMovable &) {}
+  InheritedPrivateMovable(InheritedPrivateMovable &&) {}
+};
+
+struct X1 {
+  X1(const ProtectedMovable &M) : M(M) {}
+  // CHECK-FIXES: X1(const ProtectedMovable &M) : M(M) {}
+  ProtectedMovable M;
+};
+
+struct X2 {
+  X2(const PrivateMovable &M) : M(M) {}
+  // CHECK-FIXES: X2(const PrivateMovable &M) : M(M) {}
+  PrivateMovable M;
+};
+
+struct X3 {
+  X3(const InheritedProtectedMovable &M) : M(M) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: pass by value and use std::move
+  // CHECK-FIXES: X3(InheritedProtectedMovable M) : M(std::move(M)) {}
+  InheritedProtectedMovable M;
+};
+
+struct X4 {
+  X4(const InheritedPrivateMovable &M) : M(M) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: pass by value and use std::move
+  // CHECK-FIXES: X4(InheritedPrivateMovable M) : M(std::move(M)) {}
+  InheritedPrivateMovable M;
+};
+
+struct X5 {
+  X5(const PrivateMovable &M) : M(M) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: pass by value and use std::move
+  // CHECK-FIXES: X5(PrivateMovable M) : M(std::move(M)) {}
+  PrivateMovable M;
+};


### PR DESCRIPTION
Fixed false positives when class passed by const-reference had a private move constructor, which could not be used for a fix-it.

Closes https://github.com/llvm/llvm-project/issues/140236.