### PR TITLE
[mlir] Allow using non-attribute properties in declarative rewrite patterns

### DIFF
--- a/mlir/docs/DeclarativeRewrites.md
+++ b/mlir/docs/DeclarativeRewrites.md
@@ -433,7 +433,8 @@ $in2)`, then this will be translated into C++ call `someFn($in1, $in2, $in0)`.
 In the case of properties, the placeholder will be bound to a value of the _interface_
 type of the property. Passing in a `StringProp` as an argument to a `NativeCodeCall`
 will pass a `StringRef` (as if the getter of the matched operation were called)
-and not a `std::string`.
+and not a `std::string`. See `mlir/include/mlir/IR/Properties.td` for details
+on interface vs. storage type.
 
 Positional range placeholders will be substituted by multiple `dag` object
 parameters at the `NativeCodeCall` use site. For example, if we define

--- a/mlir/docs/DeclarativeRewrites.md
+++ b/mlir/docs/DeclarativeRewrites.md
@@ -380,6 +380,11 @@ template. The string can be an arbitrary C++ expression that evaluates into some
 C++ object expected at the `NativeCodeCall` site (here it would be expecting an
 array attribute). Typically the string should be a function call.
 
+In the case of properties, the return value of the `NativeCodeCall` should
+be in terms of the _interface_ type of a property. For example, the `NativeCodeCall`
+for a `StringProp` should return a `StringRef`, which will copied into the underlying
+`std::string`, just as if it were an argument to the operation's builder.
+
 ##### `NativeCodeCall` placeholders
 
 In `NativeCodeCall`, we can use placeholders like `$_builder`, `$N` and `$N...`.
@@ -416,13 +421,19 @@ must be either passed by reference or pointer to the variable used as argument
 so that the matched value can be returned. In the same example, `$val` will be
 bound to a variable with `Attribute` type (as `I32Attr`) and the type of the
 second argument in `Foo()` could be `Attribute&` or `Attribute*`. Names with
-attribute constraints will be captured as `Attribute`s while everything else
-will be treated as `Value`s.
+attribute constraints will be captured as `Attribute`s, names with
+property constraints (which must have a concrete interface type) will be treated
+as that type, and everything else will be treated as `Value`s.
 
 Positional placeholders will be substituted by the `dag` object parameters at
 the `NativeCodeCall` use site. For example, if we define `SomeCall :
 NativeCodeCall<"someFn($1, $2, $0)">` and use it like `(SomeCall $in0, $in1,
 $in2)`, then this will be translated into C++ call `someFn($in1, $in2, $in0)`.
+
+In the case of properties, the placeholder will be bound to a value of the _interface_
+type of the property. Passing in a `StringProp` as an argument to a `NativeCodeCall`
+will pass a `StringRef` (as if the getter of the matched operation were called)
+and not a `std::string`.
 
 Positional range placeholders will be substituted by multiple `dag` object
 parameters at the `NativeCodeCall` use site. For example, if we define

--- a/mlir/docs/DeclarativeRewrites.md
+++ b/mlir/docs/DeclarativeRewrites.md
@@ -431,10 +431,9 @@ NativeCodeCall<"someFn($1, $2, $0)">` and use it like `(SomeCall $in0, $in1,
 $in2)`, then this will be translated into C++ call `someFn($in1, $in2, $in0)`.
 
 In the case of properties, the placeholder will be bound to a value of the _interface_
-type of the property. Passing in a `StringProp` as an argument to a `NativeCodeCall`
-will pass a `StringRef` (as if the getter of the matched operation were called)
-and not a `std::string`. See `mlir/include/mlir/IR/Properties.td` for details
-on interface vs. storage type.
+type of the property. For example, passing in a `StringProp` as an argument to a `NativeCodeCall` will pass a `StringRef` (as if the getter of the matched
+operation were called) and not a `std::string`. See
+`mlir/include/mlir/IR/Properties.td` for details on interface vs. storage type.
 
 Positional range placeholders will be substituted by multiple `dag` object
 parameters at the `NativeCodeCall` use site. For example, if we define

--- a/mlir/include/mlir/IR/Properties.td
+++ b/mlir/include/mlir/IR/Properties.td
@@ -400,6 +400,18 @@ class ConfinedProperty<Property p, Pred pred, string newSummary = "">
   : ConfinedProp<p, pred, newSummary>,
     Deprecated<"moved to shorter name ConfinedProp">;
 
