### PR TITLE
support in LLDB for the DWARF operations `DW_OP_GNU_implicit_pointer/DW_OP_implicit_pointer`.

### DIFF
--- a/lldb/include/lldb/Core/Value.h
+++ b/lldb/include/lldb/Core/Value.h
@@ -82,6 +82,10 @@ public:
 
   ValueType GetValueType() const;
 
+  void setImplictPointerDIEoffset(uint64_t offset);
+  void setImplictPointerOffset(int64_t offset);
+  uint64_t getImplictPointerDIEoffset() const;
+  int64_t getImplictPointerOffset() const;
   AddressType GetValueAddressType() const;
 
   ContextType GetContextType() const { return m_context_type; }
@@ -182,6 +186,12 @@ protected:
   ValueType m_value_type = ValueType::Scalar;
   ContextType m_context_type = ContextType::Invalid;
   DataBufferHeap m_data_buffer;
+  struct {
+    /* 4- or 8-byte offset of DIE  */
+    uint64_t die_offset = 0;
+    /* The byte offset into the resulting data.  */
+    int64_t result_offset;
+  } implicit_pointer;
 };
 
 class ValueList {

--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -34,7 +34,7 @@ public:
            SymbolContextScope *owner_scope, const RangeList &scope_range,
            Declaration *decl, const DWARFExpressionList &location,
            bool external, bool artificial, bool location_is_constant_data,
-           bool static_member = false);
+           bool static_member = false, bool is_implicit_pointer = false);
 
   virtual ~Variable();
 
@@ -97,6 +97,9 @@ public:
 
   void SetLocationIsConstantValueData(bool b) { m_loc_is_const_data = b; }
 
+  bool IsImplicitPointer() const { return m_is_implicit_pointer; }
+
+  void SetIsImplicitPointer(bool b) { m_is_implicit_pointer = b; }
   typedef size_t (*GetVariableCallback)(void *baton, const char *name,
                                         VariableList &var_list);
 
@@ -140,7 +143,8 @@ protected:
   unsigned m_loc_is_const_data : 1;
   /// Non-zero if variable is static member of a class or struct.
   unsigned m_static_member : 1;
-
+  /// Non-zero if the variable is a implicit pointer type.
+  unsigned m_is_implicit_pointer : 1;
 private:
   Variable(const Variable &rhs) = delete;
   Variable &operator=(const Variable &rhs) = delete;

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -19,6 +19,7 @@
 #include "lldb/Target/StackFrame.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/ValueObject/ValueObject.h"
+#include "lldb/Symbol/Variable.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-forward.h"
@@ -174,7 +175,13 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
         if (auto persisted_valobj = valobj_sp->Persist())
           valobj_sp = persisted_valobj;
       }
