### PR TITLE
[Clang][Cygwin] Use correct BuiltinVaListKind.

### DIFF
--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -984,6 +984,10 @@ public:
     this->WCharType = TargetInfo::UnsignedShort;
   }
 
+  BuiltinVaListKind getBuiltinVaListKind() const override {
+    return TargetInfo::CharPtrBuiltinVaList;
+  }
+
   void getTargetDefines(const LangOptions &Opts,
                         MacroBuilder &Builder) const override {
     X86_64TargetInfo::getTargetDefines(Opts, Builder);


### PR DESCRIPTION
This was in older patches for Cygwin support, but was somehow lost in the latest rounds.