### PR TITLE
[compiler-rt][test] Use packaging.version.Version to compare glibc versions

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -713,9 +713,9 @@ if config.host_os == "Linux":
         if config.android:
             return
 
-        from distutils.version import LooseVersion
+        from packaging.version import Version
 
-        ver = LooseVersion(ver_string)
+        ver = Version(ver_string)
         any_glibc = False
         for required in [
             "2.19",
@@ -727,7 +727,7 @@ if config.host_os == "Linux":
             "2.38",
             "2.40",
         ]:
-            if ver >= LooseVersion(required):
+            if ver >= Version(required):
                 config.available_features.add("glibc-" + required)
                 any_glibc = True
             if any_glibc:


### PR DESCRIPTION
Instead of distutils.LooseVersion. distutils was depracated (https://peps.python.org/pep-0632/) and has been removed in Python 3.12 (https://docs.python.org/3/whatsnew/3.12.html)

> Of note, the distutils package has been removed from the standard library.

packaging's version is able to handle glibc's major.minor: https://packaging.pypa.io/en/latest/version.html#packaging.version.Version

> For these modules or types, use the standards-defined Python Packaging Authority packages specified:
> distutils.version — use the packaging package

Relates to https://github.com/llvm/llvm-project/issues/54337