### PR TITLE
[lldb][docs][NFC] Remove references to obsolete gnu-libstdc++ category

### DIFF
--- a/lldb/docs/use/variable.rst
+++ b/lldb/docs/use/variable.rst
@@ -1209,16 +1209,15 @@ Categories
 ----------
 
 Categories are a way to group related formatters. For instance, LLDB itself
-groups the formatters for the libstdc++ types in a category named
-gnu-libstdc++. Basically, categories act like containers in which to store
-formatters for a same library or OS release.
+groups the formatters for STL types in a category named cpluspus. Basically,
+categories act like containers in which to store formatters for a same library
+or OS release.
 
 By default, several categories are created in LLDB:
 
 - default: this is the category where every formatter ends up, unless another category is specified
 - objc: formatters for basic and common Objective-C types that do not specifically depend on macOS
-- gnu-libstdc++: formatters for std::string, std::vector, std::list and std::map as implemented by libstdcpp
-- libcxx: formatters for std::string, std::vector, std::list and std::map as implemented by libcxx
+- cplusplus: formatters for STL types (currently only libc++ and libstdc++ are supported). Enabled when debugging C++ targets.
 - system: truly basic types for which a formatter is required
 - AppKit: Cocoa classes
 - CoreFoundation: CF classes
@@ -1246,12 +1245,11 @@ that the search order is:
 - AppKit
 - CoreServices
 - CoreGraphics
-- gnu-libstdc++
-- libcxx
+- cplusplus
 - VectorTypes
 - system
 
-As said, gnu-libstdc++ and libcxx contain formatters for C++ STL data types.
+As said, cplusplus contain formatters for C++ STL data types.
 system contains formatters for char* and char[], which reflect the behavior of
 older versions of LLDB which had built-in formatters for these types. Because
 now these are formatters, you can even replace them with your own if so you

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-disabling/TestDataFormatterDisabling.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-disabling/TestDataFormatterDisabling.py
@@ -46,8 +46,6 @@ class DataFormatterDisablingTestCase(TestBase):
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(cleanup)
 
-        # self.runCmd('type category enable system VectorTypes libcxx gnu-libstdc++ CoreGraphics CoreServices AppKit CoreFoundation objc default', check=False)
-
         self.expect(
             "type category list",
             substrs=[


### PR DESCRIPTION
This is still leftover from the days when the libc++ and libstdc++ formatters were both written in python and in separate categories. Since then we group libstdc++ and libc++ formatters into the same cateogry.

This patch removes references to the obsolete `gnu-libstdc++` category from the docs (and a test).

See [this thread](https://github.com/llvm/llvm-project/pull/140761#discussion_r2102386080) for more context