### PR TITLE
[AArch64] Fix unused-variable warning for non-dbg builds.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11040,8 +11040,7 @@ SDValue AArch64TargetLowering::LowerSETCCCARRY(SDValue Op,
 static SDValue emitVectorComparison(SDValue LHS, SDValue RHS,
                                     AArch64CC::CondCode CC, bool NoNans, EVT VT,
                                     const SDLoc &DL, SelectionDAG &DAG) {
-  EVT SrcVT = LHS.getValueType();
-  assert(VT.getSizeInBits() == SrcVT.getSizeInBits() &&
+  assert(VT.getSizeInBits() == LHS.getValueType().getSizeInBits() &&
          "function only supposed to emit natural comparisons");
 
   switch (CC) {


### PR DESCRIPTION
AArch64ISelLowering.cpp currently fails -Wunused-variable because SrcVT is only used in assert(), so it is an unused variable if not using debug builds. This behavior was introduced in 2c0a2261.