+/// Defines a constant value of type `prop` to be used in pattern matching.
+/// When used as a constraint, forms a matcher that tests that the property is
+/// equal to the given value (and matches any other constraints on the property).
+/// The constant value is given as a string and should be of the _interface_ type
+/// of the attribute.
+class ConstantProp<Property prop, string val>
+    : ConfinedProp<prop,
+        CPred<"$_self == " # val>,
+        "constant '" # prop.summary # "': " # val> {
+  string value = val;
+}
+
 //===----------------------------------------------------------------------===//
 // Primitive property combinators
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/IR/Properties.td
+++ b/mlir/include/mlir/IR/Properties.td
@@ -405,6 +405,9 @@ class ConfinedProperty<Property p, Pred pred, string newSummary = "">
 /// equal to the given value (and matches any other constraints on the property).
 /// The constant value is given as a string and should be of the _interface_ type
 /// of the attribute.
+///
+/// This requires that the given property's inference type be comparable to the
+/// given value with `==`, and does require specify a concrete property type.
 class ConstantProp<Property prop, string val>
     : ConfinedProp<prop,
         CPred<"$_self == " # val>,

--- a/mlir/include/mlir/TableGen/Pattern.h
+++ b/mlir/include/mlir/TableGen/Pattern.h
@@ -99,7 +99,8 @@ public:
   // Returns this DAG leaf as a constraint. Asserts if fails.
   Constraint getAsConstraint() const;
 
-  // Returns this DAG leaf as a property constraint. Asserts if fails.
+  // Returns this DAG leaf as a property constraint. Asserts if fails. This
+  // allows access to the interface type.
   PropConstraint getAsPropConstraint() const;
 
   // Returns this DAG leaf as a property definition. Asserts if fails.
@@ -301,9 +302,8 @@ public:
     //
     // * Properties not associated with an operation (ex. as arguments to
     //   native code) have their corresponding PropConstraint stored in the
-    //   `dag` field,
-    //  and set `operandIndexOrNumValues` to -1 to indicate they aren't part of
-    //  an operation.
+    //   `dag` field. (They'll and set `operandIndexOrNumValues` to -1 to
+    //   indicate they aren't part of an operation.)
     //
     // * If a symbol is defined in a `variadic` DAG, `dag` specifies the DAG
     //   of the parent operation, `operandIndexOrNumValues` specifies the

--- a/mlir/include/mlir/TableGen/Pattern.h
+++ b/mlir/include/mlir/TableGen/Pattern.h
@@ -73,11 +73,22 @@ public:
   // specifies an attribute constraint.
   bool isAttrMatcher() const;
 
+  // Returns true if this DAG leaf is matching a property. That is, it
+  // specifies a property constraint.
+  bool isPropMatcher() const;
+
+  // Returns true if this DAG leaf is describing a property. That is, it
+  // is a subclass of `Property` in tablegen.
+  bool isPropDefinition() const;
+
   // Returns true if this DAG leaf is wrapping native code call.
   bool isNativeCodeCall() const;
 
   // Returns true if this DAG leaf is specifying a constant attribute.
   bool isConstantAttr() const;
+
+  // Returns true if this DAG leaf is specifying a constant property.
+  bool isConstantProp() const;
 
   // Returns true if this DAG leaf is specifying an enum case.
   bool isEnumCase() const;
@@ -88,8 +99,17 @@ public:
   // Returns this DAG leaf as a constraint. Asserts if fails.
   Constraint getAsConstraint() const;
 
+  // Returns this DAG leaf as a property constraint. Asserts if fails.
+  PropConstraint getAsPropConstraint() const;
+
+  // Returns this DAG leaf as a property definition. Asserts if fails.
+  Property getAsProperty() const;
+
   // Returns this DAG leaf as an constant attribute. Asserts if fails.
   ConstantAttr getAsConstantAttr() const;
+
+  // Returns this DAG leaf as an constant property. Asserts if fails.
+  ConstantProp getAsConstantProp() const;
 
   // Returns this DAG leaf as an enum case.
   // Precondition: isEnumCase()
