### PR TITLE
[Remarks] Remove an upcast footgun. NFC

### DIFF
--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -718,7 +718,7 @@ public:
   }
 
 private:
-  /// The IR value that the optimization operates on.
+  /// The IR region (currently basic block) that the optimization operates on.
   /// This is currently used to provide run-time hotness information with PGO.
   const BasicBlock *CodeRegion = nullptr;
 };

--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -523,7 +523,7 @@ public:
 
   /// \p PassName is the name of the pass emitting this diagnostic. \p
   /// RemarkName is a textual identifier for the remark (single-word,
-  /// camel-case). \p Fn is the function where the diagnostic is being emitted.
+  /// CamelCase). \p Fn is the function where the diagnostic is being emitted.
   /// \p Loc is the location information to use in the diagnostic. If line table
   /// information is available, the diagnostic will include the source code
   /// location.
@@ -588,7 +588,7 @@ protected:
   /// be emitted.
   const char *PassName;
 
-  /// Textual identifier for the remark (single-word, camel-case). Can be used
+  /// Textual identifier for the remark (single-word, CamelCase). Can be used
   /// by external tools reading the output file for optimization remarks to
   /// identify the remark.
   StringRef RemarkName;
@@ -663,18 +663,17 @@ class DiagnosticInfoIROptimization : public DiagnosticInfoOptimizationBase {
 public:
   /// \p PassName is the name of the pass emitting this diagnostic. \p
   /// RemarkName is a textual identifier for the remark (single-word,
-  /// camel-case). \p Fn is the function where the diagnostic is being emitted.
+  /// CamelCase). \p Fn is the function where the diagnostic is being emitted.
   /// \p Loc is the location information to use in the diagnostic. If line table
   /// information is available, the diagnostic will include the source code
-  /// location. \p CodeRegion is IR value (currently basic block) that the
-  /// optimization operates on. This is currently used to provide run-time
-  /// hotness information with PGO.
+  /// location. \p CodeRegion is IR value that the optimization operates on.
+  /// This is currently used to provide run-time hotness information with PGO.
   DiagnosticInfoIROptimization(enum DiagnosticKind Kind,
                                enum DiagnosticSeverity Severity,
                                const char *PassName, StringRef RemarkName,
                                const Function &Fn,
                                const DiagnosticLocation &Loc,
-                               const Value *CodeRegion = nullptr)
+                               const BasicBlock *CodeRegion = nullptr)
       : DiagnosticInfoOptimizationBase(Kind, Severity, PassName, RemarkName, Fn,
                                        Loc),
         CodeRegion(CodeRegion) {}
@@ -712,16 +711,16 @@ public:
     *this << Msg.str();
   }
 
-  const Value *getCodeRegion() const { return CodeRegion; }
+  const BasicBlock *getCodeRegion() const { return CodeRegion; }
 
   static bool classof(const DiagnosticInfo *DI) {
     return DI->getKind() >= DK_FirstRemark && DI->getKind() <= DK_LastRemark;
   }
 
 private:
-  /// The IR value (currently basic block) that the optimization operates on.
+  /// The IR value that the optimization operates on.
   /// This is currently used to provide run-time hotness information with PGO.
-  const Value *CodeRegion = nullptr;
+  const BasicBlock *CodeRegion = nullptr;
 };
 
 /// Diagnostic information for applied optimization remarks.
@@ -730,11 +729,11 @@ public:
   /// \p PassName is the name of the pass emitting this diagnostic. If this name
   /// matches the regular expression given in -Rpass=, then the diagnostic will
   /// be emitted. \p RemarkName is a textual identifier for the remark (single-
-  /// word, camel-case). \p Loc is the debug location and \p CodeRegion is the
-  /// region that the optimization operates on (currently only block is
-  /// supported).
+  /// word, CamelCase). \p Loc is the debug location and \p CodeRegion is the
+  /// region that the optimization operates on.
   OptimizationRemark(const char *PassName, StringRef RemarkName,
-                     const DiagnosticLocation &Loc, const Value *CodeRegion);
+                     const DiagnosticLocation &Loc,
+                     const BasicBlock *CodeRegion);
 
   /// Same as above, but the debug location and code region are derived from \p
   /// Instr.
