### PR TITLE
[Cygwin] wint_t is unsigned int

### DIFF
--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -639,6 +639,7 @@ public:
   CygwinX86_32TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
       : X86_32TargetInfo(Triple, Opts) {
     this->WCharType = TargetInfo::UnsignedShort;
+    this->WIntType = TargetInfo::UnsignedInt;
     DoubleAlign = LongLongAlign = 64;
     resetDataLayout("e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-"
                     "i128:128-f80:32-n8:16:32-a:0:32-S32",
@@ -966,6 +967,7 @@ public:
   CygwinX86_64TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
       : X86_64TargetInfo(Triple, Opts) {
     this->WCharType = TargetInfo::UnsignedShort;
+    this->WIntType = TargetInfo::UnsignedInt;
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/test/Preprocessor/init-x86.c
+++ b/clang/test/Preprocessor/init-x86.c
@@ -1486,3 +1486,431 @@
 
 // RUN: %clang_cc1 -E -dM -triple=i386-unknown-openbsd -x c++ < /dev/null | FileCheck -match-full-lines -check-prefix I386-OPENBSD-CXX %s
 // I386-OPENBSD-CXX: #define __STDCPP_DEFAULT_NEW_ALIGNMENT__ 16UL
+
+// RUN: %clang_cc1 -E -dM -ffreestanding -fgnuc-version=4.2.1 -triple=i386-pc-windows-cygnus -target-cpu pentium4 < /dev/null | FileCheck -match-full-lines -check-prefix I386-CYGWIN %s
+// I386-CYGWIN-NOT:#define _LP64
+// I386-CYGWIN:#define __BIGGEST_ALIGNMENT__ 16
+// I386-CYGWIN:#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+// I386-CYGWIN:#define __CHAR16_TYPE__ unsigned short
+// I386-CYGWIN:#define __CHAR32_TYPE__ unsigned int
+// I386-CYGWIN:#define __CHAR_BIT__ 8
+// I386-CYGWIN:#define __CYGWIN32__ 1
+// I386-CYGWIN:#define __CYGWIN__ 1
+// I386-CYGWIN:#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+// I386-CYGWIN:#define __DBL_DIG__ 15
+// I386-CYGWIN:#define __DBL_EPSILON__ 2.2204460492503131e-16
+// I386-CYGWIN:#define __DBL_HAS_DENORM__ 1
+// I386-CYGWIN:#define __DBL_HAS_INFINITY__ 1
+// I386-CYGWIN:#define __DBL_HAS_QUIET_NAN__ 1
+// I386-CYGWIN:#define __DBL_MANT_DIG__ 53
+// I386-CYGWIN:#define __DBL_MAX_10_EXP__ 308
+// I386-CYGWIN:#define __DBL_MAX_EXP__ 1024
+// I386-CYGWIN:#define __DBL_MAX__ 1.7976931348623157e+308
+// I386-CYGWIN:#define __DBL_MIN_10_EXP__ (-307)
+// I386-CYGWIN:#define __DBL_MIN_EXP__ (-1021)
+// I386-CYGWIN:#define __DBL_MIN__ 2.2250738585072014e-308
+// I386-CYGWIN:#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+// I386-CYGWIN:#define __FLT_DENORM_MIN__ 1.40129846e-45F
+// I386-CYGWIN:#define __FLT_DIG__ 6
+// I386-CYGWIN:#define __FLT_EPSILON__ 1.19209290e-7F
+// I386-CYGWIN:#define __FLT_HAS_DENORM__ 1
+// I386-CYGWIN:#define __FLT_HAS_INFINITY__ 1
+// I386-CYGWIN:#define __FLT_HAS_QUIET_NAN__ 1
+// I386-CYGWIN:#define __FLT_MANT_DIG__ 24
+// I386-CYGWIN:#define __FLT_MAX_10_EXP__ 38
+// I386-CYGWIN:#define __FLT_MAX_EXP__ 128
+// I386-CYGWIN:#define __FLT_MAX__ 3.40282347e+38F
+// I386-CYGWIN:#define __FLT_MIN_10_EXP__ (-37)
+// I386-CYGWIN:#define __FLT_MIN_EXP__ (-125)
+// I386-CYGWIN:#define __FLT_MIN__ 1.17549435e-38F
+// I386-CYGWIN:#define __FLT_RADIX__ 2
+// I386-CYGWIN:#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_INT_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+// I386-CYGWIN:#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+// I386-CYGWIN:#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+// I386-CYGWIN:#define __ILP32__ 1
+// I386-CYGWIN:#define __INT16_C(c) c
+// I386-CYGWIN:#define __INT16_C_SUFFIX__
+// I386-CYGWIN:#define __INT16_FMTd__ "hd"
+// I386-CYGWIN:#define __INT16_FMTi__ "hi"
+// I386-CYGWIN:#define __INT16_MAX__ 32767
+// I386-CYGWIN:#define __INT16_TYPE__ short
+// I386-CYGWIN:#define __INT32_C(c) c
+// I386-CYGWIN:#define __INT32_C_SUFFIX__
+// I386-CYGWIN:#define __INT32_FMTd__ "d"
+// I386-CYGWIN:#define __INT32_FMTi__ "i"
+// I386-CYGWIN:#define __INT32_MAX__ 2147483647
+// I386-CYGWIN:#define __INT32_TYPE__ int
+// I386-CYGWIN:#define __INT64_C(c) c##LL
+// I386-CYGWIN:#define __INT64_C_SUFFIX__ LL
+// I386-CYGWIN:#define __INT64_FMTd__ "lld"
+// I386-CYGWIN:#define __INT64_FMTi__ "lli"
+// I386-CYGWIN:#define __INT64_MAX__ 9223372036854775807LL
+// I386-CYGWIN:#define __INT64_TYPE__ long long int
+// I386-CYGWIN:#define __INT8_C(c) c
+// I386-CYGWIN:#define __INT8_C_SUFFIX__
+// I386-CYGWIN:#define __INT8_FMTd__ "hhd"
+// I386-CYGWIN:#define __INT8_FMTi__ "hhi"
+// I386-CYGWIN:#define __INT8_MAX__ 127
+// I386-CYGWIN:#define __INT8_TYPE__ signed char
+// I386-CYGWIN:#define __INTMAX_C(c) c##LL
+// I386-CYGWIN:#define __INTMAX_C_SUFFIX__ LL
+// I386-CYGWIN:#define __INTMAX_FMTd__ "lld"
+// I386-CYGWIN:#define __INTMAX_FMTi__ "lli"
+// I386-CYGWIN:#define __INTMAX_MAX__ 9223372036854775807LL
+// I386-CYGWIN:#define __INTMAX_TYPE__ long long int
+// I386-CYGWIN:#define __INTMAX_WIDTH__ 64
+// I386-CYGWIN:#define __INTPTR_FMTd__ "d"
+// I386-CYGWIN:#define __INTPTR_FMTi__ "i"
+// I386-CYGWIN:#define __INTPTR_MAX__ 2147483647
+// I386-CYGWIN:#define __INTPTR_TYPE__ int
+// I386-CYGWIN:#define __INTPTR_WIDTH__ 32
+// I386-CYGWIN:#define __INT_FAST16_FMTd__ "hd"
+// I386-CYGWIN:#define __INT_FAST16_FMTi__ "hi"
+// I386-CYGWIN:#define __INT_FAST16_MAX__ 32767
+// I386-CYGWIN:#define __INT_FAST16_TYPE__ short
+// I386-CYGWIN:#define __INT_FAST32_FMTd__ "d"
+// I386-CYGWIN:#define __INT_FAST32_FMTi__ "i"
+// I386-CYGWIN:#define __INT_FAST32_MAX__ 2147483647
+// I386-CYGWIN:#define __INT_FAST32_TYPE__ int
+// I386-CYGWIN:#define __INT_FAST64_FMTd__ "lld"
+// I386-CYGWIN:#define __INT_FAST64_FMTi__ "lli"
+// I386-CYGWIN:#define __INT_FAST64_MAX__ 9223372036854775807LL
+// I386-CYGWIN:#define __INT_FAST64_TYPE__ long long int
+// I386-CYGWIN:#define __INT_FAST8_FMTd__ "hhd"
+// I386-CYGWIN:#define __INT_FAST8_FMTi__ "hhi"
+// I386-CYGWIN:#define __INT_FAST8_MAX__ 127
+// I386-CYGWIN:#define __INT_FAST8_TYPE__ signed char
+// I386-CYGWIN:#define __INT_LEAST16_FMTd__ "hd"
+// I386-CYGWIN:#define __INT_LEAST16_FMTi__ "hi"
+// I386-CYGWIN:#define __INT_LEAST16_MAX__ 32767
+// I386-CYGWIN:#define __INT_LEAST16_TYPE__ short
+// I386-CYGWIN:#define __INT_LEAST32_FMTd__ "d"
+// I386-CYGWIN:#define __INT_LEAST32_FMTi__ "i"
+// I386-CYGWIN:#define __INT_LEAST32_MAX__ 2147483647
+// I386-CYGWIN:#define __INT_LEAST32_TYPE__ int
+// I386-CYGWIN:#define __INT_LEAST64_FMTd__ "lld"
+// I386-CYGWIN:#define __INT_LEAST64_FMTi__ "lli"
+// I386-CYGWIN:#define __INT_LEAST64_MAX__ 9223372036854775807LL
+// I386-CYGWIN:#define __INT_LEAST64_TYPE__ long long int
+// I386-CYGWIN:#define __INT_LEAST8_FMTd__ "hhd"
+// I386-CYGWIN:#define __INT_LEAST8_FMTi__ "hhi"
+// I386-CYGWIN:#define __INT_LEAST8_MAX__ 127
+// I386-CYGWIN:#define __INT_LEAST8_TYPE__ signed char
+// I386-CYGWIN:#define __INT_MAX__ 2147483647
+// I386-CYGWIN:#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+// I386-CYGWIN:#define __LDBL_DIG__ 18
+// I386-CYGWIN:#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+// I386-CYGWIN:#define __LDBL_HAS_DENORM__ 1
+// I386-CYGWIN:#define __LDBL_HAS_INFINITY__ 1
+// I386-CYGWIN:#define __LDBL_HAS_QUIET_NAN__ 1
+// I386-CYGWIN:#define __LDBL_MANT_DIG__ 64
+// I386-CYGWIN:#define __LDBL_MAX_10_EXP__ 4932
+// I386-CYGWIN:#define __LDBL_MAX_EXP__ 16384
+// I386-CYGWIN:#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+// I386-CYGWIN:#define __LDBL_MIN_10_EXP__ (-4931)
+// I386-CYGWIN:#define __LDBL_MIN_EXP__ (-16381)
+// I386-CYGWIN:#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+// I386-CYGWIN:#define __LITTLE_ENDIAN__ 1
+// I386-CYGWIN:#define __LONG_LONG_MAX__ 9223372036854775807LL
+// I386-CYGWIN:#define __LONG_MAX__ 2147483647L
+// I386-CYGWIN-NOT:#define __LP64__
+// I386-CYGWIN:#define __NO_MATH_INLINES 1
+// I386-CYGWIN:#define __POINTER_WIDTH__ 32
+// I386-CYGWIN:#define __PTRDIFF_TYPE__ int
+// I386-CYGWIN:#define __PTRDIFF_WIDTH__ 32
+// I386-CYGWIN:#define __REGISTER_PREFIX__
+// I386-CYGWIN:#define __SCHAR_MAX__ 127
+// I386-CYGWIN:#define __SHRT_MAX__ 32767
+// I386-CYGWIN:#define __SIG_ATOMIC_MAX__ 2147483647
+// I386-CYGWIN:#define __SIG_ATOMIC_WIDTH__ 32
+// I386-CYGWIN:#define __SIZEOF_DOUBLE__ 8
+// I386-CYGWIN:#define __SIZEOF_FLOAT__ 4
+// I386-CYGWIN:#define __SIZEOF_INT__ 4
+// I386-CYGWIN:#define __SIZEOF_LONG_DOUBLE__ 12
+// I386-CYGWIN:#define __SIZEOF_LONG_LONG__ 8
+// I386-CYGWIN:#define __SIZEOF_LONG__ 4
+// I386-CYGWIN:#define __SIZEOF_POINTER__ 4
+// I386-CYGWIN:#define __SIZEOF_PTRDIFF_T__ 4
+// I386-CYGWIN:#define __SIZEOF_SHORT__ 2
+// I386-CYGWIN:#define __SIZEOF_SIZE_T__ 4
+// I386-CYGWIN:#define __SIZEOF_WCHAR_T__ 2
+// I386-CYGWIN:#define __SIZEOF_WINT_T__ 4
+// I386-CYGWIN:#define __SIZE_MAX__ 4294967295U
+// I386-CYGWIN:#define __SIZE_TYPE__ unsigned int
+// I386-CYGWIN:#define __SIZE_WIDTH__ 32
+// I386-CYGWIN:#define __UINT16_C(c) c
+// I386-CYGWIN:#define __UINT16_C_SUFFIX__
+// I386-CYGWIN:#define __UINT16_MAX__ 65535
+// I386-CYGWIN:#define __UINT16_TYPE__ unsigned short
+// I386-CYGWIN:#define __UINT32_C(c) c##U
+// I386-CYGWIN:#define __UINT32_C_SUFFIX__ U
+// I386-CYGWIN:#define __UINT32_MAX__ 4294967295U
+// I386-CYGWIN:#define __UINT32_TYPE__ unsigned int
+// I386-CYGWIN:#define __UINT64_C(c) c##ULL
+// I386-CYGWIN:#define __UINT64_C_SUFFIX__ ULL
+// I386-CYGWIN:#define __UINT64_MAX__ 18446744073709551615ULL
+// I386-CYGWIN:#define __UINT64_TYPE__ long long unsigned int
+// I386-CYGWIN:#define __UINT8_C(c) c
+// I386-CYGWIN:#define __UINT8_C_SUFFIX__
+// I386-CYGWIN:#define __UINT8_MAX__ 255
+// I386-CYGWIN:#define __UINT8_TYPE__ unsigned char
+// I386-CYGWIN:#define __UINTMAX_C(c) c##ULL
+// I386-CYGWIN:#define __UINTMAX_C_SUFFIX__ ULL
+// I386-CYGWIN:#define __UINTMAX_MAX__ 18446744073709551615ULL
+// I386-CYGWIN:#define __UINTMAX_TYPE__ long long unsigned int
+// I386-CYGWIN:#define __UINTMAX_WIDTH__ 64
+// I386-CYGWIN:#define __UINTPTR_MAX__ 4294967295U
+// I386-CYGWIN:#define __UINTPTR_TYPE__ unsigned int
+// I386-CYGWIN:#define __UINTPTR_WIDTH__ 32
+// I386-CYGWIN:#define __UINT_FAST16_MAX__ 65535
+// I386-CYGWIN:#define __UINT_FAST16_TYPE__ unsigned short
+// I386-CYGWIN:#define __UINT_FAST32_MAX__ 4294967295U
+// I386-CYGWIN:#define __UINT_FAST32_TYPE__ unsigned int
+// I386-CYGWIN:#define __UINT_FAST64_MAX__ 18446744073709551615ULL
+// I386-CYGWIN:#define __UINT_FAST64_TYPE__ long long unsigned int
+// I386-CYGWIN:#define __UINT_FAST8_MAX__ 255
+// I386-CYGWIN:#define __UINT_FAST8_TYPE__ unsigned char
+// I386-CYGWIN:#define __UINT_LEAST16_MAX__ 65535
+// I386-CYGWIN:#define __UINT_LEAST16_TYPE__ unsigned short
+// I386-CYGWIN:#define __UINT_LEAST32_MAX__ 4294967295U
+// I386-CYGWIN:#define __UINT_LEAST32_TYPE__ unsigned int
+// I386-CYGWIN:#define __UINT_LEAST64_MAX__ 18446744073709551615ULL
+// I386-CYGWIN:#define __UINT_LEAST64_TYPE__ long long unsigned int
+// I386-CYGWIN:#define __UINT_LEAST8_MAX__ 255
+// I386-CYGWIN:#define __UINT_LEAST8_TYPE__ unsigned char
+// I386-CYGWIN:#define __USER_LABEL_PREFIX__ _
+// I386-CYGWIN:#define __WCHAR_MAX__ 65535
+// I386-CYGWIN:#define __WCHAR_TYPE__ unsigned short
+// I386-CYGWIN:#define __WCHAR_WIDTH__ 16
+// I386-CYGWIN:#define __WINT_TYPE__ unsigned int
+// I386-CYGWIN:#define __WINT_WIDTH__ 32
+// I386-CYGWIN:#define __i386 1
+// I386-CYGWIN:#define __i386__ 1
+// I386-CYGWIN:#define __unix 1
+// I386-CYGWIN:#define __unix__ 1
+// I386-CYGWIN:#define i386 1
+// I386-CYGWIN:#define unix 1
+
+// RUN: %clang_cc1 -E -dM -ffreestanding -fgnuc-version=4.2.1 -triple=x86_64-pc-windows-cygnus < /dev/null | FileCheck -match-full-lines -check-prefix X86_64-CYGWIN %s
+// X86_64-CYGWIN:#define _LP64 1
+// X86_64-CYGWIN:#define __BIGGEST_ALIGNMENT__ 16
+// X86_64-CYGWIN:#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+// X86_64-CYGWIN:#define __CHAR16_TYPE__ unsigned short
+// X86_64-CYGWIN:#define __CHAR32_TYPE__ unsigned int
+// X86_64-CYGWIN:#define __CHAR_BIT__ 8
+// X86_64-CYGWIN:#define __CYGWIN__ 1
+// X86_64-CYGWIN:#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+// X86_64-CYGWIN:#define __DBL_DIG__ 15
+// X86_64-CYGWIN:#define __DBL_EPSILON__ 2.2204460492503131e-16
+// X86_64-CYGWIN:#define __DBL_HAS_DENORM__ 1
+// X86_64-CYGWIN:#define __DBL_HAS_INFINITY__ 1
+// X86_64-CYGWIN:#define __DBL_HAS_QUIET_NAN__ 1
+// X86_64-CYGWIN:#define __DBL_MANT_DIG__ 53
+// X86_64-CYGWIN:#define __DBL_MAX_10_EXP__ 308
+// X86_64-CYGWIN:#define __DBL_MAX_EXP__ 1024
+// X86_64-CYGWIN:#define __DBL_MAX__ 1.7976931348623157e+308
+// X86_64-CYGWIN:#define __DBL_MIN_10_EXP__ (-307)
+// X86_64-CYGWIN:#define __DBL_MIN_EXP__ (-1021)
+// X86_64-CYGWIN:#define __DBL_MIN__ 2.2250738585072014e-308
+// X86_64-CYGWIN:#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+// X86_64-CYGWIN:#define __FLT_DENORM_MIN__ 1.40129846e-45F
+// X86_64-CYGWIN:#define __FLT_DIG__ 6
+// X86_64-CYGWIN:#define __FLT_EPSILON__ 1.19209290e-7F
+// X86_64-CYGWIN:#define __FLT_HAS_DENORM__ 1
+// X86_64-CYGWIN:#define __FLT_HAS_INFINITY__ 1
+// X86_64-CYGWIN:#define __FLT_HAS_QUIET_NAN__ 1
+// X86_64-CYGWIN:#define __FLT_MANT_DIG__ 24
+// X86_64-CYGWIN:#define __FLT_MAX_10_EXP__ 38
+// X86_64-CYGWIN:#define __FLT_MAX_EXP__ 128
+// X86_64-CYGWIN:#define __FLT_MAX__ 3.40282347e+38F
+// X86_64-CYGWIN:#define __FLT_MIN_10_EXP__ (-37)
+// X86_64-CYGWIN:#define __FLT_MIN_EXP__ (-125)
+// X86_64-CYGWIN:#define __FLT_MIN__ 1.17549435e-38F
+// X86_64-CYGWIN:#define __FLT_RADIX__ 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_INT_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+// X86_64-CYGWIN:#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+// X86_64-CYGWIN:#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+// X86_64-CYGWIN:#define __INT16_C(c) c
+// X86_64-CYGWIN:#define __INT16_C_SUFFIX__
+// X86_64-CYGWIN:#define __INT16_FMTd__ "hd"
+// X86_64-CYGWIN:#define __INT16_FMTi__ "hi"
+// X86_64-CYGWIN:#define __INT16_MAX__ 32767
+// X86_64-CYGWIN:#define __INT16_TYPE__ short
+// X86_64-CYGWIN:#define __INT32_C(c) c
+// X86_64-CYGWIN:#define __INT32_C_SUFFIX__
+// X86_64-CYGWIN:#define __INT32_FMTd__ "d"
+// X86_64-CYGWIN:#define __INT32_FMTi__ "i"
+// X86_64-CYGWIN:#define __INT32_MAX__ 2147483647
+// X86_64-CYGWIN:#define __INT32_TYPE__ int
+// X86_64-CYGWIN:#define __INT64_C(c) c##L
+// X86_64-CYGWIN:#define __INT64_C_SUFFIX__ L
+// X86_64-CYGWIN:#define __INT64_FMTd__ "ld"
+// X86_64-CYGWIN:#define __INT64_FMTi__ "li"
+// X86_64-CYGWIN:#define __INT64_MAX__ 9223372036854775807L
+// X86_64-CYGWIN:#define __INT64_TYPE__ long int
+// X86_64-CYGWIN:#define __INT8_C(c) c
+// X86_64-CYGWIN:#define __INT8_C_SUFFIX__
+// X86_64-CYGWIN:#define __INT8_FMTd__ "hhd"
+// X86_64-CYGWIN:#define __INT8_FMTi__ "hhi"
+// X86_64-CYGWIN:#define __INT8_MAX__ 127
+// X86_64-CYGWIN:#define __INT8_TYPE__ signed char
+// X86_64-CYGWIN:#define __INTMAX_C(c) c##L
+// X86_64-CYGWIN:#define __INTMAX_C_SUFFIX__ L
+// X86_64-CYGWIN:#define __INTMAX_FMTd__ "ld"
+// X86_64-CYGWIN:#define __INTMAX_FMTi__ "li"
+// X86_64-CYGWIN:#define __INTMAX_MAX__ 9223372036854775807L
+// X86_64-CYGWIN:#define __INTMAX_TYPE__ long int
+// X86_64-CYGWIN:#define __INTMAX_WIDTH__ 64
+// X86_64-CYGWIN:#define __INTPTR_FMTd__ "ld"
+// X86_64-CYGWIN:#define __INTPTR_FMTi__ "li"
+// X86_64-CYGWIN:#define __INTPTR_MAX__ 9223372036854775807L
+// X86_64-CYGWIN:#define __INTPTR_TYPE__ long int
+// X86_64-CYGWIN:#define __INTPTR_WIDTH__ 64
+// X86_64-CYGWIN:#define __INT_FAST16_FMTd__ "hd"
+// X86_64-CYGWIN:#define __INT_FAST16_FMTi__ "hi"
+// X86_64-CYGWIN:#define __INT_FAST16_MAX__ 32767
+// X86_64-CYGWIN:#define __INT_FAST16_TYPE__ short
+// X86_64-CYGWIN:#define __INT_FAST32_FMTd__ "d"
+// X86_64-CYGWIN:#define __INT_FAST32_FMTi__ "i"
+// X86_64-CYGWIN:#define __INT_FAST32_MAX__ 2147483647
+// X86_64-CYGWIN:#define __INT_FAST32_TYPE__ int
+// X86_64-CYGWIN:#define __INT_FAST64_FMTd__ "ld"
+// X86_64-CYGWIN:#define __INT_FAST64_FMTi__ "li"
+// X86_64-CYGWIN:#define __INT_FAST64_MAX__ 9223372036854775807L
+// X86_64-CYGWIN:#define __INT_FAST64_TYPE__ long int
+// X86_64-CYGWIN:#define __INT_FAST8_FMTd__ "hhd"
+// X86_64-CYGWIN:#define __INT_FAST8_FMTi__ "hhi"
+// X86_64-CYGWIN:#define __INT_FAST8_MAX__ 127
+// X86_64-CYGWIN:#define __INT_FAST8_TYPE__ signed char
+// X86_64-CYGWIN:#define __INT_LEAST16_FMTd__ "hd"
+// X86_64-CYGWIN:#define __INT_LEAST16_FMTi__ "hi"
+// X86_64-CYGWIN:#define __INT_LEAST16_MAX__ 32767
+// X86_64-CYGWIN:#define __INT_LEAST16_TYPE__ short
+// X86_64-CYGWIN:#define __INT_LEAST32_FMTd__ "d"
+// X86_64-CYGWIN:#define __INT_LEAST32_FMTi__ "i"
+// X86_64-CYGWIN:#define __INT_LEAST32_MAX__ 2147483647
+// X86_64-CYGWIN:#define __INT_LEAST32_TYPE__ int
+// X86_64-CYGWIN:#define __INT_LEAST64_FMTd__ "ld"
+// X86_64-CYGWIN:#define __INT_LEAST64_FMTi__ "li"
+// X86_64-CYGWIN:#define __INT_LEAST64_MAX__ 9223372036854775807L
+// X86_64-CYGWIN:#define __INT_LEAST64_TYPE__ long int
+// X86_64-CYGWIN:#define __INT_LEAST8_FMTd__ "hhd"
+// X86_64-CYGWIN:#define __INT_LEAST8_FMTi__ "hhi"
+// X86_64-CYGWIN:#define __INT_LEAST8_MAX__ 127
+// X86_64-CYGWIN:#define __INT_LEAST8_TYPE__ signed char
+// X86_64-CYGWIN:#define __INT_MAX__ 2147483647
+// X86_64-CYGWIN:#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+// X86_64-CYGWIN:#define __LDBL_DIG__ 18
+// X86_64-CYGWIN:#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+// X86_64-CYGWIN:#define __LDBL_HAS_DENORM__ 1
+// X86_64-CYGWIN:#define __LDBL_HAS_INFINITY__ 1
+// X86_64-CYGWIN:#define __LDBL_HAS_QUIET_NAN__ 1
+// X86_64-CYGWIN:#define __LDBL_MANT_DIG__ 64
+// X86_64-CYGWIN:#define __LDBL_MAX_10_EXP__ 4932
+// X86_64-CYGWIN:#define __LDBL_MAX_EXP__ 16384
+// X86_64-CYGWIN:#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+// X86_64-CYGWIN:#define __LDBL_MIN_10_EXP__ (-4931)
+// X86_64-CYGWIN:#define __LDBL_MIN_EXP__ (-16381)
+// X86_64-CYGWIN:#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+// X86_64-CYGWIN:#define __LITTLE_ENDIAN__ 1
+// X86_64-CYGWIN:#define __LONG_LONG_MAX__ 9223372036854775807LL
+// X86_64-CYGWIN:#define __LONG_MAX__ 9223372036854775807L
+// X86_64-CYGWIN:#define __LP64__ 1
+// X86_64-CYGWIN:#define __MMX__ 1
+// X86_64-CYGWIN:#define __NO_MATH_INLINES 1
+// X86_64-CYGWIN:#define __POINTER_WIDTH__ 64
+// X86_64-CYGWIN:#define __PTRDIFF_TYPE__ long int
+// X86_64-CYGWIN:#define __PTRDIFF_WIDTH__ 64
+// X86_64-CYGWIN:#define __REGISTER_PREFIX__
+// X86_64-CYGWIN:#define __SCHAR_MAX__ 127
+// X86_64-CYGWIN:#define __SHRT_MAX__ 32767
+// X86_64-CYGWIN:#define __SIG_ATOMIC_MAX__ 2147483647
+// X86_64-CYGWIN:#define __SIG_ATOMIC_WIDTH__ 32
+// X86_64-CYGWIN:#define __SIZEOF_DOUBLE__ 8
+// X86_64-CYGWIN:#define __SIZEOF_FLOAT__ 4
+// X86_64-CYGWIN:#define __SIZEOF_INT__ 4
+// X86_64-CYGWIN:#define __SIZEOF_LONG_DOUBLE__ 16
+// X86_64-CYGWIN:#define __SIZEOF_LONG_LONG__ 8
+// X86_64-CYGWIN:#define __SIZEOF_LONG__ 8
+// X86_64-CYGWIN:#define __SIZEOF_POINTER__ 8
+// X86_64-CYGWIN:#define __SIZEOF_PTRDIFF_T__ 8
+// X86_64-CYGWIN:#define __SIZEOF_SHORT__ 2
+// X86_64-CYGWIN:#define __SIZEOF_SIZE_T__ 8
+// X86_64-CYGWIN:#define __SIZEOF_WCHAR_T__ 2
+// X86_64-CYGWIN:#define __SIZEOF_WINT_T__ 4
+// X86_64-CYGWIN:#define __SIZE_MAX__ 18446744073709551615UL
+// X86_64-CYGWIN:#define __SIZE_TYPE__ long unsigned int
+// X86_64-CYGWIN:#define __SIZE_WIDTH__ 64
+// X86_64-CYGWIN:#define __SSE2_MATH__ 1
+// X86_64-CYGWIN:#define __SSE2__ 1
+// X86_64-CYGWIN:#define __SSE_MATH__ 1
+// X86_64-CYGWIN:#define __SSE__ 1
+// X86_64-CYGWIN:#define __UINT16_C(c) c
+// X86_64-CYGWIN:#define __UINT16_C_SUFFIX__
+// X86_64-CYGWIN:#define __UINT16_MAX__ 65535
+// X86_64-CYGWIN:#define __UINT16_TYPE__ unsigned short
+// X86_64-CYGWIN:#define __UINT32_C(c) c##U
+// X86_64-CYGWIN:#define __UINT32_C_SUFFIX__ U
+// X86_64-CYGWIN:#define __UINT32_MAX__ 4294967295U
+// X86_64-CYGWIN:#define __UINT32_TYPE__ unsigned int
+// X86_64-CYGWIN:#define __UINT64_C(c) c##UL
+// X86_64-CYGWIN:#define __UINT64_C_SUFFIX__ UL
+// X86_64-CYGWIN:#define __UINT64_MAX__ 18446744073709551615UL
+// X86_64-CYGWIN:#define __UINT64_TYPE__ long unsigned int
+// X86_64-CYGWIN:#define __UINT8_C(c) c
+// X86_64-CYGWIN:#define __UINT8_C_SUFFIX__
+// X86_64-CYGWIN:#define __UINT8_MAX__ 255
+// X86_64-CYGWIN:#define __UINT8_TYPE__ unsigned char
+// X86_64-CYGWIN:#define __UINTMAX_C(c) c##UL
+// X86_64-CYGWIN:#define __UINTMAX_C_SUFFIX__ UL
+// X86_64-CYGWIN:#define __UINTMAX_MAX__ 18446744073709551615UL
+// X86_64-CYGWIN:#define __UINTMAX_TYPE__ long unsigned int
+// X86_64-CYGWIN:#define __UINTMAX_WIDTH__ 64
+// X86_64-CYGWIN:#define __UINTPTR_MAX__ 18446744073709551615UL
+// X86_64-CYGWIN:#define __UINTPTR_TYPE__ long unsigned int
+// X86_64-CYGWIN:#define __UINTPTR_WIDTH__ 64
+// X86_64-CYGWIN:#define __UINT_FAST16_MAX__ 65535
+// X86_64-CYGWIN:#define __UINT_FAST16_TYPE__ unsigned short
+// X86_64-CYGWIN:#define __UINT_FAST32_MAX__ 4294967295U
+// X86_64-CYGWIN:#define __UINT_FAST32_TYPE__ unsigned int
+// X86_64-CYGWIN:#define __UINT_FAST64_MAX__ 18446744073709551615UL
+// X86_64-CYGWIN:#define __UINT_FAST64_TYPE__ long unsigned int
+// X86_64-CYGWIN:#define __UINT_FAST8_MAX__ 255
+// X86_64-CYGWIN:#define __UINT_FAST8_TYPE__ unsigned char
+// X86_64-CYGWIN:#define __UINT_LEAST16_MAX__ 65535
+// X86_64-CYGWIN:#define __UINT_LEAST16_TYPE__ unsigned short
+// X86_64-CYGWIN:#define __UINT_LEAST32_MAX__ 4294967295U
+// X86_64-CYGWIN:#define __UINT_LEAST32_TYPE__ unsigned int
+// X86_64-CYGWIN:#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+// X86_64-CYGWIN:#define __UINT_LEAST64_TYPE__ long unsigned int
+// X86_64-CYGWIN:#define __UINT_LEAST8_MAX__ 255
+// X86_64-CYGWIN:#define __UINT_LEAST8_TYPE__ unsigned char
+// X86_64-CYGWIN:#define __USER_LABEL_PREFIX__
+// X86_64-CYGWIN:#define __WCHAR_MAX__ 65535
+// X86_64-CYGWIN:#define __WCHAR_TYPE__ unsigned short
+// X86_64-CYGWIN:#define __WCHAR_WIDTH__ 16
+// X86_64-CYGWIN:#define __WINT_TYPE__ unsigned int
+// X86_64-CYGWIN:#define __WINT_WIDTH__ 32
+// X86_64-CYGWIN:#define __amd64 1
+// X86_64-CYGWIN:#define __amd64__ 1
+// X86_64-CYGWIN:#define __unix 1
+// X86_64-CYGWIN:#define __unix__ 1
+// X86_64-CYGWIN:#define __x86_64 1
+// X86_64-CYGWIN:#define __x86_64__ 1
+// X86_64-CYGWIN:#define unix 1

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -2090,12 +2090,6 @@
 // WEBASSEMBLY-CXX-ATOMICS:#define _REENTRANT 1
 // WEBASSEMBLY-CXX-ATOMICS:#define __STDCPP_THREADS__ 1
 
-// RUN: %clang_cc1 -E -dM -ffreestanding -triple i686-windows-cygnus < /dev/null | FileCheck -match-full-lines -check-prefix CYGWIN-X32 %s
-// CYGWIN-X32: #define __USER_LABEL_PREFIX__ _
-
-// RUN: %clang_cc1 -E -dM -ffreestanding -triple x86_64-windows-cygnus < /dev/null | FileCheck -match-full-lines -check-prefix CYGWIN-X64 %s
-// CYGWIN-X64: #define __USER_LABEL_PREFIX__
-
 // RUN: %clang_cc1 -E -dM -ffreestanding -fgnuc-version=4.2.1 -triple=avr \
 // RUN:   < /dev/null \
 // RUN:   | FileCheck -match-full-lines -check-prefix=AVR %s


### PR DESCRIPTION
On Cygwin environment, wint_t is unsigned int as shown here:
```
$ echo | gcc -m32 -xc - -E -dM | grep WINT_T
145:#define __SIZEOF_WINT_T__ 4
315:#define __WINT_TYPE__ unsigned int
```

```
$ echo | gcc -xc - -E -dM | grep WINT_T
147:#define __SIZEOF_WINT_T__ 4
317:#define __WINT_TYPE__ unsigned int
```

```
$ LANG=C gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-cygwin/15/lto-wrapper.exe
Target: x86_64-pc-cygwin
(snip)
```