### PR TITLE
Revert "[MemProf] Drop unneccessary REQUIRES: x86-linux directives."

### DIFF
--- a/llvm/test/Transforms/PGOProfile/memprof-call-site-at-alloc-site.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof-call-site-at-alloc-site.ll
@@ -2,6 +2,7 @@
 ; allocation call stack but does not call one of the memory allocation
 ; functions.
 
+; REQUIRES: x86_64-linux
 ; RUN: split-file %s %t
 ; RUN: llvm-profdata merge %t/memprof-call-site-at-alloc-site.yaml -o %t/memprof-call-site-at-alloc-site.memprofdata
 ; RUN: opt < %t/memprof-call-site-at-alloc-site.ll -passes='memprof-use<profile-filename=%t/memprof-call-site-at-alloc-site.memprofdata>' -memprof-print-match-info -S 2>&1 | FileCheck %s

--- a/llvm/test/Transforms/PGOProfile/memprof-dump-matched-alloc-site.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof-dump-matched-alloc-site.ll
@@ -23,6 +23,7 @@
 ;
 ; Here we expect to match the allocation site to encompass 3 frames.
 
+; REQUIRES: x86_64-linux
 ; RUN: split-file %s %t
 ; RUN: llvm-profdata merge %t/memprof-dump-matched-alloc-site.yaml -o %t/memprof-dump-matched-alloc-site.memprofdata
 ; RUN: opt < %t/memprof-dump-matched-alloc-site.ll -passes='memprof-use<profile-filename=%t/memprof-dump-matched-alloc-site.memprofdata>' -memprof-print-match-info -S 2>&1 | FileCheck %s

--- a/llvm/test/Transforms/PGOProfile/memprof-dump-matched-call-sites.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof-dump-matched-call-sites.ll
@@ -31,6 +31,7 @@
 ; Note that f3 is considered to be an allocation site, not a call site, because
 ; it directly calls new after inlining.
 
+; REQUIRES: x86_64-linux
 ; RUN: split-file %s %t
 ; RUN: llvm-profdata merge %t/memprof-dump-matched-call-site.yaml -o %t/memprof-dump-matched-call-site.memprofdata
 ; RUN: opt < %t/memprof-dump-matched-call-site.ll -passes='memprof-use<profile-filename=%t/memprof-dump-matched-call-site.memprofdata>' -memprof-print-match-info -S 2>&1 | FileCheck %s

--- a/llvm/test/Transforms/PGOProfile/memprof-undrift.test
+++ b/llvm/test/Transforms/PGOProfile/memprof-undrift.test
@@ -1,3 +1,4 @@
+; REQUIRES: x86_64-linux
 
 ; Make sure that we can undrift the MemProf profile and annotate the IR
 ; accordingly.

--- a/llvm/test/Transforms/PGOProfile/memprof_annotate_yaml.test
+++ b/llvm/test/Transforms/PGOProfile/memprof_annotate_yaml.test
@@ -1,3 +1,4 @@
+; REQUIRES: x86_64-linux
 
 ; Make sure that we can ingest the MemProf profile in YAML and
 ; annotate a call to new as cold.

--- a/llvm/test/Transforms/PGOProfile/memprof_discard_threshold.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof_discard_threshold.ll
@@ -1,5 +1,7 @@
 ;; Tests option to discard small noncold contexts.
 
+;; Avoid failures on big-endian systems that can't read the profile properly
+; REQUIRES: x86_64-linux
 
 ;; Generate the profile and the IR.
 ; RUN: split-file %s %t

--- a/llvm/test/Transforms/PGOProfile/memprof_match_hot_cold_new_calls.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof_match_hot_cold_new_calls.ll
@@ -1,6 +1,8 @@
 ;; Tests optional matching of memprof profile on call to operator new
 ;; with manual hot/cold hint.
 
+;; Avoid failures on big-endian systems that can't read the profile properly
+; REQUIRES: x86_64-linux
 
 ;; Generate the profile and the IR.
 ; RUN: split-file %s %t

--- a/llvm/test/Transforms/PGOProfile/memprof_missing_leaf.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof_missing_leaf.ll
@@ -3,6 +3,8 @@
 ;; matching and we are able to match the next call frame up the inlined
 ;; context.
 
+;; Avoid failures on big-endian systems that can't read the profile properly
+; REQUIRES: x86_64-linux
 
 ;; # To generate below LLVM IR for use in matching.
 ;; $ clang++ -gmlt -fdebug-info-for-profiling -S memprof_missing_leaf.cc \

--- a/llvm/test/tools/llvm-profdata/memprof-yaml-invalid.test
+++ b/llvm/test/tools/llvm-profdata/memprof-yaml-invalid.test
@@ -1,3 +1,4 @@
+; REQUIRES: x86_64-linux
 ; RUN: split-file %s %t
 ; RUN: not llvm-profdata merge %t/memprof-invalid.yaml -o %t/memprof-invalid.indexed
 


### PR DESCRIPTION
Reverts llvm/llvm-project#142718

Breaks ppc aix builds:     https://lab.llvm.org/buildbot/#/builders/64/builds/4036
