### PR TITLE
Fix an error introduced in #138518

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2160,6 +2160,11 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
            "paren init for non-call init");
     Exprs = MultiExprArg(List->getExprs(), List->getNumExprs());
   }
+  if (auto *List = dyn_cast_or_null<CXXParenListInitExpr>(Initializer)) {
+    assert(InitStyle == CXXNewInitializationStyle::Parens &&
+           "paren init for non-call init");
+    Exprs = List->getInitExprs();
+  }
 
   // C++11 [expr.new]p15:
   //   A new-expression that creates an object of type T initializes that

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2159,8 +2159,7 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
     assert(InitStyle == CXXNewInitializationStyle::Parens &&
            "paren init for non-call init");
     Exprs = MultiExprArg(List->getExprs(), List->getNumExprs());
-  }
-  if (auto *List = dyn_cast_or_null<CXXParenListInitExpr>(Initializer)) {
+  } else if (auto *List = dyn_cast_or_null<CXXParenListInitExpr>(Initializer)) {
     assert(InitStyle == CXXNewInitializationStyle::Parens &&
            "paren init for non-call init");
     Exprs = List->getInitExprs();

--- a/clang/test/SemaCXX/paren-list-init-expr.cpp
+++ b/clang/test/SemaCXX/paren-list-init-expr.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -ast-dump %s | FileCheck %s
+struct Node {
+  long val;
+};
+template <bool>
+void CallNew() {
+    new Node(0);
+}
+// CHECK-LABEL: FunctionTemplateDecl {{.*}} CallNew
+// CHECK: |-FunctionDecl {{.*}} CallNew 'void ()'
+// CHECK:  `-CXXNewExpr {{.*}} 'operator new' 'void *(unsigned long)'
+// CHECK:  `-CXXParenListInitExpr {{.*}} 'Node'
+// CHECK:  `-ImplicitCastExpr {{.*}} 'long' <IntegralCast>
+// CHECK:  `-IntegerLiteral {{.*}} 'int' 0
+// CHECK: `-FunctionDecl {{.*}} used CallNew 'void ()' implicit_instantiation
+// CHECK:   |-TemplateArgument integral 'true'
+// CHECK:   `-CXXNewExpr {{.*}} 'operator new' 'void *(unsigned long)'
+// CHECK:   `-CXXParenListInitExpr {{.*}} 'Node'
+// CHECK:   `-ImplicitCastExpr {{.*}} 'long' <IntegralCast>
+// CHECK:   `-IntegerLiteral {{.*}} 'int' 0
+void f() {
+    (void)CallNew<true>; 
+}

--- a/clang/test/SemaCXX/paren-list-init-expr.cpp
+++ b/clang/test/SemaCXX/paren-list-init-expr.cpp
@@ -8,13 +8,13 @@ void CallNew() {
 }
 // CHECK-LABEL: FunctionTemplateDecl {{.*}} CallNew
 // CHECK: |-FunctionDecl {{.*}} CallNew 'void ()'
-// CHECK:  `-CXXNewExpr {{.*}} 'operator new' 'void *(unsigned long)'
+// CHECK:  `-CXXNewExpr {{.*}} 'operator new'
 // CHECK:  `-CXXParenListInitExpr {{.*}} 'Node'
 // CHECK:  `-ImplicitCastExpr {{.*}} 'long' <IntegralCast>
 // CHECK:  `-IntegerLiteral {{.*}} 'int' 0
 // CHECK: `-FunctionDecl {{.*}} used CallNew 'void ()' implicit_instantiation
 // CHECK:   |-TemplateArgument integral 'true'
-// CHECK:   `-CXXNewExpr {{.*}} 'operator new' 'void *(unsigned long)'
+// CHECK:   `-CXXNewExpr {{.*}} 'operator new'
 // CHECK:   `-CXXParenListInitExpr {{.*}} 'Node'
 // CHECK:   `-ImplicitCastExpr {{.*}} 'long' <IntegralCast>
 // CHECK:   `-IntegerLiteral {{.*}} 'int' 0


### PR DESCRIPTION
CXXParenListInitExpr arguments would lose casts leading to incorrect types being used (e.g. only 32 bits of a 64 bit value being initialized). See https://github.com/llvm/llvm-project/pull/138518#issuecomment-2906276916 and https://github.com/llvm/llvm-project/pull/138518#issuecomment-2944538713 for details and context.
