### PR TITLE
[bazel][test] Continue fixing bazel build from 97dee78

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang-tools-extra/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang-tools-extra/unittests/BUILD.bazel
@@ -2,6 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_test")
 
 package(
@@ -54,6 +55,15 @@ cc_test(
     ],
 )
 
+expand_template(
+    name = "clang_doc_config",
+    out = "clang-doc/config.h",
+    substitutions = {
+        "#define CLANG_DOC_TEST_ASSET_DIR \"${CLANG_DOC_TEST_ASSET_DIR}\"": "#define CLANG_DOC_TEST_ASSET_DIR \"clang-tools-extra/clang-doc/assets\"",
+    },
+    template = "clang-doc/config.h.cmake",
+)
+
 cc_test(
     name = "clang_doc_test",
     size = "small",
@@ -65,7 +75,6 @@ cc_test(
         allow_empty = False,
     ),
     data = ["//clang-tools-extra/clang-doc:assets"],
-    local_defines = ['CLANG_DOC_TEST_ASSET_DIR=\\"clang-tools-extra/clang-doc/assets\\"'],
     deps = [
         "//clang:ast",
         "//clang:basic",

--- a/utils/bazel/llvm-project-overlay/clang-tools-extra/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang-tools-extra/unittests/BUILD.bazel
@@ -56,12 +56,17 @@ cc_test(
 )
 
 expand_template(
-    name = "clang_doc_config",
+    name = "clang_doc_config_h",
     out = "clang-doc/config.h",
     substitutions = {
         "#define CLANG_DOC_TEST_ASSET_DIR \"${CLANG_DOC_TEST_ASSET_DIR}\"": "#define CLANG_DOC_TEST_ASSET_DIR \"clang-tools-extra/clang-doc/assets\"",
     },
     template = "clang-doc/config.h.cmake",
+)
+
+cc_library(
+    name = "clang_doc_config",
+    hdrs = ["clang-doc/config.h"],
 )
 
 cc_test(
@@ -73,9 +78,12 @@ cc_test(
             "clang-doc/*.h",
         ],
         allow_empty = False,
+        exclude = ["clang-doc/config.h"],
     ),
     data = ["//clang-tools-extra/clang-doc:assets"],
+    includes = ["clang-doc"],
     deps = [
+        ":clang_doc_config",
         "//clang:ast",
         "//clang:basic",
         "//clang-tools-extra/clang-doc:generators",


### PR DESCRIPTION
this continues the work in 0967a6f by generating a header from clang-tools-extra/unittests/clang-doc/config.h.cmake

not clear all the tests pass yet, but fixes this build error at least:

ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/6a1efeb401da192d3572f00e2f11245b/external/llvm-project/clang-tools-extra/unittests/BUILD.bazel:57:8: Compiling clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp failed: (Exit 1): clang failed: error executing CppCompile command (from target @@llvm-project//clang-tools-extra/unittests:clang_doc_test) /usr/lib/llvm-18/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer ... (remaining 328 arguments skipped)
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/llvm-project/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp:12:10: fatal error: 'config.h' file not found
   12 | #include "config.h"
      |          ^~~~~~~~~~
1 error generated.