### PR TITLE
[AArch64] Add MSVC-style mangling for SVE types.

### DIFF
--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -2828,6 +2828,13 @@ void MicrosoftCXXNameMangler::mangleType(const BuiltinType *T, Qualifiers,
     break;
 #include "clang/Basic/HLSLIntangibleTypes.def"
 
+#define SVE_TYPE(Name, Id, SingletonId)                                        \
+  case BuiltinType::Id:                                                        \
+    mangleArtificialTagType(TagTypeKind::Struct, #Name, {"__clang"});          \
+    break;
+#define SVE_SCALAR_TYPE(Name, MangledName, Id, SingletonId, Bits)
+#include "clang/Basic/AArch64ACLETypes.def"
+
     // Issue an error for any type not explicitly handled.
   default:
     Error(Range.getBegin(), "built-in type: ",

--- a/clang/test/CodeGenCXX/aarch64-mangle-sve-vectors-msvc.cpp
+++ b/clang/test/CodeGenCXX/aarch64-mangle-sve-vectors-msvc.cpp
@@ -1,7 +1,13 @@
-// RUN: not %clang_cc1 -triple aarch64-unknown-windows-msvc %s -emit-llvm \
-// RUN:   -o - 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -triple aarch64-unknown-windows-msvc %s -emit-llvm \
+// RUN:   -o - | FileCheck %s
 
 template<typename T> struct S {};
 
-// CHECK: cannot mangle this built-in type: __SVInt8_t yet
+// CHECK: void @"?f1@@YAXU?$S@U__SVInt8_t@__clang@@@@@Z"
 void f1(S<__SVInt8_t>) {}
+// CHECK: void @"?f2@@YAXU?$S@U__SVInt32_t@__clang@@@@@Z"
+void f2(S<__SVInt32_t>) {}
+// CHECK: void @"?f3@@YAXU?$S@U__SVBool_t@__clang@@@@@Z"
+void f3(S<__SVBool_t>) {}
+// CHECK: void @"?f4@@YAXU?$S@U__clang_svfloat64x4_t@__clang@@@@@Z"
+void f4(S<__clang_svfloat64x4_t>) {}


### PR DESCRIPTION
No released version of MSVC supports these types, so make up a mangling that's unlikely to conflict, for now.