### PR TITLE
[lldb][llvm][AIX] Added support for getProcFile with TID

### DIFF
--- a/lldb/include/lldb/Host/aix/Support.h
+++ b/lldb/include/lldb/Host/aix/Support.h
@@ -1,0 +1,23 @@
+//===-- Support.h -----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_HOST_AIX_SUPPORT_H
+#define LLDB_HOST_AIX_SUPPORT_H
+
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include <memory>
+
+namespace lldb_private {
+
+llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+getProcFile(::pid_t pid, ::pid_t tid, const llvm::Twine &file);
+
+} // namespace lldb_private
+
+#endif // #ifndef LLDB_HOST_AIX_SUPPORT_H

--- a/lldb/source/Host/CMakeLists.txt
+++ b/lldb/source/Host/CMakeLists.txt
@@ -142,6 +142,7 @@ else()
     add_host_subdirectory(aix
       aix/Host.cpp
       aix/HostInfoAIX.cpp
+      aix/Support.cpp
       )
   endif()
 endif()

--- a/lldb/source/Host/aix/Support.cpp
+++ b/lldb/source/Host/aix/Support.cpp
@@ -1,0 +1,24 @@
+//===-- Support.cpp -------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Host/aix/Support.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+lldb_private::getProcFile(::pid_t pid, ::pid_t tid, const llvm::Twine &file) {
+  Log *log = GetLog(LLDBLog::Host);
+  std::string File =
+      ("/proc/" + llvm::Twine(pid) + "/lwp/" + llvm::Twine(tid) + "/" + file)
+          .str();
+  auto Ret = llvm::MemoryBuffer::getFileAsStream(File);
+  if (!Ret)
+    LLDB_LOG(log, "Failed to open {0}: {1}", File, Ret.getError().message());
+  return Ret;
+}

--- a/lldb/unittests/Host/posix/SupportTest.cpp
+++ b/lldb/unittests/Host/posix/SupportTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/posix/Support.h"
+#include "lldb/Host/aix/Support.h"
 #include "llvm/Support/Threading.h"
 #include "gtest/gtest.h"
 
@@ -19,3 +20,11 @@ TEST(Support, getProcFile_Pid) {
   ASSERT_TRUE(*BufferOrError);
 }
 #endif // #ifndef __APPLE__
+
+#if defined(_AIX) && defined(LLVM_ENABLE_THREADING)
+TEST(Support, getProcFile_Tid) {
+  auto BufferOrError = getProcFile(getpid(), llvm::get_threadid(), "lwpstatus");
+  ASSERT_TRUE(BufferOrError);
+  ASSERT_TRUE(*BufferOrError);
+}
+#endif // #ifdef _AIX && LLVM_ENABLE_THREADING

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -142,6 +142,8 @@ uint64_t llvm::get_threadid() {
   return uint64_t(gettid());
 #elif defined(__linux__)
   return uint64_t(syscall(__NR_gettid));
+#elif defined(_AIX)
+  return uint64_t(thread_self());
 #else
   return uint64_t(pthread_self());
 #endif


### PR DESCRIPTION
This PR is in reference to porting LLDB on AIX.
Link to discussions on llvm discourse and github:

1. https://discourse.llvm.org/t/port-lldb-to-ibm-aix/80640
2. https://github.com/llvm/llvm-project/issues/101657
The complete changes for porting are present in this draft PR:
https://github.com/llvm/llvm-project/pull/102601

- Added changes to getProcFile() with threadID, including testcase for AIX.
- Added support for AIX to get_threadid() from llvm. (ref to get thread ID: https://www.ibm.com/docs/sk/aix/7.3.0?topic=t-thread-self-subroutine)
@labath @DhruvSrivastavaX 