### PR TITLE
[llvm] annotate interfaces in llvm/ProfileData for DLL export

### DIFF
--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -665,7 +665,8 @@ public:
   /// \param NextIDs The list of {FalseID, TrueID} indexed by ID
   ///        The first element [0] should be the root node.
   /// \param Offset Offset of index to final decisions.
-  LLVM_ABI TVIdxBuilder(const SmallVectorImpl<ConditionIDs> &NextIDs, int Offset = 0);
+  LLVM_ABI TVIdxBuilder(const SmallVectorImpl<ConditionIDs> &NextIDs,
+                        int Offset = 0);
 };
 } // namespace mcdc
 
@@ -1055,10 +1056,12 @@ public:
   LLVM_ABI CoverageData getCoverageForFile(StringRef Filename) const;
 
   /// Get the coverage for a particular function.
-  LLVM_ABI CoverageData getCoverageForFunction(const FunctionRecord &Function) const;
+  LLVM_ABI CoverageData
+  getCoverageForFunction(const FunctionRecord &Function) const;
 
   /// Get the coverage for an expansion within a coverage set.
-  LLVM_ABI CoverageData getCoverageForExpansion(const ExpansionRecord &Expansion) const;
+  LLVM_ABI CoverageData
+  getCoverageForExpansion(const ExpansionRecord &Expansion) const;
 
   /// Gets all of the functions covered by this profile.
   iterator_range<FunctionRecordIterator> getCoveredFunctions() const {
@@ -1097,7 +1100,8 @@ class LineCoverageStats {
 
 public:
   LLVM_ABI LineCoverageStats(ArrayRef<const CoverageSegment *> LineSegments,
-                    const CoverageSegment *WrappedSegment, unsigned Line);
+                             const CoverageSegment *WrappedSegment,
+                             unsigned Line);
 
   uint64_t getExecutionCount() const { return ExecutionCount; }
 

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -71,13 +71,13 @@ enum class coveragemap_error {
   invalid_or_missing_arch_specifier
 };
 
-const std::error_category &coveragemap_category();
+LLVM_ABI const std::error_category &coveragemap_category();
 
 inline std::error_code make_error_code(coveragemap_error E) {
   return std::error_code(static_cast<int>(E), coveragemap_category());
 }
 
-class CoverageMapError : public ErrorInfo<CoverageMapError> {
+class LLVM_ABI CoverageMapError : public ErrorInfo<CoverageMapError> {
 public:
   CoverageMapError(coveragemap_error Err, const Twine &ErrStr = Twine())
       : Err(Err), Msg(ErrStr.str()) {
@@ -210,11 +210,11 @@ public:
   ArrayRef<CounterExpression> getExpressions() const { return Expressions; }
 
   /// Return a counter that represents the expression that adds LHS and RHS.
-  Counter add(Counter LHS, Counter RHS, bool Simplify = true);
+  LLVM_ABI Counter add(Counter LHS, Counter RHS, bool Simplify = true);
 
   /// Return a counter that represents the expression that subtracts RHS from
   /// LHS.
-  Counter subtract(Counter LHS, Counter RHS, bool Simplify = true);
+  LLVM_ABI Counter subtract(Counter LHS, Counter RHS, bool Simplify = true);
 
   /// K to V map. K will be Counter in most cases. V may be Counter or
   /// Expression.
@@ -222,7 +222,7 @@ public:
 
   /// \return A counter equivalent to \C, with each term in its
   /// expression replaced with term from \p Map.
-  Counter subst(Counter C, const SubstMap &Map);
+  LLVM_ABI Counter subst(Counter C, const SubstMap &Map);
 };
 
 using LineColPair = std::pair<unsigned, unsigned>;
@@ -473,7 +473,7 @@ public:
 
   // Compare executed test vectors against each other to find an independence
   // pairs for each condition.  This processing takes the most time.
-  void findIndependencePairs();
+  LLVM_ABI void findIndependencePairs();
 
   const CounterMappingRegion &getDecisionRegion() const { return Region; }
   unsigned getNumConditions() const {
@@ -665,7 +665,7 @@ public:
   /// \param NextIDs The list of {FalseID, TrueID} indexed by ID
   ///        The first element [0] should be the root node.
   /// \param Offset Offset of index to final decisions.
-  TVIdxBuilder(const SmallVectorImpl<ConditionIDs> &NextIDs, int Offset = 0);
+  LLVM_ABI TVIdxBuilder(const SmallVectorImpl<ConditionIDs> &NextIDs, int Offset = 0);
 };
 } // namespace mcdc
 
@@ -684,21 +684,21 @@ public:
   void setCounts(ArrayRef<uint64_t> Counts) { CounterValues = Counts; }
   void setBitmap(BitVector &&Bitmap_) { Bitmap = std::move(Bitmap_); }
 
-  void dump(const Counter &C, raw_ostream &OS) const;
+  LLVM_ABI void dump(const Counter &C, raw_ostream &OS) const;
   void dump(const Counter &C) const { dump(C, dbgs()); }
 
   /// Return the number of times that a region of code associated with this
   /// counter was executed.
-  Expected<int64_t> evaluate(const Counter &C) const;
+  LLVM_ABI Expected<int64_t> evaluate(const Counter &C) const;
 
   /// Return an MCDC record that indicates executed test vectors and condition
   /// pairs.
-  Expected<MCDCRecord>
+  LLVM_ABI Expected<MCDCRecord>
   evaluateMCDCRegion(const CounterMappingRegion &Region,
                      ArrayRef<const CounterMappingRegion *> Branches,
                      bool IsVersion11);
 
-  unsigned getMaxCounterID(const Counter &C) const;
+  LLVM_ABI unsigned getMaxCounterID(const Counter &C) const;
 };
 
 /// Code coverage information for a single function.
@@ -761,7 +761,7 @@ class FunctionRecordIterator
   StringRef Filename;
 
   /// Skip records whose primary file is not \c Filename.
-  void skipOtherFiles();
+  LLVM_ABI void skipOtherFiles();
 
 public:
   FunctionRecordIterator(ArrayRef<FunctionRecord> Records_,
@@ -1007,7 +1007,7 @@ class CoverageMapping {
   /// defined in the specified file. This is guaranteed to return a superset of
   /// such records: extra records not in the file may be included if there is
   /// a hash collision on the filename. Clients must be robust to collisions.
-  ArrayRef<unsigned>
+  LLVM_ABI ArrayRef<unsigned>
   getImpreciseRecordIndicesForFilename(StringRef Filename) const;
 
 public:
@@ -1015,14 +1015,14 @@ public:
   CoverageMapping &operator=(const CoverageMapping &) = delete;
 
   /// Load the coverage mapping using the given readers.
-  static Expected<std::unique_ptr<CoverageMapping>>
+  LLVM_ABI static Expected<std::unique_ptr<CoverageMapping>>
   load(ArrayRef<std::unique_ptr<CoverageMappingReader>> CoverageReaders,
        IndexedInstrProfReader &ProfileReader);
 
   /// Load the coverage mapping from the given object files and profile. If
   /// \p Arches is non-empty, it must specify an architecture for each object.
   /// Ignores non-instrumented object files unless all are not instrumented.
-  static Expected<std::unique_ptr<CoverageMapping>>
+  LLVM_ABI static Expected<std::unique_ptr<CoverageMapping>>
   load(ArrayRef<StringRef> ObjectFilenames, StringRef ProfileFilename,
        vfs::FileSystem &FS, ArrayRef<StringRef> Arches = {},
        StringRef CompilationDir = "",
@@ -1045,20 +1045,20 @@ public:
 
   /// Returns a lexicographically sorted, unique list of files that are
   /// covered.
-  std::vector<StringRef> getUniqueSourceFiles() const;
+  LLVM_ABI std::vector<StringRef> getUniqueSourceFiles() const;
 
   /// Get the coverage for a particular file.
   ///
   /// The given filename must be the name as recorded in the coverage
   /// information. That is, only names returned from getUniqueSourceFiles will
   /// yield a result.
-  CoverageData getCoverageForFile(StringRef Filename) const;
+  LLVM_ABI CoverageData getCoverageForFile(StringRef Filename) const;
 
   /// Get the coverage for a particular function.
-  CoverageData getCoverageForFunction(const FunctionRecord &Function) const;
+  LLVM_ABI CoverageData getCoverageForFunction(const FunctionRecord &Function) const;
 
   /// Get the coverage for an expansion within a coverage set.
-  CoverageData getCoverageForExpansion(const ExpansionRecord &Expansion) const;
+  LLVM_ABI CoverageData getCoverageForExpansion(const ExpansionRecord &Expansion) const;
 
   /// Gets all of the functions covered by this profile.
   iterator_range<FunctionRecordIterator> getCoveredFunctions() const {
@@ -1079,7 +1079,7 @@ public:
   ///
   /// Every instantiation group in a program is attributed to exactly one file:
   /// the file in which the definition for the common function begins.
-  std::vector<InstantiationGroup>
+  LLVM_ABI std::vector<InstantiationGroup>
   getInstantiationGroups(StringRef Filename) const;
 };
 
@@ -1096,7 +1096,7 @@ class LineCoverageStats {
   LineCoverageStats() = default;
 
 public:
-  LineCoverageStats(ArrayRef<const CoverageSegment *> LineSegments,
+  LLVM_ABI LineCoverageStats(ArrayRef<const CoverageSegment *> LineSegments,
                     const CoverageSegment *WrappedSegment, unsigned Line);
 
   uint64_t getExecutionCount() const { return ExecutionCount; }
@@ -1136,7 +1136,7 @@ public:
 
   const LineCoverageStats &operator*() const { return Stats; }
 
-  LineCoverageIterator &operator++();
+  LLVM_ABI LineCoverageIterator &operator++();
 
   LineCoverageIterator getEnd() const {
     auto EndIt = *this;

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_PROFILEDATA_COVERAGE_COVERAGEMAPPINGREADER_H
 #define LLVM_PROFILEDATA_COVERAGE_COVERAGEMAPPINGREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ProfileData/Coverage/CoverageMapping.h"
 #include "llvm/ProfileData/InstrProf.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <cstddef>

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_COVERAGE_COVERAGEMAPPINGREADER_H
 #define LLVM_PROFILEDATA_COVERAGE_COVERAGEMAPPINGREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ProfileData/Coverage/CoverageMapping.h"
@@ -46,7 +47,7 @@ class CoverageMappingIterator {
   CoverageMappingRecord Record;
   coveragemap_error ReadErr;
 
-  void increment();
+  LLVM_ABI void increment();
 
 public:
   using iterator_category = std::input_iterator_tag;
@@ -112,10 +113,10 @@ protected:
 
   RawCoverageReader(StringRef Data) : Data(Data) {}
 
-  Error readULEB128(uint64_t &Result);
-  Error readIntMax(uint64_t &Result, uint64_t MaxPlus1);
-  Error readSize(uint64_t &Result);
-  Error readString(StringRef &Result);
+  LLVM_ABI Error readULEB128(uint64_t &Result);
+  LLVM_ABI Error readIntMax(uint64_t &Result, uint64_t MaxPlus1);
+  LLVM_ABI Error readSize(uint64_t &Result);
+  LLVM_ABI Error readString(StringRef &Result);
 };
 
 /// Checks if the given coverage mapping data is exported for
@@ -125,7 +126,7 @@ public:
   RawCoverageMappingDummyChecker(StringRef MappingData)
       : RawCoverageReader(MappingData) {}
 
-  Expected<bool> isDummy();
+  LLVM_ABI Expected<bool> isDummy();
 };
 
 /// Reader for the raw coverage mapping data.
@@ -149,7 +150,7 @@ public:
   RawCoverageMappingReader &
   operator=(const RawCoverageMappingReader &) = delete;
 
-  Error read();
+  LLVM_ABI Error read();
 
 private:
   Error decodeCounter(unsigned Value, Counter &C);
@@ -161,7 +162,7 @@ private:
 
 /// Reader for the coverage mapping data that is emitted by the
 /// frontend and stored in an object file.
-class BinaryCoverageReader : public CoverageMappingReader {
+class LLVM_ABI BinaryCoverageReader : public CoverageMappingReader {
 public:
   struct ProfileMappingRecord {
     CovMapVersion Version;
@@ -245,7 +246,7 @@ public:
   RawCoverageFilenamesReader &
   operator=(const RawCoverageFilenamesReader &) = delete;
 
-  Error read(CovMapVersion Version);
+  LLVM_ABI Error read(CovMapVersion Version);
 };
 
 } // end namespace coverage

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingWriter.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingWriter.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_PROFILEDATA_COVERAGE_COVERAGEMAPPINGWRITER_H
 #define LLVM_PROFILEDATA_COVERAGE_COVERAGEMAPPINGWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ProfileData/Coverage/CoverageMapping.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingWriter.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingWriter.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_COVERAGE_COVERAGEMAPPINGWRITER_H
 #define LLVM_PROFILEDATA_COVERAGE_COVERAGEMAPPINGWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ProfileData/Coverage/CoverageMapping.h"
@@ -30,11 +31,11 @@ class CoverageFilenamesSectionWriter {
   ArrayRef<std::string> Filenames;
 
 public:
-  CoverageFilenamesSectionWriter(ArrayRef<std::string> Filenames);
+  LLVM_ABI CoverageFilenamesSectionWriter(ArrayRef<std::string> Filenames);
 
   /// Write encoded filenames to the given output stream. If \p Compress is
   /// true, attempt to compress the filenames.
-  void write(raw_ostream &OS, bool Compress = true);
+  LLVM_ABI void write(raw_ostream &OS, bool Compress = true);
 };
 
 /// Writer for instrumentation based coverage mapping data.
@@ -51,7 +52,7 @@ public:
         MappingRegions(MappingRegions) {}
 
   /// Write encoded coverage mapping data to the given output stream.
-  void write(raw_ostream &OS);
+  LLVM_ABI void write(raw_ostream &OS);
 };
 
 /// Writer for the coverage mapping testing format.
@@ -70,7 +71,7 @@ public:
         CoverageRecordsData(CoverageRecordsData) {}
 
   /// Encode to the given output stream.
-  void
+  LLVM_ABI void
   write(raw_ostream &OS,
         TestingFormatVersion Version = TestingFormatVersion::CurrentVersion);
 };

--- a/llvm/include/llvm/ProfileData/DataAccessProf.h
+++ b/llvm/include/llvm/ProfileData/DataAccessProf.h
@@ -17,7 +17,6 @@
 #ifndef LLVM_PROFILEDATA_DATAACCESSPROF_H_
 #define LLVM_PROFILEDATA_DATAACCESSPROF_H_
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfoVariant.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
@@ -25,6 +24,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/StringSaver.h"
 
@@ -157,13 +157,15 @@ public:
   /// duplicated symbol names or content hashes are seen. The user of this
   /// class should aggregate counters that correspond to the same symbol name
   /// or with the same string literal hash before calling 'set*' methods.
-  LLVM_ABI Error setDataAccessProfile(SymbolHandleRef SymbolID, uint64_t AccessCount);
+  LLVM_ABI Error setDataAccessProfile(SymbolHandleRef SymbolID,
+                                      uint64_t AccessCount);
   /// Similar to the method above, for records with \p Locations representing
   /// the `filename:line` where this symbol shows up. Note because of linker's
   /// merge of identical symbols (e.g., unnamed_addr string literals), one
   /// symbol is likely to have multiple locations.
-  LLVM_ABI Error setDataAccessProfile(SymbolHandleRef SymbolID, uint64_t AccessCount,
-                             ArrayRef<SourceLocation> Locations);
+  LLVM_ABI Error setDataAccessProfile(SymbolHandleRef SymbolID,
+                                      uint64_t AccessCount,
+                                      ArrayRef<SourceLocation> Locations);
   /// Add a symbol that's seen in the profiled binary without samples.
   LLVM_ABI Error addKnownSymbolWithoutSamples(SymbolHandleRef SymbolID);
 

--- a/llvm/include/llvm/ProfileData/DataAccessProf.h
+++ b/llvm/include/llvm/ProfileData/DataAccessProf.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_PROFILEDATA_DATAACCESSPROF_H_
 #define LLVM_PROFILEDATA_DATAACCESSPROF_H_
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfoVariant.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
@@ -138,33 +139,33 @@ public:
   /// - Serialized strings.
   /// - The encoded hashes.
   /// - Records.
-  Error serialize(ProfOStream &OS) const;
+  LLVM_ABI Error serialize(ProfOStream &OS) const;
 
   /// Deserialize this class from the given buffer.
-  Error deserialize(const unsigned char *&Ptr);
+  LLVM_ABI Error deserialize(const unsigned char *&Ptr);
 
   /// Returns a profile record for \p SymbolID, or std::nullopt if there
   /// isn't a record. Internally, this function will canonicalize the symbol
   /// name before the lookup.
-  std::optional<DataAccessProfRecord>
+  LLVM_ABI std::optional<DataAccessProfRecord>
   getProfileRecord(const SymbolHandleRef SymID) const;
 
   /// Returns true if \p SymID is seen in profiled binaries and cold.
-  bool isKnownColdSymbol(const SymbolHandleRef SymID) const;
+  LLVM_ABI bool isKnownColdSymbol(const SymbolHandleRef SymID) const;
 
   /// Methods to set symbolized data access profile. Returns error if
   /// duplicated symbol names or content hashes are seen. The user of this
   /// class should aggregate counters that correspond to the same symbol name
   /// or with the same string literal hash before calling 'set*' methods.
-  Error setDataAccessProfile(SymbolHandleRef SymbolID, uint64_t AccessCount);
+  LLVM_ABI Error setDataAccessProfile(SymbolHandleRef SymbolID, uint64_t AccessCount);
   /// Similar to the method above, for records with \p Locations representing
   /// the `filename:line` where this symbol shows up. Note because of linker's
   /// merge of identical symbols (e.g., unnamed_addr string literals), one
   /// symbol is likely to have multiple locations.
-  Error setDataAccessProfile(SymbolHandleRef SymbolID, uint64_t AccessCount,
+  LLVM_ABI Error setDataAccessProfile(SymbolHandleRef SymbolID, uint64_t AccessCount,
                              ArrayRef<SourceLocation> Locations);
   /// Add a symbol that's seen in the profiled binary without samples.
-  Error addKnownSymbolWithoutSamples(SymbolHandleRef SymbolID);
+  LLVM_ABI Error addKnownSymbolWithoutSamples(SymbolHandleRef SymbolID);
 
   /// The following methods return array reference for various internal data
   /// structures.

--- a/llvm/include/llvm/ProfileData/GCOV.h
+++ b/llvm/include/llvm/ProfileData/GCOV.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_PROFILEDATA_GCOV_H
 #define LLVM_PROFILEDATA_GCOV_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -22,6 +21,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -317,7 +317,7 @@ public:
 };
 
 LLVM_ABI void gcovOneInput(const GCOV::Options &options, StringRef filename,
-                  StringRef gcno, StringRef gcda, GCOVFile &file);
+                           StringRef gcno, StringRef gcda, GCOVFile &file);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/ProfileData/GCOV.h
+++ b/llvm/include/llvm/ProfileData/GCOV.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_GCOV_H
 #define LLVM_PROFILEDATA_GCOV_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -192,11 +193,11 @@ class GCOVFile {
 public:
   GCOVFile() = default;
 
-  bool readGCNO(GCOVBuffer &Buffer);
-  bool readGCDA(GCOVBuffer &Buffer);
+  LLVM_ABI bool readGCNO(GCOVBuffer &Buffer);
+  LLVM_ABI bool readGCDA(GCOVBuffer &Buffer);
   GCOV::GCOVVersion getVersion() const { return version; }
-  void print(raw_ostream &OS) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &OS) const;
+  LLVM_ABI void dump() const;
 
   std::vector<std::string> filenames;
   StringMap<unsigned> filenameToIdx;
@@ -223,7 +224,7 @@ private:
 struct GCOVArc {
   GCOVArc(GCOVBlock &src, GCOVBlock &dst, uint32_t flags)
       : src(src), dst(dst), flags(flags) {}
-  bool onTree() const;
+  LLVM_ABI bool onTree() const;
 
   GCOVBlock &src;
   GCOVBlock &dst;
@@ -240,18 +241,18 @@ public:
 
   GCOVFunction(GCOVFile &file) : file(file) {}
 
-  StringRef getName(bool demangle) const;
-  StringRef getFilename() const;
-  uint64_t getEntryCount() const;
-  GCOVBlock &getExitBlock() const;
+  LLVM_ABI StringRef getName(bool demangle) const;
+  LLVM_ABI StringRef getFilename() const;
+  LLVM_ABI uint64_t getEntryCount() const;
+  LLVM_ABI GCOVBlock &getExitBlock() const;
 
   iterator_range<BlockIterator> blocksRange() const {
     return make_range(blocks.begin(), blocks.end());
   }
 
-  void propagateCounts(const GCOVBlock &v, GCOVArc *pred);
-  void print(raw_ostream &OS) const;
-  void dump() const;
+  LLVM_ABI void propagateCounts(const GCOVBlock &v, GCOVArc *pred);
+  LLVM_ABI void print(raw_ostream &OS) const;
+  LLVM_ABI void dump() const;
 
   GCOVFile &file;
   uint32_t ident = 0;
@@ -296,14 +297,14 @@ public:
     return make_range(succ.begin(), succ.end());
   }
 
-  void print(raw_ostream &OS) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &OS) const;
+  LLVM_ABI void dump() const;
 
-  static uint64_t
+  LLVM_ABI static uint64_t
   augmentOneCycle(GCOVBlock *src,
                   std::vector<std::pair<GCOVBlock *, size_t>> &stack);
-  static uint64_t getCyclesCount(const BlockVector &blocks);
-  static uint64_t getLineCount(const BlockVector &Blocks);
+  LLVM_ABI static uint64_t getCyclesCount(const BlockVector &blocks);
+  LLVM_ABI static uint64_t getLineCount(const BlockVector &Blocks);
 
 public:
   uint32_t number;
@@ -315,7 +316,7 @@ public:
   GCOVArc *incoming = nullptr;
 };
 
-void gcovOneInput(const GCOV::Options &options, StringRef filename,
+LLVM_ABI void gcovOneInput(const GCOV::Options &options, StringRef filename,
                   StringRef gcno, StringRef gcda, GCOVFile &file);
 
 } // end namespace llvm

--- a/llvm/include/llvm/ProfileData/IndexedMemProfData.h
+++ b/llvm/include/llvm/ProfileData/IndexedMemProfData.h
@@ -15,10 +15,10 @@
 #ifndef LLVM_PROFILEDATA_INDEXEDMEMPROFDATA_H
 #define LLVM_PROFILEDATA_INDEXEDMEMPROFDATA_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ProfileData/DataAccessProf.h"
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/ProfileData/MemProf.h"
+#include "llvm/Support/Compiler.h"
 
 #include <functional>
 #include <optional>

--- a/llvm/include/llvm/ProfileData/IndexedMemProfData.h
+++ b/llvm/include/llvm/ProfileData/IndexedMemProfData.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_PROFILEDATA_INDEXEDMEMPROFDATA_H
 #define LLVM_PROFILEDATA_INDEXEDMEMPROFDATA_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ProfileData/DataAccessProf.h"
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/ProfileData/MemProf.h"
@@ -87,7 +88,7 @@ private:
 } // namespace memprof
 
 // Write the MemProf data to OS.
