### PR TITLE
[sanitizer_common] Remove <procfs.h> workaround on Solaris

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_solaris.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_solaris.cpp
@@ -9,9 +9,6 @@
 // Information about the process mappings (Solaris-specific parts).
 //===----------------------------------------------------------------------===//
 
-// Before Solaris 11.4, <procfs.h> doesn't work in a largefile environment.
-#undef _FILE_OFFSET_BITS
-
 // Avoid conflict between `_TIME_BITS` defined vs. `_FILE_OFFSET_BITS`
 // undefined in some Linux configurations.
 #undef _TIME_BITS


### PR DESCRIPTION
`sanitizer_procmaps_solaris.cpp` currently uses `#undef _FILE_OFFSET_BITS` to hack around the fact that old versions of Solaris `<procfs.h>` don't work in a largefile environment:

```
/usr/include/sys/procfs.h:42:2: error: #error "Cannot use procfs in the large file compilation environment"
   42 | #error  "Cannot use procfs in the large file compilation environment"
      |  ^~~~~
```

However, this is no longer an issue on either Solaris 11.4 or Illumos.  The workaround only existed for the benefit of Solaris 11.3.  While that had never been supported by LLVM, the sanitizer runtime libs were imported into GCC's `libsanitzer`.  With the removal of Solaris 11.3 support in GCC 15, this is no longer an issue and the workaround can be removed.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11`.