### PR TITLE
[LLDB] Remove redundant check in DemangledNameInfo::hasBasename

### DIFF
--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -71,8 +71,7 @@ struct DemangledNameInfo {
 
   /// Returns \c true if this object holds a valid basename range.
   bool hasBasename() const {
-    return BasenameRange.second > BasenameRange.first &&
-           BasenameRange.second > 0;
+    return BasenameRange.second > BasenameRange.first;
   }
 };
 


### PR DESCRIPTION
This patch removes a redundant check in DemangledNameInfo::hasBasename.

Since the start and end range are unsigned, if end > start, then end is always greater than 0.