### PR TITLE
[SPIR-V] Remove XFAIL from the passing test

### DIFF
--- a/llvm/test/CodeGen/SPIRV/constant/local-arbitrary-width-integers-constants-type-promotion.ll
+++ b/llvm/test/CodeGen/SPIRV/constant/local-arbitrary-width-integers-constants-type-promotion.ll
@@ -1,8 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
-; TODO: This test currently fails with LLVM_ENABLE_EXPENSIVE_CHECKS enabled
-; XFAIL: expensive_checks
-
 define i4 @getConstantI4() {
   ret i4 2 ; i4 => OpTypeInt 8
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/141279#issuecomment-2909561544