### PR TITLE
Thread safety analysis: Skip functions acquiring/releasing parameters

### DIFF
--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -2401,6 +2401,36 @@ public:
 } // end namespace SelfLockingTest
 
 
+namespace ExcludeImplementation {
+
+class LOCKABLE Mutex2 {
+public:
+  // We don't require EXCLUSIVE_(UN)LOCK_FUNCTION(impl) on these methods.
+  void Lock() EXCLUSIVE_LOCK_FUNCTION() { impl.Lock(); }
+  void Unlock() EXCLUSIVE_UNLOCK_FUNCTION() { impl.Unlock(); }
+
+  void LockAlt() EXCLUSIVE_LOCK_FUNCTION(this) { impl.Lock(); }
+  void UnlockAlt() EXCLUSIVE_UNLOCK_FUNCTION(this) { impl.Unlock(); }
+
+private:
+  Mutex impl;
+};
+
+struct LOCKABLE Mutex3 {
+  Mutex impl;
+};
+
+void Lock(Mutex3* mu) EXCLUSIVE_LOCK_FUNCTION(mu) {
+  mu->impl.Lock();
+}
+
+void Unlock(Mutex3* mu) EXCLUSIVE_UNLOCK_FUNCTION(mu) {
+  mu->impl.Unlock();
+}
+
+} // namespace ExcludeImplementation
+
+
 namespace InvalidNonstatic {
 
 // Forward decl here causes bogus "invalid use of non-static data member"


### PR DESCRIPTION
The analysis already excludes functions with a zero-argument acquire or release attribute. According to the requirements enforced by -Wthread-safety-attributes, these are methods of a capability class where the attribute implicitly refers to `this`.

C doesn't have class methods, so the lock/unlock implementations are free functions. If we disable the analysis for all free functions with attributes, this would obviously exclude too much. But maybe we can exclude functions where the attribute directly refers to a parameter. Mutex implementations should typically do that, and I don't see why other functions should. (Typically, other functions acquire or release a global mutex or a member of a parameter.)

Fixes #139933.