### PR TITLE
[LLD][COFF] Add support for DLL imports on ARM64EC

### DIFF
--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -1490,6 +1490,17 @@ void DLLFile::parse() {
     symtab.addLazyDLLSymbol(this, s, impName);
     if (code)
       symtab.addLazyDLLSymbol(this, s, symbolName);
+    if (symtab.isEC()) {
+      StringRef impAuxName = saver().save("__imp_aux_" + symbolName);
+      symtab.addLazyDLLSymbol(this, s, impAuxName);
+
+      if (code) {
+        std::optional<std::string> mangledName =
+            getArm64ECMangledFunctionName(symbolName);
+        if (mangledName)
+          symtab.addLazyDLLSymbol(this, s, *mangledName);
+      }
+    }
   }
 }
 

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -771,7 +771,7 @@ void SymbolTable::addLazyDLLSymbol(DLLFile *f, DLLFile::Symbol *sym,
     return;
   }
   auto *u = dyn_cast<Undefined>(s);
-  if (!u || u->weakAlias || s->pendingArchiveLoad)
+  if (!u || (u->weakAlias && !u->isECAlias(machine)) || s->pendingArchiveLoad)
     return;
   s->pendingArchiveLoad = true;
   f->makeImport(sym);

--- a/lld/test/COFF/link-dll-arm64ec.s
+++ b/lld/test/COFF/link-dll-arm64ec.s
@@ -1,0 +1,60 @@
+REQUIRES: aarch64, x86
+RUN: split-file %s %t.dir && cd %t.dir
+
+RUN: llvm-mc -filetype=obj -triple=arm64ec-windows test.s -o test.obj
+RUN: llvm-mc -filetype=obj -triple=arm64ec-windows dll.s -o dll.obj
+RUN: llvm-mc -filetype=obj -triple=arm64ec-windows %S/Inputs/loadconfig-arm64ec.s -o loadconfig-arm64ec.obj
+
+RUN: lld-link -machine:arm64ec -dll -noentry -out:import.dll loadconfig-arm64ec.obj dll.obj \
+RUN:          -export:func -export:func2=func -export:func3=func -export:func4=func \
+RUN:          -export:data,DATA -noimplib
+
+RUN: lld-link -machine:arm64ec -dll -noentry -out:out.dll loadconfig-arm64ec.obj test.obj import.dll \
+RUN:          -lldmingw -exclude-all-symbols -auto-import:no
+
+RUN: llvm-readobj --coff-imports out.dll | FileCheck --check-prefix=IMPORTS %s
+IMPORTS:      Import {
+IMPORTS-NEXT:   Name: import.dll
+IMPORTS-NEXT:   ImportLookupTableRVA:
+IMPORTS-NEXT:   ImportAddressTableRVA:
+IMPORTS-NEXT:   Symbol: data (0)
+IMPORTS-NEXT:   Symbol: func (0)
+IMPORTS-NEXT:   Symbol: func2 (0)
+IMPORTS-NEXT:   Symbol: func3 (0)
+IMPORTS-NEXT:   Symbol: func4 (0)
+IMPORTS-NEXT: }
+
+#--- test.s
+    .weak_anti_dep func
+    .weak_anti_dep "#func"
+    .set func,"#func"
+    .set "#func",thunk
+
+    .section .test, "r"
+    .rva __imp_data
+    .rva func
+    .rva "#func2"
+    .rva __imp_aux_func3
+    .rva __imp_func4
+
+    .text
+    .globl thunk
+thunk:
+    ret
+
+    .globl __icall_helper_arm64ec
+    .p2align 2, 0x0
+__icall_helper_arm64ec:
+    mov w0, #0
+    ret
+
+#--- dll.s
+    .text
+    .globl func
+func:
+    ret
+
+    .data
+    .globl data
+data:
+    .word 0


### PR DESCRIPTION
Define additional `__imp_aux_` and mangled lazy symbols. Also allow overriding EC aliases with lazy symbols, as we do for other lazy symbol types.