### PR TITLE
Enable WPD without lto

### DIFF
--- a/clang/lib/CodeGen/CGVTables.cpp
+++ b/clang/lib/CodeGen/CGVTables.cpp
@@ -1359,7 +1359,8 @@ void CodeGenModule::EmitVTableTypeMetadata(const CXXRecordDecl *RD,
   // Emit type metadata on vtables with LTO or IR instrumentation.
   // In IR instrumentation, the type metadata is used to find out vtable
   // definitions (for type profiling) among all global variables.
-  if (!getCodeGenOpts().LTOUnit && !getCodeGenOpts().hasProfileIRInstr())
+  if (!getCodeGenOpts().LTOUnit && !getCodeGenOpts().hasProfileIRInstr() &&
+      !getCodeGenOpts().WholeProgramVTables)
     return;
 
   CharUnits ComponentWidth = GetTargetTypeStoreSize(getVTableComponentType());

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7970,8 +7970,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         IsDeviceOffloadAction ? D.getLTOMode() : D.getOffloadLTOMode();
     auto OtherIsUsingLTO = OtherLTOMode != LTOK_None;
 
-    if ((!IsUsingLTO && !OtherIsUsingLTO) ||
-        (IsPS4 && !UnifiedLTO && (D.getLTOMode() != LTOK_Full)))
+    if (!IsUsingLTO && !OtherIsUsingLTO && !UnifiedLTO) {
+      if (Arg *A = Args.getLastArg(options::OPT_O_Group))
+        if (!A->getOption().matches(options::OPT_O0))
+          CmdArgs.push_back("-fwhole-program-vtables");
+    } else if ((!IsUsingLTO && !OtherIsUsingLTO) ||
+               (IsPS4 && !UnifiedLTO && (D.getLTOMode() != LTOK_Full)))
       D.Diag(diag::err_drv_argument_only_allowed_with)
           << "-fwhole-program-vtables"
           << ((IsPS4 && !UnifiedLTO) ? "-flto=full" : "-flto");

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1295,6 +1295,9 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
   MPM.addPass(GlobalOptPass());
   MPM.addPass(GlobalDCEPass());
 
+  if (Phase == ThinOrFullLTOPhase::None && Level != OptimizationLevel::O0)
+    MPM.addPass(WholeProgramDevirtPass(nullptr, nullptr));
+
   return MPM;
 }
 


### PR DESCRIPTION
I have created this draft to collect some opinions about the idea of allowing devirtualization without the need to `lto` or forcing any kind of visibility.

I think applying **speculative** devirtualization could not need `lto` because it will be safe to be done to each single module without caring if there are other modules/lib that may do inheritance or caring about the visibility.

So, I suggest that if `lto` is enabled, the original logic will apply. If `nolto`, the speculative devirtualizaation will apply (maybe without the other features like virtual constant prop).

The idea could be done by either refactoring the current WPD pass and make it able to run with/out `lto`, or creating a new pass.

-Side note- there are some code snippets that are commented, I just mean that they maybe not needed for the case of `nolto`, but generally if the idea got accepted, that code will be refactored to work only with `lto`.

This work could be useful for cases that don't need `lto`.
I think there are some open issues related to devirtualization, and they don't need `lto`, this solution could be useful for them.
Also I tested it on SPEC, highest performance was around 2-3% and worst regression was not more than 1.5%.

Could you put your feedback please ?