### PR TITLE
[AMDGPU] Cluster export instruction in PostRA Scheduler

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1129,6 +1129,7 @@ GCNTargetMachine::createPostMachineScheduler(MachineSchedContext *C) const {
        getOptLevel() >= CodeGenOptLevel::Less) &&
       EnableVOPD)
     DAG->addMutation(createVOPDPairingMutation());
+  DAG->addMutation(createAMDGPUExportClusteringDAGMutation());
   return DAG;
 }
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/AMDGPU/export-cluster-postra.mir
+++ b/llvm/test/CodeGen/AMDGPU/export-cluster-postra.mir
@@ -23,12 +23,12 @@ body: |
     ; CHECK-NEXT: }
     ; CHECK-NEXT: $vgpr6 = nofpexcept V_CVT_PKRTZ_F16_F32_e64 0, killed $vgpr6, 0, 1065353216, 0, 0, implicit $mode, implicit $exec
     ; CHECK-NEXT: $vgpr5 = nofpexcept V_CVT_PKRTZ_F16_F32_e64 0, killed $vgpr5, 0, 1065353216, 0, 0, implicit $mode, implicit $exec
-    ; CHECK-NEXT: EXP 0, killed $vgpr0, killed $vgpr6, undef $vgpr0, undef $vgpr0, -1, 0, 3, implicit $exec
-    ; CHECK-NEXT: EXP 1, killed $vgpr1, killed $vgpr5, undef $vgpr0, undef $vgpr0, -1, 0, 3, implicit $exec
     ; CHECK-NEXT: $vgpr7 = nnan nsz arcp contract afn reassoc nofpexcept V_MUL_F32_e32 killed $sgpr0, $vgpr2, implicit $mode, implicit $exec
     ; CHECK-NEXT: $vgpr2 = nnan nsz arcp contract afn reassoc nofpexcept V_ADD_F32_e64 0, killed $vgpr2, 0, killed $sgpr1, 1, 0, implicit $mode, implicit $exec
     ; CHECK-NEXT: $vgpr3 = nofpexcept V_CVT_PKRTZ_F16_F32_e32 killed $vgpr7, killed $vgpr3, implicit $mode, implicit $exec
     ; CHECK-NEXT: $vgpr2 = nofpexcept V_CVT_PKRTZ_F16_F32_e32 killed $vgpr4, killed $vgpr2, implicit $mode, implicit $exec
+    ; CHECK-NEXT: EXP 0, killed $vgpr0, killed $vgpr6, undef $vgpr0, undef $vgpr0, -1, 0, 3, implicit $exec
+    ; CHECK-NEXT: EXP 1, killed $vgpr1, killed $vgpr5, undef $vgpr0, undef $vgpr0, -1, 0, 3, implicit $exec
     ; CHECK-NEXT: EXP_DONE 2, killed $vgpr3, killed $vgpr2, undef $vgpr0, undef $vgpr0, -1, 0, 3, implicit $exec
     BUNDLE implicit-def $sgpr0, implicit-def $sgpr1, implicit $sgpr8_sgpr9_sgpr10_sgpr11 {
       $sgpr0 = S_BUFFER_LOAD_DWORD_IMM $sgpr8_sgpr9_sgpr10_sgpr11, 20, 0 :: (dereferenceable invariant load (s32))


### PR DESCRIPTION
DAG mutation needs to be applied post-RA to maintain order established during pre-RA scheduler.