### PR TITLE
[BOLT][NFC] Align fdata pattern ordering in link_fdata.py

### DIFF
--- a/bolt/test/link_fdata.py
+++ b/bolt/test/link_fdata.py
@@ -33,7 +33,7 @@ prefix_pat = re.compile(f"^# {args.prefix}: (.*)")
 # <is symbol?> <closest elf symbol or DSO name> <relative FROM address>
 # <is symbol?> <closest elf symbol or DSO name> <relative TO address>
 # <number of mispredictions> <number of branches>
-fdata_pat = re.compile(r"([01].*) (?P<exec>\d+) (?P<mispred>\d+)")
+fdata_pat = re.compile(r"([01].*) (?P<mispred>\d+) (?P<exec>\d+)")
 
 # Pre-aggregated profile:
 # {T|B|F|f} [<start_id>:]<start_offset> [<end_id>:]<end_offset> [<ft_end>]
@@ -61,7 +61,7 @@ with open(args.input, "r") as f:
         preagg_match = preagg_pat.match(profile_line)
         nolbr_match = nolbr_pat.match(profile_line)
         if fdata_match:
-            src_dst, execnt, mispred = fdata_match.groups()
+            src_dst, mispred, execnt = fdata_match.groups()
             # Split by whitespaces not preceded by a backslash (negative lookbehind)
             chunks = re.split(r"(?<!\\) +", src_dst)
             # Check if the number of records separated by non-escaped whitespace
@@ -69,7 +69,7 @@ with open(args.input, "r") as f:
             assert (
                 len(chunks) == 6
             ), f"ERROR: wrong format/whitespaces must be escaped:\n{line}"
-            exprs.append(("FDATA", (*chunks, execnt, mispred)))
+            exprs.append(("FDATA", (*chunks, mispred, execnt)))
         elif nolbr_match:
             loc, count = nolbr_match.groups()
             # Split by whitespaces not preceded by a backslash (negative lookbehind)


### PR DESCRIPTION
The mispred and execnt values were originally recorded in reverse order and then consumed in the opposite order to compensate.

This patch records and uses them in the same order (FDATA) for clarity. That order is:
```
<is symbol?> <closest ELF symbol or DSO name> <relative FROM address> 
<is symbol?> <closest ELF symbol or DSO name> <relative TO address> 
<number of mispredictions> <number of branches>
```