### PR TITLE
[SDAG] Remove noundef workaround for range metadata/attributes

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -4468,23 +4468,13 @@ void SelectionDAGBuilder::visitAlloca(const AllocaInst &I) {
 }
 
 static const MDNode *getRangeMetadata(const Instruction &I) {
-  // If !noundef is not present, then !range violation results in a poison
-  // value rather than immediate undefined behavior. In theory, transferring
-  // these annotations to SDAG is fine, but in practice there are key SDAG
-  // transforms that are known not to be poison-safe, such as folding logical
-  // and/or to bitwise and/or. For now, only transfer !range if !noundef is
-  // also present.
-  if (!I.hasMetadata(LLVMContext::MD_noundef))
-    return nullptr;
   return I.getMetadata(LLVMContext::MD_range);
 }
 
 static std::optional<ConstantRange> getRange(const Instruction &I) {
-  if (const auto *CB = dyn_cast<CallBase>(&I)) {
-    // see comment in getRangeMetadata about this check
-    if (CB->hasRetAttr(Attribute::NoUndef))
-      return CB->getRange();
-  }
+  if (const auto *CB = dyn_cast<CallBase>(&I))
+    if (std::optional<ConstantRange> CR = CB->getRange())
+      return CR;
   if (const MDNode *Range = getRangeMetadata(I))
     return getConstantRangeFromMetadata(*Range);
   return std::nullopt;

--- a/llvm/test/CodeGen/AArch64/lower-range-metadata-func-call.ll
+++ b/llvm/test/CodeGen/AArch64/lower-range-metadata-func-call.ll
@@ -62,7 +62,6 @@ define i32 @test_call_known_max_range_attr_no_noundef() #0 {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
 ; CHECK-NEXT:    bl foo
-; CHECK-NEXT:    and w0, w0, #0x3ff
 ; CHECK-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
 ; CHECK-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/X86/pr37063.ll
+++ b/llvm/test/CodeGen/X86/pr37063.ll
@@ -7,7 +7,7 @@ define void @foo(ptr) {
 ; CHECK-LABEL: foo:
 ; CHECK:       # %bb.0: # %start
 ; CHECK-NEXT:    movl (%rdi), %eax
-; CHECK-NEXT:    andl $6, %eax
+; CHECK-NEXT:    andl $-2, %eax
 ; CHECK-NEXT:    cmpl $4, %eax
 ; CHECK-NEXT:    jne bar # TAILCALL
 ; CHECK-NEXT:  # %bb.1: # %bb1


### PR DESCRIPTION
In https://reviews.llvm.org/D157685 I changed SDAG to only transfer range metadata to SDAG if it also has !noundef. At the time, this was necessary because SDAG incorrectly propagated poison when folding logical and/or to bitwise and/or.

The root cause of that issue has since been addressed by https://github.com/llvm/llvm-project/pull/84924, so drop the workaround now.