### PR TITLE
[flang][OpenMP] Show error for task depend with no valid modifiers

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -4420,6 +4420,13 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Depend &x) {
     CheckDoacross(*doaDep);
     CheckDependenceType(doaDep->GetDepType());
   } else {
+    using Modifier = parser::OmpDependClause::TaskDep::Modifier;
+    auto &modifiers{std::get<std::optional<std::list<Modifier>>>(taskDep->t)};
+    if (!modifiers) {
+      context_.Say(GetContext().clauseSource,
+          "A DEPEND clause on a TASK construct must have a valid task dependence type"_err_en_US);
+      return;
+    }
     CheckTaskDependenceType(taskDep->GetTaskDepType());
   }
 

--- a/flang/test/Semantics/OpenMP/task-depend.f90
+++ b/flang/test/Semantics/OpenMP/task-depend.f90
@@ -1,0 +1,8 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+
+program test
+! ERROR: A DEPEND clause on a TASK construct must have a valid task dependence type
+!$omp task depend(ii)
+!$omp end task
+end
+


### PR DESCRIPTION
If a "TASK DEPEND" clause is not given a valid task dependece type modifier, the semantic checks for the clause will result in an ICE because they assume that such modifiers will be present. Check whether the modifiers are present and show an appropriate error instead of crashing the compiler if they are not.

Fixes llvm#133678.