### PR TITLE
[RISCV] Add BREV8 to isSignExtendedW in RISCVOptWInstrs.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
@@ -503,6 +503,7 @@ static bool isSignExtendedW(Register SrcReg, const RISCVSubtarget &ST,
         return false;
       [[fallthrough]];
     case RISCV::REM:
+    case RISCV::BREV8:
     case RISCV::ANDI:
     case RISCV::ORI:
     case RISCV::XORI:

--- a/llvm/test/CodeGen/RISCV/rv64zbkb-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbkb-intrinsic.ll
@@ -42,7 +42,6 @@ define signext i32 @brev8_i32(i32 signext %a) nounwind {
 ; RV64ZBKB-LABEL: brev8_i32:
 ; RV64ZBKB:       # %bb.0:
 ; RV64ZBKB-NEXT:    brev8 a0, a0
-; RV64ZBKB-NEXT:    sext.w a0, a0
 ; RV64ZBKB-NEXT:    ret
   %val = call i32 @llvm.riscv.brev8.i32(i32 %a)
   ret i32 %val


### PR DESCRIPTION
If the input to a BREV8 has 33 sign bits, the result does too. BREV8 reverses the bits in each byte. If bits 63:32 are all the same, reversing the bits in each of those 4 bytes still keeps them the same.