### PR TITLE
[Github] Add pr-subscribers-infrastructure notifications

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -1121,3 +1121,6 @@ tablegen:
   - llvm/include/TableGen/**
   - llvm/lib/TableGen/**
   - llvm/utils/TableGen/**
+
+infrastructure:
+  - .ci/**


### PR DESCRIPTION
This patch sets up the new PRs labeller for a
pr-subscribers-infrastructure team that can be used for recieving notifications about infrastructure changes in the monorepo. This is primarily centered around the .ci directory currently where most of the action is taking place.