### PR TITLE
Fix error that reference to PointerType is ambiguous in clang/lib/Analysis/UnsafeBufferUsage.cpp

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -37,7 +37,6 @@
 #include <set>
 #include <sstream>
 
-using namespace llvm;
 using namespace clang;
 
 #ifndef NDEBUG
@@ -247,11 +246,11 @@ private:
 
 // Because we're dealing with raw pointers, let's define what we mean by that.
 static bool hasPointerType(const Expr &E) {
-  return isa<clang::PointerType>(E.getType().getCanonicalType());
+  return isa<PointerType>(E.getType().getCanonicalType());
 }
 
 static bool hasArrayType(const Expr &E) {
-  return isa<clang::ArrayType>(E.getType().getCanonicalType());
+  return isa<ArrayType>(E.getType().getCanonicalType());
 }
 
 static void
@@ -474,7 +473,7 @@ static bool isSafeSpanTwoParamConstruct(const CXXConstructExpr &Node,
   auto HaveEqualConstantValues = [&Ctx](const Expr *E0, const Expr *E1) {
     if (auto E0CV = E0->getIntegerConstantExpr(Ctx))
       if (auto E1CV = E1->getIntegerConstantExpr(Ctx)) {
-        return APSInt::compareValues(*E0CV, *E1CV) == 0;
+        return llvm::APSInt::compareValues(*E0CV, *E1CV) == 0;
       }
     return false;
   };
@@ -485,7 +484,7 @@ static bool isSafeSpanTwoParamConstruct(const CXXConstructExpr &Node,
       }
     return false;
   };
-  std::optional<APSInt> Arg1CV = Arg1->getIntegerConstantExpr(Ctx);
+  std::optional<llvm::APSInt> Arg1CV = Arg1->getIntegerConstantExpr(Ctx);
 
   if (Arg1CV && Arg1CV->isZero())
     // Check form 5:
