### PR TITLE
[LLVM][MLGO] Fix: Index correctly into features to get default inlining decision

### DIFF
--- a/llvm/lib/Analysis/MLInlineAdvisor.cpp
+++ b/llvm/lib/Analysis/MLInlineAdvisor.cpp
@@ -441,7 +441,7 @@ std::unique_ptr<InlineAdvice> MLInlineAdvisor::getAdviceImpl(CallBase &CB) {
   }
   // This one would have been set up to be right at the end.
   if (!InteractiveChannelBaseName.empty() && InteractiveIncludeDefault)
-    *ModelRunner->getTensor<int64_t>(InlineCostFeatureIndex::NumberOfFeatures) =
+    *ModelRunner->getTensor<int64_t>(FeatureIndex::NumberOfFeatures) =
         GetDefaultAdvice(CB);
   return getAdviceFromModel(CB, ORE);
 }

--- a/llvm/test/Transforms/Inline/ML/interactive-mode.ll
+++ b/llvm/test/Transforms/Inline/ML/interactive-mode.ll
@@ -23,6 +23,7 @@
 ; CHECK:      unsimplified_common_instructions: 5
 ; CHECK:      callee_users: 3
 ; CHECK-DEFAULT: inlining_default: 0
+; CHECK-DEFAULT: inlining_default: 1
 ; CHECK:      observation: 5
 ; CHECK-NOT:  observation: 6
 


### PR DESCRIPTION
Currently, `InlineCostFeatureIndex::NumberOfFeatures` results in an index in the middle of the feature vector, therefore not correctly setting the default inlining decision and overwriting another feature. `FeatureIndex::NumberOfFeatures` is the last index of the feature vector, where the default inlining decision gets appended to when enabled. 