### PR TITLE
[RISCV] Add shlcofideleg extension

### DIFF
--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -119,6 +119,7 @@
 // CHECK-NEXT:     sha                  1.0       'Sha' (Augmented Hypervisor)
 // CHECK-NEXT:     shcounterenw         1.0       'Shcounterenw' (Support writeable hcounteren enable bit for any hpmcounter that is not read-only zero)
 // CHECK-NEXT:     shgatpa              1.0       'Shgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare)
+// CHECK-NEXT:     shlcofideleg         1.0       'Shlcofideleg' (Delegating LCOFI interrupts to VS-mode)
 // CHECK-NEXT:     shtvala              1.0       'Shtvala' (htval provides all needed values)
 // CHECK-NEXT:     shvsatpa             1.0       'Shvsatpa' (vsatp supports all modes supported by satp)
 // CHECK-NEXT:     shvstvala            1.0       'Shvstvala' (vstval provides all needed values)

--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -119,7 +119,7 @@
 // CHECK-NEXT:     sha                  1.0       'Sha' (Augmented Hypervisor)
 // CHECK-NEXT:     shcounterenw         1.0       'Shcounterenw' (Support writeable hcounteren enable bit for any hpmcounter that is not read-only zero)
 // CHECK-NEXT:     shgatpa              1.0       'Shgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare)
-// CHECK-NEXT:     shlcofideleg         1.0       'Shlcofideleg' (Delegating LCOFI interrupts to VS-mode)
+// CHECK-NEXT:     shlcofideleg         1.0       'Shlcofideleg' (Delegating LCOFI Interrupts to VS-mode)
 // CHECK-NEXT:     shtvala              1.0       'Shtvala' (htval provides all needed values)
 // CHECK-NEXT:     shvsatpa             1.0       'Shvsatpa' (vsatp supports all modes supported by satp)
 // CHECK-NEXT:     shvstvala            1.0       'Shvstvala' (vstval provides all needed values)

--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -24,6 +24,7 @@
 // CHECK-NOT: __riscv_sha {{.*$}}
 // CHECK-NOT: __riscv_shcounterenw {{.*$}}
 // CHECK-NOT: __riscv_shgatpa {{.*$}}
+// CHECK-NOT: __riscv_shlcofideleg {{.*$}}
 // CHECK-NOT: __riscv_shtvala {{.*$}}
 // CHECK-NOT: __riscv_shvsatpa {{.*$}}
 // CHECK-NOT: __riscv_shvstvala {{.*$}}
@@ -369,6 +370,14 @@
 // RUN:   -march=rv64ishgatpa -E -dM %s \
 // RUN:   -o - | FileCheck --check-prefix=CHECK-SHGATPA-EXT %s
 // CHECK-SHGATPA-EXT: __riscv_shgatpa 1000000{{$}}
+
+// RUN: %clang --target=riscv32-unknown-linux-gnu \
+// RUN:   -march=rv32ishlcofideleg -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-SHLCOFIDELEG-EXT %s
+// RUN: %clang --target=riscv64-unknown-linux-gnu \
+// RUN:   -march=rv64ishlcofideleg -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-SHLCOFIDELEG-EXT %s
+// CHECK-SHLCOFIDELEG-EXT: __riscv_shlcofideleg 1000000{{$}}
 
 // RUN: %clang --target=riscv32-unknown-linux-gnu \
 // RUN:   -march=rv32ishtvala -E -dM %s \

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -123,6 +123,7 @@ on support follow.
      ``Sha``           Supported
      ``Shcounterenw``  Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
      ``Shgatpa``       Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
+     ``Shlcofideleg``  Supported
      ``Shtvala``       Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
      ``Shvsatpa``      Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
      ``Shvstvala``     Assembly Support (`See note <#riscv-profiles-extensions-note>`__)

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -201,6 +201,7 @@ Changes to the RISC-V Backend
 * Adds experimental assembler support for the SiFive Xsfmm* Attached Matrix
   Extensions.
 * `-mcpu=andes-a25` and `-mcpu=andes-ax25` were added.
+* The `Shlcofideleg` extension was added.
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -906,6 +906,10 @@ def FeatureStdExtShvsatpa
     : RISCVExtension<1, 0,
                      "vsatp supports all modes supported by satp">;
 
+def FeatureStdExtShlcofideleg
+    : RISCVExtension<1, 0,
+                     "Delegating LCOFI Interrupts to VS-mode">;
+
 def FeatureStdExtSmaia
     : RISCVExtension<1, 0,
                      "Advanced Interrupt Architecture Machine Level">;

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -47,6 +47,7 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+shcounterenw %s -o - | FileCheck --check-prefixes=CHECK,RV32SHCOUNTERENW %s
 ; RUN: llc -mtriple=riscv32 -mattr=+shgatpa %s -o - | FileCheck --check-prefixes=CHECK,RV32SHGATPA %s
 ; RUN: llc -mtriple=riscv32 -mattr=+shvsatpa %s -o - | FileCheck --check-prefixes=CHECK,RV32SHVSATPA %s
