### PR TITLE
[Support][Cygwin] Fix handling of Process symbol lookup.

### DIFF
--- a/llvm/lib/Support/DynamicLibrary.cpp
+++ b/llvm/lib/Support/DynamicLibrary.cpp
@@ -25,8 +25,7 @@ using namespace llvm::sys;
 class DynamicLibrary::HandleSet {
   typedef std::vector<void *> HandleList;
   HandleList Handles;
-  void *Process = nullptr;
-  bool ProcessAdded = false;
+  void *Process = &Invalid;
 
 public:
   static void *DLOpen(const char *Filename, std::string *Err);
@@ -59,7 +58,7 @@ public:
       Handles.push_back(Handle);
     } else {
 #ifndef _WIN32
-      if (Process) {
+      if (Process != &Invalid) {
         if (CanClose)
           DLClose(Process);
         if (Process == Handle)
@@ -67,7 +66,6 @@ public:
       }
 #endif
       Process = Handle;
-      ProcessAdded = true;
     }
     return true;
   }
@@ -99,11 +97,11 @@ public:
     assert(!((Order & SO_LoadedFirst) && (Order & SO_LoadedLast)) &&
            "Invalid Ordering");
 
-    if (!ProcessAdded || (Order & SO_LoadedFirst)) {
+    if (Process == &Invalid || (Order & SO_LoadedFirst)) {
       if (void *Ptr = LibLookup(Symbol, Order))
         return Ptr;
     }
-    if (ProcessAdded) {
+    if (Process != &Invalid) {
       // Use OS facilities to search the current binary and all loaded libs.
       if (void *Ptr = DLSym(Process, Symbol))
         return Ptr;

--- a/llvm/lib/Support/DynamicLibrary.cpp
+++ b/llvm/lib/Support/DynamicLibrary.cpp
@@ -26,6 +26,7 @@ class DynamicLibrary::HandleSet {
   typedef std::vector<void *> HandleList;
   HandleList Handles;
   void *Process = nullptr;
+  bool ProcessAdded = false;
 
 public:
   static void *DLOpen(const char *Filename, std::string *Err);
@@ -66,6 +67,7 @@ public:
       }
 #endif
       Process = Handle;
+      ProcessAdded = true;
     }
     return true;
   }
@@ -97,11 +99,11 @@ public:
     assert(!((Order & SO_LoadedFirst) && (Order & SO_LoadedLast)) &&
            "Invalid Ordering");
 
-    if (!Process || (Order & SO_LoadedFirst)) {
+    if (!ProcessAdded || (Order & SO_LoadedFirst)) {
       if (void *Ptr = LibLookup(Symbol, Order))
         return Ptr;
     }
-    if (Process) {
+    if (ProcessAdded) {
       // Use OS facilities to search the current binary and all loaded libs.
       if (void *Ptr = DLSym(Process, Symbol))
         return Ptr;

--- a/llvm/lib/Support/Unix/DynamicLibrary.inc
+++ b/llvm/lib/Support/Unix/DynamicLibrary.inc
@@ -17,7 +17,7 @@ DynamicLibrary::HandleSet::~HandleSet() {
   // Close the libraries in reverse order.
   for (void *Handle : llvm::reverse(Handles))
     ::dlclose(Handle);
-  if (Process)
+  if (Process != &Invalid)
     ::dlclose(Process);
 
   // llvm_shutdown called, Return to default

--- a/llvm/lib/Support/Windows/DynamicLibrary.inc
+++ b/llvm/lib/Support/Windows/DynamicLibrary.inc
@@ -26,7 +26,7 @@ DynamicLibrary::HandleSet::~HandleSet() {
     FreeLibrary(HMODULE(Handle));
 
   // 'Process' should not be released on Windows.
-  assert((!Process || Process == this) && "Bad Handle");
+  assert((Process == &Invalid || Process == this) && "Bad Handle");
   // llvm_shutdown called, Return to default
   DynamicLibrary::SearchOrder = DynamicLibrary::SO_Linker;
 }
@@ -60,7 +60,7 @@ static DynamicLibrary::HandleSet *IsOpenedHandlesInstance(void *Handle) {
 
 void DynamicLibrary::HandleSet::DLClose(void *Handle) {
   if (HandleSet *HS = IsOpenedHandlesInstance(Handle))
-    HS->Process = nullptr; // Just drop the *Process* handle.
+    HS->Process = &Invalid; // Just drop the *Process* handle.
   else
     FreeLibrary((HMODULE)Handle);
 }
@@ -89,7 +89,7 @@ void *DynamicLibrary::HandleSet::DLSym(void *Handle, const char *Symbol) {
     return (void *)uintptr_t(GetProcAddress((HMODULE)Handle, Symbol));
 
   // Could have done a dlclose on the *Process* handle
-  if (!HS->Process)
+  if (HS->Process == &Invalid)
     return nullptr;
 
   // Trials indicate EnumProcessModulesEx is consistantly faster than using


### PR DESCRIPTION
In Unix/DynamicLibrary.inc, it was already known that Cygwin required use of `RTLD_DEFAULT` as the `Handle` parameter to `DLSym` to search all modules for a symbol.  Unfortunately, RTLD_DEFAULT is defined as NULL, so the existing checks of the `Process` handle meant `DLSym` would never be called on Cygwin.  Use the existing `&Invalid` sentinel instead of `nullptr` for the `Process` handle.