### PR TITLE
Revert "[clang-repl] Ensure clang-repl accepts all C keywords supported in all language models (#142749)

### DIFF
--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -1171,7 +1171,6 @@ Parser::isCXXDeclarationSpecifier(ImplicitTypenameContext AllowImplicitTypename,
   case tok::kw_inline:
   case tok::kw_virtual:
   case tok::kw_explicit:
-  case tok::kw__Noreturn:
 
     // Modules
   case tok::kw___module_private__:
@@ -1226,7 +1225,6 @@ Parser::isCXXDeclarationSpecifier(ImplicitTypenameContext AllowImplicitTypename,
     // GNU
   case tok::kw_restrict:
   case tok::kw__Complex:
-  case tok::kw__Imaginary:
   case tok::kw___attribute:
   case tok::kw___auto_type:
     return TPResult::True;

--- a/clang/test/Interpreter/disambiguate-decl-stmt.cpp
+++ b/clang/test/Interpreter/disambiguate-decl-stmt.cpp
@@ -102,16 +102,3 @@ __attribute((noreturn)) Attrs2::Attrs2() = default;
 
 // Extra semicolon
 namespace N {};
-
-// Test C keywords supported in all language modes.
-// https://clang.llvm.org/docs/LanguageExtensions.html#c-keywords-supported-in-all-language-modes
-
-_Alignas(16) int aligned_var;
-int align = _Alignof(double);
-_Atomic int atomic_var = 0;
-_Complex double complex_val = 1.0 + 2.0i;
-_Float16 f = 1.5;
-_Thread_local int counter = 0;
-_Static_assert(sizeof(int) == 4, "int must be 4 bytes");
-_Imaginary float i = 2.0f; // expected-error {{imaginary types are not supported}}
-_Noreturn void noreturn_func() { while (true) {} }


### PR DESCRIPTION
This reverts commit 7ca7bcb7d8dcf26fc0281697fe47aa6cdb3884c0.

