### PR TITLE
[clang][Driver][OpenMP][SPIR-V] Fix SPIR-V OpenMP DeviceRTL expected file name

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -2811,7 +2811,7 @@ void tools::addOpenMPDeviceRTL(const Driver &D,
 
   StringRef ArchPrefix = Triple.isAMDGCN()  ? "amdgpu"
                          : Triple.isNVPTX() ? "nvptx"
-                                            : "spirv64";
+                                            : "spirv";
   std::string LibOmpTargetName = ("libomptarget-" + ArchPrefix + ".bc").str();
 
   // First check whether user specifies bc library

--- a/clang/test/Driver/spirv-openmp-toolchain.c
+++ b/clang/test/Driver/spirv-openmp-toolchain.c
@@ -54,7 +54,7 @@
 
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp -fopenmp-targets=spirv64-intel \
 // RUN: --sysroot=%S/Inputs/spirv-openmp/ %s 2>&1 | FileCheck --check-prefix=CHECK-GPULIB %s
-// CHECK-GPULIB: "-cc1" "-triple" "spirv64-intel"{{.*}}"-mlink-builtin-bitcode" "{{.*}}libomptarget-spirv64.bc"
+// CHECK-GPULIB: "-cc1" "-triple" "spirv64-intel"{{.*}}"-mlink-builtin-bitcode" "{{.*}}libomptarget-spirv.bc"
 
 // RUN: not %clang -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=spirv64-intel \
 // RUN:        --libomptarget-spirv-bc-path=%t/ -nogpulib %s 2>&1 \


### PR DESCRIPTION
The option name to specify the path is `--libomptarget-spirv-bc-path` so the existing error gives an invalid option name (`--libomptarget-spirv64-bc-path`) when it can't find the file. Also the expected file name is weird, we expect the file name to be `libomptarget-spirv64.bc`. and use the same prefix `spirv64` to suggest the option to the user.

Also the `nvptx` triple is `nvptx64` and the option/filename there is just `nvptx`, so we should be consistent.