### PR TITLE
[compiler-rt][Mips] Fix stat size check on mips64 musl

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -102,6 +102,8 @@ const unsigned struct_kernel_stat_sz = SANITIZER_ANDROID
                                            ? FIRST_32_SECOND_64(104, 128)
 #      if defined(_ABIN32) && _MIPS_SIM == _ABIN32
                                            : FIRST_32_SECOND_64(176, 216);
+#      elif SANITIZER_MUSL
+                                           : FIRST_32_SECOND_64(160, 208);
 #      else
                                            : FIRST_32_SECOND_64(160, 216);
 #      endif


### PR DESCRIPTION
The sizes of the struct stat on MIPS64 differ in musl vs glibc.

See https://godbolt.org/z/qf9bcq8Y8 for the proof. Prior to this change, compilation for MIPS64 musl would fail.