### PR TITLE
[AArch64] Fix FEAT_SVE_AES2 instructions to depend on SVE2 not SVE2P1

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -78,7 +78,7 @@ let F = [HasSME2p2, HasSVE2p2_or_SME2p2, HasNonStreamingSVE_or_SME2p2,
 def SME2p2Unsupported : AArch64Unsupported;
 
 def SME2p1Unsupported : AArch64Unsupported {
-  let F = !listconcat([HasSME2p1, HasSVE2p1_or_SME2p1, HasNonStreamingSVE2p1_or_SSVE_AES, 
+  let F = !listconcat([HasSME2p1, HasSVE2p1_or_SME2p1,
                        HasSME_MOP4, HasSME_TMOP, HasNonStreamingSVE_or_SSVE_FEXPA, 
                        HasNonStreamingSVE2_or_SSVE_BitPerm],
                        SME2p2Unsupported.F);
@@ -86,7 +86,8 @@ def SME2p1Unsupported : AArch64Unsupported {
 
 def SME2Unsupported : AArch64Unsupported {
   let F = !listconcat([HasSME2, HasSVE2_or_SME2, HasSVE2p1_or_SME2, HasSSVE_FP8FMA,
-                      HasSMEF8F16, HasSMEF8F32, HasSMEF16F16_or_SMEF8F16, HasSMEB16B16],
+                      HasSMEF8F16, HasSMEF8F32, HasSMEF16F16_or_SMEF8F16, HasSMEB16B16,
+                      HasNonStreamingSVE2_or_SSVE_AES],
                       SME2p1Unsupported.F);
 }
 

--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -4097,7 +4097,7 @@ let Predicates = [HasSVEBitPerm, HasNonStreamingSVE2_or_SSVE_BitPerm] in {
   defm BGRP_ZZZ : sve2_misc_bitwise<0b1110, "bgrp", int_aarch64_sve_bgrp_x>;
 }
 
-let Predicates = [HasSVEAES2, HasNonStreamingSVE2p1_or_SSVE_AES] in {
+let Predicates = [HasSVEAES2, HasNonStreamingSVE2_or_SSVE_AES] in {
   // SVE_AES2 multi-vector instructions (x2)
   def AESE_2ZZI_B    : sve_crypto_binary_multi2<0b000, "aese">;
   def AESD_2ZZI_B    : sve_crypto_binary_multi2<0b010, "aesd">;

--- a/llvm/test/MC/AArch64/SME2p1/directive-arch-negative.s
+++ b/llvm/test/MC/AArch64/SME2p1/directive-arch-negative.s
@@ -21,5 +21,5 @@ bfadd za.h[w8, 3], {z20.h-z21.h}
 .arch armv9-a+sve-aes2+ssve-aes
 .arch armv9-a+nossve-aes
 aesdimc {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]
-// CHECK: error: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK: error: instruction requires: sve-aes2
 // CHECK: aesdimc {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]

--- a/llvm/test/MC/AArch64/SME2p1/directive-arch_extension-negative.s
+++ b/llvm/test/MC/AArch64/SME2p1/directive-arch_extension-negative.s
@@ -23,5 +23,5 @@ bfadd za.h[w8, 3], {z20.h-z21.h}
 .arch_extension ssve-aes
 .arch_extension nossve-aes
 aesdimc {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]
-// CHECK: error: instruction requires: sve2p1 or ssve-aes
+// CHECK: error: instruction requires: sve2 or ssve-aes
 // CHECK: aesdimc {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]

--- a/llvm/test/MC/AArch64/SVE2p1/aesd.s
+++ b/llvm/test/MC/AArch64/SVE2p1/aesd.s
@@ -18,36 +18,36 @@
 aesd    {z0.b-z1.b}, {z0.b-z1.b}, z0.q[0]  // 01000101-00100010-11101100-00000000
 // CHECK-INST: aesd    { z0.b, z1.b }, { z0.b, z1.b }, z0.q[0]
 // CHECK-ENCODING: [0x00,0xec,0x22,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4522ec00 <unknown>
 
 aesd    {z20.b-z21.b}, {z20.b-z21.b}, z10.q[2]  // 01000101-00110010-11101101-01010100
 // CHECK-INST: aesd    { z20.b, z21.b }, { z20.b, z21.b }, z10.q[2]
 // CHECK-ENCODING: [0x54,0xed,0x32,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4532ed54 <unknown>
 
 aesd    {z30.b-z31.b}, {z30.b-z31.b}, z31.q[3]  // 01000101-00111010-11101111-11111110
 // CHECK-INST: aesd    { z30.b, z31.b }, { z30.b, z31.b }, z31.q[3]
 // CHECK-ENCODING: [0xfe,0xef,0x3a,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453aeffe <unknown>
 
 // x4
 aesd    {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]  // 01000101-00100110-11101100-00000000
 // CHECK-INST: aesd    { z0.b - z3.b }, { z0.b - z3.b }, z0.q[0]
 // CHECK-ENCODING: [0x00,0xec,0x26,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4526ec00 <unknown>
 
 aesd    {z20.b-z23.b}, {z20.b-z23.b}, z13.q[1]  // 01000101-00101110-11101101-10110100
 // CHECK-INST: aesd    { z20.b - z23.b }, { z20.b - z23.b }, z13.q[1]
 // CHECK-ENCODING: [0xb4,0xed,0x2e,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 452eedb4 <unknown>
 
 aesd    {z28.b-z31.b}, {z28.b-z31.b}, z31.q[3]  // 01000101-00111110-11101111-11111100
 // CHECK-INST: aesd    { z28.b - z31.b }, { z28.b - z31.b }, z31.q[3]
 // CHECK-ENCODING: [0xfc,0xef,0x3e,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453eeffc <unknown>

--- a/llvm/test/MC/AArch64/SVE2p1/aesdimc.s
+++ b/llvm/test/MC/AArch64/SVE2p1/aesdimc.s
@@ -19,36 +19,36 @@
 aesdimc {z0.b-z1.b}, {z0.b-z1.b}, z0.q[0]  // 01000101-00100011-11101100-00000000
 // CHECK-INST: aesdimc { z0.b, z1.b }, { z0.b, z1.b }, z0.q[0]
 // CHECK-ENCODING: [0x00,0xec,0x23,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4523ec00 <unknown>
 
 aesdimc {z20.b-z21.b}, {z20.b-z21.b}, z10.q[2]  // 01000101-00110011-11101101-01010100
 // CHECK-INST: aesdimc { z20.b, z21.b }, { z20.b, z21.b }, z10.q[2]
 // CHECK-ENCODING: [0x54,0xed,0x33,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4533ed54 <unknown>
 
 aesdimc {z30.b-z31.b}, {z30.b-z31.b}, z31.q[3]  // 01000101-00111011-11101111-11111110
 // CHECK-INST: aesdimc { z30.b, z31.b }, { z30.b, z31.b }, z31.q[3]
 // CHECK-ENCODING: [0xfe,0xef,0x3b,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453beffe <unknown>
 
 // x4
 aesdimc {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]  // 01000101-00100111-11101100-00000000
 // CHECK-INST: aesdimc { z0.b - z3.b }, { z0.b - z3.b }, z0.q[0]
 // CHECK-ENCODING: [0x00,0xec,0x27,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4527ec00 <unknown>
 
 aesdimc {z20.b-z23.b}, {z20.b-z23.b}, z13.q[1]  // 01000101-00101111-11101101-10110100
 // CHECK-INST: aesdimc { z20.b - z23.b }, { z20.b - z23.b }, z13.q[1]
 // CHECK-ENCODING: [0xb4,0xed,0x2f,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 452fedb4 <unknown>
 
 aesdimc {z28.b-z31.b}, {z28.b-z31.b}, z31.q[3]  // 01000101-00111111-11101111-11111100
 // CHECK-INST: aesdimc { z28.b - z31.b }, { z28.b - z31.b }, z31.q[3]
 // CHECK-ENCODING: [0xfc,0xef,0x3f,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453feffc <unknown>

--- a/llvm/test/MC/AArch64/SVE2p1/aese.s
+++ b/llvm/test/MC/AArch64/SVE2p1/aese.s
@@ -18,36 +18,36 @@
 aese    {z0.b-z1.b}, {z0.b-z1.b}, z0.q[0]  // 01000101-00100010-11101000-00000000
 // CHECK-INST: aese    { z0.b, z1.b }, { z0.b, z1.b }, z0.q[0]
 // CHECK-ENCODING: [0x00,0xe8,0x22,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4522e800 <unknown>
 
 aese    {z20.b-z21.b}, {z20.b-z21.b}, z10.q[2]  // 01000101-00110010-11101001-01010100
 // CHECK-INST: aese    { z20.b, z21.b }, { z20.b, z21.b }, z10.q[2]
 // CHECK-ENCODING: [0x54,0xe9,0x32,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4532e954 <unknown>
 
 aese    {z30.b-z31.b}, {z30.b-z31.b}, z31.q[3]  // 01000101-00111010-11101011-11111110
 // CHECK-INST: aese    { z30.b, z31.b }, { z30.b, z31.b }, z31.q[3]
 // CHECK-ENCODING: [0xfe,0xeb,0x3a,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453aebfe <unknown>
 
 // x4
 aese    {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]  // 01000101-00100110-11101000-00000000
 // CHECK-INST: aese    { z0.b - z3.b }, { z0.b - z3.b }, z0.q[0]
 // CHECK-ENCODING: [0x00,0xe8,0x26,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4526e800 <unknown>
 
 aese    {z20.b-z23.b}, {z20.b-z23.b}, z13.q[1]  // 01000101-00101110-11101001-10110100
 // CHECK-INST: aese    { z20.b - z23.b }, { z20.b - z23.b }, z13.q[1]
 // CHECK-ENCODING: [0xb4,0xe9,0x2e,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 452ee9b4 <unknown>
 
 aese    {z28.b-z31.b}, {z28.b-z31.b}, z31.q[3]  // 01000101-00111110-11101011-11111100
 // CHECK-INST: aese    { z28.b - z31.b }, { z28.b - z31.b }, z31.q[3]
 // CHECK-ENCODING: [0xfc,0xeb,0x3e,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453eebfc <unknown>

--- a/llvm/test/MC/AArch64/SVE2p1/aesemc.s
+++ b/llvm/test/MC/AArch64/SVE2p1/aesemc.s
@@ -18,36 +18,36 @@
 aesemc  {z0.b-z1.b}, {z0.b-z1.b}, z0.q[0]  // 01000101-00100011-11101000-00000000
 // CHECK-INST: aesemc  { z0.b, z1.b }, { z0.b, z1.b }, z0.q[0]
 // CHECK-ENCODING: [0x00,0xe8,0x23,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4523e800 <unknown>
 
 aesemc  {z22.b-z23.b}, {z22.b-z23.b}, z13.q[1]  // 01000101-00101011-11101001-10110110
 // CHECK-INST: aesemc  { z22.b, z23.b }, { z22.b, z23.b }, z13.q[1]
 // CHECK-ENCODING: [0xb6,0xe9,0x2b,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 452be9b6 <unknown>
 
 aesemc  {z30.b-z31.b}, {z30.b-z31.b}, z31.q[3]  // 01000101-00111011-11101011-11111110
 // CHECK-INST: aesemc  { z30.b, z31.b }, { z30.b, z31.b }, z31.q[3]
 // CHECK-ENCODING: [0xfe,0xeb,0x3b,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453bebfe <unknown>
 
 // x4
 aesemc  {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]  // 01000101-00100111-11101000-00000000
 // CHECK-INST: aesemc  { z0.b - z3.b }, { z0.b - z3.b }, z0.q[0]
 // CHECK-ENCODING: [0x00,0xe8,0x27,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4527e800 <unknown>
 
 aesemc  {z20.b-z23.b}, {z20.b-z23.b}, z10.q[2]  // 01000101-00110111-11101001-01010100
 // CHECK-INST: aesemc  { z20.b - z23.b }, { z20.b - z23.b }, z10.q[2]
 // CHECK-ENCODING: [0x54,0xe9,0x37,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4537e954 <unknown>
 
 aesemc  {z28.b-z31.b}, {z28.b-z31.b}, z31.q[3]  // 01000101-00111111-11101011-11111100
 // CHECK-INST: aesemc  { z28.b - z31.b }, { z28.b - z31.b }, z31.q[3]
 // CHECK-ENCODING: [0xfc,0xeb,0x3f,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453febfc <unknown>

--- a/llvm/test/MC/AArch64/SVE2p1/directive-arch-negative.s
+++ b/llvm/test/MC/AArch64/SVE2p1/directive-arch-negative.s
@@ -15,5 +15,5 @@ bfadd   z23.h, p3/m, z23.h, z13.h
 .arch armv9-a+sve2p1+sve-aes2
 .arch armv9-a+nosve-aes2
 aesdimc {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]
-// CHECK: error: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK: error: instruction requires: sve-aes2
 // CHECK: aesdimc {z0.b-z3.b}, {z0.b-z3.b}, z0.q[0]

--- a/llvm/test/MC/AArch64/SVE2p1/pmlal.s
+++ b/llvm/test/MC/AArch64/SVE2p1/pmlal.s
@@ -17,17 +17,17 @@
 pmlal   {z0.q-z1.q}, z0.d, z0.d  // 01000101-00100000-11111100-00000000
 // CHECK-INST: pmlal   { z0.q, z1.q }, z0.d, z0.d
 // CHECK-ENCODING: [0x00,0xfc,0x20,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4520fc00 <unknown>
 
 pmlal   {z22.q-z23.q}, z13.d, z8.d  // 01000101-00101000-11111101-10110110
 // CHECK-INST: pmlal   { z22.q, z23.q }, z13.d, z8.d
 // CHECK-ENCODING: [0xb6,0xfd,0x28,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4528fdb6 <unknown>
 
 pmlal   {z30.q-z31.q}, z31.d, z31.d  // 01000101-00111111-11111111-11111110
 // CHECK-INST: pmlal   { z30.q, z31.q }, z31.d, z31.d
 // CHECK-ENCODING: [0xfe,0xff,0x3f,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453ffffe <unknown>

--- a/llvm/test/MC/AArch64/SVE2p1/pmull.s
+++ b/llvm/test/MC/AArch64/SVE2p1/pmull.s
@@ -17,17 +17,17 @@
 pmull   {z0.q-z1.q}, z0.d, z0.d  // 01000101-00100000-11111000-00000000
 // CHECK-INST: pmull   { z0.q, z1.q }, z0.d, z0.d
 // CHECK-ENCODING: [0x00,0xf8,0x20,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4520f800 <unknown>
 
 pmull   {z22.q-z23.q}, z13.d, z8.d  // 01000101-00101000-11111001-10110110
 // CHECK-INST: pmull   { z22.q, z23.q }, z13.d, z8.d
 // CHECK-ENCODING: [0xb6,0xf9,0x28,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 4528f9b6 <unknown>
 
 pmull   {z30.q-z31.q}, z31.d, z31.d  // 01000101-00111111-11111011-11111110
 // CHECK-INST: pmull   { z30.q, z31.q }, z31.d, z31.d
 // CHECK-ENCODING: [0xfe,0xfb,0x3f,0x45]
-// CHECK-ERROR: instruction requires: sve2p1 or ssve-aes sve-aes2
+// CHECK-ERROR: instruction requires: sve2 or ssve-aes sve-aes2
 // CHECK-UNKNOWN: 453ffbfe <unknown>


### PR DESCRIPTION
Change instructions to only require `(SVE2 or SSVE-AES) and SVE-AES2` to be consistent with the fact that `+ssve-aes` only implies `+sme2` and not `+sme2p1`.