### PR TITLE
[RISCV] Select signed bitfield insert for XAndesPerf

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -696,8 +696,8 @@ bool RISCVDAGToDAGISel::trySignedBitfieldInsertInSign(SDNode *Node) {
   if (!N0.hasOneUse())
     return false;
 
-  auto BitfieldInsert = [&](SDValue N0, unsigned Msb, unsigned Lsb, SDLoc DL,
-                            MVT VT) {
+  auto BitfieldInsert = [&](SDValue N0, unsigned Msb, unsigned Lsb,
+                            const SDLoc &DL, MVT VT) {
     unsigned Opc = RISCV::NDS_BFOS;
     // If the Lsb is equal to the Msb, then the Lsb should be 0.
     if (Lsb == Msb)

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -683,6 +683,59 @@ bool RISCVDAGToDAGISel::trySignedBitfieldExtract(SDNode *Node) {
   return false;
 }
 
+bool RISCVDAGToDAGISel::trySignedBitfieldInsertInSign(SDNode *Node) {
+  // Only supported with XAndesPerf at the moment.
+  if (!Subtarget->hasVendorXAndesPerf())
+    return false;
+
+  auto *N1C = dyn_cast<ConstantSDNode>(Node->getOperand(1));
+  if (!N1C)
+    return false;
+
+  SDValue N0 = Node->getOperand(0);
+  if (!N0.hasOneUse())
+    return false;
+
+  auto BitfieldInsert = [&](SDValue N0, unsigned Msb, unsigned Lsb, SDLoc DL,
+                            MVT VT) {
+    unsigned Opc = RISCV::NDS_BFOS;
+    // If the Lsb is equal to the Msb, then the Lsb should be 0.
+    if (Lsb == Msb)
+      Lsb = 0;
+    return CurDAG->getMachineNode(Opc, DL, VT, N0.getOperand(0),
+                                  CurDAG->getTargetConstant(Lsb, DL, VT),
+                                  CurDAG->getTargetConstant(Msb, DL, VT));
+  };
+
+  SDLoc DL(Node);
+  MVT VT = Node->getSimpleValueType(0);
+  const unsigned RightShAmt = N1C->getZExtValue();
+
+  // Transform (sra (shl X, C1) C2) with C1 > C2
+  //        -> (NDS.BFOS X, lsb, msb)
+  if (N0.getOpcode() == ISD::SHL) {
+    auto *N01C = dyn_cast<ConstantSDNode>(N0->getOperand(1));
+    if (!N01C)
+      return false;
+
+    const unsigned LeftShAmt = N01C->getZExtValue();
+    // Make sure that this is a bitfield insertion (i.e., the shift-right
+    // amount should be less than the left-shift).
+    if (LeftShAmt <= RightShAmt)
+      return false;
+
+    const unsigned MsbPlusOne = VT.getSizeInBits() - RightShAmt;
+    const unsigned Msb = MsbPlusOne - 1;
+    const unsigned Lsb = LeftShAmt - RightShAmt;
+
+    SDNode *Sbi = BitfieldInsert(N0, Msb, Lsb, DL, VT);
+    ReplaceNode(Node, Sbi);
+    return true;
+  }
+
+  return false;
+}
+
 bool RISCVDAGToDAGISel::tryUnsignedBitfieldExtract(SDNode *Node,
                                                    const SDLoc &DL, MVT VT,
                                                    SDValue X, unsigned Msb,
@@ -1212,6 +1265,9 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
   }
   case ISD::SRA: {
     if (trySignedBitfieldExtract(Node))
+      return;
+
+    if (trySignedBitfieldInsertInSign(Node))
       return;
 
     // Optimize (sra (sext_inreg X, i16), C) ->

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -77,6 +77,7 @@ public:
 
   bool tryShrinkShlLogicImm(SDNode *Node);
   bool trySignedBitfieldExtract(SDNode *Node);
+  bool trySignedBitfieldInsertInSign(SDNode *Node);
   bool tryUnsignedBitfieldExtract(SDNode *Node, const SDLoc &DL, MVT VT,
                                   SDValue X, unsigned Msb, unsigned Lsb);
   bool tryUnsignedBitfieldInsertInZero(SDNode *Node, const SDLoc &DL, MVT VT,

--- a/llvm/test/CodeGen/RISCV/rv32xandesperf.ll
+++ b/llvm/test/CodeGen/RISCV/rv32xandesperf.ll
@@ -159,8 +159,7 @@ define i32 @bfos_from_ashr_sexti16_i32(i16 %x) {
 define i32 @bfos_from_ashr_shl_with_msb_zero_insert_i32(i32 %x) {
 ; CHECK-LABEL: bfos_from_ashr_shl_with_msb_zero_insert_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 31
-; CHECK-NEXT:    srai a0, a0, 17
+; CHECK-NEXT:    nds.bfos a0, a0, 0, 14
 ; CHECK-NEXT:    ret
   %shl = shl i32 %x, 31
   %lshr = ashr i32 %shl, 17
@@ -172,8 +171,7 @@ define i32 @bfos_from_ashr_shl_with_msb_zero_insert_i32(i32 %x) {
 define i32 @bfos_from_ashr_shl_insert_i32(i32 %x) {
 ; CHECK-LABEL: bfos_from_ashr_shl_insert_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 29
-; CHECK-NEXT:    srai a0, a0, 11
+; CHECK-NEXT:    nds.bfos a0, a0, 18, 20
 ; CHECK-NEXT:    ret
   %shl = shl i32 %x, 29
   %lshr = ashr i32 %shl, 11

--- a/llvm/test/CodeGen/RISCV/rv32xandesperf.ll
+++ b/llvm/test/CodeGen/RISCV/rv32xandesperf.ll
@@ -154,6 +154,34 @@ define i32 @bfos_from_ashr_sexti16_i32(i16 %x) {
   ret i32 %ashr
 }
 
+; MSB = 0
+
+define i32 @bfos_from_ashr_shl_with_msb_zero_insert_i32(i32 %x) {
+; CHECK-LABEL: bfos_from_ashr_shl_with_msb_zero_insert_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 31
+; CHECK-NEXT:    srai a0, a0, 17
+; CHECK-NEXT:    ret
+  %shl = shl i32 %x, 31
+  %lshr = ashr i32 %shl, 17
+  ret i32 %lshr
+}
+
+; MSB < LSB
+
+define i32 @bfos_from_ashr_shl_insert_i32(i32 %x) {
+; CHECK-LABEL: bfos_from_ashr_shl_insert_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 29
+; CHECK-NEXT:    srai a0, a0, 11
+; CHECK-NEXT:    ret
+  %shl = shl i32 %x, 29
+  %lshr = ashr i32 %shl, 11
+  ret i32 %lshr
+}
+
+; sext
+
 define i32 @sexti1_i32(i32 %a) {
 ; CHECK-LABEL: sexti1_i32:
 ; CHECK:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rv64xandesperf.ll
+++ b/llvm/test/CodeGen/RISCV/rv64xandesperf.ll
@@ -212,6 +212,56 @@ define i64 @bfos_from_ashr_sexti16_i64(i16 %x) {
   ret i64 %ashr
 }
 
+; MSB = 0
+
+define i32 @bfos_from_ashr_shl_with_msb_zero_insert_i32(i32 %x) {
+; CHECK-LABEL: bfos_from_ashr_shl_with_msb_zero_insert_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 63
+; CHECK-NEXT:    srai a0, a0, 49
+; CHECK-NEXT:    ret
+  %shl = shl i32 %x, 31
+  %lshr = ashr i32 %shl, 17
+  ret i32 %lshr
+}
+
+define i64 @bfos_from_ashr_shl_with_msb_zero_insert_i64(i64 %x) {
+; CHECK-LABEL: bfos_from_ashr_shl_with_msb_zero_insert_i64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 63
+; CHECK-NEXT:    srai a0, a0, 17
+; CHECK-NEXT:    ret
+  %shl = shl i64 %x, 63
+  %lshr = ashr i64 %shl, 17
+  ret i64 %lshr
+}
+
+; MSB < LSB
+
+define i32 @bfos_from_ashr_shl_insert_i32(i32 %x) {
+; CHECK-LABEL: bfos_from_ashr_shl_insert_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 61
+; CHECK-NEXT:    srai a0, a0, 43
+; CHECK-NEXT:    ret
+  %shl = shl i32 %x, 29
+  %lshr = ashr i32 %shl, 11
+  ret i32 %lshr
+}
+
+define i64 @bfos_from_ashr_shl_insert_i64(i64 %x) {
+; CHECK-LABEL: bfos_from_ashr_shl_insert_i64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 29
+; CHECK-NEXT:    srai a0, a0, 11
+; CHECK-NEXT:    ret
+  %shl = shl i64 %x, 29
+  %lshr = ashr i64 %shl, 11
+  ret i64 %lshr
+}
+
+; sext
+
 define signext i32 @sexti1_i32(i32 signext %a) {
 ; CHECK-LABEL: sexti1_i32:
 ; CHECK:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rv64xandesperf.ll
+++ b/llvm/test/CodeGen/RISCV/rv64xandesperf.ll
@@ -217,8 +217,7 @@ define i64 @bfos_from_ashr_sexti16_i64(i16 %x) {
 define i32 @bfos_from_ashr_shl_with_msb_zero_insert_i32(i32 %x) {
 ; CHECK-LABEL: bfos_from_ashr_shl_with_msb_zero_insert_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 63
-; CHECK-NEXT:    srai a0, a0, 49
+; CHECK-NEXT:    nds.bfos a0, a0, 0, 14
 ; CHECK-NEXT:    ret
   %shl = shl i32 %x, 31
   %lshr = ashr i32 %shl, 17
@@ -228,8 +227,7 @@ define i32 @bfos_from_ashr_shl_with_msb_zero_insert_i32(i32 %x) {
 define i64 @bfos_from_ashr_shl_with_msb_zero_insert_i64(i64 %x) {
 ; CHECK-LABEL: bfos_from_ashr_shl_with_msb_zero_insert_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 63
-; CHECK-NEXT:    srai a0, a0, 17
+; CHECK-NEXT:    nds.bfos a0, a0, 0, 46
 ; CHECK-NEXT:    ret
   %shl = shl i64 %x, 63
   %lshr = ashr i64 %shl, 17
@@ -241,8 +239,7 @@ define i64 @bfos_from_ashr_shl_with_msb_zero_insert_i64(i64 %x) {
 define i32 @bfos_from_ashr_shl_insert_i32(i32 %x) {
 ; CHECK-LABEL: bfos_from_ashr_shl_insert_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 61
-; CHECK-NEXT:    srai a0, a0, 43
+; CHECK-NEXT:    nds.bfos a0, a0, 18, 20
 ; CHECK-NEXT:    ret
   %shl = shl i32 %x, 29
   %lshr = ashr i32 %shl, 11
@@ -252,8 +249,7 @@ define i32 @bfos_from_ashr_shl_insert_i32(i32 %x) {
 define i64 @bfos_from_ashr_shl_insert_i64(i64 %x) {
 ; CHECK-LABEL: bfos_from_ashr_shl_insert_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 29
-; CHECK-NEXT:    srai a0, a0, 11
+; CHECK-NEXT:    nds.bfos a0, a0, 18, 52
 ; CHECK-NEXT:    ret
   %shl = shl i64 %x, 29
   %lshr = ashr i64 %shl, 11


### PR DESCRIPTION
This patch is similar to #142737

The XAndesPerf extension includes signed bitfield extraction
instruction `NDS.BFOS, which can extract the bits from 0 to Len - 1,
place them starting at bit Lsb, zero-filled the bits from 0 to Lsb -1, 
and sign-extend the result.

When Lsb == Msb, it is a special case where the Lsb will be set to 0 instead of
being equal to the Msb.