### PR TITLE
[JITLink] [test] Generalize UNSUPPORTED markings for Windows/arm64

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/Generic/all-load-multifile-archive-with-duplicate-member-filenames.test
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/all-load-multifile-archive-with-duplicate-member-filenames.test
@@ -8,7 +8,7 @@
 # RUN:     | FileCheck %s
 #
 # FIXME: Enable this test on Windows/arm64 once that backend is available.
-# UNSUPPORTED: target=aarch64-pc-windows-{{.*}}
+# UNSUPPORTED: target=aarch64-{{.*}}-windows-{{.*}}
 #
 # Check that synthesized archive member names are unambiguous, even if an
 # archive contains multiple files with the same name.

--- a/llvm/test/ExecutionEngine/JITLink/Generic/all-load-multifile-archive.test
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/all-load-multifile-archive.test
@@ -7,7 +7,7 @@
 # RUN:     | FileCheck %s
 #
 # FIXME: Enable this test on Windows/arm64 once that backend is available.
-# UNSUPPORTED: target=aarch64-pc-windows-{{.*}}
+# UNSUPPORTED: target=aarch64-{{.*}}-windows-{{.*}}
 #
 # Check that the llvm-jitlink -all-load option loads all members of
 # multi-file archives.

--- a/llvm/test/ExecutionEngine/JITLink/Generic/sectcreate.test
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/sectcreate.test
@@ -6,7 +6,7 @@
 # Use -sectcreate to create a section from a data file.
 
 # Jitlink does not support ARM64 COFF files.
-# UNSUPPORTED: target=aarch64-pc-windows-{{.*}}
+# UNSUPPORTED: target=aarch64-{{.*}}-windows-{{.*}}
 
 # On MinGW targets, when compiling the main() function, it gets
 # an implicitly generated call to __main(), which is missing in


### PR DESCRIPTION
Don't needlessly specify the vendor field as "pc"; in MinGW configurations, the vendor field is often "w64".