### PR TITLE
[OpenMP][test] XFAIL misc_bugs/many-microtask-args.c on SPARC

### DIFF
--- a/openmp/runtime/test/misc_bugs/many-microtask-args.c
+++ b/openmp/runtime/test/misc_bugs/many-microtask-args.c
@@ -1,4 +1,8 @@
 // RUN: %libomp-compile-and-run
+//
+// Issue #139905
+// XFAIL: target={{sparc.*}}
+
 #include <stdio.h>
 
 int main()


### PR DESCRIPTION
As detailed in Issue #139905, the `libomp :: misc_bugs/many-microtask-args.c` test currently `FAIL`s on SPARC:

```
# | Too many args to microtask: 17!

```
This happens on every target that lacks an assembler implementation of `__kmp_invoke_microtask`, so this patch `XFAIL`s the test on SPARC.

The `target={{sparc.*}}` syntax requires PR #142380.

Tested on `sparc-sun-solaris2.11`, `sparcv9-sun-solaris2.11`, `sparc-unknown-linux-gnu`, and `sparc64-unknown-linux-gnu`.