### PR TITLE
[Offload] Fix APU detection for MI300 testing

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -36,8 +36,7 @@ if 'HSA_ENABLE_SDMA' in os.environ:
 
 # Architectures like gfx942 may or may not be APUs so an additional environment
 # variable is required as some tests can be APU specific.
-if 'IS_APU' in os.environ:
-    config.environment['IS_APU'] = os.environ['IS_APU']
+config.environment['IS_APU'] = os.environ.get('IS_APU', '0')
 
 # set default environment variables for test
 if 'CHECK_OPENMP_ENV' in os.environ:


### PR DESCRIPTION
Summary:
We have this check when the target is MI300 but it fails if this
environment variable isn't set. Set a default value of '0' if not
present so that will be converted to bool false.
