### PR TITLE
[RISCV] Correct Branch Range

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
@@ -133,8 +133,8 @@ bool RISCVAsmBackend::fixupNeedsRelaxationAdvanced(const MCFixup &Fixup,
   case RISCV::fixup_riscv_branch:
   case RISCV::fixup_riscv_qc_e_branch:
     // For conditional branch instructions the immediate must be
-    // in the range [-4096, 4095].
-    return !isInt<13>(Offset);
+    // in the range [-4096, 4094].
+    return Offset > 4094 || Offset < -4096;
   }
 }
 


### PR DESCRIPTION
This aligns the code with the other cases, which take into account the min/max range of `isShiftedInt<N, 1>`. Given IALIGN is always 16 or 32 (bits), this should not make a difference to anything valid.