### PR TITLE
[scan-build][Windows] Fix driver name transformation in scan-build

### DIFF
--- a/clang/tools/scan-build/bin/scan-build
+++ b/clang/tools/scan-build/bin/scan-build
@@ -1898,7 +1898,7 @@ if ($Clang !~ /\+\+(\.exe)?$/) {
   # Determine operating system under which this copy of Perl was built.
   my $IsWinBuild = ($^O =~/msys|cygwin|MSWin32/);
   if($IsWinBuild) {
-    $ClangCXX =~ s/.exe$/++.exe/;
+    $ClangCXX =~ s/\-\d+(\.\d+)?.exe$/++.exe/;
   }
   else {
     $ClangCXX =~ s/\-\d+(\.\d+)?$//;


### PR DESCRIPTION
On Windows system, scan-build resolves clang++ driver name as "clang-{ver}++.exe" from "clang-{ver}.exe" but should transform to "clang++.exe".