### PR TITLE
[flang] Support nested hermetic modules in hermetic module files

### DIFF
--- a/flang/docs/ModFiles.md
+++ b/flang/docs/ModFiles.md
@@ -172,6 +172,11 @@ When the compiler reads a hermetic module file, the copies of the dependent
 modules are read into their own scope, and will not conflict with other modules
 of the same name that client code might `USE`.
 
+The copies of the module files can be copies of hermetic modules as well,
+in which case they and their dependencies are surrounded by compiler directives
+(`!DIR$ BEGIN_NESTED_HERMETIC_MODULE` and `!DIR$ END_NESTED_HERMETIC_MODULE`)
+to represent the nesting.
+
 One can use the `-fhermetic-module-files` option when building the top-level
 module files of a library for which not all of the implementation modules
 will (or can) be shipped.

--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -214,6 +214,8 @@ public:
   NODE(CompilerDirective, NoVector)
   NODE(CompilerDirective, NoUnroll)
   NODE(CompilerDirective, NoUnrollAndJam)
+  NODE(CompilerDirective, BeginNestedHermeticModule)
+  NODE(CompilerDirective, EndNestedHermeticModule)
   NODE(parser, ComplexLiteralConstant)
   NODE(parser, ComplexPart)
   NODE(parser, ComponentArraySpec)

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3354,6 +3354,8 @@ struct StmtFunctionStmt {
 // !DIR$ NOVECTOR
 // !DIR$ NOUNROLL
 // !DIR$ NOUNROLL_AND_JAM
+// !DIR$ BEGIN_NESTED_HERMETIC_MODULE
+// !DIR$ END_NESTED_HERMETIC_MODULE
 // !DIR$ <anything else>
 struct CompilerDirective {
   UNION_CLASS_BOILERPLATE(CompilerDirective);
@@ -3382,11 +3384,14 @@ struct CompilerDirective {
   EMPTY_CLASS(NoVector);
   EMPTY_CLASS(NoUnroll);
   EMPTY_CLASS(NoUnrollAndJam);
+  EMPTY_CLASS(BeginNestedHermeticModule);
+  EMPTY_CLASS(EndNestedHermeticModule);
   EMPTY_CLASS(Unrecognized);
   CharBlock source;
   std::variant<std::list<IgnoreTKR>, LoopCount, std::list<AssumeAligned>,
-      VectorAlways, std::list<NameValue>, Unroll, UnrollAndJam, Unrecognized,
-      NoVector, NoUnroll, NoUnrollAndJam>
+      VectorAlways, std::list<NameValue>, Unroll, UnrollAndJam, NoVector,
+      NoUnroll, NoUnrollAndJam, BeginNestedHermeticModule,
+      EndNestedHermeticModule, Unrecognized>
       u;
 };
 

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -94,6 +94,8 @@ public:
   void set_moduleFileHash(ModuleCheckSumType x) { moduleFileHash_ = x; }
   const Symbol *previous() const { return previous_; }
   void set_previous(const Symbol *p) { previous_ = p; }
+  bool isHermetic() const { return isHermetic_; }
+  void set_isHermetic(bool yes = true) { isHermetic_ = yes; }
 
 private:
   bool isSubmodule_;
@@ -101,6 +103,7 @@ private:
   const Scope *scope_{nullptr};
   std::optional<ModuleCheckSumType> moduleFileHash_;
   const Symbol *previous_{nullptr}; // same name, different module file hash
+  bool isHermetic_{false};
 };
 
 class MainProgramDetails : public WithOmpDeclarative {
@@ -690,7 +693,6 @@ public:
   const SymbolVector &specificProcs() const { return specificProcs_; }
   const std::vector<SourceName> &bindingNames() const { return bindingNames_; }
   void AddSpecificProc(const Symbol &, SourceName bindingName);
-  const SymbolVector &uses() const { return uses_; }
 
   // specific and derivedType indicate a specific procedure or derived type
   // with the same name as this generic. Only one of them may be set in
@@ -704,7 +706,10 @@ public:
   const Symbol *derivedType() const { return derivedType_; }
   void set_derivedType(Symbol &derivedType);
   void clear_derivedType();
-  void AddUse(const Symbol &);
+  const std::optional<UseDetails> originalUseDetails() const {
+    return originalUseDetails_;
+  }
+  void set_originalUseDetails(const UseDetails &x) { originalUseDetails_ = x; }
 
   // Copy in specificProcs, specific, and derivedType from another generic
   void CopyFrom(const GenericDetails &);
@@ -719,12 +724,11 @@ private:
   // all of the specific procedures for this generic
   SymbolVector specificProcs_;
   std::vector<SourceName> bindingNames_;
-  // Symbols used from other modules merged into this one
-  SymbolVector uses_;
   // a specific procedure with the same name as this generic, if any
   Symbol *specific_{nullptr};
   // a derived type with the same name as this generic, if any
   Symbol *derivedType_{nullptr};
+  std::optional<UseDetails> originalUseDetails_;
 };
 llvm::raw_ostream &operator<<(llvm::raw_ostream &, const GenericDetails &);
 

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1294,6 +1294,8 @@ TYPE_PARSER(construct<StatOrErrmsg>("STAT =" >> statVariable) ||
 // !DIR$ LOOP COUNT (n1[, n2]...)
 // !DIR$ name[=value] [, name[=value]]...
 // !DIR$ UNROLL [n]
+// !DIR$ BEGIN_NESTED_HERMETIC_MODULE
+// !DIR$ END_NESTED_HERMETIC_MODULE
 // !DIR$ <anything else>
 constexpr auto ignore_tkr{
     "IGNORE_TKR" >> optionalList(construct<CompilerDirective::IgnoreTKR>(
@@ -1315,18 +1317,23 @@ constexpr auto nounroll{"NOUNROLL" >> construct<CompilerDirective::NoUnroll>()};
 constexpr auto nounrollAndJam{
     "NOUNROLL_AND_JAM" >> construct<CompilerDirective::NoUnrollAndJam>()};
 TYPE_PARSER(beginDirective >> "DIR$ "_tok >>
-    sourced((construct<CompilerDirective>(ignore_tkr) ||
-                construct<CompilerDirective>(loopCount) ||
-                construct<CompilerDirective>(assumeAligned) ||
-                construct<CompilerDirective>(vectorAlways) ||
-                construct<CompilerDirective>(unrollAndJam) ||
-                construct<CompilerDirective>(unroll) ||
-                construct<CompilerDirective>(novector) ||
-                construct<CompilerDirective>(nounrollAndJam) ||
-                construct<CompilerDirective>(nounroll) ||
-                construct<CompilerDirective>(
-                    many(construct<CompilerDirective::NameValue>(
-                        name, maybe(("="_tok || ":"_tok) >> digitString64))))) /
+    sourced(
+        (construct<CompilerDirective>(ignore_tkr) ||
+            construct<CompilerDirective>(loopCount) ||
+            construct<CompilerDirective>(assumeAligned) ||
+            construct<CompilerDirective>(vectorAlways) ||
+            construct<CompilerDirective>(unrollAndJam) ||
+            construct<CompilerDirective>(unroll) ||
+            construct<CompilerDirective>(novector) ||
+            construct<CompilerDirective>(nounrollAndJam) ||
+            construct<CompilerDirective>(nounroll) ||
+            construct<CompilerDirective>("BEGIN_NESTED_HERMETIC_MODULE" >>
+                construct<CompilerDirective::BeginNestedHermeticModule>()) ||
+            construct<CompilerDirective>("End_NESTED_HERMETIC_MODULE" >>
+                construct<CompilerDirective::EndNestedHermeticModule>()) ||
+            construct<CompilerDirective>(
+                many(construct<CompilerDirective::NameValue>(
+                    name, maybe(("="_tok || ":"_tok) >> digitString64))))) /
             endOfStmt ||
         construct<CompilerDirective>(pure<CompilerDirective::Unrecognized>()) /
             SkipTo<'\n'>{}))

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -1867,6 +1867,12 @@ public:
             [&](const CompilerDirective::NoUnrollAndJam &) {
               Word("!DIR$ NOUNROLL_AND_JAM");
             },
+            [&](const CompilerDirective::BeginNestedHermeticModule &) {
+              Word("!DIR$ BEGIN_NESTED_HERMETIC_MODULE");
+            },
+            [&](const CompilerDirective::EndNestedHermeticModule &) {
+              Word("!DIR$ END_NESTED_HERMETIC_MODULE");
+            },
             [&](const CompilerDirective::Unrecognized &) {
               Word("!DIR$ ");
               Word(x.source.ToString());

--- a/flang/lib/Semantics/mod-file.h
+++ b/flang/lib/Semantics/mod-file.h
@@ -66,6 +66,7 @@ private:
   void WriteAll(const Scope &);
   void WriteOne(const Scope &);
   void Write(const Symbol &);
+  std::string WriteModuleAndDependents(const Symbol &);
   std::string GetAsString(const Symbol &);
   void PrepareRenamings(const Scope &);
   void PutSymbols(const Scope &, UnorderedSymbolSet *hermetic);

--- a/flang/test/Semantics/modfile07.f90
+++ b/flang/test/Semantics/modfile07.f90
@@ -399,10 +399,14 @@ contains
 end
 !Expect: m7c.mod
 !module m7c
-! use m7a, only: g => g_integer
-! use m7b, only: g => g_real
+! usem7a, only: m7a$s=>s
+! usem7b, only: m7b$s=>s
+! private::m7a$s
+! private::m7b$s
 ! private :: s
 ! interface g
+!  procedure :: m7a$s
+!  procedure :: m7b$s
 !  procedure :: s
 ! end interface
 !contains
@@ -481,10 +485,14 @@ contains
 end
 !Expect: m8c.mod
 !module m8c
-! use m8a, only: g
-! use m8b, only: g
+! usem8a,only:m8a$s=>s
+! usem8b,only:m8b$s=>s
+! private::m8a$s
+! private::m8b$s
 ! private :: s
 ! interface g
+!  procedure::m8a$s
+!  procedure::m8b$s
 !  procedure :: s
 ! end interface
 !contains
@@ -536,10 +544,12 @@ contains
 end
 !Expect: m9b.mod
 !module m9b
-! use m9a,only:g
+! use m9a,only:m9a$s=>s
+! private::m9a$s
 ! private::s
 ! interface g
-!   procedure::s
+!  procedure::m9a$s
+!  procedure::s
 ! end interface
 !contains
 ! subroutine s(x)
@@ -553,22 +563,48 @@ end
 
 module m10a
   interface operator(.ne.)
+    module procedure proc
   end interface
+ contains
+  elemental logical function proc(x, y)
+    logical, intent(in) :: x
+    integer, intent(in) :: y
+  end
 end
 !Expect: m10a.mod
 !module m10a
 ! interface operator(.ne.)
+!  procedure::proc
 ! end interface
+!contains
+! elementalfunctionproc(x,y)
+!  logical(4),intent(in)::x
+!  integer(4),intent(in)::y
+!  logical(4)::proc
+! end
 !end
 
 module m10b
   interface operator(<>)
+    module procedure proc
   end interface
+ contains
+  elemental logical function proc(x, y)
+    logical, intent(in) :: x
+    real, intent(in) :: y
+  end
 end
 !Expect: m10b.mod
 !module m10b
 ! interface operator(<>)
+!  procedure::proc
 ! end interface
+!contains
+! elementalfunctionproc(x,y)
+!  logical(4),intent(in)::x
+!  real(4),intent(in)::y
+!  logical(4)::proc
+! end
 !end
 
 module m10c
@@ -579,9 +615,13 @@ module m10c
 end
 !Expect: m10c.mod
 !module m10c
-! use m10a,only:operator(.ne.)
-! use m10b,only:operator(.ne.)
+! usem10a,only:m10a$proc=>proc
+! usem10b,only:m10b$proc=>proc
+! private::m10a$proc
+! private::m10b$proc
 ! interface operator(.ne.)
+!  procedure::m10a$proc
+!  procedure::m10b$proc
 ! end interface
 !end
 
@@ -592,9 +632,13 @@ module m10d
 end
 !Expect: m10d.mod
 !module m10d
-! use m10a,only:operator(.ne.)
-! use m10c,only:operator(.ne.)
+! usem10a,only:m10a$proc=>proc
+! usem10b,only:m10b$proc=>proc
+! private::m10a$proc
+! private::m10b$proc
 ! interface operator(.ne.)
+!  procedure::m10a$proc
+!  procedure::m10b$proc
 ! end interface
 ! private::operator(.ne.)
 !end

--- a/flang/test/Semantics/modfile69.f90
+++ b/flang/test/Semantics/modfile69.f90
@@ -21,7 +21,6 @@ end
 !Expect: m2.mod
 !module m2
 !use m1,only:bar=>foo
-!use m1,only:bar=>foo
 !interface bar
 !end interface
 !end

--- a/flang/test/Semantics/modfile76.F90
+++ b/flang/test/Semantics/modfile76.F90
@@ -1,0 +1,26 @@
+!RUN: %flang -c -fhermetic-module-files -DWHICH=1 %s && %flang -c -fhermetic-module-files -DWHICH=2 %s && %flang -c -fhermetic-module-files %s && cat modfile76c.mod | FileCheck %s
+
+#if WHICH == 1
+module modfile76a
+  integer :: global_variable = 0
+end
+#elif WHICH == 2
+module modfile76b
+  use modfile76a
+ contains
+  subroutine test
+  end
+end
+#else
+module modfile76c
+  use modfile76a
+  use modfile76b
+end
+#endif
+
+!CHECK: module modfile76c
+!CHECK: module modfile76a
+!CHECK: !dir$ begin_nested_hermetic_module
+!CHECK: module modfile76b
+!CHECK: module modfile76a
+!CHECK: !dir$ end_nested_hermetic_module

--- a/flang/test/Semantics/modfile77.F90
+++ b/flang/test/Semantics/modfile77.F90
@@ -1,0 +1,37 @@
+!RUN: %flang -c -fhermetic-module-files -DWHICH=1 %s && %flang -c -fhermetic-module-files -DWHICH=2 %s && %flang -c -fhermetic-module-files %s && cat modfile77c.mod | FileCheck %s
+
+#if WHICH == 1
+module modfile77a
+  interface gen
+    procedure proc
+  end interface
+ contains
+  subroutine proc
+    print *, 'ok'
+  end
+end
+#elif WHICH == 2
+module modfile77b
+  use modfile77a
+end
+#else
+module modfile77c
+  use modfile77a
+  use modfile77b
+end
+#endif
+
+!CHECK: module modfile77c
+!CHECK: use modfile77a,only:proc
+!CHECK: interface gen
+!CHECK: procedure::proc
+!CHECK: end interface
+!CHECK: end
+!CHECK: module modfile77a
+!CHECK: interface gen
+!CHECK: procedure::proc
+!CHECK: end interface
+!CHECK: contains
+!CHECK: subroutine proc()
+!CHECK: end
+!CHECK: end


### PR DESCRIPTION
When a module is built with -fhermetic-module-files, the non-intrinsic modules on which it depends are copied into its module file so that they don't have to be available on any search path when the module file is parsed.  When one of these nested modules was itself built hermetically, its dependencies also need to be copied.

This can lead to problems with duplication.  This patch adds compiler directives to the module file to preserve the nesting structure.