### PR TITLE
[clang][AIX] Fix -print-runtime-dir fallback on AIX

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -934,13 +934,13 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
     return *Path;
 
   if (T.isOSAIX()) {
+    // Strip the OS version from the triple on AIX.
     llvm::Triple AIXTriple;
     if (T.getEnvironment() == Triple::UnknownEnvironment) {
       // Strip unknown environment from the triple.
       AIXTriple = llvm::Triple(T.getArchName(), T.getVendorName(),
                                llvm::Triple::getOSTypeName(T.getOS()));
     } else {
-      // Get the triple without the OS version.
       AIXTriple = getTripleWithoutOSVersion();
     }
     if (auto Path = getPathForTriple(AIXTriple))

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -938,7 +938,7 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
     if (T.getEnvironment() == Triple::UnknownEnvironment) {
       // Strip unknown environment from the triple.
       AIXTriple = llvm::Triple(T.getArchName(), T.getVendorName(),
-                     llvm::Triple::getOSTypeName(T.getOS()));
+                               llvm::Triple::getOSTypeName(T.getOS()));
     } else {
       // Get the triple without the OS version.
       AIXTriple = getTripleWithoutOSVersion();

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -933,11 +933,16 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
   if (auto Path = getPathForTriple(T))
     return *Path;
 
-  if (T.isOSAIX() && T.getEnvironment() == Triple::UnknownEnvironment) {
-    // Strip unknown environment from the triple.
-    const llvm::Triple AIXTriple(
-        llvm::Triple(T.getArchName(), T.getVendorName(),
-                     llvm::Triple::getOSTypeName(T.getOS())));
+  if (T.isOSAIX()) {
+    llvm::Triple AIXTriple;
+    if (T.getEnvironment() == Triple::UnknownEnvironment) {
+      // Strip unknown environment from the triple.
+      AIXTriple = llvm::Triple(T.getArchName(), T.getVendorName(),
+                     llvm::Triple::getOSTypeName(T.getOS()));
+    } else {
+      // Get the triple without the OS version.
+      AIXTriple = getTripleWithoutOSVersion();
+    }
     if (auto Path = getPathForTriple(AIXTriple))
       return *Path;
   }
@@ -987,14 +992,6 @@ std::optional<std::string> ToolChain::getRuntimePath() const {
   if (Triple.isOSDarwin())
     return {};
 
-  // For AIX, get the triple without the OS version.
-  if (Triple.isOSAIX()) {
-    const llvm::Triple &TripleWithoutVersion = getTripleWithoutOSVersion();
-    llvm::sys::path::append(P, TripleWithoutVersion.str());
-    if (getVFS().exists(P))
-      return std::string(P);
-    return {};
-  }
   llvm::sys::path::append(P, Triple.str());
   return std::string(P);
 }

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -934,13 +934,13 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
     return *Path;
 
   if (T.isOSAIX()) {
-    // Strip the OS version from the triple on AIX.
     llvm::Triple AIXTriple;
     if (T.getEnvironment() == Triple::UnknownEnvironment) {
-      // Strip unknown environment from the triple.
+      // Strip unknown environment and the OS version from the triple.
       AIXTriple = llvm::Triple(T.getArchName(), T.getVendorName(),
                                llvm::Triple::getOSTypeName(T.getOS()));
     } else {
+      // Strip the OS version from the triple.
       AIXTriple = getTripleWithoutOSVersion();
     }
     if (auto Path = getPathForTriple(AIXTriple))

--- a/clang/test/Driver/aix-print-runtime-dir.c
+++ b/clang/test/Driver/aix-print-runtime-dir.c
@@ -1,14 +1,6 @@
 // Test output of -print-runtime-dir on AIX
 
 // RUN: %clang -print-runtime-dir --target=powerpc-ibm-aix \
-// RUN:        -resource-dir=%S/Inputs/resource_dir \
-// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR %s
-
-// RUN: %clang -print-runtime-dir --target=powerpc64-ibm-aix \
-// RUN:        -resource-dir=%S/Inputs/resource_dir \
-// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR %s
-
-// RUN: %clang -print-runtime-dir --target=powerpc-ibm-aix \
 // RUN:        -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir\
 // RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR32-PER-TARGET %s
 
@@ -24,7 +16,6 @@
 // RUN:        -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir \
 // RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR64-UNKNOWN-ENV %s 
 
-// PRINT-RUNTIME-DIR: lib{{/|\\}}aix{{$}}
 // PRINT-RUNTIME-DIR32-PER-TARGET: lib{{/|\\}}powerpc-ibm-aix{{$}}
 // PRINT-RUNTIME-DIR64-PER-TARGET: lib{{/|\\}}powerpc64-ibm-aix{{$}}
 // PRINT-RUNTIME-DIR32-UNKNOWN-ENV: lib{{/|\\}}powerpc-ibm-aix


### PR DESCRIPTION
If the runtime path is not found (by getTargetSubDirPath()), since per target runtime directory is enabled on AIX, we should fall back to the target subdirectory rather than the OS subdirectory.