### PR TITLE
[FuzzMutate] Use llvm::any_of (NFC)

### DIFF
--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -389,9 +389,9 @@ static bool isUnsupportedFunction(Function *F) {
         Attribute::Preallocated,   Attribute::ByRef,
         Attribute::ZExt,           Attribute::SExt};
 
-    return std::any_of(
-        std::begin(ABIAttrs), std::end(ABIAttrs),
-        [&](Attribute::AttrKind kind) { return A.hasAttribute(kind); });
+    return llvm::any_of(ABIAttrs, [&](Attribute::AttrKind kind) {
+      return A.hasAttribute(kind);
+    });
   };
 
   auto FuncAttrs = F->getAttributes();


### PR DESCRIPTION
Note that llvm::any_of can accommodate std::begin(Range), not just
Range.begin().
