### PR TITLE
[MemProf] Emit remarks when hinting allocations not needing cloning

### DIFF
--- a/llvm/include/llvm/Analysis/MemoryProfileInfo.h
+++ b/llvm/include/llvm/Analysis/MemoryProfileInfo.h
@@ -19,6 +19,9 @@
 #include <map>
 
 namespace llvm {
+
+class OptimizationRemarkEmitter;
+
 namespace memprof {
 
 /// Return the allocation type for a given set of memory profile values.
@@ -85,6 +88,10 @@ private:
   // The allocation's leaf stack id.
   uint64_t AllocStackId = 0;
 
+  // If the client provides a remarks emitter object, we will emit remarks on
+  // allocations for which we apply non-context sensitive allocation hints.
+  OptimizationRemarkEmitter *ORE;
+
   void deleteTrieNode(CallStackTrieNode *Node) {
     if (!Node)
       return;
@@ -111,7 +118,7 @@ private:
                      uint64_t &ColdBytes);
 
 public:
-  CallStackTrie() = default;
+  CallStackTrie(OptimizationRemarkEmitter *ORE = nullptr) : ORE(ORE) {}
   ~CallStackTrie() { deleteTrieNode(Alloc); }
 
   bool empty() const { return Alloc == nullptr; }

--- a/llvm/include/llvm/Transforms/Utils/Cloning.h
+++ b/llvm/include/llvm/Transforms/Utils/Cloning.h
@@ -42,6 +42,7 @@ class Instruction;
 class Loop;
 class LoopInfo;
 class Module;
+class OptimizationRemarkEmitter;
 class PGOContextualProfile;
 class ProfileSummaryInfo;
 class ReturnInst;
@@ -314,7 +315,8 @@ InlineResult InlineFunction(CallBase &CB, InlineFunctionInfo &IFI,
                             bool MergeAttributes = false,
                             AAResults *CalleeAAR = nullptr,
                             bool InsertLifetime = true,
-                            Function *ForwardVarArgsTo = nullptr);
+                            Function *ForwardVarArgsTo = nullptr,
+                            OptimizationRemarkEmitter *ORE = nullptr);
 
 /// Same as above, but it will update the contextual profile. If the contextual
 /// profile is invalid (i.e. not loaded because it is not present), it defaults

--- a/llvm/lib/Analysis/MemoryProfileInfo.cpp
+++ b/llvm/lib/Analysis/MemoryProfileInfo.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Analysis/MemoryProfileInfo.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
@@ -143,13 +144,6 @@ std::string llvm::memprof::getAllocTypeAttributeString(AllocationType Type) {
     assert(false && "Unexpected alloc type");
   }
   llvm_unreachable("invalid alloc type");
-}
-
-static void addAllocTypeAttribute(LLVMContext &Ctx, CallBase *CI,
-                                  AllocationType AllocType) {
-  auto AllocTypeString = getAllocTypeAttributeString(AllocType);
-  auto A = llvm::Attribute::get(Ctx, "memprof", AllocTypeString);
-  CI->addFnAttr(A);
 }
 
 bool llvm::memprof::hasSingleAllocType(uint8_t AllocTypes) {
@@ -475,7 +469,9 @@ bool CallStackTrie::buildMIBNodes(CallStackTrieNode *Node, LLVMContext &Ctx,
 
 void CallStackTrie::addSingleAllocTypeAttribute(CallBase *CI, AllocationType AT,
                                                 StringRef Descriptor) {
-  addAllocTypeAttribute(CI->getContext(), CI, AT);
+  auto AllocTypeString = getAllocTypeAttributeString(AT);
+  auto A = llvm::Attribute::get(CI->getContext(), "memprof", AllocTypeString);
+  CI->addFnAttr(A);
   if (MemProfReportHintedSizes) {
     std::vector<ContextTotalSize> ContextSizeInfo;
     collectContextSizeInfo(Alloc, ContextSizeInfo);
@@ -485,6 +481,12 @@ void CallStackTrie::addSingleAllocTypeAttribute(CallBase *CI, AllocationType AT,
              << getAllocTypeAttributeString(AT) << ": " << TotalSize << "\n";
     }
   }
+  if (ORE)
+    ORE->emit(OptimizationRemark(DEBUG_TYPE, "MemprofAttribute", CI)
+              << ore::NV("AllocationCall", CI) << " in function "
+              << ore::NV("Caller", CI->getFunction())
+              << " marked with memprof allocation attribute "
+              << ore::NV("Attribute", AllocTypeString));
 }
 
 // Build and attach the minimal necessary MIB metadata. If the alloc has a

--- a/llvm/lib/Transforms/IPO/Inliner.cpp
+++ b/llvm/lib/Transforms/IPO/Inliner.cpp
@@ -382,9 +382,10 @@ PreservedAnalyses InlinerPass::run(LazyCallGraph::SCC &InitialC,
           &FAM.getResult<BlockFrequencyAnalysis>(*(CB->getCaller())),
           &FAM.getResult<BlockFrequencyAnalysis>(Callee));
 
-      InlineResult IR =
-          InlineFunction(*CB, IFI, /*MergeAttributes=*/true,
-                         &FAM.getResult<AAManager>(*CB->getCaller()));
+      InlineResult IR = InlineFunction(
+          *CB, IFI, /*MergeAttributes=*/true,
+          &FAM.getResult<AAManager>(*CB->getCaller()), true, nullptr,
+          &FAM.getResult<OptimizationRemarkEmitterAnalysis>(*CB->getCaller()));
       if (!IR.isSuccess()) {
         Advice->recordUnsuccessfulInlining(IR);
         continue;

--- a/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/MemoryBuiltins.h"
 #include "llvm/Analysis/MemoryProfileInfo.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/Constant.h"
@@ -968,7 +969,8 @@ readMemprof(Module &M, Function &F, IndexedInstrProfReader *MemProfReader,
             const TargetLibraryInfo &TLI,
             std::map<uint64_t, AllocMatchInfo> &FullStackIdToAllocMatchInfo,
             std::set<std::vector<uint64_t>> &MatchedCallSites,
-            DenseMap<uint64_t, LocToLocMap> &UndriftMaps) {
+            DenseMap<uint64_t, LocToLocMap> &UndriftMaps,
+            OptimizationRemarkEmitter &ORE) {
   auto &Ctx = M.getContext();
   // Previously we used getIRPGOFuncName() here. If F is local linkage,
   // getIRPGOFuncName() returns FuncName with prefix 'FileName;'. But
@@ -1135,7 +1137,7 @@ readMemprof(Module &M, Function &F, IndexedInstrProfReader *MemProfReader,
         // We may match this instruction's location list to multiple MIB
         // contexts. Add them to a Trie specialized for trimming the contexts to
         // the minimal needed to disambiguate contexts with unique behavior.
-        CallStackTrie AllocTrie;
+        CallStackTrie AllocTrie(&ORE);
         uint64_t TotalSize = 0;
         uint64_t TotalColdSize = 0;
         for (auto *AllocInfo : AllocInfoIter->second) {
@@ -1282,8 +1284,9 @@ PreservedAnalyses MemProfUsePass::run(Module &M, ModuleAnalysisManager &AM) {
       continue;
 
     const TargetLibraryInfo &TLI = FAM.getResult<TargetLibraryAnalysis>(F);
+    auto &ORE = FAM.getResult<OptimizationRemarkEmitterAnalysis>(F);
     readMemprof(M, F, MemProfReader.get(), TLI, FullStackIdToAllocMatchInfo,
-                MatchedCallSites, UndriftMaps);
+                MatchedCallSites, UndriftMaps, ORE);
   }
 
   if (ClPrintMemProfMatchInfo) {

--- a/llvm/test/Transforms/Inline/memprof_inline.ll
+++ b/llvm/test/Transforms/Inline/memprof_inline.ll
@@ -28,7 +28,12 @@
 ;; }
 
 
-; RUN: opt -passes=inline %s -S | FileCheck %s
+;; Also check that remarks are emitted when the allocations are hinted.
+; RUN: opt -passes=inline -pass-remarks=memory-profile-info %s -S 2>&1 | FileCheck %s
+
+; CHECK: remark: memprof_inline.cc:5:10: call in function _Z4foo2v marked with memprof allocation attribute cold
+; CHECK: remark: memprof_inline.cc:5:10: call in function main marked with memprof allocation attribute notcold
+; CHECK: remark: memprof_inline.cc:5:10: call in function main marked with memprof allocation attribute cold
 
 ; ModuleID = 'memprof_inline.cc'
 source_filename = "memprof_inline.cc"

--- a/llvm/test/Transforms/PGOProfile/memprof.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof.ll
@@ -64,8 +64,9 @@
 ; RUN: opt < %s -passes='pgo-instr-use,memprof-use<profile-filename=%t.pgomemprofdata>' -pgo-test-profile-file=%t.pgomemprofdata -pgo-warn-missing-function -S 2>&1 | FileCheck %s --check-prefixes=MEMPROF,ALL,PGO
 
 ;; Check that the total sizes are reported if requested. A message should be
-;; emitted for the pruned context.
-; RUN: opt < %s -passes='memprof-use<profile-filename=%t.memprofdata>' -pgo-warn-missing-function -S -memprof-report-hinted-sizes 2>&1 | FileCheck %s --check-prefixes=TOTALSIZESSINGLE,TOTALSIZES,TOTALSIZENOKEEPALL
+;; emitted for the pruned context. Also check that remarks are emitted for the
+;; allocations hinted without context sensitivity.
+; RUN: opt < %s -passes='memprof-use<profile-filename=%t.memprofdata>' -pgo-warn-missing-function -S -memprof-report-hinted-sizes -pass-remarks=memory-profile-info 2>&1 | FileCheck %s --check-prefixes=TOTALSIZESSINGLE,TOTALSIZES,TOTALSIZENOKEEPALL,REMARKSINGLE
 
 ;; Check that the total sizes are reported if requested, and prevent pruning
 ;; via -memprof-keep-all-not-cold-contexts.
@@ -386,7 +387,9 @@ for.end:                                          ; preds = %for.cond
 ; TOTALSIZESTHRESH60: Total size for full allocation context hash 18254812774972004394 and dominant alloc type cold: 10
 ; TOTALSIZESTHRESH60: Total size for full allocation context hash 1093248920606587996 and dominant alloc type cold: 10
 ; TOTALSIZESSINGLE: Total size for full allocation context hash 6792096022461663180 and single alloc type notcold: 10
+; REMARKSINGLE: remark: memprof.cc:25:13: call in function main marked with memprof allocation attribute notcold
 ; TOTALSIZESSINGLE: Total size for full allocation context hash 15737101490731057601 and single alloc type cold: 10
+; REMARKSINGLE: remark: memprof.cc:26:13: call in function main marked with memprof allocation attribute cold
 ;; For context sensitive allocations the full context hash and size in bytes
 ;; are in separate metadata nodes included on the MIB metadata.
 ; TOTALSIZES: !"cold", ![[CONTEXT1:[0-9]+]]}


### PR DESCRIPTION
The context disambiguation code already emits remarks when hinting
allocations (by adding hotness attributes) during cloning. However,
we did not yet emit hints when applying the hotness attributes during
building of the metadata (during matching and again after inlining).
Add remarks when we apply the hint attributes for these
non-context-sensitive allocations.
