### PR TITLE
[libc++] Add missing C++20 [time.point.arithmetic]

### DIFF
--- a/libcxx/include/__chrono/time_point.h
+++ b/libcxx/include/__chrono/time_point.h
@@ -58,6 +58,19 @@ public:
 
   // arithmetic
 
+#if _LIBCPP_STD_VER >= 20
+  _LIBCPP_HIDE_FROM_ABI constexpr time_point& operator++() {
+    ++__d_;
+    return *this;
+  }
+  _LIBCPP_HIDE_FROM_ABI constexpr time_point operator++(int) { return time_point(__d_++); }
+  _LIBCPP_HIDE_FROM_ABI constexpr time_point& operator--() {
+    --__d_;
+    return *this;
+  }
+  _LIBCPP_HIDE_FROM_ABI constexpr time_point operator--(int) { return time_point(__d_--); }
+#endif // _LIBCPP_STD_VER >= 20
+
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 time_point& operator+=(const duration& __d) {
     __d_ += __d;
     return *this;

--- a/libcxx/include/__chrono/time_point.h
+++ b/libcxx/include/__chrono/time_point.h
@@ -63,12 +63,12 @@ public:
     ++__d_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr time_point operator++(int) { return time_point(__d_++); }
+  _LIBCPP_HIDE_FROM_ABI constexpr time_point operator++(int) { return time_point{__d_++}; }
   _LIBCPP_HIDE_FROM_ABI constexpr time_point& operator--() {
     --__d_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr time_point operator--(int) { return time_point(__d_--); }
+  _LIBCPP_HIDE_FROM_ABI constexpr time_point operator--(int) { return time_point{__d_--}; }
 #endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 time_point& operator+=(const duration& __d) {

--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -132,6 +132,11 @@ public:
 
     // arithmetic
 
+    constexpr time_point& operator++();    // C++20
+    constexpr time_point  operator++(int); // C++20
+    constexpr time_point& operator--();    // C++20
+    constexpr time_point  operator--(int); // C++20
+
     time_point& operator+=(const duration& d); // constexpr in C++17
     time_point& operator-=(const duration& d); // constexpr in C++17
 

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
@@ -19,11 +19,13 @@
 #include "test_macros.h"
 
 constexpr bool test() {
-  typedef std::chrono::system_clock Clock;
-  typedef std::chrono::milliseconds Duration;
+  using Clock    = std::chrono::system_clock;
+  using Duration = std::chrono::milliseconds;
   std::chrono::time_point<Clock, Duration> t{Duration{5}};
   std::chrono::time_point<Clock, Duration>& tref{++t};
-  return &tref == &t && tref.time_since_epoch() == Duration{6};
+  assert(&tref == &t);
+  assert(tref.time_since_epoch() == Duration{6});
+  return true;
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <chrono>
+
+// time_point
+
+// constexpr time_point& operator++();
+
+#include <chrono>
+#include <cassert>
+
+#include "test_macros.h"
+
+constexpr bool constexpr_test() {
+  typedef std::chrono::system_clock Clock;
+  typedef std::chrono::milliseconds Duration;
+  std::chrono::time_point<Clock, Duration> t(Duration(5));
+  return (++t).time_since_epoch() == Duration(6);
+}
+
+int main(int, char**) {
+  typedef std::chrono::system_clock Clock;
+  typedef std::chrono::milliseconds Duration;
+  std::chrono::time_point<Clock, Duration> t(Duration(3));
+  std::chrono::time_point<Clock, Duration>& tref = ++t;
+  assert(&tref == &t);
+  assert(t.time_since_epoch() == Duration(4));
+
+  static_assert(constexpr_test());
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
@@ -29,7 +29,7 @@ constexpr bool test() {
 }
 
 int main(int, char**) {
-  assert(test());
+      test();
   static_assert(test());
   return 0;
 }

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++03, c++11, c++14, c++17
+// REQUIRES: std-at-least-c++20
 
 // <chrono>
 
@@ -13,27 +13,21 @@
 
 // constexpr time_point& operator++();
 
-#include <chrono>
 #include <cassert>
+#include <chrono>
 
 #include "test_macros.h"
 
-constexpr bool constexpr_test() {
+constexpr bool test() {
   typedef std::chrono::system_clock Clock;
   typedef std::chrono::milliseconds Duration;
-  std::chrono::time_point<Clock, Duration> t(Duration(5));
-  return (++t).time_since_epoch() == Duration(6);
+  std::chrono::time_point<Clock, Duration> t{Duration{5}};
+  std::chrono::time_point<Clock, Duration>& tref{++t};
+  return &tref == &t && tref.time_since_epoch() == Duration{6};
 }
 
 int main(int, char**) {
-  typedef std::chrono::system_clock Clock;
-  typedef std::chrono::milliseconds Duration;
-  std::chrono::time_point<Clock, Duration> t(Duration(3));
-  std::chrono::time_point<Clock, Duration>& tref = ++t;
-  assert(&tref == &t);
-  assert(t.time_since_epoch() == Duration(4));
-
-  static_assert(constexpr_test());
-
+  assert(test());
+  static_assert(test());
   return 0;
 }

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++.pass.cpp
@@ -29,7 +29,7 @@ constexpr bool test() {
 }
 
 int main(int, char**) {
-      test();
+  test();
   static_assert(test());
   return 0;
 }

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++int.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++int.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <chrono>
+
+// time_point
+
+// constexpr time_point operator++(int);
+
+#include <chrono>
+#include <cassert>
+
+#include "test_macros.h"
+
+constexpr bool test_constexpr() {
+  typedef std::chrono::system_clock Clock;
+  typedef std::chrono::milliseconds Duration;
+  std::chrono::time_point<Clock, Duration> t1(Duration(3));
+  std::chrono::time_point<Clock, Duration> t2 = t1++;
+  return t1.time_since_epoch() == Duration(4) && t2.time_since_epoch() == Duration(3);
+}
+
+int main(int, char**) {
+  typedef std::chrono::system_clock Clock;
+  typedef std::chrono::milliseconds Duration;
+  std::chrono::time_point<Clock, Duration> t1(Duration(3));
+  std::chrono::time_point<Clock, Duration> t2 = t1++;
+  assert(t1.time_since_epoch() == Duration(4));
+  assert(t2.time_since_epoch() == Duration(3));
+
+  static_assert(test_constexpr());
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++int.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++int.pass.cpp
@@ -19,11 +19,13 @@
 #include "test_macros.h"
 
 constexpr bool test() {
-  typedef std::chrono::system_clock Clock;
-  typedef std::chrono::milliseconds Duration;
+  using Clock    = std::chrono::system_clock;
+  using Duration = std::chrono::milliseconds;
   std::chrono::time_point<Clock, Duration> t1{Duration{3}};
   std::chrono::time_point<Clock, Duration> t2{t1++};
-  return t1.time_since_epoch() == Duration{4} && t2.time_since_epoch() == Duration{3};
+  assert(t1.time_since_epoch() == Duration{4});
+  assert(t2.time_since_epoch() == Duration{3});
+  return true;
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++int.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++int.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++03, c++11, c++14, c++17
+// REQUIRES: std-at-least-c++20
 
 // <chrono>
 
@@ -13,28 +13,21 @@
 
 // constexpr time_point operator++(int);
 
-#include <chrono>
 #include <cassert>
+#include <chrono>
 
 #include "test_macros.h"
 
-constexpr bool test_constexpr() {
+constexpr bool test() {
   typedef std::chrono::system_clock Clock;
   typedef std::chrono::milliseconds Duration;
-  std::chrono::time_point<Clock, Duration> t1(Duration(3));
-  std::chrono::time_point<Clock, Duration> t2 = t1++;
-  return t1.time_since_epoch() == Duration(4) && t2.time_since_epoch() == Duration(3);
+  std::chrono::time_point<Clock, Duration> t1{Duration{3}};
+  std::chrono::time_point<Clock, Duration> t2{t1++};
+  return t1.time_since_epoch() == Duration{4} && t2.time_since_epoch() == Duration{3};
 }
 
 int main(int, char**) {
-  typedef std::chrono::system_clock Clock;
-  typedef std::chrono::milliseconds Duration;
-  std::chrono::time_point<Clock, Duration> t1(Duration(3));
-  std::chrono::time_point<Clock, Duration> t2 = t1++;
-  assert(t1.time_since_epoch() == Duration(4));
-  assert(t2.time_since_epoch() == Duration(3));
-
-  static_assert(test_constexpr());
-
+  assert(test());
+  static_assert(test());
   return 0;
 }

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_++int.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_++int.pass.cpp
@@ -29,7 +29,7 @@ constexpr bool test() {
 }
 
 int main(int, char**) {
-  assert(test());
+  test();
   static_assert(test());
   return 0;
 }

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_--.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_--.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++03, c++11, c++14, c++17
+// REQUIRES: std-at-least-c++20
 
 // <chrono>
 
@@ -13,27 +13,21 @@
 
 // constexpr time_point& operator--();
 
-#include <chrono>
 #include <cassert>
+#include <chrono>
 
 #include "test_macros.h"
 
-constexpr bool constexpr_test() {
+constexpr bool test() {
   typedef std::chrono::system_clock Clock;
   typedef std::chrono::milliseconds Duration;
-  std::chrono::time_point<Clock, Duration> t(Duration(5));
-  return (--t).time_since_epoch() == Duration(4);
+  std::chrono::time_point<Clock, Duration> t{Duration{5}};
+  std::chrono::time_point<Clock, Duration>& tref{--t};
+  return &tref == &t && tref.time_since_epoch() == Duration{4};
 }
 
 int main(int, char**) {
-  typedef std::chrono::system_clock Clock;
-  typedef std::chrono::milliseconds Duration;
-  std::chrono::time_point<Clock, Duration> t(Duration(3));
-  std::chrono::time_point<Clock, Duration>& tref = --t;
-  assert(&tref == &t);
-  assert(t.time_since_epoch() == Duration(2));
-
-  static_assert(constexpr_test());
-
+  assert(test());
+  static_assert(test());
   return 0;
 }

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_--.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_--.pass.cpp
@@ -29,7 +29,7 @@ constexpr bool test() {
 }
 
 int main(int, char**) {
-  assert(test());
+  test();
   static_assert(test());
   return 0;
 }

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_--.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_--.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <chrono>
+
+// time_point
+
+// constexpr time_point& operator--();
+
+#include <chrono>
+#include <cassert>
+
+#include "test_macros.h"
+
+constexpr bool constexpr_test() {
+  typedef std::chrono::system_clock Clock;
+  typedef std::chrono::milliseconds Duration;
+  std::chrono::time_point<Clock, Duration> t(Duration(5));
+  return (--t).time_since_epoch() == Duration(4);
+}
+
+int main(int, char**) {
+  typedef std::chrono::system_clock Clock;
+  typedef std::chrono::milliseconds Duration;
+  std::chrono::time_point<Clock, Duration> t(Duration(3));
+  std::chrono::time_point<Clock, Duration>& tref = --t;
+  assert(&tref == &t);
+  assert(t.time_since_epoch() == Duration(2));
+
+  static_assert(constexpr_test());
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_--.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_--.pass.cpp
@@ -19,11 +19,13 @@
 #include "test_macros.h"
 
 constexpr bool test() {
-  typedef std::chrono::system_clock Clock;
-  typedef std::chrono::milliseconds Duration;
+  using Clock    = std::chrono::system_clock;
+  using Duration = std::chrono::milliseconds;
   std::chrono::time_point<Clock, Duration> t{Duration{5}};
   std::chrono::time_point<Clock, Duration>& tref{--t};
-  return &tref == &t && tref.time_since_epoch() == Duration{4};
+  assert(&tref == &t);
+  assert(tref.time_since_epoch() == Duration{4});
+  return true;
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_--int.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_--int.pass.cpp
@@ -19,11 +19,13 @@
 #include "test_macros.h"
 
 constexpr bool test() {
-  typedef std::chrono::system_clock Clock;
-  typedef std::chrono::milliseconds Duration;
+  using Clock    = std::chrono::system_clock;
+  using Duration = std::chrono::milliseconds;
   std::chrono::time_point<Clock, Duration> t1{Duration{3}};
   std::chrono::time_point<Clock, Duration> t2{t1--};
-  return t1.time_since_epoch() == Duration{2} && t2.time_since_epoch() == Duration{3};
+  assert(t1.time_since_epoch() == Duration{2});
+  assert(t2.time_since_epoch() == Duration{3});
+  return true;
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_--int.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_--int.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <chrono>
+
+// time_point
+
+// constexpr time_point operator--(int);
+
+#include <chrono>
+#include <cassert>
+
+#include "test_macros.h"
+
+constexpr bool test_constexpr() {
+  typedef std::chrono::system_clock Clock;
+  typedef std::chrono::milliseconds Duration;
+  std::chrono::time_point<Clock, Duration> t1(Duration(3));
+  std::chrono::time_point<Clock, Duration> t2 = t1--;
+  return t1.time_since_epoch() == Duration(2) && t2.time_since_epoch() == Duration(3);
+}
+
+int main(int, char**) {
+  typedef std::chrono::system_clock Clock;
+  typedef std::chrono::milliseconds Duration;
+  std::chrono::time_point<Clock, Duration> t1(Duration(3));
+  std::chrono::time_point<Clock, Duration> t2 = t1--;
+  assert(t1.time_since_epoch() == Duration(2));
+  assert(t2.time_since_epoch() == Duration(3));
+
+  static_assert(test_constexpr());
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_--int.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_--int.pass.cpp
@@ -29,7 +29,7 @@ constexpr bool test() {
 }
 
 int main(int, char**) {
-  assert(test());
+  test();
   static_assert(test());
   return 0;
 }

--- a/libcxx/test/std/time/time.point/time.point.arithmetic/op_--int.pass.cpp
+++ b/libcxx/test/std/time/time.point/time.point.arithmetic/op_--int.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++03, c++11, c++14, c++17
+// REQUIRES: std-at-least-c++20
 
 // <chrono>
 
@@ -13,28 +13,21 @@
 
 // constexpr time_point operator--(int);
 
-#include <chrono>
 #include <cassert>
+#include <chrono>
 
 #include "test_macros.h"
 
-constexpr bool test_constexpr() {
+constexpr bool test() {
   typedef std::chrono::system_clock Clock;
   typedef std::chrono::milliseconds Duration;
-  std::chrono::time_point<Clock, Duration> t1(Duration(3));
-  std::chrono::time_point<Clock, Duration> t2 = t1--;
-  return t1.time_since_epoch() == Duration(2) && t2.time_since_epoch() == Duration(3);
+  std::chrono::time_point<Clock, Duration> t1{Duration{3}};
+  std::chrono::time_point<Clock, Duration> t2{t1--};
+  return t1.time_since_epoch() == Duration{2} && t2.time_since_epoch() == Duration{3};
 }
 
 int main(int, char**) {
-  typedef std::chrono::system_clock Clock;
-  typedef std::chrono::milliseconds Duration;
-  std::chrono::time_point<Clock, Duration> t1(Duration(3));
-  std::chrono::time_point<Clock, Duration> t2 = t1--;
-  assert(t1.time_since_epoch() == Duration(2));
-  assert(t2.time_since_epoch() == Duration(3));
-
-  static_assert(test_constexpr());
-
+  assert(test());
+  static_assert(test());
   return 0;
 }


### PR DESCRIPTION
This was part of https://wg21.link/p0355r7, but apparently never implemented.