### PR TITLE
[flang][OpenMP] Fix for crash of derived types in atomic constructs

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2735,7 +2735,9 @@ inline void OmpStructureChecker::ErrIfNonScalarAssignmentStmt(
           "statement"_err_en_US);
     if (v->Rank() != 0 ||
         (v->GetType().has_value() &&
-            v->GetType()->category() == common::TypeCategory::Character))
+            v->GetType()->category() == common::TypeCategory::Character) ||
+        (v->GetType().has_value() &&
+            v->GetType()->category() == common::TypeCategory::Derived))
       context_.Say(var.GetSource(),
           "Expected scalar variable "
           "on the LHS of atomic assignment "

--- a/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
+++ b/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
@@ -159,4 +159,13 @@ program sample
     !ERROR: Expected scalar variable on the LHS of atomic assignment statement
     !ERROR: Expected scalar expression on the RHS of atomic assignment statement
         l = r
+
+    !$omp atomic read
+    !ERROR: Expected scalar variable on the LHS of atomic assignment statement
+    !ERROR: Expected scalar variable of intrinsic type on RHS of atomic assignment statement
+        z = sample_type(2,2)
+
+    !$omp atomic write
+    !ERROR: Expected scalar variable on the LHS of atomic assignment statement
+        z = sample_type(2,2)
 end program


### PR DESCRIPTION
Add check to err out if derived types are used on the LHS of atomic constructs.

Fixes https://github.com/llvm/llvm-project/issues/126451