### PR TITLE
[Sanitizer] Fix android test env issue

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
@@ -1,10 +1,10 @@
 // RUN: %clangxx -O2 %s -o %t
 
 // Case 1: Try setting a path that is an invalid/inaccessible directory.
-// RUN: not %env %run %t 2>&1 | FileCheck %s --check-prefix=ERROR1
+// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=ERROR1
 
 // Case 2: Try setting a path that is too large.
-// RUN: not %env %run %t A 2>&1 | FileCheck %s --check-prefix=ERROR2
+// RUN: not %run %t A 2>&1 | FileCheck %s --check-prefix=ERROR2
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
@@ -1,10 +1,10 @@
 // RUN: %clangxx -O2 %s -o %t
 
 // Case 1: Try setting a path that is an invalid/inaccessible directory.
-// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=ERROR1
+// RUN: not %env %run %t 2>&1 | FileCheck %s --check-prefix=ERROR1
 
 // Case 2: Try setting a path that is too large.
-// RUN: not %run %t A 2>&1 | FileCheck %s --check-prefix=ERROR2
+// RUN: not %env %run %t A 2>&1 | FileCheck %s --check-prefix=ERROR2
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/android_commands/android_run.py
+++ b/compiler-rt/test/sanitizer_common/android_commands/android_run.py
@@ -12,10 +12,13 @@ def build_env():
     args = []
     # Android linker ignores RPATH. Set LD_LIBRARY_PATH to Output dir.
     args.append("LD_LIBRARY_PATH=%s" % (ANDROID_TMPDIR,))
-    for (key, value) in list(os.environ.items()):
-        if key in ["ASAN_ACTIVATION_OPTIONS", "SCUDO_OPTIONS", "HOME", "TMPDIR"] or key.endswith(
-            "SAN_OPTIONS"
-        ):
+    for key, value in list(os.environ.items()):
+        if key in [
+            "ASAN_ACTIVATION_OPTIONS",
+            "SCUDO_OPTIONS",
+            "HOME",
+            "TMPDIR",
+        ] or key.endswith("SAN_OPTIONS"):
             args.append('%s="%s"' % (key, value.replace('"', '\\"')))
     return " ".join(args)
 

--- a/compiler-rt/test/sanitizer_common/android_commands/android_run.py
+++ b/compiler-rt/test/sanitizer_common/android_commands/android_run.py
@@ -13,7 +13,7 @@ def build_env():
     # Android linker ignores RPATH. Set LD_LIBRARY_PATH to Output dir.
     args.append("LD_LIBRARY_PATH=%s" % (ANDROID_TMPDIR,))
     for (key, value) in list(os.environ.items()):
-        if key in ["ASAN_ACTIVATION_OPTIONS", "SCUDO_OPTIONS"] or key.endswith(
+        if key in ["ASAN_ACTIVATION_OPTIONS", "SCUDO_OPTIONS", "HOME", "TMPDIR"] or key.endswith(
             "SAN_OPTIONS"
         ):
             args.append('%s="%s"' % (key, value.replace('"', '\\"')))


### PR DESCRIPTION
I attempted to fix android tests in https://github.com/llvm/llvm-project/pull/142207 (broken by https://github.com/llvm/llvm-project/pull/141820). They are still failing but now I have more info.

https://lab.llvm.org/buildbot/#/builders/186/builds/9504/steps/16/logs/stdio

ERROR: Can't open file: //foo.8862 (reason: 30)

I believe the reason is that on android the HOME and TMPDIR environment variables are not being set correctly, or they are not read correctly. (https://github.com/llvm/llvm-project/pull/142234#issuecomment-2923694428)