### PR TITLE
[NFC][lldb][lldb-dap][test] show the expected value in the error message.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
+++ b/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
@@ -48,7 +48,7 @@ class TestDAP_optimized(lldbdap_testcase.DAPTestCaseBase):
         value: str = optimized_variable["value"]
         self.assertTrue(
             value.startswith("<error:"),
-            f"expect error for value: '{expected_value}'",
+            f"expect error for value: '{value}'",
         )
         error_msg = optimized_variable["$__lldb_extensions"]["error"]
         self.assertTrue(

--- a/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
+++ b/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
@@ -45,9 +45,14 @@ class TestDAP_optimized(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_breakpoints(breakpoint_ids)
         optimized_variable = self.dap_server.get_local_variable("argc")
 
-        self.assertTrue(optimized_variable["value"].startswith("<error:"))
+        expected_value: str = optimized_variable["value"]
+        self.assertTrue(
+            expected_value.startswith("<error:"),
+            f"expect error for value: '{expected_value}'",
+        )
         error_msg = optimized_variable["$__lldb_extensions"]["error"]
         self.assertTrue(
             ("could not evaluate DW_OP_entry_value: no parent function" in error_msg)
             or ("variable not available" in error_msg)
         )
+        self.continue_to_exit()

--- a/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
+++ b/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
@@ -45,9 +45,9 @@ class TestDAP_optimized(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_breakpoints(breakpoint_ids)
         optimized_variable = self.dap_server.get_local_variable("argc")
 
-        expected_value: str = optimized_variable["value"]
+        value: str = optimized_variable["value"]
         self.assertTrue(
-            expected_value.startswith("<error:"),
+            value.startswith("<error:"),
             f"expect error for value: '{expected_value}'",
         )
         error_msg = optimized_variable["$__lldb_extensions"]["error"]


### PR DESCRIPTION
Show the expected value in the error message so we can see the expected value without searching through the log messages.

Related #141689