### PR TITLE
[InstCombine] Add cast support in simplifyUsingControlFlow

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -1317,6 +1317,10 @@ static Value *simplifyUsingControlFlow(InstCombiner &Self, PHINode &PN,
       return nullptr;
 
     Cond = BI->getCondition();
+
+    if (Cond->getType() != PN.getType())
+      return nullptr;
+
     AddSucc(ConstantInt::getTrue(Context), BI->getSuccessor(0));
     AddSucc(ConstantInt::getFalse(Context), BI->getSuccessor(1));
   } else if (auto *SI = dyn_cast<SwitchInst>(IDom->getTerminator())) {

--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -1290,6 +1290,8 @@ static Value *simplifyUsingControlFlow(InstCombiner &Self, PHINode &PN,
   //         ...      ...
   //          \       /
   //       phi [v1] [v2]
+  if (!PN.getType()->isIntegerTy())
+    return nullptr;
   // Make sure all inputs are constants.
   if (!all_of(PN.operands(), [](Value *V) { return isa<ConstantInt>(V); }))
     return nullptr;

--- a/llvm/test/DebugInfo/X86/instcombine-fold-cast-into-phi.ll
+++ b/llvm/test/DebugInfo/X86/instcombine-fold-cast-into-phi.ll
@@ -4,7 +4,7 @@
 ;; user (otherwise the dbg use becomes poison after the original phi is
 ;; deleted). Check the new phi inherits the DebugLoc.
 
-; CHECK: %[[phi:.*]] = phi i8 [ 1, %{{.*}} ], [ 0, %{{.*}} ], !dbg ![[dbg:[0-9]+]]
+; CHECK: %[[phi:.*]] = phi i8 [ 2, %{{.*}} ], [ 0, %{{.*}} ], !dbg ![[dbg:[0-9]+]]
 ; CHECK: #dbg_value(i8 %[[phi]], ![[#]], !DIExpression(DW_OP_LLVM_convert, 8, DW_ATE_signed, DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_stack_value)
 ; CHECK: ![[dbg]] = !DILocation(line: 123,
 
@@ -19,7 +19,7 @@ if.then:                                          ; preds = entry
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
-  %p.0 = phi i32 [ 1, %if.then ], [ 0, %entry ], !dbg !13
+  %p.0 = phi i32 [ 2, %if.then ], [ 0, %entry ], !dbg !13
   call void @llvm.dbg.value(metadata i32 %p.0, metadata !4, metadata !DIExpression()), !dbg !13
   %x = trunc i32 %p.0 to i8
   %callff = call float @ff(i8  %x)

--- a/llvm/test/Transforms/InstCombine/phi-int-users.ll
+++ b/llvm/test/Transforms/InstCombine/phi-int-users.ll
@@ -13,7 +13,7 @@ define void @f1(i1 %a) {
 ; CHECK:       [[BB2]]:
 ; CHECK-NEXT:    br label %[[BB3]]
 ; CHECK:       [[BB3]]:
-; CHECK-NEXT:    [[PHI:%.*]] = phi i64 [ 0, %[[BB2]] ], [ 1, %[[BB1]] ]
+; CHECK-NEXT:    [[PHI:%.*]] = zext i1 [[A]] to i64
 ; CHECK-NEXT:    [[INTTOPTR:%.*]] = inttoptr i64 [[PHI]] to ptr
 ; CHECK-NEXT:    store i32 0, ptr [[INTTOPTR]], align 4
 ; CHECK-NEXT:    br label %[[BB1]]

--- a/llvm/test/Transforms/InstCombine/phi-int-users.ll
+++ b/llvm/test/Transforms/InstCombine/phi-int-users.ll
@@ -13,7 +13,7 @@ define void @f1(i1 %a) {
 ; CHECK:       [[BB2]]:
 ; CHECK-NEXT:    br label %[[BB3]]
 ; CHECK:       [[BB3]]:
-; CHECK-NEXT:    [[PHI:%.*]] = zext i1 [[A]] to i64
+; CHECK-NEXT:    [[PHI:%.*]] = phi i64 [ 0, %[[BB2]] ], [ 1, %[[BB1]] ]
 ; CHECK-NEXT:    [[INTTOPTR:%.*]] = inttoptr i64 [[PHI]] to ptr
 ; CHECK-NEXT:    store i32 0, ptr [[INTTOPTR]], align 4
 ; CHECK-NEXT:    br label %[[BB1]]

--- a/llvm/test/Transforms/InstCombine/simple_phi_condition.ll
+++ b/llvm/test/Transforms/InstCombine/simple_phi_condition.ll
@@ -669,7 +669,7 @@ define i32 @test_phi_to_zext(i8 noundef %0) {
 ; CHECK:       sw.1:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[DOT0:%.*]] = phi i32 [ 1, [[SW_1]] ], [ 0, [[SW_0]] ], [ 255, [[SW_255]] ]
+; CHECK-NEXT:    [[DOT0:%.*]] = zext i8 [[TMP0]] to i32
 ; CHECK-NEXT:    ret i32 [[DOT0]]
 ;
 entry:
@@ -713,7 +713,8 @@ define i32 @test_phi_to_zext_inverted(i8 noundef %0) {
 ; CHECK:       sw.1:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[DOT0:%.*]] = phi i32 [ -256, [[SW_255]] ], [ -2, [[SW_1]] ], [ -1, [[SW_0]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = zext i8 [[TMP0]] to i32
+; CHECK-NEXT:    [[DOT0:%.*]] = xor i32 [[TMP1]], -1
 ; CHECK-NEXT:    ret i32 [[DOT0]]
 ;
 entry:
@@ -753,7 +754,7 @@ define i8 @test_multiple_predecessors_phi_to_zext(i1 %cond, i1 %cond2) {
 ; CHECK:       if2.false:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[RET:%.*]] = phi i8 [ 0, [[IF_FALSE]] ], [ 1, [[IF2_TRUE]] ], [ 1, [[IF2_FALSE]] ]
+; CHECK-NEXT:    [[RET:%.*]] = zext i1 [[COND]] to i8
 ; CHECK-NEXT:    ret i8 [[RET]]
 ;
 entry:
@@ -793,7 +794,7 @@ define i32 @test_phi_to_sext(i8 noundef %0) {
 ; CHECK:       sw.1:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[DOT0:%.*]] = phi i32 [ 1, [[SW_1]] ], [ 0, [[SW_0]] ], [ -1, [[SW_255]] ]
+; CHECK-NEXT:    [[DOT0:%.*]] = sext i8 [[TMP0]] to i32
 ; CHECK-NEXT:    ret i32 [[DOT0]]
 ;
 entry:
@@ -837,7 +838,8 @@ define i32 @test_phi_to_sext_inverted(i8 noundef %0) {
 ; CHECK:       sw.1:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[DOT0:%.*]] = phi i32 [ -2, [[SW_1]] ], [ -1, [[SW_0]] ], [ 0, [[SW_255]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = xor i8 [[TMP0]], -1
+; CHECK-NEXT:    [[DOT0:%.*]] = sext i8 [[TMP1]] to i32
 ; CHECK-NEXT:    ret i32 [[DOT0]]
 ;
 entry:
@@ -877,7 +879,7 @@ define i8 @test_multiple_predecessors_phi_to_sext(i1 %cond, i1 %cond2) {
 ; CHECK:       if2.false:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[RET:%.*]] = phi i8 [ 0, [[IF_FALSE]] ], [ -1, [[IF2_TRUE]] ], [ -1, [[IF2_FALSE]] ]
+; CHECK-NEXT:    [[RET:%.*]] = sext i1 [[COND]] to i8
 ; CHECK-NEXT:    ret i8 [[RET]]
 ;
 entry:
@@ -995,7 +997,7 @@ define i8 @test_phi_to_trunc(i32 %0) {
 ; CHECK:       sw.255:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[DOT0:%.*]] = phi i8 [ -1, [[SW_255]] ], [ 1, [[SW_1]] ], [ 0, [[ENTRY:%.*]] ]
+; CHECK-NEXT:    [[DOT0:%.*]] = trunc i32 [[TMP0]] to i8
 ; CHECK-NEXT:    ret i8 [[DOT0]]
 ;
 entry:
@@ -1034,7 +1036,8 @@ define i8 @test_phi_to_trunc_inverted(i32 %0) {
 ; CHECK:       sw.255:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[DOT0:%.*]] = phi i8 [ 0, [[SW_255]] ], [ -2, [[SW_1]] ], [ -1, [[ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = trunc i32 [[TMP0]] to i8
+; CHECK-NEXT:    [[DOT0:%.*]] = xor i8 [[TMP1]], -1
 ; CHECK-NEXT:    ret i8 [[DOT0]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/simple_phi_condition.ll
+++ b/llvm/test/Transforms/InstCombine/simple_phi_condition.ll
@@ -741,12 +741,20 @@ merge:
   ret i32 %.0
 }
 
-define i8 @test_multiple_predecessors_phi_to_zext(i1 %cond, i1 %cond2) {
+define i8 @test_multiple_predecessors_phi_to_zext(i2 %cond, i2 %cond2) {
 ; CHECK-LABEL: @test_multiple_predecessors_phi_to_zext(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    br i1 [[COND:%.*]], label [[IF_TRUE:%.*]], label [[IF_FALSE:%.*]]
+; CHECK-NEXT:    switch i2 [[COND:%.*]], label [[DEFAULT:%.*]] [
+; CHECK-NEXT:      i2 1, label [[IF_TRUE:%.*]]
+; CHECK-NEXT:      i2 0, label [[IF_FALSE:%.*]]
+; CHECK-NEXT:    ]
 ; CHECK:       if.true:
-; CHECK-NEXT:    br i1 [[COND2:%.*]], label [[IF2_TRUE:%.*]], label [[IF2_FALSE:%.*]]
+; CHECK-NEXT:    switch i2 [[COND2:%.*]], label [[DEFAULT]] [
+; CHECK-NEXT:      i2 1, label [[IF2_TRUE:%.*]]
+; CHECK-NEXT:      i2 0, label [[IF2_FALSE:%.*]]
+; CHECK-NEXT:    ]
+; CHECK:       default:
+; CHECK-NEXT:    unreachable
 ; CHECK:       if.false:
 ; CHECK-NEXT:    br label [[MERGE:%.*]]
 ; CHECK:       if2.true:
@@ -754,14 +762,23 @@ define i8 @test_multiple_predecessors_phi_to_zext(i1 %cond, i1 %cond2) {
 ; CHECK:       if2.false:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[RET:%.*]] = zext i1 [[COND]] to i8
+; CHECK-NEXT:    [[RET:%.*]] = zext i2 [[COND]] to i8
 ; CHECK-NEXT:    ret i8 [[RET]]
 ;
 entry:
-  br i1 %cond, label %if.true, label %if.false
+  switch i2 %cond, label %default [
+  i2 1, label %if.true
+  i2 0, label %if.false
+  ]
 
 if.true:
-  br i1 %cond2, label %if2.true, label %if2.false
+  switch i2 %cond2, label %default [
+  i2 1, label %if2.true
+  i2 0, label %if2.false
+  ]
+
+default:
+  unreachable
 
 if.false:
   br label %merge
@@ -866,12 +883,20 @@ merge:
   ret i32 %.0
 }
 
-define i8 @test_multiple_predecessors_phi_to_sext(i1 %cond, i1 %cond2) {
+define i8 @test_multiple_predecessors_phi_to_sext(i2 %cond, i2 %cond2) {
 ; CHECK-LABEL: @test_multiple_predecessors_phi_to_sext(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    br i1 [[COND:%.*]], label [[IF_TRUE:%.*]], label [[IF_FALSE:%.*]]
+; CHECK-NEXT:    switch i2 [[COND:%.*]], label [[DEFAULT:%.*]] [
+; CHECK-NEXT:      i2 -1, label [[IF_TRUE:%.*]]
+; CHECK-NEXT:      i2 0, label [[IF_FALSE:%.*]]
+; CHECK-NEXT:    ]
 ; CHECK:       if.true:
-; CHECK-NEXT:    br i1 [[COND2:%.*]], label [[IF2_TRUE:%.*]], label [[IF2_FALSE:%.*]]
+; CHECK-NEXT:    switch i2 [[COND2:%.*]], label [[DEFAULT]] [
+; CHECK-NEXT:      i2 -1, label [[IF2_TRUE:%.*]]
+; CHECK-NEXT:      i2 0, label [[IF2_FALSE:%.*]]
+; CHECK-NEXT:    ]
+; CHECK:       default:
+; CHECK-NEXT:    unreachable
 ; CHECK:       if.false:
 ; CHECK-NEXT:    br label [[MERGE:%.*]]
 ; CHECK:       if2.true:
@@ -879,14 +904,23 @@ define i8 @test_multiple_predecessors_phi_to_sext(i1 %cond, i1 %cond2) {
 ; CHECK:       if2.false:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[RET:%.*]] = sext i1 [[COND]] to i8
+; CHECK-NEXT:    [[RET:%.*]] = sext i2 [[COND]] to i8
 ; CHECK-NEXT:    ret i8 [[RET]]
 ;
 entry:
-  br i1 %cond, label %if.true, label %if.false
+  switch i2 %cond, label %default [
+  i2 3, label %if.true
+  i2 0, label %if.false
+  ]
 
 if.true:
-  br i1 %cond2, label %if2.true, label %if2.false
+  switch i2 %cond2, label %default [
+  i2 3, label %if2.true
+  i2 0, label %if2.false
+  ]
+
+default:
+  unreachable
 
 if.false:
   br label %merge


### PR DESCRIPTION
Common patterns where phi node can be replaced by trunc, zext or sext.

In the case of a cast and invert is needed this now produces 2 instructions but only removes one phi instruction it is possible to avoid but when I looked at the llvm-opt-benchmark results it looked like it made things better more then worse but is a bit hard to say as there is so many changes.

proof: https://alive2.llvm.org/ce/z/Rppn3Y

closes https://github.com/llvm/llvm-project/issues/54561 closes https://github.com/llvm/llvm-project/issues/67842 closes https://github.com/llvm/llvm-project/issues/67843