### PR TITLE
[lldb] Fix warnings

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -4262,6 +4262,8 @@ TypeSystemClang::GetTypeClass(lldb::opaque_compiler_type_t type) {
 
   case clang::Type::HLSLAttributedResource:
     break;
+  case clang::Type::HLSLInlineSpirv:
+    break;
   }
   // We don't know hot to display this type...
   return lldb::eTypeClassOther;
@@ -5128,6 +5130,8 @@ lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type,
 
   case clang::Type::HLSLAttributedResource:
     break;
+  case clang::Type::HLSLInlineSpirv:
+    break;
   }
   count = 0;
   return lldb::eEncodingInvalid;
@@ -5291,6 +5295,8 @@ lldb::Format TypeSystemClang::GetFormat(lldb::opaque_compiler_type_t type) {
     break;
 
   case clang::Type::HLSLAttributedResource:
+    break;
+  case clang::Type::HLSLInlineSpirv:
     break;
   }
   // We don't know hot to display this type...


### PR DESCRIPTION
This patch fixes:

  lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4137:11:
  error: enumeration value 'HLSLInlineSpirv' not handled in switch
  [-Werror,-Wswitch]

  lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4844:11:
  error: enumeration value 'HLSLInlineSpirv' not handled in switch
  [-Werror,-Wswitch]

  lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:5142:11:
  error: enumeration value 'HLSLInlineSpirv' not handled in switch
  [-Werror,-Wswitch]
