### PR TITLE
[flang-rt] Explicitly define the default ShallowCopy* templates

### DIFF
--- a/flang-rt/lib/runtime/tools.cpp
+++ b/flang-rt/lib/runtime/tools.cpp
@@ -136,6 +136,10 @@ RT_API_ATTRS void ShallowCopyDiscontiguousToDiscontiguous(
   }
 }
 
+// Explicitly instantiate the default case to conform to the C++ standard
+template RT_API_ATTRS void ShallowCopyDiscontiguousToDiscontiguous<char, -1>(
+    const Descriptor &to, const Descriptor &from);
+
 template <typename P, int RANK>
 RT_API_ATTRS void ShallowCopyDiscontiguousToContiguous(
     const Descriptor &to, const Descriptor &from) {
@@ -153,6 +157,9 @@ RT_API_ATTRS void ShallowCopyDiscontiguousToContiguous(
   }
 }
 
+template RT_API_ATTRS void ShallowCopyDiscontiguousToContiguous<char, -1>(
+    const Descriptor &to, const Descriptor &from);
+
 template <typename P, int RANK>
 RT_API_ATTRS void ShallowCopyContiguousToDiscontiguous(
     const Descriptor &to, const Descriptor &from) {
@@ -169,6 +176,9 @@ RT_API_ATTRS void ShallowCopyContiguousToDiscontiguous(
     }
   }
 }
+
+template RT_API_ATTRS void ShallowCopyContiguousToDiscontiguous<char, -1>(
+    const Descriptor &to, const Descriptor &from);
 
 // ShallowCopy helper for calling the correct specialised variant based on
 // scenario


### PR DESCRIPTION
Not explicitly defining the default case for ShallowCopy* functions does not meet the requirements for gcc to actually instantiate the templates, leading to build errors that show up with gcc but not with clang.