### PR TITLE
[ASTWriter] Do not write ObjCCategories if empty.

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -4631,11 +4631,10 @@ namespace {
 
       // Perform a binary search to find the local redeclarations for this
       // declaration (if any).
-      const ObjCCategoriesInfo Compare = { LocalID, 0 };
-      const ObjCCategoriesInfo *Result
-        = std::lower_bound(M.ObjCCategoriesMap,
-                           M.ObjCCategoriesMap + M.LocalNumObjCCategoriesInMap,
-                           Compare);
+      const ObjCCategoriesInfo Compare = {LocalID, 0};
+      const ObjCCategoriesInfo *Result = std::lower_bound(
+          M.ObjCCategoriesMap,
+          M.ObjCCategoriesMap + M.LocalNumObjCCategoriesInMap, Compare);
       if (Result == M.ObjCCategoriesMap + M.LocalNumObjCCategoriesInMap ||
           LocalID != Result->getDefinitionID()) {
         // We didn't find anything. If the class definition is in this module

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -4972,6 +4972,9 @@ void ASTWriter::WriteCUDAPragmas(Sema &SemaRef) {
 }
 
 void ASTWriter::WriteObjCCategories() {
+  if (ObjCClassesWithCategories.empty())
+    return;
+
   SmallVector<ObjCCategoriesInfo, 2> CategoriesMap;
   RecordData Categories;
 

--- a/clang/test/Modules/objc-categories.cpp
+++ b/clang/test/Modules/objc-categories.cpp
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t.pcm
+
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -x c++ -std=c++11  -emit-module -fmodules -fmodule-name=cxx_library  %S/Inputs/module.modulemap -o %t.pcm
+// RUN: llvm-bcanalyzer %t.pcm | FileCheck %s --check-prefix=CXX_LIBRARY
+// CXX_LIBRARY: AST_BLOCK
+// CXX_LIBRARY-NOT: OBJC_CATEGORIES
+// CXX_LIBRARY-NOT: OBJC_CATEGORIES_MAP
+
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -x objective-c -emit-module -fmodules -fmodule-name=category_top  %S/Inputs/module.modulemap -o %t.pcm
+// RUN: llvm-bcanalyzer %t.pcm | FileCheck %s --check-prefix=CATEGORY_TOP
+// CATEGORY_TOP: AST_BLOCK
+// CATEGORY_TOP: OBJC_CATEGORIES
+// CATEGORY_TOP: OBJC_CATEGORIES_MAP
+


### PR DESCRIPTION
This is a fix for a completely unrelated patch, that started to cause failures in the explicit-build.cpp test because the size of the b.pcm and b-not-a.pcm files became the same. The alignment added by empty ObjCCategory blobs being written to the file causes them to become the same size, and the error 'module file has a different size than expected' will not be emitted as the pcms only track module size, not content, for whether they are valid.

This prevents that issue by not saving the ObjCCategories if it is empty. The change in clang/lib/Serialization/ASTReaderDecl.cpp is just a format, but shows that the only use of ObjCCategoriesMap loaded from the file will be OK with null (never loaded) data. It is a bit of a weird fix, but should help decrease the size of the modules for objects that are not used.