### PR TITLE
Fix handling of integer template argument in emitc.call_opaque

### DIFF
--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -692,6 +692,22 @@ static LogicalResult printOperation(CppEmitter &emitter,
     return failure();
   os << callOpaqueOp.getCallee();
 
+  // Template arguments can't refer to SSA values and as such the template
+  // arguments which are supplied in form of attributes can be emitted as is. We
+  // don't need to handle integer attributes specially like we do for arguments
+  // - see below.
+  auto emitTemplateArgs = [&](Attribute attr) -> LogicalResult {
+    return emitter.emitAttribute(op.getLoc(), attr);
+  };
+
+  if (callOpaqueOp.getTemplateArgs()) {
+    os << "<";
+    if (failed(interleaveCommaWithError(*callOpaqueOp.getTemplateArgs(), os,
+                                        emitTemplateArgs)))
+      return failure();
+    os << ">";
+  }
+
   auto emitArgs = [&](Attribute attr) -> LogicalResult {
     if (auto t = dyn_cast<IntegerAttr>(attr)) {
       // Index attributes are treated specially as operand index.
@@ -710,14 +726,6 @@ static LogicalResult printOperation(CppEmitter &emitter,
 
     return success();
   };
-
-  if (callOpaqueOp.getTemplateArgs()) {
-    os << "<";
-    if (failed(interleaveCommaWithError(*callOpaqueOp.getTemplateArgs(), os,
-                                        emitArgs)))
-      return failure();
-    os << ">";
-  }
 
   os << "(";
 

--- a/mlir/test/Target/Cpp/common-cpp.mlir
+++ b/mlir/test/Target/Cpp/common-cpp.mlir
@@ -109,3 +109,11 @@ func.func @apply() -> !emitc.ptr<i32> {
 func.func @array_type(%arg0: !emitc.array<3xi32>, %arg1: !emitc.array<10x20xf32>) {
   return
 }
+
+// CHECK: call_opaque_with_template_arg
+func.func @call_opaque_with_template_arg() {
+  emitc.call_opaque "init_tile"() {template_args = [512 : index]} : () -> ()
+  // CHECK-NEXT: init_tile<512>();
+  // CHECK-NEXT: return
+  return
+}


### PR DESCRIPTION
Integer attributes supplied to `emitc.call_opaque` as arguments were treated as index into the operands list. This should be the case only for the normal arguments but not for the template arguments which can't refer to SSA values. This commit updates the handling of template arguments in mlir-to-cpp by removing special handling of integer attributes.