### PR TITLE
[CIR] Update tests for global vars

### DIFF
--- a/clang/test/CIR/Lowering/global-var-simple.cpp
+++ b/clang/test/CIR/Lowering/global-var-simple.cpp
@@ -1,137 +1,140 @@
 // Global variables of intergal types
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck %s --input-file %t-cir.ll
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck %s -check-prefix=OGCG --input-file %t.ll
+
+// Note: The differences between CHECK and OGCG represent incorrect IR lowering
+//       with ClangIR enabled and will be fixed in a future patch.
 
 char c;
 // CHECK: @c = dso_local global i8 0, align 1
-// OGCG:  @c = dso_local global i8 0, align 1
+// OGCG:  @c = global i8 0, align 1
 
 signed char sc;
 // CHECK: @sc = dso_local global i8 0, align 1
-// OGCG:  @sc = dso_local global i8 0, align 1
+// OGCG:  @sc = global i8 0, align 1
 
 unsigned char uc;
 // CHECK: @uc = dso_local global i8 0, align 1
-// OGCG:  @uc = dso_local global i8 0, align 1
+// OGCG:  @uc = global i8 0, align 1
 
 short ss;
 // CHECK: @ss = dso_local global i16 0, align 2
-// OGCG:  @ss = dso_local global i16 0, align 2
+// OGCG:  @ss = global i16 0, align 2
 
 unsigned short us = 100;
 // CHECK: @us = dso_local global i16 100, align 2
-// OGCG:  @us = dso_local global i16 100, align 2
+// OGCG:  @us = global i16 100, align 2
 
 int si = 42;
 // CHECK: @si = dso_local global i32 42, align 4
-// OGCG:  @si = dso_local global i32 42, align 4
+// OGCG:  @si = global i32 42, align 4
 
 unsigned ui;
 // CHECK: @ui = dso_local global i32 0, align 4
-// OGCG:  @ui = dso_local global i32 0, align 4
+// OGCG:  @ui = global i32 0, align 4
 
 long sl;
 // CHECK: @sl = dso_local global i64 0, align 8
-// OGCG:  @sl = dso_local global i64 0, align 8
+// OGCG:  @sl = global i64 0, align 8
 
 unsigned long ul;
 // CHECK: @ul = dso_local global i64 0, align 8
-// OGCG:  @ul = dso_local global i64 0, align 8
+// OGCG:  @ul = global i64 0, align 8
 
 long long sll;
 // CHECK: @sll = dso_local global i64 0, align 8
-// OGCG:  @sll = dso_local global i64 0, align 8
+// OGCG:  @sll = global i64 0, align 8
 
 unsigned long long ull = 123456;
 // CHECK: @ull = dso_local global i64 123456, align 8
-// OGCG:  @ull = dso_local global i64 123456, align 8
+// OGCG:  @ull = global i64 123456, align 8
 
 __int128 s128;
 // CHECK: @s128 = dso_local global i128 0, align 16
-// OGCG:  @s128 = dso_local global i128 0, align 16
+// OGCG:  @s128 = global i128 0, align 16
 
 unsigned __int128 u128;
 // CHECK: @u128 = dso_local global i128 0, align 16
-// OGCG:  @u128 = dso_local global i128 0, align 16
+// OGCG:  @u128 = global i128 0, align 16
 
 wchar_t wc;
 // CHECK: @wc = dso_local global i32 0, align 4
-// OGCG:  @wc = dso_local global i32 0, align 4
+// OGCG:  @wc = global i32 0, align 4
 
 char8_t c8;
 // CHECK: @c8 = dso_local global i8 0, align 1
-// OGCG:  @c8 = dso_local global i8 0, align 1
+// OGCG:  @c8 = global i8 0, align 1
 
 char16_t c16;
 // CHECK: @c16 = dso_local global i16 0, align 2
-// OGCG:  @c16 = dso_local global i16 0, align 2
+// OGCG:  @c16 = global i16 0, align 2
 
 char32_t c32;
 // CHECK: @c32 = dso_local global i32 0, align 4
-// OGCG:  @c32 = dso_local global i32 0, align 4
+// OGCG:  @c32 = global i32 0, align 4
 
 _BitInt(20) sb20;
 // CHECK: @sb20 = dso_local global i20 0, align 4
