### PR TITLE
[tsan] Change personality CHECK to Printf() + Die()

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
@@ -259,7 +259,14 @@ static void ReExecIfNeeded(bool ignore_heap) {
             "WARNING: Program is run with randomized virtual address "
             "space, which wouldn't work with ThreadSanitizer on Android.\n"
             "Re-execing with fixed virtual address space.\n");
-    CHECK_NE(personality(old_personality | ADDR_NO_RANDOMIZE), -1);
+
+    if (personality(old_personality | ADDR_NO_RANDOMIZE) == -1) {
+      Printf("FATAL: ThreadSanitizer: unable to disable ASLR (perhaps "
+             "sandboxing is enabled?).\n");
+      Printf("FATAL: Please rerun without sandboxing or ASLR.\n");
+      Die();
+    }
+
     reexec = true;
   }
 #      endif
@@ -287,7 +294,16 @@ static void ReExecIfNeeded(bool ignore_heap) {
               "possibly due to high-entropy ASLR.\n"
               "Re-execing with fixed virtual address space.\n"
               "N.B. reducing ASLR entropy is preferable.\n");
-      CHECK_NE(personality(old_personality | ADDR_NO_RANDOMIZE), -1);
+
+      if (personality(old_personality | ADDR_NO_RANDOMIZE) == -1) {
+        Printf("FATAL: ThreadSanitizer: encountered an incompatible memory "
+               "but was unable to disable ASLR (perhaps sandboxing is "
+               "enabled?).\n");
+        Printf("FATAL: Please rerun with lower ASLR entropy, ASLR disabled, "
+               "and/or sandboxing disabled.\n");
+        Die();
+      }
+
       reexec = true;
     } else {
       Printf(

--- a/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
@@ -261,8 +261,9 @@ static void ReExecIfNeeded(bool ignore_heap) {
             "Re-execing with fixed virtual address space.\n");
 
     if (personality(old_personality | ADDR_NO_RANDOMIZE) == -1) {
-      Printf("FATAL: ThreadSanitizer: unable to disable ASLR (perhaps "
-             "sandboxing is enabled?).\n");
+      Printf(
+          "FATAL: ThreadSanitizer: unable to disable ASLR (perhaps "
+          "sandboxing is enabled?).\n");
       Printf("FATAL: Please rerun without sandboxing and/or ASLR.\n");
       Die();
     }
@@ -296,11 +297,13 @@ static void ReExecIfNeeded(bool ignore_heap) {
               "N.B. reducing ASLR entropy is preferable.\n");
 
       if (personality(old_personality | ADDR_NO_RANDOMIZE) == -1) {
-        Printf("FATAL: ThreadSanitizer: encountered an incompatible memory "
-               "but was unable to disable ASLR (perhaps sandboxing is "
-               "enabled?).\n");
-        Printf("FATAL: Please rerun with lower ASLR entropy, ASLR disabled, "
-               "and/or sandboxing disabled.\n");
+        Printf(
+            "FATAL: ThreadSanitizer: encountered an incompatible memory "
+            "but was unable to disable ASLR (perhaps sandboxing is "
+            "enabled?).\n");
+        Printf(
+            "FATAL: Please rerun with lower ASLR entropy, ASLR disabled, "
+            "and/or sandboxing disabled.\n");
         Die();
       }
 

--- a/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
@@ -299,7 +299,7 @@ static void ReExecIfNeeded(bool ignore_heap) {
       if (personality(old_personality | ADDR_NO_RANDOMIZE) == -1) {
         Printf(
             "FATAL: ThreadSanitizer: encountered an incompatible memory "
-            "but was unable to disable ASLR (perhaps sandboxing is "
+            "layout but was unable to disable ASLR (perhaps sandboxing is "
             "enabled?).\n");
         Printf(
             "FATAL: Please rerun with lower ASLR entropy, ASLR disabled, "

--- a/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
@@ -263,7 +263,7 @@ static void ReExecIfNeeded(bool ignore_heap) {
     if (personality(old_personality | ADDR_NO_RANDOMIZE) == -1) {
       Printf("FATAL: ThreadSanitizer: unable to disable ASLR (perhaps "
              "sandboxing is enabled?).\n");
-      Printf("FATAL: Please rerun without sandboxing or ASLR.\n");
+      Printf("FATAL: Please rerun without sandboxing and/or ASLR.\n");
       Die();
     }
 


### PR DESCRIPTION
Currently, if TSan needs to disable ASLR but is unable to do so, it aborts with a cryptic message:
```
    ThreadSanitizer: CHECK failed: tsan_platform_linux.cpp:290 "((personality(old_personality | ADDR_NO_RANDOMIZE))) != ((-1))"
```
and a segfault (https://github.com/google/sanitizers/issues/837#issuecomment-2939267531).

This patch replaces the CHECK with more user-friendly diagnostics and suggestions via printf, followed by Die().