### PR TITLE
[RISCV] Add bltu/bgeu zero => bnez/beqz canonicalisation to RISCVInstrInfo::simplifyInstruction

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -4191,6 +4191,24 @@ bool RISCVInstrInfo::simplifyInstruction(MachineInstr &MI) const {
       return true;
     }
     break;
+  case RISCV::BLTU:
+    // bltu zero, rs, imm => bne rs, zero, imm
+    if (MI.getOperand(0).getReg() == RISCV::X0) {
+      MachineOperand MO0 = MI.getOperand(0);
+      MI.removeOperand(0);
+      MI.insert(MI.operands_begin() + 1, {MO0});
+      MI.setDesc(get(RISCV::BNE));
+    }
+    break;
+  case RISCV::BGEU:
+    // bgeu zero, rs, imm => beq rs, zero, imm
+    if (MI.getOperand(0).getReg() == RISCV::X0) {
+      MachineOperand MO0 = MI.getOperand(0);
+      MI.removeOperand(0);
+      MI.insert(MI.operands_begin() + 1, {MO0});
+      MI.setDesc(get(RISCV::BEQ));
+    }
+    break;
   }
   return false;
 }

--- a/llvm/test/CodeGen/RISCV/machine-copyprop-simplifyinstruction.mir
+++ b/llvm/test/CodeGen/RISCV/machine-copyprop-simplifyinstruction.mir
@@ -742,3 +742,39 @@ body: |
     renamable $x10 = MAXU renamable $x11, renamable $x11
     PseudoRET implicit $x10
 ...
+---
+name: bltu
+body: |
+  ; CHECK-LABEL: name: bltu
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   renamable $x11 = COPY $x12
+  ; CHECK-NEXT:   BNE $x12, $x0, %bb.1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   PseudoRET
+  bb.0:
+    renamable $x11 = COPY $x12
+    BLTU $x0, renamable $x11, %bb.1
+  bb.1:
+    PseudoRET
+...
+---
+name: bgeu
+body: |
+  ; CHECK-LABEL: name: bgeu
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   renamable $x11 = COPY $x12
+  ; CHECK-NEXT:   BEQ $x12, $x0, %bb.1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   PseudoRET
+  bb.0:
+    renamable $x11 = COPY $x12
+    BGEU $x0, renamable $x11, %bb.1
+  bb.1:
+    PseudoRET
+...


### PR DESCRIPTION
We can end up with bltu/bgeu with the zero register as the 0th operand after tail duplication and then machine copy propagation. Canonicalising in simplifyInstruction (called from MachineCopyPropagation) both produces easier to read assembly output, and means it's possible that the compressed c.beqz/c.bnez forms are produced.