### PR TITLE
[llvm][RISCV] Handle required features of intrinsic correctly

### DIFF
--- a/clang/include/clang/Basic/riscv_andes_vector.td
+++ b/clang/include/clang/Basic/riscv_andes_vector.td
@@ -30,7 +30,7 @@ multiclass RVVFPMAD {
   }
 }
 
-let RequiredFeatures = ["Xandesvpackfph"],
+let RequiredFeatures = ["xandesvpackfph"],
     UnMaskedPolicyScheme = HasPassthruOperand in {
 let ManualCodegen = [{
   {
@@ -86,7 +86,7 @@ let ManualCodegen = [{
 
 multiclass RVVD4DOT<list<list<string>> i_suffixes_prototypes,
                     list<list<string>> l_suffixes_prototypes> {
-  let RequiredFeatures = ["Xandesvdot"],
+  let RequiredFeatures = ["xandesvdot"],
       UnMaskedPolicyScheme = HasPolicyOperand,
       HasMaskedOffOperand = false,
       Log2LMUL = [-1, 0, 1, 2, 3],

--- a/clang/include/clang/Basic/riscv_sifive_vector.td
+++ b/clang/include/clang/Basic/riscv_sifive_vector.td
@@ -50,7 +50,7 @@ multiclass RVVVCIXBuiltinSet<list<string> range, string prototype,
                              string suffix = "Uv"> {
   foreach r = range in
     let RequiredFeatures = !if(!and(UseGPR, !eq(r, "l")),
-                               ["Xsfvcp", "RV64"], ["Xsfvcp"]) in
+                               ["xsfvcp", "64bit"], ["xsfvcp"]) in
       defm : VCIXBuiltinSet<NAME, NAME, suffix, prototype, r, intrinsic_types>;
 }
 
@@ -126,7 +126,7 @@ multiclass RVVVFNRCLIPBuiltinSet<string suffix, string prototype, string type_ra
 }
 
 let UnMaskedPolicyScheme = HasPolicyOperand in
-  let RequiredFeatures = ["Xsfvqmaccdod"] in {
+  let RequiredFeatures = ["xsfvqmaccdod"] in {
     defm sf_vqmaccu_2x8x2 : RVVVQMACCDODBuiltinSet<[["", "v", "vv(FixedSEW:8)SUv(FixedSEW:8)Uv"]]>;
     defm sf_vqmacc_2x8x2 : RVVVQMACCDODBuiltinSet<[["", "v", "vv(FixedSEW:8)Sv(FixedSEW:8)v"]]>;
     defm sf_vqmaccus_2x8x2 : RVVVQMACCDODBuiltinSet<[["", "v", "vv(FixedSEW:8)SUv(FixedSEW:8)v"]]>;
@@ -134,7 +134,7 @@ let UnMaskedPolicyScheme = HasPolicyOperand in
   }
 
 let UnMaskedPolicyScheme = HasPolicyOperand in
-  let RequiredFeatures = ["Xsfvqmaccqoq"] in {
+  let RequiredFeatures = ["xsfvqmaccqoq"] in {
     defm sf_vqmaccu_4x8x4 : RVVVQMACCQOQBuiltinSet<[["", "w", "ww(FixedSEW:8)SUv(FixedSEW:8)Uv"]]>;
     defm sf_vqmacc_4x8x4 : RVVVQMACCQOQBuiltinSet<[["", "w", "ww(FixedSEW:8)Sv(FixedSEW:8)v"]]>;
     defm sf_vqmaccus_4x8x4 : RVVVQMACCQOQBuiltinSet<[["", "w", "ww(FixedSEW:8)SUv(FixedSEW:8)v"]]>;
@@ -142,10 +142,10 @@ let UnMaskedPolicyScheme = HasPolicyOperand in
   }
 
 let UnMaskedPolicyScheme = HasPolicyOperand in
-  let RequiredFeatures = ["Xsfvfwmaccqqq"] in
+  let RequiredFeatures = ["xsfvfwmaccqqq"] in
     defm sf_vfwmacc_4x4x4 : RVVVFWMACCBuiltinSet<[["", "Fw", "FwFwSvv"]]>;
 
-let UnMaskedPolicyScheme = HasPassthruOperand, RequiredFeatures = ["Xsfvfnrclipxfqf"] in {
+let UnMaskedPolicyScheme = HasPassthruOperand, RequiredFeatures = ["xsfvfnrclipxfqf"] in {
 let ManualCodegen = [{
   {
     // LLVM intrinsic

--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -117,8 +117,8 @@ multiclass RVVIndexedLoad<string op> {
         defvar eew = eew_list[0];
         defvar eew_type = eew_list[1];
         let Name = op # eew # "_v", IRName = op, MaskedIRName = op # "_mask",
-            RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                   !if(!eq(type, "y"), ["Zvfbfmin"],
+            RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                   !if(!eq(type, "y"), ["zvfbfmin"],
                                                    []<string>)) in {
           def: RVVOutOp0Op1Builtin<"v", "vPCe" # eew_type # "Uv", type>;
             if !not(IsFloat<type>.val) then {
@@ -129,9 +129,9 @@ multiclass RVVIndexedLoad<string op> {
       defvar eew64 = "64";
       defvar eew64_type = "(Log2EEW:6)";
       let Name = op # eew64 # "_v", IRName = op, MaskedIRName = op # "_mask",
-          RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin", "RV64"],
-                                 !if(!eq(type, "y"), ["Zvfbfmin", "RV64"],
-                                                 ["RV64"])) in {
+          RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin", "64bit"],
+                                 !if(!eq(type, "y"), ["zvfbfmin", "64bit"],
+                                                 ["64bit"])) in {
           def: RVVOutOp0Op1Builtin<"v", "vPCe" # eew64_type # "Uv", type>;
             if !not(IsFloat<type>.val) then {
               def: RVVOutOp0Op1Builtin<"Uv", "UvPCUe" # eew64_type # "Uv", type>;
@@ -224,8 +224,8 @@ multiclass RVVIndexedStore<string op> {
           defvar eew = eew_list[0];
           defvar eew_type = eew_list[1];
           let Name = op # eew  # "_v", IRName = op, MaskedIRName = op # "_mask",
-          RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                 !if(!eq(type, "y"), ["Zvfbfmin"],
+          RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                 !if(!eq(type, "y"), ["zvfbfmin"],
                                                  []<string>)) in  {
             def : RVVBuiltin<"v", "0Pe" # eew_type # "Uvv", type>;
             if !not(IsFloat<type>.val) then {
@@ -236,9 +236,9 @@ multiclass RVVIndexedStore<string op> {
         defvar eew64 = "64";
         defvar eew64_type = "(Log2EEW:6)";
         let Name = op # eew64  # "_v", IRName = op, MaskedIRName = op # "_mask",
-            RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin", "RV64"],
-                                   !if(!eq(type, "y"), ["Zvfbfmin", "RV64"],
-                                                   ["RV64"])) in  {
+            RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin", "64bit"],
+                                   !if(!eq(type, "y"), ["zvfbfmin", "64bit"],
+                                                   ["64bit"])) in  {
           def : RVVBuiltin<"v", "0Pe" # eew64_type # "Uvv", type>;
           if !not(IsFloat<type>.val) then {
             def : RVVBuiltin<"Uv", "0PUe" # eew64_type # "UvUv", type>;
@@ -362,11 +362,11 @@ multiclass RVVNonTupleVCreateBuiltin<int dst_lmul, list<int> src_lmul_list> {
     def vcreate # src_v # dst_v : RVVBuiltin<src_v # dst_v,
                                              dst_v # src_s,
                                              "csilfd">;
-    let RequiredFeatures = ["Zvfhmin"] in
+    let RequiredFeatures = ["zvfhmin"] in
       def vcreate_h # src_v # dst_v : RVVBuiltin<src_v # dst_v,
                                                  dst_v # src_s,
                                                  "x", dst_v>;
-    let RequiredFeatures = ["Zvfbfmin"] in
+    let RequiredFeatures = ["zvfbfmin"] in
       def vcreate_bf16 # src_v # dst_v : RVVBuiltin<src_v # dst_v,
                                                     dst_v # src_s,
                                                     "y", dst_v>;
@@ -689,9 +689,9 @@ let HasBuiltinAlias = false,
 def vlm: RVVVLEMaskBuiltin;
 defm vle8: RVVVLEBuiltin<["c"]>;
 defm vle16: RVVVLEBuiltin<["s"]>;
-let Name = "vle16_v", RequiredFeatures = ["Zvfhmin"] in
+let Name = "vle16_v", RequiredFeatures = ["zvfhmin"] in
   defm vle16_h: RVVVLEBuiltin<["x"]>;
-let Name = "vle16_v", RequiredFeatures = ["Zvfbfmin"] in
+let Name = "vle16_v", RequiredFeatures = ["zvfbfmin"] in
   defm vle16_bf16 : RVVVLEBuiltin<["y"]>;
 defm vle32: RVVVLEBuiltin<["i","f"]>;
 defm vle64: RVVVLEBuiltin<["l","d"]>;
@@ -699,9 +699,9 @@ defm vle64: RVVVLEBuiltin<["l","d"]>;
 def vsm : RVVVSEMaskBuiltin;
 defm vse8 : RVVVSEBuiltin<["c"]>;
 defm vse16: RVVVSEBuiltin<["s"]>;
-let Name = "vse16_v", RequiredFeatures = ["Zvfhmin"] in
+let Name = "vse16_v", RequiredFeatures = ["zvfhmin"] in
   defm vse16_h: RVVVSEBuiltin<["x"]>;
-let Name = "vse16_v", RequiredFeatures = ["Zvfbfmin"] in
+let Name = "vse16_v", RequiredFeatures = ["zvfbfmin"] in
   defm vse16_bf16: RVVVSEBuiltin<["y"]>;
 defm vse32: RVVVSEBuiltin<["i","f"]>;
 defm vse64: RVVVSEBuiltin<["l","d"]>;
@@ -709,18 +709,18 @@ defm vse64: RVVVSEBuiltin<["l","d"]>;
 // 7.5. Vector Strided Instructions
 defm vlse8: RVVVLSEBuiltin<["c"]>;
 defm vlse16: RVVVLSEBuiltin<["s"]>;
-let Name = "vlse16_v", RequiredFeatures = ["Zvfhmin"] in
+let Name = "vlse16_v", RequiredFeatures = ["zvfhmin"] in
   defm vlse16_h: RVVVLSEBuiltin<["x"]>;
-let Name = "vlse16_v", RequiredFeatures = ["Zvfbfmin"] in
+let Name = "vlse16_v", RequiredFeatures = ["zvfbfmin"] in
   defm vlse16_bf16: RVVVLSEBuiltin<["y"]>;
 defm vlse32: RVVVLSEBuiltin<["i","f"]>;
 defm vlse64: RVVVLSEBuiltin<["l","d"]>;
 
 defm vsse8 : RVVVSSEBuiltin<["c"]>;
 defm vsse16: RVVVSSEBuiltin<["s"]>;
-let Name = "vsse16_v", RequiredFeatures = ["Zvfhmin"] in
+let Name = "vsse16_v", RequiredFeatures = ["zvfhmin"] in
   defm vsse16_h: RVVVSSEBuiltin<["x"]>;
-let Name = "vsse16_v", RequiredFeatures = ["Zvfbfmin"] in
+let Name = "vsse16_v", RequiredFeatures = ["zvfbfmin"] in
   defm vsse16_bf: RVVVSSEBuiltin<["y"]>;
 defm vsse32: RVVVSSEBuiltin<["i","f"]>;
 defm vsse64: RVVVSSEBuiltin<["l","d"]>;
@@ -735,9 +735,9 @@ defm : RVVIndexedStore<"vsoxei">;
 // 7.7. Unit-stride Fault-Only-First Loads
 defm vle8ff: RVVVLEFFBuiltin<["c"]>;
 defm vle16ff: RVVVLEFFBuiltin<["s"]>;
-let Name = "vle16ff_v", RequiredFeatures = ["Zvfhmin"] in
+let Name = "vle16ff_v", RequiredFeatures = ["zvfhmin"] in
   defm vle16ff: RVVVLEFFBuiltin<["x"]>;
-let Name = "vle16ff_v", RequiredFeatures = ["Zvfbfmin"] in
+let Name = "vle16ff_v", RequiredFeatures = ["zvfbfmin"] in
   defm vle16ff: RVVVLEFFBuiltin<["y"]>;
 defm vle32ff: RVVVLEFFBuiltin<["i", "f"]>;
 defm vle64ff: RVVVLEFFBuiltin<["l", "d"]>;
@@ -757,8 +757,8 @@ multiclass RVVUnitStridedSegLoadTuple<string op> {
             IRName = op # nf,
             MaskedIRName = op # nf # "_mask",
             NF = nf,
-            RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                   !if(!eq(type, "y"), ["Zvfbfmin"],
+            RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                   !if(!eq(type, "y"), ["zvfbfmin"],
                                                    []<string>)),
             ManualCodegen = [{
     {
@@ -824,8 +824,8 @@ multiclass RVVUnitStridedSegStoreTuple<string op> {
           MaskedIRName = op # nf # "_mask",
           NF = nf,
           HasMaskedOffOperand = false,
-          RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                 !if(!eq(type, "y"), ["Zvfbfmin"],
+          RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                 !if(!eq(type, "y"), ["zvfbfmin"],
                                                  []<string>)),
           ManualCodegen = [{
     {
@@ -878,8 +878,8 @@ multiclass RVVUnitStridedSegLoadFFTuple<string op> {
             IRName = op # nf # "ff",
             MaskedIRName = op # nf # "ff_mask",
             NF = nf,
-            RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                   !if(!eq(type, "y"), ["Zvfbfmin"],
+            RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                   !if(!eq(type, "y"), ["zvfbfmin"],
                                                    []<string>)),
             ManualCodegen = [{
     {
@@ -954,8 +954,8 @@ multiclass RVVStridedSegLoadTuple<string op> {
             IRName = op # nf,
             MaskedIRName = op # nf # "_mask",
             NF = nf,
-            RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                   !if(!eq(type, "y"), ["Zvfbfmin"],
+            RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                   !if(!eq(type, "y"), ["zvfbfmin"],
                                                    []<string>)),
             ManualCodegen = [{
     {
@@ -1023,8 +1023,8 @@ multiclass RVVStridedSegStoreTuple<string op> {
             NF = nf,
             HasMaskedOffOperand = false,
             MaskedPolicyScheme = NonePolicy,
-            RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                   !if(!eq(type, "y"), ["Zvfbfmin"],
+            RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                   !if(!eq(type, "y"), ["zvfbfmin"],
                                                    []<string>)),
             ManualCodegen = [{
     {
@@ -1073,8 +1073,8 @@ multiclass RVVIndexedSegLoadTuple<string op> {
             IRName = op # nf,
             MaskedIRName = op # nf # "_mask",
             NF = nf,
-            RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                   !if(!eq(type, "y"), ["Zvfbfmin"],
+            RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                   !if(!eq(type, "y"), ["zvfbfmin"],
                                                    []<string>)),
             ManualCodegen = [{
     {
@@ -1142,8 +1142,8 @@ multiclass RVVIndexedSegStoreTuple<string op> {
             NF = nf,
             HasMaskedOffOperand = false,
             MaskedPolicyScheme = NonePolicy,
-            RequiredFeatures = !if(!eq(type, "x"), ["Zvfhmin"],
-                                   !if(!eq(type, "y"), ["Zvfbfmin"],
+            RequiredFeatures = !if(!eq(type, "x"), ["zvfhmin"],
+                                   !if(!eq(type, "y"), ["zvfbfmin"],
                                                    []<string>)),
             ManualCodegen = [{
     {
@@ -1387,10 +1387,10 @@ let HasMasked = false,
                                    [["v", "Uv", "UvUv"]]>;
     defm vmv_v : RVVOutBuiltinSet<"vmv_v_v", "csilfd",
                                    [["v", "v", "vv"]]>;
-    let RequiredFeatures = ["Zvfhmin"] in
+    let RequiredFeatures = ["zvfhmin"] in
       defm vmv_v : RVVOutBuiltinSet<"vmv_v_v", "x",
                                     [["v", "v", "vv"]]>;
-    let RequiredFeatures = ["Zvfbfmin"] in
+    let RequiredFeatures = ["zvfbfmin"] in
       defm vmv_v : RVVOutBuiltinSet<"vmv_v_v", "y",
                                     [["v", "v", "vv"]]>;
   let SupportOverloading = false in
@@ -1655,7 +1655,7 @@ let ManualCodegen = [{
       defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "f",
                                            [["vv", "w", "wvvu"],
                                             ["vf", "w", "wveu"]]>;
-      let RequiredFeatures = ["Zvfh"] in
+      let RequiredFeatures = ["zvfh"] in
         defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "x",
                                              [["vv", "w", "wvvu"],
                                               ["vf", "w", "wveu"]]>;
@@ -1671,7 +1671,7 @@ let ManualCodegen = [{
     defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "f",
                                          [["vv", "w", "wvv"],
                                           ["vf", "w", "wve"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "x",
                                            [["vv", "w", "wvv"],
                                             ["vf", "w", "wve"]]>;
@@ -1786,7 +1786,7 @@ let ManualCodegen = [{
 
     // Vector BF16 widening multiply-accumulate
     let Log2LMUL = [-2, -1, 0, 1, 2],
-        RequiredFeatures = ["Zvfbfwma"],
+        RequiredFeatures = ["zvfbfwma"],
         HasMaskedOffOperand = false in
     defm vfwmaccbf16 : RVVOutOp1Op2BuiltinSet<"vfwmaccbf16", "y",
                                               [["vv", "Fw", "FwFwvvu"],
@@ -1800,7 +1800,7 @@ let ManualCodegen = [{
 
   // Vector BF16 widening multiply-accumulate
   let Log2LMUL = [-2, -1, 0, 1, 2],
-      RequiredFeatures = ["Zvfbfwma"],
+      RequiredFeatures = ["zvfbfwma"],
       HasMaskedOffOperand = false in
   defm vfwmaccbf16 : RVVOutOp1Op2BuiltinSet<"vfwmaccbf16", "y",
                                             [["vv", "Fw", "FwFwvv"],
@@ -1856,28 +1856,28 @@ let ManualCodegen = [{
   let HasFRMRoundModeOp = 1 in {
     // 13.8. Vector Floating-Point Square-Root Instruction
     defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "fd", [["v", "v", "vvu"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "x", [["v", "v", "vvu"]]>;
 
     // 13.10. Vector Floating-Point Reciprocal Estimate Instruction
     defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "fd", [["v", "v", "vvu"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "x", [["v", "v", "vvu"]]>;
   }
   // 13.8. Vector Floating-Point Square-Root Instruction
   defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "fd", [["v", "v", "vv"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "x", [["v", "v", "vv"]]>;
 
   // 13.10. Vector Floating-Point Reciprocal Estimate Instruction
   defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "fd", [["v", "v", "vv"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "x", [["v", "v", "vv"]]>;
 }
 
 // 13.9. Vector Floating-Point Reciprocal Square-Root Estimate Instruction
 defm vfrsqrt7 : RVVOutBuiltinSet<"vfrsqrt7", "fd", [["v", "v", "vv"]]>;
-let RequiredFeatures = ["Zvfh"] in
+let RequiredFeatures = ["zvfh"] in
   defm vfrsqrt7 : RVVOutBuiltinSet<"vfrsqrt7", "x", [["v", "v", "vv"]]>;
 
 // 13.11. Vector Floating-Point MIN/MAX Instructions
@@ -1890,10 +1890,10 @@ defm vfsgnjn : RVVFloatingBinBuiltinSet;
 defm vfsgnjx : RVVFloatingBinBuiltinSet;
 }
 defm vfneg_v : RVVPseudoVFUnaryBuiltin<"vfsgnjn", "fd">;
-let RequiredFeatures = ["Zvfh"] in
+let RequiredFeatures = ["zvfh"] in
   defm vfneg_v : RVVPseudoVFUnaryBuiltin<"vfsgnjn", "x">;
 defm vfabs_v : RVVPseudoVFUnaryBuiltin<"vfsgnjx", "fd">;
-let RequiredFeatures = ["Zvfh"] in
+let RequiredFeatures = ["zvfh"] in
   defm vfabs_v : RVVPseudoVFUnaryBuiltin<"vfsgnjx", "x">;
 
 // 13.13. Vector Floating-Point Compare Instructions
@@ -1910,7 +1910,7 @@ defm vmfge : RVVFloatingMaskOutBuiltinSet;
 // 13.14. Vector Floating-Point Classify Instruction
 let UnMaskedPolicyScheme = HasPassthruOperand in {
 defm vfclass : RVVOp0BuiltinSet<"vfclass", "fd", [["v", "Uv", "Uvv"]]>;
-let RequiredFeatures = ["Zvfh"] in
+let RequiredFeatures = ["zvfh"] in
   defm vfclass : RVVOp0BuiltinSet<"vfclass", "x", [["v", "Uv", "Uvv"]]>;
 }
 
@@ -1927,15 +1927,15 @@ let HasMasked = false,
     }] in {
   defm vmerge : RVVOutOp1BuiltinSet<"vmerge", "fd",
                                     [["vvm", "v", "vvvm"]]>;
-  let RequiredFeatures = ["Zvfhmin"] in
+  let RequiredFeatures = ["zvfhmin"] in
     defm vmerge : RVVOutOp1BuiltinSet<"vmerge", "x",
                                       [["vvm", "v", "vvvm"]]>;
-  let RequiredFeatures = ["Zvfbfmin"] in
+  let RequiredFeatures = ["zvfbfmin"] in
     defm vmerge : RVVOutOp1BuiltinSet<"vmerge", "y",
                                       [["vvm", "v", "vvvm"]]>;
   defm vfmerge : RVVOutOp1BuiltinSet<"vfmerge", "fd",
                                      [["vfm", "v", "vvem"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm vfmerge : RVVOutOp1BuiltinSet<"vfmerge", "x",
                                        [["vfm", "v", "vvem"]]>;
 }
@@ -1948,7 +1948,7 @@ let HasMasked = false,
     OverloadedName = "vfmv_v" in {
   defm vfmv_v : RVVOutBuiltinSet<"vfmv_v_f", "fd",
                                  [["f", "v", "ve"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm vfmv_v : RVVOutBuiltinSet<"vfmv_v_f", "x",
                                    [["f", "v", "ve"]]>;
 }
@@ -1957,12 +1957,12 @@ let HasMasked = false,
 let UnMaskedPolicyScheme = HasPassthruOperand in {
 let OverloadedName = "vfcvt_rtz_xu" in {
   defm : RVVConvBuiltinSet<"vfcvt_rtz_xu_f_v", "fd", [["Uv", "Uvv"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm : RVVConvBuiltinSet<"vfcvt_rtz_xu_f_v", "x", [["Uv", "Uvv"]]>;
 }
 let OverloadedName = "vfcvt_rtz_x" in {
   defm : RVVConvBuiltinSet<"vfcvt_rtz_x_f_v", "fd", [["Iv", "Ivv"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm : RVVConvBuiltinSet<"vfcvt_rtz_x_f_v", "x", [["Iv", "Ivv"]]>;
 }
 
@@ -1970,25 +1970,25 @@ let OverloadedName = "vfcvt_rtz_x" in {
 let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
   let OverloadedName = "vfwcvt_rtz_xu" in {
     defm : RVVConvBuiltinSet<"vfwcvt_rtz_xu_f_v", "f", [["Uw", "Uwv"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm : RVVConvBuiltinSet<"vfwcvt_rtz_xu_f_v", "x", [["Uw", "Uwv"]]>;
   }
   let OverloadedName = "vfwcvt_rtz_x" in {
     defm : RVVConvBuiltinSet<"vfwcvt_rtz_x_f_v", "f", [["Iw", "Iwv"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm : RVVConvBuiltinSet<"vfwcvt_rtz_x_f_v", "x", [["Iw", "Iwv"]]>;
   }
   let OverloadedName = "vfwcvt_f" in {
     defm : RVVConvBuiltinSet<"vfwcvt_f_xu_v", "si", [["Fw", "FwUv"]]>;
     defm : RVVConvBuiltinSet<"vfwcvt_f_x_v", "si", [["Fw", "Fwv"]]>;
-    let RequiredFeatures = ["Zvfh"] in {
+    let RequiredFeatures = ["zvfh"] in {
       defm : RVVConvBuiltinSet<"vfwcvt_f_xu_v", "c", [["Fw", "FwUv"]]>;
       defm : RVVConvBuiltinSet<"vfwcvt_f_x_v", "c", [["Fw", "Fwv"]]>;
     }
   }
   let OverloadedName = "vfwcvt_f" in {
     defm : RVVConvBuiltinSet<"vfwcvt_f_f_v", "f", [["w", "wv"]]>;
-    let RequiredFeatures = ["Zvfhmin"] in
+    let RequiredFeatures = ["zvfhmin"] in
       defm : RVVConvBuiltinSet<"vfwcvt_f_f_v", "x", [["w", "wv"]]>;
   }
 }
@@ -1997,17 +1997,17 @@ let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
 let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
   let OverloadedName = "vfncvt_rtz_xu" in {
     defm : RVVConvBuiltinSet<"vfncvt_rtz_xu_f_w", "si", [["Uv", "UvFw"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm : RVVConvBuiltinSet<"vfncvt_rtz_xu_f_w", "c", [["Uv", "UvFw"]]>;
   }
   let OverloadedName = "vfncvt_rtz_x" in {
     defm : RVVConvBuiltinSet<"vfncvt_rtz_x_f_w", "si", [["Iv", "IvFw"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm : RVVConvBuiltinSet<"vfncvt_rtz_x_f_w", "c", [["Iv", "IvFw"]]>;
   }
   let OverloadedName = "vfncvt_rod_f" in {
     defm : RVVConvBuiltinSet<"vfncvt_rod_f_f_w", "f", [["v", "vw"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm : RVVConvBuiltinSet<"vfncvt_rod_f_f_w", "x", [["v", "vw"]]>;
   }
 }
@@ -2063,18 +2063,18 @@ let ManualCodegen = [{
     // 14.17. Single-Width Floating-Point/Integer Type-Convert Instructions
     let OverloadedName = "vfcvt_x" in {
       defm : RVVConvBuiltinSet<"vfcvt_x_f_v", "fd", [["Iv", "Ivvu"]]>;
-      let RequiredFeatures = ["Zvfh"] in
+      let RequiredFeatures = ["zvfh"] in
         defm : RVVConvBuiltinSet<"vfcvt_x_f_v", "x", [["Iv", "Ivvu"]]>;
     }
     let OverloadedName = "vfcvt_xu" in {
       defm : RVVConvBuiltinSet<"vfcvt_xu_f_v", "fd", [["Uv", "Uvvu"]]>;
-      let RequiredFeatures = ["Zvfh"] in
+      let RequiredFeatures = ["zvfh"] in
         defm : RVVConvBuiltinSet<"vfcvt_xu_f_v", "x", [["Uv", "Uvvu"]]>;
     }
     let OverloadedName = "vfcvt_f" in {
       defm : RVVConvBuiltinSet<"vfcvt_f_x_v", "fd", [["v", "vIvu"]]>;
       defm : RVVConvBuiltinSet<"vfcvt_f_xu_v", "fd", [["v", "vUvu"]]>;
-      let RequiredFeatures = ["Zvfh"] in {
+      let RequiredFeatures = ["zvfh"] in {
         defm : RVVConvBuiltinSet<"vfcvt_f_x_v", "x", [["v", "vIvu"]]>;
         defm : RVVConvBuiltinSet<"vfcvt_f_xu_v", "x", [["v", "vUvu"]]>;
       }
@@ -2084,12 +2084,12 @@ let ManualCodegen = [{
     let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
       let OverloadedName = "vfwcvt_x" in {
         defm : RVVConvBuiltinSet<"vfwcvt_x_f_v", "f", [["Iw", "Iwvu"]]>;
-        let RequiredFeatures = ["Zvfh"] in
+        let RequiredFeatures = ["zvfh"] in
           defm : RVVConvBuiltinSet<"vfwcvt_x_f_v", "x", [["Iw", "Iwvu"]]>;
       }
       let OverloadedName = "vfwcvt_xu" in {
         defm : RVVConvBuiltinSet<"vfwcvt_xu_f_v", "f", [["Uw", "Uwvu"]]>;
-        let RequiredFeatures = ["Zvfh"] in
+        let RequiredFeatures = ["zvfh"] in
           defm : RVVConvBuiltinSet<"vfwcvt_xu_f_v", "x", [["Uw", "Uwvu"]]>;
       }
     }
@@ -2097,25 +2097,25 @@ let ManualCodegen = [{
     let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
       let OverloadedName = "vfncvt_x" in {
         defm : RVVConvBuiltinSet<"vfncvt_x_f_w", "si", [["Iv", "IvFwu"]]>;
-        let RequiredFeatures = ["Zvfh"] in
+        let RequiredFeatures = ["zvfh"] in
           defm : RVVConvBuiltinSet<"vfncvt_x_f_w", "c", [["Iv", "IvFwu"]]>;
       }
       let OverloadedName = "vfncvt_xu" in {
         defm : RVVConvBuiltinSet<"vfncvt_xu_f_w", "si", [["Uv", "UvFwu"]]>;
-        let RequiredFeatures = ["Zvfh"] in
+        let RequiredFeatures = ["zvfh"] in
           defm : RVVConvBuiltinSet<"vfncvt_xu_f_w", "c", [["Uv", "UvFwu"]]>;
       }
       let OverloadedName = "vfncvt_f" in {
         defm : RVVConvBuiltinSet<"vfncvt_f_x_w", "f", [["v", "vIwu"]]>;
         defm : RVVConvBuiltinSet<"vfncvt_f_xu_w", "f", [["v", "vUwu"]]>;
-        let RequiredFeatures = ["Zvfh"] in {
+        let RequiredFeatures = ["zvfh"] in {
           defm : RVVConvBuiltinSet<"vfncvt_f_x_w", "x", [["v", "vIwu"]]>;
           defm : RVVConvBuiltinSet<"vfncvt_f_xu_w", "x", [["v", "vUwu"]]>;
         }
       }
       let OverloadedName = "vfncvt_f" in {
         defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "f", [["v", "vwu"]]>;
-        let RequiredFeatures = ["Zvfhmin"] in
+        let RequiredFeatures = ["zvfhmin"] in
           defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "x", [["v", "vwu"]]>;
       }
     }
@@ -2129,18 +2129,18 @@ let ManualCodegen = [{
   // 13.17. Single-Width Floating-Point/Integer Type-Convert Instructions
   let OverloadedName = "vfcvt_x" in {
     defm : RVVConvBuiltinSet<"vfcvt_x_f_v", "fd", [["Iv", "Ivv"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm : RVVConvBuiltinSet<"vfcvt_x_f_v", "x", [["Iv", "Ivv"]]>;
   }
   let OverloadedName = "vfcvt_xu" in {
     defm : RVVConvBuiltinSet<"vfcvt_xu_f_v", "fd", [["Uv", "Uvv"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm : RVVConvBuiltinSet<"vfcvt_xu_f_v", "x", [["Uv", "Uvv"]]>;
   }
   let OverloadedName = "vfcvt_f" in {
     defm : RVVConvBuiltinSet<"vfcvt_f_x_v", "fd", [["v", "vIv"]]>;
     defm : RVVConvBuiltinSet<"vfcvt_f_xu_v", "fd", [["v", "vUv"]]>;
-    let RequiredFeatures = ["Zvfh"] in {
+    let RequiredFeatures = ["zvfh"] in {
       defm : RVVConvBuiltinSet<"vfcvt_f_x_v", "x", [["v", "vIv"]]>;
       defm : RVVConvBuiltinSet<"vfcvt_f_xu_v", "x", [["v", "vUv"]]>;
     }
@@ -2150,12 +2150,12 @@ let ManualCodegen = [{
   let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
     let OverloadedName = "vfwcvt_x" in {
       defm : RVVConvBuiltinSet<"vfwcvt_x_f_v", "f", [["Iw", "Iwv"]]>;
-      let RequiredFeatures = ["Zvfh"] in
+      let RequiredFeatures = ["zvfh"] in
         defm : RVVConvBuiltinSet<"vfwcvt_x_f_v", "x", [["Iw", "Iwv"]]>;
     }
     let OverloadedName = "vfwcvt_xu" in {
       defm : RVVConvBuiltinSet<"vfwcvt_xu_f_v", "f", [["Uw", "Uwv"]]>;
-      let RequiredFeatures = ["Zvfh"] in
+      let RequiredFeatures = ["zvfh"] in
         defm : RVVConvBuiltinSet<"vfwcvt_xu_f_v", "x", [["Uw", "Uwv"]]>;
     }
   }
@@ -2163,25 +2163,25 @@ let ManualCodegen = [{
   let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
     let OverloadedName = "vfncvt_x" in {
       defm : RVVConvBuiltinSet<"vfncvt_x_f_w", "si", [["Iv", "IvFw"]]>;
-      let RequiredFeatures = ["Zvfh"] in
+      let RequiredFeatures = ["zvfh"] in
         defm : RVVConvBuiltinSet<"vfncvt_x_f_w", "c", [["Iv", "IvFw"]]>;
     }
     let OverloadedName = "vfncvt_xu" in {
       defm : RVVConvBuiltinSet<"vfncvt_xu_f_w", "si", [["Uv", "UvFw"]]>;
-      let RequiredFeatures = ["Zvfh"] in
+      let RequiredFeatures = ["zvfh"] in
         defm : RVVConvBuiltinSet<"vfncvt_xu_f_w", "c", [["Uv", "UvFw"]]>;
     }
     let OverloadedName = "vfncvt_f" in {
       defm : RVVConvBuiltinSet<"vfncvt_f_x_w", "f", [["v", "vIw"]]>;
       defm : RVVConvBuiltinSet<"vfncvt_f_xu_w", "f", [["v", "vUw"]]>;
-      let RequiredFeatures = ["Zvfh"] in {
+      let RequiredFeatures = ["zvfh"] in {
         defm : RVVConvBuiltinSet<"vfncvt_f_x_w", "x", [["v", "vIw"]]>;
         defm : RVVConvBuiltinSet<"vfncvt_f_xu_w", "x", [["v", "vUw"]]>;
       }
     }
     let OverloadedName = "vfncvt_f" in {
       defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "f", [["v", "vw"]]>;
-      let RequiredFeatures = ["Zvfhmin"] in
+      let RequiredFeatures = ["zvfhmin"] in
         defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "x", [["v", "vw"]]>;
     }
   }
@@ -2345,7 +2345,7 @@ let HasMasked = false, MaskedPolicyScheme = NonePolicy in {
   let HasVL = false, OverloadedName = "vfmv_f" in {
     defm vfmv_f : RVVOp0BuiltinSet<"vfmv_f_s", "fd",
                                    [["s", "ve", "ev"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm vfmv_f : RVVOp0BuiltinSet<"vfmv_f_s", "x",
                                      [["s", "ve", "ev"]]>;
   }
@@ -2355,7 +2355,7 @@ let HasMasked = false, MaskedPolicyScheme = NonePolicy in {
     defm vfmv_s : RVVOutBuiltinSet<"vfmv_s_f", "fd",
                                    [["f", "v", "ve"],
                                     ["x", "Uv", "UvUe"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm vfmv_s : RVVOutBuiltinSet<"vfmv_s_f", "x",
                                      [["f", "v", "ve"],
                                       ["x", "Uv", "UvUe"]]>;
@@ -2383,13 +2383,13 @@ defm vrgather : RVVOutBuiltinSet<"vrgather_vv", "csilfd",
                                  [["vv", "v", "vvUv"]]>;
 defm vrgather : RVVOutBuiltinSet<"vrgather_vx", "csilfd",
                                  [["vx", "v", "vvz"]]>;
-let RequiredFeatures = ["Zvfhmin"] in {
+let RequiredFeatures = ["zvfhmin"] in {
   defm vrgather : RVVOutBuiltinSet<"vrgather_vv", "x",
                                    [["vv", "v", "vvUv"]]>;
   defm vrgather : RVVOutBuiltinSet<"vrgather_vx", "x",
                                    [["vx", "v", "vvz"]]>;
 }
-let RequiredFeatures = ["Zvfbfmin"] in {
+let RequiredFeatures = ["zvfbfmin"] in {
   defm vrgather : RVVOutBuiltinSet<"vrgather_vv", "y",
                                    [["vv", "v", "vvUv"]]>;
   defm vrgather : RVVOutBuiltinSet<"vrgather_vx", "y",
@@ -2397,7 +2397,7 @@ let RequiredFeatures = ["Zvfbfmin"] in {
 }
 defm vrgatherei16 : RVVOutBuiltinSet<"vrgatherei16_vv", "csilfd",
                                      [["vv", "v", "vv(Log2EEW:4)Uv"]]>;
-let RequiredFeatures = ["Zvfh"] in
+let RequiredFeatures = ["zvfh"] in
 defm vrgatherei16 : RVVOutBuiltinSet<"vrgatherei16_vv", "x",
                                      [["vv", "v", "vv(Log2EEW:4)Uv"]]>;
 // unsigned type
@@ -2422,10 +2422,10 @@ let HasMasked = false,
   // signed and floating type
   defm vcompress : RVVOutBuiltinSet<"vcompress", "csilfd",
                                     [["vm", "v", "vvm"]]>;
-  let RequiredFeatures = ["Zvfhmin"] in
+  let RequiredFeatures = ["zvfhmin"] in
     defm vcompress : RVVOutBuiltinSet<"vcompress", "x",
                                       [["vm", "v", "vvm"]]>;
-  let RequiredFeatures = ["Zvfbfmin"] in
+  let RequiredFeatures = ["zvfbfmin"] in
     defm vcompress : RVVOutBuiltinSet<"vcompress", "y",
                                       [["vm", "v", "vvm"]]>;
   // unsigned type
@@ -2476,13 +2476,13 @@ let HasMasked = false, HasVL = false, IRName = "" in {
     def vreinterpret_u_f : RVVBuiltin<"FvUv", "UvFv", "il", "Uv">;
     def vreinterpret_f_i : RVVBuiltin<"vFv", "Fvv", "il", "Fv">;
     def vreinterpret_f_u : RVVBuiltin<"UvFv", "FvUv", "il", "Fv">;
-    let RequiredFeatures = ["Zvfhmin"] in {
+    let RequiredFeatures = ["zvfhmin"] in {
       def vreinterpret_i_h : RVVBuiltin<"Fvv", "vFv", "s", "v">;
       def vreinterpret_u_h : RVVBuiltin<"FvUv", "UvFv", "s", "Uv">;
       def vreinterpret_h_i : RVVBuiltin<"vFv", "Fvv", "s", "Fv">;
       def vreinterpret_h_u : RVVBuiltin<"UvFv", "FvUv", "s", "Fv">;
     }
-    let RequiredFeatures = ["Zvfbfmin"] in {
+    let RequiredFeatures = ["zvfbfmin"] in {
       def vreinterpret_i_bf16 : RVVBuiltin<"vIv", "Ivv", "y", "Iv">;
       def vreinterpret_u_bf16 : RVVBuiltin<"vUv", "Uvv", "y", "Uv">;
       def vreinterpret_bf16_i : RVVBuiltin<"Ivv", "vIv", "y", "v">;
@@ -2552,9 +2552,9 @@ let HasMasked = false, HasVL = false, IRName = "" in {
         return llvm::PoisonValue::get(ResultType);
       }] in {
     def vundefined : RVVBuiltin<"v", "v", "csilfd">;
-    let RequiredFeatures = ["Zvfhmin"] in
+    let RequiredFeatures = ["zvfhmin"] in
       def vundefined_h : RVVBuiltin<"v", "v", "x">;
-    let RequiredFeatures = ["Zvfbfmin"] in
+    let RequiredFeatures = ["zvfbfmin"] in
       def vundefined_bf16 : RVVBuiltin<"v", "v", "y">;
     def vundefined_u : RVVBuiltin<"Uv", "Uv", "csil">;
 
@@ -2562,9 +2562,9 @@ let HasMasked = false, HasVL = false, IRName = "" in {
       let NF = nf in {
         defvar T = "(Tuple:" # nf # ")";
         def : RVVBuiltin<T # "v", T # "v", "csilfd">;
-        let RequiredFeatures = ["Zvfhmin"] in
+        let RequiredFeatures = ["zvfhmin"] in
           def : RVVBuiltin<T # "v", T # "v", "x">;
-        let RequiredFeatures = ["Zvfbfmin"] in
+        let RequiredFeatures = ["zvfbfmin"] in
           def : RVVBuiltin<T # "v", T # "v", "y">;
         def : RVVBuiltin<T # "Uv", T # "Uv", "csil">;
       }
@@ -2584,10 +2584,10 @@ let HasMasked = false, HasVL = false, IRName = "" in {
                         "(SFixedLog2LMUL:0)", "(SFixedLog2LMUL:1)", "(SFixedLog2LMUL:2)"] in {
       def vlmul_trunc # dst_lmul : RVVBuiltin<"v" # dst_lmul # "v",
                                               dst_lmul # "vv", "csilfd", dst_lmul # "v">;
-      let RequiredFeatures = ["Zvfhmin"] in
+      let RequiredFeatures = ["zvfhmin"] in
         def vlmul_trunc_h # dst_lmul : RVVBuiltin<"v" # dst_lmul # "v",
                                                   dst_lmul # "vv", "x", dst_lmul # "v">;
-      let RequiredFeatures = ["Zvfbfmin"] in
+      let RequiredFeatures = ["zvfbfmin"] in
         def vlmul_trunc_bf16 # dst_lmul : RVVBuiltin<"v" # dst_lmul # "v",
                                                      dst_lmul # "vv", "y", dst_lmul # "v">;
       def vlmul_trunc_u # dst_lmul : RVVBuiltin<"Uv" # dst_lmul # "Uv",
@@ -2608,10 +2608,10 @@ let HasMasked = false, HasVL = false, IRName = "" in {
                         "(LFixedLog2LMUL:1)", "(LFixedLog2LMUL:2)", "(LFixedLog2LMUL:3)"] in {
       def vlmul_ext # dst_lmul : RVVBuiltin<"v" # dst_lmul # "v",
                                             dst_lmul # "vv", "csilfd", dst_lmul # "v">;
-      let RequiredFeatures = ["Zvfhmin"] in
+      let RequiredFeatures = ["zvfhmin"] in
         def vlmul_ext_h # dst_lmul : RVVBuiltin<"v" # dst_lmul # "v",
                                                 dst_lmul # "vv", "x", dst_lmul # "v">;
-      let RequiredFeatures = ["Zvfbfmin"] in
+      let RequiredFeatures = ["zvfbfmin"] in
         def vlmul_ext_bf16 # dst_lmul : RVVBuiltin<"v" # dst_lmul # "v",
                                                    dst_lmul # "vv", "y", dst_lmul # "v">;
       def vlmul_ext_u # dst_lmul : RVVBuiltin<"Uv" # dst_lmul # "Uv",
@@ -2643,18 +2643,18 @@ let HasMasked = false, HasVL = false, IRName = "" in {
       }] in {
     foreach dst_lmul = ["(SFixedLog2LMUL:0)", "(SFixedLog2LMUL:1)", "(SFixedLog2LMUL:2)"] in {
       def : RVVBuiltin<"v" # dst_lmul # "v", dst_lmul # "vvKz", "csilfd", dst_lmul # "v">;
-      let RequiredFeatures = ["Zvfhmin"] in
+      let RequiredFeatures = ["zvfhmin"] in
         def : RVVBuiltin<"v" # dst_lmul # "v", dst_lmul # "vvKz", "x", dst_lmul # "v">;
-      let RequiredFeatures = ["Zvfbfmin"] in
+      let RequiredFeatures = ["zvfbfmin"] in
         def : RVVBuiltin<"v" # dst_lmul # "v", dst_lmul # "vvKz", "y", dst_lmul # "v">;
       def : RVVBuiltin<"Uv" # dst_lmul # "Uv", dst_lmul # "UvUvKz", "csil", dst_lmul # "Uv">;
     }
     foreach nf = NFList in {
       defvar T = "(Tuple:" # nf # ")";
       def : RVVBuiltin<T # "vv", "v" # T # "vKz", "csilfd", "v">;
-      let RequiredFeatures = ["Zvfhmin"] in
+      let RequiredFeatures = ["zvfhmin"] in
         def : RVVBuiltin<T # "vv", "v" # T # "vKz", "x", "v">;
-      let RequiredFeatures = ["Zvfbfmin"] in
+      let RequiredFeatures = ["zvfbfmin"] in
         def : RVVBuiltin<T # "vv", "v" # T # "vKz", "y", "v">;
       def : RVVBuiltin<T # "UvUv", "Uv" # T # "UvKz", "csil", "Uv">;
     }
@@ -2684,18 +2684,18 @@ let HasMasked = false, HasVL = false, IRName = "" in {
       }] in {
     foreach dst_lmul = ["(LFixedLog2LMUL:1)", "(LFixedLog2LMUL:2)", "(LFixedLog2LMUL:3)"] in {
       def : RVVBuiltin<"v" # dst_lmul # "v", dst_lmul # "v" # dst_lmul # "vKzv", "csilfd">;
-      let RequiredFeatures = ["Zvfhmin"] in
+      let RequiredFeatures = ["zvfhmin"] in
         def : RVVBuiltin<"v" # dst_lmul # "v", dst_lmul # "v" # dst_lmul # "vKzv", "x">;
-      let RequiredFeatures = ["Zvfbfmin"] in
+      let RequiredFeatures = ["zvfbfmin"] in
         def : RVVBuiltin<"v" # dst_lmul # "v", dst_lmul # "v" # dst_lmul # "vKzv", "y">;
       def : RVVBuiltin<"Uv" # dst_lmul # "Uv", dst_lmul # "Uv" # dst_lmul #"UvKzUv", "csil">;
     }
     foreach nf = NFList in {
       defvar T = "(Tuple:" # nf # ")";
       def : RVVBuiltin<"v" # T # "v", T # "v" # T # "vKzv", "csilfd">;
-      let RequiredFeatures = ["Zvfhmin"] in
+      let RequiredFeatures = ["zvfhmin"] in
         def : RVVBuiltin<"v" # T # "v", T # "v" # T # "vKzv", "x">;
-      let RequiredFeatures = ["Zvfbfmin"] in
+      let RequiredFeatures = ["zvfbfmin"] in
         def : RVVBuiltin<"v" # T # "v", T # "v" # T # "vKzv", "y">;
       def : RVVBuiltin<"Uv" # T # "Uv", T # "Uv" # T # "UvKzUv", "csil">;
     }
@@ -2742,9 +2742,9 @@ let HasMasked = false, HasVL = false, IRName = "" in {
         defvar V = VString<nf, /*signed=*/true>.S;
         defvar UV = VString<nf, /*signed=*/false>.S;
         def : RVVBuiltin<T # "v", T # "v" # V, "csilfd">;
-        let RequiredFeatures = ["Zvfhmin"] in
+        let RequiredFeatures = ["zvfhmin"] in
           def : RVVBuiltin<T # "v", T # "v" # V, "x">;
-        let RequiredFeatures = ["Zvfbfmin"] in
+        let RequiredFeatures = ["zvfbfmin"] in
           def : RVVBuiltin<T # "v", T # "v" # V, "y">;
         def : RVVBuiltin<T # "Uv", T # "Uv" # UV, "csil">;
       }
@@ -2794,7 +2794,7 @@ multiclass RVVSignedWidenBinBuiltinSetVwsll
 
 let UnMaskedPolicyScheme = HasPassthruOperand in {
   // zvkb
-  let RequiredFeatures = ["Zvkb"] in {
+  let RequiredFeatures = ["zvkb"] in {
     defm vandn   : RVVUnsignedBinBuiltinSet;
     defm vbrev8  : RVVOutBuiltinSetZvbb;
     defm vrev8   : RVVOutBuiltinSetZvbb;
@@ -2803,7 +2803,7 @@ let UnMaskedPolicyScheme = HasPassthruOperand in {
   }
 
   // zvbb
-  let RequiredFeatures = ["Zvbb"] in {
+  let RequiredFeatures = ["zvbb"] in {
     defm vbrev   : RVVOutBuiltinSetZvbb;
     defm vclz    : RVVOutBuiltinSetZvbb;
     defm vctz    : RVVOutBuiltinSetZvbb;
@@ -2814,7 +2814,7 @@ let UnMaskedPolicyScheme = HasPassthruOperand in {
   }
 
   // zvbc
-  let RequiredFeatures = ["Zvbc"] in {
+  let RequiredFeatures = ["zvbc"] in {
     defm vclmul  : RVVInt64BinBuiltinSet;
     defm vclmulh : RVVInt64BinBuiltinSet;
   }
@@ -2822,13 +2822,13 @@ let UnMaskedPolicyScheme = HasPassthruOperand in {
 
 let UnMaskedPolicyScheme = HasPolicyOperand, HasMasked = false in {
   // zvkg
-  let RequiredFeatures = ["Zvkg"] in {
+  let RequiredFeatures = ["zvkg"] in {
     defm vghsh   : RVVOutOp2BuiltinSetVVZvk;
     defm vgmul   : RVVOutBuiltinSetZvk<HasVV=1, HasVS=0>;
   }
 
   // zvkned
-  let RequiredFeatures = ["Zvkned"] in {
+  let RequiredFeatures = ["zvkned"] in {
     defm vaesdf  : RVVOutBuiltinSetZvk;
     defm vaesdm  : RVVOutBuiltinSetZvk;
     defm vaesef  : RVVOutBuiltinSetZvk;
@@ -2839,29 +2839,21 @@ let UnMaskedPolicyScheme = HasPolicyOperand, HasMasked = false in {
     defm vaesz   : RVVOutBuiltinSetZvk<HasVV=0>;
   }
 
-  // zvknha
-  let RequiredFeatures = ["Zvknha"] in {
-    defm vsha2ch : RVVOutOp2BuiltinSetVVZvk<"i">;
-    defm vsha2cl : RVVOutOp2BuiltinSetVVZvk<"i">;
-    defm vsha2ms : RVVOutOp2BuiltinSetVVZvk<"i">;
-  }
-
-  // zvknhb
-  let RequiredFeatures = ["Zvknhb"] in {
-    defm vsha2ch : RVVOutOp2BuiltinSetVVZvk<"il">;
-    defm vsha2cl : RVVOutOp2BuiltinSetVVZvk<"il">;
-    defm vsha2ms : RVVOutOp2BuiltinSetVVZvk<"il">;
-  }
+  // zvknha and zvknhb has duplicated intrinsic but they don't imply each other,
+  // so we need to handle it manually in SemaRISCV.cpp.
+  defm vsha2ch : RVVOutOp2BuiltinSetVVZvk<"il">;
+  defm vsha2cl : RVVOutOp2BuiltinSetVVZvk<"il">;
+  defm vsha2ms : RVVOutOp2BuiltinSetVVZvk<"il">;
 
   // zvksed
-  let RequiredFeatures = ["Zvksed"] in {
+  let RequiredFeatures = ["zvksed"] in {
     let UnMaskedPolicyScheme = HasPassthruOperand in
     defm vsm4k   : RVVOutOp1BuiltinSet<"vsm4k", "i", [["vi", "Uv", "UvUvKz"]]>;
     defm vsm4r   : RVVOutBuiltinSetZvk;
   }
 
   // zvksh
-  let RequiredFeatures = ["Zvksh"] in {
+  let RequiredFeatures = ["zvksh"] in {
     defm vsm3c   : RVVOutOp2BuiltinSetVIZvk;
     let UnMaskedPolicyScheme = HasPassthruOperand in
     defm vsm3me  : RVVOutOp1BuiltinSet<"vsm3me", "i", [["vv", "Uv", "UvUvUv"]]>;

--- a/clang/include/clang/Basic/riscv_vector_common.td
+++ b/clang/include/clang/Basic/riscv_vector_common.td
@@ -466,7 +466,7 @@ let HasMaskedOffOperand = false in {
     defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
                                   [["vv", "v", "vvvv"],
                                    ["vf", "v", "vvev"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm "" : RVVOutOp1BuiltinSet<NAME, "x",
                                     [["vv", "v", "vvvv"],
                                      ["vf", "v", "vvev"]]>;
@@ -475,7 +475,7 @@ let HasMaskedOffOperand = false in {
     defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
                                   [["vv", "v", "vvvvu"],
                                    ["vf", "v", "vvevu"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm "" : RVVOutOp1BuiltinSet<NAME, "x",
                                     [["vv", "v", "vvvvu"],
                                      ["vf", "v", "vvevu"]]>;
@@ -487,7 +487,7 @@ let HasMaskedOffOperand = false, Log2LMUL = [-2, -1, 0, 1, 2] in {
     defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "f",
                                       [["vv", "w", "wwvv"],
                                        ["vf", "w", "wwev"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "x",
                                         [["vv", "w", "wwvv"],
                                          ["vf", "w", "wwev"]]>;
@@ -496,7 +496,7 @@ let HasMaskedOffOperand = false, Log2LMUL = [-2, -1, 0, 1, 2] in {
     defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "f",
                                       [["vv", "w", "wwvvu"],
                                        ["vf", "w", "wwevu"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "x",
                                         [["vv", "w", "wwvvu"],
                                          ["vf", "w", "wwevu"]]>;
@@ -507,7 +507,7 @@ multiclass RVVFloatingBinBuiltinSet {
   defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
                                 [["vv", "v", "vvv"],
                                  ["vf", "v", "vve"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVOutOp1BuiltinSet<NAME, "x",
                                   [["vv", "v", "vvv"],
                                    ["vf", "v", "vve"]]>;
@@ -517,7 +517,7 @@ multiclass RVVFloatingBinBuiltinSetRoundingMode {
   defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
                                 [["vv", "v", "vvvu"],
                                  ["vf", "v", "vveu"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVOutOp1BuiltinSet<NAME, "x",
                                   [["vv", "v", "vvvu"],
                                    ["vf", "v", "vveu"]]>;
@@ -526,7 +526,7 @@ multiclass RVVFloatingBinBuiltinSetRoundingMode {
 multiclass RVVFloatingBinVFBuiltinSet {
   defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
                                 [["vf", "v", "vve"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVOutOp1BuiltinSet<NAME, "x",
                                   [["vf", "v", "vve"]]>;
 }
@@ -534,7 +534,7 @@ multiclass RVVFloatingBinVFBuiltinSet {
 multiclass RVVFloatingBinVFBuiltinSetRoundingMode {
   defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
                                 [["vf", "v", "vveu"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVOutOp1BuiltinSet<NAME, "x",
                                   [["vf", "v", "vveu"]]>;
 }
@@ -543,7 +543,7 @@ multiclass RVVFloatingMaskOutBuiltinSet {
   defm "" : RVVOp0Op1BuiltinSet<NAME, "fd",
                                 [["vv", "vm", "mvv"],
                                  ["vf", "vm", "mve"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVOp0Op1BuiltinSet<NAME, "x",
                                   [["vv", "vm", "mvv"],
                                    ["vf", "vm", "mve"]]>;
@@ -593,7 +593,7 @@ let UnMaskedPolicyScheme = HasPolicyOperand,
   multiclass RVVSlideUpBuiltinSet {
     defm "" : RVVOutBuiltinSet<NAME, "csilfd",
                                [["vx","v", "vvvz"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm "" : RVVOutBuiltinSet<NAME, "x",
                                  [["vx","v", "vvvz"]]>;
     defm "" : RVVOutBuiltinSet<NAME, "csil",
@@ -618,7 +618,7 @@ let UnMaskedPolicyScheme = HasPassthruOperand,
   multiclass RVVSlideDownBuiltinSet {
     defm "" : RVVOutBuiltinSet<NAME, "csilfd",
                                [["vx","v", "vvz"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm "" : RVVOutBuiltinSet<NAME, "x",
                                  [["vx","v", "vvz"]]>;
     defm "" : RVVOutBuiltinSet<NAME, "csil",
@@ -663,28 +663,28 @@ let HasMaskedOffOperand = true in {
   multiclass RVVFloatingReductionBuiltin {
     defm "" : RVVOutOp0BuiltinSet<NAME, "fd",
                                   [["vs", "vSv", "SvvSv"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm "" : RVVOutOp0BuiltinSet<NAME, "x",
                                     [["vs", "vSv", "SvvSv"]]>;
   }
   multiclass RVVFloatingReductionBuiltinRoundingMode {
     defm "" : RVVOutOp0BuiltinSet<NAME, "fd",
                                   [["vs", "vSv", "SvvSvu"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm "" : RVVOutOp0BuiltinSet<NAME, "x",
                                     [["vs", "vSv", "SvvSvu"]]>;
   }
   multiclass RVVFloatingWidenReductionBuiltin {
     defm "" : RVVOutOp0BuiltinSet<NAME, "f",
                                   [["vs", "vSw", "SwvSw"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm "" : RVVOutOp0BuiltinSet<NAME, "x",
                                     [["vs", "vSw", "SwvSw"]]>;
   }
   multiclass RVVFloatingWidenReductionBuiltinRoundingMode {
     defm "" : RVVOutOp0BuiltinSet<NAME, "f",
                                   [["vs", "vSw", "SwvSwu"]]>;
-    let RequiredFeatures = ["Zvfh"] in
+    let RequiredFeatures = ["zvfh"] in
       defm "" : RVVOutOp0BuiltinSet<NAME, "x",
                                     [["vs", "vSw", "SwvSwu"]]>;
   }
@@ -750,7 +750,7 @@ multiclass RVVFloatingWidenBinBuiltinSet {
   defm "" : RVVWidenBuiltinSet<NAME, "f",
                                [["vv", "w", "wvv"],
                                 ["vf", "w", "wve"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVWidenBuiltinSet<NAME, "x",
                                  [["vv", "w", "wvv"],
                                   ["vf", "w", "wve"]]>;
@@ -760,7 +760,7 @@ multiclass RVVFloatingWidenBinBuiltinSetRoundingMode {
   defm "" : RVVWidenBuiltinSet<NAME, "f",
                                [["vv", "w", "wvvu"],
                                 ["vf", "w", "wveu"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVWidenBuiltinSet<NAME, "x",
                                  [["vv", "w", "wvvu"],
                                   ["vf", "w", "wveu"]]>;
@@ -770,7 +770,7 @@ multiclass RVVFloatingWidenOp0BinBuiltinSet {
   defm "" : RVVWidenWOp0BuiltinSet<NAME # "_w", "f",
                                    [["wv", "w", "wwv"],
                                     ["wf", "w", "wwe"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVWidenWOp0BuiltinSet<NAME # "_w", "x",
                                      [["wv", "w", "wwv"],
                                       ["wf", "w", "wwe"]]>;
@@ -780,7 +780,7 @@ multiclass RVVFloatingWidenOp0BinBuiltinSetRoundingMode {
   defm "" : RVVWidenWOp0BuiltinSet<NAME # "_w", "f",
                                    [["wv", "w", "wwvu"],
                                     ["wf", "w", "wweu"]]>;
-  let RequiredFeatures = ["Zvfh"] in
+  let RequiredFeatures = ["zvfh"] in
     defm "" : RVVWidenWOp0BuiltinSet<NAME # "_w", "x",
                                      [["wv", "w", "wwvu"],
                                       ["wf", "w", "wweu"]]>;

--- a/clang/include/clang/Support/RISCVVIntrinsicUtils.h
+++ b/clang/include/clang/Support/RISCVVIntrinsicUtils.h
@@ -494,7 +494,7 @@ struct RVVIntrinsicRecord {
   const char *OverloadedName;
 
   // Required target features for this intrinsic.
-  std::string RequiredExtensions;
+  const char *RequiredExtensions;
 
   // Prototype for this intrinsic, index of RVVSignatureTable.
   uint16_t PrototypeIndex;

--- a/clang/include/clang/Support/RISCVVIntrinsicUtils.h
+++ b/clang/include/clang/Support/RISCVVIntrinsicUtils.h
@@ -11,7 +11,6 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitmaskEnum.h"
-#include "llvm/ADT/Bitset.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include <cstdint>
@@ -484,51 +483,6 @@ public:
                                    Policy &PolicyAttrs, bool HasFRMRoundModeOp);
 };
 
-// RVVRequire should be sync'ed with target features, but only
-// required features used in riscv_vector.td.
-enum RVVRequire {
-  RVV_REQ_RV64,
-  RVV_REQ_Zvfhmin,
-  RVV_REQ_Xandesvdot,
-  RVV_REQ_Xandesvpackfph,
-  RVV_REQ_Xsfvcp,
-  RVV_REQ_Xsfvfnrclipxfqf,
-  RVV_REQ_Xsfvfwmaccqqq,
-  RVV_REQ_Xsfvqmaccdod,
-  RVV_REQ_Xsfvqmaccqoq,
-  RVV_REQ_Zvbb,
-  RVV_REQ_Zvbc,
-  RVV_REQ_Zvkb,
-  RVV_REQ_Zvkg,
-  RVV_REQ_Zvkned,
-  RVV_REQ_Zvknha,
-  RVV_REQ_Zvknhb,
-  RVV_REQ_Zvksed,
-  RVV_REQ_Zvksh,
-  RVV_REQ_Zvfbfwma,
-  RVV_REQ_Zvfbfmin,
-  RVV_REQ_Zvfh,
-  RVV_REQ_Experimental,
-  RVV_REQ_NUM,
-};
-
-llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, enum RVVRequire Require);
-
-struct RequiredExtensionBits {
-  llvm::Bitset<RVV_REQ_NUM> Bits;
-  RequiredExtensionBits() {}
-  RequiredExtensionBits(std::initializer_list<RVVRequire> Init) {
-    for (auto I : Init)
-      Bits.set(I);
-  }
-
-  void set(unsigned I) { Bits.set(I); }
-  bool operator[](unsigned I) const { return Bits[I]; }
-};
-
-llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                              const RequiredExtensionBits &Exts);
-
 // Raw RVV intrinsic info, used to expand later.
 // This struct is highly compact for minimized code size.
 struct RVVIntrinsicRecord {
@@ -540,7 +494,7 @@ struct RVVIntrinsicRecord {
   const char *OverloadedName;
 
   // Required target features for this intrinsic.
-  RequiredExtensionBits RequiredExtensions;
+  std::string RequiredExtensions;
 
   // Prototype for this intrinsic, index of RVVSignatureTable.
   uint16_t PrototypeIndex;

--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -46,6 +46,9 @@ struct RVVIntrinsicDef {
   /// Mapping to which clang built-in function, e.g. __builtin_rvv_vadd.
   std::string BuiltinName;
 
+  /// Mapping to RequiredFeatures in riscv_vector.td
+  std::string RequiredExtensions;
+
   /// Function signature, first element is return type.
   RVVTypes Signature;
 };
@@ -177,7 +180,6 @@ namespace {
 class RISCVIntrinsicManagerImpl : public sema::RISCVIntrinsicManager {
 private:
   Sema &S;
-  ASTContext &Context;
   RVVTypeCache TypeCache;
   bool ConstructedRISCVVBuiltins;
   bool ConstructedRISCVSiFiveVectorBuiltins;
@@ -204,7 +206,7 @@ private:
                               IntrinsicKind K);
 
 public:
-  RISCVIntrinsicManagerImpl(clang::Sema &S) : S(S), Context(S.Context) {
+  RISCVIntrinsicManagerImpl(clang::Sema &S) : S(S) {
     ConstructedRISCVVBuiltins = false;
     ConstructedRISCVSiFiveVectorBuiltins = false;
     ConstructedRISCVAndesVectorBuiltins = false;
@@ -222,40 +224,9 @@ public:
 
 void RISCVIntrinsicManagerImpl::ConstructRVVIntrinsics(
     ArrayRef<RVVIntrinsicRecord> Recs, IntrinsicKind K) {
-  const TargetInfo &TI = Context.getTargetInfo();
-  static const std::pair<const char *, unsigned> FeatureCheckList[] = {
-      {"64bit", RVV_REQ_RV64},
-      {"xandesvdot", RVV_REQ_Xandesvdot},
-      {"xandesvpackfph", RVV_REQ_Xandesvpackfph},
-      {"xsfvcp", RVV_REQ_Xsfvcp},
-      {"xsfvfnrclipxfqf", RVV_REQ_Xsfvfnrclipxfqf},
-      {"xsfvfwmaccqqq", RVV_REQ_Xsfvfwmaccqqq},
-      {"xsfvqmaccdod", RVV_REQ_Xsfvqmaccdod},
-      {"xsfvqmaccqoq", RVV_REQ_Xsfvqmaccqoq},
-      {"zvbb", RVV_REQ_Zvbb},
-      {"zvbc", RVV_REQ_Zvbc},
-      {"zvkb", RVV_REQ_Zvkb},
-      {"zvkg", RVV_REQ_Zvkg},
-      {"zvkned", RVV_REQ_Zvkned},
-      {"zvknha", RVV_REQ_Zvknha},
-      {"zvknhb", RVV_REQ_Zvknhb},
-      {"zvksed", RVV_REQ_Zvksed},
-      {"zvksh", RVV_REQ_Zvksh},
-      {"zvfbfwma", RVV_REQ_Zvfbfwma},
-      {"zvfbfmin", RVV_REQ_Zvfbfmin},
-      {"zvfh", RVV_REQ_Zvfh},
-      {"experimental", RVV_REQ_Experimental}};
-
   // Construction of RVVIntrinsicRecords need to sync with createRVVIntrinsics
   // in RISCVVEmitter.cpp.
   for (auto &Record : Recs) {
-    // Check requirements.
-    if (llvm::any_of(FeatureCheckList, [&](const auto &Item) {
-          return Record.RequiredExtensions[Item.second] &&
-                 !TI.hasFeature(Item.first);
-        }))
-      continue;
-
     // Create Intrinsics for each type and LMUL.
     BasicType BaseType = BasicType::Unknown;
     ArrayRef<PrototypeDescriptor> BasicProtoSeq =
@@ -414,7 +385,7 @@ void RISCVIntrinsicManagerImpl::InitRVVIntrinsic(
   uint32_t Index = IntrinsicList.size();
   assert(IntrinsicList.size() == (size_t)Index &&
          "Intrinsics indices overflow.");
-  IntrinsicList.push_back({BuiltinName, Signature});
+  IntrinsicList.push_back({BuiltinName, Record.RequiredExtensions, Signature});
 
   // Creating mapping to Intrinsics.
   Intrinsics.insert({Name, Index});
@@ -477,6 +448,9 @@ void RISCVIntrinsicManagerImpl::CreateRVVIntrinsicDecl(LookupResult &LR,
   if (IsOverload)
     RVVIntrinsicDecl->addAttr(OverloadableAttr::CreateImplicit(Context));
 
+  if (IDef.RequiredExtensions != "")
+    RVVIntrinsicDecl->addAttr(
+        TargetAttr::CreateImplicit(Context, IDef.RequiredExtensions));
   // Setup alias to __builtin_rvv_*
   IdentifierInfo &IntrinsicII =
       PP.getIdentifierTable().get("__builtin_rvv_" + IDef.BuiltinName);
@@ -584,6 +558,17 @@ bool SemaRISCV::CheckBuiltinFunctionCall(const TargetInfo &TI,
   const FunctionDecl *FD = SemaRef.getCurFunctionDecl();
   llvm::StringMap<bool> FunctionFeatureMap;
   Context.getFunctionFeatureMap(FunctionFeatureMap, FD);
+
+  if (const auto *A = TheCall->getCalleeDecl()->getAttr<TargetAttr>()) {
+    StringRef FeaturesStr = A->getFeaturesStr();
+    llvm::SmallVector<StringRef> RequiredFeatures;
+    FeaturesStr.split(RequiredFeatures, ',');
+    for (auto RF : RequiredFeatures)
+      if (!TI.hasFeature(RF) && !FunctionFeatureMap.lookup(RF))
+        return Diag(TheCall->getBeginLoc(),
+                    diag::err_riscv_builtin_requires_extension)
+               << /* IsExtension */ true << TheCall->getSourceRange() << RF;
+  }
 
   // vmulh.vv, vmulh.vx, vmulhu.vv, vmulhu.vx, vmulhsu.vv, vmulhsu.vx,
   // vsmul.vv, vsmul.vx are not included for EEW=64 in Zve64*.
@@ -782,6 +767,13 @@ bool SemaRISCV::CheckBuiltinFunctionCall(const TargetInfo &TI,
       return Diag(TheCall->getBeginLoc(),
                   diag::err_riscv_builtin_requires_extension)
              << /* IsExtension */ true << TheCall->getSourceRange() << "zvknhb";
+    // If ElemSize is 32, check at least zvknha or zvknhb is enabled.
+    if (!TI.hasFeature("zvknha") && !FunctionFeatureMap.lookup("zvknha") &&
+        !TI.hasFeature("zvknhb") && !FunctionFeatureMap.lookup("zvknhb"))
+      return Diag(TheCall->getBeginLoc(),
+                  diag::err_riscv_builtin_requires_extension)
+             << /* IsExtension */ true << TheCall->getSourceRange()
+             << "zvknha or zvknhb";
 
     return CheckInvalidVLENandLMUL(TI, FunctionFeatureMap, TheCall, SemaRef,
                                    Arg0Type, ElemSize * 4) ||

--- a/clang/lib/Support/RISCVVIntrinsicUtils.cpp
+++ b/clang/lib/Support/RISCVVIntrinsicUtils.cpp
@@ -1210,49 +1210,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, enum PolicyScheme PS) {
   return OS;
 }
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, enum RVVRequire Require) {
-  switch (Require) {
-    STRINGIFY(RVV_REQ_RV64)
-    STRINGIFY(RVV_REQ_Zvfhmin)
-    STRINGIFY(RVV_REQ_Xandesvdot)
-    STRINGIFY(RVV_REQ_Xandesvpackfph)
-    STRINGIFY(RVV_REQ_Xsfvcp)
-    STRINGIFY(RVV_REQ_Xsfvfnrclipxfqf)
-    STRINGIFY(RVV_REQ_Xsfvfwmaccqqq)
-    STRINGIFY(RVV_REQ_Xsfvqmaccdod)
-    STRINGIFY(RVV_REQ_Xsfvqmaccqoq)
-    STRINGIFY(RVV_REQ_Zvbb)
-    STRINGIFY(RVV_REQ_Zvbc)
-    STRINGIFY(RVV_REQ_Zvkb)
-    STRINGIFY(RVV_REQ_Zvkg)
-    STRINGIFY(RVV_REQ_Zvkned)
-    STRINGIFY(RVV_REQ_Zvknha)
-    STRINGIFY(RVV_REQ_Zvknhb)
-    STRINGIFY(RVV_REQ_Zvksed)
-    STRINGIFY(RVV_REQ_Zvksh)
-    STRINGIFY(RVV_REQ_Zvfbfwma)
-    STRINGIFY(RVV_REQ_Zvfbfmin)
-    STRINGIFY(RVV_REQ_Zvfh)
-    STRINGIFY(RVV_REQ_Experimental)
-  default:
-    llvm_unreachable("Unsupported RVVRequire!");
-    break;
-  }
-  return OS;
-}
-
 #undef STRINGIFY
-
-llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                              const RequiredExtensionBits &Exts) {
-  OS << "{";
-  ListSeparator LS;
-  for (unsigned I = 0; I < RVV_REQ_NUM; I++)
-    if (Exts[I])
-      OS << LS << static_cast<RVVRequire>(I);
-  OS << "}";
-  return OS;
-}
 
 raw_ostream &operator<<(raw_ostream &OS, const RVVIntrinsicRecord &Record) {
   OS << "{";
@@ -1262,7 +1220,7 @@ raw_ostream &operator<<(raw_ostream &OS, const RVVIntrinsicRecord &Record) {
     OS << "/*OverloadedName=*/nullptr, ";
   else
     OS << "/*OverloadedName=*/\"" << Record.OverloadedName << "\", ";
-  OS << "/*RequiredExtensions=*/" << Record.RequiredExtensions << ", ";
+  OS << "/*RequiredExtensions=*/\"" << Record.RequiredExtensions << "\", ";
   OS << "/*PrototypeIndex=*/" << Record.PrototypeIndex << ", ";
   OS << "/*SuffixIndex=*/" << Record.SuffixIndex << ", ";
   OS << "/*OverloadedSuffixIndex=*/" << Record.OverloadedSuffixIndex << ", ";

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-handcrafted/zvfhmin-error.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-handcrafted/zvfhmin-error.c
@@ -17,7 +17,7 @@
 // CHECK-ZVF-NEXT:    ret <vscale x 4 x half> [[TMP0]]
 //
 
-// CHECK-ZVFHMIN-ERR: no matching function for call to '__riscv_vfadd'
+// CHECK-ZVFHMIN-ERR: builtin requires at least one of the following extensions: zvfh
 
 vfloat16m1_t test_vfadd_vv_f16m1(vfloat16m1_t op1, vfloat16m1_t op2, size_t vl) {
   return __riscv_vfadd(op1, op2, vl);

--- a/clang/test/Sema/rvv-required-features-invalid.c
+++ b/clang/test/Sema/rvv-required-features-invalid.c
@@ -5,37 +5,46 @@
 #include <sifive_vector.h>
 
 vint8m1_t test_vloxei64_v_i8m1(const int8_t *base, vuint64m8_t bindex, size_t vl) {
-  return __riscv_vloxei64(base, bindex, vl); // expected-error {{call to undeclared function '__riscv_vloxei64'}} expected-error {{returning 'int' from a function with incompatible result type 'vint8m1_t'}}
+  return __riscv_vloxei64(base, bindex, vl); // expected-error {{builtin requires at least one of the following extensions: 64bit}}
 }
 
 void test_vsoxei64_v_i8m1(int8_t *base, vuint64m8_t bindex, vint8m1_t value, size_t vl) {
-  __riscv_vsoxei64(base, bindex, value, vl); // expected-error {{call to undeclared function '__riscv_vsoxei64'}}
+  __riscv_vsoxei64(base, bindex, value, vl); // expected-error {{builtin requires at least one of the following extensions: 64bit}}
 }
 
 void test_xsfvcp_sf_vc_x_se_u64m1(uint64_t rs1, size_t vl) {
   __riscv_sf_vc_x_se_u64m1(1, 1, 1, rs1, vl); // expected-error {{call to undeclared function '__riscv_sf_vc_x_se_u64m1'}}
 }
 
-void test_xsfvqmaccdod() {
-  __riscv_sf_vqmacc_2x8x2(); // expected-error {{call to undeclared function '__riscv_sf_vqmacc_2x8x2'}}
+void test_xsfvqmaccdod(vint32m8_t vd, vint8m1_t vs1, vint8m8_t vs2, size_t vl) {
+  __riscv_sf_vqmacc_2x8x2(vd, vs1, vs2, vl); // expected-error {{builtin requires at least one of the following extensions: xsfvqmaccdod}}
 }
 
-void test_xsfvqmaccqoq() {
-  __riscv_sf_vqmacc_4x8x4(); // expected-error {{call to undeclared function '__riscv_sf_vqmacc_4x8x4'}}
+void test_xsfvqmaccqoq(vint32m1_t vd, vint8m1_t vs1, vint8mf2_t vs2, size_t vl) {
+  __riscv_sf_vqmacc_4x8x4(vd, vs1, vs2, vl); // expected-error {{builtin requires at least one of the following extensions: xsfvqmaccqoq}}
 }
 
-void test_xsfvfwmaccqqq() {
-  __riscv_sf_vfwmacc_4x4x4(); // expected-error {{call to undeclared function '__riscv_sf_vfwmacc_4x4x4'}}
+void test_xsfvfwmaccqqq(vfloat32m4_t vd, vbfloat16m1_t vs1, vbfloat16m2_t vs2, size_t vl) {
+  // expected-error@-1 {{RISC-V type 'vbfloat16m1_t' (aka '__rvv_bfloat16m1_t') requires the 'zvfbfmin' extension}}
+  // expected-error@-2 {{RISC-V type 'vbfloat16m2_t' (aka '__rvv_bfloat16m2_t') requires the 'zvfbfmin' extension}}
+  __riscv_sf_vfwmacc_4x4x4(vd, vs1, vs2, vl); // expected-error {{RISC-V type 'vbfloat16m1_t' (aka '__rvv_bfloat16m1_t') requires the 'zvfbfmin' extension}}
+  // expected-error@-1 {{RISC-V type 'vbfloat16m2_t' (aka '__rvv_bfloat16m2_t') requires the 'zvfbfmin' extension}}
+  // expected-error@-2 {{RISC-V type '__rvv_bfloat16m1_t' requires the 'zvfbfmin' extension}}
+  // expected-error@-3 {{RISC-V type '__rvv_bfloat16m2_t' requires the 'zvfbfmin' extension}}
+  // expected-error@-4 {{builtin requires at least one of the following extensions: xsfvfwmaccqqq}}
 }
 
-void test_xsfvfnrclipxfqf() {
-  __riscv_sf_vfnrclip_x_f_qf(); // expected-error {{call to undeclared function '__riscv_sf_vfnrclip_x_f_qf'}}
+void test_xsfvfnrclipxfqf(vfloat32m1_t vs2, float rs1, size_t vl) {
+  __riscv_sf_vfnrclip_x_f_qf(vs2, rs1, vl); // expected-error {{builtin requires at least one of the following extensions: xsfvfnrclipxfqf}}
 }
 
-void test_xsfvfnrclipxufqf() {
-  __riscv_sf_vfnrclip_xu_f_qf(); // expected-error {{call to undeclared function '__riscv_sf_vfnrclip_xu_f_qf'}}
+void test_xsfvfnrclipxufqf(vfloat32mf2_t vs2, float rs1, size_t vl) {
+  __riscv_sf_vfnrclip_xu_f_qf(vs2, rs1, 2, vl); // expected-error {{builtin requires at least one of the following extensions: xsfvfnrclipxfqf}}
 }
 
-void test_zvfbfwma_vfwmaccbf16() {
-  __riscv_vfwmaccbf16(); // expected-error {{call to undeclared function '__riscv_vfwmaccbf16'}}
+void test_zvfbfwma_vfwmaccbf16(vfloat32m4_t vd, __bf16 vs1, vbfloat16m2_t vs2, size_t vl) {
+  // expected-error@-1 {{RISC-V type 'vbfloat16m2_t' (aka '__rvv_bfloat16m2_t') requires the 'zvfbfmin' extension}}
+  __riscv_vfwmaccbf16(vd, vs1, vs2, vl); // expected-error {{RISC-V type 'vbfloat16m2_t' (aka '__rvv_bfloat16m2_t') requires the 'zvfbfmin' extension}}
+  // expected-error@-1 {{RISC-V type '__rvv_bfloat16m2_t' requires the 'zvfbfmin' extension}}
+  // expected-error@-2 {{builtin requires at least one of the following extensions: zvfbfwma}}
 }

--- a/clang/test/Sema/zvk-invalid-features.c
+++ b/clang/test/Sema/zvk-invalid-features.c
@@ -3,48 +3,48 @@
 
 #include <riscv_vector.h>
 
-void test_zvk_features() {
+void test_zvk_features(vuint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1, vuint64m1_t vs2_64, vuint64m1_t vs1_64, size_t vl) {
   // zvbb
-  __riscv_vbrev(); // expected-error {{call to undeclared function '__riscv_vbrev'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vclz(); // expected-error {{call to undeclared function '__riscv_vclz'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vctz(); // expected-error {{call to undeclared function '__riscv_vctz'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vcpopv(); // expected-error {{call to undeclared function '__riscv_vcpopv'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vwsll(); // expected-error {{call to undeclared function '__riscv_vwsll'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vbrev(vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvbb}}
+  __riscv_vclz(vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvbb}}
+  __riscv_vctz(vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvbb}}
+  __riscv_vcpop(vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvbb}}
+  __riscv_vwsll(vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvbb}}
 
   // zvbc
-  __riscv_vclmul(); // expected-error {{call to undeclared function '__riscv_vclmul'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vclmulh(); // expected-error {{call to undeclared function '__riscv_vclmulh'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vclmul(vs2_64, vs1_64, vl); // expected-error {{builtin requires at least one of the following extensions: zvbc}}
+  __riscv_vclmulh(vs2_64, vs1_64, vl); // expected-error {{builtin requires at least one of the following extensions: zvbc}}
 
   // zvkb
-  __riscv_vandn(); // expected-error {{call to undeclared function '__riscv_vandn'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vbrev8(); // expected-error {{call to undeclared function '__riscv_vbrev8'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vrev8(); // expected-error {{call to undeclared function '__riscv_vrev8'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vrol(); // expected-error {{call to undeclared function '__riscv_vrol'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vror(); // expected-error {{call to undeclared function '__riscv_vror'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vandn(vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvkb}}
+  __riscv_vbrev8(vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvkb}}
+  __riscv_vrev8(vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvkb}}
+  __riscv_vrol(vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvkb}}
+  __riscv_vror(vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvkb}}
 
   // zvkg
-  __riscv_vghsh(); // expected-error {{call to undeclared function '__riscv_vghsh'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vgmul(); // expected-error {{call to undeclared function '__riscv_vgmul'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vghsh(vd, vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvkg}}
+  __riscv_vgmul(vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvkg}}
 
   // zvkned
-  __riscv_vaesdf(); // expected-error {{call to undeclared function '__riscv_vaesdf'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vaesdm(); // expected-error {{call to undeclared function '__riscv_vaesdm'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vaesef(); // expected-error {{call to undeclared function '__riscv_vaesef'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vaesem(); // expected-error {{call to undeclared function '__riscv_vaesem'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vaeskf1(); // expected-error {{call to undeclared function '__riscv_vaeskf1'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vaeskf2(); // expected-error {{call to undeclared function '__riscv_vaeskf2'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vaesz(); // expected-error {{call to undeclared function '__riscv_vaesz'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vaesdf_vv(vd, vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvkned}}
+  __riscv_vaesdm_vv(vd, vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvkned}}
+  __riscv_vaesef_vv(vd, vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvkned}}
+  __riscv_vaesem_vv(vd, vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvkned}}
+  __riscv_vaeskf1(vs2, 0, vl); // expected-error {{builtin requires at least one of the following extensions: zvkned}}
+  __riscv_vaeskf2(vd, vs2, 0, vl); // expected-error {{builtin requires at least one of the following extensions: zvkned}}
+  __riscv_vaesz(vd, vs2, vl); // expected-error {{builtin requires at least one of the following extensions: zvkned}}
 
   // zvknha or zvknhb
-  __riscv_vsha2ch(); // expected-error {{call to undeclared function '__riscv_vsha2ch'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vsha2cl(); // expected-error {{call to undeclared function '__riscv_vsha2cl'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vsha2ms(); // expected-error {{call to undeclared function '__riscv_vsha2ms'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vsha2ch(vd, vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvknha or zvknhb}}
+  __riscv_vsha2cl(vd, vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvknha or zvknhb}}
+  __riscv_vsha2ms(vd, vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvknha or zvknhb}}
 
   //zvksed
-  __riscv_vsm4k(); // expected-error {{call to undeclared function '__riscv_vsm4k'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vsm4r(); // expected-error {{call to undeclared function '__riscv_vsm4r'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vsm4k(vs2, 0, vl); // expected-error {{builtin requires at least one of the following extensions: zvksed}}
+  __riscv_vsm4r_vv(vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvksed}}
 
   // zvksh
-  __riscv_vsm3c(); // expected-error {{call to undeclared function '__riscv_vsm3c'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vsm3me(); // expected-error {{call to undeclared function '__riscv_vsm3me'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vsm3c(vd, vs2, 0, vl); // expected-error {{builtin requires at least one of the following extensions: zvksh}}
+  __riscv_vsm3me(vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvksh}}
 }

--- a/clang/test/Sema/zvk-invalid-zvknha.c
+++ b/clang/test/Sema/zvk-invalid-zvknha.c
@@ -3,9 +3,9 @@
 
 #include <riscv_vector.h>
 
-void test_zvk_features() {
+void test_zvk_features(vuint64m1_t vd, vuint64m1_t vs2, vuint64m1_t vs1, size_t vl) {
   // zvknhb
-  __riscv_vsha2ch_vv_u64m1(); // expected-error {{call to undeclared function '__riscv_vsha2ch_vv_u64m1'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vsha2cl_vv_u64m1(); // expected-error {{call to undeclared function '__riscv_vsha2cl_vv_u64m1'; ISO C99 and later do not support implicit function declarations}}
-  __riscv_vsha2ms_vv_u64m1(); // expected-error {{call to undeclared function '__riscv_vsha2ms_vv_u64m1'; ISO C99 and later do not support implicit function declarations}}
+  __riscv_vsha2ch_vv_u64m1(vd, vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvknhb}}
+  __riscv_vsha2cl_vv_u64m1(vd, vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvknhb}}
+  __riscv_vsha2ms_vv_u64m1(vd, vs2, vs1, vl); // expected-error {{builtin requires at least one of the following extensions: zvknhb}}
 }

--- a/clang/test/Sema/zvk-target-attributes.c
+++ b/clang/test/Sema/zvk-target-attributes.c
@@ -9,3 +9,27 @@ __attribute__((target("arch=+zvl128b")))
 void test_zvk_features(vuint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1, size_t vl) {
   __riscv_vsha2ch_vv_u32m1(vd, vs2, vs1, vl);
 }
+
+__attribute__((target("arch=+v,+zvkn")))
+vuint32m4_t testcase1(vuint32m4_t pt, vuint32m1_t rk, size_t vl)
+{
+  return __riscv_vaesz_vs_u32m1_u32m4(pt, rk, vl);
+}
+
+__attribute__((target("arch=+v,+zvknc")))
+vuint32m4_t testcase2(vuint32m4_t pt, vuint32m1_t rk, size_t vl)
+{
+  return __riscv_vaesz_vs_u32m1_u32m4(pt, rk, vl);
+}
+
+__attribute__((target("arch=+v,+zvkned")))
+vuint32m4_t testcase3(vuint32m4_t pt, vuint32m1_t rk, size_t vl)
+{
+  return __riscv_vaesz_vs_u32m1_u32m4(pt, rk, vl);
+}
+
+__attribute__((target("arch=+v,+zvkng")))
+vuint32m4_t testcase4(vuint32m4_t pt, vuint32m1_t rk, size_t vl)
+{
+  return __riscv_vaesz_vs_u32m1_u32m4(pt, rk, vl);
+}

--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -45,7 +45,7 @@ struct SemaRecord {
   unsigned Log2LMULMask;
 
   // Required extensions for this intrinsic.
-  RequiredExtensionBits RequiredExtensions;
+  std::string RequiredExtensions;
 
   // Prototype for this intrinsic.
   SmallVector<PrototypeDescriptor> Prototype;
@@ -768,35 +768,13 @@ void RVVEmitter::createRVVIntrinsics(
       Log2LMULMask |= 1 << (Log2LMUL + 3);
 
     SR.Log2LMULMask = Log2LMULMask;
-
-    for (auto RequiredFeature : RequiredFeatures) {
-      unsigned RequireExt =
-          StringSwitch<RVVRequire>(RequiredFeature)
-              .Case("RV64", RVV_REQ_RV64)
-              .Case("Zvfhmin", RVV_REQ_Zvfhmin)
-              .Case("Xandesvpackfph", RVV_REQ_Xandesvpackfph)
-              .Case("Xandesvdot", RVV_REQ_Xandesvdot)
-              .Case("Xsfvcp", RVV_REQ_Xsfvcp)
-              .Case("Xsfvfnrclipxfqf", RVV_REQ_Xsfvfnrclipxfqf)
-              .Case("Xsfvfwmaccqqq", RVV_REQ_Xsfvfwmaccqqq)
-              .Case("Xsfvqmaccdod", RVV_REQ_Xsfvqmaccdod)
-              .Case("Xsfvqmaccqoq", RVV_REQ_Xsfvqmaccqoq)
-              .Case("Zvbb", RVV_REQ_Zvbb)
-              .Case("Zvbc", RVV_REQ_Zvbc)
-              .Case("Zvkb", RVV_REQ_Zvkb)
-              .Case("Zvkg", RVV_REQ_Zvkg)
-              .Case("Zvkned", RVV_REQ_Zvkned)
-              .Case("Zvknha", RVV_REQ_Zvknha)
-              .Case("Zvknhb", RVV_REQ_Zvknhb)
-              .Case("Zvksed", RVV_REQ_Zvksed)
-              .Case("Zvksh", RVV_REQ_Zvksh)
-              .Case("Zvfbfwma", RVV_REQ_Zvfbfwma)
-              .Case("Zvfbfmin", RVV_REQ_Zvfbfmin)
-              .Case("Zvfh", RVV_REQ_Zvfh)
-              .Case("Experimental", RVV_REQ_Experimental);
-      SR.RequiredExtensions.set(RequireExt);
+    std::string RFs;
+    for (unsigned i = 0; i < RequiredFeatures.size(); ++i) {
+      RFs += RequiredFeatures[i].str();
+      if (i < RequiredFeatures.size() - 1)
+        RFs += ",";
     }
-
+    SR.RequiredExtensions = RFs;
     SR.NF = NF;
     SR.HasMasked = HasMasked;
     SR.HasVL = HasVL;

--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -768,12 +768,8 @@ void RVVEmitter::createRVVIntrinsics(
       Log2LMULMask |= 1 << (Log2LMUL + 3);
 
     SR.Log2LMULMask = Log2LMULMask;
-    std::string RFs;
-    for (unsigned i = 0; i < RequiredFeatures.size(); ++i) {
-      RFs += RequiredFeatures[i].str();
-      if (i < RequiredFeatures.size() - 1)
-        RFs += ",";
-    }
+    std::string RFs =
+        join(RequiredFeatures.begin(), RequiredFeatures.end(), ",");
     SR.RequiredExtensions = RFs;
     SR.NF = NF;
     SR.HasMasked = HasMasked;
@@ -816,7 +812,7 @@ void RVVEmitter::createRVVIntrinsicRecords(std::vector<RVVIntrinsicRecord> &Out,
     R.PrototypeLength = SR.Prototype.size();
     R.SuffixLength = SR.Suffix.size();
     R.OverloadedSuffixSize = SR.OverloadedSuffix.size();
-    R.RequiredExtensions = SR.RequiredExtensions;
+    R.RequiredExtensions = SR.RequiredExtensions.c_str();
     R.TypeRangeMask = SR.TypeRangeMask;
     R.Log2LMULMask = SR.Log2LMULMask;
     R.NF = SR.NF;


### PR DESCRIPTION
Current approach generates intrinsic records when users specify
corresponding required features by using command line option.
However it's not able to handle features passed by using target
attributes correctly where each function might have different
features.
This patch resolves this by generating all of intrinsic records which
carry the required features in their function declaration using
attribute and check the required extensions in CheckBuiltinFunctionCall.

This should fix
[56592](https://github.com/llvm/llvm-project/issues/56592), [134962](https://github.com/llvm/llvm-project/issues/134962) and [121603](https://github.com/llvm/llvm-project/issues/121603)