### PR TITLE
[clang][NFC] Refactor replaceExternalDecls to use llvm::any_of

### DIFF
--- a/clang/include/clang/AST/DeclContextInternals.h
+++ b/clang/include/clang/AST/DeclContextInternals.h
@@ -176,7 +176,10 @@ public:
     DeclListNode::Decls *Tail = erase_if([Decls](NamedDecl *ND) {
       if (ND->isFromASTFile())
         return true;
+      // FIXME: Can we get rid of this loop completely?
       return llvm::any_of(Decls, [ND](NamedDecl *D) {
+        // Only replace the local declaration if the external declaration has
+        // higher visiblities.
         return D->getModuleOwnershipKind() <= ND->getModuleOwnershipKind() &&
                D->declarationReplaces(ND, /*IsKnownNewer=*/false);
       });

--- a/clang/include/clang/AST/DeclContextInternals.h
+++ b/clang/include/clang/AST/DeclContextInternals.h
@@ -176,14 +176,10 @@ public:
     DeclListNode::Decls *Tail = erase_if([Decls](NamedDecl *ND) {
       if (ND->isFromASTFile())
         return true;
-      // FIXME: Can we get rid of this loop completely?
-      for (NamedDecl *D : Decls)
-        // Only replace the local declaration if the external declaration has
-        // higher visibilities.
-        if (D->getModuleOwnershipKind() <= ND->getModuleOwnershipKind() &&
-            D->declarationReplaces(ND, /*IsKnownNewer=*/false))
-          return true;
-      return false;
+      return llvm::any_of(Decls, [ND](NamedDecl *D) {
+        return D->getModuleOwnershipKind() <= ND->getModuleOwnershipKind() &&
+               D->declarationReplaces(ND, /*IsKnownNewer=*/false);
+      });
     });
 
     // Don't have any pending external decls any more.


### PR DESCRIPTION
This patch simplifies the declaration replacement logic in replaceExternalDecls by replacing a manual loop with an idiomatic use of llvm::any_of. This improves code readability and aligns with common LLVM coding style.