### PR TITLE
[InstSimplify] Handle nsz when simplifying X * 0.0

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -5844,6 +5844,9 @@ static Value *simplifyFMAFMul(Value *Op0, Value *Op1, FastMathFlags FMF,
     KnownFPClass Known =
         computeKnownFPClass(Op0, FMF, fcInf | fcNan, /*Depth=*/0, Q);
     if (Known.isKnownNever(fcInf | fcNan)) {
+      // if nsz is set, return 0.0
+      if (FMF.noSignedZeros())
+        return ConstantFP::getZero(Op0->getType());
       // +normal number * (-)0.0 --> (-)0.0
       if (Known.SignBit == false)
         return Op1;

--- a/llvm/test/Transforms/InstSimplify/floating-point-arithmetic.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-arithmetic.ll
@@ -211,6 +211,22 @@ define double @fmul_nnan_ninf_nneg_n0.0_commute(i127 %x) {
   ret double %r
 }
 
+define float @fmul_ninf_nnan_mul_zero_nsz(float nofpclass(inf nan) %f) {
+; CHECK-LABEL: @fmul_ninf_nnan_mul_zero_nsz(
+; CHECK-NEXT:     ret float 0.000000e+00
+;
+  %r = fmul nsz float %f, 0.0
+  ret float %r
+}
+
+define float @fmul_ninf_nnan_mul_nzero_nsz(float nofpclass(inf nan) %f) {
+; CHECK-LABEL: @fmul_ninf_nnan_mul_nzero_nsz(
+; CHECK-NEXT:     ret float 0.000000e+00
+;
+  %r = fmul nsz float %f, -0.0
+  ret float %r
+}
+
 define float @src_mul_nzero_neg(float nofpclass(inf nan pzero psub pnorm) %f) {
 ; CHECK-LABEL: @src_mul_nzero_neg(
 ; CHECK-NEXT:    ret float 0.000000e+00


### PR DESCRIPTION
If ValueTracking can guarantee non-NaN and non-INF and the `nsz` fast-math flag is set, we can simplify X * 0.0 ==> 0.0.

https://alive2.llvm.org/ce/z/XacRQZ