### PR TITLE
[InstCombine] Relax guard against FP min/max in select fold

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1730,7 +1730,7 @@ Instruction *InstCombinerImpl::FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
     if (CI->hasOneUse()) {
       Value *Op0 = CI->getOperand(0), *Op1 = CI->getOperand(1);
       if (((TV == Op0 && FV == Op1) || (FV == Op0 && TV == Op1)) &&
-          !CI->isEquality() && !CI->isCommutative())
+          !CI->isCommutative())
         return nullptr;
     }
   }

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1729,7 +1729,8 @@ Instruction *InstCombinerImpl::FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
   if (auto *CI = dyn_cast<FCmpInst>(SI->getCondition())) {
     if (CI->hasOneUse()) {
       Value *Op0 = CI->getOperand(0), *Op1 = CI->getOperand(1);
-      if ((TV == Op0 && FV == Op1) || (FV == Op0 && TV == Op1))
+      if (((TV == Op0 && FV == Op1) || (FV == Op0 && TV == Op1)) &&
+          !CI->isEquality() && !CI->isCommutative())
         return nullptr;
     }
   }

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -271,7 +271,7 @@ define i1 @test_fcmp_select_var_const_unordered(double %x, double %y) {
 
 define i1 @test_fcmp_ord_select_fcmp_oeq_var_const(double %x) {
 ; CHECK-LABEL:    @test_fcmp_ord_select_fcmp_oeq_var_const(
-; CHECK-NEXT:     [[CMP1:%.*]] = fcmp oeq double [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:     [[CMP1:%.*]] = fcmp oeq double [[X:%.*]], 1.000000e+00
 ; CHECK-NEXT:     ret i1 [[CMP1]]
 ;
   %cmp1 = fcmp ord double %x, 0.000000e+00

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -268,3 +268,14 @@ define i1 @test_fcmp_select_var_const_unordered(double %x, double %y) {
   %cmp2 = fcmp ugt double %sel, 0x3E80000000000000
   ret i1 %cmp2
 }
+
+define i1 @test_fcmp_ord_select_fcmp_oeq_var_const(double %x) {
+; CHECK-LABEL:    @test_fcmp_ord_select_fcmp_oeq_var_const(
+; CHECK-NEXT:     [[CMP1:%.*]] = fcmp oeq double [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:     ret i1 [[CMP1]]
+;
+  %cmp1 = fcmp ord double %x, 0.000000e+00
+  %sel = select i1 %cmp1, double %x, double 0.000000e+00
+  %cmp2 = fcmp oeq double %sel, 1.000000e+00
+  ret i1 %cmp2
+}


### PR DESCRIPTION
FCmp's commutativity predicates do not work with min/max semantics

Closes #142711