### PR TITLE
[clang][modules] rename "AST" to precompiled in diagnostic messages NFCI

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSerializationKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSerializationKinds.td
@@ -13,13 +13,13 @@ def err_fe_unable_to_read_pch_file : Error<
     "unable to read PCH file %0: '%1'">;
 def err_fe_not_a_pch_file : Error<
     "input is not a PCH file: '%0'">;
-def err_fe_pch_malformed : Error<
-    "malformed or corrupted AST file: '%0'">, DefaultFatal;
+def err_fe_ast_file_malformed : Error<
+    "malformed or corrupted precompiled file: '%0'">, DefaultFatal;
 def err_fe_pch_malformed_block : Error<
     "malformed block record in PCH file: '%0'">, DefaultFatal;
 def err_fe_ast_file_modified : Error<
     "file '%0' has been modified since the "
-    "%select{precompiled header|module file|AST file}1 '%2' was built"
+    "%select{precompiled header|module file|precompiled file}1 '%2' was built"
     ": %select{size|mtime|content}3 changed%select{| (was %5, now %6)}4">,
     DefaultFatal;
 def err_fe_pch_file_overridden : Error<
@@ -31,19 +31,19 @@ def note_module_cache_path : Note<
     "after modifying system headers, please delete the module cache at '%0'">;
 
 def err_ast_file_targetopt_mismatch : Error<
-    "AST file '%0' was compiled for the %1 '%2' but the current translation "
+    "precompiled file '%0' was compiled for the %1 '%2' but the current translation "
     "unit is being compiled for target '%3'">;
 def err_ast_file_targetopt_feature_mismatch : Error<
-    "%select{AST file '%1' was|current translation unit is}0 compiled with the target "
-    "feature '%2' but the %select{current translation unit is|AST file '%1' was}0 "
+    "%select{precompiled file '%1' was|current translation unit is}0 compiled with the target "
+    "feature '%2' but the %select{current translation unit is|precompiled file '%1' was}0 "
     "not">;
 def err_ast_file_langopt_mismatch : Error<"%0 was %select{disabled|enabled}1 in "
-    "AST file '%3' but is currently %select{disabled|enabled}2">;
+    "precompiled file '%3' but is currently %select{disabled|enabled}2">;
 def err_ast_file_langopt_value_mismatch : Error<
-  "%0 differs in AST file '%1' vs. current file">;
+  "%0 differs in precompiled file '%1' vs. current file">;
 def err_ast_file_diagopt_mismatch : Error<"%0 is currently enabled, but was not in "
-  "the AST file '%1'">;
-def err_ast_file_modulecache_mismatch : Error<"AST file '%2' was compiled with module cache "
+  "the precompiled file '%1'">;
+def err_ast_file_modulecache_mismatch : Error<"precompiled file '%2' was compiled with module cache "
   "path '%0', but the path is currently '%1'">;
 def warn_pch_vfsoverlay_mismatch : Warning<
   "PCH was compiled with different VFS overlay files than are currently in use">,
@@ -52,27 +52,27 @@ def note_pch_vfsoverlay_files : Note<"%select{PCH|current translation unit}0 has
 def note_pch_vfsoverlay_empty : Note<"%select{PCH|current translation unit}0 has no VFS overlays">;
 
 def err_ast_file_version_too_old : Error<
-    "%select{PCH|module|AST}0 file '%1' uses an older format that is no longer supported">;
+    "%select{PCH|module|precompiled}0 file '%1' uses an older format that is no longer supported">;
 def err_ast_file_version_too_new : Error<
-    "%select{PCH|module|AST}0 file '%1' uses a newer format that cannot be read">;
+    "%select{PCH|module|precompiled }0 file '%1' uses a newer format that cannot be read">;
 def err_ast_file_different_branch : Error<
-    "%select{PCH|module|AST}0 file '%1' built from a different branch (%2) than the compiler (%3)">;
+    "%select{PCH|module|precompiled}0 file '%1' built from a different branch (%2) than the compiler (%3)">;
 def err_ast_file_with_compiler_errors : Error<
-    "%select{PCH|module|AST}0 file '%1' contains compiler errors">;
+    "%select{PCH|module|precompiled}0 file '%1' contains compiler errors">;
 
 def err_module_file_conflict : Error<
   "module '%0' is defined in both '%1' and '%2'">, DefaultFatal;
 def err_ast_file_not_found : Error<
-  "%select{PCH|module|AST}0 file '%1' not found%select{|: %3}2">, DefaultFatal;
+  "%select{PCH|module|precompiled}0 file '%1' not found%select{|: %3}2">, DefaultFatal;
 def err_ast_file_out_of_date : Error<
-  "%select{PCH|module|AST}0 file '%1' is out of date and "
+  "%select{PCH|module|precompiled}0 file '%1' is out of date and "
   "needs to be rebuilt%select{|: %3}2">, DefaultFatal;
 def err_ast_file_invalid : Error<
-  "file '%1' is not a valid precompiled %select{PCH|module|AST}0 file: %2">, DefaultFatal;
+  "file '%1' is not a valid %select{PCH|module|precompiled}0 file: %2">, DefaultFatal;
 def note_module_file_imported_by : Note<
   "imported by %select{|module '%2' in }1'%0'">;
 def err_module_file_not_module : Error<
-  "AST file '%0' was not built as a module">, DefaultFatal;
+  "precompiled file '%0' was not built as a module">, DefaultFatal;
 def err_module_file_missing_top_level_submodule : Error<
   "module file '%0' is missing its top-level submodule">, DefaultFatal;
 def note_module_file_conflict : Note<
@@ -84,14 +84,14 @@ def remark_module_import : Remark<
   InGroup<ModuleImport>;
 
 def err_imported_module_not_found : Error<
-    "module '%0' in AST file '%1' %select{(imported by AST file '%2') |}4"
+    "module '%0' in precompiled file '%1' %select{(imported by precompiled file '%2') |}4"
     "is not defined in any loaded module map file; "
     "maybe you need to load '%3'?">, DefaultFatal;
 def note_imported_by_pch_module_not_found : Note<
     "consider adding '%0' to the header search path">;
 def err_imported_module_modmap_changed : Error<
-    "module '%0' %select{in|imported by}4 AST file '%1' found in a different module map file"
-    " (%2) than when the importing AST file was built (%3)">, DefaultFatal;
+    "module '%0' %select{in|imported by}4 precompiled file '%1' found in a different module map file"
+    " (%2) than when the importing precompiled file was built (%3)">, DefaultFatal;
 def err_imported_module_relocated : Error<
     "module '%0' was built in directory '%1' but now resides in "
     "directory '%2'">, DefaultFatal;
@@ -100,18 +100,18 @@ def err_module_different_modmap : Error<
     "%select{| not}1 used when the module was built">;
 
 def err_ast_file_macro_def_undef : Error<
-    "macro '%0' was %select{defined|undef'd}1 in the AST file '%2' but "
+    "macro '%0' was %select{defined|undef'd}1 in the precompiled file '%2' but "
     "%select{undef'd|defined}1 on the command line">;
 def err_ast_file_macro_def_conflict : Error<
-    "definition of macro '%0' differs between the AST file '%3' ('%1') "
+    "definition of macro '%0' differs between the precompiled file '%3' ('%1') "
     "and the command line ('%2')">;
 def err_ast_file_undef : Error<
-    "%select{command line contains|AST file '%1' was built with}0 "
-    "'-undef' but %select{AST file '%1' was not built with it|"
+    "%select{command line contains|precompiled file '%1' was built with}0 "
+    "'-undef' but %select{precompiled file '%1' was not built with it|"
     "it is not present on the command line}0">;
 def err_ast_file_pp_detailed_record : Error<
-    "%select{command line contains|AST file '%1' was built with}0 "
-    "'-detailed-preprocessing-record' but %select{AST file '%1' was not "
+    "%select{command line contains|precompiled file '%1' was built with}0 "
+    "'-detailed-preprocessing-record' but %select{precompiled file '%1' was not "
     "built with it|it is not present on the command line}0">;
 
 def err_module_odr_violation_missing_decl : Error<

