### PR TITLE
NFCI: [clang][deps] Simplify handling of main TU context hash

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -325,8 +325,6 @@ private:
   const ArrayRef<StringRef> StableDirs;
   /// Path to the main source file.
   std::string MainFile;
-  /// Hash identifying the compilation conditions of the current TU.
-  std::string ContextHash;
   /// Non-modular file dependencies. This includes the main source file and
   /// textually included header files.
   std::vector<std::string> FileDeps;

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -632,13 +632,6 @@ void ModuleDepCollectorPP::LexedFileChanged(FileID FID,
   if (Reason != LexedFileChangeReason::EnterFile)
     return;
 
-  // This has to be delayed as the context hash can change at the start of
-  // `CompilerInstance::ExecuteAction`.
-  if (MDC.ContextHash.empty()) {
-    MDC.ContextHash = MDC.ScanInstance.getInvocation().getModuleHash();
-    MDC.Consumer.handleContextHash(MDC.ContextHash);
-  }
-
   SourceManager &SM = MDC.ScanInstance.getSourceManager();
 
   // Dependency generation really does want to go all the way to the
@@ -719,6 +712,9 @@ void ModuleDepCollectorPP::EndOfMainFile() {
 
   for (const Module *M : MDC.DirectModularDeps)
     handleTopLevelModule(M);
+
+  MDC.Consumer.handleContextHash(
+      MDC.ScanInstance.getInvocation().getModuleHash());
 
   MDC.Consumer.handleDependencyOutputOpts(*MDC.Opts);
 


### PR DESCRIPTION
Instead of handling the context hash in a preprocessor callback on each file change, do it once at the end of the scan.