### PR TITLE
[Serialization] Remove an unused local variable (NFC)

### DIFF
--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -34,8 +34,6 @@ public:
   }
 
   std::time_t getModuleTimestamp(StringRef ModuleFilename) override {
-    std::string TimestampFilename =
-        serialization::ModuleFile::getTimestampFilename(ModuleFilename);
     llvm::sys::fs::file_status Status;
     if (llvm::sys::fs::status(ModuleFilename, Status) != std::error_code{})
       return 0;


### PR DESCRIPTION
Note that getTimestampFilename just constructs a file name, so it's
mostly a "pure" function except possible heap allocation.
