### PR TITLE
[lldb] add missing cmake build type argument

### DIFF
--- a/lldb/utils/lldb-dotest/lldb-dotest.in
+++ b/lldb/utils/lldb-dotest/lldb-dotest.in
@@ -21,6 +21,7 @@ has_libcxx = @LLDB_HAS_LIBCXX@
 libcxx_libs_dir = "@LIBCXX_LIBRARY_DIR@"
 libcxx_include_dir = "@LIBCXX_GENERATED_INCLUDE_DIR@"
 libcxx_include_target_dir = "@LIBCXX_GENERATED_INCLUDE_TARGET_DIR@"
+cmake_build_type = "@CMAKE_BUILD_TYPE@"
 
 if __name__ == '__main__':
     wrapper_args = sys.argv[1:]
@@ -52,6 +53,7 @@ if __name__ == '__main__':
     if lldb_build_intel_pt == "1":
         cmd.extend(['--enable-plugin', 'intel-pt'])
     cmd.extend(['--lldb-obj-root', lldb_obj_root])
+    cmd.extend(['--cmake-build-type', cmake_build_type])
     cmd.extend(wrapper_args)
     # Invoke dotest.py and return exit code.
     print(' '.join(cmd))


### PR DESCRIPTION
Necessary argument after https://github.com/llvm/llvm-project/commit/7dc7c155251c0008d5d59b84f0c9056365740f11