### PR TITLE
[Sanitizer] XFAIL android test because env var is not read

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
@@ -1,10 +1,10 @@
 // RUN: %clangxx -O2 %s -o %t
 
 // Case 1: Try setting a path that is an invalid/inaccessible directory.
-// RUN: not %env %run %t 2>&1 | FileCheck %s --check-prefix=ERROR1
+// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=ERROR1
 
 // Case 2: Try setting a path that is too large.
-// RUN: not %env %run %t A 2>&1 | FileCheck %s --check-prefix=ERROR2
+// RUN: not %run %t A 2>&1 | FileCheck %s --check-prefix=ERROR2
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
@@ -2,7 +2,7 @@
 // RUN: %clangxx -O2 %s -o %t
 // RUN: %env HOME=%t.homedir TMPDIR=%t.tmpdir %run %t 2>&1 | FileCheck %s
 
-// FIXME: Environment variables are no propagated or not properly read on android.
+// FIXME: Environment variables are not propagated or not properly read on android.
 // XFAIL: android
 
 #include <sanitizer/common_interface_defs.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
@@ -2,6 +2,9 @@
 // RUN: %clangxx -O2 %s -o %t
 // RUN: %env HOME=%t.homedir TMPDIR=%t.tmpdir %run %t 2>&1 | FileCheck %s
 
+// FIXME: Environment variables are no propagated or not properly read on android.
+// XFAIL: android
+
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
I attempted to fix android tests in https://github.com/llvm/llvm-project/pull/142207 (broken by https://github.com/llvm/llvm-project/pull/141820). They are still failing but now I have more info.

https://lab.llvm.org/buildbot/#/builders/186/builds/9504/steps/16/logs/stdio

> ERROR: Can't open file: //foo.8862 (reason: 30)

I believe the reason is that on android the `HOME` and `TMPDIR` environment variables are not being set correctly, or they are not read correctly. I will follow up with more investigation and hopefully a fix, but for now lets xfail this test for android to fix the bots.

Also remove an extra `%env` left in a related test.