### PR TITLE
[clang] Default-construct values with DenseMap::try_emplace (NFC)

### DIFF
--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -1201,7 +1201,7 @@ void SymbolCollector::addRef(SymbolID ID, const SymbolRef &SR) {
 }
 
 SymbolID SymbolCollector::getSymbolIDCached(const Decl *D) {
-  auto It = DeclToIDCache.try_emplace(D, SymbolID{});
+  auto It = DeclToIDCache.try_emplace(D);
   if (It.second)
     It.first->second = getSymbolID(D);
   return It.first->second;
@@ -1210,7 +1210,7 @@ SymbolID SymbolCollector::getSymbolIDCached(const Decl *D) {
 SymbolID SymbolCollector::getSymbolIDCached(const llvm::StringRef MacroName,
                                             const MacroInfo *MI,
                                             const SourceManager &SM) {
-  auto It = MacroToIDCache.try_emplace(MI, SymbolID{});
+  auto It = MacroToIDCache.try_emplace(MI);
   if (It.second)
     It.first->second = getSymbolID(MacroName, MI, SM);
   return It.first->second;


### PR DESCRIPTION
try_emplace can default-construct values, so we do not need to do so
on our own.
