### PR TITLE
CodeGen: Move ABI option enums to support

### DIFF
--- a/llvm/include/llvm/Support/CodeGen.h
+++ b/llvm/include/llvm/Support/CodeGen.h
@@ -50,6 +50,22 @@ namespace llvm {
     };
   }
 
+  namespace FloatABI {
+  enum ABIType {
+    Default, // Target-specific (either soft or hard depending on triple, etc).
+    Soft,    // Soft float.
+    Hard     // Hard float.
+  };
+  }
+
+  enum class EABI {
+    Unknown,
+    Default, // Default means not specified
+    EABI4,   // Target-specific (either 4, 5 or gnu depending on triple).
+    EABI5,
+    GNU
+  };
+
   /// Code generation optimization level.
   enum class CodeGenOptLevel {
     None = 0,      ///< -O0

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
 
 #include <memory>
@@ -24,14 +25,6 @@ namespace llvm {
 struct fltSemantics;
 class MachineFunction;
 class MemoryBuffer;
-
-namespace FloatABI {
-enum ABIType {
-  Default, // Target-specific (either soft or hard depending on triple, etc).
-  Soft,    // Soft float.
-  Hard     // Hard float.
-};
-}
 
 namespace FPOpFusion {
 enum FPOpFusionMode {
@@ -69,14 +62,6 @@ enum class BasicBlockSection {
           // seek to use Basic Block Sections, e.g. MachineFunctionSplitter.
           // This option cannot be set via the command line.
   None    // Do not use Basic Block Sections.
-};
-
-enum class EABI {
-  Unknown,
-  Default, // Default means not specified
-  EABI4,   // Target-specific (either 4, 5 or gnu depending on triple).
-  EABI5,
-  GNU
 };
 
 /// Identify a debugger for "tuning" the debug info.


### PR DESCRIPTION
Move these out of TargetOptions and into Support to avoid
the dependency on Target. There are similar ABI options
already in Support/CodeGen.h.