### PR TITLE
[lldb] Avoid creating a temporary instance of std::string (NFC)

### DIFF
--- a/lldb/tools/lldb-dap/Handler/SetExceptionBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetExceptionBreakpointsRequestHandler.cpp
@@ -76,7 +76,7 @@ void SetExceptionBreakpointsRequestHandler::operator()(
 
   for (const auto &value : *filters) {
     const auto filter = GetAsString(value);
-    auto *exc_bp = dap.GetExceptionBreakpoint(std::string(filter));
+    auto *exc_bp = dap.GetExceptionBreakpoint(filter);
     if (exc_bp) {
       exc_bp->SetBreakpoint();
       unset_filters.erase(std::string(filter));


### PR DESCRIPTION
GetExceptionBreakpoint takes StringRef to look for a matching
breakpoint, so we don't need to create a temporary instance of
std::string on our own.
