### PR TITLE
[Sanitizer][test] Emit to stderr to fix android

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
@@ -1,7 +1,6 @@
 // Test __sanitizer_set_report_path and __sanitizer_get_report_path:
 // RUN: %clangxx -O2 %s -o %t
-// RUN: %env HOME=%t.homedir TMPDIR=%t.tmpdir %run %t 2>%t.err | FileCheck %s
-// RUN: FileCheck %s --input-file=%t.err --check-prefix=ERROR
+// RUN: %env HOME=%t.homedir TMPDIR=%t.tmpdir %run %t 2>&1 | FileCheck %s
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>
@@ -12,31 +11,31 @@ int main(int argc, char **argv) {
   sprintf(buff, "%s.report_path/report", argv[0]);
   __sanitizer_set_report_path(buff);
   // CHECK: {{.*}}.report_path/report.[[PID:[0-9]+]]
-  printf("%s\n", __sanitizer_get_report_path());
+  fprintf(stderr, "%s\n", __sanitizer_get_report_path());
 
   strcpy(buff, "%H/foo");
   __sanitizer_set_report_path(buff);
   // CHECK: [[T:.*]].homedir/foo.[[PID]]
-  printf("%s\n", __sanitizer_get_report_path());
+  fprintf(stderr, "%s\n", __sanitizer_get_report_path());
 
   strcpy(buff, "%t/foo");
   __sanitizer_set_report_path(buff);
   // CHECK: [[T]].tmpdir/foo.[[PID]]
-  printf("%s\n", __sanitizer_get_report_path());
+  fprintf(stderr, "%s\n", __sanitizer_get_report_path());
 
   strcpy(buff, "%H/%p/%%foo");
   __sanitizer_set_report_path(buff);
   // CHECK: [[T]].homedir/[[PID]]/%foo.[[PID]]
-  printf("%s\n", __sanitizer_get_report_path());
+  fprintf(stderr, "%s\n", __sanitizer_get_report_path());
 
   strcpy(buff, "%%foo%%bar");
   __sanitizer_set_report_path(buff);
   // CHECK: %foo%bar.[[PID]]
-  printf("%s\n", __sanitizer_get_report_path());
+  fprintf(stderr, "%s\n", __sanitizer_get_report_path());
 
   strcpy(buff, "%%foo%ba%%r");
   __sanitizer_set_report_path(buff);
-  // ERROR: Unexpected pattern: %%foo%ba%%r
+  // CHECK: Unexpected pattern: %%foo%ba%%r
   // CHECK: %%foo%ba%%r.[[PID]]
-  printf("%s\n", __sanitizer_get_report_path());
+  fprintf(stderr, "%s\n", __sanitizer_get_report_path());
 }


### PR DESCRIPTION
This test is broken on android by https://github.com/llvm/llvm-project/pull/141820

https://lab.llvm.org/buildbot/#/builders/186/builds/9498

> FileCheck error: '' is empty.

I suspect that on android printf only works if its emitted to stderr because this use to work

https://github.com/llvm/llvm-project/blob/a2ce5647200ad40ae356affd44db7d054de444d2/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp#L21-L22

Only emit to stderr and see if that fixes the test.