### PR TITLE
[clang-format] Add options to control wrapped lambda brace indent.

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -2541,7 +2541,7 @@ the configuration (without a prefix: ``Auto``).
 
   * ``bool IndentBraces`` Indent the wrapped braces themselves.
 
-  * ``bool IndentBracesLambdaNested`` Indent nested wrapped lambda braces.
+  * ``bool IndentLambdaBracesNested`` Indent nested wrapped lambda braces.
 
     .. code-block:: c++
 
@@ -2559,7 +2559,7 @@ the configuration (without a prefix: ``Auto``).
               return true;
             });
 
-  * ``bool IndentBracesLambdaUnnested`` Indent unnested wrapped lambda braces.
+  * ``bool IndentLambdaBracesUnnested`` Indent unnested wrapped lambda braces.
 
     .. code-block:: c++
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -2541,6 +2541,40 @@ the configuration (without a prefix: ``Auto``).
 
   * ``bool IndentBraces`` Indent the wrapped braces themselves.
 
+  * ``bool IndentBracesLambdaNested`` Indent nested wrapped lambda braces.
+
+    .. code-block:: c++
+
+      false:
+      function(
+          []()
+          {
+            return true;
+          });
+
+      true:
+      function(
+          []()
+            {
+              return true;
+            });
+
+  * ``bool IndentBracesLambdaUnnested`` Indent unnested wrapped lambda braces.
+
+    .. code-block:: c++
+
+      false:
+      auto foo = []()
+      {
+        return true;
+      };
+
+      true:
+      auto foo = []()
+        {
+          return true;
+        };
+
   * ``bool SplitEmptyFunction`` If ``false``, empty function body can be put on a single line.
     This option is used only if the opening brace of the function has
     already been wrapped, i.e. the ``AfterFunction`` brace wrapping mode is

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -988,6 +988,8 @@ clang-format
   ``enum`` enumerator lists.
 - Add ``OneLineFormatOffRegex`` option for turning formatting off for one line.
 - Add ``SpaceAfterOperatorKeyword`` option.
