### PR TITLE
[clang-format] Handle Java text blocks

### DIFF
--- a/clang/lib/Format/FormatTokenLexer.cpp
+++ b/clang/lib/Format/FormatTokenLexer.cpp
@@ -698,29 +698,16 @@ void FormatTokenLexer::tryParseJavaTextBlock() {
   if (FormatTok->TokenText != "\"\"")
     return;
 
-  const auto *Str = Lex->getBufferLocation();
+  const auto *S = Lex->getBufferLocation();
   const auto *End = Lex->getBuffer().end();
 
-  if (Str == End || *Str != '\"')
+  if (S == End || *S != '\"')
     return;
 
-  // Skip the `"""` that begins a text block.
-  const auto *S = Str + 1;
-
-  // From docs.oracle.com/en/java/javase/15/text-blocks/#text-block-syntax:
-  // A text block begins with three double-quote characters followed by a line
-  // terminator.
-  while (S < End && *S != '\n') {
-    if (!isblank(*S))
-      return;
-    ++S;
-  }
+  ++S; // Skip the `"""` that begins a text block.
 
   // Find the `"""` that ends the text block.
-  for (int Count = 0; Count < 3; ++S) {
-    if (S == End)
-      return;
-
+  for (int Count = 0; Count < 3 && S < End; ++S) {
     switch (*S) {
     case '\\':
       Count = -1;
@@ -733,7 +720,7 @@ void FormatTokenLexer::tryParseJavaTextBlock() {
     }
   }
 
-  // Skip the text block.
+  // Ignore the possibly invalid text block.
   resetLexer(SourceMgr.getFileOffset(Lex->getSourceLocation(S)));
 }
 

--- a/clang/lib/Format/FormatTokenLexer.h
+++ b/clang/lib/Format/FormatTokenLexer.h
@@ -72,6 +72,8 @@ private:
 
   bool canPrecedeRegexLiteral(FormatToken *Prev);
 
+  void tryParseJavaTextBlock();
+
   // Tries to parse a JavaScript Regex literal starting at the current token,
   // if that begins with a slash and is in a location where JavaScript allows
   // regex literals. Changes the current token to a regex literal and updates

--- a/clang/unittests/Format/FormatTestJava.cpp
+++ b/clang/unittests/Format/FormatTestJava.cpp
@@ -836,11 +836,16 @@ TEST_F(FormatTestJava, TextBlock) {
       "  }\n"
       "}");
 
-  verifyNoChange("String name = \"\"\"\n"
+  verifyNoChange("String name = \"\"\"\r\n"
                  "        red\n"
                  "        green\n"
                  "        blue\\\n"
                  "    \"\"\";");
+
+  verifyFormat("String name = \"\"\"Pat Q. Smith\"\"\";");
+
+  verifyNoChange("String name = \"\"\"\n"
+                 "              Pat Q. Smith");
 }
 
 } // namespace

--- a/clang/unittests/Format/FormatTestJava.cpp
+++ b/clang/unittests/Format/FormatTestJava.cpp
@@ -791,6 +791,58 @@ TEST_F(FormatTestJava, AlignCaseArrows) {
                Style);
 }
 
+TEST_F(FormatTestJava, TextBlock) {
+  verifyNoChange("String myStr = \"\"\"\n"
+                 "hello\n"
+                 "there\n"
+                 "\"\"\";");
+
+  verifyNoChange("String tb = \"\"\"\n"
+                 "            the new\"\"\";");
+
+  verifyNoChange("System.out.println(\"\"\"\n"
+                 "    This is the first line\n"
+                 "    This is the second line\n"
+                 "    \"\"\");");
+
+  verifyNoChange("void writeHTML() {\n"
+                 "  String html = \"\"\" \n"
+                 "                <html>\n"
+                 "                    <p>Hello World.</p>\n"
+                 "                </html>\n"
+                 "\"\"\";\n"
+                 "  writeOutput(html);\n"
+                 "}");
+
+  verifyNoChange("String colors = \"\"\"\t\n"
+                 "    red\n"
+                 "    green\n"
+                 "    blue\"\"\".indent(4);");
+
+  verifyNoChange("String code = \"\"\"\n"
+                 "    String source = \\\"\"\"\n"
+                 "        String message = \"Hello, World!\";\n"
+                 "        System.out.println(message);\n"
+                 "        \\\"\"\";\n"
+                 "    \"\"\";");
+
+  verifyNoChange(
+      "class Outer {\n"
+      "  void printPoetry() {\n"
+      "    String lilacs = \"\"\"\n"
+      "Passing the apple-tree blows of white and pink in the orchards\n"
+      "\"\"\";\n"
+      "    System.out.println(lilacs);\n"
+      "  }\n"
+      "}");
+
+  verifyNoChange("String name = \"\"\"\n"
+                 "        red\n"
+                 "        green\n"
+                 "        blue\\\n"
+                 "    \"\"\";");
+}
+
 } // namespace
 } // namespace test
 } // namespace format


### PR DESCRIPTION
Fix #61954