### PR TITLE
Revert "[IR] Avoid UB in `SymbolTableListTraits`"

### DIFF
--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -546,10 +546,6 @@ private:
     return &BasicBlock::InstList;
   }
 
-  static size_t getSublistOffset(Instruction *) {
-    return offsetof(BasicBlock, InstList);
-  }
-
   /// Dedicated function for splicing debug-info: when we have an empty
   /// splice (i.e. zero instructions), the caller may still intend any
   /// debug-info in between the two "positions" to be spliced.

--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -811,10 +811,6 @@ private:
     return &Function::BasicBlocks;
   }
 
-  static size_t getSublistOffset(BasicBlock *) {
-    return offsetof(Function, BasicBlocks);
-  }
-
 public:
   const BasicBlock       &getEntryBlock() const   { return front(); }
         BasicBlock       &getEntryBlock()         { return front(); }

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -608,9 +608,6 @@ private:
   static GlobalListType Module::*getSublistAccess(GlobalVariable*) {
     return &Module::GlobalList;
   }
-  static size_t getSublistOffset(GlobalVariable *) {
-    return offsetof(Module, GlobalList);
-  }
   friend class llvm::SymbolTableListTraits<llvm::GlobalVariable>;
 
 public:
@@ -620,9 +617,6 @@ public:
   FunctionListType       &getFunctionList()           { return FunctionList; }
   static FunctionListType Module::*getSublistAccess(Function*) {
     return &Module::FunctionList;
-  }
-  static size_t getSublistOffset(Function *) {
-    return offsetof(Module, FunctionList);
   }
 
   /// Detach \p Alias from the list but don't delete it.
@@ -663,9 +657,6 @@ private: // Please use functions like insertAlias(), removeAlias() etc.
   static AliasListType Module::*getSublistAccess(GlobalAlias*) {
     return &Module::AliasList;
   }
-  static size_t getSublistOffset(GlobalAlias *) {
-    return offsetof(Module, AliasList);
-  }
   friend class llvm::SymbolTableListTraits<llvm::GlobalAlias>;
 
   /// Get the Module's list of ifuncs (constant).
@@ -675,9 +666,6 @@ private: // Please use functions like insertAlias(), removeAlias() etc.
 
   static IFuncListType Module::*getSublistAccess(GlobalIFunc*) {
     return &Module::IFuncList;
-  }
-  static size_t getSublistOffset(GlobalIFunc *) {
-    return offsetof(Module, IFuncList);
   }
   friend class llvm::SymbolTableListTraits<llvm::GlobalIFunc>;
 

--- a/llvm/include/llvm/IR/SymbolTableListTraits.h
+++ b/llvm/include/llvm/IR/SymbolTableListTraits.h
@@ -77,8 +77,10 @@ private:
   /// getListOwner - Return the object that owns this list.  If this is a list
   /// of instructions, it returns the BasicBlock that owns them.
   ItemParentClass *getListOwner() {
-    size_t Offset = ItemParentClass::getSublistOffset(
-        static_cast<ValueSubClass *>(nullptr));
+    size_t Offset = reinterpret_cast<size_t>(
+        &((ItemParentClass *)nullptr->*ItemParentClass::getSublistAccess(
+                                           static_cast<ValueSubClass *>(
+                                               nullptr))));
     ListTy *Anchor = static_cast<ListTy *>(this);
     return reinterpret_cast<ItemParentClass*>(reinterpret_cast<char*>(Anchor)-
                                               Offset);


### PR DESCRIPTION
Reverts llvm/llvm-project#139096 due to invalid uses of `offsetof` on non-standard-layout types.
