### PR TITLE
Revert "[libc] clean up string_utils memory functions"

### DIFF
--- a/libc/src/string/CMakeLists.txt
+++ b/libc/src/string/CMakeLists.txt
@@ -15,8 +15,10 @@ add_header_library(
   HDRS
     string_utils.h
   DEPENDS
+    .memory_utils.inline_bzero
+    .memory_utils.inline_memcpy
     libc.hdr.types.size_t
-    libc.hdr.limits_macros
+    libc.include.stdlib
     libc.src.__support.CPP.bitset
     libc.src.__support.CPP.type_traits
     libc.src.__support.common

--- a/libc/src/string/string_utils.h
+++ b/libc/src/string/string_utils.h
@@ -14,19 +14,19 @@
 #ifndef LLVM_LIBC_SRC_STRING_STRING_UTILS_H
 #define LLVM_LIBC_SRC_STRING_STRING_UTILS_H
 
-#include "hdr/limits_macros.h"
 #include "hdr/types/size_t.h"
 #include "src/__support/CPP/bitset.h"
 #include "src/__support/CPP/type_traits.h" // cpp::is_same_v
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+#include "src/string/memory_utils/inline_bzero.h"
+#include "src/string/memory_utils/inline_memcpy.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
 
 template <typename Word> LIBC_INLINE constexpr Word repeat_byte(Word byte) {
-  static_assert(CHAR_BIT == 8, "repeat_byte assumes a byte is 8 bits.");
-  constexpr size_t BITS_IN_BYTE = CHAR_BIT;
+  constexpr size_t BITS_IN_BYTE = 8;
   constexpr size_t BYTE_MASK = 0xff;
   Word result = 0;
   byte = byte & BYTE_MASK;
@@ -189,7 +189,8 @@ LIBC_INLINE char *string_token(char *__restrict src,
   if (LIBC_UNLIKELY(src == nullptr && ((src = *saveptr) == nullptr)))
     return nullptr;
 
-  static_assert(CHAR_BIT == 8, "bitset of 256 assumes char is 8 bits");
+  static_assert(sizeof(char) == sizeof(cpp::byte),
+                "bitset of 256 assumes char is 8 bits");
   cpp::bitset<256> delimiter_set;
   for (; *delimiter_string != '\0'; ++delimiter_string)
     delimiter_set.set(static_cast<size_t>(*delimiter_string));
@@ -219,7 +220,7 @@ LIBC_INLINE size_t strlcpy(char *__restrict dst, const char *__restrict src,
   if (!size)
     return len;
   size_t n = len < size - 1 ? len : size - 1;
-  __builtin_memcpy(dst, src, n);
+  inline_memcpy(dst, src, n);
   dst[n] = '\0';
   return len;
 }

--- a/libc/src/string/strsep.cpp
+++ b/libc/src/string/strsep.cpp
@@ -12,8 +12,6 @@
 #include "src/__support/macros/null_check.h"
 #include "src/string/string_utils.h"
 
-#include "src/__support/common.h"
-
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(char *, strsep,

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4188,10 +4188,9 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_bitset",
-        ":__support_cpp_type_traits",
         ":__support_macros_optimization",
-        ":hdr_limits_macros",
         ":llvm_libc_types_size_t",
+        ":string_memory_utils",
         ":types_size_t",
     ],
 )


### PR DESCRIPTION
Reverts llvm/llvm-project#143031

The PR cause a llvm check failed for our buildbot after the include issue was fixed. It blocks our downstream work.

bot: https://lab.llvm.org/buildbot/#/builders/10/builds/6850