### PR TITLE
[AMDGPU] Use MachineRegisterInfo::def_instructions (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/R600OptimizeVectorRegisters.cpp
+++ b/llvm/lib/Target/AMDGPU/R600OptimizeVectorRegisters.cpp
@@ -324,11 +324,8 @@ bool R600VectorRegMerger::runOnMachineFunction(MachineFunction &Fn) {
       if (MI.getOpcode() != R600::REG_SEQUENCE) {
         if (TII->get(MI.getOpcode()).TSFlags & R600_InstFlag::TEX_INST) {
           Register Reg = MI.getOperand(1).getReg();
-          for (MachineRegisterInfo::def_instr_iterator
-               It = MRI->def_instr_begin(Reg), E = MRI->def_instr_end();
-               It != E; ++It) {
-            RemoveMI(&(*It));
-          }
+          for (MachineInstr &DefMI : MRI->def_instructions(Reg))
+            RemoveMI(&DefMI);
         }
         continue;
       }

--- a/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
@@ -287,13 +287,10 @@ void SIScheduleBlock::fastSchedule() {
 static bool isDefBetween(Register Reg, SlotIndex First, SlotIndex Last,
                          const MachineRegisterInfo *MRI,
                          const LiveIntervals *LIS) {
-  for (MachineRegisterInfo::def_instr_iterator
-       UI = MRI->def_instr_begin(Reg),
-       UE = MRI->def_instr_end(); UI != UE; ++UI) {
-    const MachineInstr* MI = &*UI;
-    if (MI->isDebugValue())
+  for (const MachineInstr &MI : MRI->def_instructions(Reg)) {
+    if (MI.isDebugValue())
       continue;
-    SlotIndex InstSlot = LIS->getInstructionIndex(*MI).getRegSlot();
+    SlotIndex InstSlot = LIS->getInstructionIndex(MI).getRegSlot();
     if (InstSlot >= First && InstSlot <= Last)
       return true;
   }

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -4060,9 +4060,9 @@ SIRegisterInfo::getNumDefinedPhysRegs(const MachineRegisterInfo &MRI,
                                       const TargetRegisterClass &RC) const {
   for (MCPhysReg Reg : reverse(RC.getRegisters())) {
     for (MCRegAliasIterator AI(Reg, this, true); AI.isValid(); ++AI) {
-      if (std::any_of(
-              MRI.def_instr_begin(*AI), MRI.def_instr_end(),
-              [](const MachineInstr &MI) { return !MI.isImplicitDef(); }))
+      if (llvm::any_of(MRI.def_instructions(*AI), [](const MachineInstr &MI) {
+            return !MI.isImplicitDef();
+          }))
         return getHWRegIndex(Reg) + 1;
     }
   }


### PR DESCRIPTION
Note that def_instructions is defined as:

  inline iterator_range<def_instr_iterator>
  def_instructions(Register Reg) const {
    return make_range(def_instr_begin(Reg), def_instr_end());
  }
