### PR TITLE
[X86] Return from SimplifyDemandedBitsForTargetNode for X86ISD::CMOV/ANDP after computing KnownBits. NFC

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -44789,7 +44789,7 @@ bool X86TargetLowering::SimplifyDemandedBitsForTargetNode(
 
     // Only known if known in both the LHS and RHS.
     Known = Known.intersectWith(Known2);
-    break;
+    return false;
   }
   case X86ISD::BEXTR:
   case X86ISD::BEXTRI: {


### PR DESCRIPTION
If we break out of the switch, I believe we fall back to the generic SimplifyDemandedBitsForTargetNode which will call computeKnownBitsForTargetNode. This will recurse again and calculate it's own KnownBits. Since we already did the recursion, we should keep the results.