### PR TITLE
[docs] Update ir-normalizer to normalize

### DIFF
--- a/llvm/docs/Passes.rst
+++ b/llvm/docs/Passes.rst
@@ -554,7 +554,7 @@ variables with initializers are marked as internal.
 An interprocedural variant of :ref:`Sparse Conditional Constant Propagation
 <passes-sccp>`.
 
-``ir-normalizer``: Transforms IR into a normal form that's easier to diff
+``normalize``: Transforms IR into a normal form that's easier to diff
 ----------------------------------------------------------------------------
 
 This pass aims to transform LLVM Modules into a normal form by reordering and

--- a/llvm/docs/Passes.rst
+++ b/llvm/docs/Passes.rst
@@ -555,7 +555,7 @@ An interprocedural variant of :ref:`Sparse Conditional Constant Propagation
 <passes-sccp>`.
 
 ``normalize``: Transforms IR into a normal form that's easier to diff
-----------------------------------------------------------------------------
+---------------------------------------------------------------------
 
 This pass aims to transform LLVM Modules into a normal form by reordering and
 renaming instructions while preserving the same semantics. The normalizer makes


### PR DESCRIPTION
While the class name is IRNormalizer the registered name is "normalize" and the docs should match this.

Fixes #136347.