### PR TITLE
[MLIR] Fix incorrect slice contiguity inference in `vector::isContiguousSlice`

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/Utils/VectorUtils.h
+++ b/mlir/include/mlir/Dialect/Vector/Utils/VectorUtils.h
@@ -47,7 +47,9 @@ Value createOrFoldDimOp(OpBuilder &b, Location loc, Value source, int64_t dim);
 /// on a 2D slice. Otherwise, returns a failure.
 FailureOr<std::pair<int, int>> isTranspose2DSlice(vector::TransposeOp op);
 
-/// Return true if `vectorType` is a contiguous slice of `memrefType`.
+/// Return true if `vectorType` is a contiguous slice of `memrefType`,
+/// in the sense that it can be read/written from/to a contiguous area
+/// of the memref.
 ///
 /// The leading unit dimensions of the vector type are ignored as they
 /// are not relevant to the result. Let N be the number of the vector

--- a/mlir/include/mlir/Dialect/Vector/Utils/VectorUtils.h
+++ b/mlir/include/mlir/Dialect/Vector/Utils/VectorUtils.h
@@ -54,9 +54,9 @@ FailureOr<std::pair<int, int>> isTranspose2DSlice(vector::TransposeOp op);
 /// dimensions after ignoring a leading sequence of unit ones.
 ///
 /// For `vectorType` to be a contiguous slice of `memrefType`
-///   a) the N trailing dimensions of the latter must be contiguous, and
-///   b) the trailing N dimensions of `vectorType` and `memrefType`,
-///      except the first of them, must match.
+///   a) the N trailing dimensions of `memrefType` must be contiguous, and
+///   b) the N-1 trailing dimensions of `vectorType` and `memrefType`
+///      must match.
 ///
 /// Examples:
 ///
@@ -69,15 +69,15 @@ FailureOr<std::pair<int, int>> isTranspose2DSlice(vector::TransposeOp op);
 ///   Ex.4 contiguous slice, leading unit dimension of the vector ignored,
 ///        2 != 3 (allowed)
 ///     vector<1x2x2xi32> from memref<5x4x3x2xi32>
-///   Ex.5. contiguous slice, leasing two unit dims of the vector ignored,
+///   Ex.5. contiguous slice, leading two unit dims of the vector ignored,
 ///         2 != 3 (allowed)
 ///     vector<1x1x2x2xi32> from memref<5x4x3x2xi32>
 ///   Ex.6. non-contiguous slice, 2 != 3, no leading sequence of unit dims
 ///     vector<2x1x2x2xi32> from memref<5x4x3x2xi32>)
-///   Ex.7 contiguous slice, memref needs to be contiguous only on the last
+///   Ex.7 contiguous slice, memref needs to be contiguous only in the last
 ///        dimension
 ///     vector<1x1x2xi32> from memref<2x2x2xi32, strided<[8, 4, 1]>>
-///   Ex.8 non-contiguous slice, memref needs to be contiguous one the last
+///   Ex.8 non-contiguous slice, memref needs to be contiguous in the last
 ///        two dimensions, and it isn't
 ///     vector<1x2x2xi32> from memref<2x2x2xi32, strided<[8, 4, 1]>>
 bool isContiguousSlice(MemRefType memrefType, VectorType vectorType);

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
@@ -630,7 +630,9 @@ public:
     if (transferReadOp.getMask())
       return failure();
 
-    int64_t firstDimToCollapse = sourceType.getRank() - vectorType.getRank();
+    // Determinine the first memref dimension to collapse
+    int64_t firstDimToCollapse =
+        sourceType.getRank() - sourceType.getMaxCollapsableTrailingDims();
 
     // 1. Collapse the source memref
     Value collapsedSource =
@@ -722,7 +724,9 @@ public:
     if (transferWriteOp.getMask())
       return failure();
 
