### PR TITLE
[bazel] Fix LLVM plugin tests under Analysis.

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
@@ -33,6 +33,80 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "inline_advisor_plugin",
+    srcs = glob(["Analysis/InlineAdvisorPlugin/*.cpp"]),
+    deps = [
+        "//llvm:Analysis",
+        "//llvm:Core",
+        "//llvm:Passes",
+        "//llvm:Support",
+    ],
+)
+
+cc_shared_library(
+    name = "inline_advisor_plugin_shared",
+    shared_lib_name = "InlineAdvisorPlugin.so",
+    deps = [":inline_advisor_plugin"],
+)
+
+cc_test(
+    name = "plugin_inline_advisor_analysis_test",
+    srcs = ["Analysis/PluginInlineAdvisorAnalysisTest.cpp"],
+    data = [
+        ":inline_advisor_plugin_shared",
+    ],
+    deps = [
+        "//llvm:Analysis",
+        "//llvm:AsmParser",
+        "//llvm:Core",
+        "//llvm:Passes",
+        "//llvm:Support",
+        "//llvm:TestingSupport",
+        "//llvm:attributes_gen",
+        "//llvm:config",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "inline_order_plugin",
+    srcs = glob(["Analysis/InlineOrderPlugin/*.cpp"]),
+    deps = [
+        "//llvm:Analysis",
+        "//llvm:Core",
+        "//llvm:Passes",
+        "//llvm:Support",
+    ],
+)
+
+cc_shared_library(
+    name = "inline_order_plugin_shared",
+    shared_lib_name = "InlineOrderPlugin.so",
+    deps = [":inline_order_plugin"],
+)
+
+cc_test(
+    name = "plugin_inline_order_analysis_test",
+    srcs = ["Analysis/PluginInlineOrderAnalysisTest.cpp"],
+    data = [
+        ":inline_order_plugin_shared",
+    ],
+    deps = [
+        "//llvm:Analysis",
+        "//llvm:AsmParser",
+        "//llvm:Core",
+        "//llvm:Passes",
+        "//llvm:Support",
+        "//llvm:TestingSupport",
+        "//llvm:attributes_gen",
+        "//llvm:config",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
 cc_test(
     name = "analysis_tests",
     size = "small",
@@ -45,6 +119,12 @@ cc_test(
             "Analysis/TFUtilsTest.cpp",
             "Analysis/TrainingLoggerTest.cpp",
             "Analysis/MLModelRunnerTest.cpp",
+            # These tests dynamically load Plugins which both pull in
+            # llvm/lib/Analysis/ProfileSummaryInfo.cpp, which registers flags;
+            # if built into the same cc_test target, those flags will be
+            # registered twice and cause runtime failures.
+            "Analysis/PluginInlineAdvisorAnalysisTest.cpp",
+            "Analysis/PluginInlineOrderAnalysisTest.cpp",
         ],
     ),
     deps = [


### PR DESCRIPTION
Those tests were broken on bazel as a side effect of 8830e380.

This commit is tested with this command on Linux:

    bazelisk test \
        @llvm-project//llvm/unittests:analysis_tests \
        @llvm-project//llvm/unittests:plugin_inline_advisor_analysis_test \
        @llvm-project//llvm/unittests:plugin_inline_order_analysis_test