### PR TITLE
[InstCombine] Always rewrite multi-use GEP for pointer difference

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -2112,7 +2112,7 @@ Value *InstCombinerImpl::OptimizePointerDifference(Value *LHS, Value *RHS,
   // then the final multiplication is also nuw.
   if (auto *I = dyn_cast<Instruction>(Result))
     if (IsNUW && !GEP2 && !Swapped && GEP1NW.isInBounds() &&
-        I->getOpcode() == Instruction::Mul) {
+        I->getOpcode() == Instruction::Mul && !I->hasNoUnsignedWrap()) {
       if (!I->use_empty()) {
         // If the offset calculation is reused by the GEP, add the nuw flag to
         // a separate clone. This may improve folds and will get CSEd if not

--- a/llvm/test/Transforms/InstCombine/sub-gep.ll
+++ b/llvm/test/Transforms/InstCombine/sub-gep.ll
@@ -782,7 +782,8 @@ define i64 @sub_multi_use_nuw(ptr %base, i64 %idx) {
 ; CHECK-NEXT:    [[P2_IDX:%.*]] = shl nsw i64 [[IDX:%.*]], 2
 ; CHECK-NEXT:    [[P2:%.*]] = getelementptr inbounds i8, ptr [[BASE:%.*]], i64 [[P2_IDX]]
 ; CHECK-NEXT:    call void @use(ptr [[P2]])
-; CHECK-NEXT:    ret i64 [[P2_IDX]]
+; CHECK-NEXT:    [[D:%.*]] = shl nuw nsw i64 [[IDX]], 2
+; CHECK-NEXT:    ret i64 [[D]]
 ;
   %p2 = getelementptr inbounds [0 x i32], ptr %base, i64 0, i64 %idx
   call void @use(ptr %p2)

--- a/llvm/test/Transforms/InstCombine/sub-gep.ll
+++ b/llvm/test/Transforms/InstCombine/sub-gep.ll
@@ -760,6 +760,38 @@ entry:
   ret i64 %ret
 }
 
+declare void @use(ptr)
+
+define i64 @sub_multi_use(ptr %base, i64 %idx) {
+; CHECK-LABEL: @sub_multi_use(
+; CHECK-NEXT:    [[P2:%.*]] = getelementptr inbounds [0 x i32], ptr [[BASE:%.*]], i64 0, i64 [[IDX:%.*]]
+; CHECK-NEXT:    call void @use(ptr [[P2]])
+; CHECK-NEXT:    [[P2_IDX:%.*]] = shl nsw i64 [[IDX]], 2
+; CHECK-NEXT:    ret i64 [[P2_IDX]]
+;
+  %p2 = getelementptr inbounds [0 x i32], ptr %base, i64 0, i64 %idx
+  call void @use(ptr %p2)
+  %i1 = ptrtoint ptr %base to i64
+  %i2 = ptrtoint ptr %p2 to i64
+  %d = sub i64 %i2, %i1
+  ret i64 %d
+}
+
+define i64 @sub_multi_use_nuw(ptr %base, i64 %idx) {
+; CHECK-LABEL: @sub_multi_use_nuw(
+; CHECK-NEXT:    [[P2:%.*]] = getelementptr inbounds [0 x i32], ptr [[BASE:%.*]], i64 0, i64 [[IDX:%.*]]
+; CHECK-NEXT:    call void @use(ptr [[P2]])
+; CHECK-NEXT:    [[P2_IDX:%.*]] = shl nuw nsw i64 [[IDX]], 2
+; CHECK-NEXT:    ret i64 [[P2_IDX]]
+;
+  %p2 = getelementptr inbounds [0 x i32], ptr %base, i64 0, i64 %idx
+  call void @use(ptr %p2)
+  %i1 = ptrtoint ptr %base to i64
+  %i2 = ptrtoint ptr %p2 to i64
+  %d = sub nuw i64 %i2, %i1
+  ret i64 %d
+}
+
 define i1 @_gep_phi1(ptr %str1) {
 ; CHECK-LABEL: @_gep_phi1(
 ; CHECK-NEXT:  entry:

--- a/llvm/test/Transforms/InstCombine/sub-gep.ll
+++ b/llvm/test/Transforms/InstCombine/sub-gep.ll
@@ -764,9 +764,9 @@ declare void @use(ptr)
 
 define i64 @sub_multi_use(ptr %base, i64 %idx) {
 ; CHECK-LABEL: @sub_multi_use(
-; CHECK-NEXT:    [[P2:%.*]] = getelementptr inbounds [0 x i32], ptr [[BASE:%.*]], i64 0, i64 [[IDX:%.*]]
+; CHECK-NEXT:    [[P2_IDX:%.*]] = shl nsw i64 [[IDX:%.*]], 2
+; CHECK-NEXT:    [[P2:%.*]] = getelementptr inbounds i8, ptr [[BASE:%.*]], i64 [[P2_IDX]]
 ; CHECK-NEXT:    call void @use(ptr [[P2]])
-; CHECK-NEXT:    [[P2_IDX:%.*]] = shl nsw i64 [[IDX]], 2
 ; CHECK-NEXT:    ret i64 [[P2_IDX]]
 ;
   %p2 = getelementptr inbounds [0 x i32], ptr %base, i64 0, i64 %idx
@@ -779,9 +779,9 @@ define i64 @sub_multi_use(ptr %base, i64 %idx) {
 
 define i64 @sub_multi_use_nuw(ptr %base, i64 %idx) {
 ; CHECK-LABEL: @sub_multi_use_nuw(
-; CHECK-NEXT:    [[P2:%.*]] = getelementptr inbounds [0 x i32], ptr [[BASE:%.*]], i64 0, i64 [[IDX:%.*]]
+; CHECK-NEXT:    [[P2_IDX:%.*]] = shl nsw i64 [[IDX:%.*]], 2
+; CHECK-NEXT:    [[P2:%.*]] = getelementptr inbounds i8, ptr [[BASE:%.*]], i64 [[P2_IDX]]
 ; CHECK-NEXT:    call void @use(ptr [[P2]])
-; CHECK-NEXT:    [[P2_IDX:%.*]] = shl nuw nsw i64 [[IDX]], 2
 ; CHECK-NEXT:    ret i64 [[P2_IDX]]
 ;
   %p2 = getelementptr inbounds [0 x i32], ptr %base, i64 0, i64 %idx


### PR DESCRIPTION
Resolve the TODO in OptimizePointerDifference: Always rewrite (non-trivial, multi-use) GEPs to reuse the offset arithmetic, even if there is only one GEP involved in the subtraction.

I plan to extend this code to deeper GEP chains, in which case always rewriting seems like a good idea.