### PR TITLE
[Clang] Link libgcc_s.1.dylib when building for macOS 10.5 and older

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1645,14 +1645,15 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
     CmdArgs.push_back("-lSystem");
 
   // Select the dynamic runtime library and the target specific static library.
-  if (isTargetIOSBased()) {
-    // If we are compiling as iOS / simulator, don't attempt to link libgcc_s.1,
-    // it never went into the SDK.
-    // Linking against libgcc_s.1 isn't needed for iOS 5.0+
-    if (isIPhoneOSVersionLT(5, 0) && !isTargetIOSSimulator() &&
-        getTriple().getArch() != llvm::Triple::aarch64)
-      CmdArgs.push_back("-lgcc_s.1");
-  }
+  // If we are compiling as iOS / simulator, don't attempt to link libgcc_s.1,
+  // it never went into the SDK.
+  // Linking against libgcc_s.1 isn't needed for iOS 5.0+ or macOS 10.6+
+  if (isTargetIOSBased() && isIPhoneOSVersionLT(5, 0) &&
+      !isTargetIOSSimulator() && getTriple().getArch() != llvm::Triple::aarch64)
+    CmdArgs.push_back("-lgcc_s.1");
+  else if (isTargetMacOSBased() && isMacosxVersionLT(10, 6) &&
+           getTriple().getArch() != llvm::Triple::aarch64)
+    CmdArgs.push_back("-lgcc_s.1");
   AddLinkRuntimeLib(Args, CmdArgs, "builtins");
 }
 

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1648,12 +1648,13 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
   // If we are compiling as iOS / simulator, don't attempt to link libgcc_s.1,
   // it never went into the SDK.
   // Linking against libgcc_s.1 isn't needed for iOS 5.0+ or macOS 10.6+
-  if (isTargetIOSBased() && isIPhoneOSVersionLT(5, 0) &&
-      !isTargetIOSSimulator() && getTriple().getArch() != llvm::Triple::aarch64)
-    CmdArgs.push_back("-lgcc_s.1");
-  else if (isTargetMacOSBased() && isMacosxVersionLT(10, 6) &&
-           getTriple().getArch() != llvm::Triple::aarch64)
-    CmdArgs.push_back("-lgcc_s.1");
+  if (getTriple().getArch() != llvm::Triple::aarch64) {
+    if (isTargetIOSBased() && isIPhoneOSVersionLT(5, 0) &&
+        !isTargetIOSSimulator())
+      CmdArgs.push_back("-lgcc_s.1");
+    else if (isTargetMacOSBased() && isMacosxVersionLT(10, 6))
+      CmdArgs.push_back("-lgcc_s.1");
+  }
   AddLinkRuntimeLib(Args, CmdArgs, "builtins");
 }
 

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1648,13 +1648,11 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
   // If we are compiling as iOS / simulator, don't attempt to link libgcc_s.1,
   // it never went into the SDK.
   // Linking against libgcc_s.1 isn't needed for iOS 5.0+ or macOS 10.6+
-  if (getTriple().getArch() != llvm::Triple::aarch64) {
-    if (isTargetIOSBased() && isIPhoneOSVersionLT(5, 0) &&
-        !isTargetIOSSimulator())
-      CmdArgs.push_back("-lgcc_s.1");
-    else if (isTargetMacOSBased() && isMacosxVersionLT(10, 6))
-      CmdArgs.push_back("-lgcc_s.1");
-  }
+  if (getTriple().getArch() != llvm::Triple::aarch64 &&
+      ((isTargetIOSBased() && isIPhoneOSVersionLT(5, 0) &&
+        !isTargetIOSSimulator()) ||
+       (isTargetMacOSBased() && isMacosxVersionLT(10, 6))))
+    CmdArgs.push_back("-lgcc_s.1");
   AddLinkRuntimeLib(Args, CmdArgs, "builtins");
 }
 

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1645,9 +1645,11 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
     CmdArgs.push_back("-lSystem");
 
   // Select the dynamic runtime library and the target specific static library.
-  // If we are compiling as iOS / simulator, don't attempt to link libgcc_s.1,
-  // it never went into the SDK.
-  // Linking against libgcc_s.1 isn't needed for iOS 5.0+ or macOS 10.6+
+  // Some old Darwin versions put builtins, libunwind, and some other stuff in
+  // libgcc_s.1.dylib. MacOS X 10.6 and iOS 5 moved those functions to
+  // libSystem, and made libgcc_s.1.dylib a stub. We never link libgcc_s when
+  // building for aarch64 or iOS simulator, since libgcc_s was made obsolete
+  // before either existed.
   if (getTriple().getArch() != llvm::Triple::aarch64 &&
       ((isTargetIOSBased() && isIPhoneOSVersionLT(5, 0) &&
         !isTargetIOSSimulator()) ||

--- a/clang/test/Driver/darwin-ld.c
+++ b/clang/test/Driver/darwin-ld.c
@@ -240,6 +240,15 @@
 // RUN: FileCheck -check-prefix=LINK_NO_IOS_ARM64_LIBGCC_S %s < %t.log
 // LINK_NO_IOS_ARM64_LIBGCC_S-NOT: lgcc_s.1
 
+// Check that clang links with libgcc_s.1 for Mac OS X 10.5 and earlier, but not arm64
+// RUN: %clang -target x86_64-apple-macosx10.5 -mmacosx-version-min=10.5 -### %t.o 2> %t.log
+// RUN: FileCheck -check-prefix=LINK_OSX_LIBGCC_S %s < %t.log
+// LINK_OSX_LIBGCC_S: lgcc_s.1
+
+// RUN: %clang -target arm64-apple-macosx10.5 -mmacosx-version-min=10.5 -### %t.o 2> %t.log
+// RUN: FileCheck -check-prefix=LINK_NO_OSX_ARM64_LIBGCC_S %s < %t.log
+// LINK_NO_OSX_ARM64_LIBGCC_S-NOT: lgcc_s.1
+
 // RUN: %clang -target x86_64-apple-darwin12 -rdynamic -### %t.o \
 // RUN:   -fuse-ld= -mlinker-version=100 2> %t.log
 // RUN: FileCheck -check-prefix=LINK_NO_EXPORT_DYNAMIC %s < %t.log


### PR DESCRIPTION
There are a lot of symbols that were moved from libgcc_s into libSystem in 10.6, like libunwind and some builtins. We already do this for iOS versions < 5.0 for the same reason.  This matches the behavior of the version of GCC shipped with Xcode before Apple switched entirely to Clang.