### PR TITLE
[UBSan] Move type:*=sanitize handling.

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -875,8 +875,7 @@ ASTContext::insertCanonicalTemplateTemplateParmDeclInternal(
 bool ASTContext::isTypeIgnoredBySanitizer(const SanitizerMask &Mask,
                                           const QualType &Ty) const {
   std::string TyName = Ty.getUnqualifiedType().getAsString(getPrintingPolicy());
-  return NoSanitizeL->containsType(Mask, TyName) &&
-         !NoSanitizeL->containsType(Mask, TyName, "sanitize");
+  return NoSanitizeL->containsType(Mask, TyName);
 }
 
 TargetCXXABI::Kind ASTContext::getCXXABIKind() const {

--- a/clang/lib/Basic/NoSanitizeList.cpp
+++ b/clang/lib/Basic/NoSanitizeList.cpp
@@ -34,7 +34,11 @@ bool NoSanitizeList::containsGlobal(SanitizerMask Mask, StringRef GlobalName,
 
 bool NoSanitizeList::containsType(SanitizerMask Mask, StringRef MangledTypeName,
                                   StringRef Category) const {
-  return SSCL->inSection(Mask, "type", MangledTypeName, Category);
+  auto NoSan = SSCL->inSectionBlame(Mask, "type", FileName, Category);
+  if (NoSan == llvm::SpecialCaseList::NotFound)
+    return false;
+  auto San = SSCL->inSectionBlame(Mask, "type", FileName, "sanitize");
+  return San == llvm::SpecialCaseList::NotFound || NoSan > San;
 }
 
 bool NoSanitizeList::containsFunction(SanitizerMask Mask,

--- a/clang/lib/Basic/NoSanitizeList.cpp
+++ b/clang/lib/Basic/NoSanitizeList.cpp
@@ -34,10 +34,10 @@ bool NoSanitizeList::containsGlobal(SanitizerMask Mask, StringRef GlobalName,
 
 bool NoSanitizeList::containsType(SanitizerMask Mask, StringRef MangledTypeName,
                                   StringRef Category) const {
-  auto NoSan = SSCL->inSectionBlame(Mask, "type", FileName, Category);
+  auto NoSan = SSCL->inSectionBlame(Mask, "type", MangledTypeName, Category);
   if (NoSan == llvm::SpecialCaseList::NotFound)
     return false;
-  auto San = SSCL->inSectionBlame(Mask, "type", FileName, "sanitize");
+  auto San = SSCL->inSectionBlame(Mask, "type", MangledTypeName, "sanitize");
   return San == llvm::SpecialCaseList::NotFound || NoSan > San;
 }
 

--- a/clang/test/CodeGen/ubsan-type-ignorelist-category-2.test
+++ b/clang/test/CodeGen/ubsan-type-ignorelist-category-2.test
@@ -1,19 +1,22 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-0.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-1.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-2.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-3.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-4.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-5.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-6.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-7.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-0.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,SANITIZE
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-1.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,IGNORE
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-2.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,SANITIZE
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-3.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,IGNORE
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-4.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,SANITIZE
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-5.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,IGNORE
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-6.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,SANITIZE
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-7.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,IGNORE
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsanitize=signed-integer-overflow,unsigned-integer-overflow -fsanitize-ignorelist=%t/order-8.ignorelist -emit-llvm %t/test.c -o - | FileCheck %s --check-prefixes=CHECK,SANITIZE
 
-// The same type can appear multiple times within an ignorelist. This is a test
-// to make sure "=sanitize" has priority regardless of the order in which
-// duplicate type entries appear. This is a precautionary measure; we would
-// much rather eagerly sanitize than silently forgo sanitization.
+
+// The same type can appear multiple times within an ignorelist. Any ``=sanitize`` type
+// entries enable sanitizer instrumentation, even if it was ignored by entries before.
+// If multiple entries match the source, than the latest entry takes the
+// precedence.
+
 
 //--- order-0.ignorelist
 type:int
@@ -40,19 +43,39 @@ type:int=sanitize
 type:in*
 
 //--- order-6.ignorelist
-type:int=sanitize
-type:in*
-
-//--- order-7.ignorelist
 type:int
 type:int=sanitize
 
+//--- order-7.ignorelist
+[{unsigned-integer-overflow,signed-integer-overflow}]
+type:*
+type:int=sanitize
+type:i*t
+type:*nt=sanitize
+[{unsigned-integer-overflow,signed-integer-overflow}]
+type:*
+type:int
+type:i*t=sanitize
+type:*nt
 
+//--- order-8.ignorelist
+[{unsigned-integer-overflow,signed-integer-overflow}]
+type:*
+type:int
+type:i*t=sanitize
+type:*nt
+[{unsigned-integer-overflow,signed-integer-overflow}]
+type:*
+type:int=sanitize
+type:i*t
+type:*nt=sanitize
 
 
 //--- test.c
-// CHECK-LABEL: @test
+// CHECK-LABEL: define dso_local void @test
 void test(int A) {
-// CHECK: @llvm.sadd.with.overflow.i32
+// IGNORE: %inc = add nsw
+// SANITIZE: @llvm.sadd.with.overflow.i32
   ++A;
 }
+


### PR DESCRIPTION
As discussed in https://github.com/llvm/llvm-project/issues/139128, this PR moves  =sanitize handling from `ASTContext::isTypeIgnoredBySanitizer` to `NoSanitizeList::containsType`.

Before this PR: "=sanitize" has priority regardless of the order
After this PR: If multiple entries match the source, than the latest entry takes the precedence.