### PR TITLE
[utils][tests] Adjust timeout-hang.py tolerances

### DIFF
--- a/llvm/utils/lit/tests/timeout-hang.py
+++ b/llvm/utils/lit/tests/timeout-hang.py
@@ -8,20 +8,21 @@
 # throwing an exception. We expect this to fail immediately, rather than
 # timeout.
 
-# DEFINE: %{timeout}=1
+# DEFINE: %{grace_period}=5
+# DEFINE: %{hard_timeout}=15
 
 # RUN: not %{lit} %{inputs}/timeout-hang/run-nonexistent.txt \
-# RUN: --timeout=%{timeout} --param external=0 | %{python} %s %{timeout}
+# RUN: --timeout=%{hard_timeout} --param external=0 | %{python} %s %{grace_period}
 
 import sys
 import re
 
-timeout_time = float(sys.argv[1])
+grace_time = float(sys.argv[1])
 testing_time = float(re.search(r"Testing Time: (.*)s", sys.stdin.read()).group(1))
 
-if testing_time < timeout_time:
-    print("Testing took less than timeout")
+if testing_time <= grace_time:
+    print("Testing finished within the grace period")
     sys.exit(0)
 else:
-    print("Testing took as long or longer than timeout")
+    print("Testing took {}s, which is beyond the grace period of {}s".format(testing_time, grace_time))
     sys.exit(1)

--- a/llvm/utils/lit/tests/timeout-hang.py
+++ b/llvm/utils/lit/tests/timeout-hang.py
@@ -8,6 +8,10 @@
 # throwing an exception. We expect this to fail immediately, rather than
 # timeout.
 
+# lit should return immediately once it fails to execute the non-existent file.
+# This will take a variable amount of time depending on process scheduling, but
+# it should always be significantly less than the hard timeout, which is the
+# point where lit would cancel the test.
 # DEFINE: %{grace_period}=5
 # DEFINE: %{hard_timeout}=15
 

--- a/llvm/utils/lit/tests/timeout-hang.py
+++ b/llvm/utils/lit/tests/timeout-hang.py
@@ -24,5 +24,9 @@ if testing_time <= grace_time:
     print("Testing finished within the grace period")
     sys.exit(0)
 else:
-    print("Testing took {}s, which is beyond the grace period of {}s".format(testing_time, grace_time))
+    print(
+        "Testing took {}s, which is beyond the grace period of {}s".format(
+            testing_time, grace_time
+        )
+    )
     sys.exit(1)


### PR DESCRIPTION
The subject test sporadically fails on the AIX builder: https://lab.llvm.org/buildbot/#/builders/64/builds/3921/steps/6/logs/FAIL__lit___timeout-hang_py

This appears to be an environment issue potentially connected to high load because the problem is not observed on other AIX machines.

This patch separates the "hard" timeout value from the value used to signal a hang. This allows for a more generous "hard" timeout value, which allows observation of cases that take longer to finish despite not hanging.