### PR TITLE
[flang] Add aarch64 processor defines

### DIFF
--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1656,6 +1656,10 @@ void CompilerInvocation::setDefaultPredefinitions() {
       fortranOptions.predefinitions.emplace_back("__64BIT__", "1");
     }
     break;
+  case llvm::Triple::ArchType::aarch64:
+    fortranOptions.predefinitions.emplace_back("__aarch64__", "1");
+    fortranOptions.predefinitions.emplace_back("__aarch64", "1");
+    break;
   }
 }
 

--- a/flang/test/Driver/predefined-macros-aarch64.f90
+++ b/flang/test/Driver/predefined-macros-aarch64.f90
@@ -1,4 +1,4 @@
-! Test predefined macro for 64 bit X86 architecture
+! Test predefined macro for AArch64
 
 ! REQUIRES: aarch64-registered-target
 

--- a/flang/test/Driver/predefined-macros-aarch64.f90
+++ b/flang/test/Driver/predefined-macros-aarch64.f90
@@ -1,0 +1,16 @@
+! Test predefined macro for 64 bit X86 architecture
+
+! REQUIRES: aarch64-registered-target
+
+! RUN: %flang_fc1 -triple aarch64-unknown-linux-gnu -cpp -E %s | FileCheck %s
+
+! CHECK: integer :: var1 = 1
+! CHECK: integer :: var2 = 1
+
+#if __aarch64__
+  integer :: var1 = __aarch64__
+#endif
+#if __aarch64
+  integer :: var2 = __aarch64
+#endif
+end program


### PR DESCRIPTION
This patch adds aarch64 specific processor defines when targeting
aarch64, similar to the ones for ppc64 and x86_64
