### PR TITLE
[SPIRV] Fix type mismatch assertion in insertvalue.

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -1711,11 +1711,12 @@ Instruction *SPIRVEmitIntrinsics::visitInsertValueInst(InsertValueInst &I) {
   B.SetInsertPoint(&I);
   SmallVector<Type *, 1> Types = {I.getInsertedValueOperand()->getType()};
   SmallVector<Value *> Args;
-  for (auto &Op : I.operands())
-    if (isa<UndefValue>(Op))
-      Args.push_back(UndefValue::get(B.getInt32Ty()));
-    else
-      Args.push_back(Op);
+  Value *AggregateOp = I.getAggregateOperand();
+  if (isa<UndefValue>(AggregateOp))
+    Args.push_back(UndefValue::get(B.getInt32Ty()));
+  else
+    Args.push_back(AggregateOp);
+  Args.push_back(I.getInsertedValueOperand());
   for (auto &Op : I.indices())
     Args.push_back(B.getInt32(Op));
   Instruction *NewI =

--- a/llvm/test/CodeGen/SPIRV/instructions/insertvalue-undef-ptr.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/insertvalue-undef-ptr.ll
@@ -1,0 +1,27 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+
+; CHECK-LABEL: Begin function original_testcase
+define fastcc void @original_testcase() {
+top:
+  ; CHECK: OpCompositeInsert
+  %0 = insertvalue [1 x ptr] zeroinitializer, ptr poison, 0
+  ret void
+}
+
+; CHECK-LABEL: Begin function additional_testcases
+define fastcc void @additional_testcases() {
+top:
+  ; Test with different pointer types
+  ; CHECK: OpCompositeInsert
+  %1 = insertvalue [1 x ptr] zeroinitializer, ptr undef, 0
+  ; CHECK-NEXT: OpCompositeInsert
+  %2 = insertvalue {ptr, i32} zeroinitializer, ptr poison, 0
+  ; CHECK-NEXT: OpCompositeInsert
+  %3 = insertvalue {ptr, ptr} undef, ptr null, 0
+
+  ; Test with undef aggregate
+  ; CHECK-NEXT: OpCompositeInsert
+  %4 = insertvalue [1 x ptr] undef, ptr undef, 0
+
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/instructions/insertvalue-undef-ptr.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/insertvalue-undef-ptr.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-LABEL: Begin function original_testcase
 define fastcc void @original_testcase() {


### PR DESCRIPTION
The code was incorrectly converting all `undef` arguments to `i32`, while the `spv_insertv` intrinsics only expects that for the first operand, representing the aggregate type.

Fixes https://github.com/llvm/llvm-project/issues/127977