### PR TITLE
[gn build] Use shutil.which to find git in write_vcsrevision.py

### DIFF
--- a/llvm/utils/gn/build/write_vcsrevision.py
+++ b/llvm/utils/gn/build/write_vcsrevision.py
@@ -6,20 +6,11 @@ import argparse
 import os
 import subprocess
 import sys
+import shutil
 
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 LLVM_DIR = os.path.dirname(os.path.dirname(os.path.dirname(THIS_DIR)))
-
-
-def which(program):
-    # distutils.spawn.which() doesn't find .bat files,
-    # https://bugs.python.org/issue2200
-    for path in os.environ["PATH"].split(os.pathsep):
-        candidate = os.path.join(path, program)
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    return None
 
 
 def main():
@@ -46,11 +37,11 @@ def main():
 
     vcsrevision_contents = ""
     if args.write_git_rev:
-        git, use_shell = which("git"), False
+        git, use_shell = shutil.which("git"), False
         if not git:
-            git = which("git.exe")
+            git = shutil.which("git.exe")
         if not git:
-            git, use_shell = which("git.bat"), True
+            git, use_shell = shutil.which("git.bat"), True
         git_dir = (
             subprocess.check_output(
                 [git, "rev-parse", "--git-dir"], cwd=LLVM_DIR, shell=use_shell


### PR DESCRIPTION
Relates to https://github.com/llvm/llvm-project/issues/54337

This is just a comment referencing distutils but even so, we can ditch the custom which and use the one Python 3.3 added. Which has the .bat bug fixed:
https://docs.python.org/3.3/library/shutil.html#shutil.which

I tested this on Windows:
```
C:\Users\tcwg>touch foo.bat

C:\Users\tcwg>python
Python 3.11.9 (tags/v3.11.9:de54cf5, Apr  2 2024, 12:24:25) [MSC v.1938 64 bit (ARM64)] on win32 Type "help", "copyright", "credits" or "license" for more information.
>>> import shutil
>>> shutil.which("foo")
'.\\foo.BAT'
```

I just ran the script manually and got reasonable results, I haven't done a GN build.