### PR TITLE
[X86][NFC] - Remove fild/fist c++ predicates from patfrag

### DIFF
--- a/llvm/lib/Target/X86/X86InstrFragments.td
+++ b/llvm/lib/Target/X86/X86InstrFragments.td
@@ -842,23 +842,17 @@ def X86fldf80 : PatFrag<(ops node:$ptr), (X86fld node:$ptr), [{
   return cast<MemIntrinsicSDNode>(N)->getMemoryVT() == MVT::f80;
 }]>;
 
-def X86fild16 : PatFrag<(ops node:$ptr), (X86fild node:$ptr), [{
-  return cast<MemIntrinsicSDNode>(N)->getMemoryVT() == MVT::i16;
-}]> {
+def X86fild16 : PatFrag<(ops node:$ptr), (X86fild node:$ptr)> {
   let IsLoad = true;
   let MemoryVT = i16;
 }
 
-def X86fild32 : PatFrag<(ops node:$ptr), (X86fild node:$ptr), [{
-  return cast<MemIntrinsicSDNode>(N)->getMemoryVT() == MVT::i32;
-}]> {
+def X86fild32 : PatFrag<(ops node:$ptr), (X86fild node:$ptr)> {
   let IsLoad = true;
   let MemoryVT = i32;
 }
 
-def X86fild64 : PatFrag<(ops node:$ptr), (X86fild node:$ptr), [{
-  return cast<MemIntrinsicSDNode>(N)->getMemoryVT() == MVT::i64;
-}]> {
+def X86fild64 : PatFrag<(ops node:$ptr), (X86fild node:$ptr)> {
   let IsLoad = true;
   let MemoryVT = i64;
 }
@@ -873,26 +867,20 @@ def X86fist64 : PatFrag<(ops node:$val, node:$ptr),
   return cast<MemIntrinsicSDNode>(N)->getMemoryVT() == MVT::i64;
 }]>;
 
-def X86fp_to_i16mem : PatFrag<(ops node:$val, node:$ptr),
-                              (X86fp_to_mem node:$val, node:$ptr), [{
-  return cast<MemIntrinsicSDNode>(N)->getMemoryVT() == MVT::i16;
-}]> {
+def X86fp_to_i16mem
+    : PatFrag<(ops node:$val, node:$ptr), (X86fp_to_mem node:$val, node:$ptr)> {
   let IsStore = true;
   let MemoryVT = i16;
 }
 
-def X86fp_to_i32mem : PatFrag<(ops node:$val, node:$ptr),
-                              (X86fp_to_mem node:$val, node:$ptr), [{
-  return cast<MemIntrinsicSDNode>(N)->getMemoryVT() == MVT::i32;
-}]> {
+def X86fp_to_i32mem
+    : PatFrag<(ops node:$val, node:$ptr), (X86fp_to_mem node:$val, node:$ptr)> {
   let IsStore = true;
   let MemoryVT = i32;
 }
 
-def X86fp_to_i64mem : PatFrag<(ops node:$val, node:$ptr),
-                              (X86fp_to_mem node:$val, node:$ptr), [{
-  return cast<MemIntrinsicSDNode>(N)->getMemoryVT() == MVT::i64;
-}]> {
+def X86fp_to_i64mem
+    : PatFrag<(ops node:$val, node:$ptr), (X86fp_to_mem node:$val, node:$ptr)> {
   let IsStore = true;
   let MemoryVT = i64;
 }


### PR DESCRIPTION
Drop the c++ predicates and use MemoryVT for memory size check for FILD and FIST. 