### PR TITLE
modulemap: add arm64 intrinsics header

### DIFF
--- a/clang/lib/Headers/module.modulemap
+++ b/clang/lib/Headers/module.modulemap
@@ -35,6 +35,14 @@ module _Builtin_intrinsics [system] [extern_c] {
     }
   }
 
+  explicit module arm64 {
+    requires arm64
+    requires windows
+
+    header "arm64intr.h"
+    export *
+  }
+
   explicit module intel {
     requires x86
     export *


### PR DESCRIPTION
The header was missing from the modulemap definition, resulting in a breakage for Swift with recent Windows SDK headers.