### PR TITLE
[clang] Reduce LateInstantiatedAttrVec vector default size.

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14015,7 +14015,7 @@ public:
                               Decl *D)
         : TmplAttr(A), Scope(S), NewDecl(D) {}
   };
-  typedef SmallVector<LateInstantiatedAttribute, 16> LateInstantiatedAttrVec;
+  typedef SmallVector<LateInstantiatedAttribute, 1> LateInstantiatedAttrVec;
 
   void InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
                         const Decl *Pattern, Decl *Inst,


### PR DESCRIPTION
This increases clang's template instantiation depths.

I can see 7% increase (1510 -> 1612 on my local machine) for the `clang/test/SemaTemplate/instantiation-depth-default.cpp` case. 

No performance regressions have been observed: https://llvm-compile-time-tracker.com/compare.php?from=5f8cf33650c0c71119ecf81f07014329d9466d0d&to=05c2403b0f784325f5b88760ef43a15b6aaf4181&stat=instructions:u
