### PR TITLE
[libc++] Run macOS jobs after the Stage 2 CI

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -184,7 +184,7 @@ jobs:
             **/crash_diagnostics/*
 
   macos:
-    needs: [ stage3 ]
+    needs: [ stage2 ]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Our CI is currently having major difficulties, which causes the Stage 3 CI to basically never succeed. As a result, our macOS CI jobs have not been running recently. This patch gates the macOS CI jobs on Stage 2 instead of Stage 3 so that they actually run sometimes.