### PR TITLE
[bazel] Port 0a3e9aa336d1926691e1353e7251ff0704c32a69

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -960,7 +960,10 @@ cc_library(
         "include/llvm/Analysis/WithCache.h",
     ] + [":llvm_intrinsics_headers"],
     copts = llvm_copts,
-    textual_hdrs = glob(["include/llvm/IR/*.def"]),
+    textual_hdrs = glob([
+        "include/llvm/IR/*.def",
+        "lib/IR/*.def",
+    ]),
     deps = [
         ":BinaryFormat",
         ":Demangle",


### PR DESCRIPTION
llvm/lib/IR/RuntimeLibcalls.cpp needs to include llvm/lib/IR/ZOSLibcallNames.def