### PR TITLE
[mlir][gpu] Fix bug with gpu.printf global location

### DIFF
--- a/mlir/include/mlir/IR/Location.h
+++ b/mlir/include/mlir/IR/Location.h
@@ -21,6 +21,7 @@ namespace mlir {
 
 class Location;
 class WalkResult;
+class UnknownLoc;
 
 //===----------------------------------------------------------------------===//
 // LocationAttr
@@ -51,6 +52,15 @@ public:
       return WalkResult::advance();
     });
     return result;
+  }
+
+  /// Return an instance of the given location type if one is nested under the
+  /// current location else return unknown location.
+  template <typename T, typename UnknownT = UnknownLoc>
+  LocationAttr findInstanceOfOrUnknown() {
+    if (T result = findInstanceOf<T>())
+      return result;
+    return UnknownT::get(getContext());
   }
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast.

--- a/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
@@ -543,9 +543,9 @@ LogicalResult GPUPrintfOpToVPrintfLowering::matchAndRewrite(
   // the device code, not the host code
   auto moduleOp = gpuPrintfOp->getParentOfType<gpu::GPUModuleOp>();
 
-  // Convert the location to a valid global location of type FileLineColLoc if
-  // found else UnknownLoc. Remove any metadata from the location which is not
-  // valid for a global location.
+  // Create a valid global location removing any metadata attached to the
+  // location as debug info metadata inside of a function cannot be used outside
+  // of that function.
   Location globalLoc = loc->findInstanceOfOrUnknown<FileLineColLoc>();
 
   auto vprintfType =

--- a/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
@@ -543,14 +543,20 @@ LogicalResult GPUPrintfOpToVPrintfLowering::matchAndRewrite(
   // the device code, not the host code
   auto moduleOp = gpuPrintfOp->getParentOfType<gpu::GPUModuleOp>();
 
+  // Convert the location to a valid global location of type FileLineColLoc if
+  // found else UnknownLoc. Remove any metadata from the location which is not
+  // valid for a global location.
+  Location globalLoc = loc->findInstanceOfOrUnknown<FileLineColLoc>();
+
   auto vprintfType =
       LLVM::LLVMFunctionType::get(rewriter.getI32Type(), {ptrType, ptrType});
-  LLVM::LLVMFuncOp vprintfDecl =
-      getOrDefineFunction(moduleOp, loc, rewriter, "vprintf", vprintfType);
+  LLVM::LLVMFuncOp vprintfDecl = getOrDefineFunction(
+      moduleOp, globalLoc, rewriter, "vprintf", vprintfType);
 
   // Create the global op or find an existing one.
-  LLVM::GlobalOp global = getOrCreateStringConstant(
-      rewriter, loc, moduleOp, llvmI8, "printfFormat_", adaptor.getFormat());
+  LLVM::GlobalOp global =
+      getOrCreateStringConstant(rewriter, globalLoc, moduleOp, llvmI8,
+                                "printfFormat_", adaptor.getFormat());
 
   // Get a pointer to the format string's first element
   Value globalPtr = rewriter.create<LLVM::AddressOfOp>(loc, global);

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-debuginfo.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-debuginfo.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-opt %s -convert-gpu-to-nvvm='has-redux=1' -mlir-print-debuginfo | FileCheck %s
+
+#di_file = #llvm.di_file<"foo.mlir" in "/tmp/">
+#di_compile_unit = #llvm.di_compile_unit<
+  id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file,
+  producer = "MLIR", isOptimized = true, emissionKind = Full
+>
+#di_subprogram = #llvm.di_subprogram<
+  compileUnit = #di_compile_unit, scope = #di_file, name = "test_const_printf_with_loc",
+  file = #di_file, subprogramFlags = "Definition"
+>
+
+// CHECK-DAG: [[LOC:#[a-zA-Z0-9_]+]] = loc("foo.mlir":0:0)
+#loc = loc("foo.mlir":0:0)
+
+gpu.module @test_module_56 {
+  // CHECK-DAG: llvm.mlir.global internal constant @[[$PRINT_GLOBAL0:[A-Za-z0-9_]+]]("Hello, world with location\0A\00") {addr_space = 0 : i32} loc([[LOC]])
+  // CHECK-DAG: llvm.func @vprintf(!llvm.ptr, !llvm.ptr) -> i32 loc([[LOC]])
+
+  gpu.func @test_const_printf_with_loc() {
+    gpu.printf "Hello, world with location\n" loc(fused<#di_subprogram>[#loc])
+    gpu.return
+  }
+}

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-debuginfo.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-debuginfo.mlir
@@ -13,7 +13,7 @@
 // CHECK-DAG: [[LOC:#[a-zA-Z0-9_]+]] = loc("foo.mlir":0:0)
 #loc = loc("foo.mlir":0:0)
 
-gpu.module @test_module_56 {
+gpu.module @test_module_1 {
   // CHECK-DAG: llvm.mlir.global internal constant @[[$PRINT_GLOBAL0:[A-Za-z0-9_]+]]("Hello, world with location\0A\00") {addr_space = 0 : i32} loc([[LOC]])
   // CHECK-DAG: llvm.func @vprintf(!llvm.ptr, !llvm.ptr) -> i32 loc([[LOC]])
 

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-debuginfo.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-debuginfo.mlir
@@ -13,6 +13,7 @@
 // CHECK-DAG: [[LOC:#[a-zA-Z0-9_]+]] = loc("foo.mlir":0:0)
 #loc = loc("foo.mlir":0:0)
 
+// Check that debug info metadata from the function is removed from the global location.
 gpu.module @test_module_1 {
   // CHECK-DAG: llvm.mlir.global internal constant @[[$PRINT_GLOBAL0:[A-Za-z0-9_]+]]("Hello, world with location\0A\00") {addr_space = 0 : i32} loc([[LOC]])
   // CHECK-DAG: llvm.func @vprintf(!llvm.ptr, !llvm.ptr) -> i32 loc([[LOC]])


### PR DESCRIPTION
Bug description: Global variables and functions created during gpu.printf conversion to NVVM may contain debug info metadata from function containing the gpu.printf which cannot be used out of that function.