### PR TITLE
[RISCV] Fold SRLIW+SLLI+ADD into SRLIW+SHXADD

### DIFF
--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -3688,15 +3688,14 @@ define ptr @test_gep_gep_dont_crash(ptr %p, i64 %a1, i64 %a2) {
 ; RV64ZBA-LABEL: test_gep_gep_dont_crash:
 ; RV64ZBA:       # %bb.0:
 ; RV64ZBA-NEXT:    srliw a2, a2, 6
-; RV64ZBA-NEXT:    add a1, a2, a1
+; RV64ZBA-NEXT:    sh3add a0, a2, a0
 ; RV64ZBA-NEXT:    sh3add a0, a1, a0
 ; RV64ZBA-NEXT:    ret
 ;
 ; RV64XANDESPERF-LABEL: test_gep_gep_dont_crash:
 ; RV64XANDESPERF:       # %bb.0:
 ; RV64XANDESPERF-NEXT:    srliw a2, a2, 6
-; RV64XANDESPERF-NEXT:    slli a2, a2, 3
-; RV64XANDESPERF-NEXT:    add a0, a0, a2
+; RV64XANDESPERF-NEXT:    nds.lea.d a0, a0, a2
 ; RV64XANDESPERF-NEXT:    nds.lea.d a0, a0, a1
 ; RV64XANDESPERF-NEXT:    ret
   %lshr = lshr i64 %a2, 6
@@ -4276,12 +4275,24 @@ entry:
 }
 
 define ptr @shl_and_gep(ptr %p, i64 %i) {
-; CHECK-LABEL: shl_and_gep:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    srliw a1, a1, 2
-; CHECK-NEXT:    slli a1, a1, 3
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV64I-LABEL: shl_and_gep:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    srliw a1, a1, 2
+; RV64I-NEXT:    slli a1, a1, 3
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: shl_and_gep:
+; RV64ZBA:       # %bb.0:
+; RV64ZBA-NEXT:    srliw a1, a1, 2
+; RV64ZBA-NEXT:    sh3add a0, a1, a0
+; RV64ZBA-NEXT:    ret
+;
+; RV64XANDESPERF-LABEL: shl_and_gep:
+; RV64XANDESPERF:       # %bb.0:
+; RV64XANDESPERF-NEXT:    srliw a1, a1, 2
+; RV64XANDESPERF-NEXT:    nds.lea.d a0, a0, a1
+; RV64XANDESPERF-NEXT:    ret
   %shl = shl i64 %i, 1
   %and = and i64 %shl, 8589934584
   %gep = getelementptr i8, ptr %p, i64 %and
@@ -4289,12 +4300,24 @@ define ptr @shl_and_gep(ptr %p, i64 %i) {
 }
 
 define ptr @shr_and_gep(ptr %p, i64 %i) {
-; CHECK-LABEL: shr_and_gep:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    srliw a1, a1, 6
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV64I-LABEL: shr_and_gep:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    srliw a1, a1, 6
+; RV64I-NEXT:    slli a1, a1, 1
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: shr_and_gep:
+; RV64ZBA:       # %bb.0:
+; RV64ZBA-NEXT:    srliw a1, a1, 6
+; RV64ZBA-NEXT:    sh1add a0, a1, a0
+; RV64ZBA-NEXT:    ret
+;
+; RV64XANDESPERF-LABEL: shr_and_gep:
+; RV64XANDESPERF:       # %bb.0:
+; RV64XANDESPERF-NEXT:    srliw a1, a1, 6
+; RV64XANDESPERF-NEXT:    nds.lea.h a0, a0, a1
+; RV64XANDESPERF-NEXT:    ret
   %lshr = lshr i64 %i, 6
   %and = and i64 %lshr, 67108863
   %gep = getelementptr i16, ptr %p, i64 %and
@@ -4302,13 +4325,27 @@ define ptr @shr_and_gep(ptr %p, i64 %i) {
 }
 
 define ptr @slt_select_gep(ptr %p, i32 %y) {
-; CHECK-LABEL: slt_select_gep:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    srli a1, a1, 28
-; CHECK-NEXT:    andi a1, a1, 8
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    addi a0, a0, 16
-; CHECK-NEXT:    ret
+; RV64I-LABEL: slt_select_gep:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    srli a1, a1, 28
+; RV64I-NEXT:    andi a1, a1, 8
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    addi a0, a0, 16
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: slt_select_gep:
+; RV64ZBA:       # %bb.0:
+; RV64ZBA-NEXT:    srliw a1, a1, 31
+; RV64ZBA-NEXT:    sh3add a0, a1, a0
+; RV64ZBA-NEXT:    addi a0, a0, 16
+; RV64ZBA-NEXT:    ret
+;
+; RV64XANDESPERF-LABEL: slt_select_gep:
+; RV64XANDESPERF:       # %bb.0:
+; RV64XANDESPERF-NEXT:    srliw a1, a1, 31
+; RV64XANDESPERF-NEXT:    nds.lea.d a0, a0, a1
+; RV64XANDESPERF-NEXT:    addi a0, a0, 16
+; RV64XANDESPERF-NEXT:    ret
   %cmp = icmp slt i32 %y, 0
   %select = select i1 %cmp, i64 24, i64 16
   %gep = getelementptr i8, ptr %p, i64 %select
@@ -4316,12 +4353,26 @@ define ptr @slt_select_gep(ptr %p, i32 %y) {
 }
 
 define i32 @shr_and_add(i32 %x, i32 %y) {
-; CHECK-LABEL: shr_and_add:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    srliw a1, a1, 9
-; CHECK-NEXT:    slli a1, a1, 2
-; CHECK-NEXT:    addw a0, a0, a1
-; CHECK-NEXT:    ret
+; RV64I-LABEL: shr_and_add:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    srliw a1, a1, 9
+; RV64I-NEXT:    slli a1, a1, 2
+; RV64I-NEXT:    addw a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: shr_and_add:
+; RV64ZBA:       # %bb.0:
+; RV64ZBA-NEXT:    srliw a1, a1, 9
+; RV64ZBA-NEXT:    sh2add a0, a1, a0
+; RV64ZBA-NEXT:    sext.w a0, a0
+; RV64ZBA-NEXT:    ret
+;
+; RV64XANDESPERF-LABEL: shr_and_add:
+; RV64XANDESPERF:       # %bb.0:
+; RV64XANDESPERF-NEXT:    srliw a1, a1, 9
+; RV64XANDESPERF-NEXT:    nds.lea.w a0, a0, a1
+; RV64XANDESPERF-NEXT:    sext.w a0, a0
+; RV64XANDESPERF-NEXT:    ret
   %lshr = lshr i32 %y, 7
   %and = and i32 %lshr, 33554428
   %add = add i32 %x, %and
@@ -4344,9 +4395,8 @@ define ptr @udiv1280_gep(ptr %p, i16 zeroext %i) {
 ; RV64ZBA-NEXT:    lui a2, 13
 ; RV64ZBA-NEXT:    addi a2, a2, -819
 ; RV64ZBA-NEXT:    mul a1, a1, a2
-; RV64ZBA-NEXT:    srli a1, a1, 23
-; RV64ZBA-NEXT:    srliw a1, a1, 3
-; RV64ZBA-NEXT:    sh3add.uw a0, a1, a0
+; RV64ZBA-NEXT:    srliw a1, a1, 26
+; RV64ZBA-NEXT:    sh3add a0, a1, a0
 ; RV64ZBA-NEXT:    ret
 ;
 ; RV64XANDESPERF-LABEL: udiv1280_gep:
@@ -4354,9 +4404,8 @@ define ptr @udiv1280_gep(ptr %p, i16 zeroext %i) {
 ; RV64XANDESPERF-NEXT:    lui a2, 13
 ; RV64XANDESPERF-NEXT:    addi a2, a2, -819
 ; RV64XANDESPERF-NEXT:    mul a1, a1, a2
-; RV64XANDESPERF-NEXT:    srli a1, a1, 23
-; RV64XANDESPERF-NEXT:    srliw a1, a1, 3
-; RV64XANDESPERF-NEXT:    nds.lea.d.ze a0, a0, a1
+; RV64XANDESPERF-NEXT:    srliw a1, a1, 26
+; RV64XANDESPERF-NEXT:    nds.lea.d a0, a0, a1
 ; RV64XANDESPERF-NEXT:    ret
   %udiv = udiv i16 %i, 1280
   %idx.ext = zext nneg i16 %udiv to i64


### PR DESCRIPTION
This handles RV64 SRLIW, similarly to SRLI.

Also fixing the comments for SRLI combines that did not match the code.