### PR TITLE
[lldb] Run TestFrameLanguageCommands.py only on Darwin

### DIFF
--- a/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
+++ b/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipUnlessDarwin
     def test(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
Tests using ObjC do not readily run on Linux.
