### PR TITLE
[clang-format] Handle bit-field colon of non-numeric-constant size

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1411,7 +1411,9 @@ private:
         assert(Prev);
         if (Prev->isPointerOrReference())
           Prev->setFinalizedType(TT_PointerOrReference);
-      } else if (CurrentToken && CurrentToken->is(tok::numeric_constant)) {
+      } else if ((CurrentToken && CurrentToken->is(tok::numeric_constant)) ||
+                 (Prev && Prev->is(TT_StartOfName) && !Scopes.empty() &&
+                  Scopes.back() == ST_Class)) {
         Tok->setType(TT_BitFieldColon);
       } else if (Contexts.size() == 1 &&
                  !Line.getFirstNonComment()->isOneOf(tok::kw_enum, tok::kw_case,

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -4076,6 +4076,14 @@ TEST_F(TokenAnnotatorTest, EnumColonInTypedef) {
   EXPECT_TOKEN(Tokens[2], tok::colon, TT_Unknown); // Not TT_InheritanceColon.
 }
 
+TEST_F(TokenAnnotatorTest, BitFieldColon) {
+  auto Tokens = annotate("class C {\n"
+                         "  int f : SIZE;\n"
+                         "};");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_BitFieldColon);
+}
+
 } // namespace
 } // namespace format
 } // namespace clang


### PR DESCRIPTION
Fix #142050