### PR TITLE
[Driver][X86] Fix LIT test failure on Solaris/MacOS

### DIFF
--- a/clang/test/Driver/cl-x86-flags.c
+++ b/clang/test/Driver/cl-x86-flags.c
@@ -137,10 +137,10 @@ void f(void) {
 }
 
 
-// RUN: not %clang_cl -### --target=i386 -mapx-features=ndd %s 2>&1 | FileCheck --check-prefix=NON-APX %s
-// RUN: not %clang_cl -### --target=i386 -mapxf %s 2>&1 | FileCheck --check-prefix=NON-APX %s
-// RUN: %clang_cl -### --target=i386 -mno-apxf %s 2>&1 > /dev/null
-// NON-APX:      error: unsupported option '-mapx-features=|-mapxf' for target 'i386'
+// RUN: not %clang_cl -### --target=i386-pc-windows -mapx-features=ndd %s 2>&1 | FileCheck --check-prefix=NON-APX %s
+// RUN: not %clang_cl -### --target=i386-pc-windows -mapxf %s 2>&1 | FileCheck --check-prefix=NON-APX %s
+// RUN: %clang_cl -### --target=i386-pc-windows -mno-apxf %s 2>&1 > /dev/null
+// NON-APX:      error: unsupported option '-mapx-features=|-mapxf' for target 'i386-pc-windows{{.*}}'
 // NON-APX-NOT:  error: {{.*}} -mapx-features=
 
 // RUN: %clang_cl --target=x86_64-pc-windows -mapxf %s -### 2>&1 | FileCheck -check-prefix=APXF %s

--- a/clang/test/Driver/cl-x86-flags.c
+++ b/clang/test/Driver/cl-x86-flags.c
@@ -137,14 +137,14 @@ void f(void) {
 }
 
 
-// RUN: not %clang_cl -### --target=i386-pc-windows -mapx-features=ndd %s 2>&1 | FileCheck --check-prefix=NON-APX %s
-// RUN: not %clang_cl -### --target=i386-pc-windows -mapxf %s 2>&1 | FileCheck --check-prefix=NON-APX %s
-// RUN: %clang_cl -### --target=i386-pc-windows -mno-apxf %s 2>&1 > /dev/null
+// RUN: not %clang_cl -### --target=i386-pc-windows -mapx-features=ndd -- 2>&1 %s | FileCheck --check-prefix=NON-APX %s
+// RUN: not %clang_cl -### --target=i386-pc-windows -mapxf -- 2>&1 %s | FileCheck --check-prefix=NON-APX %s
+// RUN: %clang_cl -### --target=i386-pc-windows -mno-apxf -- 2>&1 %s > /dev/null
 // NON-APX:      error: unsupported option '-mapx-features=|-mapxf' for target 'i386-pc-windows{{.*}}'
 // NON-APX-NOT:  error: {{.*}} -mapx-features=
 
-// RUN: %clang_cl --target=x86_64-pc-windows -mapxf %s -### 2>&1 | FileCheck -check-prefix=APXF %s
-// RUN: %clang_cl --target=x86_64-pc-windows -mapxf -mno-apxf %s -### 2>&1 | FileCheck -check-prefix=NO-APXF %s
-// RUN: %clang_cl --target=x86_64-pc-windows -mapx-features=egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu %s -### 2>&1 | FileCheck -check-prefix=APXF %s
+// RUN: %clang_cl --target=x86_64-pc-windows -mapxf -### -- 2>&1 %s | FileCheck -check-prefix=APXF %s
+// RUN: %clang_cl --target=x86_64-pc-windows -mapxf -mno-apxf -### -- 2>&1 %s | FileCheck -check-prefix=NO-APXF %s
+// RUN: %clang_cl --target=x86_64-pc-windows -mapx-features=egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu -### -- 2>&1 %s | FileCheck -check-prefix=APXF %s
 // APXF: "-target-feature" "+egpr" "-target-feature" "+push2pop2" "-target-feature" "+ppx" "-target-feature" "+ndd" "-target-feature" "+ccmp" "-target-feature" "+nf" "-target-feature" "+cf" "-target-feature" "+zu"
 // NO-APXF: "-target-feature" "-egpr" "-target-feature" "-push2pop2" "-target-feature" "-ppx" "-target-feature" "-ndd" "-target-feature" "-ccmp" "-target-feature" "-nf" "-target-feature" "-cf" "-target-feature" "-zu"


### PR DESCRIPTION
The LIT test is introduced by https://github.com/llvm/llvm-project/pull/140874. Fixed by using "--" to separate options from input file names.