### PR TITLE
[AArch64] Add SUBS(CSEL) fold from brcond.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -24534,6 +24534,19 @@ static SDValue performBRCONDCombine(SDNode *N,
   if (CC != AArch64CC::EQ && CC != AArch64CC::NE)
     return SDValue();
 
+  // Fold away brcond(NE, cmp(csel(1, 0, CC, Cmp), 1)) -> brcond(~CC, Cmp)
+  if (isCMP(Cmp) && CC == AArch64CC::NE && isOneConstant(Cmp.getOperand(1))) {
+    SDValue CSel = Cmp.getOperand(0);
+    auto CSelCC = getCSETCondCode(CSel);
+    if (CSelCC) {
+      SDLoc DL(N);
+      return DAG.getNode(
+          N->getOpcode(), DL, N->getVTList(), Chain, Dest,
+          DAG.getConstant(getInvertedCondCode(*CSelCC), DL, MVT::i32),
+          CSel.getOperand(3));
+    }
+  }
+
   unsigned CmpOpc = Cmp.getOpcode();
   if (CmpOpc != AArch64ISD::ADDS && CmpOpc != AArch64ISD::SUBS)
     return SDValue();

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
@@ -451,11 +451,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -470,11 +469,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -489,11 +487,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -508,11 +505,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -527,11 +523,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a_fp.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a_fp.ll
@@ -77,11 +77,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -96,11 +95,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -115,11 +113,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -134,11 +131,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -153,11 +149,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -557,11 +552,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -576,11 +570,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -595,11 +588,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -614,11 +606,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -633,11 +624,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -1037,11 +1027,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -1056,11 +1045,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -1075,11 +1063,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -1094,11 +1081,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -1113,11 +1099,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -1517,11 +1502,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -1536,11 +1520,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -1555,11 +1538,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -1574,11 +1556,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -1593,11 +1574,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -1997,11 +1977,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_monotonic(ptr %ptr, b
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -2016,11 +1995,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_acquire(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -2035,11 +2013,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_release(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -2054,11 +2031,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_acq_rel(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -2073,11 +2049,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -2477,11 +2452,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_monotonic(ptr %ptr, b
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -2496,11 +2470,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_acquire(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -2515,11 +2488,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_release(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -2534,11 +2506,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_acq_rel(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -2553,11 +2524,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lse2.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lse2.ll
@@ -9,7 +9,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -24,7 +23,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -39,7 +37,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -54,7 +51,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -69,7 +65,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -84,7 +79,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
 ; -O1:    ldxrh w0, [x8]
@@ -99,7 +93,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acquire:
 ; -O1:    ldaxrh w0, [x8]
@@ -114,7 +107,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_release:
 ; -O1:    ldxrh w0, [x8]
@@ -129,7 +121,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w0, [x8]
@@ -144,7 +135,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w0, [x8]
@@ -159,7 +149,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O1:    ldxr w0, [x8]
@@ -174,7 +163,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O1:    ldaxr w0, [x8]
@@ -189,7 +177,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O1:    ldxr w0, [x8]
@@ -204,7 +191,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O1:    ldaxr w0, [x8]
@@ -219,7 +205,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O1:    ldaxr w0, [x8]
@@ -234,7 +219,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -249,7 +233,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -264,7 +247,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -279,7 +261,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -294,7 +275,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -394,7 +374,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -409,7 +388,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -424,7 +402,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -439,7 +416,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -454,7 +430,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -610,7 +585,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -627,7 +601,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -644,7 +617,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -661,7 +633,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -678,7 +649,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -695,7 +665,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -712,7 +681,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -729,7 +697,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -746,7 +713,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -763,7 +729,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -780,7 +745,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -797,7 +761,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -814,7 +777,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -831,7 +793,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -848,7 +809,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -865,7 +825,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -882,7 +841,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -899,7 +857,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -916,7 +873,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -933,7 +889,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1045,7 +1000,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1062,7 +1016,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1079,7 +1032,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1096,7 +1048,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1113,7 +1064,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1375,7 +1325,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1392,7 +1341,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1409,7 +1357,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1426,7 +1373,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1443,7 +1389,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1460,7 +1405,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1477,7 +1421,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1494,7 +1437,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1511,7 +1453,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1528,7 +1469,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1545,7 +1485,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1562,7 +1501,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1579,7 +1517,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1596,7 +1533,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1613,7 +1549,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1630,7 +1565,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -1647,7 +1581,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -1664,7 +1597,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -1681,7 +1613,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -1698,7 +1629,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1810,7 +1740,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1827,7 +1756,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1844,7 +1772,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1861,7 +1788,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1878,7 +1804,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2140,7 +2065,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2157,7 +2081,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2174,7 +2097,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2191,7 +2113,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2208,7 +2129,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2225,7 +2145,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2242,7 +2161,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2259,7 +2177,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2276,7 +2193,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2293,7 +2209,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2310,7 +2225,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2327,7 +2241,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2344,7 +2257,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2361,7 +2273,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2378,7 +2289,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2395,7 +2305,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2412,7 +2321,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2429,7 +2337,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2446,7 +2353,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2463,7 +2369,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2585,7 +2490,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2602,7 +2506,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2619,7 +2522,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2636,7 +2538,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2653,7 +2554,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2926,7 +2826,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2945,7 +2844,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2964,7 +2862,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2983,7 +2880,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3002,7 +2898,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3021,7 +2916,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3040,7 +2934,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3059,7 +2952,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3078,7 +2970,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3097,7 +2988,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3116,7 +3006,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3135,7 +3024,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -3154,7 +3042,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -3173,7 +3060,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -3192,7 +3078,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -3211,7 +3096,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -3230,7 +3114,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -3249,7 +3132,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -3268,7 +3150,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -3287,7 +3168,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -3431,7 +3311,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3450,7 +3329,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3469,7 +3347,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3488,7 +3365,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3507,7 +3383,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3830,7 +3705,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3847,7 +3721,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3864,7 +3737,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3881,7 +3753,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3898,7 +3769,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3915,7 +3785,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3932,7 +3801,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3949,7 +3817,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3966,7 +3833,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3983,7 +3849,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4000,7 +3865,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4017,7 +3881,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4034,7 +3897,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4051,7 +3913,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4068,7 +3929,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4085,7 +3945,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4102,7 +3961,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4119,7 +3977,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4136,7 +3993,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4153,7 +4009,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4275,7 +4130,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4292,7 +4146,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4309,7 +4162,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4326,7 +4178,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4343,7 +4194,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4615,7 +4465,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4632,7 +4481,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4649,7 +4497,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4666,7 +4513,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4683,7 +4529,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4700,7 +4545,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -4717,7 +4561,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -4734,7 +4577,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -4751,7 +4593,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -4768,7 +4609,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4785,7 +4625,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4802,7 +4641,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4819,7 +4657,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4836,7 +4673,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4853,7 +4689,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4870,7 +4705,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4887,7 +4721,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4904,7 +4737,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4921,7 +4753,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4938,7 +4769,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5060,7 +4890,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -5077,7 +4906,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -5094,7 +4922,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -5111,7 +4938,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -5128,7 +4954,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -5402,7 +5227,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5423,7 +5247,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5444,7 +5267,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5465,7 +5287,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5486,7 +5307,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5507,7 +5327,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5528,7 +5347,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5549,7 +5367,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5570,7 +5387,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5591,7 +5407,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5611,7 +5426,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5630,7 +5444,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5649,7 +5462,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5668,7 +5480,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5687,7 +5498,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5706,7 +5516,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5725,7 +5534,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5744,7 +5552,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5763,7 +5570,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5782,7 +5588,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5917,7 +5722,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5938,7 +5742,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5959,7 +5762,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5980,7 +5782,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6001,7 +5802,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6327,7 +6127,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6348,7 +6147,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6369,7 +6167,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6390,7 +6187,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6411,7 +6207,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6432,7 +6227,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -6453,7 +6247,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -6474,7 +6267,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -6495,7 +6287,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -6516,7 +6307,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -6536,7 +6326,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6555,7 +6344,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6574,7 +6362,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6593,7 +6380,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6612,7 +6398,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6631,7 +6416,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6650,7 +6434,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6669,7 +6452,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6688,7 +6470,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6707,7 +6488,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6842,7 +6622,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6863,7 +6642,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6884,7 +6662,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6905,7 +6682,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6926,7 +6702,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -7252,7 +7027,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7273,7 +7047,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7294,7 +7067,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7315,7 +7087,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7336,7 +7107,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -7357,7 +7127,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -7378,7 +7147,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -7399,7 +7167,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -7420,7 +7187,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -7441,7 +7207,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -7461,7 +7226,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -7480,7 +7244,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -7499,7 +7262,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -7518,7 +7280,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -7537,7 +7298,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -7556,7 +7316,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7575,7 +7334,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7594,7 +7352,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7613,7 +7370,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7632,7 +7388,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7767,7 +7522,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7788,7 +7542,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7809,7 +7562,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7830,7 +7582,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7851,7 +7602,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8177,7 +7927,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8198,7 +7947,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8219,7 +7967,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8240,7 +7987,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8261,7 +8007,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8282,7 +8027,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -8303,7 +8047,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -8324,7 +8067,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -8345,7 +8087,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -8366,7 +8107,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -8386,7 +8126,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -8405,7 +8144,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -8424,7 +8162,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -8443,7 +8180,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -8462,7 +8198,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -8481,7 +8216,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -8500,7 +8234,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -8519,7 +8252,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -8538,7 +8270,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -8557,7 +8288,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -8692,7 +8422,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8713,7 +8442,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8734,7 +8462,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8755,7 +8482,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8776,7 +8502,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lse2_lse128.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lse2_lse128.ll
@@ -2009,7 +2009,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2026,7 +2025,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casab w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2043,7 +2041,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    caslb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2060,7 +2057,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2077,7 +2073,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2094,7 +2089,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    mvn w10, w8
 ; -O0:    cash w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2111,7 +2105,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casah w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2128,7 +2121,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    caslh w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2145,7 +2137,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalh w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2162,7 +2153,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalh w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2179,7 +2169,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    mvn w10, w8
 ; -O0:    cas w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2196,7 +2185,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casa w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2213,7 +2201,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casl w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2230,7 +2217,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casal w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2247,7 +2233,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casal w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2264,7 +2249,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    mvn x10, x8
 ; -O0:    cas x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    and x10, x8, x1
@@ -2281,7 +2265,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    mvn x10, x8
 ; -O0:    casa x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    and x10, x8, x1
@@ -2298,7 +2281,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    mvn x10, x8
 ; -O0:    casl x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    and x10, x8, x1
@@ -2315,7 +2297,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    mvn x10, x8
 ; -O0:    casal x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    and x10, x8, x1
@@ -2332,7 +2313,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    mvn x10, x8
 ; -O0:    casal x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    and x10, x8, x1
@@ -2464,7 +2444,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    mvn w10, w8
 ; -O0:    casb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2481,7 +2460,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casab w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2498,7 +2476,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    caslb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    and w10, w8, w1
@@ -2515,7 +2492,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2532,7 +2508,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    and w10, w8, w1

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lsfe.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lsfe.ll
@@ -379,11 +379,10 @@ define dso_local double @atomicrmw_fadd_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -394,11 +393,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -409,11 +407,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -424,11 +421,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -439,11 +435,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -456,11 +451,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -475,11 +469,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -494,11 +487,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -513,11 +505,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -532,11 +523,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -549,11 +539,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_monotonic:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -564,11 +553,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acquire:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -579,11 +567,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_release:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -594,11 +581,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -609,11 +595,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -624,11 +609,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_monotonic:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -639,11 +623,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acquire:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -654,11 +637,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_release:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -669,11 +651,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -684,11 +665,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-outline_atomics.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-outline_atomics.ll
@@ -2119,7 +2119,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2136,7 +2135,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2153,7 +2151,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2170,7 +2167,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2187,7 +2183,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2204,7 +2199,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_relax
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2221,7 +2215,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_acq
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2238,7 +2231,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2255,7 +2247,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2272,7 +2263,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2289,7 +2279,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2306,7 +2295,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2323,7 +2311,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2340,7 +2327,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2357,7 +2343,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2374,7 +2359,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_relax
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2391,7 +2375,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_acq
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2408,7 +2391,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2425,7 +2407,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2442,7 +2423,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2564,7 +2544,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2581,7 +2560,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2598,7 +2576,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2615,7 +2592,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2632,7 +2608,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3985,7 +3960,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -4004,7 +3978,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -4023,7 +3996,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -4042,7 +4014,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -4061,7 +4032,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -4080,7 +4050,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_relax
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -4099,7 +4068,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_acq
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -4118,7 +4086,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -4137,7 +4104,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -4156,7 +4122,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -4174,7 +4139,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4191,7 +4155,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4208,7 +4171,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4225,7 +4187,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4242,7 +4203,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4259,7 +4219,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_relax
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4276,7 +4235,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_acq
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4293,7 +4251,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4310,7 +4267,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4327,7 +4283,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4440,7 +4395,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -4459,7 +4413,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -4478,7 +4431,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -4497,7 +4449,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -4516,7 +4467,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -4840,7 +4790,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -4859,7 +4808,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -4878,7 +4826,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -4897,7 +4844,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -4916,7 +4862,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -4935,7 +4880,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_relax
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -4954,7 +4898,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_acq
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -4973,7 +4916,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -4992,7 +4934,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5011,7 +4952,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8, uxth
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5029,7 +4969,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5046,7 +4985,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5063,7 +5001,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5080,7 +5017,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5097,7 +5033,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5114,7 +5049,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_relax
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5131,7 +5065,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_acq
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5148,7 +5081,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5165,7 +5097,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5182,7 +5113,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5295,7 +5225,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5314,7 +5243,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5333,7 +5261,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5352,7 +5279,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5371,7 +5297,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8, uxtb
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5695,7 +5620,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -5714,7 +5638,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -5733,7 +5656,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -5752,7 +5674,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -5771,7 +5692,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -5790,7 +5710,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -5809,7 +5728,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -5828,7 +5746,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -5847,7 +5764,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -5866,7 +5782,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -5884,7 +5799,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5901,7 +5815,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5918,7 +5831,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5935,7 +5847,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5952,7 +5863,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5969,7 +5879,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_relax
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5986,7 +5895,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_acq
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6003,7 +5911,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6020,7 +5927,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6037,7 +5943,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6150,7 +6055,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -6169,7 +6073,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -6188,7 +6091,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -6207,7 +6109,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -6226,7 +6127,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -6550,7 +6450,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -6569,7 +6468,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -6588,7 +6486,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -6607,7 +6504,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -6626,7 +6522,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -6645,7 +6540,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -6664,7 +6558,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -6683,7 +6576,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -6702,7 +6594,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -6721,7 +6612,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -6739,7 +6629,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6756,7 +6645,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6773,7 +6661,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6790,7 +6677,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6807,7 +6693,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6824,7 +6709,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_relax
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6841,7 +6725,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_acq
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6858,7 +6741,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6875,7 +6757,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6892,7 +6773,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_acq_rel
 ; -O0:    subs x8, x0, x8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7005,7 +6885,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_relax
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7024,7 +6903,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_acq
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7043,7 +6921,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7062,7 +6939,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7081,7 +6957,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas1_acq_rel
 ; -O0:    subs w8, w0, w8
-; -O0:    subs w8, w8, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-rcpc.ll
@@ -9,7 +9,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -24,7 +23,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -39,7 +37,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -54,7 +51,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -69,7 +65,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -84,7 +79,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
 ; -O1:    ldxrh w0, [x8]
@@ -99,7 +93,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acquire:
 ; -O1:    ldaxrh w0, [x8]
@@ -114,7 +107,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_release:
 ; -O1:    ldxrh w0, [x8]
@@ -129,7 +121,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w0, [x8]
@@ -144,7 +135,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w0, [x8]
@@ -159,7 +149,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O1:    ldxr w0, [x8]
@@ -174,7 +163,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O1:    ldaxr w0, [x8]
@@ -189,7 +177,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O1:    ldxr w0, [x8]
@@ -204,7 +191,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O1:    ldaxr w0, [x8]
@@ -219,7 +205,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O1:    ldaxr w0, [x8]
@@ -234,7 +219,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -249,7 +233,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -264,7 +247,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -279,7 +261,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -294,7 +275,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -394,7 +374,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -409,7 +388,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -424,7 +402,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -439,7 +416,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -454,7 +430,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -610,7 +585,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -627,7 +601,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -644,7 +617,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -661,7 +633,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -678,7 +649,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -695,7 +665,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -712,7 +681,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -729,7 +697,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -746,7 +713,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -763,7 +729,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -780,7 +745,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -797,7 +761,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -814,7 +777,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -831,7 +793,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -848,7 +809,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -865,7 +825,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -882,7 +841,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -899,7 +857,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -916,7 +873,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -933,7 +889,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1045,7 +1000,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1062,7 +1016,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1079,7 +1032,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1096,7 +1048,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1113,7 +1064,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1375,7 +1325,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1392,7 +1341,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1409,7 +1357,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1426,7 +1373,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1443,7 +1389,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1460,7 +1405,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1477,7 +1421,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1494,7 +1437,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1511,7 +1453,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1528,7 +1469,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1545,7 +1485,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1562,7 +1501,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1579,7 +1517,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1596,7 +1533,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1613,7 +1549,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1630,7 +1565,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -1647,7 +1581,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -1664,7 +1597,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -1681,7 +1613,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -1698,7 +1629,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1810,7 +1740,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1827,7 +1756,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1844,7 +1772,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1861,7 +1788,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1878,7 +1804,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2140,7 +2065,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2157,7 +2081,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2174,7 +2097,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2191,7 +2113,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2208,7 +2129,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2225,7 +2145,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2242,7 +2161,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2259,7 +2177,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2276,7 +2193,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2293,7 +2209,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2310,7 +2225,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2327,7 +2241,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2344,7 +2257,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2361,7 +2273,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2378,7 +2289,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2395,7 +2305,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2412,7 +2321,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2429,7 +2337,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2446,7 +2353,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2463,7 +2369,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2585,7 +2490,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2602,7 +2506,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2619,7 +2522,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2636,7 +2538,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2653,7 +2554,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2926,7 +2826,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2945,7 +2844,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2964,7 +2862,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2983,7 +2880,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3002,7 +2898,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3021,7 +2916,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3040,7 +2934,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3059,7 +2952,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3078,7 +2970,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3097,7 +2988,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3116,7 +3006,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3135,7 +3024,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -3154,7 +3042,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -3173,7 +3060,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -3192,7 +3078,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -3211,7 +3096,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -3230,7 +3114,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -3249,7 +3132,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -3268,7 +3150,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -3287,7 +3168,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -3431,7 +3311,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3450,7 +3329,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3469,7 +3347,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3488,7 +3365,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3507,7 +3383,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3830,7 +3705,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3847,7 +3721,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3864,7 +3737,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3881,7 +3753,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3898,7 +3769,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3915,7 +3785,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3932,7 +3801,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3949,7 +3817,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3966,7 +3833,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3983,7 +3849,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4000,7 +3865,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4017,7 +3881,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4034,7 +3897,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4051,7 +3913,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4068,7 +3929,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4085,7 +3945,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4102,7 +3961,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4119,7 +3977,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4136,7 +3993,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4153,7 +4009,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4275,7 +4130,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4292,7 +4146,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4309,7 +4162,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4326,7 +4178,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4343,7 +4194,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4615,7 +4465,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4632,7 +4481,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4649,7 +4497,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4666,7 +4513,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4683,7 +4529,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4700,7 +4545,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -4717,7 +4561,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -4734,7 +4577,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -4751,7 +4593,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -4768,7 +4609,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4785,7 +4625,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4802,7 +4641,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4819,7 +4657,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4836,7 +4673,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4853,7 +4689,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4870,7 +4705,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4887,7 +4721,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4904,7 +4737,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4921,7 +4753,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4938,7 +4769,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5060,7 +4890,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -5077,7 +4906,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -5094,7 +4922,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -5111,7 +4938,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -5128,7 +4954,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -5402,7 +5227,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5423,7 +5247,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5444,7 +5267,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5465,7 +5287,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5486,7 +5307,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5507,7 +5327,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5528,7 +5347,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5549,7 +5367,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5570,7 +5387,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5591,7 +5407,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5611,7 +5426,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5630,7 +5444,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5649,7 +5462,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5668,7 +5480,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5687,7 +5498,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5706,7 +5516,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5725,7 +5534,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5744,7 +5552,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5763,7 +5570,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5782,7 +5588,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5917,7 +5722,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5938,7 +5742,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5959,7 +5762,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5980,7 +5782,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6001,7 +5802,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6327,7 +6127,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6348,7 +6147,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6369,7 +6167,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6390,7 +6187,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6411,7 +6207,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6432,7 +6227,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -6453,7 +6247,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -6474,7 +6267,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -6495,7 +6287,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -6516,7 +6307,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -6536,7 +6326,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6555,7 +6344,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6574,7 +6362,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6593,7 +6380,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6612,7 +6398,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6631,7 +6416,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6650,7 +6434,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6669,7 +6452,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6688,7 +6470,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6707,7 +6488,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6842,7 +6622,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6863,7 +6642,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6884,7 +6662,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6905,7 +6682,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6926,7 +6702,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -7252,7 +7027,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7273,7 +7047,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7294,7 +7067,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7315,7 +7087,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7336,7 +7107,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -7357,7 +7127,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -7378,7 +7147,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -7399,7 +7167,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -7420,7 +7187,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -7441,7 +7207,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -7461,7 +7226,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -7480,7 +7244,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -7499,7 +7262,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -7518,7 +7280,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -7537,7 +7298,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -7556,7 +7316,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7575,7 +7334,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7594,7 +7352,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7613,7 +7370,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7632,7 +7388,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7767,7 +7522,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7788,7 +7542,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7809,7 +7562,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7830,7 +7582,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7851,7 +7602,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8177,7 +7927,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8198,7 +7947,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8219,7 +7967,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8240,7 +7987,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8261,7 +8007,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8282,7 +8027,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -8303,7 +8047,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -8324,7 +8067,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -8345,7 +8087,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -8366,7 +8107,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -8386,7 +8126,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -8405,7 +8144,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -8424,7 +8162,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -8443,7 +8180,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -8462,7 +8198,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -8481,7 +8216,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -8500,7 +8234,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -8519,7 +8252,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -8538,7 +8270,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -8557,7 +8288,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -8692,7 +8422,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8713,7 +8442,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8734,7 +8462,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8755,7 +8482,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8776,7 +8502,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-rcpc3.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-rcpc3.ll
@@ -9,7 +9,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -24,7 +23,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -39,7 +37,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -54,7 +51,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -69,7 +65,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -84,7 +79,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
 ; -O1:    ldxrh w0, [x8]
@@ -99,7 +93,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acquire:
 ; -O1:    ldaxrh w0, [x8]
@@ -114,7 +107,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_release:
 ; -O1:    ldxrh w0, [x8]
@@ -129,7 +121,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w0, [x8]
@@ -144,7 +135,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w0, [x8]
@@ -159,7 +149,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O1:    ldxr w0, [x8]
@@ -174,7 +163,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O1:    ldaxr w0, [x8]
@@ -189,7 +177,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O1:    ldxr w0, [x8]
@@ -204,7 +191,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O1:    ldaxr w0, [x8]
@@ -219,7 +205,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O1:    ldaxr w0, [x8]
@@ -234,7 +219,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -249,7 +233,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -264,7 +247,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -279,7 +261,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -294,7 +275,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -394,7 +374,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -409,7 +388,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -424,7 +402,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -439,7 +416,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -454,7 +430,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -610,7 +585,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -627,7 +601,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -644,7 +617,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -661,7 +633,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -678,7 +649,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -695,7 +665,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -712,7 +681,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -729,7 +697,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -746,7 +713,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -763,7 +729,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -780,7 +745,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -797,7 +761,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -814,7 +777,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -831,7 +793,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -848,7 +809,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -865,7 +825,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -882,7 +841,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -899,7 +857,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -916,7 +873,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -933,7 +889,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1045,7 +1000,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1062,7 +1016,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1079,7 +1032,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1096,7 +1048,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1113,7 +1064,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1375,7 +1325,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1392,7 +1341,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1409,7 +1357,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1426,7 +1373,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1443,7 +1389,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1460,7 +1405,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1477,7 +1421,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1494,7 +1437,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1511,7 +1453,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1528,7 +1469,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1545,7 +1485,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1562,7 +1501,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1579,7 +1517,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1596,7 +1533,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1613,7 +1549,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1630,7 +1565,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -1647,7 +1581,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -1664,7 +1597,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -1681,7 +1613,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -1698,7 +1629,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1810,7 +1740,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1827,7 +1756,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1844,7 +1772,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1861,7 +1788,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1878,7 +1804,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2140,7 +2065,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2157,7 +2081,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2174,7 +2097,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2191,7 +2113,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2208,7 +2129,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2225,7 +2145,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2242,7 +2161,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2259,7 +2177,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2276,7 +2193,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2293,7 +2209,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2310,7 +2225,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2327,7 +2241,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2344,7 +2257,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2361,7 +2273,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2378,7 +2289,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2395,7 +2305,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2412,7 +2321,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2429,7 +2337,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2446,7 +2353,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2463,7 +2369,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2585,7 +2490,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2602,7 +2506,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2619,7 +2522,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2636,7 +2538,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2653,7 +2554,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2926,7 +2826,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2945,7 +2844,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2964,7 +2862,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2983,7 +2880,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3002,7 +2898,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3021,7 +2916,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3040,7 +2934,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3059,7 +2952,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3078,7 +2970,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3097,7 +2988,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3116,7 +3006,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3135,7 +3024,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -3154,7 +3042,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -3173,7 +3060,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -3192,7 +3078,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -3211,7 +3096,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -3230,7 +3114,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -3249,7 +3132,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -3268,7 +3150,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -3287,7 +3168,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -3431,7 +3311,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3450,7 +3329,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3469,7 +3347,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3488,7 +3365,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3507,7 +3383,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3830,7 +3705,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3847,7 +3721,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3864,7 +3737,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3881,7 +3753,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3898,7 +3769,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3915,7 +3785,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3932,7 +3801,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3949,7 +3817,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3966,7 +3833,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3983,7 +3849,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4000,7 +3865,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4017,7 +3881,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4034,7 +3897,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4051,7 +3913,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4068,7 +3929,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4085,7 +3945,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4102,7 +3961,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4119,7 +3977,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4136,7 +3993,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4153,7 +4009,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4275,7 +4130,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4292,7 +4146,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4309,7 +4162,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4326,7 +4178,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4343,7 +4194,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4615,7 +4465,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4632,7 +4481,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4649,7 +4497,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4666,7 +4513,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4683,7 +4529,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4700,7 +4545,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -4717,7 +4561,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -4734,7 +4577,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -4751,7 +4593,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -4768,7 +4609,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4785,7 +4625,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4802,7 +4641,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4819,7 +4657,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4836,7 +4673,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4853,7 +4689,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4870,7 +4705,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4887,7 +4721,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4904,7 +4737,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4921,7 +4753,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4938,7 +4769,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5060,7 +4890,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -5077,7 +4906,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -5094,7 +4922,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -5111,7 +4938,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -5128,7 +4954,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -5402,7 +5227,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5423,7 +5247,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5444,7 +5267,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5465,7 +5287,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5486,7 +5307,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5507,7 +5327,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5528,7 +5347,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5549,7 +5367,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5570,7 +5387,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5591,7 +5407,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5611,7 +5426,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5630,7 +5444,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5649,7 +5462,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5668,7 +5480,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5687,7 +5498,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5706,7 +5516,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5725,7 +5534,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5744,7 +5552,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5763,7 +5570,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5782,7 +5588,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5917,7 +5722,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5938,7 +5742,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5959,7 +5762,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5980,7 +5782,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6001,7 +5802,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6327,7 +6127,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6348,7 +6147,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6369,7 +6167,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6390,7 +6187,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6411,7 +6207,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6432,7 +6227,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -6453,7 +6247,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -6474,7 +6267,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -6495,7 +6287,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -6516,7 +6307,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -6536,7 +6326,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6555,7 +6344,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6574,7 +6362,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6593,7 +6380,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6612,7 +6398,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6631,7 +6416,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6650,7 +6434,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6669,7 +6452,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6688,7 +6470,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6707,7 +6488,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6842,7 +6622,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6863,7 +6642,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6884,7 +6662,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6905,7 +6682,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6926,7 +6702,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -7252,7 +7027,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7273,7 +7047,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7294,7 +7067,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7315,7 +7087,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7336,7 +7107,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -7357,7 +7127,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -7378,7 +7147,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -7399,7 +7167,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -7420,7 +7187,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -7441,7 +7207,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -7461,7 +7226,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -7480,7 +7244,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -7499,7 +7262,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -7518,7 +7280,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -7537,7 +7298,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -7556,7 +7316,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7575,7 +7334,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7594,7 +7352,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7613,7 +7370,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7632,7 +7388,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7767,7 +7522,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7788,7 +7542,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7809,7 +7562,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7830,7 +7582,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7851,7 +7602,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8177,7 +7927,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8198,7 +7947,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8219,7 +7967,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8240,7 +7987,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8261,7 +8007,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8282,7 +8027,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -8303,7 +8047,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -8324,7 +8067,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -8345,7 +8087,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -8366,7 +8107,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -8386,7 +8126,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -8405,7 +8144,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -8424,7 +8162,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -8443,7 +8180,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -8462,7 +8198,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -8481,7 +8216,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -8500,7 +8234,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -8519,7 +8252,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -8538,7 +8270,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -8557,7 +8288,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -8692,7 +8422,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8713,7 +8442,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8734,7 +8462,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8755,7 +8482,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8776,7 +8502,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-v8_1a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-v8_1a.ll
@@ -2059,7 +2059,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2076,7 +2075,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casab w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2093,7 +2091,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    caslb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2110,7 +2107,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2127,7 +2123,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2144,7 +2139,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    mvn w10, w8
 ; -O0:    cash w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2161,7 +2155,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casah w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2178,7 +2171,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    caslh w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2195,7 +2187,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalh w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2212,7 +2203,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalh w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2229,7 +2219,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    mvn w10, w8
 ; -O0:    cas w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2246,7 +2235,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casa w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2263,7 +2251,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casl w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2280,7 +2267,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casal w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2297,7 +2283,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casal w8, w10, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2314,7 +2299,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    mvn x10, x8
 ; -O0:    cas x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    and x10, x8, x1
@@ -2331,7 +2315,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    mvn x10, x8
 ; -O0:    casa x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    and x10, x8, x1
@@ -2348,7 +2331,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    mvn x10, x8
 ; -O0:    casl x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    and x10, x8, x1
@@ -2365,7 +2347,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    mvn x10, x8
 ; -O0:    casal x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    and x10, x8, x1
@@ -2382,7 +2363,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    mvn x10, x8
 ; -O0:    casal x8, x10, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    and x10, x8, x1
@@ -2514,7 +2494,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    mvn w10, w8
 ; -O0:    casb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2531,7 +2510,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casab w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2548,7 +2526,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    caslb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    and w10, w8, w1
@@ -2565,7 +2542,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2582,7 +2558,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    mvn w10, w8
 ; -O0:    casalb w8, w10, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    and w10, w8, w1

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-v8a.ll
@@ -9,7 +9,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -24,7 +23,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -39,7 +37,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -54,7 +51,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -69,7 +65,6 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -84,7 +79,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
 ; -O1:    ldxrh w0, [x8]
@@ -99,7 +93,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acquire:
 ; -O1:    ldaxrh w0, [x8]
@@ -114,7 +107,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_release:
 ; -O1:    ldxrh w0, [x8]
@@ -129,7 +121,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w0, [x8]
@@ -144,7 +135,6 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w0, [x8]
@@ -159,7 +149,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O1:    ldxr w0, [x8]
@@ -174,7 +163,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O1:    ldaxr w0, [x8]
@@ -189,7 +177,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O1:    ldxr w0, [x8]
@@ -204,7 +191,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O1:    ldaxr w0, [x8]
@@ -219,7 +205,6 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O1:    ldaxr w0, [x8]
@@ -234,7 +219,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -249,7 +233,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -264,7 +247,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -279,7 +261,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -294,7 +275,6 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -394,7 +374,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -409,7 +388,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -424,7 +402,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -439,7 +416,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -454,7 +430,6 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -610,7 +585,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -627,7 +601,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -644,7 +617,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -661,7 +633,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -678,7 +649,6 @@ define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -695,7 +665,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -712,7 +681,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -729,7 +697,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -746,7 +713,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -763,7 +729,6 @@ define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -780,7 +745,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -797,7 +761,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -814,7 +777,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -831,7 +793,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -848,7 +809,6 @@ define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -865,7 +825,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -882,7 +841,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -899,7 +857,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -916,7 +873,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -933,7 +889,6 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1045,7 +1000,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1062,7 +1016,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1079,7 +1032,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1096,7 +1048,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1113,7 +1064,6 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1375,7 +1325,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1392,7 +1341,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1409,7 +1357,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1426,7 +1373,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1443,7 +1389,6 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1460,7 +1405,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1477,7 +1421,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1494,7 +1437,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1511,7 +1453,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1528,7 +1469,6 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1545,7 +1485,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1562,7 +1501,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1579,7 +1517,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1596,7 +1533,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1613,7 +1549,6 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1630,7 +1565,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -1647,7 +1581,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -1664,7 +1597,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -1681,7 +1613,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -1698,7 +1629,6 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1810,7 +1740,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1827,7 +1756,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1844,7 +1772,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1861,7 +1788,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1878,7 +1804,6 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2140,7 +2065,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2157,7 +2081,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2174,7 +2097,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2191,7 +2113,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2208,7 +2129,6 @@ define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2225,7 +2145,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2242,7 +2161,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2259,7 +2177,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2276,7 +2193,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2293,7 +2209,6 @@ define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2310,7 +2225,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2327,7 +2241,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2344,7 +2257,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2361,7 +2273,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2378,7 +2289,6 @@ define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2395,7 +2305,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2412,7 +2321,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2429,7 +2337,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2446,7 +2353,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2463,7 +2369,6 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2585,7 +2490,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2602,7 +2506,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2619,7 +2522,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2636,7 +2538,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2653,7 +2554,6 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2926,7 +2826,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2945,7 +2844,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2964,7 +2862,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2983,7 +2880,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3002,7 +2898,6 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3021,7 +2916,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3040,7 +2934,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3059,7 +2952,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3078,7 +2970,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3097,7 +2988,6 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3116,7 +3006,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3135,7 +3024,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -3154,7 +3042,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -3173,7 +3060,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -3192,7 +3078,6 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -3211,7 +3096,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -3230,7 +3114,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -3249,7 +3132,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -3268,7 +3150,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -3287,7 +3168,6 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -3431,7 +3311,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3450,7 +3329,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3469,7 +3347,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3488,7 +3365,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3507,7 +3383,6 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3830,7 +3705,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3847,7 +3721,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3864,7 +3737,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3881,7 +3753,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3898,7 +3769,6 @@ define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3915,7 +3785,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3932,7 +3801,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3949,7 +3817,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3966,7 +3833,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3983,7 +3849,6 @@ define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4000,7 +3865,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4017,7 +3881,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4034,7 +3897,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4051,7 +3913,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4068,7 +3929,6 @@ define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4085,7 +3945,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4102,7 +3961,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4119,7 +3977,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4136,7 +3993,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4153,7 +4009,6 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4275,7 +4130,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4292,7 +4146,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4309,7 +4162,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4326,7 +4178,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4343,7 +4194,6 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4615,7 +4465,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4632,7 +4481,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4649,7 +4497,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4666,7 +4513,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4683,7 +4529,6 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4700,7 +4545,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -4717,7 +4561,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -4734,7 +4577,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -4751,7 +4593,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -4768,7 +4609,6 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4785,7 +4625,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4802,7 +4641,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4819,7 +4657,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4836,7 +4673,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4853,7 +4689,6 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4870,7 +4705,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4887,7 +4721,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4904,7 +4737,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4921,7 +4753,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4938,7 +4769,6 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5060,7 +4890,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -5077,7 +4906,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -5094,7 +4922,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -5111,7 +4938,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -5128,7 +4954,6 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -5402,7 +5227,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5423,7 +5247,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5444,7 +5267,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5465,7 +5287,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5486,7 +5307,6 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5507,7 +5327,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5528,7 +5347,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5549,7 +5367,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5570,7 +5387,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5591,7 +5407,6 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5611,7 +5426,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5630,7 +5444,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5649,7 +5462,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5668,7 +5480,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5687,7 +5498,6 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5706,7 +5516,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5725,7 +5534,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5744,7 +5552,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5763,7 +5570,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5782,7 +5588,6 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5917,7 +5722,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5938,7 +5742,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5959,7 +5762,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5980,7 +5782,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6001,7 +5802,6 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6327,7 +6127,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6348,7 +6147,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6369,7 +6167,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6390,7 +6187,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6411,7 +6207,6 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6432,7 +6227,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -6453,7 +6247,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -6474,7 +6267,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -6495,7 +6287,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -6516,7 +6307,6 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxth
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -6536,7 +6326,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6555,7 +6344,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6574,7 +6362,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6593,7 +6380,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6612,7 +6398,6 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6631,7 +6416,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6650,7 +6434,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6669,7 +6452,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6688,7 +6470,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6707,7 +6488,6 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6842,7 +6622,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6863,7 +6642,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6884,7 +6662,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6905,7 +6682,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6926,7 +6702,6 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w9, uxtb
 ; -O0:    stlxrb w10, w12, [x11]
 ; -O0:    subs w9, w8, w9, uxtb
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -7252,7 +7027,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7273,7 +7047,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7294,7 +7067,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7315,7 +7087,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7336,7 +7107,6 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -7357,7 +7127,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -7378,7 +7147,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -7399,7 +7167,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -7420,7 +7187,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -7441,7 +7207,6 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -7461,7 +7226,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -7480,7 +7244,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -7499,7 +7262,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -7518,7 +7280,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -7537,7 +7298,6 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -7556,7 +7316,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7575,7 +7334,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7594,7 +7352,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7613,7 +7370,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7632,7 +7388,6 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7767,7 +7522,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7788,7 +7542,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7809,7 +7562,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7830,7 +7582,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7851,7 +7602,6 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8177,7 +7927,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8198,7 +7947,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8219,7 +7967,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8240,7 +7987,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8261,7 +8007,6 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8282,7 +8027,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -8303,7 +8047,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -8324,7 +8067,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -8345,7 +8087,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -8366,7 +8107,6 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    cmp w8, w12, uxth
 ; -O0:    stlxrh w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -8386,7 +8126,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -8405,7 +8144,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -8424,7 +8162,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -8443,7 +8180,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -8462,7 +8198,6 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -8481,7 +8216,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -8500,7 +8234,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -8519,7 +8252,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -8538,7 +8270,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -8557,7 +8288,6 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
 ; -O0:    subs x9, x8, x9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -8692,7 +8422,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8713,7 +8442,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8734,7 +8462,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8755,7 +8482,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8776,7 +8502,6 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    cmp w8, w12, uxtb
 ; -O0:    stlxrb w10, w13, [x11]
 ; -O0:    subs w9, w8, w9
-; -O0:    subs w9, w9, #1
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-v8a_fp.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-v8a_fp.ll
@@ -5,11 +5,10 @@
 
 define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -20,11 +19,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fadd_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -35,11 +33,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -50,11 +47,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -65,11 +61,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -82,11 +77,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -101,11 +95,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -120,11 +113,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -139,11 +131,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -158,11 +149,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -175,11 +165,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_monotonic:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -190,11 +179,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fadd_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_acquire:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -205,11 +193,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_release:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -220,11 +207,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_acq_rel:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -235,11 +221,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_seq_cst:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -250,11 +235,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_monotonic:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -265,11 +249,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fadd_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_acquire:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -280,11 +263,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_release:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -295,11 +277,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_acq_rel:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -310,11 +291,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_seq_cst:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -500,11 +480,10 @@ define dso_local double @atomicrmw_fadd_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -515,11 +494,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -530,11 +508,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -545,11 +522,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -560,11 +536,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -577,11 +552,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -596,11 +570,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -615,11 +588,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -634,11 +606,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -653,11 +624,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -670,11 +640,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_monotonic:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -685,11 +654,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acquire:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -700,11 +668,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_release:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -715,11 +682,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -730,11 +696,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -745,11 +710,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_monotonic:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -760,11 +724,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acquire:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -775,11 +738,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_release:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -790,11 +752,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -805,11 +766,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -995,11 +955,10 @@ define dso_local double @atomicrmw_fsub_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1010,11 +969,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fmax_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1025,11 +983,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1040,11 +997,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1055,11 +1011,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1072,11 +1027,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -1091,11 +1045,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -1110,11 +1063,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -1129,11 +1081,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -1148,11 +1099,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -1165,11 +1115,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_monotonic:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1180,11 +1129,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fmax_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_acquire:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1195,11 +1143,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_release:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1210,11 +1157,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_acq_rel:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1225,11 +1171,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_seq_cst:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1240,11 +1185,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_monotonic:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -1255,11 +1199,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fmax_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_acquire:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -1270,11 +1213,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_release:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -1285,11 +1227,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_acq_rel:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -1300,11 +1241,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_seq_cst:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -1490,11 +1430,10 @@ define dso_local double @atomicrmw_fmax_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1505,11 +1444,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fmin_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1520,11 +1458,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1535,11 +1472,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1550,11 +1486,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1567,11 +1502,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_monotonic(ptr %ptr, bfloa
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -1586,11 +1520,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acquire(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -1605,11 +1538,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_release(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -1624,11 +1556,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -1643,11 +1574,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -1660,11 +1590,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_monotonic:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1675,11 +1604,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fmin_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_acquire:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1690,11 +1618,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_release:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1705,11 +1632,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_acq_rel:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1720,11 +1646,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_seq_cst:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1735,11 +1660,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_monotonic:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -1750,11 +1674,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fmin_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_acquire:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -1765,11 +1688,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_release:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -1780,11 +1702,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_acq_rel:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -1795,11 +1716,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_seq_cst:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -1985,11 +1905,10 @@ define dso_local double @atomicrmw_fmin_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2000,11 +1919,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_monotonic(ptr %ptr, half 
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2015,11 +1933,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_acquire(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2030,11 +1947,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_release(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2045,11 +1961,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_acq_rel(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2062,11 +1977,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_monotonic(ptr %ptr, b
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -2081,11 +1995,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_acquire(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -2100,11 +2013,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_release(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -2119,11 +2031,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_acq_rel(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -2138,11 +2049,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -2155,11 +2065,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_monotonic:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2170,11 +2079,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_monotonic(ptr %ptr, flo
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_acquire:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2185,11 +2093,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_acquire(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_release:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2200,11 +2107,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_release(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_acq_rel:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2215,11 +2121,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_acq_rel(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_seq_cst:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2230,11 +2135,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_seq_cst(ptr %ptr, float
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_monotonic:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -2245,11 +2149,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_monotonic(ptr %ptr, d
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_acquire:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -2260,11 +2163,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_acquire(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_release:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -2275,11 +2177,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_release(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_acq_rel:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -2290,11 +2191,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_acq_rel(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_seq_cst:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -2480,11 +2380,10 @@ define dso_local double @atomicrmw_fmaximum_double_unaligned_seq_cst(ptr %ptr, d
 
 define dso_local half @atomicrmw_fminimum_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2495,11 +2394,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_monotonic(ptr %ptr, half 
 
 define dso_local half @atomicrmw_fminimum_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2510,11 +2408,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_acquire(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2525,11 +2422,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_release(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2540,11 +2436,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_acq_rel(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2557,11 +2452,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_monotonic(ptr %ptr, b
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_monotonic:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -2576,11 +2470,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_acquire(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_acquire:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -2595,11 +2488,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_release(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_release:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -2614,11 +2506,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_acq_rel(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_acq_rel:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -2633,11 +2524,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_seq_cst:
 ; -O0:    add w8, w8, w9
 ; -O0:    add w8, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
 ; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w9, w8, uxth
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -2650,11 +2540,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 
 define dso_local float @atomicrmw_fminimum_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_monotonic:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2665,11 +2554,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_monotonic(ptr %ptr, flo
 
 define dso_local float @atomicrmw_fminimum_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_acquire:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2680,11 +2568,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_acquire(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_release:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2695,11 +2582,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_release(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_acq_rel:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2710,11 +2596,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_acq_rel(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_seq_cst:
-; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
 ; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
-; -O0:    subs w8, w8, #1
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2725,11 +2610,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_seq_cst(ptr %ptr, float
 
 define dso_local double @atomicrmw_fminimum_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_monotonic:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -2740,11 +2624,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_monotonic(ptr %ptr, d
 
 define dso_local double @atomicrmw_fminimum_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_acquire:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -2755,11 +2638,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_acquire(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_release:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -2770,11 +2652,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_release(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_acq_rel:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -2785,11 +2666,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_acq_rel(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_seq_cst:
-; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
 ; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
-; -O0:    subs w8, w8, #1
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]

--- a/llvm/test/CodeGen/AArch64/atomicrmw-O0.ll
+++ b/llvm/test/CodeGen/AArch64/atomicrmw-O0.ll
@@ -32,9 +32,7 @@ define i8 @test_rmw_add_8(ptr %dst)   {
 ; NOLSE-NEXT:  .LBB0_4: // %atomicrmw.start
 ; NOLSE-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; NOLSE-NEXT:    subs w9, w8, w9, uxtb
-; NOLSE-NEXT:    cset w9, eq
 ; NOLSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; NOLSE-NEXT:    subs w9, w9, #1
 ; NOLSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; NOLSE-NEXT:    b.ne .LBB0_1
 ; NOLSE-NEXT:    b .LBB0_5
@@ -45,7 +43,7 @@ define i8 @test_rmw_add_8(ptr %dst)   {
 ;
 ; LSE-LABEL: test_rmw_add_8:
 ; LSE:       // %bb.0: // %entry
-; LSE-NEXT:    mov w8, #1
+; LSE-NEXT:    mov w8, #1 // =0x1
 ; LSE-NEXT:    ldaddalb w8, w0, [x0]
 ; LSE-NEXT:    ret
 entry:
@@ -81,9 +79,7 @@ define i16 @test_rmw_add_16(ptr %dst)   {
 ; NOLSE-NEXT:  .LBB1_4: // %atomicrmw.start
 ; NOLSE-NEXT:    // in Loop: Header=BB1_1 Depth=1
 ; NOLSE-NEXT:    subs w9, w8, w9, uxth
-; NOLSE-NEXT:    cset w9, eq
 ; NOLSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; NOLSE-NEXT:    subs w9, w9, #1
 ; NOLSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; NOLSE-NEXT:    b.ne .LBB1_1
 ; NOLSE-NEXT:    b .LBB1_5
@@ -94,7 +90,7 @@ define i16 @test_rmw_add_16(ptr %dst)   {
 ;
 ; LSE-LABEL: test_rmw_add_16:
 ; LSE:       // %bb.0: // %entry
-; LSE-NEXT:    mov w8, #1
+; LSE-NEXT:    mov w8, #1 // =0x1
 ; LSE-NEXT:    ldaddalh w8, w0, [x0]
 ; LSE-NEXT:    ret
 entry:
@@ -130,9 +126,7 @@ define i32 @test_rmw_add_32(ptr %dst)   {
 ; NOLSE-NEXT:  .LBB2_4: // %atomicrmw.start
 ; NOLSE-NEXT:    // in Loop: Header=BB2_1 Depth=1
 ; NOLSE-NEXT:    subs w9, w8, w9
-; NOLSE-NEXT:    cset w9, eq
 ; NOLSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; NOLSE-NEXT:    subs w9, w9, #1
 ; NOLSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; NOLSE-NEXT:    b.ne .LBB2_1
 ; NOLSE-NEXT:    b .LBB2_5
@@ -143,7 +137,7 @@ define i32 @test_rmw_add_32(ptr %dst)   {
 ;
 ; LSE-LABEL: test_rmw_add_32:
 ; LSE:       // %bb.0: // %entry
-; LSE-NEXT:    mov w8, #1
+; LSE-NEXT:    mov w8, #1 // =0x1
 ; LSE-NEXT:    ldaddal w8, w0, [x0]
 ; LSE-NEXT:    ret
 entry:
@@ -179,9 +173,7 @@ define i64 @test_rmw_add_64(ptr %dst)   {
 ; NOLSE-NEXT:  .LBB3_4: // %atomicrmw.start
 ; NOLSE-NEXT:    // in Loop: Header=BB3_1 Depth=1
 ; NOLSE-NEXT:    subs x9, x8, x9
-; NOLSE-NEXT:    cset w9, eq
 ; NOLSE-NEXT:    str x8, [sp, #8] // 8-byte Folded Spill
-; NOLSE-NEXT:    subs w9, w9, #1
 ; NOLSE-NEXT:    str x8, [sp, #24] // 8-byte Folded Spill
 ; NOLSE-NEXT:    b.ne .LBB3_1
 ; NOLSE-NEXT:    b .LBB3_5
@@ -192,7 +184,7 @@ define i64 @test_rmw_add_64(ptr %dst)   {
 ;
 ; LSE-LABEL: test_rmw_add_64:
 ; LSE:       // %bb.0: // %entry
-; LSE-NEXT:    mov w8, #1
+; LSE-NEXT:    mov w8, #1 // =0x1
 ; LSE-NEXT:    // kill: def $x8 killed $w8
 ; LSE-NEXT:    ldaddal x8, x0, [x0]
 ; LSE-NEXT:    ret
@@ -326,9 +318,7 @@ define i8 @test_rmw_nand_8(ptr %dst)   {
 ; NOLSE-NEXT:  .LBB5_4: // %atomicrmw.start
 ; NOLSE-NEXT:    // in Loop: Header=BB5_1 Depth=1
 ; NOLSE-NEXT:    subs w9, w8, w9, uxtb
-; NOLSE-NEXT:    cset w9, eq
 ; NOLSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; NOLSE-NEXT:    subs w9, w9, #1
 ; NOLSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; NOLSE-NEXT:    b.ne .LBB5_1
 ; NOLSE-NEXT:    b .LBB5_5
@@ -354,9 +344,7 @@ define i8 @test_rmw_nand_8(ptr %dst)   {
 ; LSE-NEXT:    mov w8, w9
 ; LSE-NEXT:    casalb w8, w10, [x11]
 ; LSE-NEXT:    subs w9, w8, w9, uxtb
-; LSE-NEXT:    cset w9, eq
 ; LSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; LSE-NEXT:    subs w9, w9, #1
 ; LSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; LSE-NEXT:    b.ne .LBB5_1
 ; LSE-NEXT:    b .LBB5_2
@@ -398,9 +386,7 @@ define i16 @test_rmw_nand_16(ptr %dst)   {
 ; NOLSE-NEXT:  .LBB6_4: // %atomicrmw.start
 ; NOLSE-NEXT:    // in Loop: Header=BB6_1 Depth=1
 ; NOLSE-NEXT:    subs w9, w8, w9, uxth
-; NOLSE-NEXT:    cset w9, eq
 ; NOLSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; NOLSE-NEXT:    subs w9, w9, #1
 ; NOLSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; NOLSE-NEXT:    b.ne .LBB6_1
 ; NOLSE-NEXT:    b .LBB6_5
@@ -426,9 +412,7 @@ define i16 @test_rmw_nand_16(ptr %dst)   {
 ; LSE-NEXT:    mov w8, w9
 ; LSE-NEXT:    casalh w8, w10, [x11]
 ; LSE-NEXT:    subs w9, w8, w9, uxth
-; LSE-NEXT:    cset w9, eq
 ; LSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; LSE-NEXT:    subs w9, w9, #1
 ; LSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; LSE-NEXT:    b.ne .LBB6_1
 ; LSE-NEXT:    b .LBB6_2
@@ -470,9 +454,7 @@ define i32 @test_rmw_nand_32(ptr %dst)   {
 ; NOLSE-NEXT:  .LBB7_4: // %atomicrmw.start
 ; NOLSE-NEXT:    // in Loop: Header=BB7_1 Depth=1
 ; NOLSE-NEXT:    subs w9, w8, w9
-; NOLSE-NEXT:    cset w9, eq
 ; NOLSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; NOLSE-NEXT:    subs w9, w9, #1
 ; NOLSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; NOLSE-NEXT:    b.ne .LBB7_1
 ; NOLSE-NEXT:    b .LBB7_5
@@ -498,9 +480,7 @@ define i32 @test_rmw_nand_32(ptr %dst)   {
 ; LSE-NEXT:    mov w8, w9
 ; LSE-NEXT:    casal w8, w10, [x11]
 ; LSE-NEXT:    subs w9, w8, w9
-; LSE-NEXT:    cset w9, eq
 ; LSE-NEXT:    str w8, [sp, #12] // 4-byte Folded Spill
-; LSE-NEXT:    subs w9, w9, #1
 ; LSE-NEXT:    str w8, [sp, #28] // 4-byte Folded Spill
 ; LSE-NEXT:    b.ne .LBB7_1
 ; LSE-NEXT:    b .LBB7_2
@@ -545,9 +525,7 @@ define i64 @test_rmw_nand_64(ptr %dst)   {
 ; NOLSE-NEXT:  .LBB8_4: // %atomicrmw.start
 ; NOLSE-NEXT:    // in Loop: Header=BB8_1 Depth=1
 ; NOLSE-NEXT:    subs x9, x8, x9
-; NOLSE-NEXT:    cset w9, eq
 ; NOLSE-NEXT:    str x8, [sp, #8] // 8-byte Folded Spill
-; NOLSE-NEXT:    subs w9, w9, #1
 ; NOLSE-NEXT:    str x8, [sp, #24] // 8-byte Folded Spill
 ; NOLSE-NEXT:    b.ne .LBB8_1
 ; NOLSE-NEXT:    b .LBB8_5
@@ -576,9 +554,7 @@ define i64 @test_rmw_nand_64(ptr %dst)   {
 ; LSE-NEXT:    mov x8, x9
 ; LSE-NEXT:    casal x8, x10, [x11]
 ; LSE-NEXT:    subs x9, x8, x9
-; LSE-NEXT:    cset w9, eq
 ; LSE-NEXT:    str x8, [sp, #8] // 8-byte Folded Spill
-; LSE-NEXT:    subs w9, w9, #1
 ; LSE-NEXT:    str x8, [sp, #24] // 8-byte Folded Spill
 ; LSE-NEXT:    b.ne .LBB8_1
 ; LSE-NEXT:    b .LBB8_2
@@ -613,7 +589,7 @@ define i128 @test_rmw_nand_128(ptr %dst)   {
 ; NOLSE-NEXT:    // implicit-def: $x8
 ; NOLSE-NEXT:    mov w8, w10
 ; NOLSE-NEXT:    orr x14, x8, #0xfffffffffffffffe
-; NOLSE-NEXT:    mov x15, #-1
+; NOLSE-NEXT:    mov x15, #-1 // =0xffffffffffffffff
 ; NOLSE-NEXT:  .LBB9_2: // %atomicrmw.start
 ; NOLSE-NEXT:    // Parent Loop BB9_1 Depth=1
 ; NOLSE-NEXT:    // => This Inner Loop Header: Depth=2
@@ -672,7 +648,7 @@ define i128 @test_rmw_nand_128(ptr %dst)   {
 ; LSE-NEXT:    // implicit-def: $x9
 ; LSE-NEXT:    mov w9, w12
 ; LSE-NEXT:    orr x2, x9, #0xfffffffffffffffe
-; LSE-NEXT:    mov x9, #-1
+; LSE-NEXT:    mov x9, #-1 // =0xffffffffffffffff
 ; LSE-NEXT:    // kill: def $x2 killed $x2 def $x2_x3
 ; LSE-NEXT:    mov x3, x9
 ; LSE-NEXT:    caspal x0, x1, x2, x3, [x8]

--- a/llvm/test/CodeGen/AArch64/i128_with_overflow.ll
+++ b/llvm/test/CodeGen/AArch64/i128_with_overflow.ll
@@ -10,9 +10,7 @@ define i128 @test_uadd_i128(i128 noundef %x, i128 noundef %y) {
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    adds x0, x0, x2
 ; CHECK-SD-NEXT:    adcs x1, x1, x3
-; CHECK-SD-NEXT:    cset w8, hs
-; CHECK-SD-NEXT:    cmp w8, #1
-; CHECK-SD-NEXT:    b.ne .LBB0_2
+; CHECK-SD-NEXT:    b.lo .LBB0_2
 ; CHECK-SD-NEXT:  // %bb.1: // %if.then
 ; CHECK-SD-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
 ; CHECK-SD-NEXT:    .cfi_def_cfa_offset 16
@@ -66,9 +64,7 @@ define i128 @test_sadd_i128(i128 noundef %x, i128 noundef %y) {
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    adds x0, x0, x2
 ; CHECK-SD-NEXT:    adcs x1, x1, x3
-; CHECK-SD-NEXT:    cset w8, vs
-; CHECK-SD-NEXT:    cmp w8, #1
-; CHECK-SD-NEXT:    b.ne .LBB1_2
+; CHECK-SD-NEXT:    b.vc .LBB1_2
 ; CHECK-SD-NEXT:  // %bb.1: // %if.then
 ; CHECK-SD-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
 ; CHECK-SD-NEXT:    .cfi_def_cfa_offset 16
@@ -122,9 +118,7 @@ define i128 @test_usub_i128(i128 noundef %x, i128 noundef %y) {
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    subs x0, x0, x2
 ; CHECK-SD-NEXT:    sbcs x1, x1, x3
-; CHECK-SD-NEXT:    cset w8, lo
-; CHECK-SD-NEXT:    cmp w8, #1
-; CHECK-SD-NEXT:    b.ne .LBB2_2
+; CHECK-SD-NEXT:    b.hs .LBB2_2
 ; CHECK-SD-NEXT:  // %bb.1: // %if.then
 ; CHECK-SD-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
 ; CHECK-SD-NEXT:    .cfi_def_cfa_offset 16
@@ -178,9 +172,7 @@ define i128 @test_ssub_i128(i128 noundef %x, i128 noundef %y) {
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    subs x0, x0, x2
 ; CHECK-SD-NEXT:    sbcs x1, x1, x3
-; CHECK-SD-NEXT:    cset w8, vs
-; CHECK-SD-NEXT:    cmp w8, #1
-; CHECK-SD-NEXT:    b.ne .LBB3_2
+; CHECK-SD-NEXT:    b.vc .LBB3_2
 ; CHECK-SD-NEXT:  // %bb.1: // %if.then
 ; CHECK-SD-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
 ; CHECK-SD-NEXT:    .cfi_def_cfa_offset 16


### PR DESCRIPTION
This folds away subs(csel(1, 0, cc)) from brcond, that can be produced in certain places from compares that are not already subs (like adc/sbc generated from i128 add_with_overflow intrinsics).