### PR TITLE
[clang-doc] [test] Generalize error message patterns

### DIFF
--- a/clang-tools-extra/test/clang-doc/invalid-options.cpp
+++ b/clang-tools-extra/test/clang-doc/invalid-options.cpp
@@ -2,7 +2,7 @@
 // RUN: rm -rf %t && touch %t
 // RUN: not clang-doc %s -output=%t/subdir 2>&1 | FileCheck %s --check-prefix=OUTPUT-FAIL
 // OUTPUT-FAIL: clang-doc error:
-// OUTPUT-FAIL: {{(Not a directory|no such file or directory)}}
+// OUTPUT-FAIL: {{(Not a directory|[Nn]o such file or directory)}}
 
 /// Invalid format option.
 // RUN: rm -rf %t && mkdir %t && touch %t/file


### PR DESCRIPTION
On Windows, we hit the "no such file or directory" case, not the "Not a directory" one.

MS STL produces the "no such file or directory" message for `std::error_code(ENOENT, std::generic_category()).message()`, while libc++ and libstdc++ produce a similar message with a capital N.

Adjust the error message regex to match for either of them.

That said, this kind of test is very brittle with respect to portability.