### PR TITLE
AArch64: Partially move setting of libcall names out of TargetLowering

### DIFF
--- a/llvm/lib/IR/RuntimeLibcalls.cpp
+++ b/llvm/lib/IR/RuntimeLibcalls.cpp
@@ -16,6 +16,21 @@ static cl::opt<bool>
     HexagonEnableFastMathRuntimeCalls("hexagon-fast-math", cl::Hidden,
                                       cl::desc("Enable Fast Math processing"));
 
+static void setAArch64LibcallNames(RuntimeLibcallsInfo &Info,
+                                   const Triple &TT) {
+  if (TT.isWindowsArm64EC()) {
+    // FIXME: are there calls we need to exclude from this?
+#define HANDLE_LIBCALL(code, name)                                             \
+  {                                                                            \
+    const char *libcallName = Info.getLibcallName(RTLIB::code);                \
+    if (libcallName && libcallName[0] != '#')                                  \
+      Info.setLibcallName(RTLIB::code, "#" #name);                             \
+  }
+#include "llvm/IR/RuntimeLibcalls.def"
+#undef HANDLE_LIBCALL
+  }
+}
+
 /// Set default libcall names. If a target wants to opt-out of a libcall it
 /// should be placed here.
 void RuntimeLibcallsInfo::initLibcalls(const Triple &TT) {
@@ -246,6 +261,9 @@ void RuntimeLibcallsInfo::initLibcalls(const Triple &TT) {
       setLibcallCallingConv(LC.Op, LC.CC);
     }
   }
+
+  if (TT.getArch() == Triple::ArchType::aarch64)
+    setAArch64LibcallNames(*this, TT);
 
   if (TT.getArch() == Triple::ArchType::avr) {
     // Division rtlib functions (not supported), use divmod functions instead

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -1986,18 +1986,6 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
   for (ISD::NodeType Op : {ISD::FLDEXP, ISD::STRICT_FLDEXP, ISD::FFREXP})
     if (isOperationExpand(Op, MVT::f16))
       setOperationAction(Op, MVT::f16, Promote);
-
-  if (Subtarget->isWindowsArm64EC()) {
-    // FIXME: are there calls we need to exclude from this?
-#define HANDLE_LIBCALL(code, name)                                             \
-  {                                                                            \
-    const char *libcallName = getLibcallName(RTLIB::code);                     \
-    if (libcallName && libcallName[0] != '#')                                  \
-      setLibcallName(RTLIB::code, "#" #name);                                  \
-  }
-#include "llvm/IR/RuntimeLibcalls.def"
-#undef HANDLE_LIBCALL
-  }
 }
 
 void AArch64TargetLowering::addTypeForNEON(MVT VT) {


### PR DESCRIPTION
Move the parts that aren't dependent on the subtarget into
RuntimeLibcallInfo, which should contain the superset of all possible
runtime calls and be accurate outside of codegen.