### PR TITLE
[lldb] skip unnamed symbol test on arm 32 architecture

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -799,6 +799,20 @@ def skipUnlessArch(arch):
     return skipTestIfFn(arch_doesnt_match)
 
 
+def skipIfArch(arch):
+    """Decorate the item to skip tests if running on the specified architecture."""
+
+    def arch_matches():
+        target_arch = lldbplatformutil.getArchitecture()
+        if arch == target_arch:
+            return (
+                "Test does not run on " + arch + ", but target arch is " + target_arch
+            )
+        return None
+
+    return skipTestIfFn(arch_matches)
+
+
 def skipIfTargetAndroid(bugnumber=None, api_levels=None, archs=None):
     """Decorator to skip tests when the target is Android.
 

--- a/lldb/test/API/python_api/unnamed_symbol_lookup/TestUnnamedSymbolLookup.py
+++ b/lldb/test/API/python_api/unnamed_symbol_lookup/TestUnnamedSymbolLookup.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 # --keep-symbol causes error on Windows: llvm-strip.exe: error: option is not supported for COFF
 @skipIfWindows
+# Unnamed symbols don't get into the .eh_frame section on ARM, so LLDB can't find them.
+@skipIfArch("arm")
 class TestUnnamedSymbolLookup(TestBase):
     def test_unnamed_symbol_lookup(self):
         """Test looking up unnamed symbol synthetic name"""


### PR DESCRIPTION
The test fails because LLDB does not recognize any function which is not in the symbol table on armv7 

https://lab.llvm.org/buildbot/#/builders/18/builds/16431