@@ -775,12 +774,11 @@ public:
   /// \p PassName is the name of the pass emitting this diagnostic. If this name
   /// matches the regular expression given in -Rpass-missed=, then the
   /// diagnostic will be emitted. \p RemarkName is a textual identifier for the
-  /// remark (single-word, camel-case). \p Loc is the debug location and \p
-  /// CodeRegion is the region that the optimization operates on (currently only
-  /// block is supported).
+  /// remark (single-word, CamelCase). \p Loc is the debug location and \p
+  /// CodeRegion is the region that the optimization operates on.
   OptimizationRemarkMissed(const char *PassName, StringRef RemarkName,
                            const DiagnosticLocation &Loc,
-                           const Value *CodeRegion);
+                           const BasicBlock *CodeRegion);
 
   /// Same as above but \p Inst is used to derive code region and debug
   /// location.
@@ -821,12 +819,11 @@ public:
   /// \p PassName is the name of the pass emitting this diagnostic. If this name
   /// matches the regular expression given in -Rpass-analysis=, then the
   /// diagnostic will be emitted. \p RemarkName is a textual identifier for the
-  /// remark (single-word, camel-case). \p Loc is the debug location and \p
-  /// CodeRegion is the region that the optimization operates on (currently only
-  /// block is supported).
+  /// remark (single-word, CamelCase). \p Loc is the debug location and \p
+  /// CodeRegion is the region that the optimization operates on.
   OptimizationRemarkAnalysis(const char *PassName, StringRef RemarkName,
                              const DiagnosticLocation &Loc,
-                             const Value *CodeRegion);
+                             const BasicBlock *CodeRegion);
 
   /// This is ctor variant allows a pass to build an optimization remark
   /// from an existing remark.
@@ -869,7 +866,7 @@ protected:
   OptimizationRemarkAnalysis(enum DiagnosticKind Kind, const char *PassName,
                              StringRef RemarkName,
                              const DiagnosticLocation &Loc,
-                             const Value *CodeRegion);
+                             const BasicBlock *CodeRegion);
 
 private:
   /// This is deprecated now and only used by the function API below.
@@ -895,14 +892,14 @@ public:
   /// \p PassName is the name of the pass emitting this diagnostic. If this name
   /// matches the regular expression given in -Rpass-analysis=, then the
   /// diagnostic will be emitted. \p RemarkName is a textual identifier for the
-  /// remark (single-word, camel-case). \p Loc is the debug location and \p
-  /// CodeRegion is the region that the optimization operates on (currently only
-  /// block is supported). The front-end will append its own message related to
-  /// options that address floating-point non-commutativity.
+  /// remark (single-word, CamelCase). \p Loc is the debug location and \p
+  /// CodeRegion is the region that the optimization operates on. The front-end
+  /// will append its own message related to options that address floating-point
+  /// non-commutativity.
   OptimizationRemarkAnalysisFPCommute(const char *PassName,
                                       StringRef RemarkName,
                                       const DiagnosticLocation &Loc,
-                                      const Value *CodeRegion)
+                                      const BasicBlock *CodeRegion)
       : OptimizationRemarkAnalysis(DK_OptimizationRemarkAnalysisFPCommute,
                                    PassName, RemarkName, Loc, CodeRegion) {}
 
@@ -937,13 +934,13 @@ public:
   /// \p PassName is the name of the pass emitting this diagnostic. If this name
   /// matches the regular expression given in -Rpass-analysis=, then the
   /// diagnostic will be emitted. \p RemarkName is a textual identifier for the
-  /// remark (single-word, camel-case). \p Loc is the debug location and \p
-  /// CodeRegion is the region that the optimization operates on (currently only
-  /// block is supported). The front-end will append its own message related to
-  /// options that address pointer aliasing legality.
+  /// remark (single-word, CamelCase). \p Loc is the debug location and \p
+  /// CodeRegion is the region that the optimization operates on. The front-end
+  /// will append its own message related to options that address pointer
+  /// aliasing legality.
   OptimizationRemarkAnalysisAliasing(const char *PassName, StringRef RemarkName,
                                      const DiagnosticLocation &Loc,
-                                     const Value *CodeRegion)
+                                     const BasicBlock *CodeRegion)
       : OptimizationRemarkAnalysis(DK_OptimizationRemarkAnalysisAliasing,
                                    PassName, RemarkName, Loc, CodeRegion) {}
 
