### PR TITLE
[clang][SPIRV] Fix build issue after c474f8f

### DIFF
--- a/clang/lib/Sema/SemaSPIRV.cpp
+++ b/clang/lib/Sema/SemaSPIRV.cpp
@@ -129,8 +129,6 @@ static bool checkGenericCastToPtr(Sema &SemaRef, CallExpr *Call) {
     AddrSpace = SemaRef.LangOpts.isSYCL() ? LangAS::sycl_private
                                           : LangAS::opencl_private;
     break;
-  default:
-    llvm_unreachable("Invalid builtin function");
   }
   Qual.setAddressSpace(AddrSpace);
   Call->setType(SemaRef.getASTContext().getPointerType(


### PR DESCRIPTION
Remove unneeded default label which triggers a warning with -Wcovered-switch-default