@@ -279,6 +299,12 @@ public:
     //   the DAG of the operation, `operandIndexOrNumValues` specifies the
     //   operand index, and `variadicSubIndex` must be set to `std::nullopt`.
     //
+    // * Properties not associated with an operation (ex. as arguments to
+    //   native code) have their corresponding PropConstraint stored in the
+    //   `dag` field,
+    //  and set `operandIndexOrNumValues` to -1 to indicate they aren't part of
+    //  an operation.
+    //
     // * If a symbol is defined in a `variadic` DAG, `dag` specifies the DAG
     //   of the parent operation, `operandIndexOrNumValues` specifies the
     //   declared operand index of the variadic operand in the parent
@@ -364,12 +390,20 @@ public:
 
     // What kind of entity this symbol represents:
     // * Attr: op attribute
+    // * Prop: op property
     // * Operand: op operand
     // * Result: op result
     // * Value: a value not attached to an op (e.g., from NativeCodeCall)
     // * MultipleValues: a pack of values not attached to an op (e.g., from
     //   NativeCodeCall). This kind supports indexing.
-    enum class Kind : uint8_t { Attr, Operand, Result, Value, MultipleValues };
+    enum class Kind : uint8_t {
+      Attr,
+      Prop,
+      Operand,
+      Result,
+      Value,
+      MultipleValues
+    };
 
     // Creates a SymbolInfo instance. `dagAndConstant` is only used for `Attr`
     // and `Operand` so should be std::nullopt for `Result` and `Value` kind.
@@ -383,6 +417,15 @@ public:
     }
     static SymbolInfo getAttr() {
       return SymbolInfo(nullptr, Kind::Attr, std::nullopt);
+    }
+    static SymbolInfo getProp(const Operator *op, int index) {
+      return SymbolInfo(op, Kind::Prop,
+                        DagAndConstant(nullptr, index, std::nullopt));
+    }
+    static SymbolInfo getProp(const PropConstraint *constraint) {
+      return SymbolInfo(nullptr, Kind::Prop,
+                        DagAndConstant(constraint, -1, std::nullopt));
+      ;
     }
     static SymbolInfo
     getOperand(DagNode node, const Operator *op, int operandIndex,
@@ -487,6 +530,10 @@ public:
   // Registers the given `symbol` as bound to an attr. Returns false if `symbol`
   // is already bound.
   bool bindAttr(StringRef symbol);
+
+  // Registers the given `symbol` as bound to a property that satisfies the
+  // given `constraint`. `constraint` must name a concrete interface type.
+  bool bindProp(StringRef symbol, const PropConstraint &constraint);
 
   // Returns true if the given `symbol` is bound.
   bool contains(StringRef symbol) const;

--- a/mlir/include/mlir/TableGen/Pattern.h
+++ b/mlir/include/mlir/TableGen/Pattern.h
@@ -300,10 +300,9 @@ public:
     //   the DAG of the operation, `operandIndexOrNumValues` specifies the
     //   operand index, and `variadicSubIndex` must be set to `std::nullopt`.
     //
-    // * Properties not associated with an operation (ex. as arguments to
+    // * Properties not associated with an operation (e.g. as arguments to
     //   native code) have their corresponding PropConstraint stored in the
-    //   `dag` field. (They'll and set `operandIndexOrNumValues` to -1 to
-    //   indicate they aren't part of an operation.)
+    //   `dag` field. This constraint is only used when
     //
     // * If a symbol is defined in a `variadic` DAG, `dag` specifies the DAG
     //   of the parent operation, `operandIndexOrNumValues` specifies the
@@ -423,9 +422,9 @@ public:
                         DagAndConstant(nullptr, index, std::nullopt));
     }
     static SymbolInfo getProp(const PropConstraint *constraint) {
+      // -1 for anthe `operandIndexOrNumValues` is a sentinel value.
       return SymbolInfo(nullptr, Kind::Prop,
                         DagAndConstant(constraint, -1, std::nullopt));
-      ;
     }
     static SymbolInfo
     getOperand(DagNode node, const Operator *op, int operandIndex,

--- a/mlir/include/mlir/TableGen/Property.h
+++ b/mlir/include/mlir/TableGen/Property.h
@@ -32,9 +32,9 @@ class Pred;
 // Wrapper class providing helper methods for accesing property constraint
 // values.
 class PropConstraint : public Constraint {
+public:
   using Constraint::Constraint;
 
-public:
   static bool classof(const Constraint *c) { return c->getKind() == CK_Prop; }
 
   StringRef getInterfaceType() const;
@@ -143,6 +143,10 @@ public:
   // property constraints, this function is added for future-proofing)
   Property getBaseProperty() const;
 
+  // Returns true if this property is backed by a TableGen definition and that
+  // definition is a subclass of `className`.
+  bool isSubClassOf(StringRef className) const;
+
 private:
   // Elements describing a Property, in general fetched from the record.
   StringRef summary;
@@ -169,6 +173,21 @@ struct NamedProperty {
   Property prop;
 };
 
+// Wrapper class providing helper methods for processing constant property
+// values defined using the `ConstantProp` subclass of `Property`
+// in TableGen.
+class ConstantProp : public Property {
+public:
+  explicit ConstantProp(const llvm::DefInit *def) : Property(def) {
+    assert(isSubClassOf("ConstantProp"));
+  }
+
+  static bool classof(Property *p) { return p->isSubClassOf("ConstantProp"); }
+
+  // Return the constant value of the property as an expression
+  // that produces an interface-type constant.
+  StringRef getValue() const;
+};
 } // namespace tblgen
 } // namespace mlir
 

