### PR TITLE
[lldb-dap] Adjust the stepInTargets tests on non-intel platforms.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
+++ b/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
@@ -30,6 +30,8 @@ class TestDAP_stepInTargets(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(
             len(breakpoint_ids), len(lines), "expect correct number of breakpoints"
         )
+        # Dynamic capability 'supportsStepInTargetsRequest' is sent in
+        # 'configurationDone' which is called prior to continue.
         self.continue_to_breakpoints(breakpoint_ids)
 
         threads = self.dap_server.get_threads()
@@ -89,8 +91,8 @@ class TestDAP_stepInTargets(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(
             len(breakpoint_ids), len(bp_lines), "expect correct number of breakpoints"
         )
-        # Dynamic capability is sent in 'configurationDone' which is called
-        # prior to continue.
+        # Dynamic capability 'supportsStepInTargetsRequest' is sent in
+        # 'configurationDone' which is called prior to continue.
         self.continue_to_breakpoints(breakpoint_ids)
 
         is_supported = self.dap_server.get_initialize_value(
@@ -115,8 +117,8 @@ class TestDAP_stepInTargets(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(
             len(breakpoint_ids), len(bp_lines), "expect correct number of breakpoints"
         )
-        # Dynamic capability is sent in 'configurationDone' which is called
-        # prior to continue.
+        # Dynamic capability 'supportsStepInTargetsRequest' is sent in
+        # 'configurationDone' which is called prior to continue.
         self.continue_to_breakpoints(breakpoint_ids)
 
         is_supported = self.dap_server.get_initialize_value(

--- a/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
+++ b/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
@@ -89,13 +89,16 @@ class TestDAP_stepInTargets(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(
             len(breakpoint_ids), len(bp_lines), "expect correct number of breakpoints"
         )
+        # Dynamic capability is sent in 'configurationDone' which is called
+        # prior to continue.
+        self.continue_to_breakpoints(breakpoint_ids)
+
         is_supported = self.dap_server.get_initialize_value(
             "supportsStepInTargetsRequest"
         )
 
-        self.assertEqual(
+        self.assertTrue(
             is_supported,
-            True,
             f"expect capability `stepInTarget` is supported with architecture {self.getArchitecture()}",
         )
         # clear breakpoints.
@@ -112,15 +115,17 @@ class TestDAP_stepInTargets(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(
             len(breakpoint_ids), len(bp_lines), "expect correct number of breakpoints"
         )
+        # Dynamic capability is sent in 'configurationDone' which is called
+        # prior to continue.
+        self.continue_to_breakpoints(breakpoint_ids)
+
         is_supported = self.dap_server.get_initialize_value(
             "supportsStepInTargetsRequest"
         )
 
-        self.assertEqual(
+        self.assertFalse(
             is_supported,
-            False,
-            f"expect capability `stepInTarget` is not supported with architecture {self.getArchitecture()}",
+            f"expect capability `stepInTarget` is supported with architecture {self.getArchitecture()}",
         )
         # clear breakpoints.
-        self.set_source_breakpoints(source, [])
         self.continue_to_exit()

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -363,9 +363,6 @@ class StepInTargetsRequestHandler
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral GetCommand() { return "stepInTargets"; }
-  FeatureSet GetSupportedFeatures() const override {
-    return {protocol::eAdapterFeatureStepInTargetsRequest};
-  }
   llvm::Expected<protocol::StepInTargetsResponseBody>
   Run(const protocol::StepInTargetsArguments &args) const override;
 };


### PR DESCRIPTION
This test is failing for me on arm64 due to the capabilities not being sent until 'configurationDone' is called.

I adjusted the test to ensure we call 'configurationDone' so the value is sent to the test correctly.