-// OGCG:  @sb20 = dso_local global i20 0, align 4
+// OGCG:  @sb20 = global i32 0, align 4
 
 unsigned _BitInt(48) ub48;
 // CHECK: @ub48 = dso_local global i48 0, align 8
-// OGCG:  @ub48 = dso_local global i48 0, align 8
+// OGCG:  @ub48 = global i64 0, align 8
 
 bool boolfalse = false;
 // CHECK: @boolfalse = dso_local global i8 0, align 1
-// OGCG:  @boolfalse = dso_local global i8 0, align 1
+// OGCG:  @boolfalse = global i8 0, align 1
 
 _Float16 f16;
 // CHECK: @f16 = dso_local global half 0xH0000, align 2
-// OGCG:  @f16 = dso_local global half 0xH0000, align 2
+// OGCG:  @f16 = global half 0xH0000, align 2
 
 __bf16 bf16;
 // CHECK: @bf16 = dso_local global bfloat 0xR0000, align 2
-// OGCG:  @bf16 = dso_local global bfloat 0xR0000, align 2
+// OGCG:  @bf16 = global bfloat 0xR0000, align 2
 
 float f;
 // CHECK: @f = dso_local global float 0.000000e+00, align 4
-// OGCG:  @f = dso_local global float 0.000000e+00, align 4
+// OGCG:  @f = global float 0.000000e+00, align 4
 
 double d = 1.25;
 // CHECK: @d = dso_local global double 1.250000e+00, align 8
-// OGCG:  @d = dso_local global double 1.250000e+00, align 8
+// OGCG:  @d = global double 1.250000e+00, align 8
 
 long double ld;
 // CHECK: @ld = dso_local global x86_fp80 0xK00000000000000000000, align 16
-// OGCG:  @ld = dso_local global x86_fp80 0xK00000000000000000000, align 16
+// OGCG:  @ld = global x86_fp80 0xK00000000000000000000, align 16
 
 __float128 f128;
 // CHECK: @f128 = dso_local global fp128 0xL00000000000000000000000000000000, align 16
-// OGCG:  @f128 = dso_local global fp128 0xL00000000000000000000000000000000, align 16
+// OGCG:  @f128 = global fp128 0xL00000000000000000000000000000000, align 16
 
 void *vp;
 // CHECK: @vp = dso_local global ptr null, align 8
-// OGCG:  @vp = dso_local global ptr null, align 8
+// OGCG:  @vp = global ptr null, align 8
 
 int *ip = 0;
 // CHECK: @ip = dso_local global ptr null, align 8
-// OGCG:  @ip = dso_local global ptr null, align 8
+// OGCG:  @ip = global ptr null, align 8
 
 double *dp;
 // CHECK: @dp = dso_local global ptr null, align 8
-// OGCG:  @dp = dso_local global ptr null, align 8
+// OGCG:  @dp = global ptr null, align 8
 
 char **cpp;
 // CHECK: @cpp = dso_local global ptr null, align 8
-// OGCG:  @cpp = dso_local global ptr null, align 8
+// OGCG:  @cpp = global ptr null, align 8
 
 void (*fp)();
 // CHECK: @fp = dso_local global ptr null, align 8
-// OGCG:  @fp = dso_local global ptr null, align 8
+// OGCG:  @fp = global ptr null, align 8
 
 int (*fpii)(int) = 0;
 // CHECK: @fpii = dso_local global ptr null, align 8
-// OGCG:  @fpii = dso_local global ptr null, align 8
+// OGCG:  @fpii = global ptr null, align 8
 
 void (*fpvar)(int, ...);
 // CHECK: @fpvar = dso_local global ptr null, align 8
-// OGCG:  @fpvar = dso_local global ptr null, align 8
+// OGCG:  @fpvar = global ptr null, align 8

--- a/clang/test/CIR/Lowering/global-var-simple.cpp
+++ b/clang/test/CIR/Lowering/global-var-simple.cpp
@@ -1,103 +1,137 @@
 // Global variables of intergal types
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s
-
-// Note: Currently unsupported features include alignment..
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck %s --input-file %t-cir.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck %s -check-prefix=OGCG --input-file %t.ll
 
 char c;
