### PR TITLE
[KeyInstr][Clang] Reset atomGroup number for each function

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -36,6 +36,7 @@
 #include "clang/CodeGen/CGFunctionInfo.h"
 #include "clang/Frontend/FrontendDiagnostic.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Frontend/OpenMP/OMPIRBuilder.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Dominators.h"
@@ -1506,6 +1507,11 @@ void CodeGenFunction::GenerateCode(GlobalDecl GD, llvm::Function *Fn,
     // Disable debug info indefinitely for this function
     DebugInfo = nullptr;
   }
+  // Finalize function debug info on exit.
+  auto Cleanup = llvm::make_scope_exit([this] {
+    if (CGDebugInfo *DI = getDebugInfo())
+      DI->completeFunction();
+  });
 
   // The function might not have a body if we're generating thunks for a
   // function declaration.

--- a/clang/test/DebugInfo/KeyInstructions/multi-func.c
+++ b/clang/test/DebugInfo/KeyInstructions/multi-func.c
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -gkey-instructions -gno-column-info -x c++ %s -debug-info-kind=line-tables-only -emit-llvm -o - \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -gkey-instructions -gno-column-info -x c %s -debug-info-kind=line-tables-only -emit-llvm -o - \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// Check atomGroup is reset to start at 1 in each function.
+
+int g;
+// CHECK: store{{.*}}, !dbg [[AG:!.*]]
+void a() { g = 0; }
+
+// CHECK: store{{.*}}, !dbg [[BG:!.*]]
+void b() { g = 0; }
+
+// CHECK: [[A:!.*]] = distinct !DISubprogram(name: "a",
+// CHECK: [[AG]] = !DILocation(line: 11, scope: [[A]], atomGroup: 1, atomRank: 1)
+// CHECK: [[B:!.*]] = distinct !DISubprogram(name: "b",
+// CHECK: [[BG]] = !DILocation(line: 14, scope: [[B]], atomGroup: 1, atomRank: 1)


### PR DESCRIPTION
CGDebugInfo::completeFunction was added previously but mistakenly not called (dropped through the cracks while putting together the patch stack). Moved out of #134652 and #134654.