### PR TITLE
[lldb] Adding const modifier to SBAddress methods

### DIFF
--- a/lldb/include/lldb/API/SBAddress.h
+++ b/lldb/include/lldb/API/SBAddress.h
@@ -56,7 +56,7 @@ public:
   // will only return valid values if the address has been resolved to a code
   // or data address using "void SBAddress::SetLoadAddress(...)" or
   // "lldb::SBAddress SBTarget::ResolveLoadAddress (...)".
-  lldb::SBSymbolContext GetSymbolContext(uint32_t resolve_scope);
+  lldb::SBSymbolContext GetSymbolContext(uint32_t resolve_scope) const;
 
   // The following functions grab individual objects for a given address and
   // are less efficient if you want more than one symbol related objects. Use
@@ -69,21 +69,21 @@ public:
   // One or more bits from the SymbolContextItem enumerations can be logically
   // OR'ed together to more efficiently retrieve multiple symbol objects.
 
-  lldb::SBSection GetSection();
+  lldb::SBSection GetSection() const;
 
-  lldb::addr_t GetOffset();
+  lldb::addr_t GetOffset() const;
 
-  lldb::SBModule GetModule();
+  lldb::SBModule GetModule() const;
 
-  lldb::SBCompileUnit GetCompileUnit();
+  lldb::SBCompileUnit GetCompileUnit() const;
 
-  lldb::SBFunction GetFunction();
+  lldb::SBFunction GetFunction() const;
 
-  lldb::SBBlock GetBlock();
+  lldb::SBBlock GetBlock() const;
 
-  lldb::SBSymbol GetSymbol();
+  lldb::SBSymbol GetSymbol() const;
 
-  lldb::SBLineEntry GetLineEntry();
+  lldb::SBLineEntry GetLineEntry() const;
 
 protected:
   friend class SBAddressRange;

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -585,7 +585,7 @@ public:
                                          lldb::addr_t vm_addr);
 
   SBSymbolContext ResolveSymbolContextForAddress(const SBAddress &addr,
-                                                 uint32_t resolve_scope);
+                                                 uint32_t resolve_scope) const;
 
   /// Read target memory. If a target process is running then memory
   /// is read from here. Otherwise the memory is read from the object

--- a/lldb/source/API/SBAddress.cpp
+++ b/lldb/source/API/SBAddress.cpp
@@ -149,7 +149,7 @@ bool SBAddress::OffsetAddress(addr_t offset) {
   return false;
 }
 
