### PR TITLE
[libc++] Remove invalid char_traits instantiations from a test

### DIFF
--- a/libcxx/test/std/input.output/iostream.forward/iosfwd.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.forward/iosfwd.pass.cpp
@@ -33,91 +33,76 @@ int main(int, char**)
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_ios<wchar_t>*       >();
 #endif
-    test<std::basic_ios<unsigned short>*>();
 
     test<std::basic_streambuf<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_streambuf<wchar_t>*       >();
 #endif
-    test<std::basic_streambuf<unsigned short>*>();
 
     test<std::basic_istream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_istream<wchar_t>*       >();
 #endif
-    test<std::basic_istream<unsigned short>*>();
 
     test<std::basic_ostream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_ostream<wchar_t>*       >();
 #endif
-    test<std::basic_ostream<unsigned short>*>();
 
     test<std::basic_iostream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_iostream<wchar_t>*       >();
 #endif
-    test<std::basic_iostream<unsigned short>*>();
 
     test<std::basic_stringbuf<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_stringbuf<wchar_t>*       >();
 #endif
-    test<std::basic_stringbuf<unsigned short>*>();
 
     test<std::basic_istringstream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_istringstream<wchar_t>*       >();
 #endif
-    test<std::basic_istringstream<unsigned short>*>();
 
     test<std::basic_ostringstream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_ostringstream<wchar_t>*       >();
 #endif
-    test<std::basic_ostringstream<unsigned short>*>();
 
     test<std::basic_stringstream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_stringstream<wchar_t>*       >();
 #endif
-    test<std::basic_stringstream<unsigned short>*>();
 
     test<std::basic_filebuf<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_filebuf<wchar_t>*       >();
 #endif
-    test<std::basic_filebuf<unsigned short>*>();
 
     test<std::basic_ifstream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_ifstream<wchar_t>*       >();
 #endif
-    test<std::basic_ifstream<unsigned short>*>();
 
     test<std::basic_ofstream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_ofstream<wchar_t>*       >();
 #endif
-    test<std::basic_ofstream<unsigned short>*>();
 
     test<std::basic_fstream<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::basic_fstream<wchar_t>*       >();
 #endif
-    test<std::basic_fstream<unsigned short>*>();
 
     test<std::istreambuf_iterator<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::istreambuf_iterator<wchar_t>*       >();
 #endif
-    test<std::istreambuf_iterator<unsigned short>*>();
 
     test<std::ostreambuf_iterator<char>*          >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<std::ostreambuf_iterator<wchar_t>*       >();
 #endif
-    test<std::ostreambuf_iterator<unsigned short>*>();
 
     test<std::ios* >();
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS


### PR DESCRIPTION
We had a test which created invalid char_traits instantiations for non-character types. This patch removes them.