### PR TITLE
[CIR] Extend VecShuffleOp verifier to catch invalid index

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1599,6 +1599,14 @@ LogicalResult cir::VecShuffleOp::verify() {
                          << " and " << getResult().getType() << " don't match";
   }
 
+  const uint64_t maxValidIndex =
+      getVec1().getType().getSize() + getVec2().getType().getSize() - 1;
+  for (const auto &idxAttr : getIndices().getAsRange<cir::IntAttr>()) {
+    if (idxAttr.getUInt() > maxValidIndex)
+      return emitOpError() << ": index for __builtin_shufflevector must be "
+                              "less than the total number of vector elements";
+  }
+
   return success();
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1602,7 +1602,7 @@ LogicalResult cir::VecShuffleOp::verify() {
   const uint64_t maxValidIndex =
       getVec1().getType().getSize() + getVec2().getType().getSize() - 1;
   for (const auto &idxAttr : getIndices().getAsRange<cir::IntAttr>()) {
-    if (idxAttr.getUInt() > maxValidIndex)
+    if (idxAttr.getSInt() != -1 && idxAttr.getUInt() > maxValidIndex)
       return emitOpError() << ": index for __builtin_shufflevector must be "
                               "less than the total number of vector elements";
   }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1586,26 +1586,28 @@ OpFoldResult cir::VecExtractOp::fold(FoldAdaptor adaptor) {
 LogicalResult cir::VecShuffleOp::verify() {
   // The number of elements in the indices array must match the number of
   // elements in the result type.
-  if (getIndices().size() != getResult().getType().getSize())
+  if (getIndices().size() != getResult().getType().getSize()) {
     return emitOpError() << ": the number of elements in " << getIndices()
                          << " and " << getResult().getType() << " don't match";
+  }
 
   // The element types of the two input vectors and of the result type must
   // match.
   if (getVec1().getType().getElementType() !=
-      getResult().getType().getElementType())
+      getResult().getType().getElementType()) {
     return emitOpError() << ": element types of " << getVec1().getType()
                          << " and " << getResult().getType() << " don't match";
+  }
 
   const uint64_t maxValidIndex =
       getVec1().getType().getSize() + getVec2().getType().getSize() - 1;
   if (llvm::any_of(
           getIndices().getAsRange<cir::IntAttr>(), [&](cir::IntAttr idxAttr) {
             return idxAttr.getSInt() != -1 && idxAttr.getUInt() > maxValidIndex;
-          }))
+          })) {
     return emitOpError() << ": index for __builtin_shufflevector must be "
                             "less than the total number of vector elements";
-
+  }
   return success();
 }
 

--- a/clang/test/CIR/IR/invalid-vector-shuffle-wrong-index.cir
+++ b/clang/test/CIR/IR/invalid-vector-shuffle-wrong-index.cir
@@ -1,0 +1,16 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+module  {
+  cir.func @fold_shuffle_vector_op_test() -> !cir.vector<4 x !s32i> {
+    %vec_1 = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<3> : !s32i, #cir.int<5> : !s32i, #cir.int<7> : !s32i]> : !cir.vector<4 x !s32i>
+    %vec_2 = cir.const #cir.const_vector<[#cir.int<2> : !s32i, #cir.int<4> : !s32i, #cir.int<6> : !s32i, #cir.int<8> : !s32i]> : !cir.vector<4 x !s32i>
+
+    // expected-error @below {{index for __builtin_shufflevector must be less than the total number of vector elements}}
+    %new_vec = cir.vec.shuffle(%vec_1, %vec_2 : !cir.vector<4 x !s32i>) [#cir.int<9> : !s64i, #cir.int<4> : !s64i,
+      #cir.int<1> : !s64i, #cir.int<5> : !s64i] : !cir.vector<4 x !s32i>
+    cir.return %new_vec : !cir.vector<4 x !s32i>
+  }
+}


### PR DESCRIPTION
Extend the verifier to catch index larger than the size of vector elements in VecShuffleOp

Issue https://github.com/llvm/llvm-project/issues/136487