### PR TITLE
[lldb] Disable TestTargetWatchAddress.py on Windows x86_64

### DIFF
--- a/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
+++ b/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
@@ -160,6 +160,11 @@ class TargetWatchpointCreateByAddressPITestCase(TestBase):
     # No size constraint on MIPS for watches
     @skipIf(archs=["mips", "mipsel", "mips64", "mips64el"])
     @skipIf(archs=["s390x"])  # Likewise on SystemZ
+    @skipIf(
+        oslist=["windows"],
+        archs=["x86_64"],
+        bugnumber="github.com/llvm/llvm-project/issues/142196",
+    )
     def test_watch_address_with_invalid_watch_size(self):
         """Exercise SBTarget.WatchpointCreateByAddress() API but pass an invalid watch_size."""
         self.build()


### PR DESCRIPTION
See #142196 and https://github.com/llvm/llvm-zorg/pull/452 for details.