### PR TITLE
[lldb-dap][test] Fix DAP disassemble test

### DIFF
--- a/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
+++ b/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
@@ -2,13 +2,9 @@
 Test lldb-dap disassemble request
 """
 
-
-import dap_server
-from lldbsuite.test.decorators import *
-from lldbsuite.test.lldbtest import *
-from lldbsuite.test import lldbutil
+from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.lldbtest import line_number
 import lldbdap_testcase
-import os
 
 
 class TestDAP_disassemble(lldbdap_testcase.DAPTestCaseBase):
@@ -23,15 +19,23 @@ class TestDAP_disassemble(lldbdap_testcase.DAPTestCaseBase):
         self.set_source_breakpoints(source, [line_number(source, "// breakpoint 1")])
         self.continue_to_next_stop()
 
-        _, pc_assembly = self.disassemble(frameIndex=0)
-        self.assertIn("location", pc_assembly, "Source location missing.")
-        self.assertIn("instruction", pc_assembly, "Assembly instruction missing.")
+        insts_with_bp, pc_with_bp_assembly = self.disassemble(frameIndex=0)
+        no_bp = self.set_source_breakpoints(source, [])
+        self.assertEqual(len(no_bp), 0, "expect no breakpoints.")
+        self.assertIn(
+            "instruction", pc_with_bp_assembly, "Assembly instruction missing."
+        )
 
-        # The calling frame (qsort) is coming from a system library, as a result
-        # we should not have a source location.
-        _, qsort_assembly = self.disassemble(frameIndex=1)
-        self.assertNotIn("location", qsort_assembly, "Source location not expected.")
-        self.assertIn("instruction", pc_assembly, "Assembly instruction missing.")
+        # the disassembly instructions should be the same even if there is a breakpoint;
+        insts_no_bp, pc_no_bp_assembly = self.disassemble(frameIndex=0)
+        self.assertDictEqual(
+            insts_with_bp,
+            insts_no_bp,
+            "Expects instructions are the same after removing breakpoints.",
+        )
+        self.assertIn("instruction", pc_no_bp_assembly, "Assembly instruction missing.")
+
+        self.continue_to_exit()
 
     @skipIfWindows
     def test_disassemble_backwards(self):
@@ -74,3 +78,7 @@ class TestDAP_disassemble(lldbdap_testcase.DAPTestCaseBase):
             backwards_instructions,
             f"requested instruction should be preceeded by {backwards_instructions} instructions. Actual index: {frame_instruction_index}",
         )
+
+        # clear breakpoints
+        self.set_source_breakpoints(source, [])
+        self.continue_to_exit()

--- a/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
+++ b/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
@@ -16,18 +16,27 @@ class TestDAP_disassemble(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         source = "main.c"
-        self.set_source_breakpoints(source, [line_number(source, "// breakpoint 1")])
+        bp_line_no = line_number(source, "// breakpoint 1")
+        self.set_source_breakpoints(source, [bp_line_no])
         self.continue_to_next_stop()
 
         insts_with_bp, pc_with_bp_assembly = self.disassemble(frameIndex=0)
+        self.assertIn("location", pc_with_bp_assembly, "Source location missing.")
+        self.assertEqual(
+            pc_with_bp_assembly["line"], bp_line_no, "Expects the same line number"
+        )
         no_bp = self.set_source_breakpoints(source, [])
-        self.assertEqual(len(no_bp), 0, "expect no breakpoints.")
+        self.assertEqual(len(no_bp), 0, "Expects no breakpoints.")
         self.assertIn(
             "instruction", pc_with_bp_assembly, "Assembly instruction missing."
         )
 
-        # the disassembly instructions should be the same even if there is a breakpoint;
         insts_no_bp, pc_no_bp_assembly = self.disassemble(frameIndex=0)
+        self.assertIn("location", pc_no_bp_assembly, "Source location missing.")
+        self.assertEqual(
+            pc_with_bp_assembly["line"], bp_line_no, "Expects the same line number"
+        )
+        # the disassembly instructions should be the same with breakpoint and no breakpoint;
         self.assertDictEqual(
             insts_with_bp,
             insts_no_bp,

--- a/lldb/test/API/tools/lldb-dap/disassemble/main.c
+++ b/lldb/test/API/tools/lldb-dap/disassemble/main.c
@@ -6,9 +6,7 @@ int compare_ints(const void *a, const void *b) {
   int arg1 = *(const int *)a;
   int arg2 = *(const int *)b;
 
-  // breakpoint 1
-
-  if (arg1 < arg2)
+  if (arg1 < arg2) // breakpoint 1
     return -1;
   if (arg1 > arg2)
     return 1;


### PR DESCRIPTION
compare the instructions before and after setting breakpoint to make sure they are the same. 
Do not use the source location as it is not guaranteed to exist.