### PR TITLE
[lldb][test] Free buffers in demangling tests to avoid leaks

### DIFF
--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -642,8 +642,10 @@ TEST_P(DemanglingInfoCorrectnessTestFixutre, Correctness) {
   // function names.
   if (Root->getKind() !=
           llvm::itanium_demangle::Node::Kind::KFunctionEncoding &&
-      Root->getKind() != llvm::itanium_demangle::Node::Kind::KDotSuffix)
+      Root->getKind() != llvm::itanium_demangle::Node::Kind::KDotSuffix) {
+    std::free(OB.getBuffer());
     return;
+  }
 
   ASSERT_TRUE(OB.NameInfo.hasBasename());
 
@@ -670,6 +672,7 @@ TEST_P(DemanglingInfoCorrectnessTestFixutre, Correctness) {
                        return_right, qualifiers, suffix);
 
   EXPECT_EQ(reconstructed_name, demangled);
+  std::free(OB.getBuffer());
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Test case added by f669b9c3eca9438d33259aefb8156f977f1df382 / #137793. Note that the `DemanglingParts` case above also frees the buffer; this new test case is inconsistent.