### PR TITLE
[lldb] Remove an unused local variable (NFC)

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -1094,7 +1094,6 @@ public:
             interpreter, "breakpoint list",
             "List some or all breakpoints at configurable levels of detail.",
             nullptr) {
-    CommandArgumentEntry arg;
     CommandArgumentData bp_id_arg;
 
     // Define the first (and only) variant of this arg.


### PR DESCRIPTION
Note that CommandArgumentEntry is an alias for:

  std::vector<CommandArgumentData>
