### PR TITLE
[InstCombine] Avoid to create bitreverse.i1 for or of trunc to i1

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -4117,7 +4117,8 @@ bool llvm::recognizeBSwapOrBitReverseIdiom(
   if (!MatchBSwaps && !MatchBitReversals)
     return false;
   Type *ITy = I->getType();
-  if (!ITy->isIntOrIntVectorTy() || ITy->getScalarSizeInBits() > 128)
+  if (!ITy->isIntOrIntVectorTy() || ITy->getScalarSizeInBits() == 1 ||
+      ITy->getScalarSizeInBits() > 128)
     return false;  // Can't do integer/elements > 128 bits.
 
   // Try to find all the pieces corresponding to the bswap.

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2035,3 +2035,15 @@ define i32 @or_xor_and_commuted3(i32 %x, i32 %y, i32 %z) {
   %or1 = or i32 %xor, %yy
   ret i32 %or1
 }
+
+define i1 @or_truncs(i8 %x) {
+; CHECK-LABEL: @or_truncs(
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[X:%.*]] to i1
+; CHECK-NEXT:    [[OR1:%.*]] = call i1 @llvm.bitreverse.i1(i1 [[TRUNC]])
+; CHECK-NEXT:    ret i1 [[OR1]]
+;
+  %trunc1 = trunc i8 %x to i1
+  %trunc2 = trunc i8 %x to i1
+  %or1 = or i1 %trunc1, %trunc2
+  ret i1 %or1
+}

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2038,8 +2038,8 @@ define i32 @or_xor_and_commuted3(i32 %x, i32 %y, i32 %z) {
 
 define i1 @or_truncs(i8 %x) {
 ; CHECK-LABEL: @or_truncs(
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[X:%.*]] to i1
-; CHECK-NEXT:    [[OR1:%.*]] = call i1 @llvm.bitreverse.i1(i1 [[TRUNC]])
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[X:%.*]], 1
+; CHECK-NEXT:    [[OR1:%.*]] = icmp ne i8 [[TMP1]], 0
 ; CHECK-NEXT:    ret i1 [[OR1]]
 ;
   %trunc1 = trunc i8 %x to i1


### PR DESCRIPTION
Avoid to create bitreverse.i1 as it hinder optimizations due to there is less optimizations for bitreverse and also is a bit strange to create a i1 bitreverse

this change avoids this transform a couple of times in llvm-opt-benchmark.