### PR TITLE
[RISCV] Use proper LLA operand for constant from load

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -20813,7 +20813,7 @@ RISCVTargetLowering::getTargetConstantFromLoad(LoadSDNode *Ld) const {
 
   // Simple case, LLA.
   if (Ptr.getOpcode() == RISCVISD::LLA) {
-    auto *CNode = GetSupportedConstantPool(Ptr);
+    auto *CNode = GetSupportedConstantPool(Ptr.getOperand(0));
     if (!CNode || CNode->getTargetFlags() != 0)
       return nullptr;
 


### PR DESCRIPTION
This fix resolves retrieving the constant from a load instruction when the large address LLA mode is used. Depending on build settings, the constant pool can be resolved already here, or later during linking. If llc is used on a short snippet of IR, the former tends to be the case, while in a full project, it can be the latter. The extracted value is used for computing known bits in instructions then using those constants as operands.

The LLA instruction has a single operand, which here is the actual constant pool reference that we want to unpack.

The lambda helper GetSupportedConstantPool checks that the SDValue passed in is ConstantPoolSDNode. But we've just checked that the opcode is RISCVISD::LLA. Thus, for the LLA case, **this retrieval always silently fails**. Operand 0 of the instruction, on the other hand, is frequently a ConstantPoolSDNode, which can be verified by dumping the DAG.

This is also in line with the later case in the method, for RISCVISD::ADD_LO, although that is clouded a bit by the glue between LO and HI. For both subinstructions, the actual constant pool SD node is found in an operand.

In short, the wrong object was checked and the retrieval always failed, gracefully. By referring to the right object, proper known bits support etc is enabled. If the operand is somehow incompatible, the existing checks in GetSupportedConstantPool should kick in and thus be safe.