### PR TITLE
[RISCV] Use X0_Pair for storing 0 using Zilsd.

### DIFF
--- a/llvm/test/CodeGen/RISCV/zilsd.ll
+++ b/llvm/test/CodeGen/RISCV/zilsd.ll
@@ -110,10 +110,8 @@ entry:
 define void @store_g() nounwind {
 ; CHECK-LABEL: store_g:
 ; CHECK:       # %bb.0: # %entyr
-; CHECK-NEXT:    li a0, 0
-; CHECK-NEXT:    lui a2, %hi(g)
-; CHECK-NEXT:    li a1, 0
-; CHECK-NEXT:    sd a0, %lo(g)(a2)
+; CHECK-NEXT:    lui a0, %hi(g)
+; CHECK-NEXT:    sd zero, %lo(g)(a0)
 ; CHECK-NEXT:    ret
 entyr:
   store i64 0, ptr @g


### PR DESCRIPTION
When we're creating a Zilsd store from a split i64 value, check if both inputs are 0 and use X0_Pair instead of a REG_SEQUENCE.