### PR TITLE
[KeyInstr][Clang] Break and Continue stmt atoms

### DIFF
--- a/clang/lib/CodeGen/CGCleanup.cpp
+++ b/clang/lib/CodeGen/CGCleanup.cpp
@@ -1118,6 +1118,7 @@ void CodeGenFunction::EmitBranchThroughCleanup(JumpDest Dest) {
 
   // Create the branch.
   llvm::BranchInst *BI = Builder.CreateBr(Dest.getBlock());
+  addInstToCurrentSourceAtom(BI, nullptr);
 
   // Calculate the innermost active normal cleanup.
   EHScopeStack::stable_iterator

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -1727,6 +1727,7 @@ void CodeGenFunction::EmitContinueStmt(const ContinueStmt &S) {
   if (HaveInsertPoint())
     EmitStopPoint(&S);
 
+  ApplyAtomGroup Grp(getDebugInfo());
   EmitBranchThroughCleanup(BreakContinueStack.back().ContinueBlock);
 }
 

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -1715,6 +1715,7 @@ void CodeGenFunction::EmitBreakStmt(const BreakStmt &S) {
   if (HaveInsertPoint())
     EmitStopPoint(&S);
 
+  ApplyAtomGroup Grp(getDebugInfo());
   EmitBranchThroughCleanup(BreakContinueStack.back().BreakBlock);
 }
 

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -106,6 +106,19 @@ void e() {
   }
 }
 
+void f() {
+// - Check the `break` keyword gets an atom group.
+// CHECK: entry:
+// CHECK-NEXT: br label %for.cond
+
+// CHECK: for.cond:
+// CHECK: br label %for.end, !dbg [[fG1R1:!.*]]
+  for ( ; ; )
+  {
+    break;
+  }
+}
+
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
@@ -131,3 +144,5 @@ void e() {
 // CHECK: [[dG1R1]] = !DILocation(line: 91, column: 3, scope: ![[#]], atomGroup: 1, atomRank: 1)
 
 // CHECK: [[eG1R1]] = !DILocation(line: 105, column: 5, scope: ![[#]], atomGroup: 1, atomRank: 1)
+
+// CHECK: [[fG1R1]] = !DILocation(line: 118, column: 5, scope: ![[#]], atomGroup: 1, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -93,6 +93,19 @@ void d() {
   }
 }
 
+void e() {
+// - Check the `continue` keyword gets an atom group.
+// CHECK: entry:
+// CHECK-NEXT: br label %for.cond
+
+// CHECK: for.cond:
+// CHECK: br label %for.cond, !dbg [[eG1R1:!.*]], !llvm.loop
+  for ( ; ; )
+  {
+    continue;
+  }
+}
+
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
@@ -116,3 +129,5 @@ void d() {
 // CHECK: [[cG2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 
 // CHECK: [[dG1R1]] = !DILocation(line: 91, column: 3, scope: ![[#]], atomGroup: 1, atomRank: 1)
+
+// CHECK: [[eG1R1]] = !DILocation(line: 105, column: 5, scope: ![[#]], atomGroup: 1, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/switch.c
+++ b/clang/test/DebugInfo/KeyInstructions/switch.c
@@ -16,18 +16,19 @@ void a(int A, int B) {
 // CHECK:   i32 1, label %sw.bb1
 // CHECK: ], !dbg [[G2R1:!.*]]
     switch ((g = A)) {
+// CHECK: br label %sw.epilog[[#]], !dbg [[G3R1:!.*]]
     case 0: break;
     case 1: {
 // CHECK: sw.bb1:
-// CHECK: %1 = load i32, ptr %B.addr{{.*}}, !dbg [[G3R2:!.*]]
+// CHECK: %1 = load i32, ptr %B.addr{{.*}}, !dbg [[G4R2:!.*]]
 // CHECK: switch i32 %1, label %{{.*}} [
 // CHECK:   i32 0, label %sw.bb2
-// CHECK: ], !dbg [[G3R1:!.*]]
+// CHECK: ], !dbg [[G4R1:!.*]]
     switch ((B)) {
         case 0: {
 // Test that assignments in constant-folded switches don't go missing.
 // CHECK-CXX: sw.bb2:
-// CHECK-CXX: store i32 1, ptr %C{{.*}}, !dbg [[G4R1:!.*]]
+// CHECK-CXX: store i32 1, ptr %C{{.*}}, !dbg [[G5R1:!.*]]
 #ifdef __cplusplus
             switch (const int C = 1; C) {
                 case 0: break;
@@ -35,17 +36,16 @@ void a(int A, int B) {
                 default: break;
             }
 #endif
-        } break;
-        default: break;
+        };
     }
-    } break;
-    default: break;
+    };
     }
 }
 
 // CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
-// CHECK: [[G3R2]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 2)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
-// CHECK-CXX: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
+// CHECK: [[G4R2]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 2)
+// CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
+// CHECK-CXX: [[G5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)


### PR DESCRIPTION
Based on top of https://github.com/llvm/llvm-project/pull/134646

This patch is part of a stack that teaches Clang to generate Key Instructions
metadata for C and C++.

RFC:
https://discourse.llvm.org/t/rfc-improving-is-stmt-placement-for-better-interactive-debugging/82668

The feature is only functional in LLVM if LLVM is built with CMake flag
LLVM_EXPERIMENTAL_KEY_INSTRUCTIONs. Eventually that flag will be removed.