### PR TITLE
[ValueTracking] Support scalable vector splats of ConstantInt/ConstantFP in isGuaranteedNotToBeUndefOrPoison.

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -7587,7 +7587,7 @@ static bool isGuaranteedNotToBeUndefOrPoison(
       if (isa<ConstantExpr>(C)) {
         // Scalable vectors can use a ConstantExpr to build a splat.
         if (Constant *SplatC = C->getSplatValue())
-          if (isa<ConstantInt>(SplatC))
+          if (isa<ConstantInt>(SplatC) || isa<ConstantFP>(SplatC))
             return true;
       } else {
         if (includesUndef(Kind) && C->containsUndefElement())

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -7579,16 +7579,23 @@ static bool isGuaranteedNotToBeUndefOrPoison(
     if (isa<UndefValue>(C))
       return !includesUndef(Kind);
 
-    if (isa<ConstantInt>(C) || isa<GlobalVariable>(C) || isa<ConstantFP>(V) ||
+    if (isa<ConstantInt>(C) || isa<GlobalVariable>(C) || isa<ConstantFP>(C) ||
         isa<ConstantPointerNull>(C) || isa<Function>(C))
       return true;
 
-    if (C->getType()->isVectorTy() && !isa<ConstantExpr>(C)) {
-      if (includesUndef(Kind) && C->containsUndefElement())
-        return false;
-      if (includesPoison(Kind) && C->containsPoisonElement())
-        return false;
-      return !C->containsConstantExpression();
+    if (C->getType()->isVectorTy()) {
+      if (isa<ConstantExpr>(C)) {
+        // Scalable vectors can use a ConstantExpr to build a splat.
+        if (Constant *SplatC = C->getSplatValue())
+          if (isa<ConstantInt>(SplatC))
+            return true;
+      } else {
+        if (includesUndef(Kind) && C->containsUndefElement())
+          return false;
+        if (includesPoison(Kind) && C->containsPoisonElement())
+          return false;
+        return !C->containsConstantExpression();
+      }
     }
   }
 

--- a/llvm/test/Transforms/Attributor/nofpclass.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass.ll
@@ -2665,7 +2665,7 @@ define [4 x float] @constant_aggregate_zero() {
 
 define <vscale x 4 x float> @scalable_splat_pnorm() {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-; CHECK-LABEL: define <vscale x 4 x float> @scalable_splat_pnorm
+; CHECK-LABEL: define noundef <vscale x 4 x float> @scalable_splat_pnorm
 ; CHECK-SAME: () #[[ATTR3]] {
 ; CHECK-NEXT:    ret <vscale x 4 x float> splat (float 1.000000e+00)
 ;

--- a/llvm/test/Transforms/InstCombine/select-and-or.ll
+++ b/llvm/test/Transforms/InstCombine/select-and-or.ll
@@ -109,7 +109,7 @@ define <vscale x 2 x i1> @logical_or_implies_scalablevec(<vscale x 2 x i32> %x) 
 ; CHECK-LABEL: @logical_or_implies_scalablevec(
 ; CHECK-NEXT:    [[C1:%.*]] = icmp eq <vscale x 2 x i32> [[X:%.*]], zeroinitializer
 ; CHECK-NEXT:    [[C2:%.*]] = icmp eq <vscale x 2 x i32> [[X]], splat (i32 42)
-; CHECK-NEXT:    [[RES:%.*]] = select <vscale x 2 x i1> [[C1]], <vscale x 2 x i1> splat (i1 true), <vscale x 2 x i1> [[C2]]
+; CHECK-NEXT:    [[RES:%.*]] = or <vscale x 2 x i1> [[C1]], [[C2]]
 ; CHECK-NEXT:    ret <vscale x 2 x i1> [[RES]]
 ;
   %c1 = icmp eq <vscale x 2 x i32> %x, zeroinitializer
@@ -148,7 +148,7 @@ define <vscale x 2 x i1> @logical_and_implies_scalablevec(<vscale x 2 x i32> %x)
 ; CHECK-LABEL: @logical_and_implies_scalablevec(
 ; CHECK-NEXT:    [[C1:%.*]] = icmp ne <vscale x 2 x i32> [[X:%.*]], zeroinitializer
 ; CHECK-NEXT:    [[C2:%.*]] = icmp ne <vscale x 2 x i32> [[X]], splat (i32 42)
-; CHECK-NEXT:    [[RES:%.*]] = select <vscale x 2 x i1> [[C1]], <vscale x 2 x i1> [[C2]], <vscale x 2 x i1> zeroinitializer
+; CHECK-NEXT:    [[RES:%.*]] = and <vscale x 2 x i1> [[C1]], [[C2]]
 ; CHECK-NEXT:    ret <vscale x 2 x i1> [[RES]]
 ;
   %c1 = icmp ne <vscale x 2 x i32> %x, zeroinitializer

--- a/llvm/test/Transforms/InstCombine/select-and-or.ll
+++ b/llvm/test/Transforms/InstCombine/select-and-or.ll
@@ -104,6 +104,20 @@ define i1 @logical_or_implies(i32 %x) {
   ret i1 %res
 }
 
+; Safe to convert to or due to poison implication.
+define <vscale x 2 x i1> @logical_or_implies_scalablevec(<vscale x 2 x i32> %x) {
+; CHECK-LABEL: @logical_or_implies_scalablevec(
+; CHECK-NEXT:    [[C1:%.*]] = icmp eq <vscale x 2 x i32> [[X:%.*]], zeroinitializer
+; CHECK-NEXT:    [[C2:%.*]] = icmp eq <vscale x 2 x i32> [[X]], splat (i32 42)
+; CHECK-NEXT:    [[RES:%.*]] = select <vscale x 2 x i1> [[C1]], <vscale x 2 x i1> splat (i1 true), <vscale x 2 x i1> [[C2]]
+; CHECK-NEXT:    ret <vscale x 2 x i1> [[RES]]
+;
+  %c1 = icmp eq <vscale x 2 x i32> %x, zeroinitializer
+  %c2 = icmp eq <vscale x 2 x i32> %x, splat (i32 42)
+  %res = select <vscale x 2 x i1> %c1, <vscale x 2 x i1> splat (i1 true), <vscale x 2 x i1> %c2
+  ret <vscale x 2 x i1> %res
+}
+
 ; Will fold after conversion to or.
 define i1 @logical_or_implies_folds(i32 %x) {
 ; CHECK-LABEL: @logical_or_implies_folds(
@@ -127,6 +141,20 @@ define i1 @logical_and_implies(i32 %x) {
   %c2 = icmp ne i32 %x, 42
   %res = select i1 %c1, i1 %c2, i1 false
   ret i1 %res
+}
+
+; Safe to convert to and due to poison implication.
+define <vscale x 2 x i1> @logical_and_implies_scalablevec(<vscale x 2 x i32> %x) {
+; CHECK-LABEL: @logical_and_implies_scalablevec(
+; CHECK-NEXT:    [[C1:%.*]] = icmp ne <vscale x 2 x i32> [[X:%.*]], zeroinitializer
+; CHECK-NEXT:    [[C2:%.*]] = icmp ne <vscale x 2 x i32> [[X]], splat (i32 42)
+; CHECK-NEXT:    [[RES:%.*]] = select <vscale x 2 x i1> [[C1]], <vscale x 2 x i1> [[C2]], <vscale x 2 x i1> zeroinitializer
+; CHECK-NEXT:    ret <vscale x 2 x i1> [[RES]]
+;
+  %c1 = icmp ne <vscale x 2 x i32> %x, zeroinitializer
+  %c2 = icmp ne <vscale x 2 x i32> %x, splat (i32 42)
+  %res = select <vscale x 2 x i1> %c1, <vscale x 2 x i1> %c2, <vscale x 2 x i1> zeroinitializer
+  ret <vscale x 2 x i1> %res
 }
 
 ; Will fold after conversion to and.


### PR DESCRIPTION
Scalable vectors use insertelt+shufflevector ConstantExpr to
represent a splat.