### PR TITLE
[clang][python][test] Check if libclang.so is loadable

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -4370,12 +4370,17 @@ class Config:
         try:
             library = cdll.LoadLibrary(self.get_filename())
         except OSError as e:
-            msg = (
-                str(e) + ". To provide a path to libclang use "
-                "Config.set_library_path() or "
-                "Config.set_library_file()."
-            )
-            raise LibclangError(msg)
+            if "wrong ELF class: ELFCLASS32" in str(e):
+                print("warning: skipping check-clang-python"
+                      " since libclang cannot be loaded", file=sys.stderr)
+                os._exit(0)
+            else:
+                msg = (
+                    str(e) + ". To provide a path to libclang use "
+                    "Config.set_library_path() or "
+                    "Config.set_library_file()."
+                )
+                raise LibclangError(msg)
 
         return library
 


### PR DESCRIPTION
When building a 32-bit `clang` on a 64-bit system (like `i686-pc-linux-gnu` on a Linux/x86_64 system), `ninja check-all` fails:

```
FAILED: tools/clang/bindings/python/tests/CMakeFiles/check-clang-python tools/clang/bindings/python/tests/CMakeFiles/check-clang-python
cd clang/bindings/python && /usr/bin/cmake -E env CLANG_NO_DEFAULT_CONFIG=1 CLANG_LIBRARY_PATH=lib /usr/bin/python3.11 -m unittest discover
EEEEEEEE
```
and stops with `exit 1`.

Further investigation shows that, `python3.11`, a 64-bit binary, tries to load the freshly build 32-bit `libclang.so`, which cannot work, thus breaking the build.

Rather than trying to second-guess this situation, which seems very fragile, it's better to actually handle this situation when trying the load, which is what this patch does.  The exact error message from `cdll.LoadLibrary` differs between systems:

- On Linux, you get ``` clang.cindex.LibclangError: lib/libclang.so: wrong ELF class: ELFCLASS32. ``` while
- on Solaris, there's ``` clang.cindex.LibclangError: ld.so.1: python3.11: lib/libclang.so: wrong ELF class: ELFCLASS32. ```

To allow for both cases, this patch just looks for the common `"wrong ELF class: ELFCLASS32"`.

Tested on `amd64-pc-solaris2.11`, `i386-pc-solaris2.11`, `sparcv9-sun-solaris2.11`, `sparc-sun-solaris2.11`, `x86_64-pc-linux-gnu`, and `i686-pc-linux-gnu`.