### PR TITLE
[CIR] Introduce cir::RecordKind::Class

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -431,6 +431,11 @@ def CIR_RecordType : CIR_Type<"Record", "record",
     will be the same type. Attempting to build a record with an existing name,
     but a different body will result in an error.
 
+    Each record type will have a `RecordKind` that is either `Class`, `Struct`,
+    or `Union`, depending on the C/C++ type that it is representing. Note that
+    `Class` and `Struct` are semantically identical, but the kind preserves the
+    keyword that was used to declare the type in the original source code.
+
     A few examples:
 
     ```mlir
@@ -482,8 +487,9 @@ def CIR_RecordType : CIR_Type<"Record", "record",
   let extraClassDeclaration = [{
     using Base::verifyInvariants;
 
-    enum RecordKind : uint32_t { Struct, Union };
+    enum RecordKind : uint32_t { Class, Struct, Union };
 
+    bool isClass() const { return getKind() == RecordKind::Class; };
     bool isStruct() const { return getKind() == RecordKind::Struct; };
     bool isUnion() const { return getKind() == RecordKind::Union; };
     bool isComplete() const { return !isIncomplete(); };
@@ -493,6 +499,8 @@ def CIR_RecordType : CIR_Type<"Record", "record",
     size_t getNumElements() const { return getMembers().size(); };
     std::string getKindAsStr() {
       switch (getKind()) {
+      case RecordKind::Class:
+        return "class";
       case RecordKind::Union:
         return "union";
       case RecordKind::Struct:

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -83,6 +83,7 @@ public:
   cir::RecordType::RecordKind getRecordKind(const clang::TagTypeKind kind) {
     switch (kind) {
     case clang::TagTypeKind::Class:
+      return cir::RecordType::Class;
     case clang::TagTypeKind::Struct:
       return cir::RecordType::Struct;
     case clang::TagTypeKind::Union:

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -98,6 +98,8 @@ Type RecordType::parse(mlir::AsmParser &parser) {
     kind = RecordKind::Struct;
   else if (parser.parseOptionalKeyword("union").succeeded())
     kind = RecordKind::Union;
+  else if (parser.parseOptionalKeyword("class").succeeded())
+    kind = RecordKind::Class;
   else {
     parser.emitError(loc, "unknown record type");
     return {};
@@ -167,6 +169,9 @@ void RecordType::print(mlir::AsmPrinter &printer) const {
     break;
   case RecordKind::Union:
     printer << "union ";
+    break;
+  case RecordKind::Class:
+    printer << "class ";
     break;
   }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1584,6 +1584,7 @@ static void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
     // Convert struct members.
     llvm::SmallVector<mlir::Type> llvmMembers;
     switch (type.getKind()) {
+    case cir::RecordType::Class:
     case cir::RecordType::Struct:
       for (mlir::Type ty : type.getMembers())
         llvmMembers.push_back(convertTypeForMemory(converter, dataLayout, ty));
@@ -1767,6 +1768,7 @@ mlir::LogicalResult CIRToLLVMGetMemberOpLowering::matchAndRewrite(
   assert(recordTy && "expected record type");
 
   switch (recordTy.getKind()) {
+  case cir::RecordType::Class:
   case cir::RecordType::Struct: {
     // Since the base address is a pointer to an aggregate, the first offset
     // is always zero. The second offset tell us which member it will access.

--- a/clang/test/CIR/CodeGen/class.cpp
+++ b/clang/test/CIR/CodeGen/class.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// CIR: !rec_IncompleteC = !cir.record<class "IncompleteC" incomplete>
+// CIR: !rec_CompleteC = !cir.record<class "CompleteC" {!s32i, !s8i}>
+
+// Note: LLVM and OGCG do not emit the type for incomplete classes.
+
+// LLVM: %class.CompleteC = type { i32, i8 }
+
+// OGCG: %class.CompleteC = type { i32, i8 }
+
+class IncompleteC;
+IncompleteC *p;
+
+// CIR: cir.global external @p = #cir.ptr<null> : !cir.ptr<!rec_IncompleteC>
+// LLVM: @p = global ptr null
+// OGCG: @p = global ptr null, align 8
+
+class CompleteC {
+public:    
+  int a;
+  char b;
+};
+
+CompleteC cc;
+
+// CIR:       cir.global external @cc = #cir.zero : !rec_CompleteC
+// LLVM:  @cc = global %class.CompleteC zeroinitializer
+// OGCG:  @cc = global %class.CompleteC zeroinitializer

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -1,15 +1,19 @@
 // RUN: cir-opt %s | FileCheck %s
 
+!rec_C = !cir.record<class "C" incomplete>
 !rec_S = !cir.record<struct "S" incomplete>
 !rec_U = !cir.record<union "U" incomplete>
 
+// CHECK: !rec_C = !cir.record<class "C" incomplete>
 // CHECK: !rec_S = !cir.record<struct "S" incomplete>
 // CHECK: !rec_U = !cir.record<union "U" incomplete>
 
 module  {
     cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!rec_S>
     cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!rec_U>
+    cir.global external @p3 = #cir.ptr<null> : !cir.ptr<!rec_C>
 }
 
 // CHECK: cir.global external @p1 = #cir.ptr<null> : !cir.ptr<!rec_S>
 // CHECK: cir.global external @p2 = #cir.ptr<null> : !cir.ptr<!rec_U>
+// CHECK: cir.global external @p3 = #cir.ptr<null> : !cir.ptr<!rec_C>


### PR DESCRIPTION
When cir::RecordType was initially upstreamed, we decided that there was no reason to distinguish between RecordKind::Class and RecordKind::Struct since they are semantically equivalent. I think this was a mistake because classic codegen does preserve the distinction (which is visible in the AST) and preserving the distinction in CIR will aid the possibility of eventually using the classic codegen lit tests with CIR.

This change introduces RecordKind::Class, which is already present in the incubator implementation.