### PR TITLE
RuntimeLibcalls: Fix missing const on getLibcallNames

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -81,10 +81,7 @@ struct RuntimeLibcallsInfo {
     return LibcallCallingConvs[Call];
   }
 
-  iterator_range<const char **> getLibcallNames() {
-    return llvm::make_range(LibcallRoutineNames,
-                            LibcallRoutineNames + RTLIB::UNKNOWN_LIBCALL);
-  }
+  ArrayRef<const char *> getLibcallNames() const { return LibcallRoutineNames; }
 
 private:
   /// Stores the name each libcall.

--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -81,7 +81,10 @@ struct RuntimeLibcallsInfo {
     return LibcallCallingConvs[Call];
   }
 
-  ArrayRef<const char *> getLibcallNames() const { return LibcallRoutineNames; }
+  ArrayRef<const char *> getLibcallNames() const {
+    // Trim UNKNOWN_LIBCALL from the end
+    return ArrayRef(LibcallRoutineNames).drop_back();
+  }
 
 private:
   /// Stores the name each libcall.


### PR DESCRIPTION
This is made simpler by just returning the array ref instead of
the fancy range.