### PR TITLE
Thread Safety Analysis: Warn when using negative reentrant capability

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -494,6 +494,9 @@ Improvements to Clang's diagnostics
   :doc:`ThreadSafetyAnalysis` still does not perform alias analysis. The
   feature will be default-enabled with ``-Wthread-safety`` in a future release.
 - The :doc:`ThreadSafetyAnalysis` now supports reentrant capabilities.
+- New warning group ``-Wthread-safety-pedantic`` warns about contradictory
+  :doc:`ThreadSafetyAnalysis` usage patterns; currently warns about use of a
+  reentrant capability as a negative capability.
 - Clang will now do a better job producing common nested names, when producing
   common types for ternary operator, template argument deduction and multiple return auto deduction.
 - The ``-Wsign-compare`` warning now treats expressions with bitwise not(~) and minus(-) as signed integers

--- a/clang/docs/ThreadSafetyAnalysis.rst
+++ b/clang/docs/ThreadSafetyAnalysis.rst
@@ -536,6 +536,7 @@ Warning flags
 * ``-Wthread-safety-pointer``: Checks when passing or returning pointers to
   guarded variables, or pointers to guarded data, as function argument or
   return value respectively.
+* ``-Wthread-safety-pedantic``: Contradictory usage patterns.
 
 :ref:`negative` are an experimental feature, which are enabled with:
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1272,6 +1272,7 @@ def Most : DiagGroup<"most", [
 def ThreadSafetyAttributes : DiagGroup<"thread-safety-attributes">;
 def ThreadSafetyAnalysis   : DiagGroup<"thread-safety-analysis">;
 def ThreadSafetyPrecise    : DiagGroup<"thread-safety-precise">;
+def ThreadSafetyPedantic   : DiagGroup<"thread-safety-pedantic">;
 def ThreadSafetyReferenceReturn  : DiagGroup<"thread-safety-reference-return">;
 def ThreadSafetyReference  : DiagGroup<"thread-safety-reference",
                                              [ThreadSafetyReferenceReturn]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4254,6 +4254,11 @@ def warn_fun_requires_lock_precise :
   InGroup<ThreadSafetyPrecise>, DefaultIgnore;
 def note_found_mutex_near_match : Note<"found near match '%0'">;
 
+// Pedantic thread safety warnings
+def warn_thread_reentrant_with_negative_capability : Warning<
+  "%0 is marked reentrant but used as a negative capability; this may be contradictory">,
+  InGroup<ThreadSafetyPedantic>, DefaultIgnore;
+
 // Verbose thread safety warnings
 def warn_thread_safety_verbose : Warning<"thread safety verbose warning">,
   InGroup<ThreadSafetyVerbose>, DefaultIgnore;


### PR DESCRIPTION
The purpose of negative capabilities is documented as helping to prevent
double locking, which is not an issue for most reentrant capabilities
(such as mutexes).

Introduce a pedantic warning group to warn about using a reentrant
capability as a negative capability: this usage is likely contradictory.

Context: https://github.com/llvm/llvm-project/pull/137133#discussion_r2109224265