### PR TITLE
[NewGVN] Fix lifetime coercion

### DIFF
--- a/llvm/test/Transforms/NewGVN/coercion-different-ptr.ll
+++ b/llvm/test/Transforms/NewGVN/coercion-different-ptr.ll
@@ -2,7 +2,7 @@
 ; RUN: opt -S -passes=newgvn < %s | FileCheck %s
 
 
-; FIXME: MemorySSA says that load1 depends on the lifetime start.
+; MemorySSA says that load1 depends on the lifetime start.
 ; That's OK since MemorySSA is may-alias; however, NewGVN should
 ; check whether the lifetime start *actually* defines the loaded pointer
 ; before simplifying to uninitialized memory.
@@ -13,7 +13,8 @@ define void @foo(ptr %arg) {
 ; CHECK-NEXT:    [[ALLOCA:%.*]] = alloca i8, align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(i64 1, ptr [[ALLOCA]])
 ; CHECK-NEXT:    [[LOAD:%.*]] = load ptr, ptr [[ARG]], align 8
-; CHECK-NEXT:    [[CALL:%.*]] = call ptr undef(ptr [[ALLOCA]])
+; CHECK-NEXT:    [[LOAD1:%.*]] = load ptr, ptr [[LOAD]], align 8
+; CHECK-NEXT:    [[CALL:%.*]] = call ptr [[LOAD1]](ptr [[ALLOCA]])
 ; CHECK-NEXT:    ret void
 ;
 bb:


### PR DESCRIPTION
Before commit 14dee0a, NewGVN would not miscompile the function foo, because `isMustAlias` would return false for non-pointers, particularly for `lifetime.start`. We need to check whether the loaded pointer is defined by`lifetime.start` in order to safely simplify the load to uninitialized memory.

For `getInitialValueOfAllocation`, the behavior depends on the allocation function. Therefore, we take a conservative approach: we check whether it's a pointer type. If it is, then—based on the earlier check—we know that the allocation function defines the loaded pointer.

