### PR TITLE
[llvm] annotate interfaces in llvm/Option and llvm/Remarks for DLL export

### DIFF
--- a/llvm/include/llvm/Option/Arg.h
+++ b/llvm/include/llvm/Option/Arg.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_OPTION_ARG_H
 #define LLVM_OPTION_ARG_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/Option.h"
@@ -70,15 +71,15 @@ private:
   std::unique_ptr<Arg> Alias;
 
 public:
-  Arg(const Option Opt, StringRef Spelling, unsigned Index,
+  LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
       const Arg *BaseArg = nullptr);
-  Arg(const Option Opt, StringRef Spelling, unsigned Index,
+  LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
       const char *Value0, const Arg *BaseArg = nullptr);
-  Arg(const Option Opt, StringRef Spelling, unsigned Index,
+  LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
       const char *Value0, const char *Value1, const Arg *BaseArg = nullptr);
   Arg(const Arg &) = delete;
   Arg &operator=(const Arg &) = delete;
-  ~Arg();
+  LLVM_ABI ~Arg();
 
   const Option &getOption() const { return Opt; }
 
@@ -134,23 +135,23 @@ public:
   }
 
   /// Append the argument onto the given array as strings.
-  void render(const ArgList &Args, ArgStringList &Output) const;
+  LLVM_ABI void render(const ArgList &Args, ArgStringList &Output) const;
 
   /// Append the argument, render as an input, onto the given
   /// array as strings.
   ///
   /// The distinction is that some options only render their values
   /// when rendered as a input (e.g., Xlinker).
-  void renderAsInput(const ArgList &Args, ArgStringList &Output) const;
+  LLVM_ABI void renderAsInput(const ArgList &Args, ArgStringList &Output) const;
 
-  void print(raw_ostream &O) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &O) const;
+  LLVM_ABI void dump() const;
 
   /// Return a formatted version of the argument and its values, for
   /// diagnostics. Since this is for diagnostics, if this Arg was produced
   /// through an alias, this returns the string representation of the alias
   /// that the user wrote.
-  std::string getAsString(const ArgList &Args) const;
+  LLVM_ABI std::string getAsString(const ArgList &Args) const;
 };
 
 } // end namespace opt

--- a/llvm/include/llvm/Option/Arg.h
+++ b/llvm/include/llvm/Option/Arg.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_OPTION_ARG_H
 #define LLVM_OPTION_ARG_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/Option.h"
+#include "llvm/Support/Compiler.h"
 #include <string>
 
 namespace llvm {
@@ -72,11 +72,12 @@ private:
 
 public:
   LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
-      const Arg *BaseArg = nullptr);
+               const Arg *BaseArg = nullptr);
   LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
-      const char *Value0, const Arg *BaseArg = nullptr);
+               const char *Value0, const Arg *BaseArg = nullptr);
   LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
-      const char *Value0, const char *Value1, const Arg *BaseArg = nullptr);
+               const char *Value0, const char *Value1,
+               const Arg *BaseArg = nullptr);
   Arg(const Arg &) = delete;
   Arg &operator=(const Arg &) = delete;
   LLVM_ABI ~Arg();

--- a/llvm/include/llvm/Option/ArgList.h
+++ b/llvm/include/llvm/Option/ArgList.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OPTION_ARGLIST_H
 #define LLVM_OPTION_ARGLIST_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/iterator_range.h"
@@ -139,7 +140,7 @@ private:
 
   /// Get the range of indexes in which options with the specified IDs might
   /// reside, or (0, 0) if there are no such options.
-  OptRange getRange(std::initializer_list<OptSpecifier> Ids) const;
+  LLVM_ABI OptRange getRange(std::initializer_list<OptSpecifier> Ids) const;
 
 protected:
   // Make the default special members protected so they won't be used to slice
@@ -178,7 +179,7 @@ public:
   /// @{
 
   /// append - Append \p A to the arg list.
-  void append(Arg *A);
+  LLVM_ABI void append(Arg *A);
 
   const arglist_type &getArgs() const { return Args; }
 
@@ -227,7 +228,7 @@ public:
   /// @{
 
   /// eraseArg - Remove any option matching \p Id.
-  void eraseArg(OptSpecifier Id);
+  LLVM_ABI void eraseArg(OptSpecifier Id);
 
   /// @}
   /// @name Arg Access
@@ -284,11 +285,11 @@ public:
   /// @{
 
   /// getLastArgValue - Return the value of the last argument, or a default.
