### PR TITLE
[LLVM][Tests] remove %exeext from lli-child-target parameter.

### DIFF
--- a/llvm/test/ExecutionEngine/MCJIT/remote/cross-module-a.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/cross-module-a.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -extra-module=%p/Inputs/cross-module-b.ll -disable-lazy-compilation=true -remote-mcjit -mcjit-remote-process=lli-child-target%exeext %s > /dev/null
+; RUN: %lli -jit-kind=mcjit -extra-module=%p/Inputs/cross-module-b.ll -disable-lazy-compilation=true -remote-mcjit -mcjit-remote-process=lli-child-target %s > /dev/null
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/eh.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/eh.ll
@@ -1,5 +1,5 @@
 ; REQUIRES: cxx-shared-library
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target%exeext %s
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target %s
 ; XFAIL: target=arm{{.*}}, target={{.*-(cygwin|windows-msvc|windows-gnu)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/multi-module-a.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/multi-module-a.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -extra-module=%p/Inputs/multi-module-b.ll -extra-module=%p/Inputs/multi-module-c.ll -disable-lazy-compilation=true -remote-mcjit -mcjit-remote-process=lli-child-target%exeext %s > /dev/null
+; RUN: %lli -jit-kind=mcjit -extra-module=%p/Inputs/multi-module-b.ll -extra-module=%p/Inputs/multi-module-c.ll -disable-lazy-compilation=true -remote-mcjit -mcjit-remote-process=lli-child-target %s > /dev/null
 ; REQUIRES: thread_support
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/simpletest-remote.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/simpletest-remote.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target%exeext %s > /dev/null
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target %s > /dev/null
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/stubs-remote.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/stubs-remote.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -disable-lazy-compilation=false -mcjit-remote-process=lli-child-target%exeext %s
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -disable-lazy-compilation=false -mcjit-remote-process=lli-child-target %s
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/test-common-symbols-remote.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/test-common-symbols-remote.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -O0 -disable-lazy-compilation=false -mcjit-remote-process=lli-child-target%exeext %s
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -O0 -disable-lazy-compilation=false -mcjit-remote-process=lli-child-target %s
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/test-data-align-remote.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/test-data-align-remote.ll
@@ -1,4 +1,4 @@
-; RUN:  %lli -jit-kind=mcjit -remote-mcjit -O0 -mcjit-remote-process=lli-child-target%exeext %s
+; RUN:  %lli -jit-kind=mcjit -remote-mcjit -O0 -mcjit-remote-process=lli-child-target %s
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/test-fp-no-external-funcs-remote.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/test-fp-no-external-funcs-remote.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target%exeext %s > /dev/null
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target %s > /dev/null
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/test-global-init-nonzero-remote.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/test-global-init-nonzero-remote.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target%exeext %s > /dev/null
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target %s > /dev/null
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/test-global-init-nonzero-sm-pic.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/test-global-init-nonzero-sm-pic.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target%exeext \
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target \
 ; RUN:   -relocation-model=pic -code-model=small %s > /dev/null
 ; XFAIL: target={{(mips|mipsel)-.*}}, target={{(aarch64|arm).*}}, target={{(i686|i386).*}}
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}

--- a/llvm/test/ExecutionEngine/MCJIT/remote/test-ptr-reloc-remote.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/test-ptr-reloc-remote.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -O0 -mcjit-remote-process=lli-child-target%exeext %s
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -O0 -mcjit-remote-process=lli-child-target %s
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}
 ; REQUIRES: thread_support
 ; UNSUPPORTED: target=powerpc64-unknown-linux-gnu

--- a/llvm/test/ExecutionEngine/MCJIT/remote/test-ptr-reloc-sm-pic.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/remote/test-ptr-reloc-sm-pic.ll
@@ -1,4 +1,4 @@
-; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target%exeext \
+; RUN: %lli -jit-kind=mcjit -remote-mcjit -mcjit-remote-process=lli-child-target \
 ; RUN:   -O0 -relocation-model=pic -code-model=small %s
 ; XFAIL: target={{(mips|mipsel)-.*}}, target={{(aarch64|arm).*}}, target={{(i686|i386).*}}
 ; XFAIL: target={{.*-windows-(gnu|msvc)}}


### PR DESCRIPTION
Its presence seems to actively hinder the ToolSubst mechanism that was supposed to fill in the path to the tool, which prevented these tests from working on Cygwin.