### PR TITLE
[BOLT] Support dumping intermediate profile storage from DataAggregator

### DIFF
--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -49,6 +49,8 @@ static cl::opt<bool>
                      cl::desc("aggregate basic samples (without LBR info)"),
                      cl::cat(AggregatorCategory));
 
+extern cl::opt<bool> DumpData;
+
 static cl::opt<std::string>
     ITraceAggregation("itrace",
                       cl::desc("Generate LBR info with perf itrace argument"),
@@ -585,6 +587,9 @@ void DataAggregator::processProfile(BinaryContext &BC) {
 
   for (auto &MemEvents : NamesToMemEvents)
     llvm::stable_sort(MemEvents.second.Data);
+
+  if (opts::DumpData)
+    dump();
 
   // Release intermediate storage.
   clear(BranchLBRs);


### PR DESCRIPTION
DataReader (fdata) supports dumping intermediate storage for debugging
purposes. DataAggregator inherits from DataReader and uses the same
structures however it didn't support dumping them. Fix that omission.

Test Plan: TBD
