### PR TITLE
[lldb] Provide TrackingOutputBufferDeleter for custom unique_ptr deleter

### DIFF
--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -160,23 +160,4 @@ private:
 };
 } // namespace lldb_private
 
-/// Custom deleter to use with unique_ptr.
-///
-/// Usage:
-/// \code{.cpp}
-///
-/// auto OB =
-///     std::unique_ptr<TrackingOutputBuffer, TrackingOutputBufferDeleter>(
-///         new TrackingOutputBuffer());
-///
-/// \endcode
-struct TrackingOutputBufferDeleter {
-  void operator()(TrackingOutputBuffer *TOB) {
-    if (!TOB)
-      return;
-    std::free(TOB->getBuffer());
-    delete TOB;
-  }
-};
-
 #endif // LLDB_CORE_DEMANGLEDNAMEINFO_H

--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -160,6 +160,16 @@ private:
 };
 } // namespace lldb_private
 
+/// Custom deleter to use with unique_ptr.
+///
+/// Usage:
+/// \code{.cpp}
+///
+/// auto OB =
+///     std::unique_ptr<TrackingOutputBuffer, TrackingOutputBufferDeleter>(
+///         new TrackingOutputBuffer());
+///
+/// \endcode
 struct TrackingOutputBufferDeleter {
   void operator()(TrackingOutputBuffer *TOB) {
     if (!TOB)

--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -13,6 +13,7 @@
 #include "llvm/Demangle/Utility.h"
 
 #include <cstddef>
+#include <cstdlib>
 #include <utility>
 
 namespace lldb_private {
@@ -158,5 +159,14 @@ private:
   unsigned FunctionPrintingDepth = 0;
 };
 } // namespace lldb_private
+
+struct TrackingOutputBufferDeleter {
+  void operator()(TrackingOutputBuffer *TOB) {
+    if (!TOB)
+      return;
+    std::free(TOB->getBuffer());
+    delete TOB;
+  }
+};
 
 #endif // LLDB_CORE_DEMANGLEDNAMEINFO_H

--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -13,7 +13,6 @@
 #include "llvm/Demangle/Utility.h"
 
 #include <cstddef>
-#include <cstdlib>
 #include <utility>
 
 namespace lldb_private {

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -31,6 +31,25 @@
 using namespace lldb;
 using namespace lldb_private;
 
+/// Custom deleter to use with unique_ptr.
+///
+/// Usage:
+/// \code{.cpp}
+///
+/// auto OB =
+///     std::unique_ptr<TrackingOutputBuffer, TrackingOutputBufferDeleter>(
+///         new TrackingOutputBuffer());
+///
+/// \endcode
+struct TrackingOutputBufferDeleter {
+  void operator()(TrackingOutputBuffer *TOB) {
+    if (!TOB)
+      return;
+    std::free(TOB->getBuffer());
+    delete TOB;
+  }
+};
+
 TEST(MangledTest, ResultForValidName) {
   ConstString MangledName("_ZN1a1b1cIiiiEEvm");
   Mangled TheMangled(MangledName);

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -26,6 +26,7 @@
 
 #include "gtest/gtest.h"
 
+#include <cstdlib>
 #include <memory>
 
 using namespace lldb;


### PR DESCRIPTION
Suggested in #142676 as a way to automatically free the buffer in tests