+- Add ``IndentBracesLambdaNested`` and ``IndentBracesLambdaUnnested`` to
+  ``BraceWrapping`` options for controlling wrapped lambda brace indentation.
 
 clang-refactor
 --------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -685,7 +685,7 @@ Bug Fixes in This Version
 - Fixed an assertion failure in serialization of constexpr structs containing unions. (#GH140130)
 - Fixed duplicate entries in TableGen that caused the wrong attribute to be selected. (GH#140701)
 - Fixed type mismatch error when 'builtin-elementwise-math' arguments have different qualifiers, this should be well-formed. (#GH141397)
-- Constant evaluation now correctly runs the destructor of a variable declared in 
+- Constant evaluation now correctly runs the destructor of a variable declared in
   the second clause of a C-style ``for`` loop. (#GH139818)
 
 Bug Fixes to Compiler Builtins
@@ -988,7 +988,7 @@ clang-format
   ``enum`` enumerator lists.
 - Add ``OneLineFormatOffRegex`` option for turning formatting off for one line.
 - Add ``SpaceAfterOperatorKeyword`` option.
-- Add ``IndentBracesLambdaNested`` and ``IndentBracesLambdaUnnested`` to
+- Add ``IndentLambdaBracesNested`` and ``IndentLambdaBracesUnnested`` to
   ``BraceWrapping`` options for controlling wrapped lambda brace indentation.
 
 clang-refactor

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1547,6 +1547,38 @@ struct FormatStyle {
     bool BeforeWhile;
     /// Indent the wrapped braces themselves.
     bool IndentBraces;
+    /// Indent nested wrapped lambda braces.
+    /// \code
+    ///   false:
+    ///   function(
+    ///       []()
+    ///       {
+    ///         return true;
+    ///       });
+    ///
+    ///   true:
+    ///   function(
+    ///       []()
+    ///         {
+    ///           return true;
+    ///         });
+    /// \endcode
+    bool IndentBracesLambdaNested;
+    /// Indent unnested wrapped lambda braces.
+    /// \code
+    ///   false:
+    ///   auto foo = []()
+    ///   {
+    ///     return true;
+    ///   };
+    ///
+    ///   true:
+    ///   auto foo = []()
+    ///     {
+    ///       return true;
+    ///     };
+    /// \endcode
+    bool IndentBracesLambdaUnnested;
     /// If ``false``, empty function body can be put on a single line.
     /// This option is used only if the opening brace of the function has
     /// already been wrapped, i.e. the ``AfterFunction`` brace wrapping mode is

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1563,7 +1563,7 @@ struct FormatStyle {
     ///           return true;
     ///         });
     /// \endcode
-    bool IndentBracesLambdaNested;
+    bool IndentLambdaBracesNested;
     /// Indent unnested wrapped lambda braces.
     /// \code
     ///   false:
@@ -1578,7 +1578,7 @@ struct FormatStyle {
     ///       return true;
     ///     };
     /// \endcode
-    bool IndentBracesLambdaUnnested;
+    bool IndentLambdaBracesUnnested;
     /// If ``false``, empty function body can be put on a single line.
     /// This option is used only if the opening brace of the function has
     /// already been wrapped, i.e. the ``AfterFunction`` brace wrapping mode is

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1339,8 +1339,8 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
     const auto From = Style.LambdaBodyIndentation == FormatStyle::LBI_Signature
                           ? CurrentState.Indent
                           : State.FirstIndent;
-    const auto Indent = Nested ? Style.BraceWrapping.IndentBracesLambdaNested
-                               : Style.BraceWrapping.IndentBracesLambdaUnnested;
+    const auto Indent = Nested ? Style.BraceWrapping.IndentLambdaBracesNested
+                               : Style.BraceWrapping.IndentLambdaBracesUnnested;
     return From + (Indent * Style.IndentWidth);
   }
 
@@ -2126,8 +2126,8 @@ void ContinuationIndenter::moveStateToNewBlock(LineState &State, bool NewLine) {
       State.NextToken->is(TT_LambdaLBrace) &&
       !State.Line->MightBeFunctionDecl) {
     const auto Nested = State.NextToken->NestingLevel > 0;
-    const auto Indent = Nested ? Style.BraceWrapping.IndentBracesLambdaNested
-                               : Style.BraceWrapping.IndentBracesLambdaUnnested;
+    const auto Indent = Nested ? Style.BraceWrapping.IndentLambdaBracesNested
+                               : Style.BraceWrapping.IndentLambdaBracesUnnested;
     State.Stack.back().NestedBlockIndent =
         State.FirstIndent + (Indent * Style.IndentWidth);
   }

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1334,12 +1334,15 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
            Style.IndentWidth;
   }
 
-  if (Style.BraceWrapping.BeforeLambdaBody &&
-      Style.BraceWrapping.IndentBraces && Current.is(TT_LambdaLBrace)) {
+  if (Style.BraceWrapping.BeforeLambdaBody && Current.is(TT_LambdaLBrace)) {
+    const auto Nested = Current.NestingLevel != 0;
     const auto From = Style.LambdaBodyIndentation == FormatStyle::LBI_Signature
                           ? CurrentState.Indent
                           : State.FirstIndent;
-    return From + Style.IndentWidth;
+    const auto Indent =
+        (Style.BraceWrapping.IndentBracesLambdaNested && Nested) ||
+        (Style.BraceWrapping.IndentBracesLambdaUnnested && !Nested);
+    return From + (Indent * Style.IndentWidth);
   }
 
   if ((NextNonComment->is(tok::l_brace) && NextNonComment->is(BK_Block)) ||
@@ -2123,8 +2126,12 @@ void ContinuationIndenter::moveStateToNewBlock(LineState &State, bool NewLine) {
   if (Style.LambdaBodyIndentation == FormatStyle::LBI_OuterScope &&
       State.NextToken->is(TT_LambdaLBrace) &&
       !State.Line->MightBeFunctionDecl) {
-    const auto Indent = Style.IndentWidth * Style.BraceWrapping.IndentBraces;
-    State.Stack.back().NestedBlockIndent = State.FirstIndent + Indent;
+    const auto Nested = State.NextToken->NestingLevel != 0;
+    const auto Indent =
+        (Style.BraceWrapping.IndentBracesLambdaNested && Nested) ||
+        (Style.BraceWrapping.IndentBracesLambdaUnnested && !Nested);
+    State.Stack.back().NestedBlockIndent =
+        State.FirstIndent + (Indent * Style.IndentWidth);
   }
   unsigned NestedBlockIndent = State.Stack.back().NestedBlockIndent;
   // ObjC block sometimes follow special indentation rules.

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1335,13 +1335,12 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
   }
 
   if (Style.BraceWrapping.BeforeLambdaBody && Current.is(TT_LambdaLBrace)) {
-    const auto Nested = Current.NestingLevel != 0;
+    const auto Nested = Current.NestingLevel > 0;
     const auto From = Style.LambdaBodyIndentation == FormatStyle::LBI_Signature
                           ? CurrentState.Indent
                           : State.FirstIndent;
-    const auto Indent =
-        (Style.BraceWrapping.IndentBracesLambdaNested && Nested) ||
-        (Style.BraceWrapping.IndentBracesLambdaUnnested && !Nested);
+    const auto Indent = Nested ? Style.BraceWrapping.IndentBracesLambdaNested
+                               : Style.BraceWrapping.IndentBracesLambdaUnnested;
     return From + (Indent * Style.IndentWidth);
   }
 
@@ -2126,10 +2125,9 @@ void ContinuationIndenter::moveStateToNewBlock(LineState &State, bool NewLine) {
   if (Style.LambdaBodyIndentation == FormatStyle::LBI_OuterScope &&
       State.NextToken->is(TT_LambdaLBrace) &&
       !State.Line->MightBeFunctionDecl) {
-    const auto Nested = State.NextToken->NestingLevel != 0;
-    const auto Indent =
-        (Style.BraceWrapping.IndentBracesLambdaNested && Nested) ||
-        (Style.BraceWrapping.IndentBracesLambdaUnnested && !Nested);
+    const auto Nested = State.NextToken->NestingLevel > 0;
+    const auto Indent = Nested ? Style.BraceWrapping.IndentBracesLambdaNested
+                               : Style.BraceWrapping.IndentBracesLambdaUnnested;
     State.Stack.back().NestedBlockIndent =
         State.FirstIndent + (Indent * Style.IndentWidth);
   }

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -196,10 +196,10 @@ template <> struct MappingTraits<FormatStyle::BraceWrappingFlags> {
     IO.mapOptional("BeforeLambdaBody", Wrapping.BeforeLambdaBody);
     IO.mapOptional("BeforeWhile", Wrapping.BeforeWhile);
     IO.mapOptional("IndentBraces", Wrapping.IndentBraces);
-    IO.mapOptional("IndentBracesLambdaNested",
-                   Wrapping.IndentBracesLambdaNested);
-    IO.mapOptional("IndentBracesLambdaUnnested",
-                   Wrapping.IndentBracesLambdaUnnested);
+    IO.mapOptional("IndentLambdaBracesNested",
+                   Wrapping.IndentLambdaBracesNested);
+    IO.mapOptional("IndentLambdaBracesUnnested",
+                   Wrapping.IndentLambdaBracesUnnested);
     IO.mapOptional("SplitEmptyFunction", Wrapping.SplitEmptyFunction);
     IO.mapOptional("SplitEmptyRecord", Wrapping.SplitEmptyRecord);
     IO.mapOptional("SplitEmptyNamespace", Wrapping.SplitEmptyNamespace);
@@ -1386,8 +1386,8 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
                             /*BeforeLambdaBody=*/false,
                             /*BeforeWhile=*/false,
                             /*IndentBraces=*/false,
-                            /*IndentBracesLambdaNested=*/false,
-                            /*IndentBracesLambdaUnnested=*/false,
+                            /*IndentLambdaBracesNested=*/false,
+                            /*IndentLambdaBracesUnnested=*/false,
                             /*SplitEmptyFunction=*/true,
                             /*SplitEmptyRecord=*/true,
                             /*SplitEmptyNamespace=*/true};
@@ -1458,8 +1458,8 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
         /*BeforeLambdaBody=*/true,
         /*BeforeWhile=*/true,
         /*IndentBraces=*/true,
-        /*IndentBracesLambdaNested=*/true,
-        /*IndentBracesLambdaUnnested=*/true,
+        /*IndentLambdaBracesNested=*/true,
+        /*IndentLambdaBracesUnnested=*/true,
         /*SplitEmptyFunction=*/true,
         /*SplitEmptyRecord=*/true,
         /*SplitEmptyNamespace=*/true};
@@ -1560,8 +1560,8 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
                              /*BeforeLambdaBody=*/false,
                              /*BeforeWhile=*/false,
                              /*IndentBraces=*/false,
-                             /*IndentBracesLambdaNested=*/false,
-                             /*IndentBracesLambdaUnnested=*/false,
+                             /*IndentLambdaBracesNested=*/false,
+                             /*IndentLambdaBracesUnnested=*/false,
                              /*SplitEmptyFunction=*/true,
                              /*SplitEmptyRecord=*/true,
                              /*SplitEmptyNamespace=*/true};

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -196,6 +196,10 @@ template <> struct MappingTraits<FormatStyle::BraceWrappingFlags> {
     IO.mapOptional("BeforeLambdaBody", Wrapping.BeforeLambdaBody);
     IO.mapOptional("BeforeWhile", Wrapping.BeforeWhile);
     IO.mapOptional("IndentBraces", Wrapping.IndentBraces);
+    IO.mapOptional("IndentBracesLambdaNested",
+                   Wrapping.IndentBracesLambdaNested);
+    IO.mapOptional("IndentBracesLambdaUnnested",
+                   Wrapping.IndentBracesLambdaUnnested);
     IO.mapOptional("SplitEmptyFunction", Wrapping.SplitEmptyFunction);
     IO.mapOptional("SplitEmptyRecord", Wrapping.SplitEmptyRecord);
     IO.mapOptional("SplitEmptyNamespace", Wrapping.SplitEmptyNamespace);
@@ -1382,6 +1386,8 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
                             /*BeforeLambdaBody=*/false,
                             /*BeforeWhile=*/false,
                             /*IndentBraces=*/false,
+                            /*IndentBracesLambdaNested=*/false,
+                            /*IndentBracesLambdaUnnested=*/false,
                             /*SplitEmptyFunction=*/true,
                             /*SplitEmptyRecord=*/true,
                             /*SplitEmptyNamespace=*/true};
@@ -1452,6 +1458,8 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
         /*BeforeLambdaBody=*/true,
         /*BeforeWhile=*/true,
         /*IndentBraces=*/true,
+        /*IndentBracesLambdaNested=*/true,
+        /*IndentBracesLambdaUnnested=*/true,
         /*SplitEmptyFunction=*/true,
         /*SplitEmptyRecord=*/true,
         /*SplitEmptyNamespace=*/true};
@@ -1552,6 +1560,8 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
                              /*BeforeLambdaBody=*/false,
                              /*BeforeWhile=*/false,
                              /*IndentBraces=*/false,
+                             /*IndentBracesLambdaNested=*/false,
+                             /*IndentBracesLambdaUnnested=*/false,
                              /*SplitEmptyFunction=*/true,
                              /*SplitEmptyRecord=*/true,
                              /*SplitEmptyNamespace=*/true};

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -236,6 +236,8 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, BeforeLambdaBody);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, BeforeWhile);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentBraces);
+  CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentBracesLambdaNested);
+  CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentBracesLambdaUnnested);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyFunction);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyRecord);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyNamespace);

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -236,8 +236,8 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, BeforeLambdaBody);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, BeforeWhile);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentBraces);
-  CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentBracesLambdaNested);
-  CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentBracesLambdaUnnested);
+  CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentLambdaBracesNested);
+  CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentLambdaBracesUnnested);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyFunction);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyRecord);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyNamespace);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -24372,7 +24372,7 @@ TEST_F(FormatTest, LambdaBracesIndentationNested) {
                "    });",
                Style);
 
