### PR TITLE
[ModuleMap] Fix module build after #141750

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -178,9 +178,10 @@ module LLVM_DebugInfo_CodeView {
   module * { export * }
 
   // These are intended for (repeated) textual inclusion.
+  textual header "llvm/DebugInfo/CodeView/CodeViewLanguages.def"
   textual header "llvm/DebugInfo/CodeView/CodeViewRegisters.def"
-  textual header "llvm/DebugInfo/CodeView/CodeViewTypes.def"
   textual header "llvm/DebugInfo/CodeView/CodeViewSymbols.def"
+  textual header "llvm/DebugInfo/CodeView/CodeViewTypes.def"
 }
 
 module LLVM_DWARFLinker {


### PR DESCRIPTION
Add `CodeViewLanguages.def` to textual header in LLVM_DebugInfo_CodeView
to fix clang module build of LLVM.
