### PR TITLE
[clang][docs] Remove reference to deleted line in sanitizer doc

### DIFF
--- a/clang/docs/SanitizerSpecialCaseList.rst
+++ b/clang/docs/SanitizerSpecialCaseList.rst
@@ -156,7 +156,6 @@ tool-specific docs.
 
 .. code-block:: bash
 
-    # The line above is explained in the note above
     # Lines starting with # are ignored.
     # Turn off checks for the source file
     # Entries without sections are placed into [*] and apply to all sanitizers


### PR DESCRIPTION
This was added by 8eb34700c2b1847ec6dfb8f92b305b65278d2ec0 which added an opt into the new ignore list behaviour.

Then 81d1df2a39f0616be4b530cbf86b3f575442a347 flipped it so you had to opt into the old behaviour, but didn't remove the "The line above" bit.