### PR TITLE
[PowerPC][NFC] Update lowering STXVP to STXV in Oct word spilling

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
@@ -1255,8 +1255,8 @@ void PPCRegisterInfo::lowerOctWordSpilling(MachineBasicBlock::iterator II,
   bool IsLittleEndian = Subtarget.isLittleEndian();
   bool IsKilled = MI.getOperand(0).isKill();
 
-  assert(!SrcReg.isVirtual() &&
-          "Spilling register pairs does not support virtual registers.");
+  assert(PPC::VSRpRCRegClass.contains(SrcReg) &&
+          "Expecting STXVP to be utilizing a VSRp register.");
 
   addFrameReference(
       BuildMI(MBB, II, DL, TII.get(PPC::STXV))

--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.cpp
@@ -1295,8 +1295,8 @@ void PPCRegisterInfo::lowerACCSpilling(MachineBasicBlock::iterator II,
   const PPCSubtarget &Subtarget = MF.getSubtarget<PPCSubtarget>();
   const TargetInstrInfo &TII = *Subtarget.getInstrInfo();
   DebugLoc DL = MI.getDebugLoc();
-  bool IsKilled = MI.getOperand(0).isKill();
   Register SrcReg = MI.getOperand(0).getReg();
+  bool IsKilled = MI.getOperand(0).isKill();
 
   bool IsPrimed = PPC::ACCRCRegClass.contains(SrcReg);
   Register Reg =


### PR DESCRIPTION
Remove explicit register arithmetic from spilling ACC and STXVP code.