### PR TITLE
[libc++][Android] Always redirect <stdatomic.h> to <atomic>

### DIFF
--- a/libcxx/include/atomic
+++ b/libcxx/include/atomic
@@ -598,7 +598,10 @@ template <class T>
 #    define _LIBCPP_STDATOMIC_H_HAS_DEFINITELY_BEEN_INCLUDED 0
 #  endif
 
-#  if _LIBCPP_STD_VER < 23 && _LIBCPP_STDATOMIC_H_HAS_DEFINITELY_BEEN_INCLUDED
+// The Android LLVM toolchain has historically allowed combining the <atomic>
+// and <stdatomic.h> headers in dialects before C++23, so for backwards
+// compatibility, preserve that ability when targeting Android.
+#  if _LIBCPP_STD_VER < 23 && !defined(__ANDROID__) && _LIBCPP_STDATOMIC_H_HAS_DEFINITELY_BEEN_INCLUDED
 #    error <atomic> is incompatible with <stdatomic.h> before C++23. Please compile with -std=c++23.
 #  endif
 

--- a/libcxx/include/stdatomic.h
+++ b/libcxx/include/stdatomic.h
@@ -126,7 +126,10 @@ using std::atomic_signal_fence                         // see below
 #    pragma GCC system_header
 #  endif
 
-#  if defined(__cplusplus) && _LIBCPP_STD_VER >= 23
+// The Android LLVM toolchain has historically allowed combining the <atomic>
+// and <stdatomic.h> headers in dialects before C++23, so for backwards
+// compatibility, preserve that ability when targeting Android.
+#  if defined(__cplusplus) && (_LIBCPP_STD_VER >= 23 || defined(__ANDROID__))
 
 #    include <atomic>
 #    include <version>

--- a/libcxx/test/libcxx/atomics/atomics.syn/compatible_with_stdatomic.compile.pass.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.syn/compatible_with_stdatomic.compile.pass.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: no-threads
-// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+
+// On Android, libc++'s <stdatomic.h> header always redirects to <atomic>, even before C++23.
+// UNSUPPORTED: (c++03 || c++11 || c++14 || c++17 || c++20) && !android
 
 // This test verifies that <stdatomic.h> redirects to <atomic>.
 

--- a/libcxx/test/libcxx/atomics/atomics.syn/incompatible_with_stdatomic.verify.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.syn/incompatible_with_stdatomic.verify.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: no-threads
 // REQUIRES: c++03 || c++11 || c++14 || c++17 || c++20
 
+// On Android, libc++'s <stdatomic.h> header always redirects to <atomic>, even before C++23.
+// XFAIL: android
+
 // No diagnostic gets emitted when we build with modules.
 // XFAIL: clang-modules-build
 

--- a/libcxx/test/libcxx/atomics/stdatomic.h.syn/dont_hijack_header.cxx23.compile.pass.cpp
+++ b/libcxx/test/libcxx/atomics/stdatomic.h.syn/dont_hijack_header.cxx23.compile.pass.cpp
@@ -21,6 +21,9 @@
 // doesn't work at all if we don't use the <stdatomic.h> provided by libc++ in C++23 and above.
 // XFAIL: (c++11 || c++14 || c++17 || c++20) && gcc
 
+// On Android, libc++'s <stdatomic.h> header always redirects to <atomic>, even before C++23.
+// XFAIL: android
+
 #include <atomic>
 #include <stdatomic.h>
 #include <type_traits>


### PR DESCRIPTION
When targeting Android, enable the <stdatomic.h> to <atomic> redirection for C++ language dialects before C++23, because this redirection historically existed for Android's C++ toolchain. Currently, the Android toolchain achieves this redirection with a stdatomic.h in the sysroot (from Bionic) that defines the C API either directly or by aliasing std identifiers from <atomic>. The Android team's LLVM build scripts then copy Bionic's header over the one in the Clang resource directory.

Hopefully, by moving Android's redirection into LLVM itself, the Android stdatomic.h situation can be simplified eventually.