### PR TITLE
Revert "[mlir]: Added properties/attributes ignore flags to OperationEquivalence"

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1322,14 +1322,7 @@ struct OperationEquivalence {
     // When provided, the location attached to the operation are ignored.
     IgnoreLocations = 1,
 
-    // When provided, the discardable attributes attached to the operation are
-    // ignored.
-    IgnoreDiscardableAttrs = 2,
-
-    // When provided, the properties attached to the operation are ignored.
-    IgnoreProperties = 4,
-
-    LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ IgnoreProperties)
+    LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ IgnoreLocations)
   };
 
   /// Compute a hash for the given operation.

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -680,14 +680,9 @@ llvm::hash_code OperationEquivalence::computeHash(
   //   - Operation Name
   //   - Attributes
   //   - Result Types
-  DictionaryAttr dictAttrs;
-  if (!(flags & Flags::IgnoreDiscardableAttrs))
-    dictAttrs = op->getRawDictionaryAttrs();
-  llvm::hash_code hashProperties;
-  if (!(flags & Flags::IgnoreProperties))
-    hashProperties = op->hashProperties();
-  llvm::hash_code hash = llvm::hash_combine(
-      op->getName(), dictAttrs, op->getResultTypes(), hashProperties);
+  llvm::hash_code hash =
+      llvm::hash_combine(op->getName(), op->getRawDictionaryAttrs(),
+                         op->getResultTypes(), op->hashProperties());
 
   //   - Location if required
   if (!(flags & Flags::IgnoreLocations))
@@ -841,19 +836,14 @@ OperationEquivalence::isRegionEquivalentTo(Region *lhs, Region *rhs,
     return true;
 
   // 1. Compare the operation properties.
-  if (!(flags & IgnoreDiscardableAttrs) &&
-      lhs->getRawDictionaryAttrs() != rhs->getRawDictionaryAttrs())
-    return false;
-
   if (lhs->getName() != rhs->getName() ||
+      lhs->getRawDictionaryAttrs() != rhs->getRawDictionaryAttrs() ||
       lhs->getNumRegions() != rhs->getNumRegions() ||
       lhs->getNumSuccessors() != rhs->getNumSuccessors() ||
       lhs->getNumOperands() != rhs->getNumOperands() ||
-      lhs->getNumResults() != rhs->getNumResults())
-    return false;
-  if (!(flags & IgnoreProperties) &&
-      !(lhs->getName().compareOpProperties(lhs->getPropertiesStorage(),
-                                           rhs->getPropertiesStorage())))
+      lhs->getNumResults() != rhs->getNumResults() ||
+      !lhs->getName().compareOpProperties(lhs->getPropertiesStorage(),
+                                          rhs->getPropertiesStorage()))
     return false;
   if (!(flags & IgnoreLocations) && lhs->getLoc() != rhs->getLoc())
     return false;

--- a/mlir/unittests/IR/OperationSupportTest.cpp
+++ b/mlir/unittests/IR/OperationSupportTest.cpp
@@ -315,7 +315,6 @@ TEST(OperandStorageTest, PopulateDefaultAttrs) {
 TEST(OperationEquivalenceTest, HashWorksWithFlags) {
   MLIRContext context;
   context.getOrLoadDialect<test::TestDialect>();
-  OpBuilder b(&context);
 
   auto *op1 = createOp(&context);
   // `op1` has an unknown loc.
@@ -326,36 +325,12 @@ TEST(OperationEquivalenceTest, HashWorksWithFlags) {
         op, OperationEquivalence::ignoreHashValue,
         OperationEquivalence::ignoreHashValue, flags);
   };
-  // Check ignore location.
   EXPECT_EQ(getHash(op1, OperationEquivalence::IgnoreLocations),
             getHash(op2, OperationEquivalence::IgnoreLocations));
   EXPECT_NE(getHash(op1, OperationEquivalence::None),
             getHash(op2, OperationEquivalence::None));
-  op1->setLoc(NameLoc::get(StringAttr::get(&context, "foo")));
-  // Check ignore discardable dictionary attributes.
-  SmallVector<NamedAttribute> newAttrs = {
-      b.getNamedAttr("foo", b.getStringAttr("f"))};
-  op1->setAttrs(newAttrs);
-  EXPECT_EQ(getHash(op1, OperationEquivalence::IgnoreDiscardableAttrs),
-            getHash(op2, OperationEquivalence::IgnoreDiscardableAttrs));
-  EXPECT_NE(getHash(op1, OperationEquivalence::None),
-            getHash(op2, OperationEquivalence::None));
   op1->destroy();
   op2->destroy();
-
-  // Check ignore properties.
-  auto req1 = b.getI32IntegerAttr(10);
-  Operation *opWithProperty1 = b.create<test::OpAttrMatch1>(
-      b.getUnknownLoc(), req1, nullptr, nullptr, req1);
-  auto req2 = b.getI32IntegerAttr(60);
-  Operation *opWithProperty2 = b.create<test::OpAttrMatch1>(
-      b.getUnknownLoc(), req2, nullptr, nullptr, req2);
-  EXPECT_NE(getHash(op1, OperationEquivalence::None),
-            getHash(op2, OperationEquivalence::None));
-  EXPECT_EQ(getHash(opWithProperty1, OperationEquivalence::IgnoreProperties),
-            getHash(opWithProperty2, OperationEquivalence::IgnoreProperties));
-  opWithProperty1->destroy();
-  opWithProperty2->destroy();
 }
 
 } // namespace


### PR DESCRIPTION
Reverts llvm/llvm-project#141664

See https://github.com/llvm/llvm-project/pull/141664#issuecomment-2927867604