### PR TITLE
[lldb] Set default object format to `MachO` in `ObjectFileMachO`

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5148,6 +5148,7 @@ void ObjectFileMachO::GetAllArchSpecs(const llvm::MachO::mach_header &header,
   llvm::Triple base_triple = base_arch.GetTriple();
   base_triple.setOS(llvm::Triple::UnknownOS);
   base_triple.setOSName(llvm::StringRef());
+  base_triple.setObjectFormat(llvm::Triple::MachO);
 
   if (header.filetype == MH_PRELOAD) {
     if (header.cputype == CPU_TYPE_ARM) {

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -94,4 +94,58 @@ TEST_F(ObjectFileMachOTest, IndirectSymbolsInTheSharedCache) {
   for (size_t i = 0; i < 10; i++)
     OF->ParseSymtab(symtab);
 }
+
+TEST_F(ObjectFileMachOTest, ObjectFileFormatWithoutLoadCommand) {
+  // A Mach-O file without the load command LC_BUILD_VERSION.
+  const char *yamldata = R"(
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x0100000C
+  cpusubtype:      0x00000000
+  filetype:        0x00000001
+  ncmds:           1
+  sizeofcmds:      152
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         152
+    segname:         __TEXT
+    vmaddr:          0
+    vmsize:          4
+    fileoff:         184
+    filesize:        4
+    maxprot:         7
+    initprot:        7
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0000000000000000
+        content:         'AABBCCDD'
+        size:            4
+        offset:          184
+        align:           0
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+...
+)";
+  
+  // Perform setup.
+  llvm::Expected<TestFile> file = TestFile::fromYaml(yamldata);
+  EXPECT_THAT_EXPECTED(file, llvm::Succeeded());
+  auto module_sp = std::make_shared<Module>(file->moduleSpec());
+  ASSERT_NE(module_sp, nullptr);
+  auto object_file = module_sp->GetObjectFile();
+  ASSERT_NE(object_file, nullptr);
+
+  // Verify that the object file is recognized as Mach-O.
+  ASSERT_EQ(object_file->GetArchitecture().GetTriple().getObjectFormat(), llvm::Triple::MachO);
+}
 #endif

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -136,7 +136,7 @@ LoadCommands:
         reserved3:       0x00000000
 ...
 )";
-  
+
   // Perform setup.
   llvm::Expected<TestFile> file = TestFile::fromYaml(yamldata);
   EXPECT_THAT_EXPECTED(file, llvm::Succeeded());
@@ -146,6 +146,7 @@ LoadCommands:
   ASSERT_NE(object_file, nullptr);
 
   // Verify that the object file is recognized as Mach-O.
-  ASSERT_EQ(object_file->GetArchitecture().GetTriple().getObjectFormat(), llvm::Triple::MachO);
+  ASSERT_EQ(object_file->GetArchitecture().GetTriple().getObjectFormat(),
+            llvm::Triple::MachO);
 }
 #endif

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -95,7 +95,7 @@ TEST_F(ObjectFileMachOTest, IndirectSymbolsInTheSharedCache) {
     OF->ParseSymtab(symtab);
 }
 
-TEST_F(ObjectFileMachOTest, ObjectFileFormatWithoutLoadCommand) {
+TEST_F(ObjectFileMachOTest, ObjectFormatWithoutVersionLoadCommand) {
   // A Mach-O file without the load command LC_BUILD_VERSION.
   const char *yamldata = R"(
 --- !mach-o


### PR DESCRIPTION
# The Change

This patch sets the **default** object format of `ObjectFileMachO` to be `MachO` (instead of what currently ends up to be `ELF`, see below). This should be **the correct thing to do**, because the code before the line of change has already verified the Mach-O header.

The existing logic:
* In `ObjectFileMachO`, the object format is unassigned by default. So it's `UnknownObjectFormat` (see [code](https://github.com/llvm/llvm-project/blob/54d544b83141dc0b20727673f68793728ed54793/llvm/lib/TargetParser/Triple.cpp#L1024)).
* The code then looks at load commands like `LC_VERSION_MIN_*` ([code](https://github.com/llvm/llvm-project/blob/54d544b83141dc0b20727673f68793728ed54793/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp#L5180-L5217)) and `LC_BUILD_VERSION` ([code](https://github.com/llvm/llvm-project/blob/54d544b83141dc0b20727673f68793728ed54793/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp#L5231-L5252)) and assign the Triple's OS and Environment if they exist.
* If the above sets the Triple's OS to macOS, then the object format defaults to `MachO`; otherwise it is `ELF` ([code](https://github.com/llvm/llvm-project/blob/54d544b83141dc0b20727673f68793728ed54793/llvm/lib/TargetParser/Triple.cpp#L936-L937))

# Impact

For **production usage** where Mach-O files have the said load commands (which is [expected](https://www.google.com/search?q=Are+mach-o+files+expected+to+have+the+LC_BUILD_VERSION+load+command%3F)), this patch won't change anything.
* **Important note**: It's not clear if there are legitimate production use cases where the Mach-O files don't have said load commands. If there is, the exiting code think they are `ELF`. This patch changes it to `MachO`. This is considered a fix for such files.

For **unit tests**, this patch will simplify the yaml data by not requiring the said load commands.

# Test

A unit test is added to verify the patch, i.e. it fails without the patch and succeeds with.

```
$ ninja lldb-unit-test-deps
$ tools/lldb/unittests/ObjectFile/MachO/ObjectFileMachOTests --gtest_filter="*ObjectFormatWithoutVersionLoadCommand*"
...
[ RUN      ] ObjectFileMachOTest.ObjectFormatWithoutVersionLoadCommand
[       OK ] ObjectFileMachOTest.ObjectFormatWithoutVersionLoadCommand (3 ms)
...
```

Double-checked that this patch doesn't break any existing tests on both macOS ([result](https://pastebin.com/teFMALCS)) and Linux ([result](https://pastebin.com/DXzCx3As)).