### PR TITLE
[libc++] Avoid spuriously unsupporting the new FTM tests

### DIFF
--- a/libcxx/test/libcxx/feature_test_macro/generate_header_test.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/generate_header_test.sh.py
@@ -7,6 +7,7 @@
 # ===----------------------------------------------------------------------===##
 
 # RUN: %{python} %s %{libcxx-dir}/utils %{libcxx-dir}/test/libcxx/feature_test_macro/test_data.json %t/tests
+# END.
 
 import os
 import sys


### PR DESCRIPTION
The new FTM tests contain text that they validate against to check the output of the FTM generation script. However, that text lexically contains the characters `// UNSUPPORTED: <...>`, which leads Lit to make the whole test unsupported under these conditions. To prevent that from happening, an `# END.` block can be used to prevent Lit from looking further into the file for directives.