### PR TITLE
[CIR] Add empty handlers for Using and UsingShadow decls

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1135,12 +1135,17 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
     emitGlobalOpenACCDecl(cast<OpenACCDeclareDecl>(decl));
     break;
   case Decl::Enum:
+  case Decl::Using:          // using X; [C++]
   case Decl::UsingDirective: // using namespace X; [C++]
   case Decl::Typedef:
   case Decl::TypeAlias: // using foo = bar; [C++11]
   case Decl::Record:
   case Decl::CXXRecord:
     assert(!cir::MissingFeatures::generateDebugInfo());
+    break;
+
+  // No code generation needed.
+  case Decl::UsingShadow:
     break;
 
   // C++ Decls

--- a/clang/test/CIR/CodeGen/namespace.cpp
+++ b/clang/test/CIR/CodeGen/namespace.cpp
@@ -50,3 +50,46 @@ int f4(void) {
 // CHECK:   %[[G3_ADDR:.*]] = cir.get_global @_ZN4test5test22g3E : !cir.ptr<!s32i>
 // CHECK:   %[[G3_VAL:.*]] = cir.load{{.*}} %[[G3_ADDR]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   %[[SUM2:.*]] = cir.binop(add, %[[SUM]], %[[G3_VAL]]) nsw : !s32i
+
+using test2::f3;
+using test2::g3;
+
+int f5() {
+  f3();
+  return g3;
+}
+
+// CHECK: cir.func @_Z2f5v()
+// CHECK:   cir.call @_ZN4test5test22f3Ev()
+// CHECK:   %[[G3_ADDR:.*]] = cir.get_global @_ZN4test5test22g3E : !cir.ptr<!s32i>
+// CHECK:   %[[G3_VAL:.*]] = cir.load{{.*}} %[[G3_ADDR]] : !cir.ptr<!s32i>, !s32i
+
+namespace test3 {
+  struct S {
+    int a;
+  } s;
+}
+
+using test3::s;
+
+int f6() {
+  return s.a;
+}
+
+// CHECK: cir.func @_Z2f6v()
+// CHECK:   cir.get_global @_ZN5test31sE : !cir.ptr<!rec_test33A3AS>
+// CHECK:   cir.get_member %{{.*}}[0] {name = "a"}
+
+int shadowedFunc() {
+  return 3;
+}
+
+namespace shadow {
+  using ::shadowedFunc;
+}
+
+void f7() {
+  shadow::shadowedFunc();
+}
+
+// CHECK: cir.func @_Z2f7v()


### PR DESCRIPTION
This adds emitTopLevelDecl "handlers" for Using and UsingShadow. These don't actually need any handling, but they need to be present in the switch to avoid hitting the default handler, which issues a diagnostic about the decl kind not being implemented.

There are several other decl kinds that don't need any handling. Those will be added when I have test cases for them.