### PR TITLE
[LLD][Cygwin] Add libcygwin to exclude from auto-export library list

### DIFF
--- a/lld/COFF/MinGW.cpp
+++ b/lld/COFF/MinGW.cpp
@@ -46,6 +46,8 @@ AutoExporter::AutoExporter(
       "libclang_rt.profile-arm",
       "libclang_rt.profile-i386",
       "libclang_rt.profile-x86_64",
+      "libcygwin",
+      "libmsys-2.0",
       "libc++",
       "libc++abi",
       "libflang_rt.runtime",


### PR DESCRIPTION
Linking for Cygwin target always needs -lcygwin but should not auto-exported from it, same as -lmingw for MinGW target.