### PR TITLE
[NFC][LLVM] Fix some `llvm` namespace usage in Bitcode writer

### DIFF
--- a/llvm/include/llvm/Analysis/ModuleSummaryAnalysis.h
+++ b/llvm/include/llvm/Analysis/ModuleSummaryAnalysis.h
@@ -103,6 +103,8 @@ createImmutableModuleSummaryIndexWrapperPass(const ModuleSummaryIndex *Index);
 /// consistency between summary analysis and the ThinLTO backend processing.
 bool mayHaveMemprofSummary(const CallBase *CB);
 
+extern FunctionSummary::ForceSummaryHotnessType ForceSummaryEdgesCold;
+
 } // end namespace llvm
 
 #endif // LLVM_ANALYSIS_MODULESUMMARYANALYSIS_H

--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -63,10 +63,8 @@ using namespace llvm::memprof;
 
 // Option to force edges cold which will block importing when the
 // -import-cold-multiplier is set to 0. Useful for debugging.
-namespace llvm {
-FunctionSummary::ForceSummaryHotnessType ForceSummaryEdgesCold =
+FunctionSummary::ForceSummaryHotnessType llvm::ForceSummaryEdgesCold =
     FunctionSummary::FSHT_None;
-} // namespace llvm
 
 static cl::opt<FunctionSummary::ForceSummaryHotnessType, true> FSEC(
     "force-summary-edges-cold", cl::Hidden, cl::location(ForceSummaryEdgesCold),

--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -60,9 +60,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-namespace llvm {
-class Argument;
-}
 
 using namespace llvm;
 

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Analysis/ModuleSummaryAnalysis.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/Bitcode/BitcodeCommon.h"
 #include "llvm/Bitcode/BitcodeReader.h"
@@ -116,10 +117,6 @@ static cl::opt<bool>
                                 cl::init(true),
 #endif
                                 cl::desc(""));
-
-namespace llvm {
-extern FunctionSummary::ForceSummaryHotnessType ForceSummaryEdgesCold;
-}
 
 extern llvm::cl::opt<bool> UseNewDbgInfoFormat;
 


### PR DESCRIPTION
- Add declaration of `ForceSummaryEdgesCold` to ModuleSummaryAnalysis.h and do not use namespace scope for its definition in ModuleSummaryAnalysis.cpp
- No need of forward declaration of `Argument`.
- include ModuleSummaryAnalysis.h in BitcodeWriter.cpp to get declaration of `ForceSummaryEdgesCold`