### PR TITLE
[RISCV] Don't select sh{1,2,3}add if shl doesn't have one use

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14884,10 +14884,7 @@ static SDValue combineShlAddIAddImpl(SDNode *N, SDValue AddI, SDValue Other,
     return SDValue();
 
   APInt VShift;
-  if (!sd_match(SHLVal, m_BinOp(ISD::SHL, m_Value(), m_ConstInt(VShift))))
-    return SDValue();
-
-  if (!SHLVal.hasOneUse())
+  if (!sd_match(SHLVal, m_OneUse(m_Shl(m_Value(), m_ConstInt(VShift)))))
     return SDValue();
 
   if (VShift.slt(1) || VShift.sgt(3))

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14887,6 +14887,9 @@ static SDValue combineShlAddIAddImpl(SDNode *N, SDValue AddI, SDValue Other,
   if (!sd_match(SHLVal, m_BinOp(ISD::SHL, m_Value(), m_ConstInt(VShift))))
     return SDValue();
 
+  if (!SHLVal.hasOneUse())
+    return SDValue();
+
   if (VShift.slt(1) || VShift.sgt(3))
     return SDValue();
 

--- a/llvm/test/CodeGen/RISCV/reassoc-shl-addi-add.ll
+++ b/llvm/test/CodeGen/RISCV/reassoc-shl-addi-add.ll
@@ -8,10 +8,10 @@ declare i32 @callee(i32 noundef, i32 noundef, i32 noundef, i32 noundef)
 define void @t1(i32 noundef %a, i32 noundef %b, i32 noundef %c, i32 noundef %d) #0 {
 ; CHECK-LABEL: t1:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    sh2add a2, a0, a2
-; CHECK-NEXT:    sh2add a1, a0, a1
-; CHECK-NEXT:    addi a1, a1, 45
-; CHECK-NEXT:    addi a2, a2, 45
+; CHECK-NEXT:    slli a4, a0, 2
+; CHECK-NEXT:    addi a4, a4, 45
+; CHECK-NEXT:    add a1, a4, a1
+; CHECK-NEXT:    add a2, a4, a2
 ; CHECK-NEXT:    sh2add a3, a0, a3
 ; CHECK-NEXT:    mv a0, a1
 ; CHECK-NEXT:    tail callee
@@ -133,12 +133,11 @@ entry:
 define void @t8(i32 noundef %a, i32 noundef %b, i32 noundef %c, i32 noundef %d) #0 {
 ; CHECK-LABEL: t8:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    sh3add a2, a0, a2
-; CHECK-NEXT:    sh3add a1, a0, a1
 ; CHECK-NEXT:    lui a4, 1
 ; CHECK-NEXT:    addi a4, a4, 1307
-; CHECK-NEXT:    add a1, a1, a4
-; CHECK-NEXT:    add a2, a2, a4
+; CHECK-NEXT:    sh3add a4, a0, a4
+; CHECK-NEXT:    add a1, a4, a1
+; CHECK-NEXT:    add a2, a4, a2
 ; CHECK-NEXT:    sh3add a3, a0, a3
 ; CHECK-NEXT:    mv a0, a1
 ; CHECK-NEXT:    tail callee
@@ -155,10 +154,10 @@ entry:
 define void @t9(i32 noundef %a, i32 noundef %b, i32 noundef %c, i32 noundef %d) #0 {
 ; CHECK-LABEL: t9:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    sh2add a2, a0, a2
-; CHECK-NEXT:    sh2add a1, a0, a1
-; CHECK-NEXT:    addi a1, a1, -42
-; CHECK-NEXT:    addi a2, a2, -42
+; CHECK-NEXT:    slli a4, a0, 2
+; CHECK-NEXT:    addi a4, a4, -42
+; CHECK-NEXT:    add a1, a4, a1
+; CHECK-NEXT:    add a2, a4, a2
 ; CHECK-NEXT:    sh2add a3, a0, a3
 ; CHECK-NEXT:    mv a0, a1
 ; CHECK-NEXT:    tail callee


### PR DESCRIPTION
Try to fix https://github.com/llvm/llvm-project/pull/130829#pullrequestreview-2730533158. There's no benefit if shl doesn't have one use.