### PR TITLE
[clang][docs] Fix docs-clang-html.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -821,6 +821,7 @@ As well as one of the following:
 
 The warning can be resolved by removing one of the conditions above. In rough
 order of preference, this may be done by:
+
   1. Marking the object ``const`` (if possible)
   2. Moving the object's definition to a source file
   3. Giving the object non-hidden visibility, e.g. using ``__attribute((visibility("default")))``.


### PR DESCRIPTION
I observed that docs-clang-html is failing since https://github.com/llvm/llvm-project/pull/142158 with the following:

Warning, treated as error:
tools/clang/docs/DiagnosticsReference.rst:18000:Unexpected indentation. ninja: build stopped: subcommand failed.

Adding an extra empty line here fixes the build.