### PR TITLE
[RISCV] Allocate feature bits for Zifencei and Zmmul

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/riscv.c
+++ b/compiler-rt/lib/builtins/cpu_model/riscv.c
@@ -134,6 +134,10 @@ struct {
 #define ZCLSD_BITMASK (1ULL << 9)
 #define ZCMP_GROUPID 1
 #define ZCMP_BITMASK (1ULL << 10)
+#define ZIFENCEI_GROUPID 1
+#define ZIFENCEI_BITMASK (1ULL << 11)
+#define ZMMUL_GROUPID 1
+#define ZMMUL_BITMASK (1ULL << 12)
 
 #if defined(__linux__)
 

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -134,7 +134,8 @@ def HasStdExtZicond : Predicate<"Subtarget->hasStdExtZicond()">,
                           "(Integer Conditional Operations)">;
 
 def FeatureStdExtZifencei
-    : RISCVExtension<2, 0, "fence.i">;
+    : RISCVExtension<2, 0, "fence.i">,
+      RISCVExtensionBitmask<1, 11>;
 def HasStdExtZifencei : Predicate<"Subtarget->hasStdExtZifencei()">,
                         AssemblerPredicate<(all_of FeatureStdExtZifencei),
                                            "'Zifencei' (fence.i)">;
@@ -192,7 +193,8 @@ def NoHasStdExtZilsd : Predicate<"!Subtarget->hasStdExtZilsd()">;
 // Multiply Extensions
 
 def FeatureStdExtZmmul
-    : RISCVExtension<1, 0, "Integer Multiplication">;
+    : RISCVExtension<1, 0, "Integer Multiplication">,
+      RISCVExtensionBitmask<1, 12>;
 def HasStdExtZmmul : Predicate<"Subtarget->hasStdExtZmmul()">,
                      AssemblerPredicate<(all_of FeatureStdExtZmmul),
                      "'Zmmul' (Integer Multiplication)">;


### PR DESCRIPTION
As proposed in https://github.com/riscv-non-isa/riscv-c-api-doc/pull/110.

No real compiler-rt implementation as Linux does not list these extensions in hwprobe.