### PR TITLE
[MLIR] Use cached symbol tables to get the called function during bufferization

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.cpp
@@ -265,10 +265,7 @@ struct CallOpInterface
     //    bufferized callee.
     SmallVector<Value> newOperands;
 
-    // TODO Avoid recomputing the symbol tables every time.
-    SymbolTableCollection symbolTable;
-
-    FuncOp funcOp = getCalledFunction(callOp, symbolTable);
+    FuncOp funcOp = getCalledFunction(callOp, state.getSymbolTables());
     assert(funcOp && "expected CallOp to a FuncOp");
     FunctionType funcType = funcOp.getFunctionType();
 


### PR DESCRIPTION
Avoid recomputing the symbol tables by using the `BufferizationState` class introduced in #141019.
There is also one similar TODO remaining within the `getBufferType` function, but that requires more reasoning and one more API change.