### PR TITLE
[NFC][clangd][test] add clang-tidy config to ensure test cases sandbox

### DIFF
--- a/clang-tools-extra/clangd/test/Inputs/path-mappings/server/.clang-tidy
+++ b/clang-tools-extra/clangd/test/Inputs/path-mappings/server/.clang-tidy
@@ -1,0 +1,1 @@
+InheritParentConfig: false

--- a/clang-tools-extra/clangd/test/Inputs/path-mappings/server/.clang-tidy
+++ b/clang-tools-extra/clangd/test/Inputs/path-mappings/server/.clang-tidy
@@ -1,1 +1,0 @@
-InheritParentConfig: false

--- a/clang-tools-extra/clangd/test/path-mappings.test
+++ b/clang-tools-extra/clangd/test/path-mappings.test
@@ -2,7 +2,7 @@
 # RUN: rm -rf %t
 # RUN: cp -r %S/Inputs/path-mappings %t
 #
-# RUN: clangd --path-mappings 'C:\client=%t/server' -lit-test < %s | FileCheck -strict-whitespace %s
+# RUN: clangd --clang-tidy=false --path-mappings 'C:\client=%t/server' -lit-test < %s | FileCheck -strict-whitespace %s
 {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"clangd","capabilities":{},"trace":"off"}}
 ---
 {

--- a/clang-tools-extra/clangd/test/system-include-extractor.test
+++ b/clang-tools-extra/clangd/test/system-include-extractor.test
@@ -32,6 +32,9 @@
 # RUN: echo 'printf "End of search list.\r\n" >&2' >> %t.dir/bin/my_driver.sh
 # RUN: chmod +x %t.dir/bin/my_driver.sh
 
+# Create fake clang-tidy config to ensure sandbox
+# RUN: echo 'InheritParentConfig: false' >> %t.dir/.clang-tidy
+
 # Create header files my/dir/a.h and my/dir2/b.h
 # RUN: mkdir -p %t.dir/my/dir
 # RUN: touch %t.dir/my/dir/a.h

--- a/clang-tools-extra/clangd/test/system-include-extractor.test
+++ b/clang-tools-extra/clangd/test/system-include-extractor.test
@@ -32,9 +32,6 @@
 # RUN: echo 'printf "End of search list.\r\n" >&2' >> %t.dir/bin/my_driver.sh
 # RUN: chmod +x %t.dir/bin/my_driver.sh
 
-# Create fake clang-tidy config to ensure sandbox
-# RUN: echo 'InheritParentConfig: false' >> %t.dir/.clang-tidy
-
 # Create header files my/dir/a.h and my/dir2/b.h
 # RUN: mkdir -p %t.dir/my/dir
 # RUN: touch %t.dir/my/dir/a.h
@@ -55,7 +52,7 @@
 # Bless the mock driver we've just created so that clangd can execute it.
 # Note: include clangd's stderr in the FileCheck input with "2>&1" so that we
 # can match output lines like "ASTWorker building file"
-# RUN: clangd -lit-test -query-driver="**.test,**.sh" < %t.test 2>&1 | FileCheck -strict-whitespace %t.test
+# RUN: clangd --clang-tidy=false -lit-test -query-driver="**.test,**.sh" < %t.test 2>&1 | FileCheck -strict-whitespace %t.test
 {"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}
 ---
 {
@@ -91,4 +88,4 @@
 
 # Run clangd a second time, to make sure it picks up the driver name from the config file
 # Note, we need to pass -enable-config because -lit-test otherwise disables it
-# RUN: clangd -lit-test -enable-config -query-driver="**.test,**.sh" < %t.test 2>&1 | FileCheck -strict-whitespace %t.test
+# RUN: clangd --clang-tidy=false -lit-test -enable-config -query-driver="**.test,**.sh" < %t.test 2>&1 | FileCheck -strict-whitespace %t.test


### PR DESCRIPTION
Under previous test setup, the test result will be influenced by clang-tidy file in parent folder (between llvm-projects root and build folder). It is inconventient and leads some confusion.
This PR wants to ensure sandbox to avoid outside's clang-tidy influenece test result.
