### PR TITLE
[clang-tidy] Fix false positives with template in `misc-unconventional-assign-operator` check

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UnconventionalAssignOperatorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnconventionalAssignOperatorCheck.cpp
@@ -66,8 +66,11 @@ void UnconventionalAssignOperatorCheck::registerMatchers(
                                 hasArgument(0, cxxThisExpr())),
             cxxOperatorCallExpr(
                 hasOverloadedOperatorName("="),
-                hasArgument(
-                    0, unaryOperator(hasOperatorName("*"),
+                hasArgument(0, unaryOperator(hasOperatorName("*"),
+                                             hasUnaryOperand(cxxThisExpr())))),
+            binaryOperator(
+                hasOperatorName("="),
+                hasLHS(unaryOperator(hasOperatorName("*"),
                                      hasUnaryOperand(cxxThisExpr())))))))));
   const auto IsGoodAssign = cxxMethodDecl(IsAssign, HasGoodReturnType);
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -209,7 +209,7 @@ Changes in existing checks
   on ``operator""`` with template parameters.
 
 - Improved :doc:`misc-unconventional-assign-operator
-  <clang-tidy/checks/misc/misc-unconventional-assign-operator>` check by fixing
+  <clang-tidy/checks/misc/unconventional-assign-operator>` check by fixing
   false positives when copy assignment operator function in a template class
   returns the result of another assignment to ``*this``(``return *this=...``).
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -208,6 +208,11 @@ Changes in existing checks
   <clang-tidy/checks/misc/unused-using-decls>` check by fixing false positives
   on ``operator""`` with template parameters.
 
+- Improved :doc:`misc-unconventional-assign-operator
+  <clang-tidy/checks/misc/misc-unconventional-assign-operator>` check by fixing
+  false positives when copy assignment operator function in a template class
+  returns the result of another assignment to ``*this``(``return *this=...``).
+
 - Improved :doc:`misc-use-internal-linkage
   <clang-tidy/checks/misc/use-internal-linkage>` check by fix false positives
   for function or variable in header file which contains macro expansion and

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -204,14 +204,14 @@ Changes in existing checks
   <clang-tidy/checks/misc/redundant-expression>` check by providing additional
   examples and fixing some macro related false positives.
 
-- Improved :doc:`misc-unused-using-decls
-  <clang-tidy/checks/misc/unused-using-decls>` check by fixing false positives
-  on ``operator""`` with template parameters.
-
 - Improved :doc:`misc-unconventional-assign-operator
   <clang-tidy/checks/misc/unconventional-assign-operator>` check by fixing
   false positives when copy assignment operator function in a template class
   returns the result of another assignment to ``*this``(``return *this=...``).
+
+- Improved :doc:`misc-unused-using-decls
+  <clang-tidy/checks/misc/unused-using-decls>` check by fixing false positives
+  on ``operator""`` with template parameters.
 
 - Improved :doc:`misc-use-internal-linkage
   <clang-tidy/checks/misc/use-internal-linkage>` check by fix false positives

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -207,7 +207,7 @@ Changes in existing checks
 - Improved :doc:`misc-unconventional-assign-operator
   <clang-tidy/checks/misc/unconventional-assign-operator>` check by fixing
   false positives when copy assignment operator function in a template class
-  returns the result of another assignment to ``*this``(``return *this=...``).
+  returns the result of another assignment to ``*this`` (``return *this=...``).
 
 - Improved :doc:`misc-unused-using-decls
   <clang-tidy/checks/misc/unused-using-decls>` check by fixing false positives

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unconventional-assign-operator.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unconventional-assign-operator.cpp
@@ -163,3 +163,16 @@ struct TemplateTypeAlias {
   Alias3<TypeAlias::Alias> &operator=(double) { return *this; }
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: operator=() should return 'TemplateTypeAlias&' [misc-unconventional-assign-operator]
 };
+
+namespace issue143237 {
+template<typename T>
+struct B {
+  explicit B(int) {
+  }
+
+  B& operator=(int n) {
+    // No warning
+    return *this = B(n);
+  }
+};
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unconventional-assign-operator.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unconventional-assign-operator.cpp
@@ -164,15 +164,15 @@ struct TemplateTypeAlias {
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: operator=() should return 'TemplateTypeAlias&' [misc-unconventional-assign-operator]
 };
 
-namespace issue143237 {
+namespace gh143237 {
 template<typename T>
-struct B {
-  explicit B(int) {
+struct TemplateAssignment {
+  explicit TemplateAssignment(int) {
   }
 
-  B& operator=(int n) {
+  TemplateAssignment& operator=(int n) {
     // No warning
-    return *this = B(n);
+    return *this = TemplateAssignment(n);
   }
 };
 }


### PR DESCRIPTION
Fix false positives when copy assignment operator function in a template class returns the result of another assignment to `*this`, this check doesn't consider this situation that there will be a `BinaryOperator` for assignment rather than `CXXOperatorCallExpr` since `this`'s type is dependent.

Closes #143237.