### PR TITLE
[clang-doc] Fix assertions error in Serialize.cpp

### DIFF
--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -113,9 +113,9 @@ getFunctionPrototype(const FunctionDecl *FuncDecl) {
       Stream << " " << ParamDecl->getNameAsString();
 
     // Print default argument if it exists
-    if (ParamDecl->hasDefaultArg()) {
-      const Expr *DefaultArg = ParamDecl->getDefaultArg();
-      if (DefaultArg) {
+    if (ParamDecl->hasDefaultArg() &&
+        !ParamDecl->hasUninstantiatedDefaultArg()) {
+      if (const Expr *DefaultArg = ParamDecl->getDefaultArg()) {
         Stream << " = ";
         DefaultArg->printPretty(Stream, nullptr, Ctx.getPrintingPolicy());
       }


### PR DESCRIPTION
We can only print and use a default arg, if it is instantiated.
I was unable to reduce the test case for this to something of reasonable
size, but this is easily hit by running clang-doc to generate clang's
documentation. For now, we can fix the assertion quickly to unbreak
users, and add the proper test once it is small enough.