### PR TITLE
[lldb] Disable TestReverseContinueBreakpoints.py and TestReverseContinueWatchpoints.py for Windows x86_64

### DIFF
--- a/lldb/test/API/functionalities/reverse-execution/TestReverseContinueBreakpoints.py
+++ b/lldb/test/API/functionalities/reverse-execution/TestReverseContinueBreakpoints.py
@@ -63,10 +63,20 @@ class TestReverseContinueBreakpoints(ReverseTestBase):
         self.assertEqual(threads_now, initial_threads)
 
     @skipIfRemote
+    @skipIf(
+        oslist=["windows"],
+        archs=["x86_64"],
+        bugnumber="github.com/llvm/llvm-project/issues/138084",
+    )
     def test_reverse_continue_skip_breakpoint(self):
         self.reverse_continue_skip_breakpoint_internal(async_mode=False)
 
     @skipIfRemote
+    @skipIf(
+        oslist=["windows"],
+        archs=["x86_64"],
+        bugnumber="github.com/llvm/llvm-project/issues/138084",
+    )
     def test_reverse_continue_skip_breakpoint_async(self):
         self.reverse_continue_skip_breakpoint_internal(async_mode=True)
 

--- a/lldb/test/API/functionalities/reverse-execution/TestReverseContinueWatchpoints.py
+++ b/lldb/test/API/functionalities/reverse-execution/TestReverseContinueWatchpoints.py
@@ -64,12 +64,22 @@ class TestReverseContinueWatchpoints(ReverseTestBase):
     @skipIfRemote
     # Watchpoints don't work in single-step mode
     @skipIf(macos_version=["<", "15.0"], archs=["arm64"])
+    @skipIf(
+        oslist=["windows"],
+        archs=["x86_64"],
+        bugnumber="github.com/llvm/llvm-project/issues/138084",
+    )
     def test_reverse_continue_skip_watchpoint(self):
         self.reverse_continue_skip_watchpoint_internal(async_mode=False)
 
     @skipIfRemote
     # Watchpoints don't work in single-step mode
     @skipIf(macos_version=["<", "15.0"], archs=["arm64"])
+    @skipIf(
+        oslist=["windows"],
+        archs=["x86_64"],
+        bugnumber="github.com/llvm/llvm-project/issues/138084",
+    )
     def test_reverse_continue_skip_watchpoint_async(self):
         self.reverse_continue_skip_watchpoint_internal(async_mode=True)
 


### PR DESCRIPTION
See #138084 for details.