### PR TITLE
[LLDB] Fix std::shared_ptr formatter crash on windows

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -379,7 +379,7 @@ LibStdcppSharedPtrSyntheticFrontEnd::CalculateNumChildren() {
 
 lldb::ValueObjectSP
 LibStdcppSharedPtrSyntheticFrontEnd::GetChildAtIndex(uint32_t idx) {
-  if (idx == 0)
+  if (idx == 0 && m_ptr_obj)
     return m_ptr_obj->GetSP();
   if (idx == 1) {
     if (m_ptr_obj && !m_obj_obj) {


### PR DESCRIPTION
lldb-dap crashes when requesting variables if the scope includes a std::shared_ptr, as it assumes that m_ptr_obj is not null after Update. This is however only true if Update doesn't fail for any reason, and the problem is that LibStdcppSharedPtrSyntheticFrontEnd is used even when running on windows and not using libstdcpp. As _M_ptr is not present in the class, so is m_ptr_obj always null, which results in a crash when calling GetChildAtIndex with idx= 0. 

This commit only fixes the crash by adding a null check, whether or not it's a bug that LibStdcppSharedPtrSyntheticFrontEnd is used on windows at all is difficult for me to decide, and there doesn't seem to be any support for microsoft STL regardless.

A minimal example showcasing the bug is easy to provide:
```cpp
#include <iostream>
#include <memory>
int main(int arg, char** argv)
{
    std::shared_ptr<int> broken = std::make_shared<int>();
    std::cout<<"Hello world!"<<std::endl;   
}
```
Compiling the above with clang++ and setting a breakpoint before printing hello world and debugging should produce the crash on all DAP clients running on windows.