### PR TITLE
[Clang] Fix an out of bound access in -verify comment parsing

### DIFF
--- a/clang/lib/Frontend/VerifyDiagnosticConsumer.cpp
+++ b/clang/lib/Frontend/VerifyDiagnosticConsumer.cpp
@@ -812,7 +812,7 @@ bool VerifyDiagnosticConsumer::HandleComment(Preprocessor &PP,
     C2 += C.substr(last, loc-last);
     last = loc + 1;
 
-    if (C[last] == '\n' || C[last] == '\r') {
+    if (last < C.size() && (C[last] == '\n' || C[last] == '\r')) {
       ++last;
 
       // Escape \r\n  or \n\r, but not \n\n.

--- a/clang/test/Frontend/verify-gh141221.c
+++ b/clang/test/Frontend/verify-gh141221.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -verify %s
+
+// Check that we don't crash if the file ends in a splice
+// This file should *NOT* end with a new line
+a;
+// expected-error@-1 {{}} \


### PR DESCRIPTION
When the comment ends with a splice at EOF.

Fixes #141221