### PR TITLE
Fixed small memory leak in libprofile

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -1088,8 +1088,10 @@ const char *__llvm_profile_get_filename(void) {
     return "\0";
   }
   Filename = getCurFilename(FilenameBuf, 1);
-  if (!Filename)
+  if (!Filename) {
+    free(FilenameBuf);
     return "\0";
+  }
 
   return FilenameBuf;
 }


### PR DESCRIPTION
Inside `getCurFilename`, there is this code snippit
```
if (!lprofCurFilename.FilenamePat || !lprofCurFilename.FilenamePat[0])
    return 0;
```
If this is true, we return `"\0"`, but would leak the memory in `FilenameBuf`.
This pull request adds a free before then to properly free the memory. There was already a check that we allocated memory, so there is no need to worry about freeing unallocated memory.