### PR TITLE
[RISCV] Add RISCVISD::VQDOT*_VL to RISCVSelectionDAGInfo::verifyTargetNode.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.cpp
@@ -37,7 +37,8 @@ void RISCVSelectionDAGInfo::verifyTargetNode(const SelectionDAG &DAG,
            N->getOperand(2).getValueType() == VT &&
            "Expected result and first 3 operands to have the same type!");
     EVT MaskVT = N->getOperand(3).getValueType();
-    assert(MaskVT.isScalableVector() && MaskVT.getVectorElementType() == MVT::i1 &&
+    assert(MaskVT.isScalableVector() &&
+           MaskVT.getVectorElementType() == MVT::i1 &&
            MaskVT.getVectorElementCount() == VT.getVectorElementCount() &&
            "Expected mask VT to be an i1 scalable vector with same number of "
            "elements as the result");

--- a/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.cpp
@@ -17,3 +17,35 @@ RISCVSelectionDAGInfo::RISCVSelectionDAGInfo()
     : SelectionDAGGenTargetInfo(RISCVGenSDNodeInfo) {}
 
 RISCVSelectionDAGInfo::~RISCVSelectionDAGInfo() = default;
+
+void RISCVSelectionDAGInfo::verifyTargetNode(const SelectionDAG &DAG,
+                                             const SDNode *N) const {
+#ifndef NDEBUG
+  switch (N->getOpcode()) {
+  default:
+    return SelectionDAGGenTargetInfo::verifyTargetNode(DAG, N);
+  case RISCVISD::VQDOT_VL:
+  case RISCVISD::VQDOTU_VL:
+  case RISCVISD::VQDOTSU_VL: {
+    assert(N->getNumValues() == 1 && "Expected one result!");
+    assert(N->getNumOperands() == 5 && "Expected five operands!");
+    EVT VT = N->getValueType(0);
+    assert(VT.isScalableVector() && VT.getVectorElementType() == MVT::i32 &&
+           "Expected result to be an i32 scalable vector");
+    assert(N->getOperand(0).getValueType() == VT &&
+           N->getOperand(1).getValueType() == VT &&
+           N->getOperand(2).getValueType() == VT &&
+           "Expected result and first 3 operands to have the same type!");
+    EVT MaskVT = N->getOperand(3).getValueType();
+    assert(MaskVT.isScalableVector() && MaskVT.getVectorElementType() == MVT::i1 &&
+           MaskVT.getVectorElementCount() == VT.getVectorElementCount() &&
+           "Expected mask VT to be an i1 scalable vector with same number of "
+           "elements as the result");
+    assert((N->getOperand(4).getValueType() == MVT::i32 ||
+            N->getOperand(4).getValueType() == MVT::i64) &&
+           "Expect VL operand to be i32 or i64");
+    break;
+  }
+  }
+#endif
+}

--- a/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.h
@@ -31,6 +31,9 @@ public:
 
   ~RISCVSelectionDAGInfo() override;
 
+  void verifyTargetNode(const SelectionDAG &DAG,
+                        const SDNode *N) const override;
+
   bool hasPassthruOp(unsigned Opcode) const {
     return GenNodeInfo.getDesc(Opcode).TSFlags & RISCVISD::HasPassthruOpMask;
   }


### PR DESCRIPTION
After seeing the bug that #142185 fixed, I thought it might be a good idea to start verifying that nodes are formed correctly.

This patch introduces the verifyTargetNode function and adds these opcodes. More opcodes can be added in later patches.