### PR TITLE
[clang][bytecode] Simplify diagnoseUnknownDecl if we're not diagnosing

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -136,6 +136,10 @@ static void diagnoseNonConstVariable(InterpState &S, CodePtr OpPC,
                                      const ValueDecl *VD);
 static bool diagnoseUnknownDecl(InterpState &S, CodePtr OpPC,
                                 const ValueDecl *D) {
+  // This function tries pretty hard to produce a good diagnostic. Just skip
+  // tha if nobody will see it anyway.
+  if (!S.diagnosing())
+    return false;
 
   if (isa<ParmVarDecl>(D)) {
     if (D->getType()->isReferenceType())
@@ -168,6 +172,9 @@ static bool diagnoseUnknownDecl(InterpState &S, CodePtr OpPC,
 
 static void diagnoseNonConstVariable(InterpState &S, CodePtr OpPC,
                                      const ValueDecl *VD) {
+  if (!S.diagnosing())
+    return;
+
   const SourceInfo &Loc = S.Current->getSource(OpPC);
   if (!S.getLangOpts().CPlusPlus) {
     S.FFDiag(Loc);

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -152,6 +152,9 @@ static QualType getElemType(const Pointer &P) {
 
 static void diagnoseNonConstexprBuiltin(InterpState &S, CodePtr OpPC,
                                         unsigned ID) {
+  if (!S.diagnosing())
+    return;
+
   auto Loc = S.Current->getSource(OpPC);
   if (S.getLangOpts().CPlusPlus11)
     S.CCEDiag(Loc, diag::note_constexpr_invalid_function)

--- a/clang/lib/AST/ByteCode/InterpState.h
+++ b/clang/lib/AST/ByteCode/InterpState.h
@@ -53,6 +53,8 @@ public:
   InterpState(const InterpState &) = delete;
   InterpState &operator=(const InterpState &) = delete;
 
+  bool diagnosing() const { return getEvalStatus().Diag != nullptr; }
+
   // Stack frame accessors.
   Frame *getSplitFrame() { return Parent.getCurrentFrame(); }
   Frame *getCurrentFrame() override;


### PR DESCRIPTION
See the added comment.

This improves compile times a bit:
https://llvm-compile-time-tracker.com/compare.php?from=ac62f73f19ae9fb415d3fc423949b8d7543e8717&to=0d6cf47197a4ee11cdd1ee4a48ea38a2907c3d45&stat=instructions:u