### PR TITLE
[lldb] Add release note for riscv32 elf core file support in LLDB

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -279,6 +279,7 @@ Changes to LLDB
   supporting reverse execution, such as [rr](https://rr-project.org).
   When using reverse execution, `process continue --forward` returns to the
   forward execution.
+* LLDB now supports RISC-V 32-bit ELF core files.
 
 ### Changes to lldb-dap
 


### PR DESCRIPTION
Add a release note for riscv32 elf core file support in LLDB.