--- a/clang/test/Modules/check-for-sanitizer-feature.cpp
+++ b/clang/test/Modules/check-for-sanitizer-feature.cpp
@@ -43,7 +43,7 @@
 //
 // Import the PCH without ASan enabled (we expect an error).
 // RUN: not %clang_cc1 -x c -include-pch %t.asan_pch %s -verify 2>&1 | FileCheck %s --check-prefix=PCH_MISMATCH
-// PCH_MISMATCH: AST file '{{.*}}.asan_pch' was compiled with the target feature '-fsanitize=address' but the current translation unit is not
+// PCH_MISMATCH: precompiled file '{{.*}}.asan_pch' was compiled with the target feature '-fsanitize=address' but the current translation unit is not
 //
 // Emit a PCH with UBSan enabled.
 // RUN: %clang_cc1 -x c -fsanitize=null %S/Inputs/check-for-sanitizer-feature/check.h -emit-pch -o %t.ubsan_pch

--- a/clang/test/Modules/cxx20-force-check-input.cppm
+++ b/clang/test/Modules/cxx20-force-check-input.cppm
@@ -29,5 +29,5 @@ module;
 export module a;
 export using ::foo;
 
-// CHECK-HEADER-FAILURE: fatal error:{{.*}}foo.h' has been modified since the AST file {{.*}}was built
-// CHECK-FAILURE: fatal error:{{.*}}a.cppm' has been modified since the AST file {{.*}}was built
+// CHECK-HEADER-FAILURE: fatal error:{{.*}}foo.h' has been modified since the precompiled file {{.*}}was built
+// CHECK-FAILURE: fatal error:{{.*}}a.cppm' has been modified since the precompiled file {{.*}}was built

--- a/clang/test/Modules/explicit-build.cpp
+++ b/clang/test/Modules/explicit-build.cpp
@@ -153,7 +153,7 @@
 // RUN:            -fmodule-file=%t/a.pch \
 // RUN:            %s 2>&1 | FileCheck --check-prefix=CHECK-A-AS-PCH %s
 //
-// CHECK-A-AS-PCH: fatal error: AST file '{{.*}}a.pch' was not built as a module
+// CHECK-A-AS-PCH: fatal error: precompiled file '{{.*}}a.pch' was not built as a module
 
 // -------------------------------
 // Try to import a non-AST file with -fmodule-file=
@@ -164,7 +164,7 @@
 // RUN:            -fmodule-file=%t/not.pcm \
 // RUN:            %s 2>&1 | FileCheck --check-prefix=CHECK-BAD-FILE %s
 //
-// CHECK-BAD-FILE: fatal error: file '{{.*}}not.pcm' is not a valid precompiled module file: file too small to contain AST file magic
+// CHECK-BAD-FILE: fatal error: file '{{.*}}not.pcm' is not a valid module file: file too small to contain precompiled file magic
 
 // RUN: not %clang_cc1 -triple=x86_64-linux-gnu -x c++ -std=c++11 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -Rmodule-build -fno-modules-error-recovery \
 // RUN:            -fmodule-file=%t/nonexistent.pcm \

--- a/clang/test/Modules/fatal-module-loader-error.m
+++ b/clang/test/Modules/fatal-module-loader-error.m
@@ -8,13 +8,13 @@
 
 #ifdef IMPLICIT
 
-// expected-error@+1{{Module.pcm' is not a valid precompiled module file}}
+// expected-error@+1{{Module.pcm' is not a valid module file}}
 #import <Module/Module.h>
 #pragma clang __debug crash;
 
 #else
 
-// expected-error@+1{{Module.pcm' is not a valid precompiled module file}}
+// expected-error@+1{{Module.pcm' is not a valid module file}}
 @import Module;
 #pragma clang __debug crash;
 

--- a/clang/test/Modules/ignored_macros.m
+++ b/clang/test/Modules/ignored_macros.m
@@ -10,7 +10,7 @@
 // RUN: %clang_cc1 -fmodules-cache-path=%t.modules -fmodules -fimplicit-module-maps -I %S/Inputs -emit-pch -o %t.pch -x objective-c-header %s -verify
 // RUN: not %clang_cc1 -fmodules-cache-path=%t.modules -DIGNORED=1 -fmodules -fimplicit-module-maps -I %S/Inputs -include-pch %t.pch %s > %t.err 2>&1
 // RUN: FileCheck -check-prefix=CHECK-CONFLICT %s < %t.err
