### PR TITLE
[AArch64] Fix `APAS` instructions to disassemble to self not to `SYS` alias

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1817,7 +1817,6 @@ class APASI : SimpleSystemI<0, (ins GPR64:$Xt), "apas", "\t$Xt">, Sched<[]> {
   bits<5> Xt;
   let Inst{20-5} = 0b0111001110000000;
   let Inst{4-0} = Xt;
-  let DecoderNamespace = "APAS";
 }
 
 // Hint instructions that take both a CRm and a 3-bit immediate.

--- a/llvm/test/MC/Disassembler/AArch64/armv9.6a-rme-gpc3.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9.6a-rme-gpc3.txt
@@ -9,10 +9,10 @@
 [0xa3,0x21,0x3e,0xd5]
 [0xa4,0x21,0x1e,0xd5]
 
-# CHECK:      	sys	#6, c7, c0, #0, x0
-# CHECK-NEXT: 	sys	#6, c7, c0, #0, x1
-# CHECK-NEXT: 	sys	#6, c7, c0, #0, x2
-# CHECK-NEXT: 	sys	#6, c7, c0, #0, x17
-# CHECK-NEXT: 	sys	#6, c7, c0, #0, x30
+# CHECK:      	 apas x0
+# CHECK-NEXT: 	 apas x1
+# CHECK-NEXT: 	 apas x2
+# CHECK-NEXT: 	 apas x17
+# CHECK-NEXT: 	 apas x30
 # CHECK-NEXT: 	mrs	x3, GPCBW_EL3
 # CHECK-NEXT: 	msr	GPCBW_EL3, x4

--- a/llvm/test/MC/Disassembler/AArch64/armv9.6a-rme-gpc3.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9.6a-rme-gpc3.txt
@@ -9,10 +9,10 @@
 [0xa3,0x21,0x3e,0xd5]
 [0xa4,0x21,0x1e,0xd5]
 
-# CHECK:      	 apas x0
-# CHECK-NEXT: 	 apas x1
-# CHECK-NEXT: 	 apas x2
-# CHECK-NEXT: 	 apas x17
-# CHECK-NEXT: 	 apas x30
+# CHECK:      	apas x0
+# CHECK-NEXT: 	apas x1
+# CHECK-NEXT: 	apas x2
+# CHECK-NEXT: 	apas x17
+# CHECK-NEXT: 	apas x30
 # CHECK-NEXT: 	mrs	x3, GPCBW_EL3
 # CHECK-NEXT: 	msr	GPCBW_EL3, x4


### PR DESCRIPTION
`APAS` instructions currently incorrectly disassemble to `SYS` aliases. Fix this so that they disassemble to the actual `APAS` instruction.