+; RUN: llc -mtriple=riscv32 -mattr=+shlcofideleg %s -o - | FileCheck --check-prefixes=CHECK,RV32SHLCOFIDELEG %s
 ; RUN: llc -mtriple=riscv32 -mattr=+ssccfg %s -o - | FileCheck --check-prefixes=CHECK,RV32SSCCFG %s
 ; RUN: llc -mtriple=riscv32 -mattr=+ssccptr %s -o - | FileCheck --check-prefixes=CHECK,RV32SSCCPTR %s
 ; RUN: llc -mtriple=riscv32 -mattr=+sscofpmf %s -o - | FileCheck --check-prefixes=CHECK,RV32SSCOFPMF %s
@@ -222,6 +223,7 @@
 ; RUN: llc -mtriple=riscv64 -mattr=+shcounterenw %s -o - | FileCheck --check-prefixes=CHECK,RV64SHCOUNTERENW %s
 ; RUN: llc -mtriple=riscv64 -mattr=+shgatpa %s -o - | FileCheck --check-prefixes=CHECK,RV64SHGATPA %s
 ; RUN: llc -mtriple=riscv64 -mattr=+shvsatpa %s -o - | FileCheck --check-prefixes=CHECK,RV64SHVSATPA %s
+; RUN: llc -mtriple=riscv64 -mattr=+shlcofideleg %s -o - | FileCheck --check-prefixes=CHECK,RV64SHLCOFIDELEG %s
 ; RUN: llc -mtriple=riscv64 -mattr=+ssccfg %s -o - | FileCheck --check-prefixes=CHECK,RV64SSCCFG %s
 ; RUN: llc -mtriple=riscv64 -mattr=+ssccptr %s -o - | FileCheck --check-prefixes=CHECK,RV64SSCCPTR %s
 ; RUN: llc -mtriple=riscv64 -mattr=+sscofpmf %s -o - | FileCheck --check-prefixes=CHECK,RV64SSCOFPMF %s
@@ -396,6 +398,7 @@
 ; RV32SHCOUNTERENW: .attribute 5, "rv32i2p1_shcounterenw1p0"
 ; RV32SHGATPA: .attribute 5, "rv32i2p1_shgatpa1p0"
 ; RV32SHVSATPA: .attribute 5, "rv32i2p1_shvsatpa1p0"
+; RV32SHLCOFIDELEG: .attribute 5, "rv32i2p1_shlcofideleg1p0"
 ; RV32SSCCFG: .attribute 5, "rv32i2p1_ssccfg1p0"
 ; RV32SSCCPTR: .attribute 5, "rv32i2p1_ssccptr1p0"
 ; RV32SSCOFPMF: .attribute 5, "rv32i2p1_sscofpmf1p0"
@@ -572,6 +575,7 @@
 ; RV64SHCOUNTERENW: .attribute 5, "rv64i2p1_shcounterenw1p0"
 ; RV64SHGATPA: .attribute 5, "rv64i2p1_shgatpa1p0"
 ; RV64SHVSATPA: .attribute 5, "rv64i2p1_shvsatpa1p0"
+; RV64SHLCOFIDELEG: .attribute 5, "rv64i2p1_shlcofideleg1p0"
 ; RV64SSCCFG: .attribute 5, "rv64i2p1_ssccfg1p0"
 ; RV64SSCCPTR: .attribute 5, "rv64i2p1_ssccptr1p0"
 ; RV64SSCOFPMF: .attribute 5, "rv64i2p1_sscofpmf1p0"

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -124,6 +124,7 @@
 ; CHECK-NEXT:   shcounterenw                     - 'Shcounterenw' (Support writeable hcounteren enable bit for any hpmcounter that is not read-only zero).
 ; CHECK-NEXT:   shgatpa                          - 'Shgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare).
 ; CHECK-NEXT:   shifted-zextw-fusion             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
+; CHECK-NEXT:   shlcofideleg                     - 'Shlcofideleg' (Delegating LCOFI Interrupts to VS-mode).
 ; CHECK-NEXT:   short-forward-branch-opt         - Enable short forward branch optimization.
 ; CHECK-NEXT:   shtvala                          - 'Shtvala' (htval provides all needed values).
 ; CHECK-NEXT:   shvsatpa                         - 'Shvsatpa' (vsatp supports all modes supported by satp).

--- a/llvm/test/MC/RISCV/attribute-arch.s
+++ b/llvm/test/MC/RISCV/attribute-arch.s
@@ -309,6 +309,9 @@
 .attribute arch, "rv32i_shvsatpa1p0"
 # CHECK: attribute      5, "rv32i2p1_shvsatpa1p0"
 
+.attribute arch, "rv32i_shlcofideleg1p0"
+# CHECK: attribute      5, "rv32i2p1_shlcofideleg1p0"
+
 .attribute arch, "rv32i_shtvala1p0"
 # CHECK: attribute      5, "rv32i2p1_shtvala1p0"
 

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1090,6 +1090,7 @@ R"(All available -march extensions for RISC-V
     sha                  1.0
     shcounterenw         1.0
     shgatpa              1.0
+    shlcofideleg         1.0
     shtvala              1.0
     shvsatpa             1.0
     shvstvala            1.0


### PR DESCRIPTION
This is for `shlcofideleg` extension, that supports delegating LCOFI interrupts to VS-mode.

Spec: https://github.com/riscv/riscv-isa-manual/blob/main/src/hypervisor.adoc