### PR TITLE
[ARM,AArch64] Don't put BTI at asm goto branch targets

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -2042,6 +2042,17 @@ references can be used instead of numeric references.
       return -1;
   }
 
+ASM Goto versus Branch Target Enforcement
+=========================================
+
+Some target architectures implement branch target enforcement, by requiring
+indirect (register-controlled) branch instructions to jump only to locations
+marked by a special instruction (such as AArch64 ``bti``).
+
+The assembler code inside an ``asm goto`` statement is expected not to use a
+branch instruction of that kind to transfer control to any of its destination
+labels. Therefore, using a label in an ``asm goto`` statement does not cause
+clang to put a ``bti`` or equivalent instruction at the label.
 
 Constexpr strings in GNU ASM statements
 =======================================

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -41,6 +41,11 @@ Potentially Breaking Changes
 - For ARM targets when compiling assembly files, the features included in the selected CPU
   or Architecture's FPU are included. If you wish not to use a specific feature,
   the relevant ``+no`` option will need to be amended to the command line option.
+- When compiling with branch target enforcement, ``asm goto``
+  statements will no longer guarantee to place a ``bti`` or
+  ``endbr64`` instruction at the labels named as possible branch
+  destinations, so it is not safe to use a register-controlled branch
+  instruction to branch to one. (In line with gcc.)
 
 C/C++ Language Potentially Breaking Changes
 -------------------------------------------

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -9596,6 +9596,14 @@ may not be equal to the address provided for the same block to this
 instruction's ``indirect labels`` operand. The assembly code may only transfer
 control to addresses provided via this instruction's ``indirect labels``.
 
