### PR TITLE
Revert "[clang] Fix handle_cxx.cpp after 9e306ad4"

### DIFF
--- a/clang/tools/clang-fuzzer/handle-cxx/handle_cxx.cpp
+++ b/clang/tools/clang-fuzzer/handle-cxx/handle_cxx.cpp
@@ -32,9 +32,9 @@ void clang_fuzzer::HandleCXX(const std::string &S,
   llvm::IntrusiveRefCntPtr<FileManager> Files(
       new FileManager(FileSystemOptions()));
   IgnoringDiagConsumer Diags;
-  DiagnosticOptions DiagOpts;
+  IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
   DiagnosticsEngine Diagnostics(
-      IntrusiveRefCntPtr<clang::DiagnosticIDs>(new DiagnosticIDs()), DiagOpts,
+      IntrusiveRefCntPtr<clang::DiagnosticIDs>(new DiagnosticIDs()), &*DiagOpts,
       &Diags, false);
   std::unique_ptr<clang::CompilerInvocation> Invocation(
       tooling::newInvocation(&Diagnostics, CC1Args, /*BinaryName=*/nullptr));


### PR DESCRIPTION
This reverts commit d25f95fdbc5314f30618912e18f00ad4dd720fa0, after 9e306ad4 was rolled back in e2a88553 (r576388).