### PR TITLE
[clang] Reduce TemplateDeclInstantiator size.

### DIFF
--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -587,8 +587,9 @@ enum class TemplateSubstitutionKind : char {
     /// specializations that will need to be instantiated after the
     /// enclosing class's instantiation is complete.
     SmallVector<std::pair<ClassTemplateDecl *,
-                                ClassTemplatePartialSpecializationDecl *>, 1>
-      OutOfLinePartialSpecs;
+                          ClassTemplatePartialSpecializationDecl *>,
+                1>
+        OutOfLinePartialSpecs;
 
     /// A list of out-of-line variable template partial
     /// specializations that will need to be instantiated after the
@@ -596,7 +597,7 @@ enum class TemplateSubstitutionKind : char {
     /// FIXME: Verify that this is needed.
     SmallVector<
         std::pair<VarTemplateDecl *, VarTemplatePartialSpecializationDecl *>, 1>
-    OutOfLineVarPartialSpecs;
+        OutOfLineVarPartialSpecs;
 
   public:
     TemplateDeclInstantiator(Sema &SemaRef, DeclContext *Owner,

--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -587,7 +587,7 @@ enum class TemplateSubstitutionKind : char {
     /// specializations that will need to be instantiated after the
     /// enclosing class's instantiation is complete.
     SmallVector<std::pair<ClassTemplateDecl *,
-                                ClassTemplatePartialSpecializationDecl *>, 4>
+                                ClassTemplatePartialSpecializationDecl *>, 1>
       OutOfLinePartialSpecs;
 
     /// A list of out-of-line variable template partial
@@ -595,7 +595,7 @@ enum class TemplateSubstitutionKind : char {
     /// enclosing variable's instantiation is complete.
     /// FIXME: Verify that this is needed.
     SmallVector<
-        std::pair<VarTemplateDecl *, VarTemplatePartialSpecializationDecl *>, 4>
+        std::pair<VarTemplateDecl *, VarTemplatePartialSpecializationDecl *>, 1>
     OutOfLineVarPartialSpecs;
 
   public:

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2394,7 +2394,7 @@ Decl *TemplateDeclInstantiator::VisitVarTemplateDecl(VarTemplateDecl *D) {
     // Queue up any out-of-line partial specializations of this member
     // variable template; the client will force their instantiation once
     // the enclosing class has been instantiated.
-    SmallVector<VarTemplatePartialSpecializationDecl *, 4> PartialSpecs;
+    SmallVector<VarTemplatePartialSpecializationDecl *, 1> PartialSpecs;
     D->getPartialSpecializations(PartialSpecs);
     for (unsigned I = 0, N = PartialSpecs.size(); I != N; ++I)
       if (PartialSpecs[I]->getFirstDecl()->isOutOfLine())


### PR DESCRIPTION
This gives us another ~1.85% improvement (1617->1647 for the `instantiation-depth-default.cpp`) on clang's template instantiation depths, 

No performance regressions have been observed:  https://llvm-compile-time-tracker.com/compare.php?from=702e228249906d43687952d9a2f3d2f90d8024c6&to=61be4bfea92d52cfc3e48a3cabb1bc80cbebb7fa&stat=instructions:u
