### PR TITLE
[JITLink] [test] Extend preexisting MinGW XFAILs to new tests

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/Generic/all-load-multifile-archive-with-duplicate-member-filenames.test
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/all-load-multifile-archive-with-duplicate-member-filenames.test
@@ -10,6 +10,11 @@
 # FIXME: Enable this test on Windows/arm64 once that backend is available.
 # UNSUPPORTED: target=aarch64-pc-windows-{{.*}}
 #
+# On MinGW targets, when compiling the main() function, it gets
+# an implicitly generated call to __main(), which is missing in
+# this context.
+# XFAIL: target={{.*}}-windows-gnu
+#
 # Check that synthesized archive member names are unambiguous, even if an
 # archive contains multiple files with the same name.
 #

--- a/llvm/test/ExecutionEngine/JITLink/Generic/all-load-multifile-archive.test
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/all-load-multifile-archive.test
@@ -9,6 +9,11 @@
 # FIXME: Enable this test on Windows/arm64 once that backend is available.
 # UNSUPPORTED: target=aarch64-pc-windows-{{.*}}
 #
+# On MinGW targets, when compiling the main() function, it gets
+# an implicitly generated call to __main(), which is missing in
+# this context.
+# XFAIL: target={{.*}}-windows-gnu
+#
 # Check that the llvm-jitlink -all-load option loads all members of
 # multi-file archives.
 #


### PR DESCRIPTION
This extends the preexisting XFAILs from
4c642b62b99fa128c180f28278637b32be5e5576 to these new tests from 6fa8657a622173c177d863b763550de4d388f73c.