-    int64_t firstDimToCollapse = sourceType.getRank() - vectorType.getRank();
+    // Determinine the first memref dimension to collapse
+    int64_t firstDimToCollapse =
+        sourceType.getRank() - sourceType.getMaxCollapsableTrailingDims();
 
     // 1. Collapse the source memref
     Value collapsedSource =

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
@@ -582,7 +582,8 @@ static SmallVector<Value> getCollapsedIndices(RewriterBase &rewriter,
 
 namespace {
 
-/// Helper functon to return the index of the last dynamic dimension in `shape`.
+/// Helper function to return the index of the last dynamic dimension
+/// in `shape` or -1 if there are no dynamic dimensions.
 int64_t lastDynIndex(ArrayRef<int64_t> shape) {
   return static_cast<int64_t>(
       std::distance(

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
@@ -642,7 +642,7 @@ public:
     // Determinine the first memref dimension to collapse
     int64_t firstDimToCollapse = std::max(
         lastDynIndex(sourceType.getShape()),
-        sourceType.getRank() - sourceType.getMaxContiguousTrailingDims());
+        sourceType.getRank() - sourceType.getNumContiguousTrailingDims());
 
     // 1. Collapse the source memref
     Value collapsedSource =
@@ -737,7 +737,7 @@ public:
     // Determinine the first memref dimension to collapse
     int64_t firstDimToCollapse = std::max(
         lastDynIndex(sourceType.getShape()),
-        sourceType.getRank() - sourceType.getMaxContiguousTrailingDims());
+        sourceType.getRank() - sourceType.getNumContiguousTrailingDims());
 
     // 1. Collapse the source memref
     Value collapsedSource =

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransferOpTransforms.cpp
@@ -642,7 +642,7 @@ public:
     // Determinine the first memref dimension to collapse
     int64_t firstDimToCollapse = std::max(
         lastDynIndex(sourceType.getShape()),
-        sourceType.getRank() - sourceType.getMaxCollapsableTrailingDims());
+        sourceType.getRank() - sourceType.getMaxContiguousTrailingDims());
 
     // 1. Collapse the source memref
     Value collapsedSource =
@@ -737,7 +737,7 @@ public:
     // Determinine the first memref dimension to collapse
     int64_t firstDimToCollapse = std::max(
         lastDynIndex(sourceType.getShape()),
-        sourceType.getRank() - sourceType.getMaxCollapsableTrailingDims());
+        sourceType.getRank() - sourceType.getMaxContiguousTrailingDims());
 
     // 1. Collapse the source memref
     Value collapsedSource =

--- a/mlir/lib/Dialect/Vector/Utils/VectorUtils.cpp
+++ b/mlir/lib/Dialect/Vector/Utils/VectorUtils.cpp
@@ -258,7 +258,7 @@ bool vector::isContiguousSlice(MemRefType memrefType, VectorType vectorType) {
   if (vectorType.isScalable())
     return false;
 
-  // Ignore a leading contiguous sequence of unit dimensions in the vector.
+  // Ignore a leading sequence of adjacent unit dimensions in the vector.
   ArrayRef<int64_t> vectorShape =
       vectorType.getShape().drop_while([](auto v) { return v == 1; });
   auto vecRank = vectorShape.size();


### PR DESCRIPTION
Previously, slices were sometimes marked as non-contiguous when they were actually contiguous. This occurred when the vector type had leading unit dimensions, e.g., `vector<1x1x...x1xd0xd1x...xdn-1xT>`. In such cases, only the trailing `n` dimensions of the memref need to be contiguous, not the entire vector rank.

This affects how `FlattenContiguousRowMajorTransfer{Read,Write}Pattern` flattens `transfer_read` and `transfer_write` ops.

The patterns used to collapse a number of dimensions equal to the vector rank which missed some opportunities when the leading unit dimensions of the vector span non-contiguous dimensions of the memref.
Now that the contiguity of the slice is determined correctly, there is a choice how many dimensions of the
memref to collapse, ranging from 
  a) the number of vector dimensions after ignoring the leading unit dimensions, up to
  b) the maximum number of contiguous memref dimensions

This patch makes a choice to do minimal memref collapsing. The rationale behind this decision is that
this way the least amount of information is discarded.

(It follows that in some cases where the patterns used to trigger and collapse some memref dimensions, after this patch the patterns may collapse less dimensions).


