### PR TITLE
[OpenMP][test] Support target= in tests

### DIFF
--- a/openmp/libompd/test/lit.site.cfg.in
+++ b/openmp/libompd/test/lit.site.cfg.in
@@ -12,10 +12,14 @@ config.library_dir = "@LIBOMP_LIBRARY_DIR@"
 config.ompd_library_dir = "@CMAKE_CURRENT_BINARY_DIR@/../src/"
 config.omp_header_directory = "@LIBOMP_BINARY_DIR@/src"
 config.operating_system = "@CMAKE_SYSTEM_NAME@"
+config.target_triple = "@LLVM_TARGET_TRIPLE@"
 
 config.ompt_plugin = "@OMPT_PLUGIN@"
 config.ompt_include_dir = "@LIBOMP_INCLUDE_DIR@"
 config.ompd_module = "@CMAKE_CURRENT_BINARY_DIR@/../gdb-plugin/python-module/ompd/"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg")

--- a/openmp/runtime/test/lit.cfg
+++ b/openmp/runtime/test/lit.cfg
@@ -70,7 +70,6 @@ if config.operating_system != 'Haiku':
         libs += " -latomic"
 
 # Allow REQUIRES / UNSUPPORTED / XFAIL to work
-config.target_triple = [ ]
 for feature in config.test_compiler_features:
     config.available_features.add(feature)
 

--- a/openmp/runtime/test/lit.site.cfg.in
+++ b/openmp/runtime/test/lit.site.cfg.in
@@ -12,6 +12,7 @@ config.libomp_obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
 config.library_dir = "@LIBOMP_LIBRARY_DIR@"
 config.omp_header_directory = "@LIBOMP_BINARY_DIR@/src"
 config.operating_system = "@CMAKE_SYSTEM_NAME@"
+config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.hwloc_library_dir = "@LIBOMP_HWLOC_LIBRARY_DIR@"
 config.using_hwloc = @LIBOMP_USE_HWLOC@
 config.has_ompt = @LIBOMP_OMPT_SUPPORT@ and @LIBOMP_OMPT_OPTIONAL@
@@ -23,6 +24,9 @@ config.has_omit_frame_pointer_flag = @OPENMP_TEST_COMPILER_HAS_OMIT_FRAME_POINTE
 config.target_arch = "@LIBOMP_ARCH@"
 config.compiler_frontend_variant = "@CMAKE_C_COMPILER_FRONTEND_VARIANT@"
 config.compiler_simulate_id = "@CMAKE_C_SIMULATE_ID@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@LIBOMP_BASE_DIR@/test/lit.cfg")

--- a/openmp/tools/archer/tests/lit.cfg
+++ b/openmp/tools/archer/tests/lit.cfg
@@ -58,7 +58,6 @@ if config.has_libatomic:
     libs += " -latomic"
 
 # Allow XFAIL to work
-config.target_triple = [ ]
 for feature in config.test_compiler_features:
     config.available_features.add(feature)
 

--- a/openmp/tools/archer/tests/lit.site.cfg.in
+++ b/openmp/tools/archer/tests/lit.site.cfg.in
@@ -11,11 +11,15 @@ config.libomp_obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
 config.omp_library_dir = "@LIBOMP_LIBRARY_DIR@"
 config.omp_header_dir = "@LIBOMP_INCLUDE_DIR@"
 config.operating_system = "@CMAKE_SYSTEM_NAME@"
+config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.has_libatomic = @LIBARCHER_HAVE_LIBATOMIC@
 config.has_tsan = @OPENMP_TEST_ENABLE_TSAN@
 
 config.test_archer_flags = "@LIBARCHER_TEST_FLAGS@"
 config.libarcher_obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg")

--- a/openmp/tools/multiplex/tests/lit.cfg
+++ b/openmp/tools/multiplex/tests/lit.cfg
@@ -63,7 +63,6 @@ if 'CHECK_OPENMP_ENV' in os.environ:
         config.environment[name] = value
 
 # Allow XFAIL to work
-config.target_triple = [ ]
 for feature in config.test_compiler_features:
     config.available_features.add(feature)
 

--- a/openmp/tools/multiplex/tests/lit.site.cfg.in
+++ b/openmp/tools/multiplex/tests/lit.site.cfg.in
@@ -11,6 +11,10 @@ config.omp_library_dir = "@LIBOMP_LIBRARY_DIR@"
 config.omp_header_dir = "@LIBOMP_INCLUDE_DIR@"
 config.ompt_print_callback_dir = "@OMPT_PRINT_CALLBACKS_DIR@"
 config.operating_system = "@CMAKE_SYSTEM_NAME@"
+config.target_triple = "@LLVM_TARGET_TRIPLE@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg")


### PR DESCRIPTION
LLVM is moving towards the `target=<target triple RE>` syntax in `XFAIL: ` etc., and I'll need the same in a subsequent patch.

This patch adds the necessary infrastructure.

Tested on `sparc-sun-solaris2.11`, `sparcv9-sun-solaris2.11`, `sparc-unknown-linux-gnu`, `sparc64-unknown-linux-gnu`, `i386-pc-solaris2.11`, `amd64-pc-solaris2.11`, `i686-pc-linux-gnu`, and `x86_64-pc-linux-gnu`.