### PR TITLE
[utils] Fix utils/demangle_tree.py:parse_line to correctly check for closing parenthesis

### DIFF
--- a/llvm/utils/demangle_tree.py
+++ b/llvm/utils/demangle_tree.py
@@ -28,7 +28,7 @@ def parse_line(line):
     if open_paren == -1:
         return None, None
     close_paren = line.rfind(")", open_paren)
-    if open_paren == -1:
+    if close_paren == -1:
         return None, None
     mangled = line[question:open_paren]
     demangled = line[open_paren + 1 : close_paren]


### PR DESCRIPTION
Previously, parse_line incorrectly repeated the check for open_paren instead of verifying the presence of a closing parenthesis. This caused inputs with an unmatched opening parenthesis to be parsed incorrectly.

For example:
    print(parse_line('?foo (bar'))
    → before: ('?foo', 'ba')   [incorrect]
    → after:  (None, None)     [correct]

Fixed the condition to properly check close_paren.