### PR TITLE
[XRay] Fix tail call sleds for AArch64

### DIFF
--- a/llvm/lib/CodeGen/XRayInstrumentation.cpp
+++ b/llvm/lib/CodeGen/XRayInstrumentation.cpp
@@ -296,8 +296,9 @@ bool XRayInstrumentation::run(MachineFunction &MF) {
     case Triple::ArchType::riscv64: {
       // For the architectures which don't have a single return instruction
       InstrumentationOptions op;
-      // RISC-V supports patching tail calls.
-      op.HandleTailcall = MF.getTarget().getTargetTriple().isRISCV();
+      // AArch64 and RISC-V support patching tail calls.
+      op.HandleTailcall = MF.getTarget().getTargetTriple().isAArch64() ||
+                          MF.getTarget().getTargetTriple().isRISCV() ;
       op.HandleAllReturns = true;
       prependRetWithPatchableExit(MF, TII, op);
       break;

--- a/llvm/lib/CodeGen/XRayInstrumentation.cpp
+++ b/llvm/lib/CodeGen/XRayInstrumentation.cpp
@@ -298,7 +298,7 @@ bool XRayInstrumentation::run(MachineFunction &MF) {
       InstrumentationOptions op;
       // AArch64 and RISC-V support patching tail calls.
       op.HandleTailcall = MF.getTarget().getTargetTriple().isAArch64() ||
-                          MF.getTarget().getTargetTriple().isRISCV() ;
+                          MF.getTarget().getTargetTriple().isRISCV();
       op.HandleAllReturns = true;
       prependRetWithPatchableExit(MF, TII, op);
       break;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -163,6 +163,7 @@ unsigned AArch64InstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
         F.getFnAttributeAsParsedInteger("patchable-function-entry", 9) * 4;
     break;
   case TargetOpcode::PATCHABLE_FUNCTION_EXIT:
+  case TargetOpcode::PATCHABLE_TAIL_CALL:
   case TargetOpcode::PATCHABLE_TYPED_EVENT_CALL:
     // An XRay sled can be 4 bytes of alignment plus a 32-byte block.
     NumBytes = 36;

--- a/llvm/test/CodeGen/AArch64/xray-tail-call-sled.ll
+++ b/llvm/test/CodeGen/AArch64/xray-tail-call-sled.ll
@@ -21,8 +21,12 @@ define i32 @callee() nounwind noinline uwtable "function-instrument"="xray-alway
 ; CHECK-LINUX-LABEL: .Lxray_sleds_start0:
 ; CHECK-LINUX-NEXT:  [[TMP:.Ltmp[0-9]+]]:
 ; CHECK-LINUX:         .xword .Lxray_sled_0-[[TMP]]
+; CHECK-LINUX:         .xword
+; CHECK-LINUX-NEXT:    .byte   0x00
 ; CHECK-LINUX:       [[TMP:.Ltmp[0-9]+]]:
 ; CHECK-LINUX-NEXT:    .xword .Lxray_sled_1-[[TMP]]
+; CHECK-LINUX:         .xword
+; CHECK-LINUX-NEXT:    .byte   0x01
 ; CHECK-LINUX-LABEL: Lxray_sleds_end0:
 ; CHECK-LINUX-LABEL: .section xray_fn_idx,"ao",@progbits,callee{{$}}
 ; CHECK-LINUX:         .xword .Lxray_sleds_start0
@@ -32,8 +36,12 @@ define i32 @callee() nounwind noinline uwtable "function-instrument"="xray-alway
 ; CHECK-MACOS-LABEL: lxray_sleds_start0:
 ; CHECK-MACOS-NEXT:  [[TMP:Ltmp[0-9]+]]:
 ; CHECK-MACOS:         .quad Lxray_sled_0-[[TMP]]
+; CHECK-MACOS-NEXT:    .quad
+; CHECK-MACOS-NEXT:    .byte   0x00
 ; CHECK-MACOS:       [[TMP:Ltmp[0-9]+]]:
 ; CHECK-MACOS-NEXT:    .quad Lxray_sled_1-[[TMP]]
+; CHECK-MACOS-NEXT:    .quad
+; CHECK-MACOS-NEXT:    .byte   0x01
 ; CHECK-MACOS-LABEL: Lxray_sleds_end0:
 ; CHECK-MACOS-LABEL: .section __DATA,xray_fn_idx,regular,live_support{{$}}
 ; CHECK-MACOS:       [[IDX:lxray_fn_idx[0-9]+]]:
@@ -60,7 +68,11 @@ define i32 @caller() nounwind noinline uwtable "function-instrument"="xray-alway
 ; CHECK-LINUX-LABEL: .section xray_instr_map,"ao",@progbits,caller{{$}}
 ; CHECK-LINUX-LABEL: Lxray_sleds_start1:
 ; CHECK-LINUX:         .xword .Lxray_sled_2
+; CHECK-LINUX-NEXT:    .xword
+; CHECK-LINUX-NEXT:    .byte   0x00
 ; CHECK-LINUX:         .xword .Lxray_sled_3
+; CHECK-LINUX-NEXT:    .xword
+; CHECK-LINUX-NEXT:    .byte   0x02
 ; CHECK-LINUX-LABEL: Lxray_sleds_end1:
 ; CHECK-LINUX-LABEL: .section xray_fn_idx,"ao",@progbits,caller{{$}}
 ; CHECK-LINUX:       [[IDX:\.Lxray_fn_idx[0-9]+]]:
@@ -70,7 +82,11 @@ define i32 @caller() nounwind noinline uwtable "function-instrument"="xray-alway
 ; CHECK-MACOS-LABEL: .section __DATA,xray_instr_map,regular,live_support{{$}}
 ; CHECK-MACOS-LABEL: lxray_sleds_start1:
 ; CHECK-MACOS:         .quad Lxray_sled_2
+; CHECK-MACOS-NEXT:    .quad
+; CHECK-MACOS-NEXT:    .byte   0x00
 ; CHECK-MACOS:         .quad Lxray_sled_3
+; CHECK-MACOS-NEXT:    .quad
+; CHECK-MACOS-NEXT:    .byte   0x02
 ; CHECK-MACOS-LABEL: Lxray_sleds_end1:
 ; CHECK-MACOS-LABEL: .section __DATA,xray_fn_idx,regular,live_support{{$}}
 ; CHECK-MACOS:       [[IDX:lxray_fn_idx[0-9]+]]:


### PR DESCRIPTION
This addresses issue #141051.
XRay uses a special event kind for tail calls on some architectures. This feature is implemented on AArch64, but wasn't fully activated.
Tests in `llvm/test/CodeGen/AArch64/xray-tail-call-sled.ll` were incomplete and did not check for the emitted sled type.
This patch correctly enables emission of tail call sleds on AArch64 and fixes the tests to check the sled kind.