### PR TITLE
[clang][analyzer] Correct SMT Layer for _BitInt cases refutations

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
@@ -572,7 +572,8 @@ public:
   // TODO: Refactor to put elsewhere
   static inline QualType getAPSIntType(ASTContext &Ctx,
                                        const llvm::APSInt &Int) {
-    const QualType Ty = Ctx.getIntTypeForBitwidth(Int.getBitWidth(), Int.isSigned());
+    const QualType Ty =
+        Ctx.getIntTypeForBitwidth(Int.getBitWidth(), Int.isSigned());
     if (!Ty.isNull())
       return Ty;
     // If Ty is Null, could be because the original type was a _BitInt.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
@@ -572,9 +572,8 @@ public:
   // TODO: Refactor to put elsewhere
   static inline QualType getAPSIntType(ASTContext &Ctx,
                                        const llvm::APSInt &Int) {
-    QualType Ty;
-    if (!(Ty = Ctx.getIntTypeForBitwidth(Int.getBitWidth(), Int.isSigned()))
-             .isNull())
+    const QualType Ty = Ctx.getIntTypeForBitwidth(Int.getBitWidth(), Int.isSigned());
+    if (!Ty.isNull())
       return Ty;
     // If Ty is Null, could be because the original type was a _BitInt.
     // Get the size of the _BitInt type (expressed in bits) and round it up to
@@ -583,8 +582,6 @@ public:
     unsigned Pow2DestWidth =
         std::max(llvm::bit_ceil(Int.getBitWidth()), CharTypeSize);
     return Ctx.getIntTypeForBitwidth(Pow2DestWidth, Int.isSigned());
-    // Ty = Ctx.getIntTypeForBitwidth(Pow2DestWidth, Int.isSigned());
-    // return Ty;
   }
 
   // Get the QualTy for the input APSInt, and fix it if it has a bitwidth of 1.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
@@ -577,16 +577,16 @@ public:
     // Get the bit size and round up to next power of 2, max char size
     if (Ty.isNull()) {
       unsigned CharTypeSize = Ctx.getTypeSize(Ctx.CharTy);
-      unsigned pow2DestWidth =
+      unsigned Pow2DestWidth =
           std::max(llvm::bit_ceil(Int.getBitWidth()), CharTypeSize);
-      Ty = Ctx.getIntTypeForBitwidth(pow2DestWidth, Int.isSigned());
+      Ty = Ctx.getIntTypeForBitwidth(Pow2DestWidth, Int.isSigned());
     }
     return Ty;
   }
 
-  static inline bool IsPower2(unsigned bits) {
-    return bits > 0 && (bits & (bits - 1)) == 0;
-  }
+  // static inline bool IsPower2(unsigned bits) {
+  //   return bits > 0 && (bits & (bits - 1)) == 0;
+  // }
 
   // Get the QualTy for the input APSInt, and fix it if it has a bitwidth of 1.
   static inline std::pair<llvm::APSInt, QualType>
@@ -601,8 +601,8 @@ public:
     if (APSIntBitwidth == 1 && Ty.isNull()) {
       NewInt = Int.extend(Ctx.getTypeSize(Ctx.BoolTy));
       Ty = getAPSIntType(Ctx, NewInt);
-    } else if (!IsPower2(APSIntBitwidth) && !getAPSIntType(Ctx, Int).isNull()) {
-      Ty = getAPSIntType(Ctx, Int);
+    } else if (!llvm::isPowerOf2_32(APSIntBitwidth) &&
+               !getAPSIntType(Ctx, Int).isNull()) {
       NewInt = Int.extend(Ctx.getTypeSize(Ty));
     } else
       NewInt = Int;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
@@ -584,10 +584,6 @@ public:
     return Ty;
   }
 
-  // static inline bool IsPower2(unsigned bits) {
-  //   return bits > 0 && (bits & (bits - 1)) == 0;
-  // }
-
   // Get the QualTy for the input APSInt, and fix it if it has a bitwidth of 1.
   static inline std::pair<llvm::APSInt, QualType>
   fixAPSInt(ASTContext &Ctx, const llvm::APSInt &Int) {
@@ -601,8 +597,7 @@ public:
     if (APSIntBitwidth == 1 && Ty.isNull()) {
       NewInt = Int.extend(Ctx.getTypeSize(Ctx.BoolTy));
       Ty = getAPSIntType(Ctx, NewInt);
-    } else if (!llvm::isPowerOf2_32(APSIntBitwidth) &&
-               !getAPSIntType(Ctx, Int).isNull()) {
+    } else if (!llvm::isPowerOf2_32(APSIntBitwidth) && !Ty.isNull()) {
       NewInt = Int.extend(Ctx.getTypeSize(Ty));
     } else
       NewInt = Int;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
@@ -577,12 +577,14 @@ public:
              .isNull())
       return Ty;
     // If Ty is Null, could be because the original type was a _BitInt.
-    // Get the bit size and round up to next power of 2, max char size
+    // Get the size of the _BitInt type (expressed in bits) and round it up to
+    // the next power of 2 that is at least the bit size of 'char' (usually 8).
     unsigned CharTypeSize = Ctx.getTypeSize(Ctx.CharTy);
     unsigned Pow2DestWidth =
         std::max(llvm::bit_ceil(Int.getBitWidth()), CharTypeSize);
-    Ty = Ctx.getIntTypeForBitwidth(Pow2DestWidth, Int.isSigned());
-    return Ty;
+    return Ctx.getIntTypeForBitwidth(Pow2DestWidth, Int.isSigned());
+    // Ty = Ctx.getIntTypeForBitwidth(Pow2DestWidth, Int.isSigned());
+    // return Ty;
   }
 
   // Get the QualTy for the input APSInt, and fix it if it has a bitwidth of 1.