@@ -528,10 +527,10 @@ static bool isSafeSpanTwoParamConstruct(const CXXConstructExpr &Node,
   QualType Arg0Ty = Arg0->IgnoreImplicit()->getType();
 
   if (auto *ConstArrTy = Ctx.getAsConstantArrayType(Arg0Ty)) {
-    const APSInt ConstArrSize = APSInt(ConstArrTy->getSize());
+    const llvm::APSInt ConstArrSize = llvm::APSInt(ConstArrTy->getSize());
 
     // Check form 4:
-    return Arg1CV && APSInt::compareValues(ConstArrSize, *Arg1CV) == 0;
+    return Arg1CV && llvm::APSInt::compareValues(ConstArrSize, *Arg1CV) == 0;
   }
   // Check form 6:
   if (auto CCast = dyn_cast<CStyleCastExpr>(Arg0)) {
@@ -968,8 +967,7 @@ static bool hasUnsafePrintfStringArg(const CallExpr &Node, ASTContext &Ctx,
   if (!FirstParmTy->isPointerType())
     return false; // possibly some user-defined printf function
 
-  QualType FirstPteTy =
-      FirstParmTy->castAs<clang::PointerType>()->getPointeeType();
+  QualType FirstPteTy = FirstParmTy->castAs<PointerType>()->getPointeeType();
 
   if (!Ctx.getFILEType()
            .isNull() && //`FILE *` must be in the context if it is fprintf
@@ -1053,8 +1051,7 @@ static bool hasUnsafeSnprintfBuffer(const CallExpr &Node,
   if (!FirstParmTy->isPointerType())
     return false; // Not an snprint
 
-  QualType FirstPteTy =
-      FirstParmTy->castAs<clang::PointerType>()->getPointeeType();
+  QualType FirstPteTy = FirstParmTy->castAs<PointerType>()->getPointeeType();
   const Expr *Buf = Node.getArg(0), *Size = Node.getArg(1);
 
   if (FirstPteTy.isConstQualified() || !Buf->getType()->isPointerType() ||
@@ -1101,9 +1098,10 @@ static bool hasUnsafeSnprintfBuffer(const CallExpr &Node,
       // explicit cast will be needed, which will make this check unreachable.
       // Therefore, the array extent is same as its' bytewise size.
       if (Size->EvaluateAsInt(ER, Ctx)) {
-        APSInt EVal = ER.Val.getInt(); // Size must have integer type
+        llvm::APSInt EVal = ER.Val.getInt(); // Size must have integer type
 
-        return APSInt::compareValues(EVal, APSInt(CAT->getSize(), true)) != 0;
+        return llvm::APSInt::compareValues(
+                   EVal, llvm::APSInt(CAT->getSize(), true)) != 0;
       }
     }
   }
@@ -2150,8 +2148,8 @@ namespace {
 // declarations to its uses and make sure we've covered all uses with our
 // analysis before we try to fix the declaration.
 class DeclUseTracker {
-  using UseSetTy = SmallSet<const DeclRefExpr *, 16>;
-  using DefMapTy = DenseMap<const VarDecl *, const DeclStmt *>;
+  using UseSetTy = llvm::SmallSet<const DeclRefExpr *, 16>;
+  using DefMapTy = llvm::DenseMap<const VarDecl *, const DeclStmt *>;
 
   // Allocate on the heap for easier move.
   std::unique_ptr<UseSetTy> Uses{std::make_unique<UseSetTy>()};
@@ -3642,7 +3640,7 @@ static FixItList fixVarDeclWithArray(const VarDecl *D, const ASTContext &Ctx,
     }
 
     SmallString<32> Replacement;
-    raw_svector_ostream OS(Replacement);
+    llvm::raw_svector_ostream OS(Replacement);
     OS << "std::array<" << ElemTypeTxt << ", " << ArraySizeTxt << "> "
        << IdentText->str();
 
@@ -4066,7 +4064,8 @@ static void applyGadgets(const Decl *D, FixableGadgetList FixableGadgets,
 #endif
 
   // Fixpoint iteration for pointer assignments
-  using DepMapTy = DenseMap<const VarDecl *, llvm::SetVector<const VarDecl *>>;
+  using DepMapTy =
+      llvm::DenseMap<const VarDecl *, llvm::SetVector<const VarDecl *>>;
   DepMapTy DependenciesMap{};
   DepMapTy PtrAssignmentGraph{};
 

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -247,11 +247,11 @@ private:
 
 // Because we're dealing with raw pointers, let's define what we mean by that.
 static bool hasPointerType(const Expr &E) {
-  return isa<PointerType>(E.getType().getCanonicalType());
+  return isa<clang::PointerType>(E.getType().getCanonicalType());
 }
 
 static bool hasArrayType(const Expr &E) {
-  return isa<ArrayType>(E.getType().getCanonicalType());
+  return isa<clang::ArrayType>(E.getType().getCanonicalType());
 }
 
 static void
@@ -968,7 +968,8 @@ static bool hasUnsafePrintfStringArg(const CallExpr &Node, ASTContext &Ctx,
   if (!FirstParmTy->isPointerType())
     return false; // possibly some user-defined printf function
 
-  QualType FirstPteTy = FirstParmTy->castAs<PointerType>()->getPointeeType();
+  QualType FirstPteTy =
+      FirstParmTy->castAs<clang::PointerType>()->getPointeeType();
 
   if (!Ctx.getFILEType()
            .isNull() && //`FILE *` must be in the context if it is fprintf
@@ -1052,7 +1053,8 @@ static bool hasUnsafeSnprintfBuffer(const CallExpr &Node,
   if (!FirstParmTy->isPointerType())
     return false; // Not an snprint
 
-  QualType FirstPteTy = FirstParmTy->castAs<PointerType>()->getPointeeType();
+  QualType FirstPteTy =
+      FirstParmTy->castAs<clang::PointerType>()->getPointeeType();
   const Expr *Buf = Node.getArg(0), *Size = Node.getArg(1);
 
   if (FirstPteTy.isConstQualified() || !Buf->getType()->isPointerType() ||


### PR DESCRIPTION
The CI on my PR https://github.com/llvm/llvm-project/pull/138895 is failing with errors like

`clang/lib/Analysis/UnsafeBufferUsage.cpp:971:45: error: reference to 'PointerType' is ambiguous`

This patch should resolve it by removing `using namespace llvm`