### PR TITLE
[Offload] Add specifier for the host type

### DIFF
--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -18,6 +18,7 @@ def : Enum {
     Etor<"ALL", "Devices of all types">,
     Etor<"GPU", "GPU device type">,
     Etor<"CPU", "CPU device type">,
+    Etor<"Host", "Host device type">,
   ];
 }
 

--- a/offload/liboffload/include/generated/OffloadAPI.h
+++ b/offload/liboffload/include/generated/OffloadAPI.h
@@ -320,6 +320,8 @@ typedef enum ol_device_type_t {
   OL_DEVICE_TYPE_GPU = 2,
   /// CPU device type
   OL_DEVICE_TYPE_CPU = 3,
+  /// Host device type
+  OL_DEVICE_TYPE_HOST = 4,
   /// @cond
   OL_DEVICE_TYPE_FORCE_UINT32 = 0x7fffffff
   /// @endcond

--- a/offload/liboffload/include/generated/OffloadPrint.hpp
+++ b/offload/liboffload/include/generated/OffloadPrint.hpp
@@ -224,6 +224,9 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   case OL_DEVICE_TYPE_CPU:
     os << "OL_DEVICE_TYPE_CPU";
     break;
+  case OL_DEVICE_TYPE_HOST:
+    os << "OL_DEVICE_TYPE_HOST";
+    break;
   default:
     os << "unknown enumerator";
     break;

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -252,7 +252,8 @@ ol_impl_result_t olGetDeviceInfoImplDetail(ol_device_handle_t Device,
   case OL_DEVICE_INFO_PLATFORM:
     return ReturnValue(Device->Platform);
   case OL_DEVICE_INFO_TYPE:
-    return ReturnValue(OL_DEVICE_TYPE_GPU);
+    return Device == HostDevice() ? ReturnValue(OL_DEVICE_TYPE_HOST)
+                                  : ReturnValue(OL_DEVICE_TYPE_GPU);
   case OL_DEVICE_INFO_NAME:
     return ReturnValue(GetInfo({"Device Name"}).c_str());
   case OL_DEVICE_INFO_VENDOR:

--- a/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
+++ b/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
@@ -19,6 +19,13 @@ TEST_P(olGetDeviceInfoTest, SuccessType) {
                                  sizeof(ol_device_type_t), &DeviceType));
 }
 
+TEST_P(olGetDeviceInfoTest, HostSuccessType) {
+  ol_device_type_t DeviceType;
+  ASSERT_SUCCESS(olGetDeviceInfo(Host, OL_DEVICE_INFO_TYPE,
+                                 sizeof(ol_device_type_t), &DeviceType));
+  ASSERT_EQ(DeviceType, OL_DEVICE_TYPE_HOST);
+}
+
 TEST_P(olGetDeviceInfoTest, SuccessPlatform) {
   ol_platform_handle_t Platform = nullptr;
   ASSERT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_PLATFORM,


### PR DESCRIPTION
Summary:
We use this sepcial type to indicate a host value, this will be refined
later but for now it's used as a stand-in device for transfers and
queues. It needs a special kind because it is not a device target as the
other ones so we need to differentiate it between a CPU and GPU type.

Fixes: https://github.com/llvm/llvm-project/issues/141436
