### PR TITLE
[lldb-dap] Test Gardening, attach tests.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
@@ -2,26 +2,16 @@
 Test lldb-dap "port" configuration to "attach" request
 """
 
-import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import lldbutil
 from lldbsuite.test import lldbplatformutil
 from lldbgdbserverutils import Pipe
 import lldbdap_testcase
-import os
-import shutil
-import subprocess
-import tempfile
-import threading
-import sys
-import socket
+import lldb
 
 
-@skip("https://github.com/llvm/llvm-project/issues/138803")
+@skip(bugnumber="https://github.com/llvm/llvm-project/issues/138803")
 class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
-    default_timeout = 20
-
     def set_and_hit_breakpoint(self, continueToExit=True):
         self.dap_server.wait_for_stopped()
 
@@ -50,7 +40,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
     def get_debug_server_pipe(self):
         pipe = Pipe(self.getBuildDir())
         self.addTearDownHook(lambda: pipe.close())
-        pipe.finish_connection(self.default_timeout)
+        pipe.finish_connection(self.DEFAULT_TIMEOUT)
         return pipe
 
     @skipIfWindows
@@ -73,28 +63,33 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         )
 
         # Read the port number from the debug server pipe.
-        port = pipe.read(10, self.default_timeout)
+        port = pipe.read(10, self.DEFAULT_TIMEOUT)
         # Trim null byte, convert to int
         port = int(port[:-1])
         self.assertIsNotNone(
             port, " Failed to read the port number from debug server pipe"
         )
 
-        self.attach(program=program, gdbRemotePort=port, sourceInitFile=True)
+        self.attach(
+            program=program,
+            gdbRemotePort=port,
+            sourceInitFile=True,
+            stopOnEntry=True,
+        )
         self.set_and_hit_breakpoint(continueToExit=True)
-        self.process.terminate()
 
     @skipIfWindows
     @skipIfNetBSD
-    def test_by_port_and_pid(self):
+    def test_fails_if_both_port_and_pid_are_set(self):
         """
         Tests attaching to a process by process ID and port number.
         """
         program = self.build_and_create_debug_adapter_for_attach()
 
-        # It is not necessary to launch "lldb-server" to obtain the actual port and pid for attaching.
-        # However, when providing the port number and pid directly, "lldb-dap" throws an error message, which is expected.
-        # So, used random pid and port numbers here.
+        # It is not necessary to launch "lldb-server" to obtain the actual port
+        # and pid for attaching. However, when providing the port number and pid
+        # directly, "lldb-dap" throws an error message, which is expected. So,
+        # used random pid and port numbers here.
 
         pid = 1354
         port = 1234
@@ -106,10 +101,9 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
             sourceInitFile=True,
             expectFailure=True,
         )
-        if not (response and response["success"]):
-            self.assertFalse(
-                response["success"], "The user can't specify both pid and port"
-            )
+        self.assertFalse(
+            response["success"], "The user can't specify both pid and port"
+        )
 
     @skipIfWindows
     @skipIfNetBSD
@@ -123,11 +117,10 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         response = self.attach(
             program=program, gdbRemotePort=port, sourceInitFile=True, expectFailure=True
         )
-        if not (response and response["success"]):
-            self.assertFalse(
-                response["success"],
-                "The user can't attach with invalid port (%s)" % port,
-            )
+        self.assertFalse(
+            response["success"],
+            "The user can't attach with invalid port (%s)" % port,
+        )
 
     @skipIfWindows
     @skipIfNetBSD
@@ -147,9 +140,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         response = self.attach(
             program=program, gdbRemotePort=port, sourceInitFile=True, expectFailure=True
         )
-        if not (response and response["success"]):
-            self.assertFalse(
-                response["success"],
-                "The user can't attach with illegal port (%s)" % port,
-            )
-        self.process.terminate()
+        self.assertFalse(
+            response["success"],
+            "The user can't attach with illegal port (%s)" % port,
+        )


### PR DESCRIPTION
Trimming unused imports, adjusting the test to use the `DEFAULT_TIMEOUT` instead of a custom timeout and adjusting the flow to stopOnEntry for improving consistency.