### PR TITLE
[SPIR-V] Add Vertex execution model

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -302,6 +302,8 @@ getExecutionModel(const SPIRVSubtarget &STI, const Function &F) {
   const auto value = attribute.getValueAsString();
   if (value == "compute")
     return SPIRV::ExecutionModel::GLCompute;
+  if (value == "vertex")
+    return SPIRV::ExecutionModel::Vertex;
 
   report_fatal_error("This HLSL entry point is not supported by this backend.");
 }

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -280,6 +280,8 @@ getExecutionModel(const SPIRVSubtarget &STI, const Function &F) {
     const auto value = attribute.getValueAsString();
     if (value == "compute")
       return SPIRV::ExecutionModel::GLCompute;
+    if (value == "vertex")
+      return SPIRV::ExecutionModel::Vertex;
 
     report_fatal_error(
         "This HLSL entry point is not supported by this backend.");

--- a/llvm/test/CodeGen/SPIRV/ExecutionMode_Vertex.ll
+++ b/llvm/test/CodeGen/SPIRV/ExecutionMode_Vertex.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv-unknown-vulkan1.3-vertex %s -o - | FileCheck %s
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-vertex %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-vertex %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK: OpCapability Shader
 ; CHECK: OpEntryPoint Vertex %[[#entry:]] "main"

--- a/llvm/test/CodeGen/SPIRV/ExecutionMode_Vertex.ll
+++ b/llvm/test/CodeGen/SPIRV/ExecutionMode_Vertex.ll
@@ -1,0 +1,12 @@
+; RUN: llc -O0 -mtriple=spirv-unknown-vulkan1.3-vertex %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-vertex %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: OpCapability Shader
+; CHECK: OpEntryPoint Vertex %[[#entry:]] "main"
+
+define void @main() #1 {
+entry:
+  ret void
+}
+
+attributes #1 = { "hlsl.shader"="vertex" }


### PR DESCRIPTION
Adds backend handling of the vertex shader type compiling from HLSL.

Fixes #136961