### PR TITLE
[RISCV] Update evaluateBranch for Xqci

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
@@ -212,23 +212,23 @@ public:
       return true;
     }
 
-    if (Inst.getOpcode() == RISCV::C_JAL || Inst.getOpcode() == RISCV::C_J) {
+    switch (Inst.getOpcode()) {
+    case RISCV::C_J:
+    case RISCV::C_JAL:
+    case RISCV::QC_E_J:
+    case RISCV::QC_E_JAL:
       Target = Addr + Inst.getOperand(0).getImm();
       return true;
-    }
-
-    if (Inst.getOpcode() == RISCV::JAL) {
+    case RISCV::JAL:
       Target = Addr + Inst.getOperand(1).getImm();
       return true;
-    }
-
-    if (Inst.getOpcode() == RISCV::JALR) {
+    case RISCV::JALR: {
       if (auto TargetRegState = getGPRState(Inst.getOperand(1).getReg())) {
         Target = *TargetRegState + Inst.getOperand(2).getImm();
         return true;
       }
-
       return false;
+    }
     }
 
     return false;

--- a/llvm/test/MC/Disassembler/RISCV/branch-targets-xcv.txt
+++ b/llvm/test/MC/Disassembler/RISCV/branch-targets-xcv.txt
@@ -1,0 +1,25 @@
+# RUN: llvm-mc -assemble -triple riscv32 \
+# RUN:   -mattr=+xcvbi \
+# RUN:   %s -filetype=obj -o - \
+# RUN:   | llvm-objdump -d -M no-aliases - \
+# RUN:   --mattr=+xcvbi \
+# RUN:   | FileCheck %s
+
+.option exact
+
+# CHECK-LABEL: <label1>:
+label1:
+
+# CHECK-NEXT: cv.beqimm a0, 0x1, 0x0 <label1>
+  cv.beqimm a0, 1, label1
+# CHECK-NEXT: cv.beqimm a0, 0x1, 0x10 <label2>
+  cv.beqimm a0, 1, label2
+
+# CHECK-NEXT: cv.bneimm a0, 0x2, 0x0 <label1>
+  cv.bneimm a0, 2, label1
+# CHECK-NEXT: cv.bneimm a0, 0x2, 0x10 <label2>
+  cv.bneimm a0, 2, label2
+
+
+label2:
+

--- a/llvm/test/MC/Disassembler/RISCV/branch-targets-xqci.txt
+++ b/llvm/test/MC/Disassembler/RISCV/branch-targets-xqci.txt
@@ -1,0 +1,36 @@
+# RUN: llvm-mc -assemble -triple riscv32 \
+# RUN:   -mattr=+experimental-xqcilb,+experimental-xqcibi \
+# RUN:   %s -filetype=obj -o - \
+# RUN:   | llvm-objdump -d -M no-aliases - \
+# RUN:   --mattr=+experimental-xqcilb,+experimental-xqcibi \
+# RUN:   | FileCheck %s
+
+.option exact
+
+# CHECK-LABEL: <label1>:
+label1:
+
+# CHECK-NEXT: qc.e.j 0x0 <label1>
+  qc.e.j label1
+# CHECK-NEXT: qc.e.j 0x2c <label2>
+  qc.e.j label2
+
+# CHECK-NEXT: qc.e.jal 0x0 <label1>
+  qc.e.jal label1
+# CHECK-NEXT: qc.e.jal 0x2c <label2>
+  qc.e.jal label2
+
+# CHECK-NEXT: qc.beqi a0, 0x1, 0x0 <label1>
+  qc.beqi a0, 1, label1
+
+# CHECK-NEXT: qc.bnei a0, 0x1, 0x2c <label2>
+  qc.bnei a0, 1, label2
+
+# CHECK-NEXT: qc.e.beqi a0, 0x2, 0x0 <label1>
+  qc.e.beqi a0, 2, label1
+
+# CHECK-NEXT: qc.e.bnei a0, 0x2, 0x2c <label2>
+  qc.e.bnei a0, 2, label2
+
+label2:
+


### PR DESCRIPTION
This implements RISCVMCInstrAnalysis::evaluateBranch for the two Xqci pc-relative jumps, which were otherwise not being displayed correctly when disassembling.

This also adds tests for all Xqci branches, and also the Core-V branches as they work, but did not have coverage.