### PR TITLE
[llvm] annotate interfaces in llvm/ObjCopy and llvm/Object for DLL export

### DIFF
--- a/llvm/include/llvm/ObjCopy/COFF/COFFObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/COFF/COFFObjcopy.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_OBJCOPY_COFF_COFFOBJCOPY_H
 #define LLVM_OBJCOPY_COFF_COFFOBJCOPY_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class Error;
 class raw_ostream;

--- a/llvm/include/llvm/ObjCopy/COFF/COFFObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/COFF/COFFObjcopy.h
@@ -26,7 +26,7 @@ namespace coff {
 /// Apply the transformations described by \p Config and \p COFFConfig
 /// to \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnBinary(const CommonConfig &Config, const COFFConfig &,
+LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config, const COFFConfig &,
                              object::COFFObjectFile &In, raw_ostream &Out);
 
 } // end namespace coff

--- a/llvm/include/llvm/ObjCopy/COFF/COFFObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/COFF/COFFObjcopy.h
@@ -28,8 +28,10 @@ namespace coff {
 /// Apply the transformations described by \p Config and \p COFFConfig
 /// to \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config, const COFFConfig &,
-                             object::COFFObjectFile &In, raw_ostream &Out);
+LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config,
+                                      const COFFConfig &,
+                                      object::COFFObjectFile &In,
+                                      raw_ostream &Out);
 
 } // end namespace coff
 } // end namespace objcopy

--- a/llvm/include/llvm/ObjCopy/CommonConfig.h
+++ b/llvm/include/llvm/ObjCopy/CommonConfig.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_OBJCOPY_COMMONCONFIG_H
 #define LLVM_OBJCOPY_COMMONCONFIG_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/CachedHashString.h"
 #include "llvm/ADT/DenseSet.h"
@@ -17,6 +16,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/ELFTypes.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/MemoryBuffer.h"

--- a/llvm/include/llvm/ObjCopy/CommonConfig.h
+++ b/llvm/include/llvm/ObjCopy/CommonConfig.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OBJCOPY_COMMONCONFIG_H
 #define LLVM_OBJCOPY_COMMONCONFIG_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/CachedHashString.h"
 #include "llvm/ADT/DenseSet.h"
@@ -104,7 +105,7 @@ class NameOrPattern {
 public:
   // ErrorCallback is used to handle recoverable errors. An Error returned
   // by the callback aborts the parsing and is then returned by this function.
-  static Expected<NameOrPattern>
+  LLVM_ABI static Expected<NameOrPattern>
   create(StringRef Pattern, MatchStyle MS,
          llvm::function_ref<Error(Error)> ErrorCallback);
 

--- a/llvm/include/llvm/ObjCopy/ConfigManager.h
+++ b/llvm/include/llvm/ObjCopy/ConfigManager.h
@@ -9,14 +9,14 @@
 #ifndef LLVM_OBJCOPY_CONFIGMANAGER_H
 #define LLVM_OBJCOPY_CONFIGMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ObjCopy/COFF/COFFConfig.h"
 #include "llvm/ObjCopy/CommonConfig.h"
 #include "llvm/ObjCopy/ELF/ELFConfig.h"
 #include "llvm/ObjCopy/MachO/MachOConfig.h"
 #include "llvm/ObjCopy/MultiFormatConfig.h"
-#include "llvm/ObjCopy/wasm/WasmConfig.h"
 #include "llvm/ObjCopy/XCOFF/XCOFFConfig.h"
+#include "llvm/ObjCopy/wasm/WasmConfig.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace objcopy {

--- a/llvm/include/llvm/ObjCopy/ConfigManager.h
+++ b/llvm/include/llvm/ObjCopy/ConfigManager.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OBJCOPY_CONFIGMANAGER_H
 #define LLVM_OBJCOPY_CONFIGMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ObjCopy/COFF/COFFConfig.h"
 #include "llvm/ObjCopy/CommonConfig.h"
 #include "llvm/ObjCopy/ELF/ELFConfig.h"
@@ -20,7 +21,7 @@
 namespace llvm {
 namespace objcopy {
 
-struct ConfigManager : public MultiFormatConfig {
+struct LLVM_ABI ConfigManager : public MultiFormatConfig {
   virtual ~ConfigManager() {}
 
   const CommonConfig &getCommonConfig() const override { return Common; }

--- a/llvm/include/llvm/ObjCopy/ELF/ELFObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/ELF/ELFObjcopy.h
@@ -27,7 +27,7 @@ namespace elf {
 /// \p In, which must represent an IHex file, and writes the result
 /// into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnIHex(const CommonConfig &Config,
+LLVM_ABI Error executeObjcopyOnIHex(const CommonConfig &Config,
                            const ELFConfig &ELFConfig, MemoryBuffer &In,
                            raw_ostream &Out);
 
@@ -35,14 +35,14 @@ Error executeObjcopyOnIHex(const CommonConfig &Config,
 /// \p In, which is treated as a raw binary input, and writes the result
 /// into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnRawBinary(const CommonConfig &Config,
+LLVM_ABI Error executeObjcopyOnRawBinary(const CommonConfig &Config,
                                 const ELFConfig &ELFConfig, MemoryBuffer &In,
                                 raw_ostream &Out);
 
 /// Apply the transformations described by \p Config and \p ELFConfig to
 /// \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnBinary(const CommonConfig &Config,
+LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config,
                              const ELFConfig &ELFConfig,
                              object::ELFObjectFileBase &In, raw_ostream &Out);
 

--- a/llvm/include/llvm/ObjCopy/ELF/ELFObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/ELF/ELFObjcopy.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_OBJCOPY_ELF_ELFOBJCOPY_H
 #define LLVM_OBJCOPY_ELF_ELFOBJCOPY_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class Error;
 class MemoryBuffer;

--- a/llvm/include/llvm/ObjCopy/ELF/ELFObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/ELF/ELFObjcopy.h
@@ -30,23 +30,24 @@ namespace elf {
 /// into \p Out.
 /// \returns any Error encountered whilst performing the operation.
 LLVM_ABI Error executeObjcopyOnIHex(const CommonConfig &Config,
-                           const ELFConfig &ELFConfig, MemoryBuffer &In,
-                           raw_ostream &Out);
+                                    const ELFConfig &ELFConfig,
+                                    MemoryBuffer &In, raw_ostream &Out);
 
 /// Apply the transformations described by \p Config and \p ELFConfig to
 /// \p In, which is treated as a raw binary input, and writes the result
 /// into \p Out.
 /// \returns any Error encountered whilst performing the operation.
 LLVM_ABI Error executeObjcopyOnRawBinary(const CommonConfig &Config,
-                                const ELFConfig &ELFConfig, MemoryBuffer &In,
-                                raw_ostream &Out);
+                                         const ELFConfig &ELFConfig,
+                                         MemoryBuffer &In, raw_ostream &Out);
 
 /// Apply the transformations described by \p Config and \p ELFConfig to
 /// \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
 LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config,
-                             const ELFConfig &ELFConfig,
-                             object::ELFObjectFileBase &In, raw_ostream &Out);
+                                      const ELFConfig &ELFConfig,
+                                      object::ELFObjectFileBase &In,
+                                      raw_ostream &Out);
 
 } // end namespace elf
 } // end namespace objcopy

--- a/llvm/include/llvm/ObjCopy/MachO/MachOObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/MachO/MachOObjcopy.h
@@ -27,14 +27,14 @@ namespace macho {
 /// Apply the transformations described by \p Config and \p MachOConfig to
 /// \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnBinary(const CommonConfig &Config,
+LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config,
                              const MachOConfig &MachOConfig,
                              object::MachOObjectFile &In, raw_ostream &Out);
 
 /// Apply the transformations described by \p Config and \p MachOConfig to
 /// \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnMachOUniversalBinary(
+LLVM_ABI Error executeObjcopyOnMachOUniversalBinary(
     const MultiFormatConfig &Config, const object::MachOUniversalBinary &In,
     raw_ostream &Out);
 

--- a/llvm/include/llvm/ObjCopy/MachO/MachOObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/MachO/MachOObjcopy.h
@@ -30,8 +30,9 @@ namespace macho {
 /// \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
 LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config,
-                             const MachOConfig &MachOConfig,
-                             object::MachOObjectFile &In, raw_ostream &Out);
+                                      const MachOConfig &MachOConfig,
+                                      object::MachOObjectFile &In,
+                                      raw_ostream &Out);
 
 /// Apply the transformations described by \p Config and \p MachOConfig to
 /// \p In and writes the result into \p Out.

--- a/llvm/include/llvm/ObjCopy/MachO/MachOObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/MachO/MachOObjcopy.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_OBJCOPY_MACHO_MACHOOBJCOPY_H
 #define LLVM_OBJCOPY_MACHO_MACHOOBJCOPY_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class Error;
 class raw_ostream;

--- a/llvm/include/llvm/ObjCopy/ObjCopy.h
+++ b/llvm/include/llvm/ObjCopy/ObjCopy.h
@@ -28,14 +28,14 @@ class MultiFormatConfig;
 /// Writes a result in a file specified by \p Config.OutputFilename.
 /// \returns any Error encountered whilst performing the operation.
 LLVM_ABI Error executeObjcopyOnArchive(const MultiFormatConfig &Config,
-                              const object::Archive &Ar);
+                                       const object::Archive &Ar);
 
 /// Applies the transformations described by \p Config to \p In and writes
 /// the result into \p Out. This function does the dispatch based on the
 /// format of the input binary (COFF, ELF, MachO or wasm).
 /// \returns any Error encountered whilst performing the operation.
 LLVM_ABI Error executeObjcopyOnBinary(const MultiFormatConfig &Config,
-                             object::Binary &In, raw_ostream &Out);
+                                      object::Binary &In, raw_ostream &Out);
 
 } // end namespace objcopy
 } // end namespace llvm

--- a/llvm/include/llvm/ObjCopy/ObjCopy.h
+++ b/llvm/include/llvm/ObjCopy/ObjCopy.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OBJCOPY_OBJCOPY_H
 #define LLVM_OBJCOPY_OBJCOPY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -26,14 +27,14 @@ class MultiFormatConfig;
 /// each member in archive \p Ar.
 /// Writes a result in a file specified by \p Config.OutputFilename.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnArchive(const MultiFormatConfig &Config,
+LLVM_ABI Error executeObjcopyOnArchive(const MultiFormatConfig &Config,
                               const object::Archive &Ar);
 
 /// Applies the transformations described by \p Config to \p In and writes
 /// the result into \p Out. This function does the dispatch based on the
 /// format of the input binary (COFF, ELF, MachO or wasm).
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnBinary(const MultiFormatConfig &Config,
+LLVM_ABI Error executeObjcopyOnBinary(const MultiFormatConfig &Config,
                              object::Binary &In, raw_ostream &Out);
 
 } // end namespace objcopy

--- a/llvm/include/llvm/ObjCopy/wasm/WasmObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/wasm/WasmObjcopy.h
@@ -25,7 +25,7 @@ namespace wasm {
 /// Apply the transformations described by \p Config and \p WasmConfig
 /// to \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnBinary(const CommonConfig &Config, const WasmConfig &,
+LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config, const WasmConfig &,
                              object::WasmObjectFile &In, raw_ostream &Out);
 
 } // end namespace wasm

--- a/llvm/include/llvm/ObjCopy/wasm/WasmObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/wasm/WasmObjcopy.h
@@ -27,8 +27,10 @@ namespace wasm {
 /// Apply the transformations described by \p Config and \p WasmConfig
 /// to \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config, const WasmConfig &,
-                             object::WasmObjectFile &In, raw_ostream &Out);
+LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config,
+                                      const WasmConfig &,
+                                      object::WasmObjectFile &In,
+                                      raw_ostream &Out);
 
 } // end namespace wasm
 } // end namespace objcopy

--- a/llvm/include/llvm/ObjCopy/wasm/WasmObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/wasm/WasmObjcopy.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_OBJCOPY_WASM_WASMOBJCOPY_H
 #define LLVM_OBJCOPY_WASM_WASMOBJCOPY_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class Error;
 class raw_ostream;

--- a/llvm/include/llvm/Object/Archive.h
+++ b/llvm/include/llvm/Object/Archive.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_ARCHIVE_H
 #define LLVM_OBJECT_ARCHIVE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/fallible_iterator.h"
 #include "llvm/ADT/iterator_range.h"
@@ -61,10 +62,10 @@ public:
   virtual Expected<const char *> getNextChildLoc() const = 0;
   virtual Expected<bool> isThin() const = 0;
 
-  Expected<sys::fs::perms> getAccessMode() const;
-  Expected<sys::TimePoint<std::chrono::seconds>> getLastModified() const;
-  Expected<unsigned> getUID() const;
-  Expected<unsigned> getGID() const;
+  LLVM_ABI Expected<sys::fs::perms> getAccessMode() const;
+  LLVM_ABI Expected<sys::TimePoint<std::chrono::seconds>> getLastModified() const;
+  LLVM_ABI Expected<unsigned> getUID() const;
+  LLVM_ABI Expected<unsigned> getGID() const;
 
   /// Returns the size in bytes of the format-defined member header of the
   /// concrete archive type.
@@ -99,7 +100,7 @@ struct UnixArMemHdrType {
   char Terminator[2];
 };
 
