### PR TITLE
[libc] added nullptr checks for wcspbrk

### DIFF
--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -66,6 +66,7 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.wchar_macros
     libc.src.__support.wctype_utils
+    libc.src.__support.macros.null_check
 )
 
 add_entrypoint_object(

--- a/libc/src/wchar/wcspbrk.cpp
+++ b/libc/src/wchar/wcspbrk.cpp
@@ -10,6 +10,7 @@
 
 #include "hdr/types/wchar_t.h"
 #include "src/__support/common.h"
+#include "src/__support/macros/null_check.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -23,6 +24,9 @@ bool contains_char(const wchar_t *str, wchar_t target) {
 
 LLVM_LIBC_FUNCTION(const wchar_t *, wcspbrk,
                    (const wchar_t *src, const wchar_t *breakset)) {
+  LIBC_CRASH_ON_NULLPTR(src);
+  LIBC_CRASH_ON_NULLPTR(breakset);
+
   // currently O(n * m), can be further optimized to O(n + m) with a hash set
   for (int src_idx = 0; src[src_idx] != 0; src_idx++)
     if (contains_char(breakset, src[src_idx]))

--- a/libc/test/src/wchar/wcspbrk_test.cpp
+++ b/libc/test/src/wchar/wcspbrk_test.cpp
@@ -60,3 +60,13 @@ TEST(LlvmLibcWCSPBrkTest, FindsFirstInBreakset) {
   EXPECT_EQ(LIBC_NAMESPACE::wcspbrk(src, L"34"), src + 2);
   EXPECT_EQ(LIBC_NAMESPACE::wcspbrk(src, L"43"), src + 2);
 }
+
+#if defined(LIBC_ADD_NULL_CHECKS) && !defined(LIBC_HAS_SANITIZER)
+TEST(LlvmLibcWMemcmpTest, NullptrCrash) {
+  // Passing in a nullptr should crash the program.
+  EXPECT_DEATH([] { LIBC_NAMESPACE::wcspbrk(L"aaaaaaaaaaaaaa", nullptr); },
+               WITH_SIGNAL(-1));
+  EXPECT_DEATH([] { LIBC_NAMESPACE::wcspbrk(nullptr, L"aaaaaaaaaaaaaa"); },
+               WITH_SIGNAL(-1));
+}
+#endif // LIBC_HAS_ADDRESS_SANITIZER

--- a/libc/test/src/wchar/wcspbrk_test.cpp
+++ b/libc/test/src/wchar/wcspbrk_test.cpp
@@ -62,7 +62,7 @@ TEST(LlvmLibcWCSPBrkTest, FindsFirstInBreakset) {
 }
 
 #if defined(LIBC_ADD_NULL_CHECKS) && !defined(LIBC_HAS_SANITIZER)
-TEST(LlvmLibcWMemcmpTest, NullptrCrash) {
+TEST(LlvmLibcWCSPBrkTest, NullptrCrash) {
   // Passing in a nullptr should crash the program.
   EXPECT_DEATH([] { LIBC_NAMESPACE::wcspbrk(L"aaaaaaaaaaaaaa", nullptr); },
                WITH_SIGNAL(-1));


### PR DESCRIPTION
Added CRASH_ON_NULLPTR macro to wcspbrk function and related test
