### PR TITLE
[clang-reorder-fields] Support designated initializers

### DIFF
--- a/clang-tools-extra/clang-reorder-fields/CMakeLists.txt
+++ b/clang-tools-extra/clang-reorder-fields/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
 )
 
 add_clang_library(clangReorderFields STATIC
+  Designator.cpp
   ReorderFieldsAction.cpp
 
   DEPENDS

--- a/clang-tools-extra/clang-reorder-fields/Designator.cpp
+++ b/clang-tools-extra/clang-reorder-fields/Designator.cpp
@@ -1,0 +1,199 @@
+//===-- tools/extra/clang-reorder-fields/utils/Designator.cpp ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the definition of the DesignatorIter and Designators
+/// utility classes.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Designator.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Expr.h"
+
+namespace clang {
+namespace reorder_fields {
+
+DesignatorIter &DesignatorIter::operator++() {
+  assert(!isFinished() && "Iterator is already finished");
+  switch (Tag) {
+  case STRUCT:
+    if (StructIt.Record->isUnion()) {
+      // Union always finishes on first increment.
+      StructIt.Field = StructIt.Record->field_end();
+      Type = QualType();
+      break;
+    }
+    ++StructIt.Field;
+    if (StructIt.Field != StructIt.Record->field_end()) {
+      Type = StructIt.Field->getType();
+    } else {
+      Type = QualType();
+    }
+    break;
+  case ARRAY:
+    ++ArrayIt.Index;
+    break;
+  case ARRAY_RANGE:
+    ArrayIt.Index = ArrayRangeIt.End + 1;
+    ArrayIt.Size = ArrayRangeIt.Size;
+    Tag = ARRAY;
+    break;
+  }
+  return *this;
+}
+
+bool DesignatorIter::isFinished() {
+  switch (Tag) {
+  case STRUCT:
+    return StructIt.Field == StructIt.Record->field_end();
+  case ARRAY:
+    return ArrayIt.Index == ArrayIt.Size;
+  case ARRAY_RANGE:
+    return ArrayRangeIt.End == ArrayRangeIt.Size;
+  }
+  return false;
+}
+
+Designators::Designators(const DesignatedInitExpr *DIE, const InitListExpr *ILE,
+                         const ASTContext &Context) {
+  for (const auto &D : DIE->designators()) {
+    if (D.isFieldDesignator()) {
+      RecordDecl *DesignatorRecord = D.getFieldDecl()->getParent();
+      for (auto FieldIt = DesignatorRecord->field_begin();
+           FieldIt != DesignatorRecord->field_end(); ++FieldIt) {
+        if (*FieldIt == D.getFieldDecl()) {
+          DesignatorList.push_back(
+              {FieldIt->getType(), FieldIt, DesignatorRecord});
+          break;
+        }
+      }
+    } else {
+      const QualType CurrentType = DesignatorList.empty()
+                                       ? ILE->getType()
+                                       : DesignatorList.back().getType();
+      const ConstantArrayType *CAT =
+          Context.getAsConstantArrayType(CurrentType);
+      if (!CAT) {
+        // Non-constant-sized arrays are not supported.
+        DesignatorList.clear();
+        return;
+      }
+      if (D.isArrayDesignator()) {
+        DesignatorList.push_back({CAT->getElementType(),
+                                  DIE->getArrayIndex(D)
+                                      ->EvaluateKnownConstInt(Context)
+                                      .getZExtValue(),
+                                  CAT->getSize().getZExtValue()});
+      } else if (D.isArrayRangeDesignator()) {
+        DesignatorList.push_back({CAT->getElementType(),
+                                  DIE->getArrayRangeStart(D)
+                                      ->EvaluateKnownConstInt(Context)
+                                      .getZExtValue(),
+                                  DIE->getArrayRangeEnd(D)
+                                      ->EvaluateKnownConstInt(Context)
+                                      .getZExtValue(),
+                                  CAT->getSize().getZExtValue()});
+      } else {
+        llvm_unreachable("Unexpected designator kind");
+      }
+    }
+  }
+}
+
+bool Designators::increment(const InitListExpr *ILE, const Expr *Init,
+                            const ASTContext &Context) {
+  if (DesignatorList.empty()) {
+    // First field is not designated. Initialize to the first field or
+    // array index.
+    if (ILE->getType()->isArrayType()) {
+      const ConstantArrayType *CAT =
+          Context.getAsConstantArrayType(ILE->getType());
+      // Only constant size arrays are supported.
+      if (!CAT) {
+        DesignatorList.clear();
+        return false;
+      }
+      DesignatorList.push_back(
+          {CAT->getElementType(), 0, CAT->getSize().getZExtValue()});
+    } else {
+      const RecordDecl *DesignatorRD = ILE->getType()->getAsRecordDecl();
+      DesignatorList.push_back({DesignatorRD->field_begin()->getType(),
+                                DesignatorRD->field_begin(), DesignatorRD});
+    }
+  } else {
+    while (!DesignatorList.empty()) {
+      auto &CurrentDesignator = DesignatorList.back();
+      ++CurrentDesignator;
+      if (CurrentDesignator.isFinished()) {
+        DesignatorList.pop_back();
+        continue;
+      }
+      break;
+    }
+  }
+
+  // If the designator list is empty at this point, then there must be excess
+  // elements in the initializer list. They are not currently supported.
+  if (DesignatorList.empty())
+    return false;
+
+  // Check for missing braces. If the types don't match then there are
+  // missing braces.
+  while (true) {
+    const QualType T = DesignatorList.back().getType();
+    // If the types match, there are no missing braces.
+    if (Init->getType() == T)
+      break;
+
+    // If the current type is a struct, then get its first field.
+    if (T->isRecordType()) {
+      DesignatorList.push_back({T->getAsRecordDecl()->field_begin()->getType(),
+                                T->getAsRecordDecl()->field_begin(),
+                                T->getAsRecordDecl()});
+      continue;
+    }
+    // If the current type is an array, then get its first element.
+    if (T->isArrayType()) {
+      DesignatorList.push_back(
+          {Context.getAsArrayType(T)->getElementType(), 0,
+           Context.getAsConstantArrayType(T)->getSize().getZExtValue()});
+      continue;
+    }
+
+    // The initializer doesn't match the expected type. The initializer list is
+    // invalid.
+    return false;
+  }
+
+  return true;
+}
+
+std::string Designators::toString() const {
+  if (DesignatorList.empty())
+    return "";
+  std::string Designator = "";
+  for (auto &I : DesignatorList) {
+    switch (I.getTag()) {
+    case DesignatorIter::STRUCT:
+      Designator += "." + I.getStructIter()->getName().str();
+      break;
+    case DesignatorIter::ARRAY:
+      Designator += "[" + std::to_string(I.getArrayIndex()) + "]";
+      break;
+    case DesignatorIter::ARRAY_RANGE:
+      Designator += "[" + std::to_string(I.getArrayRangeStart()) + "..." +
+                    std::to_string(I.getArrayRangeEnd()) + "]";
+    }
+  }
+  Designator += " = ";
+  return Designator;
+}
+
+} // namespace reorder_fields
+} // namespace clang

--- a/clang-tools-extra/clang-reorder-fields/Designator.h
+++ b/clang-tools-extra/clang-reorder-fields/Designator.h
@@ -115,15 +115,19 @@ private:
 
 class Designators {
 public:
-  Designators() = default;
+  /// Initialize to the first member of the struct/array. Enters implicit
+  /// initializer lists until a type that matches Init is found.
+  Designators(const Expr *Init, const InitListExpr *ILE,
+              const ASTContext *Context);
+
+  /// Initialize to the designators of the given expression.
   Designators(const DesignatedInitExpr *DIE, const InitListExpr *ILE,
-              const ASTContext &Context);
+              const ASTContext *Context);
 
   /// Moves the designators to the next initializer in the struct/array. If the
   /// type of next initializer doesn't match the expected type then there are
   /// omitted braces and we add new designators to reflect that.
-  bool increment(const InitListExpr *ILE, const Expr *Init,
-                 const ASTContext &Context);
+  bool advanceToNextField(const Expr *Init);
 
   /// Gets a string representation from a list of designators. This string will
   /// be inserted before an initializer expression to make it designated.
@@ -136,6 +140,12 @@ public:
   }
 
 private:
