### PR TITLE
[Offload] Set size correctly in olLaunchKernel cts test

### DIFF
--- a/offload/unittests/OffloadAPI/device_code/foo.c
+++ b/offload/unittests/OffloadAPI/device_code/foo.c
@@ -1,5 +1,6 @@
 #include <gpuintrin.h>
+#include <stdint.h>
 
-__gpu_kernel void foo(int *out) {
+__gpu_kernel void foo(uint32_t *out) {
   out[__gpu_thread_id(0)] = __gpu_thread_id(0);
 }

--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -47,7 +47,8 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olLaunchKernelTest);
 
 TEST_P(olLaunchKernelTest, Success) {
   void *Mem;
-  ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED, 64, &Mem));
+  ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
+                            LaunchArgs.GroupSizeX * sizeof(uint32_t), &Mem));
   struct {
     void *Mem;
   } Args{Mem};
@@ -57,7 +58,7 @@ TEST_P(olLaunchKernelTest, Success) {
 
   ASSERT_SUCCESS(olWaitQueue(Queue));
 
-  int *Data = (int *)Mem;
+  uint32_t *Data = (uint32_t *)Mem;
   for (int i = 0; i < 64; i++) {
     ASSERT_EQ(Data[i], i);
   }
@@ -67,7 +68,8 @@ TEST_P(olLaunchKernelTest, Success) {
 
 TEST_P(olLaunchKernelTest, SuccessSynchronous) {
   void *Mem;
-  ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED, 64, &Mem));
+  ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
+                            LaunchArgs.GroupSizeX * sizeof(uint32_t), &Mem));
 
   struct {
     void *Mem;
@@ -76,7 +78,7 @@ TEST_P(olLaunchKernelTest, SuccessSynchronous) {
   ASSERT_SUCCESS(olLaunchKernel(nullptr, Device, Kernel, &Args, sizeof(Args),
                                 &LaunchArgs, nullptr));
 
-  int *Data = (int *)Mem;
+  uint32_t *Data = (uint32_t *)Mem;
   for (int i = 0; i < 64; i++) {
     ASSERT_EQ(Data[i], i);
   }


### PR DESCRIPTION
It was previously not scaled by `sizeof(uint32_t)`.