@@ -598,9 +600,9 @@ public:
     if (APSIntBitwidth == 1 && Ty.isNull())
       return {Int.extend(Ctx.getTypeSize(Ctx.BoolTy)),
               getAPSIntType(Ctx, NewInt)};
-    if (!llvm::isPowerOf2_32(APSIntBitwidth) && !Ty.isNull())
-      return {Int.extend(Ctx.getTypeSize(Ty)), Ty};
-    return {Int, Ty};
+    if (llvm::isPowerOf2_32(APSIntBitwidth) || Ty.isNull())
+      return {Int, Ty};
+    return {Int.extend(Ctx.getTypeSize(Ty)), Ty};
   }
 
   // Perform implicit type conversion on binary symbolic expressions.

--- a/clang/test/Analysis/bitint-z3.c
+++ b/clang/test/Analysis/bitint-z3.c
@@ -8,9 +8,9 @@
 void clang_analyzer_warnIfReached();
 
 void c(int b, _BitInt(35) a) {
-  int d;
+  int d = 0;
   if (a)
-    b = d; // expected-warning{{Assigned value is uninitialized [core.uninitialized.Assign]}}
+    b = d;
   clang_analyzer_warnIfReached(); // expected-warning{{REACHABLE}}
 }
 

--- a/clang/test/Analysis/bitint-z3.c
+++ b/clang/test/Analysis/bitint-z3.c
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -analyze -analyzer-checker=core -w -DNO_CROSSCHECK -verify %s
+// RUN: %clang_cc1 -analyze -analyzer-checker=core -w -analyzer-config crosscheck-with-z3=true -verify %s
+// REQUIRES: z3
+
+// The SMTConv layer did not comprehend _BitInt types (because this was an
+// evolved feature) and was crashing due to needed updates in 2 places.
+// Analysis is expected to find these cases using _BitInt without crashing.
+
+_BitInt(35) a;
+int b;
+void c() {
+  int d;
+  if (a)
+    b = d; // expected-warning{{Assigned value is uninitialized [core.uninitialized.Assign]}}
+}
+
+int *d;
+_BitInt(3) e;
+void f() {
+  int g;
+  d = &g;
+  e ?: 0; // expected-warning{{Address of stack memory associated with local variable 'g' is still referred to by the global variable 'd' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]}}
+}

--- a/clang/test/Analysis/bitint-z3.c
+++ b/clang/test/Analysis/bitint-z3.c
@@ -1,23 +1,22 @@
-// RUN: %clang_cc1 -analyze -analyzer-checker=core -w -DNO_CROSSCHECK -verify %s
-// RUN: %clang_cc1 -analyze -analyzer-checker=core -w -analyzer-config crosscheck-with-z3=true -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -w \
+// RUN:   -analyzer-config crosscheck-with-z3=true -verify %s
 // REQUIRES: z3
 
-// The SMTConv layer did not comprehend _BitInt types (because this was an
-// evolved feature) and was crashing due to needed updates in 2 places.
-// Analysis is expected to find these cases using _BitInt without crashing.
+// Previously these tests were crashing because the SMTConv layer did not
+// comprehend the _BitInt types.
 
-_BitInt(35) a;
-int b;
-void c() {
+void clang_analyzer_warnIfReached();
+
+void c(int b, _BitInt(35) a) {
   int d;
   if (a)
     b = d; // expected-warning{{Assigned value is uninitialized [core.uninitialized.Assign]}}
+  clang_analyzer_warnIfReached(); // expected-warning{{REACHABLE}}
 }
 
-int *d;
-_BitInt(3) e;
-void f() {
+void f(int *d, _BitInt(3) e) {
   int g;
   d = &g;
-  e ?: 0; // expected-warning{{Address of stack memory associated with local variable 'g' is still referred to by the global variable 'd' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]}}
+  e ?: 0;
+  clang_analyzer_warnIfReached(); // expected-warning{{REACHABLE}}
 }


### PR DESCRIPTION
Since _BitInt was added later, ASTContext did not comprehend getting a type by bitwidth that's not a power of 2, and the SMT layer also did not comprehend this. This led to unexpected crashes using Z3 refutation during randomized testing. The assertion and redacted and summarized crash stack is shown here.

clang: ../../clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h:103:
   static llvm::SMTExprRef clang::ento::SMTConv::fromBinOp(llvm::SMTSolverRef &,
     const llvm::SMTExprRef &, const BinaryOperator::Opcode, const llvm::SMTExprRef &, bool):
     Assertion `*Solver->getSort(LHS) == *Solver->getSort(RHS) && "AST's must have the same sort!"' failed.
 ...
   <address> clang::ento::SMTConv::fromBinOp(std::shared_ptr<llvm::SMTSolver>&,
     llvm::SMTExpr const* const&, clang::BinaryOperatorKind, llvm::SMTExpr const* const&,
     bool) SMTConstraintManager.cpp
     clang::ASTContext&, llvm::SMTExpr const* const&, clang::QualType,
     clang::BinaryOperatorKind, llvm::SMTExpr const* const&, clang::QualType,
     clang::QualType*) SMTConstraintManager.cpp
     clang::ASTContext&, clang::ento::SymExpr const*, llvm::APSInt const&,
     llvm::APSInt const&, bool) SMTConstraintManager.cpp
     clang::ento::ExplodedNode const*, clang::ento::PathSensitiveBugReport&)