### PR TITLE
[lldb-dap] fix config value comparison

### DIFF
--- a/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
@@ -84,7 +84,7 @@ export class LLDBDapConfigurationProvider
         continue;
       }
       const value = config.get(key);
-      if (!value || value === cfg.default) {
+      if (value === undefined || value === cfg.default) {
         continue;
       }
       switch (cfg.type) {


### PR DESCRIPTION
Fix TypeSCript comparison (when defining an empty config string like `commandEscapePrefix=""` it would skip it)