### PR TITLE
[clang][bytecode] Save Constexpr bit in Function

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -49,7 +49,7 @@ bool Context::isPotentialConstantExpr(State &Parent, const FunctionDecl *FD) {
   if (!Run(Parent, Func))
     return false;
 
-  return Func->isConstexpr();
+  return Func->isValid();
 }
 
 bool Context::evaluateAsRValue(State &Parent, const Expr *E, APValue &Result) {

--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -27,6 +27,7 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
   if (const auto *F = dyn_cast<const FunctionDecl *>(Source)) {
     Variadic = F->isVariadic();
     Immediate = F->isImmediateFunction();
+    Constexpr = F->isConstexpr() || F->hasAttr<MSConstexprAttr>();
     if (const auto *CD = dyn_cast<CXXConstructorDecl>(F)) {
       Virtual = CD->isVirtual();
       Kind = FunctionKind::Ctor;
@@ -48,6 +49,7 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
     Variadic = false;
     Virtual = false;
     Immediate = false;
+    Constexpr = false;
   }
 }
 

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -150,12 +150,13 @@ public:
   /// Returns the source information at a given PC.
   SourceInfo getSource(CodePtr PC) const;
 
-  /// Checks if the function is valid to call in constexpr.
-  bool isConstexpr() const { return IsValid || isLambdaStaticInvoker(); }
+  /// Checks if the function is valid to call.
+  bool isValid() const { return IsValid || isLambdaStaticInvoker(); }
 
   /// Checks if the function is virtual.
   bool isVirtual() const { return Virtual; };
   bool isImmediate() const { return Immediate; }
+  bool isConstexpr() const { return Constexpr; }
 
   /// Checks if the function is a constructor.
   bool isConstructor() const { return Kind == FunctionKind::Ctor; }
@@ -303,6 +304,8 @@ private:
   unsigned Virtual : 1;
   LLVM_PREFERRED_TYPE(bool)
   unsigned Immediate : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned Constexpr : 1;
 
 public:
   /// Dumps the disassembled bytecode to \c llvm::errs().


### PR DESCRIPTION
Rename isConstexpr to isValid, the former was always a bad name. Save a constexpr bit in Function so we don't have to access the decl in CheckCallable.