--- a/mlir/lib/TableGen/Pattern.cpp
+++ b/mlir/lib/TableGen/Pattern.cpp
@@ -51,6 +51,16 @@ bool DagLeaf::isAttrMatcher() const {
   return isSubClassOf("AttrConstraint");
 }
 
+bool DagLeaf::isPropMatcher() const {
+  // Property matchers specify a property constraint.
+  return isSubClassOf("PropConstraint");
+}
+
+bool DagLeaf::isPropDefinition() const {
+  // Property matchers specify a property definition.
+  return isSubClassOf("Property");
+}
+
 bool DagLeaf::isNativeCodeCall() const {
   return isSubClassOf("NativeCodeCall");
 }
@@ -59,12 +69,24 @@ bool DagLeaf::isConstantAttr() const { return isSubClassOf("ConstantAttr"); }
 
 bool DagLeaf::isEnumCase() const { return isSubClassOf("EnumCase"); }
 
+bool DagLeaf::isConstantProp() const { return isSubClassOf("ConstantProp"); }
+
 bool DagLeaf::isStringAttr() const { return isa<llvm::StringInit>(def); }
 
 Constraint DagLeaf::getAsConstraint() const {
-  assert((isOperandMatcher() || isAttrMatcher()) &&
-         "the DAG leaf must be operand or attribute");
+  assert((isOperandMatcher() || isAttrMatcher() || isPropMatcher()) &&
+         "the DAG leaf must be operand, attribute, or property");
   return Constraint(cast<DefInit>(def)->getDef());
+}
+
+PropConstraint DagLeaf::getAsPropConstraint() const {
+  assert(isPropMatcher() && "the DAG leaf must be a property matcher");
+  return PropConstraint(cast<DefInit>(def)->getDef());
+}
+
+Property DagLeaf::getAsProperty() const {
+  assert(isPropDefinition() && "the DAG leaf must be a property definition");
+  return Property(cast<DefInit>(def)->getDef());
 }
 
 ConstantAttr DagLeaf::getAsConstantAttr() const {
@@ -75,6 +97,11 @@ ConstantAttr DagLeaf::getAsConstantAttr() const {
 EnumCase DagLeaf::getAsEnumCase() const {
   assert(isEnumCase() && "the DAG leaf must be an enum attribute case");
   return EnumCase(cast<DefInit>(def));
+}
+
+ConstantProp DagLeaf::getAsConstantProp() const {
+  assert(isConstantProp() && "the DAG leaf must be a constant property value");
+  return ConstantProp(cast<DefInit>(def));
 }
 
 std::string DagLeaf::getConditionTemplate() const {
@@ -232,6 +259,7 @@ SymbolInfoMap::SymbolInfo::SymbolInfo(
 int SymbolInfoMap::SymbolInfo::getStaticValueCount() const {
   switch (kind) {
   case Kind::Attr:
+  case Kind::Prop:
   case Kind::Operand:
   case Kind::Value:
     return 1;
@@ -257,6 +285,18 @@ std::string SymbolInfoMap::SymbolInfo::getVarTypeStr(StringRef name) const {
           .str();
     // TODO(suderman): Use a more exact type when available.
     return "::mlir::Attribute";
+  }
+  case Kind::Prop: {
+    if (op)
+      return cast<NamedProperty *>(op->getArg(getArgIndex()))
+          ->prop.getInterfaceType()
+          .str();
+    assert(dagAndConstant && dagAndConstant->dag &&
+           "generic properties must carry their constraint");
+    return reinterpret_cast<const DagLeaf *>(dagAndConstant->dag)
+        ->getAsPropConstraint()
+        .getInterfaceType()
+        .str();
   }
   case Kind::Operand: {
     // Use operand range for captured operands (to support potential variadic
@@ -298,6 +338,12 @@ std::string SymbolInfoMap::SymbolInfo::getValueAndRangeUse(
     assert(index < 0);
     auto repl = formatv(fmt, name);
     LLVM_DEBUG(dbgs() << repl << " (Attr)\n");
+    return std::string(repl);
+  }
+  case Kind::Prop: {
+    assert(index < 0);
+    auto repl = formatv(fmt, name);
+    LLVM_DEBUG(dbgs() << repl << " (Prop)\n");
     return std::string(repl);
   }
   case Kind::Operand: {
@@ -388,10 +434,11 @@ std::string SymbolInfoMap::SymbolInfo::getAllRangeUse(
   LLVM_DEBUG(dbgs() << "getAllRangeUse for '" << name << "': ");
   switch (kind) {
   case Kind::Attr:
+  case Kind::Prop:
   case Kind::Operand: {
     assert(index < 0 && "only allowed for symbol bound to result");
     auto repl = formatv(fmt, name);
-    LLVM_DEBUG(dbgs() << repl << " (Operand/Attr)\n");
+    LLVM_DEBUG(dbgs() << repl << " (Operand/Attr/Prop)\n");
     return std::string(repl);
   }
   case Kind::Result: {
@@ -449,9 +496,11 @@ bool SymbolInfoMap::bindOpArgument(DagNode node, StringRef symbol,
     PrintFatalError(loc, error);
   }
 
-  auto symInfo =
-      isa<NamedAttribute *>(op.getArg(argIndex))
-          ? SymbolInfo::getAttr(&op, argIndex)
+  Argument arg = op.getArg(argIndex);
+  SymbolInfo symInfo =
+      isa<NamedAttribute *>(arg) ? SymbolInfo::getAttr(&op, argIndex)
+      : isa<NamedProperty *>(arg)
+          ? SymbolInfo::getProp(&op, argIndex)
           : SymbolInfo::getOperand(node, &op, argIndex, variadicSubIndex);
 
   std::string key = symbol.str();
@@ -500,6 +549,13 @@ bool SymbolInfoMap::bindMultipleValues(StringRef symbol, int numValues) {
 
 bool SymbolInfoMap::bindAttr(StringRef symbol) {
   auto inserted = symbolInfoMap.emplace(symbol.str(), SymbolInfo::getAttr());
+  return symbolInfoMap.count(inserted->first) == 1;
+}
+
+bool SymbolInfoMap::bindProp(StringRef symbol,
+                             const PropConstraint &constraint) {
+  auto inserted =
+      symbolInfoMap.emplace(symbol.str(), SymbolInfo::getProp(&constraint));
   return symbolInfoMap.count(inserted->first) == 1;
 }
 
@@ -774,10 +830,23 @@ void Pattern::collectBoundSymbols(DagNode tree, SymbolInfoMap &infoMap,
       if (!treeArgName.empty() && treeArgName != "_") {
         DagLeaf leaf = tree.getArgAsLeaf(i);
 
-        // In (NativeCodeCall<"Foo($_self, $0, $1, $2)"> I8Attr:$a, I8:$b, $c),
+        // In (NativeCodeCall<"Foo($_self, $0, $1, $2)"> I8Attr:$a, I8:$b, $c,
+        // I8Prop:$d),
         if (leaf.isUnspecified()) {
           // This is case of $c, a Value without any constraints.
           verifyBind(infoMap.bindValue(treeArgName), treeArgName);
+        } else if (leaf.isPropMatcher()) {
+          // This is case of $d, a binding to a certain property.
+          auto propConstraint = leaf.getAsPropConstraint();
+          if (propConstraint.getInterfaceType().empty()) {
+            PrintFatalError(&def,
+                            formatv("binding symbol '{0}' in NativeCodeCall to "
+                                    "a property constraint without specifying "
+                                    "that constraint's type is unsupported",
+                                    treeArgName));
+          }
+          verifyBind(infoMap.bindProp(treeArgName, propConstraint),
+                     treeArgName);
         } else {
           auto constraint = leaf.getAsConstraint();
           bool isAttr = leaf.isAttrMatcher() || leaf.isEnumCase() ||

--- a/mlir/lib/TableGen/Pattern.cpp
+++ b/mlir/lib/TableGen/Pattern.cpp
@@ -830,8 +830,8 @@ void Pattern::collectBoundSymbols(DagNode tree, SymbolInfoMap &infoMap,
       if (!treeArgName.empty() && treeArgName != "_") {
         DagLeaf leaf = tree.getArgAsLeaf(i);
 
-        // In (NativeCodeCall<"Foo($_self, $0, $1, $2)"> I8Attr:$a, I8:$b, $c,
-        // I8Prop:$d),
+        // In (NativeCodeCall<"Foo($_self, $0, $1, $2, $3)"> I8Attr:$a, I8:$b,
+        //     $c, I8Prop:$d),
         if (leaf.isUnspecified()) {
           // This is case of $c, a Value without any constraints.
           verifyBind(infoMap.bindValue(treeArgName), treeArgName);

--- a/mlir/lib/TableGen/Property.cpp
+++ b/mlir/lib/TableGen/Property.cpp
@@ -112,3 +112,11 @@ Property Property::getBaseProperty() const {
   }
   return *this;
 }
+
+bool Property::isSubClassOf(StringRef className) const {
+  return def && def->isSubClassOf(className);
+}
+
+StringRef ConstantProp::getValue() const {
+  return def->getValueAsString("value");
+}

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3455,6 +3455,38 @@ def OpWithPropertyPredicates : TEST_Op<"op_with_property_predicates"> {
   let assemblyFormat = "attr-dict prop-dict";
 }
 
+def TestPropPatternOp1 : TEST_Op<"prop_pattern_op_1"> {
+  let arguments = (ins
+    StringProp:$tag,
+    I64Prop:$val,
+    BoolProp:$cond
+  );
+  let results = (outs I32:$results);
+  let assemblyFormat = "$tag $val $cond attr-dict";
+}
+
+def TestPropPatternOp2 : TEST_Op<"prop_pattern_op_2"> {
+  let arguments = (ins
+    I32:$input,
+    StringProp:$tag
+  );
+  let assemblyFormat = "$input $tag attr-dict";
+}
+
+def : Pat<
+  (TestPropPatternOp1 $tag, NonNegativeI64Prop:$val, ConstantProp<BoolProp, "false">),
+  (TestPropPatternOp1 $tag, (NativeCodeCall<"$0 + 1"> $val), ConstantProp<BoolProp, "true">)>;
+
+def : Pat<
+  (TestPropPatternOp2 (TestPropPatternOp1 $tag1, $val, ConstantProp<BoolProp, "true">),
+    PropConstraint<CPred<"!$_self.empty()">, "non-empty string">:$tag2),
+  (TestPropPatternOp2
+    (TestPropPatternOp1 $tag1,
+      (NativeCodeCall<"-($0)"> $val),
+      ConstantProp<BoolProp, "false">),
+    (NativeCodeCall<"$0.str() + \".\" + $1.str()"> $tag1, $tag2))
+>;
+
 //===----------------------------------------------------------------------===//
 // Test Dataflow
 //===----------------------------------------------------------------------===//

--- a/mlir/test/mlir-tblgen/pattern.mlir
+++ b/mlir/test/mlir-tblgen/pattern.mlir
@@ -586,11 +586,37 @@ func.func @testMatchMultiVariadicSubSymbol(%arg0: i32, %arg1: i32, %arg2: i32, %
 
 // CHECK-LABEL: @testMatchMixedVaradicOptional
 func.func @testMatchMixedVaradicOptional(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32) -> () {
-  // CHECK: "test.mixed_variadic_in6"(%arg0, %arg1, %arg2) <{attr1 = 2 : i32}> : (i32, i32, i32) -> () 
+  // CHECK: "test.mixed_variadic_in6"(%arg0, %arg1, %arg2) <{attr1 = 2 : i32}> : (i32, i32, i32) -> ()
   "test.mixed_variadic_optional_in7"(%arg0, %arg1, %arg2) {attr1 = 2 : i32, operandSegmentSizes = array<i32: 2, 1>} : (i32, i32, i32) -> ()
   // CHECK: test.mixed_variadic_optional_in7
   "test.mixed_variadic_optional_in7"(%arg0, %arg1) {attr1 = 2 : i32, operandSegmentSizes = array<i32: 2, 0>} : (i32, i32) -> ()
 
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// Test patterns that operate on properties
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @testSimplePropertyRewrite
+func.func @testSimplePropertyRewrite() {
+  // CHECK-NEXT: test.prop_pattern_op_1 "o1" 2 true
+  test.prop_pattern_op_1 "o1" 1 false
+  // Pattern not applied when predicate not met
+  // CHECK-NEXT: test.prop_pattern_op_1 "o2" -1 false
+  test.prop_pattern_op_1 "o2" -1 false
+  // Pattern not applied when constant doesn't match
+  // CHCEK-NEXT: test.prop_pattern_op_1 "o3" 1 true
+  test.prop_pattern_op_1 "o3" 1 true
+  return
+}
+
+// CHECK-LABEL: @testNestedPropertyRewrite
+func.func @testNestedPropertyRewrite() {
+  // CHECK: %[[v:.*]] = test.prop_pattern_op_1 "s1" -2 false
+  // CHECK: test.prop_pattern_op_2 %[[v]] "s1.t1"
+  %v = test.prop_pattern_op_1 "s1" 1 false
+  test.prop_pattern_op_2 %v "t1"
   return
 }
 

--- a/mlir/test/mlir-tblgen/rewriter-attributes-properties.td
+++ b/mlir/test/mlir-tblgen/rewriter-attributes-properties.td
@@ -45,3 +45,35 @@ def test1 : Pat<(AOp (BOp:$x $y), $_), (AOp $x, $y)>;
 // CHECK: tblgen_values.push_back((*x.getODSResults(0).begin()));
 // CHECK: tblgen_props.y = ::llvm::dyn_cast_if_present<decltype(tblgen_props.y)>(y);
 // CHECK: tblgen_AOp_0 = rewriter.create<test::AOp>(odsLoc, tblgen_types, tblgen_values, tblgen_props);
+
+// Note: These use strings to pick up a non-trivial storage/interface type
+// difference.
+def COp : NS_Op<"c_op", []> {
+  let arguments = (ins
+    I32:$x,
+    StringProp:$y
+  );
+
+  let results = (outs I32:$z);
+}
+
+def DOp : NS_Op<"d_op", []> {
+  let arguments = (ins
+    StringProp:$y
+  );
+
+  let results = (outs I32:$z);
+}
+def test2 : Pat<(COp (DOp:$x $y), $_), (COp $x, $y)>;
+// CHECK-LABEL: struct test2
+// CHECK: ::llvm::LogicalResult matchAndRewrite
+// CHECK-DAG: ::llvm::StringRef y;
+// CHECK-DAG: test::DOp x;
+// CHECK-DAG: ::llvm::SmallVector<::mlir::Operation *, 4> tblgen_ops;
+// CHECK: tblgen_ops.push_back(op0);
+// CHECK: x = castedOp1;
+// CHECK: tblgen_prop = castedOp1.getProperties().getY();
+// CHECK: y = tblgen_prop;
+// CHECK: tblgen_ops.push_back(op1);
+// CHECK: test::COp::Properties tblgen_props;
+// CHECK: tblgen_props.setY(y);

--- a/mlir/test/mlir-tblgen/rewriter-static-matcher.td
+++ b/mlir/test/mlir-tblgen/rewriter-static-matcher.td
@@ -94,10 +94,10 @@ def : Pat<(COp $_, (BOp I32Attr:$attr, I32:$int)),
 // CHECK: [[$ARR]].push_back([[$VAR]]);
 def : Pat<(AOp $x), (DOp (variadic (Foo $x)))>;
 
-// CHECK: if(::mlir::failed([[$DAG_MATCHER2]](rewriter, op1, tblgen_ops, z, x)
+// CHECK: if(::mlir::failed([[$DAG_MATCHER2]]({{.*}} x{{[,)]}}
 def : Pat<(AOp (EOp NonNegProp:$x, NonNegProp:$_, I32:$z)),
   (AOp $z)>;
 
-// CHECK: if(::mlir::failed([[$DAG_MATCHER2]](rewriter, op1, tblgen_ops, z, x)
+// CHECK: if(::mlir::failed([[$DAG_MATCHER2]]({{.*}} x{{[,)]}}
 def : Pat<(FOp $_, (EOp NonNegProp:$x, NonNegProp:$_, I32:$z)),
   (COp $x, $z)>;

--- a/mlir/test/mlir-tblgen/rewriter-static-matcher.td
+++ b/mlir/test/mlir-tblgen/rewriter-static-matcher.td
@@ -45,6 +45,24 @@ def DOp : NS_Op<"d_op", []> {
 
 def Foo : NativeCodeCall<"foo($_builder, $0)">;
 
+def NonNegProp : PropConstraint<CPred<"$_self >= 0">, "non-negative integer">;
+
+def EOp : NS_Op<"e_op", []> {
+  let arguments = (ins
+    I32Prop:$x,
+    I64Prop:$y,
+    AnyInteger:$z
+  );
+  let results = (outs I32:$res);
+}
+
+def FOp: NS_Op<"f_op", []> {
+  let arguments = (ins
+    I32Prop:$a,
+    AnyInteger:$b
+  );
+}
+
 // Test static matcher for duplicate DagNode
 // ---
 
@@ -52,8 +70,15 @@ def Foo : NativeCodeCall<"foo($_builder, $0)">;
 // CHECK-NEXT: {{.*::mlir::Type type}}
 // CHECK: static ::llvm::LogicalResult [[$ATTR_CONSTRAINT:__mlir_ods_local_attr_constraint.*]](
 // CHECK-NEXT: {{.*::mlir::Attribute attr}}
+// CHECK: template <typename T>
+// CHECK-NEXT: static ::llvm::LogicalResult [[$PROP_CONSTRAINT:__mlir_ods_local_prop_constraint.*]](
+// CHECK-NEXT: {{.*T prop}}
 // CHECK: static ::llvm::LogicalResult [[$DAG_MATCHER:static_dag_matcher.*]](
 // CHECK: if(::mlir::failed([[$ATTR_CONSTRAINT]]
+// CHECK: if(::mlir::failed([[$TYPE_CONSTRAINT]]
+// CHECK: static ::llvm::LogicalResult [[$DAG_MATCHER2:static_dag_matcher.*]](
+// CHECK-SAME: int32_t &x
+// CHECK: if(::mlir::failed([[$PROP_CONSTRAINT]]
 // CHECK: if(::mlir::failed([[$TYPE_CONSTRAINT]]
 
 // CHECK: if(::mlir::failed([[$DAG_MATCHER]](rewriter, op1, tblgen_ops
@@ -68,3 +93,11 @@ def : Pat<(COp $_, (BOp I32Attr:$attr, I32:$int)),
 // CHECK: ::llvm::SmallVector<::mlir::Value, 4> [[$ARR:tblgen_variadic_values_.*]];
 // CHECK: [[$ARR]].push_back([[$VAR]]);
 def : Pat<(AOp $x), (DOp (variadic (Foo $x)))>;
+
+// CHECK: if(::mlir::failed([[$DAG_MATCHER2]](rewriter, op1, tblgen_ops, z, x)
+def : Pat<(AOp (EOp NonNegProp:$x, NonNegProp:$_, I32:$z)),
+  (AOp $z)>;
+
+// CHECK: if(::mlir::failed([[$DAG_MATCHER2]](rewriter, op1, tblgen_ops, z, x)
+def : Pat<(FOp $_, (EOp NonNegProp:$x, NonNegProp:$_, I32:$z)),
+  (COp $x, $z)>;


### PR DESCRIPTION
This commit adds support for non-attribute properties (such as StringProp and I64Prop) in declarative rewrite patterns. The handling for properties follows the handling for attributes in most cases, including in the generation of static matchers.

Constraints that are shared between multiple types are supported by making the constraint matcher a templated function, which is the equivalent to passing ::mlir::Attribute for an arbitrary C++ type.