### PR TITLE
[HIP] disable sanitizer for `__hip_cuid`

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -971,6 +971,7 @@ void CodeGenModule::Release() {
         getModule(), Int8Ty, false, llvm::GlobalValue::ExternalLinkage,
         llvm::Constant::getNullValue(Int8Ty),
         "__hip_cuid_" + getContext().getCUIDHash());
+    getSanitizerMetadata()->disableSanitizerForGlobal(GV);
     addCompilerUsedGlobal(GV);
   }
   emitLLVMUsed();

--- a/clang/test/CodeGenCUDA/nosanitize-cuid.hip
+++ b/clang/test/CodeGenCUDA/nosanitize-cuid.hip
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -fsanitize=address -fcuda-is-device \
+// RUN:    -emit-llvm -cuid=abcd -o - %s | FileCheck  %s
+
+#include "Inputs/cuda.h"
+
+// CHECK: @__hip_cuid_{{.*}} = {{.*}} no_sanitize_address


### PR DESCRIPTION
Global variable `__hip_cuid_*` is for identifying purpose and does not need sanitization, therefore disable it for sanitizers.