### PR TITLE
[clang-tidy][NFC] run clang-format over `abseil` and `altera` checks.

### DIFF
--- a/clang-tools-extra/clang-tidy/abseil/AbseilTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/AbseilTidyModule.cpp
@@ -59,14 +59,12 @@ public:
     CheckFactories.registerCheck<NoNamespaceCheck>("abseil-no-namespace");
     CheckFactories.registerCheck<RedundantStrcatCallsCheck>(
         "abseil-redundant-strcat-calls");
-    CheckFactories.registerCheck<StrCatAppendCheck>(
-        "abseil-str-cat-append");
+    CheckFactories.registerCheck<StrCatAppendCheck>("abseil-str-cat-append");
     CheckFactories.registerCheck<StringFindStartswithCheck>(
         "abseil-string-find-startswith");
     CheckFactories.registerCheck<StringFindStrContainsCheck>(
         "abseil-string-find-str-contains");
-    CheckFactories.registerCheck<TimeComparisonCheck>(
-        "abseil-time-comparison");
+    CheckFactories.registerCheck<TimeComparisonCheck>("abseil-time-comparison");
     CheckFactories.registerCheck<TimeSubtractionCheck>(
         "abseil-time-subtraction");
     CheckFactories.registerCheck<UpgradeDurationConversionsCheck>(

--- a/clang-tools-extra/clang-tidy/abseil/DurationDivisionCheck.h
+++ b/clang-tools-extra/clang-tidy/abseil/DurationDivisionCheck.h
@@ -15,7 +15,7 @@ namespace clang::tidy::abseil {
 
 // Find potential incorrect uses of integer division of absl::Duration objects.
 //
-// For the user-facing documentation see: 
+// For the user-facing documentation see:
 // http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-division.html
 
 class DurationDivisionCheck : public ClangTidyCheck {

--- a/clang-tools-extra/clang-tidy/abseil/NoInternalDependenciesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/NoInternalDependenciesCheck.cpp
@@ -27,7 +27,8 @@ void NoInternalDependenciesCheck::registerMatchers(MatchFinder *Finder) {
       this);
 }
 
-void NoInternalDependenciesCheck::check(const MatchFinder::MatchResult &Result) {
+void NoInternalDependenciesCheck::check(
+    const MatchFinder::MatchResult &Result) {
   const auto *InternalDependency =
       Result.Nodes.getNodeAs<NestedNameSpecifierLoc>("InternalDep");
 

--- a/clang-tools-extra/clang-tidy/abseil/NoInternalDependenciesCheck.h
+++ b/clang-tools-extra/clang-tidy/abseil/NoInternalDependenciesCheck.h
@@ -1,4 +1,4 @@
-//===--- NoInternalDependenciesCheck.h - clang-tidy----------------------*- C++ -*-===//
+//===--- NoInternalDependenciesCheck.h - clang-tidy--------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang-tools-extra/clang-tidy/abseil/NoNamespaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/NoNamespaceCheck.cpp
@@ -15,10 +15,9 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::abseil {
 
 void NoNamespaceCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(
-      namespaceDecl(hasName("::absl"), unless(isInAbseilFile()))
-          .bind("abslNamespace"),
-      this);
+  Finder->addMatcher(namespaceDecl(hasName("::absl"), unless(isInAbseilFile()))
+                         .bind("abslNamespace"),
+                     this);
 }
 
 void NoNamespaceCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/clang-tidy/abseil/RedundantStrcatCallsCheck.h
+++ b/clang-tools-extra/clang-tidy/abseil/RedundantStrcatCallsCheck.h
@@ -13,8 +13,8 @@
 
 namespace clang::tidy::abseil {
 
-/// Flags redundant calls to absl::StrCat when the result is being passed to 
-///	another call of absl::StrCat/absl::StrAppend. Also suggests a fix to 
+/// Flags redundant calls to absl::StrCat when the result is being passed to
+///	another call of absl::StrCat/absl::StrAppend. Also suggests a fix to
 ///	collapse the calls.
 /// Example:
 ///   StrCat(1, StrCat(2, 3))  ==>  StrCat(1, 2, 3)

--- a/clang-tools-extra/clang-tidy/abseil/StrCatAppendCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/StrCatAppendCheck.cpp
@@ -34,15 +34,15 @@ AST_MATCHER_P(Stmt, IgnoringTemporaries, ast_matchers::internal::Matcher<Stmt>,
   return InnerMatcher.matches(*E, Finder, Builder);
 }
 
-}  // namespace
+} // namespace
 
 // TODO: str += StrCat(...)
 //       str.append(StrCat(...))
 
 void StrCatAppendCheck::registerMatchers(MatchFinder *Finder) {
   const auto StrCat = functionDecl(hasName("::absl::StrCat"));
-  // The arguments of absl::StrCat are implicitly converted to AlphaNum. This 
-  // matches to the arguments because of that behavior. 
+  // The arguments of absl::StrCat are implicitly converted to AlphaNum. This
+  // matches to the arguments because of that behavior.
   const auto AlphaNum = IgnoringTemporaries(cxxConstructExpr(
       argumentCountIs(1), hasType(cxxRecordDecl(hasName("::absl::AlphaNum"))),
       hasArgument(0, ignoringImpCasts(declRefExpr(to(equalsBoundNode("LHS")),
@@ -73,7 +73,7 @@ void StrCatAppendCheck::registerMatchers(MatchFinder *Finder) {
 void StrCatAppendCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *Op = Result.Nodes.getNodeAs<CXXOperatorCallExpr>("Op");
   const auto *Call = Result.Nodes.getNodeAs<CallExpr>("Call");
-  assert(Op != nullptr && Call != nullptr && "Matcher does not work as expected");
+  assert(Op && Call && "Matcher does not work as expected");
 
   // Handles the case 'x = absl::StrCat(x)', which has no effect.
   if (Call->getNumArgs() == 1) {

--- a/clang-tools-extra/clang-tidy/abseil/StrCatAppendCheck.h
+++ b/clang-tools-extra/clang-tidy/abseil/StrCatAppendCheck.h
@@ -14,7 +14,7 @@
 namespace clang::tidy::abseil {
 
 /// Flags uses of absl::StrCat to append to a string. Suggests absl::StrAppend
-/// should be used instead. 
+/// should be used instead.
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/abseil/str-cat-append.html

--- a/clang-tools-extra/clang-tidy/abseil/TimeSubtractionCheck.h
+++ b/clang-tools-extra/clang-tidy/abseil/TimeSubtractionCheck.h
@@ -26,7 +26,7 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  void emitDiagnostic(const Expr* Node, llvm::StringRef Replacement);
+  void emitDiagnostic(const Expr *Node, llvm::StringRef Replacement);
 };
 
 } // namespace clang::tidy::abseil

--- a/clang-tools-extra/clang-tidy/abseil/UpgradeDurationConversionsCheck.h
+++ b/clang-tools-extra/clang-tidy/abseil/UpgradeDurationConversionsCheck.h
@@ -16,7 +16,8 @@
 
 namespace clang::tidy::abseil {
 
-/// Finds deprecated uses of `absl::Duration` arithmetic operators and factories.
+/// Finds deprecated uses of `absl::Duration` arithmetic operators and
+/// factories.
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/abseil/upgrade-duration-conversions.html

--- a/clang-tools-extra/clang-tidy/altera/StructPackAlignCheck.cpp
+++ b/clang-tools-extra/clang-tidy/altera/StructPackAlignCheck.cpp
@@ -47,7 +47,7 @@ void StructPackAlignCheck::check(const MatchFinder::MatchResult &Result) {
   // Do not trigger on templated struct declarations because the packing and
   // alignment requirements are unknown.
   if (Struct->isTemplated())
-     return;
+    return;
 
   // Packing and alignment requirements for invalid decls are meaningless.
   if (Struct->isInvalidDecl())

--- a/clang-tools-extra/clang-tidy/altera/StructPackAlignCheck.h
+++ b/clang-tools-extra/clang-tidy/altera/StructPackAlignCheck.h
@@ -22,7 +22,7 @@ class StructPackAlignCheck : public ClangTidyCheck {
 public:
   StructPackAlignCheck(StringRef Name, ClangTidyContext *Context)
       : ClangTidyCheck(Name, Context),
-    MaxConfiguredAlignment(Options.get("MaxConfiguredAlignment", 128)) {}
+        MaxConfiguredAlignment(Options.get("MaxConfiguredAlignment", 128)) {}
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;

--- a/clang-tools-extra/clang-tidy/altera/UnrollLoopsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/altera/UnrollLoopsCheck.cpp
@@ -247,8 +247,8 @@ bool UnrollLoopsCheck::extractValue(int &Value, const BinaryOperator *Op,
   return true;
 }
 
-bool UnrollLoopsCheck::exprHasLargeNumIterations(const Expr *Expression,
-                                                 const ASTContext *Context) const {
+bool UnrollLoopsCheck::exprHasLargeNumIterations(
+    const Expr *Expression, const ASTContext *Context) const {
   Expr::EvalResult Result;
   if (Expression->EvaluateAsRValue(Result, *Context)) {
     if (!Result.Val.isInt())


### PR DESCRIPTION
For ease of future developing, I make a series of clang-format patches on all clang-tidy code.
Typically, all new contributors should follow the existing style, so making it consistent will give a benefit in it.

After landing all commits, I will add them to `.git-blame-ignore-revs`.

