### PR TITLE
[memprof] Improve a comment (NFC)

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
@@ -762,9 +762,9 @@ static AllocationType addCallStack(CallStackTrie &AllocTrie,
   return AllocType;
 }
 
-// Helper to compare the InlinedCallStack computed from an instruction's debug
-// info to a list of Frames from profile data (either the allocation data or a
-// callsite).
+// Return true if InlinedCallStack, computed from a call instruction's debug
+// info, is a prefix of ProfileCallStack, a list of Frames from profile data
+// (either the allocation data or a callsite).
 static bool
 stackFrameIncludesInlinedCallStack(ArrayRef<Frame> ProfileCallStack,
                                    ArrayRef<uint64_t> InlinedCallStack) {


### PR DESCRIPTION
We can go one step further than "compare" and mention "prefix" to
succinctly describe the function.
