### PR TITLE
[lld][macho] fix test failure by adding # REQUIRES: aarch64

### DIFF
--- a/lld/test/MachO/order-file-strip-hashes.s
+++ b/lld/test/MachO/order-file-strip-hashes.s
@@ -1,3 +1,5 @@
+# REQUIRES: aarch64
+
 # RUN: rm -rf %t && split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/a.s -o %t/a.o
 


### PR DESCRIPTION
fix the test failures caused by https://github.com/llvm/llvm-project/pull/140670

https://lab.llvm.org/buildbot/#/builders/144/builds/26745

```
FAIL: lld::order-file-strip-hashes.s
[view all 14 lines](https://lab.llvm.org/buildbot/#/builders/144/builds/26745/steps/6/logs/FAIL__lld__order-file-strip-hashes_s) 
******************** TEST 'lld :: MachO/order-file-strip-hashes.s' FAILED ********************
Exit Code: 1
Command Output (stderr):
--
rm -rf /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/tools/lld/test/MachO/Output/order-file-strip-hashes.s.tmp && split-file /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/llvm-project/lld/test/MachO/order-file-strip-hashes.s /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/tools/lld/test/MachO/Output/order-file-strip-hashes.s.tmp # RUN: at line 1
+ rm -rf /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/tools/lld/test/MachO/Output/order-file-strip-hashes.s.tmp
+ split-file /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/llvm-project/lld/test/MachO/order-file-strip-hashes.s /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/tools/lld/test/MachO/Output/order-file-strip-hashes.s.tmp
/home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/bin/llvm-mc -filetype=obj -triple=arm64-apple-darwin /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/tools/lld/test/MachO/Output/order-file-strip-hashes.s.tmp/a.s -o /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/tools/lld/test/MachO/Output/order-file-strip-hashes.s.tmp/a.o # RUN: at line 2
+ /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/bin/llvm-mc -filetype=obj -triple=arm64-apple-darwin /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/tools/lld/test/MachO/Output/order-file-strip-hashes.s.tmp/a.s -o /home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/tools/lld/test/MachO/Output/order-file-strip-hashes.s.tmp/a.o
/home/buildbot/buildbot-root/llvm-clang-x86_64-sie-ubuntu-fast/build/bin/llvm-mc: error: unable to get target for 'arm64-apple-darwin', see --version and --triple.
```