### PR TITLE
[NVPTX] Enable OpenCL 3d_image_writes support

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -172,6 +172,10 @@ public:
     Opts["cl_khr_local_int32_base_atomics"] = true;
     Opts["cl_khr_local_int32_extended_atomics"] = true;
 
+    Opts["__opencl_c_images"] = true;
+    Opts["__opencl_c_3d_image_writes"] = true;
+    Opts["cl_khr_3d_image_writes"] = true;
+
     Opts["__opencl_c_generic_address_space"] = true;
   }
 

--- a/clang/test/Misc/nvptx.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx.languageOptsOpenCL.cl
@@ -108,11 +108,10 @@
 #endif
 
 // Core feature in CL 2.0, but not supported on nvptx
-#ifdef cl_khr_3d_image_writes
-#error "Incorrect cl_khr_3d_image_writes define"
+#ifndef cl_khr_3d_image_writes
+#error "Missing cl_khr_3d_image_writes define"
 #endif
 #pragma OPENCL EXTENSION cl_khr_3d_image_writes: enable
-// expected-warning@-1{{unsupported OpenCL extension 'cl_khr_3d_image_writes' - ignoring}}
 
 #ifdef cl_khr_gl_msaa_sharing
 #error "Incorrect cl_khr_gl_msaa_sharing define"

--- a/clang/test/Misc/nvptx.unsupported_core.cl
+++ b/clang/test/Misc/nvptx.unsupported_core.cl
@@ -1,7 +1,0 @@
-// RUN: %clang_cc1 -cl-std=CL2.0 -triple nvptx-unknown-unknown -Wpedantic-core-features %s 2> %t
-// RUN: FileCheck --check-prefixes=CHECK-C < %t %s
-// RUN: %clang_cc1 -cl-std=CLC++ -triple nvptx-unknown-unknown -Wpedantic-core-features %s 2> %t
-// RUN: FileCheck --check-prefixes=CHECK-CPP < %t %s
-
-// CHECK-C: cl_khr_3d_image_writes is a core feature in OpenCL C version 2.0 but not supported on this target
-// CHECK-CPP: cl_khr_3d_image_writes is a core feature in C++ for OpenCL version 1.0 but not supported on this target


### PR DESCRIPTION
NV supports opencl_3d_image_writes according
https://developer.nvidia.com/blog/nvidia-is-now-opencl-3-0-conformant/

This PR allows removing explicit enabling of image extensions via -cl-ext command line option, e.g. at
https://github.com/intel/llvm/blob/43b3d42e2b2060e9e9e3a96469a1982dc4c10ddd/libclc/CMakeLists.txt#L503