### PR TITLE
[clang] Use range-based for loops (NFC)

### DIFF
--- a/clang/lib/Sema/ParsedAttr.cpp
+++ b/clang/lib/Sema/ParsedAttr.cpp
@@ -91,7 +91,8 @@ void AttributePool::takePool(AttributePool &pool) {
 
 void AttributePool::takeFrom(ParsedAttributesView &List, AttributePool &Pool) {
   assert(&Pool != this && "AttributePool can't take attributes from itself");
-  llvm::for_each(List.AttrList, [&Pool](ParsedAttr *A) { Pool.remove(A); });
+  for (ParsedAttr *A : List.AttrList)
+    Pool.remove(A);
   llvm::append_range(Attrs, List.AttrList);
 }
 

--- a/clang/tools/clang-installapi/Options.cpp
+++ b/clang/tools/clang-installapi/Options.cpp
@@ -1083,10 +1083,10 @@ void Options::addConditionalCC1Args(std::vector<std::string> &ArgStrings,
   // Add specific to platform arguments.
   PathSeq PlatformSearchPaths =
       getPathsForPlatform(FEOpts.SystemFwkPaths, mapToPlatformType(Targ));
-  llvm::for_each(PlatformSearchPaths, [&ArgStrings](const StringRef Path) {
+  for (StringRef Path : PlatformSearchPaths) {
     ArgStrings.push_back("-iframework");
     ArgStrings.push_back(Path.str());
-  });
+  }
 
   // Add specific to header type arguments.
   if (Type == HeaderType::Project)

--- a/clang/unittests/StaticAnalyzer/BlockEntranceCallbackTest.cpp
+++ b/clang/unittests/StaticAnalyzer/BlockEntranceCallbackTest.cpp
@@ -111,10 +111,10 @@ llvm::SmallVector<StringRef> parseEachDiag(StringRef Diags) {
   llvm::SmallVector<StringRef> Fragments;
   llvm::SplitString(Diags, Fragments, "\n");
   // Drop the prefix like "test.BlockEntranceTester: " from each fragment.
-  llvm::for_each(Fragments, [](StringRef &Fragment) {
+  for (StringRef &Fragment : Fragments) {
     Fragment = Fragment.drop_until([](char Ch) { return Ch == ' '; });
     Fragment.consume_front(" ");
-  });
+  }
   llvm::sort(Fragments);
   return Fragments;
 }


### PR DESCRIPTION
Note that use of llvm::for_each is discouraged unless we have functors
readily available.
