### PR TITLE
[llvm] add missing #include of Compiler.h

### DIFF
--- a/llvm/include/llvm/Analysis/LoopUnrollAnalyzer.h
+++ b/llvm/include/llvm/Analysis/LoopUnrollAnalyzer.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/IR/InstVisitor.h"
+#include "llvm/Support/Compiler.h"
 
 // This class is used to get an estimate of the optimization effects that we
 // could get from complete loop unrolling. It comes from the fact that some

--- a/llvm/include/llvm/Analysis/Passes.h
+++ b/llvm/include/llvm/Analysis/Passes.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_ANALYSIS_PASSES_H
 #define LLVM_ANALYSIS_PASSES_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
   class FunctionPass;
   class ImmutablePass;


### PR DESCRIPTION
Fixes a build break introduced in #136623. There were two files updated to reference the `LLVM_ABI` macro that were not updated to `#include "llvm/Support/Compiler.h"`

Failing build log [here](https://green.lab.llvm.org/job/llvm.org/job/clang-stage2-Rthinlto/794/consoleFull#-471199310f80d942a-f672-4696-b0d9-c66cae8aa9dd)