### PR TITLE
[llvm-reduce] Remove unused includes (NFC)

### DIFF
--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -18,7 +18,6 @@
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
-#include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineJumpTableInfo.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"

--- a/llvm/tools/llvm-reduce/deltas/Delta.cpp
+++ b/llvm/tools/llvm-reduce/deltas/Delta.cpp
@@ -18,8 +18,6 @@
 #include "TestRunner.h"
 #include "Utils.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/Analysis/ModuleSummaryAnalysis.h"
-#include "llvm/Analysis/ProfileSummaryInfo.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -31,7 +29,6 @@
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/WithColor.h"
-#include <fstream>
 
 using namespace llvm;
 

--- a/llvm/tools/llvm-reduce/deltas/ReduceAliases.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceAliases.cpp
@@ -12,8 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "ReduceAliases.h"
-#include "Utils.h"
-#include "llvm/IR/Constants.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 

--- a/llvm/tools/llvm-reduce/deltas/ReduceArguments.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceArguments.cpp
@@ -14,7 +14,6 @@
 #include "ReduceArguments.h"
 #include "Utils.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/IR/Constants.h"
 #include "llvm/IR/FMF.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Intrinsics.h"

--- a/llvm/tools/llvm-reduce/deltas/ReduceBasicBlocks.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceBasicBlocks.cpp
@@ -13,9 +13,7 @@
 
 #include "ReduceBasicBlocks.h"
 #include "Utils.h"
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/IR/BasicBlock.h"
-#include "llvm/IR/Constants.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"

--- a/llvm/tools/llvm-reduce/deltas/ReduceDIMetadata.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDIMetadata.cpp
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "ReduceDIMetadata.h"
-#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/DebugInfoMetadata.h"

--- a/llvm/tools/llvm-reduce/deltas/ReduceDbgRecords.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDbgRecords.cpp
@@ -18,7 +18,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "ReduceDbgRecords.h"
-#include "Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/DebugProgramInstruction.h"

--- a/llvm/tools/llvm-reduce/deltas/ReduceDistinctMetadata.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDistinctMetadata.cpp
@@ -12,11 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "ReduceDistinctMetadata.h"
-#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/IR/InstIterator.h"
-#include <algorithm>
 #include <queue>
 
 using namespace llvm;

--- a/llvm/tools/llvm-reduce/deltas/ReduceFunctionBodies.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceFunctionBodies.cpp
@@ -13,7 +13,6 @@
 
 #include "ReduceFunctionBodies.h"
 #include "Utils.h"
-#include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/Instructions.h"
 
 using namespace llvm;

--- a/llvm/tools/llvm-reduce/deltas/ReduceFunctions.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceFunctions.cpp
@@ -14,10 +14,8 @@
 
 #include "ReduceFunctions.h"
 #include "Utils.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
-#include <iterator>
 
 using namespace llvm;
 

--- a/llvm/tools/llvm-reduce/deltas/ReduceGlobalVarInitializers.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceGlobalVarInitializers.cpp
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "ReduceGlobalVarInitializers.h"
-#include "llvm/IR/Constants.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Transforms/Utils/Cloning.h"

--- a/llvm/tools/llvm-reduce/deltas/ReduceGlobalVars.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceGlobalVars.cpp
@@ -13,7 +13,6 @@
 
 #include "ReduceGlobalVars.h"
 #include "Utils.h"
-#include "llvm/IR/Constants.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"

--- a/llvm/tools/llvm-reduce/deltas/ReduceInstructionsMIR.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceInstructionsMIR.cpp
@@ -15,7 +15,6 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFunction.h"
-#include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandBundles.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandBundles.cpp
@@ -18,8 +18,6 @@
 #include "llvm/ADT/Sequence.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/InstrTypes.h"
-#include "llvm/Support/raw_ostream.h"
-#include <algorithm>
 #include <iterator>
 #include <vector>
 

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandsSkip.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandsSkip.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "ReduceOperandsSkip.h"
-#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Dominators.h"

--- a/llvm/tools/llvm-reduce/deltas/ReduceSpecialGlobals.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceSpecialGlobals.cpp
@@ -17,7 +17,6 @@
 #include "ReduceSpecialGlobals.h"
 #include "Utils.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/IR/Constants.h"
 #include "llvm/IR/GlobalValue.h"
 
 using namespace llvm;

--- a/llvm/tools/llvm-reduce/deltas/SimplifyInstructions.cpp
+++ b/llvm/tools/llvm-reduce/deltas/SimplifyInstructions.cpp
@@ -13,7 +13,6 @@
 
 #include "SimplifyInstructions.h"
 #include "llvm/Analysis/InstructionSimplify.h"
-#include "llvm/IR/Constants.h"
 
 using namespace llvm;
 

--- a/llvm/tools/llvm-reduce/llvm-reduce.cpp
+++ b/llvm/tools/llvm-reduce/llvm-reduce.cpp
@@ -21,11 +21,9 @@
 #include "llvm/CodeGen/CommandFlags.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
-#include <system_error>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
These are identified by misc-include-cleaner.  I've filtered out those
that break builds.  Also, I'm staying away from llvm-config.h,
config.h, and Compiler.h, which likely cause platform- or
compiler-specific build failures.
