### PR TITLE
[lldb-dap] Correct the disconnect helper on server shutdown.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
+++ b/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
@@ -102,7 +102,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         process.send_signal(signal.SIGINT)
 
         self.dap_server.wait_for_terminated()
-        self.assertIsNone(
+        self.assertIsNotNone(
             self.dap_server.exit_status,
             "Process exited before interrupting lldb-dap server",
         )

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -820,7 +820,7 @@ void DAP::SendTerminatedEvent() {
   });
 }
 
-llvm::Error DAP::Disconnect() { return Disconnect(is_attach); }
+llvm::Error DAP::Disconnect() { return Disconnect(!is_attach); }
 
 llvm::Error DAP::Disconnect(bool terminateDebuggee) {
   lldb::SBError error;

--- a/lldb/tools/lldb-dap/Handler/DisconnectRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisconnectRequestHandler.cpp
@@ -20,7 +20,7 @@ namespace lldb_dap {
 /// Disconnect request; value of command field is 'disconnect'.
 Error DisconnectRequestHandler::Run(
     const std::optional<DisconnectArguments> &arguments) const {
-  bool terminateDebuggee = dap.is_attach ? false : true;
+  bool terminateDebuggee = !dap.is_attach;
 
   if (arguments && arguments->terminateDebuggee)
     terminateDebuggee = *arguments->terminateDebuggee;


### PR DESCRIPTION
Previously, we incorrectly handled the disconnect operation if we signal lldb-dap running in server mode.

Updated to correctly disconnect the attach vs launch behavior on server shutdown.