### PR TITLE
[clang-doc] Fix brittle check in test

### DIFF
--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -267,7 +267,8 @@ static llvm::Error handleMappingFailures(llvm::Error Err) {
 
 static llvm::Error createDirectories(llvm::StringRef OutDirectory) {
   if (std::error_code Err = llvm::sys::fs::create_directories(OutDirectory))
-    return llvm::createFileError(OutDirectory, Err);
+    return llvm::createFileError(OutDirectory, Err,
+                                 "failed to create directory.");
   return llvm::Error::success();
 }
 

--- a/clang-tools-extra/test/clang-doc/invalid-options.cpp
+++ b/clang-tools-extra/test/clang-doc/invalid-options.cpp
@@ -2,7 +2,7 @@
 // RUN: rm -rf %t && touch %t
 // RUN: not clang-doc %s -output=%t/subdir 2>&1 | FileCheck %s --check-prefix=OUTPUT-FAIL
 // OUTPUT-FAIL: clang-doc error:
-// OUTPUT-FAIL: {{(Not a directory|[Nn]o such file or directory)}}
+// OUTPUT-FAIL-SAME: failed to create directory.
 
 /// Invalid format option.
 // RUN: rm -rf %t && mkdir %t && touch %t/file


### PR DESCRIPTION
Instead of having a platform specific error diagnostic, use a fixed one
with more direct context for the error.