### PR TITLE
[CGData] Make an option to skip reading Names into StableFunctionMap

### DIFF
--- a/llvm/include/llvm/CGData/CGDataPatchItem.h
+++ b/llvm/include/llvm/CGData/CGDataPatchItem.h
@@ -1,0 +1,33 @@
+//===- CGDataPatchItem.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains support for patching codegen data.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CGDATA_CGDATAPATCHITEM_H
+#define LLVM_CGDATA_CGDATAPATCHITEM_H
+
+#include "llvm/ADT/ArrayRef.h"
+
+namespace llvm {
+
+/// A struct to define how the data stream should be patched.
+struct CGDataPatchItem {
+  // Where to patch.
+  uint64_t Pos;
+  // Source data.
+  OwningArrayRef<uint64_t> D;
+
+  CGDataPatchItem(uint64_t Pos, const uint64_t *D, int N)
+      : Pos(Pos), D(ArrayRef<uint64_t>(D, N)) {}
+};
+
+} // namespace llvm
+
+#endif // LLVM_CGDATA_CGDATAPATCHITEM_H

--- a/llvm/include/llvm/CGData/CodeGenData.h
+++ b/llvm/include/llvm/CGData/CodeGenData.h
@@ -282,6 +282,9 @@ enum CGDataVersion {
   Version1 = 1,
   // Version 2 supports the stable function merging map.
   Version2 = 2,
+  // Version 3 adds the total size of the Names in the stable function map so
+  // we can skip reading them into the memory for non-assertion builds.
+  Version3 = 3,
   CurrentVersion = CG_DATA_INDEX_VERSION
 };
 const uint64_t Version = CGDataVersion::CurrentVersion;

