### PR TITLE
[flang][OpenMP] Skip implicit typing for OpenMPDeclarativeConstruct

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1661,6 +1661,9 @@ public:
   }
   bool Pre(const parser::OpenMPDeclarativeConstruct &x) {
     AddOmpSourceRange(x.source);
+    // Without skipping implicit typing, declarative constructs
+    // can implicitly declare variables instead of only using the
+    // ones already declared in the Fortran sources.
     SkipImplicitTyping(true);
     return true;
   }

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1513,6 +1513,7 @@ public:
 
   bool Pre(const parser::OpenMPDeclareSimdConstruct &x) {
     AddOmpSourceRange(x.source);
+    SkipImplicitTyping(true);
     return true;
   }
 

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1513,11 +1513,7 @@ public:
 
   bool Pre(const parser::OpenMPDeclareSimdConstruct &x) {
     AddOmpSourceRange(x.source);
-    SkipImplicitTyping(true);
     return true;
-  }
-  void Post(const parser::OpenMPDeclareSimdConstruct &x) {
-    SkipImplicitTyping(false);
   }
 
   bool Pre(const parser::OmpInitializerProc &x) {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1516,6 +1516,9 @@ public:
     SkipImplicitTyping(true);
     return true;
   }
+  void Post(const parser::OpenMPDeclareSimdConstruct &x) {
+    SkipImplicitTyping(false);
+  }
 
   bool Pre(const parser::OmpInitializerProc &x) {
     auto &procDes = std::get<parser::ProcedureDesignator>(x.t);
@@ -1662,9 +1665,11 @@ public:
   }
   bool Pre(const parser::OpenMPDeclarativeConstruct &x) {
     AddOmpSourceRange(x.source);
+    SkipImplicitTyping(true);
     return true;
   }
   void Post(const parser::OpenMPDeclarativeConstruct &) {
+    SkipImplicitTyping(false);
     messageHandler().set_currStmtSource(std::nullopt);
   }
   bool Pre(const parser::OpenMPDepobjConstruct &x) {

--- a/flang/test/Semantics/OpenMP/declare-simd-linear.f90
+++ b/flang/test/Semantics/OpenMP/declare-simd-linear.f90
@@ -1,5 +1,5 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenmp
-! Test declare simd with linear clause
+! Test declare simd with linear clause does not cause an implicit declaration of i
 
 module mod
 contains

--- a/flang/test/Semantics/OpenMP/declare-simd-linear.f90
+++ b/flang/test/Semantics/OpenMP/declare-simd-linear.f90
@@ -3,16 +3,10 @@
 
 module mod
 contains
-subroutine sub(m,i)
+subroutine test(i)
 !$omp declare simd linear(i:1)
   implicit none
-  integer*8 i,n
-  value i
-  parameter(n=10000)
-  real*4 a,b,m
-  common/com1/a(n)
-  common/com2/b(n)
-  a(i) = b(i) + m
+  integer*8 i
   i=i+2
 end subroutine
 end module

--- a/flang/test/Semantics/OpenMP/declare-simd-linear.f90
+++ b/flang/test/Semantics/OpenMP/declare-simd-linear.f90
@@ -1,0 +1,18 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+! Test declare simd with linear clause
+
+module mod
+contains
+subroutine sub(m,i)
+!$omp declare simd linear(i:1)
+  implicit none
+  integer*8 i,n
+  value i
+  parameter(n=10000)
+  real*4 a,b,m
+  common/com1/a(n)
+  common/com2/b(n)
+  a(i) = b(i) + m
+  i=i+2
+end subroutine
+end module

--- a/flang/test/Semantics/OpenMP/linear-clause01.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause01.f90
@@ -24,12 +24,10 @@ subroutine linear_clause_02(arg_01, arg_02)
     !$omp declare simd linear(uval(arg_02))
     integer, value, intent(in) :: arg_02
 
-    !ERROR: The list item 'var' specified without the REF 'linear-modifier' must be of INTEGER type
     !ERROR: If the `linear-modifier` is REF or UVAL, the list item 'var' must be a dummy argument without the VALUE attribute
     !ERROR: The list item `var` must be a dummy argument
     !ERROR: The list item `var` in a LINEAR clause must not be Cray Pointer or a variable with POINTER attribute
     !$omp declare simd linear(uval(var))
-    !ERROR: The type of 'var' has already been implicitly declared
     integer, pointer :: var
 end subroutine linear_clause_02
 


### PR DESCRIPTION
DeclareSimdConstruct (and other declarative constructs) can currently implicitly declare variables regardless of whether the source code contains "implicit none" or not. This causes semantic analysis issues if the implicit type does not match the declared type. To solve it, skip implicit typing for OpenMPDeclarativeConstruct. Fixes issue #140754.