### PR TITLE
[lldb] Add Python properties to SBBreakpoint and similar

### DIFF
--- a/lldb/bindings/interface/SBBreakpointExtensions.i
+++ b/lldb/bindings/interface/SBBreakpointExtensions.i
@@ -50,6 +50,15 @@ STRING_EXTENSION_OUTSIDE(SBBreakpoint)
         enabled = property(IsEnabled, SetEnabled, doc='''A read/write property that configures whether this breakpoint is enabled or not.''')
         one_shot = property(IsOneShot, SetOneShot, doc='''A read/write property that configures whether this breakpoint is one-shot (deleted when hit) or not.''')
         num_locations = property(GetNumLocations, None, doc='''A read only property that returns the count of locations of this breakpoint.''')
+        auto_continue = property(GetAutoContinue, SetAutoContinue, doc='A read/write property that configures the auto-continue property of this breakpoint.')
+        condition = property(GetCondition, SetCondition, doc='A read/write property that configures the condition of this breakpoint.')
+        hit_count = property(GetHitCount, doc='A read only property that returns the hit count of this breakpoint.')
+        ignore_count = property(GetIgnoreCount, SetIgnoreCount, doc='A read/write property that configures the ignore count of this breakpoint.')
+        queue_name = property(GetQueueName, SetQueueName, doc='A read/write property that configures the queue name criteria of this breakpoint.')
+        target = property(GetTarget, doc='A read only property that returns the target of this breakpoint.')
+        thread_id = property(GetThreadID, SetThreadID, doc='A read/write property that configures the thread id criteria of this breakpoint.')
+        thread_index = property(GetThreadIndex, SetThreadIndex, doc='A read/write property that configures the thread index criteria of this breakpoint.')
+        thread_name = property(GetThreadName, SetThreadName, doc='A read/write property that configures the thread name criteria of this breakpoint.')
     %}
 #endif
 }

--- a/lldb/bindings/interface/SBBreakpointLocationExtensions.i
+++ b/lldb/bindings/interface/SBBreakpointLocationExtensions.i
@@ -7,6 +7,19 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBBreakpointLocation, lldb::eDescriptionLevelFull
     # our own equality operator here
     def __eq__(self, other):
       return not self.__ne__(other)
+
+    addr = property(GetAddress, doc='A read only property that returns the address of this breakpoint location.')
+    auto_continue = property(GetAutoContinue, SetAutoContinue, doc='A read/write property that configures the auto-continue property of this breakpoint location.')
+    breakpoint = property(GetBreakpoint, doc='A read only property that returns the parent breakpoint of this breakpoint location.')
+    condition = property(GetCondition, SetCondition, doc='A read/write property that configures the condition of this breakpoint location.')
+    hit_count = property(GetHitCount, doc='A read only property that returns the hit count of this breakpoint location.')
+    id = property(GetID, doc='A read only property that returns the id of this breakpoint location.')
+    ignore_count = property(GetIgnoreCount, SetIgnoreCount, doc='A read/write property that configures the ignore count of this breakpoint location.')
+    load_addr = property(GetLoadAddress, doc='A read only property that returns the load address of this breakpoint location.')
+    queue_name = property(GetQueueName, SetQueueName, doc='A read/write property that configures the queue name criteria of this breakpoint location.')
+    thread_id = property(GetThreadID, SetThreadID, doc='A read/write property that configures the thread id criteria of this breakpoint location.')
+    thread_index = property(GetThreadIndex, SetThreadIndex, doc='A read/write property that configures the thread index criteria of this breakpoint location.')
+    thread_name = property(GetThreadName, SetThreadName, doc='A read/write property that configures the thread name criteria of this breakpoint location.')
     %}
 #endif
 }

--- a/lldb/bindings/interface/SBBreakpointNameExtensions.i
+++ b/lldb/bindings/interface/SBBreakpointNameExtensions.i
@@ -7,6 +7,16 @@ STRING_EXTENSION_OUTSIDE(SBBreakpointName)
     # our own equality operator here
     def __eq__(self, other):
       return not self.__ne__(other)
+
+    auto_continue = property(GetAutoContinue, SetAutoContinue, doc='A read/write property that configures the auto-continue property of this breakpoint name.')
+    condition = property(GetCondition, SetCondition, doc='A read/write property that configures the condition of this breakpoint name.')
+    enabled = property(IsEnabled, SetEnabled, doc='''A read/write property that configures whether this breakpoint name is enabled or not.''')
+    ignore_count = property(GetIgnoreCount, SetIgnoreCount, doc='A read/write property that configures the ignore count of this breakpoint name.')
+    one_shot = property(IsOneShot, SetOneShot, doc='''A read/write property that configures whether this breakpoint name is one-shot (deleted when hit) or not.''')
+    queue_name = property(GetQueueName, SetQueueName, doc='A read/write property that configures the queue name criteria of this breakpoint name.')
+    thread_id = property(GetThreadID, SetThreadID, doc='A read/write property that configures the thread id criteria of this breakpoint name.')
+    thread_index = property(GetThreadIndex, SetThreadIndex, doc='A read/write property that configures the thread index criteria of this breakpoint name.')
+    thread_name = property(GetThreadName, SetThreadName, doc='A read/write property that configures the thread name criteria of this breakpoint name.')
     %}
 #endif
 }

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_ignore_count/TestBreakpointIgnoreCount.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_ignore_count/TestBreakpointIgnoreCount.py
@@ -175,11 +175,11 @@ class BreakpointIgnoreCountTestCase(TestBase):
         if use_location:
             loc = bkpt.location[0]
             self.assertTrue(loc.IsValid(), "Got a valid location")
