### PR TITLE
[clang][modules][deps]Remove -F option from test for clang-scan-deps

### DIFF
--- a/clang/test/ClangScanDeps/modules-pch-common-stale.c
+++ b/clang/test/ClangScanDeps/modules-pch-common-stale.c
@@ -27,7 +27,7 @@ module mod_tu_extra { header "mod_tu_extra.h" }
 
 // Clean: scan the PCH.
 // RUN: clang-scan-deps -format experimental-full -o %t/deps_pch_clean.json -- \
-// RUN:     %clang -x c-header %t/prefix.h -o %t/prefix.h.pch -F %t \
+// RUN:     %clang -x c-header %t/prefix.h -o %t/prefix.h.pch \
 // RUN:     -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
 
 // Clean: build the PCH.
@@ -38,7 +38,7 @@ module mod_tu_extra { header "mod_tu_extra.h" }
 
 // Clean: scan the TU.
 // RUN: clang-scan-deps -format experimental-full -o %t/deps_tu_clean.json -- \
-// RUN:     %clang -c %t/tu.c -o %t/tu.o -include %t/prefix.h -F %t \
+// RUN:     %clang -c %t/tu.c -o %t/tu.o -include %t/prefix.h \
 // RUN:     -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
 // RUN: cat %t/deps_tu_clean.json | sed 's:\\\\\?:/:g' | FileCheck %s --check-prefix=CHECK-TU-CLEAN -DPREFIX=%/t
 // CHECK-TU-CLEAN:      {
@@ -94,7 +94,7 @@ module mod_tu_extra { header "mod_tu_extra.h" }
 
 // Incremental: scan the PCH.
 // RUN: clang-scan-deps -format experimental-full -o %t/deps_pch_incremental.json -- \
-// RUN:     %clang -x c-header %t/prefix.h -o %t/prefix.h.pch -F %t \
+// RUN:     %clang -x c-header %t/prefix.h -o %t/prefix.h.pch \
 // RUN:     -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
 
 // Incremental: build the PCH.
@@ -107,7 +107,7 @@ module mod_tu_extra { header "mod_tu_extra.h" }
 //              TU that depend on modules imported from the PCH and discover the
 //              new dependency on 'mod_tu_extra'.
 // RUN: clang-scan-deps -format experimental-full -o %t/deps_tu_incremental.json -- \
-// RUN:     %clang -c %t/tu.c -o %t/tu.o -include %t/prefix.h -F %t \
+// RUN:     %clang -c %t/tu.c -o %t/tu.o -include %t/prefix.h \
 // RUN:     -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
 // RUN: cat %t/deps_tu_incremental.json | sed 's:\\\\\?:/:g' | FileCheck %s --check-prefix=CHECK-TU-INCREMENTAL -DPREFIX=%/t
 // CHECK-TU-INCREMENTAL:      {


### PR DESCRIPTION
Remove the redundant -F option from test because not all platforms support -F, which is a g++ extension.  The option is unnecessary because all files in the test have paths specified.