### PR TITLE
clang.llvm.org/get_started.html: remove shallow clone misinformation

### DIFF
--- a/clang/www/get_started.html
+++ b/clang/www/get_started.html
@@ -54,7 +54,7 @@ follows:</p>
     <li>The above command is very slow. It can be made faster by creating a shallow clone. Shallow clone saves storage and speeds up the checkout time. This is done by using the command:
       <ul>
         <li><tt>git clone --depth=1 https://github.com/llvm/llvm-project.git (using this only the latest version of llvm can be built)</tt></li>
-        <li>For normal users looking to just compile, this command works fine. But if someone later becomes a contributor, since they can't push code from a shallow clone, it needs to be converted into a full clone:
+        <li>For normal users looking to just compile, this command works fine. But if someone later becomes a contributor, since this hides all history, they may want to convert this into a full clone:
           <ul>
             <li><tt>cd llvm-project</tt></li>
             <li><tt>git fetch --unshallow</tt></li>


### PR DESCRIPTION
I pushed this from a shallow clone