### PR TITLE
[SelectionDAG] Use reportFatalUsageError() for invalid operand bundles

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3275,12 +3275,13 @@ void SelectionDAGBuilder::visitInvoke(const InvokeInst &I) {
 
   // Deopt and ptrauth bundles are lowered in helper functions, and we don't
   // have to do anything here to lower funclet bundles.
-  assert(!I.hasOperandBundlesOtherThan(
-             {LLVMContext::OB_deopt, LLVMContext::OB_gc_transition,
-              LLVMContext::OB_gc_live, LLVMContext::OB_funclet,
-              LLVMContext::OB_cfguardtarget, LLVMContext::OB_ptrauth,
-              LLVMContext::OB_clang_arc_attachedcall}) &&
-         "Cannot lower invokes with arbitrary operand bundles yet!");
+  if (I.hasOperandBundlesOtherThan(
+          {LLVMContext::OB_deopt, LLVMContext::OB_gc_transition,
+           LLVMContext::OB_gc_live, LLVMContext::OB_funclet,
+           LLVMContext::OB_cfguardtarget, LLVMContext::OB_ptrauth,
+           LLVMContext::OB_clang_arc_attachedcall}))
+    reportFatalUsageError(
+        "Cannot lower invokes with arbitrary operand bundles!");
 
   const Value *Callee(I.getCalledOperand());
   const Function *Fn = dyn_cast<Function>(Callee);
@@ -3380,9 +3381,10 @@ void SelectionDAGBuilder::visitCallBr(const CallBrInst &I) {
 
   // Deopt bundles are lowered in LowerCallSiteWithDeoptBundle, and we don't
   // have to do anything here to lower funclet bundles.
-  assert(!I.hasOperandBundlesOtherThan(
-             {LLVMContext::OB_deopt, LLVMContext::OB_funclet}) &&
-         "Cannot lower callbrs with arbitrary operand bundles yet!");
+  if (I.hasOperandBundlesOtherThan(
+          {LLVMContext::OB_deopt, LLVMContext::OB_funclet}))
+    reportFatalUsageError(
+        "Cannot lower callbrs with arbitrary operand bundles!");
 
   assert(I.isInlineAsm() && "Only know how to handle inlineasm callbr");
   visitInlineAsm(I);
@@ -9549,12 +9551,12 @@ void SelectionDAGBuilder::visitCall(const CallInst &I) {
   // Deopt bundles are lowered in LowerCallSiteWithDeoptBundle, and we don't
   // have to do anything here to lower funclet bundles.
   // CFGuardTarget bundles are lowered in LowerCallTo.
-  assert(!I.hasOperandBundlesOtherThan(
-             {LLVMContext::OB_deopt, LLVMContext::OB_funclet,
-              LLVMContext::OB_cfguardtarget, LLVMContext::OB_preallocated,
-              LLVMContext::OB_clang_arc_attachedcall, LLVMContext::OB_kcfi,
-              LLVMContext::OB_convergencectrl}) &&
-         "Cannot lower calls with arbitrary operand bundles!");
+  if (I.hasOperandBundlesOtherThan(
+          {LLVMContext::OB_deopt, LLVMContext::OB_funclet,
+           LLVMContext::OB_cfguardtarget, LLVMContext::OB_preallocated,
+           LLVMContext::OB_clang_arc_attachedcall, LLVMContext::OB_kcfi,
+           LLVMContext::OB_convergencectrl}))
+    reportFatalUsageError("Cannot lower calls with arbitrary operand bundles!");
 
   SDValue Callee = getValue(I.getCalledOperand());
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3281,7 +3281,7 @@ void SelectionDAGBuilder::visitInvoke(const InvokeInst &I) {
            LLVMContext::OB_cfguardtarget, LLVMContext::OB_ptrauth,
            LLVMContext::OB_clang_arc_attachedcall}))
     reportFatalUsageError(
-        "Cannot lower invokes with arbitrary operand bundles!");
+        "cannot lower invokes with arbitrary operand bundles!");
 
   const Value *Callee(I.getCalledOperand());
   const Function *Fn = dyn_cast<Function>(Callee);
@@ -3384,7 +3384,7 @@ void SelectionDAGBuilder::visitCallBr(const CallBrInst &I) {
   if (I.hasOperandBundlesOtherThan(
           {LLVMContext::OB_deopt, LLVMContext::OB_funclet}))
     reportFatalUsageError(
-        "Cannot lower callbrs with arbitrary operand bundles!");
+        "cannot lower callbrs with arbitrary operand bundles!");
 
   assert(I.isInlineAsm() && "Only know how to handle inlineasm callbr");
   visitInlineAsm(I);