-// CHECK: @c = dso_local global i8 0
+// CHECK: @c = dso_local global i8 0, align 1
+// OGCG:  @c = dso_local global i8 0, align 1
 
 signed char sc;
-// CHECK: @sc = dso_local global i8 0
+// CHECK: @sc = dso_local global i8 0, align 1
+// OGCG:  @sc = dso_local global i8 0, align 1
 
 unsigned char uc;
-// CHECK: @uc = dso_local global i8 0
+// CHECK: @uc = dso_local global i8 0, align 1
+// OGCG:  @uc = dso_local global i8 0, align 1
 
 short ss;
-// CHECK: @ss = dso_local global i16 0
+// CHECK: @ss = dso_local global i16 0, align 2
+// OGCG:  @ss = dso_local global i16 0, align 2
 
 unsigned short us = 100;
-// CHECK: @us = dso_local global i16 100
+// CHECK: @us = dso_local global i16 100, align 2
+// OGCG:  @us = dso_local global i16 100, align 2
 
 int si = 42;
-// CHECK: @si = dso_local global i32 42
+// CHECK: @si = dso_local global i32 42, align 4
+// OGCG:  @si = dso_local global i32 42, align 4
 
 unsigned ui;
-// CHECK: @ui = dso_local global i32 0
+// CHECK: @ui = dso_local global i32 0, align 4
+// OGCG:  @ui = dso_local global i32 0, align 4
 
 long sl;
-// CHECK: @sl = dso_local global i64 0
+// CHECK: @sl = dso_local global i64 0, align 8
+// OGCG:  @sl = dso_local global i64 0, align 8
 
 unsigned long ul;
-// CHECK: @ul = dso_local global i64 0
+// CHECK: @ul = dso_local global i64 0, align 8
+// OGCG:  @ul = dso_local global i64 0, align 8
 
 long long sll;
-// CHECK: @sll = dso_local global i64 0
+// CHECK: @sll = dso_local global i64 0, align 8
+// OGCG:  @sll = dso_local global i64 0, align 8
 
 unsigned long long ull = 123456;
-// CHECK: @ull = dso_local global i64 123456
+// CHECK: @ull = dso_local global i64 123456, align 8
+// OGCG:  @ull = dso_local global i64 123456, align 8
 
 __int128 s128;
-// CHECK: @s128 = dso_local global i128 0
+// CHECK: @s128 = dso_local global i128 0, align 16
+// OGCG:  @s128 = dso_local global i128 0, align 16
 
 unsigned __int128 u128;
-// CHECK: @u128 = dso_local global i128 0
+// CHECK: @u128 = dso_local global i128 0, align 16
+// OGCG:  @u128 = dso_local global i128 0, align 16
 
 wchar_t wc;
-// CHECK: @wc = dso_local global i32 0
+// CHECK: @wc = dso_local global i32 0, align 4
+// OGCG:  @wc = dso_local global i32 0, align 4
 
 char8_t c8;
-// CHECK: @c8 = dso_local global i8 0
+// CHECK: @c8 = dso_local global i8 0, align 1
+// OGCG:  @c8 = dso_local global i8 0, align 1
 
 char16_t c16;
-// CHECK: @c16 = dso_local global i16 0
+// CHECK: @c16 = dso_local global i16 0, align 2
+// OGCG:  @c16 = dso_local global i16 0, align 2
 
 char32_t c32;
-// CHECK: @c32 = dso_local global i32 0
+// CHECK: @c32 = dso_local global i32 0, align 4
+// OGCG:  @c32 = dso_local global i32 0, align 4
 
 _BitInt(20) sb20;
-// CHECK: @sb20 = dso_local global i20 0
+// CHECK: @sb20 = dso_local global i20 0, align 4
+// OGCG:  @sb20 = dso_local global i20 0, align 4
 
 unsigned _BitInt(48) ub48;
-// CHECK: @ub48 = dso_local global i48 0
+// CHECK: @ub48 = dso_local global i48 0, align 8
+// OGCG:  @ub48 = dso_local global i48 0, align 8
 
 bool boolfalse = false;
