### PR TITLE
llvm-tli-checker: Remove TLINameList helper struct

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -452,6 +452,12 @@ public:
     return false;
   }
 
+  /// Return the canonical name for a LibFunc. This should not be used for
+  /// semantic purposes, use getName instead.
+  static StringRef getStandardName(LibFunc F) {
+    return TargetLibraryInfoImpl::StandardNames[F];
+  }
+
   StringRef getName(LibFunc F) const {
     auto State = getState(F);
     if (State == TargetLibraryInfoImpl::Unavailable)


### PR DESCRIPTION
This avoids subclassing std::vector and a static constructor.
This started as a refactor to make TargetLibraryInfo available during
printing so a custom name could be reported. It turns out this struct
wasn't doing anything, other than providing a hacky way of printing the
standard name instead of the target's custom name. Just remove this and
stop hacking on the TargetLibraryInfo to falsely report the function
is available later.