### PR TITLE
Write file to tmp directory

### DIFF
--- a/llvm/unittests/Object/OffloadingBundleTest.cpp
+++ b/llvm/unittests/Object/OffloadingBundleTest.cpp
@@ -74,8 +74,11 @@ TEST(OffloadingBundleTest, checkExtractCodeObject) {
   int64_t Offset = 8192;
   int64_t Size = 4048;
 
-  Error Err = extractCodeObject(**ObjOrErr, Offset, Size,
-                                StringRef("checkExtractCodeObject.co"));
+  llvm::unittest::TempDir Tmp("tmpdir", /*Unique=*/true);
+  SmallString<128> FileName(Tmp.path().begin(), Tmp.path().end());
+  sys::path::append(FileName, "checkExtractCodeObject.co");
+
+  Error Err = extractCodeObject(**ObjOrErr, Offset, Size, StringRef(FileName));
   EXPECT_FALSE(errorToBool(std::move(Err)));
 }
 


### PR DESCRIPTION
This makes the test more portable.  In google, the test was failing because a test cannot write to its own directory in a sandbox.