### PR TITLE
[RISCV] Add ORC_B to isSignExtendedW in RISCVOptWInstrs.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
@@ -503,6 +503,7 @@ static bool isSignExtendedW(Register SrcReg, const RISCVSubtarget &ST,
         return false;
       [[fallthrough]];
     case RISCV::REM:
+    case RISCV::ORC_B:
     case RISCV::ANDI:
     case RISCV::ORI:
     case RISCV::XORI:

--- a/llvm/test/CodeGen/RISCV/rv64zbb-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbb-intrinsic.ll
@@ -8,7 +8,6 @@ define signext i32 @orcb32(i32 signext %a) nounwind {
 ; RV64ZBB-LABEL: orcb32:
 ; RV64ZBB:       # %bb.0:
 ; RV64ZBB-NEXT:    orc.b a0, a0
-; RV64ZBB-NEXT:    sext.w a0, a0
 ; RV64ZBB-NEXT:    ret
   %tmp = call i32 @llvm.riscv.orc.b.i32(i32 %a)
   ret i32 %tmp
@@ -30,10 +29,9 @@ define signext i32 @orcb32_knownbits(i32 signext %a) nounwind {
 ; RV64ZBB-NEXT:    lui a1, 1044480
 ; RV64ZBB-NEXT:    and a0, a0, a1
 ; RV64ZBB-NEXT:    lui a1, 2048
-; RV64ZBB-NEXT:    addi a1, a1, 1
+; RV64ZBB-NEXT:    addiw a1, a1, 1
 ; RV64ZBB-NEXT:    or a0, a0, a1
 ; RV64ZBB-NEXT:    orc.b a0, a0
-; RV64ZBB-NEXT:    sext.w a0, a0
 ; RV64ZBB-NEXT:    ret
   %tmp = and i32 %a, 4278190080 ; 0xFF000000
   %tmp2 = or i32 %tmp, 8388609 ; 0x800001


### PR DESCRIPTION
If the input to ORC_B has 33 sign bits, the result does too. ORC_B Ors the bits in each byte together and writes that value to every bit in the byte. If the bytes in bits 63:32 are known to have the same value in all bits, then this OR does change anything.