### PR TITLE
[lldb] Emit an error when using --wait-for without a name or pid

### DIFF
--- a/lldb/test/Shell/Driver/TestWaitFor.test
+++ b/lldb/test/Shell/Driver/TestWaitFor.test
@@ -1,0 +1,2 @@
+# RUN: not %lldb --wait-for 2>&1 | FileCheck %s
+# CHECK: error: --wait-for requires a name (--attach-name)

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -280,6 +280,12 @@ SBError Driver::ProcessArgs(const opt::InputArgList &args, bool &exiting) {
   }
 
   if (args.hasArg(OPT_wait_for)) {
+    if (!args.hasArg(OPT_attach_name)) {
+      error.SetErrorStringWithFormat(
+          "--wait-for requires a name (--attach-name)");
+      return error;
+    }
+
     m_option_data.m_wait_for = true;
   }
 

--- a/lldb/tools/driver/Options.td
+++ b/lldb/tools/driver/Options.td
@@ -19,9 +19,11 @@ def: Separate<["-"], "n">,
   HelpText<"Alias for --attach-name">,
   Group<grp_attach>;
 
-def wait_for: F<"wait-for">,
-  HelpText<"Tells the debugger to wait for a process with the given pid or name to launch before attaching.">,
-  Group<grp_attach>;
+def wait_for
+    : F<"wait-for">,
+      HelpText<"Tells the debugger to wait for the process with the name "
+               "specified by --attach-name to launch before attaching.">,
+      Group<grp_attach>;
 def: Flag<["-"], "w">,
   Alias<wait_for>,
   HelpText<"Alias for --wait-for">,


### PR DESCRIPTION
Emit an error when using --wait-for without a name and correct the help
output to specify a name must be provided, rather than a name or PID.

Motivated by https://discourse.llvm.org/t/why-is-wait-for-not-attaching/86636