-// CHECK-CONFLICT: AST file '{{.*}}' was compiled with module cache path
+// CHECK-CONFLICT: precompiled file '{{.*}}' was compiled with module cache path
 
 // Third trial: pass -DIGNORED=1 only to the second invocation, but
 // make it ignored. There should be no failure, IGNORED is defined in

--- a/clang/test/Modules/load_failure.c
+++ b/clang/test/Modules/load_failure.c
@@ -15,7 +15,7 @@
 // RUN: FileCheck -check-prefix=CHECK-FAILURE %s < %t.out
 
 // FIXME: Clean up diagnostic text below and give it a location
-// CHECK-FAILURE: error: C99 was disabled in AST file '{{.*}}load_failure.pcm' but is currently enabled
+// CHECK-FAILURE: error: C99 was disabled in precompiled file '{{.*}}load_failure.pcm' but is currently enabled
 // FIXME: When we have a syntax for modules in C, use that.
 
 

--- a/clang/test/Modules/merge-target-features.cpp
+++ b/clang/test/Modules/merge-target-features.cpp
@@ -20,7 +20,7 @@
 // RUN:   -target-cpu i386 \
 // RUN:   -fsyntax-only merge-target-features.cpp 2>&1 \
 // RUN:   | FileCheck --check-prefix=SUBSET --implicit-check-not=error: %s
-// SUBSET: error: AST file '{{.*}}foo.pcm' was compiled with the target feature '+sse2' but the current translation unit is not
+// SUBSET: error: precompiled file '{{.*}}foo.pcm' was compiled with the target feature '+sse2' but the current translation unit is not
 // SUBSET: error: {{.*}} configuration mismatch
 //
 // RUN: %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
@@ -57,8 +57,8 @@
 // RUN:   -target-cpu i386 -target-feature +cx16 \
 // RUN:   -fsyntax-only merge-target-features.cpp 2>&1 \
 // RUN:   | FileCheck --check-prefix=MISMATCH --implicit-check-not=error: %s
-// MISMATCH: error: AST file '{{.*}}foo.pcm' was compiled with the target feature '+sse2' but the current translation unit is not
-// MISMATCH: error: current translation unit is compiled with the target feature '+cx16' but the AST file '{{.*}}foo.pcm' was not
+// MISMATCH: error: precompiled file '{{.*}}foo.pcm' was compiled with the target feature '+sse2' but the current translation unit is not
+// MISMATCH: error: current translation unit is compiled with the target feature '+cx16' but the precompiled file '{{.*}}foo.pcm' was not
 // MISMATCH: error: {{.*}} configuration mismatch
 
 #include "foo.h"

--- a/clang/test/Modules/mismatch-diagnostics.cpp
+++ b/clang/test/Modules/mismatch-diagnostics.cpp
@@ -29,5 +29,5 @@ export module mismatching_module;
 
 //--- use.cpp
 import mismatching_module;
-// CHECK: error: POSIX thread support was enabled in AST file '{{.*[/|\\\\]}}mismatching_module.pcm' but is currently disabled
+// CHECK: error: POSIX thread support was enabled in precompiled file '{{.*[/|\\\\]}}mismatching_module.pcm' but is currently disabled
 // CHECK-NEXT: module file {{.*[/|\\\\]}}mismatching_module.pcm cannot be loaded due to a configuration mismatch with the current compilation

--- a/clang/test/Modules/module-imported-by-pch-path.m
+++ b/clang/test/Modules/module-imported-by-pch-path.m
@@ -12,6 +12,6 @@ void test() {
   (void)MyModuleVersion; // should be found by implicit import
 }
 
