### PR TITLE
[clang-tidy] Fix false positives with deducing this in `readability-convert-member-functions-to-static` check

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStatic.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStatic.cpp
@@ -62,6 +62,16 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
       return false; // Stop traversal.
     }
 
+    bool VisitDeclRefExpr(const DeclRefExpr *E) {
+      if (const auto *PVD = dyn_cast_if_present<ParmVarDecl>(E->getDecl());
+          PVD && PVD->isExplicitObjectParameter()) {
+        Used = true;
+        return false; // Stop traversal.
+      }
+
+      return true;
+    }
+
     // If we enter a class declaration, don't traverse into it as any usages of
     // `this` will correspond to the nested class.
     bool TraverseCXXRecordDecl(CXXRecordDecl *RD) { return true; }

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStatic.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStatic.cpp
@@ -62,16 +62,6 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
       return false; // Stop traversal.
     }
 
-    bool VisitDeclRefExpr(const DeclRefExpr *E) {
-      if (const auto *PVD = dyn_cast_if_present<ParmVarDecl>(E->getDecl());
-          PVD && PVD->isExplicitObjectParameter()) {
-        Used = true;
-        return false; // Stop traversal.
-      }
-
-      return true;
-    }
-
     // If we enter a class declaration, don't traverse into it as any usages of
     // `this` will correspond to the nested class.
     bool TraverseCXXRecordDecl(CXXRecordDecl *RD) { return true; }
@@ -89,10 +79,10 @@ void ConvertMemberFunctionsToStatic::registerMatchers(MatchFinder *Finder) {
       cxxMethodDecl(
           isDefinition(), isUserProvided(),
           unless(anyOf(
-              isExpansionInSystemHeader(), isVirtual(), isStatic(),
-              hasTrivialBody(), isOverloadedOperator(), cxxConstructorDecl(),
-              cxxDestructorDecl(), cxxConversionDecl(), isTemplate(),
-              isDependentContext(),
+              isExplicitObjectMemberFunction(), isExpansionInSystemHeader(),
+              isVirtual(), isStatic(), hasTrivialBody(), isOverloadedOperator(),
+              cxxConstructorDecl(), cxxDestructorDecl(), cxxConversionDecl(),
+              isTemplate(), isDependentContext(),
               ofClass(anyOf(
                   isLambda(),
                   hasAnyDependentBases()) // Method might become virtual

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStatic.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStatic.cpp
@@ -79,10 +79,11 @@ void ConvertMemberFunctionsToStatic::registerMatchers(MatchFinder *Finder) {
       cxxMethodDecl(
           isDefinition(), isUserProvided(),
           unless(anyOf(
-              isExplicitObjectMemberFunction(), isExpansionInSystemHeader(),
-              isVirtual(), isStatic(), hasTrivialBody(), isOverloadedOperator(),
-              cxxConstructorDecl(), cxxDestructorDecl(), cxxConversionDecl(),
-              isTemplate(), isDependentContext(),
+              isExpansionInSystemHeader(), isVirtual(), isStatic(),
+              hasTrivialBody(), isOverloadedOperator(), cxxConstructorDecl(),
+              cxxDestructorDecl(), cxxConversionDecl(),
+              isExplicitObjectMemberFunction(), isTemplate(),
+              isDependentContext(),
               ofClass(anyOf(
                   isLambda(),
                   hasAnyDependentBases()) // Method might become virtual

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -252,6 +252,10 @@ Changes in existing checks
   tolerating fix-it breaking compilation when functions is used as pointers
   to avoid matching usage of functions within the current compilation unit.
 
+- Improved :doc:`readability-convert-member-functions-to-static
+  <clang-tidy/checks/readability/convert-member-functions-to-static>` check by
+  fixing false positives on member functions with an explicit object parameter.
+
 - Improved :doc:`readability-math-missing-parentheses
   <clang-tidy/checks/readability/math-missing-parentheses>` check by fixing
   false negatives where math expressions are the operand of assignment operators

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
@@ -5,10 +5,18 @@ namespace std{
   void println(const char *format, const std::string &str) {}
 }
 
-namespace PR141381 {
 struct Hello {
   std::string str_;
 
-  void hello(this Hello &self) { std::println("Hello, {0}!", self.str_); }
+  void ByValueSelf(this Hello self) { std::println("Hello, {0}!", self.str_); }
+
+  void ByLRefSelf(this Hello &self) { std::println("Hello, {0}!", self.str_); }
+
+  void ByRRefSelf(this Hello&& self) {}
+
+  template<typename Self> void ByForwardRefSelf(this Self&& self) {}
+
+  void MultiParam(this Hello &self, int a, double b) {}
+
+  void UnnamedExplicitObjectParam(this Hello &) {}
 };
-}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
@@ -1,0 +1,14 @@
+// RUN: %check_clang_tidy -std=c++23 %s readability-convert-member-functions-to-static %t
+
+namespace std{
+  class string {};
+  void println(const char *format, const std::string &str) {}
+}
+
+namespace PR141381 {
+struct Hello {
+  std::string str_;
+
+  void hello(this Hello &self) { std::println("Hello, {0}!", self.str_); }
+};
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++23 %s readability-convert-member-functions-to-static %t
+// RUN: %check_clang_tidy -std=c++23-or-later %s readability-convert-member-functions-to-static %t
 
 namespace std{
   class string {};


### PR DESCRIPTION
Fixes #141381.

Add check for `DeclRefExpr` which points to an explicit object parameter.