### PR TITLE
[HWASan] Handle default attribute on personality function thunks.

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1842,16 +1842,11 @@ void HWAddressSanitizer::instrumentPersonalityFunctions() {
         Int32Ty, {Int32Ty, Int32Ty, Int64Ty, PtrTy, PtrTy}, false);
     bool IsLocal = P.first && (!isa<GlobalValue>(P.first) ||
                                cast<GlobalValue>(P.first)->hasLocalLinkage());
-    auto *ThunkFn = Function::Create(ThunkFnTy,
-                                     IsLocal ? GlobalValue::InternalLinkage
-                                             : GlobalValue::LinkOnceODRLinkage,
-                                     ThunkName, &M);
-    // TODO: think about other attributes as well.
-    if (any_of(P.second, [](const Function *F) {
-          return F->hasFnAttribute("branch-target-enforcement");
-        })) {
-      ThunkFn->addFnAttr("branch-target-enforcement");
-    }
+    auto *ThunkFn = Function::createWithDefaultAttr(
+        ThunkFnTy,
+        IsLocal ? GlobalValue::InternalLinkage
+                : GlobalValue::LinkOnceODRLinkage,
+        M.getDataLayout().getProgramAddressSpace(), ThunkName, &M);
     if (!IsLocal) {
       ThunkFn->setVisibility(GlobalValue::HiddenVisibility);
       ThunkFn->setComdat(M.getOrInsertComdat(ThunkName));


### PR DESCRIPTION
Function::createWithDefaultAttr deals with default attributes so no need to manually deal with them here.