### PR TITLE
[NFC][PowerPC] clang-format spill and restore opcodes

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.h
@@ -235,8 +235,7 @@ enum PPCMachineCombinerPattern : unsigned {
    PPC::SPILL_QUADWORD}
 
 #define FutureStoreOpcodes                                                     \
-  {NoInstr,                                                                    \
-   PPC::STW,                                                                   \
+  {PPC::STW,                                                                   \
    PPC::STD,                                                                   \
    PPC::STFD,                                                                  \
    PPC::STFS,                                                                  \

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.h
@@ -102,68 +102,157 @@ enum PPCMachineCombinerPattern : unsigned {
 // Define list of load and store spill opcodes.
 #define NoInstr PPC::INSTRUCTION_LIST_END
 #define Pwr8LoadOpcodes                                                        \
-  {                                                                            \
-    PPC::LWZ, PPC::LD, PPC::LFD, PPC::LFS, PPC::RESTORE_CR,                    \
-        PPC::RESTORE_CRBIT, PPC::LVX, PPC::LXVD2X, PPC::LXSDX, PPC::LXSSPX,    \
-        PPC::SPILLTOVSR_LD, NoInstr, NoInstr, NoInstr, NoInstr, PPC::EVLDD,    \
-        PPC::RESTORE_QUADWORD                                                  \
-  }
+  {PPC::LWZ,                                                                   \
+   PPC::LD,                                                                    \
+   PPC::LFD,                                                                   \
+   PPC::LFS,                                                                   \
+   PPC::RESTORE_CR,                                                            \
+   PPC::RESTORE_CRBIT,                                                         \
+   PPC::LVX,                                                                   \
+   PPC::LXVD2X,                                                                \
+   PPC::LXSDX,                                                                 \
+   PPC::LXSSPX,                                                                \
+   PPC::SPILLTOVSR_LD,                                                         \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   PPC::EVLDD,                                                                 \
+   PPC::RESTORE_QUADWORD}
 
 #define Pwr9LoadOpcodes                                                        \
-  {                                                                            \
-    PPC::LWZ, PPC::LD, PPC::LFD, PPC::LFS, PPC::RESTORE_CR,                    \
-        PPC::RESTORE_CRBIT, PPC::LVX, PPC::LXV, PPC::DFLOADf64,                \
-        PPC::DFLOADf32, PPC::SPILLTOVSR_LD, NoInstr, NoInstr, NoInstr,         \
-        NoInstr, NoInstr, PPC::RESTORE_QUADWORD                                \
-  }
+  {PPC::LWZ,                                                                   \
+   PPC::LD,                                                                    \
+   PPC::LFD,                                                                   \
+   PPC::LFS,                                                                   \
+   PPC::RESTORE_CR,                                                            \
+   PPC::RESTORE_CRBIT,                                                         \
+   PPC::LVX,                                                                   \
+   PPC::LXV,                                                                   \
+   PPC::DFLOADf64,                                                             \
+   PPC::DFLOADf32,                                                             \
+   PPC::SPILLTOVSR_LD,                                                         \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   PPC::RESTORE_QUADWORD}
 
 #define Pwr10LoadOpcodes                                                       \
-  {                                                                            \
-    PPC::LWZ, PPC::LD, PPC::LFD, PPC::LFS, PPC::RESTORE_CR,                    \
-        PPC::RESTORE_CRBIT, PPC::LVX, PPC::LXV, PPC::DFLOADf64,                \
-        PPC::DFLOADf32, PPC::SPILLTOVSR_LD, PPC::LXVP, PPC::RESTORE_ACC,       \
-        PPC::RESTORE_UACC, NoInstr, NoInstr, PPC::RESTORE_QUADWORD             \
-  }
+  {PPC::LWZ,                                                                   \
+   PPC::LD,                                                                    \
+   PPC::LFD,                                                                   \
+   PPC::LFS,                                                                   \
+   PPC::RESTORE_CR,                                                            \
+   PPC::RESTORE_CRBIT,                                                         \
+   PPC::LVX,                                                                   \
+   PPC::LXV,                                                                   \
+   PPC::DFLOADf64,                                                             \
+   PPC::DFLOADf32,                                                             \
+   PPC::SPILLTOVSR_LD,                                                         \
+   PPC::LXVP,                                                                  \
+   PPC::RESTORE_ACC,                                                           \
+   PPC::RESTORE_UACC,                                                          \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   PPC::RESTORE_QUADWORD}
 
 #define FutureLoadOpcodes                                                      \
-  {                                                                            \
-    PPC::LWZ, PPC::LD, PPC::LFD, PPC::LFS, PPC::RESTORE_CR,                    \
-        PPC::RESTORE_CRBIT, PPC::LVX, PPC::LXV, PPC::DFLOADf64,                \
-        PPC::DFLOADf32, PPC::SPILLTOVSR_LD, PPC::LXVP, PPC::RESTORE_ACC,       \
-        PPC::RESTORE_UACC, PPC::RESTORE_WACC, NoInstr, PPC::RESTORE_QUADWORD   \
-  }
+  {PPC::LWZ,                                                                   \
+   PPC::LD,                                                                    \
+   PPC::LFD,                                                                   \
+   PPC::LFS,                                                                   \
+   PPC::RESTORE_CR,                                                            \
+   PPC::RESTORE_CRBIT,                                                         \
+   PPC::LVX,                                                                   \
+   PPC::LXV,                                                                   \
+   PPC::DFLOADf64,                                                             \
+   PPC::DFLOADf32,                                                             \
+   PPC::SPILLTOVSR_LD,                                                         \
+   PPC::LXVP,                                                                  \
+   PPC::RESTORE_ACC,                                                           \
+   PPC::RESTORE_UACC,                                                          \
+   PPC::RESTORE_WACC,                                                          \
+   NoInstr,                                                                    \
+   PPC::RESTORE_QUADWORD}
 
 #define Pwr8StoreOpcodes                                                       \
-  {                                                                            \
-    PPC::STW, PPC::STD, PPC::STFD, PPC::STFS, PPC::SPILL_CR, PPC::SPILL_CRBIT, \
-        PPC::STVX, PPC::STXVD2X, PPC::STXSDX, PPC::STXSSPX,                    \
-        PPC::SPILLTOVSR_ST, NoInstr, NoInstr, NoInstr, NoInstr, PPC::EVSTDD,   \
-        PPC::SPILL_QUADWORD                                                    \
-  }
+  {PPC::STW,                                                                   \
+   PPC::STD,                                                                   \
+   PPC::STFD,                                                                  \
+   PPC::STFS,                                                                  \
+   PPC::SPILL_CR,                                                              \
+   PPC::SPILL_CRBIT,                                                           \
+   PPC::STVX,                                                                  \
+   PPC::STXVD2X,                                                               \
+   PPC::STXSDX,                                                                \
+   PPC::STXSSPX,                                                               \
+   PPC::SPILLTOVSR_ST,                                                         \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   PPC::EVSTDD,                                                                \
+   PPC::SPILL_QUADWORD}
 
 #define Pwr9StoreOpcodes                                                       \
-  {                                                                            \
-    PPC::STW, PPC::STD, PPC::STFD, PPC::STFS, PPC::SPILL_CR, PPC::SPILL_CRBIT, \
-        PPC::STVX, PPC::STXV, PPC::DFSTOREf64, PPC::DFSTOREf32,                \
-        PPC::SPILLTOVSR_ST, NoInstr, NoInstr, NoInstr, NoInstr, NoInstr,       \
-        PPC::SPILL_QUADWORD                                                    \
-  }
+  {PPC::STW,                                                                   \
+   PPC::STD,                                                                   \
+   PPC::STFD,                                                                  \
+   PPC::STFS,                                                                  \
+   PPC::SPILL_CR,                                                              \
+   PPC::SPILL_CRBIT,                                                           \
+   PPC::STVX,                                                                  \
+   PPC::STXV,                                                                  \
+   PPC::DFSTOREf64,                                                            \
+   PPC::DFSTOREf32,                                                            \
+   PPC::SPILLTOVSR_ST,                                                         \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   PPC::SPILL_QUADWORD}
 
 #define Pwr10StoreOpcodes                                                      \
-  {                                                                            \
-    PPC::STW, PPC::STD, PPC::STFD, PPC::STFS, PPC::SPILL_CR, PPC::SPILL_CRBIT, \
-        PPC::STVX, PPC::STXV, PPC::DFSTOREf64, PPC::DFSTOREf32,                \
-        PPC::SPILLTOVSR_ST, PPC::STXVP, PPC::SPILL_ACC, PPC::SPILL_UACC,       \
-        NoInstr, NoInstr, PPC::SPILL_QUADWORD                                  \
-  }
+  {PPC::STW,                                                                   \
+   PPC::STD,                                                                   \
+   PPC::STFD,                                                                  \
+   PPC::STFS,                                                                  \
+   PPC::SPILL_CR,                                                              \
+   PPC::SPILL_CRBIT,                                                           \
+   PPC::STVX,                                                                  \
+   PPC::STXV,                                                                  \
+   PPC::DFSTOREf64,                                                            \
+   PPC::DFSTOREf32,                                                            \
+   PPC::SPILLTOVSR_ST,                                                         \
+   PPC::STXVP,                                                                 \
+   PPC::SPILL_ACC,                                                             \
+   PPC::SPILL_UACC,                                                            \
+   NoInstr,                                                                    \
+   NoInstr,                                                                    \
+   PPC::SPILL_QUADWORD}
 
 #define FutureStoreOpcodes                                                     \
-  {                                                                            \
-    PPC::STW, PPC::STD, PPC::STFD, PPC::STFS, PPC::SPILL_CR, PPC::SPILL_CRBIT, \
-        PPC::STVX, PPC::STXV, PPC::DFSTOREf64, PPC::DFSTOREf32,                \
-        PPC::SPILLTOVSR_ST, PPC::STXVP, PPC::SPILL_ACC, PPC::SPILL_UACC,       \
-        PPC::SPILL_WACC, NoInstr, PPC::SPILL_QUADWORD                          \
-  }
+  {NoInstr,                                                                    \
+   PPC::STW,                                                                   \
+   PPC::STD,                                                                   \
+   PPC::STFD,                                                                  \
+   PPC::STFS,                                                                  \
+   PPC::SPILL_CR,                                                              \
+   PPC::SPILL_CRBIT,                                                           \
+   PPC::STVX,                                                                  \
+   PPC::STXV,                                                                  \
+   PPC::DFSTOREf64,                                                            \
+   PPC::DFSTOREf32,                                                            \
+   PPC::SPILLTOVSR_ST,                                                         \
+   PPC::STXVP,                                                                 \
+   PPC::SPILL_ACC,                                                             \
+   PPC::SPILL_UACC,                                                            \
+   PPC::SPILL_WACC,                                                            \
+   NoInstr,                                                                    \
+   PPC::SPILL_QUADWORD}
 
 // Initialize arrays for load and store spill opcodes on supported subtargets.
 #define StoreOpcodesForSpill                                                   \


### PR DESCRIPTION
Reformat spill and restore opCode lists.