@@ -1044,12 +1041,11 @@ public:
 
   /// \p PassName is the name of the pass emitting this diagnostic.  \p
   /// RemarkName is a textual identifier for the remark (single-word,
-  /// camel-case).  \p Loc is the debug location and \p CodeRegion is the
-  /// region that the optimization operates on (currently basic block is
-  /// supported).
+  /// CamelCase).  \p Loc is the debug location and \p CodeRegion is the
+  /// region that the optimization operates on.
   DiagnosticInfoOptimizationFailure(const char *PassName, StringRef RemarkName,
                                     const DiagnosticLocation &Loc,
-                                    const Value *CodeRegion);
+                                    const BasicBlock *CodeRegion);
 
   static bool classof(const DiagnosticInfo *DI) {
     return DI->getKind() == DK_OptimizationFailure;

--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -2746,7 +2746,7 @@ OptimizationRemarkAnalysis &
 LoopAccessInfo::recordAnalysis(StringRef RemarkName, const Instruction *I) {
   assert(!Report && "Multiple reports generated");
 
-  const Value *CodeRegion = TheLoop->getHeader();
+  const BasicBlock *CodeRegion = TheLoop->getHeader();
   DebugLoc DL = TheLoop->getStartLoc();
 
   if (I) {
@@ -2757,8 +2757,8 @@ LoopAccessInfo::recordAnalysis(StringRef RemarkName, const Instruction *I) {
       DL = I->getDebugLoc();
   }
 
-  Report = std::make_unique<OptimizationRemarkAnalysis>(DEBUG_TYPE, RemarkName, DL,
-                                                   CodeRegion);
+  Report = std::make_unique<OptimizationRemarkAnalysis>(DEBUG_TYPE, RemarkName,
+                                                        DL, CodeRegion);
   return *Report;
 }
 

--- a/llvm/lib/CodeGen/HardwareLoops.cpp
+++ b/llvm/lib/CodeGen/HardwareLoops.cpp
@@ -90,7 +90,7 @@ static void debugHWLoopFailure(const StringRef DebugMsg,
 
 static OptimizationRemarkAnalysis
 createHWLoopAnalysis(StringRef RemarkName, Loop *L, Instruction *I) {
-  Value *CodeRegion = L->getHeader();
+  BasicBlock *CodeRegion = L->getHeader();
   DebugLoc DL = L->getStartLoc();
 
   if (I) {

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -284,10 +284,10 @@ void DiagnosticInfoOptimizationBase::print(DiagnosticPrinter &DP) const {
 OptimizationRemark::OptimizationRemark(const char *PassName,
                                        StringRef RemarkName,
                                        const DiagnosticLocation &Loc,
-                                       const Value *CodeRegion)
-    : DiagnosticInfoIROptimization(
-          DK_OptimizationRemark, DS_Remark, PassName, RemarkName,
-          *cast<BasicBlock>(CodeRegion)->getParent(), Loc, CodeRegion) {}
+                                       const BasicBlock *CodeRegion)
+    : DiagnosticInfoIROptimization(DK_OptimizationRemark, DS_Remark, PassName,
+                                   RemarkName, *CodeRegion->getParent(), Loc,
+                                   CodeRegion) {}
 
 OptimizationRemark::OptimizationRemark(const char *PassName,
                                        StringRef RemarkName,
@@ -315,10 +315,10 @@ bool OptimizationRemark::isEnabled() const {
 
 OptimizationRemarkMissed::OptimizationRemarkMissed(
     const char *PassName, StringRef RemarkName, const DiagnosticLocation &Loc,
-    const Value *CodeRegion)
-    : DiagnosticInfoIROptimization(
-          DK_OptimizationRemarkMissed, DS_Remark, PassName, RemarkName,
-          *cast<BasicBlock>(CodeRegion)->getParent(), Loc, CodeRegion) {}
+    const BasicBlock *CodeRegion)
+    : DiagnosticInfoIROptimization(DK_OptimizationRemarkMissed, DS_Remark,
+                                   PassName, RemarkName,
+                                   *CodeRegion->getParent(), Loc, CodeRegion) {}
 
 OptimizationRemarkMissed::OptimizationRemarkMissed(const char *PassName,
                                                    StringRef RemarkName,
@@ -343,10 +343,10 @@ bool OptimizationRemarkMissed::isEnabled() const {
 
 OptimizationRemarkAnalysis::OptimizationRemarkAnalysis(
     const char *PassName, StringRef RemarkName, const DiagnosticLocation &Loc,
-    const Value *CodeRegion)
-    : DiagnosticInfoIROptimization(
-          DK_OptimizationRemarkAnalysis, DS_Remark, PassName, RemarkName,
-          *cast<BasicBlock>(CodeRegion)->getParent(), Loc, CodeRegion) {}
+    const BasicBlock *CodeRegion)
+    : DiagnosticInfoIROptimization(DK_OptimizationRemarkAnalysis, DS_Remark,
+                                   PassName, RemarkName,
+                                   *CodeRegion->getParent(), Loc, CodeRegion) {}
 
 OptimizationRemarkAnalysis::OptimizationRemarkAnalysis(const char *PassName,
                                                        StringRef RemarkName,
@@ -358,10 +358,9 @@ OptimizationRemarkAnalysis::OptimizationRemarkAnalysis(const char *PassName,
 
 OptimizationRemarkAnalysis::OptimizationRemarkAnalysis(
     enum DiagnosticKind Kind, const char *PassName, StringRef RemarkName,
-    const DiagnosticLocation &Loc, const Value *CodeRegion)
+    const DiagnosticLocation &Loc, const BasicBlock *CodeRegion)
     : DiagnosticInfoIROptimization(Kind, DS_Remark, PassName, RemarkName,
-                                   *cast<BasicBlock>(CodeRegion)->getParent(),
-                                   Loc, CodeRegion) {}
+                                   *CodeRegion->getParent(), Loc, CodeRegion) {}
 
 OptimizationRemarkAnalysis::OptimizationRemarkAnalysis(const char *PassName,
                                                        StringRef RemarkName,
@@ -387,10 +386,10 @@ void DiagnosticInfoSrcMgr::print(DiagnosticPrinter &DP) const {
 
 DiagnosticInfoOptimizationFailure::DiagnosticInfoOptimizationFailure(
     const char *PassName, StringRef RemarkName, const DiagnosticLocation &Loc,
-    const Value *CodeRegion)
-    : DiagnosticInfoIROptimization(
-          DK_OptimizationFailure, DS_Warning, PassName, RemarkName,
-          *cast<BasicBlock>(CodeRegion)->getParent(), Loc, CodeRegion) {}
+    const BasicBlock *CodeRegion)
+    : DiagnosticInfoIROptimization(DK_OptimizationFailure, DS_Warning, PassName,
+                                   RemarkName, *CodeRegion->getParent(), Loc,
+                                   CodeRegion) {}
 
 bool DiagnosticInfoOptimizationFailure::isEnabled() const {
   // Only print warnings.

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -815,7 +815,7 @@ static void debugVectorizationMessage(const StringRef Prefix,
 static OptimizationRemarkAnalysis
 createLVAnalysis(const char *PassName, StringRef RemarkName, Loop *TheLoop,
                  Instruction *I, DebugLoc DL = {}) {
-  Value *CodeRegion = I ? I->getParent() : TheLoop->getHeader();
+  BasicBlock *CodeRegion = I ? I->getParent() : TheLoop->getHeader();
   // If debug location is attached to the instruction, use it. Otherwise if DL
   // was not provided, use the loop's.
   if (I && I->getDebugLoc())

--- a/polly/include/polly/ScopDetectionDiagnostic.h
+++ b/polly/include/polly/ScopDetectionDiagnostic.h
@@ -137,7 +137,7 @@ public:
   /// Get the Basic Block containing this remark.
   ///
   /// @return The Basic Block containing this remark.
-  virtual const Value *getRemarkBB() const = 0;
+  virtual const BasicBlock *getRemarkBB() const = 0;
 
   /// Generate a reasonable diagnostic message describing this error.
   ///
@@ -219,7 +219,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   //@}
@@ -243,7 +243,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   std::string getEndUserMessage() const override;
   const DebugLoc &getDebugLoc() const override;
@@ -269,7 +269,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   std::string getEndUserMessage() const override;
   const DebugLoc &getDebugLoc() const override;
@@ -295,7 +295,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   std::string getEndUserMessage() const override;
   const DebugLoc &getDebugLoc() const override;
@@ -344,7 +344,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   //@}
 };
@@ -369,7 +369,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   //@}
 };
@@ -392,7 +392,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   //@}
 };
@@ -426,7 +426,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   //@}
 };
@@ -446,7 +446,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   //@}
 };
@@ -466,7 +466,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   //@}
 };
@@ -490,7 +490,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   std::string getEndUserMessage() const override;
   //@}
@@ -521,7 +521,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   std::string getEndUserMessage() const override;
   //@}
@@ -546,7 +546,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   std::string getEndUserMessage() const override;
   //@}
@@ -577,7 +577,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   std::string getEndUserMessage() const override;
@@ -605,7 +605,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   std::string getEndUserMessage() const override;
@@ -633,7 +633,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   std::string getEndUserMessage() const override;
@@ -661,7 +661,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   std::string getEndUserMessage() const override;
@@ -685,7 +685,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   std::string getEndUserMessage() const override;
@@ -724,7 +724,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   std::string getEndUserMessage() const override;
@@ -766,7 +766,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   //@}
@@ -788,7 +788,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   //@}
@@ -810,7 +810,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   //@}
@@ -832,7 +832,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   std::string getEndUserMessage() const override;
   const DebugLoc &getDebugLoc() const override;
@@ -855,7 +855,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   std::string getEndUserMessage() const override;
   const DebugLoc &getDebugLoc() const override;
@@ -879,7 +879,7 @@ public:
   /// @name RejectReason interface
   //@{
   std::string getRemarkName() const override;
-  const Value *getRemarkBB() const override;
+  const BasicBlock *getRemarkBB() const override;
   std::string getMessage() const override;
   const DebugLoc &getDebugLoc() const override;
   std::string getEndUserMessage() const override;

--- a/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
+++ b/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
@@ -201,7 +201,7 @@ std::string ReportInvalidTerminator::getRemarkName() const {
   return "InvalidTerminator";
 }
 
-const Value *ReportInvalidTerminator::getRemarkBB() const { return BB; }
+const BasicBlock *ReportInvalidTerminator::getRemarkBB() const { return BB; }
 
 std::string ReportInvalidTerminator::getMessage() const {
   return ("Invalid instruction terminates BB: " + BB->getName()).str();
@@ -222,7 +222,7 @@ std::string ReportUnreachableInExit::getRemarkName() const {
   return "UnreachableInExit";
 }
 
-const Value *ReportUnreachableInExit::getRemarkBB() const { return BB; }
+const BasicBlock *ReportUnreachableInExit::getRemarkBB() const { return BB; }
 
 std::string ReportUnreachableInExit::getMessage() const {
   std::string BBName = BB->getName().str();
@@ -246,7 +246,7 @@ std::string ReportIndirectPredecessor::getRemarkName() const {
   return "IndirectPredecessor";
 }
 
-const Value *ReportIndirectPredecessor::getRemarkBB() const {
+const BasicBlock *ReportIndirectPredecessor::getRemarkBB() const {
   if (Inst)
     return Inst->getParent();
   return nullptr;
@@ -277,7 +277,7 @@ std::string ReportIrreducibleRegion::getRemarkName() const {
   return "IrreducibleRegion";
 }
 
-const Value *ReportIrreducibleRegion::getRemarkBB() const {
+const BasicBlock *ReportIrreducibleRegion::getRemarkBB() const {
   return R->getEntry();
 }
 
@@ -311,7 +311,7 @@ bool ReportAffFunc::classof(const RejectReason *RR) {
 
 std::string ReportUndefCond::getRemarkName() const { return "UndefCond"; }
 
-const Value *ReportUndefCond::getRemarkBB() const { return BB; }
+const BasicBlock *ReportUndefCond::getRemarkBB() const { return BB; }
 
 std::string ReportUndefCond::getMessage() const {
   return ("Condition based on 'undef' value in BB: " + BB->getName()).str();
@@ -326,7 +326,7 @@ bool ReportUndefCond::classof(const RejectReason *RR) {
 
 std::string ReportInvalidCond::getRemarkName() const { return "InvalidCond"; }
 
-const Value *ReportInvalidCond::getRemarkBB() const { return BB; }
+const BasicBlock *ReportInvalidCond::getRemarkBB() const { return BB; }
 
 std::string ReportInvalidCond::getMessage() const {
   return ("Condition in BB '" + BB->getName()).str() +
@@ -342,7 +342,7 @@ bool ReportInvalidCond::classof(const RejectReason *RR) {
 
 std::string ReportUndefOperand::getRemarkName() const { return "UndefOperand"; }
 
-const Value *ReportUndefOperand::getRemarkBB() const { return BB; }
+const BasicBlock *ReportUndefOperand::getRemarkBB() const { return BB; }
 
 std::string ReportUndefOperand::getMessage() const {
   return ("undef operand in branch at BB: " + BB->getName()).str();
@@ -357,7 +357,7 @@ bool ReportUndefOperand::classof(const RejectReason *RR) {
 
 std::string ReportNonAffBranch::getRemarkName() const { return "NonAffBranch"; }
 
-const Value *ReportNonAffBranch::getRemarkBB() const { return BB; }
+const BasicBlock *ReportNonAffBranch::getRemarkBB() const { return BB; }
 
 std::string ReportNonAffBranch::getMessage() const {
   return ("Non affine branch in BB '" + BB->getName()).str() +
@@ -373,7 +373,7 @@ bool ReportNonAffBranch::classof(const RejectReason *RR) {
 
 std::string ReportNoBasePtr::getRemarkName() const { return "NoBasePtr"; }
 
-const Value *ReportNoBasePtr::getRemarkBB() const { return Inst->getParent(); }
+const BasicBlock *ReportNoBasePtr::getRemarkBB() const { return Inst->getParent(); }
 
 std::string ReportNoBasePtr::getMessage() const { return "No base pointer"; }
 
@@ -386,7 +386,7 @@ bool ReportNoBasePtr::classof(const RejectReason *RR) {
 
 std::string ReportUndefBasePtr::getRemarkName() const { return "UndefBasePtr"; }
 
-const Value *ReportUndefBasePtr::getRemarkBB() const {
+const BasicBlock *ReportUndefBasePtr::getRemarkBB() const {
   return Inst->getParent();
 }
 
@@ -405,7 +405,7 @@ std::string ReportVariantBasePtr::getRemarkName() const {
   return "VariantBasePtr";
 }
 
-const Value *ReportVariantBasePtr::getRemarkBB() const {
+const BasicBlock *ReportVariantBasePtr::getRemarkBB() const {
   return Inst->getParent();
 }
 
@@ -428,7 +428,7 @@ std::string ReportDifferentArrayElementSize::getRemarkName() const {
   return "DifferentArrayElementSize";
 }
 
-const Value *ReportDifferentArrayElementSize::getRemarkBB() const {
+const BasicBlock *ReportDifferentArrayElementSize::getRemarkBB() const {
   return Inst->getParent();
 }
 
@@ -455,7 +455,7 @@ std::string ReportNonAffineAccess::getRemarkName() const {
   return "NonAffineAccess";
 }
 
-const Value *ReportNonAffineAccess::getRemarkBB() const {
+const BasicBlock *ReportNonAffineAccess::getRemarkBB() const {
   return Inst->getParent();
 }
 
@@ -482,7 +482,7 @@ ReportLoopBound::ReportLoopBound(Loop *L, const SCEV *LoopCount)
 
 std::string ReportLoopBound::getRemarkName() const { return "LoopBound"; }
 
-const Value *ReportLoopBound::getRemarkBB() const { return L->getHeader(); }
+const BasicBlock *ReportLoopBound::getRemarkBB() const { return L->getHeader(); }
 
 std::string ReportLoopBound::getMessage() const {
   return "Non affine loop bound '" + *LoopCount +
@@ -506,7 +506,7 @@ std::string ReportLoopHasNoExit::getRemarkName() const {
   return "LoopHasNoExit";
 }
 
-const Value *ReportLoopHasNoExit::getRemarkBB() const { return L->getHeader(); }
+const BasicBlock *ReportLoopHasNoExit::getRemarkBB() const { return L->getHeader(); }
 
 std::string ReportLoopHasNoExit::getMessage() const {
   return "Loop " + L->getHeader()->getName() + " has no exit.";
@@ -529,7 +529,7 @@ std::string ReportLoopHasMultipleExits::getRemarkName() const {
   return "ReportLoopHasMultipleExits";
 }
 
-const Value *ReportLoopHasMultipleExits::getRemarkBB() const {
+const BasicBlock *ReportLoopHasMultipleExits::getRemarkBB() const {
   return L->getHeader();
 }
 
@@ -554,7 +554,7 @@ std::string ReportLoopOnlySomeLatches::getRemarkName() const {
   return "LoopHasNoExit";
 }
 
-const Value *ReportLoopOnlySomeLatches::getRemarkBB() const {
+const BasicBlock *ReportLoopOnlySomeLatches::getRemarkBB() const {
   return L->getHeader();
 }
 
@@ -582,7 +582,7 @@ ReportFuncCall::ReportFuncCall(Instruction *Inst)
 
 std::string ReportFuncCall::getRemarkName() const { return "FuncCall"; }
 
-const Value *ReportFuncCall::getRemarkBB() const { return Inst->getParent(); }
+const BasicBlock *ReportFuncCall::getRemarkBB() const { return Inst->getParent(); }
 
 std::string ReportFuncCall::getMessage() const {
   return "Call instruction: " + *Inst;
@@ -611,7 +611,7 @@ std::string ReportNonSimpleMemoryAccess::getRemarkName() const {
   return "NonSimpleMemoryAccess";
 }
 
-const Value *ReportNonSimpleMemoryAccess::getRemarkBB() const {
+const BasicBlock *ReportNonSimpleMemoryAccess::getRemarkBB() const {
   return Inst->getParent();
 }
 
@@ -673,7 +673,7 @@ std::string ReportAlias::formatInvalidAlias(std::string Prefix,
 
 std::string ReportAlias::getRemarkName() const { return "Alias"; }
 
-const Value *ReportAlias::getRemarkBB() const { return Inst->getParent(); }
+const BasicBlock *ReportAlias::getRemarkBB() const { return Inst->getParent(); }
 
 std::string ReportAlias::getMessage() const {
   return formatInvalidAlias("Possible aliasing: ");
@@ -711,7 +711,7 @@ ReportIntToPtr::ReportIntToPtr(Instruction *BaseValue)
 
 std::string ReportIntToPtr::getRemarkName() const { return "IntToPtr"; }
 
-const Value *ReportIntToPtr::getRemarkBB() const {
+const BasicBlock *ReportIntToPtr::getRemarkBB() const {
   return BaseValue->getParent();
 }
 
@@ -735,7 +735,7 @@ ReportAlloca::ReportAlloca(Instruction *Inst)
 
 std::string ReportAlloca::getRemarkName() const { return "Alloca"; }
 
-const Value *ReportAlloca::getRemarkBB() const { return Inst->getParent(); }
+const BasicBlock *ReportAlloca::getRemarkBB() const { return Inst->getParent(); }
 
 std::string ReportAlloca::getMessage() const {
   return "Alloca instruction: " + *Inst;
@@ -757,7 +757,7 @@ ReportUnknownInst::ReportUnknownInst(Instruction *Inst)
 
 std::string ReportUnknownInst::getRemarkName() const { return "UnknownInst"; }
 
-const Value *ReportUnknownInst::getRemarkBB() const {
+const BasicBlock *ReportUnknownInst::getRemarkBB() const {
   return Inst->getParent();
 }
 
@@ -781,7 +781,7 @@ ReportEntry::ReportEntry(BasicBlock *BB)
 
 std::string ReportEntry::getRemarkName() const { return "Entry"; }
 
-const Value *ReportEntry::getRemarkBB() const { return BB; }
+const BasicBlock *ReportEntry::getRemarkBB() const { return BB; }
 
 std::string ReportEntry::getMessage() const {
   return "Region containing entry block of function is invalid!";
@@ -807,7 +807,7 @@ ReportUnprofitable::ReportUnprofitable(Region *R)
 
 std::string ReportUnprofitable::getRemarkName() const { return "Unprofitable"; }
 
-const Value *ReportUnprofitable::getRemarkBB() const { return R->getEntry(); }
+const BasicBlock *ReportUnprofitable::getRemarkBB() const { return R->getEntry(); }
 
 std::string ReportUnprofitable::getMessage() const {
   return "Region can not profitably be optimized!";

--- a/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
+++ b/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
@@ -373,7 +373,9 @@ bool ReportNonAffBranch::classof(const RejectReason *RR) {
 
 std::string ReportNoBasePtr::getRemarkName() const { return "NoBasePtr"; }
 
-const BasicBlock *ReportNoBasePtr::getRemarkBB() const { return Inst->getParent(); }
+const BasicBlock *ReportNoBasePtr::getRemarkBB() const {
+  return Inst->getParent();
+}
 
 std::string ReportNoBasePtr::getMessage() const { return "No base pointer"; }
 
@@ -482,7 +484,9 @@ ReportLoopBound::ReportLoopBound(Loop *L, const SCEV *LoopCount)
 
 std::string ReportLoopBound::getRemarkName() const { return "LoopBound"; }
 
-const BasicBlock *ReportLoopBound::getRemarkBB() const { return L->getHeader(); }
+const BasicBlock *ReportLoopBound::getRemarkBB() const {
+  return L->getHeader();
+}
 
 std::string ReportLoopBound::getMessage() const {
   return "Non affine loop bound '" + *LoopCount +
@@ -506,7 +510,9 @@ std::string ReportLoopHasNoExit::getRemarkName() const {
   return "LoopHasNoExit";
 }
 
-const BasicBlock *ReportLoopHasNoExit::getRemarkBB() const { return L->getHeader(); }
+const BasicBlock *ReportLoopHasNoExit::getRemarkBB() const {
+  return L->getHeader();
+}
 
 std::string ReportLoopHasNoExit::getMessage() const {
   return "Loop " + L->getHeader()->getName() + " has no exit.";
@@ -582,7 +588,9 @@ ReportFuncCall::ReportFuncCall(Instruction *Inst)
 
 std::string ReportFuncCall::getRemarkName() const { return "FuncCall"; }
 
-const BasicBlock *ReportFuncCall::getRemarkBB() const { return Inst->getParent(); }
+const BasicBlock *ReportFuncCall::getRemarkBB() const {
+  return Inst->getParent();
+}
 
 std::string ReportFuncCall::getMessage() const {
   return "Call instruction: " + *Inst;
@@ -735,7 +743,9 @@ ReportAlloca::ReportAlloca(Instruction *Inst)
 
 std::string ReportAlloca::getRemarkName() const { return "Alloca"; }
 
-const BasicBlock *ReportAlloca::getRemarkBB() const { return Inst->getParent(); }
+const BasicBlock *ReportAlloca::getRemarkBB() const {
+  return Inst->getParent();
+}
 
 std::string ReportAlloca::getMessage() const {
   return "Alloca instruction: " + *Inst;
@@ -807,7 +817,9 @@ ReportUnprofitable::ReportUnprofitable(Region *R)
 
 std::string ReportUnprofitable::getRemarkName() const { return "Unprofitable"; }
 
-const BasicBlock *ReportUnprofitable::getRemarkBB() const { return R->getEntry(); }
+const BasicBlock *ReportUnprofitable::getRemarkBB() const {
+  return R->getEntry();
+}
 
 std::string ReportUnprofitable::getMessage() const {
   return "Region can not profitably be optimized!";

--- a/polly/lib/Transform/ManualOptimizer.cpp
+++ b/polly/lib/Transform/ManualOptimizer.cpp
@@ -152,7 +152,7 @@ private:
   /// Check whether a schedule after a  transformation is legal. Return the old
   /// schedule without the transformation.
   isl::schedule
-  checkDependencyViolation(llvm::MDNode *LoopMD, llvm::Value *CodeRegion,
+  checkDependencyViolation(llvm::MDNode *LoopMD, llvm::BasicBlock *CodeRegion,
                            const isl::schedule_node &OrigBand,
                            StringRef DebugLocAttr, StringRef TransPrefix,
                            StringRef RemarkName, StringRef TransformationName) {
@@ -235,7 +235,7 @@ public:
     // TODO: Works only for original loop; for transformed loops, should track
     // where the loop's body code comes from.
     Loop *Loop = Attr->OriginalLoop;
-    Value *CodeRegion = nullptr;
+    BasicBlock *CodeRegion = nullptr;
     if (Loop)
       CodeRegion = Loop->getHeader();
 


### PR DESCRIPTION
CodeRegion's were previously passed as Value*, but then immediately upcast to BasicBlock. Let's keep the type information around until the use cases for non-BasicBlock code regions actually materialize.