-Error writeMemProf(
+LLVM_ABI Error writeMemProf(
     ProfOStream &OS, memprof::IndexedMemProfData &MemProfData,
     memprof::IndexedVersion MemProfVersionRequested, bool MemProfFullSchema,
     std::unique_ptr<memprof::DataAccessProfData> DataAccessProfileData,

--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -69,18 +69,18 @@ struct PatchItem {
 // back patching.
 class ProfOStream {
 public:
-  ProfOStream(raw_fd_ostream &FD);
-  ProfOStream(raw_string_ostream &STR);
+  LLVM_ABI ProfOStream(raw_fd_ostream &FD);
+  LLVM_ABI ProfOStream(raw_string_ostream &STR);
 
-  [[nodiscard]] uint64_t tell() const;
-  void write(uint64_t V);
-  void write32(uint32_t V);
-  void writeByte(uint8_t V);
+  [[nodiscard]] LLVM_ABI uint64_t tell() const;
+  LLVM_ABI void write(uint64_t V);
+  LLVM_ABI void write32(uint32_t V);
+  LLVM_ABI void writeByte(uint8_t V);
 
   // \c patch can only be called when all data is written and flushed.
   // For raw_string_ostream, the patch is done on the target string
   // directly and it won't be reflected in the stream's internal buffer.
-  void patch(ArrayRef<PatchItem> P);
+  LLVM_ABI void patch(ArrayRef<PatchItem> P);
 
   // If \c OS is an instance of \c raw_fd_ostream, this field will be
   // true. Otherwise, \c OS will be an raw_string_ostream.
@@ -104,7 +104,7 @@ inline uint64_t getInstrMaxCountValue() {
 /// The name of the section depends on the object format type \p OF. If
 /// \p AddSegmentInfo is true, a segment prefix and additional linker hints may
 /// be added to the section name (this is the default).
-std::string getInstrProfSectionName(InstrProfSectKind IPSK,
+LLVM_ABI std::string getInstrProfSectionName(InstrProfSectKind IPSK,
                                     Triple::ObjectFormatType OF,
                                     bool AddSegmentInfo = true);
 
@@ -215,21 +215,21 @@ inline StringRef getInstrProfNameSeparator() { return "\01"; }
 
 /// Determines whether module targets a GPU eligable for PGO
 /// instrumentation
-bool isGPUProfTarget(const Module &M);
+LLVM_ABI bool isGPUProfTarget(const Module &M);
 
 /// Please use getIRPGOFuncName for LLVM IR instrumentation. This function is
 /// for front-end (Clang, etc) instrumentation.
 /// Return the modified name for function \c F suitable to be
 /// used the key for profile lookup. Variable \c InLTO indicates if this
 /// is called in LTO optimization passes.
-std::string getPGOFuncName(const Function &F, bool InLTO = false,
+LLVM_ABI std::string getPGOFuncName(const Function &F, bool InLTO = false,
                            uint64_t Version = INSTR_PROF_INDEX_VERSION);
 
 /// Return the modified name for a function suitable to be
 /// used the key for profile lookup. The function's original
 /// name is \c RawFuncName and has linkage of type \c Linkage.
 /// The function is defined in module \c FileName.
-std::string getPGOFuncName(StringRef RawFuncName,
+LLVM_ABI std::string getPGOFuncName(StringRef RawFuncName,
                            GlobalValue::LinkageTypes Linkage,
                            StringRef FileName,
                            uint64_t Version = INSTR_PROF_INDEX_VERSION);
@@ -237,39 +237,39 @@ std::string getPGOFuncName(StringRef RawFuncName,
 /// \return the modified name for function \c F suitable to be
 /// used as the key for IRPGO profile lookup. \c InLTO indicates if this is
 /// called from LTO optimization passes.
-std::string getIRPGOFuncName(const Function &F, bool InLTO = false);
+LLVM_ABI std::string getIRPGOFuncName(const Function &F, bool InLTO = false);
 
 /// \return the filename and the function name parsed from the output of
 /// \c getIRPGOFuncName()
-std::pair<StringRef, StringRef> getParsedIRPGOName(StringRef IRPGOName);
+LLVM_ABI std::pair<StringRef, StringRef> getParsedIRPGOName(StringRef IRPGOName);
 
 /// Return the name of the global variable used to store a function
 /// name in PGO instrumentation. \c FuncName is the IRPGO function name
 /// (returned by \c getIRPGOFuncName) for LLVM IR instrumentation and PGO
 /// function name (returned by \c getPGOFuncName) for front-end instrumentation.
-std::string getPGOFuncNameVarName(StringRef FuncName,
+LLVM_ABI std::string getPGOFuncNameVarName(StringRef FuncName,
                                   GlobalValue::LinkageTypes Linkage);
 
 /// Create and return the global variable for function name used in PGO
 /// instrumentation. \c FuncName is the IRPGO function name (returned by
 /// \c getIRPGOFuncName) for LLVM IR instrumentation and PGO function name
 /// (returned by \c getPGOFuncName) for front-end instrumentation.
-GlobalVariable *createPGOFuncNameVar(Function &F, StringRef PGOFuncName);
+LLVM_ABI GlobalVariable *createPGOFuncNameVar(Function &F, StringRef PGOFuncName);
 
 /// Create and return the global variable for function name used in PGO
 /// instrumentation. \c FuncName is the IRPGO function name (returned by
 /// \c getIRPGOFuncName) for LLVM IR instrumentation and PGO function name
 /// (returned by \c getPGOFuncName) for front-end instrumentation.
-GlobalVariable *createPGOFuncNameVar(Module &M,
+LLVM_ABI GlobalVariable *createPGOFuncNameVar(Module &M,
                                      GlobalValue::LinkageTypes Linkage,
                                      StringRef PGOFuncName);
 
 /// Return the initializer in string of the PGO name var \c NameVar.
-StringRef getPGOFuncNameVarInitializer(GlobalVariable *NameVar);
+LLVM_ABI StringRef getPGOFuncNameVarInitializer(GlobalVariable *NameVar);
 
 /// Given a PGO function name, remove the filename prefix and return
 /// the original (static) function name.
-StringRef getFuncNameWithoutPrefix(StringRef PGOFuncName,
+LLVM_ABI StringRef getFuncNameWithoutPrefix(StringRef PGOFuncName,
                                    StringRef FileName = "<unknown>");
 
 /// Given a vector of strings (names of global objects like functions or,
@@ -281,7 +281,7 @@ StringRef getFuncNameWithoutPrefix(StringRef PGOFuncName,
 ///  third field is the uncompressed strings; otherwise it is the
 /// compressed string. When the string compression is off, the
 /// second field will have value zero.
-Error collectGlobalObjectNameStrings(ArrayRef<std::string> NameStrs,
+LLVM_ABI Error collectGlobalObjectNameStrings(ArrayRef<std::string> NameStrs,
                                      bool doCompression, std::string &Result);
 
 /// Produce \c Result string with the same format described above. The input
@@ -289,20 +289,20 @@ Error collectGlobalObjectNameStrings(ArrayRef<std::string> NameStrs,
 /// The global variable element in 'NameVars' is a string containing the pgo
 /// name of a function. See `createPGOFuncNameVar` that creates these global
 /// variables.
-Error collectPGOFuncNameStrings(ArrayRef<GlobalVariable *> NameVars,
+LLVM_ABI Error collectPGOFuncNameStrings(ArrayRef<GlobalVariable *> NameVars,
                                 std::string &Result, bool doCompression = true);
 
-Error collectVTableStrings(ArrayRef<GlobalVariable *> VTables,
+LLVM_ABI Error collectVTableStrings(ArrayRef<GlobalVariable *> VTables,
                            std::string &Result, bool doCompression);
 
 /// Check if INSTR_PROF_RAW_VERSION_VAR is defined. This global is only being
 /// set in IR PGO compilation.
-bool isIRPGOFlagSet(const Module *M);
+LLVM_ABI bool isIRPGOFlagSet(const Module *M);
 
 /// Check if we can safely rename this Comdat function. Instances of the same
 /// comdat function may have different control flows thus can not share the
 /// same counter variable.
-bool canRenameComdatFunc(const Function &F, bool CheckAddressTaken = false);
+LLVM_ABI bool canRenameComdatFunc(const Function &F, bool CheckAddressTaken = false);
 
 enum InstrProfValueKind : uint32_t {
 #define VALUE_PROF_KIND(Enumerator, Value, Descr) Enumerator = Value,
@@ -312,7 +312,7 @@ enum InstrProfValueKind : uint32_t {
 /// Get the value profile data for value site \p SiteIdx from \p InstrProfR
 /// and annotate the instruction \p Inst with the value profile meta data.
 /// Annotate up to \p MaxMDCount (default 3) number of records per value site.
-void annotateValueSite(Module &M, Instruction &Inst,
+LLVM_ABI void annotateValueSite(Module &M, Instruction &Inst,
                        const InstrProfRecord &InstrProfR,
                        InstrProfValueKind ValueKind, uint32_t SiteIndx,
                        uint32_t MaxMDCount = 3);
@@ -320,7 +320,7 @@ void annotateValueSite(Module &M, Instruction &Inst,
 /// Same as the above interface but using an ArrayRef, as well as \p Sum.
 /// This function will not annotate !prof metadata on the instruction if the
 /// referenced array is empty.
-void annotateValueSite(Module &M, Instruction &Inst,
+LLVM_ABI void annotateValueSite(Module &M, Instruction &Inst,
                        ArrayRef<InstrProfValueData> VDs, uint64_t Sum,
                        InstrProfValueKind ValueKind, uint32_t MaxMDCount);
 
@@ -328,7 +328,7 @@ void annotateValueSite(Module &M, Instruction &Inst,
 // of this metadata for backward compatibility and generating 'PGOName' only.
 /// Extract the value profile data from \p Inst and returns them if \p Inst is
 /// annotated with value profile data. Returns an empty vector otherwise.
-SmallVector<InstrProfValueData, 4>
+LLVM_ABI SmallVector<InstrProfValueData, 4>
 getValueProfDataFromInst(const Instruction &Inst, InstrProfValueKind ValueKind,
                          uint32_t MaxNumValueData, uint64_t &TotalC,
                          bool GetNoICPValue = false);
@@ -338,30 +338,30 @@ inline StringRef getPGOFuncNameMetadataName() { return "PGOFuncName"; }
 inline StringRef getPGONameMetadataName() { return "PGOName"; }
 
 /// Return the PGOFuncName meta data associated with a function.
-MDNode *getPGOFuncNameMetadata(const Function &F);
+LLVM_ABI MDNode *getPGOFuncNameMetadata(const Function &F);
 
-std::string getPGOName(const GlobalVariable &V, bool InLTO = false);
+LLVM_ABI std::string getPGOName(const GlobalVariable &V, bool InLTO = false);
 
 /// Create the PGOFuncName meta data if PGOFuncName is different from
 /// function's raw name. This should only apply to internal linkage functions
 /// declared by users only.
 /// TODO: Update all callers to 'createPGONameMetadata' and deprecate this
 /// function.
-void createPGOFuncNameMetadata(Function &F, StringRef PGOFuncName);
+LLVM_ABI void createPGOFuncNameMetadata(Function &F, StringRef PGOFuncName);
 
 /// Create the PGOName metadata if a global object's PGO name is different from
 /// its mangled name. This should apply to local-linkage global objects only.
-void createPGONameMetadata(GlobalObject &GO, StringRef PGOName);
+LLVM_ABI void createPGONameMetadata(GlobalObject &GO, StringRef PGOName);
 
 /// Check if we can use Comdat for profile variables. This will eliminate
 /// the duplicated profile variables for Comdat functions.
-bool needsComdatForCounter(const GlobalObject &GV, const Module &M);
+LLVM_ABI bool needsComdatForCounter(const GlobalObject &GV, const Module &M);
 
 /// \c NameStrings is a string composed of one or more possibly encoded
 /// sub-strings. The substrings are separated by `\01` (returned by
 /// InstrProf.h:getInstrProfNameSeparator). This method decodes the string and
 /// calls `NameCallback` for each substring.
-Error readAndDecodeStrings(StringRef NameStrings,
+LLVM_ABI Error readAndDecodeStrings(StringRef NameStrings,
                            std::function<Error(StringRef)> NameCallback);
 
 /// An enum describing the attributes of an instrumented profile.
@@ -388,7 +388,7 @@ enum class InstrProfKind {
   LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/LoopEntriesInstrumentation)
 };
 
-const std::error_category &instrprof_category();
+LLVM_ABI const std::error_category &instrprof_category();
 
 enum class instrprof_error {
   success = 0,
@@ -431,7 +431,7 @@ struct TemporalProfTraceTy {
   /// Use a set of temporal profile traces to create a list of balanced
   /// partitioning function nodes used by BalancedPartitioning to generate a
   /// function order that reduces page faults during startup
-  static void createBPFunctionNodes(ArrayRef<TemporalProfTraceTy> Traces,
+  LLVM_ABI static void createBPFunctionNodes(ArrayRef<TemporalProfTraceTy> Traces,
                                     std::vector<BPFunctionNode> &Nodes,
                                     bool RemoveOutlierUNs = true);
 };
@@ -440,7 +440,7 @@ inline std::error_code make_error_code(instrprof_error E) {
   return std::error_code(static_cast<int>(E), instrprof_category());
 }
 
-class InstrProfError : public ErrorInfo<InstrProfError> {
+class LLVM_ABI InstrProfError : public ErrorInfo<InstrProfError> {
 public:
   InstrProfError(instrprof_error Err, const Twine &ErrStr = Twine())
       : Err(Err), Msg(ErrStr.str()) {
@@ -503,7 +503,7 @@ public:
   // Returns the canonical name of the given PGOName. In a canonical name, all
   // suffixes that begins with "." except ".__uniq." are stripped.
   // FIXME: Unify this with `FunctionSamples::getCanonicalFnName`.
-  static StringRef getCanonicalName(StringRef PGOName);
+  LLVM_ABI static StringRef getCanonicalName(StringRef PGOName);
 
 private:
   using AddrIntervalMap =
@@ -577,22 +577,22 @@ public:
   /// only initialize the symtab with reference to the data and
   /// the section base address. The decompression will be delayed
   /// until before it is used. See also \c create(StringRef) method.
-  Error create(object::SectionRef &Section);
+  LLVM_ABI Error create(object::SectionRef &Section);
 
   /// \c NameStrings is a string composed of one of more sub-strings
   ///  encoded in the format described in \c collectPGOFuncNameStrings.
   /// This method is a wrapper to \c readAndDecodeStrings method.
-  Error create(StringRef NameStrings);
+  LLVM_ABI Error create(StringRef NameStrings);
 
   /// Initialize symtab states with function names and vtable names. \c
   /// FuncNameStrings is a string composed of one or more encoded function name
   /// strings, and \c VTableNameStrings composes of one or more encoded vtable
   /// names. This interface is solely used by raw profile reader.
-  Error create(StringRef FuncNameStrings, StringRef VTableNameStrings);
+  LLVM_ABI Error create(StringRef FuncNameStrings, StringRef VTableNameStrings);
 
   /// Initialize 'this' with the set of vtable names encoded in
   /// \c CompressedVTableNames.
-  Error initVTableNamesFromCompressedStrings(StringRef CompressedVTableNames);
+  LLVM_ABI Error initVTableNamesFromCompressedStrings(StringRef CompressedVTableNames);
 
   /// This interface is used by reader of CoverageMapping test
   /// format.
@@ -604,7 +604,7 @@ public:
   /// indicates if this is called from LTO optimization passes.
   /// A canonical name, removing non-__uniq suffixes, is added if
   /// \c AddCanonical is true.
-  Error create(Module &M, bool InLTO = false, bool AddCanonical = true);
+  LLVM_ABI Error create(Module &M, bool InLTO = false, bool AddCanonical = true);
 
   /// Create InstrProfSymtab from a set of names iteratable from
   /// \p IterRange. This interface is used by IndexedProfReader.
@@ -667,15 +667,15 @@ public:
   }
 
   /// Return a function's hash, or 0, if the function isn't in this SymTab.
-  uint64_t getFunctionHashFromAddress(uint64_t Address);
+  LLVM_ABI uint64_t getFunctionHashFromAddress(uint64_t Address);
 
   /// Return a vtable's hash, or 0 if the vtable doesn't exist in this SymTab.
-  uint64_t getVTableHashFromAddress(uint64_t Address);
+  LLVM_ABI uint64_t getVTableHashFromAddress(uint64_t Address);
 
   /// Return function's PGO name from the function name's symbol
   /// address in the object file. If an error occurs, return
   /// an empty string.
-  StringRef getFuncName(uint64_t FuncNameAddress, size_t NameSize);
+  LLVM_ABI StringRef getFuncName(uint64_t FuncNameAddress, size_t NameSize);
 
   /// Return name of functions or global variables from the name's md5 hash
   /// value. If not found, return an empty string.
@@ -702,7 +702,7 @@ public:
   inline StringRef getNameData() const { return Data; }
 
   /// Dump the symbols in this table.
-  void dumpNames(raw_ostream &OS) const;
+  LLVM_ABI void dumpNames(raw_ostream &OS) const;
 };
 
 Error InstrProfSymtab::create(StringRef D, uint64_t BaseAddr) {
@@ -814,17 +814,17 @@ struct OverlapStats {
 
   OverlapStats(OverlapStatsLevel L = ProgramLevel) : Level(L) {}
 
-  void dump(raw_fd_ostream &OS) const;
+  LLVM_ABI void dump(raw_fd_ostream &OS) const;
 
   void setFuncInfo(StringRef Name, uint64_t Hash) {
     FuncName = Name;
     FuncHash = Hash;
   }
 
-  Error accumulateCounts(const std::string &BaseFilename,
+  LLVM_ABI Error accumulateCounts(const std::string &BaseFilename,
                          const std::string &TestFilename, bool IsCS);
-  void addOneMismatch(const CountSumOrPercent &MismatchFunc);
-  void addOneUnique(const CountSumOrPercent &UniqueFunc);
+  LLVM_ABI void addOneMismatch(const CountSumOrPercent &MismatchFunc);
+  LLVM_ABI void addOneUnique(const CountSumOrPercent &UniqueFunc);
 
   static inline double score(uint64_t Val1, uint64_t Val2, double Sum1,
                              double Sum2) {
@@ -861,13 +861,13 @@ struct InstrProfValueSiteRecord {
 
   /// Merge data from another InstrProfValueSiteRecord
   /// Optionally scale merged counts by \p Weight.
-  void merge(InstrProfValueSiteRecord &Input, uint64_t Weight,
+  LLVM_ABI void merge(InstrProfValueSiteRecord &Input, uint64_t Weight,
              function_ref<void(instrprof_error)> Warn);
   /// Scale up value profile data counts by N (Numerator) / D (Denominator).
-  void scale(uint64_t N, uint64_t D, function_ref<void(instrprof_error)> Warn);
+  LLVM_ABI void scale(uint64_t N, uint64_t D, function_ref<void(instrprof_error)> Warn);
 
   /// Compute the overlap b/w this record and Input record.
-  void overlap(InstrProfValueSiteRecord &Input, uint32_t ValueKind,
+  LLVM_ABI void overlap(InstrProfValueSiteRecord &Input, uint32_t ValueKind,
                OverlapStats &Overlap, OverlapStats &FuncLevelOverlap);
 };
 
@@ -920,18 +920,18 @@ struct InstrProfRecord {
 
   /// Add ValueData for ValueKind at value Site.  We do not support adding sites
   /// out of order.  Site must go up from 0 one by one.
-  void addValueData(uint32_t ValueKind, uint32_t Site,
+  LLVM_ABI void addValueData(uint32_t ValueKind, uint32_t Site,
                     ArrayRef<InstrProfValueData> VData,
                     InstrProfSymtab *SymTab);
 
   /// Merge the counts in \p Other into this one.
   /// Optionally scale merged counts by \p Weight.
-  void merge(InstrProfRecord &Other, uint64_t Weight,
+  LLVM_ABI void merge(InstrProfRecord &Other, uint64_t Weight,
              function_ref<void(instrprof_error)> Warn);
 
   /// Scale up profile counts (including value profile data) by
   /// a factor of (N / D).
-  void scale(uint64_t N, uint64_t D, function_ref<void(instrprof_error)> Warn);
+  LLVM_ABI void scale(uint64_t N, uint64_t D, function_ref<void(instrprof_error)> Warn);
 
   /// Sort value profile data (per site) by count.
   void sortValueData() {
@@ -950,14 +950,14 @@ struct InstrProfRecord {
   void clearValueData() { ValueData = nullptr; }
 
   /// Compute the sums of all counts and store in Sum.
-  void accumulateCounts(CountSumOrPercent &Sum) const;
+  LLVM_ABI void accumulateCounts(CountSumOrPercent &Sum) const;
 
   /// Compute the overlap b/w this IntrprofRecord and Other.
-  void overlap(InstrProfRecord &Other, OverlapStats &Overlap,
+  LLVM_ABI void overlap(InstrProfRecord &Other, OverlapStats &Overlap,
                OverlapStats &FuncLevelOverlap, uint64_t ValueCutoff);
 
   /// Compute the overlap of value profile counts.
-  void overlapValueProfData(uint32_t ValueKind, InstrProfRecord &Src,
+  LLVM_ABI void overlapValueProfData(uint32_t ValueKind, InstrProfRecord &Src,
                             OverlapStats &Overlap,
                             OverlapStats &FuncLevelOverlap);
 
@@ -1187,15 +1187,15 @@ struct Header {
 
   // Reads a header struct from the buffer. Header fields are in machine native
   // endianness.
-  static Expected<Header> readFromBuffer(const unsigned char *Buffer);
+  LLVM_ABI static Expected<Header> readFromBuffer(const unsigned char *Buffer);
 
   // Returns the size of the header in bytes for all valid fields based on the
   // version. I.e a older version header will return a smaller size.
-  size_t size() const;
+  LLVM_ABI size_t size() const;
 
   // Return the indexed profile version, i.e., the least significant 32 bits
   // in Header.Version.
-  uint64_t getIndexedProfileVersion() const;
+  LLVM_ABI uint64_t getIndexedProfileVersion() const;
 };
 
 // Profile summary data recorded in the profile data file in indexed
@@ -1340,11 +1340,11 @@ struct Header {
 } // end namespace RawInstrProf
 
 // Create the variable for the profile file name.
-void createProfileFileNameVar(Module &M, StringRef InstrProfileOutput);
+LLVM_ABI void createProfileFileNameVar(Module &M, StringRef InstrProfileOutput);
 
 // Whether to compress function names in profile records, and filenames in
 // code coverage mappings. Used by the Instrumentation library and unit tests.
-extern cl::opt<bool> DoInstrProfNameCompression;
+LLVM_ABI extern cl::opt<bool> DoInstrProfNameCompression;
 
 } // end namespace llvm
 #endif // LLVM_PROFILEDATA_INSTRPROF_H

--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -105,8 +105,8 @@ inline uint64_t getInstrMaxCountValue() {
 /// \p AddSegmentInfo is true, a segment prefix and additional linker hints may
 /// be added to the section name (this is the default).
 LLVM_ABI std::string getInstrProfSectionName(InstrProfSectKind IPSK,
-                                    Triple::ObjectFormatType OF,
-                                    bool AddSegmentInfo = true);
+                                             Triple::ObjectFormatType OF,
+                                             bool AddSegmentInfo = true);
 
 /// Return the name profile runtime entry point to do value profiling
 /// for a given site.
@@ -222,17 +222,17 @@ LLVM_ABI bool isGPUProfTarget(const Module &M);
 /// Return the modified name for function \c F suitable to be
 /// used the key for profile lookup. Variable \c InLTO indicates if this
 /// is called in LTO optimization passes.
-LLVM_ABI std::string getPGOFuncName(const Function &F, bool InLTO = false,
-                           uint64_t Version = INSTR_PROF_INDEX_VERSION);
+LLVM_ABI std::string
+getPGOFuncName(const Function &F, bool InLTO = false,
+               uint64_t Version = INSTR_PROF_INDEX_VERSION);
 
 /// Return the modified name for a function suitable to be
 /// used the key for profile lookup. The function's original
 /// name is \c RawFuncName and has linkage of type \c Linkage.
 /// The function is defined in module \c FileName.
-LLVM_ABI std::string getPGOFuncName(StringRef RawFuncName,
-                           GlobalValue::LinkageTypes Linkage,
-                           StringRef FileName,
-                           uint64_t Version = INSTR_PROF_INDEX_VERSION);
+LLVM_ABI std::string
+getPGOFuncName(StringRef RawFuncName, GlobalValue::LinkageTypes Linkage,
+               StringRef FileName, uint64_t Version = INSTR_PROF_INDEX_VERSION);
 
 /// \return the modified name for function \c F suitable to be
 /// used as the key for IRPGO profile lookup. \c InLTO indicates if this is
@@ -241,28 +241,30 @@ LLVM_ABI std::string getIRPGOFuncName(const Function &F, bool InLTO = false);
 
 /// \return the filename and the function name parsed from the output of
 /// \c getIRPGOFuncName()
-LLVM_ABI std::pair<StringRef, StringRef> getParsedIRPGOName(StringRef IRPGOName);
+LLVM_ABI std::pair<StringRef, StringRef>
+getParsedIRPGOName(StringRef IRPGOName);
 
 /// Return the name of the global variable used to store a function
 /// name in PGO instrumentation. \c FuncName is the IRPGO function name
 /// (returned by \c getIRPGOFuncName) for LLVM IR instrumentation and PGO
 /// function name (returned by \c getPGOFuncName) for front-end instrumentation.
 LLVM_ABI std::string getPGOFuncNameVarName(StringRef FuncName,
-                                  GlobalValue::LinkageTypes Linkage);
+                                           GlobalValue::LinkageTypes Linkage);
 
 /// Create and return the global variable for function name used in PGO
 /// instrumentation. \c FuncName is the IRPGO function name (returned by
 /// \c getIRPGOFuncName) for LLVM IR instrumentation and PGO function name
 /// (returned by \c getPGOFuncName) for front-end instrumentation.
-LLVM_ABI GlobalVariable *createPGOFuncNameVar(Function &F, StringRef PGOFuncName);
+LLVM_ABI GlobalVariable *createPGOFuncNameVar(Function &F,
+                                              StringRef PGOFuncName);
 
 /// Create and return the global variable for function name used in PGO
 /// instrumentation. \c FuncName is the IRPGO function name (returned by
 /// \c getIRPGOFuncName) for LLVM IR instrumentation and PGO function name
 /// (returned by \c getPGOFuncName) for front-end instrumentation.
 LLVM_ABI GlobalVariable *createPGOFuncNameVar(Module &M,
-                                     GlobalValue::LinkageTypes Linkage,
-                                     StringRef PGOFuncName);
+                                              GlobalValue::LinkageTypes Linkage,
+                                              StringRef PGOFuncName);
 
 /// Return the initializer in string of the PGO name var \c NameVar.
 LLVM_ABI StringRef getPGOFuncNameVarInitializer(GlobalVariable *NameVar);
@@ -270,7 +272,7 @@ LLVM_ABI StringRef getPGOFuncNameVarInitializer(GlobalVariable *NameVar);
 /// Given a PGO function name, remove the filename prefix and return
 /// the original (static) function name.
 LLVM_ABI StringRef getFuncNameWithoutPrefix(StringRef PGOFuncName,
-                                   StringRef FileName = "<unknown>");
+                                            StringRef FileName = "<unknown>");
 
 /// Given a vector of strings (names of global objects like functions or,
 /// virtual tables) \c NameStrs, the method generates a combined string \c
@@ -282,7 +284,8 @@ LLVM_ABI StringRef getFuncNameWithoutPrefix(StringRef PGOFuncName,
 /// compressed string. When the string compression is off, the
 /// second field will have value zero.
 LLVM_ABI Error collectGlobalObjectNameStrings(ArrayRef<std::string> NameStrs,
-                                     bool doCompression, std::string &Result);
+                                              bool doCompression,
+                                              std::string &Result);
 
 /// Produce \c Result string with the same format described above. The input
 /// is vector of PGO function name variables that are referenced.
@@ -290,10 +293,11 @@ LLVM_ABI Error collectGlobalObjectNameStrings(ArrayRef<std::string> NameStrs,
 /// name of a function. See `createPGOFuncNameVar` that creates these global
 /// variables.
 LLVM_ABI Error collectPGOFuncNameStrings(ArrayRef<GlobalVariable *> NameVars,
-                                std::string &Result, bool doCompression = true);
+                                         std::string &Result,
+                                         bool doCompression = true);
 
 LLVM_ABI Error collectVTableStrings(ArrayRef<GlobalVariable *> VTables,
-                           std::string &Result, bool doCompression);
+                                    std::string &Result, bool doCompression);
 
 /// Check if INSTR_PROF_RAW_VERSION_VAR is defined. This global is only being
 /// set in IR PGO compilation.
@@ -302,7 +306,8 @@ LLVM_ABI bool isIRPGOFlagSet(const Module *M);
 /// Check if we can safely rename this Comdat function. Instances of the same
 /// comdat function may have different control flows thus can not share the
 /// same counter variable.
-LLVM_ABI bool canRenameComdatFunc(const Function &F, bool CheckAddressTaken = false);
+LLVM_ABI bool canRenameComdatFunc(const Function &F,
+                                  bool CheckAddressTaken = false);
 
 enum InstrProfValueKind : uint32_t {
 #define VALUE_PROF_KIND(Enumerator, Value, Descr) Enumerator = Value,
@@ -313,16 +318,17 @@ enum InstrProfValueKind : uint32_t {
 /// and annotate the instruction \p Inst with the value profile meta data.
 /// Annotate up to \p MaxMDCount (default 3) number of records per value site.
 LLVM_ABI void annotateValueSite(Module &M, Instruction &Inst,
-                       const InstrProfRecord &InstrProfR,
-                       InstrProfValueKind ValueKind, uint32_t SiteIndx,
-                       uint32_t MaxMDCount = 3);
+                                const InstrProfRecord &InstrProfR,
+                                InstrProfValueKind ValueKind, uint32_t SiteIndx,
+                                uint32_t MaxMDCount = 3);
 
 /// Same as the above interface but using an ArrayRef, as well as \p Sum.
 /// This function will not annotate !prof metadata on the instruction if the
 /// referenced array is empty.
 LLVM_ABI void annotateValueSite(Module &M, Instruction &Inst,
-                       ArrayRef<InstrProfValueData> VDs, uint64_t Sum,
-                       InstrProfValueKind ValueKind, uint32_t MaxMDCount);
+                                ArrayRef<InstrProfValueData> VDs, uint64_t Sum,
+                                InstrProfValueKind ValueKind,
+                                uint32_t MaxMDCount);
 
 // TODO: Unify metadata name 'PGOFuncName' and 'PGOName', by supporting read
 // of this metadata for backward compatibility and generating 'PGOName' only.
@@ -361,8 +367,8 @@ LLVM_ABI bool needsComdatForCounter(const GlobalObject &GV, const Module &M);
 /// sub-strings. The substrings are separated by `\01` (returned by
 /// InstrProf.h:getInstrProfNameSeparator). This method decodes the string and
 /// calls `NameCallback` for each substring.
-LLVM_ABI Error readAndDecodeStrings(StringRef NameStrings,
-                           std::function<Error(StringRef)> NameCallback);
+LLVM_ABI Error readAndDecodeStrings(
+    StringRef NameStrings, std::function<Error(StringRef)> NameCallback);
 
 /// An enum describing the attributes of an instrumented profile.
 enum class InstrProfKind {
@@ -431,9 +437,10 @@ struct TemporalProfTraceTy {
   /// Use a set of temporal profile traces to create a list of balanced
   /// partitioning function nodes used by BalancedPartitioning to generate a
   /// function order that reduces page faults during startup
-  LLVM_ABI static void createBPFunctionNodes(ArrayRef<TemporalProfTraceTy> Traces,
-                                    std::vector<BPFunctionNode> &Nodes,
-                                    bool RemoveOutlierUNs = true);
+  LLVM_ABI static void
+  createBPFunctionNodes(ArrayRef<TemporalProfTraceTy> Traces,
+                        std::vector<BPFunctionNode> &Nodes,
+                        bool RemoveOutlierUNs = true);
 };
 
 inline std::error_code make_error_code(instrprof_error E) {
@@ -592,7 +599,8 @@ public:
 
   /// Initialize 'this' with the set of vtable names encoded in
   /// \c CompressedVTableNames.
-  LLVM_ABI Error initVTableNamesFromCompressedStrings(StringRef CompressedVTableNames);
+  LLVM_ABI Error
+  initVTableNamesFromCompressedStrings(StringRef CompressedVTableNames);
 
   /// This interface is used by reader of CoverageMapping test
   /// format.
@@ -604,7 +612,8 @@ public:
   /// indicates if this is called from LTO optimization passes.
   /// A canonical name, removing non-__uniq suffixes, is added if
   /// \c AddCanonical is true.
-  LLVM_ABI Error create(Module &M, bool InLTO = false, bool AddCanonical = true);
+  LLVM_ABI Error create(Module &M, bool InLTO = false,
+                        bool AddCanonical = true);
 
   /// Create InstrProfSymtab from a set of names iteratable from
   /// \p IterRange. This interface is used by IndexedProfReader.
@@ -822,7 +831,7 @@ struct OverlapStats {
   }
 
   LLVM_ABI Error accumulateCounts(const std::string &BaseFilename,
-                         const std::string &TestFilename, bool IsCS);
+                                  const std::string &TestFilename, bool IsCS);
   LLVM_ABI void addOneMismatch(const CountSumOrPercent &MismatchFunc);
   LLVM_ABI void addOneUnique(const CountSumOrPercent &UniqueFunc);
 
@@ -862,13 +871,14 @@ struct InstrProfValueSiteRecord {
   /// Merge data from another InstrProfValueSiteRecord
   /// Optionally scale merged counts by \p Weight.
   LLVM_ABI void merge(InstrProfValueSiteRecord &Input, uint64_t Weight,
-             function_ref<void(instrprof_error)> Warn);
+                      function_ref<void(instrprof_error)> Warn);
   /// Scale up value profile data counts by N (Numerator) / D (Denominator).
-  LLVM_ABI void scale(uint64_t N, uint64_t D, function_ref<void(instrprof_error)> Warn);
+  LLVM_ABI void scale(uint64_t N, uint64_t D,
+                      function_ref<void(instrprof_error)> Warn);
 
   /// Compute the overlap b/w this record and Input record.
   LLVM_ABI void overlap(InstrProfValueSiteRecord &Input, uint32_t ValueKind,
-               OverlapStats &Overlap, OverlapStats &FuncLevelOverlap);
+                        OverlapStats &Overlap, OverlapStats &FuncLevelOverlap);
 };
 
 /// Profiling information for a single function.
@@ -921,17 +931,18 @@ struct InstrProfRecord {
   /// Add ValueData for ValueKind at value Site.  We do not support adding sites
   /// out of order.  Site must go up from 0 one by one.
   LLVM_ABI void addValueData(uint32_t ValueKind, uint32_t Site,
-                    ArrayRef<InstrProfValueData> VData,
-                    InstrProfSymtab *SymTab);
+                             ArrayRef<InstrProfValueData> VData,
+                             InstrProfSymtab *SymTab);
 
   /// Merge the counts in \p Other into this one.
   /// Optionally scale merged counts by \p Weight.
   LLVM_ABI void merge(InstrProfRecord &Other, uint64_t Weight,
-             function_ref<void(instrprof_error)> Warn);
+                      function_ref<void(instrprof_error)> Warn);
 
   /// Scale up profile counts (including value profile data) by
   /// a factor of (N / D).
-  LLVM_ABI void scale(uint64_t N, uint64_t D, function_ref<void(instrprof_error)> Warn);
+  LLVM_ABI void scale(uint64_t N, uint64_t D,
+                      function_ref<void(instrprof_error)> Warn);
 
   /// Sort value profile data (per site) by count.
   void sortValueData() {
@@ -954,12 +965,12 @@ struct InstrProfRecord {
 
   /// Compute the overlap b/w this IntrprofRecord and Other.
   LLVM_ABI void overlap(InstrProfRecord &Other, OverlapStats &Overlap,
-               OverlapStats &FuncLevelOverlap, uint64_t ValueCutoff);
+                        OverlapStats &FuncLevelOverlap, uint64_t ValueCutoff);
 
   /// Compute the overlap of value profile counts.
   LLVM_ABI void overlapValueProfData(uint32_t ValueKind, InstrProfRecord &Src,
-                            OverlapStats &Overlap,
-                            OverlapStats &FuncLevelOverlap);
+                                     OverlapStats &Overlap,
+                                     OverlapStats &FuncLevelOverlap);
 
   enum CountPseudoKind {
     NotPseudo = 0,

--- a/llvm/include/llvm/ProfileData/InstrProfCorrelator.h
+++ b/llvm/include/llvm/ProfileData/InstrProfCorrelator.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_PROFILEDATA_INSTRPROFCORRELATOR_H
 #define LLVM_PROFILEDATA_INSTRPROFCORRELATOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Debuginfod/BuildIDFetcher.h"
 #include "llvm/Object/BuildID.h"
@@ -37,7 +38,7 @@ public:
   /// correlate.
   enum ProfCorrelatorKind { NONE, DEBUG_INFO, BINARY };
 
-  static llvm::Expected<std::unique_ptr<InstrProfCorrelator>>
+  LLVM_ABI static llvm::Expected<std::unique_ptr<InstrProfCorrelator>>
   get(StringRef Filename, ProfCorrelatorKind FileKind,
       const object::BuildIDFetcher *BIDFetcher = nullptr,
       const ArrayRef<llvm::object::BuildID> BIs = {});
@@ -52,7 +53,7 @@ public:
   virtual Error dumpYaml(int MaxWarnings, raw_ostream &OS) = 0;
 
   /// Return the number of ProfileData elements.
-  std::optional<size_t> getDataSize() const;
+  LLVM_ABI std::optional<size_t> getDataSize() const;
 
   /// Return a pointer to the names string that this class constructs.
   const char *getNamesPointer() const { return Names.c_str(); }
@@ -65,9 +66,9 @@ public:
     return Ctx->CountersSectionEnd - Ctx->CountersSectionStart;
   }
 
-  static const char *FunctionNameAttributeName;
-  static const char *CFGHashAttributeName;
-  static const char *NumCountersAttributeName;
+  LLVM_ABI static const char *FunctionNameAttributeName;
+  LLVM_ABI static const char *CFGHashAttributeName;
+  LLVM_ABI static const char *NumCountersAttributeName;
 
   enum InstrProfCorrelatorKind { CK_32Bit, CK_64Bit };
   InstrProfCorrelatorKind getKind() const { return Kind; }
@@ -75,7 +76,7 @@ public:
 
 protected:
   struct Context {
-    static llvm::Expected<std::unique_ptr<Context>>
+    LLVM_ABI static llvm::Expected<std::unique_ptr<Context>>
     get(std::unique_ptr<MemoryBuffer> Buffer, const object::ObjectFile &Obj,
         ProfCorrelatorKind FileKind);
     std::unique_ptr<MemoryBuffer> Buffer;

--- a/llvm/include/llvm/ProfileData/InstrProfCorrelator.h
+++ b/llvm/include/llvm/ProfileData/InstrProfCorrelator.h
@@ -12,11 +12,11 @@
 #ifndef LLVM_PROFILEDATA_INSTRPROFCORRELATOR_H
 #define LLVM_PROFILEDATA_INSTRPROFCORRELATOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Debuginfod/BuildIDFetcher.h"
 #include "llvm/Object/BuildID.h"
 #include "llvm/ProfileData/InstrProf.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/YAMLTraits.h"

--- a/llvm/include/llvm/ProfileData/InstrProfData.inc
+++ b/llvm/include/llvm/ProfileData/InstrProfData.inc
@@ -405,14 +405,14 @@ typedef struct ValueProfRecord {
   /*!
    * Read data from this record and save it to Record.
    */
-  void deserializeTo(InstrProfRecord &Record,
+  LLVM_ABI void deserializeTo(InstrProfRecord &Record,
                      InstrProfSymtab *SymTab);
   /*
    * In-place byte swap:
    * Do byte swap for this instance. \c Old is the original order before
    * the swap, and \c New is the New byte order.
    */
-  void swapBytes(llvm::endianness Old, llvm::endianness New);
+  LLVM_ABI void swapBytes(llvm::endianness Old, llvm::endianness New);
 #endif
 } ValueProfRecord;
 
@@ -449,41 +449,41 @@ typedef struct ValueProfData {
    * Return the total size in bytes of the on-disk value profile data
    * given the data stored in Record.
    */
-  static uint32_t getSize(const InstrProfRecord &Record);
+  LLVM_ABI static uint32_t getSize(const InstrProfRecord &Record);
   /*!
    * Return a pointer to \c ValueProfData instance ready to be streamed.
    */
-  static std::unique_ptr<ValueProfData>
+  LLVM_ABI static std::unique_ptr<ValueProfData>
   serializeFrom(const InstrProfRecord &Record);
   /*!
    * Check the integrity of the record.
    */
-  Error checkIntegrity();
+  LLVM_ABI Error checkIntegrity();
   /*!
    * Return a pointer to \c ValueProfileData instance ready to be read.
    * All data in the instance are properly byte swapped. The input
    * data is assumed to be in little endian order.
    */
-  static Expected<std::unique_ptr<ValueProfData>>
+  LLVM_ABI static Expected<std::unique_ptr<ValueProfData>>
   getValueProfData(const unsigned char *SrcBuffer,
                    const unsigned char *const SrcBufferEnd,
                    llvm::endianness SrcDataEndianness);
   /*!
    * Swap byte order from \c Endianness order to host byte order.
    */
-  void swapBytesToHost(llvm::endianness Endianness);
+  LLVM_ABI void swapBytesToHost(llvm::endianness Endianness);
   /*!
    * Swap byte order from host byte order to \c Endianness order.
    */
-  void swapBytesFromHost(llvm::endianness Endianness);
+  LLVM_ABI void swapBytesFromHost(llvm::endianness Endianness);
   /*!
    * Return the total size of \c ValueProfileData.
    */
-  uint32_t getSize() const { return TotalSize; }
+  LLVM_ABI uint32_t getSize() const { return TotalSize; }
   /*!
    * Read data from this data and save it to \c Record.
    */
-  void deserializeTo(InstrProfRecord &Record,
+  LLVM_ABI void deserializeTo(InstrProfRecord &Record,
                      InstrProfSymtab *SymTab);
   void operator delete(void *ptr) { ::operator delete(ptr); }
 #endif

--- a/llvm/include/llvm/ProfileData/InstrProfReader.h
+++ b/llvm/include/llvm/ProfileData/InstrProfReader.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_PROFILEDATA_INSTRPROFREADER_H
 #define LLVM_PROFILEDATA_INSTRPROFREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/ProfileSummary.h"
@@ -25,6 +24,7 @@
 #include "llvm/ProfileData/MemProf.h"
 #include "llvm/ProfileData/MemProfSummary.h"
 #include "llvm/ProfileData/MemProfYAML.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/LineIterator.h"
@@ -554,8 +554,9 @@ public:
   }
 
   LLVM_ABI bool readValueProfilingData(const unsigned char *&D,
-                              const unsigned char *const End);
-  LLVM_ABI data_type ReadData(StringRef K, const unsigned char *D, offset_type N);
+                                       const unsigned char *const End);
+  LLVM_ABI data_type ReadData(StringRef K, const unsigned char *D,
+                              offset_type N);
 
   // Used for testing purpose only.
   void setValueProfDataEndianness(llvm::endianness Endianness) {
@@ -719,7 +720,8 @@ private:
 public:
   IndexedMemProfReader() = default;
 
-  LLVM_ABI Error deserialize(const unsigned char *Start, uint64_t MemProfOffset);
+  LLVM_ABI Error deserialize(const unsigned char *Start,
+                             uint64_t MemProfOffset);
 
   LLVM_ABI Expected<memprof::MemProfRecord>
   getMemProfRecord(const uint64_t FuncNameHash) const;

--- a/llvm/include/llvm/ProfileData/InstrProfReader.h
+++ b/llvm/include/llvm/ProfileData/InstrProfReader.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_INSTRPROFREADER_H
 #define LLVM_PROFILEDATA_INSTRPROFREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/ProfileSummary.h"
@@ -158,7 +159,7 @@ public:
   virtual InstrProfSymtab &getSymtab() = 0;
 
   /// Compute the sum of counts and return in Sum.
-  void accumulateCounts(CountSumOrPercent &Sum, bool IsCS);
+  LLVM_ABI void accumulateCounts(CountSumOrPercent &Sum, bool IsCS);
 
 protected:
   std::unique_ptr<InstrProfSymtab> Symtab;
@@ -203,7 +204,7 @@ public:
 
   /// Factory method to create an appropriately typed reader for the given
   /// instrprof file.
-  static Expected<std::unique_ptr<InstrProfReader>> create(
+  LLVM_ABI static Expected<std::unique_ptr<InstrProfReader>> create(
       const Twine &Path, vfs::FileSystem &FS,
       const InstrProfCorrelator *Correlator = nullptr,
       const object::BuildIDFetcher *BIDFetcher = nullptr,
@@ -211,7 +212,7 @@ public:
           InstrProfCorrelator::ProfCorrelatorKind::NONE,
       std::function<void(Error)> Warn = nullptr);
 
-  static Expected<std::unique_ptr<InstrProfReader>> create(
+  LLVM_ABI static Expected<std::unique_ptr<InstrProfReader>> create(
       std::unique_ptr<MemoryBuffer> Buffer,
       const InstrProfCorrelator *Correlator = nullptr,
       const object::BuildIDFetcher *BIDFetcher = nullptr,
@@ -242,7 +243,7 @@ public:
 ///
 /// Each record consists of a function name, a function hash, a number of
 /// counters, and then each counter value, in that order.
-class TextInstrProfReader : public InstrProfReader {
+class LLVM_ABI TextInstrProfReader : public InstrProfReader {
 private:
   /// The profile data file contents.
   std::unique_ptr<MemoryBuffer> DataBuffer;
@@ -535,7 +536,7 @@ public:
   static StringRef GetInternalKey(StringRef K) { return K; }
   static StringRef GetExternalKey(StringRef K) { return K; }
 
-  hash_value_type ComputeHash(StringRef K);
+  LLVM_ABI hash_value_type ComputeHash(StringRef K);
 
   static std::pair<offset_type, offset_type>
   ReadKeyDataLength(const unsigned char *&D) {
@@ -552,9 +553,9 @@ public:
     return StringRef((const char *)D, N);
   }
 
-  bool readValueProfilingData(const unsigned char *&D,
+  LLVM_ABI bool readValueProfilingData(const unsigned char *&D,
                               const unsigned char *const End);
-  data_type ReadData(StringRef K, const unsigned char *D, offset_type N);
+  LLVM_ABI data_type ReadData(StringRef K, const unsigned char *D, offset_type N);
 
   // Used for testing purpose only.
   void setValueProfDataEndianness(llvm::endianness Endianness) {
@@ -718,22 +719,22 @@ private:
 public:
   IndexedMemProfReader() = default;
 
-  Error deserialize(const unsigned char *Start, uint64_t MemProfOffset);
+  LLVM_ABI Error deserialize(const unsigned char *Start, uint64_t MemProfOffset);
 
-  Expected<memprof::MemProfRecord>
+  LLVM_ABI Expected<memprof::MemProfRecord>
   getMemProfRecord(const uint64_t FuncNameHash) const;
 
-  DenseMap<uint64_t, SmallVector<memprof::CallEdgeTy, 0>>
+  LLVM_ABI DenseMap<uint64_t, SmallVector<memprof::CallEdgeTy, 0>>
   getMemProfCallerCalleePairs() const;
 
   // Return the entire MemProf profile.
-  memprof::AllMemProfData getAllMemProfData() const;
+  LLVM_ABI memprof::AllMemProfData getAllMemProfData() const;
 
   memprof::MemProfSummary *getSummary() const { return MemProfSum.get(); }
 };
 
 /// Reader for the indexed binary instrprof format.
-class IndexedInstrProfReader : public InstrProfReader {
+class LLVM_ABI IndexedInstrProfReader : public InstrProfReader {
 private:
   /// The profile data file contents.
   std::unique_ptr<MemoryBuffer> DataBuffer;

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_INSTRPROFWRITER_H
 #define LLVM_PROFILEDATA_INSTRPROFWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringMap.h"
@@ -94,7 +95,7 @@ public:
   // MemprofGenerateRandomHotness is enabled. The random seed can be either
   // provided by MemprofGenerateRandomHotnessSeed, or if that is 0, one will be
   // generated in the writer using the current time.
-  InstrProfWriter(bool Sparse = false,
+  LLVM_ABI InstrProfWriter(bool Sparse = false,
                   uint64_t TemporalProfTraceReservoirSize = 0,
                   uint64_t MaxTemporalProfTraceLength = 0,
                   bool WritePrevVersion = false,
@@ -104,14 +105,14 @@ public:
                   bool MemProfFullSchema = false,
                   bool MemprofGenerateRandomHotness = false,
                   unsigned MemprofGenerateRandomHotnessSeed = 0);
-  ~InstrProfWriter();
+  LLVM_ABI ~InstrProfWriter();
 
   StringMap<ProfilingData> &getProfileData() { return FunctionData; }
 
   /// Add function counts for the given function. If there are already counts
   /// for this function and the hash and number of counts match, each counter is
   /// summed. Optionally scale counts by \p Weight.
-  void addRecord(NamedInstrProfRecord &&I, uint64_t Weight,
+  LLVM_ABI void addRecord(NamedInstrProfRecord &&I, uint64_t Weight,
                  function_ref<void(Error)> Warn);
   void addRecord(NamedInstrProfRecord &&I, function_ref<void(Error)> Warn) {
     addRecord(std::move(I), 1, Warn);
@@ -120,45 +121,45 @@ public:
 
   /// Add \p SrcTraces using reservoir sampling where \p SrcStreamSize is the
   /// total number of temporal profiling traces the source has seen.
-  void addTemporalProfileTraces(SmallVectorImpl<TemporalProfTraceTy> &SrcTraces,
+  LLVM_ABI void addTemporalProfileTraces(SmallVectorImpl<TemporalProfTraceTy> &SrcTraces,
                                 uint64_t SrcStreamSize);
 
   /// Add the entire MemProfData \p Incoming to the writer context.
-  bool addMemProfData(memprof::IndexedMemProfData Incoming,
+  LLVM_ABI bool addMemProfData(memprof::IndexedMemProfData Incoming,
                       function_ref<void(Error)> Warn);
 
   // Add a binary id to the binary ids list.
-  void addBinaryIds(ArrayRef<llvm::object::BuildID> BIs);
+  LLVM_ABI void addBinaryIds(ArrayRef<llvm::object::BuildID> BIs);
 
-  void addDataAccessProfData(
+  LLVM_ABI void addDataAccessProfData(
       std::unique_ptr<memprof::DataAccessProfData> DataAccessProfile);
 
   /// Merge existing function counts from the given writer.
-  void mergeRecordsFromWriter(InstrProfWriter &&IPW,
+  LLVM_ABI void mergeRecordsFromWriter(InstrProfWriter &&IPW,
                               function_ref<void(Error)> Warn);
 
   /// Write the profile to \c OS
-  Error write(raw_fd_ostream &OS);
+  LLVM_ABI Error write(raw_fd_ostream &OS);
 
   /// Write the profile to a string output stream \c OS
-  Error write(raw_string_ostream &OS);
+  LLVM_ABI Error write(raw_string_ostream &OS);
 
   /// Write the profile in text format to \c OS
-  Error writeText(raw_fd_ostream &OS);
+  LLVM_ABI Error writeText(raw_fd_ostream &OS);
 
   /// Write temporal profile trace data to the header in text format to \c OS
-  void writeTextTemporalProfTraceData(raw_fd_ostream &OS,
+  LLVM_ABI void writeTextTemporalProfTraceData(raw_fd_ostream &OS,
                                       InstrProfSymtab &Symtab);
 
-  Error validateRecord(const InstrProfRecord &Func);
+  LLVM_ABI Error validateRecord(const InstrProfRecord &Func);
 
   /// Write \c Record in text format to \c OS
-  static void writeRecordInText(StringRef Name, uint64_t Hash,
+  LLVM_ABI static void writeRecordInText(StringRef Name, uint64_t Hash,
                                 const InstrProfRecord &Counters,
                                 InstrProfSymtab &Symtab, raw_fd_ostream &OS);
 
   /// Write the profile, returning the raw data. For testing.
-  std::unique_ptr<MemoryBuffer> writeBuffer();
+  LLVM_ABI std::unique_ptr<MemoryBuffer> writeBuffer();
 
   /// Update the attributes of the current profile from the attributes
   /// specified. An error is returned if IR and FE profiles are mixed.
@@ -206,15 +207,15 @@ public:
   }
 
   // Internal interfaces for testing purpose only.
-  void setValueProfDataEndianness(llvm::endianness Endianness);
-  void setOutputSparse(bool Sparse);
+  LLVM_ABI void setValueProfDataEndianness(llvm::endianness Endianness);
+  LLVM_ABI void setOutputSparse(bool Sparse);
   void setMemProfVersionRequested(memprof::IndexedVersion Version) {
     MemProfVersionRequested = Version;
   }
   void setMemProfFullSchema(bool Full) { MemProfFullSchema = Full; }
   // Compute the overlap b/w this object and Other. Program level result is
   // stored in Overlap and function level result is stored in FuncLevelOverlap.
-  void overlapRecord(NamedInstrProfRecord &&Other, OverlapStats &Overlap,
+  LLVM_ABI void overlapRecord(NamedInstrProfRecord &&Other, OverlapStats &Overlap,
                      OverlapStats &FuncLevelOverlap,
                      const OverlapFuncFilters &FuncFilter);
 

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_PROFILEDATA_INSTRPROFWRITER_H
 #define LLVM_PROFILEDATA_INSTRPROFWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringMap.h"
@@ -24,6 +23,7 @@
 #include "llvm/ProfileData/IndexedMemProfData.h"
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/ProfileData/MemProfSummaryBuilder.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <memory>
@@ -96,15 +96,15 @@ public:
   // provided by MemprofGenerateRandomHotnessSeed, or if that is 0, one will be
   // generated in the writer using the current time.
   LLVM_ABI InstrProfWriter(bool Sparse = false,
-                  uint64_t TemporalProfTraceReservoirSize = 0,
-                  uint64_t MaxTemporalProfTraceLength = 0,
-                  bool WritePrevVersion = false,
-                  memprof::IndexedVersion MemProfVersionRequested =
-                      static_cast<memprof::IndexedVersion>(
-                          memprof::MinimumSupportedVersion),
-                  bool MemProfFullSchema = false,
-                  bool MemprofGenerateRandomHotness = false,
-                  unsigned MemprofGenerateRandomHotnessSeed = 0);
+                           uint64_t TemporalProfTraceReservoirSize = 0,
+                           uint64_t MaxTemporalProfTraceLength = 0,
+                           bool WritePrevVersion = false,
+                           memprof::IndexedVersion MemProfVersionRequested =
+                               static_cast<memprof::IndexedVersion>(
+                                   memprof::MinimumSupportedVersion),
+                           bool MemProfFullSchema = false,
+                           bool MemprofGenerateRandomHotness = false,
+                           unsigned MemprofGenerateRandomHotnessSeed = 0);
   LLVM_ABI ~InstrProfWriter();
 
   StringMap<ProfilingData> &getProfileData() { return FunctionData; }
@@ -113,7 +113,7 @@ public:
   /// for this function and the hash and number of counts match, each counter is
   /// summed. Optionally scale counts by \p Weight.
   LLVM_ABI void addRecord(NamedInstrProfRecord &&I, uint64_t Weight,
-                 function_ref<void(Error)> Warn);
+                          function_ref<void(Error)> Warn);
   void addRecord(NamedInstrProfRecord &&I, function_ref<void(Error)> Warn) {
     addRecord(std::move(I), 1, Warn);
   }
@@ -121,12 +121,13 @@ public:
 
   /// Add \p SrcTraces using reservoir sampling where \p SrcStreamSize is the
   /// total number of temporal profiling traces the source has seen.
-  LLVM_ABI void addTemporalProfileTraces(SmallVectorImpl<TemporalProfTraceTy> &SrcTraces,
-                                uint64_t SrcStreamSize);
+  LLVM_ABI void
+  addTemporalProfileTraces(SmallVectorImpl<TemporalProfTraceTy> &SrcTraces,
+                           uint64_t SrcStreamSize);
 
   /// Add the entire MemProfData \p Incoming to the writer context.
   LLVM_ABI bool addMemProfData(memprof::IndexedMemProfData Incoming,
-                      function_ref<void(Error)> Warn);
+                               function_ref<void(Error)> Warn);
 
   // Add a binary id to the binary ids list.
   LLVM_ABI void addBinaryIds(ArrayRef<llvm::object::BuildID> BIs);
@@ -136,7 +137,7 @@ public:
 
   /// Merge existing function counts from the given writer.
   LLVM_ABI void mergeRecordsFromWriter(InstrProfWriter &&IPW,
-                              function_ref<void(Error)> Warn);
+                                       function_ref<void(Error)> Warn);
 
   /// Write the profile to \c OS
   LLVM_ABI Error write(raw_fd_ostream &OS);
@@ -149,14 +150,15 @@ public:
 
   /// Write temporal profile trace data to the header in text format to \c OS
   LLVM_ABI void writeTextTemporalProfTraceData(raw_fd_ostream &OS,
-                                      InstrProfSymtab &Symtab);
+                                               InstrProfSymtab &Symtab);
 
   LLVM_ABI Error validateRecord(const InstrProfRecord &Func);
 
   /// Write \c Record in text format to \c OS
   LLVM_ABI static void writeRecordInText(StringRef Name, uint64_t Hash,
-                                const InstrProfRecord &Counters,
-                                InstrProfSymtab &Symtab, raw_fd_ostream &OS);
+                                         const InstrProfRecord &Counters,
+                                         InstrProfSymtab &Symtab,
+                                         raw_fd_ostream &OS);
 
   /// Write the profile, returning the raw data. For testing.
   LLVM_ABI std::unique_ptr<MemoryBuffer> writeBuffer();
@@ -215,9 +217,10 @@ public:
   void setMemProfFullSchema(bool Full) { MemProfFullSchema = Full; }
   // Compute the overlap b/w this object and Other. Program level result is
   // stored in Overlap and function level result is stored in FuncLevelOverlap.
-  LLVM_ABI void overlapRecord(NamedInstrProfRecord &&Other, OverlapStats &Overlap,
-                     OverlapStats &FuncLevelOverlap,
-                     const OverlapFuncFilters &FuncFilter);
+  LLVM_ABI void overlapRecord(NamedInstrProfRecord &&Other,
+                              OverlapStats &Overlap,
+                              OverlapStats &FuncLevelOverlap,
+                              const OverlapFuncFilters &FuncFilter);
 
 private:
   void addRecord(StringRef Name, uint64_t Hash, InstrProfRecord &&I,

--- a/llvm/include/llvm/ProfileData/ItaniumManglingCanonicalizer.h
+++ b/llvm/include/llvm/ProfileData/ItaniumManglingCanonicalizer.h
@@ -67,7 +67,7 @@ public:
   /// Add an equivalence between \p First and \p Second. Both manglings must
   /// live at least as long as the canonicalizer.
   LLVM_ABI EquivalenceError addEquivalence(FragmentKind Kind, StringRef First,
-                                  StringRef Second);
+                                           StringRef Second);
 
   using Key = uintptr_t;
 

--- a/llvm/include/llvm/ProfileData/ItaniumManglingCanonicalizer.h
+++ b/llvm/include/llvm/ProfileData/ItaniumManglingCanonicalizer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_ITANIUMMANGLINGCANONICALIZER_H
 #define LLVM_PROFILEDATA_ITANIUMMANGLINGCANONICALIZER_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -34,10 +35,10 @@ class StringRef;
 /// different manglings.
 class ItaniumManglingCanonicalizer {
 public:
-  ItaniumManglingCanonicalizer();
+  LLVM_ABI ItaniumManglingCanonicalizer();
   ItaniumManglingCanonicalizer(const ItaniumManglingCanonicalizer &) = delete;
   void operator=(const ItaniumManglingCanonicalizer &) = delete;
-  ~ItaniumManglingCanonicalizer();
+  LLVM_ABI ~ItaniumManglingCanonicalizer();
 
   enum class EquivalenceError {
     Success,
@@ -65,7 +66,7 @@ public:
 
   /// Add an equivalence between \p First and \p Second. Both manglings must
   /// live at least as long as the canonicalizer.
-  EquivalenceError addEquivalence(FragmentKind Kind, StringRef First,
+  LLVM_ABI EquivalenceError addEquivalence(FragmentKind Kind, StringRef First,
                                   StringRef Second);
 
   using Key = uintptr_t;
@@ -78,11 +79,11 @@ public:
   /// ABI mangling.
   ///
   /// The string denoted by Mangling must live as long as the canonicalizer.
-  Key canonicalize(StringRef Mangling);
+  LLVM_ABI Key canonicalize(StringRef Mangling);
 
   /// Find a canonical key for the specified mangling, if one has already been
   /// formed. Otherwise returns Key().
-  Key lookup(StringRef Mangling);
+  LLVM_ABI Key lookup(StringRef Mangling);
 
 private:
   struct Impl;

--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_MEMPROF_H
 #define LLVM_PROFILEDATA_MEMPROF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLForwardCompat.h"
@@ -79,10 +80,10 @@ enum class Meta : uint64_t {
 using MemProfSchema = llvm::SmallVector<Meta, static_cast<int>(Meta::Size)>;
 
 // Returns the full schema currently in use.
-MemProfSchema getFullSchema();
+LLVM_ABI MemProfSchema getFullSchema();
 
 // Returns the schema consisting of the fields used for hot cold memory hinting.
-MemProfSchema getHotColdSchema();
+LLVM_ABI MemProfSchema getHotColdSchema();
 
 // Holds the actual MemInfoBlock data with all fields. Contents may be read or
 // written partially by providing an appropriate schema to the serialize and
@@ -396,7 +397,7 @@ struct IndexedAllocationInfo {
       : CSId(CSId), Info(MB) {}
 
   // Returns the size in bytes when this allocation info struct is serialized.
-  size_t serializedSize(const MemProfSchema &Schema,
+  LLVM_ABI size_t serializedSize(const MemProfSchema &Schema,
                         IndexedVersion Version) const;
 
   bool operator==(const IndexedAllocationInfo &Other) const {
@@ -457,7 +458,7 @@ struct IndexedMemProfRecord {
     AllocSites.append(Other.AllocSites);
   }
 
-  size_t serializedSize(const MemProfSchema &Schema,
+  LLVM_ABI size_t serializedSize(const MemProfSchema &Schema,
                         IndexedVersion Version) const;
 
   bool operator==(const IndexedMemProfRecord &Other) const {
@@ -471,26 +472,26 @@ struct IndexedMemProfRecord {
 
   // Serializes the memprof records in \p Records to the ostream \p OS based
   // on the schema provided in \p Schema.
-  void serialize(const MemProfSchema &Schema, raw_ostream &OS,
+  LLVM_ABI void serialize(const MemProfSchema &Schema, raw_ostream &OS,
                  IndexedVersion Version,
                  llvm::DenseMap<CallStackId, LinearCallStackId>
                      *MemProfCallStackIndexes = nullptr) const;
 
   // Deserializes memprof records from the Buffer.
-  static IndexedMemProfRecord deserialize(const MemProfSchema &Schema,
+  LLVM_ABI static IndexedMemProfRecord deserialize(const MemProfSchema &Schema,
                                           const unsigned char *Buffer,
                                           IndexedVersion Version);
 
   // Convert IndexedMemProfRecord to MemProfRecord.  Callback is used to
   // translate CallStackId to call stacks with frames inline.
-  MemProfRecord toMemProfRecord(
+  LLVM_ABI MemProfRecord toMemProfRecord(
       llvm::function_ref<std::vector<Frame>(const CallStackId)> Callback) const;
 };
 
 // Returns the GUID for the function name after canonicalization. For
 // memprof, we remove any .llvm suffix added by LTO. MemProfRecords are
 // mapped to functions using this GUID.
-GlobalValue::GUID getGUID(const StringRef FunctionName);
+LLVM_ABI GlobalValue::GUID getGUID(const StringRef FunctionName);
 
 // Holds call site information with frame contents inline.
 struct CallSiteInfo {
@@ -551,7 +552,7 @@ struct MemProfRecord {
 // ids in the schema. Subsequent entries are integers which map to memprof::Meta
 // enum class entries. After successfully reading the schema, the pointer is one
 // byte past the schema contents.
-Expected<MemProfSchema> readMemProfSchema(const unsigned char *&Buffer);
+LLVM_ABI Expected<MemProfSchema> readMemProfSchema(const unsigned char *&Buffer);
 
 // Trait for reading IndexedMemProfRecord data from the on-disk hash table.
 class RecordLookupTrait {

--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_PROFILEDATA_MEMPROF_H
 #define LLVM_PROFILEDATA_MEMPROF_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLForwardCompat.h"
@@ -24,6 +23,7 @@
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/ProfileData/MemProfData.inc"
 #include "llvm/Support/BLAKE3.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/HashBuilder.h"
@@ -398,7 +398,7 @@ struct IndexedAllocationInfo {
 
   // Returns the size in bytes when this allocation info struct is serialized.
   LLVM_ABI size_t serializedSize(const MemProfSchema &Schema,
-                        IndexedVersion Version) const;
+                                 IndexedVersion Version) const;
 
   bool operator==(const IndexedAllocationInfo &Other) const {
     if (Other.Info != Info)
@@ -459,7 +459,7 @@ struct IndexedMemProfRecord {
   }
 
   LLVM_ABI size_t serializedSize(const MemProfSchema &Schema,
-                        IndexedVersion Version) const;
+                                 IndexedVersion Version) const;
 
   bool operator==(const IndexedMemProfRecord &Other) const {
     if (Other.AllocSites != AllocSites)
@@ -473,14 +473,14 @@ struct IndexedMemProfRecord {
   // Serializes the memprof records in \p Records to the ostream \p OS based
   // on the schema provided in \p Schema.
   LLVM_ABI void serialize(const MemProfSchema &Schema, raw_ostream &OS,
-                 IndexedVersion Version,
-                 llvm::DenseMap<CallStackId, LinearCallStackId>
-                     *MemProfCallStackIndexes = nullptr) const;
+                          IndexedVersion Version,
+                          llvm::DenseMap<CallStackId, LinearCallStackId>
+                              *MemProfCallStackIndexes = nullptr) const;
 
   // Deserializes memprof records from the Buffer.
   LLVM_ABI static IndexedMemProfRecord deserialize(const MemProfSchema &Schema,
-                                          const unsigned char *Buffer,
-                                          IndexedVersion Version);
+                                                   const unsigned char *Buffer,
+                                                   IndexedVersion Version);
 
   // Convert IndexedMemProfRecord to MemProfRecord.  Callback is used to
   // translate CallStackId to call stacks with frames inline.
@@ -552,7 +552,8 @@ struct MemProfRecord {
 // ids in the schema. Subsequent entries are integers which map to memprof::Meta
 // enum class entries. After successfully reading the schema, the pointer is one
 // byte past the schema contents.
-LLVM_ABI Expected<MemProfSchema> readMemProfSchema(const unsigned char *&Buffer);
+LLVM_ABI Expected<MemProfSchema>
+readMemProfSchema(const unsigned char *&Buffer);
 
 // Trait for reading IndexedMemProfRecord data from the on-disk hash table.
 class RecordLookupTrait {

--- a/llvm/include/llvm/ProfileData/MemProfCommon.h
+++ b/llvm/include/llvm/ProfileData/MemProfCommon.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFCOMMON_H
 #define LLVM_PROFILEDATA_MEMPROFCOMMON_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace memprof {
@@ -23,7 +23,8 @@ struct Frame;
 
 /// Return the allocation type for a given set of memory profile values.
 LLVM_ABI AllocationType getAllocType(uint64_t TotalLifetimeAccessDensity,
-                            uint64_t AllocCount, uint64_t TotalLifetime);
+                                     uint64_t AllocCount,
+                                     uint64_t TotalLifetime);
 
 /// Helper to generate a single hash id for a given callstack, used for emitting
 /// matching statistics and useful for uniquing such statistics across modules.

--- a/llvm/include/llvm/ProfileData/MemProfCommon.h
+++ b/llvm/include/llvm/ProfileData/MemProfCommon.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFCOMMON_H
 #define LLVM_PROFILEDATA_MEMPROFCOMMON_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 
 namespace llvm {
@@ -21,13 +22,13 @@ namespace memprof {
 struct Frame;
 
 /// Return the allocation type for a given set of memory profile values.
-AllocationType getAllocType(uint64_t TotalLifetimeAccessDensity,
+LLVM_ABI AllocationType getAllocType(uint64_t TotalLifetimeAccessDensity,
                             uint64_t AllocCount, uint64_t TotalLifetime);
 
 /// Helper to generate a single hash id for a given callstack, used for emitting
 /// matching statistics and useful for uniquing such statistics across modules.
 /// Also used to dedup contexts when computing the summary.
-uint64_t computeFullStackId(ArrayRef<Frame> CallStack);
+LLVM_ABI uint64_t computeFullStackId(ArrayRef<Frame> CallStack);
 
 } // namespace memprof
 } // namespace llvm

--- a/llvm/include/llvm/ProfileData/MemProfRadixTree.h
+++ b/llvm/include/llvm/ProfileData/MemProfRadixTree.h
@@ -357,7 +357,8 @@ public:
 
 // Defined in MemProfRadixTree.cpp
 extern template class LLVM_TEMPLATE_ABI CallStackRadixTreeBuilder<FrameId>;
-extern template class LLVM_TEMPLATE_ABI CallStackRadixTreeBuilder<LinearFrameId>;
+extern template class LLVM_TEMPLATE_ABI
+    CallStackRadixTreeBuilder<LinearFrameId>;
 
 } // namespace memprof
 } // namespace llvm

--- a/llvm/include/llvm/ProfileData/MemProfRadixTree.h
+++ b/llvm/include/llvm/ProfileData/MemProfRadixTree.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ProfileData/IndexedMemProfData.h"
 #include "llvm/ProfileData/MemProf.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace memprof {
@@ -353,6 +354,11 @@ public:
     return std::move(CallStackPos);
   }
 };
+
+// Defined in MemProfRadixTree.cpp
+extern template class LLVM_TEMPLATE_ABI CallStackRadixTreeBuilder<FrameId>;
+extern template class LLVM_TEMPLATE_ABI CallStackRadixTreeBuilder<LinearFrameId>;
+
 } // namespace memprof
 } // namespace llvm
 #endif // LLVM_PROFILEDATA_MEMPROFRADIXTREE_H

--- a/llvm/include/llvm/ProfileData/MemProfReader.h
+++ b/llvm/include/llvm/ProfileData/MemProfReader.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFREADER_H_
 #define LLVM_PROFILEDATA_MEMPROFREADER_H_
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -106,7 +107,7 @@ using CallStackMap = llvm::DenseMap<uint64_t, llvm::SmallVector<uint64_t>>;
 
 // Specializes the MemProfReader class to populate the contents from raw binary
 // memprof profiles from instrumentation based profiling.
-class RawMemProfReader final : public MemProfReader {
+class LLVM_ABI RawMemProfReader final : public MemProfReader {
 public:
   RawMemProfReader(const RawMemProfReader &) = delete;
   RawMemProfReader &operator=(const RawMemProfReader &) = delete;
@@ -217,18 +218,18 @@ public:
 
   // Return true if the \p DataBuffer starts with "---" indicating it is a YAML
   // file.
-  static bool hasFormat(const MemoryBuffer &DataBuffer);
+  LLVM_ABI static bool hasFormat(const MemoryBuffer &DataBuffer);
   // Wrapper around hasFormat above, reading the file instead of the memory
   // buffer.
-  static bool hasFormat(const StringRef Path);
+  LLVM_ABI static bool hasFormat(const StringRef Path);
 
   // Create a YAMLMemProfReader after sanity checking the contents of the file
   // at \p Path or the \p Buffer.
-  static Expected<std::unique_ptr<YAMLMemProfReader>> create(const Twine &Path);
-  static Expected<std::unique_ptr<YAMLMemProfReader>>
+  LLVM_ABI static Expected<std::unique_ptr<YAMLMemProfReader>> create(const Twine &Path);
+  LLVM_ABI static Expected<std::unique_ptr<YAMLMemProfReader>>
   create(std::unique_ptr<MemoryBuffer> Buffer);
 
-  void parse(StringRef YAMLData);
+  LLVM_ABI void parse(StringRef YAMLData);
 
   std::unique_ptr<memprof::DataAccessProfData> takeDataAccessProfData() {
     return std::move(DataAccessProfileData);

--- a/llvm/include/llvm/ProfileData/MemProfReader.h
+++ b/llvm/include/llvm/ProfileData/MemProfReader.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFREADER_H_
 #define LLVM_PROFILEDATA_MEMPROFREADER_H_
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -26,6 +25,7 @@
 #include "llvm/ProfileData/InstrProfReader.h"
 #include "llvm/ProfileData/MemProfData.inc"
 #include "llvm/ProfileData/MemProfRadixTree.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -225,7 +225,8 @@ public:
 
   // Create a YAMLMemProfReader after sanity checking the contents of the file
   // at \p Path or the \p Buffer.
-  LLVM_ABI static Expected<std::unique_ptr<YAMLMemProfReader>> create(const Twine &Path);
+  LLVM_ABI static Expected<std::unique_ptr<YAMLMemProfReader>>
+  create(const Twine &Path);
   LLVM_ABI static Expected<std::unique_ptr<YAMLMemProfReader>>
   create(std::unique_ptr<MemoryBuffer> Buffer);
 

--- a/llvm/include/llvm/ProfileData/MemProfSummary.h
+++ b/llvm/include/llvm/ProfileData/MemProfSummary.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFSUMMARY_H
 #define LLVM_PROFILEDATA_MEMPROFSUMMARY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ProfileData/InstrProf.h"
 
 namespace llvm {
@@ -46,11 +47,11 @@ public:
   uint64_t getMaxColdTotalSize() const { return MaxColdTotalSize; }
   uint64_t getMaxWarmTotalSize() const { return MaxWarmTotalSize; }
   uint64_t getMaxHotTotalSize() const { return MaxHotTotalSize; }
-  void printSummaryYaml(raw_ostream &OS) const;
+  LLVM_ABI void printSummaryYaml(raw_ostream &OS) const;
   /// Write to indexed MemProf profile.
-  void write(ProfOStream &OS) const;
+  LLVM_ABI void write(ProfOStream &OS) const;
   /// Read from indexed MemProf profile.
-  static std::unique_ptr<MemProfSummary> deserialize(const unsigned char *&);
+  LLVM_ABI static std::unique_ptr<MemProfSummary> deserialize(const unsigned char *&);
 };
 
 } // namespace memprof

--- a/llvm/include/llvm/ProfileData/MemProfSummary.h
+++ b/llvm/include/llvm/ProfileData/MemProfSummary.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFSUMMARY_H
 #define LLVM_PROFILEDATA_MEMPROFSUMMARY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ProfileData/InstrProf.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace memprof {
@@ -51,7 +51,8 @@ public:
   /// Write to indexed MemProf profile.
   LLVM_ABI void write(ProfOStream &OS) const;
   /// Read from indexed MemProf profile.
-  LLVM_ABI static std::unique_ptr<MemProfSummary> deserialize(const unsigned char *&);
+  LLVM_ABI static std::unique_ptr<MemProfSummary>
+  deserialize(const unsigned char *&);
 };
 
 } // namespace memprof

--- a/llvm/include/llvm/ProfileData/MemProfSummaryBuilder.h
+++ b/llvm/include/llvm/ProfileData/MemProfSummaryBuilder.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFSUMMARYBUILDER_H
 #define LLVM_PROFILEDATA_MEMPROFSUMMARYBUILDER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ProfileData/MemProf.h"
 #include "llvm/ProfileData/MemProfSummary.h"
 
@@ -40,9 +41,9 @@ public:
   MemProfSummaryBuilder() = default;
   ~MemProfSummaryBuilder() = default;
 
-  void addRecord(const IndexedMemProfRecord &);
-  void addRecord(const MemProfRecord &);
-  std::unique_ptr<MemProfSummary> getSummary();
+  LLVM_ABI void addRecord(const IndexedMemProfRecord &);
+  LLVM_ABI void addRecord(const MemProfRecord &);
+  LLVM_ABI std::unique_ptr<MemProfSummary> getSummary();
 };
 
 } // namespace memprof

--- a/llvm/include/llvm/ProfileData/MemProfSummaryBuilder.h
+++ b/llvm/include/llvm/ProfileData/MemProfSummaryBuilder.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFSUMMARYBUILDER_H
 #define LLVM_PROFILEDATA_MEMPROFSUMMARYBUILDER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ProfileData/MemProf.h"
 #include "llvm/ProfileData/MemProfSummary.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace memprof {

--- a/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
@@ -15,10 +15,10 @@
 #ifndef LLVM_PROFILEDATA_CTXINSTRPROFILEREADER_H
 #define LLVM_PROFILEDATA_CTXINSTRPROFILEREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Bitstream/BitstreamReader.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/ProfileData/PGOCtxProfWriter.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <map>
 
@@ -223,6 +223,7 @@ public:
   LLVM_ABI Expected<PGOCtxProfile> loadProfiles();
 };
 
-LLVM_ABI void convertCtxProfToYaml(raw_ostream &OS, const PGOCtxProfile &Profile);
+LLVM_ABI void convertCtxProfToYaml(raw_ostream &OS,
+                                   const PGOCtxProfile &Profile);
 } // namespace llvm
 #endif

--- a/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_PROFILEDATA_CTXINSTRPROFILEREADER_H
 #define LLVM_PROFILEDATA_CTXINSTRPROFILEREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Bitstream/BitstreamReader.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/ProfileData/PGOCtxProfWriter.h"
@@ -219,9 +220,9 @@ public:
       : Magic(Buffer.substr(0, PGOCtxProfileWriter::ContainerMagic.size())),
         Cursor(Buffer.substr(PGOCtxProfileWriter::ContainerMagic.size())) {}
 
-  Expected<PGOCtxProfile> loadProfiles();
+  LLVM_ABI Expected<PGOCtxProfile> loadProfiles();
 };
 
-void convertCtxProfToYaml(raw_ostream &OS, const PGOCtxProfile &Profile);
+LLVM_ABI void convertCtxProfToYaml(raw_ostream &OS, const PGOCtxProfile &Profile);
 } // namespace llvm
 #endif

--- a/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_PROFILEDATA_PGOCTXPROFWRITER_H_
 #define LLVM_PROFILEDATA_PGOCTXPROFWRITER_H_
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Bitstream/BitCodeEnums.h"
 #include "llvm/Bitstream/BitstreamWriter.h"
@@ -74,7 +75,7 @@ enum PGOCtxProfileBlockIDs {
 /// like value profiling - which would appear as additional records. For
 /// example, value profiling would produce a new record with a new record ID,
 /// containing the profiled values (much like the counters)
-class PGOCtxProfileWriter final : public ctx_profile::ProfileWriter {
+class LLVM_ABI PGOCtxProfileWriter final : public ctx_profile::ProfileWriter {
   enum class EmptyContextCriteria { None, EntryIsZero, AllAreZero };
 
   BitstreamWriter Writer;
@@ -111,6 +112,6 @@ public:
   static constexpr StringRef ContainerMagic = "CTXP";
 };
 
-Error createCtxProfFromYAML(StringRef Profile, raw_ostream &Out);
+LLVM_ABI Error createCtxProfFromYAML(StringRef Profile, raw_ostream &Out);
 } // namespace llvm
 #endif

--- a/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
@@ -13,11 +13,11 @@
 #ifndef LLVM_PROFILEDATA_PGOCTXPROFWRITER_H_
 #define LLVM_PROFILEDATA_PGOCTXPROFWRITER_H_
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Bitstream/BitCodeEnums.h"
 #include "llvm/Bitstream/BitstreamWriter.h"
 #include "llvm/ProfileData/CtxInstrContextNode.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 enum PGOCtxProfileRecords {

--- a/llvm/include/llvm/ProfileData/ProfileCommon.h
+++ b/llvm/include/llvm/ProfileData/ProfileCommon.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_PROFILEDATA_PROFILECOMMON_H
 #define LLVM_PROFILEDATA_PROFILECOMMON_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/ProfileSummary.h"
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/ProfileData/SampleProf.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <algorithm>
 #include <cstdint>
@@ -97,7 +97,7 @@ public:
       : ProfileSummaryBuilder(std::move(Cutoffs)) {}
 
   LLVM_ABI void addRecord(const sampleprof::FunctionSamples &FS,
-                 bool isCallsiteSample = false);
+                          bool isCallsiteSample = false);
   LLVM_ABI std::unique_ptr<ProfileSummary>
   computeSummaryForProfiles(const sampleprof::SampleProfileMap &Profiles);
   LLVM_ABI std::unique_ptr<ProfileSummary> getSummary();

--- a/llvm/include/llvm/ProfileData/ProfileCommon.h
+++ b/llvm/include/llvm/ProfileData/ProfileCommon.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_PROFILECOMMON_H
 #define LLVM_PROFILEDATA_PROFILECOMMON_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/ProfileSummary.h"
 #include "llvm/ProfileData/InstrProf.h"
@@ -28,13 +29,13 @@
 
 namespace llvm {
 
-extern cl::opt<bool> UseContextLessSummary;
-extern cl::opt<int> ProfileSummaryCutoffHot;
-extern cl::opt<int> ProfileSummaryCutoffCold;
-extern cl::opt<unsigned> ProfileSummaryHugeWorkingSetSizeThreshold;
-extern cl::opt<unsigned> ProfileSummaryLargeWorkingSetSizeThreshold;
-extern cl::opt<uint64_t> ProfileSummaryHotCount;
-extern cl::opt<uint64_t> ProfileSummaryColdCount;
+LLVM_ABI extern cl::opt<bool> UseContextLessSummary;
+LLVM_ABI extern cl::opt<int> ProfileSummaryCutoffHot;
+LLVM_ABI extern cl::opt<int> ProfileSummaryCutoffCold;
+LLVM_ABI extern cl::opt<unsigned> ProfileSummaryHugeWorkingSetSizeThreshold;
+LLVM_ABI extern cl::opt<unsigned> ProfileSummaryLargeWorkingSetSizeThreshold;
+LLVM_ABI extern cl::opt<uint64_t> ProfileSummaryHotCount;
+LLVM_ABI extern cl::opt<uint64_t> ProfileSummaryColdCount;
 
 namespace sampleprof {
 
@@ -63,17 +64,17 @@ protected:
   ~ProfileSummaryBuilder() = default;
 
   inline void addCount(uint64_t Count);
-  void computeDetailedSummary();
+  LLVM_ABI void computeDetailedSummary();
 
 public:
   /// A vector of useful cutoff values for detailed summary.
-  static const ArrayRef<uint32_t> DefaultCutoffs;
+  LLVM_ABI static const ArrayRef<uint32_t> DefaultCutoffs;
 
   /// Find the summary entry for a desired percentile of counts.
-  static const ProfileSummaryEntry &
+  LLVM_ABI static const ProfileSummaryEntry &
   getEntryForPercentile(const SummaryEntryVector &DS, uint64_t Percentile);
-  static uint64_t getHotCountThreshold(const SummaryEntryVector &DS);
-  static uint64_t getColdCountThreshold(const SummaryEntryVector &DS);
+  LLVM_ABI static uint64_t getHotCountThreshold(const SummaryEntryVector &DS);
+  LLVM_ABI static uint64_t getColdCountThreshold(const SummaryEntryVector &DS);
 };
 
 class InstrProfSummaryBuilder final : public ProfileSummaryBuilder {
@@ -83,11 +84,11 @@ public:
   InstrProfSummaryBuilder(std::vector<uint32_t> Cutoffs)
       : ProfileSummaryBuilder(std::move(Cutoffs)) {}
 
-  void addEntryCount(uint64_t Count);
-  void addInternalCount(uint64_t Count);
+  LLVM_ABI void addEntryCount(uint64_t Count);
+  LLVM_ABI void addInternalCount(uint64_t Count);
 
-  void addRecord(const InstrProfRecord &);
-  std::unique_ptr<ProfileSummary> getSummary();
+  LLVM_ABI void addRecord(const InstrProfRecord &);
+  LLVM_ABI std::unique_ptr<ProfileSummary> getSummary();
 };
 
 class SampleProfileSummaryBuilder final : public ProfileSummaryBuilder {
@@ -95,11 +96,11 @@ public:
   SampleProfileSummaryBuilder(std::vector<uint32_t> Cutoffs)
       : ProfileSummaryBuilder(std::move(Cutoffs)) {}
 
-  void addRecord(const sampleprof::FunctionSamples &FS,
+  LLVM_ABI void addRecord(const sampleprof::FunctionSamples &FS,
                  bool isCallsiteSample = false);
-  std::unique_ptr<ProfileSummary>
+  LLVM_ABI std::unique_ptr<ProfileSummary>
   computeSummaryForProfiles(const sampleprof::SampleProfileMap &Profiles);
-  std::unique_ptr<ProfileSummary> getSummary();
+  LLVM_ABI std::unique_ptr<ProfileSummary> getSummary();
 };
 
 /// This is called when a count is seen in the profile.

--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_PROFILEDATA_SAMPLEPROF_H
 #define LLVM_PROFILEDATA_SAMPLEPROF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -43,7 +44,7 @@ namespace llvm {
 class DILocation;
 class raw_ostream;
 
-const std::error_category &sampleprof_category();
+LLVM_ABI const std::error_category &sampleprof_category();
 
 enum class sampleprof_error {
   success = 0,
@@ -281,11 +282,11 @@ static inline bool hasSecFlag(const SecHdrTableEntry &Entry, SecFlagType Flag) {
 struct LineLocation {
   LineLocation(uint32_t L, uint32_t D) : LineOffset(L), Discriminator(D) {}
 
-  void print(raw_ostream &OS) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &OS) const;
+  LLVM_ABI void dump() const;
 
   // Serialize the line location to the output stream using ULEB128 encoding.
-  void serialize(raw_ostream &OS);
+  LLVM_ABI void serialize(raw_ostream &OS);
 
   bool operator<(const LineLocation &O) const {
     return LineOffset < O.LineOffset ||
@@ -314,7 +315,7 @@ struct LineLocationHash {
   }
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const LineLocation &Loc);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const LineLocation &Loc);
 
 /// Representation of a single sample record.
 ///
@@ -428,12 +429,12 @@ public:
 
   /// Merge the samples in \p Other into this record.
   /// Optionally scale sample counts by \p Weight.
-  sampleprof_error merge(const SampleRecord &Other, uint64_t Weight = 1);
-  void print(raw_ostream &OS, unsigned Indent) const;
-  void dump() const;
+  LLVM_ABI sampleprof_error merge(const SampleRecord &Other, uint64_t Weight = 1);
+  LLVM_ABI void print(raw_ostream &OS, unsigned Indent) const;
+  LLVM_ABI void dump() const;
   /// Serialize the sample record to the output stream using ULEB128 encoding.
   /// The \p NameTable is used to map function names to their IDs.
-  std::error_code
+  LLVM_ABI std::error_code
   serialize(raw_ostream &OS,
             const MapVector<FunctionId, uint32_t> &NameTable) const;
 
@@ -450,7 +451,7 @@ private:
   CallTargetMap CallTargets;
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const SampleRecord &Sample);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const SampleRecord &Sample);
 
 // State of context associated with FunctionSamples
 enum ContextStateMask {
@@ -755,8 +756,8 @@ class FunctionSamples {
 public:
   FunctionSamples() = default;
 
-  void print(raw_ostream &OS = dbgs(), unsigned Indent = 0) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &OS = dbgs(), unsigned Indent = 0) const;
+  LLVM_ABI void dump() const;
 
   sampleprof_error addTotalSamples(uint64_t Num, uint64_t Weight = 1) {
     bool Overflowed;
@@ -931,7 +932,7 @@ public:
   /// \p Loc with the maximum total sample count. If \p Remapper or \p
   /// FuncNameToProfNameMap is not nullptr, use them to find FunctionSamples
   /// with equivalent name as \p CalleeName.
-  const FunctionSamples *findFunctionSamplesAt(
+  LLVM_ABI const FunctionSamples *findFunctionSamplesAt(
       const LineLocation &Loc, StringRef CalleeName,
       SampleProfileReaderItaniumRemapper *Remapper,
       const HashKeyMap<std::unordered_map, FunctionId, FunctionId>
@@ -1156,13 +1157,13 @@ public:
 
   /// Returns the line offset to the start line of the subprogram.
   /// We assume that a single function will not exceed 65535 LOC.
-  static unsigned getOffset(const DILocation *DIL);
+  LLVM_ABI static unsigned getOffset(const DILocation *DIL);
 
   /// Returns a unique call site identifier for a given debug location of a call
   /// instruction. This is wrapper of two scenarios, the probe-based profile and
   /// regular profile, to hide implementation details from the sample loader and
   /// the context tracker.
-  static LineLocation getCallSiteIdentifier(const DILocation *DIL,
+  LLVM_ABI static LineLocation getCallSiteIdentifier(const DILocation *DIL,
                                             bool ProfileIsFS = false);
 
   /// Returns a unique hash code for a combination of a callsite location and
@@ -1186,30 +1187,30 @@ public:
   /// If \p Remapper or \p FuncNameToProfNameMap is not nullptr, it will be used
   /// to find matching FunctionSamples with not exactly the same but equivalent
   /// name.
-  const FunctionSamples *findFunctionSamples(
+  LLVM_ABI const FunctionSamples *findFunctionSamples(
       const DILocation *DIL,
       SampleProfileReaderItaniumRemapper *Remapper = nullptr,
       const HashKeyMap<std::unordered_map, FunctionId, FunctionId>
           *FuncNameToProfNameMap = nullptr) const;
 
-  static bool ProfileIsProbeBased;
+  LLVM_ABI static bool ProfileIsProbeBased;
 
-  static bool ProfileIsCS;
+  LLVM_ABI static bool ProfileIsCS;
 
-  static bool ProfileIsPreInlined;
+  LLVM_ABI static bool ProfileIsPreInlined;
 
   SampleContext &getContext() const { return Context; }
 
   void setContext(const SampleContext &FContext) { Context = FContext; }
 
   /// Whether the profile uses MD5 to represent string.
-  static bool UseMD5;
+  LLVM_ABI static bool UseMD5;
 
   /// Whether the profile contains any ".__uniq." suffix in a name.
-  static bool HasUniqSuffix;
+  LLVM_ABI static bool HasUniqSuffix;
 
   /// If this profile uses flow sensitive discriminators.
-  static bool ProfileIsFS;
+  LLVM_ABI static bool ProfileIsFS;
 
   /// GUIDToFuncNameMap saves the mapping from GUID to the symbol name, for
   /// all the function symbols defined or declared in current module.
@@ -1223,7 +1224,7 @@ public:
 
   // Find all the names in the current FunctionSamples including names in
   // all the inline instances and names of call targets.
-  void findAllNames(DenseSet<FunctionId> &NameSet) const;
+  LLVM_ABI void findAllNames(DenseSet<FunctionId> &NameSet) const;
 
   bool operator==(const FunctionSamples &Other) const {
     return (GUIDToFuncNameMap == Other.GUIDToFuncNameMap ||
@@ -1311,7 +1312,7 @@ static inline FunctionId getRepInFormat(StringRef Name) {
   return FunctionId(Function::getGUIDAssumingExternalLinkage(Name));
 }
 
-raw_ostream &operator<<(raw_ostream &OS, const FunctionSamples &FS);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const FunctionSamples &FS);
 
 /// This class provides operator overloads to the map container using MD5 as the
 /// key type, so that existing code can still work in most cases using
@@ -1352,7 +1353,7 @@ public:
 
 using NameFunctionSamples = std::pair<hash_code, const FunctionSamples *>;
 
-void sortFuncProfiles(const SampleProfileMap &ProfileMap,
+LLVM_ABI void sortFuncProfiles(const SampleProfileMap &ProfileMap,
                       std::vector<NameFunctionSamples> &SortedProfiles);
 
 /// Sort a LocationT->SampleT map by LocationT.
@@ -1391,7 +1392,7 @@ public:
   // mainly to honor the preinliner decsion. Note that when MergeColdContext is
   // true, preinliner decsion is not honored anyway so TrimBaseProfileOnly will
   // be ignored.
-  void trimAndMergeColdContextProfiles(uint64_t ColdCountThreshold,
+  LLVM_ABI void trimAndMergeColdContextProfiles(uint64_t ColdCountThreshold,
                                        bool TrimColdContext,
                                        bool MergeColdContext,
                                        uint32_t ColdContextFrameLength,
@@ -1407,10 +1408,10 @@ private:
 /// nested profile to flatten profile conversion, etc.
 class ProfileConverter {
 public:
-  ProfileConverter(SampleProfileMap &Profiles);
+  LLVM_ABI ProfileConverter(SampleProfileMap &Profiles);
   // Convert a full context-sensitive flat sample profile into a nested sample
   // profile.
-  void convertCSProfiles();
+  LLVM_ABI void convertCSProfiles();
   struct FrameNode {
     FrameNode(FunctionId FName = FunctionId(),
               FunctionSamples *FSamples = nullptr,
@@ -1426,7 +1427,7 @@ public:
     // Callsite location in parent context
     LineLocation CallSiteLoc;
 
-    FrameNode *getOrCreateChildFrame(const LineLocation &CallSite,
+    LLVM_ABI FrameNode *getOrCreateChildFrame(const LineLocation &CallSite,
                                      FunctionId CalleeName);
   };
 
@@ -1543,9 +1544,9 @@ public:
   void setToCompress(bool TC) { ToCompress = TC; }
   bool toCompress() { return ToCompress; }
 
-  std::error_code read(const uint8_t *Data, uint64_t ListSize);
-  std::error_code write(raw_ostream &OS);
-  void dump(raw_ostream &OS = dbgs()) const;
+  LLVM_ABI std::error_code read(const uint8_t *Data, uint64_t ListSize);
+  LLVM_ABI std::error_code write(raw_ostream &OS);
+  LLVM_ABI void dump(raw_ostream &OS = dbgs()) const;
 
 private:
   // Determine whether or not to compress the symbol list when

--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_PROFILEDATA_SAMPLEPROF_H
 #define LLVM_PROFILEDATA_SAMPLEPROF_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -25,6 +24,7 @@
 #include "llvm/ProfileData/FunctionId.h"
 #include "llvm/ProfileData/HashKeyMap.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/MathExtras.h"
@@ -429,7 +429,8 @@ public:
 
   /// Merge the samples in \p Other into this record.
   /// Optionally scale sample counts by \p Weight.
-  LLVM_ABI sampleprof_error merge(const SampleRecord &Other, uint64_t Weight = 1);
+  LLVM_ABI sampleprof_error merge(const SampleRecord &Other,
+                                  uint64_t Weight = 1);
   LLVM_ABI void print(raw_ostream &OS, unsigned Indent) const;
   LLVM_ABI void dump() const;
   /// Serialize the sample record to the output stream using ULEB128 encoding.
@@ -1164,7 +1165,7 @@ public:
   /// regular profile, to hide implementation details from the sample loader and
   /// the context tracker.
   LLVM_ABI static LineLocation getCallSiteIdentifier(const DILocation *DIL,
-                                            bool ProfileIsFS = false);
+                                                     bool ProfileIsFS = false);
 
   /// Returns a unique hash code for a combination of a callsite location and
   /// the callee function name.
@@ -1353,8 +1354,9 @@ public:
 
 using NameFunctionSamples = std::pair<hash_code, const FunctionSamples *>;
 
-LLVM_ABI void sortFuncProfiles(const SampleProfileMap &ProfileMap,
-                      std::vector<NameFunctionSamples> &SortedProfiles);
+LLVM_ABI void
+sortFuncProfiles(const SampleProfileMap &ProfileMap,
+                 std::vector<NameFunctionSamples> &SortedProfiles);
 
 /// Sort a LocationT->SampleT map by LocationT.
 ///
@@ -1393,10 +1395,10 @@ public:
   // true, preinliner decsion is not honored anyway so TrimBaseProfileOnly will
   // be ignored.
   LLVM_ABI void trimAndMergeColdContextProfiles(uint64_t ColdCountThreshold,
-                                       bool TrimColdContext,
-                                       bool MergeColdContext,
-                                       uint32_t ColdContextFrameLength,
-                                       bool TrimBaseProfileOnly);
+                                                bool TrimColdContext,
+                                                bool MergeColdContext,
+                                                uint32_t ColdContextFrameLength,
+                                                bool TrimBaseProfileOnly);
 
 private:
   SampleProfileMap &ProfileMap;
@@ -1428,7 +1430,7 @@ public:
     LineLocation CallSiteLoc;
 
     LLVM_ABI FrameNode *getOrCreateChildFrame(const LineLocation &CallSite,
-                                     FunctionId CalleeName);
+                                              FunctionId CalleeName);
   };
 
   static void flattenProfile(SampleProfileMap &ProfileMap,

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -225,6 +225,7 @@
 #ifndef LLVM_PROFILEDATA_SAMPLEPROFREADER_H
 #define LLVM_PROFILEDATA_SAMPLEPROFREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -273,18 +274,18 @@ public:
 
   /// Create a remapper from the given remapping file. The remapper will
   /// be used for profile read in by Reader.
-  static ErrorOr<std::unique_ptr<SampleProfileReaderItaniumRemapper>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<SampleProfileReaderItaniumRemapper>>
   create(StringRef Filename, vfs::FileSystem &FS, SampleProfileReader &Reader,
          LLVMContext &C);
 
   /// Create a remapper from the given Buffer. The remapper will
   /// be used for profile read in by Reader.
-  static ErrorOr<std::unique_ptr<SampleProfileReaderItaniumRemapper>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<SampleProfileReaderItaniumRemapper>>
   create(std::unique_ptr<MemoryBuffer> &B, SampleProfileReader &Reader,
          LLVMContext &C);
 
   /// Apply remappings to the profile read by Reader.
-  void applyRemapping(LLVMContext &Ctx);
+  LLVM_ABI void applyRemapping(LLVMContext &Ctx);
 
   bool hasApplied() { return RemappingApplied; }
 
@@ -299,7 +300,7 @@ public:
 
   /// Return the equivalent name in the profile for \p FunctionName if
   /// it exists.
-  std::optional<StringRef> lookUpNameInProfile(StringRef FunctionName);
+  LLVM_ABI std::optional<StringRef> lookUpNameInProfile(StringRef FunctionName);
 
 private:
   // The buffer holding the content read from remapping file.
@@ -395,7 +396,7 @@ public:
   virtual std::error_code readImpl() = 0;
 
   /// Print the profile for \p FunctionSamples on stream \p OS.
-  void dumpFunctionProfile(const FunctionSamples &FS, raw_ostream &OS = dbgs());
+  LLVM_ABI void dumpFunctionProfile(const FunctionSamples &FS, raw_ostream &OS = dbgs());
 
   /// Collect functions with definitions in Module M. For reader which
   /// support loading function profiles on demand, return true when the
@@ -404,10 +405,10 @@ public:
   virtual bool collectFuncsFromModule() { return false; }
 
   /// Print all the profiles on stream \p OS.
-  void dump(raw_ostream &OS = dbgs());
+  LLVM_ABI void dump(raw_ostream &OS = dbgs());
 
   /// Print all the profiles on stream \p OS in the JSON format.
-  void dumpJson(raw_ostream &OS = dbgs());
+  LLVM_ABI void dumpJson(raw_ostream &OS = dbgs());
 
   /// Return the samples collected for function \p F.
   FunctionSamples *getSamplesFor(const Function &F) {
@@ -456,7 +457,7 @@ public:
   /// Create a sample profile reader appropriate to the file format.
   /// Create a remapper underlying if RemapFilename is not empty.
   /// Parameter P specifies the FSDiscriminatorPass.
-  static ErrorOr<std::unique_ptr<SampleProfileReader>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<SampleProfileReader>>
   create(StringRef Filename, LLVMContext &C, vfs::FileSystem &FS,
          FSDiscriminatorPass P = FSDiscriminatorPass::Base,
          StringRef RemapFilename = "");
@@ -464,7 +465,7 @@ public:
   /// Create a sample profile reader from the supplied memory buffer.
   /// Create a remapper underlying if RemapFilename is not empty.
   /// Parameter P specifies the FSDiscriminatorPass.
-  static ErrorOr<std::unique_ptr<SampleProfileReader>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<SampleProfileReader>>
   create(std::unique_ptr<MemoryBuffer> &B, LLVMContext &C, vfs::FileSystem &FS,
          FSDiscriminatorPass P = FSDiscriminatorPass::Base,
          StringRef RemapFilename = "");
@@ -544,7 +545,7 @@ protected:
   }
 
   /// Compute summary for this profile.
-  void computeSummary();
+  LLVM_ABI void computeSummary();
 
   /// Read sample profiles for the given functions and write them to the given
   /// profile map. Currently it's only used for extended binary format to load
@@ -608,7 +609,7 @@ protected:
   bool SkipFlatProf = false;
 };
 
-class SampleProfileReaderText : public SampleProfileReader {
+class LLVM_ABI SampleProfileReaderText : public SampleProfileReader {
 public:
   SampleProfileReaderText(std::unique_ptr<MemoryBuffer> B, LLVMContext &C)
       : SampleProfileReader(std::move(B), C, SPF_Text) {}
@@ -631,7 +632,7 @@ private:
   std::list<SampleContextFrameVector> CSNameTable;
 };
 
-class SampleProfileReaderBinary : public SampleProfileReader {
+class LLVM_ABI SampleProfileReaderBinary : public SampleProfileReader {
 public:
   SampleProfileReaderBinary(std::unique_ptr<MemoryBuffer> B, LLVMContext &C,
                             SampleProfileFormat Format = SPF_None)
@@ -730,7 +731,7 @@ private:
   virtual std::error_code verifySPMagic(uint64_t Magic) = 0;
 };
 
-class SampleProfileReaderRawBinary : public SampleProfileReaderBinary {
+class LLVM_ABI SampleProfileReaderRawBinary : public SampleProfileReaderBinary {
 private:
   std::error_code verifySPMagic(uint64_t Magic) override;
 
@@ -762,7 +763,7 @@ public:
 /// commonly used sections of a profile in extensible binary format. It is
 /// possible to define other types of profile inherited from
 /// SampleProfileReaderExtBinaryBase/SampleProfileWriterExtBinaryBase.
-class SampleProfileReaderExtBinaryBase : public SampleProfileReaderBinary {
+class LLVM_ABI SampleProfileReaderExtBinaryBase : public SampleProfileReaderBinary {
 private:
   std::error_code decompressSection(const uint8_t *SecStart,
                                     const uint64_t SecSize,
@@ -845,7 +846,7 @@ private:
                        SampleProfileMap &Profiles) override;
 };
 
-class SampleProfileReaderExtBinary : public SampleProfileReaderExtBinaryBase {
+class LLVM_ABI SampleProfileReaderExtBinary : public SampleProfileReaderExtBinaryBase {
 private:
   std::error_code verifySPMagic(uint64_t Magic) override;
   std::error_code readCustomSection(const SecHdrTableEntry &Entry) override {
@@ -878,7 +879,7 @@ enum HistType {
   HIST_TYPE_INDIR_CALL_TOPN
 };
 
-class SampleProfileReaderGCC : public SampleProfileReader {
+class LLVM_ABI SampleProfileReaderGCC : public SampleProfileReader {
 public:
   SampleProfileReaderGCC(std::unique_ptr<MemoryBuffer> B, LLVMContext &C)
       : SampleProfileReader(std::move(B), C, SPF_GCC),

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -225,7 +225,6 @@
 #ifndef LLVM_PROFILEDATA_SAMPLEPROFREADER_H
 #define LLVM_PROFILEDATA_SAMPLEPROFREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -234,6 +233,7 @@
 #include "llvm/ProfileData/GCOV.h"
 #include "llvm/ProfileData/SampleProf.h"
 #include "llvm/ProfileData/SymbolRemappingReader.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Discriminator.h"
 #include "llvm/Support/ErrorOr.h"
@@ -396,7 +396,8 @@ public:
   virtual std::error_code readImpl() = 0;
 
   /// Print the profile for \p FunctionSamples on stream \p OS.
-  LLVM_ABI void dumpFunctionProfile(const FunctionSamples &FS, raw_ostream &OS = dbgs());
+  LLVM_ABI void dumpFunctionProfile(const FunctionSamples &FS,
+                                    raw_ostream &OS = dbgs());
 
   /// Collect functions with definitions in Module M. For reader which
   /// support loading function profiles on demand, return true when the
@@ -763,7 +764,8 @@ public:
 /// commonly used sections of a profile in extensible binary format. It is
 /// possible to define other types of profile inherited from
 /// SampleProfileReaderExtBinaryBase/SampleProfileWriterExtBinaryBase.
-class LLVM_ABI SampleProfileReaderExtBinaryBase : public SampleProfileReaderBinary {
+class LLVM_ABI SampleProfileReaderExtBinaryBase
+    : public SampleProfileReaderBinary {
 private:
   std::error_code decompressSection(const uint8_t *SecStart,
                                     const uint64_t SecSize,
@@ -846,7 +848,8 @@ private:
                        SampleProfileMap &Profiles) override;
 };
 
-class LLVM_ABI SampleProfileReaderExtBinary : public SampleProfileReaderExtBinaryBase {
+class LLVM_ABI SampleProfileReaderExtBinary
+    : public SampleProfileReaderExtBinaryBase {
 private:
   std::error_code verifySPMagic(uint64_t Magic) override;
   std::error_code readCustomSection(const SecHdrTableEntry &Entry) override {

--- a/llvm/include/llvm/ProfileData/SampleProfWriter.h
+++ b/llvm/include/llvm/ProfileData/SampleProfWriter.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_PROFILEDATA_SAMPLEPROFWRITER_H
 #define LLVM_PROFILEDATA_SAMPLEPROFWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/ProfileSummary.h"
@@ -65,7 +66,7 @@ public:
   virtual void Erase(size_t CurrentOutputSize) = 0;
 };
 
-class DefaultFunctionPruningStrategy : public FunctionPruningStrategy {
+class LLVM_ABI DefaultFunctionPruningStrategy : public FunctionPruningStrategy {
   std::vector<NameFunctionSamples> SortedFunctions;
 
 public:
@@ -86,7 +87,7 @@ public:
 };
 
 /// Sample-based profile writer. Base class.
-class SampleProfileWriter {
+class LLVM_ABI SampleProfileWriter {
 public:
   virtual ~SampleProfileWriter() = default;
 
@@ -163,7 +164,7 @@ protected:
 };
 
 /// Sample-based profile writer (text format).
-class SampleProfileWriterText : public SampleProfileWriter {
+class LLVM_ABI SampleProfileWriterText : public SampleProfileWriter {
 public:
   std::error_code writeSample(const FunctionSamples &S) override;
 
@@ -198,7 +199,7 @@ private:
 };
 
 /// Sample-based profile writer (binary format).
-class SampleProfileWriterBinary : public SampleProfileWriter {
+class LLVM_ABI SampleProfileWriterBinary : public SampleProfileWriter {
 public:
   SampleProfileWriterBinary(std::unique_ptr<raw_ostream> &OS)
       : SampleProfileWriter(OS) {}
@@ -264,7 +265,7 @@ const std::array<SmallVector<SecHdrTableEntry, 8>, NumOfLayout>
                                           {SecFuncMetadata, 0, 0, 0, 0}}),
 };
 
-class SampleProfileWriterExtBinaryBase : public SampleProfileWriterBinary {
+class LLVM_ABI SampleProfileWriterExtBinaryBase : public SampleProfileWriterBinary {
   using SampleProfileWriterBinary::SampleProfileWriterBinary;
 public:
   std::error_code write(const SampleProfileMap &ProfileMap) override;
@@ -407,7 +408,7 @@ private:
   ProfileSymbolList *ProfSymList = nullptr;
 };
 
-class SampleProfileWriterExtBinary : public SampleProfileWriterExtBinaryBase {
+class LLVM_ABI SampleProfileWriterExtBinary : public SampleProfileWriterExtBinaryBase {
 public:
   SampleProfileWriterExtBinary(std::unique_ptr<raw_ostream> &OS)
       : SampleProfileWriterExtBinaryBase(OS) {}

--- a/llvm/include/llvm/ProfileData/SampleProfWriter.h
+++ b/llvm/include/llvm/ProfileData/SampleProfWriter.h
@@ -193,7 +193,7 @@ private:
   /// cannot be skipped.
   bool MarkFlatProfiles = false;
 
-  friend ErrorOr<std::unique_ptr<SampleProfileWriter>>
+  LLVM_ABI_FRIEND friend ErrorOr<std::unique_ptr<SampleProfileWriter>>
   SampleProfileWriter::create(std::unique_ptr<raw_ostream> &OS,
                               SampleProfileFormat Format);
 };
@@ -225,7 +225,7 @@ protected:
   void addNames(const FunctionSamples &S);
 
 private:
-  friend ErrorOr<std::unique_ptr<SampleProfileWriter>>
+  LLVM_ABI_FRIEND friend ErrorOr<std::unique_ptr<SampleProfileWriter>>
   SampleProfileWriter::create(std::unique_ptr<raw_ostream> &OS,
                               SampleProfileFormat Format);
 };

--- a/llvm/include/llvm/ProfileData/SampleProfWriter.h
+++ b/llvm/include/llvm/ProfileData/SampleProfWriter.h
@@ -12,11 +12,11 @@
 #ifndef LLVM_PROFILEDATA_SAMPLEPROFWRITER_H
 #define LLVM_PROFILEDATA_SAMPLEPROFWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/ProfileSummary.h"
 #include "llvm/ProfileData/SampleProf.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
@@ -265,7 +265,8 @@ const std::array<SmallVector<SecHdrTableEntry, 8>, NumOfLayout>
                                           {SecFuncMetadata, 0, 0, 0, 0}}),
 };
 
-class LLVM_ABI SampleProfileWriterExtBinaryBase : public SampleProfileWriterBinary {
+class LLVM_ABI SampleProfileWriterExtBinaryBase
+    : public SampleProfileWriterBinary {
   using SampleProfileWriterBinary::SampleProfileWriterBinary;
 public:
   std::error_code write(const SampleProfileMap &ProfileMap) override;
@@ -408,7 +409,8 @@ private:
   ProfileSymbolList *ProfSymList = nullptr;
 };
 
-class LLVM_ABI SampleProfileWriterExtBinary : public SampleProfileWriterExtBinaryBase {
+class LLVM_ABI SampleProfileWriterExtBinary
+    : public SampleProfileWriterExtBinaryBase {
 public:
   SampleProfileWriterExtBinary(std::unique_ptr<raw_ostream> &OS)
       : SampleProfileWriterExtBinaryBase(OS) {}

--- a/llvm/include/llvm/ProfileData/SymbolRemappingReader.h
+++ b/llvm/include/llvm/ProfileData/SymbolRemappingReader.h
@@ -59,9 +59,9 @@
 #ifndef LLVM_PROFILEDATA_SYMBOLREMAPPINGREADER_H
 #define LLVM_PROFILEDATA_SYMBOLREMAPPINGREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ProfileData/ItaniumManglingCanonicalizer.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {

--- a/llvm/include/llvm/ProfileData/SymbolRemappingReader.h
+++ b/llvm/include/llvm/ProfileData/SymbolRemappingReader.h
@@ -59,6 +59,7 @@
 #ifndef LLVM_PROFILEDATA_SYMBOLREMAPPINGREADER_H
 #define LLVM_PROFILEDATA_SYMBOLREMAPPINGREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ProfileData/ItaniumManglingCanonicalizer.h"
 #include "llvm/Support/Error.h"
@@ -83,7 +84,7 @@ public:
   int64_t getLineNum() const { return Line; }
   StringRef getMessage() const { return Message; }
 
-  static char ID;
+  LLVM_ABI static char ID;
 
 private:
   std::string File;
@@ -99,7 +100,7 @@ class SymbolRemappingReader {
 public:
   /// Read remappings from the given buffer, which must live as long as
   /// the remapper.
-  Error read(MemoryBuffer &B);
+  LLVM_ABI Error read(MemoryBuffer &B);
 
   /// A Key represents an equivalence class of symbol names.
   using Key = uintptr_t;

--- a/llvm/lib/ProfileData/MemProfCommon.cpp
+++ b/llvm/lib/ProfileData/MemProfCommon.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ProfileData/MemProf.h"
 #include "llvm/Support/BLAKE3.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/HashBuilder.h"
 
 using namespace llvm;
@@ -21,7 +22,7 @@ using namespace llvm::memprof;
 
 // Upper bound on lifetime access density (accesses per byte per lifetime sec)
 // for marking an allocation cold.
-cl::opt<float> MemProfLifetimeAccessDensityColdThreshold(
+LLVM_ABI cl::opt<float> MemProfLifetimeAccessDensityColdThreshold(
     "memprof-lifetime-access-density-cold-threshold", cl::init(0.05),
     cl::Hidden,
     cl::desc("The threshold the lifetime access density (accesses per byte per "
@@ -29,20 +30,20 @@ cl::opt<float> MemProfLifetimeAccessDensityColdThreshold(
 
 // Lower bound on lifetime to mark an allocation cold (in addition to accesses
 // per byte per sec above). This is to avoid pessimizing short lived objects.
-cl::opt<unsigned> MemProfAveLifetimeColdThreshold(
+LLVM_ABI cl::opt<unsigned> MemProfAveLifetimeColdThreshold(
     "memprof-ave-lifetime-cold-threshold", cl::init(200), cl::Hidden,
     cl::desc("The average lifetime (s) for an allocation to be considered "
              "cold"));
 
 // Lower bound on average lifetime accesses density (total life time access
 // density / alloc count) for marking an allocation hot.
-cl::opt<unsigned> MemProfMinAveLifetimeAccessDensityHotThreshold(
+LLVM_ABI cl::opt<unsigned> MemProfMinAveLifetimeAccessDensityHotThreshold(
     "memprof-min-ave-lifetime-access-density-hot-threshold", cl::init(1000),
     cl::Hidden,
     cl::desc("The minimum TotalLifetimeAccessDensity / AllocCount for an "
              "allocation to be considered hot"));
 
-cl::opt<bool>
+LLVM_ABI cl::opt<bool>
     MemProfUseHotHints("memprof-use-hot-hints", cl::init(false), cl::Hidden,
                        cl::desc("Enable use of hot hints (only supported for "
                                 "unambigously hot allocations)"));

--- a/llvm/lib/ProfileData/MemProfRadixTree.cpp
+++ b/llvm/lib/ProfileData/MemProfRadixTree.cpp
@@ -241,12 +241,13 @@ computeFrameHistogram(llvm::MapVector<CallStackId, llvm::SmallVector<FrameIdTy>>
 }
 
 // Explicitly instantiate function with the utilized FrameIdTy.
-template llvm::DenseMap<FrameId, FrameStat> LLVM_ABI computeFrameHistogram<FrameId>(
-    llvm::MapVector<CallStackId, llvm::SmallVector<FrameId>>
-        &MemProfCallStackData);
+template llvm::DenseMap<FrameId, FrameStat>
+    LLVM_ABI computeFrameHistogram<FrameId>(
+        llvm::MapVector<CallStackId, llvm::SmallVector<FrameId>>
+            &MemProfCallStackData);
 template llvm::DenseMap<LinearFrameId, FrameStat>
-LLVM_ABI computeFrameHistogram<LinearFrameId>(
-    llvm::MapVector<CallStackId, llvm::SmallVector<LinearFrameId>>
-        &MemProfCallStackData);
+    LLVM_ABI computeFrameHistogram<LinearFrameId>(
+        llvm::MapVector<CallStackId, llvm::SmallVector<LinearFrameId>>
+            &MemProfCallStackData);
 } // namespace memprof
 } // namespace llvm

--- a/llvm/lib/ProfileData/MemProfRadixTree.cpp
+++ b/llvm/lib/ProfileData/MemProfRadixTree.cpp
@@ -220,8 +220,8 @@ void CallStackRadixTreeBuilder<FrameIdTy>::build(
 }
 
 // Explicitly instantiate class with the utilized FrameIdTy.
-template class CallStackRadixTreeBuilder<FrameId>;
-template class CallStackRadixTreeBuilder<LinearFrameId>;
+template class LLVM_EXPORT_TEMPLATE CallStackRadixTreeBuilder<FrameId>;
+template class LLVM_EXPORT_TEMPLATE CallStackRadixTreeBuilder<LinearFrameId>;
 
 template <typename FrameIdTy>
 llvm::DenseMap<FrameIdTy, FrameStat>
@@ -241,11 +241,11 @@ computeFrameHistogram(llvm::MapVector<CallStackId, llvm::SmallVector<FrameIdTy>>
 }
 
 // Explicitly instantiate function with the utilized FrameIdTy.
-template llvm::DenseMap<FrameId, FrameStat> computeFrameHistogram<FrameId>(
+template llvm::DenseMap<FrameId, FrameStat> LLVM_ABI computeFrameHistogram<FrameId>(
     llvm::MapVector<CallStackId, llvm::SmallVector<FrameId>>
         &MemProfCallStackData);
 template llvm::DenseMap<LinearFrameId, FrameStat>
-computeFrameHistogram<LinearFrameId>(
+LLVM_ABI computeFrameHistogram<LinearFrameId>(
     llvm::MapVector<CallStackId, llvm::SmallVector<LinearFrameId>>
         &MemProfCallStackData);
 } // namespace memprof

--- a/llvm/unittests/ProfileData/MemProfTest.cpp
+++ b/llvm/unittests/ProfileData/MemProfTest.cpp
@@ -28,7 +28,8 @@
 
 LLVM_ABI extern llvm::cl::opt<float> MemProfLifetimeAccessDensityColdThreshold;
 LLVM_ABI extern llvm::cl::opt<unsigned> MemProfAveLifetimeColdThreshold;
-LLVM_ABI extern llvm::cl::opt<unsigned> MemProfMinAveLifetimeAccessDensityHotThreshold;
+LLVM_ABI extern llvm::cl::opt<unsigned>
+    MemProfMinAveLifetimeAccessDensityHotThreshold;
 LLVM_ABI extern llvm::cl::opt<bool> MemProfUseHotHints;
 
 namespace llvm {

--- a/llvm/unittests/ProfileData/MemProfTest.cpp
+++ b/llvm/unittests/ProfileData/MemProfTest.cpp
@@ -19,16 +19,17 @@
 #include "llvm/ProfileData/MemProfData.inc"
 #include "llvm/ProfileData/MemProfRadixTree.h"
 #include "llvm/ProfileData/MemProfReader.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #include <initializer_list>
 
-extern llvm::cl::opt<float> MemProfLifetimeAccessDensityColdThreshold;
-extern llvm::cl::opt<unsigned> MemProfAveLifetimeColdThreshold;
-extern llvm::cl::opt<unsigned> MemProfMinAveLifetimeAccessDensityHotThreshold;
-extern llvm::cl::opt<bool> MemProfUseHotHints;
+LLVM_ABI extern llvm::cl::opt<float> MemProfLifetimeAccessDensityColdThreshold;
+LLVM_ABI extern llvm::cl::opt<unsigned> MemProfAveLifetimeColdThreshold;
+LLVM_ABI extern llvm::cl::opt<unsigned> MemProfMinAveLifetimeAccessDensityHotThreshold;
+LLVM_ABI extern llvm::cl::opt<bool> MemProfUseHotHints;
 
 namespace llvm {
 namespace memprof {


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/ProfileData` library. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS on Linux:
- Manually annotate the file `llvm/include/llvm/ProfileData/InstrProfData.inc` because it is skipped by IDS
- Add `LLVM_TEMPLATE_ABI` and `LLVM_EXPORT_TEMPLATE` to exported instantiated templates.
- Add `LLVM_ABI_FRIEND` to friend member functions declared with `LLVM_ABI`
- Add `LLVM_ABI` to a small number of symbols that require export but are not declared in headers

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang