### PR TITLE
[lldb][Expression] Remove m_found_function_with_type_info in favour of boolean return

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
@@ -481,7 +481,10 @@ private:
   ///
   /// \param[in] namespace_decl
   ///     If valid and module is non-NULL, the parent namespace.
-  void LookupFunction(NameSearchContext &context, lldb::ModuleSP module_sp,
+  ///
+  /// \returns Returns \c true if we successfully found a function
+  /// and could create a decl with correct type-info for it.
+  bool LookupFunction(NameSearchContext &context, lldb::ModuleSP module_sp,
                       ConstString name,
                       const CompilerDeclContext &namespace_decl);
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/NameSearchContext.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/NameSearchContext.h
@@ -40,7 +40,6 @@ struct NameSearchContext {
   llvm::SmallSet<CompilerType, 5> m_function_types;
 
   bool m_found_variable = false;
-  bool m_found_function_with_type_info = false;
   bool m_found_local_vars_nsp = false;
   bool m_found_type = false;
 


### PR DESCRIPTION
I've been skimming this code while investigating a bug around module lookup and this looked like something we could clean up. We don't need to be carrying around state inside of `NameSearchContext` to tell us to look into modules. We can signal this via a boolean return from `LookupFunction`.