-// CHECK: @boolfalse = dso_local global i8 0
+// CHECK: @boolfalse = dso_local global i8 0, align 1
+// OGCG:  @boolfalse = dso_local global i8 0, align 1
 
 _Float16 f16;
-// CHECK: @f16 = dso_local global half
+// CHECK: @f16 = dso_local global half 0xH0000, align 2
+// OGCG:  @f16 = dso_local global half 0xH0000, align 2
 
 __bf16 bf16;
-// CHECK: @bf16 = dso_local global bfloat
+// CHECK: @bf16 = dso_local global bfloat 0xR0000, align 2
+// OGCG:  @bf16 = dso_local global bfloat 0xR0000, align 2
 
 float f;
-// CHECK: @f = dso_local global float 0.000000e+00
+// CHECK: @f = dso_local global float 0.000000e+00, align 4
+// OGCG:  @f = dso_local global float 0.000000e+00, align 4
 
 double d = 1.25;
-// CHECK: @d = dso_local global double 1.250000e+00
+// CHECK: @d = dso_local global double 1.250000e+00, align 8
+// OGCG:  @d = dso_local global double 1.250000e+00, align 8
 
 long double ld;
-// CHECK: @ld = dso_local global x86_fp80 0xK00
+// CHECK: @ld = dso_local global x86_fp80 0xK00000000000000000000, align 16
+// OGCG:  @ld = dso_local global x86_fp80 0xK00000000000000000000, align 16
 
 __float128 f128;
-// CHECK: @f128 = dso_local global fp128 0xL00
+// CHECK: @f128 = dso_local global fp128 0xL00000000000000000000000000000000, align 16
+// OGCG:  @f128 = dso_local global fp128 0xL00000000000000000000000000000000, align 16
 
 void *vp;
-// CHECK: @vp = dso_local global ptr null
+// CHECK: @vp = dso_local global ptr null, align 8
+// OGCG:  @vp = dso_local global ptr null, align 8
 
 int *ip = 0;
-// CHECK: @ip = dso_local global ptr null
+// CHECK: @ip = dso_local global ptr null, align 8
+// OGCG:  @ip = dso_local global ptr null, align 8
 
 double *dp;
-// CHECK: @dp = dso_local global ptr null
+// CHECK: @dp = dso_local global ptr null, align 8
+// OGCG:  @dp = dso_local global ptr null, align 8
 
 char **cpp;
-// CHECK: @cpp = dso_local global ptr null
+// CHECK: @cpp = dso_local global ptr null, align 8
+// OGCG:  @cpp = dso_local global ptr null, align 8
 
 void (*fp)();
-// CHECK: @fp = dso_local global ptr null
+// CHECK: @fp = dso_local global ptr null, align 8
+// OGCG:  @fp = dso_local global ptr null, align 8
 
 int (*fpii)(int) = 0;
-// CHECK: @fpii = dso_local global ptr null
+// CHECK: @fpii = dso_local global ptr null, align 8
+// OGCG:  @fpii = dso_local global ptr null, align 8
 
 void (*fpvar)(int, ...);
-// CHECK: @fpvar = dso_local global ptr null
+// CHECK: @fpvar = dso_local global ptr null, align 8
+// OGCG:  @fpvar = dso_local global ptr null, align 8

--- a/clang/test/CIR/Lowering/hello.c
+++ b/clang/test/CIR/Lowering/hello.c
@@ -1,15 +1,18 @@
 // Smoke test for ClangIR-to-LLVM IR code generation
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck %s --input-file %t-cir.ll
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck %s -check-prefix=OGCG --input-file %t.ll
+
+// Note: The differences between CHECK and OGCG represent incorrect IR lowering
+//       with ClangIR enabled and will be fixed in a future patch.
 
 int b = 2;
 
 // CHECK: @b = dso_local global i32 2, align 4
-// OGCG:  @b = dso_local global i32 2, align 4
+// OGCG:  @b = global i32 2, align 4
 
 int a;
 
 // CHECK: @a = dso_local global i32 0, align 4
-// OGCG:  @a = dso_local global i32 0, align 4
+// OGCG:  @a = global i32 0, align 4