@@ -9556,7 +9556,7 @@ void SelectionDAGBuilder::visitCall(const CallInst &I) {
            LLVMContext::OB_cfguardtarget, LLVMContext::OB_preallocated,
            LLVMContext::OB_clang_arc_attachedcall, LLVMContext::OB_kcfi,
            LLVMContext::OB_convergencectrl}))
-    reportFatalUsageError("Cannot lower calls with arbitrary operand bundles!");
+    reportFatalUsageError("cannot lower calls with arbitrary operand bundles!");
 
   SDValue Callee = getValue(I.getCalledOperand());
 

--- a/llvm/test/CodeGen/X86/invalid-operand-bundle-call.ll
+++ b/llvm/test/CodeGen/X86/invalid-operand-bundle-call.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=x86_64-unknown-linux-gnu < %s 2>&1 | FileCheck %s
 
-; CHECK: LLVM ERROR: Cannot lower calls with arbitrary operand bundles!
+; CHECK: LLVM ERROR: cannot lower calls with arbitrary operand bundles!
 
 declare void @g()
 

--- a/llvm/test/CodeGen/X86/invalid-operand-bundle-call.ll
+++ b/llvm/test/CodeGen/X86/invalid-operand-bundle-call.ll
@@ -1,0 +1,10 @@
+; RUN: not llc -mtriple=x86_64-unknown-linux-gnu < %s 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: Cannot lower calls with arbitrary operand bundles!
+
+declare void @g()
+
+define void @f(i32 %arg) {
+  call void @g() [ "foo"(i32 %arg) ]
+  ret void
+}

--- a/llvm/test/CodeGen/X86/invalid-operand-bundle-callbr.ll
+++ b/llvm/test/CodeGen/X86/invalid-operand-bundle-callbr.ll
@@ -1,0 +1,11 @@
+; RUN: not llc -mtriple=x86_64-unknown-linux-gnu < %s 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: Cannot lower callbrs with arbitrary operand bundles!
+
+define void @f(i32 %arg) {
+  callbr void asm "", ""() [ "foo"(i32 %arg) ]
+    to label %cont []
+
+cont:
+  ret void
+}

--- a/llvm/test/CodeGen/X86/invalid-operand-bundle-callbr.ll
+++ b/llvm/test/CodeGen/X86/invalid-operand-bundle-callbr.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=x86_64-unknown-linux-gnu < %s 2>&1 | FileCheck %s
 
-; CHECK: LLVM ERROR: Cannot lower callbrs with arbitrary operand bundles!
+; CHECK: LLVM ERROR: cannot lower callbrs with arbitrary operand bundles!
 
 define void @f(i32 %arg) {
   callbr void asm "", ""() [ "foo"(i32 %arg) ]

--- a/llvm/test/CodeGen/X86/invalid-operand-bundle-invoke.ll
+++ b/llvm/test/CodeGen/X86/invalid-operand-bundle-invoke.ll
@@ -1,0 +1,19 @@
+; RUN: not llc -mtriple=x86_64-unknown-linux-gnu < %s 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: Cannot lower invokes with arbitrary operand bundles!
+
+declare void @g()
+declare i32 @__gxx_personality_v0(...)
+
+define void @f(i32 %arg) personality ptr @__gxx_personality_v0 {
+  invoke void @g() [ "foo"(i32 %arg) ]
+    to label %cont unwind label %lpad
+
+lpad:
+  %l = landingpad {ptr, i32}
+    cleanup
+  resume {ptr, i32} %l
+
+cont:
+  ret void
+}

--- a/llvm/test/CodeGen/X86/invalid-operand-bundle-invoke.ll
+++ b/llvm/test/CodeGen/X86/invalid-operand-bundle-invoke.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=x86_64-unknown-linux-gnu < %s 2>&1 | FileCheck %s
 
-; CHECK: LLVM ERROR: Cannot lower invokes with arbitrary operand bundles!
+; CHECK: LLVM ERROR: cannot lower invokes with arbitrary operand bundles!
 
 declare void @g()
 declare i32 @__gxx_personality_v0(...)


### PR DESCRIPTION
Replace the asserts with reportFatalUsageError(), as these can be reached with invalid user-provided IR.

Fixes https://github.com/llvm/llvm-project/issues/142531.