--- a/llvm/include/llvm/CGData/CodeGenData.inc
+++ b/llvm/include/llvm/CGData/CodeGenData.inc
@@ -49,4 +49,4 @@ CG_DATA_SECT_ENTRY(CG_merge, CG_DATA_QUOTE(CG_DATA_MERGE_COMMON),
 #endif
 
 /* Indexed codegen data format version (start from 1). */
-#define CG_DATA_INDEX_VERSION 2
+#define CG_DATA_INDEX_VERSION 3

--- a/llvm/include/llvm/CGData/CodeGenDataReader.h
+++ b/llvm/include/llvm/CGData/CodeGenDataReader.h
@@ -27,12 +27,6 @@ class CodeGenDataReader {
   std::string LastErrorMsg;
 
 public:
-  struct Options {
-    /// Whether to read the Names into the stable function map.
-    /// Names are usually used for validation and debugging purpose.
-    bool ReadStableFunctionMapNames = true;
-  };
-
   CodeGenDataReader() = default;
   virtual ~CodeGenDataReader() = default;
 
@@ -57,20 +51,12 @@ public:
   /// Factory method to create an appropriately typed reader for the given
   /// codegen data file path and file system.
   LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
-  create(const Twine &Path, vfs::FileSystem &FS) {
-    return create(Path, FS, {});
-  }
-  LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
-  create(const Twine &Path, vfs::FileSystem &FS, Options Opts);
+  create(const Twine &Path, vfs::FileSystem &FS);
 
   /// Factory method to create an appropriately typed reader for the given
   /// memory buffer.
   LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
-  create(std::unique_ptr<MemoryBuffer> Buffer) {
-    return create(std::move(Buffer), {});
-  }
-  LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
-  create(std::unique_ptr<MemoryBuffer> Buffer, Options Opts);
+  create(std::unique_ptr<MemoryBuffer> Buffer);
 
   /// Extract the cgdata embedded in sections from the given object file and
   /// merge them into the GlobalOutlineRecord. This is a static helper that
@@ -91,8 +77,6 @@ protected:
   /// The stable function map that has been read. When it's released by
   // releaseStableFunctionMap(), it's no longer valid.
   StableFunctionMapRecord FunctionMapRecord;
-
-  Options Opts;
 
   /// Set the current error and return same.
   Error error(cgdata_error Err, const std::string &ErrMsg = "") {
@@ -122,11 +106,8 @@ class LLVM_ABI IndexedCodeGenDataReader : public CodeGenDataReader {
   IndexedCGData::Header Header;
 
 public:
-  IndexedCodeGenDataReader(std::unique_ptr<MemoryBuffer> DataBuffer,
-                           Options Opts)
-      : DataBuffer(std::move(DataBuffer)) {
-    this->Opts = Opts;
-  }
+  IndexedCodeGenDataReader(std::unique_ptr<MemoryBuffer> DataBuffer)
+      : DataBuffer(std::move(DataBuffer)) {}
   IndexedCodeGenDataReader(const IndexedCodeGenDataReader &) = delete;
   IndexedCodeGenDataReader &
   operator=(const IndexedCodeGenDataReader &) = delete;

--- a/llvm/include/llvm/CGData/CodeGenDataReader.h
+++ b/llvm/include/llvm/CGData/CodeGenDataReader.h
@@ -27,6 +27,12 @@ class CodeGenDataReader {
   std::string LastErrorMsg;
 
 public:
+  struct Options {
+    /// Whether to read the Names into the stable function map.
+    /// Names are usually used for validation and debugging purpose.
+    bool ReadStableFunctionMapNames = true;
+  };
+
   CodeGenDataReader() = default;
   virtual ~CodeGenDataReader() = default;
 
@@ -51,12 +57,20 @@ public:
   /// Factory method to create an appropriately typed reader for the given
   /// codegen data file path and file system.
   LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
-  create(const Twine &Path, vfs::FileSystem &FS);
+  create(const Twine &Path, vfs::FileSystem &FS) {
+    return create(Path, FS, {});
+  }
+  LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
+  create(const Twine &Path, vfs::FileSystem &FS, Options Opts);
 
   /// Factory method to create an appropriately typed reader for the given
   /// memory buffer.
   LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
-  create(std::unique_ptr<MemoryBuffer> Buffer);
+  create(std::unique_ptr<MemoryBuffer> Buffer) {
+    return create(std::move(Buffer), {});
+  }
+  LLVM_ABI static Expected<std::unique_ptr<CodeGenDataReader>>
+  create(std::unique_ptr<MemoryBuffer> Buffer, Options Opts);
 
   /// Extract the cgdata embedded in sections from the given object file and
   /// merge them into the GlobalOutlineRecord. This is a static helper that
@@ -77,6 +91,8 @@ protected:
   /// The stable function map that has been read. When it's released by
   // releaseStableFunctionMap(), it's no longer valid.
   StableFunctionMapRecord FunctionMapRecord;
+
+  Options Opts;
 
   /// Set the current error and return same.
   Error error(cgdata_error Err, const std::string &ErrMsg = "") {
@@ -106,8 +122,11 @@ class LLVM_ABI IndexedCodeGenDataReader : public CodeGenDataReader {
   IndexedCGData::Header Header;
 
 public:
-  IndexedCodeGenDataReader(std::unique_ptr<MemoryBuffer> DataBuffer)
-      : DataBuffer(std::move(DataBuffer)) {}
+  IndexedCodeGenDataReader(std::unique_ptr<MemoryBuffer> DataBuffer,
+                           Options Opts)
+      : DataBuffer(std::move(DataBuffer)) {
+    this->Opts = Opts;
+  }
   IndexedCodeGenDataReader(const IndexedCodeGenDataReader &) = delete;
   IndexedCodeGenDataReader &
   operator=(const IndexedCodeGenDataReader &) = delete;

--- a/llvm/include/llvm/CGData/StableFunctionMapRecord.h
+++ b/llvm/include/llvm/CGData/StableFunctionMapRecord.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CGDATA_STABLEFUNCTIONMAPRECORD_H
 #define LLVM_CGDATA_STABLEFUNCTIONMAPRECORD_H
 
+#include "llvm/CGData/CGDataPatchItem.h"
 #include "llvm/CGData/StableFunctionMap.h"
 #include "llvm/ObjectYAML/YAML.h"
 #include "llvm/Support/Compiler.h"
@@ -36,13 +37,16 @@ struct StableFunctionMapRecord {
   /// A static helper function to serialize the stable function map without
   /// owning the stable function map.
   LLVM_ABI static void serialize(raw_ostream &OS,
-                                 const StableFunctionMap *FunctionMap);
+                                 const StableFunctionMap *FunctionMap,
+                                 std::vector<CGDataPatchItem> &PatchItems);
 
   /// Serialize the stable function map to a raw_ostream.
-  LLVM_ABI void serialize(raw_ostream &OS) const;
+  LLVM_ABI void serialize(raw_ostream &OS,
+                          std::vector<CGDataPatchItem> &PatchItems) const;
 
   /// Deserialize the stable function map from a raw_ostream.
-  LLVM_ABI void deserialize(const unsigned char *&Ptr);
+  LLVM_ABI void deserialize(const unsigned char *&Ptr,
+                            bool ReadStableFunctionMapNames = true);
 
   /// Serialize the stable function map to a YAML stream.
   LLVM_ABI void serializeYAML(yaml::Output &YOS) const;

--- a/llvm/lib/CGData/CodeGenData.cpp
+++ b/llvm/lib/CGData/CodeGenData.cpp
@@ -155,14 +155,7 @@ CodeGenData &CodeGenData::getInstance() {
       // Instead, just emit an warning message and fall back as if no CGData
       // were available.
       auto FS = vfs::getRealFileSystem();
-      CodeGenDataReader::Options Opts;
-#ifdef NDEBUG
-      // Do not read the stable function map names for non-assertion builds
-      // to save memory and time for production use.
-      Opts.ReadStableFunctionMapNames = false;
-#endif
-      auto ReaderOrErr =
-          CodeGenDataReader::create(CodeGenDataUsePath, *FS, Opts);
+      auto ReaderOrErr = CodeGenDataReader::create(CodeGenDataUsePath, *FS);
       if (Error E = ReaderOrErr.takeError()) {
         warn(std::move(E), CodeGenDataUsePath);
         return;

--- a/llvm/lib/CGData/CodeGenDataReader.cpp
+++ b/llvm/lib/CGData/CodeGenDataReader.cpp
@@ -113,23 +113,25 @@ Error IndexedCodeGenDataReader::read() {
 }
 
 Expected<std::unique_ptr<CodeGenDataReader>>
-CodeGenDataReader::create(const Twine &Path, vfs::FileSystem &FS) {
+CodeGenDataReader::create(const Twine &Path, vfs::FileSystem &FS,
+                          Options Opts) {
   // Set up the buffer to read.
   auto BufferOrError = setupMemoryBuffer(Path, FS);
   if (Error E = BufferOrError.takeError())
     return std::move(E);
-  return CodeGenDataReader::create(std::move(BufferOrError.get()));
+  return CodeGenDataReader::create(std::move(BufferOrError.get()), Opts);
 }
 
 Expected<std::unique_ptr<CodeGenDataReader>>
-CodeGenDataReader::create(std::unique_ptr<MemoryBuffer> Buffer) {
+CodeGenDataReader::create(std::unique_ptr<MemoryBuffer> Buffer, Options Opts) {
   if (Buffer->getBufferSize() == 0)
     return make_error<CGDataError>(cgdata_error::empty_cgdata);
 
   std::unique_ptr<CodeGenDataReader> Reader;
   // Create the reader.
   if (IndexedCodeGenDataReader::hasFormat(*Buffer))
-    Reader = std::make_unique<IndexedCodeGenDataReader>(std::move(Buffer));
+    Reader =
+        std::make_unique<IndexedCodeGenDataReader>(std::move(Buffer), Opts);
   else if (TextCodeGenDataReader::hasFormat(*Buffer))
     Reader = std::make_unique<TextCodeGenDataReader>(std::move(Buffer));
   else

--- a/llvm/lib/CGData/StableFunctionMapRecord.cpp
+++ b/llvm/lib/CGData/StableFunctionMapRecord.cpp
@@ -94,9 +94,8 @@ void StableFunctionMapRecord::serialize(
   // reading them if needed.
   const uint64_t NamesByteSizeOffset = Writer.OS.tell();
   Writer.write<uint64_t>(0);
-  for (auto &Name : Names) {
+  for (auto &Name : Names)
     Writer.OS << Name << '\0';
-  }
   // Align current position to 4 bytes.
   uint32_t Padding = offsetToAlignment(Writer.OS.tell(), Align(4));
   for (uint32_t I = 0; I < Padding; ++I)
@@ -139,9 +138,8 @@ void StableFunctionMapRecord::deserialize(const unsigned char *&Ptr,
     return;
   const auto NamesByteSize =
       endian::readNext<uint64_t, endianness::little, unaligned>(Ptr);
+  const auto NamesOffset = reinterpret_cast<uintptr_t>(Ptr);
   if (ReadStableFunctionMapNames) {
-    const auto NamesOffset = reinterpret_cast<uintptr_t>(Ptr);
-    (void)NamesOffset; // Silence unused variable warning.
     for (unsigned I = 0; I < NumNames; ++I) {
       StringRef Name(reinterpret_cast<const char *>(Ptr));
       Ptr += Name.size() + 1;
@@ -153,8 +151,7 @@ void StableFunctionMapRecord::deserialize(const unsigned char *&Ptr,
            "NamesByteSize does not match the actual size of names");
   } else {
     // skip reading Names by advancing the pointer.
-    Ptr = reinterpret_cast<const uint8_t *>(reinterpret_cast<uintptr_t>(Ptr) +
-                                            NamesByteSize);
+    Ptr = reinterpret_cast<const uint8_t *>(NamesOffset + NamesByteSize);
   }
 
   // Read StableFunctionEntries.

--- a/llvm/lib/CGData/StableFunctionMapRecord.cpp
+++ b/llvm/lib/CGData/StableFunctionMapRecord.cpp
@@ -77,26 +77,33 @@ static IndexOperandHashVecType getStableIndexOperandHashes(
   return IndexOperandHashes;
 }
 
-void StableFunctionMapRecord::serialize(raw_ostream &OS) const {
-  serialize(OS, FunctionMap.get());
+void StableFunctionMapRecord::serialize(
+    raw_ostream &OS, std::vector<CGDataPatchItem> &PatchItems) const {
+  serialize(OS, FunctionMap.get(), PatchItems);
 }
 
-void StableFunctionMapRecord::serialize(raw_ostream &OS,
-                                        const StableFunctionMap *FunctionMap) {
+void StableFunctionMapRecord::serialize(
+    raw_ostream &OS, const StableFunctionMap *FunctionMap,
+    std::vector<CGDataPatchItem> &PatchItems) {
   support::endian::Writer Writer(OS, endianness::little);
 
   // Write Names.
   ArrayRef<std::string> Names = FunctionMap->getNames();
-  uint32_t ByteSize = 4;
   Writer.write<uint32_t>(Names.size());
+  // Remember the position, write back the total size of Names, so we can skip
+  // reading them if needed.
+  const uint64_t NamesByteSizeOffset = Writer.OS.tell();
+  Writer.write<uint64_t>(0);
   for (auto &Name : Names) {
     Writer.OS << Name << '\0';
-    ByteSize += Name.size() + 1;
   }
-  // Align ByteSize to 4 bytes.
-  uint32_t Padding = offsetToAlignment(ByteSize, Align(4));
+  // Align current position to 4 bytes.
+  uint32_t Padding = offsetToAlignment(Writer.OS.tell(), Align(4));
   for (uint32_t I = 0; I < Padding; ++I)
     Writer.OS << '\0';
+  const auto NamesByteSize =
+      Writer.OS.tell() - NamesByteSizeOffset - sizeof(NamesByteSizeOffset);
+  PatchItems.emplace_back(NamesByteSizeOffset, &NamesByteSize, 1);
 
   // Write StableFunctionEntries whose pointers are sorted.
   auto FuncEntries = getStableFunctionEntries(*FunctionMap);
@@ -120,7 +127,8 @@ void StableFunctionMapRecord::serialize(raw_ostream &OS,
   }
 }
 
-void StableFunctionMapRecord::deserialize(const unsigned char *&Ptr) {
+void StableFunctionMapRecord::deserialize(const unsigned char *&Ptr,
+                                          bool ReadStableFunctionMapNames) {
   // Assert that Ptr is 4-byte aligned
   assert(((uintptr_t)Ptr % 4) == 0);
   // Read Names.
@@ -129,13 +137,25 @@ void StableFunctionMapRecord::deserialize(const unsigned char *&Ptr) {
   // Early exit if there is no name.
   if (NumNames == 0)
     return;
-  for (unsigned I = 0; I < NumNames; ++I) {
-    StringRef Name(reinterpret_cast<const char *>(Ptr));
-    Ptr += Name.size() + 1;
-    FunctionMap->getIdOrCreateForName(Name);
+  const auto NamesByteSize =
+      endian::readNext<uint64_t, endianness::little, unaligned>(Ptr);
+  if (ReadStableFunctionMapNames) {
+    const auto NamesOffset = reinterpret_cast<uintptr_t>(Ptr);
+    (void)NamesOffset; // Silence unused variable warning.
+    for (unsigned I = 0; I < NumNames; ++I) {
+      StringRef Name(reinterpret_cast<const char *>(Ptr));
+      Ptr += Name.size() + 1;
+      FunctionMap->getIdOrCreateForName(Name);
+    }
+    // Align Ptr to 4 bytes.
+    Ptr = reinterpret_cast<const uint8_t *>(alignAddr(Ptr, Align(4)));
+    assert(reinterpret_cast<uintptr_t>(Ptr) - NamesOffset == NamesByteSize &&
+           "NamesByteSize does not match the actual size of names");
+  } else {
+    // skip reading Names by advancing the pointer.
+    Ptr = reinterpret_cast<const uint8_t *>(reinterpret_cast<uintptr_t>(Ptr) +
+                                            NamesByteSize);
   }
-  // Align Ptr to 4 bytes.
-  Ptr = reinterpret_cast<const uint8_t *>(alignAddr(Ptr, Align(4)));
 
   // Read StableFunctionEntries.
   auto NumFuncs =

--- a/llvm/lib/CodeGen/GlobalMergeFunctions.cpp
+++ b/llvm/lib/CodeGen/GlobalMergeFunctions.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/ModuleSummaryAnalysis.h"
 #include "llvm/CGData/CodeGenData.h"
+#include "llvm/CGData/CodeGenDataWriter.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/StructuralHash.h"
 #include "llvm/InitializePasses.h"
@@ -526,7 +527,10 @@ void GlobalMergeFunc::emitFunctionMap(Module &M) {
   SmallVector<char> Buf;
   raw_svector_ostream OS(Buf);
 
-  StableFunctionMapRecord::serialize(OS, LocalFunctionMap.get());
+  std::vector<CGDataPatchItem> PatchItems;
+  StableFunctionMapRecord::serialize(OS, LocalFunctionMap.get(), PatchItems);
+  CGDataOStream COS(OS);
+  COS.patch(PatchItems);
 
   std::unique_ptr<MemoryBuffer> Buffer = MemoryBuffer::getMemBuffer(
       OS.str(), "in-memory stable function map", false);

--- a/llvm/test/tools/llvm-cgdata/empty.test
+++ b/llvm/test/tools/llvm-cgdata/empty.test
@@ -16,7 +16,7 @@ RUN: llvm-cgdata --show %t_emptyheader.cgdata | count 0
 
 # The version number appears when asked, as it's in the header
 RUN: llvm-cgdata --show --cgdata-version %t_emptyheader.cgdata | FileCheck %s --check-prefix=VERSION
-VERSION: Version: 2
+VERSION: Version: 3
 
 # When converting a binary file (w/ the header only) to a text file, it's an empty file as the text format does not have an explicit header.
 RUN: llvm-cgdata --convert %t_emptyheader.cgdata --format text | count 0
@@ -30,7 +30,7 @@ RUN: llvm-cgdata --convert %t_emptyheader.cgdata --format text | count 0
 #   uint64_t StableFunctionMapOffset;
 # }
 RUN: printf '\xffcgdata\x81' > %t_header.cgdata
-RUN: printf '\x02\x00\x00\x00' >> %t_header.cgdata
+RUN: printf '\x03\x00\x00\x00' >> %t_header.cgdata
 RUN: printf '\x00\x00\x00\x00' >> %t_header.cgdata
 RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_header.cgdata
 RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_header.cgdata

--- a/llvm/test/tools/llvm-cgdata/error.test
+++ b/llvm/test/tools/llvm-cgdata/error.test
@@ -22,9 +22,9 @@ RUN: printf '\xffcgdata\x81' > %t_corrupt.cgdata
 RUN: not llvm-cgdata --show %t_corrupt.cgdata 2>&1 | FileCheck %s  --check-prefix=CORRUPT
 CORRUPT: {{.}}cgdata: invalid codegen data (file header is corrupt)
 
-# The current version 2 while the header says 3.
+# The current version 3 while the header says 4.
 RUN: printf '\xffcgdata\x81' > %t_version.cgdata
-RUN: printf '\x03\x00\x00\x00' >> %t_version.cgdata
+RUN: printf '\x04\x00\x00\x00' >> %t_version.cgdata
 RUN: printf '\x00\x00\x00\x00' >> %t_version.cgdata
 RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_version.cgdata
 RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_version.cgdata

--- a/llvm/test/tools/llvm-cgdata/merge-combined-funcmap-hashtree.test
+++ b/llvm/test/tools/llvm-cgdata/merge-combined-funcmap-hashtree.test
@@ -63,4 +63,4 @@ CHECK-NEXT:  Mergeable function Count: 0
 
 ;--- merge-both-template.ll
 @.data1 = private unnamed_addr constant [72 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_outline"
-@.data2 = private unnamed_addr constant [60 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_merge"
+@.data2 = private unnamed_addr constant [68 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_merge"

--- a/llvm/test/tools/llvm-cgdata/merge-funcmap-archive.test
+++ b/llvm/test/tools/llvm-cgdata/merge-funcmap-archive.test
@@ -65,7 +65,7 @@ MAP-NEXT: ...
 ...
 
 ;--- merge-1-template.ll
-@.data = private unnamed_addr constant [60 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_merge"
+@.data = private unnamed_addr constant [68 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_merge"
 
 ;--- raw-2.cgtext
 :stable_function_map
@@ -80,4 +80,4 @@ MAP-NEXT: ...
 ...
 
 ;--- merge-2-template.ll
-@.data = private unnamed_addr constant [60 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_merge"
+@.data = private unnamed_addr constant [68 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_merge"

--- a/llvm/test/tools/llvm-cgdata/merge-funcmap-concat.test
+++ b/llvm/test/tools/llvm-cgdata/merge-funcmap-concat.test
@@ -74,5 +74,5 @@ MAP-NEXT: ...
 ; In an linked executable (as opposed to an object file), cgdata in __llvm_merge might be concatenated.
 ; Although this is not a typical workflow, we simply support this case to parse cgdata that is concatenated.
 ; In other words, the following two trees are encoded back-to-back in a binary format.
-@.data1 = private unnamed_addr constant [60 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_merge"
-@.data2 = private unnamed_addr constant [60 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_merge"
+@.data1 = private unnamed_addr constant [68 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_merge"
+@.data2 = private unnamed_addr constant [68 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_merge"

--- a/llvm/test/tools/llvm-cgdata/merge-funcmap-double.test
+++ b/llvm/test/tools/llvm-cgdata/merge-funcmap-double.test
@@ -61,7 +61,7 @@ MAP-NEXT: ...
 ...
 
 ;--- merge-1-template.ll
-@.data = private unnamed_addr constant [60 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_merge"
+@.data = private unnamed_addr constant [68 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_merge"
 
 ;--- raw-2.cgtext
 :stable_function_map
@@ -76,4 +76,4 @@ MAP-NEXT: ...
 ...
 
 ;--- merge-2-template.ll
-@.data = private unnamed_addr constant [60 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_merge"
+@.data = private unnamed_addr constant [68 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_merge"

--- a/llvm/test/tools/llvm-cgdata/merge-funcmap-single.test
+++ b/llvm/test/tools/llvm-cgdata/merge-funcmap-single.test
@@ -33,4 +33,4 @@ CHECK-NEXT:  Mergeable function Count: 0
 ...
 
 ;--- merge-single-template.ll
-@.data = private unnamed_addr constant [60 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_merge"
+@.data = private unnamed_addr constant [68 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_merge"

--- a/llvm/unittests/CGData/StableFunctionMapRecordTest.cpp
+++ b/llvm/unittests/CGData/StableFunctionMapRecordTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CGData/StableFunctionMapRecord.h"
+#include "llvm/CGData/CodeGenDataWriter.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -77,7 +78,10 @@ TEST(StableFunctionMapRecordTest, Serialize) {
   // Serialize and deserialize the map.
   SmallVector<char> Out;
   raw_svector_ostream OS(Out);
-  MapRecord1.serialize(OS);
+  std::vector<CGDataPatchItem> PatchItems;
+  MapRecord1.serialize(OS, PatchItems);
+  CGDataOStream COS(OS);
+  COS.patch(PatchItems);
 
   StableFunctionMapRecord MapRecord2;
   const uint8_t *Data = reinterpret_cast<const uint8_t *>(Out.data());


### PR DESCRIPTION
Names are used for debugging purpose and have no impact on codegen. For a non-trivial project, reading them consumes a lot of memory and slows down the compilation significantly. This patch adds a field in the indexed CGData to remember the total size of Names, and creates a command-line option to skip reading Names by advancing the pointer when deserializing the indexed CGData.