### PR TITLE
[OpenMP][Flang]Fix omp_get_cancellation return type from integer to logical

### DIFF
--- a/openmp/runtime/src/include/omp_lib.F90.var
+++ b/openmp/runtime/src/include/omp_lib.F90.var
@@ -399,7 +399,7 @@
 
           function omp_get_cancellation() bind(c)
             use omp_lib_kinds
-            integer (kind=omp_integer_kind) omp_get_cancellation
+            logical (kind=omp_logical_kind) omp_get_cancellation
           end function omp_get_cancellation
 
           function omp_is_initial_device() bind(c)


### PR DESCRIPTION
Fix #142833
According to the OpenMP 5.2 spec, modify the return type of `omp_get_cancellation()` to logical.