### PR TITLE
[llvm] annotate interfaces in llvm/LTO for DLL export

### DIFF
--- a/llvm/include/llvm/InterfaceStub/ELFObjHandler.h
+++ b/llvm/include/llvm/InterfaceStub/ELFObjHandler.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_INTERFACESTUB_ELFOBJHANDLER_H
 #define LLVM_INTERFACESTUB_ELFOBJHANDLER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
@@ -24,7 +25,7 @@ namespace ifs {
 struct IFSStub;
 
 /// Attempt to read a binary ELF file from a MemoryBuffer.
-Expected<std::unique_ptr<IFSStub>> readELFFile(MemoryBufferRef Buf);
+LLVM_ABI Expected<std::unique_ptr<IFSStub>> readELFFile(MemoryBufferRef Buf);
 
 /// Attempt to write a binary ELF stub.
 /// This function determines appropriate ELFType using the passed ELFTarget and
@@ -34,7 +35,7 @@ Expected<std::unique_ptr<IFSStub>> readELFFile(MemoryBufferRef Buf);
 /// @param Stub Source ELFStub to generate a binary ELF stub from.
 /// @param WriteIfChanged Whether or not to preserve timestamp if
 ///        the output stays the same.
-Error writeBinaryStub(StringRef FilePath, const IFSStub &Stub,
+LLVM_ABI Error writeBinaryStub(StringRef FilePath, const IFSStub &Stub,
                       bool WriteIfChanged = false);
 
 } // end namespace ifs

--- a/llvm/include/llvm/InterfaceStub/ELFObjHandler.h
+++ b/llvm/include/llvm/InterfaceStub/ELFObjHandler.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_INTERFACESTUB_ELFOBJHANDLER_H
 #define LLVM_INTERFACESTUB_ELFOBJHANDLER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include <memory>
@@ -36,7 +36,7 @@ LLVM_ABI Expected<std::unique_ptr<IFSStub>> readELFFile(MemoryBufferRef Buf);
 /// @param WriteIfChanged Whether or not to preserve timestamp if
 ///        the output stays the same.
 LLVM_ABI Error writeBinaryStub(StringRef FilePath, const IFSStub &Stub,
-                      bool WriteIfChanged = false);
+                               bool WriteIfChanged = false);
 
 } // end namespace ifs
 } // end namespace llvm

--- a/llvm/include/llvm/InterfaceStub/IFSHandler.h
+++ b/llvm/include/llvm/InterfaceStub/IFSHandler.h
@@ -15,8 +15,8 @@
 #ifndef LLVM_INTERFACESTUB_IFSHANDLER_H
 #define LLVM_INTERFACESTUB_IFSHANDLER_H
 
-#include "llvm/Support/Compiler.h"
 #include "IFSStub.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
 #include <memory>
@@ -43,20 +43,21 @@ LLVM_ABI Expected<std::unique_ptr<IFSStub>> readIFSFromBuffer(StringRef Buf);
 LLVM_ABI Error writeIFSToOutputStream(raw_ostream &OS, const IFSStub &Stub);
 
 /// Override the target platform inforation in the text stub.
-LLVM_ABI Error overrideIFSTarget(IFSStub &Stub, std::optional<IFSArch> OverrideArch,
-                        std::optional<IFSEndiannessType> OverrideEndianness,
-                        std::optional<IFSBitWidthType> OverrideBitWidth,
-                        std::optional<std::string> OverrideTriple);
+LLVM_ABI Error
+overrideIFSTarget(IFSStub &Stub, std::optional<IFSArch> OverrideArch,
+                  std::optional<IFSEndiannessType> OverrideEndianness,
+                  std::optional<IFSBitWidthType> OverrideBitWidth,
+                  std::optional<std::string> OverrideTriple);
 
 /// Validate the target platform inforation in the text stub.
 LLVM_ABI Error validateIFSTarget(IFSStub &Stub, bool ParseTriple);
 
 /// Strips target platform information from the text stub.
 LLVM_ABI void stripIFSTarget(IFSStub &Stub, bool StripTriple, bool StripArch,
-                    bool StripEndianness, bool StripBitWidth);
+                             bool StripEndianness, bool StripBitWidth);
 
 LLVM_ABI Error filterIFSSyms(IFSStub &Stub, bool StripUndefined,
-                    const std::vector<std::string> &Exclude = {});
+                             const std::vector<std::string> &Exclude = {});
 
 /// Parse llvm triple string into a IFSTarget struct.
 LLVM_ABI IFSTarget parseTriple(StringRef TripleStr);

--- a/llvm/include/llvm/InterfaceStub/IFSHandler.h
+++ b/llvm/include/llvm/InterfaceStub/IFSHandler.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_INTERFACESTUB_IFSHANDLER_H
 #define LLVM_INTERFACESTUB_IFSHANDLER_H
 
+#include "llvm/Support/Compiler.h"
 #include "IFSStub.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
@@ -36,29 +37,29 @@ struct IFSStub;
 const VersionTuple IFSVersionCurrent(3, 0);
 
 /// Attempts to read an IFS interface file from a StringRef buffer.
-Expected<std::unique_ptr<IFSStub>> readIFSFromBuffer(StringRef Buf);
+LLVM_ABI Expected<std::unique_ptr<IFSStub>> readIFSFromBuffer(StringRef Buf);
 
 /// Attempts to write an IFS interface file to a raw_ostream.
-Error writeIFSToOutputStream(raw_ostream &OS, const IFSStub &Stub);
+LLVM_ABI Error writeIFSToOutputStream(raw_ostream &OS, const IFSStub &Stub);
 
 /// Override the target platform inforation in the text stub.
