### PR TITLE
[Support] Properly zero initialize CPU set when querying affinity

### DIFF
--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -316,6 +316,7 @@ static int computeHostNumHardwareThreads() {
     return CPU_COUNT(&mask);
 #elif defined(__linux__)
   cpu_set_t Set;
+  CPU_ZERO(&Set);
   if (sched_getaffinity(0, sizeof(Set), &Set) == 0)
     return CPU_COUNT(&Set);
 #endif


### PR DESCRIPTION
This commit resolves a potential issue of working with uninitialized memory when querying the CPU's affinity. The man page of `sched_getaffinity` does not guarantee that the memory will be fully overwritten, so this change should ensure that issues are avoided.