### PR TITLE
[Offload] Explicitly create directories that contain tablegen output

### DIFF
--- a/offload/liboffload/API/CMakeLists.txt
+++ b/offload/liboffload/API/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 set(LLVM_TARGET_DEFINITIONS ${CMAKE_CURRENT_SOURCE_DIR}/OffloadAPI.td)
 set(files_to_copy "")
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 macro(offload_tablegen file)
     tablegen(OFFLOAD generated/${file}.gen ${ARGN})

--- a/offload/plugins-nextgen/common/CMakeLists.txt
+++ b/offload/plugins-nextgen/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 # The error codes in this header are shared with liboffload, so need to be
 # generated from the same source.
 include(TableGen)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
 set(LLVM_TARGET_DEFINITIONS ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API/OffloadAPI.td)
 tablegen(OFFLOAD include/OffloadErrcodes.inc -gen-errcodes -I ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API)
 add_public_tablegen_target(PluginErrcodes)


### PR DESCRIPTION
This isn't required when building with Ninja, but with the Makefile generator these directories don't get implicitly created.