### PR TITLE
[clang-format] Stop moving lambda to new line only to indent it more.

### DIFF
--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -23813,6 +23813,17 @@ TEST_F(FormatTest, FormatsLambdas) {
                "          }};\n"
                "}",
                LLVMWithBeforeLambdaBody);
+  verifyFormat("if ([]()\n"
+               "    {\n"
+               "      return true;\n"
+               "    }()) {\n"
+               "}",
+               LLVMWithBeforeLambdaBody);
+  verifyFormat("fun([]()\n"
+               "    {\n"
+               "      return 17;\n"
+               "    });",
+               LLVMWithBeforeLambdaBody);
 
   LLVMWithBeforeLambdaBody.AllowShortLambdasOnASingleLine =
       FormatStyle::ShortLambdaStyle::SLS_Empty;


### PR DESCRIPTION
Hanging indents are minimised for lambdas by pushing them onto a new line. However, it could still do this even if it would cause even more hanging indents than it otherwise would.

The handling has been expanded to check for this case and avoid moving the lambda to a new line.

Fix #141575 