--- a/clang/test/CIR/Lowering/hello.c
+++ b/clang/test/CIR/Lowering/hello.c
@@ -1,10 +1,15 @@
 // Smoke test for ClangIR-to-LLVM IR code generation
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o -  | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck %s --input-file %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck %s -check-prefix=OGCG --input-file %t.ll
 
 int b = 2;
 
-// CHECK: @b = dso_local global i32 2
+// CHECK: @b = dso_local global i32 2, align 4
+// OGCG:  @b = dso_local global i32 2, align 4
 
 int a;
 
-// CHECK: @a = dso_local global i32 0
+// CHECK: @a = dso_local global i32 0, align 4
+// OGCG:  @a = dso_local global i32 0, align 4

--- a/clang/test/CIR/global-var-linkage.cpp
+++ b/clang/test/CIR/global-var-linkage.cpp
@@ -1,11 +1,27 @@
 // Linkage types of global variables
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck %s -check-prefix=CIR --input-file %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck %s -check-prefix=LLVM --input-file %t-cir.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck %s -check-prefix=OGCG --input-file %t.ll
 
 int aaaa;
-// CHECK: cir.global external @aaaa
+// CIR: cir.global external @aaaa
+// LLVM: @aaaa = dso_local global i32 0
+// OGCG: @aaaa = dso_local global i32 0
+
 static int bbbb;
-// CHECK: cir.global internal @_ZL4bbbb
+// CIR: cir.global internal @_ZL4bbbb
+// LLVM: @_ZL4bbbb = internal global i32 0
+// OGCG: @_ZL4bbbb = internal global i32 0
+
 inline int cccc;
-// CHECK: cir.global linkonce_odr @cccc
+// CIR: cir.global linkonce_odr @cccc
+// LLVM: @cccc = linkonce_odr dso_local global i32 0
+// OGCG: @cccc = linkonce_odr dso_local global i32 0
+
 [[gnu::selectany]] int dddd;
-// CHECK: cir.global weak_odr @dddd
+// CIR: cir.global weak_odr @dddd
+// LLVM: @dddd = weak_odr dso_local global i32 0
+// OGCG: @dddd = weak_odr dso_local global i32 0

--- a/clang/test/CIR/global-var-linkage.cpp
+++ b/clang/test/CIR/global-var-linkage.cpp
@@ -3,13 +3,21 @@
 // RUN: FileCheck %s -check-prefix=CIR --input-file %t.cir
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck %s -check-prefix=LLVM --input-file %t-cir.ll
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck %s -check-prefix=OGCG --input-file %t.ll
+
+// Note: The differences between CHECK and OGCG represent incorrect IR lowering
+//       with ClangIR enabled and will be fixed in a future patch.
 
 int aaaa;
 // CIR: cir.global external @aaaa
 // LLVM: @aaaa = dso_local global i32 0
-// OGCG: @aaaa = dso_local global i32 0
+// OGCG: @aaaa = global i32 0
+
+[[gnu::selectany]] int dddd;
+// CIR: cir.global weak_odr @dddd
+// LLVM: @dddd = weak_odr dso_local global i32 0
+// OGCG: @dddd = weak_odr global i32 0, comdat
 
 static int bbbb;
 // CIR: cir.global internal @_ZL4bbbb
@@ -19,9 +27,10 @@ static int bbbb;
 inline int cccc;
 // CIR: cir.global linkonce_odr @cccc
 // LLVM: @cccc = linkonce_odr dso_local global i32 0
-// OGCG: @cccc = linkonce_odr dso_local global i32 0
+// OGCG: @cccc = linkonce_odr global i32 0
 
-[[gnu::selectany]] int dddd;
-// CIR: cir.global weak_odr @dddd
-// LLVM: @dddd = weak_odr dso_local global i32 0
-// OGCG: @dddd = weak_odr dso_local global i32 0
+// Force the global variables to be emitted
+void reference_vars() {
+    bbbb;
+    cccc;
+}


### PR DESCRIPTION
This change updates a few tests for global variable handling to also check classic codegen output so we can easily verify consistency between the two and will be alerted if the classic codegen changes.

This was useful in developing forthcoming changes to global linkage handling.