### PR TITLE
[NFC][DWP] Make `getContributionIndex` static

### DIFF
--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -70,9 +70,6 @@ struct CompileUnitIdentifiers {
 LLVM_ABI Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
                      OnCuIndexOverflow OverflowOptValue);
 
-LLVM_ABI unsigned getContributionIndex(DWARFSectionKind Kind,
-                                       uint32_t IndexVersion);
-
 LLVM_ABI Error handleSection(
     const StringMap<std::pair<MCSection *, DWARFSectionKind>> &KnownSections,
     const MCSection *StrSection, const MCSection *StrOffsetSection,

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -156,14 +156,13 @@ static bool isSupportedSectionKind(DWARFSectionKind Kind) {
   return Kind != DW_SECT_EXT_unknown;
 }
 
-namespace llvm {
 // Convert an internal section identifier into the index to use with
 // UnitIndexEntry::Contributions.
-unsigned getContributionIndex(DWARFSectionKind Kind, uint32_t IndexVersion) {
+static unsigned getContributionIndex(DWARFSectionKind Kind,
+                                     uint32_t IndexVersion) {
   assert(serializeSectionKind(Kind, IndexVersion) >= DW_SECT_INFO);
   return serializeSectionKind(Kind, IndexVersion) - DW_SECT_INFO;
 }
-} // namespace llvm
 
 // Convert a UnitIndexEntry::Contributions index to the corresponding on-disk
 // value of the section identifier.


### PR DESCRIPTION
Remove `getContributionIndex` declaration from header and make it static as it seems to be only used within the .cpp file.