### PR TITLE
[Clang] Non-polymorphic trivially relocatable types can have [[trivial_abi]]

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -8680,6 +8680,7 @@ public:
   // FIXME: This is in Sema because it requires
   // overload resolution, can we move to ASTContext?
   bool IsCXXTriviallyRelocatableType(QualType T);
+  bool IsCXXTriviallyRelocatableType(const CXXRecordDecl &RD);
 
   //// Determines if a type is replaceable
   /// according to the C++26 rules.

--- a/clang/test/SemaCXX/attr-trivial-abi.cpp
+++ b/clang/test/SemaCXX/attr-trivial-abi.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify=expected,itanium %s -std=c++11
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,itanium %s -triple x86_64-unknown-linux -std=c++11
 // RUN: %clang_cc1 -fsyntax-only -verify=expected,windows %s -triple x86_64-windows-msvc -std=c++11
 // RUN: %clang_cc1 -fsyntax-only -verify=expected,scei %s -triple x86_64-scei-ps4 -std=c++11
 

--- a/clang/test/SemaCXX/attr-trivial-abi.cpp
+++ b/clang/test/SemaCXX/attr-trivial-abi.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++11
-// RUN: %clang_cc1 -fsyntax-only -verify %s -triple x86_64-windows-msvc -std=c++11
-// RUN: %clang_cc1 -fsyntax-only -verify %s -triple x86_64-scei-ps4 -std=c++11
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,itanium %s -std=c++11
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,windows %s -triple x86_64-windows-msvc -std=c++11
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,scei %s -triple x86_64-scei-ps4 -std=c++11
 
 
 void __attribute__((trivial_abi)) foo(); // expected-warning {{'trivial_abi' attribute only applies to classes}}
@@ -165,7 +165,10 @@ static_assert(!__builtin_is_cpp_trivially_relocatable(CopyMoveDeleted), "");
 
 #endif
 
-struct __attribute__((trivial_abi)) S18 { // expected-warning {{'trivial_abi' cannot be applied to 'S18'}} expected-note {{copy constructors and move constructors are all deleted}}
+struct __attribute__((trivial_abi)) S18 { // expected-warning {{'trivial_abi' cannot be applied to 'S18'}} \
+                                          // itanium-note {{'trivial_abi' is disallowed on 'S18' because it has a field of a non-trivial class type}} \
+                                          // windows-note {{'trivial_abi' is disallowed on 'S18' because it has a field of a non-trivial class type}} \
+                                          // scei-note {{'trivial_abi' is disallowed on 'S18' because its copy constructors and move constructors are all deleted}}
   CopyMoveDeleted a;
 };
 #ifdef __ORBIS__
@@ -195,7 +198,10 @@ struct __attribute__((trivial_abi)) MoveDeleted {
 };
 static_assert(__is_trivially_relocatable(MoveDeleted), ""); // expected-warning{{deprecated}}
 static_assert(!__builtin_is_cpp_trivially_relocatable(MoveDeleted), "");
-struct __attribute__((trivial_abi)) S19 { // expected-warning {{'trivial_abi' cannot be applied to 'S19'}} expected-note {{copy constructors and move constructors are all deleted}}
+struct __attribute__((trivial_abi)) S19 { // expected-warning {{'trivial_abi' cannot be applied to 'S19'}} \
+                                          // itanium-note {{'trivial_abi' is disallowed on 'S19' because its copy constructors and move constructors are all deleted}} \
+                                          // windows-note {{'trivial_abi' is disallowed on 'S19' because it has a field of a non-trivial class type}} \
+                                          // scei-note {{'trivial_abi' is disallowed on 'S19' because its copy constructors and move constructors are all deleted}}
   CopyDeleted a;
   MoveDeleted b;
 };

--- a/clang/test/SemaObjCXX/attr-trivial-abi.mm
+++ b/clang/test/SemaObjCXX/attr-trivial-abi.mm
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -fobjc-runtime-has-weak -fobjc-weak -fobjc-arc -fsyntax-only -verify %s
+// RUN: %clang_cc1 -std=c++11 -fobjc-runtime-has-weak -fobjc-weak -fobjc-arc -triple x86_64-apple-darwin -fsyntax-only -verify %s
 
 void __attribute__((trivial_abi)) foo(); // expected-warning {{'trivial_abi' attribute only applies to classes}}
 

--- a/clang/test/SemaObjCXX/attr-trivial-abi.mm
+++ b/clang/test/SemaObjCXX/attr-trivial-abi.mm
@@ -108,7 +108,8 @@ namespace deletedCopyMoveConstructor {
     CopyMoveDeleted(CopyMoveDeleted &&) = delete;
   };
 
-  struct __attribute__((trivial_abi)) S18 { // expected-warning {{'trivial_abi' cannot be applied to 'S18'}} expected-note {{copy constructors and move constructors are all deleted}}
+  struct __attribute__((trivial_abi)) S18 { // expected-warning {{'trivial_abi' cannot be applied to 'S18'}} \
+                                            // expected-note {{'trivial_abi' is disallowed on 'S18' because it has a field of a non-trivial class type}}
     CopyMoveDeleted a;
   };
 


### PR DESCRIPTION

Use the definition of trivially relocatable types to short-circuit some checks for trivial_abi.

Note that this is mostly a no-op as there is a lot of overlap between trivial_abi and trivial relocatability (ie, I can't envision a scenario in which there would be a trivially relocatable type that would not be eligible for trivial_abi based on its special member function... which is good!)

Note that for bases and members, we need to check CanPassInRegister rather than just relocation. So we do these checks first, which leads to better diagnostics.