### PR TITLE
[libc++] Remap headers in the debug info when building the library

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -1706,6 +1706,11 @@ add_dependencies(cxx-headers generate-cxx-headers)
 target_include_directories(cxx-headers INTERFACE ${LIBCXX_GENERATED_INCLUDE_TARGET_DIR}
                                                  ${LIBCXX_GENERATED_INCLUDE_DIR})
 
+# Make sure to map the generated include directory back to libc++'s actual source directory when generating
+# debug information. Otherwise, the debug information will refer to generated headers which are created during
+# the build and generally not persistent.
+target_add_compile_flags_if_supported(cxx-headers INTERFACE "-fdebug-prefix-map=${LIBCXX_GENERATED_INCLUDE_DIR}=${LIBCXX_SOURCE_DIR}/include")
+
 if (LIBCXX_INSTALL_HEADERS)
   foreach(file ${files})
     get_filename_component(dir ${file} DIRECTORY)


### PR DESCRIPTION
The libc++ build includes a step where headers are generated. This is required in order to preprocess some files such as the assertion handler and the __config_site header. As a result, the library is built against headers located inside the build directory, and the path to those headers is what's included in the debug information of the library.

However, these headers in the build directory are usually not persistent, which means that the debug information might end up referring to headers that don't exist anymore. To solve this problem, this patch uses the -fdebug-prefix-map flag supported by Clang and GCC to remap the generated headers to the original headers in the source directory. This provides the illusion that the library was truly built against the in-source version of the headers.