+On target architectures that implement branch target enforcement by requiring
+indirect (register-controlled) branch instructions to jump only to locations
+marked by a special instruction (such as AArch64 ``bti``), the called code is
+expected not to use such an indirect branch to transfer control to the
+locations in ``indirect labels``. Therefore, including a label in the
+``indirect labels`` of a ``callbr`` does not require the compiler to put a
+``bti`` or equivalent instruction at the label.
+
 Arguments:
 """"""""""
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -70,6 +70,12 @@ Changes to the LLVM IR
   `llvm.load.relative`.
 * Inline asm calls no longer accept ``label`` arguments. Use ``callbr`` instead.
 
+* Updated semantics of the `callbr` instruction to clarify that its
+  'indirect labels' are not expected to be reached by indirect (as in
+  register-controlled) branch instructions, and therefore are not
+  guaranteed to start with a `bti` or `endbr64` instruction, where
+  those exist.
+
 Changes to LLVM infrastructure
 ------------------------------
 

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -275,18 +275,33 @@ public:
   /// of a terminator, exception-handling target, or jump table. This is
   /// either the result of an IR-level "blockaddress", or some form
   /// of target-specific branch lowering.
+  ///
+  /// The name of this function `hasAddressTaken` implies that the address of
+  /// the block is known and used in a general sense, but not necessarily that
+  /// the address is used by an indirect branch instruction. So branch target
+  /// enforcement need not put a BTI instruction (or equivalent) at the start
+  /// of a block just because this function returns true. The decision about
+  /// whether to add a BTI can be more subtle than that, and depends on the
+  /// more detailed checks that this function aggregates together.
   bool hasAddressTaken() const {
-    return MachineBlockAddressTaken || AddressTakenIRBlock;
+    return MachineBlockAddressTaken || AddressTakenIRBlock ||
+           IsInlineAsmBrIndirectTarget;
   }
 
   /// Test whether this block is used as something other than the target of a
   /// terminator, exception-handling target, jump table, or IR blockaddress.
   /// For example, its address might be loaded into a register, or
   /// stored in some branch table that isn't part of MachineJumpTableInfo.
+  ///
+  /// If this function returns true, it _does_ mean that branch target
+  /// enforcement needs to put a BTI or equivalent at the start of the block.
   bool isMachineBlockAddressTaken() const { return MachineBlockAddressTaken; }
 
   /// Test whether this block is the target of an IR BlockAddress.  (There can
   /// more than one MBB associated with an IR BB where the address is taken.)
+  ///
+  /// If this function returns true, it _does_ mean that branch target
+  /// enforcement needs to put a BTI or equivalent at the start of the block.
   bool isIRBlockAddressTaken() const { return AddressTakenIRBlock; }
 
   /// Retrieves the BasicBlock which corresponds to this MachineBasicBlock.

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -4330,6 +4330,8 @@ void AsmPrinter::emitBasicBlockStart(const MachineBasicBlock &MBB) {
       OutStreamer->emitLabel(Sym);
   } else if (isVerbose() && MBB.isMachineBlockAddressTaken()) {
     OutStreamer->AddComment("Block address taken");
+  } else if (isVerbose() && MBB.isInlineAsmBrIndirectTarget()) {
+    OutStreamer->AddComment("Inline asm indirect target");
   }
 
   // Print some verbose block comments.

--- a/llvm/lib/CodeGen/BasicBlockPathCloning.cpp
+++ b/llvm/lib/CodeGen/BasicBlockPathCloning.cpp
@@ -121,11 +121,18 @@ bool IsValidCloning(const MachineFunction &MF,
       }
       if (PathBB->isMachineBlockAddressTaken()) {
         // Avoid cloning blocks which have their address taken since we can't
-        // rewire branches to those blocks as easily (e.g., branches within
-        // inline assembly).
+        // rewire branches to those blocks as easily.
         WithColor::warning()
             << "block #" << BBID
             << " has its machine block address taken in function "
+            << MF.getName() << "\n";
+        return false;
+      }
+      if (PathBB->isInlineAsmBrIndirectTarget()) {
+        // Similarly for branches to the block within an asm goto.
+        WithColor::warning()
+            << "block #" << BBID
+            << " is a branch target of an 'asm goto' in function "
             << MF.getName() << "\n";
         return false;
       }

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3399,10 +3399,11 @@ void SelectionDAGBuilder::visitCallBr(const CallBrInst &I) {
     BasicBlock *Dest = I.getIndirectDest(i);
     MachineBasicBlock *Target = FuncInfo.getMBB(Dest);
     Target->setIsInlineAsmBrIndirectTarget();
-    // If there was a type of asm goto statement that was permitted to
-    // use an indirect call instruction to jump to its labels, then we
-    // would also have to call Target->setMachineBlockAddressTaken()
-    // here to mark the target block as requiring a BTI.
+    // If we introduce a type of asm goto statement that is permitted to use an
+    // indirect call instruction to jump to its labels, then we should add a
+    // call to Target->setMachineBlockAddressTaken() here, to mark the target
+    // block as requiring a BTI.
+
     Target->setLabelMustBeEmitted();
     // Don't add duplicate machine successors.
     if (Dests.insert(Dest).second)

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3399,7 +3399,10 @@ void SelectionDAGBuilder::visitCallBr(const CallBrInst &I) {
     BasicBlock *Dest = I.getIndirectDest(i);
     MachineBasicBlock *Target = FuncInfo.getMBB(Dest);
     Target->setIsInlineAsmBrIndirectTarget();
-    Target->setMachineBlockAddressTaken();
+    // If there was a type of asm goto statement that was permitted to
+    // use an indirect call instruction to jump to its labels, then we
+    // would also have to call Target->setMachineBlockAddressTaken()
+    // here to mark the target block as requiring a BTI.
     Target->setLabelMustBeEmitted();
     // Don't add duplicate machine successors.
     if (Dests.insert(Dest).second)

--- a/llvm/lib/Target/AArch64/AArch64BranchTargets.cpp
+++ b/llvm/lib/Target/AArch64/AArch64BranchTargets.cpp
@@ -99,7 +99,8 @@ bool AArch64BranchTargets::runOnMachineFunction(MachineFunction &MF) {
 
     // If the block itself is address-taken, it could be indirectly branched
     // to, but not called.
-    if (MBB.hasAddressTaken() || JumpTableTargets.count(&MBB))
+    if (MBB.isMachineBlockAddressTaken() || MBB.isIRBlockAddressTaken() ||
+        JumpTableTargets.count(&MBB))
       CouldJump = true;
 
     if (CouldCall || CouldJump) {

--- a/llvm/lib/Target/ARM/ARMBranchTargets.cpp
+++ b/llvm/lib/Target/ARM/ARMBranchTargets.cpp
@@ -77,7 +77,8 @@ bool ARMBranchTargets::runOnMachineFunction(MachineFunction &MF) {
     // modes. These modes do not support PACBTI. As a result, BTI instructions
     // are not added in the destination blocks.
 
-    if (IsFirstBB || MBB.hasAddressTaken() || MBB.isEHPad()) {
+    if (IsFirstBB || MBB.isMachineBlockAddressTaken() ||
+        MBB.isIRBlockAddressTaken() || MBB.isEHPad()) {
       addBTI(TII, MBB, IsFirstBB);
       MadeChange = true;
     }

--- a/llvm/test/CodeGen/AArch64/callbr-asm-label-bti.ll
+++ b/llvm/test/CodeGen/AArch64/callbr-asm-label-bti.ll
@@ -1,0 +1,40 @@
+; RUN: llc < %s -mtriple=aarch64-linux-gnu | FileCheck %s
+
+; Test function which compares two integers and returns the value of
+; the overflow flag, by using an asm goto to make the asm block branch
+; based on that flag, and then a phi to set the return value based on
+; whether the branch was taken.
+define i32 @overflow(i64 %a, i64 %b) #0 {
+asm:
+  callbr void asm sideeffect "cmp $0, $1 \0A\09 b.vs ${2:l}",
+          "r,r,!i,~{cc}"(i64 %a, i64 %b)
+          to label %fallthrough [label %indirect]
+
+indirect:
+  br label %fallthrough
+
+fallthrough:
+  ; Return 1 if we came via the 'indirect' block (because the b.vs was
+  ; taken), and 0 if we came straight from the asm block (because it
+  ; was untaken).
+  %retval = phi i32 [0, %asm], [1, %indirect]
+  ret i32 %retval
+}
+
+; CHECK: overflow:
+; CHECK-NEXT: .cfi_startproc
+; CHECK-NEXT: // %bb.{{[0-9]+}}:
+; CHECK-NEXT: bti c
+; CHECK-NEXT: //APP
+; CHECK-NEXT: cmp x0, x1
+; CHECK-NEXT: b.vs [[LABEL:\.[A-Za-z0-9_]+]]
+; CHECK-NEXT: //NO_APP
+; CHECK-NEXT: // %bb.{{[0-9]+}}:
+; CHECK-NEXT: mov w0, wzr
+; CHECK-NEXT: ret
+; CHECK-NEXT: [[LABEL]]:
+; CHECK-NOT:  bti
+; CHECK:      mov w0, #1
+; CHECK-NEXT: ret
+
+attributes #0 = { "branch-target-enforcement" "target-features"="+bti" }

--- a/llvm/test/CodeGen/AArch64/callbr-asm-label.ll
+++ b/llvm/test/CodeGen/AArch64/callbr-asm-label.ll
@@ -7,7 +7,7 @@ define i32 @test1() {
 ; CHECK:         .word b
 ; CHECK-NEXT:    .word .LBB0_2
 ; CHECK: // %bb.1:
-; CHECK: .LBB0_2: // Block address taken
+; CHECK: .LBB0_2: // Inline asm indirect target
 entry:
   callbr void asm sideeffect "1:\0A\09.word b, ${0:l}\0A\09", "!i"()
           to label %cleanup [label %indirect]
@@ -31,7 +31,7 @@ entry:
 if.then:
 ; CHECK:       .word b
 ; CHECK-NEXT:  .word .LBB1_3
-; CHECK:       .LBB1_3: // Block address taken
+; CHECK:       .LBB1_3: // Inline asm indirect target
   callbr void asm sideeffect "1:\0A\09.word b, ${0:l}\0A\09", "!i"()
           to label %if.then4 [label %if.end6]
 
@@ -46,7 +46,7 @@ if.end6:
   br i1 %phitmp, label %if.end10, label %if.then9
 
 if.then9:
-; CHECK: .LBB1_5: // Block address taken
+; CHECK: .LBB1_5: // Inline asm indirect target
   callbr void asm sideeffect "", "!i"()
           to label %if.end10 [label %l_yes]
 

--- a/llvm/test/CodeGen/AArch64/callbr-asm-outputs-indirect-isel.ll
+++ b/llvm/test/CodeGen/AArch64/callbr-asm-outputs-indirect-isel.ll
@@ -22,7 +22,7 @@ define i32 @test0() {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32all = COPY %5
   ; CHECK-NEXT:   B %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.entry.indirect_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.entry.indirect_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.5(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY %5
@@ -35,7 +35,7 @@ define i32 @test0() {
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr32all = COPY %7
   ; CHECK-NEXT:   B %bb.4
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.3.direct.indirect_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.3.direct.indirect_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.5(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:gpr32all = COPY %7
@@ -87,7 +87,7 @@ define i32 @dont_split0() {
   ; CHECK-NEXT:   $w0 = COPY [[MOVi32imm]]
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.y (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.y (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32all = COPY $wzr
   ; CHECK-NEXT:   $w0 = COPY [[COPY]]
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
@@ -116,7 +116,7 @@ define i32 @dont_split1() {
   ; CHECK-NEXT:   $w0 = COPY [[MOVi32imm]]
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.y (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.y (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   $w0 = COPY %1
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
 entry:
@@ -147,7 +147,7 @@ define i32 @dont_split2() {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY $wzr
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr32all = COPY [[COPY1]]
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.y (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.y (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   [[PHI:%[0-9]+]]:gpr32all = PHI [[COPY]], %bb.0, [[COPY2]], %bb.1
   ; CHECK-NEXT:   $w0 = COPY [[PHI]]
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
@@ -174,7 +174,7 @@ define i32 @dont_split3() {
   ; CHECK-NEXT: bb.1.x:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.v (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.v (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   [[MOVi32imm:%[0-9]+]]:gpr32 = MOVi32imm 42
   ; CHECK-NEXT:   $w0 = COPY [[MOVi32imm]]
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
@@ -198,7 +198,7 @@ define i32 @split_me0() {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32all = COPY %3
   ; CHECK-NEXT:   B %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.entry.y_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.entry.y_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY %3
@@ -248,7 +248,7 @@ define i32 @split_me1(i1 %z) {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY %5
   ; CHECK-NEXT:   B %bb.3
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.w.v_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.w.v_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.4(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr32all = COPY %5
@@ -301,7 +301,7 @@ define i32 @split_me2(i1 %z) {
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr32all = COPY %6
   ; CHECK-NEXT:   B %bb.3
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.w.v_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.w.v_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.4(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:gpr32all = COPY %6
@@ -349,7 +349,7 @@ define i32 @dont_split4() {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   B %bb.3
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.y (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.y (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY %3
@@ -383,7 +383,7 @@ define i32 @dont_split5() {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32all = COPY %3
   ; CHECK-NEXT:   B %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.y (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.y (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY %3
@@ -414,7 +414,7 @@ define i32 @split_me3() {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32all = COPY %3
   ; CHECK-NEXT:   B %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.entry.out_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.entry.out_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY %3
@@ -460,7 +460,7 @@ define i32 @dont_split6(i32 %0) {
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr32all = COPY %4
   ; CHECK-NEXT:   B %bb.3
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.loop.loop_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.loop.loop_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:gpr32all = COPY %4
@@ -495,7 +495,7 @@ define i32 @split_me4() {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32all = COPY %3
   ; CHECK-NEXT:   B %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.entry.same_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.entry.same_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY %3
@@ -526,7 +526,7 @@ define i32 @split_me5() {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32all = COPY %3
   ; CHECK-NEXT:   B %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.entry.same_crit_edge (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.entry.same_crit_edge (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY %3

--- a/llvm/test/CodeGen/PowerPC/callbr-asm-outputs-indirect-isel.ll
+++ b/llvm/test/CodeGen/PowerPC/callbr-asm-outputs-indirect-isel.ll
@@ -22,7 +22,7 @@ define void @strncpy_from_kernel_nofault_count() {
   ; CHECK-NEXT: bb.2.Efault:
   ; CHECK-NEXT:   BLR8 implicit $lr8, implicit $rm
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.3.Efault.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.3.Efault.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   STB %1, 0, $zero8 :: (store (s8) into `ptr null`)

--- a/llvm/test/CodeGen/PowerPC/ppc64-inlineasm-clobber.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-inlineasm-clobber.ll
@@ -86,7 +86,7 @@ define dso_local signext i32 @ClobberLR_BR(i32 signext %in) #0 {
 ; PPC64LE-NEXT:    ld r0, 16(r1)
 ; PPC64LE-NEXT:    mtlr r0
 ; PPC64LE-NEXT:    blr
-; PPC64LE-NEXT:  .LBB3_2: # Block address taken
+; PPC64LE-NEXT:  .LBB3_2: # Inline asm indirect target
 ; PPC64LE-NEXT:    # %return_early
 ; PPC64LE-NEXT:    # Label of block must be emitted
 ; PPC64LE-NEXT:    li r3, 0
@@ -105,7 +105,7 @@ define dso_local signext i32 @ClobberLR_BR(i32 signext %in) #0 {
 ; PPC64BE-NEXT:    ld r0, 16(r1)
 ; PPC64BE-NEXT:    mtlr r0
 ; PPC64BE-NEXT:    blr
-; PPC64BE-NEXT:  .LBB3_2: # Block address taken
+; PPC64BE-NEXT:  .LBB3_2: # Inline asm indirect target
 ; PPC64BE-NEXT:    # %return_early
 ; PPC64BE-NEXT:    # Label of block must be emitted
 ; PPC64BE-NEXT:    li r3, 0
@@ -130,7 +130,7 @@ define dso_local signext i32 @ClobberR5_BR(i32 signext %in) #0 {
 ; PPC64LE-NEXT:    #NO_APP
 ; PPC64LE-NEXT:  # %bb.1: # %return
 ; PPC64LE-NEXT:    blr
-; PPC64LE-NEXT:  .LBB4_2: # Block address taken
+; PPC64LE-NEXT:  .LBB4_2: # Inline asm indirect target
 ; PPC64LE-NEXT:    # %return_early
 ; PPC64LE-NEXT:    # Label of block must be emitted
 ; PPC64LE-NEXT:    li r3, 0
@@ -143,7 +143,7 @@ define dso_local signext i32 @ClobberR5_BR(i32 signext %in) #0 {
 ; PPC64BE-NEXT:    #NO_APP
 ; PPC64BE-NEXT:  # %bb.1: # %return
 ; PPC64BE-NEXT:    blr
-; PPC64BE-NEXT:  .LBB4_2: # Block address taken
+; PPC64BE-NEXT:  .LBB4_2: # Inline asm indirect target
 ; PPC64BE-NEXT:    # %return_early
 ; PPC64BE-NEXT:    # Label of block must be emitted
 ; PPC64BE-NEXT:    li r3, 0

--- a/llvm/test/CodeGen/RISCV/inline-asm-mem-constraint.ll
+++ b/llvm/test/CodeGen/RISCV/inline-asm-mem-constraint.ll
@@ -796,7 +796,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-NO-INTEGRATED-NEXT:    ret
-; RV32I-NO-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV32I-NO-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV32I-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -811,7 +811,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-NO-INTEGRATED-NEXT:    ret
-; RV64I-NO-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV64I-NO-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV64I-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -827,7 +827,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -843,7 +843,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -860,7 +860,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 1
@@ -877,7 +877,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV32I-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-INTEGRATED-NEXT:    ret
-; RV32I-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV32I-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV32I-INTEGRATED-NEXT:    # %fail
 ; RV32I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-INTEGRATED-NEXT:    li a0, 1
@@ -894,7 +894,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-INTEGRATED-NEXT:    ret
-; RV64I-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV64I-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV64I-INTEGRATED-NEXT:    # %fail
 ; RV64I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-INTEGRATED-NEXT:    li a0, 1
@@ -912,7 +912,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -930,7 +930,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -949,7 +949,7 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I-LARGE-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-INTEGRATED-NEXT:  .LBB14_2: # Block address taken
+; RV64I-LARGE-INTEGRATED-NEXT:  .LBB14_2: # Inline asm indirect target
 ; RV64I-LARGE-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 1
@@ -978,7 +978,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV32I-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-NO-INTEGRATED-NEXT:    ret
-; RV32I-NO-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV32I-NO-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV32I-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -997,7 +997,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-NO-INTEGRATED-NEXT:    ret
-; RV64I-NO-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV64I-NO-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV64I-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1017,7 +1017,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1037,7 +1037,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1058,7 +1058,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1079,7 +1079,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV32I-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-INTEGRATED-NEXT:    ret
-; RV32I-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV32I-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV32I-INTEGRATED-NEXT:    # %fail
 ; RV32I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-INTEGRATED-NEXT:    li a0, 1
@@ -1100,7 +1100,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-INTEGRATED-NEXT:    ret
-; RV64I-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV64I-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV64I-INTEGRATED-NEXT:    # %fail
 ; RV64I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-INTEGRATED-NEXT:    li a0, 1
@@ -1122,7 +1122,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -1144,7 +1144,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -1167,7 +1167,7 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I-LARGE-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-INTEGRATED-NEXT:  .LBB15_3: # Block address taken
+; RV64I-LARGE-INTEGRATED-NEXT:  .LBB15_3: # Inline asm indirect target
 ; RV64I-LARGE-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 1
@@ -1678,7 +1678,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-NO-INTEGRATED-NEXT:    ret
-; RV32I-NO-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV32I-NO-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV32I-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1693,7 +1693,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-NO-INTEGRATED-NEXT:    ret
-; RV64I-NO-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV64I-NO-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV64I-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1709,7 +1709,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1725,7 +1725,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1742,7 +1742,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1759,7 +1759,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV32I-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-INTEGRATED-NEXT:    ret
-; RV32I-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV32I-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV32I-INTEGRATED-NEXT:    # %fail
 ; RV32I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-INTEGRATED-NEXT:    li a0, 1
@@ -1776,7 +1776,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-INTEGRATED-NEXT:    ret
-; RV64I-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV64I-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV64I-INTEGRATED-NEXT:    # %fail
 ; RV64I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-INTEGRATED-NEXT:    li a0, 1
@@ -1794,7 +1794,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -1812,7 +1812,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -1831,7 +1831,7 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I-LARGE-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-INTEGRATED-NEXT:  .LBB26_2: # Block address taken
+; RV64I-LARGE-INTEGRATED-NEXT:  .LBB26_2: # Inline asm indirect target
 ; RV64I-LARGE-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 1
@@ -1860,7 +1860,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV32I-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-NO-INTEGRATED-NEXT:    ret
-; RV32I-NO-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV32I-NO-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV32I-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1879,7 +1879,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-NO-INTEGRATED-NEXT:    ret
-; RV64I-NO-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV64I-NO-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV64I-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1899,7 +1899,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1919,7 +1919,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1940,7 +1940,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 1
@@ -1961,7 +1961,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV32I-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-INTEGRATED-NEXT:    ret
-; RV32I-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV32I-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV32I-INTEGRATED-NEXT:    # %fail
 ; RV32I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-INTEGRATED-NEXT:    li a0, 1
@@ -1982,7 +1982,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-INTEGRATED-NEXT:    ret
-; RV64I-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV64I-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV64I-INTEGRATED-NEXT:    # %fail
 ; RV64I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-INTEGRATED-NEXT:    li a0, 1
@@ -2004,7 +2004,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -2026,7 +2026,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -2049,7 +2049,7 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I-LARGE-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-INTEGRATED-NEXT:  .LBB27_3: # Block address taken
+; RV64I-LARGE-INTEGRATED-NEXT:  .LBB27_3: # Inline asm indirect target
 ; RV64I-LARGE-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 1
@@ -2757,7 +2757,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-NO-INTEGRATED-NEXT:    ret
-; RV32I-NO-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV32I-NO-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV32I-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -2773,7 +2773,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-NO-INTEGRATED-NEXT:    ret
-; RV64I-NO-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV64I-NO-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV64I-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -2790,7 +2790,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -2807,7 +2807,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -2824,7 +2824,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 1
@@ -2842,7 +2842,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV32I-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-INTEGRATED-NEXT:    ret
-; RV32I-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV32I-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV32I-INTEGRATED-NEXT:    # %fail
 ; RV32I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-INTEGRATED-NEXT:    li a0, 1
@@ -2860,7 +2860,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV64I-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-INTEGRATED-NEXT:    ret
-; RV64I-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV64I-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV64I-INTEGRATED-NEXT:    # %fail
 ; RV64I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-INTEGRATED-NEXT:    li a0, 1
@@ -2879,7 +2879,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -2898,7 +2898,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -2917,7 +2917,7 @@ define i32 @constraint_A_with_callbr_multi_operands(i32 %a) {
 ; RV64I-LARGE-INTEGRATED-NEXT:  # %bb.1: # %normal
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-INTEGRATED-NEXT:  .LBB40_2: # Block address taken
+; RV64I-LARGE-INTEGRATED-NEXT:  .LBB40_2: # Inline asm indirect target
 ; RV64I-LARGE-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 1
@@ -2947,7 +2947,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV32I-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-NO-INTEGRATED-NEXT:    ret
-; RV32I-NO-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV32I-NO-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV32I-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -2967,7 +2967,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV64I-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-NO-INTEGRATED-NEXT:    ret
-; RV64I-NO-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV64I-NO-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV64I-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-NO-INTEGRATED-NEXT:    li a0, 1
@@ -2988,7 +2988,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -3009,7 +3009,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    li a0, 1
@@ -3030,7 +3030,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV64I-LARGE-NO-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-NO-INTEGRATED-NEXT:    li a0, 1
@@ -3052,7 +3052,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV32I-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-INTEGRATED-NEXT:    ret
-; RV32I-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV32I-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV32I-INTEGRATED-NEXT:    # %fail
 ; RV32I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-INTEGRATED-NEXT:    li a0, 1
@@ -3074,7 +3074,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV64I-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-INTEGRATED-NEXT:    ret
-; RV64I-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV64I-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV64I-INTEGRATED-NEXT:    # %fail
 ; RV64I-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-INTEGRATED-NEXT:    li a0, 1
@@ -3097,7 +3097,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV32I-MEDIUM-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -3120,7 +3120,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV64I-MEDIUM-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # %fail
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    li a0, 1
@@ -3143,7 +3143,7 @@ define i32 @constraint_A_with_multi_callbr_asm(i32 %a) {
 ; RV64I-LARGE-INTEGRATED-NEXT:  # %bb.2: # %normal1
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 0
 ; RV64I-LARGE-INTEGRATED-NEXT:    ret
-; RV64I-LARGE-INTEGRATED-NEXT:  .LBB41_3: # Block address taken
+; RV64I-LARGE-INTEGRATED-NEXT:  .LBB41_3: # Inline asm indirect target
 ; RV64I-LARGE-INTEGRATED-NEXT:    # %fail
 ; RV64I-LARGE-INTEGRATED-NEXT:    # Label of block must be emitted
 ; RV64I-LARGE-INTEGRATED-NEXT:    li a0, 1

--- a/llvm/test/CodeGen/X86/basic-block-sections-cloning-invalid.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-cloning-invalid.ll
@@ -83,5 +83,5 @@ cold:
 ;; Check the warnings
 ; WARN1: warning: block #2 is not a successor of block #0 in function foo
 ; WARN2: warning: no block with id 100 in function foo
-; WARN3: warning: block #6 has its machine block address taken in function foo
+; WARN3: warning: block #6 is a branch target of an 'asm goto' in function foo
 

--- a/llvm/test/CodeGen/X86/callbr-asm-blockplacement.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-blockplacement.ll
@@ -50,7 +50,7 @@ define i32 @foo(i32 %arg, ptr %arg3) nounwind {
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:  # %bb.4: # %bb17
 ; CHECK-NEXT:    callq widget@PLT
-; CHECK-NEXT:  .LBB0_5: # Block address taken
+; CHECK-NEXT:  .LBB0_5: # Inline asm indirect target
 ; CHECK-NEXT:    # %bb18
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movw $0, 14(%r14)

--- a/llvm/test/CodeGen/X86/callbr-asm-branch-folding.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-branch-folding.ll
@@ -53,7 +53,7 @@ define dso_local void @n(ptr %o, i32 %p, i32 %u) nounwind {
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    jmp .LBB0_9
-; CHECK-NEXT:  .LBB0_7: # Block address taken
+; CHECK-NEXT:  .LBB0_7: # Inline asm indirect target
 ; CHECK-NEXT:    # %if.then20.critedge
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl j(%rip), %edi

--- a/llvm/test/CodeGen/X86/callbr-asm-destinations.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-destinations.ll
@@ -10,7 +10,7 @@ define i32 @duplicate_normal_and_indirect_dest(i32 %a) {
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    jmp .LBB0_1
 ; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:  .LBB0_1: # Block address taken
+; CHECK-NEXT:  .LBB0_1: # Inline asm indirect target
 ; CHECK-NEXT:    # %fail
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $1, %eax
@@ -35,7 +35,7 @@ define i32 @duplicate_indirect_dest(i32 %a) {
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:  # %bb.1: # %normal
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB1_2: # Block address taken
+; CHECK-NEXT:  .LBB1_2: # Inline asm indirect target
 ; CHECK-NEXT:    # %fail
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $1, %eax

--- a/llvm/test/CodeGen/X86/callbr-asm-label-addr.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-label-addr.ll
@@ -8,7 +8,7 @@ define i32 @test1(i32 %x) {
 ; CHECK-NEXT:    .quad .Ltmp0
 ; CHECK-NEXT:    .quad .LBB0_1
 ; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:  .LBB0_1: # Block address taken
+; CHECK-NEXT:  .LBB0_1: # Inline asm indirect target
 ; CHECK-NEXT:    # %bar
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    pushq %rax

--- a/llvm/test/CodeGen/X86/callbr-asm-outputs-indirect-isel-m32.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-outputs-indirect-isel-m32.ll
@@ -22,7 +22,7 @@ define i8 @emulator_cmpxchg_emulated() {
   ; CHECK-NEXT:   $al = COPY [[SETCCr]]
   ; CHECK-NEXT:   RET 0, $al
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.efaultu64.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.efaultu64.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   [[SETCCr1:%[0-9]+]]:gr8 = SETCCr 4, implicit $eflags
   ; CHECK-NEXT:   $al = COPY [[SETCCr1]]
   ; CHECK-NEXT:   RET 0, $al
@@ -62,7 +62,7 @@ define i32 @emulator_cmpxchg_emulated2() {
   ; CHECK-NEXT:   $eax = COPY [[COPY2]]
   ; CHECK-NEXT:   RET 0, $eax
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.efaultu64.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.efaultu64.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   $eax = COPY %3
   ; CHECK-NEXT:   RET 0, $eax
 entry:
@@ -99,7 +99,7 @@ define i64 @multireg() {
   ; CHECK-NEXT:   $edx = COPY [[COPY2]]
   ; CHECK-NEXT:   RET 0, $eax, $edx
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   liveins: $eax, $edx
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:gr32 = COPY $eax

--- a/llvm/test/CodeGen/X86/callbr-asm-outputs-indirect-isel.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-outputs-indirect-isel.ll
@@ -19,7 +19,7 @@ define i32 @test0() {
   ; CHECK-NEXT:   $eax = COPY [[MOV32ri]]
   ; CHECK-NEXT:   RET 0, $eax
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.z.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.z.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   $eax = COPY %1
   ; CHECK-NEXT:   RET 0, $eax
   %direct = callbr i32 asm "", "=r,!i"()
@@ -43,7 +43,7 @@ define i32 @test1() {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gr32 = COPY %4
   ; CHECK-NEXT:   JMP_1 %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.z.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.z.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gr32 = COPY %4
@@ -77,7 +77,7 @@ define i32 @test2() {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gr32 = COPY %5
   ; CHECK-NEXT:   JMP_1 %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.z.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.z.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gr32 = COPY %5
@@ -112,7 +112,7 @@ define i32 @test3() {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gr32 = COPY [[COPY]]
   ; CHECK-NEXT:   JMP_1 %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.z.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.z.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT:   liveins: $ebx
   ; CHECK-NEXT: {{  $}}
@@ -150,7 +150,7 @@ define i32 @test4() {
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:gr32 = COPY [[COPY]]
   ; CHECK-NEXT:   JMP_1 %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.z.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.z.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT:   liveins: $ebx, $edx
   ; CHECK-NEXT: {{  $}}
@@ -187,7 +187,7 @@ define i32 @test5() {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gr32 = COPY [[COPY]]
   ; CHECK-NEXT:   JMP_1 %bb.1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.cleanup (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.cleanup (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   liveins: $ebx
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gr32 = COPY $ebx
@@ -227,7 +227,7 @@ define i64 @test6() {
   ; CHECK-NEXT:   $rax = COPY [[PHI]]
   ; CHECK-NEXT:   RET 0, $rax
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.3.foo.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.3.foo.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT:   liveins: $rdx
   ; CHECK-NEXT: {{  $}}
@@ -235,7 +235,7 @@ define i64 @test6() {
   ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:gr64 = COPY [[COPY4]]
   ; CHECK-NEXT:   JMP_1 %bb.2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.4.foo.split2 (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.4.foo.split2 (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT:   liveins: $rbx
   ; CHECK-NEXT: {{  $}}
@@ -286,7 +286,7 @@ define i32 @test7() {
   ; CHECK-NEXT:   $eax = COPY [[COPY2]]
   ; CHECK-NEXT:   RET 0, $eax
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.3.retry.split (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.3.retry.split (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT:   liveins: $edx
   ; CHECK-NEXT: {{  $}}
@@ -321,7 +321,7 @@ define i32 @test8() {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gr32 = COPY %1
   ; CHECK-NEXT:   JMP_1 %bb.1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1.cleanup (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.1.cleanup (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   $eax = COPY %1
   ; CHECK-NEXT:   RET 0, $eax
 entry:
@@ -348,7 +348,7 @@ define i64 @condition_code() {
   ; CHECK-NEXT:   $rax = COPY [[SUBREG_TO_REG]]
   ; CHECK-NEXT:   RET 0, $rax
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.c (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.2.c (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   [[SETCCr1:%[0-9]+]]:gr8 = SETCCr 4, implicit $eflags
   ; CHECK-NEXT:   [[MOVZX32rr8_1:%[0-9]+]]:gr32 = MOVZX32rr8 killed [[SETCCr1]]
   ; CHECK-NEXT:   [[SUBREG_TO_REG1:%[0-9]+]]:gr64 = SUBREG_TO_REG 0, killed [[MOVZX32rr8_1]], %subreg.sub_32bit

--- a/llvm/test/CodeGen/X86/callbr-asm-outputs-pred-succ.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-outputs-pred-succ.ll
@@ -17,12 +17,12 @@
 
 ; Check the second INLINEASM_BR target block is preceded by the block with the
 ; second INLINEASM_BR.
-; CHECK: bb.2 (%ir-block.7, machine-block-address-taken, inlineasm-br-indirect-target):
+; CHECK: bb.2 (%ir-block.7, inlineasm-br-indirect-target):
 ; CHECK-NEXT: predecessors: %bb.1
 
 ; Check the first INLINEASM_BR target block is predecessed by the block with
 ; the first INLINEASM_BR.
-; CHECK: bb.4 (%ir-block.12, machine-block-address-taken, inlineasm-br-indirect-target):
+; CHECK: bb.4 (%ir-block.12, inlineasm-br-indirect-target):
 ; CHECK-NEXT: predecessors: %bb.0
 
 @.str = private unnamed_addr constant [26 x i8] c"inline asm#1 returned %d\0A\00", align 1

--- a/llvm/test/CodeGen/X86/callbr-asm-outputs.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-outputs.ll
@@ -14,7 +14,7 @@ define i32 @test1(i32 %x) {
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:  # %bb.1: # %normal
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB0_2: # Block address taken
+; CHECK-NEXT:  .LBB0_2: # Inline asm indirect target
 ; CHECK-NEXT:    # %abnormal
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $1, %eax
@@ -47,7 +47,7 @@ define i32 @test2(i32 %out1, i32 %out2) nounwind {
 ; CHECK-NEXT:    jne .LBB1_2
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    jmp .LBB1_4
-; CHECK-NEXT:  .LBB1_2: # Block address taken
+; CHECK-NEXT:  .LBB1_2: # Inline asm indirect target
 ; CHECK-NEXT:    # %if.then.label_true_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    jmp .LBB1_9
@@ -64,15 +64,15 @@ define i32 @test2(i32 %out1, i32 %out2) nounwind {
 ; CHECK-NEXT:    popl %esi
 ; CHECK-NEXT:    popl %edi
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB1_6: # Block address taken
+; CHECK-NEXT:  .LBB1_6: # Inline asm indirect target
 ; CHECK-NEXT:    # %if.then.return_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
-; CHECK-NEXT:  .LBB1_7: # Block address taken
+; CHECK-NEXT:  .LBB1_7: # Inline asm indirect target
 ; CHECK-NEXT:    # %if.else.return_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $-1, %eax
 ; CHECK-NEXT:    jmp .LBB1_5
-; CHECK-NEXT:  .LBB1_8: # Block address taken
+; CHECK-NEXT:  .LBB1_8: # Inline asm indirect target
 ; CHECK-NEXT:    # %if.else.label_true_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:  .LBB1_9: # %label_true
@@ -130,10 +130,10 @@ define i32 @test3(i1 %cmp) nounwind {
 ; CHECK-NEXT:    popl %esi
 ; CHECK-NEXT:    popl %edi
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB2_5: # Block address taken
+; CHECK-NEXT:  .LBB2_5: # Inline asm indirect target
 ; CHECK-NEXT:    # %true.indirect_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
-; CHECK-NEXT:  .LBB2_6: # Block address taken
+; CHECK-NEXT:  .LBB2_6: # Inline asm indirect target
 ; CHECK-NEXT:    # %false.indirect_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $42, %eax
@@ -175,18 +175,18 @@ define i32 @test4(i32 %out1, i32 %out2) {
 ; CHECK-NEXT:  # %bb.2: # %asm.fallthrough2
 ; CHECK-NEXT:    addl %ecx, %eax
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB3_3: # Block address taken
+; CHECK-NEXT:  .LBB3_3: # Inline asm indirect target
 ; CHECK-NEXT:    # %entry.return_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
-; CHECK-NEXT:  .LBB3_4: # Block address taken
+; CHECK-NEXT:  .LBB3_4: # Inline asm indirect target
 ; CHECK-NEXT:    # %asm.fallthrough.return_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $-1, %eax
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB3_5: # Block address taken
+; CHECK-NEXT:  .LBB3_5: # Inline asm indirect target
 ; CHECK-NEXT:    # %entry.label_true_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
-; CHECK-NEXT:  .LBB3_6: # Block address taken
+; CHECK-NEXT:  .LBB3_6: # Inline asm indirect target
 ; CHECK-NEXT:    # %asm.fallthrough.label_true_crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $-2, %eax
@@ -226,7 +226,7 @@ define dso_local void @test5() {
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB4_2: # Block address taken
+; CHECK-NEXT:  .LBB4_2: # Inline asm indirect target
 ; CHECK-NEXT:    # %._crit_edge
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    retl

--- a/llvm/test/CodeGen/X86/callbr-asm-phi-placement.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-phi-placement.ll
@@ -16,7 +16,7 @@ define void @test1(ptr %arg, ptr %mem) nounwind {
 ; CHECK-NEXT:    pushq %rbx
 ; CHECK-NEXT:    pushq %rax
 ; CHECK-NEXT:    movq %rsi, %rbx
-; CHECK-NEXT:  .LBB0_1: # Block address taken
+; CHECK-NEXT:  .LBB0_1: # Inline asm indirect target
 ; CHECK-NEXT:    # %loop
 ; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    # Label of block must be emitted

--- a/llvm/test/CodeGen/X86/callbr-asm-sink.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm-sink.ll
@@ -16,7 +16,7 @@ define void @klist_dec_and_del(ptr) {
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    retq
-; CHECK-NEXT:  .LBB0_1: # Block address taken
+; CHECK-NEXT:  .LBB0_1: # Inline asm indirect target
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movq $0, -8(%rax)
 ; CHECK-NEXT:    retq

--- a/llvm/test/CodeGen/X86/callbr-asm.ll
+++ b/llvm/test/CodeGen/X86/callbr-asm.ll
@@ -17,7 +17,7 @@ define i32 @test1(i32 %a) {
 ; CHECK-NEXT:  # %bb.1: # %normal
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB0_2: # Block address taken
+; CHECK-NEXT:  .LBB0_2: # Inline asm indirect target
 ; CHECK-NEXT:    # %fail
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $1, %eax
@@ -48,7 +48,7 @@ define i32 @test1b(i32 %a) {
 ; CHECK-NEXT:  # %bb.1: # %normal
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    retl
-; CHECK-NEXT:  .LBB1_2: # Block address taken
+; CHECK-NEXT:  .LBB1_2: # Inline asm indirect target
 ; CHECK-NEXT:    # %fail
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    movl $1, %eax
@@ -91,14 +91,14 @@ fail:
 define i32 @test3(i32 %a) {
 ; CHECK-LABEL: test3:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:  .LBB3_1: # Block address taken
+; CHECK-NEXT:  .LBB3_1: # Inline asm indirect target
 ; CHECK-NEXT:    # %label01
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
 ; CHECK-NEXT:    # Child Loop BB3_2 Depth 2
 ; CHECK-NEXT:    # Child Loop BB3_3 Depth 3
 ; CHECK-NEXT:    # Child Loop BB3_4 Depth 4
 ; CHECK-NEXT:    # Label of block must be emitted
-; CHECK-NEXT:  .LBB3_2: # Block address taken
+; CHECK-NEXT:  .LBB3_2: # Inline asm indirect target
 ; CHECK-NEXT:    # %label02
 ; CHECK-NEXT:    # Parent Loop BB3_1 Depth=1
 ; CHECK-NEXT:    # => This Loop Header: Depth=2
@@ -106,14 +106,14 @@ define i32 @test3(i32 %a) {
 ; CHECK-NEXT:    # Child Loop BB3_4 Depth 4
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    addl $4, {{[0-9]+}}(%esp)
-; CHECK-NEXT:  .LBB3_3: # Block address taken
+; CHECK-NEXT:  .LBB3_3: # Inline asm indirect target
 ; CHECK-NEXT:    # %label03
 ; CHECK-NEXT:    # Parent Loop BB3_1 Depth=1
 ; CHECK-NEXT:    # Parent Loop BB3_2 Depth=2
 ; CHECK-NEXT:    # => This Loop Header: Depth=3
 ; CHECK-NEXT:    # Child Loop BB3_4 Depth 4
 ; CHECK-NEXT:    # Label of block must be emitted
-; CHECK-NEXT:  .LBB3_4: # Block address taken
+; CHECK-NEXT:  .LBB3_4: # Inline asm indirect target
 ; CHECK-NEXT:    # %label04
 ; CHECK-NEXT:    # Parent Loop BB3_1 Depth=1
 ; CHECK-NEXT:    # Parent Loop BB3_2 Depth=2
@@ -177,7 +177,7 @@ define void @test4() {
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    ja .LBB4_3
 ; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:  .LBB4_3: # Block address taken
+; CHECK-NEXT:  .LBB4_3: # Inline asm indirect target
 ; CHECK-NEXT:    # %quux
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    retl

--- a/llvm/test/CodeGen/X86/shrinkwrap-callbr.ll
+++ b/llvm/test/CodeGen/X86/shrinkwrap-callbr.ll
@@ -33,7 +33,7 @@ define i32 @test1(i32 %v) {
 ; CHECK-NEXT:    popq %rcx
 ; CHECK-NEXT:    .cfi_def_cfa_offset 8
 ; CHECK-NEXT:    retq
-; CHECK-NEXT:  .LBB0_4: # Block address taken
+; CHECK-NEXT:  .LBB0_4: # Inline asm indirect target
 ; CHECK-NEXT:    # %two
 ; CHECK-NEXT:    # Label of block must be emitted
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16

--- a/llvm/test/CodeGen/X86/tail-dup-asm-goto.ll
+++ b/llvm/test/CodeGen/X86/tail-dup-asm-goto.ll
@@ -39,7 +39,7 @@ define ptr @test1(ptr %arg1, ptr %arg2) {
   ; CHECK-NEXT:   INLINEASM_BR &"#$0 $1 $2", 9 /* sideeffect mayload attdialect */, 13 /* imm */, 42, 13 /* imm */, 0, 13 /* imm */, %bb.4, 12 /* clobber */, implicit-def early-clobber $df, 12 /* clobber */, implicit-def early-clobber $fpsw, 12 /* clobber */, implicit-def early-clobber $eflags
   ; CHECK-NEXT:   JMP_1 %bb.5
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.4.bb17.i.i.i (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.4.bb17.i.i.i (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.5(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.5.kmem_cache_has_cpu_partial.exit:
@@ -118,7 +118,7 @@ define void @ceph_con_v2_try_read(i32 %__trans_tmp_3.sroa.0.0.copyload, i1 %tobo
   ; CHECK-NEXT:   LIFETIME_END %stack.0.skip.i.i
   ; CHECK-NEXT:   JMP_1 %bb.1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.5.if.end.i (machine-block-address-taken, inlineasm-br-indirect-target):
+  ; CHECK-NEXT: bb.5.if.end.i (inlineasm-br-indirect-target):
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   LIFETIME_END %stack.0.skip.i.i


### PR DESCRIPTION
In 'asm goto' statements ('callbr' in LLVM IR), you can specify one or more labels / basic blocks in the containing function which the assembly code might jump to. If you're also compiling with branch target enforcement via BTI, then previously listing a basic block as a possible jump destination of an asm goto would cause a BTI instruction to be placed at the start of the block, in case the assembly code used an _indirect_ branch instruction (i.e. to a destination address read from a register) to jump to that location. Now it doesn't do that any more: branches to destination labels from the assembly code are assumed to be direct branches (to a relative offset encoded in the instruction), which don't require a BTI at their destination.

This change was proposed in https://discourse.llvm.org/t/85845 and there seemed to be no disagreement. The rationale is:

1. it brings clang's handling of asm goto in Arm and AArch64 in line with gcc's, which didn't generate BTIs at the target labels in the first place.

2. it improves performance in the Linux kernel, which uses a lot of 'asm goto' in which the assembly language just contains a NOP, and the label's address is saved elsewhere to let the kernel self-modify at run time to swap between the original NOP and a direct branch to the label. This allows hot code paths to be instrumented for debugging, at only the cost of a NOP when the instrumentation is turned off, instead of the larger cost of an indirect branch. In this situation a BTI is unnecessary (if the branch happens it's direct), and since the code paths are hot, also a noticeable performance hit.

Implementation:

`SelectionDAGBuilder::visitCallBr` is the place where 'asm goto' target labels are handled. It calls `setIsInlineAsmBrIndirectTarget()` on each target `MachineBasicBlock`. Previously it also called `setMachineBlockAddressTaken()`, which made `hasAddressTaken()` return true, which caused a BTI to be added in the Arm backends.

Now `visitCallBr` doesn't call `setMachineBlockAddressTaken()` any more on asm goto targets, but `hasAddressTaken()` also checks the flag set by `setIsInlineAsmBrIndirectTarget()`. So call sites that were using `hasAddressTaken()` don't need to be modified. But the Arm backends don't call `hasAddressTaken()` any more: instead they test two more specific query functions that cover all the reasons `hasAddressTaken()` might have returned true _except_ being an asm goto target.

Testing:

The new test `AArch64/callbr-asm-label-bti.ll` is testing the actual change, where it expects not to see a `bti` instruction after `[[LABEL]]`. The rest of the test changes are all churn, due to the flags on basic blocks changing. Actual output code hasn't changed in any of the existing tests, only comments and diagnostics.

Further work:

`RISCVIndirectBranchTracking.cpp` and `X86IndirectBranchTracking.cpp` also call `hasAddressTaken()` in a way that might benefit from using the same more specific check I've put in `ARMBranchTargets.cpp` and `AArch64BranchTargets.cpp`. But I'm not sure of that, so in this commit I've only changed the Arm backends, and left those alone.