### PR TITLE
[Offload] Correctly regenerate API files if modified

### DIFF
--- a/offload/liboffload/API/CMakeLists.txt
+++ b/offload/liboffload/API/CMakeLists.txt
@@ -2,8 +2,8 @@
 # include directory. These files are checked in with the rest of the source,
 # therefore it is only needed when making changes to the API.
 
-find_program(CLANG_FORMAT clang-format PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
-if (CLANG_FORMAT)
+find_program(clang_format clang-format PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+if (clang_format)
     set(LLVM_TARGET_DEFINITIONS ${CMAKE_CURRENT_SOURCE_DIR}/OffloadAPI.td)
 
     tablegen(OFFLOAD OffloadAPI.h -gen-api)
@@ -13,15 +13,31 @@ if (CLANG_FORMAT)
     tablegen(OFFLOAD OffloadPrint.hpp -gen-print-header)
     tablegen(OFFLOAD OffloadErrcodes.inc -gen-errcodes)
 
-    set(FILES_TO_COPY "OffloadAPI.h;OffloadEntryPoints.inc;OffloadFuncs.inc;OffloadImplFuncDecls.inc;OffloadPrint.hpp")
-    set(GEN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include/generated)
+    set(files_to_copy "OffloadAPI.h;OffloadEntryPoints.inc;OffloadFuncs.inc;OffloadImplFuncDecls.inc;OffloadPrint.hpp")
+    set(generated_dir ${CMAKE_CURRENT_SOURCE_DIR}/../include/generated)
+    set(shared_dir ${LIBOMPTARGET_INCLUDE_DIR}/Shared)
     add_public_tablegen_target(OffloadGenerate)
-    add_custom_command(TARGET OffloadGenerate POST_BUILD COMMAND ${CLANG_FORMAT}
-        -i ${TABLEGEN_OUTPUT})
-    add_custom_command(TARGET OffloadGenerate POST_BUILD COMMAND ${CMAKE_COMMAND}
-        -E copy_if_different ${FILES_TO_COPY} ${GEN_DIR})
-    add_custom_command(TARGET OffloadGenerate POST_BUILD COMMAND ${CMAKE_COMMAND}
-        -E copy_if_different OffloadErrcodes.inc "${LIBOMPTARGET_INCLUDE_DIR}/Shared/OffloadErrcodes.inc")
+
+    add_custom_target(OffloadAPI DEPENDS OffloadGenerate)
+      add_custom_command(
+          OUTPUT ${shared_dir}/OffloadErrcodes.inc
+          COMMAND ${clang_format} -i OffloadErrcodes.inc
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different OffloadErrcodes.inc ${shared_dir}
+          DEPENDS OffloadErrcodes.inc
+      )
+      add_custom_target(OffloadAPI.OffloadErrcodes.inc DEPENDS ${shared_dir}/OffloadErrcodes.inc)
+      add_dependencies(OffloadAPI OffloadAPI.OffloadErrcodes.inc)
+    foreach(file IN LISTS files_to_copy)
+      add_custom_command(
+          OUTPUT ${generated_dir}/${file}
+          COMMAND ${clang_format} -i ${file}
+          COMMAND ${CMAKE_COMMAND} -E make_directory ${generated_dir}
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different ${file} ${generated_dir}
+          DEPENDS ${file}
+      )
+      add_custom_target(OffloadAPI.${file} DEPENDS ${generated_dir}/${file})
+      add_dependencies(OffloadAPI OffloadAPI.${file})
+    endforeach()
 else()
     message(WARNING "clang-format was not found, so the OffloadGenerate target\
         will not be available. Offload will still build, but you will not be\

--- a/offload/liboffload/CMakeLists.txt
+++ b/offload/liboffload/CMakeLists.txt
@@ -19,11 +19,11 @@ if(LLVM_HAVE_LINK_VERSION_SCRIPT)
 endif()
 
 target_include_directories(LLVMOffload PUBLIC
-                            ${CMAKE_CURRENT_BINARY_DIR}/../include
-                            ${CMAKE_CURRENT_SOURCE_DIR}/include
-                            ${CMAKE_CURRENT_SOURCE_DIR}/include/generated
-                            ${CMAKE_CURRENT_SOURCE_DIR}/../include
-                            ${CMAKE_CURRENT_SOURCE_DIR}/../plugins-nextgen/common/include)
+                           ${CMAKE_CURRENT_BINARY_DIR}/../include
+                           ${CMAKE_CURRENT_SOURCE_DIR}/include
+                           ${CMAKE_CURRENT_SOURCE_DIR}/include/generated
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../include
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../plugins-nextgen/common/include)
 
 target_compile_options(LLVMOffload PRIVATE ${offload_compile_flags})
 target_link_options(LLVMOffload PRIVATE ${offload_link_flags})
@@ -32,6 +32,11 @@ target_compile_definitions(LLVMOffload PRIVATE
   TARGET_NAME="Liboffload"
   DEBUG_PREFIX="Liboffload"
 )
+
+# Make sure these are up-to-date if modified.
+if(TARGET OffloadAPI)
+  add_dependencies(LLVMOffload OffloadAPI)
+endif()
 
 set_target_properties(LLVMOffload PROPERTIES
                       POSITION_INDEPENDENT_CODE ON


### PR DESCRIPTION
Summary:
Currently these are done POST_BUILD, but they should be dependencies on
generating the library since it's a direct dependency.
