### PR TITLE
[clang-move] Teach getDeclarationList to return ArrayRef (NFC)

### DIFF
--- a/clang-tools-extra/clang-move/Move.h
+++ b/clang-tools-extra/clang-move/Move.h
@@ -49,9 +49,7 @@ public:
     bool Templated = false;    // Whether the declaration is templated.
   };
 
-  const std::vector<Declaration> getDeclarationList() const {
-    return DeclarationList;
-  }
+  ArrayRef<Declaration> getDeclarationList() const { return DeclarationList; }
 
 private:
   std::vector<Declaration> DeclarationList;


### PR DESCRIPTION
getDeclarationList is used only for read-only access to the array.  I
don't think it's actually meant to return by value.
