### PR TITLE
Thread Safety Analysis: Use replaceLock instead of removeLock+addLock

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1071,9 +1071,9 @@ private:
         return;
       }
 
-      FSet.removeLock(FactMan, Cp);
-      FSet.addLock(FactMan,
-                   std::make_unique<LockableFactEntry>(!Cp, LK_Exclusive, loc));
+      FSet.replaceLock(
+          FactMan, It,
+          std::make_unique<LockableFactEntry>(!Cp, LK_Exclusive, loc));
     } else if (Handler) {
       SourceLocation PrevLoc;
       if (const FactEntry *Neg = FSet.findLock(FactMan, !Cp))


### PR DESCRIPTION
In ScopedLockableFactEntry::unlock(), we can avoid a second search, pop_back(), and push_back() if we use the already obtained iterator into the FactSet to replace the old FactEntry and take its position in the vector.