### PR TITLE
[lldb][nfc] Fix missing move operations and constness of methods

### DIFF
--- a/lldb/include/lldb/Expression/DiagnosticManager.h
+++ b/lldb/include/lldb/Expression/DiagnosticManager.h
@@ -107,7 +107,8 @@ public:
     m_fixed_expression.clear();
   }
 
-  const DiagnosticList &Diagnostics() { return m_diagnostics; }
+  const DiagnosticList &Diagnostics() const { return m_diagnostics; }
+  DiagnosticList &Diagnostics() { return m_diagnostics; }
 
   bool HasFixIts() const {
     return llvm::any_of(m_diagnostics,

--- a/lldb/include/lldb/Symbol/VariableList.h
+++ b/lldb/include/lldb/Symbol/VariableList.h
@@ -24,6 +24,9 @@ public:
   VariableList();
   virtual ~VariableList();
 
+  VariableList(VariableList &&) = default;
+  VariableList &operator=(VariableList &&) = default;
+
   void AddVariable(const lldb::VariableSP &var_sp);
 
   bool AddVariableIfUnique(const lldb::VariableSP &var_sp);


### PR DESCRIPTION
This PR adds the missing move operators for VariableList: this class are just a wrapper around a vector, so it can use the default move operations. Subsequent patches will want to return VariableLists from functions, so the move operation is required (the copy constructors are deleted).

It also fixes constness for a method in DiagnosticManager returning its list of diagnostics. Previously, the method always returned a const list, even though the method was not const itself. Subsequent patches will make use of the ability to mutate the diagnostics.

(cherry picked from commit eef2c3e214b737c530bd66a77350c1cfe3b6921e)