### PR TITLE
[NFC] Fix evaluation order dependency in call arguments

### DIFF
--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -11788,9 +11788,8 @@ bool ARMAsmParser::parseDirectiveReq(StringRef Name, SMLoc L) {
   Parser.Lex(); // Eat the '.req' token.
   MCRegister Reg;
   SMLoc SRegLoc, ERegLoc;
-  if (check(parseRegister(Reg, SRegLoc, ERegLoc), SRegLoc,
-            "register name expected") ||
-      parseEOL())
+  const bool parseResult = parseRegister(Reg, SRegLoc, ERegLoc);
+  if (check(parseResult, SRegLoc, "register name expected") || parseEOL())
     return true;
 
   if (RegisterReqs.insert(std::make_pair(Name, Reg)).first->second != Reg)


### PR DESCRIPTION
The code in `ARMAsmParser::parseDirectiveReq` passes both `parseRegister(Reg, SRegLoc, ERegLoc)` and `SRegLoc` as arguments to `check()`. Since function arguments are indeterminately sequenced per C++17 [expr.call]/5, a compiler can evaluate `SRegLoc` before `parseRegister()` executes. This means `check()` receives a null location instead of the actual parsed source location for error reporting.

The fix separates the calls to establish explicit sequencing, ensuring `check()` receives the correct source location.

This issue was detected by [the CFamily analyzer for SonarQube](https://www.sonarsource.com/knowledge/languages/cpp/). I'm happy to provide any additional information or clarification as needed.