### PR TITLE
[alpha.webkit.UncheckedCallArgsChecker] Forwarding r-value reference should not result in a warning

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -118,7 +118,7 @@ bool tryToFindPtrOrigin(
           }
         }
       }
-      
+
       if (call->isCallToStdMove() && call->getNumArgs() == 1) {
         E = call->getArg(0)->IgnoreParenCasts();
         continue;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -118,6 +118,11 @@ bool tryToFindPtrOrigin(
           }
         }
       }
+      
+      if (call->isCallToStdMove() && call->getNumArgs() == 1) {
+        E = call->getArg(0)->IgnoreParenCasts();
+        continue;
+      }
 
       if (auto *callee = call->getDirectCallee()) {
         if (isCtorOfSafePtr(callee)) {

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
@@ -2,6 +2,20 @@
 
 #include "mock-types.h"
 
+namespace std {
+
+template <typename T> struct remove_reference {
+  typedef T type;
+};
+
+template <typename T> struct remove_reference<T&> {
+  typedef T type;
+};
+
+template<typename T> typename remove_reference<T>::type&& move(T&& t);
+
+} // namespace std
+
 RefCountableAndCheckable* makeObj();
 CheckedRef<RefCountableAndCheckable> makeObjChecked();
 void someFunction(RefCountableAndCheckable*);
@@ -51,6 +65,15 @@ CheckedObj* provide();
 void foo() {
   CheckedPtr<CheckedObj> ptr;
   ptr = provide();
+}
+
+}
+
+namespace call_with_std_move {
+
+void consume(CheckedObj&&);
+void foo(CheckedObj&& obj) {
+  consume(std::move(obj));
 }
 
 }


### PR DESCRIPTION
This PR fixes the bug that the checker emits a warning when a function takes T&& and passes it to another function using std::move. We should treat std::move like any other pointer conversion and the origin of the pointer to be that of the argument.