### PR TITLE
[RISCV] Remove -riscv-asm-relax-branches flag

### DIFF
--- a/lld/test/ELF/riscv-branch.s
+++ b/lld/test/ELF/riscv-branch.s
@@ -1,7 +1,7 @@
 # REQUIRES: riscv
 
-# RUN: llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax -riscv-asm-relax-branches=0 %s -o %t.rv32.o
-# RUN: llvm-mc -filetype=obj -triple=riscv64-unknown-elf -mattr=-relax -riscv-asm-relax-branches=0 %s -o %t.rv64.o
+# RUN: llvm-mc -filetype=obj -triple=riscv32-unknown-elf %s -o %t.rv32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64-unknown-elf %s -o %t.rv64.o
 
 # RUN: ld.lld %t.rv32.o --defsym foo=_start+4 --defsym bar=_start -o %t.rv32
 # RUN: ld.lld %t.rv64.o --defsym foo=_start+4 --defsym bar=_start -o %t.rv64
@@ -29,6 +29,8 @@
 # RUN: not ld.lld %t.rv32.o --defsym foo=_start+1 --defsym bar=_start-1 -o /dev/null 2>&1 | FileCheck --check-prefix=ERROR-ALIGN %s
 # RUN: not ld.lld %t.rv64.o --defsym foo=_start+1 --defsym bar=_start-1 -o /dev/null 2>&1 | FileCheck --check-prefix=ERROR-ALIGN %s
 # ERROR-ALIGN: improper alignment for relocation R_RISCV_BRANCH: 0x1 is not aligned to 2 bytes
+
+.option exact
 
 .global _start
 _start:

--- a/lld/test/ELF/riscv-undefined-weak.s
+++ b/lld/test/ELF/riscv-undefined-weak.s
@@ -1,7 +1,7 @@
 # REQUIRES: riscv
 # RUN: llvm-mc -filetype=obj -triple=riscv64 /dev/null -o %t2.o
 # RUN: ld.lld -shared -soname=t2 %t2.o -o %t2.so
-# RUN: llvm-mc -filetype=obj -triple=riscv64 -riscv-asm-relax-branches=0 %s -o %t.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 %s -o %t.o
 # RUN: llvm-readobj -r %t.o | FileCheck --check-prefix=RELOC %s
 
 # RUN: ld.lld -e absolute %t.o -o %t
@@ -11,6 +11,8 @@
 # RUN: ld.lld -e absolute %t.o -o %t %t2.so
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefixes=CHECK,PLT %s
 # RUN: llvm-readelf -x .data %t | FileCheck --check-prefixes=HEX,HEX-WITH-PLT %s
+
+.option exact
 
 .weak target
 .global absolute, relative, branch

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
@@ -27,8 +27,6 @@
 
 using namespace llvm;
 
-static cl::opt<bool> RelaxBranches("riscv-asm-relax-branches", cl::init(true),
-                                   cl::Hidden);
 // Temporary workaround for old linkers that do not support ULEB128 relocations,
 // which are abused by DWARF v5 DW_LLE_offset_pair/DW_RLE_offset_pair
 // implemented in Clang/LLVM.
@@ -110,9 +108,6 @@ bool RISCVAsmBackend::fixupNeedsRelaxationAdvanced(const MCFixup &Fixup,
                                                    const MCValue &,
                                                    uint64_t Value,
                                                    bool Resolved) const {
-  if (!RelaxBranches)
-    return false;
-
   int64_t Offset = int64_t(Value);
   unsigned Kind = Fixup.getTargetKind();
 

--- a/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_branch.s
+++ b/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_branch.s
@@ -1,7 +1,7 @@
 # RUN: rm -rf %t && mkdir -p %t
-# RUN: llvm-mc -triple=riscv64 -filetype=obj -riscv-asm-relax-branches=0 \
+# RUN: llvm-mc -triple=riscv64 -filetype=obj \
 # RUN:     -o %t/elf_riscv64_branch.o %s
-# RUN: llvm-mc -triple=riscv32 -filetype=obj -riscv-asm-relax-branches=0 \
+# RUN: llvm-mc -triple=riscv32 -filetype=obj \
 # RUN:     -o %t/elf_riscv32_branch.o %s
 # RUN: llvm-jitlink -noexec \
 # RUN:     -slab-allocate 100Kb -slab-address 0xfff00ff4 -slab-page-size 4096 \
@@ -12,6 +12,8 @@
 # RUN:     -abs external_func_positive_offset=0xfff00ffc -abs external_func_negative_offset=0xfff00000 \
 # RUN:     -check %s %t/elf_riscv32_branch.o
 #
+
+        .option exact
 
         .text
 # Empty main entry point.

--- a/llvm/test/MC/RISCV/option-exact-long-jump-disable.s
+++ b/llvm/test/MC/RISCV/option-exact-long-jump-disable.s
@@ -1,14 +1,16 @@
-## Test that long branches are not relaxed with -riscv-asm-relax-branches=0
+## Test that long branches are not relaxed with .option exact
 # RUN: split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c \
-# RUN:       -riscv-asm-relax-branches=0 %t/pass.s \
+# RUN:       %t/pass.s \
 # RUN:     | llvm-objdump -dr -M no-aliases - \
 # RUN:     | FileCheck %t/pass.s
 # RUN: not llvm-mc -filetype=obj -triple=riscv64 -mattr=+c -o /dev/null \
-# RUN:       -riscv-asm-relax-branches=0 %t/fail.s 2>&1 \
+# RUN:       %t/fail.s 2>&1 \
 # RUN:     | FileCheck %t/fail.s
 
 #--- pass.s
+  .option exact
+
   .text
 test_undefined:
 ## Branches to undefined symbols should not be relaxed
@@ -33,6 +35,8 @@ test_defined_in_range:
 bar:
 
 #--- fail.s
+  .option exact
+
   .text
 ## Branches to defined out-of-range symbols should report an error
 test_defined_out_of_range:


### PR DESCRIPTION
This flag has been superseded by `.option exact`, as the test updates show.

Given the flag was always hidden, it makes sense to me to remove it, and move tests that required it to use `.option exact`.