### PR TITLE
[clang-tidy][NFC] fix formatting of `namespace-comment-check`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/NamespaceCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NamespaceCommentCheck.cpp
@@ -28,12 +28,14 @@ NamespaceCommentCheck::NamespaceCommentCheck(StringRef Name,
           llvm::Regex::IgnoreCase),
       ShortNamespaceLines(Options.get("ShortNamespaceLines", 1U)),
       SpacesBeforeComments(Options.get("SpacesBeforeComments", 1U)),
-      AllowOmittingNamespaceComments(Options.get("AllowOmittingNamespaceComments", false)) {}
+      AllowOmittingNamespaceComments(
+          Options.get("AllowOmittingNamespaceComments", false)) {}
 
 void NamespaceCommentCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "ShortNamespaceLines", ShortNamespaceLines);
   Options.store(Opts, "SpacesBeforeComments", SpacesBeforeComments);
-  Options.store(Opts, "AllowOmittingNamespaceComments", AllowOmittingNamespaceComments);
+  Options.store(Opts, "AllowOmittingNamespaceComments",
+                AllowOmittingNamespaceComments);
 }
 
 void NamespaceCommentCheck::registerMatchers(MatchFinder *Finder) {
@@ -108,7 +110,7 @@ void NamespaceCommentCheck::check(const MatchFinder::MatchResult &Result) {
   // Currently for nested namespace (n1::n2::...) the AST matcher will match foo
   // then bar instead of a single match. So if we got a nested namespace we have
   // to skip the next ones.
-  for (const auto &EndOfNameLocation : Ends) {
+  for (const SourceLocation &EndOfNameLocation : Ends) {
     if (Sources.isBeforeInTranslationUnit(ND->getLocation(), EndOfNameLocation))
       return;
   }
@@ -142,7 +144,7 @@ void NamespaceCommentCheck::check(const MatchFinder::MatchResult &Result) {
 
   SourceRange OldCommentRange(AfterRBrace, AfterRBrace);
   std::string Message = "%0 not terminated with a closing comment";
-  bool hasComment = false;
+  bool HasComment = false;
 
   // Try to find existing namespace closing comment on the same line.
   if (Tok.is(tok::comment) && NextTokenIsOnSameLine) {
@@ -161,7 +163,7 @@ void NamespaceCommentCheck::check(const MatchFinder::MatchResult &Result) {
         return;
       }
 
-      hasComment = true;
+      HasComment = true;
 
       // Otherwise we need to fix the comment.
       NeedLineBreak = Comment.starts_with("/*");
@@ -185,13 +187,13 @@ void NamespaceCommentCheck::check(const MatchFinder::MatchResult &Result) {
   }
 
   std::string NamespaceNameForDiag =
-      ND->isAnonymousNamespace() ? "anonymous namespace"
-                                 : ("namespace '" + *NamespaceNameAsWritten + "'");
+      ND->isAnonymousNamespace()
+          ? "anonymous namespace"
+          : ("namespace '" + *NamespaceNameAsWritten + "'");
 
   // If no namespace comment is allowed
-  if(!hasComment && AllowOmittingNamespaceComments) {
+  if (!HasComment && AllowOmittingNamespaceComments)
     return;
-  }
 
   std::string Fix(SpacesBeforeComments, ' ');
   Fix.append("// namespace");


### PR DESCRIPTION
Fixed formatting and codestyle issues in `namespace-comment-check`

Follow up to https://github.com/llvm/llvm-project/pull/124265.