### PR TITLE
[clang-doc] add namespaces to JSON generator

### DIFF
--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -742,6 +742,7 @@ static void populateFunctionInfo(FunctionInfo &I, const FunctionDecl *D,
   I.ReturnType = getTypeInfoForType(D->getReturnType(), LO);
   I.Prototype = getFunctionPrototype(D);
   parseParameters(I, D);
+  I.IsStatic = D->isStatic();
 
   populateTemplateParameters(I.Template, D);
 

--- a/clang-tools-extra/test/clang-doc/json/function-specifiers.cpp
+++ b/clang-tools-extra/test/clang-doc/json/function-specifiers.cpp
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: FileCheck %s < %t/GlobalNamespace/index.json
+
+static void myFunction() {}
+
+void noExceptFunction() noexcept {}
+
+inline void inlineFunction() {}
+
+extern void externFunction() {}
+
+constexpr void constexprFunction() {}
+
+// CHECK:          "Functions": [
+// CHECK-NEXT:       {
+// CHECK:              "IsStatic": true,
+// COM:                FIXME: Emit ExceptionSpecificationType
+// CHECK-NOT:          "ExceptionSpecifcation" : "noexcept",
+// COM:                FIXME: Emit inline
+// CHECK-NOT:          "IsInline": true,
+// COM:                FIXME: Emit extern
+// CHECK-NOT:          "IsExtern": true,
+// COM:                FIXME: Emit constexpr
+// CHECK-NOT:          "IsConstexpr": true,

--- a/clang-tools-extra/test/clang-doc/json/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/namespace.cpp
@@ -1,0 +1,107 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: FileCheck %s < %t/GlobalNamespace/index.json
+
+class MyClass {};
+
+void myFunction(int Param);
+
+namespace NestedNamespace {
+} // namespace NestedNamespace
+
+// FIXME: Global variables are not mapped or serialized.
+static int Global;
+
+enum Color {
+  RED,
+  GREEN,
+  BLUE = 5
+};
+
+typedef int MyTypedef;
+
+// CHECK:       { 
+// CHECK-NEXT:    "Enums": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "Location": {
+// CHECK-NEXT:          "Filename": "{{.*}}namespace.cpp",
+// CHECK-NEXT:          "LineNumber": 15
+// CHECK-NEXT:        },
+// CHECK-NEXT:        "Members": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "Name": "RED",
+// CHECK-NEXT:            "Value": "0"
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "Name": "GREEN",
+// CHECK-NEXT:            "Value": "1"
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "Name": "BLUE",
+// CHECK-NEXT:            "ValueExpr": "5"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ],
+// CHECK-NEXT:        "Name": "Color",
+// CHECK-NEXT:        "Scoped": false,
+// CHECK-NEXT:        "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:   "Functions": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "IsStatic": false,
+// CHECK-NEXT:       "Name": "myFunction",
+// CHECK-NEXT:       "Params": [
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "Name": "Param",
+// CHECK-NEXT:           "Type": "int"
+// CHECK-NEXT:         }
+// CHECK-NEXT:       ],
+// CHECK-NEXT:       "ReturnType": {
+// CHECK-NEXT:         "IsBuiltIn": false,
+// CHECK-NEXT:         "IsTemplate": false,
+// CHECK-NEXT:         "Name": "void",
+// CHECK-NEXT:         "QualName": "void",
+// CHECK-NEXT:         "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "Name": "",
+// CHECK-NEXT:   "Namespaces": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "Name": "NestedNamespace",
+// CHECK-NEXT:       "Path": "",
+// CHECK-NEXT:       "QualName": "NestedNamespace",
+// CHECK-NEXT:       "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "Records": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "Name": "MyClass",
+// CHECK-NEXT:       "Path": "GlobalNamespace",
+// CHECK-NEXT:       "QualName": "MyClass",
+// CHECK-NEXT:       "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "Typedefs": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "IsUsing": false,
+// CHECK-NEXT:      "Location": {
+// CHECK-NEXT:        "Filename": "{{.*}}namespace.cpp",
+// CHECK-NEXT:        "LineNumber": 21
+// CHECK-NEXT:      },
+// CHECK-NEXT:      "Name": "MyTypedef",
+// CHECK-NEXT:      "TypeDeclaration": "",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}",
+// CHECK-NEXT:      "Underlying": {
+// CHECK-NEXT:        "IsBuiltIn": false,
+// CHECK-NEXT:        "IsTemplate": false,
+// CHECK-NEXT:        "Name": "int",
+// CHECK-NEXT:        "QualName": "int",
+// CHECK-NEXT:        "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "USR": "0000000000000000000000000000000000000000"
+// CHECK-NOT:     "Variables": [
+// CHECK-NEXT:  }


### PR DESCRIPTION
Emit namespaces to JSON. Also adds tests for namespaces and non-member constructs.