### PR TITLE
[clang][AST] Fix spaces in TypePrinter for some calling convs

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -840,6 +840,7 @@ Bug Fixes to AST Handling
 - Fixed type checking when a statement expression ends in an l-value of atomic type. (#GH106576)
 - Fixed uninitialized use check in a lambda within CXXOperatorCallExpr. (#GH129198)
 - Fixed a malformed printout of ``CXXParenListInitExpr`` in certain contexts.
+- Fixed a malformed printout of certain calling convention function attributes. (#GH143160)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -1095,13 +1095,13 @@ void TypePrinter::printFunctionAfter(const FunctionType::ExtInfo &Info,
       OS << " __attribute__((pcs(\"aapcs-vfp\")))";
       break;
     case CC_AArch64VectorCall:
-      OS << "__attribute__((aarch64_vector_pcs))";
+      OS << " __attribute__((aarch64_vector_pcs))";
       break;
     case CC_AArch64SVEPCS:
-      OS << "__attribute__((aarch64_sve_pcs))";
+      OS << " __attribute__((aarch64_sve_pcs))";
       break;
     case CC_DeviceKernel:
-      OS << "__attribute__((device_kernel))";
+      OS << " __attribute__((device_kernel))";
       break;
     case CC_IntelOclBicc:
       OS << " __attribute__((intel_ocl_bicc))";

--- a/clang/test/AST/ast-dump-type-callingconv.cpp
+++ b/clang/test/AST/ast-dump-type-callingconv.cpp
@@ -1,0 +1,24 @@
+// Verify there is a space after the parens when priting callingconv attributes.
+// RUN: %clang_cc1 -DDEVICE -triple spirv64 -ast-dump -ast-dump-filter foo %s \
+// RUN: | FileCheck -check-prefix=CHECK-DEVICE --strict-whitespace %s
+
+// RUN: %clang_cc1 -DVECTOR -triple aarch64 -ast-dump -ast-dump-filter foo %s \
+// RUN: | FileCheck -check-prefix=CHECK-VECTOR --strict-whitespace %s
+
+// RUN: %clang_cc1 -DSVE -triple aarch64 -ast-dump -ast-dump-filter foo %s \
+// RUN: | FileCheck -check-prefix=CHECK-SVE --strict-whitespace %s
+
+#ifdef DEVICE
+// CHECK-DEVICE-NOT: ()__attribute__((device_kernel))
+void foo() __attribute__((device_kernel));
+#endif
+
+#ifdef VECTOR
+// CHECK-VECTOR-NOT: ()__attribute__((aarch64_vector_pcs))
+void foo()  __attribute__((aarch64_vector_pcs));
+#endif
+
+#ifdef SVE
+// CHECK-SVE-NOT: ()__attribute__((aarch64_sve_pcs))
+void foo()  __attribute__((aarch64_sve_pcs));
+#endif

--- a/clang/test/AST/ast-dump-type-callingconv.cpp
+++ b/clang/test/AST/ast-dump-type-callingconv.cpp
@@ -1,11 +1,11 @@
 // RUN: %clang_cc1 -triple aarch64 -ast-dump -ast-dump-filter foo %s \
 // RUN: | FileCheck --strict-whitespace %s
 
-// CHECK: {{foo1 'void \(\) __attribute__\(\(device_kernel\)\)'$}}
+// CHECK: foo1 'void () __attribute__((device_kernel))'{{$}}
 void foo1() __attribute__((device_kernel));
 
-// CHECK: {{foo2 'void \(\) __attribute__\(\(aarch64_vector_pcs\)\)'$}}
+// CHECK: foo2 'void () __attribute__((aarch64_vector_pcs))'{{$}}
 void foo2()  __attribute__((aarch64_vector_pcs));
 
-// CHECK: {{foo3 'void \(\) __attribute__\(\(aarch64_sve_pcs\)\)'$}}
+// CHECK: foo3 'void () __attribute__((aarch64_sve_pcs))'{{$}}
 void foo3()  __attribute__((aarch64_sve_pcs));

--- a/clang/test/AST/ast-dump-type-callingconv.cpp
+++ b/clang/test/AST/ast-dump-type-callingconv.cpp
@@ -1,24 +1,11 @@
-// Verify there is a space after the parens when priting callingconv attributes.
-// RUN: %clang_cc1 -DDEVICE -triple spirv64 -ast-dump -ast-dump-filter foo %s \
-// RUN: | FileCheck -check-prefix=CHECK-DEVICE --strict-whitespace %s
+// RUN: %clang_cc1 -triple aarch64 -ast-dump -ast-dump-filter foo %s \
+// RUN: | FileCheck --strict-whitespace %s
 
-// RUN: %clang_cc1 -DVECTOR -triple aarch64 -ast-dump -ast-dump-filter foo %s \
-// RUN: | FileCheck -check-prefix=CHECK-VECTOR --strict-whitespace %s
+// CHECK: {{foo1 'void \(\) __attribute__\(\(device_kernel\)\)'$}}
+void foo1() __attribute__((device_kernel));
 
-// RUN: %clang_cc1 -DSVE -triple aarch64 -ast-dump -ast-dump-filter foo %s \
-// RUN: | FileCheck -check-prefix=CHECK-SVE --strict-whitespace %s
+// CHECK: {{foo2 'void \(\) __attribute__\(\(aarch64_vector_pcs\)\)'$}}
+void foo2()  __attribute__((aarch64_vector_pcs));
 
-#ifdef DEVICE
-// CHECK-DEVICE-NOT: ()__attribute__((device_kernel))
-void foo() __attribute__((device_kernel));
-#endif
-
-#ifdef VECTOR
-// CHECK-VECTOR-NOT: ()__attribute__((aarch64_vector_pcs))
-void foo()  __attribute__((aarch64_vector_pcs));
-#endif
-
-#ifdef SVE
-// CHECK-SVE-NOT: ()__attribute__((aarch64_sve_pcs))
-void foo()  __attribute__((aarch64_sve_pcs));
-#endif
+// CHECK: {{foo3 'void \(\) __attribute__\(\(aarch64_sve_pcs\)\)'$}}
+void foo3()  __attribute__((aarch64_sve_pcs));


### PR DESCRIPTION
There needs to be a space as the first character, otherwise the printed function prototype will have the CC attribute attached to the final `)`.

I noticed this looking at the AST for a function with `__attribute__((device_kernel))`
