### PR TITLE
[EarlyCSE] Correcting assertion for DSE with invariant loads

### DIFF
--- a/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
+++ b/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
@@ -1699,15 +1699,6 @@ bool EarlyCSE::processNode(DomTreeNode *Node) {
       LoadValue InVal = AvailableLoads.lookup(MemInst.getPointerOperand());
       if (InVal.DefInst &&
           InVal.DefInst == getMatchingValue(InVal, MemInst, CurrentGeneration)) {
-        // It is okay to have a LastStore to a different pointer here if MemorySSA
-        // tells us that the load and store are from the same memory generation.
-        // In that case, LastStore should keep its present value since we're
-        // removing the current store.
-        assert((!LastStore ||
-                ParseMemoryInst(LastStore, TTI).getPointerOperand() !=
-                    MemInst.getPointerOperand() ||
-                MSSA) &&
-               "can't have an intervening store if not using MemorySSA!");
         LLVM_DEBUG(dbgs() << "EarlyCSE DSE (writeback): " << Inst << '\n');
         if (!DebugCounter::shouldExecute(CSECounter)) {
           LLVM_DEBUG(dbgs() << "Skipping due to debug counter\n");

--- a/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
+++ b/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
@@ -1698,7 +1698,8 @@ bool EarlyCSE::processNode(DomTreeNode *Node) {
     if (MemInst.isValid() && MemInst.isStore()) {
       LoadValue InVal = AvailableLoads.lookup(MemInst.getPointerOperand());
       if (InVal.DefInst &&
-          InVal.DefInst == getMatchingValue(InVal, MemInst, CurrentGeneration)) {
+          InVal.DefInst ==
+              getMatchingValue(InVal, MemInst, CurrentGeneration)) {
         LLVM_DEBUG(dbgs() << "EarlyCSE DSE (writeback): " << Inst << '\n');
         if (!DebugCounter::shouldExecute(CSECounter)) {
           LLVM_DEBUG(dbgs() << "Skipping due to debug counter\n");

--- a/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
+++ b/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
@@ -1704,7 +1704,7 @@ bool EarlyCSE::processNode(DomTreeNode *Node) {
         // In that case, LastStore should keep its present value since we're
         // removing the current store.
         assert((!LastStore ||
-                ParseMemoryInst(LastStore, TTI).getPointerOperand() ==
+                ParseMemoryInst(LastStore, TTI).getPointerOperand() !=
                     MemInst.getPointerOperand() ||
                 MSSA) &&
                "can't have an intervening store if not using MemorySSA!");


### PR DESCRIPTION
This patch corrects an assertion to handle an edge case where there is a dead store into an `!invariant.load`'s pointer, but there is an interleaving store to a different (non-aliasing) address.

The assertion is in place to verify that the putatively dead store is actually dead; in particular, it ensures that at least one of the following conditions hold:
1. There were no previous stores before the putatively dead store.
2. There are no interleaving stores between the `!invariant.load` and the corresponding putatively dead store to the same address.
3. `memssa` is enabled.

However, the assertion seems to have mistakenly inverted the 2nd condition.

This bug was found through the AMD fuzzing project.