### PR TITLE
[Clang] Clarify the `[[trivial_abi]]` documentation.

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -4433,9 +4433,12 @@ in the caller ends without a destructor call when the call begins.
 If a type is trivial for the purpose of calls, it is assumed to be trivially
 relocatable for the purpose of ``__is_trivially_relocatable`` and
 ``__builtin_is_cpp_trivially_relocatable``.
-The copy constructor of a an object of such type might not be called
-when the object is passed to a function. Therefore, the ``trivial_abi``
-attribute should not be applied to objects that contain pointer to themselves.
+When a type marked with ``[[trivial_abi]]`` is used as a function argument,
+the compiler may omit the call to the copy constructor.
+Thus, side effects of the copy constructor are potentially not performed.
+For example, objects that contain pointers to themselves or otherwise depend
+on their address (or the address or their subobjects) should not be declared
+``[[trivial_abi]]``.
 
 Attribute ``trivial_abi`` has no effect in the following cases:
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -4431,7 +4431,11 @@ destroy the object before returning. The lifetime of the copy of the parameter
 in the caller ends without a destructor call when the call begins.
 
 If a type is trivial for the purpose of calls, it is assumed to be trivially
-relocatable for the purpose of ``__is_trivially_relocatable``.
+relocatable for the purpose of ``__is_trivially_relocatable`` and
+``__builtin_is_cpp_trivially_relocatable``.
+The copy constructor of a an object of such type might not be called
+when the object is passed to a function. Therefore, the ``trivial_abi``
+attribute should not be applied to objects that contain pointer to themselves.
 
 Attribute ``trivial_abi`` has no effect in the following cases:
 


### PR DESCRIPTION
Fixes #36667