### PR TITLE
[Clang] Fix a pack expansion bug in template argument deduction

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -795,6 +795,7 @@ Bug Fixes to C++ Support
 - Fix instantiation of default-initialized variable template specialization. (#GH140632) (#GH140622)
 - Clang modules now allow a module and its user to differ on TrivialAutoVarInit*
 - Fixed an access checking bug when initializing non-aggregates in default arguments (#GH62444), (#GH83608)
+- Fixed a pack substitution bug in deducing class template partial specializations. (#GH53609)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -2946,6 +2946,7 @@ ConvertDeducedTemplateArgument(Sema &S, NamedDecl *Param,
       LocalInstantiationScope Scope(S);
       MultiLevelTemplateArgumentList Args(Template, CTAI.SugaredConverted,
                                           /*Final=*/true);
+      Sema::ArgPackSubstIndexRAII OnlySubstNonPackExpansion(S, std::nullopt);
 
       if (auto *NTTP = dyn_cast<NonTypeTemplateParmDecl>(Param)) {
         Sema::InstantiatingTemplate Inst(S, Template->getLocation(), Template,

--- a/clang/test/CXX/temp/temp.fct.spec/temp.deduct/p7.cpp
+++ b/clang/test/CXX/temp/temp.fct.spec/temp.deduct/p7.cpp
@@ -54,3 +54,20 @@ namespace reversed_operator_substitution_order {
   float &s = no_adl::f<int>(true);
 }
 #endif
+
+namespace GH53609 {
+
+template <class, int>
+struct a;
+
+template <class, class...>
+struct b;
+
+template <class x, class... y, y... z>
+struct b<x, a<y, z>...> {};
+
+template <class... x> struct c: b<x>...  {};
+
+c<int> d;
+
+}


### PR DESCRIPTION
I think the intent of df18ee96206 was to substitute only those non-packs into a pack expansion type (e.g. `T` in `T::pack...`), so let's hold off pack expansions explicitly, in case there are calls coming from a substitution of pack expansion.

Fixes https://github.com/llvm/llvm-project/issues/53609