### PR TITLE
[LLVM] Skip dumping inline SDag children

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
@@ -1165,6 +1165,9 @@ static void printrWithDepthHelper(raw_ostream &OS, const SDNode *N,
     // Don't follow chain operands.
     if (Op.getValueType() == MVT::Other)
       continue;
+    // Don't print children that were fully rendered inline.
+    if (shouldPrintInline(*Op.getNode(), G))
+      continue;
     OS << '\n';
     printrWithDepthHelper(OS, Op.getNode(), G, depth - 1, indent + 2);
   }

--- a/llvm/test/CodeGen/PowerPC/ppc64-icbt-pwr7.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-icbt-pwr7.ll
@@ -11,9 +11,6 @@ entry:
 
 ; FIXME: Crashing is not really the correct behavior here, we really should just emit nothing
 ; CHECK: Cannot select: {{0x[0-9,a-f]+|t[0-9]+}}: ch = Prefetch
-; CHECK: {{0x[0-9,a-f]+|t[0-9]+}}: i32 = TargetConstant<0>
-; CHECK-NEXT: {{0x[0-9,a-f]+|t[0-9]+}}: i32 = TargetConstant<3>
-; CHECK-NEXT: {{0x[0-9,a-f]+|t[0-9]+}}: i32 = TargetConstant<0>
 
 }
 


### PR DESCRIPTION
If they're simple enough to render inline, we don't need to dump them again in the recursive walk.