-  Style.BraceWrapping.IndentBracesLambdaNested = true;
+  Style.BraceWrapping.IndentLambdaBracesNested = true;
   verifyFormat("function(\n"
                "    [&]()\n"
                "      {\n"
@@ -24389,7 +24389,7 @@ TEST_F(FormatTest, LambdaBracesIndentationNested) {
                "  });",
                Style);
 
-  Style.BraceWrapping.IndentBracesLambdaNested = false;
+  Style.BraceWrapping.IndentLambdaBracesNested = false;
   verifyFormat("function([&]()\n"
                "{\n"
                "  for (int i = 0; i < y; ++i)\n"
@@ -24411,7 +24411,7 @@ TEST_F(FormatTest, LambdaBracesIndentationUnnested) {
                "};",
                Style);
 
-  Style.BraceWrapping.IndentBracesLambdaUnnested = true;
+  Style.BraceWrapping.IndentLambdaBracesUnnested = true;
   verifyFormat("auto x = [&]()\n"
                "  {\n"
                "    for (int i = 0; i < y; ++i)\n"
@@ -24427,7 +24427,7 @@ TEST_F(FormatTest, LambdaBracesIndentationUnnested) {
                "  };",
                Style);
 
-  Style.BraceWrapping.IndentBracesLambdaUnnested = false;
+  Style.BraceWrapping.IndentLambdaBracesUnnested = false;
   verifyFormat("auto x = [&]()\n"
                "{\n"
                "  for (int i = 0; i < y; ++i)\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -24358,6 +24358,84 @@ TEST_F(FormatTest, LambdaBracesInGNU) {
                Style);
 }
 
+TEST_F(FormatTest, LambdaBracesIndentationNested) {
+  auto Style = getLLVMStyle();
+  EXPECT_EQ(Style.LambdaBodyIndentation, FormatStyle::LBI_Signature);
+
+  Style.BreakBeforeBraces = FormatStyle::BS_Custom;
+  Style.BraceWrapping.BeforeLambdaBody = true;
+  verifyFormat("function(\n"
+               "    [&]()\n"
+               "    {\n"
+               "      for (int i = 0; i < y; ++i)\n"
+               "        return 97;\n"
+               "    });",
+               Style);
+
+  Style.BraceWrapping.IndentBracesLambdaNested = true;
+  verifyFormat("function(\n"
+               "    [&]()\n"
+               "      {\n"
+               "        for (int i = 0; i < y; ++i)\n"
+               "          return 97;\n"
+               "      });",
+               Style);
+
+  Style.LambdaBodyIndentation = FormatStyle::LBI_OuterScope;
+  verifyFormat("function([&]()\n"
+               "  {\n"
+               "    for (int i = 0; i < y; ++i)\n"
+               "      return 97;\n"
+               "  });",
+               Style);
+
+  Style.BraceWrapping.IndentBracesLambdaNested = false;
+  verifyFormat("function([&]()\n"
+               "{\n"
+               "  for (int i = 0; i < y; ++i)\n"
+               "    return 97;\n"
+               "});",
+               Style);
+}
+
+TEST_F(FormatTest, LambdaBracesIndentationUnnested) {
+  auto Style = getLLVMStyle();
+  EXPECT_EQ(Style.LambdaBodyIndentation, FormatStyle::LBI_Signature);
+
+  Style.BreakBeforeBraces = FormatStyle::BS_Custom;
+  Style.BraceWrapping.BeforeLambdaBody = true;
+  verifyFormat("auto x = [&]()\n"
+               "{\n"
+               "  for (int i = 0; i < y; ++i)\n"
+               "    return 97;\n"
+               "};",
+               Style);
+
+  Style.BraceWrapping.IndentBracesLambdaUnnested = true;
+  verifyFormat("auto x = [&]()\n"
+               "  {\n"
+               "    for (int i = 0; i < y; ++i)\n"
+               "      return 97;\n"
+               "  };",
+               Style);
+
+  Style.LambdaBodyIndentation = FormatStyle::LBI_OuterScope;
+  verifyFormat("auto x = [&]()\n"
+               "  {\n"
+               "    for (int i = 0; i < y; ++i)\n"
+               "      return 97;\n"
+               "  };",
+               Style);
+
+  Style.BraceWrapping.IndentBracesLambdaUnnested = false;
+  verifyFormat("auto x = [&]()\n"
+               "{\n"
+               "  for (int i = 0; i < y; ++i)\n"
+               "    return 97;\n"
+               "};",
+               Style);
+}
+
 TEST_F(FormatTest, FormatsBlocks) {
   FormatStyle ShortBlocks = getLLVMStyle();
   ShortBlocks.AllowShortBlocksOnASingleLine = FormatStyle::SBS_Always;


### PR DESCRIPTION
Adds options to customise how wrapped lambda braces are indented when using custom brace wrapping.

`IndentBraces` was recently updated to also indent wrapped lambda braces. This has been changed to be controlled separately to allow the old behaviour to be maintained. Ideally before a release is made with the new behaviour.

In order to further increase flexibility, the indentation can be controlled separately for both nested and unnested lambdas.

Resolves #143248