### PR TITLE
fix llvm-gsymutil verification

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -660,6 +660,11 @@ void DWARFUnit::clearDIEs(bool KeepCUDie, bool KeepDWODies) {
     if (!KeepDWODies && DWO) {
       DWO->clearDIEs(KeepCUDie, KeepDWODies);
     }
+    if (!IsDWO) {
+      RangeSectionBase = 0;
+      LocSectionBase = 0;
+      AddrOffsetSectionBase = std::nullopt;
+    }
     // Do not use resize() + shrink_to_fit() to free memory occupied by dies.
     // shrink_to_fit() is a *non-binding* request to reduce capacity() to
     // size(). It depends on the implementation whether the request is


### PR DESCRIPTION
Verification crashed here https://github.com/llvm/llvm-project/blob/main/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp#L519
The reason being that during verification to extract inline_info we recreate compile unit dies. Assert fails because we previously cleaned up just the DIEs but some other fields remained initialized.
