### PR TITLE
[DenseMap] Fix MSVC buildbot failure in lookup_or

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -226,6 +226,12 @@ public:
     return Default;
   }
 
+  ValueT lookup_or(const_arg_type_t<KeyT> Val, const ValueT &Default) const {
+    if (const BucketT *Bucket = doFind(Val))
+      return Bucket->getSecond();
+    return Default;
+  }
+
   /// at - Return the entry for the specified key, or abort if no such
   /// entry exists.
   const ValueT &at(const_arg_type_t<KeyT> Val) const {

--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -220,13 +220,8 @@ public:
   // Return the entry with the specified key, or \p Default. This variant is
   // useful, because `lookup` cannot be used with non-default-constructible
   // values.
-  ValueT lookup_or(const_arg_type_t<KeyT> Val, ValueT &&Default) const {
-    if (const BucketT *Bucket = doFind(Val))
-      return Bucket->getSecond();
-    return Default;
-  }
-
-  ValueT lookup_or(const_arg_type_t<KeyT> Val, const ValueT &Default) const {
+  template <typename U = std::remove_cv_t<ValueT>>
+  ValueT lookup_or(const_arg_type_t<KeyT> Val, U &&Default) const {
     if (const BucketT *Bucket = doFind(Val))
       return Bucket->getSecond();
     return Default;


### PR DESCRIPTION
4bf67cd ([DenseMap] Fix constness issues with lookup_or) introduced a buildbot failure:

  https://lab.llvm.org/buildbot/#/builders/63/builds/6559

The patch deviates from the spec and MSVC complains, where it doesn't bind an lvalue to an rvalue reference. Fix it by qualifying the argument of lookup_or with remove_cv_t.

Proof: https://godbolt.org/z/sjTvGMbce