### PR TITLE
[flang][OpenMP] Resolve names for declare simd uniform clause

### DIFF
--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -786,7 +786,7 @@ public:
       OmpExecutableAllocateDirective, OmpDeclareSimd, OmpDeclareTarget,
       OmpThreadprivate, OmpDeclareReduction, OmpFlushed, OmpCriticalLock,
       OmpIfSpecified, OmpNone, OmpPreDetermined, OmpImplicit, OmpDependObject,
-      OmpInclusiveScan, OmpExclusiveScan, OmpInScanReduction);
+      OmpInclusiveScan, OmpExclusiveScan, OmpInScanReduction, OmpUniform);
   using Flags = common::EnumSet<Flag, Flag_enumSize>;
 
   const Scope &owner() const { return *owner_; }

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -551,9 +551,7 @@ public:
   }
 
   bool Pre(const parser::OmpClause::Uniform &x) {
-    for (const auto &name : x.v) {
-      ResolveOmpName(name, Symbol::Flag::OmpUniform);
-    }
+    ResolveOmpNameList(x.v, Symbol::Flag::OmpUniform);
     return false;
   }
 
@@ -749,7 +747,7 @@ private:
   Symbol::Flags dataSharingAttributeFlags{Symbol::Flag::OmpShared,
       Symbol::Flag::OmpPrivate, Symbol::Flag::OmpFirstPrivate,
       Symbol::Flag::OmpLastPrivate, Symbol::Flag::OmpReduction,
-      Symbol::Flag::OmpLinear};
+      Symbol::Flag::OmpLinear, Symbol::Flag::OmpUniform};
 
   Symbol::Flags privateDataSharingAttributeFlags{Symbol::Flag::OmpPrivate,
       Symbol::Flag::OmpFirstPrivate, Symbol::Flag::OmpLastPrivate};
@@ -759,7 +757,8 @@ private:
       Symbol::Flag::OmpLastPrivate, Symbol::Flag::OmpReduction,
       Symbol::Flag::OmpCriticalLock, Symbol::Flag::OmpCopyIn,
       Symbol::Flag::OmpUseDevicePtr, Symbol::Flag::OmpUseDeviceAddr,
-      Symbol::Flag::OmpIsDevicePtr, Symbol::Flag::OmpHasDeviceAddr};
+      Symbol::Flag::OmpIsDevicePtr, Symbol::Flag::OmpHasDeviceAddr,
+      Symbol::Flag::OmpUniform};
 
   Symbol::Flags ompFlagsRequireMark{Symbol::Flag::OmpThreadprivate,
       Symbol::Flag::OmpDeclareTarget, Symbol::Flag::OmpExclusiveScan,

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -747,7 +747,7 @@ private:
   Symbol::Flags dataSharingAttributeFlags{Symbol::Flag::OmpShared,
       Symbol::Flag::OmpPrivate, Symbol::Flag::OmpFirstPrivate,
       Symbol::Flag::OmpLastPrivate, Symbol::Flag::OmpReduction,
-      Symbol::Flag::OmpLinear, Symbol::Flag::OmpUniform};
+      Symbol::Flag::OmpLinear};
 
   Symbol::Flags privateDataSharingAttributeFlags{Symbol::Flag::OmpPrivate,
       Symbol::Flag::OmpFirstPrivate, Symbol::Flag::OmpLastPrivate};

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -550,6 +550,13 @@ public:
     return false;
   }
 
+  bool Pre(const parser::OmpClause::Uniform &x) {
+    for (const auto &name : x.v) {
+      ResolveOmpName(name, Symbol::Flag::OmpUniform);
+    }
+    return false;
+  }
+
   bool Pre(const parser::OmpInReductionClause &x) {
     auto &objects{std::get<parser::OmpObjectList>(x.t)};
     ResolveOmpObjectList(objects, Symbol::Flag::OmpInReduction);

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1511,6 +1511,11 @@ public:
     return false;
   }
 
+  bool Pre(const parser::OpenMPDeclareSimdConstruct &x) {
+    AddOmpSourceRange(x.source);
+    return true;
+  }
+
   bool Pre(const parser::OmpInitializerProc &x) {
     auto &procDes = std::get<parser::ProcedureDesignator>(x.t);
     auto &name = std::get<parser::Name>(procDes.u);

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -842,6 +842,9 @@ std::string Symbol::OmpFlagToClauseName(Symbol::Flag ompFlag) {
   case Symbol::Flag::OmpLinear:
     clauseName = "LINEAR";
     break;
+  case Symbol::Flag::OmpUniform:
+    clauseName = "UNIFORM";
+    break;
   case Symbol::Flag::OmpFirstPrivate:
     clauseName = "FIRSTPRIVATE";
     break;

--- a/flang/test/Semantics/OpenMP/declare-simd-uniform.f90
+++ b/flang/test/Semantics/OpenMP/declare-simd-uniform.f90
@@ -1,4 +1,5 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+! RUN: %flang_fc1 -fopenmp -fdebug-dump-symbols %s | FileCheck %s
 ! Test declare simd with uniform clause
 
 function add2(a,b,i,fact,alc) result(c)
@@ -11,3 +12,11 @@ end function
 
 end
 
+! CHECK-LABEL: Subprogram scope: add2 size=48 alignment=8 sourceRange=189 bytes
+! CHECK-NEXT:    a (OmpUniform): ObjectEntity dummy type: REAL(8) shape: 1_8:*
+! CHECK-NEXT:    add2 (Function): HostAssoc
+! CHECK-NEXT:    alc, POINTER size=24 offset=8: ObjectEntity dummy type: INTEGER(4)
+! CHECK-NEXT:    b (OmpUniform): ObjectEntity dummy type: REAL(8) shape: 1_8:*
+! CHECK-NEXT:    c size=8 offset=40: ObjectEntity funcResult type: REAL(8)
+! CHECK-NEXT:    fact (OmpUniform) size=8 offset=32: ObjectEntity dummy type: REAL(8)
+! CHECK-NEXT:    i size=4 offset=0: ObjectEntity dummy type: INTEGER(4)

--- a/flang/test/Semantics/OpenMP/declare-simd-uniform.f90
+++ b/flang/test/Semantics/OpenMP/declare-simd-uniform.f90
@@ -1,0 +1,13 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+! Test declare simd with uniform clause
+
+function add2(a,b,i,fact,alc) result(c)
+  !$omp declare simd(add2) uniform(a,b,fact)
+  integer :: i
+  integer,pointer::alc
+  double precision :: a(*),b(*),fact,c
+  c = a(i) + b(i) + fact
+end function
+
+end
+


### PR DESCRIPTION
Add a visitor for OmpClause::Uniform to resolve its parameter names.
Fixes issue #140741.