### PR TITLE
[llvm-cgdata] Fix Dangling StringRefs

### DIFF
--- a/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
+++ b/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
@@ -75,8 +75,8 @@ public:
 
 // Options
 static StringRef ToolName;
-static StringRef OutputFilename = "-";
-static StringRef Filename;
+static std::string OutputFilename = "-";
+static std::string Filename;
 static bool ShowCGDataVersion;
 static bool SkipTrim;
 static CGDataAction Action;


### PR DESCRIPTION
`OutputFilename` and `Filename` are assigned to StringRefs in `parseArgs`, but after `parseArgs` returns the `InputArgsList` that once owned the underlying strings is popped off the stack, and the StringRefs can be left pointing at garbage.

Switch to std::string to own the strings.