### PR TITLE
[lldb/cmake] Implicitly pass arguments to llvm_add_library

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -38,14 +38,11 @@ function(add_lldb_library name)
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-  # only supported parameters to this macro are the optional
-  # MODULE;SHARED;STATIC library type and source files
   cmake_parse_arguments(PARAM
     "MODULE;SHARED;STATIC;OBJECT;PLUGIN;FRAMEWORK;NO_INTERNAL_DEPENDENCIES;NO_PLUGIN_DEPENDENCIES"
-    "INSTALL_PREFIX;ENTITLEMENTS"
-    "EXTRA_CXXFLAGS;DEPENDS;LINK_LIBS;LINK_COMPONENTS;CLANG_LIBS"
+    "INSTALL_PREFIX"
+    "EXTRA_CXXFLAGS;LINK_LIBS;CLANG_LIBS"
     ${ARGN})
-  list(APPEND LLVM_LINK_COMPONENTS ${PARAM_LINK_COMPONENTS})
 
   if(PARAM_NO_INTERNAL_DEPENDENCIES)
     foreach(link_lib ${PARAM_LINK_LIBS})
@@ -91,10 +88,6 @@ function(add_lldb_library name)
     set(libkind STATIC)
   endif()
 
-  if(PARAM_ENTITLEMENTS)
-    set(pass_ENTITLEMENTS ENTITLEMENTS ${PARAM_ENTITLEMENTS})
-  endif()
-
   if(LLDB_NO_INSTALL_DEFAULT_RPATH)
     set(pass_NO_INSTALL_RPATH NO_INSTALL_RPATH)
   endif()
@@ -102,8 +95,6 @@ function(add_lldb_library name)
   llvm_add_library(${name} ${libkind} ${headers}
     ${PARAM_UNPARSED_ARGUMENTS}
     LINK_LIBS ${PARAM_LINK_LIBS}
-    DEPENDS ${PARAM_DEPENDS}
-    ${pass_ENTITLEMENTS}
     ${pass_NO_INSTALL_RPATH}
   )
 
@@ -169,14 +160,10 @@ endfunction(add_lldb_library)
 function(add_lldb_executable name)
   cmake_parse_arguments(ARG
     "GENERATE_INSTALL"
-    "INSTALL_PREFIX;ENTITLEMENTS"
+    "INSTALL_PREFIX"
     "LINK_LIBS;CLANG_LIBS;LINK_COMPONENTS;BUILD_RPATH;INSTALL_RPATH"
     ${ARGN}
     )
-
-  if(ARG_ENTITLEMENTS)
-    set(pass_ENTITLEMENTS ENTITLEMENTS ${ARG_ENTITLEMENTS})
-  endif()
 
   if(LLDB_NO_INSTALL_DEFAULT_RPATH)
     set(pass_NO_INSTALL_RPATH NO_INSTALL_RPATH)
