### PR TITLE
[bazel] fix libc bazel build broken by ff844df7.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4210,6 +4210,7 @@ libc_function(
     hdrs = ["src/string/memchr.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_utils",
     ],
 )
@@ -4220,6 +4221,7 @@ libc_function(
     hdrs = ["src/string/memcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_memory_utils",
     ],
 )
@@ -4230,6 +4232,7 @@ libc_function(
     hdrs = ["src/string/memset.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_memory_utils",
     ],
 )
@@ -4240,6 +4243,7 @@ libc_function(
     hdrs = ["src/string/memmove.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_memory_utils",
     ],
 )
@@ -4250,6 +4254,7 @@ libc_function(
     hdrs = ["src/string/mempcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_memory_utils",
     ],
 )
@@ -4271,6 +4276,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_null_check",
         ":string_memory_utils",
     ],
 )
@@ -4301,6 +4307,7 @@ libc_function(
     hdrs = ["src/string/memrchr.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_utils",
     ],
 )
@@ -4311,6 +4318,7 @@ libc_function(
     hdrs = ["src/string/strlen.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_utils",
     ],
 )
@@ -4321,6 +4329,7 @@ libc_function(
     hdrs = ["src/string/strcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_memory_utils",
         ":string_utils",
     ],
@@ -4372,6 +4381,7 @@ libc_function(
     hdrs = ["src/string/strstr.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_null_check",
         ":string_memory_utils",
         ":string_utils",
     ],
@@ -4404,6 +4414,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_cpp_bitset",
+        ":__support_macros_null_check",
         ":string_utils",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
@@ -22,6 +22,7 @@ libc_test(
     name = "strcpy_test",
     srcs = ["strcpy_test.cpp"],
     deps = [
+        "//libc:hdr_signal_macros",
         "//libc:strcpy",
     ],
 )
@@ -38,6 +39,7 @@ libc_test(
     name = "memchr_test",
     srcs = ["memchr_test.cpp"],
     deps = [
+        "//libc:hdr_signal_macros",
         "//libc:memchr",
     ],
 )
@@ -77,6 +79,7 @@ libc_test(
     name = "memrchr_test",
     srcs = ["memrchr_test.cpp"],
     deps = [
+        "//libc:hdr_signal_macros",
         "//libc:memrchr",
     ],
 )
@@ -102,6 +105,7 @@ libc_test(
     name = "strspn_test",
     srcs = ["strspn_test.cpp"],
     deps = [
+        "//libc:hdr_signal_macros",
         "//libc:strspn",
     ],
 )
@@ -142,6 +146,7 @@ libc_test(
         ":memory_check_utils",
         ":protected_pages",
         "//libc:__support_macros_properties_os",
+        "//libc:hdr_signal_macros",
         "//libc:memcpy",
     ],
 )
@@ -150,6 +155,7 @@ libc_test(
     name = "mempcpy_test",
     srcs = ["mempcpy_test.cpp"],
     deps = [
+        "//libc:hdr_signal_macros",
         "//libc:mempcpy",
     ],
 )
@@ -161,6 +167,7 @@ libc_test(
         ":memory_check_utils",
         ":protected_pages",
         "//libc:__support_macros_properties_os",
+        "//libc:hdr_signal_macros",
         "//libc:memset",
     ],
 )
@@ -171,6 +178,7 @@ libc_test(
     deps = [
         ":memory_check_utils",
         "//libc:__support_cpp_span",
+        "//libc:hdr_signal_macros",
         "//libc:memcmp",
         "//libc:memmove",
         "//libc/test/UnitTest:memory_matcher",
@@ -182,6 +190,7 @@ libc_test(
     srcs = ["memcmp_test.cpp"],
     deps = [
         ":memory_check_utils",
+        "//libc:hdr_signal_macros",
         "//libc:memcmp",
         "//libc/test/UnitTest:test_logger",
     ],


### PR DESCRIPTION
Fixes `bazelisk test @llvm-project//libc/test/src/string/...`