### PR TITLE
Revert "Revert "[Object] Handle SHT_CREL relocation sections when resolving relocation data""

### DIFF
--- a/llvm/lib/Object/RelocationResolver.cpp
+++ b/llvm/lib/Object/RelocationResolver.cpp
@@ -888,7 +888,8 @@ uint64_t resolveRelocation(RelocationResolver Resolver, const RelocationRef &R,
         return Elf64BEObj->getRelSection(R.getRawDataRefImpl())->sh_type;
       };
 
-      if (GetRelSectionType() == ELF::SHT_RELA) {
+      if (GetRelSectionType() == ELF::SHT_RELA ||
+          GetRelSectionType() == ELF::SHT_CREL) {
         Addend = getELFAddend(R);
         // LoongArch and RISCV relocations use both LocData and Addend.
         if (Obj->getArch() != Triple::loongarch32 &&


### PR DESCRIPTION
Reverts llvm/llvm-project#142068

This PR breaks several buildbots. e.g https://lab.llvm.org/buildbot/#/builders/10/builds/6340