-lldb::SBSection SBAddress::GetSection() {
+lldb::SBSection SBAddress::GetSection() const {
   LLDB_INSTRUMENT_VA(this);
 
   lldb::SBSection sb_section;
@@ -158,7 +158,7 @@ lldb::SBSection SBAddress::GetSection() {
   return sb_section;
 }
 
-lldb::addr_t SBAddress::GetOffset() {
+lldb::addr_t SBAddress::GetOffset() const {
   LLDB_INSTRUMENT_VA(this);
 
   if (m_opaque_up->IsValid())
@@ -200,7 +200,7 @@ bool SBAddress::GetDescription(SBStream &description) {
   return true;
 }
 
-SBModule SBAddress::GetModule() {
+SBModule SBAddress::GetModule() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBModule sb_module;
@@ -209,7 +209,7 @@ SBModule SBAddress::GetModule() {
   return sb_module;
 }
 
-SBSymbolContext SBAddress::GetSymbolContext(uint32_t resolve_scope) {
+SBSymbolContext SBAddress::GetSymbolContext(uint32_t resolve_scope) const {
   LLDB_INSTRUMENT_VA(this, resolve_scope);
 
   SBSymbolContext sb_sc;
@@ -219,7 +219,7 @@ SBSymbolContext SBAddress::GetSymbolContext(uint32_t resolve_scope) {
   return sb_sc;
 }
 
-SBCompileUnit SBAddress::GetCompileUnit() {
+SBCompileUnit SBAddress::GetCompileUnit() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBCompileUnit sb_comp_unit;
@@ -228,7 +228,7 @@ SBCompileUnit SBAddress::GetCompileUnit() {
   return sb_comp_unit;
 }
 
-SBFunction SBAddress::GetFunction() {
+SBFunction SBAddress::GetFunction() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBFunction sb_function;
@@ -237,7 +237,7 @@ SBFunction SBAddress::GetFunction() {
   return sb_function;
 }
 
-SBBlock SBAddress::GetBlock() {
+SBBlock SBAddress::GetBlock() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBBlock sb_block;
@@ -246,7 +246,7 @@ SBBlock SBAddress::GetBlock() {
   return sb_block;
 }
 
-SBSymbol SBAddress::GetSymbol() {
+SBSymbol SBAddress::GetSymbol() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBSymbol sb_symbol;
@@ -255,7 +255,7 @@ SBSymbol SBAddress::GetSymbol() {
   return sb_symbol;
 }
 
-SBLineEntry SBAddress::GetLineEntry() {
+SBLineEntry SBAddress::GetLineEntry() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBLineEntry sb_line_entry;

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -633,7 +633,7 @@ lldb::SBAddress SBTarget::ResolvePastLoadAddress(uint32_t stop_id,
 
 SBSymbolContext
 SBTarget::ResolveSymbolContextForAddress(const SBAddress &addr,
-                                         uint32_t resolve_scope) {
+                                         uint32_t resolve_scope) const {
   LLDB_INSTRUMENT_VA(this, addr, resolve_scope);
 
   SBSymbolContext sb_sc;

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -10,6 +10,7 @@
 #include "DAP.h"
 #include "ExceptionBreakpoint.h"
 #include "LLDBUtils.h"
+#include "Protocol/ProtocolTypes.h"
 #include "ProtocolUtils.h"
 #include "lldb/API/SBAddress.h"
 #include "lldb/API/SBCompileUnit.h"
@@ -581,8 +582,8 @@ llvm::json::Value CreateStackFrame(lldb::SBFrame &frame,
 
   EmplaceSafeString(object, "name", frame_name);
 
-  auto target = frame.GetThread().GetProcess().GetTarget();
-  auto source = CreateSource(frame.GetPCAddress(), target);
+  protocol::Source source = CreateSource(
+      frame.GetPCAddress(), frame.GetThread().GetProcess().GetTarget());
   if (!IsAssemblySource(source)) {
     // This is a normal source with a valid line entry.
     auto line_entry = frame.GetLineEntry();

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -252,7 +252,7 @@ std::string GetSBFileSpecPath(const lldb::SBFileSpec &file_spec) {
   return path;
 }
 
-lldb::SBLineEntry GetLineEntryForAddress(lldb::SBTarget &target,
+lldb::SBLineEntry GetLineEntryForAddress(const lldb::SBTarget &target,
                                          const lldb::SBAddress &address) {
   lldb::SBSymbolContext sc = target.ResolveSymbolContextForAddress(
       address, lldb::eSymbolContextLineEntry);

--- a/lldb/tools/lldb-dap/LLDBUtils.h
+++ b/lldb/tools/lldb-dap/LLDBUtils.h
@@ -182,7 +182,7 @@ std::string GetSBFileSpecPath(const lldb::SBFileSpec &file_spec);
 ///
 /// \return
 ///     The line entry for the given address.
-lldb::SBLineEntry GetLineEntryForAddress(lldb::SBTarget &target,
+lldb::SBLineEntry GetLineEntryForAddress(const lldb::SBTarget &target,
                                          const lldb::SBAddress &address);
 
 /// Helper for sending telemetry to lldb server, if client-telemetry is enabled.

--- a/lldb/tools/lldb-dap/ProtocolUtils.cpp
+++ b/lldb/tools/lldb-dap/ProtocolUtils.cpp
@@ -15,7 +15,7 @@
 namespace lldb_dap {
 
 static bool ShouldDisplayAssemblySource(
-    lldb::SBAddress address,
+    const lldb::SBAddress &address,
     lldb::StopDisassemblyType stop_disassembly_display) {
   if (stop_disassembly_display == lldb::eStopDisassemblyTypeNever)
     return false;
@@ -40,7 +40,7 @@ static bool ShouldDisplayAssemblySource(
 }
 
 static protocol::Source CreateAssemblySource(const lldb::SBTarget &target,
-                                             lldb::SBAddress address) {
+                                             const lldb::SBAddress &address) {
   protocol::Source source;
 
   auto symbol = address.GetSymbol();
@@ -87,7 +87,8 @@ protocol::Source CreateSource(const lldb::SBFileSpec &file) {
   return source;
 }
 
-protocol::Source CreateSource(lldb::SBAddress address, lldb::SBTarget &target) {
+protocol::Source CreateSource(const lldb::SBAddress &address,
+                              const lldb::SBTarget &target) {
   lldb::SBDebugger debugger = target.GetDebugger();
   lldb::StopDisassemblyType stop_disassembly_display =
       GetStopDisassemblyDisplay(debugger);

--- a/lldb/tools/lldb-dap/ProtocolUtils.h
+++ b/lldb/tools/lldb-dap/ProtocolUtils.h
@@ -40,7 +40,8 @@ protocol::Source CreateSource(const lldb::SBFileSpec &file);
 /// \return
 ///     A "Source" JSON object that follows the formal JSON
 ///     definition outlined by Microsoft.
-protocol::Source CreateSource(lldb::SBAddress address, lldb::SBTarget &target);
+protocol::Source CreateSource(const lldb::SBAddress &address,
+                              const lldb::SBTarget &target);
 
 /// Checks if the given source is for assembly code.
 bool IsAssemblySource(const protocol::Source &source);


### PR DESCRIPTION
I don't know if adding `const` specifier is considered breaking the API, but if not it could be useful as it allows for `lldb-dap` to change some objects to `const &`