### PR TITLE
[RISCV] Make RISCVIndirectBranchTracking visible in debug output

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVIndirectBranchTracking.cpp
+++ b/llvm/lib/Target/RISCV/RISCVIndirectBranchTracking.cpp
@@ -20,6 +20,9 @@
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 
+#define DEBUG_TYPE "riscv-indrect-branch-tracking"
+#define PASS_NAME "RISC-V Indirect Branch Tracking"
+
 using namespace llvm;
 
 cl::opt<uint32_t> PreferredLandingPadLabel(
@@ -27,27 +30,29 @@ cl::opt<uint32_t> PreferredLandingPadLabel(
     cl::desc("Use preferred fixed label for all labels"));
 
 namespace {
-class RISCVIndirectBranchTrackingPass : public MachineFunctionPass {
+class RISCVIndirectBranchTracking : public MachineFunctionPass {
 public:
-  RISCVIndirectBranchTrackingPass() : MachineFunctionPass(ID) {}
+  static char ID;
+  RISCVIndirectBranchTracking() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override {
-    return "RISC-V Indirect Branch Tracking";
+    return PASS_NAME;
   }
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 
 private:
-  static char ID;
   const Align LpadAlign = Align(4);
 };
 
 } // end anonymous namespace
 
-char RISCVIndirectBranchTrackingPass::ID = 0;
+INITIALIZE_PASS(RISCVIndirectBranchTracking, DEBUG_TYPE, PASS_NAME, false, false)
+
+char RISCVIndirectBranchTracking::ID = 0;
 
 FunctionPass *llvm::createRISCVIndirectBranchTrackingPass() {
-  return new RISCVIndirectBranchTrackingPass();
+  return new RISCVIndirectBranchTracking();
 }
 
 static void emitLpad(MachineBasicBlock &MBB, const RISCVInstrInfo *TII,
@@ -57,7 +62,7 @@ static void emitLpad(MachineBasicBlock &MBB, const RISCVInstrInfo *TII,
       .addImm(Label);
 }
 
-bool RISCVIndirectBranchTrackingPass::runOnMachineFunction(
+bool RISCVIndirectBranchTracking::runOnMachineFunction(
     MachineFunction &MF) {
   const auto &Subtarget = MF.getSubtarget<RISCVSubtarget>();
   const RISCVInstrInfo *TII = Subtarget.getInstrInfo();

--- a/llvm/lib/Target/RISCV/RISCVIndirectBranchTracking.cpp
+++ b/llvm/lib/Target/RISCV/RISCVIndirectBranchTracking.cpp
@@ -35,9 +35,7 @@ public:
   static char ID;
   RISCVIndirectBranchTracking() : MachineFunctionPass(ID) {}
 
-  StringRef getPassName() const override {
-    return PASS_NAME;
-  }
+  StringRef getPassName() const override { return PASS_NAME; }
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 
@@ -47,7 +45,8 @@ private:
 
 } // end anonymous namespace
 
-INITIALIZE_PASS(RISCVIndirectBranchTracking, DEBUG_TYPE, PASS_NAME, false, false)
+INITIALIZE_PASS(RISCVIndirectBranchTracking, DEBUG_TYPE, PASS_NAME, false,
+                false)
 
 char RISCVIndirectBranchTracking::ID = 0;
 
@@ -62,8 +61,7 @@ static void emitLpad(MachineBasicBlock &MBB, const RISCVInstrInfo *TII,
       .addImm(Label);
 }
 
-bool RISCVIndirectBranchTracking::runOnMachineFunction(
-    MachineFunction &MF) {
+bool RISCVIndirectBranchTracking::runOnMachineFunction(MachineFunction &MF) {
   const auto &Subtarget = MF.getSubtarget<RISCVSubtarget>();
   const RISCVInstrInfo *TII = Subtarget.getInstrInfo();
   if (!Subtarget.hasStdExtZicfilp())

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -147,6 +147,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeRISCVTarget() {
   initializeRISCVDAGToDAGISelLegacyPass(*PR);
   initializeRISCVMoveMergePass(*PR);
   initializeRISCVPushPopOptPass(*PR);
+  initializeRISCVIndirectBranchTrackingPass(*PR);
   initializeRISCVLoadStoreOptPass(*PR);
   initializeRISCVExpandAtomicPseudoPass(*PR);
   initializeRISCVRedundantCopyEliminationPass(*PR);


### PR DESCRIPTION
Fix RISC-V Indirect Branch Tracking pass was not showing in the pass debug output due to not initialized properly.