### PR TITLE
[NFC] Tweak docs for unique-object-duplication warning

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -811,7 +811,7 @@ changes to one object won't affect the others, the object's initializer will run
 once per copy, etc.
 
 Specifically, this warning fires when it detects an object which:
-  1. Appears in a header file (so it might get compiled into multiple libaries), and
+  1. Is defined as ``inline`` in a header file (so it might get compiled into multiple libaries), and
   2. Has external linkage (otherwise it's supposed to be duplicated), and
   3. Has hidden visibility.
 
@@ -819,13 +819,17 @@ As well as one of the following:
   1. The object is mutable, or
   2. The object's initializer definitely has side effects.
 
-The warning is best resolved by making the object ``const`` (if possible), or by explicitly
-giving the object non-hidden visibility, e.g. using ``__attribute((visibility("default")))``.
-Note that all levels of a pointer variable must be constant; ``const int*`` will
-trigger the warning because the pointer itself is mutable.
+The warning can be resolved by removing one of the conditions above. In rough
+order of preference, this may be done by:
+  1. Marking the object ``const`` (if possible)
+  2. Moving the object's definition to a source file
+  3. Giving the object non-hidden visibility, e.g. using ``__attribute((visibility("default")))``.
 
-This warning is currently disabled on Windows since it uses import/export rules
-instead of visibility.
+Note that for (2), all levels of a pointer variable must be constant;
+``const int*`` will trigger the warning because the pointer itself is mutable.
+
+This warning is not yet implemented for Windows, since Windows uses
+import/export rules instead of visibility.
 }];
 }
 


### PR DESCRIPTION
This improves the documentation for the unique-object-duplication warning. It clarifies the conditions for the warning to fire, provides clearer instructions on how to resolve it, and adjusts wording to be more precise.