### PR TITLE
Reland "[HLSL][RootSignature] Implement serialization of RootConstants and RootFlags"

### DIFF
--- a/clang/lib/Parse/CMakeLists.txt
+++ b/clang/lib/Parse/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(LLVM_LINK_COMPONENTS
+  FrontendHLSL
   FrontendOpenMP
   MC
   MCParser

--- a/clang/unittests/Parse/CMakeLists.txt
+++ b/clang/unittests/Parse/CMakeLists.txt
@@ -11,5 +11,6 @@ add_clang_unittest(ParseTests
   LLVMTestingSupport
   clangTesting
   LLVM_COMPONENTS
+  FrontendHLSL
   Support
   )

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -44,6 +44,8 @@ enum class RootFlags : uint32_t {
   ValidFlags = 0x00000fff
 };
 
+raw_ostream &operator<<(raw_ostream &OS, const RootFlags &Flags);
+
 enum class RootDescriptorFlags : unsigned {
   None = 0,
   DataVolatile = 0x2,
@@ -158,6 +160,8 @@ struct RootConstants {
   uint32_t Space = 0;
   ShaderVisibility Visibility = ShaderVisibility::All;
 };
+
+raw_ostream &operator<<(raw_ostream &OS, const RootConstants &Constants);
 
 enum class DescriptorType : uint8_t { SRV = 0, UAV, CBuffer };
 // Models RootDescriptor : CBV | SRV | UAV, by collecting like parameters

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -44,8 +44,6 @@ enum class RootFlags : uint32_t {
   ValidFlags = 0x00000fff
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const RootFlags &Flags);
-
 enum class RootDescriptorFlags : unsigned {
   None = 0,
   DataVolatile = 0x2,
@@ -160,8 +158,6 @@ struct RootConstants {
   uint32_t Space = 0;
   ShaderVisibility Visibility = ShaderVisibility::All;
 };
-
-raw_ostream &operator<<(raw_ostream &OS, const RootConstants &Constants);
 
 enum class DescriptorType : uint8_t { SRV = 0, UAV, CBuffer };
 // Models RootDescriptor : CBV | SRV | UAV, by collecting like parameters

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
@@ -27,6 +27,11 @@ class Metadata;
 namespace hlsl {
 namespace rootsig {
 
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const RootFlags &Flags);
+
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                 const RootConstants &Constants);
+
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                                  const DescriptorTableClause &Clause);
 

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
@@ -129,6 +129,79 @@ static raw_ostream &operator<<(raw_ostream &OS,
   return OS;
 }
 
+raw_ostream &operator<<(raw_ostream &OS, const RootFlags &Flags) {
+  OS << "RootFlags(";
+  bool FlagSet = false;
+  unsigned Remaining = llvm::to_underlying(Flags);
+  while (Remaining) {
+    unsigned Bit = 1u << llvm::countr_zero(Remaining);
+    if (Remaining & Bit) {
+      if (FlagSet)
+        OS << " | ";
+
+      switch (static_cast<RootFlags>(Bit)) {
+      case RootFlags::AllowInputAssemblerInputLayout:
+        OS << "AllowInputAssemblerInputLayout";
+        break;
+      case RootFlags::DenyVertexShaderRootAccess:
+        OS << "DenyVertexShaderRootAccess";
+        break;
+      case RootFlags::DenyHullShaderRootAccess:
+        OS << "DenyHullShaderRootAccess";
+        break;
+      case RootFlags::DenyDomainShaderRootAccess:
+        OS << "DenyDomainShaderRootAccess";
+        break;
+      case RootFlags::DenyGeometryShaderRootAccess:
+        OS << "DenyGeometryShaderRootAccess";
+        break;
+      case RootFlags::DenyPixelShaderRootAccess:
+        OS << "DenyPixelShaderRootAccess";
+        break;
+      case RootFlags::AllowStreamOutput:
+        OS << "AllowStreamOutput";
+        break;
+      case RootFlags::LocalRootSignature:
+        OS << "LocalRootSignature";
+        break;
+      case RootFlags::DenyAmplificationShaderRootAccess:
+        OS << "DenyAmplificationShaderRootAccess";
+        break;
+      case RootFlags::DenyMeshShaderRootAccess:
+        OS << "DenyMeshShaderRootAccess";
+        break;
+      case RootFlags::CBVSRVUAVHeapDirectlyIndexed:
+        OS << "CBVSRVUAVHeapDirectlyIndexed";
+        break;
+      case RootFlags::SamplerHeapDirectlyIndexed:
+        OS << "SamplerHeapDirectlyIndexed";
+        break;
+      default:
+        OS << "invalid: " << Bit;
+        break;
+      }
+
+      FlagSet = true;
+    }
+    Remaining &= ~Bit;
+  }
+
+  if (!FlagSet)
+    OS << "None";
+
+  OS << ")";
+
+  return OS;
+}
+
+raw_ostream &operator<<(raw_ostream &OS, const RootConstants &Constants) {
+  OS << "RootConstants(num32BitConstants = " << Constants.Num32BitConstants
+     << ", " << Constants.Reg << ", space = " << Constants.Space
+     << ", visibility = " << Constants.Visibility << ")";
+
+  return OS;
+}
+
 raw_ostream &operator<<(raw_ostream &OS, const DescriptorTable &Table) {
   OS << "DescriptorTable(numClauses = " << Table.NumClauses
      << ", visibility = " << Table.Visibility << ")";

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
@@ -129,66 +129,26 @@ static raw_ostream &operator<<(raw_ostream &OS,
   return OS;
 }
 
+static const EnumEntry<RootFlags> RootFlagNames[] = {
+    {"AllowInputAssemblerInputLayout",
+     RootFlags::AllowInputAssemblerInputLayout},
+    {"DenyVertexShaderRootAccess", RootFlags::DenyVertexShaderRootAccess},
+    {"DenyHullShaderRootAccess", RootFlags::DenyHullShaderRootAccess},
+    {"DenyDomainShaderRootAccess", RootFlags::DenyDomainShaderRootAccess},
+    {"DenyGeometryShaderRootAccess", RootFlags::DenyGeometryShaderRootAccess},
+    {"DenyPixelShaderRootAccess", RootFlags::DenyPixelShaderRootAccess},
+    {"AllowStreamOutput", RootFlags::AllowStreamOutput},
+    {"LocalRootSignature", RootFlags::LocalRootSignature},
+    {"DenyAmplificationShaderRootAccess",
+     RootFlags::DenyAmplificationShaderRootAccess},
+    {"DenyMeshShaderRootAccess", RootFlags::DenyMeshShaderRootAccess},
+    {"CBVSRVUAVHeapDirectlyIndexed", RootFlags::CBVSRVUAVHeapDirectlyIndexed},
+    {"SamplerHeapDirectlyIndexed", RootFlags::SamplerHeapDirectlyIndexed},
+};
+
 raw_ostream &operator<<(raw_ostream &OS, const RootFlags &Flags) {
   OS << "RootFlags(";
-  bool FlagSet = false;
-  unsigned Remaining = llvm::to_underlying(Flags);
-  while (Remaining) {
-    unsigned Bit = 1u << llvm::countr_zero(Remaining);
-    if (Remaining & Bit) {
-      if (FlagSet)
-        OS << " | ";
-
-      switch (static_cast<RootFlags>(Bit)) {
-      case RootFlags::AllowInputAssemblerInputLayout:
-        OS << "AllowInputAssemblerInputLayout";
-        break;
-      case RootFlags::DenyVertexShaderRootAccess:
-        OS << "DenyVertexShaderRootAccess";
-        break;
-      case RootFlags::DenyHullShaderRootAccess:
-        OS << "DenyHullShaderRootAccess";
-        break;
-      case RootFlags::DenyDomainShaderRootAccess:
-        OS << "DenyDomainShaderRootAccess";
-        break;
-      case RootFlags::DenyGeometryShaderRootAccess:
-        OS << "DenyGeometryShaderRootAccess";
-        break;
-      case RootFlags::DenyPixelShaderRootAccess:
-        OS << "DenyPixelShaderRootAccess";
-        break;
-      case RootFlags::AllowStreamOutput:
-        OS << "AllowStreamOutput";
-        break;
-      case RootFlags::LocalRootSignature:
-        OS << "LocalRootSignature";
-        break;
-      case RootFlags::DenyAmplificationShaderRootAccess:
-        OS << "DenyAmplificationShaderRootAccess";
-        break;
-      case RootFlags::DenyMeshShaderRootAccess:
-        OS << "DenyMeshShaderRootAccess";
-        break;
-      case RootFlags::CBVSRVUAVHeapDirectlyIndexed:
-        OS << "CBVSRVUAVHeapDirectlyIndexed";
-        break;
-      case RootFlags::SamplerHeapDirectlyIndexed:
-        OS << "SamplerHeapDirectlyIndexed";
-        break;
-      default:
-        OS << "invalid: " << Bit;
-        break;
-      }
-
-      FlagSet = true;
-    }
-    Remaining &= ~Bit;
-  }
-
-  if (!FlagSet)
-    OS << "None";
-
+  printFlags(OS, Flags, ArrayRef(RootFlagNames));
   OS << ")";
 
   return OS;

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -108,4 +108,73 @@ TEST(HLSLRootSignatureTest, DescriptorTableDump) {
   EXPECT_EQ(Out, Expected);
 }
 
+TEST(HLSLRootSignatureTest, DefaultRootConstantsDump) {
+  RootConstants Constants;
+  Constants.Num32BitConstants = 1;
+  Constants.Reg = {RegisterType::BReg, 3};
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  OS << Constants;
+  OS.flush();
+
+  std::string Expected = "RootConstants(num32BitConstants = 1, b3, space = 0, "
+                         "visibility = All)";
+  EXPECT_EQ(Out, Expected);
+}
+
+TEST(HLSLRootSignatureTest, SetRootConstantsDump) {
+  RootConstants Constants;
+  Constants.Num32BitConstants = 983;
+  Constants.Reg = {RegisterType::BReg, 34593};
+  Constants.Space = 7;
+  Constants.Visibility = ShaderVisibility::Pixel;
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  OS << Constants;
+  OS.flush();
+
+  std::string Expected = "RootConstants(num32BitConstants = 983, b34593, "
+                         "space = 7, visibility = Pixel)";
+  EXPECT_EQ(Out, Expected);
+}
+
+TEST(HLSLRootSignatureTest, NoneRootFlagsDump) {
+  RootFlags Flags = RootFlags::None;
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  OS << Flags;
+  OS.flush();
+
+  std::string Expected = "RootFlags(None)";
+  EXPECT_EQ(Out, Expected);
+}
+
+TEST(HLSLRootSignatureTest, AllRootFlagsDump) {
+  RootFlags Flags = RootFlags::ValidFlags;
+
+  std::string Out;
+  llvm::raw_string_ostream OS(Out);
+  OS << Flags;
+  OS.flush();
+
+  std::string Expected = "RootFlags("
+                         "AllowInputAssemblerInputLayout | "
+                         "DenyVertexShaderRootAccess | "
+                         "DenyHullShaderRootAccess | "
+                         "DenyDomainShaderRootAccess | "
+                         "DenyGeometryShaderRootAccess | "
+                         "DenyPixelShaderRootAccess | "
+                         "AllowStreamOutput | "
+                         "LocalRootSignature | "
+                         "DenyAmplificationShaderRootAccess | "
+                         "DenyMeshShaderRootAccess | "
+                         "CBVSRVUAVHeapDirectlyIndexed | "
+                         "SamplerHeapDirectlyIndexed)";
+
+  EXPECT_EQ(Out, Expected);
+}
+
 } // namespace


### PR DESCRIPTION
This relands #141130.

The initial commit uncovered that we are missing the correct linking of FrontendHLSL into clang/lib/Parse and clang/lib/unittests/Parse.

This change addreses this by linking them accordingly.

It was also checked and ensured that the LexHLSLRootSignature libraries do not depend on FrontendHLSL and so we are not required to link there.

Resolves: #138190 and #138192