-Error overrideIFSTarget(IFSStub &Stub, std::optional<IFSArch> OverrideArch,
+LLVM_ABI Error overrideIFSTarget(IFSStub &Stub, std::optional<IFSArch> OverrideArch,
                         std::optional<IFSEndiannessType> OverrideEndianness,
                         std::optional<IFSBitWidthType> OverrideBitWidth,
                         std::optional<std::string> OverrideTriple);
 
 /// Validate the target platform inforation in the text stub.
-Error validateIFSTarget(IFSStub &Stub, bool ParseTriple);
+LLVM_ABI Error validateIFSTarget(IFSStub &Stub, bool ParseTriple);
 
 /// Strips target platform information from the text stub.
-void stripIFSTarget(IFSStub &Stub, bool StripTriple, bool StripArch,
+LLVM_ABI void stripIFSTarget(IFSStub &Stub, bool StripTriple, bool StripArch,
                     bool StripEndianness, bool StripBitWidth);
 
-Error filterIFSSyms(IFSStub &Stub, bool StripUndefined,
+LLVM_ABI Error filterIFSSyms(IFSStub &Stub, bool StripUndefined,
                     const std::vector<std::string> &Exclude = {});
 
 /// Parse llvm triple string into a IFSTarget struct.
-IFSTarget parseTriple(StringRef TripleStr);
+LLVM_ABI IFSTarget parseTriple(StringRef TripleStr);
 
 } // end namespace ifs
 } // end namespace llvm

--- a/llvm/include/llvm/InterfaceStub/IFSStub.h
+++ b/llvm/include/llvm/InterfaceStub/IFSStub.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_INTERFACESTUB_IFSSTUB_H
 #define LLVM_INTERFACESTUB_IFSSTUB_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/VersionTuple.h"
 #include <optional>
 #include <vector>
@@ -69,7 +70,7 @@ struct IFSTarget {
   std::optional<IFSEndiannessType> Endianness;
   std::optional<IFSBitWidthType> BitWidth;
 
-  bool empty();
+  LLVM_ABI bool empty();
 };
 
 inline bool operator==(const IFSTarget &Lhs, const IFSTarget &Rhs) {
@@ -95,8 +96,8 @@ struct IFSStub {
   std::vector<IFSSymbol> Symbols;
 
   IFSStub() = default;
-  IFSStub(const IFSStub &Stub);
-  IFSStub(IFSStub &&Stub);
+  LLVM_ABI IFSStub(const IFSStub &Stub);
+  LLVM_ABI IFSStub(IFSStub &&Stub);
   virtual ~IFSStub() = default;
 };
 
@@ -107,42 +108,42 @@ struct IFSStub {
 // structure can be used for 2 different yaml schema.
 struct IFSStubTriple : IFSStub {
   IFSStubTriple() = default;
-  IFSStubTriple(const IFSStub &Stub);
-  IFSStubTriple(const IFSStubTriple &Stub);
-  IFSStubTriple(IFSStubTriple &&Stub);
+  LLVM_ABI IFSStubTriple(const IFSStub &Stub);
+  LLVM_ABI IFSStubTriple(const IFSStubTriple &Stub);
+  LLVM_ABI IFSStubTriple(IFSStubTriple &&Stub);
 };
 
 /// This function convert bit width type from IFS enum to ELF format
 /// Currently, ELFCLASS32 and ELFCLASS64 are supported.
 ///
 /// @param BitWidth IFS bit width type.
-uint8_t convertIFSBitWidthToELF(IFSBitWidthType BitWidth);
+LLVM_ABI uint8_t convertIFSBitWidthToELF(IFSBitWidthType BitWidth);
 
 /// This function convert endianness type from IFS enum to ELF format
 /// Currently, ELFDATA2LSB and ELFDATA2MSB are supported.
 ///
 /// @param Endianness IFS endianness type.
-uint8_t convertIFSEndiannessToELF(IFSEndiannessType Endianness);
+LLVM_ABI uint8_t convertIFSEndiannessToELF(IFSEndiannessType Endianness);
 
 /// This function convert symbol type from IFS enum to ELF format
 /// Currently, STT_NOTYPE, STT_OBJECT, STT_FUNC, and STT_TLS are supported.
 ///
 /// @param SymbolType IFS symbol type.
-uint8_t convertIFSSymbolTypeToELF(IFSSymbolType SymbolType);
+LLVM_ABI uint8_t convertIFSSymbolTypeToELF(IFSSymbolType SymbolType);
 
 /// This function extracts ELF bit width from e_ident[EI_CLASS] of an ELF file
 /// Currently, ELFCLASS32 and ELFCLASS64 are supported.
 /// Other endianness types are mapped to IFSBitWidthType::Unknown.
 ///
 /// @param BitWidth e_ident[EI_CLASS] value to extract bit width from.
-IFSBitWidthType convertELFBitWidthToIFS(uint8_t BitWidth);
+LLVM_ABI IFSBitWidthType convertELFBitWidthToIFS(uint8_t BitWidth);
 
 /// This function extracts ELF endianness from e_ident[EI_DATA] of an ELF file
 /// Currently, ELFDATA2LSB and ELFDATA2MSB are supported.
 /// Other endianness types are mapped to IFSEndiannessType::Unknown.
 ///
 /// @param Endianness e_ident[EI_DATA] value to extract endianness type from.
-IFSEndiannessType convertELFEndiannessToIFS(uint8_t Endianness);
+LLVM_ABI IFSEndiannessType convertELFEndiannessToIFS(uint8_t Endianness);
 
 /// This function extracts symbol type from a symbol's st_info member and
 /// maps it to an IFSSymbolType enum.
@@ -150,7 +151,7 @@ IFSEndiannessType convertELFEndiannessToIFS(uint8_t Endianness);
 /// Other symbol types are mapped to IFSSymbolType::Unknown.
 ///
 /// @param SymbolType Binary symbol st_info to extract symbol type from.
-IFSSymbolType convertELFSymbolTypeToIFS(uint8_t SymbolType);
+LLVM_ABI IFSSymbolType convertELFSymbolTypeToIFS(uint8_t SymbolType);
 } // namespace ifs
 } // end namespace llvm
 

--- a/llvm/include/llvm/LTO/Config.h
+++ b/llvm/include/llvm/LTO/Config.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_LTO_CONFIG_H
 #define LLVM_LTO_CONFIG_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -23,6 +22,7 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Target/TargetOptions.h"
 
 #include <functional>
@@ -279,8 +279,8 @@ struct Config {
   /// SaveTempsArgs can be specified to select which temps to save.
   /// If SaveTempsArgs is not provided, all temps are saved.
   LLVM_ABI Error addSaveTemps(std::string OutputFileName,
-                     bool UseInputModulePath = false,
-                     const DenseSet<StringRef> &SaveTempsArgs = {});
+                              bool UseInputModulePath = false,
+                              const DenseSet<StringRef> &SaveTempsArgs = {});
 };
 
 struct LTOLLVMDiagnosticHandler : public DiagnosticHandler {

--- a/llvm/include/llvm/LTO/Config.h
+++ b/llvm/include/llvm/LTO/Config.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_LTO_CONFIG_H
 #define LLVM_LTO_CONFIG_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -277,7 +278,7 @@ struct Config {
   ///
   /// SaveTempsArgs can be specified to select which temps to save.
   /// If SaveTempsArgs is not provided, all temps are saved.
-  Error addSaveTemps(std::string OutputFileName,
+  LLVM_ABI Error addSaveTemps(std::string OutputFileName,
                      bool UseInputModulePath = false,
                      const DenseSet<StringRef> &SaveTempsArgs = {});
 };

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_LTO_LTO_H
 #define LLVM_LTO_LTO_H
 
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 #include "llvm/ADT/DenseMap.h"
@@ -47,7 +48,7 @@ class ToolOutputFile;
 ///
 /// This is done for correctness (if value exported, ensure we always
 /// emit a copy), and compile-time optimization (allow drop of duplicates).
-void thinLTOResolvePrevailingInIndex(
+LLVM_ABI void thinLTOResolvePrevailingInIndex(
     const lto::Config &C, ModuleSummaryIndex &Index,
     function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
         isPrevailing,
@@ -58,7 +59,7 @@ void thinLTOResolvePrevailingInIndex(
 /// Update the linkages in the given \p Index to mark exported values
 /// as external and non-exported values as internal. The ThinLTO backends
 /// must apply the changes to the Module via thinLTOInternalizeModule.
-void thinLTOInternalizeAndPromoteInIndex(
+LLVM_ABI void thinLTOInternalizeAndPromoteInIndex(
     ModuleSummaryIndex &Index,
     function_ref<bool(StringRef, ValueInfo)> isExported,
     function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
@@ -66,7 +67,7 @@ void thinLTOInternalizeAndPromoteInIndex(
 
 /// Computes a unique hash for the Module considering the current list of
 /// export/import and other global analysis results.
-std::string computeLTOCacheKey(
+LLVM_ABI std::string computeLTOCacheKey(
     const lto::Config &Conf, const ModuleSummaryIndex &Index,
     StringRef ModuleID, const FunctionImporter::ImportMapTy &ImportList,
     const FunctionImporter::ExportSetTy &ExportList,
@@ -76,36 +77,36 @@ std::string computeLTOCacheKey(
     const DenseSet<GlobalValue::GUID> &CfiFunctionDecls = {});
 
 /// Recomputes the LTO cache key for a given key with an extra identifier.
-std::string recomputeLTOCacheKey(const std::string &Key, StringRef ExtraID);
+LLVM_ABI std::string recomputeLTOCacheKey(const std::string &Key, StringRef ExtraID);
 
 namespace lto {
 
-StringLiteral getThinLTODefaultCPU(const Triple &TheTriple);
+LLVM_ABI StringLiteral getThinLTODefaultCPU(const Triple &TheTriple);
 
 /// Given the original \p Path to an output file, replace any path
 /// prefix matching \p OldPrefix with \p NewPrefix. Also, create the
 /// resulting directory if it does not yet exist.
-std::string getThinLTOOutputFile(StringRef Path, StringRef OldPrefix,
+LLVM_ABI std::string getThinLTOOutputFile(StringRef Path, StringRef OldPrefix,
                                  StringRef NewPrefix);
 
 /// Setup optimization remarks.
-Expected<std::unique_ptr<ToolOutputFile>> setupLLVMOptimizationRemarks(
+LLVM_ABI Expected<std::unique_ptr<ToolOutputFile>> setupLLVMOptimizationRemarks(
     LLVMContext &Context, StringRef RemarksFilename, StringRef RemarksPasses,
     StringRef RemarksFormat, bool RemarksWithHotness,
     std::optional<uint64_t> RemarksHotnessThreshold = 0, int Count = -1);
 
 /// Setups the output file for saving statistics.
-Expected<std::unique_ptr<ToolOutputFile>>
+LLVM_ABI Expected<std::unique_ptr<ToolOutputFile>>
 setupStatsFile(StringRef StatsFilename);
 
 /// Produces a container ordering for optimal multi-threaded processing. Returns
 /// ordered indices to elements in the input array.
-std::vector<int> generateModulesOrdering(ArrayRef<BitcodeModule *> R);
+LLVM_ABI std::vector<int> generateModulesOrdering(ArrayRef<BitcodeModule *> R);
 
 /// Updates MemProf attributes (and metadata) based on whether the index
 /// has recorded that we are linking with allocation libraries containing
 /// the necessary APIs for downstream transformations.
-void updateMemProfAttributes(Module &Mod, const ModuleSummaryIndex &Index);
+LLVM_ABI void updateMemProfAttributes(Module &Mod, const ModuleSummaryIndex &Index);
 
 class LTO;
 struct SymbolResolution;
@@ -133,10 +134,10 @@ private:
   std::vector<std::pair<StringRef, Comdat::SelectionKind>> ComdatTable;
 
 public:
-  ~InputFile();
+  LLVM_ABI ~InputFile();
 
   /// Create an InputFile.
-  static Expected<std::unique_ptr<InputFile>> create(MemoryBufferRef Object);
+  LLVM_ABI static Expected<std::unique_ptr<InputFile>> create(MemoryBufferRef Object);
 
   /// The purpose of this struct is to only expose the symbol information that
   /// an LTO client should need in order to do symbol resolution.
@@ -174,7 +175,7 @@ public:
   ArrayRef<StringRef> getDependentLibraries() const { return DependentLibraries; }
 
   /// Returns the path to the InputFile.
-  StringRef getName() const;
+  LLVM_ABI StringRef getName() const;
 
   /// Returns the input file's target triple.
   StringRef getTargetTriple() const { return TargetTriple; }
@@ -188,7 +189,7 @@ public:
   }
 
   // Returns the only BitcodeModule from InputFile.
-  BitcodeModule &getSingleBitcodeModule();
+  LLVM_ABI BitcodeModule &getSingleBitcodeModule();
 
 private:
   ArrayRef<Symbol> module_symbols(unsigned I) const {
@@ -243,12 +244,12 @@ public:
   virtual bool isSensitiveToInputOrder() { return false; }
 
   // Write sharded indices and (optionally) imports to disk
-  Error emitFiles(const FunctionImporter::ImportMapTy &ImportList,
+  LLVM_ABI Error emitFiles(const FunctionImporter::ImportMapTy &ImportList,
                   StringRef ModulePath, const std::string &NewModulePath) const;
 
   // Write sharded indices to SummaryPath, (optionally) imports to disk, and
   // (optionally) record imports in ImportsFiles.
-  Error emitFiles(const FunctionImporter::ImportMapTy &ImportList,
+  LLVM_ABI Error emitFiles(const FunctionImporter::ImportMapTy &ImportList,
                   StringRef ModulePath, const std::string &NewModulePath,
                   StringRef SummaryPath,
                   std::optional<std::reference_wrapper<ImportsFilesContainer>>
@@ -300,7 +301,7 @@ private:
 /// to the same path as the input module, with suffix ".thinlto.bc"
 /// ShouldEmitImportsFiles is true it also writes a list of imported files to a
 /// similar path with ".imports" appended instead.
-ThinBackend createInProcessThinBackend(ThreadPoolStrategy Parallelism,
+LLVM_ABI ThinBackend createInProcessThinBackend(ThreadPoolStrategy Parallelism,
                                        IndexWriteCallback OnWrite = nullptr,
                                        bool ShouldEmitIndexFiles = false,
                                        bool ShouldEmitImportsFiles = false);
@@ -322,7 +323,7 @@ ThinBackend createInProcessThinBackend(ThreadPoolStrategy Parallelism,
 /// backend compilations.
 /// SaveTemps is a debugging tool that prevents temporary files created by this
 /// backend from being cleaned up.
-ThinBackend createOutOfProcessThinBackend(
+LLVM_ABI ThinBackend createOutOfProcessThinBackend(
     ThreadPoolStrategy Parallelism, IndexWriteCallback OnWrite,
     bool ShouldEmitIndexFiles, bool ShouldEmitImportsFiles,
     StringRef LinkerOutputFile, StringRef Distributor,
@@ -344,7 +345,7 @@ ThinBackend createOutOfProcessThinBackend(
 /// the objects with NativeObjectPrefix instead of NewPrefix. OnWrite is
 /// callback which receives module identifier and notifies LTO user that index
 /// file for the module (and optionally imports file) was created.
-ThinBackend createWriteIndexesThinBackend(ThreadPoolStrategy Parallelism,
+LLVM_ABI ThinBackend createWriteIndexesThinBackend(ThreadPoolStrategy Parallelism,
                                           std::string OldPrefix,
                                           std::string NewPrefix,
                                           std::string NativeObjectPrefix,
@@ -389,20 +390,20 @@ public:
   /// this constructor.
   /// FIXME: We do currently require the DiagHandler field to be set in Conf.
   /// Until that is fixed, a Config argument is required.
-  LTO(Config Conf, ThinBackend Backend = {},
+  LLVM_ABI LTO(Config Conf, ThinBackend Backend = {},
       unsigned ParallelCodeGenParallelismLevel = 1,
       LTOKind LTOMode = LTOK_Default);
-  ~LTO();
+  LLVM_ABI ~LTO();
 
   /// Add an input file to the LTO link, using the provided symbol resolutions.
   /// The symbol resolutions must appear in the enumeration order given by
   /// InputFile::symbols().
-  Error add(std::unique_ptr<InputFile> Obj, ArrayRef<SymbolResolution> Res);
+  LLVM_ABI Error add(std::unique_ptr<InputFile> Obj, ArrayRef<SymbolResolution> Res);
 
   /// Returns an upper bound on the number of tasks that the client may expect.
   /// This may only be called after all IR object files have been added. For a
   /// full description of tasks see LTOBackend.h.
-  unsigned getMaxTasks() const;
+  LLVM_ABI unsigned getMaxTasks() const;
 
   /// Runs the LTO pipeline. This function calls the supplied AddStream
   /// function to add native object files to the link.
@@ -412,17 +413,17 @@ public:
   ///
   /// The client will receive at most one callback (via either AddStream or
   /// Cache) for each task identifier.
-  Error run(AddStreamFn AddStream, FileCache Cache = {});
+  LLVM_ABI Error run(AddStreamFn AddStream, FileCache Cache = {});
 
   /// Static method that returns a list of libcall symbols that can be generated
   /// by LTO but might not be visible from bitcode symbol table.
-  static SmallVector<const char *> getRuntimeLibcallSymbols(const Triple &TT);
+  LLVM_ABI static SmallVector<const char *> getRuntimeLibcallSymbols(const Triple &TT);
 
 private:
   Config Conf;
 
   struct RegularLTOState {
-    RegularLTOState(unsigned ParallelCodeGenParallelismLevel,
+    LLVM_ABI RegularLTOState(unsigned ParallelCodeGenParallelismLevel,
                     const Config &Conf);
     struct CommonResolution {
       uint64_t Size = 0;
@@ -452,7 +453,7 @@ private:
   using ModuleMapType = MapVector<StringRef, BitcodeModule>;
 
   struct ThinLTOState {
-    ThinLTOState(ThinBackend Backend);
+    LLVM_ABI ThinLTOState(ThinBackend Backend);
 
     ThinBackend Backend;
     ModuleSummaryIndex CombinedIndex;

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -77,7 +77,8 @@ LLVM_ABI std::string computeLTOCacheKey(
     const DenseSet<GlobalValue::GUID> &CfiFunctionDecls = {});
 
 /// Recomputes the LTO cache key for a given key with an extra identifier.
-LLVM_ABI std::string recomputeLTOCacheKey(const std::string &Key, StringRef ExtraID);
+LLVM_ABI std::string recomputeLTOCacheKey(const std::string &Key,
+                                          StringRef ExtraID);
 
 namespace lto {
 
@@ -87,7 +88,7 @@ LLVM_ABI StringLiteral getThinLTODefaultCPU(const Triple &TheTriple);
 /// prefix matching \p OldPrefix with \p NewPrefix. Also, create the
 /// resulting directory if it does not yet exist.
 LLVM_ABI std::string getThinLTOOutputFile(StringRef Path, StringRef OldPrefix,
-                                 StringRef NewPrefix);
+                                          StringRef NewPrefix);
 
 /// Setup optimization remarks.
 LLVM_ABI Expected<std::unique_ptr<ToolOutputFile>> setupLLVMOptimizationRemarks(
@@ -106,7 +107,8 @@ LLVM_ABI std::vector<int> generateModulesOrdering(ArrayRef<BitcodeModule *> R);
 /// Updates MemProf attributes (and metadata) based on whether the index
 /// has recorded that we are linking with allocation libraries containing
 /// the necessary APIs for downstream transformations.
-LLVM_ABI void updateMemProfAttributes(Module &Mod, const ModuleSummaryIndex &Index);
+LLVM_ABI void updateMemProfAttributes(Module &Mod,
+                                      const ModuleSummaryIndex &Index);
 
 class LTO;
 struct SymbolResolution;
@@ -137,7 +139,8 @@ public:
   LLVM_ABI ~InputFile();
 
   /// Create an InputFile.
-  LLVM_ABI static Expected<std::unique_ptr<InputFile>> create(MemoryBufferRef Object);
+  LLVM_ABI static Expected<std::unique_ptr<InputFile>>
+  create(MemoryBufferRef Object);
 
   /// The purpose of this struct is to only expose the symbol information that
   /// an LTO client should need in order to do symbol resolution.
@@ -245,15 +248,16 @@ public:
 
   // Write sharded indices and (optionally) imports to disk
   LLVM_ABI Error emitFiles(const FunctionImporter::ImportMapTy &ImportList,
-                  StringRef ModulePath, const std::string &NewModulePath) const;
+                           StringRef ModulePath,
+                           const std::string &NewModulePath) const;
 
   // Write sharded indices to SummaryPath, (optionally) imports to disk, and
   // (optionally) record imports in ImportsFiles.
-  LLVM_ABI Error emitFiles(const FunctionImporter::ImportMapTy &ImportList,
-                  StringRef ModulePath, const std::string &NewModulePath,
-                  StringRef SummaryPath,
-                  std::optional<std::reference_wrapper<ImportsFilesContainer>>
-                      ImportsFiles) const;
+  LLVM_ABI Error emitFiles(
+      const FunctionImporter::ImportMapTy &ImportList, StringRef ModulePath,
+      const std::string &NewModulePath, StringRef SummaryPath,
+      std::optional<std::reference_wrapper<ImportsFilesContainer>> ImportsFiles)
+      const;
 };
 
 /// This callable defines the behavior of a ThinLTO backend after the thin-link
@@ -301,10 +305,9 @@ private:
 /// to the same path as the input module, with suffix ".thinlto.bc"
 /// ShouldEmitImportsFiles is true it also writes a list of imported files to a
 /// similar path with ".imports" appended instead.
-LLVM_ABI ThinBackend createInProcessThinBackend(ThreadPoolStrategy Parallelism,
-                                       IndexWriteCallback OnWrite = nullptr,
-                                       bool ShouldEmitIndexFiles = false,
-                                       bool ShouldEmitImportsFiles = false);
+LLVM_ABI ThinBackend createInProcessThinBackend(
+    ThreadPoolStrategy Parallelism, IndexWriteCallback OnWrite = nullptr,
+    bool ShouldEmitIndexFiles = false, bool ShouldEmitImportsFiles = false);
 
 /// This ThinBackend generates the index shards and then runs the individual
 /// backend jobs via an external process. It takes the same parameters as the
@@ -345,13 +348,11 @@ LLVM_ABI ThinBackend createOutOfProcessThinBackend(
 /// the objects with NativeObjectPrefix instead of NewPrefix. OnWrite is
 /// callback which receives module identifier and notifies LTO user that index
 /// file for the module (and optionally imports file) was created.
-LLVM_ABI ThinBackend createWriteIndexesThinBackend(ThreadPoolStrategy Parallelism,
-                                          std::string OldPrefix,
-                                          std::string NewPrefix,
-                                          std::string NativeObjectPrefix,
-                                          bool ShouldEmitImportsFiles,
-                                          raw_fd_ostream *LinkedObjectsFile,
-                                          IndexWriteCallback OnWrite);
+LLVM_ABI ThinBackend createWriteIndexesThinBackend(
+    ThreadPoolStrategy Parallelism, std::string OldPrefix,
+    std::string NewPrefix, std::string NativeObjectPrefix,
+    bool ShouldEmitImportsFiles, raw_fd_ostream *LinkedObjectsFile,
+    IndexWriteCallback OnWrite);
 
 /// This class implements a resolution-based interface to LLVM's LTO
 /// functionality. It supports regular LTO, parallel LTO code generation and
@@ -391,14 +392,15 @@ public:
   /// FIXME: We do currently require the DiagHandler field to be set in Conf.
   /// Until that is fixed, a Config argument is required.
   LLVM_ABI LTO(Config Conf, ThinBackend Backend = {},
-      unsigned ParallelCodeGenParallelismLevel = 1,
-      LTOKind LTOMode = LTOK_Default);
+               unsigned ParallelCodeGenParallelismLevel = 1,
+               LTOKind LTOMode = LTOK_Default);
   LLVM_ABI ~LTO();
 
   /// Add an input file to the LTO link, using the provided symbol resolutions.
   /// The symbol resolutions must appear in the enumeration order given by
   /// InputFile::symbols().
-  LLVM_ABI Error add(std::unique_ptr<InputFile> Obj, ArrayRef<SymbolResolution> Res);
+  LLVM_ABI Error add(std::unique_ptr<InputFile> Obj,
+                     ArrayRef<SymbolResolution> Res);
 
   /// Returns an upper bound on the number of tasks that the client may expect.
   /// This may only be called after all IR object files have been added. For a
@@ -417,14 +419,15 @@ public:
 
   /// Static method that returns a list of libcall symbols that can be generated
   /// by LTO but might not be visible from bitcode symbol table.
-  LLVM_ABI static SmallVector<const char *> getRuntimeLibcallSymbols(const Triple &TT);
+  LLVM_ABI static SmallVector<const char *>
+  getRuntimeLibcallSymbols(const Triple &TT);
 
 private:
   Config Conf;
 
   struct RegularLTOState {
     LLVM_ABI RegularLTOState(unsigned ParallelCodeGenParallelismLevel,
-                    const Config &Conf);
+                             const Config &Conf);
     struct CommonResolution {
       uint64_t Size = 0;
       Align Alignment;

--- a/llvm/include/llvm/LTO/LTOBackend.h
+++ b/llvm/include/llvm/LTO/LTOBackend.h
@@ -16,11 +16,11 @@
 #ifndef LLVM_LTO_LTOBACKEND_H
 #define LLVM_LTO_LTOBACKEND_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/LTO/LTO.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/Transforms/IPO/FunctionImport.h"
@@ -35,16 +35,17 @@ class Target;
 namespace lto {
 
 /// Runs middle-end LTO optimizations on \p Mod.
-LLVM_ABI bool opt(const Config &Conf, TargetMachine *TM, unsigned Task, Module &Mod,
-         bool IsThinLTO, ModuleSummaryIndex *ExportSummary,
-         const ModuleSummaryIndex *ImportSummary,
-         const std::vector<uint8_t> &CmdArgs);
+LLVM_ABI bool opt(const Config &Conf, TargetMachine *TM, unsigned Task,
+                  Module &Mod, bool IsThinLTO,
+                  ModuleSummaryIndex *ExportSummary,
+                  const ModuleSummaryIndex *ImportSummary,
+                  const std::vector<uint8_t> &CmdArgs);
 
 /// Runs a regular LTO backend. The regular LTO backend can also act as the
 /// regular LTO phase of ThinLTO, which may need to access the combined index.
 LLVM_ABI Error backend(const Config &C, AddStreamFn AddStream,
-              unsigned ParallelCodeGenParallelismLevel, Module &M,
-              ModuleSummaryIndex &CombinedIndex);
+                       unsigned ParallelCodeGenParallelismLevel, Module &M,
+                       ModuleSummaryIndex &CombinedIndex);
 
 /// Runs a ThinLTO backend.
 /// If \p ModuleMap is not nullptr, all the module files to be imported have
@@ -55,16 +56,17 @@ LLVM_ABI Error backend(const Config &C, AddStreamFn AddStream,
 /// the backend will skip optimization and only perform code generation. If
 /// \p IRAddStream is not nullptr, it will be called just before code generation
 /// to serialize the optimized IR.
-LLVM_ABI Error thinBackend(const Config &C, unsigned Task, AddStreamFn AddStream,
-                  Module &M, const ModuleSummaryIndex &CombinedIndex,
-                  const FunctionImporter::ImportMapTy &ImportList,
-                  const GVSummaryMapTy &DefinedGlobals,
-                  MapVector<StringRef, BitcodeModule> *ModuleMap,
-                  bool CodeGenOnly, AddStreamFn IRAddStream = nullptr,
-                  const std::vector<uint8_t> &CmdArgs = std::vector<uint8_t>());
+LLVM_ABI Error
+thinBackend(const Config &C, unsigned Task, AddStreamFn AddStream, Module &M,
+            const ModuleSummaryIndex &CombinedIndex,
+            const FunctionImporter::ImportMapTy &ImportList,
+            const GVSummaryMapTy &DefinedGlobals,
+            MapVector<StringRef, BitcodeModule> *ModuleMap, bool CodeGenOnly,
+            AddStreamFn IRAddStream = nullptr,
+            const std::vector<uint8_t> &CmdArgs = std::vector<uint8_t>());
 
-LLVM_ABI Error finalizeOptimizationRemarks(
-    std::unique_ptr<ToolOutputFile> DiagOutputFile);
+LLVM_ABI Error
+finalizeOptimizationRemarks(std::unique_ptr<ToolOutputFile> DiagOutputFile);
 
 /// Returns the BitcodeModule that is ThinLTO.
 LLVM_ABI BitcodeModule *findThinLTOModule(MutableArrayRef<BitcodeModule> BMs);
@@ -75,8 +77,9 @@ LLVM_ABI Expected<BitcodeModule> findThinLTOModule(MemoryBufferRef MBRef);
 /// Distributed ThinLTO: collect the referenced modules based on
 /// module summary and initialize ImportList. Returns false if the
 /// operation failed.
-LLVM_ABI bool initImportList(const Module &M, const ModuleSummaryIndex &CombinedIndex,
-                    FunctionImporter::ImportMapTy &ImportList);
+LLVM_ABI bool initImportList(const Module &M,
+                             const ModuleSummaryIndex &CombinedIndex,
+                             FunctionImporter::ImportMapTy &ImportList);
 }
 }
 

--- a/llvm/include/llvm/LTO/LTOBackend.h
+++ b/llvm/include/llvm/LTO/LTOBackend.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_LTO_LTOBACKEND_H
 #define LLVM_LTO_LTOBACKEND_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
@@ -34,14 +35,14 @@ class Target;
 namespace lto {
 
 /// Runs middle-end LTO optimizations on \p Mod.
-bool opt(const Config &Conf, TargetMachine *TM, unsigned Task, Module &Mod,
+LLVM_ABI bool opt(const Config &Conf, TargetMachine *TM, unsigned Task, Module &Mod,
          bool IsThinLTO, ModuleSummaryIndex *ExportSummary,
          const ModuleSummaryIndex *ImportSummary,
          const std::vector<uint8_t> &CmdArgs);
 
 /// Runs a regular LTO backend. The regular LTO backend can also act as the
 /// regular LTO phase of ThinLTO, which may need to access the combined index.
-Error backend(const Config &C, AddStreamFn AddStream,
+LLVM_ABI Error backend(const Config &C, AddStreamFn AddStream,
               unsigned ParallelCodeGenParallelismLevel, Module &M,
               ModuleSummaryIndex &CombinedIndex);
 
@@ -54,7 +55,7 @@ Error backend(const Config &C, AddStreamFn AddStream,
 /// the backend will skip optimization and only perform code generation. If
 /// \p IRAddStream is not nullptr, it will be called just before code generation
 /// to serialize the optimized IR.
-Error thinBackend(const Config &C, unsigned Task, AddStreamFn AddStream,
+LLVM_ABI Error thinBackend(const Config &C, unsigned Task, AddStreamFn AddStream,
                   Module &M, const ModuleSummaryIndex &CombinedIndex,
                   const FunctionImporter::ImportMapTy &ImportList,
                   const GVSummaryMapTy &DefinedGlobals,
@@ -62,19 +63,19 @@ Error thinBackend(const Config &C, unsigned Task, AddStreamFn AddStream,
                   bool CodeGenOnly, AddStreamFn IRAddStream = nullptr,
                   const std::vector<uint8_t> &CmdArgs = std::vector<uint8_t>());
 
-Error finalizeOptimizationRemarks(
+LLVM_ABI Error finalizeOptimizationRemarks(
     std::unique_ptr<ToolOutputFile> DiagOutputFile);
 
 /// Returns the BitcodeModule that is ThinLTO.
-BitcodeModule *findThinLTOModule(MutableArrayRef<BitcodeModule> BMs);
+LLVM_ABI BitcodeModule *findThinLTOModule(MutableArrayRef<BitcodeModule> BMs);
 
 /// Variant of the above.
-Expected<BitcodeModule> findThinLTOModule(MemoryBufferRef MBRef);
+LLVM_ABI Expected<BitcodeModule> findThinLTOModule(MemoryBufferRef MBRef);
 
 /// Distributed ThinLTO: collect the referenced modules based on
 /// module summary and initialize ImportList. Returns false if the
 /// operation failed.
-bool initImportList(const Module &M, const ModuleSummaryIndex &CombinedIndex,
+LLVM_ABI bool initImportList(const Module &M, const ModuleSummaryIndex &CombinedIndex,
                     FunctionImporter::ImportMapTy &ImportList);
 }
 }

--- a/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
@@ -35,6 +35,7 @@
 #ifndef LLVM_LTO_LEGACY_LTOCODEGENERATOR_H
 #define LLVM_LTO_LEGACY_LTOCODEGENERATOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/lto.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringMap.h"
@@ -64,30 +65,30 @@ class raw_ostream;
 class raw_pwrite_stream;
 
 /// Enable global value internalization in LTO.
-extern cl::opt<bool> EnableLTOInternalization;
+LLVM_ABI extern cl::opt<bool> EnableLTOInternalization;
 
 //===----------------------------------------------------------------------===//
 /// C++ class which implements the opaque lto_code_gen_t type.
 ///
 struct LTOCodeGenerator {
-  static const char *getVersionString();
+  LLVM_ABI static const char *getVersionString();
 
-  LTOCodeGenerator(LLVMContext &Context);
-  ~LTOCodeGenerator();
+  LLVM_ABI LTOCodeGenerator(LLVMContext &Context);
+  LLVM_ABI ~LTOCodeGenerator();
 
   /// Merge given module.  Return true on success.
   ///
   /// Resets \a HasVerifiedInput.
-  bool addModule(struct LTOModule *);
+  LLVM_ABI bool addModule(struct LTOModule *);
 
   /// Set the destination module.
   ///
   /// Resets \a HasVerifiedInput.
-  void setModule(std::unique_ptr<LTOModule> M);
+  LLVM_ABI void setModule(std::unique_ptr<LTOModule> M);
 
-  void setAsmUndefinedRefs(struct LTOModule *);
-  void setTargetOptions(const TargetOptions &Options);
-  void setDebugInfo(lto_debug_model);
+  LLVM_ABI void setAsmUndefinedRefs(struct LTOModule *);
+  LLVM_ABI void setTargetOptions(const TargetOptions &Options);
+  LLVM_ABI void setDebugInfo(lto_debug_model);
   void setCodePICModel(std::optional<Reloc::Model> Model) {
     Config.RelocModel = Model;
   }
@@ -100,7 +101,7 @@ struct LTOCodeGenerator {
   void setAttrs(std::vector<std::string> MAttrs) {
     Config.MAttrs = std::move(MAttrs);
   }
-  void setOptLevel(unsigned OptLevel);
+  LLVM_ABI void setOptLevel(unsigned OptLevel);
 
   void setShouldInternalize(bool Value) { ShouldInternalize = Value; }
   void setShouldEmbedUselists(bool Value) { ShouldEmbedUselists = Value; }
@@ -132,20 +133,20 @@ struct LTOCodeGenerator {
   /// name is misleading).  This function should be called before
   /// LTOCodeGenerator::compilexxx(), and
   /// LTOCodeGenerator::writeMergedModules().
-  void setCodeGenDebugOptions(ArrayRef<StringRef> Opts);
+  LLVM_ABI void setCodeGenDebugOptions(ArrayRef<StringRef> Opts);
 
   /// Parse the options set in setCodeGenDebugOptions.
   ///
   /// Like \a setCodeGenDebugOptions(), this must be called before
   /// LTOCodeGenerator::compilexxx() and
   /// LTOCodeGenerator::writeMergedModules().
-  void parseCodeGenDebugOptions();
+  LLVM_ABI void parseCodeGenDebugOptions();
 
   /// Write the merged module to the file specified by the given path.  Return
   /// true on success.
   ///
   /// Calls \a verifyMergedModuleOnce().
-  bool writeMergedModules(StringRef Path);
+  LLVM_ABI bool writeMergedModules(StringRef Path);
 
   /// Compile the merged module into a *single* output file; the path to output
   /// file is returned to the caller via argument "name". Return true on
@@ -154,7 +155,7 @@ struct LTOCodeGenerator {
   /// \note It is up to the linker to remove the intermediate output file.  Do
   /// not try to remove the object file in LTOCodeGenerator's destructor as we
   /// don't who (LTOCodeGenerator or the output file) will last longer.
-  bool compile_to_file(const char **Name);
+  LLVM_ABI bool compile_to_file(const char **Name);
 
   /// As with compile_to_file(), this function compiles the merged module into
   /// single output file. Instead of returning the output file path to the
@@ -162,17 +163,17 @@ struct LTOCodeGenerator {
   /// to the caller. This function should delete the intermediate file once
   /// its content is brought to memory. Return NULL if the compilation was not
   /// successful.
-  std::unique_ptr<MemoryBuffer> compile();
+  LLVM_ABI std::unique_ptr<MemoryBuffer> compile();
 
   /// Optimizes the merged module.  Returns true on success.
   ///
   /// Calls \a verifyMergedModuleOnce().
-  bool optimize();
+  LLVM_ABI bool optimize();
 
   /// Compiles the merged optimized module into a single output file. It brings
   /// the output to a buffer, and returns the buffer to the caller. Return NULL
   /// if the compilation was not successful.
-  std::unique_ptr<MemoryBuffer> compileOptimized();
+  LLVM_ABI std::unique_ptr<MemoryBuffer> compileOptimized();
 
   /// Compile the merged optimized module \p ParallelismLevel output files each
   /// representing a linkable partition of the module. If out contains more
@@ -181,7 +182,7 @@ struct LTOCodeGenerator {
   /// created using the \p AddStream callback. Returns true on success.
   ///
   /// Calls \a verifyMergedModuleOnce().
-  bool compileOptimized(AddStreamFn AddStream, unsigned ParallelismLevel);
+  LLVM_ABI bool compileOptimized(AddStreamFn AddStream, unsigned ParallelismLevel);
 
   /// Enable the Freestanding mode: indicate that the optimizer should not
   /// assume builtins are present on the target.
@@ -191,12 +192,12 @@ struct LTOCodeGenerator {
 
   void setDebugPassManager(bool Enabled) { Config.DebugPassManager = Enabled; }
 
-  void setDiagnosticHandler(lto_diagnostic_handler_t, void *);
+  LLVM_ABI void setDiagnosticHandler(lto_diagnostic_handler_t, void *);
 
   LLVMContext &getContext() { return Context; }
 
   void resetMergedModule() { MergedModule.reset(); }
-  void DiagnosticHandler(const DiagnosticInfo &DI);
+  LLVM_ABI void DiagnosticHandler(const DiagnosticInfo &DI);
 
 private:
   /// Verify the merged module on first call.
@@ -252,6 +253,6 @@ private:
 
 /// A convenience function that calls cl::ParseCommandLineOptions on the given
 /// set of options.
-void parseCommandLineOptions(std::vector<std::string> &Options);
+LLVM_ABI void parseCommandLineOptions(std::vector<std::string> &Options);
 } // namespace llvm
 #endif

--- a/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
@@ -35,7 +35,6 @@
 #ifndef LLVM_LTO_LEGACY_LTOCODEGENERATOR_H
 #define LLVM_LTO_LEGACY_LTOCODEGENERATOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/lto.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringMap.h"
@@ -45,6 +44,7 @@
 #include "llvm/LTO/Config.h"
 #include "llvm/LTO/LTO.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Target/TargetMachine.h"
@@ -182,7 +182,8 @@ struct LTOCodeGenerator {
   /// created using the \p AddStream callback. Returns true on success.
   ///
   /// Calls \a verifyMergedModuleOnce().
-  LLVM_ABI bool compileOptimized(AddStreamFn AddStream, unsigned ParallelismLevel);
+  LLVM_ABI bool compileOptimized(AddStreamFn AddStream,
+                                 unsigned ParallelismLevel);
 
   /// Enable the Freestanding mode: indicate that the optimizer should not
   /// assume builtins are present on the target.

--- a/llvm/include/llvm/LTO/legacy/LTOModule.h
+++ b/llvm/include/llvm/LTO/legacy/LTOModule.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_LTO_LEGACY_LTOMODULE_H
 #define LLVM_LTO_LEGACY_LTOMODULE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/lto.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
@@ -21,6 +20,7 @@
 #include "llvm/LTO/LTO.h"
 #include "llvm/Object/IRObjectFile.h"
 #include "llvm/Object/ModuleSymbolTable.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Target/TargetMachine.h"
 #include <string>
 #include <vector>
@@ -76,7 +76,7 @@ public:
   /// Returns 'true' if the memory buffer is LLVM bitcode for the specified
   /// triple.
   LLVM_ABI static bool isBitcodeForTarget(MemoryBuffer *memBuffer,
-                                 StringRef triplePrefix);
+                                          StringRef triplePrefix);
 
   /// Returns a string representing the producer identification stored in the
   /// bitcode, or "" if the bitcode does not contains any.
@@ -153,12 +153,15 @@ public:
 
   const std::vector<StringRef> &getAsmUndefinedRefs() { return _asm_undefines; }
 
-  LLVM_ABI static lto::InputFile *createInputFile(const void *buffer, size_t buffer_size,
-                                         const char *path, std::string &out_error);
+  LLVM_ABI static lto::InputFile *createInputFile(const void *buffer,
+                                                  size_t buffer_size,
+                                                  const char *path,
+                                                  std::string &out_error);
 
   LLVM_ABI static size_t getDependentLibraryCount(lto::InputFile *input);
 
-  LLVM_ABI static const char *getDependentLibrary(lto::InputFile *input, size_t index, size_t *size);
+  LLVM_ABI static const char *getDependentLibrary(lto::InputFile *input,
+                                                  size_t index, size_t *size);
 
   LLVM_ABI Expected<uint32_t> getMachOCPUType() const;
 

--- a/llvm/include/llvm/LTO/legacy/LTOModule.h
+++ b/llvm/include/llvm/LTO/legacy/LTOModule.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_LTO_LEGACY_LTOMODULE_H
 #define LLVM_LTO_LEGACY_LTOMODULE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/lto.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
@@ -63,27 +64,27 @@ private:
             TargetMachine *TM);
 
 public:
-  ~LTOModule();
+  LLVM_ABI ~LTOModule();
 
   /// Returns 'true' if the file or memory contents is LLVM bitcode.
-  static bool isBitcodeFile(const void *mem, size_t length);
-  static bool isBitcodeFile(StringRef path);
+  LLVM_ABI static bool isBitcodeFile(const void *mem, size_t length);
+  LLVM_ABI static bool isBitcodeFile(StringRef path);
 
   /// Returns 'true' if the Module is produced for ThinLTO.
-  bool isThinLTO();
+  LLVM_ABI bool isThinLTO();
 
   /// Returns 'true' if the memory buffer is LLVM bitcode for the specified
   /// triple.
-  static bool isBitcodeForTarget(MemoryBuffer *memBuffer,
+  LLVM_ABI static bool isBitcodeForTarget(MemoryBuffer *memBuffer,
                                  StringRef triplePrefix);
 
   /// Returns a string representing the producer identification stored in the
   /// bitcode, or "" if the bitcode does not contains any.
   ///
-  static std::string getProducerString(MemoryBuffer *Buffer);
+  LLVM_ABI static std::string getProducerString(MemoryBuffer *Buffer);
 
   /// Create a MemoryBuffer from a memory range with an optional name.
-  static std::unique_ptr<MemoryBuffer>
+  LLVM_ABI static std::unique_ptr<MemoryBuffer>
   makeBuffer(const void *mem, size_t length, StringRef name = "");
 
   /// Create an LTOModule. N.B. These methods take ownership of the buffer. The
@@ -94,20 +95,20 @@ public:
   /// InitializeAllTargetMCs();
   /// InitializeAllAsmPrinters();
   /// InitializeAllAsmParsers();
-  static ErrorOr<std::unique_ptr<LTOModule>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<LTOModule>>
   createFromFile(LLVMContext &Context, StringRef path,
                  const TargetOptions &options);
-  static ErrorOr<std::unique_ptr<LTOModule>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<LTOModule>>
   createFromOpenFile(LLVMContext &Context, int fd, StringRef path, size_t size,
                      const TargetOptions &options);
-  static ErrorOr<std::unique_ptr<LTOModule>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<LTOModule>>
   createFromOpenFileSlice(LLVMContext &Context, int fd, StringRef path,
                           size_t map_size, off_t offset,
                           const TargetOptions &options);
-  static ErrorOr<std::unique_ptr<LTOModule>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<LTOModule>>
   createFromBuffer(LLVMContext &Context, const void *mem, size_t length,
                    const TargetOptions &options, StringRef path = "");
-  static ErrorOr<std::unique_ptr<LTOModule>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<LTOModule>>
   createInLocalContext(std::unique_ptr<LLVMContext> Context, const void *mem,
                        size_t length, const TargetOptions &options,
                        StringRef path);
@@ -152,20 +153,20 @@ public:
 
   const std::vector<StringRef> &getAsmUndefinedRefs() { return _asm_undefines; }
 
-  static lto::InputFile *createInputFile(const void *buffer, size_t buffer_size,
+  LLVM_ABI static lto::InputFile *createInputFile(const void *buffer, size_t buffer_size,
                                          const char *path, std::string &out_error);
 
-  static size_t getDependentLibraryCount(lto::InputFile *input);
+  LLVM_ABI static size_t getDependentLibraryCount(lto::InputFile *input);
 
-  static const char *getDependentLibrary(lto::InputFile *input, size_t index, size_t *size);
+  LLVM_ABI static const char *getDependentLibrary(lto::InputFile *input, size_t index, size_t *size);
 
-  Expected<uint32_t> getMachOCPUType() const;
+  LLVM_ABI Expected<uint32_t> getMachOCPUType() const;
 
-  Expected<uint32_t> getMachOCPUSubType() const;
+  LLVM_ABI Expected<uint32_t> getMachOCPUSubType() const;
 
   /// Returns true if the module has either the @llvm.global_ctors or the
   /// @llvm.global_dtors symbol. Otherwise returns false.
-  bool hasCtorDtor() const;
+  LLVM_ABI bool hasCtorDtor() const;
 
 private:
   /// Parse metadata from the module

--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -15,13 +15,13 @@
 #ifndef LLVM_LTO_LEGACY_THINLTOCODEGENERATOR_H
 #define LLVM_LTO_LEGACY_THINLTOCODEGENERATOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/lto.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/LTO/LTO.h"
 #include "llvm/Support/CachePruning.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Triple.h"
@@ -262,21 +262,21 @@ public:
    * Index is updated to reflect linkage changes from weak resolution.
    */
   LLVM_ABI void promote(Module &Module, ModuleSummaryIndex &Index,
-               const lto::InputFile &File);
+                        const lto::InputFile &File);
 
   /**
    * Compute and emit the imported files for module at \p ModulePath.
    */
   LLVM_ABI void emitImports(Module &Module, StringRef OutputName,
-                   ModuleSummaryIndex &Index,
-                   const lto::InputFile &File);
+                            ModuleSummaryIndex &Index,
+                            const lto::InputFile &File);
 
   /**
    * Perform cross-module importing for the module identified by
    * ModuleIdentifier.
    */
   LLVM_ABI void crossModuleImport(Module &Module, ModuleSummaryIndex &Index,
-                         const lto::InputFile &File);
+                                  const lto::InputFile &File);
 
   /**
    * Compute the list of summaries and the subset of declaration summaries
@@ -291,7 +291,7 @@ public:
    * Perform internalization. Index is updated to reflect linkage changes.
    */
   LLVM_ABI void internalize(Module &Module, ModuleSummaryIndex &Index,
-                   const lto::InputFile &File);
+                            const lto::InputFile &File);
 
   /**
    * Perform post-importing ThinLTO optimizations.
@@ -304,7 +304,7 @@ public:
    * SavedObjectsDirectoryPath.
    */
   LLVM_ABI std::string writeGeneratedObject(int count, StringRef CacheEntryPath,
-                                   const MemoryBuffer &OutputBuffer);
+                                            const MemoryBuffer &OutputBuffer);
   /**@}*/
 
 private:

--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_LTO_LEGACY_THINLTOCODEGENERATOR_H
 #define LLVM_LTO_LEGACY_THINLTOCODEGENERATOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/lto.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
@@ -47,7 +48,7 @@ struct ThinLTOCodeGeneratorImpl::TargetMachineBuilder {
   std::optional<Reloc::Model> RelocModel;
   CodeGenOptLevel CGOptLevel = CodeGenOptLevel::Aggressive;
 
-  std::unique_ptr<TargetMachine> create() const;
+  LLVM_ABI std::unique_ptr<TargetMachine> create() const;
 };
 
 /// This class define an interface similar to the LTOCodeGenerator, but adapted
@@ -59,14 +60,14 @@ struct ThinLTOCodeGeneratorImpl::TargetMachineBuilder {
 class ThinLTOCodeGenerator {
 public:
   /// Add given module to the code generator.
-  void addModule(StringRef Identifier, StringRef Data);
+  LLVM_ABI void addModule(StringRef Identifier, StringRef Data);
 
   /**
    * Adds to a list of all global symbols that must exist in the final generated
    * code. If a symbol is not listed there, it will be optimized away if it is
    * inlined into every usage.
    */
-  void preserveSymbol(StringRef Name);
+  LLVM_ABI void preserveSymbol(StringRef Name);
 
   /**
    * Adds to a list of all global symbols that are cross-referenced between
@@ -74,7 +75,7 @@ public:
    * references from a ThinLTO module to this symbol is optimized away, then
    * the symbol can be discarded.
    */
-  void crossReferenceSymbol(StringRef Name);
+  LLVM_ABI void crossReferenceSymbol(StringRef Name);
 
   /**
    * Process all the modules that were added to the code generator in parallel.
@@ -83,7 +84,7 @@ public:
    * unless setGeneratedObjectsDirectory() has been called, in which case
    * results are available through getProducedBinaryFiles().
    */
-  void run();
+  LLVM_ABI void run();
 
   /**
    * Return the "in memory" binaries produced by the code generator. This is
@@ -253,20 +254,20 @@ public:
    * Produce the combined summary index from all the bitcode files:
    * "thin-link".
    */
-  std::unique_ptr<ModuleSummaryIndex> linkCombinedIndex();
+  LLVM_ABI std::unique_ptr<ModuleSummaryIndex> linkCombinedIndex();
 
   /**
    * Perform promotion and renaming of exported internal functions,
    * and additionally resolve weak and linkonce symbols.
    * Index is updated to reflect linkage changes from weak resolution.
    */
-  void promote(Module &Module, ModuleSummaryIndex &Index,
+  LLVM_ABI void promote(Module &Module, ModuleSummaryIndex &Index,
                const lto::InputFile &File);
 
   /**
    * Compute and emit the imported files for module at \p ModulePath.
    */
-  void emitImports(Module &Module, StringRef OutputName,
+  LLVM_ABI void emitImports(Module &Module, StringRef OutputName,
                    ModuleSummaryIndex &Index,
                    const lto::InputFile &File);
 
@@ -274,14 +275,14 @@ public:
    * Perform cross-module importing for the module identified by
    * ModuleIdentifier.
    */
-  void crossModuleImport(Module &Module, ModuleSummaryIndex &Index,
+  LLVM_ABI void crossModuleImport(Module &Module, ModuleSummaryIndex &Index,
                          const lto::InputFile &File);
 
   /**
    * Compute the list of summaries and the subset of declaration summaries
    * needed for importing into module.
    */
-  void gatherImportedSummariesForModule(
+  LLVM_ABI void gatherImportedSummariesForModule(
       Module &Module, ModuleSummaryIndex &Index,
       ModuleToSummariesForIndexTy &ModuleToSummariesForIndex,
       GVSummaryPtrSet &DecSummaries, const lto::InputFile &File);
@@ -289,20 +290,20 @@ public:
   /**
    * Perform internalization. Index is updated to reflect linkage changes.
    */
-  void internalize(Module &Module, ModuleSummaryIndex &Index,
+  LLVM_ABI void internalize(Module &Module, ModuleSummaryIndex &Index,
                    const lto::InputFile &File);
 
   /**
    * Perform post-importing ThinLTO optimizations.
    */
-  void optimize(Module &Module);
+  LLVM_ABI void optimize(Module &Module);
 
   /**
    * Write temporary object file to SavedObjectDirectoryPath, write symlink
    * to Cache directory if needed. Returns the path to the generated file in
    * SavedObjectsDirectoryPath.
    */
-  std::string writeGeneratedObject(int count, StringRef CacheEntryPath,
+  LLVM_ABI std::string writeGeneratedObject(int count, StringRef CacheEntryPath,
                                    const MemoryBuffer &OutputBuffer);
   /**@}*/
 

--- a/llvm/include/llvm/LineEditor/LineEditor.h
+++ b/llvm/include/llvm/LineEditor/LineEditor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LINEEDITOR_LINEEDITOR_H
 #define LLVM_LINEEDITOR_LINEEDITOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include <cstdio>
 #include <memory>
@@ -30,20 +31,20 @@ public:
   /// \param In The input stream used by the editor.
   /// \param Out The output stream used by the editor.
   /// \param Err The error stream used by the editor.
-  LineEditor(StringRef ProgName, StringRef HistoryPath = "", FILE *In = stdin,
+  LLVM_ABI LineEditor(StringRef ProgName, StringRef HistoryPath = "", FILE *In = stdin,
              FILE *Out = stdout, FILE *Err = stderr);
-  ~LineEditor();
+  LLVM_ABI ~LineEditor();
 
   /// Reads a line.
   ///
   /// \return The line, or std::optional<std::string>() on EOF.
-  std::optional<std::string> readLine() const;
+  LLVM_ABI std::optional<std::string> readLine() const;
 
-  void saveHistory();
-  void loadHistory();
-  void setHistorySize(int size);
+  LLVM_ABI void saveHistory();
+  LLVM_ABI void loadHistory();
+  LLVM_ABI void setHistorySize(int size);
 
-  static std::string getDefaultHistoryPath(StringRef ProgName);
+  LLVM_ABI static std::string getDefaultHistoryPath(StringRef ProgName);
 
   /// The action to perform upon a completion request.
   struct CompletionAction {
@@ -101,7 +102,7 @@ public:
   ///
   /// \param Buffer The string to complete
   /// \param Pos The zero-based cursor position in the StringRef
-  CompletionAction getCompletionAction(StringRef Buffer, size_t Pos) const;
+  LLVM_ABI CompletionAction getCompletionAction(StringRef Buffer, size_t Pos) const;
 
   const std::string &getPrompt() const { return Prompt; }
   void setPrompt(const std::string &P) { Prompt = P; }
@@ -114,12 +115,12 @@ private:
   std::string HistoryPath;
   std::unique_ptr<InternalData> Data;
 
-  struct CompleterConcept {
+  struct LLVM_ABI CompleterConcept {
     virtual ~CompleterConcept();
     virtual CompletionAction complete(StringRef Buffer, size_t Pos) const = 0;
   };
 
-  struct ListCompleterConcept : CompleterConcept {
+  struct LLVM_ABI ListCompleterConcept : CompleterConcept {
     ~ListCompleterConcept() override;
     CompletionAction complete(StringRef Buffer, size_t Pos) const override;
     static std::string getCommonPrefix(const std::vector<Completion> &Comps);

--- a/llvm/include/llvm/LineEditor/LineEditor.h
+++ b/llvm/include/llvm/LineEditor/LineEditor.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LINEEDITOR_LINEEDITOR_H
 #define LLVM_LINEEDITOR_LINEEDITOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdio>
 #include <memory>
 #include <optional>
@@ -31,8 +31,8 @@ public:
   /// \param In The input stream used by the editor.
   /// \param Out The output stream used by the editor.
   /// \param Err The error stream used by the editor.
-  LLVM_ABI LineEditor(StringRef ProgName, StringRef HistoryPath = "", FILE *In = stdin,
-             FILE *Out = stdout, FILE *Err = stderr);
+  LLVM_ABI LineEditor(StringRef ProgName, StringRef HistoryPath = "",
+                      FILE *In = stdin, FILE *Out = stdout, FILE *Err = stderr);
   LLVM_ABI ~LineEditor();
 
   /// Reads a line.
@@ -102,7 +102,8 @@ public:
   ///
   /// \param Buffer The string to complete
   /// \param Pos The zero-based cursor position in the StringRef
-  LLVM_ABI CompletionAction getCompletionAction(StringRef Buffer, size_t Pos) const;
+  LLVM_ABI CompletionAction getCompletionAction(StringRef Buffer,
+                                                size_t Pos) const;
 
   const std::string &getPrompt() const { return Prompt; }
   void setPrompt(const std::string &P) { Prompt = P; }

--- a/llvm/include/llvm/Linker/IRMover.h
+++ b/llvm/include/llvm/Linker/IRMover.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LINKER_IRMOVER_H
 #define LLVM_LINKER_IRMOVER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
@@ -28,17 +29,17 @@ class IRMover {
     struct KeyTy {
       ArrayRef<Type *> ETypes;
       bool IsPacked;
-      KeyTy(ArrayRef<Type *> E, bool P);
-      KeyTy(const StructType *ST);
-      bool operator==(const KeyTy &that) const;
-      bool operator!=(const KeyTy &that) const;
+      LLVM_ABI KeyTy(ArrayRef<Type *> E, bool P);
+      LLVM_ABI KeyTy(const StructType *ST);
+      LLVM_ABI bool operator==(const KeyTy &that) const;
+      LLVM_ABI bool operator!=(const KeyTy &that) const;
     };
-    static StructType *getEmptyKey();
-    static StructType *getTombstoneKey();
-    static unsigned getHashValue(const KeyTy &Key);
-    static unsigned getHashValue(const StructType *ST);
-    static bool isEqual(const KeyTy &LHS, const StructType *RHS);
-    static bool isEqual(const StructType *LHS, const StructType *RHS);
+    LLVM_ABI static StructType *getEmptyKey();
+    LLVM_ABI static StructType *getTombstoneKey();
+    LLVM_ABI static unsigned getHashValue(const KeyTy &Key);
+    LLVM_ABI static unsigned getHashValue(const StructType *ST);
+    LLVM_ABI static bool isEqual(const KeyTy &LHS, const StructType *RHS);
+    LLVM_ABI static bool isEqual(const StructType *LHS, const StructType *RHS);
   };
 
   /// Type of the Metadata map in \a ValueToValueMapTy.
@@ -53,14 +54,14 @@ public:
     DenseSet<StructType *, StructTypeKeyInfo> NonOpaqueStructTypes;
 
   public:
-    void addNonOpaque(StructType *Ty);
-    void switchToNonOpaque(StructType *Ty);
-    void addOpaque(StructType *Ty);
-    StructType *findNonOpaque(ArrayRef<Type *> ETypes, bool IsPacked);
-    bool hasType(StructType *Ty);
+    LLVM_ABI void addNonOpaque(StructType *Ty);
+    LLVM_ABI void switchToNonOpaque(StructType *Ty);
+    LLVM_ABI void addOpaque(StructType *Ty);
+    LLVM_ABI StructType *findNonOpaque(ArrayRef<Type *> ETypes, bool IsPacked);
+    LLVM_ABI bool hasType(StructType *Ty);
   };
 
-  IRMover(Module &M);
+  LLVM_ABI IRMover(Module &M);
 
   typedef std::function<void(GlobalValue &)> ValueAdder;
   using LazyCallback =
@@ -76,7 +77,7 @@ public:
   ///   Pass nullptr if there's no work to be done in such cases.
   /// - \p IsPerformingImport is true when this IR link is to perform ThinLTO
   ///   function importing from Src.
-  Error move(std::unique_ptr<Module> Src, ArrayRef<GlobalValue *> ValuesToLink,
+  LLVM_ABI Error move(std::unique_ptr<Module> Src, ArrayRef<GlobalValue *> ValuesToLink,
              LazyCallback AddLazyFor, bool IsPerformingImport);
   Module &getModule() { return Composite; }
 

--- a/llvm/include/llvm/Linker/IRMover.h
+++ b/llvm/include/llvm/Linker/IRMover.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_LINKER_IRMOVER_H
 #define LLVM_LINKER_IRMOVER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/Support/Compiler.h"
 #include <functional>
 
 namespace llvm {
@@ -77,8 +77,9 @@ public:
   ///   Pass nullptr if there's no work to be done in such cases.
   /// - \p IsPerformingImport is true when this IR link is to perform ThinLTO
   ///   function importing from Src.
-  LLVM_ABI Error move(std::unique_ptr<Module> Src, ArrayRef<GlobalValue *> ValuesToLink,
-             LazyCallback AddLazyFor, bool IsPerformingImport);
+  LLVM_ABI Error move(std::unique_ptr<Module> Src,
+                      ArrayRef<GlobalValue *> ValuesToLink,
+                      LazyCallback AddLazyFor, bool IsPerformingImport);
   Module &getModule() { return Composite; }
 
 private:

--- a/llvm/include/llvm/Linker/Linker.h
+++ b/llvm/include/llvm/Linker/Linker.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LINKER_LINKER_H
 #define LLVM_LINKER_LINKER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Linker/IRMover.h"
 
@@ -30,7 +31,7 @@ public:
     LinkOnlyNeeded = (1 << 1),
   };
 
-  Linker(Module &M);
+  LLVM_ABI Linker(Module &M);
 
   /// Link \p Src into the composite.
   ///
@@ -39,11 +40,11 @@ public:
   /// callback.
   ///
   /// Returns true on error.
-  bool linkInModule(std::unique_ptr<Module> Src, unsigned Flags = Flags::None,
+  LLVM_ABI bool linkInModule(std::unique_ptr<Module> Src, unsigned Flags = Flags::None,
                     std::function<void(Module &, const StringSet<> &)>
                         InternalizeCallback = {});
 
-  static bool linkModules(Module &Dest, std::unique_ptr<Module> Src,
+  LLVM_ABI static bool linkModules(Module &Dest, std::unique_ptr<Module> Src,
                           unsigned Flags = Flags::None,
                           std::function<void(Module &, const StringSet<> &)>
                               InternalizeCallback = {});

--- a/llvm/include/llvm/Linker/Linker.h
+++ b/llvm/include/llvm/Linker/Linker.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_LINKER_LINKER_H
 #define LLVM_LINKER_LINKER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Linker/IRMover.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class Module;
@@ -40,14 +40,15 @@ public:
   /// callback.
   ///
   /// Returns true on error.
-  LLVM_ABI bool linkInModule(std::unique_ptr<Module> Src, unsigned Flags = Flags::None,
-                    std::function<void(Module &, const StringSet<> &)>
-                        InternalizeCallback = {});
+  LLVM_ABI bool linkInModule(std::unique_ptr<Module> Src,
+                             unsigned Flags = Flags::None,
+                             std::function<void(Module &, const StringSet<> &)>
+                                 InternalizeCallback = {});
 
-  LLVM_ABI static bool linkModules(Module &Dest, std::unique_ptr<Module> Src,
-                          unsigned Flags = Flags::None,
-                          std::function<void(Module &, const StringSet<> &)>
-                              InternalizeCallback = {});
+  LLVM_ABI static bool linkModules(
+      Module &Dest, std::unique_ptr<Module> Src, unsigned Flags = Flags::None,
+      std::function<void(Module &, const StringSet<> &)> InternalizeCallback =
+          {});
 };
 
 } // End llvm namespace

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -39,6 +39,7 @@
 #include "llvm/Object/IRObjectFile.h"
 #include "llvm/Support/Caching.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
@@ -69,7 +70,7 @@ using namespace object;
 
 #define DEBUG_TYPE "lto"
 
-extern cl::opt<bool> UseNewDbgInfoFormat;
+LLVM_ABI extern cl::opt<bool> UseNewDbgInfoFormat;
 
 static cl::opt<bool>
     DumpThinCGSCCs("dump-thin-cg-sccs", cl::init(false), cl::Hidden,


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/LTO` library. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS on Linux:
- Add `LLVM_ABI` to a small number of symbols that require export but are not declared in headers

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang