### PR TITLE
[clang-format] Handle token-pasted function decl names

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3977,8 +3977,13 @@ void TokenAnnotator::calculateFormattingInformation(AnnotatedLine &Line) const {
        Tok; Tok = Tok->Next) {
     if (Tok->is(TT_StartOfName))
       SeenName = true;
-    if (Tok->Previous->EndsCppAttributeGroup)
+    const auto *Previous = Tok->Previous;
+    if (Previous->EndsCppAttributeGroup) {
       AfterLastAttribute = Tok;
+    } else if (Line.InMacroBody &&
+               Previous->endsSequence(tok::hashhash, TT_StartOfName)) {
+      Tok->setType(TT_StartOfName);
+    }
     if (const bool IsCtorOrDtor = Tok->is(TT_CtorDtorDeclName);
         IsCtorOrDtor ||
         isFunctionDeclarationName(LangOpts, *Tok, Line, ClosingParen)) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2257,6 +2257,13 @@ TEST_F(TokenAnnotatorTest, UnderstandsFunctionDeclarationNames) {
   EXPECT_TOKEN(Tokens[1], tok::identifier, TT_FunctionDeclarationName);
   EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_FunctionDeclarationLParen);
 
+  Tokens = annotate("#define FUNC(foo, bar) \\\n"
+                    "  auto foo##bar() -> Type {}");
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_TOKEN(Tokens[11], tok::identifier, TT_FunctionDeclarationName);
+  EXPECT_TOKEN(Tokens[12], tok::l_paren, TT_FunctionDeclarationLParen);
+  EXPECT_TOKEN(Tokens[14], tok::arrow, TT_TrailingReturnArrow);
+
   Tokens = annotate("int iso_time(time_t);");
   ASSERT_EQ(Tokens.size(), 7u) << Tokens;
   EXPECT_TOKEN(Tokens[1], tok::identifier, TT_FunctionDeclarationName);


### PR DESCRIPTION
Fix #142178