### PR TITLE
[LLVM][TableGen] Minor cleanup in CGIOperandList 

### DIFF
--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -1712,11 +1712,11 @@ void AsmMatcherInfo::buildInstructionOperandReference(MatchableInfo *II,
   MatchableInfo::AsmOperand *Op = &II->AsmOperands[AsmOpIdx];
 
   // Map this token to an operand.
-  unsigned Idx;
-  if (!Operands.hasOperandNamed(OperandName, Idx))
+  std::optional<unsigned> MayBeIdx = Operands.findOperandNamed(OperandName);
+  if (!MayBeIdx)
     PrintFatalError(II->TheDef->getLoc(),
                     "error: unable to find operand: '" + OperandName + "'");
-
+  unsigned Idx = *MayBeIdx;
   // If the instruction operand has multiple suboperands, but the parser
   // match class for the asm operand is still the default "ImmAsmOperand",
   // then handle each suboperand separately.

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -1712,22 +1712,21 @@ void AsmMatcherInfo::buildInstructionOperandReference(MatchableInfo *II,
   MatchableInfo::AsmOperand *Op = &II->AsmOperands[AsmOpIdx];
 
   // Map this token to an operand.
-  std::optional<unsigned> MayBeIdx = Operands.findOperandNamed(OperandName);
-  if (!MayBeIdx)
+  std::optional<unsigned> Idx = Operands.findOperandNamed(OperandName);
+  if (!Idx)
     PrintFatalError(II->TheDef->getLoc(),
                     "error: unable to find operand: '" + OperandName + "'");
-  unsigned Idx = *MayBeIdx;
   // If the instruction operand has multiple suboperands, but the parser
   // match class for the asm operand is still the default "ImmAsmOperand",
   // then handle each suboperand separately.
-  if (Op->SubOpIdx == -1 && Operands[Idx].MINumOperands > 1) {
-    const Record *Rec = Operands[Idx].Rec;
+  if (Op->SubOpIdx == -1 && Operands[*Idx].MINumOperands > 1) {
+    const Record *Rec = Operands[*Idx].Rec;
     assert(Rec->isSubClassOf("Operand") && "Unexpected operand!");
     const Record *MatchClass = Rec->getValueAsDef("ParserMatchClass");
     if (MatchClass && MatchClass->getValueAsString("Name") == "Imm") {
       // Insert remaining suboperands after AsmOpIdx in II->AsmOperands.
       StringRef Token = Op->Token; // save this in case Op gets moved
-      for (unsigned SI = 1, SE = Operands[Idx].MINumOperands; SI != SE; ++SI) {
+      for (unsigned SI = 1, SE = Operands[*Idx].MINumOperands; SI != SE; ++SI) {
         MatchableInfo::AsmOperand NewAsmOp(/*IsIsolatedToken=*/true, Token);
         NewAsmOp.SubOpIdx = SI;
         II->AsmOperands.insert(II->AsmOperands.begin() + AsmOpIdx + SI,
@@ -1740,7 +1739,7 @@ void AsmMatcherInfo::buildInstructionOperandReference(MatchableInfo *II,
   }
 
   // Set up the operand class.
-  Op->Class = getOperandClass(Operands[Idx], Op->SubOpIdx);
+  Op->Class = getOperandClass(Operands[*Idx], Op->SubOpIdx);
   Op->OrigSrcOpName = OperandName;
 
   // If the named operand is tied, canonicalize it to the untied operand.
@@ -1752,14 +1751,14 @@ void AsmMatcherInfo::buildInstructionOperandReference(MatchableInfo *II,
   //   "inc $dst"
   // so that we know how to provide the $dst operand when filling in the result.
   int OITied = -1;
-  if (Operands[Idx].MINumOperands == 1)
-    OITied = Operands[Idx].getTiedRegister();
+  if (Operands[*Idx].MINumOperands == 1)
+    OITied = Operands[*Idx].getTiedRegister();
   if (OITied != -1) {
     // The tied operand index is an MIOperand index, find the operand that
     // contains it.
-    std::pair<unsigned, unsigned> Idx = Operands.getSubOperandNumber(OITied);
-    OperandName = Operands[Idx.first].Name;
-    Op->SubOpIdx = Idx.second;
+    auto [OpIdx, SubopIdx] = Operands.getSubOperandNumber(OITied);
+    OperandName = Operands[OpIdx].Name;
+    Op->SubOpIdx = SubopIdx;
   }
 
   Op->SrcOpName = OperandName;

--- a/llvm/utils/TableGen/CodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/CodeEmitterGen.cpp
@@ -123,12 +123,11 @@ bool CodeEmitterGen::addCodeToMergeInOperand(const Record *R,
   // operand number. Non-matching operands are assumed to be in
   // order.
   unsigned OpIdx;
-  std::pair<unsigned, unsigned> SubOp;
-  if (CGI.Operands.hasSubOperandAlias(VarName, SubOp)) {
-    OpIdx = CGI.Operands[SubOp.first].MIOperandNo + SubOp.second;
-  } else if (CGI.Operands.hasOperandNamed(VarName, OpIdx)) {
+  if (auto SubOp = CGI.Operands.findSubOperandAlias(VarName)) {
+    OpIdx = CGI.Operands[SubOp->first].MIOperandNo + SubOp->second;
+  } else if (auto MayBeOpIdx = CGI.Operands.findOperandNamed(VarName)) {
     // Get the machine operand number for the indicated operand.
-    OpIdx = CGI.Operands[OpIdx].MIOperandNo;
+    OpIdx = CGI.Operands[*MayBeOpIdx].MIOperandNo;
   } else {
     PrintError(R, Twine("No operand named ") + VarName + " in record " +
                       R->getName());

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.h
@@ -127,10 +127,9 @@ public:
     /// getTiedOperand - If this operand is tied to another one, return the
     /// other operand number.  Otherwise, return -1.
     int getTiedRegister() const {
-      for (const CGIOperandList::ConstraintInfo &CI : Constraints) {
+      for (const CGIOperandList::ConstraintInfo &CI : Constraints)
         if (CI.isTied())
           return CI.getTiedOperand();
-      }
       return -1;
     }
   };
@@ -176,13 +175,13 @@ public:
   /// specified name, abort.
   unsigned getOperandNamed(StringRef Name) const;
 
-  /// hasOperandNamed - Query whether the instruction has an operand of the
-  /// given name. If so, return true and set OpIdx to the index of the
-  /// operand. Otherwise, return false.
-  bool hasOperandNamed(StringRef Name, unsigned &OpIdx) const;
+  /// findOperandNamed - Query whether the instruction has an operand of the
+  /// given name. If so, the index of the operand. Otherwise, return
+  /// std::nullopt.
+  std::optional<unsigned> findOperandNamed(StringRef Name) const;
 
-  bool hasSubOperandAlias(StringRef Name,
-                          std::pair<unsigned, unsigned> &SubOp) const;
+  std::optional<std::pair<unsigned, unsigned>>
+  findSubOperandAlias(StringRef Name) const;
 
   /// ParseOperandName - Parse an operand name like "$foo" or "$foo.bar",
   /// where $foo is a whole operand and $foo.bar refers to a suboperand.


### PR DESCRIPTION
- Change `hadOperandNamed` to return index as std::optional and rename it to `findOperandNamed`.
- Change `SubOperandAlias` to return std::optional and rename it to `findSubOperandAlias`.