### PR TITLE
[SpecialCaseList] Iterate sections and matchers in reverse order

### DIFF
--- a/llvm/lib/Support/SpecialCaseList.cpp
+++ b/llvm/lib/Support/SpecialCaseList.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/SpecialCaseList.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/LineIterator.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -66,10 +67,10 @@ Error SpecialCaseList::Matcher::insert(StringRef Pattern, unsigned LineNumber,
 }
 
 unsigned SpecialCaseList::Matcher::match(StringRef Query) const {
-  for (const auto &Glob : Globs)
+  for (const auto &Glob : reverse(Globs))
     if (Glob->Pattern.match(Query))
       return Glob->LineNo;
-  for (const auto &[Regex, LineNumber] : RegExes)
+  for (const auto &[Regex, LineNumber] : reverse(RegExes))
     if (Regex->match(Query))
       return LineNumber;
   return 0;
@@ -213,7 +214,7 @@ bool SpecialCaseList::inSection(StringRef Section, StringRef Prefix,
 unsigned SpecialCaseList::inSectionBlame(StringRef Section, StringRef Prefix,
                                          StringRef Query,
                                          StringRef Category) const {
-  for (const auto &S : Sections) {
+  for (const auto &S : reverse(Sections)) {
     if (S.SectionMatcher->match(Section)) {
       unsigned Blame = inSectionBlame(S.Entries, Prefix, Query, Category);
       if (Blame)

--- a/llvm/unittests/Support/SpecialCaseListTest.cpp
+++ b/llvm/unittests/Support/SpecialCaseListTest.cpp
@@ -311,8 +311,7 @@ TEST_F(SpecialCaseListTest, LinesInSection) {
   std::unique_ptr<SpecialCaseList> SCL = makeSpecialCaseList("fun:foo\n"
                                                              "fun:bar\n"
                                                              "fun:foo\n");
-  // FIXME: Get the last one for #139128.
-  EXPECT_EQ(1u, SCL->inSectionBlame("sect1", "fun", "foo"));
+  EXPECT_EQ(3u, SCL->inSectionBlame("sect1", "fun", "foo"));
   EXPECT_EQ(2u, SCL->inSectionBlame("sect1", "fun", "bar"));
 }
 
@@ -322,8 +321,7 @@ TEST_F(SpecialCaseListTest, LinesCrossSection) {
                                                              "fun:foo\n"
                                                              "[sect1]\n"
                                                              "fun:bar\n");
-  // FIXME: Get the last one for #139128.
-  EXPECT_EQ(1u, SCL->inSectionBlame("sect1", "fun", "foo"));
-  EXPECT_EQ(2u, SCL->inSectionBlame("sect1", "fun", "bar"));
+  EXPECT_EQ(3u, SCL->inSectionBlame("sect1", "fun", "foo"));
+  EXPECT_EQ(5u, SCL->inSectionBlame("sect1", "fun", "bar"));
 }
 }

--- a/llvm/unittests/Support/SpecialCaseListTest.cpp
+++ b/llvm/unittests/Support/SpecialCaseListTest.cpp
@@ -311,7 +311,7 @@ TEST_F(SpecialCaseListTest, LinesInSection) {
   std::unique_ptr<SpecialCaseList> SCL = makeSpecialCaseList("fun:foo\n"
                                                              "fun:bar\n"
                                                              "fun:foo\n");
-  EXPECT_EQ(1u, SCL->inSectionBlame("sect1", "fun", "foo"));
+  EXPECT_EQ(3u, SCL->inSectionBlame("sect1", "fun", "foo"));
   EXPECT_EQ(2u, SCL->inSectionBlame("sect1", "fun", "bar"));
 }
 
@@ -321,8 +321,8 @@ TEST_F(SpecialCaseListTest, LinesCrossSection) {
                                                              "fun:foo\n"
                                                              "[sect1]\n"
                                                              "fun:bar\n");
-  EXPECT_EQ(1u, SCL->inSectionBlame("sect1", "fun", "foo"));
-  EXPECT_EQ(2u, SCL->inSectionBlame("sect1", "fun", "bar"));
+  EXPECT_EQ(3u, SCL->inSectionBlame("sect1", "fun", "foo"));
+  EXPECT_EQ(5u, SCL->inSectionBlame("sect1", "fun", "bar"));
 }
 
 TEST_F(SpecialCaseListTest, Blame) {

--- a/llvm/unittests/Support/SpecialCaseListTest.cpp
+++ b/llvm/unittests/Support/SpecialCaseListTest.cpp
@@ -311,7 +311,7 @@ TEST_F(SpecialCaseListTest, LinesInSection) {
   std::unique_ptr<SpecialCaseList> SCL = makeSpecialCaseList("fun:foo\n"
                                                              "fun:bar\n"
                                                              "fun:foo\n");
-  EXPECT_EQ(3u, SCL->inSectionBlame("sect1", "fun", "foo"));
+  EXPECT_EQ(1u, SCL->inSectionBlame("sect1", "fun", "foo"));
   EXPECT_EQ(2u, SCL->inSectionBlame("sect1", "fun", "bar"));
 }
 
@@ -321,7 +321,30 @@ TEST_F(SpecialCaseListTest, LinesCrossSection) {
                                                              "fun:foo\n"
                                                              "[sect1]\n"
                                                              "fun:bar\n");
-  EXPECT_EQ(3u, SCL->inSectionBlame("sect1", "fun", "foo"));
-  EXPECT_EQ(5u, SCL->inSectionBlame("sect1", "fun", "bar"));
+  EXPECT_EQ(1u, SCL->inSectionBlame("sect1", "fun", "foo"));
+  EXPECT_EQ(2u, SCL->inSectionBlame("sect1", "fun", "bar"));
+}
+
+TEST_F(SpecialCaseListTest, Blame) {
+  std::unique_ptr<SpecialCaseList> SCL = makeSpecialCaseList("[sect1]\n"
+                                                             "src:foo*\n"
+                                                             "[sect1]\n"
+                                                             "src:bar*\n"
+                                                             "src:def\n"
+                                                             "[sect2]\n"
+                                                             "src:def\n"
+                                                             "src:de*\n");
+  EXPECT_TRUE(SCL->inSection("sect1", "src", "fooz"));
+  EXPECT_TRUE(SCL->inSection("sect1", "src", "barz"));
+  EXPECT_FALSE(SCL->inSection("sect2", "src", "fooz"));
+
+  EXPECT_TRUE(SCL->inSection("sect2", "src", "def"));
+  EXPECT_TRUE(SCL->inSection("sect1", "src", "def"));
+
+  EXPECT_EQ(2u, SCL->inSectionBlame("sect1", "src", "fooz"));
+  EXPECT_EQ(4u, SCL->inSectionBlame("sect1", "src", "barz"));
+  EXPECT_EQ(5u, SCL->inSectionBlame("sect1", "src", "def"));
+  EXPECT_EQ(8u, SCL->inSectionBlame("sect2", "src", "def"));
+  EXPECT_EQ(8u, SCL->inSectionBlame("sect2", "src", "dez"));
 }
 }


### PR DESCRIPTION
Extracted from #140529

Issue #139128 needs to find the last one in the file.

It's almost NFC, as the order of existing user of inSectionBlame is unimportant.
