### PR TITLE
[Clang] Reset ArgPackSubstIndex before rewriting CTAD template parameters

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -1099,6 +1099,10 @@ BuildDeductionGuideForTypeAlias(Sema &SemaRef,
   // parameters, used for building `TemplateArgsForBuildingFPrime`.
   SmallVector<TemplateArgument, 16> TransformedDeducedAliasArgs(
       AliasTemplate->getTemplateParameters()->size());
+  // We might be already within a pack expansion, but rewriting template
+  // parameters is independent of that. (We may or may not expand new packs
+  // when rewriting. So clear the state)
+  Sema::ArgPackSubstIndexRAII _(SemaRef, std::nullopt);
 
   for (unsigned AliasTemplateParamIdx : DeducedAliasTemplateParams) {
     auto *TP =

--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -1102,7 +1102,7 @@ BuildDeductionGuideForTypeAlias(Sema &SemaRef,
   // We might be already within a pack expansion, but rewriting template
   // parameters is independent of that. (We may or may not expand new packs
   // when rewriting. So clear the state)
-  Sema::ArgPackSubstIndexRAII _(SemaRef, std::nullopt);
+  Sema::ArgPackSubstIndexRAII PackSubstReset(SemaRef, std::nullopt);
 
   for (unsigned AliasTemplateParamIdx : DeducedAliasTemplateParams) {
     auto *TP =


### PR DESCRIPTION
032ad59 taught the instantiator to expand template argument packs for rewrite. However we might already be in a pack expansion when we synthesizing the CTAD guide, so we reset the ArgPackSubstIndex to ensure it doesn't get confused.

No release note because this is a regression in Clang 21.

Fixes https://github.com/llvm/llvm-project/issues/141425