### PR TITLE
AMDGPU: Fix broken XFAILed test for fat pointer null initializers

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/nullptr-long-address-spaces.ll
+++ b/llvm/test/CodeGen/AMDGPU/nullptr-long-address-spaces.ll
@@ -1,6 +1,6 @@
 ; XFAIL: *
-; RUN: llc < %s -mtriple=amdgcn-- -verify-machineinstrs | FileCheck -check-prefixes=CHECK,GCN %s
-; RUN: llc < %s -mtriple=r600-- -verify-machineinstrs | FileCheck -check-prefixes=CHECK,R600 %s
+; REQUIRES: asserts
+; RUN: llc -mtriple=amdgcn-- < %s
 
 ; This is a temporary xfail, as the assembly printer is broken when dealing with
 ; lowerConstant() trying to return a value of size greater than 8 bytes.
@@ -9,10 +9,10 @@
 ; The exact form of the GCN output depends on how the printer gets fixed.
 ; GCN-NEXT: .zeroes 5
 ; R600-NEXT: .long 0
-@nullptr7 = global ptr addrspace(7) addrspacecast (ptr null to ptr addrspace(7))
+; @nullptr7 = global ptr addrspace(7) addrspacecast (ptr null to ptr addrspace(7))
 
 ; CHECK-LABEL: nullptr8:
 ; The exact form of the GCN output depends on how the printer gets fixed.
 ; GCN-NEXT: .zeroes 4
 ; R600-NEXT: .long 0
-@nullptr8 = global ptr addrspace(8) addrspacecast (ptr null to ptr addrspace(7))
+@nullptr8 = global ptr addrspace(8) addrspacecast (ptr null to ptr addrspace(8))


### PR DESCRIPTION
This was failing on the buffer fat pointer lowering error in the
addrspace(7) case, not the expected asm printer breakage. Also remove
the attempt at FileChecking the result, since that is dependent on the
actual fix and we want the unexpected pass whenever the assert is fixed.