### PR TITLE
Enclose code  in nondebug in #ifndef NDEBUG/#endif

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -765,8 +765,7 @@ static bool interp__builtin_addressof(InterpState &S, CodePtr OpPC,
                                       const CallExpr *Call) {
 #ifndef NDEBUG
   assert(Call->getArg(0)->isLValue());
-  PrimType PtrT =
-      S.getContext().classify(Call->getArg(0)).value_or(PT_Ptr);
+  PrimType PtrT = S.getContext().classify(Call->getArg(0)).value_or(PT_Ptr);
   assert(PtrT == PT_Ptr &&
          "Unsupported pointer type passed to __builtin_addressof()");
 #endif

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -763,12 +763,13 @@ static bool interp__builtin_ffs(InterpState &S, CodePtr OpPC,
 static bool interp__builtin_addressof(InterpState &S, CodePtr OpPC,
                                       const InterpFrame *Frame,
                                       const CallExpr *Call) {
+#ifndef NDEBUG
   assert(Call->getArg(0)->isLValue());
-  [[maybe_unused]] PrimType PtrT =
+  PrimType PtrT =
       S.getContext().classify(Call->getArg(0)).value_or(PT_Ptr);
   assert(PtrT == PT_Ptr &&
          "Unsupported pointer type passed to __builtin_addressof()");
-  (void)PtrT;
+#endif
   return true;
 }
 


### PR DESCRIPTION
A previous change to InterpBuiltin.cpp fixed an unused variable warning by using [[maybe unused]] and (void).
The code actually serves no useful purpose in non-debug builds, so let's not include it there.
