### PR TITLE
[libc++](NFC) Remove unused include caused by wrong __has_include

### DIFF
--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -34,10 +34,6 @@
 #  define _CTYPE_DISABLE_MACROS
 #endif
 
-#if __has_include("<langinfo.h>")
-#  include <langinfo.h>
-#endif
-
 #include "include/atomic_support.h"
 #include "include/sso_allocator.h"
 


### PR DESCRIPTION
The parameter passed to __has_include has to be quoted by `<>` or `"`, not both.