### PR TITLE
[AArch64][AsmParser] Support SVE conditions even without +sve.

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -3499,43 +3499,40 @@ AArch64AsmParser::tryParseImmWithOptionalShift(OperandVector &Operands) {
 AArch64CC::CondCode
 AArch64AsmParser::parseCondCodeString(StringRef Cond, std::string &Suggestion) {
   AArch64CC::CondCode CC = StringSwitch<AArch64CC::CondCode>(Cond.lower())
-                    .Case("eq", AArch64CC::EQ)
-                    .Case("ne", AArch64CC::NE)
-                    .Case("cs", AArch64CC::HS)
-                    .Case("hs", AArch64CC::HS)
-                    .Case("cc", AArch64CC::LO)
-                    .Case("lo", AArch64CC::LO)
-                    .Case("mi", AArch64CC::MI)
-                    .Case("pl", AArch64CC::PL)
-                    .Case("vs", AArch64CC::VS)
-                    .Case("vc", AArch64CC::VC)
-                    .Case("hi", AArch64CC::HI)
-                    .Case("ls", AArch64CC::LS)
-                    .Case("ge", AArch64CC::GE)
-                    .Case("lt", AArch64CC::LT)
-                    .Case("gt", AArch64CC::GT)
-                    .Case("le", AArch64CC::LE)
-                    .Case("al", AArch64CC::AL)
-                    .Case("nv", AArch64CC::NV)
-                    .Default(AArch64CC::Invalid);
+                               .Case("eq", AArch64CC::EQ)
+                               .Case("ne", AArch64CC::NE)
+                               .Case("cs", AArch64CC::HS)
+                               .Case("hs", AArch64CC::HS)
+                               .Case("cc", AArch64CC::LO)
+                               .Case("lo", AArch64CC::LO)
+                               .Case("mi", AArch64CC::MI)
+                               .Case("pl", AArch64CC::PL)
+                               .Case("vs", AArch64CC::VS)
+                               .Case("vc", AArch64CC::VC)
+                               .Case("hi", AArch64CC::HI)
+                               .Case("ls", AArch64CC::LS)
+                               .Case("ge", AArch64CC::GE)
+                               .Case("lt", AArch64CC::LT)
+                               .Case("gt", AArch64CC::GT)
+                               .Case("le", AArch64CC::LE)
+                               .Case("al", AArch64CC::AL)
+                               .Case("nv", AArch64CC::NV)
+                               // SVE condition code aliases:
+                               .Case("none", AArch64CC::EQ)
+                               .Case("any", AArch64CC::NE)
+                               .Case("nlast", AArch64CC::HS)
+                               .Case("last", AArch64CC::LO)
+                               .Case("first", AArch64CC::MI)
+                               .Case("nfrst", AArch64CC::PL)
+                               .Case("pmore", AArch64CC::HI)
+                               .Case("plast", AArch64CC::LS)
+                               .Case("tcont", AArch64CC::GE)
+                               .Case("tstop", AArch64CC::LT)
+                               .Default(AArch64CC::Invalid);
 
-  if (CC == AArch64CC::Invalid && getSTI().hasFeature(AArch64::FeatureSVE)) {
-    CC = StringSwitch<AArch64CC::CondCode>(Cond.lower())
-                    .Case("none",  AArch64CC::EQ)
-                    .Case("any",   AArch64CC::NE)
-                    .Case("nlast", AArch64CC::HS)
-                    .Case("last",  AArch64CC::LO)
-                    .Case("first", AArch64CC::MI)
-                    .Case("nfrst", AArch64CC::PL)
-                    .Case("pmore", AArch64CC::HI)
-                    .Case("plast", AArch64CC::LS)
-                    .Case("tcont", AArch64CC::GE)
-                    .Case("tstop", AArch64CC::LT)
-                    .Default(AArch64CC::Invalid);
+  if (CC == AArch64CC::Invalid && Cond.lower() == "nfirst")
+    Suggestion = "nfrst";
 
-    if (CC == AArch64CC::Invalid && Cond.lower() == "nfirst")
-      Suggestion = "nfrst";
-  }
   return CC;
 }
 

--- a/llvm/test/MC/AArch64/SVE/condition-codes.s
+++ b/llvm/test/MC/AArch64/SVE/condition-codes.s
@@ -1,66 +1,46 @@
-// RUN: llvm-mc -triple aarch64 -show-encoding -mattr=+sve < %s | FileCheck %s
-// RUN: not llvm-mc -triple aarch64 -show-encoding -mattr=-sve < %s 2>&1 | FileCheck %s --check-prefix=CHECK-DIAG
+// RUN: llvm-mc -triple aarch64 -show-encoding < %s | FileCheck %s
 
 //------------------------------------------------------------------------------
-// Condition code aliases for SVE
+// Condition code aliases for SVE.
+// They don't actually require +sve since they're just aliases.
 //------------------------------------------------------------------------------
 
         b.none lbl
 // CHECK: b.eq lbl     // encoding: [0bAAA00000,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.none lbl
 
         b.any lbl
 // CHECK: b.ne lbl     // encoding: [0bAAA00001,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.any lbl
 
         b.nlast lbl
 // CHECK: b.hs lbl     // encoding: [0bAAA00010,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.nlast lbl
 
         b.last lbl
 // CHECK: b.lo lbl     // encoding: [0bAAA00011,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.last lbl
 
         b.first lbl
 // CHECK: b.mi lbl     // encoding: [0bAAA00100,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.first lbl
 
         b.nfrst lbl
 // CHECK: b.pl lbl     // encoding: [0bAAA00101,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.nfrst lbl
 
         b.pmore lbl
 // CHECK: b.hi lbl     // encoding: [0bAAA01000,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.pmore lbl
 
         b.plast lbl
 // CHECK: b.ls lbl     // encoding: [0bAAA01001,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.plast lbl
 
         b.tcont lbl
 // CHECK: b.ge lbl     // encoding: [0bAAA01010,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.tcont lbl
 
         b.tstop lbl
 // CHECK: b.lt lbl     // encoding: [0bAAA01011,A,A,0x54]
 // CHECK-NEXT:         //   fixup A - offset: 0, value: lbl, kind: fixup_aarch64_pcrel_branch19
-// CHECK-DIAG:  invalid condition code
-// CHECK-DIAG-NEXT:  b.tstop lbl


### PR DESCRIPTION
They're just aliases.