### PR TITLE
[lldb] Fix TestFrameLanguageCommands.py build

### DIFF
--- a/lldb/test/API/commands/command/language/Makefile
+++ b/lldb/test/API/commands/command/language/Makefile
@@ -1,4 +1,3 @@
 OBJCXX_SOURCES := main.mm
 CXX_SOURCES := lib.cpp
-LD_EXTRAS := -lobjc
 include Makefile.rules


### PR DESCRIPTION
The use of `-lobjc` resulted in this test failing to build on Linux. The flag is not necessary, this removes the flag with the expectation it will fix the test on Linux.