### PR TITLE
Added TypeKind.FLOAT16 for 32 in cindex.py

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2483,6 +2483,7 @@ class TypeKind(BaseEnumeration):
     OBJCSEL = 29
     FLOAT128 = 30
     HALF = 31
+    FLOAT16 = 32
     IBM128 = 40
     COMPLEX = 100
     POINTER = 101


### PR DESCRIPTION
fix for https://github.com/llvm/llvm-project/issues/142633

Added FLOAT16 enum for value 32