### PR TITLE
[clang] member pointer class qualification fix

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -2127,7 +2127,7 @@ static TemplateDeductionResult DeduceTemplateArgumentsByTypeMatch(
         TA = S.Context.getTypeDeclType(MPA->getMostRecentCXXRecordDecl());
       } else {
         NestedNameSpecifier *QA = MPA->getQualifier();
-        TA = QualType(QA->translateToType(S.Context), 0);
+        TA = QualType(QA->translateToType(S.Context), 0).getUnqualifiedType();
       }
       assert(!TA.isNull() && "member pointer with non-type class");
       return DeduceTemplateArgumentsByTypeMatch(

--- a/clang/test/SemaCXX/member-pointer.cpp
+++ b/clang/test/SemaCXX/member-pointer.cpp
@@ -408,3 +408,25 @@ namespace deduction2 {
     void i() { e(&C::h); }
   };
 } // namespace deduction2
+
+namespace deduction_qualifiers {
+  struct A {
+    int v;
+  };
+  using CA = const A;
+
+  template <class T> void g(const T&, int T::*);
+  template <class T> void h(const T&, int CA::*);
+
+  void test(const A a, A b) {
+    g(a, &A::v);
+    g(a, &CA::v);
+    h(a, &A::v);
+    h(a, &CA::v);
+
+    g(b, &A::v);
+    g(b, &CA::v);
+    h(b, &A::v);
+    h(b, &CA::v);
+  }
+} // namespace deduction_qualifiers


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/llvm/llvm-project/pull/130537,
which was reported here: https://github.com/llvm/llvm-project/pull/132401#issuecomment-2839690599

When deducing member pointers class, ignore top level qualifiers on the argument side, since the class portion of a member pointer is a nested-name-specifier, and these just nominate an entity.

Qualifiers on the parameter side are fine since deduction allows the parameter side to be more qualified, and these qualifiers won't be part of the result.

Since this regression was never released, there are no release notes.