### PR TITLE
Check for unsupported target options even with -Qunused-arguments

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5362,12 +5362,6 @@ void Driver::BuildJobs(Compilation &C) const {
     });
   }
 
-  // If the user passed -Qunused-arguments or there were errors, don't warn
-  // about any unused arguments.
-  if (Diags.hasErrorOccurred() ||
-      C.getArgs().hasArg(options::OPT_Qunused_arguments))
-    return;
-
   // Claim -fdriver-only here.
   (void)C.getArgs().hasArg(options::OPT_fdriver_only);
   // Claim -### here.
@@ -5420,7 +5414,10 @@ void Driver::BuildJobs(Compilation &C) const {
             !C.getActions().empty()) {
           Diag(diag::err_drv_unsupported_opt_for_target)
               << A->getSpelling() << getTargetTriple();
-        } else {
+        } else if (!Diags.hasErrorOccurred() &&
+                   !C.getArgs().hasArg(options::OPT_Qunused_arguments)) {
+          // If the user passed -Qunused-arguments or there were errors, don't
+          // warn about any unused arguments.
           Diag(clang::diag::warn_drv_unused_argument)
               << A->getAsString(C.getArgs());
         }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5362,6 +5362,12 @@ void Driver::BuildJobs(Compilation &C) const {
     });
   }
 
+  // If the user passed -Qunused-arguments or there were errors, don't
+  // warn about any unused arguments.
+  bool ReportUnusedArguments =
+      !Diags.hasErrorOccurred() &&
+      !C.getArgs().hasArg(options::OPT_Qunused_arguments);
+
   // Claim -fdriver-only here.
   (void)C.getArgs().hasArg(options::OPT_fdriver_only);
   // Claim -### here.
@@ -5414,10 +5420,7 @@ void Driver::BuildJobs(Compilation &C) const {
             !C.getActions().empty()) {
           Diag(diag::err_drv_unsupported_opt_for_target)
               << A->getSpelling() << getTargetTriple();
-        } else if (!Diags.hasErrorOccurred() &&
-                   !C.getArgs().hasArg(options::OPT_Qunused_arguments)) {
-          // If the user passed -Qunused-arguments or there were errors, don't
-          // warn about any unused arguments.
+        } else if (ReportUnusedArguments) {
           Diag(clang::diag::warn_drv_unused_argument)
               << A->getAsString(C.getArgs());
         }

--- a/clang/test/Driver/unsupported-option.c
+++ b/clang/test/Driver/unsupported-option.c
@@ -27,3 +27,10 @@
 // RUN: not %clang --target=x86_64 -### -mhtm -lc %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=UNSUP_OPT
 // UNSUP_OPT: error: unsupported option
+
+
+// RUN: not %clang -c --target=aarch64-- -mfpu=crypto-neon-fp-armv8 %s 2>&1 | \
+// RUN: FileCheck %s --check-prefix=AARCH64
+// RUN: not %clang -c -Qunused-arguments --target=aarch64-- -mfpu=crypto-neon-fp-armv8 %s 2>&1 | \
+// RUN: FileCheck %s --check-prefix=AARCH64
+// AARCH64: error: unsupported option '-mfpu=' for target 'aarch64--'

--- a/clang/test/Driver/unsupported-option.c
+++ b/clang/test/Driver/unsupported-option.c
@@ -29,8 +29,6 @@
 // UNSUP_OPT: error: unsupported option
 
 
-// RUN: not %clang -c --target=aarch64-- -mfpu=crypto-neon-fp-armv8 %s 2>&1 | \
-// RUN: FileCheck %s --check-prefix=AARCH64
-// RUN: not %clang -c -Qunused-arguments --target=aarch64-- -mfpu=crypto-neon-fp-armv8 %s 2>&1 | \
-// RUN: FileCheck %s --check-prefix=AARCH64
-// AARCH64: error: unsupported option '-mfpu=' for target 'aarch64--'
+// RUN: not %clang -c -Qunused-arguments --target=aarch64-- -mfpu=crypto-neon-fp-armv8 %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=QUNUSED_ARGUMENTS
+// QUNUSED_ARGUMENTS: error: unsupported option '-mfpu=' for target 'aarch64--'


### PR DESCRIPTION
Fix clang accidentally skipping checks for `err_drv_unsupported_opt_for_target` when `-Qunused-arguments` was active.