### PR TITLE
[mlir][CMake] Modify the behavior of `add_mlir_aggregate ` and add `mlir_c_target_link_libraries`.

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -494,11 +494,17 @@ function(add_mlir_python_common_capi_library name)
   endforeach()
   list(REMOVE_DUPLICATES _embed_libs)
 
+  # If `libMLIR-C.so` is present link against it.
+  if (MLIR_BUILD_MLIR_C_DYLIB)
+    list(APPEND _dylibs "MLIR-C")
+  endif()
+
   # Generate the aggregate .so that everything depends on.
   add_mlir_aggregate(${name}
     SHARED
     DISABLE_INSTALL
     EMBED_LIBS ${_embed_libs}
+    PUBLIC_LIBS ${_dylibs}
   )
 
   # Process any headers associated with the library

--- a/mlir/lib/CAPI/CMakeLists.txt
+++ b/mlir/lib/CAPI/CMakeLists.txt
@@ -26,6 +26,7 @@ if(MLIR_BUILD_MLIR_C_DYLIB)
   get_property(_capi_libraries GLOBAL PROPERTY MLIR_CAPI_LIBS)
   add_mlir_aggregate(MLIR-C
     SHARED
+    KEEP_CAPI
     EMBED_LIBS
       ${_capi_libraries}
   )

--- a/mlir/lib/CAPI/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/CAPI/ExecutionEngine/CMakeLists.txt
@@ -10,7 +10,5 @@ add_mlir_upstream_c_api_library(MLIRCAPIExecutionEngine
   ExecutionEngine.cpp
 
   LINK_LIBS PUBLIC
-  MLIRBuiltinToLLVMIRTranslation
   MLIRExecutionEngine
-  MLIRLLVMToLLVMIRTranslation
 )

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -819,6 +819,12 @@ endif()
 # This must come last.
 ################################################################################
 
+set(MLIRPythonCAPI_LIBS "MLIRPythonCAPI")
+
+if(MLIR_BUILD_MLIR_C_DYLIB)
+  list(APPEND MLIRPythonCAPI_LIBS "MLIR-C")
+endif()
+
 add_mlir_python_modules(MLIRPythonModules
   ROOT_PREFIX "${MLIR_BINARY_DIR}/python_packages/mlir_core/mlir"
   INSTALL_PREFIX "python_packages/mlir_core/mlir"
@@ -827,6 +833,5 @@ add_mlir_python_modules(MLIRPythonModules
     MLIRPythonExtension.RegisterEverything
     ${_ADDL_TEST_SOURCES}
   COMMON_CAPI_LINK_LIBS
-    MLIRPythonCAPI
+    ${MLIRPythonCAPI_LIBS}
 )
-

--- a/mlir/test/python/lib/CMakeLists.txt
+++ b/mlir/test/python/lib/CMakeLists.txt
@@ -26,8 +26,11 @@ add_mlir_public_c_api_library(MLIRCAPIPythonTestDialect
   MLIRPythonTestIncGen
 
   LINK_LIBS PUBLIC
-  MLIRCAPIInterfaces
-  MLIRCAPIIR
   MLIRPythonTestDialect
 )
 
+mlir_c_target_link_libraries(MLIRCAPIPythonTestDialect
+  PUBLIC
+  MLIRCAPIInterfaces
+  MLIRCAPIIR
+)


### PR DESCRIPTION
This patch modifies `add_mlir_aggregate` to link against `libMLIR.so` if `MLIR_LINK_MLIR_DYLIB` is set. This means that aggregates that are present in `libMLIR.so` are not added to the final aggregate library.

This allows using `libMLIR.so` as a single source of truth for C-API and python packages, making MLIR easier to distribute.

This patch also adds `mlir_c_target_link_libraries`, the behavior is identical to `mlir_target_link_libraries` except it targets `libMLIR-C.so`.

It also makes the python CAPI depend on `libMLIR-C.so` if `MLIR_BUILD_MLIR_C_DYLIB=1`.

Finally, it fixes some ill-configured library dependencies.