### PR TITLE
[Clang] Implement CWG2496

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -155,6 +155,8 @@ Resolutions to C++ Defect Reports
 
 - Implemented `CWG3005 Function parameters should never be name-independent <https://wg21.link/CWG3005>`_.
 
+- Implemented `CWG2496 ref-qualifiers and virtual overriding <https://wg21.link/CWG2496>`_.
+
 C Language Changes
 ------------------
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -1490,7 +1490,7 @@ static bool IsOverloadOrOverrideImpl(Sema &SemaRef, FunctionDecl *New,
   // If the function is a class member, its signature includes the
   // cv-qualifiers (if any) and ref-qualifier (if any) on the function itself.
   auto DiagnoseInconsistentRefQualifiers = [&]() {
-    if (SemaRef.LangOpts.CPlusPlus23)
+    if (SemaRef.LangOpts.CPlusPlus23 && !UseOverrideRules)
       return false;
     if (OldMethod->getRefQualifier() == NewMethod->getRefQualifier())
       return false;

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -220,18 +220,23 @@ void (*q)() throw() = S();
 namespace cwg2496 { // cwg2496: 21
 #if __cplusplus >= 201102L
 struct S {
-    virtual void f(); // expected-note {{previous declaration is here}}
-    virtual void g() &; // expected-note {{previous declaration is here}}
-    virtual void h(); // expected-note {{previous declaration is here}}
+    virtual void f(); // #cwg2496-f
+    virtual void g() &; // #cwg2496-g
+    virtual void h(); // #cwg2496-h
+    virtual void i(); // #cwg2496-i
 };
 
 struct T : S {
     virtual void f() &;
     // expected-error@-1 {{cannot overload a member function with ref-qualifier '&' with a member function without a ref-qualifier}}
+    // expected-note@#cwg2496-f {{previous declaration is here}}
     virtual void g();
     // expected-error@-1 {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&'}}
+    // expected-note@#cwg2496-g {{previous declaration is here}}
     virtual void h() &&;
     // expected-error@-1 {{cannot overload a member function with ref-qualifier '&&' with a member function without a ref-qualifier}}
+    // expected-note@#cwg2496-h {{previous declaration is here}}
+    virtual void i();
 };
 #endif
 }

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -226,6 +226,7 @@ struct S {
     virtual void i();
     virtual void j() &;
     virtual void k() &&;
+    virtual void l() &;
 };
 
 struct T : S {
@@ -241,6 +242,7 @@ struct T : S {
     virtual void i();
     virtual void j() &;
     virtual void k() &;
+    virtual void l() &&;
 };
 #endif
 }

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -223,7 +223,9 @@ struct S {
     virtual void f(); // #cwg2496-f
     virtual void g() &; // #cwg2496-g
     virtual void h(); // #cwg2496-h
-    virtual void i(); // #cwg2496-i
+    virtual void i();
+    virtual void j() &;
+    virtual void k() &&;
 };
 
 struct T : S {
@@ -237,6 +239,8 @@ struct T : S {
     // expected-error@-1 {{cannot overload a member function with ref-qualifier '&&' with a member function without a ref-qualifier}}
     // expected-note@#cwg2496-h {{previous declaration is here}}
     virtual void i();
+    virtual void j() &;
+    virtual void k() &;
 };
 #endif
 }

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -215,3 +215,23 @@ void (*q)() throw() = S();
 // since-cxx17-error@-1 {{no viable conversion from 'S' to 'void (*)() throw()'}}
 //   since-cxx17-note@#cwg2486-conv {{candidate function}}
 } // namespace cwg2486
+
+
+namespace cwg2496 { // cwg2496: 21
+#if __cplusplus >= 201102L
+struct S {
+    virtual void f(); // expected-note {{previous declaration is here}}
+    virtual void g() &; // expected-note {{previous declaration is here}}
+    virtual void h(); // expected-note {{previous declaration is here}}
+};
+
+struct T : S {
+    virtual void f() &;
+    // expected-error@-1 {{cannot overload a member function with ref-qualifier '&' with a member function without a ref-qualifier}}
+    virtual void g();
+    // expected-error@-1 {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&'}}
+    virtual void h() &&;
+    // expected-error@-1 {{cannot overload a member function with ref-qualifier '&&' with a member function without a ref-qualifier}}
+};
+#endif
+}

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -14811,7 +14811,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2496.html">2496</a></td>
     <td>CD6</td>
     <td><I>ref-qualifier</I>s and virtual overriding</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="unreleased" align="center">Clang 21</td>
   </tr>
   <tr class="open" id="2497">
     <td><a href="https://cplusplus.github.io/CWG/issues/2497.html">2497</a></td>


### PR DESCRIPTION
https://cplusplus.github.io/CWG/issues/2496.html

We failed to diagnose the following in C++23 mode

```
struct S {
    virtual void f(); // expected-note {{previous declaration is here}}
};

struct T : S {
    virtual void f() &;
};
```