### PR TITLE
[libc++] Use _BitScanForward64 more often, by fixing availability detection, avoiding calling _BitScanForward twice

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -222,15 +222,9 @@ _LIBCPP_HARDENING_MODE_DEBUG
 #    if defined(_MSC_VER) && !defined(__MINGW32__)
 #      define _LIBCPP_MSVCRT // Using Microsoft's C Runtime library
 #    endif
-#    if (defined(_M_AMD64) || defined(__x86_64__)) || (defined(_M_ARM) || defined(__arm__))
-#      define _LIBCPP_HAS_BITSCAN64 1
-#    else
-#      define _LIBCPP_HAS_BITSCAN64 0
-#    endif
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR 1
 #  else
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR 0
-#    define _LIBCPP_HAS_BITSCAN64 0
 #  endif // defined(_WIN32)
 
 #  if defined(_AIX) && !defined(__64BIT__)

--- a/libcxx/include/__cxx03/__config
+++ b/libcxx/include/__cxx03/__config
@@ -229,6 +229,9 @@ _LIBCPP_HARDENING_MODE_DEBUG
 #    if defined(_MSC_VER) && !defined(__MINGW32__)
 #      define _LIBCPP_MSVCRT // Using Microsoft's C Runtime library
 #    endif
+#    if (defined(_M_AMD64) || defined(__x86_64__)) || (defined(_M_ARM) || defined(__arm__))
+#      define _LIBCPP_HAS_BITSCAN64
+#    endif
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR
 #  endif // defined(_WIN32)
 

--- a/libcxx/include/__cxx03/__config
+++ b/libcxx/include/__cxx03/__config
@@ -229,9 +229,6 @@ _LIBCPP_HARDENING_MODE_DEBUG
 #    if defined(_MSC_VER) && !defined(__MINGW32__)
 #      define _LIBCPP_MSVCRT // Using Microsoft's C Runtime library
 #    endif
-#    if (defined(_M_AMD64) || defined(__x86_64__)) || (defined(_M_ARM) || defined(__arm__))
-#      define _LIBCPP_HAS_BITSCAN64
-#    endif
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR
 #  endif // defined(_WIN32)
 

--- a/libcxx/src/ryu/d2s.cpp
+++ b/libcxx/src/ryu/d2s.cpp
@@ -479,7 +479,7 @@ struct __floating_decimal_64 {
           36893488u, 7378697u, 1475739u, 295147u, 59029u, 11805u, 2361u, 472u, 94u, 18u, 3u };
 
         unsigned long _Trailing_zero_bits;
-#if _LIBCPP_HAS_BITSCAN64
+#if !defined(_MSC_VER) || defined(_M_AMD64) || defined(_M_ARM64) // we have own _BitScanForward64 for non-MSVC
         (void) _BitScanForward64(&_Trailing_zero_bits, __v.__mantissa); // __v.__mantissa is guaranteed nonzero
 #else // ^^^ 64-bit ^^^ / vvv 32-bit vvv
         const uint32_t _Low_mantissa = static_cast<uint32_t>(__v.__mantissa);


### PR DESCRIPTION
Use our private _BitScanForward64 for non-MSVC (in src/include/ryu/ryu.h).
Use MSVC _BitScanForward64 on _M_AMD64 and _M_ARM64, but not on the _M_ARM. 
Remove erroneous public #define _LIBCPP_HAS_BITSCAN64 (should be defined for _M_ARM64 but not for _M_ARM).