### PR TITLE
[CIR] Support inline C++ member function definitions

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -43,9 +43,31 @@ class CIRGenerator : public clang::ASTConsumer {
 
   const clang::CodeGenOptions &codeGenOpts;
 
+  unsigned handlingTopLevelDecls;
+
+  /// Use this when emitting decls to block re-entrant decl emission. It will
+  /// emit all deferred decls on scope exit. Set EmitDeferred to false if decl
+  /// emission must be deferred longer, like at the end of a tag definition.
+  struct HandlingTopLevelDeclRAII {
+    CIRGenerator &self;
+    bool emitDeferred;
+    HandlingTopLevelDeclRAII(CIRGenerator &self, bool emitDeferred = true)
+        : self{self}, emitDeferred{emitDeferred} {
+      ++self.handlingTopLevelDecls;
+    }
+    ~HandlingTopLevelDeclRAII() {
+      unsigned Level = --self.handlingTopLevelDecls;
+      if (Level == 0 && emitDeferred)
+        self.emitDeferredDecls();
+    }
+  };
+
 protected:
   std::unique_ptr<mlir::MLIRContext> mlirContext;
   std::unique_ptr<clang::CIRGen::CIRGenModule> cgm;
+
+private:
+  llvm::SmallVector<clang::FunctionDecl *, 8> deferredInlineMemberFuncDefs;
 
 public:
   CIRGenerator(clang::DiagnosticsEngine &diags,
@@ -54,6 +76,7 @@ public:
   ~CIRGenerator() override;
   void Initialize(clang::ASTContext &astContext) override;
   bool HandleTopLevelDecl(clang::DeclGroupRef group) override;
+  void HandleInlineFunctionDefinition(clang::FunctionDecl *d) override;
   void CompleteTentativeDefinition(clang::VarDecl *d) override;
 
   mlir::ModuleOp getModule() const;
@@ -61,6 +84,8 @@ public:
   const mlir::MLIRContext &getMLIRContext() const { return *mlirContext; };
 
   bool verifyModule() const;
+
+  void emitDeferredDecls();
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -137,8 +137,15 @@ struct MissingFeatures {
   static bool recordZeroInit() { return false; }
   static bool zeroSizeRecordMembers() { return false; }
 
-  // Misc
+  // CXXABI
   static bool cxxABI() { return false; }
+  static bool cxxabiThisAlignment() { return false; }
+  static bool cxxabiUseARMMethodPtrABI() { return false; }
+  static bool cxxabiUseARMGuardVarABI() { return false; }
+  static bool cxxabiAppleARM64CXXABI() { return false; }
+  static bool cxxabiStructorImplicitParam() { return false; }
+
+  // Misc
   static bool cirgenABIInfo() { return false; }
   static bool abiArgInfo() { return false; }
   static bool tryEmitAsConstant() { return false; }
@@ -187,7 +194,6 @@ struct MissingFeatures {
   static bool typeChecks() { return false; }
   static bool lambdaFieldToName() { return false; }
   static bool updateCompletedType() { return false; }
-  static bool targetSpecificCXXABI() { return false; }
   static bool moduleNameHash() { return false; }
   static bool constantFoldSwitchStatement() { return false; }
   static bool cudaSupport() { return false; }
@@ -196,13 +202,12 @@ struct MissingFeatures {
   static bool constEmitterVectorILE() { return false; }
   static bool needsGlobalCtorDtor() { return false; }
   static bool emitTypeCheck() { return false; }
-  static bool cxxabiThisDecl() { return false; }
-  static bool cxxabiThisAlignment() { return false; }
   static bool writebacks() { return false; }
   static bool cleanupsToDeactivate() { return false; }
   static bool stackBase() { return false; }
   static bool deferredDecls() { return false; }
   static bool setTargetAttributes() { return false; }
+  static bool coverageMapping() { return false; }
 
   // Missing types
   static bool dataMemberType() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.cpp
@@ -33,13 +33,24 @@ void CIRGenCXXABI::buildThisParam(CIRGenFunction &cgf,
                                 &cgm.getASTContext().Idents.get("this"),
                                 md->getThisType(), ImplicitParamKind::CXXThis);
   params.push_back(thisDecl);
-
-  // Classic codegen save thisDecl in CodeGenFunction::CXXABIThisDecl, but it
-  // doesn't seem to be needed in CIRGen.
-  assert(!cir::MissingFeatures::cxxabiThisDecl());
+  cgf.cxxabiThisDecl = thisDecl;
 
   // Classic codegen computes the alignment of thisDecl and saves it in
-  // CodeGenFunction::CXXABIThisAlignment, but it doesn't seem to be needed in
-  // CIRGen.
+  // CodeGenFunction::CXXABIThisAlignment, but it is only used in emitTypeCheck
+  // in CodeGenFunction::StartFunction().
   assert(!cir::MissingFeatures::cxxabiThisAlignment());
+}
+
+mlir::Value CIRGenCXXABI::loadIncomingCXXThis(CIRGenFunction &cgf) {
+  ImplicitParamDecl *vd = getThisDecl(cgf);
+  Address addr = cgf.getAddrOfLocalVar(vd);
+  return cgf.getBuilder().create<cir::LoadOp>(
+      cgf.getLoc(vd->getLocation()), addr.getElementType(), addr.getPointer());
+}
+
+void CIRGenCXXABI::setCXXABIThisValue(CIRGenFunction &cgf,
+                                      mlir::Value thisPtr) {
+  /// Initialize the 'this' slot.
+  assert(getThisDecl(cgf) && "no 'this' variable for function");
+  cgf.cxxabiThisValue = thisPtr;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -569,6 +569,8 @@ public:
 
   mlir::Value VisitUnaryLNot(const UnaryOperator *e);
 
+  mlir::Value VisitCXXThisExpr(CXXThisExpr *te) { return cgf.loadCXXThis(); }
+
   /// Emit a conversion from the specified type to the specified destination
   /// type, both of which are CIR scalar types.
   /// TODO: do we need ScalarConversionOpts here? Should be done in another

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This provides C++ code generation targeting the Itanium C++ ABI.  The class
+// in this file generates structures that follow the Itanium C++ ABI, which is
+// documented at:
+//  https://itanium-cxx-abi.github.io/cxx-abi/abi.html
+//  https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html
+//
+// It also supports the closely-related ARM ABI, documented at:
+// https://developer.arm.com/documentation/ihi0041/g/
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenCXXABI.h"
+#include "CIRGenFunction.h"
+
+#include "clang/AST/GlobalDecl.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using namespace clang;
+using namespace clang::CIRGen;
+
+namespace {
+
+class CIRGenItaniumCXXABI : public CIRGenCXXABI {
+public:
+  CIRGenItaniumCXXABI(CIRGenModule &cgm) : CIRGenCXXABI(cgm) {
+    assert(!cir::MissingFeatures::cxxabiUseARMMethodPtrABI());
+    assert(!cir::MissingFeatures::cxxabiUseARMGuardVarABI());
+  }
+
+  void emitInstanceFunctionProlog(SourceLocation Loc,
+                                  CIRGenFunction &CGF) override;
+};
+
+} // namespace
+
+void CIRGenItaniumCXXABI::emitInstanceFunctionProlog(SourceLocation loc,
+                                                     CIRGenFunction &cgf) {
+  // Naked functions have no prolog.
+  if (cgf.curFuncDecl && cgf.curFuncDecl->hasAttr<NakedAttr>()) {
+    cgf.cgm.errorNYI(cgf.curFuncDecl->getLocation(),
+                     "emitInstanceFunctionProlog: Naked");
+  }
+
+  /// Initialize the 'this' slot. In the Itanium C++ ABI, no prologue
+  /// adjustments are required, because they are all handled by thunks.
+  setCXXABIThisValue(cgf, loadIncomingCXXThis(cgf));
+
+  /// Classic codegen has code here to initialize the 'vtt' slot if
+  // getStructorImplicitParamDecl(cgf) returns a non-null value, but in the
+  // current implementation (of classic codegen) it never does.
+  assert(!cir::MissingFeatures::cxxabiStructorImplicitParam());
+
+  /// If this is a function that the ABI specifies returns 'this', initialize
+  /// the return slot to this' at the start of the function.
+  ///
+  /// Unlike the setting of return types, this is done within the ABI
+  /// implementation instead of by clients of CIRGenCXXBI because:
+  /// 1) getThisValue is currently protected
+  /// 2) in theory, an ABI could implement 'this' returns some other way;
+  ///    HasThisReturn only specifies a contract, not the implementation
+  if (hasThisReturn(cgf.curGD)) {
+    cgf.cgm.errorNYI(cgf.curFuncDecl->getLocation(),
+                     "emitInstanceFunctionProlog: hasThisReturn");
+  }
+}
+
+CIRGenCXXABI *clang::CIRGen::CreateCIRGenItaniumCXXABI(CIRGenModule &cgm) {
+  switch (cgm.getASTContext().getCXXABIKind()) {
+  case TargetCXXABI::GenericItanium:
+  case TargetCXXABI::GenericAArch64:
+    return new CIRGenItaniumCXXABI(cgm);
+
+  case TargetCXXABI::AppleARM64:
+    // The general Itanium ABI will do until we implement something that
+    // requires special handling.
+    assert(!cir::MissingFeatures::cxxabiAppleARM64CXXABI());
+    return new CIRGenItaniumCXXABI(cgm);
+
+  default:
+    llvm_unreachable("bad or NYI ABI kind");
+  }
+}

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -55,14 +55,6 @@ static CIRGenCXXABI *createCXXABI(CIRGenModule &cgm) {
   llvm_unreachable("invalid C++ ABI kind");
 }
 
-namespace clang::CIRGen {
-// TODO(cir): Implement target-specific CIRGenCXXABIs
-CIRGenCXXABI *CreateCIRGenItaniumCXXABI(CIRGenModule &cgm) {
-  assert(!cir::MissingFeatures::targetSpecificCXXABI());
-  return new CIRGenCXXABI(cgm);
-}
-} // namespace clang::CIRGen
-
 CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
                            clang::ASTContext &astContext,
                            const clang::CodeGenOptions &cgo,

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -19,6 +19,7 @@ add_clang_library(clangCIR
   CIRGenExprConstant.cpp
   CIRGenExprScalar.cpp
   CIRGenFunction.cpp
+  CIRGenItaniumCXXABI.cpp
   CIRGenModule.cpp
   CIRGenOpenACCClause.cpp
   CIRGenRecordLayoutBuilder.cpp

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -84,6 +84,10 @@ public:
     return true;
   }
 
+  void HandleInlineFunctionDefinition(FunctionDecl *D) override {
+    Gen->HandleInlineFunctionDefinition(D);
+  }
+
   void HandleTranslationUnit(ASTContext &C) override {
     Gen->HandleTranslationUnit(C);
 

--- a/clang/test/CIR/CodeGen/inline-cxx-func.cpp
+++ b/clang/test/CIR/CodeGen/inline-cxx-func.cpp
@@ -11,8 +11,6 @@ struct S {
   int InlineFunc() {
     return Member;
   }
-
-  int OutlineFunc();
 };
 
 // CIR: !rec_S = !cir.record<struct "S" {!s32i}>

--- a/clang/test/CIR/CodeGen/inline-cxx-func.cpp
+++ b/clang/test/CIR/CodeGen/inline-cxx-func.cpp
@@ -1,0 +1,72 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct S {
+  int Member;
+
+  int InlineFunc() {
+    return Member;
+  }
+
+  int OutlineFunc();
+};
+
+// CIR: !rec_S = !cir.record<struct "S" {!s32i}>
+// LLVM: %struct.S = type { i32 }
+// OGCG: %struct.S = type { i32 }
+
+// CIR: cir.func @_ZN1S10InlineFuncEv(%arg0: !cir.ptr<!rec_S> {{.*}}) -> !s32i
+// CIR:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["this", init]
+// CIR:   %[[RET_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR:   cir.store %arg0, %[[THIS_ADDR]] : !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>
+// CIR:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
+// CIR:   %[[MEMBER_ADDR:.*]] = cir.get_member %[[THIS]][0] {name = "Member"} : !cir.ptr<!rec_S> -> !cir.ptr<!s32i>
+// CIR:   %[[MEMBER:.*]] = cir.load{{.*}} %[[MEMBER_ADDR]] : !cir.ptr<!s32i>, !s32i
+// CIR:   cir.store %[[MEMBER]], %[[RET_ADDR]] : !s32i, !cir.ptr<!s32i>
+// CIR:   %[[RET_VAL:.*]] = cir.load %[[RET_ADDR]] : !cir.ptr<!s32i>, !s32i
+// CIR:   cir.return %[[RET_VAL]] : !s32i
+
+// LLVM: define{{.*}} i32 @_ZN1S10InlineFuncEv(ptr %[[ARG0:.*]])
+// LLVM:   %[[THIS_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[RET_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   store ptr %[[ARG0]], ptr %[[THIS_ADDR]], align 8
+// LLVM:   %[[THIS:.*]] = load ptr, ptr %[[THIS_ADDR]], align 8
+// LLVM:   %[[MEMBER_ADDR:.*]] = getelementptr %struct.S, ptr %[[THIS]], i32 0, i32 0
+// LLVM:   %[[MEMBER:.*]] = load i32, ptr %[[MEMBER_ADDR]], align 4
+// LLVM:   store i32 %[[MEMBER]], ptr %[[RET_ADDR]], align 4
+// LLVM:   %[[RET_VAL:.*]] = load i32, ptr %[[RET_ADDR]], align 4
+// LLVM:   ret i32 %[[RET_VAL]]
+
+// The inlined function is defined after use() in OGCG
+
+void use() {
+  S s;
+  s.InlineFunc();
+}
+
+// CIR: cir.func @_Z3usev()
+// CIR:   %[[S_ADDR:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s"]
+// CIR:   %[[RET_VAL:.*]] = cir.call @_ZN1S10InlineFuncEv(%[[S_ADDR]]) : (!cir.ptr<!rec_S>) -> !s32i
+// CIR:   cir.return
+
+// LLVM: define{{.*}} void @_Z3usev()
+// LLVM:   %[[S_ADDR:.*]] = alloca %struct.S
+// LLVM:   %[[RET_VAL:.*]] = call i32 @_ZN1S10InlineFuncEv(ptr %[[S_ADDR]])
+// LLVM:   ret void
+
+// OGCG: define{{.*}} void @_Z3usev()
+// OGCG:   %[[S_ADDR:.*]] = alloca %struct.S
+// OGCG:   %[[RET_VAL:.*]] = call{{.*}} i32 @_ZN1S10InlineFuncEv(ptr{{.*}} %[[S_ADDR]])
+// OGCG:   ret void
+
+// OGCG: define{{.*}} i32 @_ZN1S10InlineFuncEv(ptr{{.*}} %[[ARG0:.*]])
+// OGCG:   %[[THIS_ADDR:.*]] = alloca ptr, align 8
+// OGCG:   store ptr %[[ARG0]], ptr %[[THIS_ADDR]], align 8
+// OGCG:   %[[THIS:.*]] = load ptr, ptr %[[THIS_ADDR]], align 8
+// OGCG:   %[[MEMBER_ADDR:.*]] = getelementptr inbounds nuw %struct.S, ptr %[[THIS]], i32 0, i32 0
+// OGCG:   %[[MEMBER:.*]] = load i32, ptr %[[MEMBER_ADDR]], align 4
+// OGCG:   ret i32 %[[MEMBER]]

--- a/clang/test/CIR/CodeGen/member-functions.cpp
+++ b/clang/test/CIR/CodeGen/member-functions.cpp
@@ -13,6 +13,7 @@ void C::f() {}
 // CIR: cir.func @_ZN1C1fEv(%[[THIS_ARG:.*]]: !cir.ptr<!rec_C>
 // CIR:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>, ["this", init]
 // CIR:   cir.store %[[THIS_ARG]], %[[THIS_ADDR]] : !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>
+// CIR:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_C>>, !cir.ptr<!rec_C>
 // CIR:   cir.return
 // CIR: }
 
@@ -23,8 +24,9 @@ void C::f2(int a, int b) {}
 // CIR-NEXT:   %[[A_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR-NEXT:   %[[B_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
 // CIR-NEXT:   cir.store %[[THIS_ARG]], %[[THIS_ADDR]] : !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>
-// CIR-NEXT:   cir.store %[[A_ARG]], %[[A_ADDR]] : !s32i, !cir.ptr<!s32i> loc(#loc12)
-// CIR-NEXT:   cir.store %[[B_ARG]], %[[B_ADDR]] : !s32i, !cir.ptr<!s32i> loc(#loc12)
+// CIR-NEXT:   cir.store %[[A_ARG]], %[[A_ADDR]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   cir.store %[[B_ARG]], %[[B_ADDR]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_C>>, !cir.ptr<!rec_C>
 // CIR-NEXT:   cir.return
 // CIR-NEXT: }
 


### PR DESCRIPTION
This change upstreams the code to support emitting inline C++ function definitions, including the ASTConsumer handler for inline definitions and the code to load the 'this' pointer.

This necessitates introducing the Itanium CXXABI class. No other CXXABI subclasses are supported at this time. The Itanium CXXABI is used for AppleARM64, which will require its own handler for a few special cases (such as array cookies) later.