### PR TITLE
AArch64: Clear hasSideEffects on AUT and AUTPAC.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1943,7 +1943,7 @@ let Predicates = [HasPAuth] in {
   def AUT : Pseudo<(outs), (ins i32imm:$Key, i64imm:$Disc, GPR64noip:$AddrDisc),
                    []>, Sched<[WriteI, ReadI]> {
     let isCodeGenOnly = 1;
-    let hasSideEffects = 1;
+    let hasSideEffects = 0;
     let mayStore = 0;
     let mayLoad = 0;
     let Size = 32;
@@ -1960,7 +1960,7 @@ let Predicates = [HasPAuth] in {
                     i32imm:$PACKey, i64imm:$PACDisc, GPR64noip:$PACAddrDisc),
                []>, Sched<[WriteI, ReadI]> {
     let isCodeGenOnly = 1;
-    let hasSideEffects = 1;
+    let hasSideEffects = 0;
     let mayStore = 0;
     let mayLoad = 0;
     let Size = 48;


### PR DESCRIPTION
With hasSideEffects=1 we unnecessarily inhibit certain optimizations in
the backend such as code motion which lead to slightly less efficient
codegen when the pseudo instructions are used frequently, e.g. in the
PFP use case. These annotations do not cause the instructions to be kept
without a use because the underlying intrinsics are IntrNoMem. Users
should be expected to use another means of keeping the use alive if they
need the trapping side effect without a use (e.g. llvm.fake.use).
