### PR TITLE
[MLIR] fix func.func to llvm.func lowering where no_inline attribute is not propagated over

### DIFF
--- a/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
+++ b/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
@@ -490,6 +490,9 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<func::FuncOp> {
     if (failed(newFuncOp))
       return rewriter.notifyMatchFailure(funcOp, "Could not convert funcop");
 
+    // Propagate noinline attribute
+    newFuncOp->setNoInline(funcOp.getNoInline());
+
     rewriter.eraseOp(funcOp);
     return success();
   }

--- a/mlir/test/Conversion/FuncToLLVM/func-to-llvm.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/func-to-llvm.mlir
@@ -563,6 +563,11 @@ func.func @non_convertible_arg_type(%arg: vector<1xtf32>) {
   return
 }
 
+// CHECK: llvm.func @no_inline() attributes {no_inline}
+func.func @no_inline() attributes {no_inline} {
+  return
+}
+
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%toplevel_module: !transform.any_op {transform.readonly}) {
     %func = transform.structured.match ops{["func.func"]} in %toplevel_module


### PR DESCRIPTION
See https://godbolt.org/z/43c84TEGh

`func.func` `no_inline` attribute is not propagated to `llvm.func` even though both of them supports no inline attribute.

I had to put the fix in inside the rewrite function instead of `mlir::convertFuncOpToLLVMFuncOp` because it takes `FunctionOpInterface`, which does not have a named method to get no inline information without using get attributes. I'm happy to switch to the latter method.