### PR TITLE
[clang] Rename -Wdeprecated-switch-case to -Wdeprecated-declarations-switch-case

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -575,7 +575,8 @@ Improvements to Clang's diagnostics
 
 - ``-Wswitch`` will now diagnose unhandled enumerators in switches also when
   the enumerator is deprecated. Warnings about using deprecated enumerators in
-  switch cases have moved behind a new ``-Wdeprecated-switch-case`` flag.
+  switch cases have moved behind a new ``-Wdeprecated-declarations-switch-case``
+  flag.
 
   For example:
 
@@ -598,7 +599,7 @@ Improvements to Clang's diagnostics
   The warning can be fixed either by adding a ``default:``, or by adding
   ``case Blue:``. Since the enumerator is deprecated, the latter approach will
   trigger a ``'Blue' is deprecated`` warning, which can be turned off with
-  ``-Wno-deprecated-switch-case``.
+  ``-Wno-deprecated-declarations-switch-case``.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -234,8 +234,8 @@ def DeprecatedCopyWithDtor : DiagGroup<"deprecated-copy-with-dtor", [DeprecatedC
 def DeprecatedLiteralOperator : DiagGroup<"deprecated-literal-operator">;
 // For compatibility with GCC.
 def : DiagGroup<"deprecated-copy-dtor", [DeprecatedCopyWithDtor]>;
-def DeprecatedSwitchCase : DiagGroup<"deprecated-switch-case">;
-def DeprecatedDeclarations : DiagGroup<"deprecated-declarations", [DeprecatedSwitchCase]>;
+def DeprecatedDeclarationsSwitchCase : DiagGroup<"deprecated-declarations-switch-case">;
+def DeprecatedDeclarations : DiagGroup<"deprecated-declarations", [DeprecatedDeclarationsSwitchCase]>;
 def DeprecatedRedundantConstexprStaticDef : DiagGroup<"deprecated-redundant-constexpr-static-def">;
 def UnavailableDeclarations : DiagGroup<"unavailable-declarations">;
 def UnguardedAvailabilityNew : DiagGroup<"unguarded-availability-new">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6065,7 +6065,7 @@ def err_undeclared_use : Error<"use of undeclared %0">;
 def warn_deprecated : Warning<"%0 is deprecated">,
     InGroup<DeprecatedDeclarations>;
 def warn_deprecated_switch_case : Warning<warn_deprecated.Summary>,
-    InGroup<DeprecatedSwitchCase>;
+    InGroup<DeprecatedDeclarationsSwitchCase>;
 def note_from_diagnose_if : Note<"from 'diagnose_if' attribute on %0:">;
 def warn_property_method_deprecated :
     Warning<"property access is using %0 method which is deprecated">,

--- a/clang/test/Sema/switch-availability.c
+++ b/clang/test/Sema/switch-availability.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -verify -Wswitch -Wreturn-type -triple x86_64-apple-macosx10.12 %s
-// RUN: %clang_cc1 -verify -Wswitch -Wreturn-type -Wno-deprecated-switch-case -DNO_DEPRECATED_CASE -triple x86_64-apple-macosx10.12 %s
+// RUN: %clang_cc1 -verify -Wswitch -Wreturn-type -Wno-deprecated-declarations-switch-case -DNO_DEPRECATED_CASE -triple x86_64-apple-macosx10.12 %s
 
 enum SwitchOne {
   Unavail __attribute__((availability(macos, unavailable))),


### PR DESCRIPTION
To make it more clear that it's a subset of -Wdeprecated-declarations.

Follow-up to #138562