### PR TITLE
[clang-repl] Mark disambiguate-decl-stmt.cpp as UNSUPPORTED on ppc64le and AIX

### DIFF
--- a/clang/test/Interpreter/disambiguate-decl-stmt.cpp
+++ b/clang/test/Interpreter/disambiguate-decl-stmt.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: target=ppc64le{{.*}}, target=aix{{.*}}
 // RUN: %clang_cc1 -fsyntax-only -verify -fincremental-extensions -std=c++20 %s
 // RUN: %clang_cc1 -fsyntax-only -DMS -fms-extensions -verify -fincremental-extensions -std=c++20 %s
 


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/142749 went in, I got these set of mails from the buildbot saying 

![image](https://github.com/user-attachments/assets/da4dad69-248b-410b-b78f-a1e83902d225)

saying 

The Buildbot has detected a new failure on builder clang-ppc64le-rhel while building clang.

Full details are available at:
    https://lab.llvm.org/buildbot/#/builders/145/builds/7528

Worker for this Build: ppc64le-clang-rhel-test
Blamelist:
    Anutosh Bhat <[andersonbhat491@gmail.com](mailto:andersonbhat491@gmail.com)>,
    Jannick Kremer <[jannick.kremer@mailbox.org](mailto:jannick.kremer@mailbox.org)>,
    Jie Fu <[jiefu@tencent.com](mailto:jiefu@tencent.com)>,
    Kazu Hirata <[kazu@google.com](mailto:kazu@google.com)>,
    Rainer Orth <[ro@gcc.gnu.org](mailto:ro@gcc.gnu.org)>

BUILD FAILED: failed test (failure)

Step 7 (test-build-unified-tree-check-all) failure: test (failure)
******************** TEST 'Clang :: Interpreter/disambiguate-decl-stmt.cpp' FAILED ********************
Exit Code: 1

Command Output (stderr):
--
/home/buildbots/llvm-external-buildbots/workers/ppc64le-clang-rhel-test/clang-ppc64le-rhel/build/bin/clang -cc1 -internal-isystem /home/buildbots/llvm-external-buildbots/workers/ppc64le-clang-rhel-test/clang-ppc64le-rhel/build/lib/clang/21/include -nostdsysteminc -fsyntax-only -verify -fincremental-extensions -std=c++20 /home/buildbots/llvm-external-buildbots/workers/ppc64le-clang-rhel-test/clang-ppc64le-rhel/llvm-project/clang/test/Interpreter/disambiguate-decl-stmt.cpp # RUN: at line 1
+ /home/buildbots/llvm-external-buildbots/workers/ppc64le-clang-rhel-test/clang-ppc64le-rhel/build/bin/clang -cc1 -internal-isystem /home/buildbots/llvm-external-buildbots/workers/ppc64le-clang-rhel-test/clang-ppc64le-rhel/build/lib/clang/21/include -nostdsysteminc -fsyntax-only -verify -fincremental-extensions -std=c++20 /home/buildbots/llvm-external-buildbots/workers/ppc64le-clang-rhel-test/clang-ppc64le-rhel/llvm-project/clang/test/Interpreter/disambiguate-decl-stmt.cpp
error: 'expected-error' diagnostics seen but not expected:
  File /home/buildbots/llvm-external-buildbots/workers/ppc64le-clang-rhel-test/clang-ppc64le-rhel/llvm-project/clang/test/Interpreter/disambiguate-decl-stmt.cpp Line 113: _Float16 is not supported on this target
1 error generated.

--

********************


Sincerely,
LLVM Buildbot


This is the file I had changed hence I was responsible here.