### PR TITLE
CodeGen: fix the build against gcc-16 (invisible destructors)

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -951,4 +951,5 @@ protected:
 
 } // end namespace llvm
 
+#include "AsmPrinterHandler.h" /* expose destructor definitions */
 #endif // LLVM_CODEGEN_ASMPRINTER_H

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -12,8 +12,10 @@
 
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "CodeViewDebug.h"
+#include "DwarfCompileUnit.h"
 #include "DwarfDebug.h"
 #include "DwarfException.h"
+#include "DwarfUnit.h"
 #include "PseudoProbePrinter.h"
 #include "WasmException.h"
 #include "WinCFGuard.h"

--- a/llvm/lib/CodeGen/AsmPrinter/DebugLocStream.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugLocStream.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "DebugLocStream.h"
+#include "DwarfCompileUnit.h"
 #include "DwarfDebug.h"
+#include "DwarfUnit.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 
 using namespace llvm;


### PR DESCRIPTION
gcc-16 added a builtin to check if the destructor is trivial and exposed a requirement for a destructor to be visible:

https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=0629924777ea20d56d9ea40c3915eb0327a22ac7

As a result `llvm` build failed in places where the check happens against an incomplete type:

    [ 43%] Building CXX object lib/CodeGen/CMakeFiles/LLVMCodeGen.dir/FaultMaps.cpp.o
    In file included from /<<NIX>>/gcc-16.0.0.99999999/include/c++/16.0.0.99999999/memory:80,
                 from llvm-project/llvm/include/llvm/ADT/STLExtras.h:37,
                 from llvm-project/llvm/include/llvm/ADT/DenseMap.h:20,
                 from llvm-project/llvm/include/llvm/MC/MCExpr.h:12,
                 from llvm-project/llvm/include/llvm/MC/MCSymbol.h:18,
                 from llvm-project/llvm/include/llvm/CodeGen/FaultMaps.h:12,
                 from llvm-project/llvm/lib/CodeGen/FaultMaps.cpp:9:
    /<<NIX>>/gcc-16.0.0.99999999/include/c++/16.0.0.99999999/bits/unique_ptr.h: In instantiation of 'void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = llvm::AsmPrinterHandler]':
    /<<NIX>>/gcc-16.0.0.99999999/include/c++/16.0.0.99999999/bits/unique_ptr.h:399:17:   required from 'std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = llvm::AsmPrinterHandler; _Dp = std::default_delete<llvm::AsmPrinterHandler>]'
      399 |           get_deleter()(std::move(__ptr));
          |           ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
    /<<NIX>>/gcc-16.0.0.99999999/include/c++/16.0.0.99999999/type_traits:1458:23:   required from 'struct std::is_trivially_destructible<std::unique_ptr<llvm::AsmPrinterHandler> >'
     1458 |                     __bool_constant<__has_trivial_destructor(_Tp)>>::type
          |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    llvm-project/llvm/include/llvm/ADT/SmallVector.h:328:79:   required from 'class llvm::SmallVectorImpl<std::unique_ptr<llvm::AsmPrinterHandler> >'
      327 | template <typename T, bool = (std::is_trivially_copy_constructible<T>::value) &&
          |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      328 |                              (std::is_trivially_move_constructible<T>::value) &&
          |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
      329 |                              std::is_trivially_destructible<T>::value>
          |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    llvm-project/llvm/include/llvm/ADT/SmallVector.h:1196:22:   required from 'class llvm::SmallVector<std::unique_ptr<llvm::AsmPrinterHandler>, 1>'
     1196 | class LLVM_GSL_OWNER SmallVector : public SmallVectorImpl<T>,
          |                      ^~~~~~~~~~~
    llvm-project/llvm/include/llvm/CodeGen/AsmPrinter.h:203:54:   required from here
      203 |   SmallVector<std::unique_ptr<AsmPrinterHandler>, 1> EHHandlers;
          |                                                      ^~~~~~~~~~
    /<<NIX>>/gcc-16.0.0.99999999/include/c++/16.0.0.99999999/bits/unique_ptr.h:91:23: error: invalid application of 'sizeof' to incomplete type 'llvm::AsmPrinterHandler'
       91 |         static_assert(sizeof(_Tp)>0,
          |                       ^~~~~~~~~~~
    make[2]: *** [lib/CodeGen/CMakeFiles/LLVMCodeGen.dir/build.make:625: lib/CodeGen/CMakeFiles/LLVMCodeGen.dir/FaultMaps.cpp.o] Error 1 shuffle=1435629721
    make[1]: *** [CMakeFiles/Makefile2:16795: lib/CodeGen/CMakeFiles/LLVMCodeGen.dir/all] Error 2 shuffle=1435629721
    make: *** [Makefile:156: all] Error 2 shuffle=1435629721

The change brings in the destructors where similar build failures occur.