### PR TITLE
[LLDB] Pass `/std:...` before `--` on MSVC

### DIFF
--- a/lldb/test/Shell/helper/build.py
+++ b/lldb/test/Shell/helper/build.py
@@ -683,13 +683,13 @@ class MsvcBuilder(Builder):
             args.append("-fms-compatibility-version=19")
         args.append("/c")
 
+        if self.std:
+            args.append("/std:" + self.std)
+
         args.append("/Fo" + obj)
         if self.toolchain_type == "clang-cl":
             args.append("--")
         args.append(source)
-
-        if self.std:
-            args.append("/std:" + self.std)
 
         return ("compiling", [source], obj, self.compile_env, args)
 


### PR DESCRIPTION
From https://github.com/llvm/llvm-project/pull/140761. `MsvcBuilder` passed `/std:<value>` (if specified) after `--`, so the compiler would interpret this as a file. This moves the argument before the `--`.