### PR TITLE
[Clang] Fix a regression introduced by #138518

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13775,7 +13775,6 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
   }
 
   // Perform the initialization.
-  ParenListExpr *CXXDirectInit = dyn_cast<ParenListExpr>(Init);
   bool IsParenListInit = false;
   if (!VDecl->isInvalidDecl()) {
     InitializedEntity Entity = InitializedEntity::InitializeVariable(VDecl);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13775,6 +13775,7 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
   }
 
   // Perform the initialization.
+  ParenListExpr *CXXDirectInit = dyn_cast<ParenListExpr>(Init);
   bool IsParenListInit = false;
   if (!VDecl->isInvalidDecl()) {
     InitializedEntity Entity = InitializedEntity::InitializeVariable(VDecl);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13783,9 +13783,11 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
         VDecl->getLocation(), DirectInit, Init);
 
     MultiExprArg Args = Init;
-    if (CXXDirectInit)
-      Args = MultiExprArg(CXXDirectInit->getExprs(),
-                          CXXDirectInit->getNumExprs());
+    if (auto *CXXDirectInit = dyn_cast<ParenListExpr>(Init))
+      Args =
+          MultiExprArg(CXXDirectInit->getExprs(), CXXDirectInit->getNumExprs());
+    else if (auto *CXXDirectInit = dyn_cast<CXXParenListInitExpr>(Init))
+      Args = CXXDirectInit->getInitExprs();
 
     // Try to correct any TypoExprs in the initialization arguments.
     for (size_t Idx = 0; Idx < Args.size(); ++Idx) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14088,9 +14088,8 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
   // special case code.
 
   // C++ 8.5p11:
-  // The form of initialization (using parentheses or '=') is generally
-  // insignificant, but does matter when the entity being initialized has a
-  // class type.
+  // The form of initialization (using parentheses or '=') matters
+  // when the entity being initialized has class type.
   if (InitializedFromParenListExpr) {
     assert(DirectInit && "Call-style initializer must be direct init.");
     VDecl->setInitStyle(IsParenListInit ? VarDecl::ParenListInit

--- a/clang/test/SemaCXX/paren-list-agg-init.cpp
+++ b/clang/test/SemaCXX/paren-list-agg-init.cpp
@@ -403,3 +403,25 @@ void test() {
     S<int>{}.f(); // beforecxx20-note {{requested here}}
 }
 }
+
+namespace GH72880_regression {
+struct E {
+    int i = 42;
+};
+struct G {
+  E e;
+};
+template <typename>
+struct Test {
+  void f() {
+    constexpr E e;
+    //FIXME: We should only warn one
+    constexpr G g(e); // beforecxx20-warning 2{{C++20 extension}}
+    static_assert(g.e.i == 42);
+  }
+};
+void test() {
+    Test<int>{}.f(); // beforecxx20-note {{requested here}}
+}
+
+}


### PR DESCRIPTION
We did not handle the case where a variable could be initialized by a CXXParenListInitExpr.