### PR TITLE
[mlir][spirv] Truncate Literal String size at max number words

### DIFF
--- a/mlir/include/mlir/Target/SPIRV/SPIRVBinaryUtils.h
+++ b/mlir/include/mlir/Target/SPIRV/SPIRVBinaryUtils.h
@@ -30,10 +30,11 @@ constexpr uint32_t kMagicNumber = 0x07230203;
 /// The serializer tool ID registered to the Khronos Group
 constexpr uint32_t kGeneratorNumber = 22;
 
-// Max number of words
+/// Max number of words
+/// See https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_universal_limits
 constexpr uint32_t kMaxWordCount = 65535;
 
-// Max number of words for literal
+/// Max number of words for literal
 constexpr uint32_t kMaxLiteralWordCount = kMaxWordCount - 3;
 
 /// Appends a SPRI-V module header to `header` with the given `version` and

--- a/mlir/include/mlir/Target/SPIRV/SPIRVBinaryUtils.h
+++ b/mlir/include/mlir/Target/SPIRV/SPIRVBinaryUtils.h
@@ -31,7 +31,7 @@ constexpr uint32_t kMagicNumber = 0x07230203;
 constexpr uint32_t kGeneratorNumber = 22;
 
 /// Max number of words
-/// See https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_universal_limits
+/// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_universal_limits
 constexpr uint32_t kMaxWordCount = 65535;
 
 /// Max number of words for literal

--- a/mlir/include/mlir/Target/SPIRV/SPIRVBinaryUtils.h
+++ b/mlir/include/mlir/Target/SPIRV/SPIRVBinaryUtils.h
@@ -30,6 +30,12 @@ constexpr uint32_t kMagicNumber = 0x07230203;
 /// The serializer tool ID registered to the Khronos Group
 constexpr uint32_t kGeneratorNumber = 22;
 
+// Max number of words
+constexpr uint32_t kMaxWordCount = 65535;
+
+// Max number of words for literal
+constexpr uint32_t kMaxLiteralWordCount = kMaxWordCount - 3;
+
 /// Appends a SPRI-V module header to `header` with the given `version` and
 /// `idBound`.
 void appendModuleHeader(SmallVectorImpl<uint32_t> &header,

--- a/mlir/lib/Target/SPIRV/SPIRVBinaryUtils.cpp
+++ b/mlir/lib/Target/SPIRV/SPIRVBinaryUtils.cpp
@@ -73,9 +73,9 @@ void spirv::encodeStringLiteralInto(SmallVectorImpl<uint32_t> &binary,
   size_t encodingSize = literal.size() / 4 + 1;
   size_t sizeOfDataToCopy = literal.size();
   if (encodingSize >= kMaxLiteralWordCount) {
-    // Reserve one word for the null termination
+    // Reserve one word for the null termination.
     encodingSize = kMaxLiteralWordCount - 1;
-    // Do not override the last word (null termination) when copying
+    // Do not override the last word (null termination) when copying.
     sizeOfDataToCopy = (encodingSize - 1) * 4;
     LLVM_DEBUG(llvm::dbgs()
                << "Truncating string literal to max size ("

--- a/mlir/lib/Target/SPIRV/SPIRVBinaryUtils.cpp
+++ b/mlir/lib/Target/SPIRV/SPIRVBinaryUtils.cpp
@@ -70,18 +70,18 @@ uint32_t spirv::getPrefixedOpcode(uint32_t wordCount, spirv::Opcode opcode) {
 void spirv::encodeStringLiteralInto(SmallVectorImpl<uint32_t> &binary,
                                     StringRef literal) {
   // We need to encode the literal and the null termination.
-  auto encodingSize = literal.size() / 4 + 1;
-  auto sizeOfDataToCopy = literal.size();
+  size_t encodingSize = literal.size() / 4 + 1;
+  size_t sizeOfDataToCopy = literal.size();
   if (encodingSize >= kMaxLiteralWordCount) {
-    // reserve one word for the null termination
+    // Reserve one word for the null termination
     encodingSize = kMaxLiteralWordCount - 1;
-    // do not override the last word (null termination) when copying
+    // Do not override the last word (null termination) when copying
     sizeOfDataToCopy = (encodingSize - 1) * 4;
-    LLVM_DEBUG(llvm::dbgs() << "Truncating string literal to max size ("
-                            << std::to_string(kMaxLiteralWordCount - 1)
-                            << "): " << literal << "\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "Truncating string literal to max size ("
+               << (kMaxLiteralWordCount - 1) << "): " << literal << "\n");
   }
-  auto bufferStartSize = binary.size();
+  size_t bufferStartSize = binary.size();
   binary.resize(bufferStartSize + encodingSize, 0);
   std::memcpy(binary.data() + bufferStartSize, literal.data(),
               sizeOfDataToCopy);


### PR DESCRIPTION
If not truncated the SPIRV serialization would not fail but instead produce an invalid SPIR-V module.