### PR TITLE
[CoroSplit] Always erase lifetime intrinsics for spilled allocas

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -1226,9 +1226,12 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
     }
 
     // If it is hard to analyze, we will give up and put allocas to frame,
-    // even if they never cross suspend points.
-    // Lifetime intrinsics referring to alloca may fail guard storing to frame.
-    // Lifetime intrinsics referring to frames may block further optimizations.
+    // even if they never cross suspend points.Lifetime intrinsics referring
+    // to alloca may fail guard storing to frame.
+    //
+    // It is meaningless to retain the lifetime intrinsics refer for the
+    // member of coroutine frames and the meaningless lifetime intrinsics
+    // are possible to block further optimizations.
     for (auto *I : Lifetimes)
       I->eraseFromParent();
 

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -1225,10 +1225,6 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
         UsersToUpdate.push_back(I);
     }
 
-    // If it is hard to analyze, we will give up and put allocas to frame,
-    // even if they never cross suspend points.Lifetime intrinsics referring
-    // to alloca may fail guard storing to frame.
-    //
     // It is meaningless to retain the lifetime intrinsics refer for the
     // member of coroutine frames and the meaningless lifetime intrinsics
     // are possible to block further optimizations.


### PR DESCRIPTION
If the control flow between `lifetime.start` and `lifetime.end` is too complex, it is acceptable to give up the optimization opportunity and collect the alloca to the frame. However, storing to the frame will lengthen the lifetime of the alloca, and the sanitizer will complain. I propose we always erase lifetime intrinsics of spilled allocas.

Fix #124612 