@@ -184,7 +171,6 @@ function(add_lldb_executable name)
 
   list(APPEND LLVM_LINK_COMPONENTS ${ARG_LINK_COMPONENTS})
   add_llvm_executable(${name}
-    ${pass_ENTITLEMENTS}
     ${pass_NO_INSTALL_RPATH}
     ${ARG_UNPARSED_ARGUMENTS}
   )

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -128,6 +128,8 @@ add_lldb_library(liblldb SHARED ${option_framework}
   DEPENDS
     lldb-sbapi-dwarf-enums
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -142,8 +144,6 @@ add_lldb_library(liblldb SHARED ${option_framework}
     lldbValueObject
     lldbVersion
     ${LLDB_ALL_PLUGINS}
-  LINK_COMPONENTS
-    Support
 
   ${option_install_prefix}
 )

--- a/lldb/source/Breakpoint/CMakeLists.txt
+++ b/lldb/source/Breakpoint/CMakeLists.txt
@@ -26,6 +26,8 @@ add_lldb_library(lldbBreakpoint NO_PLUGIN_DEPENDENCIES
   WatchpointOptions.cpp
   WatchpointResource.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbExpression
@@ -34,7 +36,4 @@ add_lldb_library(lldbBreakpoint NO_PLUGIN_DEPENDENCIES
     lldbTarget
     lldbUtility
     lldbValueObject
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Commands/CMakeLists.txt
+++ b/lldb/source/Commands/CMakeLists.txt
@@ -43,6 +43,8 @@ add_lldb_library(lldbCommands NO_PLUGIN_DEPENDENCIES
   CommandOptionsProcessAttach.cpp
   CommandOptionsProcessLaunch.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -55,9 +57,6 @@ add_lldb_library(lldbCommands NO_PLUGIN_DEPENDENCIES
     lldbUtility
     lldbValueObject
     lldbVersion
-
-  LINK_COMPONENTS
-    Support
   )
 
 add_dependencies(lldbCommands LLDBOptionsGen)

--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -60,6 +60,12 @@ add_lldb_library(lldbCore NO_PLUGIN_DEPENDENCIES
   DEPENDS
     clang-tablegen-targets
 
+
+  LINK_COMPONENTS
+    Support
+    Demangle
+    TargetParser
+    Telemetry
   LINK_LIBS
     lldbBreakpoint
     lldbDataFormatters
@@ -75,12 +81,6 @@ add_lldb_library(lldbCore NO_PLUGIN_DEPENDENCIES
 
   CLANG_LIBS
     clangDriver
-
-  LINK_COMPONENTS
-    Support
-    Demangle
-    TargetParser
-    Telemetry
   )
 
 add_dependencies(lldbCore

--- a/lldb/source/DataFormatters/CMakeLists.txt
+++ b/lldb/source/DataFormatters/CMakeLists.txt
@@ -18,6 +18,8 @@ add_lldb_library(lldbDataFormatters NO_PLUGIN_DEPENDENCIES
   ValueObjectPrinter.cpp
   VectorType.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbInterpreter
@@ -25,7 +27,4 @@ add_lldb_library(lldbDataFormatters NO_PLUGIN_DEPENDENCIES
     lldbTarget
     lldbUtility
     lldbValueObject
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Expression/CMakeLists.txt
+++ b/lldb/source/Expression/CMakeLists.txt
@@ -20,6 +20,10 @@ add_lldb_library(lldbExpression NO_PLUGIN_DEPENDENCIES
   DEPENDS
   intrinsics_gen
 
+  LINK_COMPONENTS
+    Core
+    ExecutionEngine
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -28,9 +32,4 @@ add_lldb_library(lldbExpression NO_PLUGIN_DEPENDENCIES
     lldbTarget
     lldbUtility
     lldbValueObject
-
-  LINK_COMPONENTS
-    Core
-    ExecutionEngine
-    Support
   )

--- a/lldb/source/Host/CMakeLists.txt
+++ b/lldb/source/Host/CMakeLists.txt
@@ -176,14 +176,13 @@ endif()
 add_lldb_library(lldbHost NO_PLUGIN_DEPENDENCIES
   ${HOST_SOURCES}
 
+  LINK_COMPONENTS
+    Object
+    Support
   LINK_LIBS
     lldbUtility
     ${EXTRA_LIBS}
     ${LLDBObjCLibs}
     ${LLDB_LIBEDIT_LIBS}
-
-  LINK_COMPONENTS
-    Object
-    Support
   )
 

--- a/lldb/source/Host/macosx/objcxx/CMakeLists.txt
+++ b/lldb/source/Host/macosx/objcxx/CMakeLists.txt
@@ -8,13 +8,12 @@ add_lldb_library(lldbHostMacOSXObjCXX NO_PLUGIN_DEPENDENCIES
   HostThreadMacOSX.mm
   MemoryMonitorMacOSX.mm
 
-  LINK_LIBS
-    lldbUtility
-    ${EXTRA_LIBS}
-
   LINK_COMPONENTS
     Support
     TargetParser
+  LINK_LIBS
+    lldbUtility
+    ${EXTRA_LIBS}
   )
 
 target_compile_options(lldbHostMacOSXObjCXX PRIVATE

--- a/lldb/source/Initialization/CMakeLists.txt
+++ b/lldb/source/Initialization/CMakeLists.txt
@@ -11,12 +11,12 @@ add_lldb_library(lldbInitialization
   SystemInitializer.cpp
   SystemLifetimeManager.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbPluginProcessGDBRemote
     ${EXTRA_PLUGINS}
     ${LLDB_SYSTEM_LIBS}
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Interpreter/CMakeLists.txt
+++ b/lldb/source/Interpreter/CMakeLists.txt
@@ -55,6 +55,8 @@ add_lldb_library(lldbInterpreter NO_PLUGIN_DEPENDENCIES
   Property.cpp
   ScriptInterpreter.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbInterpreterInterfaces
     lldbCommands
@@ -63,9 +65,6 @@ add_lldb_library(lldbInterpreter NO_PLUGIN_DEPENDENCIES
     lldbHost
     lldbTarget
     lldbUtility
-
-  LINK_COMPONENTS
-    Support
   )
 
 add_dependencies(lldbInterpreter

--- a/lldb/source/Interpreter/Interfaces/CMakeLists.txt
+++ b/lldb/source/Interpreter/Interfaces/CMakeLists.txt
@@ -1,10 +1,9 @@
 add_lldb_library(lldbInterpreterInterfaces NO_PLUGIN_DEPENDENCIES
   ScriptedInterfaceUsages.cpp
 
-  LINK_LIBS
-    lldbUtility
-
   LINK_COMPONENTS
     Support
+  LINK_LIBS
+    lldbUtility
   )
 

--- a/lldb/source/Plugins/ABI/AArch64/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/AArch64/CMakeLists.txt
@@ -3,12 +3,12 @@ add_lldb_library(lldbPluginABIAArch64 PLUGIN
   ABIMacOSX_arm64.cpp
   ABISysV_arm64.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/ARC/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/ARC/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_lldb_library(lldbPluginABIARC PLUGIN
   ABISysV_arc.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbPluginProcessUtility
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/ARM/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/ARM/CMakeLists.txt
@@ -3,13 +3,13 @@ add_lldb_library(lldbPluginABIARM PLUGIN
   ABIMacOSX_arm.cpp
   ABISysV_arm.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbPluginProcessUtility
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/Hexagon/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/Hexagon/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_lldb_library(lldbPluginABIHexagon PLUGIN
   ABISysV_hexagon.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/LoongArch/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/LoongArch/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_lldb_library(lldbPluginABILoongArch PLUGIN
   ABISysV_loongarch.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/MSP430/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/MSP430/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_lldb_library(lldbPluginABIMSP430 PLUGIN
   ABISysV_msp430.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )
 

--- a/lldb/source/Plugins/ABI/Mips/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/Mips/CMakeLists.txt
@@ -3,12 +3,12 @@ add_lldb_library(lldbPluginABIMips PLUGIN
   ABISysV_mips.cpp
   ABISysV_mips64.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/PowerPC/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/PowerPC/CMakeLists.txt
@@ -3,13 +3,13 @@ add_lldb_library(lldbPluginABIPowerPC PLUGIN
   ABISysV_ppc.cpp
   ABISysV_ppc64.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbPluginTypeSystemClang
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/RISCV/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/RISCV/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_lldb_library(lldbPluginABIRISCV PLUGIN
   ABISysV_riscv.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbPluginProcessUtility
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/SystemZ/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/SystemZ/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_lldb_library(lldbPluginABISystemZ PLUGIN
   ABISysV_s390x.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ABI/X86/CMakeLists.txt
+++ b/lldb/source/Plugins/ABI/X86/CMakeLists.txt
@@ -6,12 +6,12 @@ add_lldb_library(lldbPluginABIX86 PLUGIN
   ABISysV_x86_64.cpp
   ABIWindows_x86_64.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/Architecture/AArch64/CMakeLists.txt
+++ b/lldb/source/Plugins/Architecture/AArch64/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_lldb_library(lldbPluginArchitectureAArch64 PLUGIN
   ArchitectureAArch64.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbPluginProcessUtility
     lldbCore
     lldbTarget
     lldbUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Architecture/Arm/CMakeLists.txt
+++ b/lldb/source/Plugins/Architecture/Arm/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_lldb_library(lldbPluginArchitectureArm PLUGIN
   ArchitectureArm.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbPluginProcessUtility
     lldbCore
     lldbTarget
     lldbUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Architecture/Mips/CMakeLists.txt
+++ b/lldb/source/Plugins/Architecture/Mips/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_lldb_library(lldbPluginArchitectureMips PLUGIN
   ArchitectureMips.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbTarget
     lldbUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Architecture/PPC64/CMakeLists.txt
+++ b/lldb/source/Plugins/Architecture/PPC64/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_lldb_library(lldbPluginArchitecturePPC64 PLUGIN
   ArchitecturePPC64.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbPluginProcessUtility
     lldbCore
     lldbTarget
     lldbUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Disassembler/LLVMC/CMakeLists.txt
+++ b/lldb/source/Plugins/Disassembler/LLVMC/CMakeLists.txt
@@ -1,10 +1,6 @@
 add_lldb_library(lldbPluginDisassemblerLLVMC PLUGIN
   DisassemblerLLVMC.cpp
 
-  LINK_LIBS
-    lldbCore
-    lldbSymbol
-    lldbTarget
   LINK_COMPONENTS
     ${LLVM_TARGETS_TO_BUILD}
     MC
@@ -12,4 +8,8 @@ add_lldb_library(lldbPluginDisassemblerLLVMC PLUGIN
     RuntimeDyld
     Support
     TargetParser
+  LINK_LIBS
+    lldbCore
+    lldbSymbol
+    lldbTarget
   )

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/CMakeLists.txt
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/CMakeLists.txt
@@ -3,6 +3,9 @@ add_lldb_library(lldbPluginDynamicLoaderMacOSXDYLD PLUGIN
   DynamicLoaderMacOS.cpp
   DynamicLoaderDarwin.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -12,7 +15,4 @@ add_lldb_library(lldbPluginDynamicLoaderMacOSXDYLD PLUGIN
     lldbTarget
     lldbUtility
     lldbPluginTypeSystemClang
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/CMakeLists.txt
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/CMakeLists.txt
@@ -2,6 +2,8 @@ add_lldb_library(lldbPluginDynamicLoaderPosixDYLD PLUGIN
   DYLDRendezvous.cpp
   DynamicLoaderPOSIXDYLD.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -10,6 +12,4 @@ add_lldb_library(lldbPluginDynamicLoaderPosixDYLD PLUGIN
     lldbTarget
     lldbPluginProcessElfCore
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/DynamicLoader/Windows-DYLD/CMakeLists.txt
+++ b/lldb/source/Plugins/DynamicLoader/Windows-DYLD/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_lldb_library(lldbPluginDynamicLoaderWindowsDYLD PLUGIN
   DynamicLoaderWindowsDYLD.cpp
 
-  LINK_LIBS
-    lldbCore
-    lldbTarget
   LINK_COMPONENTS
     Support
     TargetParser
+  LINK_LIBS
+    lldbCore
+    lldbTarget
   )

--- a/lldb/source/Plugins/DynamicLoader/wasm-DYLD/CMakeLists.txt
+++ b/lldb/source/Plugins/DynamicLoader/wasm-DYLD/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_lldb_library(lldbPluginDynamicLoaderWasmDYLD PLUGIN
   DynamicLoaderWasmDYLD.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbTarget
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/ExpressionParser/Clang/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Clang/CMakeLists.txt
@@ -29,6 +29,13 @@ add_lldb_library(lldbPluginExpressionParserClang
   DEPENDS
   intrinsics_gen
 
+  LINK_COMPONENTS
+    Core
+    ExecutionEngine
+    ipo
+    MCJIT
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbExpression
@@ -54,11 +61,4 @@ add_lldb_library(lldbPluginExpressionParserClang
     clangRewriteFrontend
     clangSema
     clangSerialization
-  LINK_COMPONENTS
-    Core
-    ExecutionEngine
-    ipo
-    MCJIT
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/Instruction/ARM/CMakeLists.txt
+++ b/lldb/source/Plugins/Instruction/ARM/CMakeLists.txt
@@ -2,6 +2,8 @@ add_lldb_library(lldbPluginInstructionARM PLUGIN
   EmulateInstructionARM.cpp
   EmulationStateARM.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -9,6 +11,4 @@ add_lldb_library(lldbPluginInstructionARM PLUGIN
     lldbSymbol
     lldbTarget
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Instruction/ARM64/CMakeLists.txt
+++ b/lldb/source/Plugins/Instruction/ARM64/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_lldb_library(lldbPluginInstructionARM64 PLUGIN
   EmulateInstructionARM64.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbInterpreter
     lldbSymbol
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Instruction/LoongArch/CMakeLists.txt
+++ b/lldb/source/Plugins/Instruction/LoongArch/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_lldb_library(lldbPluginInstructionLoongArch PLUGIN
   EmulateInstructionLoongArch.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbInterpreter
     lldbPluginProcessUtility
     lldbSymbol
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Instruction/MIPS/CMakeLists.txt
+++ b/lldb/source/Plugins/Instruction/MIPS/CMakeLists.txt
@@ -5,13 +5,13 @@ endif()
 add_lldb_library(lldbPluginInstructionMIPS PLUGIN
   EmulateInstructionMIPS.cpp
 
+  LINK_COMPONENTS
+    MC
+    Support
+    ${mips_target}
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    MC
-    Support
-    ${mips_target}
   )

--- a/lldb/source/Plugins/Instruction/MIPS64/CMakeLists.txt
+++ b/lldb/source/Plugins/Instruction/MIPS64/CMakeLists.txt
@@ -5,14 +5,14 @@ endif()
 add_lldb_library(lldbPluginInstructionMIPS64 PLUGIN
   EmulateInstructionMIPS64.cpp
 
+  LINK_COMPONENTS
+    MC
+    Support
+    ${mips_target}
   LINK_LIBS
     lldbCore
     lldbHost
     lldbInterpreter
     lldbSymbol
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    MC
-    Support
-    ${mips_target}
   )

--- a/lldb/source/Plugins/Instruction/PPC64/CMakeLists.txt
+++ b/lldb/source/Plugins/Instruction/PPC64/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_lldb_library(lldbPluginInstructionPPC64 PLUGIN
   EmulateInstructionPPC64.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbInterpreter
     lldbSymbol
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Instruction/RISCV/CMakeLists.txt
+++ b/lldb/source/Plugins/Instruction/RISCV/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_lldb_library(lldbPluginInstructionRISCV PLUGIN
   EmulateInstructionRISCV.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbInterpreter
     lldbSymbol
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/CMakeLists.txt
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_lldb_library(lldbPluginInstrumentationRuntimeMainThreadChecker PLUGIN
   InstrumentationRuntimeMainThreadChecker.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -8,6 +10,4 @@ add_lldb_library(lldbPluginInstrumentationRuntimeMainThreadChecker PLUGIN
     lldbInterpreter
     lldbSymbol
     lldbTarget
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/InstrumentationRuntime/UBSan/CMakeLists.txt
+++ b/lldb/source/Plugins/InstrumentationRuntime/UBSan/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_lldb_library(lldbPluginInstrumentationRuntimeUBSan PLUGIN
   InstrumentationRuntimeUBSan.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -9,6 +11,4 @@ add_lldb_library(lldbPluginInstrumentationRuntimeUBSan PLUGIN
     lldbSymbol
     lldbTarget
     lldbValueObject
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/JITLoader/GDB/CMakeLists.txt
+++ b/lldb/source/Plugins/JITLoader/GDB/CMakeLists.txt
@@ -9,6 +9,8 @@ lldb_tablegen(JITLoaderGDBPropertiesEnum.inc -gen-lldb-property-enum-defs
 add_lldb_library(lldbPluginJITLoaderGDB PLUGIN
   JITLoaderGDB.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -17,8 +19,6 @@ add_lldb_library(lldbPluginJITLoaderGDB PLUGIN
     lldbTarget
     lldbUtility
     lldbPluginObjectFileMachO
-  LINK_COMPONENTS
-    Support
   )
 
 add_dependencies(lldbPluginJITLoaderGDB

--- a/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
@@ -34,6 +34,8 @@ add_lldb_library(lldbPluginCPlusPlusLanguage PLUGIN
   LibStdcppUniquePointer.cpp
   MSVCUndecoratedNameParser.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbDataFormatters
@@ -45,9 +47,6 @@ add_lldb_library(lldbPluginCPlusPlusLanguage PLUGIN
     lldbPluginClangCommon
     lldbPluginCPPRuntime
     lldbPluginTypeSystemClang
-
-  LINK_COMPONENTS
-    Support
 )
 
 add_dependencies(lldbPluginCPlusPlusLanguage

--- a/lldb/source/Plugins/Language/ClangCommon/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/ClangCommon/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_lldb_library(lldbPluginClangCommon
   ClangHighlighter.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbUtility
-  LINK_COMPONENTS
-    Support
 )

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/CMakeLists.txt
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/CMakeLists.txt
@@ -8,6 +8,8 @@ add_lldb_library(lldbPluginAppleObjCRuntime PLUGIN
   AppleObjCClassDescriptorV2.cpp
   AppleObjCTypeEncodingParser.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -23,6 +25,4 @@ add_lldb_library(lldbPluginAppleObjCRuntime PLUGIN
     lldbPluginTypeSystemClang
   CLANG_LIBS
     clangAST
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/CMakeLists.txt
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_lldb_library(lldbPluginGNUstepObjCRuntime PLUGIN
   GNUstepObjCRuntime.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -15,6 +17,4 @@ add_lldb_library(lldbPluginGNUstepObjCRuntime PLUGIN
     lldbPluginTypeSystemClang
   CLANG_LIBS
     clangAST
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_lldb_library(lldbPluginObjectContainerBSDArchive PLUGIN
   ObjectContainerBSDArchive.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/ObjectFile/Breakpad/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/CMakeLists.txt
@@ -2,12 +2,12 @@ add_lldb_library(lldbPluginObjectFileBreakpad PLUGIN
   BreakpadRecords.cpp
   ObjectFileBreakpad.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbUtility
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ObjectFile/COFF/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/COFF/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_lldb_library(lldbPluginObjectFileCOFF PLUGIN
   ObjectFileCOFF.cpp
 
+  LINK_COMPONENTS
+    BinaryFormat
+    Object
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbTarget
-
-  LINK_COMPONENTS
-    BinaryFormat
-    Object
-    Support)
+  )

--- a/lldb/source/Plugins/ObjectFile/ELF/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/ELF/CMakeLists.txt
@@ -2,13 +2,13 @@ add_lldb_library(lldbPluginObjectFileELF PLUGIN
   ELFHeader.cpp
   ObjectFileELF.cpp
 
+  LINK_COMPONENTS
+    BinaryFormat
+    Object
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbTarget
-  LINK_COMPONENTS
-    BinaryFormat
-    Object
-    Support
   )

--- a/lldb/source/Plugins/ObjectFile/JSON/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/JSON/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_lldb_library(lldbPluginObjectFileJSON PLUGIN
   ObjectFileJSON.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbUtility
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/ObjectFile/Mach-O/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_lldb_library(lldbPluginObjectFileMachO PLUGIN
   ObjectFileMachO.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -8,6 +10,4 @@ add_lldb_library(lldbPluginObjectFileMachO PLUGIN
     lldbTarget
     lldbUtility
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/ObjectFile/Minidump/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/Minidump/CMakeLists.txt
@@ -2,6 +2,8 @@ add_lldb_library(lldbPluginObjectFileMinidump PLUGIN
   ObjectFileMinidump.cpp
   MinidumpFileBuilder.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -9,6 +11,4 @@ add_lldb_library(lldbPluginObjectFileMinidump PLUGIN
     lldbTarget
     lldbUtility
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/ObjectFile/PDB/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/PDB/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_lldb_library(lldbPluginObjectFilePDB PLUGIN
   ObjectFilePDB.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/ObjectFile/PECOFF/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/CMakeLists.txt
@@ -18,16 +18,16 @@ add_lldb_library(lldbPluginObjectFilePECOFF PLUGIN
   PECallFrameInfo.cpp
   WindowsMiniDump.cpp
 
+  LINK_COMPONENTS
+    BinaryFormat
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbTarget
     ${DBGHELP_LINK_FILES}
-  LINK_COMPONENTS
-    BinaryFormat
-    Support
-    TargetParser
   )
 
 add_dependencies(lldbPluginObjectFilePECOFF

--- a/lldb/source/Plugins/ObjectFile/Placeholder/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/Placeholder/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_lldb_library(lldbPluginObjectFilePlaceholder PLUGIN
   ObjectFilePlaceholder.cpp
 
+  LINK_COMPONENTS
+    Object
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbTarget
-  LINK_COMPONENTS
-    Object
-    Support
   )

--- a/lldb/source/Plugins/ObjectFile/XCOFF/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_lldb_library(lldbPluginObjectFileXCOFF PLUGIN
   ObjectFileXCOFF.cpp
 
+  LINK_COMPONENTS
+    BinaryFormat
+    Object
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbTarget
-  LINK_COMPONENTS
-    BinaryFormat
-    Object
-    Support
   )

--- a/lldb/source/Plugins/ObjectFile/wasm/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/wasm/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_lldb_library(lldbPluginObjectFileWasm PLUGIN
   ObjectFileWasm.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Platform/Android/CMakeLists.txt
+++ b/lldb/source/Plugins/Platform/Android/CMakeLists.txt
@@ -11,14 +11,14 @@ add_lldb_library(lldbPluginPlatformAndroid PLUGIN
   PlatformAndroid.cpp
   PlatformAndroidRemoteGDBServer.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbValueObject
     lldbPluginPlatformLinux
     lldbPluginPlatformGDB
-  LINK_COMPONENTS
-    Support
   )
 
 add_dependencies(lldbPluginPlatformAndroid

--- a/lldb/source/Plugins/Platform/FreeBSD/CMakeLists.txt
+++ b/lldb/source/Plugins/Platform/FreeBSD/CMakeLists.txt
@@ -1,13 +1,12 @@
 add_lldb_library(lldbPluginPlatformFreeBSD PLUGIN
   PlatformFreeBSD.cpp
 
+  LINK_COMPONENTS
+    TargetParser
    LINK_LIBS
     lldbBreakpoint
     lldbCore
     lldbHost
     lldbTarget
     lldbPluginPlatformPOSIX
-
-  LINK_COMPONENTS
-    TargetParser
   )

--- a/lldb/source/Plugins/Platform/MacOSX/CMakeLists.txt
+++ b/lldb/source/Plugins/Platform/MacOSX/CMakeLists.txt
@@ -37,6 +37,9 @@ endif()
 add_lldb_library(lldbPluginPlatformMacOSX PLUGIN
   ${PLUGIN_PLATFORM_MACOSX_SOURCES}
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -51,9 +54,6 @@ add_lldb_library(lldbPluginPlatformMacOSX PLUGIN
     ${OBJC_LIBS}
   CLANG_LIBS
     clangBasic
-  LINK_COMPONENTS
-    Support
-    TargetParser
     )
 
 add_dependencies(lldbPluginPlatformMacOSX

--- a/lldb/source/Plugins/Platform/MacOSX/objcxx/CMakeLists.txt
+++ b/lldb/source/Plugins/Platform/MacOSX/objcxx/CMakeLists.txt
@@ -4,16 +4,15 @@ include_directories(.)
 add_lldb_library(lldbPluginPlatformMacOSXObjCXX
   PlatformiOSSimulatorCoreSimulatorSupport.mm
 
+  LINK_COMPONENTS
+    Object
+    Support
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbUtility
     ${EXTRA_LIBS}
-
-  LINK_COMPONENTS
-    Object
-    Support
   )
 
 

--- a/lldb/source/Plugins/Platform/QemuUser/CMakeLists.txt
+++ b/lldb/source/Plugins/Platform/QemuUser/CMakeLists.txt
@@ -9,10 +9,10 @@ lldb_tablegen(PlatformQemuUserPropertiesEnum.inc -gen-lldb-property-enum-defs
 add_lldb_library(lldbPluginPlatformQemuUser PLUGIN
   PlatformQemuUser.cpp
 
-  LINK_LIBS
-    lldbUtility
   LINK_COMPONENTS
     Support
+  LINK_LIBS
+    lldbUtility
     )
 
 add_dependencies(lldbPluginPlatformQemuUser

--- a/lldb/source/Plugins/Platform/Windows/CMakeLists.txt
+++ b/lldb/source/Plugins/Platform/Windows/CMakeLists.txt
@@ -1,13 +1,12 @@
 add_lldb_library(lldbPluginPlatformWindows PLUGIN
   PlatformWindows.cpp
 
+   LINK_COMPONENTS
+    Support
    LINK_LIBS
     lldbBreakpoint
     lldbCore
     lldbHost
     lldbTarget
     lldbPluginPlatformGDB
-
-   LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Process/AIX/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/AIX/CMakeLists.txt
@@ -2,6 +2,8 @@ add_lldb_library(lldbPluginProcessAIX
   NativeProcessAIX.cpp
   NativeThreadAIX.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -10,8 +12,6 @@ add_lldb_library(lldbPluginProcessAIX
     lldbUtility
     lldbPluginProcessPOSIX
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )
 
 target_compile_definitions(lldbPluginProcessAIX PRIVATE "-D_ALL_SOURCE")

--- a/lldb/source/Plugins/Process/FreeBSD/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/FreeBSD/CMakeLists.txt
@@ -8,6 +8,8 @@ add_lldb_library(lldbPluginProcessFreeBSD
   NativeRegisterContextFreeBSD_x86_64.cpp
   NativeThreadFreeBSD.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbHost
     lldbSymbol
@@ -15,6 +17,4 @@ add_lldb_library(lldbPluginProcessFreeBSD
     lldbUtility
     lldbPluginProcessPOSIX
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Process/FreeBSDKernel/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/FreeBSDKernel/CMakeLists.txt
@@ -18,10 +18,10 @@ add_lldb_library(lldbPluginProcessFreeBSDKernel PLUGIN
   RegisterContextFreeBSDKernel_x86_64.cpp
   ThreadFreeBSDKernel.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbTarget
     ${FBSDKERNEL_LIBS}
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Process/Linux/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/Linux/CMakeLists.txt
@@ -18,6 +18,9 @@ add_lldb_library(lldbPluginProcessLinux
   Procfs.cpp
   SingleStepCheck.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbHost
@@ -26,7 +29,4 @@ add_lldb_library(lldbPluginProcessLinux
     lldbUtility
     lldbPluginProcessPOSIX
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/Process/NetBSD/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/NetBSD/CMakeLists.txt
@@ -4,6 +4,8 @@ add_lldb_library(lldbPluginProcessNetBSD
   NativeRegisterContextNetBSD_x86_64.cpp
   NativeThreadNetBSD.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbHost
     lldbSymbol
@@ -12,6 +14,4 @@ add_lldb_library(lldbPluginProcessNetBSD
     lldbPluginProcessPOSIX
     lldbPluginProcessUtility
     util
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Process/POSIX/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/POSIX/CMakeLists.txt
@@ -3,9 +3,9 @@ add_lldb_library(lldbPluginProcessPOSIX
   NativeProcessELF.cpp
   ProcessPOSIXLog.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbPluginProcessUtility
     lldbUtility
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Process/Utility/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/Utility/CMakeLists.txt
@@ -63,6 +63,9 @@ add_lldb_library(lldbPluginProcessUtility
   StopInfoMachException.cpp
   ThreadMemory.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -73,7 +76,4 @@ add_lldb_library(lldbPluginProcessUtility
     lldbTarget
     lldbUtility
     lldbValueObject
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/Process/Windows/Common/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/Windows/Common/CMakeLists.txt
@@ -20,6 +20,8 @@ add_lldb_library(lldbPluginProcessWindowsCommon PLUGIN
   x64/RegisterContextWindows_x64.cpp
   x86/RegisterContextWindows_x86.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -30,6 +32,4 @@ add_lldb_library(lldbPluginProcessWindowsCommon PLUGIN
     ws2_32
     rpcrt4
     psapi
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Process/elf-core/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/elf-core/CMakeLists.txt
@@ -14,13 +14,13 @@ add_lldb_library(lldbPluginProcessElfCore PLUGIN
   RegisterContextPOSIXCore_loongarch64.cpp
   RegisterUtilities.cpp
 
+  LINK_COMPONENTS
+    BinaryFormat
+    Support
   LINK_LIBS
     lldbCore
     lldbTarget
     lldbPluginDynamicLoaderPosixDYLD
     lldbPluginObjectFileELF
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    BinaryFormat
-    Support
   )

--- a/lldb/source/Plugins/Process/gdb-remote/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/gdb-remote/CMakeLists.txt
@@ -33,6 +33,9 @@ add_lldb_library(lldbPluginProcessGDBRemote PLUGIN
   ProcessGDBRemoteLog.cpp
   ThreadGDBRemote.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -45,9 +48,6 @@ add_lldb_library(lldbPluginProcessGDBRemote PLUGIN
     ${LLDB_SYSTEM_LIBS}
     ${LLDB_PLUGINS}
     ${LIBCOMPRESSION}
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )
 
 add_dependencies(lldbPluginProcessGDBRemote

--- a/lldb/source/Plugins/Process/mach-core/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/mach-core/CMakeLists.txt
@@ -2,6 +2,8 @@ add_lldb_library(lldbPluginProcessMachCore PLUGIN
   ProcessMachCore.cpp
   ThreadMachCore.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -12,6 +14,4 @@ add_lldb_library(lldbPluginProcessMachCore PLUGIN
     lldbPluginDynamicLoaderDarwinKernel
     lldbPluginDynamicLoaderMacOSXDYLD
     lldbPluginObjectFileMachO
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/Process/minidump/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/minidump/CMakeLists.txt
@@ -8,6 +8,10 @@ add_lldb_library(lldbPluginProcessMinidump PLUGIN
   ProcessMinidump.cpp
   ThreadMinidump.cpp
 
+  LINK_COMPONENTS
+    BinaryFormat
+    Object
+    Support
   LINK_LIBS
     lldbCore
     lldbTarget
@@ -15,8 +19,4 @@ add_lldb_library(lldbPluginProcessMinidump PLUGIN
     lldbPluginProcessUtility
     lldbPluginProcessElfCore
     lldbPluginObjectFilePlaceholder
-  LINK_COMPONENTS
-    BinaryFormat
-    Object
-    Support
   )

--- a/lldb/source/Plugins/Process/scripted/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/scripted/CMakeLists.txt
@@ -2,13 +2,13 @@ add_lldb_library(lldbPluginScriptedProcess PLUGIN
   ScriptedProcess.cpp
   ScriptedThread.cpp
 
+  LINK_COMPONENTS
+    BinaryFormat
+    Object
+    Support
   LINK_LIBS
     lldbCore
     lldbTarget
     lldbUtility
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    BinaryFormat
-    Object
-    Support
   )

--- a/lldb/source/Plugins/REPL/Clang/CMakeLists.txt
+++ b/lldb/source/Plugins/REPL/Clang/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_lldb_library(lldbPluginClangREPL PLUGIN
   ClangREPL.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbDataFormatters
@@ -11,7 +13,4 @@ add_lldb_library(lldbPluginClangREPL PLUGIN
     lldbPluginClangCommon
     lldbPluginCPPRuntime
     lldbPluginTypeSystemClang
-
-  LINK_COMPONENTS
-    Support
 )

--- a/lldb/source/Plugins/RegisterTypeBuilder/CMakeLists.txt
+++ b/lldb/source/Plugins/RegisterTypeBuilder/CMakeLists.txt
@@ -1,10 +1,9 @@
 add_lldb_library(lldbPluginRegisterTypeBuilderClang PLUGIN
   RegisterTypeBuilderClang.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbTarget
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -26,6 +26,8 @@ add_lldb_library(lldbPluginScriptInterpreterPython PLUGIN
   PythonReadline.cpp
   ScriptInterpreterPython.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -37,7 +39,4 @@ add_lldb_library(lldbPluginScriptInterpreterPython PLUGIN
     lldbPluginScriptInterpreterPythonInterfaces
     ${Python3_LIBRARIES}
     ${LLDB_LIBEDIT_LIBS}
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/CMakeLists.txt
@@ -29,6 +29,8 @@ add_lldb_library(lldbPluginScriptInterpreterPythonInterfaces PLUGIN
   ScriptedThreadPlanPythonInterface.cpp
   ScriptedThreadPythonInterface.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -36,9 +38,6 @@ add_lldb_library(lldbPluginScriptInterpreterPythonInterfaces PLUGIN
     lldbTarget
     ${Python3_LIBRARIES}
     ${LLDB_LIBEDIT_LIBS}
-
-  LINK_COMPONENTS
-    Support
   )
 
 

--- a/lldb/source/Plugins/SymbolFile/Breakpad/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/Breakpad/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_lldb_library(lldbPluginSymbolFileBreakpad PLUGIN
   SymbolFileBreakpad.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbUtility
     lldbPluginObjectFileBreakpad
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Plugins/SymbolFile/DWARF/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/DWARF/CMakeLists.txt
@@ -37,6 +37,9 @@ add_lldb_library(lldbPluginSymbolFileDWARF PLUGIN
   SymbolFileDWARFDebugMap.cpp
   UniqueDWARFASTType.cpp
 
+  LINK_COMPONENTS
+    DebugInfoDWARF
+    Support
   LINK_LIBS
     lldbCore
     lldbExpression
@@ -53,9 +56,6 @@ add_lldb_library(lldbPluginSymbolFileDWARF PLUGIN
   CLANG_LIBS
     clangAST
     clangBasic
-  LINK_COMPONENTS
-    DebugInfoDWARF
-    Support
   )
 
 add_dependencies(lldbPluginSymbolFileDWARF

--- a/lldb/source/Plugins/SymbolFile/NativePDB/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/CMakeLists.txt
@@ -10,6 +10,11 @@ add_lldb_library(lldbPluginSymbolFileNativePDB
   SymbolFileNativePDB.cpp
   UdtRecordCompleter.cpp
 
+  LINK_COMPONENTS
+    DebugInfoCodeView
+    DebugInfoPDB
+    Support
+    TargetParser
   LINK_LIBS
     lldbCore
     lldbSymbol
@@ -19,9 +24,4 @@ add_lldb_library(lldbPluginSymbolFileNativePDB
   CLANG_LIBS
     clangAST
     clangLex
-  LINK_COMPONENTS
-    DebugInfoCodeView
-    DebugInfoPDB
-    Support
-    TargetParser
   )

--- a/lldb/source/Plugins/SymbolFile/PDB/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/PDB/CMakeLists.txt
@@ -3,6 +3,9 @@ add_lldb_library(lldbPluginSymbolFilePDB PLUGIN
   PDBLocationToDWARFExpression.cpp
   SymbolFilePDB.cpp
 
+  LINK_COMPONENTS
+    DebugInfoPDB
+    Support
   LINK_LIBS
     lldbCore
     lldbPluginSymbolFileNativePDB
@@ -12,7 +15,4 @@ add_lldb_library(lldbPluginSymbolFilePDB PLUGIN
   CLANG_LIBS
     clangAST
     clangLex
-  LINK_COMPONENTS
-    DebugInfoPDB
-    Support
   )

--- a/lldb/source/Plugins/Trace/intel-pt/CMakeLists.txt
+++ b/lldb/source/Plugins/Trace/intel-pt/CMakeLists.txt
@@ -35,14 +35,14 @@ add_lldb_library(lldbPluginTraceIntelPT PLUGIN
   TraceIntelPTBundleLoader.cpp
   TraceIntelPTBundleSaver.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbPluginTraceCommon
     ${LIBIPT_LIBRARY}
-  LINK_COMPONENTS
-    Support
   )
 
 

--- a/lldb/source/Plugins/TraceExporter/ctf/CMakeLists.txt
+++ b/lldb/source/Plugins/TraceExporter/ctf/CMakeLists.txt
@@ -6,13 +6,13 @@ add_lldb_library(lldbPluginTraceExporterCTF PLUGIN
 CommandObjectThreadTraceExportCTF.cpp
   TraceExporterCTF.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbPluginTraceExporterCommon
-  LINK_COMPONENTS
-    Support
   )
 
 add_dependencies(lldbPluginTraceExporterCTF TraceExporterCTFOptionsGen)

--- a/lldb/source/Plugins/TypeSystem/Clang/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Clang/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_lldb_library(lldbPluginTypeSystemClang PLUGIN
   TypeSystemClang.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbSymbol
@@ -15,6 +17,4 @@ add_lldb_library(lldbPluginTypeSystemClang PLUGIN
     clangBasic
     clangFrontend
     clangSema
-  LINK_COMPONENTS
-    Support
 )

--- a/lldb/source/Plugins/UnwindAssembly/x86/CMakeLists.txt
+++ b/lldb/source/Plugins/UnwindAssembly/x86/CMakeLists.txt
@@ -2,13 +2,13 @@ add_lldb_library(lldbPluginUnwindAssemblyX86 PLUGIN
   UnwindAssembly-x86.cpp
   x86AssemblyInspectionEngine.cpp
 
+  LINK_COMPONENTS
+    Support
+    MC
+    MCDisassembler
   LINK_LIBS
     lldbCore
     lldbSymbol
     lldbTarget
     lldbUtility
-  LINK_COMPONENTS
-    Support
-    MC
-    MCDisassembler
   )

--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -33,6 +33,8 @@ add_lldb_library(lldbSymbol NO_PLUGIN_DEPENDENCIES
   Variable.cpp
   VariableList.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbExpression
@@ -40,7 +42,4 @@ add_lldb_library(lldbSymbol NO_PLUGIN_DEPENDENCIES
     lldbTarget
     lldbUtility
     lldbValueObject
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -82,6 +82,9 @@ add_lldb_library(lldbTarget
   UnwindLLDB.cpp
   VerboseTrapFrameRecognizer.cpp
 
+  LINK_COMPONENTS
+    Support
+    MC
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -92,10 +95,6 @@ add_lldb_library(lldbTarget
     lldbUtility
     lldbValueObject
     lldbPluginProcessUtility
-
-  LINK_COMPONENTS
-    Support
-    MC
   )
 
 add_dependencies(lldbTarget

--- a/lldb/source/Utility/CMakeLists.txt
+++ b/lldb/source/Utility/CMakeLists.txt
@@ -81,12 +81,11 @@ add_lldb_library(lldbUtility NO_INTERNAL_DEPENDENCIES
   XcodeSDK.cpp
   ZipFile.cpp
 
-  LINK_LIBS
-    ${LLDB_SYSTEM_LIBS}
-    # lldbUtility does not depend on other LLDB libraries
-
   LINK_COMPONENTS
     BinaryFormat
     Support
     TargetParser
+  LINK_LIBS
+    ${LLDB_SYSTEM_LIBS}
+    # lldbUtility does not depend on other LLDB libraries
   )

--- a/lldb/source/ValueObject/CMakeLists.txt
+++ b/lldb/source/ValueObject/CMakeLists.txt
@@ -19,7 +19,10 @@ add_lldb_library(lldbValueObject
   ValueObjectVariable.cpp
   ValueObjectVTable.cpp
 
-
+  LINK_COMPONENTS
+    Support
+    Demangle
+    TargetParser
   LINK_LIBS
     lldbBreakpoint
     lldbDataFormatters
@@ -31,9 +34,4 @@ add_lldb_library(lldbValueObject
     lldbUtility
     lldbPluginCPlusPlusLanguage
     lldbPluginObjCLanguage
-
-  LINK_COMPONENTS
-    Support
-    Demangle
-    TargetParser
   )

--- a/lldb/tools/driver/CMakeLists.txt
+++ b/lldb/tools/driver/CMakeLists.txt
@@ -20,14 +20,13 @@ add_lldb_tool(lldb
   Driver.cpp
   Platform.cpp
 
+  LINK_COMPONENTS
+    Option
+    Support
   LINK_LIBS
     liblldb
     lldbHost
     lldbUtility
-
-  LINK_COMPONENTS
-    Option
-    Support
   )
 
 add_dependencies(lldb

--- a/lldb/tools/intel-features/intel-mpx/CMakeLists.txt
+++ b/lldb/tools/intel-features/intel-mpx/CMakeLists.txt
@@ -1,10 +1,9 @@
 add_lldb_library(lldbIntelMPX
   cli-wrapper-mpxtable.cpp
 
-  LINK_LIBS
-    liblldb
-
   LINK_COMPONENTS
     Support
     TargetParser
+  LINK_LIBS
+    liblldb
   )

--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -70,13 +70,12 @@ add_lldb_library(lldbDAP
   Protocol/ProtocolTypes.cpp
   Protocol/ProtocolRequests.cpp
 
-  LINK_LIBS
-    liblldb
-    lldbHost
-
   LINK_COMPONENTS
     Option
     Support
+  LINK_LIBS
+    liblldb
+    lldbHost
   )
 
 target_include_directories(lldbDAP

--- a/lldb/tools/lldb-instr/CMakeLists.txt
+++ b/lldb/tools/lldb-instr/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_lldb_tool(lldb-instr
   Instrument.cpp
 
+  LINK_COMPONENTS
+    Support
   CLANG_LIBS
     clangAST
     clangBasic
@@ -10,7 +12,4 @@ add_lldb_tool(lldb-instr
     clangRewrite
     clangSerialization
     clangTooling
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/tools/lldb-server/CMakeLists.txt
+++ b/lldb/tools/lldb-server/CMakeLists.txt
@@ -49,6 +49,9 @@ add_lldb_tool(lldb-server
     LLDBServerUtilities.cpp
     SystemInitializerLLGS.cpp
 
+    LINK_COMPONENTS
+      Option
+      Support
     LINK_LIBS
       lldbHost
       lldbInitialization
@@ -60,10 +63,6 @@ add_lldb_tool(lldb-server
       lldbPluginInstructionMIPS64
       lldbPluginInstructionRISCV
       ${LLDB_SYSTEM_LIBS}
-
-    LINK_COMPONENTS
-      Option
-      Support
 )
 
 add_dependencies(lldb-server

--- a/lldb/tools/lldb-test/CMakeLists.txt
+++ b/lldb/tools/lldb-test/CMakeLists.txt
@@ -5,6 +5,8 @@ add_lldb_tool(lldb-test
   lldb-test.cpp
   SystemInitializerTest.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
@@ -18,9 +20,6 @@ add_lldb_tool(lldb-test
     lldbUtility
     lldbVersion
     ${LLDB_ALL_PLUGINS}
-
-  LINK_COMPONENTS
-    Support
   )
 
 if(Python3_RPATH)

--- a/lldb/unittests/Breakpoint/CMakeLists.txt
+++ b/lldb/unittests/Breakpoint/CMakeLists.txt
@@ -2,9 +2,9 @@ add_lldb_unittest(LLDBBreakpointTests
   BreakpointIDTest.cpp
   WatchpointAlgorithmsTests.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/unittests/Callback/CMakeLists.txt
+++ b/lldb/unittests/Callback/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_lldb_unittest(LLDBCallbackTests
   TestBreakpointSetCallback.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbBreakpoint
     lldbCore
     LLVMTestingSupport
     lldbUtilityHelpers
     lldbPluginPlatformMacOSX
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/unittests/Core/CMakeLists.txt
+++ b/lldb/unittests/Core/CMakeLists.txt
@@ -16,6 +16,9 @@ add_lldb_unittest(LLDBCoreTests
   TelemetryTest.cpp
   UniqueCStringMapTest.cpp
 
+  LINK_COMPONENTS
+    Support
+    Telemetry
   LINK_LIBS
     lldbCore
     lldbHost
@@ -29,7 +32,4 @@ add_lldb_unittest(LLDBCoreTests
     lldbUtilityHelpers
     lldbHostHelpers
     LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
-    Telemetry
   )

--- a/lldb/unittests/DAP/CMakeLists.txt
+++ b/lldb/unittests/DAP/CMakeLists.txt
@@ -10,13 +10,13 @@ add_lldb_unittest(DAPTests
   TransportTest.cpp
   VariablesTest.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     liblldb
     lldbDAP
     lldbUtilityHelpers
     LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
   )
 
 set(test_inputs

--- a/lldb/unittests/DataFormatter/CMakeLists.txt
+++ b/lldb/unittests/DataFormatter/CMakeLists.txt
@@ -4,13 +4,12 @@ add_lldb_unittest(LLDBFormatterTests
   FormatterBytecodeTest.cpp
   StringPrinterTests.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbInterpreter
     lldbSymbol
     lldbTarget
     lldbUtility
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/unittests/Disassembler/CMakeLists.txt
+++ b/lldb/unittests/Disassembler/CMakeLists.txt
@@ -22,13 +22,14 @@ endif()
 if (disas_srcs)
   add_lldb_unittest(DisassemblerTests
     ${disas_srcs}
+    LINK_COMPONENTS
+      Support
+      ${LLVM_TARGETS_TO_BUILD}
     LINK_LIBS
       lldbCore
       lldbSymbol
       lldbTarget
       lldbPluginDisassemblerLLVMC
       lldbPluginProcessUtility
-    LINK_COMPONENTS
-      Support
-      ${LLVM_TARGETS_TO_BUILD})
+    )
 endif()

--- a/lldb/unittests/Instruction/CMakeLists.txt
+++ b/lldb/unittests/Instruction/CMakeLists.txt
@@ -3,6 +3,8 @@ add_lldb_unittest(EmulatorTests
   LoongArch/TestLoongArchEmulator.cpp
   RISCV/TestRISCVEmulator.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbSymbol
@@ -10,7 +12,4 @@ add_lldb_unittest(EmulatorTests
     lldbPluginInstructionARM64
     lldbPluginInstructionLoongArch
     lldbPluginInstructionRISCV
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/unittests/OperatingSystem/CMakeLists.txt
+++ b/lldb/unittests/OperatingSystem/CMakeLists.txt
@@ -6,6 +6,8 @@ add_lldb_unittest(ProcessGdbRemoteTests
   GDBRemoteCommunicationTest.cpp
   GDBRemoteTestUtils.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     LLVMTestingSupport
     lldbCore
@@ -15,7 +17,4 @@ add_lldb_unittest(ProcessGdbRemoteTests
     lldbSymbol
     lldbTarget
     lldbValueObject
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/unittests/Platform/CMakeLists.txt
+++ b/lldb/unittests/Platform/CMakeLists.txt
@@ -5,13 +5,13 @@ add_lldb_unittest(LLDBPlatformTests
   PlatformSiginfoTest.cpp
   PlatformTest.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbPluginPlatformFreeBSD
     lldbPluginPlatformLinux
     lldbPluginPlatformMacOSX
     lldbPluginPlatformNetBSD
-  LINK_COMPONENTS
-    Support
   )
 
 add_subdirectory(Android)

--- a/lldb/unittests/Process/elf-core/CMakeLists.txt
+++ b/lldb/unittests/Process/elf-core/CMakeLists.txt
@@ -4,6 +4,8 @@ include(CMakePushCheckState)
 add_lldb_unittest(ProcessElfCoreTests
   ThreadElfCoreTest.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -12,9 +14,6 @@ add_lldb_unittest(ProcessElfCoreTests
     lldbPluginPlatformLinux
 
     LLVMTestingSupport
-
-  LINK_COMPONENTS
-    Support
   )
 
 cmake_push_check_state()

--- a/lldb/unittests/Process/gdb-remote/CMakeLists.txt
+++ b/lldb/unittests/Process/gdb-remote/CMakeLists.txt
@@ -6,6 +6,8 @@ add_lldb_unittest(ProcessGdbRemoteTests
   GDBRemoteCommunicationTest.cpp
   GDBRemoteTestUtils.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -14,7 +16,4 @@ add_lldb_unittest(ProcessGdbRemoteTests
     lldbPluginProcessGDBRemote
 
     LLVMTestingSupport
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/unittests/Process/minidump/CMakeLists.txt
+++ b/lldb/unittests/Process/minidump/CMakeLists.txt
@@ -2,6 +2,9 @@ add_lldb_unittest(LLDBMinidumpTests
   MinidumpParserTest.cpp
   RegisterContextMinidumpTest.cpp
 
+  LINK_COMPONENTS
+    ObjectYAML
+    Support
   LINK_LIBS
     lldbCore
     lldbHost
@@ -10,9 +13,6 @@ add_lldb_unittest(LLDBMinidumpTests
     lldbPluginProcessMinidump
     lldbUtilityHelpers
     LLVMTestingSupport
-  LINK_COMPONENTS
-    ObjectYAML
-    Support
   )
 
 set(test_inputs

--- a/lldb/unittests/ScriptInterpreter/Lua/CMakeLists.txt
+++ b/lldb/unittests/ScriptInterpreter/Lua/CMakeLists.txt
@@ -2,11 +2,11 @@ add_lldb_unittest(ScriptInterpreterLuaTests
   LuaTests.cpp
   ScriptInterpreterTests.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbHost
     lldbPluginScriptInterpreterLua
     lldbPluginPlatformLinux
     LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/unittests/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/unittests/ScriptInterpreter/Python/CMakeLists.txt
@@ -8,12 +8,12 @@ add_lldb_unittest(ScriptInterpreterPythonTests
   PythonDataObjectsTests.cpp
   PythonTestSuite.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbHost
     lldbPluginScriptInterpreterPython
     LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
   )
 
 if(Python3_RPATH)

--- a/lldb/unittests/SymbolFile/DWARF/CMakeLists.txt
+++ b/lldb/unittests/SymbolFile/DWARF/CMakeLists.txt
@@ -7,6 +7,9 @@ add_lldb_unittest(SymbolFileDWARFTests
   SymbolFileDWARFTests.cpp
   XcodeSDKModuleTests.cpp
 
+  LINK_COMPONENTS
+    Support
+    DebugInfoPDB
   LINK_LIBS
     lldbCore
     lldbHost
@@ -19,9 +22,6 @@ add_lldb_unittest(SymbolFileDWARFTests
     lldbUtilityHelpers
     lldbSymbolHelpers
     LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
-    DebugInfoPDB
   )
 
 set(test_inputs

--- a/lldb/unittests/SymbolFile/NativePDB/CMakeLists.txt
+++ b/lldb/unittests/SymbolFile/NativePDB/CMakeLists.txt
@@ -2,13 +2,13 @@ add_lldb_unittest(SymbolFileNativePDBTests
   PdbFPOProgramToDWARFExpressionTests.cpp
   UdtRecordCompleterTests.cpp
 
+  LINK_COMPONENTS
+    Support
+    DebugInfoPDB
   LINK_LIBS
     lldbCore
     lldbHost
     lldbSymbol
     lldbPluginSymbolFileNativePDB
     lldbUtilityHelpers
-  LINK_COMPONENTS
-    Support
-    DebugInfoPDB
   )

--- a/lldb/unittests/SymbolFile/PDB/CMakeLists.txt
+++ b/lldb/unittests/SymbolFile/PDB/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_lldb_unittest(SymbolFilePDBTests
   SymbolFilePDBTests.cpp
 
+  LINK_COMPONENTS
+    Support
+    DebugInfoPDB
   LINK_LIBS
     lldbCore
     lldbHost
@@ -11,9 +14,6 @@ add_lldb_unittest(SymbolFilePDBTests
     lldbPluginTypeSystemClang
     lldbUtilityHelpers
     LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
-    DebugInfoPDB
   )
 
 set(test_inputs

--- a/lldb/unittests/Target/CMakeLists.txt
+++ b/lldb/unittests/Target/CMakeLists.txt
@@ -14,6 +14,8 @@ add_lldb_unittest(TargetTests
   SummaryStatisticsTest.cpp
   FindFileTest.cpp
 
+  LINK_COMPONENTS
+      Support
   LINK_LIBS
       lldbCore
       lldbHost
@@ -28,8 +30,6 @@ add_lldb_unittest(TargetTests
       lldbSymbol
       lldbUtility
       lldbUtilityHelpers
-    LINK_COMPONENTS
-      Support
   )
 
 set(test_inputs

--- a/lldb/unittests/TestingSupport/CMakeLists.txt
+++ b/lldb/unittests/TestingSupport/CMakeLists.txt
@@ -3,13 +3,12 @@ add_lldb_library(lldbUtilityHelpers
   MockTildeExpressionResolver.cpp
   TestUtilities.cpp
 
-  LINK_LIBS
-    lldbUtility
-    llvm_gtest
-
   LINK_COMPONENTS
     Support
     ObjectYAML
+  LINK_LIBS
+    lldbUtility
+    llvm_gtest
   )
 
 add_subdirectory(Host)

--- a/lldb/unittests/TestingSupport/Symbol/CMakeLists.txt
+++ b/lldb/unittests/TestingSupport/Symbol/CMakeLists.txt
@@ -2,6 +2,8 @@ set_property(DIRECTORY PROPERTY EXCLUDE_FROM_ALL ON)
 add_lldb_library(lldbSymbolHelpers
   YAMLModuleTester.cpp
 
+  LINK_COMPONENTS
+    ObjectYAML
   LINK_LIBS
     lldbCore
     lldbHost
@@ -11,7 +13,4 @@ add_lldb_library(lldbSymbolHelpers
     lldbPluginTypeSystemClang
     lldbUtilityHelpers
     LLVMTestingSupport
-
-  LINK_COMPONENTS
-    ObjectYAML
   )

--- a/lldb/unittests/UnwindAssembly/ARM64/CMakeLists.txt
+++ b/lldb/unittests/UnwindAssembly/ARM64/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_lldb_unittest(Arm64InstEmulationTests
   TestArm64InstEmulation.cpp
+  LINK_COMPONENTS
+    Support
+    ${LLVM_TARGETS_TO_BUILD}
   LINK_LIBS
     lldbCore
     lldbSymbol
@@ -8,6 +11,4 @@ add_lldb_unittest(Arm64InstEmulationTests
     lldbPluginDisassemblerLLVMC
     lldbPluginInstructionARM64
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
-    ${LLVM_TARGETS_TO_BUILD})
+  )

--- a/lldb/unittests/UnwindAssembly/PPC64/CMakeLists.txt
+++ b/lldb/unittests/UnwindAssembly/PPC64/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_lldb_unittest(PPC64InstEmulationTests
   TestPPC64InstEmulation.cpp
+  LINK_COMPONENTS
+    Support
+    ${LLVM_TARGETS_TO_BUILD}
   LINK_LIBS
     lldbCore
     lldbSymbol
@@ -8,6 +11,4 @@ add_lldb_unittest(PPC64InstEmulationTests
     lldbPluginDisassemblerLLVMC
     lldbPluginInstructionPPC64
     lldbPluginProcessUtility
-  LINK_COMPONENTS
-    Support
-    ${LLVM_TARGETS_TO_BUILD})
+  )

--- a/lldb/unittests/UnwindAssembly/x86-but-no-x86-target/CMakeLists.txt
+++ b/lldb/unittests/UnwindAssembly/x86-but-no-x86-target/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_lldb_unittest(UnwindAssemblyX86ButNoX86TargetTests
     Testx86AssemblyInspectionEngine.cpp
+    LINK_COMPONENTS
+      Support
+      ${LLVM_TARGETS_TO_BUILD}
     LINK_LIBS
       lldbCore
       lldbSymbol
       lldbPluginUnwindAssemblyX86
-    LINK_COMPONENTS
-      Support
-      ${LLVM_TARGETS_TO_BUILD}
   )

--- a/lldb/unittests/UnwindAssembly/x86/CMakeLists.txt
+++ b/lldb/unittests/UnwindAssembly/x86/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_lldb_unittest(UnwindAssemblyx86Tests
     Testx86AssemblyInspectionEngine.cpp
+    LINK_COMPONENTS
+      Support
+      ${LLVM_TARGETS_TO_BUILD}
     LINK_LIBS
       lldbCore
       lldbSymbol
       lldbPluginUnwindAssemblyX86
-    LINK_COMPONENTS
-      Support
-      ${LLVM_TARGETS_TO_BUILD}
   )

--- a/lldb/unittests/Utility/CMakeLists.txt
+++ b/lldb/unittests/Utility/CMakeLists.txt
@@ -51,13 +51,13 @@ add_lldb_unittest(UtilityTests
   VMRangeTest.cpp
   XcodeSDKTest.cpp
 
+  LINK_COMPONENTS
+    Support
+    TargetParser
   LINK_LIBS
       lldbUtility
       lldbUtilityHelpers
       LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
-    TargetParser
   )
 
 set(test_inputs

--- a/lldb/unittests/ValueObject/CMakeLists.txt
+++ b/lldb/unittests/ValueObject/CMakeLists.txt
@@ -3,12 +3,11 @@ add_lldb_unittest(LLDBValueObjectTests
   DILLexerTests.cpp
   DynamicValueObjectLocalBuffer.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbValueObject
     lldbPluginPlatformLinux
     lldbPluginScriptInterpreterNone
     LLVMTestingSupport
-
-  LINK_COMPONENTS
-    Support
   )

--- a/lldb/unittests/debugserver/CMakeLists.txt
+++ b/lldb/unittests/debugserver/CMakeLists.txt
@@ -9,12 +9,12 @@ add_lldb_unittest(debugserverTests
   RNBSocketTest.cpp
   debugserver_LogCallback.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbDebugserverCommon
     lldbHost
     LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
   )
 
 target_include_directories(debugserverTests PRIVATE
@@ -33,10 +33,10 @@ if(APPLE_EMBEDDED)
     RNBSocketTest.cpp
     debugserver_LogCallback.cpp
 
+    LINK_COMPONENTS
+      Support
     LINK_LIBS
       lldbDebugserverCommon_NonUI
       lldbHost
-    LINK_COMPONENTS
-      Support
     )
 endif()

--- a/lldb/unittests/tools/lldb-server/tests/CMakeLists.txt
+++ b/lldb/unittests/tools/lldb-server/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ add_lldb_unittest(LLDBServerTests
   TestBase.cpp
   TestClient.cpp
 
+  LINK_COMPONENTS
+    Support
   LINK_LIBS
     lldbHost
     lldbCore
@@ -14,8 +16,6 @@ add_lldb_unittest(LLDBServerTests
     lldbPluginProcessGDBRemote
 
     LLVMTestingSupport
-  LINK_COMPONENTS
-    Support
   )
 
 add_dependencies(LLDBServerTests lldb-server ${ALL_LLDB_TEST_EXECUTABLES})


### PR DESCRIPTION
If we're not touching them, we don't need to do anything special to pass them along -- with one important caveat: due to how cmake arguments work, the implicitly passed arguments need to be specified before arguments that we handle.

This isn't particularly nice, but the alternative is enumerating all arguments that can be used by llvm_add_library and the macros it calls (it also relies on implicit passing of some arguments to llvm_process_sources).