-// CHECK: module 'MyModule' in AST file '{{.*MyModule.*pcm}}' (imported by AST file '[[PCH:.*header.pch]]') is not defined in any loaded module map file; maybe you need to load '[[PATH:.*folder-with-modulemap]]
+// CHECK: module 'MyModule' in precompiled file '{{.*MyModule.*pcm}}' (imported by precompiled file '[[PCH:.*header.pch]]') is not defined in any loaded module map file; maybe you need to load '[[PATH:.*folder-with-modulemap]]
 // CHECK: consider adding '[[PATH]]' to the header search path
 // CHECK: imported by '[[PCH]]'

--- a/clang/test/Modules/module-pch-different-cache-path.c
+++ b/clang/test/Modules/module-pch-different-cache-path.c
@@ -14,5 +14,5 @@
 
 pch_int x = 0;
 
-// CHECK-ERROR: AST file '{{.*}}' was compiled with module cache path '{{.*}}', but the path is currently '{{.*}}'
-// CHECK-SUCCESS-NOT: AST file '{{.*}}' was compiled with module cache path '{{.*}}', but the path is currently '{{.*}}'
+// CHECK-ERROR: precompiled file '{{.*}}' was compiled with module cache path '{{.*}}', but the path is currently '{{.*}}'
+// CHECK-SUCCESS-NOT: precompiled file '{{.*}}' was compiled with module cache path '{{.*}}', but the path is currently '{{.*}}'

--- a/clang/test/Modules/pr62359.cppm
+++ b/clang/test/Modules/pr62359.cppm
@@ -43,7 +43,7 @@ int use() {
   return 0;
 }
 
-// CHECK: OpenMP{{.*}}differs in AST file '{{.*}}Hello.pcm' vs. current file
+// CHECK: OpenMP{{.*}}differs in precompiled file '{{.*}}Hello.pcm' vs. current file
 
 //--- use2.cpp
 // expected-no-diagnostics
@@ -55,5 +55,5 @@ int use2() {
   return 0;
 }
 
-// CHECK: OpenMP{{.*}}differs in AST file '{{.*}}Hello.pcm' vs. current file
+// CHECK: OpenMP{{.*}}differs in precompiled file '{{.*}}Hello.pcm' vs. current file
 // CHECK: use of undeclared identifier 'pragma'

--- a/clang/test/Modules/resolution-change.m
+++ b/clang/test/Modules/resolution-change.m
@@ -11,11 +11,11 @@
 
 // Use the PCH with no way to resolve DependsOnA
 // RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -include-pch %t-A.pch %s -fsyntax-only 2>&1 | FileCheck -check-prefix=CHECK-NODOA %s
-// CHECK-NODOA: module 'DependsOnA' in AST file '{{.*DependsOnA.*pcm}}' (imported by AST file '{{.*A.pch}}') is not defined in any loaded module map
+// CHECK-NODOA: module 'DependsOnA' in precompiled file '{{.*DependsOnA.*pcm}}' (imported by precompiled file '{{.*A.pch}}') is not defined in any loaded module map
 
 // Use the PCH with no way to resolve A
 // RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -I %S/Inputs/modules-with-same-name/DependsOnA -include-pch %t-A.pch %s -fsyntax-only 2>&1 | FileCheck -check-prefix=CHECK-NOA %s
-// CHECK-NOA: module 'A' in AST file '{{.*A.*pcm}}' (imported by AST file '{{.*DependsOnA.*pcm}}') is not defined in any loaded module map
+// CHECK-NOA: module 'A' in precompiled file '{{.*A.*pcm}}' (imported by precompiled file '{{.*DependsOnA.*pcm}}') is not defined in any loaded module map
 
 // Use the PCH and have it resolve to the other A
 // RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -I %S/Inputs/modules-with-same-name/DependsOnA -I %S/Inputs/modules-with-same-name/path2/A -include-pch %t-A.pch %s -fsyntax-only 2>&1 | FileCheck -check-prefix=CHECK-WRONGA %s

--- a/clang/test/PCH/arc.m
+++ b/clang/test/PCH/arc.m
@@ -1,5 +1,6 @@
 // REQUIRES: x86-registered-target
 // Test this without pch.
+
 // RUN: %clang_cc1 -fblocks -triple x86_64-apple-darwin11 -fobjc-arc -include %S/Inputs/arc.h -emit-llvm-only %s
 
 // Test with pch.
