### PR TITLE
[RISCV] Mark QC Relocations as Relaxable

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
@@ -624,6 +624,7 @@ uint64_t RISCVMCCodeEmitter::getImmOpValue(const MCInst &MI, unsigned OpNo,
       break;
     case RISCVMCExpr::VK_QC_ABS20:
       FixupKind = RISCV::fixup_riscv_qc_abs20_u;
+      RelaxCandidate = true;
       break;
     }
   } else if (Kind == MCExpr::SymbolRef || Kind == MCExpr::Binary) {
@@ -642,8 +643,10 @@ uint64_t RISCVMCCodeEmitter::getImmOpValue(const MCInst &MI, unsigned OpNo,
       FixupKind = RISCV::fixup_riscv_qc_e_branch;
     } else if (MIFrm == RISCVII::InstFormatQC_EAI) {
       FixupKind = RISCV::fixup_riscv_qc_e_32;
+      RelaxCandidate = true;
     } else if (MIFrm == RISCVII::InstFormatQC_EJ) {
       FixupKind = RISCV::fixup_riscv_qc_e_jump_plt;
+      RelaxCandidate = true;
     }
   }
 

--- a/llvm/test/MC/RISCV/xqcibi-relocations.s
+++ b/llvm/test/MC/RISCV/xqcibi-relocations.s
@@ -74,6 +74,17 @@ same_section:
 same_section_extern:
   nop
 
+.option relax
+
+# ASM: qc.bnei t3, 14, same_section
+# OBJ: qc.bnei t3, 0xe, 0x28 <same_section>
+qc.bnei t3, 14, same_section
+
+# ASM: qc.e.bgeui s2, 24, same_section
+# OBJ-NEXT: qc.e.bgeui s2, 0x18, 0x28 <same_section>
+qc.e.bgeui s2, 24, same_section
+
+.option norelax
 
 .section .text.second, "ax", @progbits
 

--- a/llvm/test/MC/RISCV/xqcilb-relocations.s
+++ b/llvm/test/MC/RISCV/xqcilb-relocations.s
@@ -76,6 +76,24 @@ same_section:
 same_section_extern:
   nop
 
+.option relax
+
+# ASM: qc.e.j same_section
+# OBJ: qc.e.j 0x38 <same_section_extern+0x4>
+# OBJ-NEXT: R_RISCV_VENDOR QUALCOMM{{$}}
+# OBJ-NEXT: R_RISCV_CUSTOM195 same_section{{$}}
+# OBJ-NEXT: R_RISCV_RELAX
+qc.e.j same_section
+
+# ASM: qc.e.jal same_section
+# OBJ-NEXT: qc.e.jal 0x3e <same_section_extern+0xa>
+# OBJ-NEXT: R_RISCV_VENDOR QUALCOMM{{$}}
+# OBJ-NEXT: R_RISCV_CUSTOM195 same_section{{$}}
+# OBJ-NEXT: R_RISCV_RELAX
+qc.e.jal same_section
+
+.option norelax
+
 .section .text.other, "ax", @progbits
 
 # ASM-LABEL: other_section:

--- a/llvm/test/MC/RISCV/xqcili-relocations.s
+++ b/llvm/test/MC/RISCV/xqcili-relocations.s
@@ -84,7 +84,7 @@ qc.li a1, %qc.abs20(abs_symbol)
 qc.e.li s1, abs_symbol
 
 # ASM: qc.li a1, %qc.abs20(undef)
-# OBJ: qc.li a1, 0x0
+# OBJ-NEXT: qc.li a1, 0x0
 # OBJ-NEXT: R_RISCV_VENDOR QUALCOMM{{$}}
 # OBJ-NEXT: R_RISCV_CUSTOM192 undef{{$}}
 # OBJ-NEXT: R_RISCV_RELAX

--- a/llvm/test/MC/RISCV/xqcili-relocations.s
+++ b/llvm/test/MC/RISCV/xqcili-relocations.s
@@ -70,6 +70,35 @@ qc.e.li s3, other_section
 same_section:
   nop
 
+.option relax
+
+# ASM: qc.li a1, %qc.abs20(0)
+# OBJ: qc.li a1, 0x0
+# OBJ-NEXT: R_RISCV_VENDOR QUALCOMM{{$}}
+# OBJ-NEXT: R_RISCV_CUSTOM192 *ABS*{{$}}
+# OBJ-NEXT: R_RISCV_RELAX
+qc.li a1, %qc.abs20(abs_symbol)
+
+# ASM: qc.e.li s1, 0
+# OBJ-NEXT: qc.e.li s1, 0x0
+qc.e.li s1, abs_symbol
+
+# ASM: qc.li a1, %qc.abs20(undef)
+# OBJ: qc.li a1, 0x0
+# OBJ-NEXT: R_RISCV_VENDOR QUALCOMM{{$}}
+# OBJ-NEXT: R_RISCV_CUSTOM192 undef{{$}}
+# OBJ-NEXT: R_RISCV_RELAX
+qc.li a1, %qc.abs20(undef)
+
+# ASM: qc.e.li s1, undef
+# OBJ-NEXT: qc.e.li s1, 0x0
+# OBJ-NEXT: R_RISCV_VENDOR QUALCOMM{{$}}
+# OBJ-NEXT: R_RISCV_CUSTOM194 undef{{$}}
+# OBJ-NEXT: R_RISCV_RELAX
+qc.e.li s1, undef
+
+.option norelax
+
 .section .text.other, "ax", @progbits
 
 # ASM-LABEL: other_section:


### PR DESCRIPTION
Some of the QC relocations are relaxable, in particular there are relaxations defined for:
- `R_RISCV_QC_E_JUMP_PLT`
- `R_RISCV_QC_E_32`
- `R_RISCV_QC_ABS20_U`

This change ensures that llvm-mc correctly emits R_RISCV_RELAX relocations for the relevant fixups.