### PR TITLE
[flang][fir][OpenMP] Refactor privtization code into shared location

### DIFF
--- a/flang/include/flang/Lower/Support/Utils.h
+++ b/flang/include/flang/Lower/Support/Utils.h
@@ -94,6 +94,14 @@ bool isEqual(const Fortran::lower::SomeExpr *x,
              const Fortran::lower::SomeExpr *y);
 bool isEqual(const Fortran::lower::ExplicitIterSpace::ArrayBases &x,
              const Fortran::lower::ExplicitIterSpace::ArrayBases &y);
+
+template <typename OpType, typename OperandsStructType>
+void privatizeSymbol(
+    lower::AbstractConverter &converter, fir::FirOpBuilder &firOpBuilder,
+    lower::SymMap &symTable, std::function<void(OpType, mlir::Type)> initGen,
+    llvm::SetVector<const semantics::Symbol *> &allPrivatizedSymbols,
+    const semantics::Symbol *symToPrivatize, OperandsStructType *clauseOps);
+
 } // end namespace Fortran::lower
 
 // DenseMapInfo for pointers to Fortran::lower::SomeExpr.

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2029,10 +2029,6 @@ private:
   void handleLocalitySpecs(const IncrementLoopInfo &info) {
     Fortran::semantics::SemanticsContext &semanticsContext =
         bridge.getSemanticsContext();
-    // TODO Extract `DataSharingProcessor` from omp to a more general location.
-    Fortran::lower::omp::DataSharingProcessor dsp(
-        *this, semanticsContext, getEval(),
-        /*useDelayedPrivatization=*/true, localSymbols);
     fir::LocalitySpecifierOperands privateClauseOps;
     auto doConcurrentLoopOp =
         mlir::dyn_cast_if_present<fir::DoConcurrentLoopOp>(info.loopOp);
@@ -2041,10 +2037,17 @@ private:
     // complete.
     bool useDelayedPriv =
         enableDelayedPrivatizationStaging && doConcurrentLoopOp;
+    llvm::SetVector<const Fortran::semantics::Symbol *> allPrivatizedSymbols;
 
     for (const Fortran::semantics::Symbol *sym : info.localSymList) {
       if (useDelayedPriv) {
-        dsp.privatizeSymbol<fir::LocalitySpecifierOp>(sym, &privateClauseOps);
+        Fortran::lower::privatizeSymbol<fir::LocalitySpecifierOp>(
+            *this, this->getFirOpBuilder(), localSymbols,
+            [this](fir::LocalitySpecifierOp result, mlir::Type argType) {
+              TODO(this->toLocation(),
+                   "Localizers that need init regions are not supported yet.");
+            },
+            allPrivatizedSymbols, sym, &privateClauseOps);
         continue;
       }
 
@@ -2053,7 +2056,13 @@ private:
 
     for (const Fortran::semantics::Symbol *sym : info.localInitSymList) {
       if (useDelayedPriv) {
-        dsp.privatizeSymbol<fir::LocalitySpecifierOp>(sym, &privateClauseOps);
+        Fortran::lower::privatizeSymbol<fir::LocalitySpecifierOp>(
+            *this, this->getFirOpBuilder(), localSymbols,
+            [this](fir::LocalitySpecifierOp result, mlir::Type argType) {
+              TODO(this->toLocation(),
+                   "Localizers that need init regions are not supported yet.");
+            },
+            allPrivatizedSymbols, sym, &privateClauseOps);
         continue;
       }
 
@@ -2083,7 +2092,7 @@ private:
           builder->getArrayAttr(privateClauseOps.privateSyms));
 
       for (auto [sym, privateVar] : llvm::zip_equal(
-               dsp.getAllSymbolsToPrivatize(), privateClauseOps.privateVars)) {
+               allPrivatizedSymbols, privateClauseOps.privateVars)) {
         auto arg = doConcurrentLoopOp.getRegion().begin()->addArgument(
             privateVar.getType(), doConcurrentLoopOp.getLoc());
         bindSymbol(*sym, hlfir::translateToExtendedValue(

--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.h
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.h
@@ -153,10 +153,8 @@ public:
                : llvm::ArrayRef<const semantics::Symbol *>();
   }
 
-  template <typename OpType = mlir::omp::PrivateClauseOp,
-            typename OperandsStructType = mlir::omp::PrivateClauseOps>
   void privatizeSymbol(const semantics::Symbol *symToPrivatize,
-                       OperandsStructType *clauseOps);
+                       mlir::omp::PrivateClauseOps *clauseOps);
 };
 
 } // namespace omp


### PR DESCRIPTION
Refactors the utils needed to create privtization/locatization ops for both the fir and OpenMP dialects into a shared location isolating OpenMP stuff out of it as much as possible.