### PR TITLE
[lldb] Add build option to specify the libxml 2 version

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -51,7 +51,7 @@ macro(add_optional_dependency variable description package found)
   message(STATUS "${description}: ${${variable}}")
 endmacro()
 
-option(LLDB_LIBXML2_VERSION "Sepcify the version of libxml 2 to use with LLDB" "2.8")
+set(LLDB_LIBXML2_VERSION "2.8" CACHE STRING "Sepcify the version of libxml 2 to use with LLDB")
 
 add_optional_dependency(LLDB_ENABLE_SWIG "Enable SWIG to generate LLDB bindings" SWIG SWIG_FOUND VERSION 4)
 add_optional_dependency(LLDB_ENABLE_LIBEDIT "Enable editline support in LLDB" LibEdit LibEdit_FOUND)

--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -52,7 +52,7 @@ macro(add_optional_dependency variable description package found)
 endmacro()
 
 set(LLDB_LIBXML2_VERSION "2.8" CACHE STRING
-  "Sepcify the version of libxml 2 to use with LLDB. This is only meant to be overridden for local
+  "Specify the version of libxml 2 to use with LLDB. This is only meant to be overridden for local
   static builds of libxml 2. Use at your own risk.")
 mark_as_advanced(LLDB_LIBXML2_VERSION)
 

--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -51,7 +51,10 @@ macro(add_optional_dependency variable description package found)
   message(STATUS "${description}: ${${variable}}")
 endmacro()
 
-set(LLDB_LIBXML2_VERSION "2.8" CACHE STRING "Sepcify the version of libxml 2 to use with LLDB")
+set(LLDB_LIBXML2_VERSION "2.8" CACHE STRING
+  "Sepcify the version of libxml 2 to use with LLDB. This is only meant to be overridden for local
+  static builds of libxml 2. Use at your own risk.")
+mark_as_advanced(LLDB_LIBXML2_VERSION)
 
 add_optional_dependency(LLDB_ENABLE_SWIG "Enable SWIG to generate LLDB bindings" SWIG SWIG_FOUND VERSION 4)
 add_optional_dependency(LLDB_ENABLE_LIBEDIT "Enable editline support in LLDB" LibEdit LibEdit_FOUND)

--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -51,13 +51,15 @@ macro(add_optional_dependency variable description package found)
   message(STATUS "${description}: ${${variable}}")
 endmacro()
 
+option(LLDB_LIBXML2_VERSION "Sepcify the version of libxml 2 to use with LLDB" "2.8")
+
 add_optional_dependency(LLDB_ENABLE_SWIG "Enable SWIG to generate LLDB bindings" SWIG SWIG_FOUND VERSION 4)
 add_optional_dependency(LLDB_ENABLE_LIBEDIT "Enable editline support in LLDB" LibEdit LibEdit_FOUND)
 add_optional_dependency(LLDB_ENABLE_CURSES "Enable curses support in LLDB" CursesAndPanel CURSESANDPANEL_FOUND)
 add_optional_dependency(LLDB_ENABLE_LZMA "Enable LZMA compression support in LLDB" LibLZMA LIBLZMA_FOUND)
 add_optional_dependency(LLDB_ENABLE_LUA "Enable Lua scripting support in LLDB" LuaAndSwig LUAANDSWIG_FOUND)
 add_optional_dependency(LLDB_ENABLE_PYTHON "Enable Python scripting support in LLDB" PythonAndSwig PYTHONANDSWIG_FOUND)
-add_optional_dependency(LLDB_ENABLE_LIBXML2 "Enable Libxml 2 support in LLDB" LibXml2 LIBXML2_FOUND VERSION 2.8)
+add_optional_dependency(LLDB_ENABLE_LIBXML2 "Enable Libxml 2 support in LLDB" LibXml2 LIBXML2_FOUND VERSION ${LLDB_LIBXML2_VERSION})
 add_optional_dependency(LLDB_ENABLE_FBSDVMCORE "Enable libfbsdvmcore support in LLDB" FBSDVMCore FBSDVMCore_FOUND QUIET)
 
 option(LLDB_USE_ENTITLEMENTS "When codesigning, use entitlements if available" ON)


### PR DESCRIPTION
The Swift Windows toolchain uses its own static build of libxml 2, which is more recent than 2.8, resulting in the provided libxml 2 to be rejected. This change allows to specify a custom version for libxml 2, while defaulting to 2.8.