### PR TITLE
[lldb] switch to CalculateNumChildren where possible

### DIFF
--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -276,7 +276,13 @@ public:
                                      name.AsCString());
     }
     uint32_t idx = *optional_idx;
-    if (idx >= CalculateNumChildrenIgnoringErrors())
+    auto num_children_or_err = CalculateNumChildren();
+    if (!num_children_or_err) {
+      llvm::consumeError(num_children_or_err.takeError());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
+    }
+    if (idx >= *num_children_or_err)
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     return idx;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -279,7 +279,13 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -534,7 +534,13 @@ llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -593,7 +593,13 @@ llvm::Expected<size_t> lldb_private::formatters::
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -731,7 +737,13 @@ llvm::Expected<size_t> lldb_private::formatters::
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -868,7 +880,13 @@ lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -1073,7 +1091,13 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -1235,7 +1259,13 @@ llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -133,7 +133,13 @@ public:
                                      name.AsCString());
     }
     uint32_t idx = *optional_idx;
-    if (idx >= CalculateNumChildrenIgnoringErrors())
+    auto num_children_or_err = CalculateNumChildren();
+    if (!num_children_or_err) {
+      llvm::consumeError(num_children_or_err.takeError());
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
+    }
+    if (idx >= *num_children_or_err)
       return llvm::createStringError("Type has no child named '%s'",
                                      name.AsCString());
     return idx;

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -395,7 +395,13 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -533,7 +539,13 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;
@@ -672,7 +684,13 @@ llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
                                    name.AsCString());
   }
   uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
+  auto num_children_or_err = CalculateNumChildren();
+  if (!num_children_or_err) {
+    llvm::consumeError(num_children_or_err.takeError());
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+  if (idx >= *num_children_or_err)
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());
   return idx;


### PR DESCRIPTION
This patch is a follow up to https://github.com/llvm/llvm-project/pull/136693.

`CalculateNumChildrenIgnoringErrors ` is replaced with `CalculateNumChildren` in the methods that return an `llvm::Expected` as suggested by @Michael137 [here](https://github.com/llvm/llvm-project/pull/136693#discussion_r2056319358).

