### PR TITLE
[MLIR] Add missing move constructor / assignment operator to DialectRegistry

### DIFF
--- a/mlir/include/mlir/IR/DialectRegistry.h
+++ b/mlir/include/mlir/IR/DialectRegistry.h
@@ -145,6 +145,8 @@ public:
   explicit DialectRegistry();
   DialectRegistry(const DialectRegistry &) = delete;
   DialectRegistry &operator=(const DialectRegistry &other) = delete;
+  DialectRegistry(DialectRegistry &&) = default;
+  DialectRegistry &operator=(DialectRegistry &&other) = default;
 
   template <typename ConcreteDialect>
   void insert() {


### PR DESCRIPTION
Fix after #140963
