### PR TITLE
[Github] Bump PR Code Format clang-format version

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install clang-format
         uses: aminya/setup-cpp@17c11551771948abc5752bbf3183482567c7caf0 # v1.1.1
         with:
-          clangformat: 19.1.6
+          clangformat: 20.1.5
 
       - name: Setup Python env
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0


### PR DESCRIPTION
As we have discussed in the past, we should be using the latest version. This has not been updated in a while.