### PR TITLE
[mlir][spirv] Fix FuncOpVectorUnroll to process placeholder values in all blocks

### DIFF
--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -1038,7 +1038,7 @@ struct FuncOpVectorUnroll final : OpRewritePattern<func::FuncOp> {
       // Since all newly created operations are in the beginning, reaching the
       // end of them means that any later `vector.insert_strided_slice` should
       // not be touched.
-      if (op->getBlock() == &entryBlock &&
+      if (op->getBlock() != &entryBlock ||
           static_cast<size_t>(std::distance(entryBlock.begin(),
                                             op->getIterator())) >= newOpCount)
         return;

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -1035,9 +1035,11 @@ struct FuncOpVectorUnroll final : OpRewritePattern<func::FuncOp> {
         }
       }
 
-      // Since all newly created operations are in the beginning, reaching the
-      // end of them means that any later `vector.insert_strided_slice` should
-      // not be touched.
+      // Only consider `vector.insert_strided_slice` ops that were newly created
+      // at the beginning of the entry block. Once we encounter operations
+      // outside the entry block or past the `newOpCount`-th operation in the
+      // entry block, we skip and leave exisintg `vector.insert_strided_slice`
+      // ops as is.
       if (op->getBlock() != &entryBlock ||
           static_cast<size_t>(std::distance(entryBlock.begin(),
                                             op->getIterator())) >= newOpCount)

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -1030,7 +1030,9 @@ struct FuncOpVectorUnroll final : OpRewritePattern<func::FuncOp> {
     }
 
     // Replace dummy operands of new `vector.insert_strided_slice` ops with
-    // their corresponding new function arguments.
+    // their corresponding new function arguments. The new
+    // `vector.insert_strided_slice` ops are inserted only into the entry block,
+    // so iterating over that block is sufficient.
     size_t unrolledInputIdx = 0;
     for (auto [count, op] : enumerate(entryBlock.getOperations())) {
       Operation &curOp = op;


### PR DESCRIPTION
`FuncOpVectorUnroll` contains logic that replaces function arguments by placeholders values. These replacements also involve changing all instructions in the function that use the arguments to use these placeholders. These placeholder values will later be changed back to use the function arguments (either new or original if already legal).

The current implementation however only replaces back (the second replacement, i.e. replacing the placeholder values to new/legal arguments) the first block of instructions and not all of the blocks. This may leave some instructions to use these placeholder values (which for already legal arguments are just zeroattr values that will get DCE'd) instead of the arguments, which is incorrect.

Closes #132158.