### PR TITLE
[clang][Lex] Use getBufferName() in isInPredefinedFile()

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -1531,11 +1531,8 @@ public:
 
   /// Returns whether \p Loc is located in a built-in or command line source.
   bool isInPredefinedFile(SourceLocation Loc) const {
-    PresumedLoc Presumed = getPresumedLoc(Loc);
-    if (Presumed.isInvalid())
-      return false;
-    StringRef Filename(Presumed.getFilename());
-    return Filename == "<built-in>" || Filename == "<command line>";
+    StringRef BufferName = getBufferName(Loc);
+    return BufferName == "<built-in>" || BufferName == "<command line>";
   }
 
   /// Returns if a SourceLocation is in a system header.


### PR DESCRIPTION
I don't think this depends on #line directives, to it should be fine to use getBufferName.