### PR TITLE
[lldb-dap] DisassembleRequestHandler: use a better invalid instruction

### DIFF
--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -27,6 +27,7 @@ namespace lldb_dap {
 
 static protocol::DisassembledInstruction GetInvalidInstruction() {
   DisassembledInstruction invalid_inst;
+  invalid_inst.address = LLDB_INVALID_ADDRESS;
   invalid_inst.presentationHint =
       DisassembledInstruction::eDisassembledInstructionPresentationHintInvalid;
   return invalid_inst;

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
@@ -847,8 +847,15 @@ bool fromJSON(const llvm::json::Value &Params, DisassembledInstruction &DI,
 }
 
 llvm::json::Value toJSON(const DisassembledInstruction &DI) {
-  llvm::json::Object result{{"address", "0x" + llvm::utohexstr(DI.address)},
-                            {"instruction", DI.instruction}};
+  llvm::json::Object result{{"instruction", DI.instruction}};
+  if (DI.address == LLDB_INVALID_ADDRESS) {
+    // VSCode has explicit comparisons to the string "-1" in order to check for
+    // invalid instructions. See
+    // https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+    result.insert({"address", "-1"});
+  } else {
+    result.insert({"address", "0x" + llvm::utohexstr(DI.address)});
+  }
 
   if (DI.instructionBytes)
     result.insert({"instructionBytes", *DI.instructionBytes});

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
@@ -849,7 +849,7 @@ bool fromJSON(const llvm::json::Value &Params, DisassembledInstruction &DI,
 llvm::json::Value toJSON(const DisassembledInstruction &DI) {
   llvm::json::Object result{{"instruction", DI.instruction}};
   if (DI.address == LLDB_INVALID_ADDRESS) {
-    // VSCode has explicit comparisons to the string "-1" in order to check for
+    // VS Code has explicit comparisons to the string "-1" in order to check for
     // invalid instructions. See
     // https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
     result.insert({"address", "-1"});


### PR DESCRIPTION
DisassembleRequestHandler: use a better invalid instruction value that fits VSCode client