### PR TITLE
[DirectX] Add support for implicit binding to DXILForwardHandleAccesses pass

### DIFF
--- a/llvm/lib/Target/DirectX/DXILForwardHandleAccesses.cpp
+++ b/llvm/lib/Target/DirectX/DXILForwardHandleAccesses.cpp
@@ -75,6 +75,7 @@ static bool forwardHandleAccesses(Function &F, DominatorTree &DT) {
       if (auto *II = dyn_cast<IntrinsicInst>(&Inst)) {
         switch (II->getIntrinsicID()) {
         case Intrinsic::dx_resource_handlefrombinding:
+        case Intrinsic::dx_resource_handlefromimplicitbinding:
           processHandle(II, HandleMap);
           break;
         default:

--- a/llvm/test/CodeGen/DirectX/ForwardHandleAccesses/buffer-O0.ll
+++ b/llvm/test/CodeGen/DirectX/ForwardHandleAccesses/buffer-O0.ll
@@ -18,8 +18,8 @@ entry:
   store target("dx.RawBuffer", <4 x float>, 1, 0) %_ZL2In_h.i.i, ptr @_ZL2In, align 4
   store ptr @_ZL2In, ptr %this.addr.i.i, align 4
   %this1.i.i = load ptr, ptr %this.addr.i.i, align 4
-  ; CHECK: [[OUT:%.*]] = call target("dx.RawBuffer", <4 x float>, 1, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_v4f32_1_0t(i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
-  %_ZL3Out_h.i.i = call target("dx.RawBuffer", <4 x float>, 1, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_v4f32_1_0t(i32 0, i32 1, i32 1, i32 0, i1 false, ptr null)
+  ; CHECK: [[OUT:%.*]] = call target("dx.RawBuffer", <4 x float>, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_v4f32_1_0t(i32 100, i32 0, i32 1, i32 0, i1 false, ptr null)
+  %_ZL3Out_h.i.i = call target("dx.RawBuffer", <4 x float>, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_v4f32_1_0t(i32 100, i32 0, i32 1, i32 0, i1 false, ptr null)
   store target("dx.RawBuffer", <4 x float>, 1, 0) %_ZL3Out_h.i.i, ptr @_ZL3Out, align 4
   store ptr @_ZL3Out, ptr %this.addr.i.i.i, align 4
   %this1.i.i.i = load ptr, ptr %this.addr.i.i.i, align 4

--- a/llvm/test/CodeGen/DirectX/ForwardHandleAccesses/cbuffer-access.ll
+++ b/llvm/test/CodeGen/DirectX/ForwardHandleAccesses/cbuffer-access.ll
@@ -1,9 +1,11 @@
 ; RUN: opt -S -dxil-forward-handle-accesses -mtriple=dxil--shadermodel6.3-library %s | FileCheck %s
 
 %__cblayout_CB = type <{ float, i32, i32 }>
+%__cblayout_CB2 = type <{ float }>
 %struct.Scalars = type { float, i32, i32 }
 
 @CB.cb = local_unnamed_addr global target("dx.CBuffer", target("dx.Layout", %__cblayout_CB, 12, 0, 4, 8)) poison
+@CB2.cb = local_unnamed_addr global target("dx.CBuffer", target("dx.Layout", %__cblayout_CB2, 4, 0)) poison
 
 define void @main() local_unnamed_addr #1 {
 entry:
@@ -17,6 +19,13 @@ entry:
   %0 = call { float, float, float, float } @llvm.dx.resource.load.cbufferrow.4(target("dx.CBuffer", target("dx.Layout", %__cblayout_CB, 12, 0, 4, 8)) %cb, i32 0)
   %1 = extractvalue { float, float, float, float } %0, 0
   call void @llvm.dx.resource.store.rawbuffer(target("dx.RawBuffer", %struct.Scalars, 1, 0) %_ZL3Out_h.i.i, i32 0, i32 0, float %1)
+  
+  ; CHECK: [[CB2:%.*]] = tail call target({{.*}}) @llvm.dx.resource.handlefromimplicitbinding
+  %h2 = tail call target("dx.CBuffer", target("dx.Layout", %__cblayout_CB2, 4, 0)) @llvm.dx.resource.handlefromimplicitbinding(i32 100, i32 0, i32 1, i32 0, i1 false, ptr null)
+  store target("dx.CBuffer", target("dx.Layout", %__cblayout_CB2, 4, 0)) %h2, ptr @CB2.cb, align 4
+  ; CHECK-NOT: load target({{.*}}), ptr @CB2.cb
+  %cb2 = load target("dx.CBuffer", target("dx.Layout", %__cblayout_CB2, 4, 0)), ptr @CB2.cb, align 4
+
   ret void
 }
 


### PR DESCRIPTION
Since the `DXILResourceImplicitBinding` pass has been moved after `DXILForwardHandleAccesses` pass the forward-handle pass needs to handle `llvm.dx.resource.handlefromimplicitbinding` calls as well.