### PR TITLE
[clang] Add regression tests for narrowing with is_constant_evaluated.

### DIFF
--- a/clang/test/SemaCXX/builtin-is-constant-evaluated.cpp
+++ b/clang/test/SemaCXX/builtin-is-constant-evaluated.cpp
@@ -143,3 +143,14 @@ namespace fold_initializer {
   const float A::f = __builtin_is_constant_evaluated();
   static_assert(fold(A::f == 1.0f));
 }
+
+namespace narrowing {
+  struct X { unsigned u; };
+  constexpr int f(X x) {return x.u;}
+  void g() {
+    static_assert(f({0xFFFFFFFFLL + __builtin_is_constant_evaluated()}) == 0);
+    f({0x100000000LL - __builtin_is_constant_evaluated()}); // expected-error {{constant expression evaluates to 4294967296}} \
+    // expected-warning {{implicit conversion}} \
+    // expected-note {{insert an explicit cast to silence this issue}}
+  }
+}


### PR DESCRIPTION
As discussed in #142707, in the context of determining whether a conversion is a narrowing conversion, is_constant_evaluation should be false, even it's a subexpression of a manifestly constant-evaluated expression.