### PR TITLE
[clang-doc] fix FileCheck for conversion function HTML test

### DIFF
--- a/clang-tools-extra/test/clang-doc/conversion_function.cpp
+++ b/clang-tools-extra/test/clang-doc/conversion_function.cpp
@@ -4,7 +4,7 @@
 // RUN: find %t/ -regex ".*/[0-9A-F]*.yaml" -exec cat {} ";" | FileCheck %s --check-prefix=CHECK-YAML
 
 // RUN: clang-doc --format=html --output=%t --executor=standalone %s 
-// FileCheck %s --check-prefix=CHECK-HTML
+// RUN: FileCheck %s < %t/GlobalNamespace/MyStruct.html --check-prefix=CHECK-HTML
 
 template <typename T>
 struct MyStruct {
@@ -14,5 +14,5 @@ struct MyStruct {
 // Output correct conversion names.
 // CHECK-YAML:         Name:            'operator T'
 
-// CHECK-HTML: <h3 id='{{[0-9A-F]*}}'>operator T</h3>
+// CHECK-HTML: <h3 id="{{[0-9A-F]*}}">operator T</h3>
 // CHECK-HTML: <p>public T operator T()</p>


### PR DESCRIPTION
The HTML FileCheck was missing the RUN command. Fixing that revealed an error in the HTML check.