### PR TITLE
[flang] Disable noalias by default

### DIFF
--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -15,9 +15,6 @@
 /// Force setting the no-alias attribute on fuction arguments when possible.
 static llvm::cl::opt<bool> forceNoAlias("force-no-alias", llvm::cl::Hidden,
                                         llvm::cl::init(false));
-/// Force setting the no-capture attribute on fuction arguments when possible.
-static llvm::cl::opt<bool> forceNoCapture("force-no-capture", llvm::cl::Hidden,
-                                          llvm::cl::init(false));
 
 namespace fir {
 
@@ -361,7 +358,7 @@ void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm,
   // TODO: re-enable setNoAlias by default (when optimizing for speed) once
   // function specialization is fixed.
   bool setNoAlias = forceNoAlias;
-  bool setNoCapture = forceNoCapture;
+  bool setNoCapture = config.OptLevel.isOptimizingForSpeed();
 
   pm.addPass(fir::createFunctionAttr(
       {framePointerKind, config.InstrumentFunctionEntry,

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -10,6 +10,14 @@
 /// common to flang and the test tools.
 
 #include "flang/Optimizer/Passes/Pipelines.h"
+#include "llvm/Support/CommandLine.h"
+
+/// Force setting the no-alias attribute on fuction arguments when possible.
+static llvm::cl::opt<bool> forceNoAlias("force-no-alias", llvm::cl::Hidden,
+                                        llvm::cl::init(false));
+/// Force setting the no-capture attribute on fuction arguments when possible.
+static llvm::cl::opt<bool> forceNoCapture("force-no-capture", llvm::cl::Hidden,
+                                          llvm::cl::init(false));
 
 namespace fir {
 
@@ -350,9 +358,10 @@ void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm,
   else
     framePointerKind = mlir::LLVM::framePointerKind::FramePointerKind::None;
 
-  bool setNoCapture = false, setNoAlias = false;
-  if (config.OptLevel.isOptimizingForSpeed())
-    setNoCapture = setNoAlias = true;
+  // TODO: re-enable setNoAlias by default (when optimizing for speed) once
+  // function specialization is fixed.
+  bool setNoAlias = forceNoAlias;
+  bool setNoCapture = forceNoCapture;
 
   pm.addPass(fir::createFunctionAttr(
       {framePointerKind, config.InstrumentFunctionEntry,

--- a/flang/test/Fir/polymorphic.fir
+++ b/flang/test/Fir/polymorphic.fir
@@ -1,4 +1,4 @@
-// RUN: tco %s | FileCheck %s
+// RUN: tco --force-no-capture %s | FileCheck %s
 
 // Test code gen for unlimited polymorphic type descriptor.
 

--- a/flang/test/Fir/polymorphic.fir
+++ b/flang/test/Fir/polymorphic.fir
@@ -1,4 +1,4 @@
-// RUN: tco --force-no-capture %s | FileCheck %s
+// RUN: tco %s | FileCheck %s
 
 // Test code gen for unlimited polymorphic type descriptor.
 

--- a/flang/test/Fir/struct-passing-x86-64-byval.fir
+++ b/flang/test/Fir/struct-passing-x86-64-byval.fir
@@ -1,7 +1,7 @@
 // Test X86-64 ABI rewrite of struct passed by value (BIND(C), VALUE derived types).
 // This test test cases where the struct must be passed on the stack according
 // to the System V ABI.
-// RUN: tco --target=x86_64-unknown-linux-gnu --force-no-capture --force-no-alias %s | FileCheck %s
+// RUN: tco --target=x86_64-unknown-linux-gnu --force-no-alias %s | FileCheck %s
 
 module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
 

--- a/flang/test/Fir/struct-passing-x86-64-byval.fir
+++ b/flang/test/Fir/struct-passing-x86-64-byval.fir
@@ -1,7 +1,7 @@
 // Test X86-64 ABI rewrite of struct passed by value (BIND(C), VALUE derived types).
 // This test test cases where the struct must be passed on the stack according
 // to the System V ABI.
-// RUN: tco --target=x86_64-unknown-linux-gnu %s | FileCheck %s
+// RUN: tco --target=x86_64-unknown-linux-gnu --force-no-capture --force-no-alias %s | FileCheck %s
 
 module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
 

--- a/flang/test/Fir/target-rewrite-complex-10-x86.fir
+++ b/flang/test/Fir/target-rewrite-complex-10-x86.fir
@@ -1,6 +1,6 @@
 // Test COMPLEX(10) passing and returning on X86
 // RUN: fir-opt --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=AMD64
-// RUN: tco -target="x86_64-unknown-linux-gnu" --force-no-alias --force-no-capture %s | FileCheck %s --check-prefix=AMD64_LLVM
+// RUN: tco -target="x86_64-unknown-linux-gnu" --force-no-alias %s | FileCheck %s --check-prefix=AMD64_LLVM
 
 module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
 

--- a/flang/test/Fir/target-rewrite-complex-10-x86.fir
+++ b/flang/test/Fir/target-rewrite-complex-10-x86.fir
@@ -1,6 +1,6 @@
 // Test COMPLEX(10) passing and returning on X86
 // RUN: fir-opt --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=AMD64
-// RUN: tco -target="x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=AMD64_LLVM
+// RUN: tco -target="x86_64-unknown-linux-gnu" --force-no-alias --force-no-capture %s | FileCheck %s --check-prefix=AMD64_LLVM
 
 module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
 

--- a/flang/test/Fir/target.fir
+++ b/flang/test/Fir/target.fir
@@ -1,4 +1,4 @@
-// RUN: tco --target=i386-unknown-linux-gnu --force-no-alias --force-no-capture %s | FileCheck %s --check-prefix=I32
+// RUN: tco --target=i386-unknown-linux-gnu --force-no-alias %s | FileCheck %s --check-prefix=I32
 // RUN: tco --target=x86_64-unknown-linux-gnu %s | FileCheck %s --check-prefix=X64
 // RUN: tco --target=aarch64-unknown-linux-gnu %s | FileCheck %s --check-prefix=AARCH64
 // RUN: tco --target=powerpc64le-unknown-linux-gnu %s | FileCheck %s --check-prefix=PPC

--- a/flang/test/Fir/target.fir
+++ b/flang/test/Fir/target.fir
@@ -1,4 +1,4 @@
-// RUN: tco --target=i386-unknown-linux-gnu %s | FileCheck %s --check-prefix=I32
+// RUN: tco --target=i386-unknown-linux-gnu --force-no-alias --force-no-capture %s | FileCheck %s --check-prefix=I32
 // RUN: tco --target=x86_64-unknown-linux-gnu %s | FileCheck %s --check-prefix=X64
 // RUN: tco --target=aarch64-unknown-linux-gnu %s | FileCheck %s --check-prefix=AARCH64
 // RUN: tco --target=powerpc64le-unknown-linux-gnu %s | FileCheck %s --check-prefix=PPC


### PR DESCRIPTION
With these enabled we see a 70% performance regression for exchange2_r on neoverse-v1 (aws graviton 3) using `-mcpu=native -Ofast -flto`. There is also a smaller regression on neoverse-v2.

This appears to be because function specialization is no longer kicking in during LTO for digits_2. This can be seen in the output executable: previously it contained specialized copies of the function with names like `_QMbrute_forcePdigits_2.specialized.4`. Now there are no names like this.

The bug is not in flang - instead in the function specialization pass - but due to the size of the regression I would like to request that this is disabled until function specialization has been fixed.