@@ -14,5 +15,5 @@
 array0 a0;
 array1 a1;
 
-// CHECK-ERR1: Objective-C automated reference counting was enabled in AST file '{{.*}}' but is currently disabled
-// CHECK-ERR2: Objective-C automated reference counting was disabled in AST file '{{.*}}' but is currently enabled
+// CHECK-ERR1: Objective-C automated reference counting was enabled in precompiled file '{{.*}}' but is currently disabled
+// CHECK-ERR2: Objective-C automated reference counting was disabled in precompiled file '{{.*}}' but is currently enabled

--- a/clang/test/PCH/fuzzy-pch.c
+++ b/clang/test/PCH/fuzzy-pch.c
@@ -24,8 +24,8 @@ BAR bar = 17;
 #  error BAR was not defined
 #endif
 
-// CHECK-FOO: definition of macro 'FOO' differs between the AST file '{{.*}}' ('1') and the command line ('blah')
-// CHECK-NOFOO: macro 'FOO' was defined in the AST file '{{.*}}' but undef'd on the command line
+// CHECK-FOO: definition of macro 'FOO' differs between the precompiled file '{{.*}}' ('1') and the command line ('blah')
+// CHECK-NOFOO: macro 'FOO' was defined in the precompiled file '{{.*}}' but undef'd on the command line
 
-// CHECK-UNDEF: command line contains '-undef' but AST file '{{.*}}' was not built with it
+// CHECK-UNDEF: command line contains '-undef' but precompiled file '{{.*}}' was not built with it
 

--- a/clang/test/PCH/module-hash-difference.m
+++ b/clang/test/PCH/module-hash-difference.m
@@ -4,5 +4,5 @@
 // RUN: not %clang_cc1 -fsyntax-only -include-pch %t.pch %s -I %S/Inputs/modules -fmodules -fimplicit-module-maps -fmodules-cache-path=%t.mcp -fdisable-module-hash 2> %t.err
 // RUN: FileCheck -input-file=%t.err %s
 
-// CHECK: error: AST file '{{.*}}' was compiled with module cache path {{.*}}, but the path is currently {{.*}}
+// CHECK: error: precompiled file '{{.*}}' was compiled with module cache path {{.*}}, but the path is currently {{.*}}
 @import Foo;

--- a/clang/test/PCH/ms-pch-macro.c
+++ b/clang/test/PCH/ms-pch-macro.c
@@ -33,7 +33,7 @@ BAR bar = 17;
 #  error BAR was not defined
 #endif
 
-// CHECK-FOO: definition of macro 'FOO' differs between the AST file '{{.*}}1.pch' ('1') and the command line ('blah')
-// CHECK-NOFOO: macro 'FOO' was defined in the AST file '{{.*}}1.pch' but undef'd on the command line
+// CHECK-FOO: definition of macro 'FOO' differs between the precompiled file '{{.*}}1.pch' ('1') and the command line ('blah')
+// CHECK-NOFOO: macro 'FOO' was defined in the precompiled file '{{.*}}1.pch' but undef'd on the command line
 
 // expected-warning@2 {{definition of macro 'BAR' does not match definition in precompiled header}}

--- a/clang/test/PCH/no-validate-pch.cl
+++ b/clang/test/PCH/no-validate-pch.cl
@@ -16,8 +16,8 @@
 // CHECK: note: previous definition is here
 // CHECK: #define X 4
 
-// CHECK-VAL: error: __OPTIMIZE__ predefined macro was enabled in AST file '{{.*}}' but is currently disabled
-// CHECK-VAL: error: definition of macro 'X' differs between the AST file '{{.*}}' ('4') and the command line ('5')
+// CHECK-VAL: error: __OPTIMIZE__ predefined macro was enabled in precompiled file '{{.*}}' but is currently disabled
+// CHECK-VAL: error: definition of macro 'X' differs between the precompiled file '{{.*}}' ('4') and the command line ('5')
 
 void test(void) {
   int a = ONE;


### PR DESCRIPTION
As follow up to: https://github.com/llvm/llvm-project/commit/883130e33325282cfd31b68f5db52891442c20b7 