### PR TITLE
Global string alignment

### DIFF
--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -52,7 +52,7 @@ GlobalVariable *IRBuilderBase::CreateGlobalString(StringRef Str,
       *M, StrConstant->getType(), true, GlobalValue::PrivateLinkage,
       StrConstant, Name, nullptr, GlobalVariable::NotThreadLocal, AddressSpace);
   GV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
-  GV->setAlignment(Align(1));
+  GV->setAlignment(M->getDataLayout().getPrefTypeAlign(getInt8Ty()));
   return GV;
 }
 

--- a/llvm/test/Transforms/InstCombine/SystemZ/printf-opt-alignment.ll
+++ b/llvm/test/Transforms/InstCombine/SystemZ/printf-opt-alignment.ll
@@ -1,0 +1,15 @@
+; RUN: opt < %s --passes=instcombine -S -mtriple=systemz-unknown | FileCheck %s
+;
+; Check that string replacements inserted by the instcombiner are properly aligned.
+; The specific case checked replaces `printf("foo\n")` with `puts("foo")`
+
+@msg1 = constant [17 x i8] c"Alignment Check\0A\00", align 2
+; CHECK: c"Alignment Check\00", align 2
+
+; Function Attrs: noinline nounwind
+define dso_local void @foo() #0 {
+  %call = call signext i32 (ptr, ...) @printf(ptr noundef @msg1)
+  ret void
+}
+
+declare signext i32 @printf(ptr noundef, ...) #1


### PR DESCRIPTION
When creating global strings, some targets have requirements that need to be taken into account. Previously, the global strings created by `IRBuilder::createGlobalString` had a hard-coded alignment of `1`.

This commit makes it so that the alignment is taken from the data layout instead, giving targets the chance to align global strings according to their preferences.

This PR is motivated by (and should fix) #141491, where the 1-byte alignment in a global string created by a `printf` optimization led to the resulting assembly in a `-fno-PIC` compile to unexpectedly reference the GOT based on whether the code contained `printf` statements of the form `printf("foo\n");`.

I don't know and would appreciate feedback on whether this is the correct place to fix something like that.