### PR TITLE
[llvm] Call hash_combine_range with ranges (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -27,7 +27,7 @@ template <> struct DenseMapInfo<SmallVector<sandboxir::Value *>> {
     return SmallVector<sandboxir::Value *>({(sandboxir::Value *)-2});
   }
   static unsigned getHashValue(const SmallVector<sandboxir::Value *> &Vec) {
-    return hash_combine_range(Vec.begin(), Vec.end());
+    return hash_combine_range(Vec);
   }
   static bool isEqual(const SmallVector<sandboxir::Value *> &Vec1,
                       const SmallVector<sandboxir::Value *> &Vec2) {

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -748,7 +748,7 @@ static std::error_code getStatus(HANDLE FileHandle, file_status &Result) {
     PathHash = (static_cast<uint64_t>(Info.nFileIndexHigh) << 32ULL) |
                static_cast<uint64_t>(Info.nFileIndexLow);
   } else {
-    PathHash = hash_combine_range(ntPath.begin(), ntPath.end());
+    PathHash = hash_combine_range(ntPath);
   }
 
   Result = file_status(


### PR DESCRIPTION
We can now invoke hash_combine_range with a range.
