### PR TITLE
[CIR] Fix missing return value warning in maybePromoteBoolResult

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -104,6 +104,7 @@ public:
       return builder.createBoolToInt(value, dstTy);
     if (mlir::isa<cir::BoolType>(dstTy))
       return value;
+    llvm_unreachable("Can only promote integer or boolean types");
   }
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
This is NFC and simply adds an llvm_unreachable