### PR TITLE
[TableGen] Remove last remnant of CompositeIndices

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -703,7 +703,7 @@ struct TupleExpander : SetTheory::Expander {
           RV.setValue(BitInit::get(RK, true));
 
         // Copy fields from the RegisterTuples def.
-        if (Field == "SubRegIndices" || Field == "CompositeIndices") {
+        if (Field == "SubRegIndices") {
           NewReg->addValue(*Def->getValue(Field));
           continue;
         }


### PR DESCRIPTION
The rest of the support was removed in 2012 by:
599593630999 "Remove support for 'CompositeIndices' and sub-register cycles."
