### PR TITLE
[flang][runtime] Accommodate change of type in assignment to allocatable

### DIFF
--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -330,6 +330,7 @@ RT_API_ATTRS void Assign(Descriptor &to, const Descriptor &from,
       }
       flags &= ~NeedFinalization;
       toElementBytes = to.ElementBytes(); // may have changed
+      toDerived = toAddendum ? toAddendum->derivedType() : nullptr;
     }
   }
   if (toDerived && (flags & CanBeDefinedAssignment)) {


### PR DESCRIPTION
When an assignment to a derived type allocatable requires (re)allocation, its type may change to that of the right-hand side.  The code didn't update its derived type pointer, leading to the wrong type being put into the descriptors created for elemental defined assignment subroutine calls.

Fixes https://github.com/llvm/llvm-project/issues/141835.