-class ArchiveMemberHeader : public CommonArchiveMemberHeader<UnixArMemHdrType> {
+class LLVM_ABI ArchiveMemberHeader : public CommonArchiveMemberHeader<UnixArMemHdrType> {
 public:
   ArchiveMemberHeader(const Archive *Parent, const char *RawHeaderPtr,
                       uint64_t Size, Error *Err);
@@ -133,7 +134,7 @@ struct BigArMemHdrType {
 };
 
 // Define file member header of AIX big archive.
-class BigArchiveMemberHeader
+class LLVM_ABI BigArchiveMemberHeader
     : public CommonArchiveMemberHeader<BigArMemHdrType> {
 
 public:
@@ -153,7 +154,7 @@ public:
   Expected<bool> isThin() const override { return false; }
 };
 
-class Archive : public Binary {
+class LLVM_ABI Archive : public Binary {
   virtual void anchor();
 
 public:
@@ -171,8 +172,8 @@ public:
     Expected<bool> isThinMember() const;
 
   public:
-    Child(const Archive *Parent, const char *Start, Error *Err);
-    Child(const Archive *Parent, StringRef Data, uint16_t StartOfFile);
+    LLVM_ABI Child(const Archive *Parent, const char *Start, Error *Err);
+    LLVM_ABI Child(const Archive *Parent, StringRef Data, uint16_t StartOfFile);
 
     Child(const Child &C)
         : Parent(C.Parent), Data(C.Data), StartOfFile(C.StartOfFile) {
@@ -218,10 +219,10 @@ public:
     }
 
     const Archive *getParent() const { return Parent; }
-    Expected<Child> getNext() const;
+    LLVM_ABI Expected<Child> getNext() const;
 
-    Expected<StringRef> getName() const;
-    Expected<std::string> getFullName() const;
+    LLVM_ABI Expected<StringRef> getName() const;
+    LLVM_ABI Expected<std::string> getFullName() const;
     Expected<StringRef> getRawName() const { return Header->getRawName(); }
 
     Expected<sys::TimePoint<std::chrono::seconds>> getLastModified() const {
@@ -240,17 +241,17 @@ public:
     }
 
     /// \return the size of the archive member without the header or padding.
-    Expected<uint64_t> getSize() const;
+    LLVM_ABI Expected<uint64_t> getSize() const;
     /// \return the size in the archive header for this member.
-    Expected<uint64_t> getRawSize() const;
+    LLVM_ABI Expected<uint64_t> getRawSize() const;
 
-    Expected<StringRef> getBuffer() const;
-    uint64_t getChildOffset() const;
+    LLVM_ABI Expected<StringRef> getBuffer() const;
+    LLVM_ABI uint64_t getChildOffset() const;
     uint64_t getDataOffset() const { return getChildOffset() + StartOfFile; }
 
-    Expected<MemoryBufferRef> getMemoryBufferRef() const;
+    LLVM_ABI Expected<MemoryBufferRef> getMemoryBufferRef() const;
 
-    Expected<std::unique_ptr<Binary>>
+    LLVM_ABI Expected<std::unique_ptr<Binary>>
     getAsBinary(LLVMContext *Context = nullptr) const;
   };
 
@@ -299,10 +300,10 @@ public:
       return (Parent == other.Parent) && (SymbolIndex == other.SymbolIndex);
     }
 
-    StringRef getName() const;
-    Expected<Child> getMember() const;
-    Symbol getNext() const;
-    bool isECSymbol() const;
+    LLVM_ABI StringRef getName() const;
+    LLVM_ABI Expected<Child> getMember() const;
+    LLVM_ABI Symbol getNext() const;
+    LLVM_ABI bool isECSymbol() const;
   };
 
   class symbol_iterator {
@@ -416,7 +417,7 @@ public:
   bool Has64BitGlobalSymtab = false;
 
 public:
-  BigArchive(MemoryBufferRef Source, Error &Err);
+  LLVM_ABI BigArchive(MemoryBufferRef Source, Error &Err);
   uint64_t getFirstChildOffset() const override { return FirstChildOffset; }
   uint64_t getLastChildOffset() const { return LastChildOffset; }
   bool isEmpty() const override { return getFirstChildOffset() == 0; }

--- a/llvm/include/llvm/Object/Archive.h
+++ b/llvm/include/llvm/Object/Archive.h
@@ -13,12 +13,12 @@
 #ifndef LLVM_OBJECT_ARCHIVE_H
 #define LLVM_OBJECT_ARCHIVE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/fallible_iterator.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -63,7 +63,8 @@ public:
   virtual Expected<bool> isThin() const = 0;
 
   LLVM_ABI Expected<sys::fs::perms> getAccessMode() const;
-  LLVM_ABI Expected<sys::TimePoint<std::chrono::seconds>> getLastModified() const;
+  LLVM_ABI Expected<sys::TimePoint<std::chrono::seconds>>
+  getLastModified() const;
   LLVM_ABI Expected<unsigned> getUID() const;
   LLVM_ABI Expected<unsigned> getGID() const;
 
@@ -100,7 +101,8 @@ struct UnixArMemHdrType {
   char Terminator[2];
 };
 
-class LLVM_ABI ArchiveMemberHeader : public CommonArchiveMemberHeader<UnixArMemHdrType> {
+class LLVM_ABI ArchiveMemberHeader
+    : public CommonArchiveMemberHeader<UnixArMemHdrType> {
 public:
   ArchiveMemberHeader(const Archive *Parent, const char *RawHeaderPtr,
                       uint64_t Size, Error *Err);
@@ -333,8 +335,8 @@ public:
   static Expected<std::unique_ptr<Archive>> create(MemoryBufferRef Source);
 
   // Explicitly non-copyable.
-  Archive(Archive const&) = delete;
-  Archive& operator=(Archive const&) = delete;
+  Archive(Archive const &) = delete;
+  Archive &operator=(Archive const &) = delete;
 
   /// Size field is 10 decimal digits long
   static const uint64_t MaxMemberSize = 9999999999;

--- a/llvm/include/llvm/Object/Archive.h
+++ b/llvm/include/llvm/Object/Archive.h
@@ -75,7 +75,7 @@ public:
 };
 
 template <typename T>
-class CommonArchiveMemberHeader : public AbstractArchiveMemberHeader {
+class LLVM_ABI CommonArchiveMemberHeader : public AbstractArchiveMemberHeader {
 public:
   CommonArchiveMemberHeader(const Archive *Parent, const T *RawHeaderPtr)
       : AbstractArchiveMemberHeader(Parent), ArMemHdr(RawHeaderPtr){};
@@ -331,6 +331,10 @@ public:
 
   Archive(MemoryBufferRef Source, Error &Err);
   static Expected<std::unique_ptr<Archive>> create(MemoryBufferRef Source);
+
+  // Explicitly non-copyable.
+  Archive(Archive const&) = delete;
+  Archive& operator=(Archive const&) = delete;
 
   /// Size field is 10 decimal digits long
   static const uint64_t MaxMemberSize = 9999999999;

--- a/llvm/include/llvm/Object/ArchiveWriter.h
+++ b/llvm/include/llvm/Object/ArchiveWriter.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_OBJECT_ARCHIVEWRITER_H
 #define LLVM_OBJECT_ARCHIVEWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Object/Archive.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -36,10 +36,11 @@ struct NewArchiveMember {
   getOldMember(const object::Archive::Child &OldMember, bool Deterministic);
 
   LLVM_ABI static Expected<NewArchiveMember> getFile(StringRef FileName,
-                                            bool Deterministic);
+                                                     bool Deterministic);
 };
 
-LLVM_ABI Expected<std::string> computeArchiveRelativePath(StringRef From, StringRef To);
+LLVM_ABI Expected<std::string> computeArchiveRelativePath(StringRef From,
+                                                          StringRef To);
 
 enum class SymtabWritingMode {
   NoSymtab,     // Do not write symbol table.
@@ -52,19 +53,19 @@ enum class SymtabWritingMode {
 LLVM_ABI void warnToStderr(Error Err);
 
 // Write an archive directly to an output stream.
-LLVM_ABI Error writeArchiveToStream(raw_ostream &Out,
-                           ArrayRef<NewArchiveMember> NewMembers,
-                           SymtabWritingMode WriteSymtab,
-                           object::Archive::Kind Kind, bool Deterministic,
-                           bool Thin, std::optional<bool> IsEC = std::nullopt,
-                           function_ref<void(Error)> Warn = warnToStderr);
+LLVM_ABI Error writeArchiveToStream(
+    raw_ostream &Out, ArrayRef<NewArchiveMember> NewMembers,
+    SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
+    bool Deterministic, bool Thin, std::optional<bool> IsEC = std::nullopt,
+    function_ref<void(Error)> Warn = warnToStderr);
 
-LLVM_ABI Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
-                   SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
-                   bool Deterministic, bool Thin,
-                   std::unique_ptr<MemoryBuffer> OldArchiveBuf = nullptr,
-                   std::optional<bool> IsEC = std::nullopt,
-                   function_ref<void(Error)> Warn = warnToStderr);
+LLVM_ABI Error
+writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
+             SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
+             bool Deterministic, bool Thin,
+             std::unique_ptr<MemoryBuffer> OldArchiveBuf = nullptr,
+             std::optional<bool> IsEC = std::nullopt,
+             function_ref<void(Error)> Warn = warnToStderr);
 
 // writeArchiveToBuffer is similar to writeArchive but returns the Archive in a
 // buffer instead of writing it out to a file.

--- a/llvm/include/llvm/Object/ArchiveWriter.h
+++ b/llvm/include/llvm/Object/ArchiveWriter.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_ARCHIVEWRITER_H
 #define LLVM_OBJECT_ARCHIVEWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Object/Archive.h"
 
 namespace llvm {
@@ -24,21 +25,21 @@ struct NewArchiveMember {
   unsigned UID = 0, GID = 0, Perms = 0644;
 
   NewArchiveMember() = default;
-  NewArchiveMember(MemoryBufferRef BufRef);
+  LLVM_ABI NewArchiveMember(MemoryBufferRef BufRef);
 
   // Detect the archive format from the object or bitcode file. This helps
   // assume the archive format when creating or editing archives in the case
   // one isn't explicitly set.
-  object::Archive::Kind detectKindFromObject() const;
+  LLVM_ABI object::Archive::Kind detectKindFromObject() const;
 
-  static Expected<NewArchiveMember>
+  LLVM_ABI static Expected<NewArchiveMember>
   getOldMember(const object::Archive::Child &OldMember, bool Deterministic);
 
-  static Expected<NewArchiveMember> getFile(StringRef FileName,
+  LLVM_ABI static Expected<NewArchiveMember> getFile(StringRef FileName,
                                             bool Deterministic);
 };
 
-Expected<std::string> computeArchiveRelativePath(StringRef From, StringRef To);
+LLVM_ABI Expected<std::string> computeArchiveRelativePath(StringRef From, StringRef To);
 
 enum class SymtabWritingMode {
   NoSymtab,     // Do not write symbol table.
@@ -48,17 +49,17 @@ enum class SymtabWritingMode {
   BigArchive64  // Only write the 64-bit symbol table.
 };
 
-void warnToStderr(Error Err);
+LLVM_ABI void warnToStderr(Error Err);
 
 // Write an archive directly to an output stream.
-Error writeArchiveToStream(raw_ostream &Out,
+LLVM_ABI Error writeArchiveToStream(raw_ostream &Out,
                            ArrayRef<NewArchiveMember> NewMembers,
                            SymtabWritingMode WriteSymtab,
                            object::Archive::Kind Kind, bool Deterministic,
                            bool Thin, std::optional<bool> IsEC = std::nullopt,
                            function_ref<void(Error)> Warn = warnToStderr);
 
-Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
+LLVM_ABI Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
                    SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
                    bool Deterministic, bool Thin,
                    std::unique_ptr<MemoryBuffer> OldArchiveBuf = nullptr,
@@ -67,7 +68,7 @@ Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
 
 // writeArchiveToBuffer is similar to writeArchive but returns the Archive in a
 // buffer instead of writing it out to a file.
-Expected<std::unique_ptr<MemoryBuffer>>
+LLVM_ABI Expected<std::unique_ptr<MemoryBuffer>>
 writeArchiveToBuffer(ArrayRef<NewArchiveMember> NewMembers,
                      SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
                      bool Deterministic, bool Thin,

--- a/llvm/include/llvm/Object/Binary.h
+++ b/llvm/include/llvm/Object/Binary.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_BINARY_H
 #define LLVM_OBJECT_BINARY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/Types.h"
 #include "llvm/Object/Error.h"
 #include "llvm/Support/CBindingWrapping.h"
@@ -29,7 +30,7 @@ class StringRef;
 
 namespace object {
 
-class Binary {
+class LLVM_ABI Binary {
 private:
   unsigned int TypeID;
 
@@ -189,7 +190,7 @@ DEFINE_ISA_CONVERSION_FUNCTIONS(Binary, LLVMBinaryRef)
 /// Create a Binary from Source, autodetecting the file type.
 ///
 /// @param Source The data to create the Binary from.
-Expected<std::unique_ptr<Binary>> createBinary(MemoryBufferRef Source,
+LLVM_ABI Expected<std::unique_ptr<Binary>> createBinary(MemoryBufferRef Source,
                                                LLVMContext *Context = nullptr,
                                                bool InitContent = true);
 
@@ -241,7 +242,7 @@ template <typename T> const T* OwningBinary<T>::getBinary() const {
   return Bin.get();
 }
 
-Expected<OwningBinary<Binary>> createBinary(StringRef Path,
+LLVM_ABI Expected<OwningBinary<Binary>> createBinary(StringRef Path,
                                             LLVMContext *Context = nullptr,
                                             bool InitContent = true);
 

--- a/llvm/include/llvm/Object/Binary.h
+++ b/llvm/include/llvm/Object/Binary.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_OBJECT_BINARY_H
 #define LLVM_OBJECT_BINARY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/Types.h"
 #include "llvm/Object/Error.h"
 #include "llvm/Support/CBindingWrapping.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/TargetParser/Triple.h"
@@ -190,9 +190,9 @@ DEFINE_ISA_CONVERSION_FUNCTIONS(Binary, LLVMBinaryRef)
 /// Create a Binary from Source, autodetecting the file type.
 ///
 /// @param Source The data to create the Binary from.
-LLVM_ABI Expected<std::unique_ptr<Binary>> createBinary(MemoryBufferRef Source,
-                                               LLVMContext *Context = nullptr,
-                                               bool InitContent = true);
+LLVM_ABI Expected<std::unique_ptr<Binary>>
+createBinary(MemoryBufferRef Source, LLVMContext *Context = nullptr,
+             bool InitContent = true);
 
 template <typename T> class OwningBinary {
   std::unique_ptr<T> Bin;
@@ -242,9 +242,9 @@ template <typename T> const T* OwningBinary<T>::getBinary() const {
   return Bin.get();
 }
 
-LLVM_ABI Expected<OwningBinary<Binary>> createBinary(StringRef Path,
-                                            LLVMContext *Context = nullptr,
-                                            bool InitContent = true);
+LLVM_ABI Expected<OwningBinary<Binary>>
+createBinary(StringRef Path, LLVMContext *Context = nullptr,
+             bool InitContent = true);
 
 } // end namespace object
 

--- a/llvm/include/llvm/Object/BuildID.h
+++ b/llvm/include/llvm/Object/BuildID.h
@@ -15,9 +15,9 @@
 #ifndef LLVM_DEBUGINFO_OBJECT_BUILDID_H
 #define LLVM_DEBUGINFO_OBJECT_BUILDID_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace object {

--- a/llvm/include/llvm/Object/BuildID.h
+++ b/llvm/include/llvm/Object/BuildID.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_DEBUGINFO_OBJECT_BUILDID_H
 #define LLVM_DEBUGINFO_OBJECT_BUILDID_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -30,13 +31,13 @@ typedef ArrayRef<uint8_t> BuildIDRef;
 class ObjectFile;
 
 /// Parses a build ID from a hex string.
-BuildID parseBuildID(StringRef Str);
+LLVM_ABI BuildID parseBuildID(StringRef Str);
 
 /// Returns the build ID, if any, contained in the given object file.
-BuildIDRef getBuildID(const ObjectFile *Obj);
+LLVM_ABI BuildIDRef getBuildID(const ObjectFile *Obj);
 
 /// BuildIDFetcher searches local cache directories for debug info.
-class BuildIDFetcher {
+class LLVM_ABI BuildIDFetcher {
 public:
   BuildIDFetcher(std::vector<std::string> DebugFileDirectories)
       : DebugFileDirectories(std::move(DebugFileDirectories)) {}

--- a/llvm/include/llvm/Object/COFF.h
+++ b/llvm/include/llvm/Object/COFF.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_COFF_H
 #define LLVM_OBJECT_COFF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/Object/Binary.h"
@@ -876,7 +877,7 @@ struct coff_dynamic_relocation64_v2 {
   support::ulittle32_t Flags;
 };
 
-class COFFObjectFile : public ObjectFile {
+class LLVM_ABI COFFObjectFile : public ObjectFile {
 private:
   COFFObjectFile(MemoryBufferRef Object);
 
@@ -1234,22 +1235,22 @@ public:
                           uint32_t I, const COFFObjectFile *Owner)
       : ImportTable(Table), Index(I), OwningObject(Owner) {}
 
-  bool operator==(const ImportDirectoryEntryRef &Other) const;
-  void moveNext();
+  LLVM_ABI bool operator==(const ImportDirectoryEntryRef &Other) const;
+  LLVM_ABI void moveNext();
 
-  imported_symbol_iterator imported_symbol_begin() const;
-  imported_symbol_iterator imported_symbol_end() const;
-  iterator_range<imported_symbol_iterator> imported_symbols() const;
+  LLVM_ABI imported_symbol_iterator imported_symbol_begin() const;
+  LLVM_ABI imported_symbol_iterator imported_symbol_end() const;
+  LLVM_ABI iterator_range<imported_symbol_iterator> imported_symbols() const;
 
-  imported_symbol_iterator lookup_table_begin() const;
-  imported_symbol_iterator lookup_table_end() const;
-  iterator_range<imported_symbol_iterator> lookup_table_symbols() const;
+  LLVM_ABI imported_symbol_iterator lookup_table_begin() const;
+  LLVM_ABI imported_symbol_iterator lookup_table_end() const;
+  LLVM_ABI iterator_range<imported_symbol_iterator> lookup_table_symbols() const;
 
-  Error getName(StringRef &Result) const;
-  Error getImportLookupTableRVA(uint32_t &Result) const;
-  Error getImportAddressTableRVA(uint32_t &Result) const;
+  LLVM_ABI Error getName(StringRef &Result) const;
+  LLVM_ABI Error getImportLookupTableRVA(uint32_t &Result) const;
+  LLVM_ABI Error getImportAddressTableRVA(uint32_t &Result) const;
 
-  Error
+  LLVM_ABI Error
   getImportTableEntry(const coff_import_directory_table_entry *&Result) const;
 
 private:
@@ -1265,17 +1266,17 @@ public:
                                uint32_t I, const COFFObjectFile *Owner)
       : Table(T), Index(I), OwningObject(Owner) {}
 
-  bool operator==(const DelayImportDirectoryEntryRef &Other) const;
-  void moveNext();
+  LLVM_ABI bool operator==(const DelayImportDirectoryEntryRef &Other) const;
+  LLVM_ABI void moveNext();
 
-  imported_symbol_iterator imported_symbol_begin() const;
-  imported_symbol_iterator imported_symbol_end() const;
-  iterator_range<imported_symbol_iterator> imported_symbols() const;
+  LLVM_ABI imported_symbol_iterator imported_symbol_begin() const;
+  LLVM_ABI imported_symbol_iterator imported_symbol_end() const;
+  LLVM_ABI iterator_range<imported_symbol_iterator> imported_symbols() const;
 
-  Error getName(StringRef &Result) const;
-  Error getDelayImportTable(
+  LLVM_ABI Error getName(StringRef &Result) const;
+  LLVM_ABI Error getDelayImportTable(
       const delay_import_directory_table_entry *&Result) const;
-  Error getImportAddress(int AddrIndex, uint64_t &Result) const;
+  LLVM_ABI Error getImportAddress(int AddrIndex, uint64_t &Result) const;
 
 private:
   const delay_import_directory_table_entry *Table;
@@ -1291,17 +1292,17 @@ public:
                           const COFFObjectFile *Owner)
       : ExportTable(Table), Index(I), OwningObject(Owner) {}
 
-  bool operator==(const ExportDirectoryEntryRef &Other) const;
-  void moveNext();
+  LLVM_ABI bool operator==(const ExportDirectoryEntryRef &Other) const;
+  LLVM_ABI void moveNext();
 
-  Error getDllName(StringRef &Result) const;
-  Error getOrdinalBase(uint32_t &Result) const;
-  Error getOrdinal(uint32_t &Result) const;
-  Error getExportRVA(uint32_t &Result) const;
-  Error getSymbolName(StringRef &Result) const;
+  LLVM_ABI Error getDllName(StringRef &Result) const;
+  LLVM_ABI Error getOrdinalBase(uint32_t &Result) const;
+  LLVM_ABI Error getOrdinal(uint32_t &Result) const;
+  LLVM_ABI Error getExportRVA(uint32_t &Result) const;
+  LLVM_ABI Error getSymbolName(StringRef &Result) const;
 
-  Error isForwarder(bool &Result) const;
-  Error getForwardTo(StringRef &Result) const;
+  LLVM_ABI Error isForwarder(bool &Result) const;
+  LLVM_ABI Error getForwardTo(StringRef &Result) const;
 
 private:
   const export_directory_table_entry *ExportTable;
@@ -1319,13 +1320,13 @@ public:
                     const COFFObjectFile *Owner)
       : Entry32(nullptr), Entry64(Entry), Index(I), OwningObject(Owner) {}
 
-  bool operator==(const ImportedSymbolRef &Other) const;
-  void moveNext();
+  LLVM_ABI bool operator==(const ImportedSymbolRef &Other) const;
+  LLVM_ABI void moveNext();
 
-  Error getSymbolName(StringRef &Result) const;
-  Error isOrdinal(bool &Result) const;
-  Error getOrdinal(uint16_t &Result) const;
-  Error getHintNameRVA(uint32_t &Result) const;
+  LLVM_ABI Error getSymbolName(StringRef &Result) const;
+  LLVM_ABI Error isOrdinal(bool &Result) const;
+  LLVM_ABI Error getOrdinal(uint16_t &Result) const;
+  LLVM_ABI Error getHintNameRVA(uint32_t &Result) const;
 
 private:
   const import_lookup_table_entry32 *Entry32;
@@ -1341,11 +1342,11 @@ public:
                const COFFObjectFile *Owner)
       : Header(Header), Index(0) {}
 
-  bool operator==(const BaseRelocRef &Other) const;
-  void moveNext();
+  LLVM_ABI bool operator==(const BaseRelocRef &Other) const;
+  LLVM_ABI void moveNext();
 
-  Error getType(uint8_t &Type) const;
-  Error getRVA(uint32_t &Result) const;
+  LLVM_ABI Error getType(uint8_t &Type) const;
+  LLVM_ABI Error getRVA(uint32_t &Result) const;
 
 private:
   const coff_base_reloc_block_header *Header;
@@ -1358,14 +1359,14 @@ public:
   DynamicRelocRef(const void *Header, const COFFObjectFile *Owner)
       : Obj(Owner), Header(reinterpret_cast<const uint8_t *>(Header)) {}
 
-  bool operator==(const DynamicRelocRef &Other) const;
-  void moveNext();
-  uint32_t getType() const;
-  void getContents(ArrayRef<uint8_t> &Ref) const;
+  LLVM_ABI bool operator==(const DynamicRelocRef &Other) const;
+  LLVM_ABI void moveNext();
+  LLVM_ABI uint32_t getType() const;
+  LLVM_ABI void getContents(ArrayRef<uint8_t> &Ref) const;
 
-  arm64x_reloc_iterator arm64x_reloc_begin() const;
-  arm64x_reloc_iterator arm64x_reloc_end() const;
-  iterator_range<arm64x_reloc_iterator> arm64x_relocs() const;
+  LLVM_ABI arm64x_reloc_iterator arm64x_reloc_begin() const;
+  LLVM_ABI arm64x_reloc_iterator arm64x_reloc_end() const;
+  LLVM_ABI iterator_range<arm64x_reloc_iterator> arm64x_relocs() const;
 
 private:
   Error validate() const;
@@ -1382,15 +1383,15 @@ public:
   Arm64XRelocRef(const coff_base_reloc_block_header *Header, uint32_t Index = 0)
       : Header(Header), Index(Index) {}
 
-  bool operator==(const Arm64XRelocRef &Other) const;
-  void moveNext();
+  LLVM_ABI bool operator==(const Arm64XRelocRef &Other) const;
+  LLVM_ABI void moveNext();
 
   COFF::Arm64XFixupType getType() const {
     return COFF::Arm64XFixupType((getReloc() >> 12) & 3);
   }
   uint32_t getRVA() const { return Header->PageRVA + (getReloc() & 0xfff); }
-  uint8_t getSize() const;
-  uint64_t getValue() const;
+  LLVM_ABI uint8_t getSize() const;
+  LLVM_ABI uint64_t getValue() const;
 
 private:
   const support::ulittle16_t &getReloc(uint32_t Offset = 0) const {
@@ -1414,20 +1415,20 @@ public:
   explicit ResourceSectionRef(StringRef Ref)
       : BBS(Ref, llvm::endianness::little) {}
 
-  Error load(const COFFObjectFile *O);
-  Error load(const COFFObjectFile *O, const SectionRef &S);
+  LLVM_ABI Error load(const COFFObjectFile *O);
+  LLVM_ABI Error load(const COFFObjectFile *O, const SectionRef &S);
 
-  Expected<ArrayRef<UTF16>>
+  LLVM_ABI Expected<ArrayRef<UTF16>>
   getEntryNameString(const coff_resource_dir_entry &Entry);
-  Expected<const coff_resource_dir_table &>
+  LLVM_ABI Expected<const coff_resource_dir_table &>
   getEntrySubDir(const coff_resource_dir_entry &Entry);
-  Expected<const coff_resource_data_entry &>
+  LLVM_ABI Expected<const coff_resource_data_entry &>
   getEntryData(const coff_resource_dir_entry &Entry);
-  Expected<const coff_resource_dir_table &> getBaseTable();
-  Expected<const coff_resource_dir_entry &>
+  LLVM_ABI Expected<const coff_resource_dir_table &> getBaseTable();
+  LLVM_ABI Expected<const coff_resource_dir_entry &>
   getTableEntry(const coff_resource_dir_table &Table, uint32_t Index);
 
-  Expected<StringRef> getContents(const coff_resource_data_entry &Entry);
+  LLVM_ABI Expected<StringRef> getContents(const coff_resource_data_entry &Entry);
 
 private:
   BinaryByteStream BBS;

--- a/llvm/include/llvm/Object/COFF.h
+++ b/llvm/include/llvm/Object/COFF.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_OBJECT_COFF_H
 #define LLVM_OBJECT_COFF_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/Object/Binary.h"
@@ -21,6 +20,7 @@
 #include "llvm/Object/Error.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/BinaryByteStream.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -1244,7 +1244,8 @@ public:
 
   LLVM_ABI imported_symbol_iterator lookup_table_begin() const;
   LLVM_ABI imported_symbol_iterator lookup_table_end() const;
-  LLVM_ABI iterator_range<imported_symbol_iterator> lookup_table_symbols() const;
+  LLVM_ABI iterator_range<imported_symbol_iterator>
+  lookup_table_symbols() const;
 
   LLVM_ABI Error getName(StringRef &Result) const;
   LLVM_ABI Error getImportLookupTableRVA(uint32_t &Result) const;
@@ -1274,8 +1275,8 @@ public:
   LLVM_ABI iterator_range<imported_symbol_iterator> imported_symbols() const;
 
   LLVM_ABI Error getName(StringRef &Result) const;
-  LLVM_ABI Error getDelayImportTable(
-      const delay_import_directory_table_entry *&Result) const;
+  LLVM_ABI Error
+  getDelayImportTable(const delay_import_directory_table_entry *&Result) const;
   LLVM_ABI Error getImportAddress(int AddrIndex, uint64_t &Result) const;
 
 private:
@@ -1428,7 +1429,8 @@ public:
   LLVM_ABI Expected<const coff_resource_dir_entry &>
   getTableEntry(const coff_resource_dir_table &Table, uint32_t Index);
 
-  LLVM_ABI Expected<StringRef> getContents(const coff_resource_data_entry &Entry);
+  LLVM_ABI Expected<StringRef>
+  getContents(const coff_resource_data_entry &Entry);
 
 private:
   BinaryByteStream BBS;

--- a/llvm/include/llvm/Object/COFFImportFile.h
+++ b/llvm/include/llvm/Object/COFFImportFile.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_OBJECT_COFFIMPORTFILE_H
 #define LLVM_OBJECT_COFFIMPORTFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/Mangler.h"
 #include "llvm/Object/COFF.h"
@@ -33,7 +34,7 @@ constexpr std::string_view NullImportDescriptorSymbolName =
 constexpr std::string_view NullThunkDataPrefix = "\x7f";
 constexpr std::string_view NullThunkDataSuffix = "_NULL_THUNK_DATA";
 
-class COFFImportFile : public SymbolicFile {
+class LLVM_ABI COFFImportFile : public SymbolicFile {
 private:
   enum SymbolIndex { ImpSymbol, ThunkSymbol, ECAuxSymbol, ECThunkSymbol };
 
@@ -135,7 +136,7 @@ struct COFFShortExport {
 /// linking both ARM64EC and pure ARM64 objects, and the linker will pick only
 /// the exports relevant to the target platform. For non-hybrid targets,
 /// the NativeExports parameter should not be used.
-Error writeImportLibrary(StringRef ImportName, StringRef Path,
+LLVM_ABI Error writeImportLibrary(StringRef ImportName, StringRef Path,
                          ArrayRef<COFFShortExport> Exports,
                          COFF::MachineTypes Machine, bool MinGW,
                          ArrayRef<COFFShortExport> NativeExports = {});

--- a/llvm/include/llvm/Object/COFFImportFile.h
+++ b/llvm/include/llvm/Object/COFFImportFile.h
@@ -16,12 +16,12 @@
 #ifndef LLVM_OBJECT_COFFIMPORTFILE_H
 #define LLVM_OBJECT_COFFIMPORTFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/Mangler.h"
 #include "llvm/Object/COFF.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Object/SymbolicFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -137,9 +137,9 @@ struct COFFShortExport {
 /// the exports relevant to the target platform. For non-hybrid targets,
 /// the NativeExports parameter should not be used.
 LLVM_ABI Error writeImportLibrary(StringRef ImportName, StringRef Path,
-                         ArrayRef<COFFShortExport> Exports,
-                         COFF::MachineTypes Machine, bool MinGW,
-                         ArrayRef<COFFShortExport> NativeExports = {});
+                                  ArrayRef<COFFShortExport> Exports,
+                                  COFF::MachineTypes Machine, bool MinGW,
+                                  ArrayRef<COFFShortExport> NativeExports = {});
 
 } // namespace object
 } // namespace llvm

--- a/llvm/include/llvm/Object/COFFModuleDefinition.h
+++ b/llvm/include/llvm/Object/COFFModuleDefinition.h
@@ -18,9 +18,9 @@
 #ifndef LLVM_OBJECT_COFFMODULEDEFINITION_H
 #define LLVM_OBJECT_COFFMODULEDEFINITION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/Object/COFFImportFile.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace object {

--- a/llvm/include/llvm/Object/COFFModuleDefinition.h
+++ b/llvm/include/llvm/Object/COFFModuleDefinition.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_OBJECT_COFFMODULEDEFINITION_H
 #define LLVM_OBJECT_COFFMODULEDEFINITION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/Object/COFFImportFile.h"
 
@@ -39,7 +40,7 @@ struct COFFModuleDefinition {
   uint32_t MinorOSVersion = 0;
 };
 
-Expected<COFFModuleDefinition>
+LLVM_ABI Expected<COFFModuleDefinition>
 parseCOFFModuleDefinition(MemoryBufferRef MB, COFF::MachineTypes Machine,
                           bool MingwDef = false, bool AddUnderscores = true);
 

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_OBJECT_DXCONTAINER_H
 #define LLVM_OBJECT_DXCONTAINER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -245,7 +246,7 @@ private:
 public:
   RootSignature(StringRef PD) : PartData(PD) {}
 
-  Error parse();
+  LLVM_ABI Error parse();
   uint32_t getVersion() const { return Version; }
   uint32_t getNumParameters() const { return NumParameters; }
   uint32_t getRootParametersOffset() const { return RootParametersOffset; }
@@ -337,7 +338,7 @@ public:
   PSVRuntimeInfo(StringRef D) : Data(D), Size(0) {}
 
   // Parsing depends on the shader kind
-  Error parse(uint16_t ShaderKind);
+  LLVM_ABI Error parse(uint16_t ShaderKind);
 
   uint32_t getSize() const { return Size; }
   uint32_t getResourceCount() const { return Resources.size(); }
@@ -381,9 +382,9 @@ public:
     return SemanticIndexTable;
   }
 
-  uint8_t getSigInputCount() const;
-  uint8_t getSigOutputCount() const;
-  uint8_t getSigPatchOrPrimCount() const;
+  LLVM_ABI uint8_t getSigInputCount() const;
+  LLVM_ABI uint8_t getSigOutputCount() const;
+  LLVM_ABI uint8_t getSigPatchOrPrimCount() const;
 
   SigElementArray getSigInputElements() const { return SigInputElements; }
   SigElementArray getSigOutputElements() const { return SigOutputElements; }
@@ -460,7 +461,7 @@ public:
 
   bool isEmpty() const { return Parameters.isEmpty(); }
 
-  Error initialize(StringRef Part);
+  LLVM_ABI Error initialize(StringRef Part);
 };
 
 } // namespace DirectX
@@ -528,7 +529,7 @@ public:
 
     // Implementation for updating the iterator state based on a specified
     // offest.
-    void updateIteratorImpl(const uint32_t Offset);
+    LLVM_ABI void updateIteratorImpl(const uint32_t Offset);
 
   public:
     PartIterator &operator++() {
@@ -564,7 +565,7 @@ public:
   PartIterator end() const { return PartIterator(*this, PartOffsets.end()); }
 
   StringRef getData() const { return Data.getBuffer(); }
-  static Expected<DXContainer> create(MemoryBufferRef Object);
+  LLVM_ABI static Expected<DXContainer> create(MemoryBufferRef Object);
 
   const dxbc::Header &getHeader() const { return Header; }
 

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -15,12 +15,12 @@
 #ifndef LLVM_OBJECT_DXCONTAINER_H
 #define LLVM_OBJECT_DXCONTAINER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/DXContainer.h"
 #include "llvm/Object/Error.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"

--- a/llvm/include/llvm/Object/Decompressor.h
+++ b/llvm/include/llvm/Object/Decompressor.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_OBJECT_DECOMPRESSOR_H
 #define LLVM_OBJECT_DECOMPRESSOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Error.h"
 
@@ -27,7 +27,7 @@ public:
   /// @param IsLE        Flag determines if Data is in little endian form.
   /// @param Is64Bit     Flag determines if object is 64 bit.
   LLVM_ABI static Expected<Decompressor> create(StringRef Name, StringRef Data,
-                                       bool IsLE, bool Is64Bit);
+                                                bool IsLE, bool Is64Bit);
 
   /// Resize the buffer and uncompress section data into it.
   /// @param Out         Destination buffer.

--- a/llvm/include/llvm/Object/Decompressor.h
+++ b/llvm/include/llvm/Object/Decompressor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OBJECT_DECOMPRESSOR_H
 #define LLVM_OBJECT_DECOMPRESSOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compression.h"
@@ -25,7 +26,7 @@ public:
   /// @param Data        Section content.
   /// @param IsLE        Flag determines if Data is in little endian form.
   /// @param Is64Bit     Flag determines if object is 64 bit.
-  static Expected<Decompressor> create(StringRef Name, StringRef Data,
+  LLVM_ABI static Expected<Decompressor> create(StringRef Name, StringRef Data,
                                        bool IsLE, bool Is64Bit);
 
   /// Resize the buffer and uncompress section data into it.
@@ -36,7 +37,7 @@ public:
   }
 
   /// Uncompress section data to raw buffer provided.
-  Error decompress(MutableArrayRef<uint8_t> Output);
+  LLVM_ABI Error decompress(MutableArrayRef<uint8_t> Output);
 
   /// Return memory buffer size required for decompression.
   uint64_t getDecompressedSize() { return DecompressedSize; }

--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -71,9 +71,9 @@ struct VersionEntry {
   bool IsVerDef;
 };
 
-StringRef getELFRelocationTypeName(uint32_t Machine, uint32_t Type);
-uint32_t getELFRelativeRelocationType(uint32_t Machine);
-StringRef getELFSectionTypeName(uint32_t Machine, uint32_t Type);
+LLVM_ABI StringRef getELFRelocationTypeName(uint32_t Machine, uint32_t Type);
+LLVM_ABI uint32_t getELFRelativeRelocationType(uint32_t Machine);
+LLVM_ABI StringRef getELFSectionTypeName(uint32_t Machine, uint32_t Type);
 
 // Subclasses of ELFFile may need this for template instantiation
 inline std::pair<unsigned char, unsigned char>

--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -257,7 +257,7 @@ public:
   LLVM_ELF_IMPORT_TYPES_ELFT(ELFT)
 
   // Default ctor required to instantiate the template for DLL export.
-  ELFFile(const ELFFile&) = default;
+  ELFFile(const ELFFile &) = default;
 
   // This is a callback that can be passed to a number of functions.
   // It can be used to ignore non-critical errors (warnings), which is

--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -256,6 +256,9 @@ class ELFFile {
 public:
   LLVM_ELF_IMPORT_TYPES_ELFT(ELFT)
 
+  // Default ctor required to instantiate the template for DLL export.
+  ELFFile(const ELFFile&) = default;
+
   // This is a callback that can be passed to a number of functions.
   // It can be used to ignore non-critical errors (warnings), which is
   // useful for dumpers, like llvm-readobj.

--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_OBJECT_ELFOBJECTFILE_H
 #define LLVM_OBJECT_ELFOBJECTFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -27,6 +26,7 @@
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Object/SymbolicFile.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttributeParser.h"
 #include "llvm/Support/ELFAttributes.h"
 #include "llvm/Support/Error.h"
@@ -46,7 +46,8 @@ template <typename T> class SmallVectorImpl;
 namespace object {
 
 constexpr int NumElfSymbolTypes = 16;
-LLVM_ABI extern const llvm::EnumEntry<unsigned> ElfSymbolTypes[NumElfSymbolTypes];
+LLVM_ABI extern const llvm::EnumEntry<unsigned>
+    ElfSymbolTypes[NumElfSymbolTypes];
 
 class elf_symbol_iterator;
 

--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_ELFOBJECTFILE_H
 #define LLVM_OBJECT_ELFOBJECTFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -45,7 +46,7 @@ template <typename T> class SmallVectorImpl;
 namespace object {
 
 constexpr int NumElfSymbolTypes = 16;
-extern const llvm::EnumEntry<unsigned> ElfSymbolTypes[NumElfSymbolTypes];
+LLVM_ABI extern const llvm::EnumEntry<unsigned> ElfSymbolTypes[NumElfSymbolTypes];
 
 class elf_symbol_iterator;
 
@@ -55,7 +56,7 @@ struct ELFPltEntry {
   uint64_t Address;
 };
 
-class ELFObjectFileBase : public ObjectFile {
+class LLVM_ABI ELFObjectFileBase : public ObjectFile {
   friend class ELFRelocationRef;
   friend class ELFSectionRef;
   friend class ELFSymbolRef;

--- a/llvm/include/llvm/Object/Error.h
+++ b/llvm/include/llvm/Object/Error.h
@@ -64,7 +64,8 @@ public:
 ///
 /// For errors that don't require their own specific sub-error (most errors)
 /// this class can be used to describe the error via a string message.
-class LLVM_ABI GenericBinaryError : public ErrorInfo<GenericBinaryError, BinaryError> {
+class LLVM_ABI GenericBinaryError
+    : public ErrorInfo<GenericBinaryError, BinaryError> {
 public:
   static char ID;
   GenericBinaryError(const Twine &Msg);

--- a/llvm/include/llvm/Object/Error.h
+++ b/llvm/include/llvm/Object/Error.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_ERROR_H
 #define LLVM_OBJECT_ERROR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <system_error>
 
@@ -22,7 +23,7 @@ class Twine;
 
 namespace object {
 
-const std::error_category &object_category();
+LLVM_ABI const std::error_category &object_category();
 
 enum class object_error {
   // Error code 0 is absent. Use std::error_code() instead.
@@ -49,7 +50,7 @@ inline std::error_code make_error_code(object_error e) {
 ///
 /// Currently inherits from ECError for easy interoperability with
 /// std::error_code, but this will be removed in the future.
-class BinaryError : public ErrorInfo<BinaryError, ECError> {
+class LLVM_ABI BinaryError : public ErrorInfo<BinaryError, ECError> {
   void anchor() override;
 public:
   static char ID;
@@ -63,7 +64,7 @@ public:
 ///
 /// For errors that don't require their own specific sub-error (most errors)
 /// this class can be used to describe the error via a string message.
-class GenericBinaryError : public ErrorInfo<GenericBinaryError, BinaryError> {
+class LLVM_ABI GenericBinaryError : public ErrorInfo<GenericBinaryError, BinaryError> {
 public:
   static char ID;
   GenericBinaryError(const Twine &Msg);
@@ -79,7 +80,7 @@ private:
 /// llvm::Error.  In the cases we want to loop through the children and ignore the
 /// non-objects in the archive this is used to test the error to see if an
 /// error() function needs to called on the llvm::Error.
-Error isNotObjectErrorInvalidFileType(llvm::Error Err);
+LLVM_ABI Error isNotObjectErrorInvalidFileType(llvm::Error Err);
 
 inline Error createError(const Twine &Err) {
   return make_error<StringError>(Err, object_error::parse_failed);

--- a/llvm/include/llvm/Object/FaultMapParser.h
+++ b/llvm/include/llvm/Object/FaultMapParser.h
@@ -155,11 +155,11 @@ public:
   }
 };
 
-LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
-                        const FaultMapParser::FunctionFaultInfoAccessor &);
+LLVM_ABI raw_ostream &
+operator<<(raw_ostream &OS, const FaultMapParser::FunctionFaultInfoAccessor &);
 
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
-                        const FaultMapParser::FunctionInfoAccessor &);
+                                 const FaultMapParser::FunctionInfoAccessor &);
 
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const FaultMapParser &);
 

--- a/llvm/include/llvm/Object/FaultMapParser.h
+++ b/llvm/include/llvm/Object/FaultMapParser.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OBJECT_FAULTMAPPARSER_H
 #define LLVM_OBJECT_FAULTMAPPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include <cassert>
 #include <cstdint>
@@ -154,13 +155,13 @@ public:
   }
 };
 
-raw_ostream &operator<<(raw_ostream &OS,
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                         const FaultMapParser::FunctionFaultInfoAccessor &);
 
-raw_ostream &operator<<(raw_ostream &OS,
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                         const FaultMapParser::FunctionInfoAccessor &);
 
-raw_ostream &operator<<(raw_ostream &OS, const FaultMapParser &);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const FaultMapParser &);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Object/GOFFObjectFile.h
+++ b/llvm/include/llvm/Object/GOFFObjectFile.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_OBJECT_GOFFOBJECTFILE_H
 #define LLVM_OBJECT_GOFFOBJECTFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/BinaryFormat/GOFF.h"
@@ -28,7 +29,7 @@ namespace llvm {
 
 namespace object {
 
-class GOFFObjectFile : public ObjectFile {
+class LLVM_ABI GOFFObjectFile : public ObjectFile {
   friend class GOFFSymbolRef;
 
   IndexedMap<const uint8_t *> EsdPtrs; // Indexed by EsdId.

--- a/llvm/include/llvm/Object/GOFFObjectFile.h
+++ b/llvm/include/llvm/Object/GOFFObjectFile.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_OBJECT_GOFFOBJECTFILE_H
 #define LLVM_OBJECT_GOFFOBJECTFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/BinaryFormat/GOFF.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertEBCDIC.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"

--- a/llvm/include/llvm/Object/IRObjectFile.h
+++ b/llvm/include/llvm/Object/IRObjectFile.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_OBJECT_IROBJECTFILE_H
 #define LLVM_OBJECT_IROBJECTFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Object/IRSymtab.h"
 #include "llvm/Object/ModuleSymbolTable.h"
 #include "llvm/Object/SymbolicFile.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class Module;
@@ -82,7 +82,6 @@ struct IRSymtabFile {
 
 /// Reads a bitcode file, creating its irsymtab if necessary.
 LLVM_ABI Expected<IRSymtabFile> readIRSymtab(MemoryBufferRef MBRef);
-
 }
 
 } // namespace llvm

--- a/llvm/include/llvm/Object/IRObjectFile.h
+++ b/llvm/include/llvm/Object/IRObjectFile.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_IROBJECTFILE_H
 #define LLVM_OBJECT_IROBJECTFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Object/IRSymtab.h"
 #include "llvm/Object/ModuleSymbolTable.h"
@@ -24,7 +25,7 @@ class Module;
 namespace object {
 class ObjectFile;
 
-class IRObjectFile : public SymbolicFile {
+class LLVM_ABI IRObjectFile : public SymbolicFile {
   std::vector<std::unique_ptr<Module>> Mods;
   ModuleSymbolTable SymTab;
   IRObjectFile(MemoryBufferRef Object,
@@ -80,7 +81,7 @@ struct IRSymtabFile {
 };
 
 /// Reads a bitcode file, creating its irsymtab if necessary.
-Expected<IRSymtabFile> readIRSymtab(MemoryBufferRef MBRef);
+LLVM_ABI Expected<IRSymtabFile> readIRSymtab(MemoryBufferRef MBRef);
 
 }
 

--- a/llvm/include/llvm/Object/IRSymtab.h
+++ b/llvm/include/llvm/Object/IRSymtab.h
@@ -23,6 +23,7 @@
 #ifndef LLVM_OBJECT_IRSYMTAB_H
 #define LLVM_OBJECT_IRSYMTAB_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
@@ -162,7 +163,7 @@ struct Header {
 
 /// Fills in Symtab and StrtabBuilder with a valid symbol and string table for
 /// Mods.
-Error build(ArrayRef<Module *> Mods, SmallVector<char, 0> &Symtab,
+LLVM_ABI Error build(ArrayRef<Module *> Mods, SmallVector<char, 0> &Symtab,
             StringTableBuilder &StrtabBuilder, BumpPtrAllocator &Alloc);
 
 /// This represents a symbol that has been read from a storage::Symbol and
@@ -373,7 +374,7 @@ struct FileContents {
 };
 
 /// Reads the contents of a bitcode file, creating its irsymtab if necessary.
-Expected<FileContents> readBitcode(const BitcodeFileContents &BFC);
+LLVM_ABI Expected<FileContents> readBitcode(const BitcodeFileContents &BFC);
 
 } // end namespace irsymtab
 } // end namespace llvm

--- a/llvm/include/llvm/Object/IRSymtab.h
+++ b/llvm/include/llvm/Object/IRSymtab.h
@@ -23,7 +23,6 @@
 #ifndef LLVM_OBJECT_IRSYMTAB_H
 #define LLVM_OBJECT_IRSYMTAB_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
@@ -31,6 +30,7 @@
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/Object/SymbolicFile.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cassert>
@@ -164,7 +164,8 @@ struct Header {
 /// Fills in Symtab and StrtabBuilder with a valid symbol and string table for
 /// Mods.
 LLVM_ABI Error build(ArrayRef<Module *> Mods, SmallVector<char, 0> &Symtab,
-            StringTableBuilder &StrtabBuilder, BumpPtrAllocator &Alloc);
+                     StringTableBuilder &StrtabBuilder,
+                     BumpPtrAllocator &Alloc);
 
 /// This represents a symbol that has been read from a storage::Symbol and
 /// possibly a storage::Uncommon.

--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_OBJECT_MACHO_H
 #define LLVM_OBJECT_MACHO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -72,18 +73,18 @@ using dice_iterator = content_iterator<DiceRef>;
 ///      if (Err) { report error ...
 class ExportEntry {
 public:
-  ExportEntry(Error *Err, const MachOObjectFile *O, ArrayRef<uint8_t> Trie);
+  LLVM_ABI ExportEntry(Error *Err, const MachOObjectFile *O, ArrayRef<uint8_t> Trie);
 
-  StringRef name() const;
-  uint64_t flags() const;
-  uint64_t address() const;
-  uint64_t other() const;
-  StringRef otherName() const;
-  uint32_t nodeOffset() const;
+  LLVM_ABI StringRef name() const;
+  LLVM_ABI uint64_t flags() const;
+  LLVM_ABI uint64_t address() const;
+  LLVM_ABI uint64_t other() const;
+  LLVM_ABI StringRef otherName() const;
+  LLVM_ABI uint32_t nodeOffset() const;
 
-  bool operator==(const ExportEntry &) const;
+  LLVM_ABI bool operator==(const ExportEntry &) const;
 
-  void moveNext();
+  LLVM_ABI void moveNext();
 
 private:
   friend class MachOObjectFile;
@@ -96,7 +97,7 @@ private:
 
   // Represents a node in the mach-o exports trie.
   struct NodeState {
-    NodeState(const uint8_t *Ptr);
+    LLVM_ABI NodeState(const uint8_t *Ptr);
 
     const uint8_t *Start;
     const uint8_t *Current;
@@ -131,16 +132,16 @@ using export_iterator = content_iterator<ExportEntry>;
 // address() methods below.
 class BindRebaseSegInfo {
 public:
-  BindRebaseSegInfo(const MachOObjectFile *Obj);
+  LLVM_ABI BindRebaseSegInfo(const MachOObjectFile *Obj);
 
   // Used to check a Mach-O Bind or Rebase entry for errors when iterating.
-  const char *checkSegAndOffsets(int32_t SegIndex, uint64_t SegOffset,
+  LLVM_ABI const char *checkSegAndOffsets(int32_t SegIndex, uint64_t SegOffset,
                                  uint8_t PointerSize, uint64_t Count = 1,
                                  uint64_t Skip = 0);
   // Used with valid SegIndex/SegOffset values from checked entries.
-  StringRef segmentName(int32_t SegIndex);
-  StringRef sectionName(int32_t SegIndex, uint64_t SegOffset);
-  uint64_t address(uint32_t SegIndex, uint64_t SegOffset);
+  LLVM_ABI StringRef segmentName(int32_t SegIndex);
+  LLVM_ABI StringRef sectionName(int32_t SegIndex, uint64_t SegOffset);
+  LLVM_ABI uint64_t address(uint32_t SegIndex, uint64_t SegOffset);
 
 private:
   struct SectionInfo {
@@ -167,19 +168,19 @@ private:
 ///    if (Err) { report error ...
 class MachORebaseEntry {
 public:
-  MachORebaseEntry(Error *Err, const MachOObjectFile *O,
+  LLVM_ABI MachORebaseEntry(Error *Err, const MachOObjectFile *O,
                    ArrayRef<uint8_t> opcodes, bool is64Bit);
 
-  int32_t segmentIndex() const;
-  uint64_t segmentOffset() const;
-  StringRef typeName() const;
-  StringRef segmentName() const;
-  StringRef sectionName() const;
-  uint64_t address() const;
+  LLVM_ABI int32_t segmentIndex() const;
+  LLVM_ABI uint64_t segmentOffset() const;
+  LLVM_ABI StringRef typeName() const;
+  LLVM_ABI StringRef segmentName() const;
+  LLVM_ABI StringRef sectionName() const;
+  LLVM_ABI uint64_t address() const;
 
-  bool operator==(const MachORebaseEntry &) const;
+  LLVM_ABI bool operator==(const MachORebaseEntry &) const;
 
-  void moveNext();
+  LLVM_ABI void moveNext();
 
 private:
   friend class MachOObjectFile;
@@ -213,24 +214,24 @@ class MachOBindEntry {
 public:
   enum class Kind { Regular, Lazy, Weak };
 
-  MachOBindEntry(Error *Err, const MachOObjectFile *O,
+  LLVM_ABI MachOBindEntry(Error *Err, const MachOObjectFile *O,
                  ArrayRef<uint8_t> Opcodes, bool is64Bit, MachOBindEntry::Kind);
 
-  int32_t segmentIndex() const;
-  uint64_t segmentOffset() const;
-  StringRef typeName() const;
-  StringRef symbolName() const;
-  uint32_t flags() const;
-  int64_t addend() const;
-  int ordinal() const;
+  LLVM_ABI int32_t segmentIndex() const;
+  LLVM_ABI uint64_t segmentOffset() const;
+  LLVM_ABI StringRef typeName() const;
+  LLVM_ABI StringRef symbolName() const;
+  LLVM_ABI uint32_t flags() const;
+  LLVM_ABI int64_t addend() const;
+  LLVM_ABI int ordinal() const;
 
-  StringRef segmentName() const;
-  StringRef sectionName() const;
-  uint64_t address() const;
+  LLVM_ABI StringRef segmentName() const;
+  LLVM_ABI StringRef sectionName() const;
+  LLVM_ABI uint64_t address() const;
 
-  bool operator==(const MachOBindEntry &) const;
+  LLVM_ABI bool operator==(const MachOBindEntry &) const;
 
-  void moveNext();
+  LLVM_ABI void moveNext();
 
 private:
   friend class MachOObjectFile;
@@ -321,22 +322,22 @@ struct ChainedFixupsSegment {
 ///   MachOChainedFixupEntry - for pointer chains embedded in data pages.
 class MachOAbstractFixupEntry {
 public:
-  MachOAbstractFixupEntry(Error *Err, const MachOObjectFile *O);
+  LLVM_ABI MachOAbstractFixupEntry(Error *Err, const MachOObjectFile *O);
 
-  int32_t segmentIndex() const;
-  uint64_t segmentOffset() const;
-  uint64_t segmentAddress() const;
-  StringRef segmentName() const;
-  StringRef sectionName() const;
-  StringRef typeName() const;
-  StringRef symbolName() const;
-  uint32_t flags() const;
-  int64_t addend() const;
-  int ordinal() const;
+  LLVM_ABI int32_t segmentIndex() const;
+  LLVM_ABI uint64_t segmentOffset() const;
+  LLVM_ABI uint64_t segmentAddress() const;
+  LLVM_ABI StringRef segmentName() const;
+  LLVM_ABI StringRef sectionName() const;
+  LLVM_ABI StringRef typeName() const;
+  LLVM_ABI StringRef symbolName() const;
+  LLVM_ABI uint32_t flags() const;
+  LLVM_ABI int64_t addend() const;
+  LLVM_ABI int ordinal() const;
 
   /// \return the location of this fixup as a VM Address. For the VM
   /// Address this fixup is pointing to, use pointerValue().
-  uint64_t address() const;
+  LLVM_ABI uint64_t address() const;
 
   /// \return the VM Address pointed to by this fixup. Use
   /// pointerValue() to compare against other VM Addresses, such as
@@ -350,7 +351,7 @@ public:
   /// raw bits.
   uint64_t rawValue() const { return RawValue; }
 
-  void moveNext();
+  LLVM_ABI void moveNext();
 
 protected:
   Error *E;
@@ -365,8 +366,8 @@ protected:
   uint64_t RawValue = 0;
   bool Done = false;
 
-  void moveToFirst();
-  void moveToEnd();
+  LLVM_ABI void moveToFirst();
+  LLVM_ABI void moveToEnd();
 
   /// \return the vm address of the start of __TEXT segment.
   uint64_t textAddress() const { return TextAddress; }
@@ -379,16 +380,16 @@ class MachOChainedFixupEntry : public MachOAbstractFixupEntry {
 public:
   enum class FixupKind { Bind, Rebase };
 
-  MachOChainedFixupEntry(Error *Err, const MachOObjectFile *O, bool Parse);
+  LLVM_ABI MachOChainedFixupEntry(Error *Err, const MachOObjectFile *O, bool Parse);
 
-  bool operator==(const MachOChainedFixupEntry &) const;
+  LLVM_ABI bool operator==(const MachOChainedFixupEntry &) const;
 
   bool isBind() const { return Kind == FixupKind::Bind; }
   bool isRebase() const { return Kind == FixupKind::Rebase; }
 
-  void moveNext();
-  void moveToFirst();
-  void moveToEnd();
+  LLVM_ABI void moveNext();
+  LLVM_ABI void moveToFirst();
+  LLVM_ABI void moveToEnd();
 
 private:
   void findNextPageWithFixups();
@@ -403,7 +404,7 @@ private:
 };
 using fixup_iterator = content_iterator<MachOChainedFixupEntry>;
 
-class MachOObjectFile : public ObjectFile {
+class LLVM_ABI MachOObjectFile : public ObjectFile {
 public:
   struct LoadCommandInfo {
     const char *Ptr;      // Where in memory the load command is.

--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_OBJECT_MACHO_H
 #define LLVM_OBJECT_MACHO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -26,6 +25,7 @@
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Object/SymbolicFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -73,7 +73,8 @@ using dice_iterator = content_iterator<DiceRef>;
 ///      if (Err) { report error ...
 class ExportEntry {
 public:
-  LLVM_ABI ExportEntry(Error *Err, const MachOObjectFile *O, ArrayRef<uint8_t> Trie);
+  LLVM_ABI ExportEntry(Error *Err, const MachOObjectFile *O,
+                       ArrayRef<uint8_t> Trie);
 
   LLVM_ABI StringRef name() const;
   LLVM_ABI uint64_t flags() const;
@@ -136,8 +137,9 @@ public:
 
   // Used to check a Mach-O Bind or Rebase entry for errors when iterating.
   LLVM_ABI const char *checkSegAndOffsets(int32_t SegIndex, uint64_t SegOffset,
-                                 uint8_t PointerSize, uint64_t Count = 1,
-                                 uint64_t Skip = 0);
+                                          uint8_t PointerSize,
+                                          uint64_t Count = 1,
+                                          uint64_t Skip = 0);
   // Used with valid SegIndex/SegOffset values from checked entries.
   LLVM_ABI StringRef segmentName(int32_t SegIndex);
   LLVM_ABI StringRef sectionName(int32_t SegIndex, uint64_t SegOffset);
@@ -169,7 +171,7 @@ private:
 class MachORebaseEntry {
 public:
   LLVM_ABI MachORebaseEntry(Error *Err, const MachOObjectFile *O,
-                   ArrayRef<uint8_t> opcodes, bool is64Bit);
+                            ArrayRef<uint8_t> opcodes, bool is64Bit);
 
   LLVM_ABI int32_t segmentIndex() const;
   LLVM_ABI uint64_t segmentOffset() const;
@@ -215,7 +217,8 @@ public:
   enum class Kind { Regular, Lazy, Weak };
 
   LLVM_ABI MachOBindEntry(Error *Err, const MachOObjectFile *O,
-                 ArrayRef<uint8_t> Opcodes, bool is64Bit, MachOBindEntry::Kind);
+                          ArrayRef<uint8_t> Opcodes, bool is64Bit,
+                          MachOBindEntry::Kind);
 
   LLVM_ABI int32_t segmentIndex() const;
   LLVM_ABI uint64_t segmentOffset() const;
@@ -380,7 +383,8 @@ class MachOChainedFixupEntry : public MachOAbstractFixupEntry {
 public:
   enum class FixupKind { Bind, Rebase };
 
-  LLVM_ABI MachOChainedFixupEntry(Error *Err, const MachOObjectFile *O, bool Parse);
+  LLVM_ABI MachOChainedFixupEntry(Error *Err, const MachOObjectFile *O,
+                                  bool Parse);
 
   LLVM_ABI bool operator==(const MachOChainedFixupEntry &) const;
 

--- a/llvm/include/llvm/Object/MachOUniversal.h
+++ b/llvm/include/llvm/Object/MachOUniversal.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_OBJECT_MACHOUNIVERSAL_H
 #define LLVM_OBJECT_MACHOUNIVERSAL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/MachO.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 
 namespace llvm {
@@ -165,7 +165,6 @@ public:
   Expected<std::unique_ptr<Archive>>
   getArchiveForArch(StringRef ArchName) const;
 };
-
 }
 }
 

--- a/llvm/include/llvm/Object/MachOUniversal.h
+++ b/llvm/include/llvm/Object/MachOUniversal.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_MACHOUNIVERSAL_H
 #define LLVM_OBJECT_MACHOUNIVERSAL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/Object/Binary.h"
@@ -27,7 +28,7 @@ namespace object {
 class Archive;
 class IRObjectFile;
 
-class MachOUniversalBinary : public Binary {
+class LLVM_ABI MachOUniversalBinary : public Binary {
   virtual void anchor();
 
   uint32_t Magic;
@@ -44,7 +45,7 @@ public:
     MachO::fat_arch_64 Header64;
 
   public:
-    ObjectForArch(const MachOUniversalBinary *Parent, uint32_t Index);
+    LLVM_ABI ObjectForArch(const MachOUniversalBinary *Parent, uint32_t Index);
 
     void clear() {
       Parent = nullptr;
@@ -102,11 +103,11 @@ public:
       return ArchFlag ? ArchFlag : std::string();
     }
 
-    Expected<std::unique_ptr<MachOObjectFile>> getAsObjectFile() const;
-    Expected<std::unique_ptr<IRObjectFile>>
+    LLVM_ABI Expected<std::unique_ptr<MachOObjectFile>> getAsObjectFile() const;
+    LLVM_ABI Expected<std::unique_ptr<IRObjectFile>>
     getAsIRObject(LLVMContext &Ctx) const;
 
-    Expected<std::unique_ptr<Archive>> getAsArchive() const;
+    LLVM_ABI Expected<std::unique_ptr<Archive>> getAsArchive() const;
   };
 
   class object_iterator {

--- a/llvm/include/llvm/Object/MachOUniversalWriter.h
+++ b/llvm/include/llvm/Object/MachOUniversalWriter.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_OBJECT_MACHOUNIVERSALWRITER_H
 #define LLVM_OBJECT_MACHOUNIVERSALWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -46,20 +47,20 @@ class Slice {
         std::string ArchName, uint32_t Align);
 
 public:
-  explicit Slice(const MachOObjectFile &O);
+  LLVM_ABI explicit Slice(const MachOObjectFile &O);
 
-  Slice(const MachOObjectFile &O, uint32_t Align);
+  LLVM_ABI Slice(const MachOObjectFile &O, uint32_t Align);
 
   /// This constructor takes pre-specified \param CPUType , \param CPUSubType ,
   /// \param ArchName , \param Align instead of inferring them from the archive
   /// members.
-  Slice(const Archive &A, uint32_t CPUType, uint32_t CPUSubType,
+  LLVM_ABI Slice(const Archive &A, uint32_t CPUType, uint32_t CPUSubType,
         std::string ArchName, uint32_t Align);
 
-  static Expected<Slice> create(const Archive &A,
+  LLVM_ABI static Expected<Slice> create(const Archive &A,
                                 LLVMContext *LLVMCtx = nullptr);
 
-  static Expected<Slice> create(const IRObjectFile &IRO, uint32_t Align);
+  LLVM_ABI static Expected<Slice> create(const IRObjectFile &IRO, uint32_t Align);
 
   void setP2Alignment(uint32_t Align) { P2Alignment = Align; }
 
@@ -99,10 +100,10 @@ public:
 
 enum class FatHeaderType { FatHeader, Fat64Header };
 
-Error writeUniversalBinary(ArrayRef<Slice> Slices, StringRef OutputFileName,
+LLVM_ABI Error writeUniversalBinary(ArrayRef<Slice> Slices, StringRef OutputFileName,
                            FatHeaderType FatHeader = FatHeaderType::FatHeader);
 
-Error writeUniversalBinaryToStream(
+LLVM_ABI Error writeUniversalBinaryToStream(
     ArrayRef<Slice> Slices, raw_ostream &Out,
     FatHeaderType FatHeader = FatHeaderType::FatHeader);
 

--- a/llvm/include/llvm/Object/MachOUniversalWriter.h
+++ b/llvm/include/llvm/Object/MachOUniversalWriter.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_OBJECT_MACHOUNIVERSALWRITER_H
 #define LLVM_OBJECT_MACHOUNIVERSALWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/MachO.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <string>
@@ -55,12 +55,13 @@ public:
   /// \param ArchName , \param Align instead of inferring them from the archive
   /// members.
   LLVM_ABI Slice(const Archive &A, uint32_t CPUType, uint32_t CPUSubType,
-        std::string ArchName, uint32_t Align);
+                 std::string ArchName, uint32_t Align);
 
   LLVM_ABI static Expected<Slice> create(const Archive &A,
-                                LLVMContext *LLVMCtx = nullptr);
+                                         LLVMContext *LLVMCtx = nullptr);
 
-  LLVM_ABI static Expected<Slice> create(const IRObjectFile &IRO, uint32_t Align);
+  LLVM_ABI static Expected<Slice> create(const IRObjectFile &IRO,
+                                         uint32_t Align);
 
   void setP2Alignment(uint32_t Align) { P2Alignment = Align; }
 
@@ -100,8 +101,9 @@ public:
 
 enum class FatHeaderType { FatHeader, Fat64Header };
 
-LLVM_ABI Error writeUniversalBinary(ArrayRef<Slice> Slices, StringRef OutputFileName,
-                           FatHeaderType FatHeader = FatHeaderType::FatHeader);
+LLVM_ABI Error
+writeUniversalBinary(ArrayRef<Slice> Slices, StringRef OutputFileName,
+                     FatHeaderType FatHeader = FatHeaderType::FatHeader);
 
 LLVM_ABI Error writeUniversalBinaryToStream(
     ArrayRef<Slice> Slices, raw_ostream &Out,

--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OBJECT_MINIDUMP_H
 #define LLVM_OBJECT_MINIDUMP_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/fallible_iterator.h"
@@ -26,7 +27,7 @@ public:
   /// Construct a new MinidumpFile object from the given memory buffer. Returns
   /// an error if this file cannot be identified as a minidump file, or if its
   /// contents are badly corrupted (i.e. we cannot read the stream directory).
-  static Expected<std::unique_ptr<MinidumpFile>> create(MemoryBufferRef Source);
+  LLVM_ABI static Expected<std::unique_ptr<MinidumpFile>> create(MemoryBufferRef Source);
 
   static bool classof(const Binary *B) { return B->isMinidump(); }
 
@@ -43,7 +44,7 @@ public:
 
   /// Returns the raw contents of the stream of the given type, or std::nullopt
   /// if the file does not contain a stream of this type.
-  std::optional<ArrayRef<uint8_t>>
+  LLVM_ABI std::optional<ArrayRef<uint8_t>>
   getRawStream(minidump::StreamType Type) const;
 
   /// Returns the raw contents of an object given by the LocationDescriptor. An
@@ -55,7 +56,7 @@ public:
 
   /// Returns the minidump string at the given offset. An error is returned if
   /// we fail to parse the string, or the string is invalid UTF16.
-  Expected<std::string> getString(size_t Offset) const;
+  LLVM_ABI Expected<std::string> getString(size_t Offset) const;
 
   /// Returns the contents of the SystemInfo stream, cast to the appropriate
   /// type. An error is returned if the file does not contain this stream, or
@@ -265,13 +266,13 @@ public:
   /// contents of the exception strema are not validated before being read, an
   /// error will be returned if the stream is not large enough to contain an
   /// exception stream, or if the stream points beyond the end of the file.
-  iterator_range<ExceptionStreamsIterator> getExceptionStreams() const;
+  LLVM_ABI iterator_range<ExceptionStreamsIterator> getExceptionStreams() const;
 
   /// Returns an iterator that pairs each descriptor with it's respective
   /// content from the Memory64List stream. An error is returned if the file
   /// does not contain a Memory64List stream, or if the descriptor data is
   /// unreadable.
-  iterator_range<FallibleMemory64Iterator> getMemory64List(Error &Err) const;
+  LLVM_ABI iterator_range<FallibleMemory64Iterator> getMemory64List(Error &Err) const;
 
   /// Returns the list of descriptors embedded in the MemoryInfoList stream. The
   /// descriptors provide properties (e.g. permissions) of interesting regions
@@ -280,7 +281,7 @@ public:
   /// contain the number of memory descriptors declared in the stream header.
   /// The consistency of the MemoryInfoList entries themselves is not checked
   /// in any way.
-  Expected<iterator_range<MemoryInfoIterator>> getMemoryInfoList() const;
+  LLVM_ABI Expected<iterator_range<MemoryInfoIterator>> getMemoryInfoList() const;
 
 private:
   static Error createError(StringRef Str) {
@@ -293,7 +294,7 @@ private:
   }
 
   /// Return a slice of the given data array, with bounds checking.
-  static Expected<ArrayRef<uint8_t>>
+  LLVM_ABI static Expected<ArrayRef<uint8_t>>
   getDataSlice(ArrayRef<uint8_t> Data, uint64_t Offset, uint64_t Size);
 
   /// Return the slice of the given data array as an array of objects of the

--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_OBJECT_MINIDUMP_H
 #define LLVM_OBJECT_MINIDUMP_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/fallible_iterator.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/BinaryFormat/Minidump.h"
 #include "llvm/Object/Binary.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -27,7 +27,8 @@ public:
   /// Construct a new MinidumpFile object from the given memory buffer. Returns
   /// an error if this file cannot be identified as a minidump file, or if its
   /// contents are badly corrupted (i.e. we cannot read the stream directory).
-  LLVM_ABI static Expected<std::unique_ptr<MinidumpFile>> create(MemoryBufferRef Source);
+  LLVM_ABI static Expected<std::unique_ptr<MinidumpFile>>
+  create(MemoryBufferRef Source);
 
   static bool classof(const Binary *B) { return B->isMinidump(); }
 
@@ -272,7 +273,8 @@ public:
   /// content from the Memory64List stream. An error is returned if the file
   /// does not contain a Memory64List stream, or if the descriptor data is
   /// unreadable.
-  LLVM_ABI iterator_range<FallibleMemory64Iterator> getMemory64List(Error &Err) const;
+  LLVM_ABI iterator_range<FallibleMemory64Iterator>
+  getMemory64List(Error &Err) const;
 
   /// Returns the list of descriptors embedded in the MemoryInfoList stream. The
   /// descriptors provide properties (e.g. permissions) of interesting regions
@@ -281,7 +283,8 @@ public:
   /// contain the number of memory descriptors declared in the stream header.
   /// The consistency of the MemoryInfoList entries themselves is not checked
   /// in any way.
-  LLVM_ABI Expected<iterator_range<MemoryInfoIterator>> getMemoryInfoList() const;
+  LLVM_ABI Expected<iterator_range<MemoryInfoIterator>>
+  getMemoryInfoList() const;
 
 private:
   static Error createError(StringRef Str) {

--- a/llvm/include/llvm/Object/ModuleSymbolTable.h
+++ b/llvm/include/llvm/Object/ModuleSymbolTable.h
@@ -15,12 +15,12 @@
 #ifndef LLVM_OBJECT_MODULESYMBOLTABLE_H
 #define LLVM_OBJECT_MODULESYMBOLTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/IR/Mangler.h"
 #include "llvm/Object/SymbolicFile.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <string>
 #include <utility>

--- a/llvm/include/llvm/Object/ModuleSymbolTable.h
+++ b/llvm/include/llvm/Object/ModuleSymbolTable.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_OBJECT_MODULESYMBOLTABLE_H
 #define LLVM_OBJECT_MODULESYMBOLTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/IR/Mangler.h"
@@ -44,17 +45,17 @@ private:
 
 public:
   ArrayRef<Symbol> symbols() const { return SymTab; }
-  void addModule(Module *M);
+  LLVM_ABI void addModule(Module *M);
 
-  void printSymbolName(raw_ostream &OS, Symbol S) const;
-  uint32_t getSymbolFlags(Symbol S) const;
+  LLVM_ABI void printSymbolName(raw_ostream &OS, Symbol S) const;
+  LLVM_ABI uint32_t getSymbolFlags(Symbol S) const;
 
   /// Parse inline ASM and collect the symbols that are defined or referenced in
   /// the current module.
   ///
   /// For each found symbol, call \p AsmSymbol with the name of the symbol found
   /// and the associated flags.
-  static void CollectAsmSymbols(
+  LLVM_ABI static void CollectAsmSymbols(
       const Module &M,
       function_ref<void(StringRef, object::BasicSymbolRef::Flags)> AsmSymbol);
 
@@ -63,7 +64,7 @@ public:
   ///
   /// For each found symbol, call \p AsmSymver with the name of the symbol and
   /// its alias.
-  static void
+  LLVM_ABI static void
   CollectAsmSymvers(const Module &M,
                     function_ref<void(StringRef, StringRef)> AsmSymver);
 };

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_OBJECT_OBJECTFILE_H
 #define LLVM_OBJECT_OBJECTFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
@@ -24,6 +23,7 @@
 #include "llvm/Object/Error.h"
 #include "llvm/Object/SymbolicFile.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/TargetParser/Triple.h"

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_OBJECTFILE_H
 #define LLVM_OBJECT_OBJECTFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
@@ -126,7 +127,7 @@ public:
   /// Whether this section is a debug section.
   bool isDebugSection() const;
 
-  bool containsSymbol(SymbolRef S) const;
+  LLVM_ABI bool containsSymbol(SymbolRef S) const;
 
   relocation_iterator relocation_begin() const;
   relocation_iterator relocation_end() const;
@@ -161,7 +162,7 @@ inline bool operator==(const SectionedAddress &LHS,
          std::tie(RHS.SectionIndex, RHS.Address);
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const SectionedAddress &Addr);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SectionedAddress &Addr);
 
 /// This is a value type class that represents a single symbol in the list of
 /// symbols in the object file.
@@ -226,7 +227,7 @@ public:
 /// This class is the base class for all object file types. Concrete instances
 /// of this object are created by createObjectFile, which figures out which type
 /// to create.
-class ObjectFile : public SymbolicFile {
+class LLVM_ABI ObjectFile : public SymbolicFile {
   virtual void anchor();
 
 protected:

--- a/llvm/include/llvm/Object/OffloadBinary.h
+++ b/llvm/include/llvm/Object/OffloadBinary.h
@@ -17,11 +17,11 @@
 #ifndef LLVM_OBJECT_OFFLOADBINARY_H
 #define LLVM_OBJECT_OFFLOADBINARY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/Binary.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <memory>
@@ -78,7 +78,8 @@ public:
   };
 
   /// Attempt to parse the offloading binary stored in \p Data.
-  LLVM_ABI static Expected<std::unique_ptr<OffloadBinary>> create(MemoryBufferRef);
+  LLVM_ABI static Expected<std::unique_ptr<OffloadBinary>>
+      create(MemoryBufferRef);
 
   /// Serialize the contents of \p File to a binary buffer to be read later.
   LLVM_ABI static SmallString<0> write(const OffloadingImage &);
@@ -188,7 +189,7 @@ public:
 /// Extracts embedded device offloading code from a memory \p Buffer to a list
 /// of \p Binaries.
 LLVM_ABI Error extractOffloadBinaries(MemoryBufferRef Buffer,
-                             SmallVectorImpl<OffloadFile> &Binaries);
+                                      SmallVectorImpl<OffloadFile> &Binaries);
 
 /// Convert a string \p Name to an image kind.
 LLVM_ABI ImageKind getImageKind(StringRef Name);
@@ -212,7 +213,7 @@ LLVM_ABI StringRef getOffloadKindName(OffloadKind Name);
 /// bind with either on or off. This is used to link mutually compatible
 /// architectures together. Returns false in the case of an exact match.
 LLVM_ABI bool areTargetsCompatible(const OffloadFile::TargetID &LHS,
-                          const OffloadFile::TargetID &RHS);
+                                   const OffloadFile::TargetID &RHS);
 
 } // namespace object
 

--- a/llvm/include/llvm/Object/OffloadBinary.h
+++ b/llvm/include/llvm/Object/OffloadBinary.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_OBJECT_OFFLOADBINARY_H
 #define LLVM_OBJECT_OFFLOADBINARY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
@@ -77,10 +78,10 @@ public:
   };
 
   /// Attempt to parse the offloading binary stored in \p Data.
-  static Expected<std::unique_ptr<OffloadBinary>> create(MemoryBufferRef);
+  LLVM_ABI static Expected<std::unique_ptr<OffloadBinary>> create(MemoryBufferRef);
 
   /// Serialize the contents of \p File to a binary buffer to be read later.
-  static SmallString<0> write(const OffloadingImage &);
+  LLVM_ABI static SmallString<0> write(const OffloadingImage &);
 
   static uint64_t getAlignment() { return 8; }
 
@@ -186,20 +187,20 @@ public:
 
 /// Extracts embedded device offloading code from a memory \p Buffer to a list
 /// of \p Binaries.
-Error extractOffloadBinaries(MemoryBufferRef Buffer,
+LLVM_ABI Error extractOffloadBinaries(MemoryBufferRef Buffer,
                              SmallVectorImpl<OffloadFile> &Binaries);
 
 /// Convert a string \p Name to an image kind.
-ImageKind getImageKind(StringRef Name);
+LLVM_ABI ImageKind getImageKind(StringRef Name);
 
 /// Convert an image kind to its string representation.
-StringRef getImageKindName(ImageKind Name);
+LLVM_ABI StringRef getImageKindName(ImageKind Name);
 
 /// Convert a string \p Name to an offload kind.
-OffloadKind getOffloadKind(StringRef Name);
+LLVM_ABI OffloadKind getOffloadKind(StringRef Name);
 
 /// Convert an offload kind to its string representation.
-StringRef getOffloadKindName(OffloadKind Name);
+LLVM_ABI StringRef getOffloadKindName(OffloadKind Name);
 
 /// If the target is AMD we check the target IDs for mutual compatibility. A
 /// target id is a string conforming to the folowing BNF syntax:
@@ -210,7 +211,7 @@ StringRef getOffloadKindName(OffloadKind Name);
 /// the state of on, off, and any when unspecified. A target marked as any can
 /// bind with either on or off. This is used to link mutually compatible
 /// architectures together. Returns false in the case of an exact match.
-bool areTargetsCompatible(const OffloadFile::TargetID &LHS,
+LLVM_ABI bool areTargetsCompatible(const OffloadFile::TargetID &LHS,
                           const OffloadFile::TargetID &RHS);
 
 } // namespace object

--- a/llvm/include/llvm/Object/OffloadBundle.h
+++ b/llvm/include/llvm/Object/OffloadBundle.h
@@ -17,12 +17,12 @@
 #ifndef LLVM_OBJECT_OFFLOADBUNDLE_H
 #define LLVM_OBJECT_OFFLOADBUNDLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -188,8 +188,8 @@ LLVM_ABI Error extractOffloadBundleFatBinary(
 
 /// Extract code object memory from the given \p Source object file at \p Offset
 /// and of \p Size, and copy into \p OutputFileName.
-LLVM_ABI Error extractCodeObject(const ObjectFile &Source, int64_t Offset, int64_t Size,
-                        StringRef OutputFileName);
+LLVM_ABI Error extractCodeObject(const ObjectFile &Source, int64_t Offset,
+                                 int64_t Size, StringRef OutputFileName);
 
 /// Extracts an Offload Bundle Entry given by URI
 LLVM_ABI Error extractOffloadBundleByURI(StringRef URIstr);

--- a/llvm/include/llvm/Object/OffloadBundle.h
+++ b/llvm/include/llvm/Object/OffloadBundle.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_OBJECT_OFFLOADBUNDLE_H
 #define LLVM_OBJECT_OFFLOADBUNDLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
@@ -49,10 +50,10 @@ private:
   static inline const uint16_t Version = 2;
 
 public:
-  static llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
+  LLVM_ABI static llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
   compress(llvm::compression::Params P, const llvm::MemoryBuffer &Input,
            bool Verbose = false);
-  static llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
+  LLVM_ABI static llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
   decompress(llvm::MemoryBufferRef &Input, bool Verbose = false);
 };
 
@@ -88,13 +89,13 @@ public:
   StringRef getFileName() const { return FileName; }
   uint64_t getNumEntries() const { return NumberOfEntries; }
 
-  static Expected<std::unique_ptr<OffloadBundleFatBin>>
+  LLVM_ABI static Expected<std::unique_ptr<OffloadBundleFatBin>>
   create(MemoryBufferRef, uint64_t SectionOffset, StringRef FileName);
-  Error extractBundle(const ObjectFile &Source);
+  LLVM_ABI Error extractBundle(const ObjectFile &Source);
 
-  Error dumpEntryToCodeObject();
+  LLVM_ABI Error dumpEntryToCodeObject();
 
-  Error readEntries(StringRef Section, uint64_t SectionOffset);
+  LLVM_ABI Error readEntries(StringRef Section, uint64_t SectionOffset);
   void dumpEntries() {
     for (OffloadBundleEntry &Entry : Entries)
       Entry.dumpInfo(outs());
@@ -182,16 +183,16 @@ public:
 
 /// Extracts fat binary in binary clang-offload-bundler format from object \p
 /// Obj and return it in \p Bundles
-Error extractOffloadBundleFatBinary(
+LLVM_ABI Error extractOffloadBundleFatBinary(
     const ObjectFile &Obj, SmallVectorImpl<OffloadBundleFatBin> &Bundles);
 
 /// Extract code object memory from the given \p Source object file at \p Offset
 /// and of \p Size, and copy into \p OutputFileName.
-Error extractCodeObject(const ObjectFile &Source, int64_t Offset, int64_t Size,
+LLVM_ABI Error extractCodeObject(const ObjectFile &Source, int64_t Offset, int64_t Size,
                         StringRef OutputFileName);
 
 /// Extracts an Offload Bundle Entry given by URI
-Error extractOffloadBundleByURI(StringRef URIstr);
+LLVM_ABI Error extractOffloadBundleByURI(StringRef URIstr);
 
 } // namespace object
 

--- a/llvm/include/llvm/Object/RelocationResolver.h
+++ b/llvm/include/llvm/Object/RelocationResolver.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_OBJECT_RELOCATIONRESOLVER_H
 #define LLVM_OBJECT_RELOCATIONRESOLVER_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <utility>
 
@@ -29,10 +30,10 @@ using RelocationResolver = uint64_t (*)(uint64_t Type, uint64_t Offset,
                                         uint64_t S, uint64_t LocData,
                                         int64_t Addend);
 
-std::pair<SupportsRelocation, RelocationResolver>
+LLVM_ABI std::pair<SupportsRelocation, RelocationResolver>
 getRelocationResolver(const ObjectFile &Obj);
 
-uint64_t resolveRelocation(RelocationResolver Resolver, const RelocationRef &R,
+LLVM_ABI uint64_t resolveRelocation(RelocationResolver Resolver, const RelocationRef &R,
                            uint64_t S, uint64_t LocData);
 
 } // end namespace object

--- a/llvm/include/llvm/Object/RelocationResolver.h
+++ b/llvm/include/llvm/Object/RelocationResolver.h
@@ -33,8 +33,9 @@ using RelocationResolver = uint64_t (*)(uint64_t Type, uint64_t Offset,
 LLVM_ABI std::pair<SupportsRelocation, RelocationResolver>
 getRelocationResolver(const ObjectFile &Obj);
 
-LLVM_ABI uint64_t resolveRelocation(RelocationResolver Resolver, const RelocationRef &R,
-                           uint64_t S, uint64_t LocData);
+LLVM_ABI uint64_t resolveRelocation(RelocationResolver Resolver,
+                                    const RelocationRef &R, uint64_t S,
+                                    uint64_t LocData);
 
 } // end namespace object
 } // end namespace llvm

--- a/llvm/include/llvm/Object/SymbolSize.h
+++ b/llvm/include/llvm/Object/SymbolSize.h
@@ -10,6 +10,7 @@
 #ifndef LLVM_OBJECT_SYMBOLSIZE_H
 #define LLVM_OBJECT_SYMBOLSIZE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Object/ObjectFile.h"
 
 namespace llvm {
@@ -22,9 +23,9 @@ struct SymEntry {
   unsigned SectionID;
 };
 
-int compareAddress(const SymEntry *A, const SymEntry *B);
+LLVM_ABI int compareAddress(const SymEntry *A, const SymEntry *B);
 
-std::vector<std::pair<SymbolRef, uint64_t>>
+LLVM_ABI std::vector<std::pair<SymbolRef, uint64_t>>
 computeSymbolSizes(const ObjectFile &O);
 
 }

--- a/llvm/include/llvm/Object/SymbolSize.h
+++ b/llvm/include/llvm/Object/SymbolSize.h
@@ -10,8 +10,8 @@
 #ifndef LLVM_OBJECT_SYMBOLSIZE_H
 #define LLVM_OBJECT_SYMBOLSIZE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace object {
@@ -27,7 +27,6 @@ LLVM_ABI int compareAddress(const SymEntry *A, const SymEntry *B);
 
 LLVM_ABI std::vector<std::pair<SymbolRef, uint64_t>>
 computeSymbolSizes(const ObjectFile &O);
-
 }
 } // namespace llvm
 

--- a/llvm/include/llvm/Object/SymbolicFile.h
+++ b/llvm/include/llvm/Object/SymbolicFile.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_OBJECT_SYMBOLICFILE_H
 #define LLVM_OBJECT_SYMBOLICFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Object/Binary.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/MemoryBufferRef.h"

--- a/llvm/include/llvm/Object/SymbolicFile.h
+++ b/llvm/include/llvm/Object/SymbolicFile.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_SYMBOLICFILE_H
 #define LLVM_OBJECT_SYMBOLICFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Object/Binary.h"
@@ -142,7 +143,7 @@ public:
 
 using basic_symbol_iterator = content_iterator<BasicSymbolRef>;
 
-class SymbolicFile : public Binary {
+class LLVM_ABI SymbolicFile : public Binary {
 public:
   SymbolicFile(unsigned int Type, MemoryBufferRef Source);
   ~SymbolicFile() override;

--- a/llvm/include/llvm/Object/TapiFile.h
+++ b/llvm/include/llvm/Object/TapiFile.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_TAPIFILE_H
 #define LLVM_OBJECT_TAPIFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
@@ -28,7 +29,7 @@ class raw_ostream;
 
 namespace object {
 
-class TapiFile : public SymbolicFile {
+class LLVM_ABI TapiFile : public SymbolicFile {
 public:
   TapiFile(MemoryBufferRef Source, const MachO::InterfaceFile &Interface,
            MachO::Architecture Arch);

--- a/llvm/include/llvm/Object/TapiFile.h
+++ b/llvm/include/llvm/Object/TapiFile.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_OBJECT_TAPIFILE_H
 #define LLVM_OBJECT_TAPIFILE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Object/SymbolicFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/TextAPI/Architecture.h"

--- a/llvm/include/llvm/Object/TapiUniversal.h
+++ b/llvm/include/llvm/Object/TapiUniversal.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_OBJECT_TAPIUNIVERSAL_H
 #define LLVM_OBJECT_TAPIUNIVERSAL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/Binary.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/TextAPI/Architecture.h"

--- a/llvm/include/llvm/Object/TapiUniversal.h
+++ b/llvm/include/llvm/Object/TapiUniversal.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_TAPIUNIVERSAL_H
 #define LLVM_OBJECT_TAPIUNIVERSAL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Support/Error.h"
@@ -25,7 +26,7 @@ namespace object {
 
 class TapiFile;
 
-class TapiUniversal : public Binary {
+class LLVM_ABI TapiUniversal : public Binary {
 public:
   class ObjectForArch {
     const TapiUniversal *Parent;
@@ -65,7 +66,7 @@ public:
       return Parent->ParsedFile->getInstallName() == getInstallName();
     }
 
-    Expected<std::unique_ptr<TapiFile>> getAsObjectFile() const;
+    LLVM_ABI Expected<std::unique_ptr<TapiFile>> getAsObjectFile() const;
   };
 
   class object_iterator {

--- a/llvm/include/llvm/Object/Wasm.h
+++ b/llvm/include/llvm/Object/Wasm.h
@@ -16,7 +16,6 @@
 #ifndef LLVM_OBJECT_WASM_H
 #define LLVM_OBJECT_WASM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Wasm.h"
@@ -24,6 +23,7 @@
 #include "llvm/MC/MCSymbolWasm.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <cstddef>
@@ -354,9 +354,11 @@ public:
   };
 
   // Sections that may or may not be present, but cannot be predecessors
-  LLVM_ABI static int DisallowedPredecessors[WASM_NUM_SEC_ORDERS][WASM_NUM_SEC_ORDERS];
+  LLVM_ABI static int DisallowedPredecessors[WASM_NUM_SEC_ORDERS]
+                                            [WASM_NUM_SEC_ORDERS];
 
-  LLVM_ABI bool isValidSectionOrder(unsigned ID, StringRef CustomSectionName = "");
+  LLVM_ABI bool isValidSectionOrder(unsigned ID,
+                                    StringRef CustomSectionName = "");
 
 private:
   bool Seen[WASM_NUM_SEC_ORDERS] = {}; // Sections that have been seen already

--- a/llvm/include/llvm/Object/Wasm.h
+++ b/llvm/include/llvm/Object/Wasm.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_OBJECT_WASM_H
 #define LLVM_OBJECT_WASM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Wasm.h"
@@ -98,7 +99,7 @@ public:
     return Info.Flags & wasm::WASM_SYMBOL_VISIBILITY_MASK;
   }
 
-  void print(raw_ostream &Out) const;
+  LLVM_ABI void print(raw_ostream &Out) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
@@ -123,7 +124,7 @@ struct WasmSegment {
   wasm::WasmDataSegment Data;
 };
 
-class WasmObjectFile : public ObjectFile {
+class LLVM_ABI WasmObjectFile : public ObjectFile {
 
 public:
   WasmObjectFile(MemoryBufferRef Object, Error &Err);
@@ -353,9 +354,9 @@ public:
   };
 
   // Sections that may or may not be present, but cannot be predecessors
-  static int DisallowedPredecessors[WASM_NUM_SEC_ORDERS][WASM_NUM_SEC_ORDERS];
+  LLVM_ABI static int DisallowedPredecessors[WASM_NUM_SEC_ORDERS][WASM_NUM_SEC_ORDERS];
 
-  bool isValidSectionOrder(unsigned ID, StringRef CustomSectionName = "");
+  LLVM_ABI bool isValidSectionOrder(unsigned ID, StringRef CustomSectionName = "");
 
 private:
   bool Seen[WASM_NUM_SEC_ORDERS] = {}; // Sections that have been seen already

--- a/llvm/include/llvm/Object/WindowsMachineFlag.h
+++ b/llvm/include/llvm/Object/WindowsMachineFlag.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_OBJECT_WINDOWSMACHINEFLAG_H
 #define LLVM_OBJECT_WINDOWSMACHINEFLAG_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/COFF.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 
 namespace llvm {

--- a/llvm/include/llvm/Object/WindowsMachineFlag.h
+++ b/llvm/include/llvm/Object/WindowsMachineFlag.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_OBJECT_WINDOWSMACHINEFLAG_H
 #define LLVM_OBJECT_WINDOWSMACHINEFLAG_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/TargetParser/Triple.h"
 
@@ -25,11 +26,11 @@ enum MachineTypes : unsigned;
 
 // Returns a user-readable string for ARMNT, ARM64, AMD64, I386.
 // Other MachineTypes values must not be passed in.
-StringRef machineToStr(COFF::MachineTypes MT);
+LLVM_ABI StringRef machineToStr(COFF::MachineTypes MT);
 
 // Maps /machine: arguments to a MachineTypes value.
 // Only returns ARMNT, ARM64, AMD64, I386, or IMAGE_FILE_MACHINE_UNKNOWN.
-COFF::MachineTypes getMachineType(StringRef S);
+LLVM_ABI COFF::MachineTypes getMachineType(StringRef S);
 
 template <typename T> Triple::ArchType getMachineArchType(T machine) {
   switch (machine) {

--- a/llvm/include/llvm/Object/WindowsResource.h
+++ b/llvm/include/llvm/Object/WindowsResource.h
@@ -28,6 +28,7 @@
 #ifndef LLVM_OBJECT_WINDOWSRESOURCE_H
 #define LLVM_OBJECT_WINDOWSRESOURCE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/Object/Binary.h"
@@ -97,7 +98,7 @@ public:
 
 class ResourceEntryRef {
 public:
-  Error moveNext(bool &End);
+  LLVM_ABI Error moveNext(bool &End);
   bool checkTypeString() const { return IsStringType; }
   ArrayRef<UTF16> getTypeString() const { return Type; }
   uint16_t getTypeID() const { return TypeID; }
@@ -135,11 +136,11 @@ private:
 
 class WindowsResource : public Binary {
 public:
-  Expected<ResourceEntryRef> getHeadEntry();
+  LLVM_ABI Expected<ResourceEntryRef> getHeadEntry();
 
   static bool classof(const Binary *V) { return V->isWinRes(); }
 
-  static Expected<std::unique_ptr<WindowsResource>>
+  LLVM_ABI static Expected<std::unique_ptr<WindowsResource>>
   createWindowsResource(MemoryBufferRef Source);
 
 private:
@@ -153,12 +154,12 @@ private:
 class WindowsResourceParser {
 public:
   class TreeNode;
-  WindowsResourceParser(bool MinGW = false);
-  Error parse(WindowsResource *WR, std::vector<std::string> &Duplicates);
-  Error parse(ResourceSectionRef &RSR, StringRef Filename,
+  LLVM_ABI WindowsResourceParser(bool MinGW = false);
+  LLVM_ABI Error parse(WindowsResource *WR, std::vector<std::string> &Duplicates);
+  LLVM_ABI Error parse(ResourceSectionRef &RSR, StringRef Filename,
               std::vector<std::string> &Duplicates);
-  void cleanUpManifests(std::vector<std::string> &Duplicates);
-  void printTree(raw_ostream &OS) const;
+  LLVM_ABI void cleanUpManifests(std::vector<std::string> &Duplicates);
+  LLVM_ABI void printTree(raw_ostream &OS) const;
   const TreeNode &getTree() const { return Root; }
   ArrayRef<std::vector<uint8_t>> getData() const { return Data; }
   ArrayRef<std::vector<UTF16>> getStringTable() const { return StringTable; }
@@ -168,8 +169,8 @@ public:
     template <typename T>
     using Children = std::map<T, std::unique_ptr<TreeNode>>;
 
-    void print(ScopedPrinter &Writer, StringRef Name) const;
-    uint32_t getTreeSize() const;
+    LLVM_ABI void print(ScopedPrinter &Writer, StringRef Name) const;
+    LLVM_ABI uint32_t getTreeSize() const;
     uint32_t getStringIndex() const { return StringIndex; }
     uint32_t getDataIndex() const { return DataIndex; }
     uint16_t getMajorVersion() const { return MajorVersion; }
@@ -257,12 +258,12 @@ private:
   bool MinGW;
 };
 
-Expected<std::unique_ptr<MemoryBuffer>>
+LLVM_ABI Expected<std::unique_ptr<MemoryBuffer>>
 writeWindowsResourceCOFF(llvm::COFF::MachineTypes MachineType,
                          const WindowsResourceParser &Parser,
                          uint32_t TimeDateStamp);
 
-void printResourceTypeName(uint16_t TypeID, raw_ostream &OS);
+LLVM_ABI void printResourceTypeName(uint16_t TypeID, raw_ostream &OS);
 } // namespace object
 } // namespace llvm
 

--- a/llvm/include/llvm/Object/WindowsResource.h
+++ b/llvm/include/llvm/Object/WindowsResource.h
@@ -28,13 +28,13 @@
 #ifndef LLVM_OBJECT_WINDOWSRESOURCE_H
 #define LLVM_OBJECT_WINDOWSRESOURCE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/Error.h"
 #include "llvm/Support/BinaryByteStream.h"
 #include "llvm/Support/BinaryStreamReader.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
@@ -155,9 +155,10 @@ class WindowsResourceParser {
 public:
   class TreeNode;
   LLVM_ABI WindowsResourceParser(bool MinGW = false);
-  LLVM_ABI Error parse(WindowsResource *WR, std::vector<std::string> &Duplicates);
+  LLVM_ABI Error parse(WindowsResource *WR,
+                       std::vector<std::string> &Duplicates);
   LLVM_ABI Error parse(ResourceSectionRef &RSR, StringRef Filename,
-              std::vector<std::string> &Duplicates);
+                       std::vector<std::string> &Duplicates);
   LLVM_ABI void cleanUpManifests(std::vector<std::string> &Duplicates);
   LLVM_ABI void printTree(raw_ostream &OS) const;
   const TreeNode &getTree() const { return Root; }

--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -176,8 +176,8 @@ public:
 // Explicit extern template declarations.
 struct XCOFFSectionHeader32;
 struct XCOFFSectionHeader64;
-extern template struct XCOFFSectionHeader<XCOFFSectionHeader32>;
-extern template struct XCOFFSectionHeader<XCOFFSectionHeader64>;
+extern template struct LLVM_TEMPLATE_ABI XCOFFSectionHeader<XCOFFSectionHeader32>;
+extern template struct LLVM_TEMPLATE_ABI XCOFFSectionHeader<XCOFFSectionHeader64>;
 
 struct XCOFFSectionHeader32 : XCOFFSectionHeader<XCOFFSectionHeader32> {
   char Name[XCOFF::NameSize];
@@ -318,8 +318,8 @@ typedef ExceptionSectionEntry<support::ubig32_t> ExceptionSectionEntry32;
 typedef ExceptionSectionEntry<support::ubig64_t> ExceptionSectionEntry64;
 
 // Explicit extern template declarations.
-extern template struct ExceptionSectionEntry<support::ubig32_t>;
-extern template struct ExceptionSectionEntry<support::ubig64_t>;
+extern template struct LLVM_TEMPLATE_ABI ExceptionSectionEntry<support::ubig32_t>;
+extern template struct LLVM_TEMPLATE_ABI ExceptionSectionEntry<support::ubig64_t>;
 
 struct XCOFFStringTable {
   uint32_t Size;
@@ -521,8 +521,8 @@ public:
   uint8_t getRelocatedLength() const;
 };
 
-extern template struct XCOFFRelocation<llvm::support::ubig32_t>;
-extern template struct XCOFFRelocation<llvm::support::ubig64_t>;
+extern template struct LLVM_TEMPLATE_ABI XCOFFRelocation<llvm::support::ubig32_t>;
+extern template struct LLVM_TEMPLATE_ABI XCOFFRelocation<llvm::support::ubig64_t>;
 
 struct XCOFFRelocation32 : XCOFFRelocation<llvm::support::ubig32_t> {};
 struct XCOFFRelocation64 : XCOFFRelocation<llvm::support::ubig64_t> {};

--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -222,7 +222,7 @@ struct LoaderSectionSymbolEntry32 {
   support::ubig32_t ImportFileID;
   support::ubig32_t ParameterTypeCheck;
 
-  Expected<StringRef>
+  LLVM_ABI Expected<StringRef>
   getSymbolName(const LoaderSectionHeader32 *LoaderSecHeader) const;
 };
 
@@ -235,7 +235,7 @@ struct LoaderSectionSymbolEntry64 {
   support::ubig32_t ImportFileID;
   support::ubig32_t ParameterTypeCheck;
 
-  Expected<StringRef>
+  LLVM_ABI Expected<StringRef>
   getSymbolName(const LoaderSectionHeader64 *LoaderSecHeader) const;
 };
 
@@ -529,7 +529,7 @@ struct XCOFFRelocation64 : XCOFFRelocation<llvm::support::ubig64_t> {};
 
 class XCOFFSymbolRef;
 
-class XCOFFObjectFile : public ObjectFile {
+class LLVM_ABI XCOFFObjectFile : public ObjectFile {
 private:
   const void *FileHeader = nullptr;
   const void *AuxiliaryHeader = nullptr;
@@ -852,10 +852,10 @@ public:
     return getRawDataRefImpl().p;
   }
 
-  Expected<StringRef> getName() const;
-  Expected<bool> isFunction() const;
-  bool isCsectSymbol() const;
-  Expected<XCOFFCsectAuxRef> getXCOFFCsectAuxRef() const;
+  LLVM_ABI Expected<StringRef> getName() const;
+  LLVM_ABI Expected<bool> isFunction() const;
+  LLVM_ABI bool isCsectSymbol() const;
+  LLVM_ABI Expected<XCOFFCsectAuxRef> getXCOFFCsectAuxRef() const;
 
 private:
   const XCOFFObjectFile *getObject() const {
@@ -887,12 +887,12 @@ class TBVectorExt {
   TBVectorExt(StringRef TBvectorStrRef, Error &Err);
 
 public:
-  static Expected<TBVectorExt> create(StringRef TBvectorStrRef);
-  uint8_t getNumberOfVRSaved() const;
-  bool isVRSavedOnStack() const;
-  bool hasVarArgs() const;
-  uint8_t getNumberOfVectorParms() const;
-  bool hasVMXInstruction() const;
+  LLVM_ABI static Expected<TBVectorExt> create(StringRef TBvectorStrRef);
+  LLVM_ABI uint8_t getNumberOfVRSaved() const;
+  LLVM_ABI bool isVRSavedOnStack() const;
+  LLVM_ABI bool hasVarArgs() const;
+  LLVM_ABI uint8_t getNumberOfVectorParms() const;
+  LLVM_ABI bool hasVMXInstruction() const;
   SmallString<32> getVectorParmsInfo() const { return VecParmsInfo; };
 };
 
@@ -930,39 +930,39 @@ public:
   ///    If the XCOFF Traceback Table is not parsed successfully or there are
   ///    extra bytes that are not recognized, \a Size will be updated to be the
   ///    size up to the end of the last successfully parsed field of the table.
-  static Expected<XCOFFTracebackTable>
+  LLVM_ABI static Expected<XCOFFTracebackTable>
   create(const uint8_t *Ptr, uint64_t &Size, bool Is64Bits = false);
-  uint8_t getVersion() const;
-  uint8_t getLanguageID() const;
+  LLVM_ABI uint8_t getVersion() const;
+  LLVM_ABI uint8_t getLanguageID() const;
 
-  bool isGlobalLinkage() const;
-  bool isOutOfLineEpilogOrPrologue() const;
-  bool hasTraceBackTableOffset() const;
-  bool isInternalProcedure() const;
-  bool hasControlledStorage() const;
-  bool isTOCless() const;
-  bool isFloatingPointPresent() const;
-  bool isFloatingPointOperationLogOrAbortEnabled() const;
+  LLVM_ABI bool isGlobalLinkage() const;
+  LLVM_ABI bool isOutOfLineEpilogOrPrologue() const;
+  LLVM_ABI bool hasTraceBackTableOffset() const;
+  LLVM_ABI bool isInternalProcedure() const;
+  LLVM_ABI bool hasControlledStorage() const;
+  LLVM_ABI bool isTOCless() const;
+  LLVM_ABI bool isFloatingPointPresent() const;
+  LLVM_ABI bool isFloatingPointOperationLogOrAbortEnabled() const;
 
-  bool isInterruptHandler() const;
-  bool isFuncNamePresent() const;
-  bool isAllocaUsed() const;
-  uint8_t getOnConditionDirective() const;
-  bool isCRSaved() const;
-  bool isLRSaved() const;
+  LLVM_ABI bool isInterruptHandler() const;
+  LLVM_ABI bool isFuncNamePresent() const;
+  LLVM_ABI bool isAllocaUsed() const;
+  LLVM_ABI uint8_t getOnConditionDirective() const;
+  LLVM_ABI bool isCRSaved() const;
+  LLVM_ABI bool isLRSaved() const;
 
-  bool isBackChainStored() const;
-  bool isFixup() const;
-  uint8_t getNumOfFPRsSaved() const;
+  LLVM_ABI bool isBackChainStored() const;
+  LLVM_ABI bool isFixup() const;
+  LLVM_ABI uint8_t getNumOfFPRsSaved() const;
 
-  bool hasVectorInfo() const;
-  bool hasExtensionTable() const;
-  uint8_t getNumOfGPRsSaved() const;
+  LLVM_ABI bool hasVectorInfo() const;
+  LLVM_ABI bool hasExtensionTable() const;
+  LLVM_ABI uint8_t getNumOfGPRsSaved() const;
 
-  uint8_t getNumberOfFixedParms() const;
+  LLVM_ABI uint8_t getNumberOfFixedParms() const;
 
-  uint8_t getNumberOfFPParms() const;
-  bool hasParmsOnStack() const;
+  LLVM_ABI uint8_t getNumberOfFPParms() const;
+  LLVM_ABI bool hasParmsOnStack() const;
 
   const std::optional<SmallString<32>> &getParmsType() const {
     return ParmsType;
@@ -991,7 +991,7 @@ public:
   const std::optional<uint64_t> &getEhInfoDisp() const { return EhInfoDisp; }
 };
 
-bool doesXCOFFTracebackTableBegin(ArrayRef<uint8_t> Bytes);
+LLVM_ABI bool doesXCOFFTracebackTableBegin(ArrayRef<uint8_t> Bytes);
 } // namespace object
 } // namespace llvm
 

--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -176,8 +176,10 @@ public:
 // Explicit extern template declarations.
 struct XCOFFSectionHeader32;
 struct XCOFFSectionHeader64;
-extern template struct LLVM_TEMPLATE_ABI XCOFFSectionHeader<XCOFFSectionHeader32>;
-extern template struct LLVM_TEMPLATE_ABI XCOFFSectionHeader<XCOFFSectionHeader64>;
+extern template struct LLVM_TEMPLATE_ABI
+    XCOFFSectionHeader<XCOFFSectionHeader32>;
+extern template struct LLVM_TEMPLATE_ABI
+    XCOFFSectionHeader<XCOFFSectionHeader64>;
 
 struct XCOFFSectionHeader32 : XCOFFSectionHeader<XCOFFSectionHeader32> {
   char Name[XCOFF::NameSize];
@@ -318,8 +320,10 @@ typedef ExceptionSectionEntry<support::ubig32_t> ExceptionSectionEntry32;
 typedef ExceptionSectionEntry<support::ubig64_t> ExceptionSectionEntry64;
 
 // Explicit extern template declarations.
-extern template struct LLVM_TEMPLATE_ABI ExceptionSectionEntry<support::ubig32_t>;
-extern template struct LLVM_TEMPLATE_ABI ExceptionSectionEntry<support::ubig64_t>;
+extern template struct LLVM_TEMPLATE_ABI
+    ExceptionSectionEntry<support::ubig32_t>;
+extern template struct LLVM_TEMPLATE_ABI
+    ExceptionSectionEntry<support::ubig64_t>;
 
 struct XCOFFStringTable {
   uint32_t Size;
@@ -521,8 +525,10 @@ public:
   uint8_t getRelocatedLength() const;
 };
 
-extern template struct LLVM_TEMPLATE_ABI XCOFFRelocation<llvm::support::ubig32_t>;
-extern template struct LLVM_TEMPLATE_ABI XCOFFRelocation<llvm::support::ubig64_t>;
+extern template struct LLVM_TEMPLATE_ABI
+    XCOFFRelocation<llvm::support::ubig32_t>;
+extern template struct LLVM_TEMPLATE_ABI
+    XCOFFRelocation<llvm::support::ubig64_t>;
 
 struct XCOFFRelocation32 : XCOFFRelocation<llvm::support::ubig32_t> {};
 struct XCOFFRelocation64 : XCOFFRelocation<llvm::support::ubig64_t> {};

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -93,8 +93,8 @@ uint8_t XCOFFRelocation<AddressType>::getRelocatedLength() const {
   return (Info & XR_BIASED_LENGTH_MASK) + 1;
 }
 
-template struct ExceptionSectionEntry<support::ubig32_t>;
-template struct ExceptionSectionEntry<support::ubig64_t>;
+template struct LLVM_EXPORT_TEMPLATE ExceptionSectionEntry<support::ubig32_t>;
+template struct LLVM_EXPORT_TEMPLATE ExceptionSectionEntry<support::ubig64_t>;
 
 template <typename T>
 Expected<StringRef> getLoaderSecSymNameInStrTbl(const T *LoaderSecHeader,
@@ -1375,11 +1375,11 @@ Expected<StringRef> XCOFFSymbolRef::getName() const {
 }
 
 // Explicitly instantiate template classes.
-template struct XCOFFSectionHeader<XCOFFSectionHeader32>;
-template struct XCOFFSectionHeader<XCOFFSectionHeader64>;
+template struct LLVM_EXPORT_TEMPLATE XCOFFSectionHeader<XCOFFSectionHeader32>;
+template struct LLVM_EXPORT_TEMPLATE XCOFFSectionHeader<XCOFFSectionHeader64>;
 
-template struct XCOFFRelocation<llvm::support::ubig32_t>;
-template struct XCOFFRelocation<llvm::support::ubig64_t>;
+template struct LLVM_EXPORT_TEMPLATE XCOFFRelocation<llvm::support::ubig32_t>;
+template struct LLVM_EXPORT_TEMPLATE XCOFFRelocation<llvm::support::ubig64_t>;
 
 template LLVM_EXPORT_TEMPLATE
     llvm::Expected<llvm::ArrayRef<llvm::object::XCOFFRelocation64>>


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/ObjCopy` and `llvm/Object` libraries. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS on Linux:
- Add `#include "llvm/Support/Compiler.h"` to files where it was not auto-added by IDS due to no pre-existing block of include statements.
- Manually annotate template class `CommonArchiveMemberHeader` with `LLVM_ABI` since IDS ignores templates and this is the simplest solution for DLL-exporting its child classes because it has methods defined out-of-line. Seems to be an uncommon situation.
- Explicitly make `Archive` class non-copyable due to the class-level `LLVM_ABI` annotation.
- Add default constructor to `ELFFile` so it can be instantiated for DLL-export as a base class.
- Add `LLVM_TEMPLATE_ABI` and `LLVM_EXPORT_TEMPLATE` to exported instantiated templates.

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang