### PR TITLE
Revert "[libc++] Re-enable std::pair trivial copy constructor for FreeBSD >= 14"

### DIFF
--- a/libcxx/include/__configuration/abi.h
+++ b/libcxx/include/__configuration/abi.h
@@ -130,7 +130,7 @@
 #  endif
 // Feature macros for disabling pre ABI v1 features. All of these options
 // are deprecated.
-#  if defined(__FreeBSD__) && __FreeBSD__ < 14
+#  if defined(__FreeBSD__)
 #    define _LIBCPP_DEPRECATED_ABI_DISABLE_PAIR_TRIVIAL_COPY_CTOR
 #  endif
 #endif

--- a/libcxx/include/__cxx03/__configuration/abi.h
+++ b/libcxx/include/__cxx03/__configuration/abi.h
@@ -116,7 +116,7 @@
 #  endif
 // Feature macros for disabling pre ABI v1 features. All of these options
 // are deprecated.
-#  if defined(__FreeBSD__) && __FreeBSD__ < 14
+#  if defined(__FreeBSD__)
 #    define _LIBCPP_DEPRECATED_ABI_DISABLE_PAIR_TRIVIAL_COPY_CTOR
 #  endif
 #endif


### PR DESCRIPTION
The ABI bump to adopt the conforming ABI v1 std::pair implementation did
not end up happening for FreeBSD 14, and instead this diff was reverted
downstream in FreeBSD[1]. Align the upstream ABI config with FreeBSD's
actual ABI.

[1] ce4f1f49e036 ("Revert commit 6255157d24e2 from llvm-project (by Dimitry Andric):")

This reverts commit 6255157d24e27c604bda8fe8ce26e896f54785c0.
