### PR TITLE
[lldb] add plugin names to process save-core error output.

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -270,6 +270,8 @@ public:
   static Status SaveCore(const lldb::ProcessSP &process_sp,
                          lldb_private::SaveCoreOptions &core_options);
 
+  static std::vector<llvm::StringRef> GetSaveCorePluginNames();
+
   // ObjectContainer
   static bool RegisterPlugin(
       llvm::StringRef name, llvm::StringRef description,

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -843,11 +843,28 @@ Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
   }
 
   // Check to see if any of the object file plugins tried and failed to save.
-  // If none ran, set the error message.
-  if (error.Success())
-    error = Status::FromErrorString(
-        "no ObjectFile plugins were able to save a core for this process");
-  return error;
+  // if any failure, return the error message.
+  if (error.Fail())
+    return error;
+
+  // Report only for the plugin that was specified.
+  if (!plugin_name.empty())
+    return Status::FromErrorStringWithFormatv(
+        "The \"{}\" plugin is not able to save a core for this process.",
+        plugin_name);
+
+  return Status::FromErrorString(
+      "no ObjectFile plugins were able to save a core for this process");
+}
+
+std::vector<llvm::StringRef> PluginManager::GetSaveCorePluginNames() {
+  std::vector<llvm::StringRef> plugin_names;
+  auto instances = GetObjectFileInstances().GetSnapshot();
+  for (auto &instance : instances) {
+    if (instance.save_core)
+      plugin_names.emplace_back(instance.name);
+  }
+  return plugin_names;
 }
 
 #pragma mark ObjectContainer

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -21,9 +21,20 @@ Status SaveCoreOptions::SetPluginName(const char *name) {
     return error;
   }
 
-  if (!PluginManager::IsRegisteredObjectFilePluginName(name)) {
-    return Status::FromErrorStringWithFormat(
-        "plugin name '%s' is not a valid ObjectFile plugin name", name);
+  std::vector<llvm::StringRef> plugin_names =
+      PluginManager::GetSaveCorePluginNames();
+  if (llvm::find(plugin_names, name) == plugin_names.end()) {
+    StreamString stream;
+    stream.Printf("plugin name '%s' is not a valid ObjectFile plugin name.",
+                  name);
+
+    if (!plugin_names.empty()) {
+      stream.PutCString(" Valid names are: ");
+      std::string plugin_names_str = llvm::join(plugin_names, ", ");
+      stream.PutCString(plugin_names_str);
+      stream.PutChar('.');
+    }
+    return Status(stream.GetString().str());
   }
 
   m_plugin_name = name;

--- a/lldb/test/API/functionalities/process_save_core/TestProcessSaveCore.py
+++ b/lldb/test/API/functionalities/process_save_core/TestProcessSaveCore.py
@@ -88,3 +88,10 @@ class ProcessSaveCoreTestCase(TestBase):
                 os.unlink(core)
             except OSError:
                 pass
+
+    def test_help(self):
+        """Test that help shows minidump as an option in plugin-names."""
+        self.expect(
+            "help process save-core",
+            substrs=["process save-core", "<plugin>", "Values:", "minidump"],
+        )

--- a/lldb/test/API/functionalities/process_save_core/TestProcessSaveCore.py
+++ b/lldb/test/API/functionalities/process_save_core/TestProcessSaveCore.py
@@ -90,8 +90,19 @@ class ProcessSaveCoreTestCase(TestBase):
                 pass
 
     def test_help(self):
-        """Test that help shows minidump as an option in plugin-names."""
+        """Test that help shows an option in plugin-names and style."""
         self.expect(
             "help process save-core",
             substrs=["process save-core", "<plugin>", "Values:", "minidump"],
+        )
+
+        self.expect(
+            "help process save-core",
+            substrs=[
+                "process save-core",
+                "<corefile-style>",
+                "Values:",
+                "full",
+                "stack",
+            ],
         )

--- a/lldb/test/Shell/Commands/command-process-save-core-not-a-plugin.test
+++ b/lldb/test/Shell/Commands/command-process-save-core-not-a-plugin.test
@@ -16,4 +16,4 @@ run
 
 process save-core --plugin-name=notaplugin dump
 # CHECK-LABEL: process save-core --plugin-name=notaplugin dump
-# CHECK: error: plugin name 'notaplugin' is not a valid ObjectFile plugin name
+# CHECK: error: plugin name 'notaplugin' is not a valid ObjectFile plugin name. Valid names are:{{.*}}minidump{{.*}}

--- a/lldb/test/Shell/Commands/command-process-save-core-not-a-plugin.test
+++ b/lldb/test/Shell/Commands/command-process-save-core-not-a-plugin.test
@@ -2,7 +2,7 @@
 # with a plugin that does not exist.
 
 # RUN: %clang_host -g %S/Inputs/main.c -o %t
-# RUN: %lldb %t -s %s -o exit 2>&1 | FileCheck %s
+# RUN: %lldb %t -o "settings set interpreter.stop-command-source-on-error false" -s %s -o exit 2>&1 | FileCheck %s
 
 b main
 # CHECK-LABEL: b main
@@ -13,6 +13,11 @@ run
 # CHECK: Process {{.*}} stopped
 # CHECK: stop reason = breakpoint 1
 # CHECK:   frame #0: {{.*}}`main at main.c
+
+process save-core --plugin-name=minidump
+# CHECK-LABEL: process save-core --plugin-name=minidump
+# CHECK: error: 'process save-core' takes one arguments:
+# CHECK: Usage: {{.*}} FILE
 
 process save-core --plugin-name=notaplugin dump
 # CHECK-LABEL: process save-core --plugin-name=notaplugin dump


### PR DESCRIPTION
continuation of [#142684](https://github.com/llvm/llvm-project/pull/142684) to show plugin names. 

From issue [#14258](https://github.com/llvm/llvm-project/issues/142581)