### PR TITLE
[clangd] Log the paths of loaded config files without --log=verbose

### DIFF
--- a/clang-tools-extra/clangd/ConfigYAML.cpp
+++ b/clang-tools-extra/clangd/ConfigYAML.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "ConfigFragment.h"
+#include "support/Logger.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
@@ -482,6 +483,7 @@ std::vector<Fragment> Fragment::parseYAML(llvm::StringRef YAML,
                                           DiagnosticCallback Diags) {
   // The YAML document may contain multiple conditional fragments.
   // The SourceManager is shared for all of them.
+  log("Loading config file at {0}", BufferName);
   auto SM = std::make_shared<llvm::SourceMgr>();
   auto Buf = llvm::MemoryBuffer::getMemBufferCopy(YAML, BufferName);
   // Adapt DiagnosticCallback to function-pointer interface.


### PR DESCRIPTION
Users sometimes forget about configuration they've placed in the user config file, or an ancestor directory of their project.

Logging the paths of loaded config files by default (without --log=verbose) surfaces more readily where clangd is getting its configuration from.