### PR TITLE
[CI][Github] Remove test naming from premerge jobs

### DIFF
--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -29,8 +29,8 @@ GITHUB_WORKFLOW_TO_TRACK = {"CI Checks": "github_llvm_premerge_checks"}
 # name.
 GITHUB_JOB_TO_TRACK = {
     "github_llvm_premerge_checks": {
-        "Build and Test Linux (Test Only - Please Ignore Results)": "premerge_linux",
-        "Build and Test Windows (Test Only - Please Ignore Results)": "premerge_windows",
+        "Build and Test Linux": "premerge_linux",
+        "Build and Test Windows": "premerge_windows",
     }
 }
 

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   premerge-checks-linux:
-    name: Build and Test Linux (Test Only - Please Ignore Results)
+    name: Build and Test Linux
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
@@ -70,7 +70,7 @@ jobs:
           include-hidden-files: 'true'
 
   premerge-checks-windows:
-    name: Build and Test Windows (Test Only - Please Ignore Results)
+    name: Build and Test Windows
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')


### PR DESCRIPTION
This patch removes the "test only please ignore" tagline from the premerge job names. Now that we are looking to sunset the old infrastructure pretty soon and the new infrastructure is reporting errors, we want people to actually pay attention to the failures and report anything erroneous.