### PR TITLE
[clang-format] Fix Microsoft calling convensions preventing function names from being marked TT_StartOfName

### DIFF
--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -114,6 +114,7 @@ namespace format {
   TYPE(LineComment)                                                            \
   TYPE(MacroBlockBegin)                                                        \
   TYPE(MacroBlockEnd)                                                          \
+  TYPE(MicrosoftCallingConvention)                                             \
   TYPE(ModulePartitionColon)                                                   \
   TYPE(NamespaceLBrace)                                                        \
   TYPE(NamespaceMacro)                                                         \

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1802,6 +1802,14 @@ private:
       if (Style.isTableGen() && !parseTableGenValue())
         return false;
       break;
+    case tok::kw___cdecl:
+    case tok::kw___stdcall:
+    case tok::kw___fastcall:
+    case tok::kw___thiscall:
+    case tok::kw___regcall:
+    case tok::kw___vectorcall:
+      Tok->setType(TT_MicrosoftCallingConvention);
+      break;
     default:
       break;
     }
@@ -2610,6 +2618,13 @@ private:
 
     // Skip "const" as it does not have an influence on whether this is a name.
     FormatToken *PreviousNotConst = Tok.getPreviousNonComment();
+
+    // Skip Microsoft calling conventions, as they come before the function
+    // name, but after the return type
+    while (PreviousNotConst &&
+           PreviousNotConst->is(TT_MicrosoftCallingConvention)) {
+      PreviousNotConst = PreviousNotConst->getPreviousNonComment();
+    }
 
     // For javascript const can be like "let" or "var"
     if (!Style.isJavaScript())

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -17504,6 +17504,12 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
   verifyFormat("A::A() : a(1) {}", SpaceFuncDecl);
   verifyFormat("void f () __attribute__((asdf));", SpaceFuncDecl);
   verifyFormat("void __attribute__((asdf)) f ();", SpaceFuncDecl);
+  verifyFormat("void __stdcall f ();", SpaceFuncDecl);
+  verifyFormat("void __cdecl f ();", SpaceFuncDecl);
+  verifyFormat("void __fastcall f ();", SpaceFuncDecl);
+  verifyFormat("void __stdcall f() {}", SpaceFuncDecl);
+  verifyFormat("void __cdecl f() {}", SpaceFuncDecl);
+  verifyFormat("void __fastcall f() {}", SpaceFuncDecl);
   verifyFormat("#define A(x) x", SpaceFuncDecl);
   verifyFormat("#define A (x) x", SpaceFuncDecl);
   verifyFormat("#if defined(x)\n"
@@ -17540,6 +17546,12 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
   verifyFormat("A::A () : a(1) {}", SpaceFuncDef);
   verifyFormat("void f() __attribute__((asdf));", SpaceFuncDef);
   verifyFormat("void __attribute__((asdf)) f();", SpaceFuncDef);
+  verifyFormat("void __stdcall f();", SpaceFuncDef);
+  verifyFormat("void __cdecl f();", SpaceFuncDef);
+  verifyFormat("void __fastcall f();", SpaceFuncDef);
+  verifyFormat("void __stdcall f () {}", SpaceFuncDef);
+  verifyFormat("void __cdecl f () {}", SpaceFuncDef);
+  verifyFormat("void __fastcall f () {}", SpaceFuncDef);
   verifyFormat("#define A(x) x", SpaceFuncDef);
   verifyFormat("#define A (x) x", SpaceFuncDef);
   verifyFormat("#if defined(x)\n"


### PR DESCRIPTION
This fixes the `SpaceBeforeParensOptions.AfterFunctionDeclarationName` and `SpaceBeforeParensOptions.AfterFunctionDefinitionName` options not adding spaces when the function has an explicit Microsoft calling convention.

Attribution Note - I have been authorized to contribute this change on behalf of my company: ArenaNet LLC