### PR TITLE
[Sanitizer] Use %device_rundir/ to fix test

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
@@ -1,6 +1,6 @@
 // Test __sanitizer_set_report_path and __sanitizer_get_report_path:
 // RUN: %clangxx -O2 %s -o %t
-// RUN: %env HOME=%t.homedir TMPDIR=%t.tmpdir %run %t 2>&1 | FileCheck %s
+// RUN: %env HOME=%device_rundir/%t.homedir TMPDIR=%device_rundir/%t.tmpdir %run %t 2>&1 | FileCheck %s
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>


### PR DESCRIPTION
I attempted to fix this test in https://github.com/llvm/llvm-project/pull/142235 but we a new error.

https://lab.llvm.org/buildbot/#/builders/186/builds/9524/steps/26/logs/stdio
> ERROR: Can't create directory: /var

The path we want is actually at `/data/local/tmp/Output/var/...`.

I found `%device_rundir/` evaluates to this prefix on android, and nothing otherwise.

https://github.com/llvm/llvm-project/blob/f057a593a7151437edd25cfbbdcf450139346f12/compiler-rt/test/lit.common.cfg.py#L658