+  /// Enters any implicit initializer lists until a type that matches the given
+  /// expression is found.
+  bool enterImplicitInitLists(const Expr *Init);
+
+  const InitListExpr *ILE;
+  const ASTContext *Context;
   SmallVector<DesignatorIter, 1> DesignatorList;
 };
 

--- a/clang-tools-extra/clang-reorder-fields/Designator.h
+++ b/clang-tools-extra/clang-reorder-fields/Designator.h
@@ -135,8 +135,11 @@ public:
 
   size_t size() const { return DesignatorList.size(); }
 
-  const DesignatorIter &operator[](unsigned Idx) const {
-    return DesignatorList[Idx];
+  SmallVector<DesignatorIter>::const_iterator begin() const {
+    return DesignatorList.begin();
+  }
+  SmallVector<DesignatorIter>::const_iterator end() const {
+    return DesignatorList.end();
   }
 
 private:

--- a/clang-tools-extra/clang-reorder-fields/Designator.h
+++ b/clang-tools-extra/clang-reorder-fields/Designator.h
@@ -1,0 +1,145 @@
+//===-- tools/extra/clang-reorder-fields/utils/Designator.h -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declarations of the DesignatorIter and Designators
+/// utility class.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_REORDER_FIELDS_UTILS_DESIGNATOR_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_REORDER_FIELDS_UTILS_DESIGNATOR_H
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Type.h"
+
+namespace clang {
+namespace reorder_fields {
+
+class DesignatorIter {
+public:
+  enum Kind { STRUCT, ARRAY, ARRAY_RANGE };
+
+  DesignatorIter(const QualType Type, RecordDecl::field_iterator Field,
+                 const RecordDecl *RD)
+      : Tag(STRUCT), Type(Type), StructIt({Field, RD}) {}
+
+  DesignatorIter(const QualType Type, uint64_t Idx, uint64_t Size)
+      : Tag(ARRAY), Type(Type), ArrayIt({Idx, Size}) {}
+
+  DesignatorIter(const QualType Type, uint64_t Start, uint64_t End,
+                 uint64_t Size)
+      : Tag(ARRAY_RANGE), Type(Type), ArrayRangeIt({Start, End, Size}) {}
+
+  /// Moves the iterator to the next element.
+  DesignatorIter &operator++();
+
+  /// Checks if the iterator has iterated through all elements.
+  bool isFinished();
+
+  Kind getTag() const { return Tag; }
+  QualType getType() const { return Type; }
+
+  const RecordDecl::field_iterator getStructIter() const {
+    assert(Tag == STRUCT && "Must be a field designator");
+    return StructIt.Field;
+  }
+
+  const RecordDecl *getStructDecl() const {
+    assert(Tag == STRUCT && "Must be a field designator");
+    return StructIt.Record;
+  }
+
+  uint64_t getArrayIndex() const {
+    assert(Tag == ARRAY && "Must be an array designator");
+    return ArrayIt.Index;
+  }
+
+  uint64_t getArrayRangeStart() const {
+    assert(Tag == ARRAY_RANGE && "Must be an array range designator");
+    return ArrayRangeIt.Start;
+  }
+
+  uint64_t getArrayRangeEnd() const {
+    assert(Tag == ARRAY_RANGE && "Must be an array range designator");
+    return ArrayRangeIt.End;
+  }
+
+  uint64_t getArraySize() const {
+    assert((Tag == ARRAY || Tag == ARRAY_RANGE) &&
+           "Must be an array or range designator");
+    if (Tag == ARRAY)
+      return ArrayIt.Size;
+    return ArrayRangeIt.Size;
+  }
+
+private:
+  /// Type of the designator.
+  Kind Tag;
+
+  /// Type of the designated entry. For arrays this is the type of the element.
+  QualType Type;
+
+  /// Field designator has the iterator to the field and the record the field
+  /// is declared in.
+  struct StructIter {
+    RecordDecl::field_iterator Field;
+    const RecordDecl *Record;
+  };
+
+  /// Array designator has an index and size of the array.
+  struct ArrayIter {
+    uint64_t Index;
+    uint64_t Size;
+  };
+
+  /// Array range designator has a start and end index and size of the array.
+  struct ArrayRangeIter {
+    uint64_t Start;
+    uint64_t End;
+    uint64_t Size;
+  };
+
+  union {
+    StructIter StructIt;
+    ArrayIter ArrayIt;
+    ArrayRangeIter ArrayRangeIt;
+  };
+};
+
+class Designators {
+public:
+  Designators() = default;
+  Designators(const DesignatedInitExpr *DIE, const InitListExpr *ILE,
+              const ASTContext &Context);
+
+  /// Moves the designators to the next initializer in the struct/array. If the
+  /// type of next initializer doesn't match the expected type then there are
+  /// omitted braces and we add new designators to reflect that.
+  bool increment(const InitListExpr *ILE, const Expr *Init,
+                 const ASTContext &Context);
+
+  /// Gets a string representation from a list of designators. This string will
+  /// be inserted before an initializer expression to make it designated.
+  std::string toString() const;
+
+  size_t size() const { return DesignatorList.size(); }
+
+  const DesignatorIter &operator[](unsigned Idx) const {
+    return DesignatorList[Idx];
+  }
+
+private:
+  SmallVector<DesignatorIter, 1> DesignatorList;
+};
+
+} // namespace reorder_fields
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_REORDER_FIELDS_UTILS_DESIGNATOR_H

--- a/clang-tools-extra/test/clang-reorder-fields/AggregatePartialInitialization.c
+++ b/clang-tools-extra/test/clang-reorder-fields/AggregatePartialInitialization.c
@@ -1,0 +1,12 @@
+// RUN: clang-reorder-fields -record-name Foo -fields-order z,y,x %s -- | FileCheck %s
+
+struct Foo {
+  int x;  // CHECK:       {{^  int z;}}
+  int y;  // CHECK-NEXT:  {{^  int y;}}
+  int z;  // CHECK-NEXT:  {{^  int x;}}
+};
+
+int main() {
+  struct Foo foo = { 0, 1 }; // CHECK: {{^  struct Foo foo = { .y = 1, .x = 0 };}}
+  return 0;
+}

--- a/clang-tools-extra/test/clang-reorder-fields/AggregatePartialInitialization.cpp
+++ b/clang-tools-extra/test/clang-reorder-fields/AggregatePartialInitialization.cpp
@@ -1,4 +1,5 @@
-// RUN: clang-reorder-fields -record-name Foo -fields-order z,y,x %s -- | FileCheck %s
+// RUN: clang-reorder-fields --extra-arg="-std=c++17" -record-name Foo -fields-order z,y,x %s -- 2>&1 | FileCheck --check-prefix=CHECK-MESSAGES %s
+// RUN: clang-reorder-fields --extra-arg="-std=c++17" -record-name Foo -fields-order z,y,x %s -- | FileCheck %s
 
 // The order of fields should not change.
 class Foo {
@@ -9,6 +10,7 @@ public:
 };
 
 int main() {
+  // CHECK-MESSAGES: :[[@LINE+1]]:13: Only full initialization without implicit values is supported
   Foo foo = { 0, 1 }; // CHECK: {{^  Foo foo = { 0, 1 };}}
   return 0;
 }

--- a/clang-tools-extra/test/clang-reorder-fields/DesignatedInitializerList.c
+++ b/clang-tools-extra/test/clang-reorder-fields/DesignatedInitializerList.c
@@ -1,0 +1,31 @@
+// RUN: clang-reorder-fields -record-name Foo -fields-order z,w,y,x %s -- | FileCheck %s
+
+struct Foo {
+  const int* x; // CHECK:      {{^  double z;}}
+  int y;        // CHECK-NEXT: {{^  int w;}}
+  double z;     // CHECK-NEXT: {{^  int y;}}
+  int w;        // CHECK-NEXT: {{^  const int\* x}}
+};
+
+struct Bar {
+  char a;
+  struct Foo b;
+  char c;
+};
+
+int main() {
+  const int x = 13;
+  struct Foo foo1 = { .x=&x, .y=0, .z=1.29, .w=17 }; // CHECK: {{^ struct Foo foo1 = { .z = 1.29, .w = 17, .y = 0, .x = &x };}}
+  struct Foo foo2 = { .x=&x, 0, 1.29, 17 };          // CHECK: {{^ struct Foo foo2 = { .z = 1.29, .w = 17, .y = 0, .x = &x };}}
+  struct Foo foo3 = { .y=0, .z=1.29, 17, .x=&x };    // CHECK: {{^ struct Foo foo3 = { .z = 1.29, .w = 17, .y = 0, .x = &x };}}
+  struct Foo foo4 = { .y=0, .z=1.29, 17 };           // CHECK: {{^ struct Foo foo4 = { .z = 1.29, .w = 17, .y = 0 };}}
+
+  struct Foo foos1[1] = { [0] = {.x=&x, 0, 1.29, 17} };              // CHECK: {{^ struct Foo foos1\[1] = { \[0] = {.z = 1.29, .w = 17, .y = 0, .x = &x} };}}
+  struct Foo foos2[1] = { [0].x=&x, [0].y=0, [0].z=1.29, [0].w=17 }; // CHECK: {{^ struct Foo foos2\[1] = { \[0].z = 1.29, \[0].w = 17, \[0].y = 0, \[0].x = &x };}}
+  struct Foo foos3[1] = { &x, 0, 1.29, 17 };                         // CHECK: {{^ struct Foo foos3\[1] = { \[0].z = 1.29, \[0].w = 17, \[0].y = 0, \[0].x = &x };}}
+  struct Foo foos4[2] = { &x, 0, 1.29, 17, &x, 0, 1.29, 17 };        // CHECK: {{^ struct Foo foos4\[2] = { \[0].z = 1.29, \[0].w = 17, \[0].y = 0, \[0].x = &x, \[1].z = 1.29, \[1].w = 17, \[1].y = 0, \[1].x = &x };}}
+
+  struct Bar bar1 = { .a='a', &x, 0, 1.29, 17, 'c' }; // CHECK: {{^ struct Bar bar1 = { .a = 'a', .b.z = 1.29, .b.w = 17, .b.y = 0, .b.x = &x, .c = 'c' };}}
+
+  return 0;
+}

--- a/clang-tools-extra/test/clang-reorder-fields/DesignatedInitializerList.cpp
+++ b/clang-tools-extra/test/clang-reorder-fields/DesignatedInitializerList.cpp
@@ -1,0 +1,24 @@
+// RUN: clang-reorder-fields --extra-arg="-std=c++20" -record-name Bar -fields-order c,a,b %s -- | FileCheck %s
+
+class Foo {
+public:
+  const int* x;
+  int y;        
+};
+
+class Bar {
+public:
+  char a; // CHECK:      {{^  int c;}}
+  Foo b;  // CHECK-NEXT: {{^  char a;}}
+  int c;  // CHECK-NEXT: {{^  Foo b;}}
+};
+
+int main() {
+  const int x = 13;
+  Bar bar1 = { 'a', { &x, 0 }, 123 };              // CHECK: {{^ Bar bar1 = { 123, 'a', { &x, 0 } };}}
+  Bar bar2 = { .a = 'a', { &x, 0 }, 123 };         // CHECK: {{^ Bar bar2 = { .c = 123, .a = 'a', .b = { &x, 0 } };}}
+  Bar bar3 = { 'a', .b { &x, 0 }, 123 };           // CHECK: {{^ Bar bar3 = { .c = 123, .a = 'a', .b = { &x, 0 } };}}
+  Bar bar4 = { .c = 123, .b { &x, 0 }, .a = 'a' }; // CHECK: {{^ Bar bar4 = { .c = 123, .a = 'a', .b = { &x, 0 } };}}
+
+  return 0;
+}

--- a/clang-tools-extra/test/clang-reorder-fields/IdiomaticZeroInitializer.c
+++ b/clang-tools-extra/test/clang-reorder-fields/IdiomaticZeroInitializer.c
@@ -1,0 +1,14 @@
+// RUN: clang-reorder-fields -record-name Foo -fields-order y,x %s -- | FileCheck %s
+
+struct Foo {
+  int x;  // CHECK:      {{^  int y;}}
+  int y;  // CHECK-NEXT: {{^  int x;}}
+};
+
+int main() {
+  // The idiomatic zero initializer should remain the same.
+  struct Foo foo0 = { 0 }; // CHECK: {{^ struct Foo foo0 = { 0 };}}
+  struct Foo foo1 = { 1 }; // CHECK: {{^ struct Foo foo1 = { .x = 1 };}}
+
+  return 0;
+}

--- a/clang-tools-extra/test/clang-reorder-fields/InitializerListExcessElements.c
+++ b/clang-tools-extra/test/clang-reorder-fields/InitializerListExcessElements.c
@@ -1,0 +1,15 @@
+// RUN: clang-reorder-fields -record-name Foo -fields-order y,x %s -- 2>&1 | FileCheck --check-prefix=CHECK-MESSAGES %s
+// RUN: clang-reorder-fields -record-name Foo -fields-order y,x %s -- | FileCheck %s
+
+// The order of fields should not change.
+struct Foo {
+  int x;  // CHECK:      {{^  int x;}}
+  int y;  // CHECK-NEXT: {{^  int y;}}
+};
+
+int main() {
+  // CHECK-MESSAGES: :[[@LINE+1]]:20: Unsupported initializer list
+  struct Foo foo = { .y=9, 123, .x=1 }; // CHECK: {{^ struct Foo foo = { .y=9, 123, .x=1 };}}
+
+  return 0;
+}


### PR DESCRIPTION
Initializer lists with designators, missing elements or omitted braces can now be rewritten. Any missing designators are added and they get sorted according to the new order.

```
struct Foo {
  int a;
  int b;
  int c;
};
struct Foo foo = { .a = 1, 2, 3 }
```

when reordering elements to "b,a,c" becomes:

```
struct Foo {
  int b;
  int a;
  int c;
};
struct Foo foo = { .b = 2, .a = 1, .c = 3 }
```