### PR TITLE
[clang] Remove the experimental prefix from -fexperimental-relative-c++-abi-vtables

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2996,14 +2996,18 @@ defm fine_grained_bitfield_accesses : BoolOption<"f", "fine-grained-bitfield-acc
   BothFlags<[], [ClangOption, CC1Option]>>,
   Group<f_clang_Group>;
 
-def fexperimental_relative_cxx_abi_vtables :
-  Flag<["-"], "fexperimental-relative-c++-abi-vtables">,
-  Group<f_clang_Group>, Visibility<[ClangOption, CC1Option]>,
-  HelpText<"Use the experimental C++ class ABI for classes with virtual tables">;
-def fno_experimental_relative_cxx_abi_vtables :
-  Flag<["-"], "fno-experimental-relative-c++-abi-vtables">,
-  Group<f_clang_Group>, Visibility<[ClangOption, CC1Option]>,
-  HelpText<"Do not use the experimental C++ class ABI for classes with virtual tables">;
+defm experimental_relative_cxx_abi_vtables
+    : BoolFOption<
+          "experimental-relative-c++-abi-vtables",
+          LangOpts<"RelativeCXXABIVTables">, DefaultFalse,
+          PosFlag<SetTrue, [], [ClangOption, CC1Option], "Use ">,
+          NegFlag<SetFalse, [], [ClangOption, CC1Option], "Do not use ">,
+          BothFlags<[], [ClangOption, CC1Option],
+                    " the C++ class ABI for classes with virtual tables">>;
+def : Flag<["-"], "frelative-c++-abi-vtables">,
+      Alias<fexperimental_relative_cxx_abi_vtables>;
+def : Flag<["-"], "fno-relative-c++-abi-vtables">,
+      Alias<fno_experimental_relative_cxx_abi_vtables>;
 
 defm experimental_omit_vtable_rtti : BoolFOption<"experimental-omit-vtable-rtti",
   LangOpts<"OmitVTableRTTI">, DefaultFalse,

--- a/clang/test/Driver/relative-vtables-flag.cpp
+++ b/clang/test/Driver/relative-vtables-flag.cpp
@@ -2,6 +2,8 @@
 // RUN: %clangxx --target=aarch64-unknown-fuchsia -fno-experimental-relative-c++-abi-vtables -c %s -### 2>&1 | FileCheck %s --check-prefix=NO-RV
 // RUN: %clangxx --target=aarch64-unknown-fuchsia -c %s -### 2>&1 | FileCheck %s --check-prefix=NO-RV
 // RUN: %clangxx --target=aarch64-unknown-linux-gnu -c %s -### 2>&1 | FileCheck %s --check-prefix=NO-RV
+// RUN: %clangxx --target=aarch64-unknown-fuchsia -frelative-c++-abi-vtables -c %s -### 2>&1 | FileCheck %s --check-prefix=RV
+// RUN: %clangxx --target=aarch64-unknown-fuchsia -fno-relative-c++-abi-vtables -c %s -### 2>&1 | FileCheck %s --check-prefix=NO-RV
 
 // RV: "-fexperimental-relative-c++-abi-vtables"
 // NO-RV-NOT: "-fexperimental-relative-c++-abi-vtables"


### PR DESCRIPTION
This actually creates an alias to the original flag omitting the experimental part. This has been in prod use for a while and isn't necessary.