### PR TITLE
[CIR] Defer definitions of global variables until they are used.

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -76,6 +76,7 @@ public:
   ~CIRGenerator() override;
   void Initialize(clang::ASTContext &astContext) override;
   bool HandleTopLevelDecl(clang::DeclGroupRef group) override;
+  void HandleTranslationUnit(clang::ASTContext &astContext) override;
   void HandleInlineFunctionDefinition(clang::FunctionDecl *d) override;
   void CompleteTentativeDefinition(clang::VarDecl *d) override;
 

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -215,6 +215,7 @@ struct MissingFeatures {
   static bool coverageMapping() { return false; }
   static bool peepholeProtection() { return false; }
   static bool instrumentation() { return false; }
+  static bool cleanupAfterErrorDiags() { return false; }
 
   // Missing types
   static bool dataMemberType() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -137,6 +137,11 @@ struct MissingFeatures {
   static bool recordZeroInit() { return false; }
   static bool zeroSizeRecordMembers() { return false; }
 
+  // Various handling of deferred processing in CIRGenModule.
+  static bool cgmRelease() { return false; }
+  static bool deferredVtables() { return false; }
+  static bool deferredFuncDecls() { return false; }
+
   // CXXABI
   static bool cxxABI() { return false; }
   static bool cxxabiThisAlignment() { return false; }
@@ -205,7 +210,7 @@ struct MissingFeatures {
   static bool writebacks() { return false; }
   static bool cleanupsToDeactivate() { return false; }
   static bool stackBase() { return false; }
-  static bool deferredDecls() { return false; }
+  static bool deferredCXXGlobalInit() { return false; }
   static bool setTargetAttributes() { return false; }
   static bool coverageMapping() { return false; }
   static bool peepholeProtection() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -167,7 +167,30 @@ public:
   clang::CharUnits getNaturalTypeAlignment(clang::QualType t,
                                            LValueBaseInfo *baseInfo);
 
+  /// This contains all the decls which have definitions but which are deferred
+  /// for emission and therefore should only be output if they are actually
+  /// used. If a decl is in this, then it is known to have not been referenced
+  /// yet.
+  std::map<llvm::StringRef, clang::GlobalDecl> deferredDecls;
+
+  // This is a list of deferred decls which we have seen that *are* actually
+  // referenced. These get code generated when the module is done.
+  std::vector<clang::GlobalDecl> deferredDeclsToEmit;
+  void addDeferredDeclToEmit(clang::GlobalDecl GD) {
+    deferredDeclsToEmit.emplace_back(GD);
+  }
+
   void emitTopLevelDecl(clang::Decl *decl);
+
+  /// Determine whether the definition must be emitted; if this returns \c
+  /// false, the definition can be emitted lazily if it's used.
+  bool mustBeEmitted(const clang::ValueDecl *d);
+
+  /// Determine whether the definition can be emitted eagerly, or should be
+  /// delayed until the end of the translation unit. This is relevant for
+  /// definitions whose linkage can change, e.g. implicit function
+  /// instantiations which may later be explicitly instantiated.
+  bool mayBeEmittedEagerly(const clang::ValueDecl *d);
 
   bool verifyModule() const;
 
@@ -178,6 +201,10 @@ public:
   getAddrOfFunction(clang::GlobalDecl gd, mlir::Type funcType = nullptr,
                     bool forVTable = false, bool dontDefer = false,
                     ForDefinition_t isForDefinition = NotForDefinition);
+
+  mlir::Operation *
+  getAddrOfGlobal(clang::GlobalDecl gd,
+                  ForDefinition_t isForDefinition = NotForDefinition);
 
   /// Emit code for a single global function or variable declaration. Forward
   /// declarations are emitted lazily.
@@ -234,7 +261,16 @@ public:
     return builder.getSizeFromCharUnits(size);
   }
 
+  /// Emit any needed decls for which code generation was deferred.
+  void emitDeferred();
+
+  /// Helper for `emitDeferred` to apply actual codegen.
+  void emitGlobalDecl(const clang::GlobalDecl &d);
+
   const llvm::Triple &getTriple() const { return target.getTriple(); }
+
+  // Finalize CIR code generation.
+  void release();
 
   /// -------
   /// Visibility and Linkage

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -69,6 +69,20 @@ bool CIRGenerator::HandleTopLevelDecl(DeclGroupRef group) {
   return true;
 }
 
+void CIRGenerator::HandleTranslationUnit(ASTContext &astContext) {
+  // Release the Builder when there is no error.
+  if (!diags.hasErrorOccurred() && cgm)
+    cgm->release();
+
+  // If there are errors before or when releasing the CGM, reset the module to
+  // stop here before invoking the backend.
+  if (diags.hasErrorOccurred()) {
+    if (cgm)
+      // TODO: cgm->clear();
+      return;
+  }
+}
+
 void CIRGenerator::HandleInlineFunctionDefinition(FunctionDecl *d) {
   if (diags.hasErrorOccurred())
     return;

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -74,13 +74,9 @@ void CIRGenerator::HandleTranslationUnit(ASTContext &astContext) {
   if (!diags.hasErrorOccurred() && cgm)
     cgm->release();
 
-  // If there are errors before or when releasing the CGM, reset the module to
+  // If there are errors before or when releasing the cgm, reset the module to
   // stop here before invoking the backend.
-  if (diags.hasErrorOccurred()) {
-    if (cgm)
-      // TODO: cgm->clear();
-      return;
-  }
+  assert(!cir::MissingFeatures::cleanupAfterErrorDiags());
 }
 
 void CIRGenerator::HandleInlineFunctionDefinition(FunctionDecl *d) {

--- a/clang/test/CIR/CodeGen/deferred-defs.cpp
+++ b/clang/test/CIR/CodeGen/deferred-defs.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR --implicit-check-not=unusedExternal \
+// RUN:   --implicit-check-not=unusedInternal
+
+extern int usedExternal;
+extern int unusedExternal;
+
+int locallyDefined;
+
+namespace {
+  int unsedInternal;
+  int usedInternal;
+}
+
+void use() {
+  usedInternal;
+  usedExternal;
+}
+
+// CIR: cir.global external @locallyDefined = #cir.int<0> : !s32i
+// CIR: cir.global "private" internal dsolocal @_ZN12_GLOBAL__N_112usedInternalE = #cir.int<0> : !s32i
+// CIR: cir.global "private" external @usedExternal : !s32i


### PR DESCRIPTION
This change adds support for deferring global variable definitions until first use whenever it is possible to do so. Although deferring function definitions uses much of the same implementation, function deferral will be added in a follow-up change.