### PR TITLE
[clang-doc] add tags to Mustache namespace template

### DIFF
--- a/clang-tools-extra/clang-doc/assets/namespace-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/namespace-template.mustache
@@ -23,23 +23,82 @@
     </head>
     <body>
         <nav class="navbar">
-            Navbar
+            <div class="navbar__container">
+                {{#ProjectName}}
+                <div class="navbar__logo">
+                    {{ProjectName}}
+                </div>
+                {{/ProjectName}}
+                <div class="navbar__menu">
+                    <ul class="navbar__links">
+                        <li class="navbar__item">
+                            <a href="/" class="navbar__link">Namespace</a>
+                        </li>
+                        <li class="navbar__item">
+                            <a href="/" class="navbar__link">Class</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
         </nav>
         <main>
             <div class="container">
                 <div class="sidebar">
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-                        sed do eiusmod tempor incididunt ut labore et dolore magna 
-                        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco 
-                        laboris nisi ut aliquip ex ea commodo consequat. 
-                        Duis aute irure dolor in reprehenderit in voluptate velit esse 
-                        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat 
-                        cupidatat non proident, sunt in culpa qui officia deserunt mollit 
-                        anim id est laborum
+                    <h2>{{RecordType}} {{Name}}</h2>
+                    <ul>
+                        {{#Enums}}
+                        <li class="sidebar-section">
+                            <a class="sidebar-item" href="#Enums">Enums</a>
+                        </li>
+                        <ul>
+                            {{#Obj}}
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{ID}}">{{EnumName}}</a>
+                            </li>
+                            {{/Obj}}
+                        </ul>
+                        {{/Enums}}
+                        {{#Typedef}}
+                        <li class="sidebar-section">Typedef</li>
+                        {{/Typedef}}
+                        {{#Record}}
+                        <li class="sidebar-section">
+                            <a class="sidebar-item" href="#Classes">Inner Classes</a>
+                        </li>
+                        <ul>
+                            {{#Links}}
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{ID}}">{{Name}}</a>
+                            </li>
+                            {{/Links}}
+                        </ul>
+                        {{/Record}}
+                    </ul>
                 </div>
                 <div class="resizer" id="resizer"></div>
                 <div class="content">
-                    Content
+                    {{#Enums}}
+                    <section id="Enums" class="section-container">
+                        <h2>Enumerations</h2>
+                        <div>
+                            {{#Obj}}
+                            {{>EnumPartial}}
+                            {{/Obj}}
+                        </div>
+                    </section>
+                    {{/Enums}}
+                    {{#Record}}
+                    <section id="Classes" class="section-container">
+                        <h2>Inner Classes</h2>
+                        <ul class="class-container">
+                        {{#Links}}
+                            <li id="{{ID}}" style="max-height: 40px;">
+                                <a href="{{Link}}"><pre><code class="language-cpp code-clang-doc" >class {{Name}}</code></pre></a>
+                            </li>
+                        {{/Links}}
+                        </ul>
+                    </section>
+                    {{/Record}}
                 </div>
             </div>
         </main>

--- a/clang-tools-extra/clang-doc/assets/namespace-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/namespace-template.mustache
@@ -58,9 +58,6 @@
                             {{/Obj}}
                         </ul>
                         {{/Enums}}
-                        {{#Typedef}}
-                        <li class="sidebar-section">Typedef</li>
-                        {{/Typedef}}
                         {{#Record}}
                         <li class="sidebar-section">
                             <a class="sidebar-item" href="#Classes">Inner Classes</a>

--- a/clang-tools-extra/test/clang-doc/mustache-index.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-index.cpp
@@ -18,9 +18,9 @@ class Foo;
 // CHECK-NEXT:          <a class="sidebar-item" href="#{{[0-9A-F]*}}">enum Color</a>
 // CHECK-NEXT:      </li>
 // CHECK-NEXT:  </ul>
-// CHECK:       <li class="sidebar-section">
-// CHECK-NEXT:      <a class="sidebar-item" href="#Classes">Inner Classes</a>
-// CHECK-NEXT:  </li>
+// CHECK:           <li class="sidebar-section">
+// CHECK-NEXT:          <a class="sidebar-item" href="#Classes">Inner Classes</a>
+// CHECK-NEXT:      </li>
 // CHECK-NEXT:  <ul>
 // CHECK-NEXT:      <li class="sidebar-item-container">
 // CHECK-NEXT:          <a class="sidebar-item" href="#{{[0-9A-F]*}}">Foo</a>
@@ -43,23 +43,23 @@ class Foo;
 // CHECK-NEXT:                  <tr>
 // CHECK-NEXT:                      <th>Name</th>
 // CHECK-NEXT:                      <th>Value</th>
-// CHECK:                  </tr>
+// CHECK:                       </tr>
 // CHECK-NEXT:                      <tr>
 // CHECK-NEXT:                          <td>RED</td>
 // CHECK-NEXT:                          <td>0</td>
-// CHECK:                      </tr>
+// CHECK:                           </tr>
 // CHECK-NEXT:                      <tr>
 // CHECK-NEXT:                          <td>BLUE</td>
 // CHECK-NEXT:                          <td>1</td>
-// CHECK:                      </tr>
+// CHECK:                           </tr>
 // CHECK-NEXT:                      <tr>
 // CHECK-NEXT:                          <td>GREEN</td>
 // CHECK-NEXT:                          <td>2</td>
-// CHECK:                      </tr>
+// CHECK:                           </tr>
 // CHECK-NEXT:                  </tbody>
 // CHECK-NEXT:              </table>
 // CHECK-NEXT:              <div>
-// CHECK-NEXT:                  Defined at line 5 of file {{.*}}/mustache-index.cpp
+// CHECK-NEXT:                  Defined at line 5 of file {{.*}}mustache-index.cpp
 // CHECK-NEXT:              </div>
 // CHECK-NEXT:          </div>
 // CHECK-NEXT:      </div>

--- a/clang-tools-extra/test/clang-doc/mustache-index.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-index.cpp
@@ -64,6 +64,7 @@ class Foo;
 // CHECK-NEXT:          </div>
 // CHECK-NEXT:      </div>
 // CHECK-NEXT:  </section>
+
 // CHECK:       <section id="Classes" class="section-container">
 // CHECK-NEXT:      <h2>Inner Classes</h2>
 // CHECK-NEXT:      <ul class="class-container">

--- a/clang-tools-extra/test/clang-doc/mustache-index.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-index.cpp
@@ -1,0 +1,74 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --format=mustache --output=%t --executor=standalone %s 
+// RUN: FileCheck %s < %t/GlobalNamespace/index.html
+
+enum Color {
+  RED,
+  BLUE,
+  GREEN
+};
+
+class Foo;
+
+// CHECK:       <li class="sidebar-section">
+// CHECK-NEXT:      <a class="sidebar-item" href="#Enums">Enums</a>
+// CHECK-NEXT:  </li>
+// CHECK-NEXT:  <ul>
+// CHECK-NEXT:      <li class="sidebar-item-container">
+// CHECK-NEXT:          <a class="sidebar-item" href="#{{[0-9A-F]*}}">enum Color</a>
+// CHECK-NEXT:      </li>
+// CHECK-NEXT:  </ul>
+// CHECK:       <li class="sidebar-section">
+// CHECK-NEXT:      <a class="sidebar-item" href="#Classes">Inner Classes</a>
+// CHECK-NEXT:  </li>
+// CHECK-NEXT:  <ul>
+// CHECK-NEXT:      <li class="sidebar-item-container">
+// CHECK-NEXT:          <a class="sidebar-item" href="#{{[0-9A-F]*}}">Foo</a>
+// CHECK-NEXT:      </li>
+// CHECK-NEXT:  </ul>
+
+// CHECK:       <section id="Enums" class="section-container">
+// CHECK-NEXT:      <h2>Enumerations</h2>
+// CHECK-NEXT:      <div>
+// CHECK-NEXT:          <div id="{{[0-9A-F]*}}" class="delimiter-container">
+// CHECK-NEXT:              <div>
+// CHECK-NEXT:                  <pre>
+// CHECK-NEXT:                      <code class="language-cpp code-clang-doc">
+// CHECK-NEXT:                          enum Color
+// CHECK-NEXT:                      </code>
+// CHECK-NEXT:                  </pre>
+// CHECK-NEXT:              </div>
+// CHECK-NEXT:              <table class="table-wrapper">
+// CHECK-NEXT:                  <tbody>
+// CHECK-NEXT:                  <tr>
+// CHECK-NEXT:                      <th>Name</th>
+// CHECK-NEXT:                      <th>Value</th>
+// CHECK:                  </tr>
+// CHECK-NEXT:                      <tr>
+// CHECK-NEXT:                          <td>RED</td>
+// CHECK-NEXT:                          <td>0</td>
+// CHECK:                      </tr>
+// CHECK-NEXT:                      <tr>
+// CHECK-NEXT:                          <td>BLUE</td>
+// CHECK-NEXT:                          <td>1</td>
+// CHECK:                      </tr>
+// CHECK-NEXT:                      <tr>
+// CHECK-NEXT:                          <td>GREEN</td>
+// CHECK-NEXT:                          <td>2</td>
+// CHECK:                      </tr>
+// CHECK-NEXT:                  </tbody>
+// CHECK-NEXT:              </table>
+// CHECK-NEXT:              <div>
+// CHECK-NEXT:                  Defined at line 5 of file {{.*}}/mustache-index.cpp
+// CHECK-NEXT:              </div>
+// CHECK-NEXT:          </div>
+// CHECK-NEXT:      </div>
+// CHECK-NEXT:  </section>
+// CHECK:       <section id="Classes" class="section-container">
+// CHECK-NEXT:      <h2>Inner Classes</h2>
+// CHECK-NEXT:      <ul class="class-container">
+// CHECK-NEXT:          <li id="{{[0-9A-F]*}}" style="max-height: 40px;">
+// CHECK-NEXT:              <a href="Foo.html"><pre><code class="language-cpp code-clang-doc" >class Foo</code></pre></a>
+// CHECK-NEXT:          </li>
+// CHECK-NEXT:      </ul>
+// CHECK-NEXT:  </section>

--- a/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
@@ -1,0 +1,13 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --format=mustache --output=%t --executor=standalone %s 
+// RUN: FileCheck %s < %t/MyNamespace/index.html
+
+namespace MyNamespace {
+  class Foo;
+}
+
+// CHECK:       <ul class="class-container">
+// CHECK-NEXT:    <li id="{{[0-9A-F]*}}" style="max-height: 40px;">
+// CHECK-NEXT:        <a href="Foo.html"><pre><code class="language-cpp code-clang-doc" >class Foo</code></pre></a>
+// CHECK-NEXT:    </li>
+// CHECK-NEXT: </ul>

--- a/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp
@@ -87,29 +87,6 @@ TEST(HTMLMustacheGeneratorTest, createResources) {
   }
 }
 
-TEST(HTMLMustacheGeneratorTest, generateDocs) {
-  auto G = getHTMLMustacheGenerator();
-  assert(G && "Could not find HTMLMustacheGenerator");
-  ClangDocContext CDCtx = getClangDocContext();
-
-  unittest::TempDir RootTestDirectory("generateDocsTest", /*Unique=*/true);
-  CDCtx.OutDirectory = RootTestDirectory.path();
-
-#if ENABLE_LOCAL_TEST
-  // FIXME: We can't read files during unit tests. Migrate to lit once
-  // tool support lands.
-  getMustacheHtmlFiles(CLANG_DOC_TEST_ASSET_DIR, CDCtx);
-
-  EXPECT_THAT_ERROR(G->generateDocs(RootTestDirectory.path(), {}, CDCtx),
-                    Succeeded())
-      << "Failed to generate docs.";
-#else
-  EXPECT_THAT_ERROR(G->generateDocs(RootTestDirectory.path(), {}, CDCtx),
-                    Failed())
-      << "Failed to generate docs.";
-#endif
-}
-
 TEST(HTMLGeneratorTest, emitFunctionHTML) {
 #if ENABLE_LOCAL_TEST
   auto G = getHTMLMustacheGenerator();
@@ -156,50 +133,6 @@ TEST(HTMLGeneratorTest, emitFunctionHTML) {
 )raw";
 
   // FIXME: Functions are not handled yet.
-  EXPECT_EQ(Expected, Actual.str());
-#endif
-}
-
-TEST(HTMLMustacheGeneratorTest, emitEnumHTML) {
-#if ENABLE_LOCAL_TEST
-  auto G = getHTMLMustacheGenerator();
-  assert(G && "Could not find HTMLMustacheGenerator");
-  ClangDocContext CDCtx = getClangDocContext();
-  std::string Buffer;
-  llvm::raw_string_ostream Actual(Buffer);
-
-  unittest::TempDir RootTestDirectory("emitEnumHTML",
-                                      /*Unique=*/true);
-  CDCtx.OutDirectory = RootTestDirectory.path();
-
-  getMustacheHtmlFiles(CLANG_DOC_TEST_ASSET_DIR, CDCtx);
-
-  // FIXME: This is a terrible hack, since we can't initialize the templates
-  // directly. We'll need to update the interfaces so that we can call
-  // SetupTemplateFiles() from outsize of HTMLMustacheGenerator.cpp
-  EXPECT_THAT_ERROR(G->generateDocs(RootTestDirectory.path(), {}, CDCtx),
-                    Succeeded())
-      << "Failed to generate docs.";
-
-  CDCtx.RepositoryUrl = "http://www.repository.com";
-
-  EnumInfo I;
-  I.Name = "e";
-  I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
-
-  I.DefLoc = Location(10, 10, "test.cpp", true);
-  I.Loc.emplace_back(12, 12, "test.cpp");
-
-  I.Members.emplace_back("X");
-  I.Scoped = true;
-
-  auto Err = G->generateDocForInfo(&I, Actual, CDCtx);
-  assert(!Err);
-
-  std::string Expected = R"raw(IT_enum
-)raw";
-
-  // FIXME: Enums are not handled yet.
   EXPECT_EQ(Expected, Actual.str());
 #endif
 }


### PR DESCRIPTION
namespace-template.mustache only rendered placeholder text. Enum and record tags were added to the template. Now, we can render an index.html for the global namespace and other namespaces.

Added tests and deleted some of the disabled unit tests.