### PR TITLE
[Offload] Fix segfault when looking for host device name

### DIFF
--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -230,6 +230,12 @@ ol_impl_result_t olGetDeviceInfoImplDetail(ol_device_handle_t Device,
   // Find the info if it exists under any of the given names
   auto GetInfo = [&](std::vector<std::string> Names) {
     InfoQueueTy DevInfo;
+    if (Device == HostDevice())
+      return std::string("Host");
+
+    if (!Device->Device)
+      return std::string("");
+
     if (auto Err = Device->Device->obtainInfoImpl(DevInfo))
       return std::string("");
 

--- a/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
+++ b/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
@@ -37,6 +37,16 @@ TEST_P(olGetDeviceInfoTest, SuccessName) {
   ASSERT_EQ(std::strlen(Name.data()), Size - 1);
 }
 
+TEST_P(olGetDeviceInfoTest, HostName) {
+  size_t Size = 0;
+  ASSERT_SUCCESS(olGetDeviceInfoSize(Host, OL_DEVICE_INFO_NAME, &Size));
+  ASSERT_GT(Size, 0ul);
+  std::vector<char> Name;
+  Name.resize(Size);
+  ASSERT_SUCCESS(olGetDeviceInfo(Host, OL_DEVICE_INFO_NAME, Size, Name.data()));
+  ASSERT_EQ(std::strlen(Name.data()), Size - 1);
+}
+
 TEST_P(olGetDeviceInfoTest, SuccessVendor) {
   size_t Size = 0;
   ASSERT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_VENDOR, &Size));


### PR DESCRIPTION
Summary:
This is done using the generic device into pointe, but no such thing
exists for the host device, leading to a segfault. This patch fixes that
for now, but in the future we should probably be more careful in general
handling the possibility that the handle is null everywhere.

Fixes: https://github.com/llvm/llvm-project/issues/141434
