### PR TITLE
[HashRecognize] Introduce dump methods for debug

### DIFF
--- a/llvm/include/llvm/Analysis/HashRecognize.h
+++ b/llvm/include/llvm/Analysis/HashRecognize.h
@@ -34,7 +34,7 @@ using ErrBits = std::tuple<KnownBits, unsigned, bool>;
 
 /// A custom std::array with 256 entries, that also has a print function.
 struct CRCTable : public std::array<APInt, 256> {
-  LLVM_DUMP_METHOD void print(raw_ostream &OS) const;
+  void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
@@ -91,7 +91,7 @@ public:
   // and return a 256-entry CRC table.
   CRCTable genSarwateTable(const APInt &GenPoly, bool ByteOrderSwapped) const;
 
-  LLVM_DUMP_METHOD void print(raw_ostream &OS) const;
+  void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;

--- a/llvm/include/llvm/Analysis/HashRecognize.h
+++ b/llvm/include/llvm/Analysis/HashRecognize.h
@@ -34,7 +34,11 @@ using ErrBits = std::tuple<KnownBits, unsigned, bool>;
 
 /// A custom std::array with 256 entries, that also has a print function.
 struct CRCTable : public std::array<APInt, 256> {
-  void print(raw_ostream &OS) const;
+  LLVM_DUMP_METHOD void print(raw_ostream &OS) const;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 };
 
 /// The structure that is returned when a polynomial algorithm was recognized by
@@ -87,7 +91,11 @@ public:
   // and return a 256-entry CRC table.
   CRCTable genSarwateTable(const APInt &GenPoly, bool ByteOrderSwapped) const;
 
-  void print(raw_ostream &OS) const;
+  LLVM_DUMP_METHOD void print(raw_ostream &OS) const;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 };
 
 class HashRecognizePrinterPass

--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -1,4 +1,4 @@
-//===- HashRecognize.h ------------------------------------------*- C++ -*-===//
+//===- HashRecognize.cpp ----------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -274,7 +274,7 @@ struct RecurrenceInfo {
   RecurrenceInfo(const Loop &L) : L(L) {}
   operator bool() const { return BO; }
 
-  void print(raw_ostream &OS, unsigned Indent) const {
+  LLVM_DUMP_METHOD void print(raw_ostream &OS, unsigned Indent = 0) const {
     OS.indent(Indent) << "Phi: ";
     Phi->print(OS);
     OS << "\n";
@@ -293,6 +293,10 @@ struct RecurrenceInfo {
       OS << "\n";
     }
   }
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const { print(dbgs()); }
+#endif
 
   bool matchSimpleRecurrence(const PHINode *P);
   bool matchConditionalRecurrence(
@@ -628,6 +632,10 @@ void CRCTable::print(raw_ostream &OS) const {
   }
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+void CRCTable::dump() const { print(dbgs()); }
+#endif
+
 void HashRecognize::print(raw_ostream &OS) const {
   if (!L.isInnermost())
     return;
@@ -670,6 +678,10 @@ void HashRecognize::print(raw_ostream &OS) const {
   OS.indent(2) << "Computed CRC lookup table:\n";
   genSarwateTable(Info.RHS, Info.ByteOrderSwapped).print(OS);
 }
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+void HashRecognize::dump() const { print(dbgs()); }
+#endif
 
 HashRecognize::HashRecognize(const Loop &L, ScalarEvolution &SE)
     : L(L), SE(SE) {}

--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -274,7 +274,7 @@ struct RecurrenceInfo {
   RecurrenceInfo(const Loop &L) : L(L) {}
   operator bool() const { return BO; }
 
-  LLVM_DUMP_METHOD void print(raw_ostream &OS, unsigned Indent = 0) const {
+  void print(raw_ostream &OS, unsigned Indent = 0) const {
     OS.indent(Indent) << "Phi: ";
     Phi->print(OS);
     OS << "\n";


### PR DESCRIPTION
Introduce dump methods to aid interactive debugging with GDB/LLDB. While at it, also fix the header comment in HashRecognize.cpp.