### PR TITLE
Wrap ifndef NDEBUG around assertion-only code

### DIFF
--- a/llvm/unittests/SandboxIR/RegionTest.cpp
+++ b/llvm/unittests/SandboxIR/RegionTest.cpp
@@ -437,10 +437,10 @@ define void @foo(i8 %v) {
 }
 !0 = !{i32 0}
 )IR");
+#ifndef NDEBUG
   llvm::Function *LLVMF = &*M->getFunction("foo");
   sandboxir::Context Ctx(C);
   auto *F = Ctx.createFunction(LLVMF);
-#ifndef NDEBUG
   EXPECT_DEATH(sandboxir::Region::createRegionsFromMD(*F, *TTI), "No region.*");
 #endif
 }


### PR DESCRIPTION
Otherwise we get unused variable warnings.