### PR TITLE
[Offload] Split offload unittests into multiple files

### DIFF
--- a/offload/unittests/CMakeLists.txt
+++ b/offload/unittests/CMakeLists.txt
@@ -2,7 +2,17 @@ add_custom_target(OffloadUnitTests)
 set_target_properties(OffloadUnitTests PROPERTIES FOLDER "Tests/UnitTests")
 
 function(add_offload_unittest test_dirname)
-  add_unittest(OffloadUnitTests ${test_dirname} ${ARGN})
+  set(TARGET_NAME "${test_dirname}.unittests")
+
+  list(TRANSFORM ARGN PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/" OUTPUT_VARIABLE FILES)
+
+  add_unittest(OffloadUnitTests "${TARGET_NAME}"
+    ${CMAKE_CURRENT_SOURCE_DIR}/common/Environment.cpp
+    ${FILES})
+  add_dependencies(${TARGET_NAME} ${PLUGINS_TEST_COMMON} OffloadUnitTestsDeviceBins)
+  target_compile_definitions(${TARGET_NAME} PRIVATE DEVICE_CODE_PATH="${OFFLOAD_TEST_DEVICE_CODE_PATH}")
+  target_link_libraries(${TARGET_NAME} PRIVATE ${PLUGINS_TEST_COMMON})
+  target_include_directories(${TARGET_NAME} PRIVATE ${PLUGINS_TEST_INCLUDE})
 endfunction()
 
 add_subdirectory(OffloadAPI)

--- a/offload/unittests/CMakeLists.txt
+++ b/offload/unittests/CMakeLists.txt
@@ -2,17 +2,17 @@ add_custom_target(OffloadUnitTests)
 set_target_properties(OffloadUnitTests PROPERTIES FOLDER "Tests/UnitTests")
 
 function(add_offload_unittest test_dirname)
-  set(TARGET_NAME "${test_dirname}.unittests")
+  set(target_name "${test_dirname}.unittests")
 
-  list(TRANSFORM ARGN PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/" OUTPUT_VARIABLE FILES)
+  list(TRANSFORM ARGN PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/" OUTPUT_VARIABLE files)
 
-  add_unittest(OffloadUnitTests "${TARGET_NAME}"
+  add_unittest(OffloadUnitTests "${target_name}"
     ${CMAKE_CURRENT_SOURCE_DIR}/common/Environment.cpp
-    ${FILES})
-  add_dependencies(${TARGET_NAME} ${PLUGINS_TEST_COMMON} OffloadUnitTestsDeviceBins)
-  target_compile_definitions(${TARGET_NAME} PRIVATE DEVICE_CODE_PATH="${OFFLOAD_TEST_DEVICE_CODE_PATH}")
-  target_link_libraries(${TARGET_NAME} PRIVATE ${PLUGINS_TEST_COMMON})
-  target_include_directories(${TARGET_NAME} PRIVATE ${PLUGINS_TEST_INCLUDE})
+    ${files})
+  add_dependencies(${target_name} ${PLUGINS_TEST_COMMON} OffloadUnitTestsDeviceBins)
+  target_compile_definitions(${target_name} PRIVATE DEVICE_CODE_PATH="${OFFLOAD_TEST_DEVICE_CODE_PATH}")
+  target_link_libraries(${target_name} PRIVATE ${PLUGINS_TEST_COMMON})
+  target_include_directories(${target_name} PRIVATE ${PLUGINS_TEST_INCLUDE})
 endfunction()
 
 add_subdirectory(OffloadAPI)

--- a/offload/unittests/OffloadAPI/CMakeLists.txt
+++ b/offload/unittests/OffloadAPI/CMakeLists.txt
@@ -3,27 +3,33 @@ set(PLUGINS_TEST_INCLUDE ${LIBOMPTARGET_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
 
 add_subdirectory(device_code)
 
-add_offload_unittest("offload.unittests"
-    ${CMAKE_CURRENT_SOURCE_DIR}/common/Environment.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/platform/olGetPlatformInfo.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/platform/olGetPlatformInfoSize.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/device/olIterateDevices.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/device/olGetDeviceInfo.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/device/olGetDeviceInfoSize.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/queue/olCreateQueue.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/queue/olWaitQueue.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/queue/olDestroyQueue.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/memory/olMemAlloc.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/memory/olMemFree.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/memory/olMemcpy.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/program/olCreateProgram.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/program/olDestroyProgram.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/kernel/olGetKernel.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/kernel/olLaunchKernel.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/event/olDestroyEvent.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/event/olWaitEvent.cpp
-    )
-add_dependencies("offload.unittests" ${PLUGINS_TEST_COMMON} OffloadUnitTestsDeviceBins)
-target_compile_definitions("offload.unittests" PRIVATE DEVICE_CODE_PATH="${OFFLOAD_TEST_DEVICE_CODE_PATH}")
-target_link_libraries("offload.unittests" PRIVATE ${PLUGINS_TEST_COMMON})
-target_include_directories("offload.unittests" PRIVATE ${PLUGINS_TEST_INCLUDE})
+add_offload_unittest("device"
+    device/olIterateDevices.cpp
+    device/olGetDeviceInfo.cpp
+    device/olGetDeviceInfoSize.cpp)
+
+add_offload_unittest("event"
+    event/olDestroyEvent.cpp
+    event/olWaitEvent.cpp)
+
+add_offload_unittest("kernel"
+    kernel/olGetKernel.cpp
+    kernel/olLaunchKernel.cpp)
+
+add_offload_unittest("memory"
+    memory/olMemAlloc.cpp
+    memory/olMemFree.cpp
+    memory/olMemcpy.cpp)
+
+add_offload_unittest("platform"
+    platform/olGetPlatformInfo.cpp
+    platform/olGetPlatformInfoSize.cpp)
+
+add_offload_unittest("program"
+    program/olCreateProgram.cpp
+    program/olDestroyProgram.cpp)
+
+add_offload_unittest("queue"
+    queue/olCreateQueue.cpp
+    queue/olWaitQueue.cpp
+    queue/olDestroyQueue.cpp)


### PR DESCRIPTION
Rather than a single `offload.unittests` file, this will produce
`device.unittests`, `event.unittests`, etc.. This should reduce time
spent building tests, and make it easier to manually run a subset of
the tests.

Note that `check-offload-unit` will still run all the tests.
