### PR TITLE
[libc] Migrate sys/ tests to ErrnoCheckingTest.

### DIFF
--- a/libc/test/src/sys/auxv/linux/CMakeLists.txt
+++ b/libc/test/src/sys/auxv/linux/CMakeLists.txt
@@ -9,6 +9,7 @@ add_libc_unittest(
     libc.include.sys_auxv
     libc.src.errno.errno
     libc.src.sys.auxv.getauxval
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
     libc.src.string.strstr
 )

--- a/libc/test/src/sys/auxv/linux/getauxval_test.cpp
+++ b/libc/test/src/sys/auxv/linux/getauxval_test.cpp
@@ -5,16 +5,18 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-#include "src/errno/libc_errno.h"
+
 #include "src/sys/auxv/getauxval.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 #include <src/string/strstr.h>
 #include <sys/auxv.h>
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcGetauxvalTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcGetauxvalTest, Basic) {
+TEST_F(LlvmLibcGetauxvalTest, Basic) {
   EXPECT_THAT(LIBC_NAMESPACE::getauxval(AT_PAGESZ),
               returns(GT(0ul)).with_errno(EQ(0)));
   const char *filename;

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -11,6 +11,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.mman.mmap
     libc.src.sys.mman.munmap
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -26,6 +27,7 @@ add_libc_unittest(
     libc.src.sys.mman.mmap
     libc.src.sys.mman.mremap
     libc.src.sys.mman.munmap
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -43,6 +45,7 @@ if (NOT LLVM_USE_SANITIZER)
       libc.src.sys.mman.mmap
       libc.src.sys.mman.munmap
       libc.src.sys.mman.mprotect
+      libc.test.UnitTest.ErrnoCheckingTest
       libc.test.UnitTest.ErrnoSetterMatcher
   )
 endif()
@@ -59,6 +62,7 @@ add_libc_unittest(
     libc.src.sys.mman.mmap
     libc.src.sys.mman.munmap
     libc.src.sys.mman.madvise
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -75,6 +79,7 @@ add_libc_unittest(
     libc.src.sys.mman.mmap
     libc.src.sys.mman.munmap
     libc.src.sys.mman.posix_madvise
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -95,6 +100,7 @@ add_libc_unittest(
     libc.src.sys.mman.mlock
     libc.src.sys.mman.munlock
     libc.src.unistd.sysconf
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -120,6 +126,7 @@ add_libc_unittest(
     libc.src.sys.resource.getrlimit
     libc.src.__support.OSUtil.osutil
     libc.src.unistd.sysconf
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -140,6 +147,7 @@ add_libc_unittest(
     libc.src.sys.mman.mlock
     libc.src.sys.mman.munlock
     libc.src.unistd.sysconf
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -153,6 +161,7 @@ add_libc_unittest(
     libc.include.sys_mman
     libc.include.sys_stat
     libc.src.unistd.sysconf
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
     libc.src.sys.mman.remap_file_pages
     libc.src.errno.errno
@@ -179,5 +188,6 @@ add_libc_unittest(
     libc.src.unistd.close
     libc.src.__support.OSUtil.osutil
     libc.hdr.fcntl_macros
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/mman/linux/madvise_test.cpp
+++ b/libc/test/src/sys/mman/linux/madvise_test.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/sys/mman/madvise.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -17,10 +17,10 @@
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcMadviseTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcMadviseTest, NoError) {
+TEST_F(LlvmLibcMadviseTest, NoError) {
   size_t alloc_size = 128;
-  LIBC_NAMESPACE::libc_errno = 0;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, alloc_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -37,8 +37,7 @@ TEST(LlvmLibcMadviseTest, NoError) {
   EXPECT_THAT(LIBC_NAMESPACE::munmap(addr, alloc_size), Succeeds());
 }
 
-TEST(LlvmLibcMadviseTest, Error_BadPtr) {
-  LIBC_NAMESPACE::libc_errno = 0;
+TEST_F(LlvmLibcMadviseTest, Error_BadPtr) {
   EXPECT_THAT(LIBC_NAMESPACE::madvise(nullptr, 8, MADV_SEQUENTIAL),
               Fails(ENOMEM));
 }

--- a/libc/test/src/sys/mman/linux/mincore_test.cpp
+++ b/libc/test/src/sys/mman/linux/mincore_test.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
-#include "src/errno/libc_errno.h"
 #include "src/sys/mman/madvise.h"
 #include "src/sys/mman/mincore.h"
 #include "src/sys/mman/mlock.h"
@@ -15,6 +14,7 @@
 #include "src/sys/mman/munlock.h"
 #include "src/sys/mman/munmap.h"
 #include "src/unistd/sysconf.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -24,64 +24,60 @@
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcMincoreTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcMincoreTest, UnMappedMemory) {
-  LIBC_NAMESPACE::libc_errno = 0;
+TEST_F(LlvmLibcMincoreTest, UnMappedMemory) {
   unsigned char vec;
   int res = LIBC_NAMESPACE::mincore(nullptr, 1, &vec);
   EXPECT_THAT(res, Fails(ENOMEM, -1));
 }
 
-TEST(LlvmLibcMincoreTest, UnalignedAddr) {
+TEST_F(LlvmLibcMincoreTest, UnalignedAddr) {
   unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
   void *addr = LIBC_NAMESPACE::mmap(nullptr, page_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_NE(addr, MAP_FAILED);
   EXPECT_EQ(reinterpret_cast<unsigned long>(addr) % page_size, 0ul);
-  LIBC_NAMESPACE::libc_errno = 0;
   int res = LIBC_NAMESPACE::mincore(static_cast<char *>(addr) + 1, 1, nullptr);
   EXPECT_THAT(res, Fails(EINVAL, -1));
   EXPECT_THAT(LIBC_NAMESPACE::munmap(addr, page_size), Succeeds());
 }
 
-TEST(LlvmLibcMincoreTest, InvalidVec) {
+TEST_F(LlvmLibcMincoreTest, InvalidVec) {
   unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
   void *addr = LIBC_NAMESPACE::mmap(nullptr, 4 * page_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_NE(addr, MAP_FAILED);
   EXPECT_EQ(reinterpret_cast<unsigned long>(addr) % page_size, 0ul);
-  LIBC_NAMESPACE::libc_errno = 0;
   int res = LIBC_NAMESPACE::mincore(addr, 1, nullptr);
   EXPECT_THAT(res, Fails(EFAULT, -1));
 }
 
-TEST(LlvmLibcMincoreTest, NoError) {
+TEST_F(LlvmLibcMincoreTest, NoError) {
   unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
   void *addr = LIBC_NAMESPACE::mmap(nullptr, page_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_NE(addr, MAP_FAILED);
   EXPECT_EQ(reinterpret_cast<unsigned long>(addr) % page_size, 0ul);
   unsigned char vec;
-  LIBC_NAMESPACE::libc_errno = 0;
   int res = LIBC_NAMESPACE::mincore(addr, 1, &vec);
   EXPECT_THAT(res, Succeeds());
   EXPECT_THAT(LIBC_NAMESPACE::munmap(addr, page_size), Succeeds());
 }
 
-TEST(LlvmLibcMincoreTest, NegativeLength) {
+TEST_F(LlvmLibcMincoreTest, NegativeLength) {
   unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
   void *addr = LIBC_NAMESPACE::mmap(nullptr, page_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_NE(addr, MAP_FAILED);
   EXPECT_EQ(reinterpret_cast<unsigned long>(addr) % page_size, 0ul);
   unsigned char vec;
-  LIBC_NAMESPACE::libc_errno = 0;
   int res = LIBC_NAMESPACE::mincore(addr, -1, &vec);
   EXPECT_THAT(res, Fails(ENOMEM, -1));
   EXPECT_THAT(LIBC_NAMESPACE::munmap(addr, page_size), Succeeds());
 }
 
-TEST(LlvmLibcMincoreTest, PageOut) {
+TEST_F(LlvmLibcMincoreTest, PageOut) {
   unsigned long page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
   unsigned char vec;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, page_size, PROT_READ | PROT_WRITE,
@@ -101,11 +97,9 @@ TEST(LlvmLibcMincoreTest, PageOut) {
 
   // page out the memory
   {
-    LIBC_NAMESPACE::libc_errno = 0;
     EXPECT_THAT(LIBC_NAMESPACE::madvise(addr, page_size, MADV_DONTNEED),
                 Succeeds());
 
-    LIBC_NAMESPACE::libc_errno = 0;
     int res = LIBC_NAMESPACE::mincore(addr, page_size, &vec);
     EXPECT_EQ(vec & 1u, 0u);
     EXPECT_THAT(res, Succeeds());

--- a/libc/test/src/sys/mman/linux/mmap_test.cpp
+++ b/libc/test/src/sys/mman/linux/mmap_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -16,10 +16,10 @@
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcMMapTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcMMapTest, NoError) {
+TEST_F(LlvmLibcMMapTest, NoError) {
   size_t alloc_size = 128;
-  LIBC_NAMESPACE::libc_errno = 0;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, alloc_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -33,8 +33,7 @@ TEST(LlvmLibcMMapTest, NoError) {
   EXPECT_THAT(LIBC_NAMESPACE::munmap(addr, alloc_size), Succeeds());
 }
 
-TEST(LlvmLibcMMapTest, Error_InvalidSize) {
-  LIBC_NAMESPACE::libc_errno = 0;
+TEST_F(LlvmLibcMMapTest, Error_InvalidSize) {
   void *addr = LIBC_NAMESPACE::mmap(nullptr, 0, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   EXPECT_THAT(addr, Fails(EINVAL, MAP_FAILED));

--- a/libc/test/src/sys/mman/linux/mprotect_test.cpp
+++ b/libc/test/src/sys/mman/linux/mprotect_test.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/mprotect.h"
 #include "src/sys/mman/munmap.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -18,10 +18,10 @@
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcMProtectTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcMProtectTest, NoError) {
+TEST_F(LlvmLibcMProtectTest, NoError) {
   size_t alloc_size = 128;
-  LIBC_NAMESPACE::libc_errno = 0;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, alloc_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -47,7 +47,7 @@ TEST(LlvmLibcMProtectTest, NoError) {
 // This test is disabled currently due to flakeyness. It will be re-enabled once
 // it is less flakey.
 /*
-TEST(LlvmLibcMProtectTest, Error_InvalidWrite) {
+TEST_F(LlvmLibcMProtectTest, Error_InvalidWrite) {
   // attempting to write to a read-only protected part of memory should cause a
   // segfault.
   EXPECT_DEATH(

--- a/libc/test/src/sys/mman/linux/mremap_test.cpp
+++ b/libc/test/src/sys/mman/linux/mremap_test.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/mremap.h"
 #include "src/sys/mman/munmap.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -17,11 +17,11 @@
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcMremapTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcMremapTest, NoError) {
+TEST_F(LlvmLibcMremapTest, NoError) {
   size_t initial_size = 128;
   size_t new_size = 256;
-  LIBC_NAMESPACE::libc_errno = 0;
 
   // Allocate memory using mmap.
   void *addr =
@@ -47,9 +47,8 @@ TEST(LlvmLibcMremapTest, NoError) {
   EXPECT_THAT(LIBC_NAMESPACE::munmap(new_addr, new_size), Succeeds());
 }
 
-TEST(LlvmLibcMremapTest, Error_InvalidSize) {
+TEST_F(LlvmLibcMremapTest, Error_InvalidSize) {
   size_t initial_size = 128;
-  LIBC_NAMESPACE::libc_errno = 0;
 
   // Allocate memory using mmap.
   void *addr =

--- a/libc/test/src/sys/mman/linux/msync_test.cpp
+++ b/libc/test/src/sys/mman/linux/msync_test.cpp
@@ -6,17 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/sys/mman/mlock.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/msync.h"
 #include "src/sys/mman/munlock.h"
 #include "src/sys/mman/munmap.h"
 #include "src/unistd/sysconf.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcMsyncTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 struct PageHolder {
   size_t size;
@@ -36,12 +37,12 @@ struct PageHolder {
   bool is_valid() { return addr != MAP_FAILED; }
 };
 
-TEST(LlvmLibcMsyncTest, UnMappedMemory) {
+TEST_F(LlvmLibcMsyncTest, UnMappedMemory) {
   EXPECT_THAT(LIBC_NAMESPACE::msync(nullptr, 1024, MS_SYNC), Fails(ENOMEM));
   EXPECT_THAT(LIBC_NAMESPACE::msync(nullptr, 1024, MS_ASYNC), Fails(ENOMEM));
 }
 
-TEST(LlvmLibcMsyncTest, LockedPage) {
+TEST_F(LlvmLibcMsyncTest, LockedPage) {
   PageHolder page;
   ASSERT_TRUE(page.is_valid());
   ASSERT_THAT(LIBC_NAMESPACE::mlock(page.addr, page.size), Succeeds());
@@ -52,14 +53,14 @@ TEST(LlvmLibcMsyncTest, LockedPage) {
   EXPECT_THAT(LIBC_NAMESPACE::msync(page.addr, page.size, MS_SYNC), Succeeds());
 }
 
-TEST(LlvmLibcMsyncTest, UnalignedAddress) {
+TEST_F(LlvmLibcMsyncTest, UnalignedAddress) {
   PageHolder page;
   ASSERT_TRUE(page.is_valid());
   EXPECT_THAT(LIBC_NAMESPACE::msync(&page[1], page.size - 1, MS_SYNC),
               Fails(EINVAL));
 }
 
-TEST(LlvmLibcMsyncTest, InvalidFlag) {
+TEST_F(LlvmLibcMsyncTest, InvalidFlag) {
   PageHolder page;
   ASSERT_TRUE(page.is_valid());
   EXPECT_THAT(LIBC_NAMESPACE::msync(page.addr, page.size, MS_SYNC | MS_ASYNC),

--- a/libc/test/src/sys/mman/linux/posix_madvise_test.cpp
+++ b/libc/test/src/sys/mman/linux/posix_madvise_test.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"
 #include "src/sys/mman/posix_madvise.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -17,10 +17,10 @@
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcPosixMadviseTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcPosixMadviseTest, NoError) {
+TEST_F(LlvmLibcPosixMadviseTest, NoError) {
   size_t alloc_size = 128;
-  LIBC_NAMESPACE::libc_errno = 0;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, alloc_size, PROT_READ,
                                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -37,8 +37,7 @@ TEST(LlvmLibcPosixMadviseTest, NoError) {
   EXPECT_THAT(LIBC_NAMESPACE::munmap(addr, alloc_size), Succeeds());
 }
 
-TEST(LlvmLibcPosixMadviseTest, Error_BadPtr) {
-  LIBC_NAMESPACE::libc_errno = 0;
+TEST_F(LlvmLibcPosixMadviseTest, Error_BadPtr) {
   // posix_madvise is a no-op on DONTNEED, so it shouldn't fail even with the
   // nullptr.
   EXPECT_EQ(LIBC_NAMESPACE::posix_madvise(nullptr, 8, POSIX_MADV_DONTNEED), 0);

--- a/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
+++ b/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"
 #include "src/sys/mman/remap_file_pages.h"
 #include "src/unistd/close.h"
 #include "src/unistd/sysconf.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -21,8 +21,9 @@
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcRemapFilePagesTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcRemapFilePagesTest, NoError) {
+TEST_F(LlvmLibcRemapFilePagesTest, NoError) {
   size_t page_size = LIBC_NAMESPACE::sysconf(_SC_PAGE_SIZE);
   ASSERT_GT(page_size, size_t(0));
 
@@ -34,7 +35,6 @@ TEST(LlvmLibcRemapFilePagesTest, NoError) {
 
   // First, allocate some memory using mmap
   size_t alloc_size = 2 * page_size;
-  LIBC_NAMESPACE::libc_errno = 0;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, alloc_size, PROT_READ | PROT_WRITE,
                                     MAP_SHARED, fd, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -44,15 +44,12 @@ TEST(LlvmLibcRemapFilePagesTest, NoError) {
   EXPECT_THAT(LIBC_NAMESPACE::remap_file_pages(addr, page_size, 0, 1, 0),
               Succeeds());
 
-  // Reset error number for the new function
-  LIBC_NAMESPACE::libc_errno = 0;
-
   // Clean up
   EXPECT_THAT(LIBC_NAMESPACE::munmap(addr, alloc_size), Succeeds());
   EXPECT_THAT(LIBC_NAMESPACE::close(fd), Succeeds());
 }
 
-TEST(LlvmLibcRemapFilePagesTest, ErrorInvalidFlags) {
+TEST_F(LlvmLibcRemapFilePagesTest, ErrorInvalidFlags) {
   size_t page_size = LIBC_NAMESPACE::sysconf(_SC_PAGE_SIZE);
   ASSERT_GT(page_size, size_t(0));
 
@@ -64,7 +61,6 @@ TEST(LlvmLibcRemapFilePagesTest, ErrorInvalidFlags) {
 
   // First, allocate some memory using mmap
   size_t alloc_size = 2 * page_size;
-  LIBC_NAMESPACE::libc_errno = 0;
   void *addr = LIBC_NAMESPACE::mmap(nullptr, alloc_size, PROT_READ | PROT_WRITE,
                                     MAP_SHARED, fd, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -80,7 +76,7 @@ TEST(LlvmLibcRemapFilePagesTest, ErrorInvalidFlags) {
   EXPECT_THAT(LIBC_NAMESPACE::close(fd), Succeeds());
 }
 
-TEST(LlvmLibcRemapFilePagesTest, ErrorInvalidAddress) {
+TEST_F(LlvmLibcRemapFilePagesTest, ErrorInvalidAddress) {
   size_t page_size = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
   ASSERT_GT(page_size, size_t(0));
 

--- a/libc/test/src/sys/mman/linux/shm_test.cpp
+++ b/libc/test/src/sys/mman/linux/shm_test.cpp
@@ -15,15 +15,17 @@
 #include "src/sys/mman/shm_unlink.h"
 #include "src/unistd/close.h"
 #include "src/unistd/ftruncate.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 #include <sys/syscall.h>
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcShmTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 // since shm_open/shm_unlink are wrappers around open/unlink, we only focus on
 // testing basic cases and name conversions.
 
-TEST(LlvmLibcShmTest, Basic) {
+TEST_F(LlvmLibcShmTest, Basic) {
   const char *name = "/test_shm_open";
   int fd;
   ASSERT_THAT(fd = LIBC_NAMESPACE::shm_open(name, O_CREAT | O_RDWR, 0666),
@@ -57,7 +59,7 @@ TEST(LlvmLibcShmTest, Basic) {
   ASSERT_THAT(LIBC_NAMESPACE::shm_unlink(name), Succeeds());
 }
 
-TEST(LlvmLibcShmTest, NameConversion) {
+TEST_F(LlvmLibcShmTest, NameConversion) {
   const char *name = "////test_shm_open";
   int fd;
   ASSERT_THAT(fd = LIBC_NAMESPACE::shm_open(name, O_CREAT | O_RDWR, 0666),

--- a/libc/test/src/sys/prctl/linux/CMakeLists.txt
+++ b/libc/test/src/sys/prctl/linux/CMakeLists.txt
@@ -10,4 +10,6 @@ add_libc_unittest(
     libc.include.sys_prctl
     libc.src.sys.prctl.prctl
     libc.src.errno.errno
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/prctl/linux/prctl_test.cpp
+++ b/libc/test/src/sys/prctl/linux/prctl_test.cpp
@@ -6,15 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/sys/prctl/prctl.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include <sys/prctl.h>
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcSysPrctlTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcSysPrctlTest, GetSetName) {
+TEST_F(LlvmLibcSysPrctlTest, GetSetName) {
   char name[17];
   unsigned long name_addr = 0;
   ASSERT_THAT(LIBC_NAMESPACE::prctl(PR_GET_NAME, name_addr, 0, 0, 0),
@@ -30,10 +31,9 @@ TEST(LlvmLibcSysPrctlTest, GetSetName) {
   ASSERT_STREQ(name, "libc-test");
 }
 
-TEST(LlvmLibcSysPrctlTest, GetTHPDisable) {
+TEST_F(LlvmLibcSysPrctlTest, GetTHPDisable) {
   // Manually check errno since the return value logic here is not
   // covered in ErrnoSetterMatcher.
-  LIBC_NAMESPACE::libc_errno = 0;
   int ret = LIBC_NAMESPACE::prctl(PR_GET_THP_DISABLE, 0, 0, 0, 0);
   ASSERT_ERRNO_SUCCESS();
   // PR_GET_THP_DISABLE return (as the function result) the current

--- a/libc/test/src/sys/random/linux/CMakeLists.txt
+++ b/libc/test/src/sys/random/linux/CMakeLists.txt
@@ -11,5 +11,6 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.math.fabs
     libc.src.sys.random.getrandom
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/random/linux/getrandom_test.cpp
+++ b/libc/test/src/sys/random/linux/getrandom_test.cpp
@@ -7,28 +7,26 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/CPP/array.h"
-#include "src/errno/libc_errno.h"
 #include "src/math/fabs.h"
 #include "src/sys/random/getrandom.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcGetRandomTest, InvalidFlag) {
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcGetRandomTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcGetRandomTest, InvalidFlag) {
   LIBC_NAMESPACE::cpp::array<char, 10> buffer;
-  LIBC_NAMESPACE::libc_errno = 0;
-  ASSERT_THAT(
-      LIBC_NAMESPACE::getrandom(buffer.data(), buffer.size(), -1),
-      LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails<ssize_t>(EINVAL));
+  ASSERT_THAT(LIBC_NAMESPACE::getrandom(buffer.data(), buffer.size(), -1),
+              Fails(EINVAL));
 }
 
-TEST(LlvmLibcGetRandomTest, InvalidBuffer) {
-  LIBC_NAMESPACE::libc_errno = 0;
-  ASSERT_THAT(
-      LIBC_NAMESPACE::getrandom(nullptr, 65536, 0),
-      LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails<ssize_t>(EFAULT));
+TEST_F(LlvmLibcGetRandomTest, InvalidBuffer) {
+  ASSERT_THAT(LIBC_NAMESPACE::getrandom(nullptr, 65536, 0), Fails(EFAULT));
 }
 
-TEST(LlvmLibcGetRandomTest, ReturnsSize) {
+TEST_F(LlvmLibcGetRandomTest, ReturnsSize) {
   LIBC_NAMESPACE::cpp::array<char, 10> buffer;
   for (size_t i = 0; i < buffer.size(); ++i) {
     // Without GRND_RANDOM set this should never fail.
@@ -37,7 +35,7 @@ TEST(LlvmLibcGetRandomTest, ReturnsSize) {
   }
 }
 
-TEST(LlvmLibcGetRandomTest, CheckValue) {
+TEST_F(LlvmLibcGetRandomTest, CheckValue) {
   // Probability of picking one particular value amongst 256 possibilities a
   // hundred times in a row is (1/256)^100 = 1.49969681e-241.
   LIBC_NAMESPACE::cpp::array<char, 100> buffer;

--- a/libc/test/src/sys/resource/CMakeLists.txt
+++ b/libc/test/src/sys/resource/CMakeLists.txt
@@ -17,4 +17,6 @@ add_libc_unittest(
     libc.src.sys.resource.setrlimit
     libc.src.unistd.close
     libc.src.unistd.unlink
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/resource/getrlimit_setrlimit_test.cpp
+++ b/libc/test/src/sys/resource/getrlimit_setrlimit_test.cpp
@@ -7,29 +7,28 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/CPP/string_view.h"
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/resource/getrlimit.h"
 #include "src/sys/resource/setrlimit.h"
 #include "src/unistd/close.h"
 #include "src/unistd/unlink.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/resource.h>
 #include <sys/stat.h>
 
-TEST(LlvmLibcResourceLimitsTest, SetNoFileLimit) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcResourceLimitsTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
+TEST_F(LlvmLibcResourceLimitsTest, SetNoFileLimit) {
   // The test strategy is to first create initialize two file descriptors
   // successfully. Next, close the files and set the file descriptor limit
   // to 4. This will allow us to open one of those file but not the other.
 
   constexpr const char *TEST_FILE1 = "testdata/resource_limits1.test";
   constexpr const char *TEST_FILE2 = "testdata/resource_limits2.test";
-  LIBC_NAMESPACE::libc_errno = 0;
 
   int fd1 = LIBC_NAMESPACE::open(TEST_FILE1, O_CREAT | O_WRONLY, S_IRWXU);
   ASSERT_GT(fd1, 0);
@@ -54,7 +53,6 @@ TEST(LlvmLibcResourceLimitsTest, SetNoFileLimit) {
   ASSERT_LT(fd2, 0);
   ASSERT_ERRNO_FAILURE();
 
-  LIBC_NAMESPACE::libc_errno = 0;
   ASSERT_THAT(LIBC_NAMESPACE::close(fd1), Succeeds(0));
 
   fd2 = LIBC_NAMESPACE::open(TEST_FILE2, O_RDONLY);
@@ -64,7 +62,6 @@ TEST(LlvmLibcResourceLimitsTest, SetNoFileLimit) {
   ASSERT_LT(fd1, 0);
   ASSERT_ERRNO_FAILURE();
 
-  LIBC_NAMESPACE::libc_errno = 0;
   ASSERT_THAT(LIBC_NAMESPACE::close(fd2), Succeeds(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::unlink(TEST_FILE1), Succeeds(0));

--- a/libc/test/src/sys/select/CMakeLists.txt
+++ b/libc/test/src/sys/select/CMakeLists.txt
@@ -12,6 +12,8 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.select.select
     libc.src.unistd.read
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -25,6 +27,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.select.select
     libc.src.unistd.read
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 

--- a/libc/test/src/sys/select/select_failure_test.cpp
+++ b/libc/test/src/sys/select/select_failure_test.cpp
@@ -8,6 +8,7 @@
 
 #include "src/sys/select/select.h"
 #include "src/unistd/read.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -15,8 +16,9 @@
 #include <unistd.h>
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+using LlvmLibcSelectTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcSelectTest, SelectInvalidFD) {
+TEST_F(LlvmLibcSelectTest, SelectInvalidFD) {
   fd_set set;
   FD_ZERO(&set);
   struct timeval timeout {

--- a/libc/test/src/sys/sendfile/CMakeLists.txt
+++ b/libc/test/src/sys/sendfile/CMakeLists.txt
@@ -18,4 +18,6 @@ add_libc_unittest(
     libc.src.unistd.read
     libc.src.unistd.unlink
     libc.src.unistd.write
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/sendfile/sendfile_test.cpp
+++ b/libc/test/src/sys/sendfile/sendfile_test.cpp
@@ -7,25 +7,24 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/CPP/string_view.h"
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/sendfile/sendfile.h"
 #include "src/unistd/close.h"
 #include "src/unistd/read.h"
 #include "src/unistd/unlink.h"
 #include "src/unistd/write.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
 #include <sys/stat.h>
 
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcSendfileTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 namespace cpp = LIBC_NAMESPACE::cpp;
 
-TEST(LlvmLibcSendfileTest, CreateAndTransfer) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-
+TEST_F(LlvmLibcSendfileTest, CreateAndTransfer) {
   // The test strategy is to
   //   1. Create a temporary file with known data.
   //   2. Use sendfile to copy it to another file.
@@ -35,7 +34,6 @@ TEST(LlvmLibcSendfileTest, CreateAndTransfer) {
   constexpr const char *OUT_FILE = "testdata/sendfile_out.test";
   const char IN_DATA[] = "sendfile test";
   constexpr ssize_t IN_SIZE = ssize_t(sizeof(IN_DATA));
-  LIBC_NAMESPACE::libc_errno = 0;
 
   int in_fd = LIBC_NAMESPACE::open(IN_FILE, O_CREAT | O_WRONLY, S_IRWXU);
   ASSERT_GT(in_fd, 0);

--- a/libc/test/src/sys/stat/CMakeLists.txt
+++ b/libc/test/src/sys/stat/CMakeLists.txt
@@ -16,6 +16,8 @@ add_libc_unittest(
     libc.src.sys.stat.chmod
     libc.src.unistd.close
     libc.src.unistd.write
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -32,6 +34,8 @@ add_libc_unittest(
     libc.src.sys.stat.fchmodat
     libc.src.unistd.close
     libc.src.unistd.write
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -48,6 +52,8 @@ add_libc_unittest(
     libc.src.sys.stat.fchmod
     libc.src.unistd.close
     libc.src.unistd.write
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -62,6 +68,8 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.stat.mkdirat
     libc.src.unistd.rmdir
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -78,6 +86,8 @@ add_libc_unittest(
     libc.src.fcntl.open
     libc.src.unistd.close
     libc.src.unistd.unlink
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -94,6 +104,8 @@ add_libc_unittest(
     libc.src.fcntl.open
     libc.src.unistd.close
     libc.src.unistd.unlink
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -110,4 +122,6 @@ add_libc_unittest(
     libc.src.fcntl.open
     libc.src.unistd.close
     libc.src.unistd.unlink
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/stat/chmod_test.cpp
+++ b/libc/test/src/sys/stat/chmod_test.cpp
@@ -6,21 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/stat/chmod.h"
 #include "src/unistd/close.h"
 #include "src/unistd/write.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
 #include <sys/stat.h>
 
-TEST(LlvmLibcChmodTest, ChangeAndOpen) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcChmodTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
+TEST_F(LlvmLibcChmodTest, ChangeAndOpen) {
   // The test file is initially writable. We open it for writing and ensure
   // that it indeed can be opened for writing. Next, we close the file and
   // make it readonly using chmod. We test that chmod actually succeeded by
@@ -28,7 +28,6 @@ TEST(LlvmLibcChmodTest, ChangeAndOpen) {
   constexpr const char *TEST_FILE = "testdata/chmod.test";
   const char WRITE_DATA[] = "test data";
   constexpr ssize_t WRITE_SIZE = ssize_t(sizeof(WRITE_DATA));
-  LIBC_NAMESPACE::libc_errno = 0;
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_APPEND | O_WRONLY);
   ASSERT_GT(fd, 0);
@@ -46,7 +45,6 @@ TEST(LlvmLibcChmodTest, ChangeAndOpen) {
   // Opening for writing should fail.
   EXPECT_EQ(LIBC_NAMESPACE::open(TEST_FILE, O_APPEND | O_WRONLY), -1);
   ASSERT_ERRNO_FAILURE();
-  LIBC_NAMESPACE::libc_errno = 0;
   // But opening for reading should succeed.
   fd = LIBC_NAMESPACE::open(TEST_FILE, O_APPEND | O_RDONLY);
   EXPECT_GT(fd, 0);
@@ -56,10 +54,7 @@ TEST(LlvmLibcChmodTest, ChangeAndOpen) {
   EXPECT_THAT(LIBC_NAMESPACE::chmod(TEST_FILE, S_IRWXU), Succeeds(0));
 }
 
-TEST(LlvmLibcChmodTest, NonExistentFile) {
-  LIBC_NAMESPACE::libc_errno = 0;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+TEST_F(LlvmLibcChmodTest, NonExistentFile) {
   ASSERT_THAT(LIBC_NAMESPACE::chmod("non-existent-file", S_IRUSR),
               Fails(ENOENT));
-  LIBC_NAMESPACE::libc_errno = 0;
 }

--- a/libc/test/src/sys/stat/fchmodat_test.cpp
+++ b/libc/test/src/sys/stat/fchmodat_test.cpp
@@ -6,21 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/stat/fchmodat.h"
 #include "src/unistd/close.h"
 #include "src/unistd/write.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
 #include <sys/stat.h>
 
-TEST(LlvmLibcFchmodatTest, ChangeAndOpen) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcFchmodatTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
+TEST_F(LlvmLibcFchmodatTest, ChangeAndOpen) {
   // The test file is initially writable. We open it for writing and ensure
   // that it indeed can be opened for writing. Next, we close the file and
   // make it readonly using chmod. We test that chmod actually succeeded by
@@ -30,7 +30,6 @@ TEST(LlvmLibcFchmodatTest, ChangeAndOpen) {
   constexpr const char *TEST_FILE_BASENAME = "fchmodat.test";
   const char WRITE_DATA[] = "fchmodat test";
   constexpr ssize_t WRITE_SIZE = ssize_t(sizeof(WRITE_DATA));
-  LIBC_NAMESPACE::libc_errno = 0;
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_WRONLY, S_IRWXU);
   ASSERT_GT(fd, 0);
@@ -49,7 +48,6 @@ TEST(LlvmLibcFchmodatTest, ChangeAndOpen) {
   // Opening for writing should fail.
   EXPECT_EQ(LIBC_NAMESPACE::open(TEST_FILE, O_APPEND | O_WRONLY), -1);
   ASSERT_ERRNO_FAILURE();
-  LIBC_NAMESPACE::libc_errno = 0;
   // But opening for reading should succeed.
   fd = LIBC_NAMESPACE::open(TEST_FILE, O_APPEND | O_RDONLY);
   EXPECT_GT(fd, 0);
@@ -62,11 +60,8 @@ TEST(LlvmLibcFchmodatTest, ChangeAndOpen) {
   EXPECT_THAT(LIBC_NAMESPACE::close(dirfd), Succeeds(0));
 }
 
-TEST(LlvmLibcFchmodatTest, NonExistentFile) {
-  LIBC_NAMESPACE::libc_errno = 0;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+TEST_F(LlvmLibcFchmodatTest, NonExistentFile) {
   ASSERT_THAT(
       LIBC_NAMESPACE::fchmodat(AT_FDCWD, "non-existent-file", S_IRUSR, 0),
       Fails(ENOENT));
-  LIBC_NAMESPACE::libc_errno = 0;
 }

--- a/libc/test/src/sys/stat/fstat_test.cpp
+++ b/libc/test/src/sys/stat/fstat_test.cpp
@@ -6,27 +6,26 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/stat/fstat.h"
 #include "src/unistd/close.h"
 #include "src/unistd/unlink.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
 #include <sys/stat.h>
 
-TEST(LlvmLibcFStatTest, CreatAndReadMode) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcFStatTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
+TEST_F(LlvmLibcFStatTest, CreatAndReadMode) {
   // The test file is initially writable. We open it for writing and ensure
   // that it indeed can be opened for writing. Next, we close the file and
   // make it readonly using chmod. We test that chmod actually succeeded by
   // trying to open the file for writing and failing.
   constexpr const char *TEST_FILE = "testdata/fstat.test";
-  LIBC_NAMESPACE::libc_errno = 0;
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_WRONLY, S_IRWXU);
   ASSERT_GT(fd, 0);
@@ -41,10 +40,7 @@ TEST(LlvmLibcFStatTest, CreatAndReadMode) {
   ASSERT_THAT(LIBC_NAMESPACE::unlink(TEST_FILE), Succeeds(0));
 }
 
-TEST(LlvmLibcFStatTest, NonExistentFile) {
-  LIBC_NAMESPACE::libc_errno = 0;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+TEST_F(LlvmLibcFStatTest, NonExistentFile) {
   struct stat statbuf;
   ASSERT_THAT(LIBC_NAMESPACE::fstat(-1, &statbuf), Fails(EBADF));
-  LIBC_NAMESPACE::libc_errno = 0;
 }

--- a/libc/test/src/sys/stat/lstat_test.cpp
+++ b/libc/test/src/sys/stat/lstat_test.cpp
@@ -6,27 +6,26 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/stat/lstat.h"
 #include "src/unistd/close.h"
 #include "src/unistd/unlink.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
 #include <sys/stat.h>
 
-TEST(LlvmLibcLStatTest, CreatAndReadMode) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcLStatTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
+TEST_F(LlvmLibcLStatTest, CreatAndReadMode) {
   // The test file is initially writable. We open it for writing and ensure
   // that it indeed can be opened for writing. Next, we close the file and
   // make it readonly using chmod. We test that chmod actually succeeded by
   // trying to open the file for writing and failing.
   constexpr const char *TEST_FILE = "testdata/lstat.test";
-  LIBC_NAMESPACE::libc_errno = 0;
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_WRONLY, S_IRWXU);
   ASSERT_GT(fd, 0);
@@ -41,11 +40,8 @@ TEST(LlvmLibcLStatTest, CreatAndReadMode) {
   ASSERT_THAT(LIBC_NAMESPACE::unlink(TEST_FILE), Succeeds(0));
 }
 
-TEST(LlvmLibcLStatTest, NonExistentFile) {
-  LIBC_NAMESPACE::libc_errno = 0;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+TEST_F(LlvmLibcLStatTest, NonExistentFile) {
   struct stat statbuf;
   ASSERT_THAT(LIBC_NAMESPACE::lstat("non-existent-file", &statbuf),
               Fails(ENOENT));
-  LIBC_NAMESPACE::libc_errno = 0;
 }

--- a/libc/test/src/sys/stat/mkdirat_test.cpp
+++ b/libc/test/src/sys/stat/mkdirat_test.cpp
@@ -8,13 +8,16 @@
 
 #include "src/sys/stat/mkdirat.h"
 #include "src/unistd/rmdir.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
 
-TEST(LlvmLibcMkdiratTest, CreateAndRemove) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcMkdiratTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcMkdiratTest, CreateAndRemove) {
   constexpr const char *FILENAME = "testdata/mkdirat.testdir";
   auto TEST_DIR = libc_make_test_file_path(FILENAME);
   ASSERT_THAT(LIBC_NAMESPACE::mkdirat(AT_FDCWD, TEST_DIR, S_IRWXU),
@@ -22,8 +25,7 @@ TEST(LlvmLibcMkdiratTest, CreateAndRemove) {
   ASSERT_THAT(LIBC_NAMESPACE::rmdir(TEST_DIR), Succeeds(0));
 }
 
-TEST(LlvmLibcMkdiratTest, BadPath) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+TEST_F(LlvmLibcMkdiratTest, BadPath) {
   ASSERT_THAT(
       LIBC_NAMESPACE::mkdirat(AT_FDCWD, "non-existent-dir/test", S_IRWXU),
       Fails(ENOENT));

--- a/libc/test/src/sys/stat/stat_test.cpp
+++ b/libc/test/src/sys/stat/stat_test.cpp
@@ -6,27 +6,26 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/stat/stat.h"
 #include "src/unistd/close.h"
 #include "src/unistd/unlink.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
 #include <sys/stat.h>
 
-TEST(LlvmLibcStatTest, CreatAndReadMode) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcStatTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
+TEST_F(LlvmLibcStatTest, CreatAndReadMode) {
   // The test file is initially writable. We open it for writing and ensure
   // that it indeed can be opened for writing. Next, we close the file and
   // make it readonly using chmod. We test that chmod actually succeeded by
   // trying to open the file for writing and failing.
   constexpr const char *TEST_FILE = "testdata/stat.test";
-  LIBC_NAMESPACE::libc_errno = 0;
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_WRONLY, S_IRWXU);
   ASSERT_GT(fd, 0);
@@ -41,11 +40,8 @@ TEST(LlvmLibcStatTest, CreatAndReadMode) {
   ASSERT_THAT(LIBC_NAMESPACE::unlink(TEST_FILE), Succeeds(0));
 }
 
-TEST(LlvmLibcStatTest, NonExistentFile) {
-  LIBC_NAMESPACE::libc_errno = 0;
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+TEST_F(LlvmLibcStatTest, NonExistentFile) {
   struct stat statbuf;
   ASSERT_THAT(LIBC_NAMESPACE::stat("non-existent-file", &statbuf),
               Fails(ENOENT));
-  LIBC_NAMESPACE::libc_errno = 0;
 }

--- a/libc/test/src/sys/statvfs/linux/CMakeLists.txt
+++ b/libc/test/src/sys/statvfs/linux/CMakeLists.txt
@@ -11,6 +11,7 @@ add_libc_unittest(
     libc.src.sys.statvfs.statvfs
     libc.src.sys.stat.mkdirat
     libc.src.unistd.rmdir
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -27,5 +28,6 @@ add_libc_unittest(
     libc.src.unistd.rmdir
     libc.src.fcntl.open
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/statvfs/linux/fstatvfs_test.cpp
+++ b/libc/test/src/sys/statvfs/linux/fstatvfs_test.cpp
@@ -8,17 +8,20 @@
 
 #include "hdr/fcntl_macros.h"
 #include "src/__support/macros/config.h"
+#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/stat/mkdirat.h"
 #include "src/sys/statvfs/fstatvfs.h"
 #include "src/unistd/close.h"
 #include "src/unistd/rmdir.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcSysFStatvfsTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcSysFStatvfsTest, FStatvfsBasic) {
+TEST_F(LlvmLibcSysFStatvfsTest, FStatvfsBasic) {
   struct statvfs buf;
 
   int fd = LIBC_NAMESPACE::open("/", O_PATH);
@@ -30,7 +33,7 @@ TEST(LlvmLibcSysFStatvfsTest, FStatvfsBasic) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 }
 
-TEST(LlvmLibcSysFStatvfsTest, FStatvfsInvalidPath) {
+TEST_F(LlvmLibcSysFStatvfsTest, FStatvfsInvalidPath) {
   struct statvfs buf;
 
   constexpr const char *FILENAME = "fstatvfs.testdir";

--- a/libc/test/src/sys/statvfs/linux/statvfs_test.cpp
+++ b/libc/test/src/sys/statvfs/linux/statvfs_test.cpp
@@ -12,18 +12,20 @@
 #include "src/sys/stat/mkdirat.h"
 #include "src/sys/statvfs/statvfs.h"
 #include "src/unistd/rmdir.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcSysStatvfsTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcSysStatvfsTest, StatvfsBasic) {
+TEST_F(LlvmLibcSysStatvfsTest, StatvfsBasic) {
   struct statvfs buf;
   // The root of the file directory must always exist
   ASSERT_THAT(LIBC_NAMESPACE::statvfs("/", &buf), Succeeds());
 }
 
-TEST(LlvmLibcSysStatvfsTest, StatvfsInvalidPath) {
+TEST_F(LlvmLibcSysStatvfsTest, StatvfsInvalidPath) {
   struct statvfs buf;
 
   ASSERT_THAT(LIBC_NAMESPACE::statvfs("", &buf), Fails(ENOENT));

--- a/libc/test/src/sys/time/utimes_test.cpp
+++ b/libc/test/src/sys/time/utimes_test.cpp
@@ -9,7 +9,6 @@
 #include "hdr/fcntl_macros.h"
 #include "hdr/sys_stat_macros.h"
 #include "hdr/types/struct_timeval.h"
-#include "src/errno/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/stdio/remove.h"
 #include "src/sys/stat/stat.h"

--- a/libc/test/src/sys/wait/CMakeLists.txt
+++ b/libc/test/src/sys/wait/CMakeLists.txt
@@ -3,23 +3,27 @@ add_custom_target(libc_sys_wait_unittests)
 add_libc_unittest(
   waitpid_test
   SUITE
-    libc_sys_stat_unittests
+    libc_sys_wait_unittests
   SRCS
     waitpid_test.cpp
   DEPENDS
     libc.include.sys_wait
     libc.src.errno.errno
     libc.src.sys.wait.waitpid
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
   wait4_test
   SUITE
-    libc_sys_stat_unittests
+    libc_sys_wait_unittests
   SRCS
     wait4_test.cpp
   DEPENDS
     libc.include.sys_wait
     libc.src.errno.errno
     libc.src.sys.wait.wait4
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/wait/wait4_test.cpp
+++ b/libc/test/src/sys/wait/wait4_test.cpp
@@ -7,16 +7,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/sys/wait/wait4.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/wait.h>
 
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcWait4Test = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
 // The test here is a simpl test for WNOHANG functionality. For a more
 // involved test, look at fork_test.
 
-TEST(LlvmLibcwait4Test, NoHangTest) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+TEST_F(LlvmLibcWait4Test, NoHangTest) {
   int status;
   ASSERT_THAT(LIBC_NAMESPACE::wait4(-1, &status, WNOHANG, nullptr),
               Fails(ECHILD));

--- a/libc/test/src/sys/wait/waitpid_test.cpp
+++ b/libc/test/src/sys/wait/waitpid_test.cpp
@@ -7,16 +7,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/sys/wait/waitpid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/wait.h>
 
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcWaitPidTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
 // The test here is a simpl test for WNOHANG functionality. For a more
 // involved test, look at fork_test.
 
-TEST(LlvmLibcWaitPidTest, NoHangTest) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+TEST_F(LlvmLibcWaitPidTest, NoHangTest) {
   int status;
   ASSERT_THAT(LIBC_NAMESPACE::waitpid(-1, &status, WNOHANG), Fails(ECHILD));
 }


### PR DESCRIPTION
See PR #132823 for a previous change to sys/epoll tests, and prior changes before that.

ErrnoCheckingTest ensures that errno is properly reset at the beginning of the test case, and is validated at the end of it. This change removes many instances of manual errno manipulation.