### PR TITLE
[MLIR][Transform] Allow ApplyRegisteredPassOp to take options as a param

### DIFF
--- a/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
@@ -406,8 +406,9 @@ def ApplyRegisteredPassOp : TransformDialectOp<"apply_registered_pass",
     This transform applies the specified pass or pass pipeline to the targeted
     ops. The name of the pass/pipeline is specified as a string attribute, as
     set during pass/pipeline registration. Optionally, pass options may be
-    specified as a string attribute with the option to pass the attribute as a
-    param. The pass options syntax is identical to the one used with "mlir-opt".
+    specified as (space-separated) string attributes with the option to pass
+    these attributes via params. The pass options syntax is identical to the one
+    used with "mlir-opt".
 
     This op first looks for a pass pipeline with the specified name. If no such
     pipeline exists, it looks for a pass with the specified name. If no such
@@ -420,16 +421,17 @@ def ApplyRegisteredPassOp : TransformDialectOp<"apply_registered_pass",
     of targeted ops.
   }];
 
-  let arguments = (ins Optional<TransformParamTypeInterface>:$dynamic_options,
-                       TransformHandleTypeInterface:$target,
-                       StrAttr:$pass_name,
-                       DefaultValuedAttr<StrAttr, "\"\"">:$static_options);
+  let arguments = (ins StrAttr:$pass_name,
+                       DefaultValuedAttr<ArrayAttr, "{}">:$options,
+                       Variadic<TransformParamTypeInterface>:$dynamic_options,
+                       TransformHandleTypeInterface:$target);
   let results = (outs TransformHandleTypeInterface:$result);
   let assemblyFormat = [{
     $pass_name (`with` `options` `=`
-      custom<ApplyRegisteredPassOptions>($dynamic_options, $static_options)^)?
+      custom<ApplyRegisteredPassOptions>($options, $dynamic_options)^)?
       `to` $target attr-dict `:` functional-type(operands, results)
   }];
+  let hasVerifier = 1;
 }
 
 def CastOp : TransformDialectOp<"cast",

--- a/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
@@ -399,15 +399,15 @@ def ApplyLoopInvariantCodeMotionOp : TransformDialectOp<"apply_licm",
 }
 
 def ApplyRegisteredPassOp : TransformDialectOp<"apply_registered_pass",
