### PR TITLE
[llvm] annotate interfaces in AsmParser, BinaryFormat, Bitcode, and Bitstream libraries for DLL export

### DIFF
--- a/llvm/include/llvm/AsmParser/Parser.h
+++ b/llvm/include/llvm/AsmParser/Parser.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_ASMPARSER_PARSER_H
 #define LLVM_ASMPARSER_PARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 #include <optional>
 
@@ -45,9 +45,9 @@ typedef llvm::function_ref<std::optional<std::string>(StringRef, StringRef)>
 /// \param Context Context in which to allocate globals info.
 /// \param Slots The optional slot mapping that will be initialized during
 ///              parsing.
-LLVM_ABI std::unique_ptr<Module> parseAssemblyFile(StringRef Filename, SMDiagnostic &Err,
-                                          LLVMContext &Context,
-                                          SlotMapping *Slots = nullptr);
+LLVM_ABI std::unique_ptr<Module>
+parseAssemblyFile(StringRef Filename, SMDiagnostic &Err, LLVMContext &Context,
+                  SlotMapping *Slots = nullptr);
 
 /// The function is a secondary interface to the LLVM Assembly Parser. It parses
 /// an ASCII string that (presumably) contains LLVM Assembly code. It returns a
@@ -60,10 +60,9 @@ LLVM_ABI std::unique_ptr<Module> parseAssemblyFile(StringRef Filename, SMDiagnos
 /// \param Context Context in which to allocate globals info.
 /// \param Slots The optional slot mapping that will be initialized during
 ///              parsing.
-LLVM_ABI std::unique_ptr<Module> parseAssemblyString(StringRef AsmString,
-                                            SMDiagnostic &Err,
-                                            LLVMContext &Context,
-                                            SlotMapping *Slots = nullptr);
+LLVM_ABI std::unique_ptr<Module>
+parseAssemblyString(StringRef AsmString, SMDiagnostic &Err,
+                    LLVMContext &Context, SlotMapping *Slots = nullptr);
 
 /// Holds the Module and ModuleSummaryIndex returned by the interfaces
 /// that parse both.
@@ -141,10 +140,9 @@ LLVM_ABI std::unique_ptr<Module> parseAssembly(
 ///              parsing.
 ///
 /// parseAssemblyFileWithIndex is a wrapper around this function.
-LLVM_ABI ParsedModuleAndIndex parseAssemblyWithIndex(MemoryBufferRef F,
-                                            SMDiagnostic &Err,
-                                            LLVMContext &Context,
-                                            SlotMapping *Slots = nullptr);
+LLVM_ABI ParsedModuleAndIndex
+parseAssemblyWithIndex(MemoryBufferRef F, SMDiagnostic &Err,
+                       LLVMContext &Context, SlotMapping *Slots = nullptr);
 
 /// Parse LLVM Assembly for summary index from a MemoryBuffer.
 ///
@@ -183,8 +181,9 @@ LLVM_ABI bool parseAssemblyInto(
 /// \param Slots The optional slot mapping that will restore the parsing state
 /// of the module.
 /// \return null on error.
-LLVM_ABI Constant *parseConstantValue(StringRef Asm, SMDiagnostic &Err, const Module &M,
-                             const SlotMapping *Slots = nullptr);
+LLVM_ABI Constant *parseConstantValue(StringRef Asm, SMDiagnostic &Err,
+                                      const Module &M,
+                                      const SlotMapping *Slots = nullptr);
 
 /// Parse a type in the given string.
 ///
@@ -192,7 +191,7 @@ LLVM_ABI Constant *parseConstantValue(StringRef Asm, SMDiagnostic &Err, const Mo
 /// of the module.
 /// \return null on error.
 LLVM_ABI Type *parseType(StringRef Asm, SMDiagnostic &Err, const Module &M,
-                const SlotMapping *Slots = nullptr);
+                         const SlotMapping *Slots = nullptr);
 
 /// Parse a string \p Asm that starts with a type.
 /// \p Read[out] gives the number of characters that have been read to parse
@@ -201,13 +200,14 @@ LLVM_ABI Type *parseType(StringRef Asm, SMDiagnostic &Err, const Module &M,
 /// \param Slots The optional slot mapping that will restore the parsing state
 /// of the module.
 /// \return null on error.
-LLVM_ABI Type *parseTypeAtBeginning(StringRef Asm, unsigned &Read, SMDiagnostic &Err,
-                           const Module &M, const SlotMapping *Slots = nullptr);
+LLVM_ABI Type *parseTypeAtBeginning(StringRef Asm, unsigned &Read,
+                                    SMDiagnostic &Err, const Module &M,
+                                    const SlotMapping *Slots = nullptr);
 
-LLVM_ABI DIExpression *parseDIExpressionBodyAtBeginning(StringRef Asm, unsigned &Read,
-                                               SMDiagnostic &Err,
-                                               const Module &M,
-                                               const SlotMapping *Slots);
+LLVM_ABI DIExpression *
+parseDIExpressionBodyAtBeginning(StringRef Asm, unsigned &Read,
+                                 SMDiagnostic &Err, const Module &M,
+                                 const SlotMapping *Slots);
 
 } // End llvm namespace
 

--- a/llvm/include/llvm/AsmParser/Parser.h
+++ b/llvm/include/llvm/AsmParser/Parser.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_ASMPARSER_PARSER_H
 #define LLVM_ASMPARSER_PARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include <memory>
@@ -44,7 +45,7 @@ typedef llvm::function_ref<std::optional<std::string>(StringRef, StringRef)>
 /// \param Context Context in which to allocate globals info.
 /// \param Slots The optional slot mapping that will be initialized during
 ///              parsing.
-std::unique_ptr<Module> parseAssemblyFile(StringRef Filename, SMDiagnostic &Err,
+LLVM_ABI std::unique_ptr<Module> parseAssemblyFile(StringRef Filename, SMDiagnostic &Err,
                                           LLVMContext &Context,
                                           SlotMapping *Slots = nullptr);
 
@@ -59,7 +60,7 @@ std::unique_ptr<Module> parseAssemblyFile(StringRef Filename, SMDiagnostic &Err,
 /// \param Context Context in which to allocate globals info.
 /// \param Slots The optional slot mapping that will be initialized during
 ///              parsing.
-std::unique_ptr<Module> parseAssemblyString(StringRef AsmString,
+LLVM_ABI std::unique_ptr<Module> parseAssemblyString(StringRef AsmString,
                                             SMDiagnostic &Err,
                                             LLVMContext &Context,
                                             SlotMapping *Slots = nullptr);
@@ -84,7 +85,7 @@ struct ParsedModuleAndIndex {
 /// \param Slots The optional slot mapping that will be initialized during
 ///              parsing.
 /// \param DataLayoutCallback Override datalayout in the llvm assembly.
-ParsedModuleAndIndex parseAssemblyFileWithIndex(
+LLVM_ABI ParsedModuleAndIndex parseAssemblyFileWithIndex(
     StringRef Filename, SMDiagnostic &Err, LLVMContext &Context,
     SlotMapping *Slots = nullptr,
     DataLayoutCallbackTy DataLayoutCallback = [](StringRef, StringRef) {
@@ -92,7 +93,7 @@ ParsedModuleAndIndex parseAssemblyFileWithIndex(
     });
 
 /// Only for use in llvm-as for testing; this does not produce a valid module.
-ParsedModuleAndIndex parseAssemblyFileWithIndexNoUpgradeDebugInfo(
+LLVM_ABI ParsedModuleAndIndex parseAssemblyFileWithIndexNoUpgradeDebugInfo(
     StringRef Filename, SMDiagnostic &Err, LLVMContext &Context,
     SlotMapping *Slots, DataLayoutCallbackTy DataLayoutCallback);
 
@@ -104,7 +105,7 @@ ParsedModuleAndIndex parseAssemblyFileWithIndexNoUpgradeDebugInfo(
 /// Parse LLVM Assembly Index from a file
 /// \param Filename The name of the file to parse
 /// \param Err Error result info.
-std::unique_ptr<ModuleSummaryIndex>
+LLVM_ABI std::unique_ptr<ModuleSummaryIndex>
 parseSummaryIndexAssemblyFile(StringRef Filename, SMDiagnostic &Err);
 
 /// The function is a secondary interface to the LLVM Assembly Parser. It parses
@@ -115,7 +116,7 @@ parseSummaryIndexAssemblyFile(StringRef Filename, SMDiagnostic &Err);
 /// Parse LLVM Assembly from a string
 /// \param AsmString The string containing assembly
 /// \param Err Error result info.
-std::unique_ptr<ModuleSummaryIndex>
+LLVM_ABI std::unique_ptr<ModuleSummaryIndex>
 parseSummaryIndexAssemblyString(StringRef AsmString, SMDiagnostic &Err);
 
 /// parseAssemblyFile and parseAssemblyString are wrappers around this function.
@@ -125,7 +126,7 @@ parseSummaryIndexAssemblyString(StringRef AsmString, SMDiagnostic &Err);
 /// \param Slots The optional slot mapping that will be initialized during
 ///              parsing.
 /// \param DataLayoutCallback Override datalayout in the llvm assembly.
-std::unique_ptr<Module> parseAssembly(
+LLVM_ABI std::unique_ptr<Module> parseAssembly(
     MemoryBufferRef F, SMDiagnostic &Err, LLVMContext &Context,
     SlotMapping *Slots = nullptr,
     DataLayoutCallbackTy DataLayoutCallback = [](StringRef, StringRef) {
@@ -140,7 +141,7 @@ std::unique_ptr<Module> parseAssembly(
 ///              parsing.
 ///
 /// parseAssemblyFileWithIndex is a wrapper around this function.
-ParsedModuleAndIndex parseAssemblyWithIndex(MemoryBufferRef F,
+LLVM_ABI ParsedModuleAndIndex parseAssemblyWithIndex(MemoryBufferRef F,
                                             SMDiagnostic &Err,
                                             LLVMContext &Context,
                                             SlotMapping *Slots = nullptr);
@@ -151,7 +152,7 @@ ParsedModuleAndIndex parseAssemblyWithIndex(MemoryBufferRef F,
 /// \param Err Error result info.
 ///
 /// parseSummaryIndexAssemblyFile is a wrapper around this function.
-std::unique_ptr<ModuleSummaryIndex>
+LLVM_ABI std::unique_ptr<ModuleSummaryIndex>
 parseSummaryIndexAssembly(MemoryBufferRef F, SMDiagnostic &Err);
 
 /// This function is the low-level interface to the LLVM Assembly Parser.
@@ -167,7 +168,7 @@ parseSummaryIndexAssembly(MemoryBufferRef F, SMDiagnostic &Err);
 ///              parsing.
 /// \return true on error.
 /// \param DataLayoutCallback Override datalayout in the llvm assembly.
-bool parseAssemblyInto(
+LLVM_ABI bool parseAssemblyInto(
     MemoryBufferRef F, Module *M, ModuleSummaryIndex *Index, SMDiagnostic &Err,
     SlotMapping *Slots = nullptr,
     DataLayoutCallbackTy DataLayoutCallback = [](StringRef, StringRef) {
@@ -182,7 +183,7 @@ bool parseAssemblyInto(
 /// \param Slots The optional slot mapping that will restore the parsing state
 /// of the module.
 /// \return null on error.
-Constant *parseConstantValue(StringRef Asm, SMDiagnostic &Err, const Module &M,
+LLVM_ABI Constant *parseConstantValue(StringRef Asm, SMDiagnostic &Err, const Module &M,
                              const SlotMapping *Slots = nullptr);
 
 /// Parse a type in the given string.
@@ -190,7 +191,7 @@ Constant *parseConstantValue(StringRef Asm, SMDiagnostic &Err, const Module &M,
 /// \param Slots The optional slot mapping that will restore the parsing state
 /// of the module.
 /// \return null on error.
-Type *parseType(StringRef Asm, SMDiagnostic &Err, const Module &M,
+LLVM_ABI Type *parseType(StringRef Asm, SMDiagnostic &Err, const Module &M,
                 const SlotMapping *Slots = nullptr);
 
 /// Parse a string \p Asm that starts with a type.
@@ -200,10 +201,10 @@ Type *parseType(StringRef Asm, SMDiagnostic &Err, const Module &M,
 /// \param Slots The optional slot mapping that will restore the parsing state
 /// of the module.
 /// \return null on error.
-Type *parseTypeAtBeginning(StringRef Asm, unsigned &Read, SMDiagnostic &Err,
+LLVM_ABI Type *parseTypeAtBeginning(StringRef Asm, unsigned &Read, SMDiagnostic &Err,
                            const Module &M, const SlotMapping *Slots = nullptr);
 
-DIExpression *parseDIExpressionBodyAtBeginning(StringRef Asm, unsigned &Read,
+LLVM_ABI DIExpression *parseDIExpressionBodyAtBeginning(StringRef Asm, unsigned &Read,
                                                SMDiagnostic &Err,
                                                const Module &M,
                                                const SlotMapping *Slots);

--- a/llvm/include/llvm/BinaryFormat/AMDGPUMetadataVerifier.h
+++ b/llvm/include/llvm/BinaryFormat/AMDGPUMetadataVerifier.h
@@ -16,10 +16,10 @@
 #ifndef LLVM_BINARYFORMAT_AMDGPUMETADATAVERIFIER_H
 #define LLVM_BINARYFORMAT_AMDGPUMETADATAVERIFIER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/MsgPackReader.h"
+#include "llvm/Support/Compiler.h"
 
 #include <cstddef>
 #include <optional>

--- a/llvm/include/llvm/BinaryFormat/AMDGPUMetadataVerifier.h
+++ b/llvm/include/llvm/BinaryFormat/AMDGPUMetadataVerifier.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_BINARYFORMAT_AMDGPUMETADATAVERIFIER_H
 #define LLVM_BINARYFORMAT_AMDGPUMETADATAVERIFIER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/MsgPackReader.h"
@@ -69,7 +70,7 @@ public:
   /// Verify given HSA metadata.
   ///
   /// \returns True when successful, false when metadata is invalid.
-  bool verify(msgpack::DocNode &HSAMetadataRoot);
+  LLVM_ABI bool verify(msgpack::DocNode &HSAMetadataRoot);
 };
 
 } // end namespace V3

--- a/llvm/include/llvm/BinaryFormat/COFF.h
+++ b/llvm/include/llvm/BinaryFormat/COFF.h
@@ -22,6 +22,7 @@
 #ifndef LLVM_BINARYFORMAT_COFF_H
 #define LLVM_BINARYFORMAT_COFF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include <cassert>
 
@@ -851,7 +852,7 @@ inline bool isReservedSectionNumber(int32_t SectionNumber) {
 
 /// Encode section name based on string table offset.
 /// The size of Out must be at least COFF::NameSize.
-bool encodeSectionName(char *Out, uint64_t Offset);
+LLVM_ABI bool encodeSectionName(char *Out, uint64_t Offset);
 
 } // End namespace COFF.
 } // End namespace llvm.

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_BINARYFORMAT_DXCONTAINER_H
 #define LLVM_BINARYFORMAT_DXCONTAINER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/SwapByteOrder.h"
 #include "llvm/TargetParser/Triple.h"

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_BINARYFORMAT_DXCONTAINER_H
 #define LLVM_BINARYFORMAT_DXCONTAINER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/SwapByteOrder.h"
@@ -59,7 +60,7 @@ struct ShaderHash {
   uint32_t Flags; // dxbc::HashFlags
   uint8_t Digest[16];
 
-  bool isPopulated();
+  LLVM_ABI bool isPopulated();
 
   void swapBytes() { sys::swapByteOrder(Flags); }
 };
@@ -173,7 +174,7 @@ enum class RootParameterType : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<RootParameterType>> getRootParameterTypes();
+LLVM_ABI ArrayRef<EnumEntry<RootParameterType>> getRootParameterTypes();
 
 #define DESCRIPTOR_RANGE(Val, Enum) Enum = Val,
 enum class DescriptorRangeType : uint32_t {
@@ -197,7 +198,7 @@ enum class ShaderVisibility : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<ShaderVisibility>> getShaderVisibility();
+LLVM_ABI ArrayRef<EnumEntry<ShaderVisibility>> getShaderVisibility();
 
 #define SHADER_VISIBILITY(Val, Enum)                                           \
   case Val:                                                                    \
@@ -229,7 +230,7 @@ enum class SamplersBorderColor : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-PartType parsePartType(StringRef S);
+LLVM_ABI PartType parsePartType(StringRef S);
 
 struct VertexPSVInfo {
   uint8_t OutputPositionPresent;
@@ -360,35 +361,35 @@ enum class SemanticKind : uint8_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<SemanticKind>> getSemanticKinds();
+LLVM_ABI ArrayRef<EnumEntry<SemanticKind>> getSemanticKinds();
 
 #define COMPONENT_TYPE(Val, Enum) Enum = Val,
 enum class ComponentType : uint8_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<ComponentType>> getComponentTypes();
+LLVM_ABI ArrayRef<EnumEntry<ComponentType>> getComponentTypes();
 
 #define INTERPOLATION_MODE(Val, Enum) Enum = Val,
 enum class InterpolationMode : uint8_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<InterpolationMode>> getInterpolationModes();
+LLVM_ABI ArrayRef<EnumEntry<InterpolationMode>> getInterpolationModes();
 
 #define RESOURCE_TYPE(Val, Enum) Enum = Val,
 enum class ResourceType : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<ResourceType>> getResourceTypes();
+LLVM_ABI ArrayRef<EnumEntry<ResourceType>> getResourceTypes();
 
 #define RESOURCE_KIND(Val, Enum) Enum = Val,
 enum class ResourceKind : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<ResourceKind>> getResourceKinds();
+LLVM_ABI ArrayRef<EnumEntry<ResourceKind>> getResourceKinds();
 
 #define RESOURCE_FLAG(Index, Enum) bool Enum = false;
 struct ResourceFlags {
@@ -555,21 +556,21 @@ enum class SigMinPrecision : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<SigMinPrecision>> getSigMinPrecisions();
+LLVM_ABI ArrayRef<EnumEntry<SigMinPrecision>> getSigMinPrecisions();
 
 #define D3D_SYSTEM_VALUE(Val, Enum) Enum = Val,
 enum class D3DSystemValue : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<D3DSystemValue>> getD3DSystemValues();
+LLVM_ABI ArrayRef<EnumEntry<D3DSystemValue>> getD3DSystemValues();
 
 #define COMPONENT_TYPE(Val, Enum) Enum = Val,
 enum class SigComponentType : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<SigComponentType>> getSigComponentTypes();
+LLVM_ABI ArrayRef<EnumEntry<SigComponentType>> getSigComponentTypes();
 
 struct ProgramSignatureHeader {
   uint32_t ParamCount;

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -499,7 +499,7 @@ toDW_LNAME(SourceLanguage language) {
   return {};
 }
 
-llvm::StringRef LanguageDescription(SourceLanguageName name);
+LLVM_ABI llvm::StringRef LanguageDescription(SourceLanguageName name);
 
 inline bool isCPlusPlus(SourceLanguage S) {
   bool result = false;
@@ -974,43 +974,43 @@ enum GDBIndexEntryLinkage { GIEL_EXTERNAL, GIEL_STATIC };
 /// isn't known.
 ///
 /// @{
-StringRef TagString(unsigned Tag);
-StringRef ChildrenString(unsigned Children);
-StringRef AttributeString(unsigned Attribute);
-StringRef FormEncodingString(unsigned Encoding);
-StringRef OperationEncodingString(unsigned Encoding);
-StringRef SubOperationEncodingString(unsigned OpEncoding,
+LLVM_ABI StringRef TagString(unsigned Tag);
+LLVM_ABI StringRef ChildrenString(unsigned Children);
+LLVM_ABI StringRef AttributeString(unsigned Attribute);
+LLVM_ABI StringRef FormEncodingString(unsigned Encoding);
+LLVM_ABI StringRef OperationEncodingString(unsigned Encoding);
+LLVM_ABI StringRef SubOperationEncodingString(unsigned OpEncoding,
                                      unsigned SubOpEncoding);
-StringRef AttributeEncodingString(unsigned Encoding);
-StringRef DecimalSignString(unsigned Sign);
-StringRef EndianityString(unsigned Endian);
-StringRef AccessibilityString(unsigned Access);
-StringRef DefaultedMemberString(unsigned DefaultedEncodings);
-StringRef VisibilityString(unsigned Visibility);
-StringRef VirtualityString(unsigned Virtuality);
-StringRef EnumKindString(unsigned EnumKind);
-StringRef LanguageString(unsigned Language);
-StringRef CaseString(unsigned Case);
-StringRef ConventionString(unsigned Convention);
-StringRef InlineCodeString(unsigned Code);
-StringRef ArrayOrderString(unsigned Order);
-StringRef LNStandardString(unsigned Standard);
-StringRef LNExtendedString(unsigned Encoding);
-StringRef MacinfoString(unsigned Encoding);
-StringRef MacroString(unsigned Encoding);
-StringRef GnuMacroString(unsigned Encoding);
-StringRef RangeListEncodingString(unsigned Encoding);
-StringRef LocListEncodingString(unsigned Encoding);
-StringRef CallFrameString(unsigned Encoding, Triple::ArchType Arch);
-StringRef ApplePropertyString(unsigned);
-StringRef UnitTypeString(unsigned);
-StringRef AtomTypeString(unsigned Atom);
-StringRef GDBIndexEntryKindString(GDBIndexEntryKind Kind);
-StringRef GDBIndexEntryLinkageString(GDBIndexEntryLinkage Linkage);
-StringRef IndexString(unsigned Idx);
-StringRef FormatString(DwarfFormat Format);
-StringRef FormatString(bool IsDWARF64);
-StringRef RLEString(unsigned RLE);
+LLVM_ABI StringRef AttributeEncodingString(unsigned Encoding);
+LLVM_ABI StringRef DecimalSignString(unsigned Sign);
+LLVM_ABI StringRef EndianityString(unsigned Endian);
+LLVM_ABI StringRef AccessibilityString(unsigned Access);
+LLVM_ABI StringRef DefaultedMemberString(unsigned DefaultedEncodings);
+LLVM_ABI StringRef VisibilityString(unsigned Visibility);
+LLVM_ABI StringRef VirtualityString(unsigned Virtuality);
+LLVM_ABI StringRef EnumKindString(unsigned EnumKind);
+LLVM_ABI StringRef LanguageString(unsigned Language);
+LLVM_ABI StringRef CaseString(unsigned Case);
+LLVM_ABI StringRef ConventionString(unsigned Convention);
+LLVM_ABI StringRef InlineCodeString(unsigned Code);
+LLVM_ABI StringRef ArrayOrderString(unsigned Order);
+LLVM_ABI StringRef LNStandardString(unsigned Standard);
+LLVM_ABI StringRef LNExtendedString(unsigned Encoding);
+LLVM_ABI StringRef MacinfoString(unsigned Encoding);
+LLVM_ABI StringRef MacroString(unsigned Encoding);
+LLVM_ABI StringRef GnuMacroString(unsigned Encoding);
+LLVM_ABI StringRef RangeListEncodingString(unsigned Encoding);
+LLVM_ABI StringRef LocListEncodingString(unsigned Encoding);
+LLVM_ABI StringRef CallFrameString(unsigned Encoding, Triple::ArchType Arch);
+LLVM_ABI StringRef ApplePropertyString(unsigned);
+LLVM_ABI StringRef UnitTypeString(unsigned);
+LLVM_ABI StringRef AtomTypeString(unsigned Atom);
+LLVM_ABI StringRef GDBIndexEntryKindString(GDBIndexEntryKind Kind);
+LLVM_ABI StringRef GDBIndexEntryLinkageString(GDBIndexEntryLinkage Linkage);
+LLVM_ABI StringRef IndexString(unsigned Idx);
+LLVM_ABI StringRef FormatString(DwarfFormat Format);
+LLVM_ABI StringRef FormatString(bool IsDWARF64);
+LLVM_ABI StringRef RLEString(unsigned RLE);
 /// @}
 
 /// \defgroup DwarfConstantsParsing Dwarf constants parsing functions
@@ -1023,17 +1023,17 @@ StringRef RLEString(unsigned RLE);
 /// \li \a getMacinfo() returns \a DW_MACINFO_invalid on invalid input.
 ///
 /// @{
-unsigned getTag(StringRef TagString);
-unsigned getOperationEncoding(StringRef OperationEncodingString);
-unsigned getSubOperationEncoding(unsigned OpEncoding,
+LLVM_ABI unsigned getTag(StringRef TagString);
+LLVM_ABI unsigned getOperationEncoding(StringRef OperationEncodingString);
+LLVM_ABI unsigned getSubOperationEncoding(unsigned OpEncoding,
                                  StringRef SubOperationEncodingString);
-unsigned getVirtuality(StringRef VirtualityString);
-unsigned getEnumKind(StringRef EnumKindString);
-unsigned getLanguage(StringRef LanguageString);
-unsigned getCallingConvention(StringRef LanguageString);
-unsigned getAttributeEncoding(StringRef EncodingString);
-unsigned getMacinfo(StringRef MacinfoString);
-unsigned getMacro(StringRef MacroString);
+LLVM_ABI unsigned getVirtuality(StringRef VirtualityString);
+LLVM_ABI unsigned getEnumKind(StringRef EnumKindString);
+LLVM_ABI unsigned getLanguage(StringRef LanguageString);
+LLVM_ABI unsigned getCallingConvention(StringRef LanguageString);
+LLVM_ABI unsigned getAttributeEncoding(StringRef EncodingString);
+LLVM_ABI unsigned getMacinfo(StringRef MacinfoString);
+LLVM_ABI unsigned getMacro(StringRef MacroString);
 /// @}
 
 /// \defgroup DwarfConstantsVersioning Dwarf version for constants
@@ -1044,12 +1044,12 @@ unsigned getMacro(StringRef MacroString);
 /// Otherwise returns 0.
 ///
 /// @{
-unsigned TagVersion(Tag T);
-unsigned AttributeVersion(Attribute A);
-unsigned FormVersion(Form F);
-unsigned OperationVersion(LocationAtom O);
-unsigned AttributeEncodingVersion(TypeKind E);
-unsigned LanguageVersion(SourceLanguage L);
+LLVM_ABI unsigned TagVersion(Tag T);
+LLVM_ABI unsigned AttributeVersion(Attribute A);
+LLVM_ABI unsigned FormVersion(Form F);
+LLVM_ABI unsigned OperationVersion(LocationAtom O);
+LLVM_ABI unsigned AttributeEncodingVersion(TypeKind E);
+LLVM_ABI unsigned LanguageVersion(SourceLanguage L);
 /// @}
 
 /// \defgroup DwarfConstantsVendor Dwarf "vendor" for constants
@@ -1058,23 +1058,23 @@ unsigned LanguageVersion(SourceLanguage L);
 /// either the DWARF standard itself or the vendor who defined the extension.
 ///
 /// @{
-unsigned TagVendor(Tag T);
-unsigned AttributeVendor(Attribute A);
-unsigned FormVendor(Form F);
-unsigned OperationVendor(LocationAtom O);
-unsigned AttributeEncodingVendor(TypeKind E);
-unsigned LanguageVendor(SourceLanguage L);
+LLVM_ABI unsigned TagVendor(Tag T);
+LLVM_ABI unsigned AttributeVendor(Attribute A);
+LLVM_ABI unsigned FormVendor(Form F);
+LLVM_ABI unsigned OperationVendor(LocationAtom O);
+LLVM_ABI unsigned AttributeEncodingVendor(TypeKind E);
+LLVM_ABI unsigned LanguageVendor(SourceLanguage L);
 /// @}
 
 /// The number of operands for the given LocationAtom.
-std::optional<unsigned> OperationOperands(LocationAtom O);
+LLVM_ABI std::optional<unsigned> OperationOperands(LocationAtom O);
 
 /// The arity of the given LocationAtom. This is the number of elements on the
 /// stack this operation operates on. Returns -1 if the arity is variable (e.g.
 /// depending on the argument) or unknown.
-std::optional<unsigned> OperationArity(LocationAtom O);
+LLVM_ABI std::optional<unsigned> OperationArity(LocationAtom O);
 
-std::optional<unsigned> LanguageLowerBound(SourceLanguage L);
+LLVM_ABI std::optional<unsigned> LanguageLowerBound(SourceLanguage L);
 
 /// The size of a reference determined by the DWARF 32/64-bit format.
 inline uint8_t getDwarfOffsetByteSize(DwarfFormat Format) {
@@ -1136,20 +1136,20 @@ inline uint8_t getUnitLengthFieldByteSize(DwarfFormat Format) {
 /// \param Params DWARF parameters to help interpret forms.
 /// \returns std::optional<uint8_t> value with the fixed byte size or
 /// std::nullopt if \p Form doesn't have a fixed byte size.
-std::optional<uint8_t> getFixedFormByteSize(dwarf::Form Form,
+LLVM_ABI std::optional<uint8_t> getFixedFormByteSize(dwarf::Form Form,
                                             FormParams Params);
 
 /// Tells whether the specified form is defined in the specified version,
 /// or is an extension if extensions are allowed.
-bool isValidFormForVersion(Form F, unsigned Version, bool ExtensionsOk = true);
+LLVM_ABI bool isValidFormForVersion(Form F, unsigned Version, bool ExtensionsOk = true);
 
 /// Returns the symbolic string representing Val when used as a value
 /// for attribute Attr.
-StringRef AttributeValueString(uint16_t Attr, unsigned Val);
+LLVM_ABI StringRef AttributeValueString(uint16_t Attr, unsigned Val);
 
 /// Returns the symbolic string representing Val when used as a value
 /// for atom Atom.
-StringRef AtomValueString(uint16_t Atom, unsigned Val);
+LLVM_ABI StringRef AtomValueString(uint16_t Atom, unsigned Val);
 
 /// Describes an entry of the various gnu_pub* debug sections.
 ///

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -980,7 +980,7 @@ LLVM_ABI StringRef AttributeString(unsigned Attribute);
 LLVM_ABI StringRef FormEncodingString(unsigned Encoding);
 LLVM_ABI StringRef OperationEncodingString(unsigned Encoding);
 LLVM_ABI StringRef SubOperationEncodingString(unsigned OpEncoding,
-                                     unsigned SubOpEncoding);
+                                              unsigned SubOpEncoding);
 LLVM_ABI StringRef AttributeEncodingString(unsigned Encoding);
 LLVM_ABI StringRef DecimalSignString(unsigned Sign);
 LLVM_ABI StringRef EndianityString(unsigned Endian);
@@ -1026,7 +1026,7 @@ LLVM_ABI StringRef RLEString(unsigned RLE);
 LLVM_ABI unsigned getTag(StringRef TagString);
 LLVM_ABI unsigned getOperationEncoding(StringRef OperationEncodingString);
 LLVM_ABI unsigned getSubOperationEncoding(unsigned OpEncoding,
-                                 StringRef SubOperationEncodingString);
+                                          StringRef SubOperationEncodingString);
 LLVM_ABI unsigned getVirtuality(StringRef VirtualityString);
 LLVM_ABI unsigned getEnumKind(StringRef EnumKindString);
 LLVM_ABI unsigned getLanguage(StringRef LanguageString);
@@ -1137,11 +1137,12 @@ inline uint8_t getUnitLengthFieldByteSize(DwarfFormat Format) {
 /// \returns std::optional<uint8_t> value with the fixed byte size or
 /// std::nullopt if \p Form doesn't have a fixed byte size.
 LLVM_ABI std::optional<uint8_t> getFixedFormByteSize(dwarf::Form Form,
-                                            FormParams Params);
+                                                     FormParams Params);
 
 /// Tells whether the specified form is defined in the specified version,
 /// or is an extension if extensions are allowed.
-LLVM_ABI bool isValidFormForVersion(Form F, unsigned Version, bool ExtensionsOk = true);
+LLVM_ABI bool isValidFormForVersion(Form F, unsigned Version,
+                                    bool ExtensionsOk = true);
 
 /// Returns the symbolic string representing Val when used as a value
 /// for attribute Attr.

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -19,6 +19,7 @@
 #ifndef LLVM_BINARYFORMAT_ELF_H
 #define LLVM_BINARYFORMAT_ELF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cstdint>
@@ -2014,20 +2015,20 @@ enum {
 constexpr unsigned CREL_HDR_ADDEND = 4;
 
 /// Convert an architecture name into ELF's e_machine value.
-uint16_t convertArchNameToEMachine(StringRef Arch);
+LLVM_ABI uint16_t convertArchNameToEMachine(StringRef Arch);
 
 /// Convert an ELF's e_machine value into an architecture name.
-StringRef convertEMachineToArchName(uint16_t EMachine);
+LLVM_ABI StringRef convertEMachineToArchName(uint16_t EMachine);
 
 // Convert a triple's architecture to ELF's e_machine value.
-uint16_t convertTripleArchTypeToEMachine(Triple::ArchType ArchType);
+LLVM_ABI uint16_t convertTripleArchTypeToEMachine(Triple::ArchType ArchType);
 
 // Convert a lowercase string identifier into an OSABI value.
-uint8_t convertNameToOSABI(StringRef Name);
+LLVM_ABI uint8_t convertNameToOSABI(StringRef Name);
 
 // Convert an OSABI value into a string that identifies the OS- or ABI-
 // specific ELF extension.
-StringRef convertOSABIToName(uint8_t OSABI);
+LLVM_ABI StringRef convertOSABIToName(uint8_t OSABI);
 
 } // end namespace ELF
 } // end namespace llvm

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -19,8 +19,8 @@
 #ifndef LLVM_BINARYFORMAT_ELF_H
 #define LLVM_BINARYFORMAT_ELF_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cstdint>
 #include <cstring>

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -1706,8 +1706,9 @@ enum CPUSubTypeRISCV {
 
 LLVM_ABI Expected<uint32_t> getCPUType(const Triple &T);
 LLVM_ABI Expected<uint32_t> getCPUSubType(const Triple &T);
-LLVM_ABI Expected<uint32_t> getCPUSubType(const Triple &T, unsigned PtrAuthABIVersion,
-                                 bool PtrAuthKernelABIVersion);
+LLVM_ABI Expected<uint32_t> getCPUSubType(const Triple &T,
+                                          unsigned PtrAuthABIVersion,
+                                          bool PtrAuthKernelABIVersion);
 
 struct x86_thread_state32_t {
   uint32_t eax;

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -1704,9 +1704,9 @@ enum CPUSubTypeRISCV {
   CPU_SUBTYPE_RISCV_ALL = 0,
 };
 
-Expected<uint32_t> getCPUType(const Triple &T);
-Expected<uint32_t> getCPUSubType(const Triple &T);
-Expected<uint32_t> getCPUSubType(const Triple &T, unsigned PtrAuthABIVersion,
+LLVM_ABI Expected<uint32_t> getCPUType(const Triple &T);
+LLVM_ABI Expected<uint32_t> getCPUSubType(const Triple &T);
+LLVM_ABI Expected<uint32_t> getCPUSubType(const Triple &T, unsigned PtrAuthABIVersion,
                                  bool PtrAuthKernelABIVersion);
 
 struct x86_thread_state32_t {

--- a/llvm/include/llvm/BinaryFormat/Magic.h
+++ b/llvm/include/llvm/BinaryFormat/Magic.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_BINARYFORMAT_MAGIC_H
 #define LLVM_BINARYFORMAT_MAGIC_H
 
+#include "llvm/Support/Compiler.h"
 #include <system_error>
 
 namespace llvm {
@@ -72,7 +73,7 @@ private:
 };
 
 /// Identify the type of a binary file based on how magical it is.
-file_magic identify_magic(StringRef magic);
+LLVM_ABI file_magic identify_magic(StringRef magic);
 
 /// Get and identify \a path's type based on its content.
 ///
@@ -80,7 +81,7 @@ file_magic identify_magic(StringRef magic);
 /// @param result Set to the type of file, or file_magic::unknown.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code identify_magic(const Twine &path, file_magic &result);
+LLVM_ABI std::error_code identify_magic(const Twine &path, file_magic &result);
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/BinaryFormat/MsgPackDocument.h
+++ b/llvm/include/llvm/BinaryFormat/MsgPackDocument.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_BINARYFORMAT_MSGPACKDOCUMENT_H
 #define LLVM_BINARYFORMAT_MSGPACKDOCUMENT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/MsgPackReader.h"
 #include <map>
 
@@ -192,12 +193,12 @@ public:
   }
 
   /// Convert this node to a string, assuming it is scalar.
-  std::string toString() const;
+  LLVM_ABI std::string toString() const;
 
   /// Convert the StringRef and use it to set this DocNode (assuming scalar). If
   /// it is a string, copy the string into the Document's strings list so we do
   /// not rely on S having a lifetime beyond this call. Tag is "" or a YAML tag.
-  StringRef fromString(StringRef S, StringRef Tag = "");
+  LLVM_ABI StringRef fromString(StringRef S, StringRef Tag = "");
 
   /// Convenience assignment operators. This only works if the destination
   /// DocNode has an associated Document, i.e. it was not constructed using the
@@ -205,20 +206,20 @@ public:
   /// remain valid for the lifetime of the Document. Use fromString to avoid
   /// that restriction.
   DocNode &operator=(const char *Val) { return *this = StringRef(Val); }
-  DocNode &operator=(StringRef Val);
-  DocNode &operator=(MemoryBufferRef Val);
-  DocNode &operator=(bool Val);
-  DocNode &operator=(int Val);
-  DocNode &operator=(unsigned Val);
-  DocNode &operator=(int64_t Val);
-  DocNode &operator=(uint64_t Val);
+  LLVM_ABI DocNode &operator=(StringRef Val);
+  LLVM_ABI DocNode &operator=(MemoryBufferRef Val);
+  LLVM_ABI DocNode &operator=(bool Val);
+  LLVM_ABI DocNode &operator=(int Val);
+  LLVM_ABI DocNode &operator=(unsigned Val);
+  LLVM_ABI DocNode &operator=(int64_t Val);
+  LLVM_ABI DocNode &operator=(uint64_t Val);
 
 private:
   // Private constructor setting KindAndDoc, used by methods in Document.
   DocNode(const KindAndDocument *KindAndDoc) : KindAndDoc(KindAndDoc) {}
 
-  void convertToArray();
-  void convertToMap();
+  LLVM_ABI void convertToArray();
+  LLVM_ABI void convertToMap();
 };
 
 /// A DocNode that is a map.
@@ -233,7 +234,7 @@ public:
   MapTy::iterator begin() { return Map->begin(); }
   MapTy::iterator end() { return Map->end(); }
   MapTy::iterator find(DocNode Key) { return Map->find(Key); }
-  MapTy::iterator find(StringRef Key);
+  LLVM_ABI MapTy::iterator find(StringRef Key);
   MapTy::iterator erase(MapTy::const_iterator I) { return Map->erase(I); }
   size_t erase(DocNode Key) { return Map->erase(Key); }
   MapTy::iterator erase(MapTy::const_iterator First,
@@ -242,13 +243,13 @@ public:
   }
   /// Member access. The string data must remain valid for the lifetime of the
   /// Document.
-  DocNode &operator[](StringRef S);
+  LLVM_ABI DocNode &operator[](StringRef S);
   /// Member access, with convenience versions for an integer key.
-  DocNode &operator[](DocNode Key);
-  DocNode &operator[](int Key);
-  DocNode &operator[](unsigned Key);
-  DocNode &operator[](int64_t Key);
-  DocNode &operator[](uint64_t Key);
+  LLVM_ABI DocNode &operator[](DocNode Key);
+  LLVM_ABI DocNode &operator[](int Key);
+  LLVM_ABI DocNode &operator[](unsigned Key);
+  LLVM_ABI DocNode &operator[](int64_t Key);
+  LLVM_ABI DocNode &operator[](uint64_t Key);
 };
 
 /// A DocNode that is an array.
@@ -269,7 +270,7 @@ public:
   }
 
   /// Element access. This extends the array if necessary, with empty nodes.
-  DocNode &operator[](size_t Index);
+  LLVM_ABI DocNode &operator[](size_t Index);
 };
 
 /// Simple in-memory representation of a document of msgpack objects with
@@ -424,7 +425,7 @@ public:
   /// map entry, a nil node otherwise.
   ///
   /// The default for Merger is to disallow any conflict.
-  bool readFromBlob(
+  LLVM_ABI bool readFromBlob(
       StringRef Blob, bool Multi,
       function_ref<int(DocNode *DestNode, DocNode SrcNode, DocNode MapKey)>
           Merger = [](DocNode *DestNode, DocNode SrcNode, DocNode MapKey) {
@@ -432,7 +433,7 @@ public:
           });
 
   /// Write a MsgPack document to a binary MsgPack blob.
-  void writeToBlob(std::string &Blob);
+  LLVM_ABI void writeToBlob(std::string &Blob);
 
   /// Copy a string into the Document's strings list, and return the copy that
   /// is owned by the Document.
@@ -449,10 +450,10 @@ public:
   bool getHexMode() const { return HexMode; }
 
   /// Convert MsgPack Document to YAML text.
-  void toYAML(raw_ostream &OS);
+  LLVM_ABI void toYAML(raw_ostream &OS);
 
   /// Read YAML text into the MsgPack document. Returns false on failure.
-  bool fromYAML(StringRef S);
+  LLVM_ABI bool fromYAML(StringRef S);
 };
 
 } // namespace msgpack

--- a/llvm/include/llvm/BinaryFormat/MsgPackDocument.h
+++ b/llvm/include/llvm/BinaryFormat/MsgPackDocument.h
@@ -17,8 +17,8 @@
 #ifndef LLVM_BINARYFORMAT_MSGPACKDOCUMENT_H
 #define LLVM_BINARYFORMAT_MSGPACKDOCUMENT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/MsgPackReader.h"
+#include "llvm/Support/Compiler.h"
 #include <map>
 
 namespace llvm {

--- a/llvm/include/llvm/BinaryFormat/MsgPackReader.h
+++ b/llvm/include/llvm/BinaryFormat/MsgPackReader.h
@@ -38,6 +38,7 @@
 #ifndef LLVM_BINARYFORMAT_MSGPACKREADER_H
 #define LLVM_BINARYFORMAT_MSGPACKREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include <cstdint>
@@ -104,9 +105,9 @@ struct Object {
 class Reader {
 public:
   /// Construct a reader, keeping a reference to the \p InputBuffer.
-  Reader(MemoryBufferRef InputBuffer);
+  LLVM_ABI Reader(MemoryBufferRef InputBuffer);
   /// Construct a reader, keeping a reference to the \p Input.
-  Reader(StringRef Input);
+  LLVM_ABI Reader(StringRef Input);
 
   Reader(const Reader &) = delete;
   Reader &operator=(const Reader &) = delete;
@@ -125,7 +126,7 @@ public:
   ///
   /// \returns true when object successfully read, false when at end of
   /// input (and so \p Obj was not updated), otherwise an error.
-  Expected<bool> read(Object &Obj);
+  LLVM_ABI Expected<bool> read(Object &Obj);
 
 private:
   MemoryBufferRef InputBuffer;

--- a/llvm/include/llvm/BinaryFormat/MsgPackWriter.h
+++ b/llvm/include/llvm/BinaryFormat/MsgPackWriter.h
@@ -28,6 +28,7 @@
 #ifndef LLVM_BINARYFORMAT_MSGPACKWRITER_H
 #define LLVM_BINARYFORMAT_MSGPACKWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/MemoryBufferRef.h"
 
@@ -48,7 +49,7 @@ public:
   ///
   /// \param OS stream to output MessagePack objects to.
   /// \param Compatible when set, write in "Compatibility Mode".
-  Writer(raw_ostream &OS, bool Compatible = false);
+  LLVM_ABI Writer(raw_ostream &OS, bool Compatible = false);
 
   Writer(const Writer &) = delete;
   Writer &operator=(const Writer &) = delete;
@@ -56,41 +57,41 @@ public:
   /// Write a \em Nil to the output stream.
   ///
   /// The output will be the \em nil format.
-  void writeNil();
+  LLVM_ABI void writeNil();
 
   /// Write a \em Boolean to the output stream.
   ///
   /// The output will be a \em bool format.
-  void write(bool b);
+  LLVM_ABI void write(bool b);
 
   /// Write a signed integer to the output stream.
   ///
   /// The output will be in the smallest possible \em int format.
   ///
   /// The format chosen may be for an unsigned integer.
-  void write(int64_t i);
+  LLVM_ABI void write(int64_t i);
 
   /// Write an unsigned integer to the output stream.
   ///
   /// The output will be in the smallest possible \em int format.
-  void write(uint64_t u);
+  LLVM_ABI void write(uint64_t u);
 
   /// Write a floating point number to the output stream.
   ///
   /// The output will be in the smallest possible \em float format.
-  void write(double d);
+  LLVM_ABI void write(double d);
 
   /// Write a string to the output stream.
   ///
   /// The output will be in the smallest possible \em str format.
-  void write(StringRef s);
+  LLVM_ABI void write(StringRef s);
 
   /// Write a memory buffer to the output stream.
   ///
   /// The output will be in the smallest possible \em bin format.
   ///
   /// \warning Do not use this overload if in \c Compatible mode.
-  void write(MemoryBufferRef Buffer);
+  LLVM_ABI void write(MemoryBufferRef Buffer);
 
   /// Write the header for an \em Array of the given size.
   ///
@@ -101,7 +102,7 @@ public:
   ///
   /// N.B. The caller must subsequently call \c Write an additional \p Size
   /// times to complete the array.
-  void writeArraySize(uint32_t Size);
+  LLVM_ABI void writeArraySize(uint32_t Size);
 
   /// Write the header for a \em Map of the given size.
   ///
@@ -113,12 +114,12 @@ public:
   /// N.B. The caller must subsequently call \c Write and additional \c Size*2
   /// times to complete the map. Each even numbered call to \c Write defines a
   /// new key, and each odd numbered call defines the previous key's value.
-  void writeMapSize(uint32_t Size);
+  LLVM_ABI void writeMapSize(uint32_t Size);
 
   /// Write a typed memory buffer (an extension type) to the output stream.
   ///
   /// The output will be in the smallest possible \em ext format.
-  void writeExt(int8_t Type, MemoryBufferRef Buffer);
+  LLVM_ABI void writeExt(int8_t Type, MemoryBufferRef Buffer);
 
 private:
   support::endian::Writer EW;

--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_BINARYFORMAT_WASM_H
 #define LLVM_BINARYFORMAT_WASM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -547,10 +548,10 @@ inline bool operator==(const WasmTableType &LHS, const WasmTableType &RHS) {
   return LHS.ElemType == RHS.ElemType && LHS.Limits == RHS.Limits;
 }
 
-llvm::StringRef toString(WasmSymbolType type);
-llvm::StringRef relocTypetoString(uint32_t type);
-llvm::StringRef sectionTypeToString(uint32_t type);
-bool relocTypeHasAddend(uint32_t type);
+LLVM_ABI llvm::StringRef toString(WasmSymbolType type);
+LLVM_ABI llvm::StringRef relocTypetoString(uint32_t type);
+LLVM_ABI llvm::StringRef sectionTypeToString(uint32_t type);
+LLVM_ABI bool relocTypeHasAddend(uint32_t type);
 
 } // end namespace wasm
 } // end namespace llvm

--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_BINARYFORMAT_WASM_H
 #define LLVM_BINARYFORMAT_WASM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {

--- a/llvm/include/llvm/BinaryFormat/XCOFF.h
+++ b/llvm/include/llvm/BinaryFormat/XCOFF.h
@@ -375,14 +375,14 @@ enum SymbolAuxType : uint8_t {
 LLVM_ABI StringRef getMappingClassString(XCOFF::StorageMappingClass SMC);
 LLVM_ABI StringRef getRelocationTypeString(XCOFF::RelocationType Type);
 LLVM_ABI StringRef getTCPUString(XCOFF::CFileCpuId TCPU);
-LLVM_ABI Expected<SmallString<32>> parseParmsType(uint32_t Value, unsigned FixedParmsNum,
-                                         unsigned FloatingParmsNum);
-LLVM_ABI Expected<SmallString<32>> parseParmsTypeWithVecInfo(uint32_t Value,
-                                                    unsigned FixedParmsNum,
-                                                    unsigned FloatingParmsNum,
-                                                    unsigned VectorParmsNum);
+LLVM_ABI Expected<SmallString<32>> parseParmsType(uint32_t Value,
+                                                  unsigned FixedParmsNum,
+                                                  unsigned FloatingParmsNum);
+LLVM_ABI Expected<SmallString<32>>
+parseParmsTypeWithVecInfo(uint32_t Value, unsigned FixedParmsNum,
+                          unsigned FloatingParmsNum, unsigned VectorParmsNum);
 LLVM_ABI Expected<SmallString<32>> parseVectorParmsType(uint32_t Value,
-                                               unsigned ParmsNum);
+                                                        unsigned ParmsNum);
 
 struct TracebackTable {
   enum LanguageID : uint8_t {
@@ -491,7 +491,8 @@ enum ExtendedTBTableFlag : uint8_t {
   TB_LONGTBTABLE2 = 0x01 ///< Additional tbtable extension exists.
 };
 
-LLVM_ABI StringRef getNameForTracebackTableLanguageId(TracebackTable::LanguageID LangId);
+LLVM_ABI StringRef
+getNameForTracebackTableLanguageId(TracebackTable::LanguageID LangId);
 LLVM_ABI SmallString<32> getExtendedTBTableFlagString(uint8_t Flag);
 LLVM_ABI XCOFF::CFileCpuId getCpuID(StringRef CPU);
 

--- a/llvm/include/llvm/BinaryFormat/XCOFF.h
+++ b/llvm/include/llvm/BinaryFormat/XCOFF.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_BINARYFORMAT_XCOFF_H
 #define LLVM_BINARYFORMAT_XCOFF_H
 
+#include "llvm/Support/Compiler.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -371,16 +372,16 @@ enum SymbolAuxType : uint8_t {
   AUX_SECT = 250    ///< Identifies a SECT auxiliary entry.
 };                  // 64-bit XCOFF file only.
 
-StringRef getMappingClassString(XCOFF::StorageMappingClass SMC);
-StringRef getRelocationTypeString(XCOFF::RelocationType Type);
-StringRef getTCPUString(XCOFF::CFileCpuId TCPU);
-Expected<SmallString<32>> parseParmsType(uint32_t Value, unsigned FixedParmsNum,
+LLVM_ABI StringRef getMappingClassString(XCOFF::StorageMappingClass SMC);
+LLVM_ABI StringRef getRelocationTypeString(XCOFF::RelocationType Type);
+LLVM_ABI StringRef getTCPUString(XCOFF::CFileCpuId TCPU);
+LLVM_ABI Expected<SmallString<32>> parseParmsType(uint32_t Value, unsigned FixedParmsNum,
                                          unsigned FloatingParmsNum);
-Expected<SmallString<32>> parseParmsTypeWithVecInfo(uint32_t Value,
+LLVM_ABI Expected<SmallString<32>> parseParmsTypeWithVecInfo(uint32_t Value,
                                                     unsigned FixedParmsNum,
                                                     unsigned FloatingParmsNum,
                                                     unsigned VectorParmsNum);
-Expected<SmallString<32>> parseVectorParmsType(uint32_t Value,
+LLVM_ABI Expected<SmallString<32>> parseVectorParmsType(uint32_t Value,
                                                unsigned ParmsNum);
 
 struct TracebackTable {
@@ -490,9 +491,9 @@ enum ExtendedTBTableFlag : uint8_t {
   TB_LONGTBTABLE2 = 0x01 ///< Additional tbtable extension exists.
 };
 
-StringRef getNameForTracebackTableLanguageId(TracebackTable::LanguageID LangId);
-SmallString<32> getExtendedTBTableFlagString(uint8_t Flag);
-XCOFF::CFileCpuId getCpuID(StringRef CPU);
+LLVM_ABI StringRef getNameForTracebackTableLanguageId(TracebackTable::LanguageID LangId);
+LLVM_ABI SmallString<32> getExtendedTBTableFlagString(uint8_t Flag);
+LLVM_ABI XCOFF::CFileCpuId getCpuID(StringRef CPU);
 
 struct CsectProperties {
   CsectProperties(StorageMappingClass SMC, SymbolType ST)

--- a/llvm/include/llvm/Bitcode/BitcodeAnalyzer.h
+++ b/llvm/include/llvm/Bitcode/BitcodeAnalyzer.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_BITCODE_BITCODEANALYZER_H
 #define LLVM_BITCODE_BITCODEANALYZER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Bitstream/BitstreamReader.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <map>
 #include <optional>
@@ -84,14 +84,15 @@ class BitcodeAnalyzer {
   std::map<unsigned, PerBlockIDStats> BlockIDStats;
 
 public:
-  LLVM_ABI BitcodeAnalyzer(StringRef Buffer,
+  LLVM_ABI
+  BitcodeAnalyzer(StringRef Buffer,
                   std::optional<StringRef> BlockInfoBuffer = std::nullopt);
   /// Analyze the bitcode file.
   LLVM_ABI Error analyze(std::optional<BCDumpOptions> O = std::nullopt,
-                std::optional<StringRef> CheckHash = std::nullopt);
+                         std::optional<StringRef> CheckHash = std::nullopt);
   /// Print stats about the bitcode file.
   LLVM_ABI void printStats(BCDumpOptions O,
-                  std::optional<StringRef> Filename = std::nullopt);
+                           std::optional<StringRef> Filename = std::nullopt);
 
 private:
   /// Read a block, updating statistics, etc.

--- a/llvm/include/llvm/Bitcode/BitcodeAnalyzer.h
+++ b/llvm/include/llvm/Bitcode/BitcodeAnalyzer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_BITCODE_BITCODEANALYZER_H
 #define LLVM_BITCODE_BITCODEANALYZER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Bitstream/BitstreamReader.h"
@@ -83,13 +84,13 @@ class BitcodeAnalyzer {
   std::map<unsigned, PerBlockIDStats> BlockIDStats;
 
 public:
-  BitcodeAnalyzer(StringRef Buffer,
+  LLVM_ABI BitcodeAnalyzer(StringRef Buffer,
                   std::optional<StringRef> BlockInfoBuffer = std::nullopt);
   /// Analyze the bitcode file.
-  Error analyze(std::optional<BCDumpOptions> O = std::nullopt,
+  LLVM_ABI Error analyze(std::optional<BCDumpOptions> O = std::nullopt,
                 std::optional<StringRef> CheckHash = std::nullopt);
   /// Print stats about the bitcode file.
-  void printStats(BCDumpOptions O,
+  LLVM_ABI void printStats(BCDumpOptions O,
                   std::optional<StringRef> Filename = std::nullopt);
 
 private:

--- a/llvm/include/llvm/Bitcode/BitcodeReader.h
+++ b/llvm/include/llvm/Bitcode/BitcodeReader.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_BITCODE_BITCODEREADER_H
 #define LLVM_BITCODE_BITCODEREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Bitstream/BitCodeEnums.h"
@@ -60,7 +61,7 @@ typedef std::function<void(Metadata **, unsigned, GetTypeByIDTy,
 // ErrorOr/std::error_code for compatibility with legacy clients. FIXME:
 // Remove these functions once no longer needed by the C and libLTO APIs.
 
-std::error_code errorToErrorCodeAndEmitErrors(LLVMContext &Ctx, Error Err);
+LLVM_ABI std::error_code errorToErrorCodeAndEmitErrors(LLVMContext &Ctx, Error Err);
 
 template <typename T>
 ErrorOr<T> expectedToErrorOrAndEmitErrors(LLVMContext &Ctx, Expected<T> Val) {
@@ -139,24 +140,24 @@ struct ParserCallbacks {
     /// bodies. If ShouldLazyLoadMetadata is true, lazily load metadata as well.
     /// If IsImporting is true, this module is being parsed for ThinLTO
     /// importing into another module.
-    Expected<std::unique_ptr<Module>>
+    LLVM_ABI Expected<std::unique_ptr<Module>>
     getLazyModule(LLVMContext &Context, bool ShouldLazyLoadMetadata,
                   bool IsImporting, ParserCallbacks Callbacks = {});
 
     /// Read the entire bitcode module and return it.
-    Expected<std::unique_ptr<Module>>
+    LLVM_ABI Expected<std::unique_ptr<Module>>
     parseModule(LLVMContext &Context, ParserCallbacks Callbacks = {});
 
     /// Returns information about the module to be used for LTO: whether to
     /// compile with ThinLTO, and whether it has a summary.
-    Expected<BitcodeLTOInfo> getLTOInfo();
+    LLVM_ABI Expected<BitcodeLTOInfo> getLTOInfo();
 
     /// Parse the specified bitcode buffer, returning the module summary index.
-    Expected<std::unique_ptr<ModuleSummaryIndex>> getSummary();
+    LLVM_ABI Expected<std::unique_ptr<ModuleSummaryIndex>> getSummary();
 
     /// Parse the specified bitcode buffer and merge its module summary index
     /// into CombinedIndex.
-    Error
+    LLVM_ABI Error
     readSummary(ModuleSummaryIndex &CombinedIndex, StringRef ModulePath,
                 std::function<bool(GlobalValue::GUID)> IsPrevailing = nullptr);
   };
@@ -171,17 +172,17 @@ struct ParserCallbacks {
   /// symbol table should prefer to use irsymtab::read instead of this function
   /// because it creates a reader for the irsymtab and handles upgrading bitcode
   /// files without a symbol table or with an old symbol table.
-  Expected<BitcodeFileContents> getBitcodeFileContents(MemoryBufferRef Buffer);
+  LLVM_ABI Expected<BitcodeFileContents> getBitcodeFileContents(MemoryBufferRef Buffer);
 
   /// Returns a list of modules in the specified bitcode buffer.
-  Expected<std::vector<BitcodeModule>>
+  LLVM_ABI Expected<std::vector<BitcodeModule>>
   getBitcodeModuleList(MemoryBufferRef Buffer);
 
   /// Read the header of the specified bitcode buffer and prepare for lazy
   /// deserialization of function bodies. If ShouldLazyLoadMetadata is true,
   /// lazily load metadata as well. If IsImporting is true, this module is
   /// being parsed for ThinLTO importing into another module.
-  Expected<std::unique_ptr<Module>>
+  LLVM_ABI Expected<std::unique_ptr<Module>>
   getLazyBitcodeModule(MemoryBufferRef Buffer, LLVMContext &Context,
                        bool ShouldLazyLoadMetadata = false,
                        bool IsImporting = false,
@@ -191,7 +192,7 @@ struct ParserCallbacks {
   /// the memory buffer if successful. If successful, this moves Buffer. On
   /// error, this *does not* move Buffer. If IsImporting is true, this module is
   /// being parsed for ThinLTO importing into another module.
-  Expected<std::unique_ptr<Module>> getOwningLazyBitcodeModule(
+  LLVM_ABI Expected<std::unique_ptr<Module>> getOwningLazyBitcodeModule(
       std::unique_ptr<MemoryBuffer> &&Buffer, LLVMContext &Context,
       bool ShouldLazyLoadMetadata = false, bool IsImporting = false,
       ParserCallbacks Callbacks = {});
@@ -199,38 +200,38 @@ struct ParserCallbacks {
   /// Read the header of the specified bitcode buffer and extract just the
   /// triple information. If successful, this returns a string. On error, this
   /// returns "".
-  Expected<std::string> getBitcodeTargetTriple(MemoryBufferRef Buffer);
+  LLVM_ABI Expected<std::string> getBitcodeTargetTriple(MemoryBufferRef Buffer);
 
   /// Return true if \p Buffer contains a bitcode file with ObjC code (category
   /// or class) in it.
-  Expected<bool> isBitcodeContainingObjCCategory(MemoryBufferRef Buffer);
+  LLVM_ABI Expected<bool> isBitcodeContainingObjCCategory(MemoryBufferRef Buffer);
 
   /// Read the header of the specified bitcode buffer and extract just the
   /// producer string information. If successful, this returns a string. On
   /// error, this returns "".
-  Expected<std::string> getBitcodeProducerString(MemoryBufferRef Buffer);
+  LLVM_ABI Expected<std::string> getBitcodeProducerString(MemoryBufferRef Buffer);
 
   /// Read the specified bitcode file, returning the module.
-  Expected<std::unique_ptr<Module>>
+  LLVM_ABI Expected<std::unique_ptr<Module>>
   parseBitcodeFile(MemoryBufferRef Buffer, LLVMContext &Context,
                    ParserCallbacks Callbacks = {});
 
   /// Returns LTO information for the specified bitcode file.
-  Expected<BitcodeLTOInfo> getBitcodeLTOInfo(MemoryBufferRef Buffer);
+  LLVM_ABI Expected<BitcodeLTOInfo> getBitcodeLTOInfo(MemoryBufferRef Buffer);
 
   /// Parse the specified bitcode buffer, returning the module summary index.
-  Expected<std::unique_ptr<ModuleSummaryIndex>>
+  LLVM_ABI Expected<std::unique_ptr<ModuleSummaryIndex>>
   getModuleSummaryIndex(MemoryBufferRef Buffer);
 
   /// Parse the specified bitcode buffer and merge the index into CombinedIndex.
-  Error readModuleSummaryIndex(MemoryBufferRef Buffer,
+  LLVM_ABI Error readModuleSummaryIndex(MemoryBufferRef Buffer,
                                ModuleSummaryIndex &CombinedIndex);
 
   /// Parse the module summary index out of an IR file and return the module
   /// summary index object if found, or an empty summary if not. If Path refers
   /// to an empty file and IgnoreEmptyThinLTOIndexFile is true, then
   /// this function will return nullptr.
-  Expected<std::unique_ptr<ModuleSummaryIndex>>
+  LLVM_ABI Expected<std::unique_ptr<ModuleSummaryIndex>>
   getModuleSummaryIndexForFile(StringRef Path,
                                bool IgnoreEmptyThinLTOIndexFile = false);
 
@@ -303,9 +304,9 @@ struct ParserCallbacks {
     return false;
   }
 
-  APInt readWideAPInt(ArrayRef<uint64_t> Vals, unsigned TypeBits);
+  LLVM_ABI APInt readWideAPInt(ArrayRef<uint64_t> Vals, unsigned TypeBits);
 
-  const std::error_category &BitcodeErrorCategory();
+  LLVM_ABI const std::error_category &BitcodeErrorCategory();
   enum class BitcodeError { CorruptedBitcode = 1 };
   inline std::error_code make_error_code(BitcodeError E) {
     return std::error_code(static_cast<int>(E), BitcodeErrorCategory());

--- a/llvm/include/llvm/Bitcode/BitcodeReader.h
+++ b/llvm/include/llvm/Bitcode/BitcodeReader.h
@@ -119,7 +119,7 @@ struct ParserCallbacks {
           IdentificationBit(IdentificationBit), ModuleBit(ModuleBit) {}
 
     // Calls the ctor.
-    friend Expected<BitcodeFileContents>
+    LLVM_ABI_FRIEND friend Expected<BitcodeFileContents>
     getBitcodeFileContents(MemoryBufferRef Buffer);
 
     Expected<std::unique_ptr<Module>>

--- a/llvm/include/llvm/Bitcode/BitcodeReader.h
+++ b/llvm/include/llvm/Bitcode/BitcodeReader.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_BITCODE_BITCODEREADER_H
 #define LLVM_BITCODE_BITCODEREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Bitstream/BitCodeEnums.h"
 #include "llvm/IR/GlobalValue.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorOr.h"
@@ -61,7 +61,8 @@ typedef std::function<void(Metadata **, unsigned, GetTypeByIDTy,
 // ErrorOr/std::error_code for compatibility with legacy clients. FIXME:
 // Remove these functions once no longer needed by the C and libLTO APIs.
 
-LLVM_ABI std::error_code errorToErrorCodeAndEmitErrors(LLVMContext &Ctx, Error Err);
+LLVM_ABI std::error_code errorToErrorCodeAndEmitErrors(LLVMContext &Ctx,
+                                                       Error Err);
 
 template <typename T>
 ErrorOr<T> expectedToErrorOrAndEmitErrors(LLVMContext &Ctx, Expected<T> Val) {
@@ -172,7 +173,8 @@ struct ParserCallbacks {
   /// symbol table should prefer to use irsymtab::read instead of this function
   /// because it creates a reader for the irsymtab and handles upgrading bitcode
   /// files without a symbol table or with an old symbol table.
-  LLVM_ABI Expected<BitcodeFileContents> getBitcodeFileContents(MemoryBufferRef Buffer);
+  LLVM_ABI Expected<BitcodeFileContents>
+  getBitcodeFileContents(MemoryBufferRef Buffer);
 
   /// Returns a list of modules in the specified bitcode buffer.
   LLVM_ABI Expected<std::vector<BitcodeModule>>
@@ -204,12 +206,14 @@ struct ParserCallbacks {
 
   /// Return true if \p Buffer contains a bitcode file with ObjC code (category
   /// or class) in it.
-  LLVM_ABI Expected<bool> isBitcodeContainingObjCCategory(MemoryBufferRef Buffer);
+  LLVM_ABI Expected<bool>
+  isBitcodeContainingObjCCategory(MemoryBufferRef Buffer);
 
   /// Read the header of the specified bitcode buffer and extract just the
   /// producer string information. If successful, this returns a string. On
   /// error, this returns "".
-  LLVM_ABI Expected<std::string> getBitcodeProducerString(MemoryBufferRef Buffer);
+  LLVM_ABI Expected<std::string>
+  getBitcodeProducerString(MemoryBufferRef Buffer);
 
   /// Read the specified bitcode file, returning the module.
   LLVM_ABI Expected<std::unique_ptr<Module>>
@@ -225,7 +229,7 @@ struct ParserCallbacks {
 
   /// Parse the specified bitcode buffer and merge the index into CombinedIndex.
   LLVM_ABI Error readModuleSummaryIndex(MemoryBufferRef Buffer,
-                               ModuleSummaryIndex &CombinedIndex);
+                                        ModuleSummaryIndex &CombinedIndex);
 
   /// Parse the module summary index out of an IR file and return the module
   /// summary index object if found, or an empty summary if not. If Path refers

--- a/llvm/include/llvm/Bitcode/BitcodeWriter.h
+++ b/llvm/include/llvm/Bitcode/BitcodeWriter.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_BITCODE_BITCODEWRITER_H
 #define LLVM_BITCODE_BITCODEWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/MC/StringTableBuilder.h"
@@ -46,10 +47,10 @@ class BitcodeWriter {
 
 public:
   /// Create a BitcodeWriter that writes to Buffer.
-  BitcodeWriter(SmallVectorImpl<char> &Buffer);
-  BitcodeWriter(raw_ostream &FS);
+  LLVM_ABI BitcodeWriter(SmallVectorImpl<char> &Buffer);
+  LLVM_ABI BitcodeWriter(raw_ostream &FS);
 
-  ~BitcodeWriter();
+  LLVM_ABI ~BitcodeWriter();
 
   /// Attempt to write a symbol table to the bitcode file. This must be called
   /// at most once after all modules have been written.
@@ -58,15 +59,15 @@ public:
   /// the symbol table is needed only to improve link-time performance. So
   /// this function may decide not to write a symbol table. It may so decide
   /// if, for example, the target is unregistered or the IR is malformed.
-  void writeSymtab();
+  LLVM_ABI void writeSymtab();
 
   /// Write the bitcode file's string table. This must be called exactly once
   /// after all modules and the optional symbol table have been written.
-  void writeStrtab();
+  LLVM_ABI void writeStrtab();
 
   /// Copy the string table for another module into this bitcode file. This
   /// should be called after copying the module itself into the bitcode file.
-  void copyStrtab(StringRef Strtab);
+  LLVM_ABI void copyStrtab(StringRef Strtab);
 
   /// Write the specified module to the buffer specified at construction time.
   ///
@@ -86,7 +87,7 @@ public:
   /// Can be used to produce the same module hash for a minimized bitcode
   /// used just for the thin link as in the regular full bitcode that will
   /// be used in the backend.
-  void writeModule(const Module &M, bool ShouldPreserveUseListOrder = false,
+  LLVM_ABI void writeModule(const Module &M, bool ShouldPreserveUseListOrder = false,
                    const ModuleSummaryIndex *Index = nullptr,
                    bool GenerateHash = false, ModuleHash *ModHash = nullptr);
 
@@ -97,10 +98,10 @@ public:
   ///
   /// ModHash is for use in ThinLTO incremental build, generated while the
   /// IR bitcode file writing.
-  void writeThinLinkBitcode(const Module &M, const ModuleSummaryIndex &Index,
+  LLVM_ABI void writeThinLinkBitcode(const Module &M, const ModuleSummaryIndex &Index,
                             const ModuleHash &ModHash);
 
-  void writeIndex(const ModuleSummaryIndex *Index,
+  LLVM_ABI void writeIndex(const ModuleSummaryIndex *Index,
                   const ModuleToSummariesForIndexTy *ModuleToSummariesForIndex,
                   const GVSummaryPtrSet *DecSummaries);
 };
@@ -126,7 +127,7 @@ public:
 /// Can be used to produce the same module hash for a minimized bitcode
 /// used just for the thin link as in the regular full bitcode that will
 /// be used in the backend.
-void WriteBitcodeToFile(const Module &M, raw_ostream &Out,
+LLVM_ABI void WriteBitcodeToFile(const Module &M, raw_ostream &Out,
                         bool ShouldPreserveUseListOrder = false,
                         const ModuleSummaryIndex *Index = nullptr,
                         bool GenerateHash = false,
@@ -139,7 +140,7 @@ void WriteBitcodeToFile(const Module &M, raw_ostream &Out,
 ///
 /// ModHash is for use in ThinLTO incremental build, generated while the IR
 /// bitcode file writing.
-void writeThinLinkBitcodeToFile(const Module &M, raw_ostream &Out,
+LLVM_ABI void writeThinLinkBitcodeToFile(const Module &M, raw_ostream &Out,
                                 const ModuleSummaryIndex &Index,
                                 const ModuleHash &ModHash);
 
@@ -149,7 +150,7 @@ void writeThinLinkBitcodeToFile(const Module &M, raw_ostream &Out,
 /// index for a distributed backend, provide the \p ModuleToSummariesForIndex
 /// map. \p DecSummaries specifies the set of summaries for which the
 /// corresponding value should be imported as a declaration (prototype).
-void writeIndexToFile(
+LLVM_ABI void writeIndexToFile(
     const ModuleSummaryIndex &Index, raw_ostream &Out,
     const ModuleToSummariesForIndexTy *ModuleToSummariesForIndex = nullptr,
     const GVSummaryPtrSet *DecSummaries = nullptr);
@@ -163,7 +164,7 @@ void writeIndexToFile(
 /// If EmbedCmdline is set, the command line is also exported in
 /// the corresponding section (__LLVM,_cmdline / .llvmcmd) - even if CmdArgs
 /// were empty.
-void embedBitcodeInModule(Module &M, MemoryBufferRef Buf, bool EmbedBitcode,
+LLVM_ABI void embedBitcodeInModule(Module &M, MemoryBufferRef Buf, bool EmbedBitcode,
                           bool EmbedCmdline,
                           const std::vector<uint8_t> &CmdArgs);
 

--- a/llvm/include/llvm/Bitcode/BitcodeWriter.h
+++ b/llvm/include/llvm/Bitcode/BitcodeWriter.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_BITCODE_BITCODEWRITER_H
 #define LLVM_BITCODE_BITCODEWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/MC/StringTableBuilder.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include <map>
 #include <memory>
@@ -87,9 +87,11 @@ public:
   /// Can be used to produce the same module hash for a minimized bitcode
   /// used just for the thin link as in the regular full bitcode that will
   /// be used in the backend.
-  LLVM_ABI void writeModule(const Module &M, bool ShouldPreserveUseListOrder = false,
-                   const ModuleSummaryIndex *Index = nullptr,
-                   bool GenerateHash = false, ModuleHash *ModHash = nullptr);
+  LLVM_ABI void writeModule(const Module &M,
+                            bool ShouldPreserveUseListOrder = false,
+                            const ModuleSummaryIndex *Index = nullptr,
+                            bool GenerateHash = false,
+                            ModuleHash *ModHash = nullptr);
 
   /// Write the specified thin link bitcode file (i.e., the minimized bitcode
   /// file) to the buffer specified at construction time. The thin link
@@ -98,12 +100,14 @@ public:
   ///
   /// ModHash is for use in ThinLTO incremental build, generated while the
   /// IR bitcode file writing.
-  LLVM_ABI void writeThinLinkBitcode(const Module &M, const ModuleSummaryIndex &Index,
-                            const ModuleHash &ModHash);
+  LLVM_ABI void writeThinLinkBitcode(const Module &M,
+                                     const ModuleSummaryIndex &Index,
+                                     const ModuleHash &ModHash);
 
-  LLVM_ABI void writeIndex(const ModuleSummaryIndex *Index,
-                  const ModuleToSummariesForIndexTy *ModuleToSummariesForIndex,
-                  const GVSummaryPtrSet *DecSummaries);
+  LLVM_ABI void
+  writeIndex(const ModuleSummaryIndex *Index,
+             const ModuleToSummariesForIndexTy *ModuleToSummariesForIndex,
+             const GVSummaryPtrSet *DecSummaries);
 };
 
 /// Write the specified module to the specified raw output stream.
@@ -128,10 +132,10 @@ public:
 /// used just for the thin link as in the regular full bitcode that will
 /// be used in the backend.
 LLVM_ABI void WriteBitcodeToFile(const Module &M, raw_ostream &Out,
-                        bool ShouldPreserveUseListOrder = false,
-                        const ModuleSummaryIndex *Index = nullptr,
-                        bool GenerateHash = false,
-                        ModuleHash *ModHash = nullptr);
+                                 bool ShouldPreserveUseListOrder = false,
+                                 const ModuleSummaryIndex *Index = nullptr,
+                                 bool GenerateHash = false,
+                                 ModuleHash *ModHash = nullptr);
 
 /// Write the specified thin link bitcode file (i.e., the minimized bitcode
 /// file) to the given raw output stream, where it will be written in a new
@@ -141,8 +145,8 @@ LLVM_ABI void WriteBitcodeToFile(const Module &M, raw_ostream &Out,
 /// ModHash is for use in ThinLTO incremental build, generated while the IR
 /// bitcode file writing.
 LLVM_ABI void writeThinLinkBitcodeToFile(const Module &M, raw_ostream &Out,
-                                const ModuleSummaryIndex &Index,
-                                const ModuleHash &ModHash);
+                                         const ModuleSummaryIndex &Index,
+                                         const ModuleHash &ModHash);
 
 /// Write the specified module summary index to the given raw output stream,
 /// where it will be written in a new bitcode block. This is used when
@@ -164,9 +168,9 @@ LLVM_ABI void writeIndexToFile(
 /// If EmbedCmdline is set, the command line is also exported in
 /// the corresponding section (__LLVM,_cmdline / .llvmcmd) - even if CmdArgs
 /// were empty.
-LLVM_ABI void embedBitcodeInModule(Module &M, MemoryBufferRef Buf, bool EmbedBitcode,
-                          bool EmbedCmdline,
-                          const std::vector<uint8_t> &CmdArgs);
+LLVM_ABI void embedBitcodeInModule(Module &M, MemoryBufferRef Buf,
+                                   bool EmbedBitcode, bool EmbedCmdline,
+                                   const std::vector<uint8_t> &CmdArgs);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Bitcode/BitcodeWriterPass.h
+++ b/llvm/include/llvm/Bitcode/BitcodeWriterPass.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_BITCODE_BITCODEWRITERPASS_H
 #define LLVM_BITCODE_BITCODEWRITERPASS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/IR/PassManager.h"
 
 namespace llvm {
@@ -28,11 +29,11 @@ class raw_ostream;
 ///
 /// If \c ShouldPreserveUseListOrder, encode use-list order so it can be
 /// reproduced when deserialized.
-ModulePass *createBitcodeWriterPass(raw_ostream &Str,
+LLVM_ABI ModulePass *createBitcodeWriterPass(raw_ostream &Str,
                                     bool ShouldPreserveUseListOrder = false);
 
 /// Check whether a pass is a BitcodeWriterPass.
-bool isBitcodeWriterPass(Pass *P);
+LLVM_ABI bool isBitcodeWriterPass(Pass *P);
 
 /// Pass for writing a module of IR out to a bitcode file.
 ///
@@ -61,7 +62,7 @@ public:
 
   /// Run the bitcode writer pass, and output the module to the selected
   /// output stream.
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 
   static bool isRequired() { return true; }
 };

--- a/llvm/include/llvm/Bitcode/BitcodeWriterPass.h
+++ b/llvm/include/llvm/Bitcode/BitcodeWriterPass.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_BITCODE_BITCODEWRITERPASS_H
 #define LLVM_BITCODE_BITCODEWRITERPASS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class Module;
@@ -29,8 +29,9 @@ class raw_ostream;
 ///
 /// If \c ShouldPreserveUseListOrder, encode use-list order so it can be
 /// reproduced when deserialized.
-LLVM_ABI ModulePass *createBitcodeWriterPass(raw_ostream &Str,
-                                    bool ShouldPreserveUseListOrder = false);
+LLVM_ABI ModulePass *
+createBitcodeWriterPass(raw_ostream &Str,
+                        bool ShouldPreserveUseListOrder = false);
 
 /// Check whether a pass is a BitcodeWriterPass.
 LLVM_ABI bool isBitcodeWriterPass(Pass *P);

--- a/llvm/include/llvm/Bitstream/BitstreamReader.h
+++ b/llvm/include/llvm/Bitstream/BitstreamReader.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_BITSTREAM_BITSTREAMREADER_H
 #define LLVM_BITSTREAM_BITSTREAMREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Bitstream/BitCodes.h"
@@ -512,7 +513,7 @@ public:
   }
 
   /// Having read the ENTER_SUBBLOCK abbrevid, and enter the block.
-  Error EnterSubBlock(unsigned BlockID, unsigned *NumWordsP = nullptr);
+  LLVM_ABI Error EnterSubBlock(unsigned BlockID, unsigned *NumWordsP = nullptr);
 
   bool ReadBlockEnd() {
     if (BlockScope.empty()) return true;
@@ -548,23 +549,23 @@ public:
   }
 
   /// Read the current record and discard it, returning the code for the record.
-  Expected<unsigned> skipRecord(unsigned AbbrevID);
+  LLVM_ABI Expected<unsigned> skipRecord(unsigned AbbrevID);
 
-  Expected<unsigned> readRecord(unsigned AbbrevID,
+  LLVM_ABI Expected<unsigned> readRecord(unsigned AbbrevID,
                                 SmallVectorImpl<uint64_t> &Vals,
                                 StringRef *Blob = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Abbrev Processing
   //===--------------------------------------------------------------------===//
-  Error ReadAbbrevRecord();
+  LLVM_ABI Error ReadAbbrevRecord();
 
   /// Read and return a block info block from the bitstream. If an error was
   /// encountered, return std::nullopt.
   ///
   /// \param ReadBlockInfoNames Whether to read block/record name information in
   /// the BlockInfo block. Only llvm-bcanalyzer uses this.
-  Expected<std::optional<BitstreamBlockInfo>>
+  LLVM_ABI Expected<std::optional<BitstreamBlockInfo>>
   ReadBlockInfoBlock(bool ReadBlockInfoNames = false);
 
   /// Set the block info to be used by this BitstreamCursor to interpret

--- a/llvm/include/llvm/Bitstream/BitstreamReader.h
+++ b/llvm/include/llvm/Bitstream/BitstreamReader.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_BITSTREAM_BITSTREAMREADER_H
 #define LLVM_BITSTREAM_BITSTREAMREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Bitstream/BitCodes.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
@@ -552,8 +552,8 @@ public:
   LLVM_ABI Expected<unsigned> skipRecord(unsigned AbbrevID);
 
   LLVM_ABI Expected<unsigned> readRecord(unsigned AbbrevID,
-                                SmallVectorImpl<uint64_t> &Vals,
-                                StringRef *Blob = nullptr);
+                                         SmallVectorImpl<uint64_t> &Vals,
+                                         StringRef *Blob = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Abbrev Processing

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -44,6 +44,7 @@
 #include "llvm/IR/Value.h"
 #include "llvm/IR/ValueSymbolTable.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/ModRef.h"
@@ -63,7 +64,7 @@ static cl::opt<bool> AllowIncompleteIR(
         "Allow incomplete IR on a best effort basis (references to unknown "
         "metadata will be dropped)"));
 
-extern llvm::cl::opt<bool> UseNewDbgInfoFormat;
+LLVM_ABI extern llvm::cl::opt<bool> UseNewDbgInfoFormat;
 
 static std::string getTypeString(Type *T) {
   std::string Result;

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -101,7 +101,7 @@ static cl::opt<bool> ExpandConstantExprs(
     cl::desc(
         "Expand constant expressions to instructions for testing purposes"));
 
-extern cl::opt<bool> UseNewDbgInfoFormat;
+LLVM_ABI extern cl::opt<bool> UseNewDbgInfoFormat;
 
 namespace {
 

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -66,6 +66,7 @@
 #include "llvm/Support/AtomicOrdering.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -120,7 +121,7 @@ namespace llvm {
 extern FunctionSummary::ForceSummaryHotnessType ForceSummaryEdgesCold;
 }
 
-extern llvm::cl::opt<bool> UseNewDbgInfoFormat;
+LLVM_ABI extern llvm::cl::opt<bool> UseNewDbgInfoFormat;
 
 namespace {
 


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/AsmParser`, `llvm/BinaryFormat`, `llvm/Bitcode` and `llvm/Bitstream libraries. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS on Linux:
- Add `LLVM_ABI_FRIEND` to friend member functions declared with `LLVM_ABI`
- Add `LLVM_ABI` symbols that require export but are not declared in headers

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang