### PR TITLE
[libc][GPU] clean up includes

### DIFF
--- a/libc/src/stdio/gpu/CMakeLists.txt
+++ b/libc/src/stdio/gpu/CMakeLists.txt
@@ -59,6 +59,7 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.FILE
     libc.src.__support.RPC.rpc_client
+    .gpu_file
 )
 
 add_entrypoint_object(
@@ -70,6 +71,7 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.FILE
     libc.src.__support.RPC.rpc_client
+    .gpu_file
 )
 
 add_entrypoint_object(
@@ -114,6 +116,7 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.FILE
     libc.src.__support.RPC.rpc_client
+    .gpu_file
 )
 
 add_entrypoint_object(
@@ -124,6 +127,7 @@ add_entrypoint_object(
     ../fopen.h
   DEPENDS
     libc.hdr.types.FILE
+    .gpu_file
 )
 
 add_entrypoint_object(
@@ -134,6 +138,8 @@ add_entrypoint_object(
     ../fclose.h
   DEPENDS
     libc.hdr.types.FILE
+    libc.hdr.stdio_macros
+    .gpu_file
 )
 
 add_entrypoint_object(
@@ -144,6 +150,7 @@ add_entrypoint_object(
     ../fread.h
   DEPENDS
     libc.hdr.types.FILE
+    .gpu_file
 )
 
 add_entrypoint_object(
@@ -254,8 +261,6 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.FILE
     .gpu_file
-    .feof
-    .ferror
 )
 
 add_entrypoint_object(

--- a/libc/src/stdio/gpu/clearerr.cpp
+++ b/libc/src/stdio/gpu/clearerr.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/clearerr.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fclose.cpp
+++ b/libc/src/stdio/gpu/fclose.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fclose.h"
-#include "src/__support/macros/config.h"
-#include "src/stdio/gpu/file.h"
 
 #include "hdr/stdio_macros.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
+#include "src/stdio/gpu/file.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/feof.cpp
+++ b/libc/src/stdio/gpu/feof.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/feof.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/ferror.cpp
+++ b/libc/src/stdio/gpu/ferror.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/ferror.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fflush.cpp
+++ b/libc/src/stdio/gpu/fflush.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fflush.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fgetc.cpp
+++ b/libc/src/stdio/gpu/fgetc.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fgetc.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/stdio_macros.h" // for EOF.
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fgets.cpp
+++ b/libc/src/stdio/gpu/fgets.cpp
@@ -7,14 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fgets.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
-#include "src/stdio/feof.h"
-#include "src/stdio/ferror.h"
 
+#include "file.h"
 #include "hdr/stdio_macros.h" // for EOF.
 #include "hdr/types/FILE.h"
-#include <stddef.h>
+#include "src/__support/common.h"
+
+#include <stdint.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/file.h
+++ b/libc/src/stdio/gpu/file.h
@@ -6,14 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/stdio_macros.h" // For stdin/out/err
+#include "hdr/types/FILE.h"
 #include "src/__support/RPC/rpc_client.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/attributes.h"
-#include "src/__support/macros/config.h"
-#include "src/string/string_utils.h"
-
-#include "hdr/stdio_macros.h" // For stdin/out/err
-#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace file {

--- a/libc/src/stdio/gpu/fopen.cpp
+++ b/libc/src/stdio/gpu/fopen.cpp
@@ -7,12 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fopen.h"
-#include "src/__support/CPP/string_view.h"
-#include "src/__support/macros/config.h"
-#include "src/stdio/gpu/file.h"
 
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
+#include "src/stdio/gpu/file.h"
 #include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/string_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fprintf.cpp
+++ b/libc/src/stdio/gpu/fprintf.cpp
@@ -11,6 +11,7 @@
 #include "hdr/types/FILE.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/arg_list.h"
+#include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
 #include "src/stdio/gpu/vfprintf_utils.h"
 

--- a/libc/src/stdio/gpu/fputc.cpp
+++ b/libc/src/stdio/gpu/fputc.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fputc.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/stdio_macros.h" // for EOF.
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fputs.cpp
+++ b/libc/src/stdio/gpu/fputs.cpp
@@ -7,13 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fputs.h"
-#include "src/__support/CPP/string_view.h"
-#include "src/__support/macros/config.h"
-#include "src/errno/libc_errno.h"
-#include "src/stdio/gpu/file.h"
 
 #include "hdr/stdio_macros.h" // for EOF.
 #include "hdr/types/FILE.h"
+#include "src/__support/CPP/string_view.h"
+#include "src/__support/common.h"
+#include "src/stdio/gpu/file.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fread.cpp
+++ b/libc/src/stdio/gpu/fread.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fread.h"
-#include "src/__support/macros/config.h"
-#include "src/stdio/gpu/file.h"
 
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
+#include "src/stdio/gpu/file.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fseek.cpp
+++ b/libc/src/stdio/gpu/fseek.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fseek.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/ftell.cpp
+++ b/libc/src/stdio/gpu/ftell.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/ftell.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/fwrite.cpp
+++ b/libc/src/stdio/gpu/fwrite.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fwrite.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/getc.cpp
+++ b/libc/src/stdio/gpu/getc.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/getc.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/stdio_macros.h" // for EOF.
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/getchar.cpp
+++ b/libc/src/stdio/gpu/getchar.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/getchar.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/stdio_macros.h" // for EOF and stdin.
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/printf.cpp
+++ b/libc/src/stdio/gpu/printf.cpp
@@ -10,6 +10,7 @@
 
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/arg_list.h"
+#include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
 #include "src/stdio/gpu/vfprintf_utils.h"
 

--- a/libc/src/stdio/gpu/putc.cpp
+++ b/libc/src/stdio/gpu/putc.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/putc.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/stdio_macros.h" // for EOF.
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/putchar.cpp
+++ b/libc/src/stdio/gpu/putchar.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/putchar.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/stdio_macros.h" // for EOF and stdout.
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/puts.cpp
+++ b/libc/src/stdio/gpu/puts.cpp
@@ -7,19 +7,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/puts.h"
-#include "src/__support/CPP/string_view.h"
-#include "src/__support/macros/config.h"
-#include "src/errno/libc_errno.h"
-#include "src/stdio/gpu/file.h"
 
 #include "hdr/stdio_macros.h" // for EOF and stdout.
+#include "src/__support/CPP/string_view.h"
+#include "src/__support/common.h"
+#include "src/stdio/gpu/file.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, puts, (const char *__restrict str)) {
   cpp::string_view str_view(str);
-  auto written = file::write_impl<LIBC_WRITE_TO_STDOUT_NEWLINE>(stdout, str,
-                                                               str_view.size());
+  auto written = file::write_impl<LIBC_WRITE_TO_STDOUT_NEWLINE>(
+      stdout, str, str_view.size());
   if (written != str_view.size() + 1)
     return EOF;
   return 0;

--- a/libc/src/stdio/gpu/remove.cpp
+++ b/libc/src/stdio/gpu/remove.cpp
@@ -7,10 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/remove.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
+#include "src/string/string_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/rename.cpp
+++ b/libc/src/stdio/gpu/rename.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/rename.h"
-#include "src/__support/CPP/string_view.h"
-#include "src/__support/macros/config.h"
-#include "src/stdio/gpu/file.h"
 
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
+#include "src/stdio/gpu/file.h"
+#include "src/string/string_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/stderr.cpp
+++ b/libc/src/stdio/gpu/stderr.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/types/FILE.h"
-#include "src/__support/macros/config.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 static struct {

--- a/libc/src/stdio/gpu/stdin.cpp
+++ b/libc/src/stdio/gpu/stdin.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/types/FILE.h"
-#include "src/__support/macros/config.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 static struct {

--- a/libc/src/stdio/gpu/stdout.cpp
+++ b/libc/src/stdio/gpu/stdout.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/types/FILE.h"
-#include "src/__support/macros/config.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 static struct {

--- a/libc/src/stdio/gpu/ungetc.cpp
+++ b/libc/src/stdio/gpu/ungetc.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/ungetc.h"
-#include "file.h"
-#include "src/__support/macros/config.h"
 
+#include "file.h"
 #include "hdr/types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/gpu/vfprintf.cpp
+++ b/libc/src/stdio/gpu/vfprintf.cpp
@@ -11,7 +11,7 @@
 #include "hdr/types/FILE.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/arg_list.h"
-#include "src/errno/libc_errno.h"
+#include "src/__support/common.h"
 #include "src/stdio/gpu/vfprintf_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/stdio/gpu/vfprintf_utils.h
+++ b/libc/src/stdio/gpu/vfprintf_utils.h
@@ -10,7 +10,7 @@
 #include "src/__support/GPU/utils.h"
 #include "src/__support/RPC/rpc_client.h"
 #include "src/__support/arg_list.h"
-#include "src/__support/macros/config.h"
+
 #include "src/stdio/gpu/file.h"
 #include "src/string/string_utils.h"
 

--- a/libc/src/stdio/gpu/vfprintf_utils.h
+++ b/libc/src/stdio/gpu/vfprintf_utils.h
@@ -10,7 +10,6 @@
 #include "src/__support/GPU/utils.h"
 #include "src/__support/RPC/rpc_client.h"
 #include "src/__support/arg_list.h"
-
 #include "src/stdio/gpu/file.h"
 #include "src/string/string_utils.h"
 

--- a/libc/src/stdio/gpu/vprintf.cpp
+++ b/libc/src/stdio/gpu/vprintf.cpp
@@ -10,7 +10,7 @@
 
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/arg_list.h"
-#include "src/errno/libc_errno.h"
+#include "src/__support/common.h"
 #include "src/stdio/gpu/vfprintf_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {


### PR DESCRIPTION
The GPU stdio functions were depending on indirect inclusion for some of
their dependencies. This patch should fix all of that.
