### PR TITLE
[llvm-lto2] Replace std::atomic_init with brace initiation. NFC

### DIFF
--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -394,8 +394,7 @@ static int run(int argc, char **argv) {
   // behavior. Instead, we don't exit in the multi-threaded case, but we make
   // sure to report the error and then at the end (after joining cleanly)
   // exit(1).
-  std::atomic<bool> HasErrors;
-  std::atomic_init(&HasErrors, false);
+  std::atomic<bool> HasErrors{false};
   Conf.DiagHandler = [&](const DiagnosticInfo &DI) {
     DiagnosticPrinterRawOStream DP(errs());
     DI.print(DP);


### PR DESCRIPTION
In C++ 20, std::atomic_init is deprecated.
This patch replaces call to std::atomic_init with brace initiation.