### PR TITLE
[LLDB] Add ifndef to platform linux

### DIFF
--- a/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
+++ b/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
@@ -34,6 +34,20 @@
 #define MAP_PRIVATE 2
 #define MAP_ANON 0x20
 
+// For other platforms that use platform linux
+#ifndef SIGILL
+#define SIGILL 4
+#endif
+#ifndef SIGBUS
+#define SIGBUS 7
+#endif
+#ifndef SIGFPE
+#define SIGFPE 8
+#endif
+#ifndef SIGSEGV
+#define SIGSEGV 11
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::platform_linux;


### PR DESCRIPTION
Another iteration of fixes for #141670. Platform linux can be used by other platforms, so we need to supply the signal values if they're not defined.

Values are from the [manpage](https://man7.org/linux/man-pages/man7/signal.7.html)