### PR TITLE
[AArch64] Add support for -mlong-calls code generation

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
@@ -466,6 +466,12 @@ void aarch64::getAArch64TargetFeatures(const Driver &D,
 
   if (Args.getLastArg(options::OPT_mno_bti_at_return_twice))
     Features.push_back("+no-bti-at-return-twice");
+
+  if (Arg *A = Args.getLastArg(options::OPT_mlong_calls,
+                               options::OPT_mno_long_calls)) {
+    if (A->getOption().matches(options::OPT_mlong_calls))
+      Features.push_back("+long-calls");
+  }
 }
 
 void aarch64::setPAuthABIInTriple(const Driver &D, const ArgList &Args,

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -825,6 +825,10 @@ def FeatureDisableFastIncVL : SubtargetFeature<"disable-fast-inc-vl",
                                                "HasDisableFastIncVL", "true",
                                                "Do not prefer INC/DEC, ALL, { 1, 2, 4 } over ADDVL">;
 
+def FeatureLongCalls : SubtargetFeature<"long-calls", "GenLongCalls", "true",
+                                        "Generate calls via indirect call "
+                                        "instructions">;
+
 //===----------------------------------------------------------------------===//
 // Architectures.
 //

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -2706,6 +2706,14 @@ bool AArch64InstructionSelector::select(MachineInstr &I) {
            "Expected small code model");
     auto Op1 = BaseMI->getOperand(1);
     auto Op2 = I.getOperand(2);
+    if (Subtarget->genLongCalls() && Op1.isSymbol()) {
+      auto MovAddr =
+          MIB.buildInstr(AArch64::MOVaddr, {I.getOperand(0)}, {})
+              .addExternalSymbol(Op1.getSymbolName(), Op1.getTargetFlags())
+              .addExternalSymbol(Op2.getSymbolName(), Op2.getTargetFlags());
+      I.eraseFromParent();
+      return constrainSelectedInstRegOperands(*MovAddr, TII, TRI, RBI);
+    }
     auto MovAddr = MIB.buildInstr(AArch64::MOVaddr, {I.getOperand(0)}, {})
                        .addGlobalAddress(Op1.getGlobal(), Op1.getOffset(),
                                          Op1.getTargetFlags())

--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.h
@@ -42,7 +42,9 @@ private:
   bool legalizeShlAshrLshr(MachineInstr &MI, MachineRegisterInfo &MRI,
                            MachineIRBuilder &MIRBuilder,
                            GISelChangeObserver &Observer) const;
-
+  bool legalizeSmallCMSymbol(MachineInstr &MI, MachineRegisterInfo &MRI,
+                             MachineIRBuilder &MIRBuilder,
+                             GISelChangeObserver &Observer) const;
   bool legalizeSmallCMGlobalValue(MachineInstr &MI, MachineRegisterInfo &MRI,
                                   MachineIRBuilder &MIRBuilder,
                                   GISelChangeObserver &Observer) const;

--- a/llvm/test/CodeGen/AArch64/aarch64-long-calls.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-long-calls.ll
@@ -1,0 +1,27 @@
+; RUN: llc -O2 -mtriple=aarch64-linux-gnu -mcpu=generic -mattr=+long-calls < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=aarch64-linux-gnu -mcpu=generic -mattr=+long-calls < %s | FileCheck %s
+
+declare void @far_func()
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly, i8, i64, i1 immarg)
+
+define void @test() {
+entry:
+  call void @far_func()
+  ret void
+}
+
+define void @test2(ptr %dst, i8 %val, i64 %len) {
+entry:
+  call void @llvm.memset.p0.i64(ptr %dst, i8 %val, i64 %len, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: test:
+; CHECK: adrp {{x[0-9]+}}, far_func
+; CHECK: add {{x[0-9]+}}, {{x[0-9]+}}, :lo12:far_func
+; CHECK: blr {{x[0-9]+}}
+
+; CHECK-LABEL: test2:
+; CHECK: adrp {{x[0-9]+}}, memset
+; CHECK: add {{x[0-9]+}}, {{x[0-9]+}}, :lo12:memset
+; CHECK: blr {{x[0-9]+}}


### PR DESCRIPTION
This patch implements backend support for -mlong-calls on AArch64 targets. When enabled, calls to external functions are lowered to an indirect call via an address computed using `adrp` and `add` rather than a direct `bl` instruction, which is limited to a ±128MB PC-relative offset.

This is particularly useful when code and/or data exceeds the 26-bit immediate range of `bl`, such as in large binaries or link-time-optimized builds.

Key changes:
- In SelectionDAG lowering (`LowerCall`), detect `-mlong-calls` and emit:
    - `adrp + add` address calculation
    - `blr` indirect call instruction

This patch ensures that long-calls are emitted correctly for both GlobalAddress and ExternalSymbol call targets.

Tested:
- New codegen tests under `llvm/test/CodeGen/AArch64/aarch64-long-calls.ll`
- Verified `adrp + add + blr` output in `.s` for global and external functions