### PR TITLE
llvm-tli-checker: Avoid a temporary string while printing

### DIFF
--- a/llvm/tools/llvm-tli-checker/llvm-tli-checker.cpp
+++ b/llvm/tools/llvm-tli-checker/llvm-tli-checker.cpp
@@ -98,16 +98,12 @@ static void reportArchiveChildIssue(const object::Archive::Child &C, int Index,
 }
 
 // Return Name, and if Name is mangled, append "aka" and the demangled name.
-static std::string getPrintableName(StringRef Name) {
-  std::string OutputName = "'";
-  OutputName += Name;
-  OutputName += "'";
+static void printPrintableName(raw_ostream &OS, StringRef Name) {
+  OS << '\'' << Name << '\'';
+
   std::string DemangledName(demangle(Name));
-  if (Name != DemangledName) {
-    OutputName += " aka ";
-    OutputName += DemangledName;
-  }
-  return OutputName;
+  if (Name != DemangledName)
+    OS << " aka " << DemangledName;
 }
 
 static void reportNumberOfEntries(const TargetLibraryInfo &TLI,
@@ -138,10 +134,10 @@ static void dumpTLIEntries(const TargetLibraryInfo &TLI) {
       StringRef Name = TLI.getName(LF);
       // If there is a custom name, print it.
       // TODO: Should we include the standard name in the printed line?
-      outs() << getPrintableName(Name);
+      printPrintableName(outs(), Name);
     } else {
       // If it's not available, refer to it by the standard name.
-      outs() << getPrintableName(TargetLibraryInfo::getStandardName(LF));
+      printPrintableName(outs(), TargetLibraryInfo::getStandardName(LF));
     }
 
     outs() << '\n';
@@ -345,7 +341,9 @@ int main(int argc, char *argv[]) {
         constexpr char YesNo[2][4] = {"no ", "yes"};
         constexpr char Indicator[4][3] = {"!!", ">>", "<<", "=="};
         outs() << Indicator[Which] << " TLI " << YesNo[TLIHas] << " SDK "
-               << YesNo[SDKHas] << ": " << getPrintableName(TLIName) << '\n';
+               << YesNo[SDKHas] << ": ";
+        printPrintableName(outs(), TLIName);
+        outs() << '\n';
       }
     }
 


### PR DESCRIPTION
Directly write to the output instead of building a string to
print.