### PR TITLE
[ci] Use different emoji for Linux and Windows job titles on GitHub

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -47,7 +47,7 @@ function at-exit {
     python3 "${MONOREPO_ROOT}"/.ci/generate_test_report_buildkite.py ":linux: Linux x64 Test Results" \
       "linux-x64-test-results" $retcode "${BUILD_DIR}"/test-results.*.xml
   else
-    python3 "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py ":linux: Linux x64 Test Results" \
+    python3 "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py ":penguin: Linux x64 Test Results" \
       $retcode "${BUILD_DIR}"/test-results.*.xml >> $GITHUB_STEP_SUMMARY
   fi
 }

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -42,7 +42,7 @@ function at-exit {
     python "${MONOREPO_ROOT}"/.ci/generate_test_report_buildkite.py ":windows: Windows x64 Test Results" \
       "windows-x64-test-results" $retcode "${BUILD_DIR}"/test-results.*.xml
   else
-    python "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py ":windows: Windows x64 Test Results" \
+    python "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py ":window: Windows x64 Test Results" \
       $retcode "${BUILD_DIR}"/test-results.*.xml >> $GITHUB_STEP_SUMMARY
   fi
 }


### PR DESCRIPTION
Buildkite has a bunch of custom emoji that include Linux and Windows logos - https://github.com/buildkite/emojis?tab=readme-ov-file#smileys--emotion.

GitHub doesn't have these so let's just use a penguin and a generic window. :penguin: :window: 

These are standard emoji so Buildkite does support them too, but there's no motivation to change it there.

Plus, I think the metrics collection might be tied to Buildkite pipeline name so keeping it the same saves hassle there.