### PR TITLE
[Clang][NFC] Use move in std::vector local in HandleTranslationUnit

### DIFF
--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -181,7 +181,7 @@ public:
         if (MergedRanges.back().second < It->second)
           MergedRanges.back().second = It->second;
       }
-      Result.push_back({Data.Ref->getName(), MergedRanges});
+      Result.push_back({Data.Ref->getName(), std::move(MergedRanges)});
     }
     printJson(Result);
   }


### PR DESCRIPTION
Static analysis flagged this since we could move MergedRanges since it is a std::vector, a local and unused after that line. So there is a potential saving.