### PR TITLE
[clang-tidy] Add check for assignment or comparision operators' operand in `readability-math-missing-parentheses`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/MathMissingParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/MathMissingParenthesesCheck.cpp
@@ -16,13 +16,15 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::readability {
 
 void MathMissingParenthesesCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(binaryOperator(unless(hasParent(binaryOperator())),
-                                    unless(isAssignmentOperator()),
-                                    unless(isComparisonOperator()),
-                                    unless(hasAnyOperatorName("&&", "||")),
-                                    hasDescendant(binaryOperator()))
-                         .bind("binOp"),
-                     this);
+  Finder->addMatcher(
+      binaryOperator(
+          unless(hasParent(binaryOperator(unless(isAssignmentOperator()),
+                                          unless(isComparisonOperator())))),
+          unless(isAssignmentOperator()), unless(isComparisonOperator()),
+          unless(hasAnyOperatorName("&&", "||")),
+          hasDescendant(binaryOperator()))
+          .bind("binOp"),
+      this);
 }
 
 static int getPrecedence(const BinaryOperator *BinOp) {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -187,6 +187,11 @@ Changes in existing checks
   <clang-tidy/checks/concurrency/mt-unsafe>` check by fixing a false positive
   where ``strerror`` was flagged as MT-unsafe.
 
+- Improved :doc:`readability-math-missing-parentheses
+  <clang-tidy/checks/readability/math-missing-parentheses>` check by fixing
+  false negatives where math expressions are the operand of assignment operators
+  or comparison operators.
+
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check by adding the option
   `AllowedTypes`, that excludes specified types from const-correctness

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -187,11 +187,6 @@ Changes in existing checks
   <clang-tidy/checks/concurrency/mt-unsafe>` check by fixing a false positive
   where ``strerror`` was flagged as MT-unsafe.
 
-- Improved :doc:`readability-math-missing-parentheses
-  <clang-tidy/checks/readability/math-missing-parentheses>` check by fixing
-  false negatives where math expressions are the operand of assignment operators
-  or comparison operators.
-
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check by adding the option
   `AllowedTypes`, that excludes specified types from const-correctness
@@ -249,6 +244,11 @@ Changes in existing checks
   <clang-tidy/checks/performance/unnecessary-value-param>` check performance by
   tolerating fix-it breaking compilation when functions is used as pointers
   to avoid matching usage of functions within the current compilation unit.
+
+- Improved :doc:`readability-math-missing-parentheses
+  <clang-tidy/checks/readability/math-missing-parentheses>` check by fixing
+  false negatives where math expressions are the operand of assignment operators
+  or comparison operators.
 
 - Improved :doc:`readability-qualified-auto
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
@@ -157,3 +157,17 @@ namespace PR92516 {
     for (j = i + 1, 2; j < 1; ++j) {}
   }
 }
+
+namespace PR141249 {
+  void AssignAsParentBinOp(int* netChange, int* nums, int k, int i) {
+    //CHECK-MESSAGES: :[[@LINE+1]]:30: warning: '-' has higher precedence than '^'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
+    netChange[i] = nums[i] ^ k - nums[i];
+  }
+}
+
+void CompareAsParentBinOp(int b) {
+  //CHECK-MESSAGES: :[[@LINE+1]]:12: warning: '*' has higher precedence than '-'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
+  if (b == 1 * 2 - 3)   {
+
+  }
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
@@ -160,13 +160,15 @@ namespace PR92516 {
 
 namespace PR141249 {
   void AssignAsParentBinOp(int* netChange, int* nums, int k, int i) {
-    //CHECK-MESSAGES: :[[@LINE+1]]:30: warning: '-' has higher precedence than '^'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
+    //CHECK-MESSAGES: :[[@LINE+2]]:30: warning: '-' has higher precedence than '^'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
+    //CHECK-FIXES: netChange[i] = nums[i] ^ (k - nums[i]);
     netChange[i] = nums[i] ^ k - nums[i];
   }
 }
 
 void CompareAsParentBinOp(int b) {
-  //CHECK-MESSAGES: :[[@LINE+1]]:12: warning: '*' has higher precedence than '-'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
+  //CHECK-MESSAGES: :[[@LINE+2]]:12: warning: '*' has higher precedence than '-'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
+  //CHECK-FIXES: if (b == (1 * 2) - 3)   {
   if (b == 1 * 2 - 3)   {
 
   }


### PR DESCRIPTION
Fixes false negative in #141249. 

Add check for math binary operators which are operands of assignment or comparision operators.

Closes #141249.
