### PR TITLE
[clang][CFG] Fix assertion failure in checkIncorrectLogicOperator

### DIFF
--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -1266,22 +1266,22 @@ private:
       // `1.0` are float16 and double respectively.  In this case, we should do
       // a conversion before comparing L1 and L2.  Their types must be
       // compatible since they are comparing with the same DRE.
-      int8_t Order = Context->getFloatingTypeOrder(NumExpr1->getType(),
-                                                   NumExpr2->getType());
-      bool convertLoseInfo = false;
+      int Order = Context->getFloatingTypeSemanticOrder(NumExpr1->getType(),
+                                                        NumExpr2->getType());
+      bool Ignored = false;
 
       if (Order > 0) {
         // type rank L1 > L2:
-        if (L2.convert(L1.getSemantics(), llvm::APFloat::rmNearestTiesToEven,
-                       &convertLoseInfo))
+        if (llvm::APFloat::opOK !=
+            L2.convert(L1.getSemantics(), llvm::APFloat::rmNearestTiesToEven,
+                       &Ignored))
           return {};
       } else if (Order < 0)
         // type rank L1 < L2:
-        if (L1.convert(L2.getSemantics(), llvm::APFloat::rmNearestTiesToEven,
-                       &convertLoseInfo))
+        if (llvm::APFloat::opOK !=
+            L1.convert(L2.getSemantics(), llvm::APFloat::rmNearestTiesToEven,
+                       &Ignored))
           return {};
-      if (convertLoseInfo)
-        return {}; // If the conversion loses info, bail
 
       llvm::APFloat MidValue = L1;
       MidValue.add(L2, llvm::APFloat::rmNearestTiesToEven);

--- a/clang/test/Sema/warn-unreachable_crash.cpp
+++ b/clang/test/Sema/warn-unreachable_crash.cpp
@@ -2,14 +2,14 @@
 
 // Previously this test will crash
 static void test(__fp16& x) {
-  if (x != 0 || x != 1.0) { // expected-note{{}}
+  if (x != 0 || x != 1.0) { // expected-note{{}} no-crash
       x = 0.9;
     } else
       x = 0.8; // expected-warning{{code will never be executed}}
 }
 
 static void test2(__fp16& x) {
-  if (x != 1 && x == 1.0) { // expected-note{{}}
+  if (x != 1 && x == 1.0) { // expected-note{{}} no-crash
       x = 0.9; // expected-warning{{code will never be executed}}
     } else
       x = 0.8;

--- a/clang/test/Sema/warn-unreachable_crash.cpp
+++ b/clang/test/Sema/warn-unreachable_crash.cpp
@@ -1,8 +1,16 @@
 // RUN: %clang_cc1 -verify -Wunreachable-code %s
 
+// Previously this test will crash
 static void test(__fp16& x) {
   if (x != 0 || x != 1.0) { // expected-note{{}}
       x = 0.9;
     } else
       x = 0.8; // expected-warning{{code will never be executed}}
+}
+
+static void test2(__fp16& x) {
+  if (x != 1 && x == 1.0) { // expected-note{{}}
+      x = 0.9; // expected-warning{{code will never be executed}}
+    } else
+      x = 0.8;
 }

--- a/clang/test/Sema/warn-unreachable_crash.cpp
+++ b/clang/test/Sema/warn-unreachable_crash.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -verify -Wunreachable-code %s
+
+static void test(__fp16& x) {
+  if (x != 0 || x != 1.0) { // expected-note{{}}
+      x = 0.9;
+    } else
+      x = 0.8; // expected-warning{{code will never be executed}}
+}


### PR DESCRIPTION
`checkIncorrectLogicOperator` checks if an expression, for example `x != 0 || x != 1.0`, is always true or false by comparing the two literals `0` and `1.0`.  But in case `x` is a 16-bit float, the two literals have distinct types---16-bit float and double, respectively. Directly comparing `APValue`s extracted from the two literals results in an assertion failure because of their distinct types.

This commit fixes the issue by doing a conversion from the "smaller" one to the "bigger" one.  The two literals must be compatible because both of them are comparing with `x`.

rdar://152456316