-
+      // FIXME: LLDB haven't implemented "optimization out" output.
+      if (valobj_sp->GetVariable()->IsImplicitPointer()) {
+        result.AppendMessageWithFormatv("expression `{0}` is an implicit "
+                                        "pointer, value has been optimized out",
+                                        expr);
+        return;
+      }
       if (verbosity == eDWIMPrintVerbosityFull) {
         StringRef flags;
         if (args.HasArgs())

--- a/lldb/source/Core/Value.cpp
+++ b/lldb/source/Core/Value.cpp
@@ -55,7 +55,8 @@ Value::Value(const void *bytes, int len)
 Value::Value(const Value &v)
     : m_value(v.m_value), m_compiler_type(v.m_compiler_type),
       m_context(v.m_context), m_value_type(v.m_value_type),
-      m_context_type(v.m_context_type), m_data_buffer() {
+      m_context_type(v.m_context_type), m_data_buffer(),
+      implicit_pointer(v.implicit_pointer) {
   const uintptr_t rhs_value =
       (uintptr_t)v.m_value.ULongLong(LLDB_INVALID_ADDRESS);
   if ((rhs_value != 0) &&
@@ -65,6 +66,8 @@ Value::Value(const Value &v)
 
     m_value = (uintptr_t)m_data_buffer.GetBytes();
   }
+  implicit_pointer.result_offset = v.implicit_pointer.result_offset;
+  implicit_pointer.die_offset = v.implicit_pointer.die_offset;
 }
 
 Value &Value::operator=(const Value &rhs) {
@@ -74,6 +77,7 @@ Value &Value::operator=(const Value &rhs) {
     m_context = rhs.m_context;
     m_value_type = rhs.m_value_type;
     m_context_type = rhs.m_context_type;
+    implicit_pointer = rhs.implicit_pointer;
     const uintptr_t rhs_value =
         (uintptr_t)rhs.m_value.ULongLong(LLDB_INVALID_ADDRESS);
     if ((rhs_value != 0) &&
@@ -641,6 +645,8 @@ void Value::Clear() {
   m_context = nullptr;
   m_context_type = ContextType::Invalid;
   m_data_buffer.Clear();
+  implicit_pointer.result_offset = 0;
+  implicit_pointer.die_offset = 0;
 }
 
 const char *Value::GetValueTypeAsCString(ValueType value_type) {
@@ -657,6 +663,19 @@ const char *Value::GetValueTypeAsCString(ValueType value_type) {
     return "host address";
   };
   llvm_unreachable("enum cases exhausted.");
+}
+
+void Value::setImplictPointerDIEoffset(uint64_t offset) {
+  implicit_pointer.die_offset = offset;
+}
+void Value::setImplictPointerOffset(int64_t offset) {
+  implicit_pointer.result_offset = offset;
+}
+uint64_t Value::getImplictPointerDIEoffset() const {
+  return implicit_pointer.die_offset;
+}
+int64_t Value::getImplictPointerOffset() const {
+  return implicit_pointer.result_offset;
 }
 
 const char *Value::GetContextTypeAsCString(ContextType context_type) {

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -43,13 +43,13 @@ Variable::Variable(lldb::user_id_t uid, const char *name, const char *mangled,
                    const RangeList &scope_range, Declaration *decl_ptr,
                    const DWARFExpressionList &location_list, bool external,
                    bool artificial, bool location_is_constant_data,
-                   bool static_member)
+                   bool static_member, bool is_implicit_pointer)
     : UserID(uid), m_name(name), m_mangled(ConstString(mangled)),
       m_symfile_type_sp(symfile_type_sp), m_scope(scope),
       m_owner_scope(context), m_scope_range(scope_range),
       m_declaration(decl_ptr), m_location_list(location_list), m_external(external),
       m_artificial(artificial), m_loc_is_const_data(location_is_constant_data),
-      m_static_member(static_member) {}
+      m_static_member(static_member), m_is_implicit_pointer(is_implicit_pointer) {}
 
 Variable::~Variable() = default;
 

--- a/lldb/source/ValueObject/ValueObjectVariable.cpp
+++ b/lldb/source/ValueObject/ValueObjectVariable.cpp
@@ -165,12 +165,17 @@ bool ValueObjectVariable::UpdateValue() {
     if (maybe_value) {
       m_value = *maybe_value;
       m_resolved_value = m_value;
-      m_value.SetContext(Value::ContextType::Variable, variable);
-
-      CompilerType compiler_type = GetCompilerType();
-      if (compiler_type.IsValid())
-        m_value.SetCompilerType(compiler_type);
-
+      CompilerType compiler_type;
+      if (m_value.getImplictPointerDIEoffset() != 0) {
+        compiler_type = m_value.GetCompilerType();
+        variable->SetIsImplicitPointer(true);
+        m_override_type = compiler_type;
+      } else {
+        m_value.SetContext(Value::ContextType::Variable, variable);
+        compiler_type = GetCompilerType();
+        if (compiler_type.IsValid())
+          m_value.SetCompilerType(compiler_type);
+      }
       Value::ValueType value_type = m_value.GetValueType();
 
       // The size of the buffer within m_value can be less than the size

--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -887,6 +887,8 @@ HANDLE_DW_OP(0xed, WASM_location, -1, -1, 0, WASM)
 HANDLE_DW_OP(0xee, WASM_location_int, -1, -1, 0, WASM)
 // Historic and not implemented in LLVM.
 HANDLE_DW_OP(0xf0, APPLE_uninit, -1, -1, 0, APPLE)
+// The GNU implicit pointer extension.
+HANDLE_DW_OP(0xf2, GNU_implicit_pointer, 2, 0, 5, GNU)
 // The GNU entry value extension.
 HANDLE_DW_OP(0xf3, GNU_entry_value, 2, 0, 0, GNU)
 HANDLE_DW_OP(0xf8, PGI_omp_thread_num, -1, -1, 0, PGI)

--- a/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
@@ -104,6 +104,8 @@ static std::vector<Desc> getOpDescriptions() {
   Descriptions[DW_OP_GNU_addr_index] = Desc(Op::Dwarf4, Op::SizeLEB);
   Descriptions[DW_OP_GNU_const_index] = Desc(Op::Dwarf4, Op::SizeLEB);
   Descriptions[DW_OP_GNU_entry_value] = Desc(Op::Dwarf4, Op::SizeLEB);
+  Descriptions[DW_OP_GNU_implicit_pointer] =
+    Desc(Op::Dwarf4, Op::SizeRefAddr, Op::SignedSizeLEB);
   // This Description acts as a marker that getSubOpDesc must be called
   // to fetch the final Description for the operation. Each such final
   // Description must share the same first SizeSubOpLEB operand.

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVLocation.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVLocation.cpp
@@ -284,6 +284,7 @@ std::string LVOperation::getOperandsDWARFInfo() {
   case dwarf::DW_OP_implicit_value:
     Stream << "TODO: DW_OP_implicit_value";
     break;
+  case dwarf::DW_OP_GNU_implicit_pointer:
   case dwarf::DW_OP_implicit_pointer:
     Stream << "implicit_pointer DIE offset " << hexString(Operands[0]) << " "
            << int(Operands[1]);


### PR DESCRIPTION
This Pull Request introduces support in LLDB for the DWARF operations `DW_OP_GNU_implicit_pointer` and `DW_OP_implicit_pointer`.
These operators are commonly found in debug information and are used to enhance the debugging experience by improving how variable expressions are represented. By introducing handling for these operations, LLDB will be able to interpret and display variable values more accurately when debugging binaries that contain such DWARF expressions. This update improves LLDB's compatibility and correctness when working with debug information generated by GCC, Clang, and other DWARF-compliant toolchains, and helps ensure a more robust debugging experience.