### PR TITLE
[BOLT] Create marker for source changes in nfc-mode testing.

### DIFF
--- a/bolt/utils/nfc-check-setup.py
+++ b/bolt/utils/nfc-check-setup.py
@@ -8,16 +8,27 @@ import sys
 import textwrap
 
 def get_relevant_bolt_changes(dir: str) -> str:
-    # Return a list of bolt source changes that are relevant to tests.
+    # Return a list of bolt source changes that are relevant to testing.
     all_changes = subprocess.run(
-        shlex.split("git show HEAD --name-only --pretty=''"), cwd=dir,
-        text=True, stdout=subprocess.PIPE)
+        shlex.split("git show HEAD --name-only --pretty=''"),
+        cwd=dir,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
     keep_bolt = subprocess.run(
-        shlex.split("grep '^bolt'"), input=all_changes.stdout,
-        text=True, stdout=subprocess.PIPE)
+        shlex.split("grep '^bolt'"),
+        input=all_changes.stdout,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
     keep_relevant = subprocess.run(
-        shlex.split("grep -v -e '^bolt/docs' -e '^bolt/utils/docker' -e '^bolt/utils/dot2html'"),
-        input=keep_bolt.stdout, text=True, stdout=subprocess.PIPE)
+        shlex.split(
+            "grep -v -e '^bolt/docs' -e '^bolt/utils/docker' -e '^bolt/utils/dot2html'"
+        ),
+        input=keep_bolt.stdout,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
     return keep_relevant.stdout
 
 def get_git_ref_or_rev(dir: str) -> str:
@@ -89,14 +100,14 @@ def main():
     # memorize the old hash for logging
     old_ref = get_git_ref_or_rev(source_dir)
 
-    if args.check_bolt_changes:
+    if args.check_bolt_sources:
         marker = f"{args.build_dir}/.llvm-bolt.changes"
         if os.path.exists(marker):
             os.remove(marker)
         file_changes = get_relevant_bolt_changes(source_dir)
         # Create a marker file if any relevant BOLT source files changed.
         if len(file_changes) > 0:
-            print (f"BOLT source changes were found:\n{file_changes}")
+            print(f"BOLT source changes were found:\n{file_changes}")
             open(marker, "a").close()
 
     # determine whether a stash is needed

--- a/bolt/utils/nfc-check-setup.py
+++ b/bolt/utils/nfc-check-setup.py
@@ -7,6 +7,18 @@ import subprocess
 import sys
 import textwrap
 
+def get_relevant_bolt_changes(dir: str) -> str:
+    # Return a list of bolt source changes that are relevant to tests.
+    all_changes = subprocess.run(
+        shlex.split("git show HEAD --name-only --pretty=''"), cwd=dir,
+        text=True, stdout=subprocess.PIPE)
+    keep_bolt = subprocess.run(
+        shlex.split("grep '^bolt'"), input=all_changes.stdout,
+        text=True, stdout=subprocess.PIPE)
+    keep_relevant = subprocess.run(
+        shlex.split("grep -v -e '^bolt/docs' -e '^bolt/utils/docker' -e '^bolt/utils/dot2html'"),
+        input=keep_bolt.stdout, text=True, stdout=subprocess.PIPE)
+    return keep_relevant.stdout
 
 def get_git_ref_or_rev(dir: str) -> str:
     # Run 'git symbolic-ref -q --short HEAD || git rev-parse --short HEAD'
@@ -35,6 +47,12 @@ def main():
         nargs="?",
         default=os.getcwd(),
         help="Path to BOLT build directory, default is current " "directory",
+    )
+    parser.add_argument(
+        "--check-bolt-sources",
+        default=False,
+        action="store_true",
+        help="Create a marker file (.llvm-bolt.changes) if any relevant BOLT sources are modified",
     )
     parser.add_argument(
         "--switch-back",
@@ -70,6 +88,16 @@ def main():
     os.replace(bolt_path, f"{bolt_path}.new")
     # memorize the old hash for logging
     old_ref = get_git_ref_or_rev(source_dir)
+
+    if args.check_bolt_changes:
+        marker = f"{args.build_dir}/.llvm-bolt.changes"
+        if os.path.exists(marker):
+            os.remove(marker)
+        file_changes = get_relevant_bolt_changes(source_dir)
+        # Create a marker file if any relevant BOLT source files changed.
+        if len(file_changes) > 0:
+            print (f"BOLT source changes were found:\n{file_changes}")
+            open(marker, "a").close()
 
     # determine whether a stash is needed
     stash = subprocess.run(


### PR DESCRIPTION
Currently NFC tests only trigger when the llvm-bolt binary itself changes.

This patch adds `--check-bolt-sources`, which scans git output for any modifications under bolt/, excluding:
- bolt/docs
- bolt/utils/docker
- bolt/utils/dot2html

If any matching files change between versions, a `.llvm-bolt.changes` marker is created. Buildbots can then use this marker to trigger in-tree tests.