### PR TITLE
[llvm-cfi-verify] Avoid creating temporary instances of std::string (NFC)

### DIFF
--- a/llvm/tools/llvm-cfi-verify/lib/FileAnalysis.cpp
+++ b/llvm/tools/llvm-cfi-verify/lib/FileAnalysis.cpp
@@ -278,8 +278,7 @@ Expected<DIInliningInfo>
 FileAnalysis::symbolizeInlinedCode(object::SectionedAddress Address) {
   assert(Symbolizer != nullptr && "Symbolizer is invalid.");
 
-  return Symbolizer->symbolizeInlinedCode(std::string(Object->getFileName()),
-                                          Address);
+  return Symbolizer->symbolizeInlinedCode(Object->getFileName(), Address);
 }
 
 CFIProtectionStatus
@@ -523,9 +522,8 @@ void FileAnalysis::parseSectionContents(ArrayRef<uint8_t> SectionBytes,
 
     // Check if this instruction exists in the range of the DWARF metadata.
     if (!IgnoreDWARFFlag) {
-      auto LineInfo =
-          Symbolizer->symbolizeCode(std::string(Object->getFileName()),
-                                    {VMAddress, Address.SectionIndex});
+      auto LineInfo = Symbolizer->symbolizeCode(
+          Object->getFileName(), {VMAddress, Address.SectionIndex});
       if (!LineInfo) {
         handleAllErrors(LineInfo.takeError(), [](const ErrorInfoBase &E) {
           errs() << "Symbolizer failed to get line: " << E.message() << "\n";


### PR DESCRIPTION
symbolizeInlinedCode and symbolizeCode take StringRef as the first
parameter.  We don't need to create temporary instances of std::string
only to be converted back to StringRef.