-            loc.SetIgnoreCount(2)
-            loc.SetCondition("i >= 3")
+            loc.ignore_count = 2
+            loc.condition = "i >= 3"
         else:
-            bkpt.SetIgnoreCount(2)
-            bkpt.SetCondition("i >= 3")
+            bkpt.ignore_count = 2
+            bkpt.condition = "i >= 3"
 
         threads = lldbutil.continue_to_breakpoint(process, bkpt)
         self.assertEqual(len(threads), 1, "Hit the breakpoint")
@@ -188,4 +188,4 @@ class BreakpointIgnoreCountTestCase(TestBase):
         val = var.GetValueAsUnsigned(10000)
         self.assertNotEqual(val, 10000, "Got the fail value for i")
         self.assertEqual(val, 5, "We didn't stop the right number of times")
-        self.assertEqual(bkpt.GetHitCount(), 3, "Hit count is not right")
+        self.assertEqual(bkpt.hit_count, 3, "Hit count is not right")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
@@ -216,16 +216,14 @@ class BreakpointNames(TestBase):
         )
 
     def check_option_values(self, bp_object):
-        self.assertEqual(bp_object.IsOneShot(), self.is_one_shot, "IsOneShot")
-        self.assertEqual(bp_object.GetIgnoreCount(), self.ignore_count, "IgnoreCount")
-        self.assertEqual(bp_object.GetCondition(), self.condition, "Condition")
-        self.assertEqual(
-            bp_object.GetAutoContinue(), self.auto_continue, "AutoContinue"
-        )
-        self.assertEqual(bp_object.GetThreadID(), self.tid, "Thread ID")
-        self.assertEqual(bp_object.GetThreadIndex(), self.tidx, "Thread Index")
-        self.assertEqual(bp_object.GetThreadName(), self.thread_name, "Thread Name")
-        self.assertEqual(bp_object.GetQueueName(), self.queue_name, "Queue Name")
+        self.assertEqual(bp_object.one_shot, self.is_one_shot, "IsOneShot")
+        self.assertEqual(bp_object.ignore_count, self.ignore_count, "IgnoreCount")
+        self.assertEqual(bp_object.condition, self.condition, "Condition")
+        self.assertEqual(bp_object.auto_continue, self.auto_continue, "AutoContinue")
+        self.assertEqual(bp_object.thread_id, self.tid, "Thread ID")
+        self.assertEqual(bp_object.thread_index, self.tidx, "Thread Index")
+        self.assertEqual(bp_object.thread_name, self.thread_name, "Thread Name")
+        self.assertEqual(bp_object.queue_name, self.queue_name, "Queue Name")
         set_cmds = lldb.SBStringList()
         bp_object.GetCommandLineCommands(set_cmds)
         self.assertEqual(

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
@@ -216,14 +216,16 @@ class BreakpointNames(TestBase):
         )
 
     def check_option_values(self, bp_object):
-        self.assertEqual(bp_object.one_shot, self.is_one_shot, "IsOneShot")
-        self.assertEqual(bp_object.ignore_count, self.ignore_count, "IgnoreCount")
-        self.assertEqual(bp_object.condition, self.condition, "Condition")
-        self.assertEqual(bp_object.auto_continue, self.auto_continue, "AutoContinue")
-        self.assertEqual(bp_object.thread_id, self.tid, "Thread ID")
-        self.assertEqual(bp_object.thread_index, self.tidx, "Thread Index")
-        self.assertEqual(bp_object.thread_name, self.thread_name, "Thread Name")
-        self.assertEqual(bp_object.queue_name, self.queue_name, "Queue Name")
+        self.assertEqual(bp_object.IsOneShot(), self.is_one_shot, "IsOneShot")
+        self.assertEqual(bp_object.GetIgnoreCount(), self.ignore_count, "IgnoreCount")
+        self.assertEqual(bp_object.GetCondition(), self.condition, "Condition")
+        self.assertEqual(
+            bp_object.GetAutoContinue(), self.auto_continue, "AutoContinue"
+        )
+        self.assertEqual(bp_object.GetThreadID(), self.tid, "Thread ID")
+        self.assertEqual(bp_object.GetThreadIndex(), self.tidx, "Thread Index")
+        self.assertEqual(bp_object.GetThreadName(), self.thread_name, "Thread Name")
+        self.assertEqual(bp_object.GetQueueName(), self.queue_name, "Queue Name")
         set_cmds = lldb.SBStringList()
         bp_object.GetCommandLineCommands(set_cmds)
         self.assertEqual(

--- a/lldb/test/API/functionalities/stop-on-sharedlibrary-load/TestStopOnSharedlibraryEvents.py
+++ b/lldb/test/API/functionalities/stop-on-sharedlibrary-load/TestStopOnSharedlibraryEvents.py
@@ -17,7 +17,7 @@ class TestStopOnSharedlibraryEvents(TestBase):
     @no_debug_info_test
     def test_auto_continue(self):
         def auto_continue(bkpt):
-            bkpt.SetAutoContinue(True)
+            bkpt.auto_continue = True
 
         self.do_test(auto_continue)
 
@@ -26,7 +26,7 @@ class TestStopOnSharedlibraryEvents(TestBase):
     @no_debug_info_test
     def test_failing_condition(self):
         def condition(bkpt):
-            bkpt.SetCondition("1 == 2")
+            bkpt.condition = "1 == 2"
 
         self.do_test(condition)
 


### PR DESCRIPTION
Update `SBBreakpoint`, `SBBreakpointLocation`, and `SBBreakpointName` to add Python properties for many of their getters/setters.