### PR TITLE
[ctxprof] Instrumentation: handle direct call targets to aliases

### DIFF
--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1343,7 +1343,8 @@ public:
   Use &getCalledOperandUse() { return Op<CalledOperandOpEndIdx>(); }
 
   /// Returns the function called, or null if this is an indirect function
-  /// invocation or the function signature does not match the call signature.
+  /// invocation or the function signature does not match the call signature, or
+  /// the call target is an alias.
   Function *getCalledFunction() const {
     if (auto *F = dyn_cast_or_null<Function>(getCalledOperand()))
       if (F->getValueType() == getFunctionType())

--- a/llvm/include/llvm/IR/IntrinsicInst.h
+++ b/llvm/include/llvm/IR/IntrinsicInst.h
@@ -1536,7 +1536,7 @@ public:
   static bool canInstrumentCallsite(const CallBase &CB) {
     return !CB.isInlineAsm() &&
            (CB.isIndirectCall() ||
-            (CB.getCalledFunction() && !CB.getCalledFunction()->isIntrinsic()));
+            (CB.getIntrinsicID() == Intrinsic::not_intrinsic));
   }
   LLVM_ABI Value *getCallee() const;
   LLVM_ABI void setCallee(Value *Callee);

--- a/llvm/test/Transforms/PGOProfile/ctx-instrumentation-aliases.ll
+++ b/llvm/test/Transforms/PGOProfile/ctx-instrumentation-aliases.ll
@@ -1,0 +1,25 @@
+; REQUIRES: x86-registered-target
+; Test that calls to aliases are instrumented, and the assembly references the
+; aliased function.
+;
+; RUN: opt -passes=ctx-instr-gen,assign-guid,ctx-instr-lower -profile-context-root=an_entrypoint \
+; RUN:   -profile-context-root=another_entrypoint_no_callees \
+; RUN:   -S %s -o %t.ll
+; RUN: llc < %t.ll | FileCheck %s
+target triple = "x86_64-unknown-linux-gnu"
+
+@foo_alias = weak_odr unnamed_addr alias void (), ptr @foo
+
+define void @foo(i32) {
+  ret void
+}
+
+define void @call_alias(ptr %a) {
+entry:
+  call void @foo(i32 0, ptr %a)
+  ret void
+}
+
+; CHECK-LABEL:   call_alias:
+; CHECK:         movq    foo@GOTPCREL(%rip), [[REG:%r[a-z0-9]+]]
+; CHECK-NEXT:    movq    [[REG]], %fs:__llvm_ctx_profile_expected_callee@TPOFF{{.*}}


### PR DESCRIPTION
This was an oversight. GlobalAliases aren't `Functions`, so `getCalledFunction` would return `nullptr` and the callsite would be deemed as uninstrumentable.