### PR TITLE
[bazel] Add the missing dependency for the introduced use of support/Utils.h

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-doc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-doc/BUILD.bazel
@@ -77,6 +77,7 @@ cc_binary(
     srcs = ["tool/ClangDocMain.cpp"],
     stamp = 0,
     deps = [
+        ":clang-doc-support",
         ":generators",
         ":lib",
         "//clang:ast",


### PR DESCRIPTION
#138066 adds the use of this unspecified dependency. 
This breaks bazel build. 
https://buildkite.com/llvm-project/upstream-bazel/builds/137154#01971745-cb44-4fd1-af59-ccef34c3f61e 