### PR TITLE
[LLD][COFF] Avoid forcing lazy symbols in loadMinGWSymbols during symbol table enumeration

### DIFF
--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -245,6 +245,7 @@ void SymbolTable::reportUndefinedSymbol(const UndefinedDiag &undefDiag) {
 }
 
 void SymbolTable::loadMinGWSymbols() {
+  std::vector<Symbol *> undefs;
   for (auto &i : symMap) {
     Symbol *sym = i.second;
     auto *undef = dyn_cast<Undefined>(sym);
@@ -252,7 +253,15 @@ void SymbolTable::loadMinGWSymbols() {
       continue;
     if (undef->getWeakAlias())
       continue;
+    undefs.push_back(sym);
+  }
 
+  for (auto sym : undefs) {
+    auto *undef = dyn_cast<Undefined>(sym);
+    if (!undef)
+      continue;
+    if (undef->getWeakAlias())
+      continue;
     StringRef name = undef->getName();
 
     if (machine == I386 && ctx.config.stdcallFixup) {

--- a/lld/test/COFF/stdcall-alias.s
+++ b/lld/test/COFF/stdcall-alias.s
@@ -1,0 +1,24 @@
+// REQUIRES: x86
+// RUN: split-file %s %t.dir && cd %t.dir
+
+// RUN: llvm-mc -filetype=obj -triple=i686-windows test.s -o test.obj
+// RUN: llvm-mc -filetype=obj -triple=i686-windows lib.s -o lib.obj
+// RUN: lld-link -dll -noentry -out:out.dll test.obj -start-lib lib.obj -end-lib -lldmingw
+
+#--- test.s
+     .section .test,"dr"
+     .rva _func@4
+
+#--- lib.s
+     .globl _func
+_func:
+     ret
+
+     // These symbols don't have lazy entries in the symbol table initially,
+     // but will be added during resolution from _func@4 to _func. Make sure this
+     // scenario is handled properly.
+     .weak_anti_dep _func@5
+     .set _func@5,_func
+
+     .weak_anti_dep _func@3
+     .set _func@3,_func


### PR DESCRIPTION
Forcing lazy symbols at this point may introduce new entries into the symbol table. Avoid mutating `symTab` while iterating over it.