### PR TITLE
[clang-tidy] Warn about misuse of sizeof operator in loops.

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -73,7 +73,7 @@ SizeofExpressionCheck::SizeofExpressionCheck(StringRef Name,
       WarnOnSizeOfPointer(Options.get("WarnOnSizeOfPointer", false)),
       WarnOnOffsetDividedBySizeOf(
           Options.get("WarnOnOffsetDividedBySizeOf", true)),
-      WarnOnLoopExprSizeOf(Options.get("WarnOnLoopExprSizeOf", true)) {}
+      WarnOnSizeOfInLoopTermination(Options.get("WarnOnSizeOfInLoopTermination", true)) {}
 
 void SizeofExpressionCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "WarnOnSizeOfConstant", WarnOnSizeOfConstant);
@@ -87,7 +87,7 @@ void SizeofExpressionCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "WarnOnSizeOfPointer", WarnOnSizeOfPointer);
   Options.store(Opts, "WarnOnOffsetDividedBySizeOf",
                 WarnOnOffsetDividedBySizeOf);
-  Options.store(Opts, "WarnOnLoopExprSizeOf", WarnOnLoopExprSizeOf);
+  Options.store(Opts, "WarnOnSizeOfInLoopTermination", WarnOnSizeOfInLoopTermination);
 }
 
 void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
@@ -137,9 +137,9 @@ void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
                        this);
   }
 
-  if (WarnOnLoopExprSizeOf) {
+  if (WarnOnSizeOfInLoopTermination) {
     Finder->addMatcher(
-        LoopExpr(has(binaryOperator(has(SizeOfExpr)))).bind("loop-expr"), this);
+        LoopExpr(has(binaryOperator(has(SizeOfExpr.bind("loop-expr"))))), this);
   }
 
   // Detect sizeof(kPtr) where kPtr is 'const char* kPtr = "abc"';

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -99,7 +99,8 @@ void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
 
   auto LoopExpr =
       [](const ast_matchers::internal::Matcher<Stmt> &InnerMatcher) {
-        return stmt(anyOf(forStmt(InnerMatcher), whileStmt(InnerMatcher), doStmt(InnerMatcher)));
+        return stmt(anyOf(forStmt(InnerMatcher), whileStmt(InnerMatcher),
+                          doStmt(InnerMatcher)));
       };
 
   const auto IntegerExpr = ignoringParenImpCasts(integerLiteral());
@@ -140,10 +141,11 @@ void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
   }
 
   if (WarnOnSizeOfInLoopTermination) {
-    Finder->addMatcher(
-        LoopExpr(hasDescendant(
-           binaryOperator(allOf(has(SizeOfExpr.bind("sizeof-expr")), isComparisonOperator()))
-        )).bind("loop-expr"), this);
+    Finder->addMatcher(LoopExpr(hasDescendant(binaryOperator(
+                                    allOf(has(SizeOfExpr.bind("sizeof-expr")),
+                                          isComparisonOperator()))))
+                           .bind("loop-expr"),
+                       this);
   }
 
   // Detect sizeof(kPtr) where kPtr is 'const char* kPtr = "abc"';
@@ -373,7 +375,7 @@ void SizeofExpressionCheck::check(const MatchFinder::MatchResult &Result) {
     auto *SizeofArgTy = Result.Nodes.getNodeAs<Type>("sizeof-arg-type");
     if (const auto member = dyn_cast<MemberPointerType>(SizeofArgTy))
       SizeofArgTy = member->getPointeeType().getTypePtr();
- 
+
     auto Loc = Result.Nodes.getNodeAs<Expr>("sizeof-expr");
 
     if (const auto type = dyn_cast<ArrayType>(SizeofArgTy)) {

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -379,6 +379,8 @@ void SizeofExpressionCheck::check(const MatchFinder::MatchResult &Result) {
     auto Loc = Result.Nodes.getNodeAs<Expr>("sizeof-expr");
 
     if (const auto type = dyn_cast<ArrayType>(SizeofArgTy)) {
+      // check if the array element size is larger than one. If true,
+      // the size of the array is higher than the number of elements
       CharUnits sSize = Ctx.getTypeSizeInChars(type->getElementType());
       if (!sSize.isOne()) {
         diag(Loc->getBeginLoc(), "suspicious usage of 'sizeof' in the loop")

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
@@ -32,7 +32,7 @@ private:
   const bool WarnOnSizeOfPointerToAggregate;
   const bool WarnOnSizeOfPointer;
   const bool WarnOnOffsetDividedBySizeOf;
-  const bool WarnOnLoopExprSizeOf;
+  const bool WarnOnSizeOfInLoopTermination;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
@@ -32,6 +32,7 @@ private:
   const bool WarnOnSizeOfPointerToAggregate;
   const bool WarnOnSizeOfPointer;
   const bool WarnOnOffsetDividedBySizeOf;
+  const bool WarnOnLoopExprSizeOf;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -219,6 +219,12 @@ Changes in existing checks
   tolerating fix-it breaking compilation when functions is used as pointers
   to avoid matching usage of functions within the current compilation unit.
 
+- Improved :doc: `bugprone-sizeof-expression
+ <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check.
+
+ Introduced WarnOnSizeOfInLoopTermination sub-class to detect misuses of sizeof expression
+ in loop conditions. 
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -146,6 +146,13 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/optional-value-conversion>` check to detect
   conversion in argument of ``std::make_optional``.
 
+- Improved :doc: `bugprone-sizeof-expression
+  <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check by adding
+  `WarnOnSizeOfInLoopTermination` option to detect misuses of ``sizeof``
+  expression in loop conditions. The check detects the use of ``sizeof``
+  opertaor to determine the number of elements in the array, where the
+  array size is higher than the number of elements in the array.
+
 - Improved :doc:`bugprone-string-constructor
   <clang-tidy/checks/bugprone/string-constructor>` check to find suspicious
   calls of ``std::string`` constructor with char pointer, start position and
@@ -218,11 +225,6 @@ Changes in existing checks
   <clang-tidy/checks/performance/unnecessary-value-param>` check performance by
   tolerating fix-it breaking compilation when functions is used as pointers
   to avoid matching usage of functions within the current compilation unit.
-
-- Improved :doc: `bugprone-sizeof-expression
- <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check by adding
- `WarnOnSizeOfInLoopTermination` option to detect misuses of ``sizeof``
-  expression in loop conditions.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -221,9 +221,8 @@ Changes in existing checks
 
 - Improved :doc: `bugprone-sizeof-expression
  <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check.
-
- Introduced WarnOnSizeOfInLoopTermination sub-class to detect misuses of sizeof expression
- in loop conditions. 
+ Introduced WarnOnSizeOfInLoopTermination sub-class to detect misuses of sizeof
+ expression in loop conditions. 
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -220,9 +220,9 @@ Changes in existing checks
   to avoid matching usage of functions within the current compilation unit.
 
 - Improved :doc: `bugprone-sizeof-expression
- <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check.
- Introduced WarnOnSizeOfInLoopTermination sub-class to detect misuses of sizeof
- expression in loop conditions. 
+ <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check by adding
+ `WarnOnSizeOfInLoopTermination` option to detect misuses of ``sizeof``
+  expression in loop conditions.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -149,9 +149,7 @@ Changes in existing checks
 - Improved :doc: `bugprone-sizeof-expression
   <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check by adding
   `WarnOnSizeOfInLoopTermination` option to detect misuses of ``sizeof``
-  expression in loop conditions. The check detects the use of ``sizeof``
-  opertaor to determine the number of elements in the array, where the
-  array size is higher than the number of elements in the array.
+  expression in loop conditions.
 
 - Improved :doc:`bugprone-string-constructor
   <clang-tidy/checks/bugprone/string-constructor>` check to find suspicious

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -322,5 +322,5 @@ Options
    When `true`, the check will warn about incorrect use of sizeof expression
    in loop termination condition. The warning triggers if the sizeof expression
    appears to be incorrectly used to determine the number of array/buffer elements.
-   e.g, ``long arr[10]; for(int i = 0; i < sizeof(arr); i++) { ... }. Default
-  is `true`.
+   e.g, ``long arr[10]; for(int i = 0; i < sizeof(arr); i++) { ... }``. Default
+   is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -316,3 +316,11 @@ Options
    When `true`, the check will warn on pointer arithmetic where the
    element count is obtained from a division with ``sizeof(...)``,
    e.g., ``Ptr + Bytes / sizeof(*T)``. Default is `true`.
+
+.. option:: WarnOnSizeOfInLoopTermination
+
+   When `true`, the check will warn about incorrect use of sizeof expression
+   in loop termination condition. The warning triggers if the sizeof expression
+   appears to be incorrectly used to determine the number of array/buffer elements.
+   e.g, ``long arr[10]; for(int i = 0; i < sizeof(arr); i++) { ... }. Default
+  is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -320,7 +320,8 @@ Options
 .. option:: WarnOnSizeOfInLoopTermination
 
    When `true`, the check will warn about incorrect use of sizeof expression
-   in loop termination condition. The warning triggers if the sizeof expression
-   appears to be incorrectly used to determine the number of array/buffer elements.
+   in loop termination condition. The warning triggers if the ``sizeof``
+   expression appears to be incorrectly used to determine the number of
+   array/buffer elements.
    e.g, ``long arr[10]; for(int i = 0; i < sizeof(arr); i++) { ... }``. Default
    is `true`.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -172,28 +172,44 @@ struct B {
   struct A a;
 };
 
-int square(int num, struct B b) {
+void loop_access_elements(int num, struct B b) {
     struct A arr[10];
-    // CHECK-MESSAGES: :[[@LINE+1]]:24: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+    char buf[20];
+
+    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
     for(int i = 0; i < sizeof(arr); i++) {
        struct A a = arr[i];
     }
+
+    // Loop warning should not trigger here, even though this code is incorrect
     // CHECK-MESSAGES: :[[@LINE+2]]:24: warning: suspicious usage of 'sizeof(K)'; did you mean 'K'? [bugprone-sizeof-expression]
     // CHECK-MESSAGES: :[[@LINE+1]]:34: warning: suspicious usage of 'sizeof(...)/sizeof(...)'; numerator is not a multiple of denominator [bugprone-sizeof-expression] 
     for(int i = 0; i < sizeof(10)/sizeof(A); i++) {
        struct A a = arr[i];
     }
     
-    for(int i = 0; i < sizeof(arr)/sizeof(A); i++) {
-       struct A a = arr[i];
-    }
+    // Should not warn here
+    for(int i = 0; i < sizeof(arr)/sizeof(A); i++) {}
 
-    // CHECK-MESSAGES: :[[@LINE+1]]:24: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
-    for(int j = 0; j < sizeof(b.a); j++) {
-
-    }
-    return 2;
+    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+    for(int j = 0; j < sizeof(b.a.array); j++) {}
+  
+    // Should not warn here
+    for(int i = 0; i < sizeof(buf); i++) {} 
+  
+    int i = 0;
+    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+    while(i <= sizeof(arr)) {i++;}
+   
+    i = 0;
+    do {
+     i++;
+    } while(i <= sizeof(arr));
 }
+
+// Add cases for while loop
+
+// Add cases for do-while loop
 
 template <int T>
 int Foo() { int A[T]; return sizeof(T); }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -164,6 +164,37 @@ int Test2(MyConstChar* A) {
   return sum;
 }
 
+struct A {
+   int array[10];
+};
+
+struct B {
+  struct A a;
+};
+
+int square(int num, struct B b) {
+    struct A arr[10];
+    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+    for(int i = 0; i < sizeof(arr); i++) {
+       struct A a = arr[i];
+    }
+    // CHECK-MESSAGES: :[[@LINE+2]]:24: warning: suspicious usage of 'sizeof(K)'; did you mean 'K'? [bugprone-sizeof-expression]
+    // CHECK-MESSAGES: :[[@LINE+1]]:34: warning: suspicious usage of 'sizeof(...)/sizeof(...)'; numerator is not a multiple of denominator [bugprone-sizeof-expression] 
+    for(int i = 0; i < sizeof(10)/sizeof(A); i++) {
+       struct A a = arr[i];
+    }
+    
+    for(int i = 0; i < sizeof(arr)/sizeof(A); i++) {
+       struct A a = arr[i];
+    }
+
+    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+    for(int j = 0; j < sizeof(b.a); j++) {
+
+    }
+    return 2;
+}
+
 template <int T>
 int Foo() { int A[T]; return sizeof(T); }
 // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: suspicious usage of 'sizeof(K)'

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -174,7 +174,7 @@ struct B {
 
 int square(int num, struct B b) {
     struct A arr[10];
-    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+    // CHECK-MESSAGES: :[[@LINE+1]]:24: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
     for(int i = 0; i < sizeof(arr); i++) {
        struct A a = arr[i];
     }
@@ -188,7 +188,7 @@ int square(int num, struct B b) {
        struct A a = arr[i];
     }
 
-    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+    // CHECK-MESSAGES: :[[@LINE+1]]:24: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
     for(int j = 0; j < sizeof(b.a); j++) {
 
     }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -173,43 +173,43 @@ struct B {
 };
 
 void loop_access_elements(int num, struct B b) {
-    struct A arr[10];
-    char buf[20];
+  struct A arr[10];
+  char buf[20];
 
-    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
-    for(int i = 0; i < sizeof(arr); i++) {
-       struct A a = arr[i];
-    }
+  // CHECK-MESSAGES: :[[@LINE+1]]:22: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+  for(int i = 0; i < sizeof(arr); i++) {
+    struct A a = arr[i];
+  }
 
-    // Loop warning should not trigger here, even though this code is incorrect
-    // CHECK-MESSAGES: :[[@LINE+2]]:24: warning: suspicious usage of 'sizeof(K)'; did you mean 'K'? [bugprone-sizeof-expression]
-    // CHECK-MESSAGES: :[[@LINE+1]]:34: warning: suspicious usage of 'sizeof(...)/sizeof(...)'; numerator is not a multiple of denominator [bugprone-sizeof-expression] 
-    for(int i = 0; i < sizeof(10)/sizeof(A); i++) {
-       struct A a = arr[i];
-    }
+  // Loop warning should not trigger here, even though this code is incorrect
+  // CHECK-MESSAGES: :[[@LINE+2]]:22: warning: suspicious usage of 'sizeof(K)'; did you mean 'K'? [bugprone-sizeof-expression]
+  // CHECK-MESSAGES: :[[@LINE+1]]:32: warning: suspicious usage of 'sizeof(...)/sizeof(...)'; numerator is not a multiple of denominator [bugprone-sizeof-expression] 
+  for(int i = 0; i < sizeof(10)/sizeof(A); i++) {
+    struct A a = arr[i];
+  }
     
-    // Should not warn here
-    for(int i = 0; i < sizeof(arr)/sizeof(A); i++) {}
+  // Should not warn here
+  for(int i = 0; i < sizeof(arr)/sizeof(A); i++) {}
 
-    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
-    for(int j = 0; j < sizeof(b.a.array); j++) {}
+  // CHECK-MESSAGES: :[[@LINE+1]]:22: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+  for(int j = 0; j < sizeof(b.a.array); j++) {}
   
-    // Should not warn here
-    for(int i = 0; i < sizeof(buf); i++) {} 
+  // Should not warn here
+  for(int i = 0; i < sizeof(buf); i++) {} 
   
-    int i = 0;
-    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
-    while(i <= sizeof(arr)) {i++;}
+  int i = 0;
+  // CHECK-MESSAGES: :[[@LINE+1]]:14: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+  while(i <= sizeof(arr)) {i++;}
    
-    i = 0;
-    do {
-     i++;
-    } while(i <= sizeof(arr));
+  i = 0;
+  do {
+    i++;
+  // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression] 
+  } while(i <= sizeof(arr));
+
+  // CHECK-MESSAGES: :[[@LINE+1]]:29: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+  for(int i = 0, j = 0; i < sizeof(arr) && j < sizeof(buf); i++, j++) {}
 }
-
-// Add cases for while loop
-
-// Add cases for do-while loop
 
 template <int T>
 int Foo() { int A[T]; return sizeof(T); }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -191,11 +191,27 @@ void loop_access_elements(int num, struct B b) {
   // Should not warn here
   for(int i = 0; i < sizeof(arr)/sizeof(A); i++) {}
 
+  // Should not warn here
+  for (int i = 0; i < 10; i++) {
+    if (sizeof(arr) != 0) {
+
+    }
+  }
+
+  for (int i = 0; i < 10; i++) {
+    // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+    for (int j = 0; j < sizeof(arr); j++) {
+    }
+  }
+
   // CHECK-MESSAGES: :[[@LINE+1]]:22: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
   for(int j = 0; j < sizeof(b.a.array); j++) {}
   
   // Should not warn here
   for(int i = 0; i < sizeof(buf); i++) {} 
+
+  // Should not warn here
+  for(int i = 0; i < (sizeof(arr) << 3); i++) {}
   
   int i = 0;
   // CHECK-MESSAGES: :[[@LINE+1]]:14: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -561,20 +561,6 @@ Improvements to Clang's diagnostics
 Improvements to Clang's time-trace
 ----------------------------------
 
-Improvements to clang-tidy
---------------------------
-
-New checks
-^^^^^^^^^^
-
-Changes in existing checks
-^^^^^^^^^^^^^^^^^^^^^^^^^^
--Improved :doc: `bugprone-sizeof-expression`
- <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check.
-
- Introduced WarnOnSizeOfInLoopTermination sub-class to detect misuses of sizeof expression
- in loop conditions.
-
 Improvements to Coverage Mapping
 --------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -561,6 +561,20 @@ Improvements to Clang's diagnostics
 Improvements to Clang's time-trace
 ----------------------------------
 
+Improvements to clang-tidy
+--------------------------
+
+New checks
+^^^^^^^^^^
+
+Changes in existing checks
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+-Improved :doc: `bugprone-sizeof-expression`
+ <clang-tidy/checks/bugprone/bugprone-sizeof-expression>` check.
+
+ Introduced WarnOnSizeOfInLoopTermination sub-class to detect misuses of sizeof expression
+ in loop conditions.
+
 Improvements to Coverage Mapping
 --------------------------------
 


### PR DESCRIPTION
The sizeof operator misuses in loop conditionals can be a source of bugs. The common misuse is attempting to retrieve the number of elements in the array by using the sizeof expression and forgetting to divide the value by the sizeof the array elements. This results in an incorrect computation of the array length and requires a warning from the sizeof checker.

Example:
```
 int array[20];

void test_for_loop() {
  // Needs warning.
  for(int i = 0; i < sizeof(array); i++) {
    array[i] = i;
  }
}

void test_while_loop() {

  int count = 0;
  // Needs warning. 
  while(count < sizeof(array)) {
    array[count] = 0;
    count = count + 2;
  }
}
```
rdar://151403083