-    [TransformOpInterface, TransformEachOpTrait,
-     FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface]> {
+    [DeclareOpInterfaceMethods<TransformOpInterface>,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Applies the specified registered pass or pass pipeline";
   let description = [{
     This transform applies the specified pass or pass pipeline to the targeted
     ops. The name of the pass/pipeline is specified as a string attribute, as
     set during pass/pipeline registration. Optionally, pass options may be
-    specified as a string attribute. The pass options syntax is identical to the
-    one used with "mlir-opt".
+    specified as a string attribute with the option to pass the attribute as a
+    param. The pass options syntax is identical to the one used with "mlir-opt".
 
     This op first looks for a pass pipeline with the specified name. If no such
     pipeline exists, it looks for a pass with the specified name. If no such
@@ -420,20 +420,15 @@ def ApplyRegisteredPassOp : TransformDialectOp<"apply_registered_pass",
     of targeted ops.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
+  let arguments = (ins Optional<TransformParamTypeInterface>:$dynamic_options,
+                       TransformHandleTypeInterface:$target,
                        StrAttr:$pass_name,
-                       DefaultValuedAttr<StrAttr, "\"\"">:$options);
+                       DefaultValuedAttr<StrAttr, "\"\"">:$static_options);
   let results = (outs TransformHandleTypeInterface:$result);
   let assemblyFormat = [{
-    $pass_name `to` $target attr-dict `:` functional-type(operands, results)
-  }];
-
-  let extraClassDeclaration = [{
-    ::mlir::DiagnosedSilenceableFailure applyToOne(
-      ::mlir::transform::TransformRewriter &rewriter,
-      ::mlir::Operation *target,
-      ::mlir::transform::ApplyToEachResultList &results,
-      ::mlir::transform::TransformState &state);
+    $pass_name (`with` `options` `=`
+      custom<ApplyRegisteredPassOptions>($dynamic_options, $static_options)^)?
+      `to` $target attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -924,7 +924,7 @@ static void printApplyRegisteredPassOptions(OpAsmPrinter &printer,
     else if (auto strAttr = dyn_cast<StringAttr>(optionAttr))
       printer.printAttribute(strAttr);
     else
-      assert(false && "each option should be either a StringAttr or UnitAttr");
+      llvm_unreachable("each option should be either a StringAttr or UnitAttr");
   }
 }
 

--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -815,8 +815,8 @@ transform::ApplyRegisteredPassOp::apply(transform::TransformRewriter &rewriter,
                << dynamicOption[0];
       }
     } else {
-      assert(false &&
-             "expected options element to be either StringAttr or UnitAttr");
+      llvm_unreachable(
+          "expected options element to be either StringAttr or UnitAttr");
     }
   }
 
@@ -915,8 +915,8 @@ static void printApplyRegisteredPassOptions(OpAsmPrinter &printer,
                                             Operation *op, ArrayAttr options,
                                             ValueRange dynamicOptions) {
   size_t currentDynamicOptionIdx = 0;
-  for (Attribute optionAttr : options) {
-    if (currentDynamicOptionIdx > 0)
+  for (auto [idx, optionAttr] : llvm::enumerate(options)) {
+    if (idx > 0)
       printer << " "; // Interleave options separator.
 
     if (isa<UnitAttr>(optionAttr))

--- a/mlir/test/Dialect/Transform/test-pass-application.mlir
+++ b/mlir/test/Dialect/Transform/test-pass-application.mlir
@@ -79,7 +79,9 @@ module attributes {transform.with_named_sequence} {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     // expected-error @below {{failed to add pass or pass pipeline to pipeline: canonicalize}}
     // expected-error @below {{<Pass-Options-Parser>: no such option invalid-option}}
-    transform.apply_registered_pass "canonicalize" with options = "invalid-option=1" to %1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "canonicalize"
+        with options = "invalid-option=1" to %1
+        : (!transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -94,7 +96,9 @@ func.func @valid_pass_option() {
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.apply_registered_pass "canonicalize" with options = "top-down=false" to %1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "canonicalize"
+        with options = "top-down=false" to %1
+        : (!transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -110,7 +114,9 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     //transform.apply_registered_pass "canonicalize" with options = "top-down=false,max-iterations=10" to %1 : (!transform.any_op) -> !transform.any_op
-    transform.apply_registered_pass "canonicalize" with options = "top-down=false test-convergence=true" to %1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "canonicalize"
+        with options = "top-down=false test-convergence=true" to %1
+        : (!transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -125,7 +131,9 @@ func.func @valid_pass_options_as_list() {
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.apply_registered_pass "canonicalize" with options = "top-down=false" "max-iterations=0" to %1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "canonicalize"
+        with options = "top-down=false" "max-iterations=0" to %1
+        : (!transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -142,7 +150,9 @@ module attributes {transform.with_named_sequence} {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %max_iter = transform.param.constant "max-iterations=10" -> !transform.any_param
     %max_rewrites = transform.param.constant "max-num-rewrites=1" -> !transform.any_param
-    %2 = transform.apply_registered_pass "canonicalize" with options = "top-down=false" %max_iter "test-convergence=true" %max_rewrites to %1 : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
+    %2 = transform.apply_registered_pass "canonicalize"
+        with options = "top-down=false" %max_iter "test-convergence=true" %max_rewrites to %1
+        : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -157,8 +167,10 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %max_iter = transform.param.constant "max-iterations=10" -> !transform.any_param
-    // expected-error @below {{expected at least one option (either a string or a param)}}
-    %2 = transform.apply_registered_pass "canonicalize" with options = ["top-down=false" %max_iter] to %1 : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
+    // expected-error @+2 {{expected at least one option (either a string or a param)}}
+    %2 = transform.apply_registered_pass "canonicalize"
+        with options = ["top-down=false" %max_iter] to %1
+        : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -172,9 +184,10 @@ func.func @invalid_options_as_pairs() {
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %max_iter = transform.param.constant "max-iterations=10" -> !transform.any_param
-    // expected-error @below {{expected 'to'}}
-    %2 = transform.apply_registered_pass "canonicalize" with options = "top-down=" false to %1 : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
+    // expected-error @+2 {{expected 'to'}}
+    %2 = transform.apply_registered_pass "canonicalize"
+        with options = "top-down=" false to %1
+        : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -190,7 +203,9 @@ module attributes {transform.with_named_sequence} {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %pass_options = transform.param.constant 42 -> !transform.any_param
     // expected-error @below {{options passed as a param must be a string, got 42}}
-    transform.apply_registered_pass "canonicalize" with options = %pass_options to %1 : (!transform.any_param, !transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "canonicalize"
+        with options = %pass_options to %1
+        : (!transform.any_param, !transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -208,7 +223,9 @@ module attributes {transform.with_named_sequence} {
     %y = transform.param.constant "y" -> !transform.any_param
     %pass_options = transform.merge_handles %x, %y : !transform.any_param
     // expected-error @below {{options passed as a param must have a single value associated, param 0 associates 2}}
-    transform.apply_registered_pass "canonicalize" with options = %pass_options to %1 : (!transform.any_param, !transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "canonicalize"
+        with options = %pass_options to %1
+        : (!transform.any_param, !transform.any_op) -> !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/Transform/test-pass-application.mlir
+++ b/mlir/test/Dialect/Transform/test-pass-application.mlir
@@ -101,19 +101,84 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
-// CHECK-LABEL: func @valid_dynamic_pass_option()
-func.func @valid_dynamic_pass_option() {
+// CHECK-LABEL: func @valid_pass_options()
+func.func @valid_pass_options() {
   return
 }
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %pass_options = transform.param.constant "top-down=false" -> !transform.any_param
-    transform.apply_registered_pass "canonicalize" with options = %pass_options to %1 : (!transform.any_param, !transform.any_op) -> !transform.any_op
+    //transform.apply_registered_pass "canonicalize" with options = "top-down=false,max-iterations=10" to %1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "canonicalize" with options = "top-down=false test-convergence=true" to %1 : (!transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
+
+// -----
+
+// CHECK-LABEL: func @valid_pass_options_as_list()
+func.func @valid_pass_options_as_list() {
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "canonicalize" with options = "top-down=false" "max-iterations=0" to %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func @valid_dynamic_pass_options()
+func.func @valid_dynamic_pass_options() {
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %max_iter = transform.param.constant "max-iterations=10" -> !transform.any_param
+    %max_rewrites = transform.param.constant "max-num-rewrites=1" -> !transform.any_param
+    %2 = transform.apply_registered_pass "canonicalize" with options = "top-down=false" %max_iter "test-convergence=true" %max_rewrites to %1 : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+func.func @invalid_dynamic_options_as_array() {
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %max_iter = transform.param.constant "max-iterations=10" -> !transform.any_param
+    // expected-error @below {{expected at least one option (either a string or a param)}}
+    %2 = transform.apply_registered_pass "canonicalize" with options = ["top-down=false" %max_iter] to %1 : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+func.func @invalid_options_as_pairs() {
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %max_iter = transform.param.constant "max-iterations=10" -> !transform.any_param
+    // expected-error @below {{expected 'to'}}
+    %2 = transform.apply_registered_pass "canonicalize" with options = "top-down=" false to %1 : (!transform.any_param, !transform.any_param, !transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
 // -----
 
 func.func @invalid_pass_option_param() {
@@ -126,7 +191,6 @@ module attributes {transform.with_named_sequence} {
     %pass_options = transform.param.constant 42 -> !transform.any_param
     // expected-error @below {{options passed as a param must be a string, got 42}}
     transform.apply_registered_pass "canonicalize" with options = %pass_options to %1 : (!transform.any_param, !transform.any_op) -> !transform.any_op
-    transform.apply_registered_pass "canonicalize" with options = "invalid-option=1" to %1 : (!transform.any_op) -> !transform.any_op
     transform.yield
   }
 }
@@ -141,8 +205,9 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
     %1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %x = transform.param.constant "x" -> !transform.any_param
-    %pass_options = transform.merge_handles %x, %x : !transform.any_param
-    // expected-error @below {{options passed as a param must be a single value, got 2}}
+    %y = transform.param.constant "y" -> !transform.any_param
+    %pass_options = transform.merge_handles %x, %y : !transform.any_param
+    // expected-error @below {{options passed as a param must have a single value associated, param 0 associates 2}}
     transform.apply_registered_pass "canonicalize" with options = %pass_options to %1 : (!transform.any_param, !transform.any_op) -> !transform.any_op
     transform.yield
   }


### PR DESCRIPTION
Makes it possible to pass around the options to a pass inside a schedule.

The refactoring also makes it so that the pass manager and pass are only
constructed once per `apply()` of the transform op versus for each target
payload given to the op's `apply()`.