### PR TITLE
[libcxx] [test] Change an MSVC mode XFAIL into UNSUPPORTED

### DIFF
--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp
@@ -21,7 +21,11 @@
 // MSVC/vcruntime falls back from the nothrow array new to the nothrow
 // scalar new, instead of falling back on the throwing array new.
 // https://developercommunity.visualstudio.com/t/vcruntime-nothrow-array-operator-new-fal/10373274
-// XFAIL: target={{.+}}-windows-msvc
+// This issue got fixed in MSVC 2022 17.14; with vcruntime from that version,
+// this test does pass. (We could try to detect it and set a feature for when
+// this is known broken, but that detection would essentially a copy of this
+// test.)
+// UNSUPPORTED: target={{.+}}-windows-msvc
 
 #include <new>
 #include <cstddef>


### PR DESCRIPTION
The underlying bug in vcruntime [1] has been fixed in the latest version of MSVC (released two weeks ago); this will cause the test which is currently marked XFAIL to start erroring, when it starts passing unexpectedly.

This version of MSVC may soon start appearing in the Github Actions runner images used for our CI.

We could try to detect the state of this bug, but in practice, such detection code would essentially be a copy of this whole test.

Therefore, just mark this test UNSUPPORTED for the MSVC mode builds. If we at some point require new enough MSVC libraries, we could remove the marking entirely.

[1] https://developercommunity.visualstudio.com/t/vcruntime-nothrow-array-operator-new-fal/10373274