### PR TITLE
[bazel] Add missing deps for #141864

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -1627,6 +1627,7 @@ cc_library(
     copts = llvm_copts,
     deps = [
         ":Analysis",
+        ":Support",
         ":TargetParser",
     ],
 )


### PR DESCRIPTION
Added in 150d466994050c52db76b64ff2ce44cddddbcad4.

```
external/llvm-project/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h:16:10: error: module llvm-project//llvm:FrontendDriver does not depend on a module exporting 'llvm/Support/Compiler.h'
#include "llvm/Support/Compiler.h"
```