### PR TITLE
[Offload] Fix missing dependencies in Offload API generation

### DIFF
--- a/offload/liboffload/API/CMakeLists.txt
+++ b/offload/liboffload/API/CMakeLists.txt
@@ -42,5 +42,7 @@ else()
             COMMAND ${CMAKE_COMMAND} -E copy_if_different generated/${file}.gen ${CMAKE_CURRENT_BINARY_DIR}/${file}
             DEPENDS generated/${file}.gen
         )
+        add_custom_target(OffloadAPI.${file} DEPENDS ${file})
+        add_dependencies(OffloadAPI OffloadAPI.${file})
     endforeach()
 endif()


### PR DESCRIPTION
Thanks to @RossBrunton for spotting this.

We attempt to clang-format the generated Offload header files, but if clang-format isn't available we just copy the generated files instead. That fallback path was missing the correct dependencies.

Fixes #142756