### PR TITLE
[CI] Upload JUnit Test Results as Artifacts

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -38,6 +38,7 @@ function at-exit {
 
   ccache --print-stats > artifacts/ccache_stats.txt
   cp "${BUILD_DIR}"/.ninja_log artifacts/.ninja_log
+  cp "${BUILD_DIR}"/test-results.*.xml artifacts/
 
   # If building fails there will be no results files.
   shopt -s nullglob

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -33,6 +33,7 @@ function at-exit {
   mkdir -p artifacts
   sccache --show-stats >> artifacts/sccache_stats.txt
   cp "${BUILD_DIR}"/.ninja_log artifacts/.ninja_log
+  cp "${BUILD_DIR}"/test-results.*.xml artifacts/
 
   # If building fails there will be no results files.
   shopt -s nullglob


### PR DESCRIPTION
This enables a script to come through later and download all the test files for further offline analysis. This is intended to enable developing a tool that can spot flaky tests.