### PR TITLE
[cmake] Introduce LLVM_DISABLE_PROJECTS to easily exclude projects

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -130,6 +130,10 @@ or to the runtimes default build
 ")
 endif()
 
+foreach(proj ${LLVM_DISABLE_PROJECTS})
+  list(REMOVE_ITEM LLVM_ENABLE_PROJECTS "${proj}")
+endforeach ()
+
 foreach(proj ${LLVM_ENABLE_PROJECTS})
   if (NOT proj STREQUAL "llvm" AND NOT "${proj}" IN_LIST LLVM_KNOWN_PROJECTS)
      MESSAGE(FATAL_ERROR "${proj} isn't a known project: ${LLVM_KNOWN_PROJECTS}. Did you mean to enable it as a runtime in LLVM_ENABLE_RUNTIMES?")

--- a/llvm/docs/CMake.rst
+++ b/llvm/docs/CMake.rst
@@ -436,6 +436,14 @@ its enabled sub-projects. Nearly all of these variable names begin with
   of the machine where LLVM is being built. If you are building a cross-compiler,
   set it to the target triple of your desired architecture.
 
+**LLVM_DISABLE_PROJECTS**:STRING
+  Semicolon-separated list of projects to exclude from the build. Sometimes it is
+  more convenient to exclude a few projects than to have to enumerate all other
+  projects. This flag can be combined with ``LLVM_ENABLE_PROJECTS`` to easily
+  select projects of interest in the build. For example, the command:
+  ``cmake ... -DLLVM_ENABLE_PROJECTS=all -DLLVM_DISABLE_PROJECTS=libclc ...``
+  allows to build all projects but ``libclc``.
+
 **LLVM_DOXYGEN_QCH_FILENAME**:STRING
   The filename of the Qt Compressed Help file that will be generated when
   ``-DLLVM_ENABLE_DOXYGEN=ON`` and


### PR DESCRIPTION
Introduces `LLVM_DISABLE_PROJECTS` to easily exclude projects from the build as described in
https://github.com/llvm/llvm-project/issues/141502