### PR TITLE
[cmake][clang-tools] Make split-file a dependency for tests

### DIFF
--- a/clang-tools-extra/test/CMakeLists.txt
+++ b/clang-tools-extra/test/CMakeLists.txt
@@ -54,7 +54,7 @@ set(CLANG_TOOLS_TEST_DEPS
 
 # Add lit test dependencies.
 set(LLVM_UTILS_DEPS
-  FileCheck count not
+  FileCheck count not split-file
 )
 foreach(dep ${LLVM_UTILS_DEPS})
   if(TARGET ${dep})


### PR DESCRIPTION
clang-doc uses split-file in some tests. We didn't notice the missing
dep, since its always built before clang-tools-extra tests run in CI.