### PR TITLE
[SPIR-V] Only emit __spirv__ when targeting HLSL

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.cpp
+++ b/clang/lib/Basic/Targets/SPIR.cpp
@@ -87,7 +87,8 @@ void SPIR64TargetInfo::getTargetDefines(const LangOptions &Opts,
 void BaseSPIRVTargetInfo::getTargetDefines(const LangOptions &Opts,
                                            MacroBuilder &Builder) const {
   DefineStd(Builder, "SPIRV", Opts);
-  DefineStd(Builder, "spirv", Opts);
+  if (Opts.HLSL)
+    DefineStd(Builder, "spirv", Opts);
 }
 
 void SPIRVTargetInfo::getTargetDefines(const LangOptions &Opts,

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -228,6 +228,7 @@
 // CHECK-SPIRV32-DAG: #define __SPIRV__ 1
 // CHECK-SPIRV32-DAG: #define __SPIRV32__ 1
 // CHECK-SPIRV32-NOT: #define __SPIRV64__ 1
+// CHECK-SPIRV32-NOT: #define __spirv__ 1
 
 // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spirv64-unknown-unknown \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIRV64
@@ -235,6 +236,7 @@
 // CHECK-SPIRV64-DAG: #define __SPIRV__ 1
 // CHECK-SPIRV64-DAG: #define __SPIRV64__ 1
 // CHECK-SPIRV64-NOT: #define __SPIRV32__ 1
+// CHECK-SPIRV64-NOT: #define __spirv__ 1
 
 // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spirv64-amd-amdhsa \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIRV64-AMDGCN
@@ -245,6 +247,7 @@
 // CHECK-SPIRV64-AMDGCN-DAG: #define __AMDGCN__ 1
 // CHECK-SPIRV64-AMDGCN-DAG: #define __AMDGPU__ 1
 // CHECK-SPIRV64-AMDGCN-NOT: #define __SPIRV32__ 1
+// CHECK-SPIRV64-AMDGCN-NOT: #define __spirv__ 1
 
 // RUN: %clang_cc1 %s -E -dM -o - -x hip -triple x86_64-unknown-linux-gnu \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-HIP


### PR DESCRIPTION
OpenCL translator has a `__spirv` namespace, and defining the `__spirv__` macro causes issues downstream on the OpenCL side. This macro is needed to keep compatibility with HLSL/DXC, but can be avoided for other targets/languages.