### PR TITLE
WordPos should be less than BITWORDS_PER_ELEMENT

### DIFF
--- a/llvm/include/llvm/ADT/SparseBitVector.h
+++ b/llvm/include/llvm/ADT/SparseBitVector.h
@@ -152,7 +152,7 @@ public:
     unsigned WordPos = Curr / BITWORD_SIZE;
     unsigned BitPos = Curr % BITWORD_SIZE;
     BitWord Copy = Bits[WordPos];
-    assert(WordPos <= BITWORDS_PER_ELEMENT
+    assert(WordPos < BITWORDS_PER_ELEMENT
            && "Word Position outside of element");
 
     // Mask off previous bits.


### PR DESCRIPTION
Bits is declared as:
```
BitWord Bits[BITWORDS_PER_ELEMENT];
```
The change modifies an assert condition to ensure that `WordPos` is strictly less than `BITWORDS_PER_ELEMENT` rather than less than or equal to it.