-  StringRef getLastArgValue(OptSpecifier Id, StringRef Default = "") const;
+  LLVM_ABI StringRef getLastArgValue(OptSpecifier Id, StringRef Default = "") const;
 
   /// getAllArgValues - Get the values of all instances of the given argument
   /// as strings.
-  std::vector<std::string> getAllArgValues(OptSpecifier Id) const;
+  LLVM_ABI std::vector<std::string> getAllArgValues(OptSpecifier Id) const;
 
   /// @}
   /// @name Translation Utilities
@@ -298,19 +299,19 @@ public:
   /// true if the option is present, false if the negation is present, and
   /// \p Default if neither option is given. If both the option and its
   /// negation are present, the last one wins.
-  bool hasFlag(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
-  bool hasFlagNoClaim(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
+  LLVM_ABI bool hasFlag(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
+  LLVM_ABI bool hasFlagNoClaim(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
 
   /// hasFlag - Given an option \p Pos, an alias \p PosAlias and its negative
   /// form \p Neg, return true if the option or its alias is present, false if
   /// the negation is present, and \p Default if none of the options are
   /// given. If multiple options are present, the last one wins.
-  bool hasFlag(OptSpecifier Pos, OptSpecifier PosAlias, OptSpecifier Neg,
+  LLVM_ABI bool hasFlag(OptSpecifier Pos, OptSpecifier PosAlias, OptSpecifier Neg,
                bool Default) const;
 
   /// Given an option Pos and its negative form Neg, render the option if Pos is
   /// present.
-  void addOptInFlag(ArgStringList &Output, OptSpecifier Pos,
+  LLVM_ABI void addOptInFlag(ArgStringList &Output, OptSpecifier Pos,
                     OptSpecifier Neg) const;
   /// Render the option if Neg is present.
   void addOptOutFlag(ArgStringList &Output, OptSpecifier Pos,
@@ -331,17 +332,17 @@ public:
 
   /// AddAllArgsExcept - Render all arguments matching any of the given ids
   /// and not matching any of the excluded ids.
-  void AddAllArgsExcept(ArgStringList &Output, ArrayRef<OptSpecifier> Ids,
+  LLVM_ABI void AddAllArgsExcept(ArgStringList &Output, ArrayRef<OptSpecifier> Ids,
                         ArrayRef<OptSpecifier> ExcludeIds) const;
   /// Render all arguments matching any of the given ids.
-  void addAllArgs(ArgStringList &Output, ArrayRef<OptSpecifier> Ids) const;
+  LLVM_ABI void addAllArgs(ArgStringList &Output, ArrayRef<OptSpecifier> Ids) const;
 
   /// AddAllArgs - Render all arguments matching the given ids.
-  void AddAllArgs(ArgStringList &Output, OptSpecifier Id0) const;
+  LLVM_ABI void AddAllArgs(ArgStringList &Output, OptSpecifier Id0) const;
 
   /// AddAllArgValues - Render the argument values of all arguments
   /// matching the given ids.
-  void AddAllArgValues(ArgStringList &Output, OptSpecifier Id0,
+  LLVM_ABI void AddAllArgValues(ArgStringList &Output, OptSpecifier Id0,
                        OptSpecifier Id1 = 0U, OptSpecifier Id2 = 0U) const;
 
   /// AddAllArgsTranslated - Render all the arguments matching the
@@ -350,13 +351,13 @@ public:
   ///
   /// \param Joined - If true, render the argument as joined with
   /// the option specifier.
-  void AddAllArgsTranslated(ArgStringList &Output, OptSpecifier Id0,
+  LLVM_ABI void AddAllArgsTranslated(ArgStringList &Output, OptSpecifier Id0,
                             const char *Translation,
                             bool Joined = false) const;
 
   /// ClaimAllArgs - Claim all arguments which match the given
   /// option id.
-  void ClaimAllArgs(OptSpecifier Id0) const;
+  LLVM_ABI void ClaimAllArgs(OptSpecifier Id0) const;
 
   template <typename... OptSpecifiers>
   void claimAllArgs(OptSpecifiers... Ids) const {
@@ -366,7 +367,7 @@ public:
 
   /// ClaimAllArgs - Claim all arguments.
   ///
-  void ClaimAllArgs() const;
+  LLVM_ABI void ClaimAllArgs() const;
   /// @}
   /// @name Arg Synthesis
   /// @{
@@ -381,16 +382,16 @@ public:
 
   /// Create an arg string for (\p LHS + \p RHS), reusing the
   /// string at \p Index if possible.
-  const char *GetOrMakeJoinedArgString(unsigned Index, StringRef LHS,
+  LLVM_ABI const char *GetOrMakeJoinedArgString(unsigned Index, StringRef LHS,
                                         StringRef RHS) const;
 
-  void print(raw_ostream &O) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &O) const;
+  LLVM_ABI void dump() const;
 
   /// @}
 };
 
-class InputArgList final : public ArgList {
+class LLVM_ABI InputArgList final : public ArgList {
 private:
   /// List of argument strings used by the contained Args.
   ///
@@ -463,7 +464,7 @@ public:
 
 /// DerivedArgList - An ordered collection of driver arguments,
 /// whose storage may be in another argument list.
-class DerivedArgList final : public ArgList {
+class LLVM_ABI DerivedArgList final : public ArgList {
   const InputArgList &BaseArgs;
 
   /// The list of arguments we synthesized.

--- a/llvm/include/llvm/Option/ArgList.h
+++ b/llvm/include/llvm/Option/ArgList.h
@@ -9,17 +9,17 @@
 #ifndef LLVM_OPTION_ARGLIST_H
 #define LLVM_OPTION_ARGLIST_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/iterator_range.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/OptSpecifier.h"
 #include "llvm/Option/Option.h"
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <cstddef>
 #include <initializer_list>
@@ -285,7 +285,8 @@ public:
   /// @{
 
   /// getLastArgValue - Return the value of the last argument, or a default.
-  LLVM_ABI StringRef getLastArgValue(OptSpecifier Id, StringRef Default = "") const;
+  LLVM_ABI StringRef getLastArgValue(OptSpecifier Id,
+                                     StringRef Default = "") const;
 
   /// getAllArgValues - Get the values of all instances of the given argument
   /// as strings.
@@ -300,19 +301,20 @@ public:
   /// \p Default if neither option is given. If both the option and its
   /// negation are present, the last one wins.
   LLVM_ABI bool hasFlag(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
-  LLVM_ABI bool hasFlagNoClaim(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
+  LLVM_ABI bool hasFlagNoClaim(OptSpecifier Pos, OptSpecifier Neg,
+                               bool Default) const;
 
   /// hasFlag - Given an option \p Pos, an alias \p PosAlias and its negative
   /// form \p Neg, return true if the option or its alias is present, false if
   /// the negation is present, and \p Default if none of the options are
   /// given. If multiple options are present, the last one wins.
-  LLVM_ABI bool hasFlag(OptSpecifier Pos, OptSpecifier PosAlias, OptSpecifier Neg,
-               bool Default) const;
+  LLVM_ABI bool hasFlag(OptSpecifier Pos, OptSpecifier PosAlias,
+                        OptSpecifier Neg, bool Default) const;
 
   /// Given an option Pos and its negative form Neg, render the option if Pos is
   /// present.
   LLVM_ABI void addOptInFlag(ArgStringList &Output, OptSpecifier Pos,
-                    OptSpecifier Neg) const;
+                             OptSpecifier Neg) const;
   /// Render the option if Neg is present.
   void addOptOutFlag(ArgStringList &Output, OptSpecifier Pos,
                      OptSpecifier Neg) const {
@@ -332,10 +334,12 @@ public:
 
   /// AddAllArgsExcept - Render all arguments matching any of the given ids
   /// and not matching any of the excluded ids.
-  LLVM_ABI void AddAllArgsExcept(ArgStringList &Output, ArrayRef<OptSpecifier> Ids,
-                        ArrayRef<OptSpecifier> ExcludeIds) const;
+  LLVM_ABI void AddAllArgsExcept(ArgStringList &Output,
+                                 ArrayRef<OptSpecifier> Ids,
+                                 ArrayRef<OptSpecifier> ExcludeIds) const;
   /// Render all arguments matching any of the given ids.
-  LLVM_ABI void addAllArgs(ArgStringList &Output, ArrayRef<OptSpecifier> Ids) const;
+  LLVM_ABI void addAllArgs(ArgStringList &Output,
+                           ArrayRef<OptSpecifier> Ids) const;
 
   /// AddAllArgs - Render all arguments matching the given ids.
   LLVM_ABI void AddAllArgs(ArgStringList &Output, OptSpecifier Id0) const;
@@ -343,7 +347,8 @@ public:
   /// AddAllArgValues - Render the argument values of all arguments
   /// matching the given ids.
   LLVM_ABI void AddAllArgValues(ArgStringList &Output, OptSpecifier Id0,
-                       OptSpecifier Id1 = 0U, OptSpecifier Id2 = 0U) const;
+                                OptSpecifier Id1 = 0U,
+                                OptSpecifier Id2 = 0U) const;
 
   /// AddAllArgsTranslated - Render all the arguments matching the
   /// given ids, but forced to separate args and using the provided
@@ -352,8 +357,8 @@ public:
   /// \param Joined - If true, render the argument as joined with
   /// the option specifier.
   LLVM_ABI void AddAllArgsTranslated(ArgStringList &Output, OptSpecifier Id0,
-                            const char *Translation,
-                            bool Joined = false) const;
+                                     const char *Translation,
+                                     bool Joined = false) const;
 
   /// ClaimAllArgs - Claim all arguments which match the given
   /// option id.
@@ -383,7 +388,7 @@ public:
   /// Create an arg string for (\p LHS + \p RHS), reusing the
   /// string at \p Index if possible.
   LLVM_ABI const char *GetOrMakeJoinedArgString(unsigned Index, StringRef LHS,
-                                        StringRef RHS) const;
+                                                StringRef RHS) const;
 
   LLVM_ABI void print(raw_ostream &O) const;
   LLVM_ABI void dump() const;

--- a/llvm/include/llvm/Option/OptSpecifier.h
+++ b/llvm/include/llvm/Option/OptSpecifier.h
@@ -22,7 +22,7 @@ public:
   OptSpecifier() = default;
   explicit OptSpecifier(bool) = delete;
   /*implicit*/ OptSpecifier(unsigned ID) : ID(ID) {}
-  /*implicit*/ OptSpecifier(const Option *Opt);
+  /*implicit*/ LLVM_ABI OptSpecifier(const Option *Opt);
 
   bool isValid() const { return ID != 0; }
 

--- a/llvm/include/llvm/Option/OptTable.h
+++ b/llvm/include/llvm/Option/OptTable.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_OPTION_OPTTABLE_H
 #define LLVM_OPTION_OPTTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringTable.h"
 #include "llvm/Option/OptSpecifier.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/StringSaver.h"
 #include <cassert>
 #include <string>
@@ -427,8 +427,8 @@ private:
 class GenericOptTable : public OptTable {
 protected:
   LLVM_ABI GenericOptTable(const StringTable &StrTable,
-                  ArrayRef<StringTable::Offset> PrefixesTable,
-                  ArrayRef<Info> OptionInfos, bool IgnoreCase = false);
+                           ArrayRef<StringTable::Offset> PrefixesTable,
+                           ArrayRef<Info> OptionInfos, bool IgnoreCase = false);
 };
 
 class PrecomputedOptTable : public OptTable {

--- a/llvm/include/llvm/Option/OptTable.h
+++ b/llvm/include/llvm/Option/OptTable.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OPTION_OPTTABLE_H
 #define LLVM_OPTION_OPTTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
@@ -50,7 +51,7 @@ public:
 /// be needed at runtime; the OptTable class maintains enough information to
 /// parse command lines without instantiating Options, while letting other
 /// parts of the driver still use Option instances where convenient.
-class OptTable {
+class LLVM_ABI OptTable {
 public:
   /// Entry for a single option instance in the option data table.
   struct Info {
@@ -425,7 +426,7 @@ private:
 /// Specialization of OptTable
 class GenericOptTable : public OptTable {
 protected:
-  GenericOptTable(const StringTable &StrTable,
+  LLVM_ABI GenericOptTable(const StringTable &StrTable,
                   ArrayRef<StringTable::Offset> PrefixesTable,
                   ArrayRef<Info> OptionInfos, bool IgnoreCase = false);
 };

--- a/llvm/include/llvm/Option/Option.h
+++ b/llvm/include/llvm/Option/Option.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_OPTION_OPTION_H
 #define LLVM_OPTION_OPTION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/OptSpecifier.h"
 #include "llvm/Option/OptTable.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 
@@ -229,7 +229,8 @@ public:
   /// \p GroupedShortOption If true, we are handling the fallback case of
   /// parsing a prefix of the current argument as a short option.
   LLVM_ABI std::unique_ptr<Arg> accept(const ArgList &Args, StringRef CurArg,
-                              bool GroupedShortOption, unsigned &Index) const;
+                                       bool GroupedShortOption,
+                                       unsigned &Index) const;
 
 private:
   std::unique_ptr<Arg> acceptInternal(const ArgList &Args, StringRef CurArg,

--- a/llvm/include/llvm/Option/Option.h
+++ b/llvm/include/llvm/Option/Option.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_OPTION_OPTION_H
 #define LLVM_OPTION_OPTION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/OptSpecifier.h"
@@ -81,7 +82,7 @@ protected:
   const OptTable *Owner;
 
 public:
-  Option(const OptTable::Info *Info, const OptTable *Owner);
+  LLVM_ABI Option(const OptTable::Info *Info, const OptTable *Owner);
 
   bool isValid() const {
     return Info != nullptr;
@@ -213,7 +214,7 @@ public:
   /// Note that matches against options which are an alias should never be
   /// done -- aliases do not participate in matching and so such a query will
   /// always be false.
-  bool matches(OptSpecifier ID) const;
+  LLVM_ABI bool matches(OptSpecifier ID) const;
 
   /// Potentially accept the current argument, returning a new Arg instance,
   /// or 0 if the option does not accept this argument (or the argument is
@@ -227,7 +228,7 @@ public:
   /// underlying storage to represent a Joined argument.
   /// \p GroupedShortOption If true, we are handling the fallback case of
   /// parsing a prefix of the current argument as a short option.
-  std::unique_ptr<Arg> accept(const ArgList &Args, StringRef CurArg,
+  LLVM_ABI std::unique_ptr<Arg> accept(const ArgList &Args, StringRef CurArg,
                               bool GroupedShortOption, unsigned &Index) const;
 
 private:
@@ -235,8 +236,8 @@ private:
                                       unsigned &Index) const;
 
 public:
-  void print(raw_ostream &O, bool AddNewLine = true) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &O, bool AddNewLine = true) const;
+  LLVM_ABI void dump() const;
 };
 
 } // end namespace opt

--- a/llvm/include/llvm/Remarks/Remark.h
+++ b/llvm/include/llvm/Remarks/Remark.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_REMARKS_REMARK_H
 #define LLVM_REMARKS_REMARK_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/Remarks.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -35,7 +36,7 @@ struct RemarkLocation {
   unsigned SourceColumn = 0;
 
   /// Implement operator<< on RemarkLocation.
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).
@@ -51,11 +52,11 @@ struct Argument {
   std::optional<RemarkLocation> Loc;
 
   /// Implement operator<< on Argument.
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
   /// Return the value of argument as int.
-  std::optional<int> getValAsInt() const;
+  LLVM_ABI std::optional<int> getValAsInt() const;
   /// Check if the argument value can be parsed as int.
-  bool isValInt() const;
+  LLVM_ABI bool isValInt() const;
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).
@@ -124,13 +125,13 @@ struct Remark {
   Remark &operator=(Remark &&) = default;
 
   /// Return a message composed from the arguments as a string.
-  std::string getArgsAsMsg() const;
+  LLVM_ABI std::string getArgsAsMsg() const;
 
   /// Clone this remark to explicitly ask for a copy.
   Remark clone() const { return *this; }
 
   /// Implement operator<< on Remark.
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 private:
   /// In order to avoid unwanted copies, "delete" the copy constructor.

--- a/llvm/include/llvm/Remarks/Remark.h
+++ b/llvm/include/llvm/Remarks/Remark.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_REMARKS_REMARK_H
 #define LLVM_REMARKS_REMARK_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/Remarks.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CBindingWrapping.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 #include <string>

--- a/llvm/include/llvm/Remarks/RemarkFormat.h
+++ b/llvm/include/llvm/Remarks/RemarkFormat.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_REMARKS_REMARKFORMAT_H
 #define LLVM_REMARKS_REMARKFORMAT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {

--- a/llvm/include/llvm/Remarks/RemarkFormat.h
+++ b/llvm/include/llvm/Remarks/RemarkFormat.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_REMARKS_REMARKFORMAT_H
 #define LLVM_REMARKS_REMARKFORMAT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
@@ -25,10 +26,10 @@ constexpr StringLiteral Magic("REMARKS");
 enum class Format { Unknown, YAML, YAMLStrTab, Bitstream };
 
 /// Parse and validate a string for the remark format.
-Expected<Format> parseFormat(StringRef FormatStr);
+LLVM_ABI Expected<Format> parseFormat(StringRef FormatStr);
 
 /// Parse and validate a magic number to a remark format.
-Expected<Format> magicToFormat(StringRef Magic);
+LLVM_ABI Expected<Format> magicToFormat(StringRef Magic);
 
 } // end namespace remarks
 } // end namespace llvm

--- a/llvm/include/llvm/Remarks/RemarkLinker.h
+++ b/llvm/include/llvm/Remarks/RemarkLinker.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_REMARKS_REMARKLINKER_H
 #define LLVM_REMARKS_REMARKLINKER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Remarks/Remark.h"
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Remarks/RemarkStringTable.h"
@@ -69,7 +70,7 @@ private:
 
 public:
   /// Set a path to prepend to the external file path.
-  void setExternalFilePrependPath(StringRef PrependPath);
+  LLVM_ABI void setExternalFilePrependPath(StringRef PrependPath);
 
   /// Set KeepAllRemarks to \p B.
   void setKeepAllRemarks(bool B) { KeepAllRemarks = B; }
@@ -79,19 +80,19 @@ public:
   /// \p Buffer.
   /// \p Buffer can be either a standalone remark container or just
   /// metadata. This takes care of uniquing and merging the remarks.
-  Error link(StringRef Buffer,
+  LLVM_ABI Error link(StringRef Buffer,
              std::optional<Format> RemarkFormat = std::nullopt);
 
   /// Link the remarks found in \p Obj by looking for the right section and
   /// calling the method above.
-  Error link(const object::ObjectFile &Obj,
+  LLVM_ABI Error link(const object::ObjectFile &Obj,
              std::optional<Format> RemarkFormat = std::nullopt);
 
   /// Serialize the linked remarks to the stream \p OS, using the format \p
   /// RemarkFormat.
   /// This clears internal state such as the string table.
   /// Note: this implies that the serialization mode is standalone.
-  Error serialize(raw_ostream &OS, Format RemarksFormat) const;
+  LLVM_ABI Error serialize(raw_ostream &OS, Format RemarksFormat) const;
 
   /// Check whether there are any remarks linked.
   bool empty() const { return Remarks.empty(); }
@@ -109,7 +110,7 @@ public:
 /// Returns a buffer with the contents of the remarks section depending on the
 /// format of the file. If the section doesn't exist, this returns an empty
 /// optional.
-Expected<std::optional<StringRef>>
+LLVM_ABI Expected<std::optional<StringRef>>
 getRemarksSectionContents(const object::ObjectFile &Obj);
 
 } // end namespace remarks

--- a/llvm/include/llvm/Remarks/RemarkLinker.h
+++ b/llvm/include/llvm/Remarks/RemarkLinker.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_REMARKS_REMARKLINKER_H
 #define LLVM_REMARKS_REMARKLINKER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Remarks/Remark.h"
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Remarks/RemarkStringTable.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <memory>
 #include <optional>
@@ -81,12 +81,12 @@ public:
   /// \p Buffer can be either a standalone remark container or just
   /// metadata. This takes care of uniquing and merging the remarks.
   LLVM_ABI Error link(StringRef Buffer,
-             std::optional<Format> RemarkFormat = std::nullopt);
+                      std::optional<Format> RemarkFormat = std::nullopt);
 
   /// Link the remarks found in \p Obj by looking for the right section and
   /// calling the method above.
   LLVM_ABI Error link(const object::ObjectFile &Obj,
-             std::optional<Format> RemarkFormat = std::nullopt);
+                      std::optional<Format> RemarkFormat = std::nullopt);
 
   /// Serialize the linked remarks to the stream \p OS, using the format \p
   /// RemarkFormat.

--- a/llvm/include/llvm/Remarks/RemarkParser.h
+++ b/llvm/include/llvm/Remarks/RemarkParser.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_REMARKS_REMARKPARSER_H
 #define LLVM_REMARKS_REMARKPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Support/Error.h"
@@ -26,7 +27,7 @@ struct Remark;
 
 class EndOfFileError : public ErrorInfo<EndOfFileError> {
 public:
-  static char ID;
+  LLVM_ABI static char ID;
 
   EndOfFileError() = default;
 
@@ -64,7 +65,7 @@ struct ParsedStringTable {
   /// SmallVector for once.
   std::vector<size_t> Offsets;
 
-  ParsedStringTable(StringRef Buffer);
+  LLVM_ABI ParsedStringTable(StringRef Buffer);
   /// Disable copy.
   ParsedStringTable(const ParsedStringTable &) = delete;
   ParsedStringTable &operator=(const ParsedStringTable &) = delete;
@@ -73,17 +74,17 @@ struct ParsedStringTable {
   ParsedStringTable &operator=(ParsedStringTable &&) = default;
 
   size_t size() const { return Offsets.size(); }
-  Expected<StringRef> operator[](size_t Index) const;
+  LLVM_ABI Expected<StringRef> operator[](size_t Index) const;
 };
 
-Expected<std::unique_ptr<RemarkParser>> createRemarkParser(Format ParserFormat,
+LLVM_ABI Expected<std::unique_ptr<RemarkParser>> createRemarkParser(Format ParserFormat,
                                                            StringRef Buf);
 
-Expected<std::unique_ptr<RemarkParser>>
+LLVM_ABI Expected<std::unique_ptr<RemarkParser>>
 createRemarkParser(Format ParserFormat, StringRef Buf,
                    ParsedStringTable StrTab);
 
-Expected<std::unique_ptr<RemarkParser>> createRemarkParserFromMeta(
+LLVM_ABI Expected<std::unique_ptr<RemarkParser>> createRemarkParserFromMeta(
     Format ParserFormat, StringRef Buf,
     std::optional<ParsedStringTable> StrTab = std::nullopt,
     std::optional<StringRef> ExternalFilePrependPath = std::nullopt);

--- a/llvm/include/llvm/Remarks/RemarkParser.h
+++ b/llvm/include/llvm/Remarks/RemarkParser.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_REMARKS_REMARKPARSER_H
 #define LLVM_REMARKS_REMARKPARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Remarks/RemarkFormat.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <memory>
 #include <optional>
@@ -77,8 +77,8 @@ struct ParsedStringTable {
   LLVM_ABI Expected<StringRef> operator[](size_t Index) const;
 };
 
-LLVM_ABI Expected<std::unique_ptr<RemarkParser>> createRemarkParser(Format ParserFormat,
-                                                           StringRef Buf);
+LLVM_ABI Expected<std::unique_ptr<RemarkParser>>
+createRemarkParser(Format ParserFormat, StringRef Buf);
 
 LLVM_ABI Expected<std::unique_ptr<RemarkParser>>
 createRemarkParser(Format ParserFormat, StringRef Buf,

--- a/llvm/include/llvm/Remarks/RemarkSerializer.h
+++ b/llvm/include/llvm/Remarks/RemarkSerializer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_REMARKS_REMARKSERIALIZER_H
 #define LLVM_REMARKS_REMARKSERIALIZER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Remarks/RemarkStringTable.h"
 #include <optional>
@@ -77,12 +78,12 @@ struct MetaSerializer {
 };
 
 /// Create a remark serializer.
-Expected<std::unique_ptr<RemarkSerializer>>
+LLVM_ABI Expected<std::unique_ptr<RemarkSerializer>>
 createRemarkSerializer(Format RemarksFormat, SerializerMode Mode,
                        raw_ostream &OS);
 
 /// Create a remark serializer that uses a pre-filled string table.
-Expected<std::unique_ptr<RemarkSerializer>>
+LLVM_ABI Expected<std::unique_ptr<RemarkSerializer>>
 createRemarkSerializer(Format RemarksFormat, SerializerMode Mode,
                        raw_ostream &OS, remarks::StringTable StrTab);
 

--- a/llvm/include/llvm/Remarks/RemarkSerializer.h
+++ b/llvm/include/llvm/Remarks/RemarkSerializer.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_REMARKS_REMARKSERIALIZER_H
 #define LLVM_REMARKS_REMARKSERIALIZER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Remarks/RemarkStringTable.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {

--- a/llvm/include/llvm/Remarks/RemarkStringTable.h
+++ b/llvm/include/llvm/Remarks/RemarkStringTable.h
@@ -16,9 +16,9 @@
 #ifndef LLVM_REMARKS_REMARKSTRINGTABLE_H
 #define LLVM_REMARKS_REMARKSTRINGTABLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include <vector>
 
 namespace llvm {

--- a/llvm/include/llvm/Remarks/RemarkStringTable.h
+++ b/llvm/include/llvm/Remarks/RemarkStringTable.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_REMARKS_REMARKSTRINGTABLE_H
 #define LLVM_REMARKS_REMARKSTRINGTABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
 #include <vector>
@@ -50,22 +51,22 @@ struct StringTable {
   StringTable &operator=(StringTable &&) = default;
 
   /// Construct a string table from a ParsedStringTable.
-  StringTable(const ParsedStringTable &Other);
+  LLVM_ABI StringTable(const ParsedStringTable &Other);
 
   /// Add a string to the table. It returns an unique ID of the string.
-  std::pair<unsigned, StringRef> add(StringRef Str);
+  LLVM_ABI std::pair<unsigned, StringRef> add(StringRef Str);
   /// Modify \p R to use strings from this string table. If the string table
   /// does not contain the strings, it adds them.
-  void internalize(Remark &R);
+  LLVM_ABI void internalize(Remark &R);
   /// Serialize the string table to a stream. It is serialized as a little
   /// endian uint64 (the size of the table in bytes) followed by a sequence of
   /// NULL-terminated strings, where the N-th string is the string with the ID N
   /// in the StrTab map.
-  void serialize(raw_ostream &OS) const;
+  LLVM_ABI void serialize(raw_ostream &OS) const;
   /// Serialize the string table to a vector. This allows users to do the actual
   /// writing to file/memory/other.
   /// The string with the ID == N should be the N-th element in the vector.
-  std::vector<StringRef> serialize() const;
+  LLVM_ABI std::vector<StringRef> serialize() const;
 };
 
 } // end namespace remarks

--- a/llvm/include/llvm/Remarks/YAMLRemarkSerializer.h
+++ b/llvm/include/llvm/Remarks/YAMLRemarkSerializer.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_REMARKS_YAMLREMARKSERIALIZER_H
 #define LLVM_REMARKS_YAMLREMARKSERIALIZER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Remarks/RemarkSerializer.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/YAMLTraits.h"
 #include <optional>
 

--- a/llvm/include/llvm/Remarks/YAMLRemarkSerializer.h
+++ b/llvm/include/llvm/Remarks/YAMLRemarkSerializer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_REMARKS_YAMLREMARKSERIALIZER_H
 #define LLVM_REMARKS_YAMLREMARKSERIALIZER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Remarks/RemarkSerializer.h"
 #include "llvm/Support/YAMLTraits.h"
 #include <optional>
@@ -31,7 +32,7 @@ namespace remarks {
 ///   - <KEY>: <VALUE>
 ///     DebugLoc:        { File: <FILE>, Line: <LINE>, Column: <COL> }
 /// ...
-struct YAMLRemarkSerializer : public RemarkSerializer {
+struct LLVM_ABI YAMLRemarkSerializer : public RemarkSerializer {
   /// The YAML streamer.
   yaml::Output YAMLOutput;
 
@@ -53,7 +54,7 @@ protected:
                        std::optional<StringTable> StrTab = std::nullopt);
 };
 
-struct YAMLMetaSerializer : public MetaSerializer {
+struct LLVM_ABI YAMLMetaSerializer : public MetaSerializer {
   std::optional<StringRef> ExternalFilename;
 
   YAMLMetaSerializer(raw_ostream &OS, std::optional<StringRef> ExternalFilename)
@@ -65,7 +66,7 @@ struct YAMLMetaSerializer : public MetaSerializer {
 /// Serialize the remarks to YAML using a string table. An remark entry looks
 /// like the regular YAML remark but instead of string entries it's using
 /// numbers that map to an index in the string table.
-struct YAMLStrTabRemarkSerializer : public YAMLRemarkSerializer {
+struct LLVM_ABI YAMLStrTabRemarkSerializer : public YAMLRemarkSerializer {
   /// Wether we already emitted the metadata in standalone mode.
   /// This should be set to true after the first invocation of `emit`.
   bool DidEmitMeta = false;
@@ -91,7 +92,7 @@ struct YAMLStrTabRemarkSerializer : public YAMLRemarkSerializer {
   }
 };
 
-struct YAMLStrTabMetaSerializer : public YAMLMetaSerializer {
+struct LLVM_ABI YAMLStrTabMetaSerializer : public YAMLMetaSerializer {
   /// The string table is part of the metadata.
   const StringTable &StrTab;
 


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/Options` and `llvm/Remarks` libraries. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

These changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`. No manual fixups were required.

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang