### PR TITLE
[AArch64][Subtarget] add missing direct include of Triple.h

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -26,6 +26,7 @@
 #include "llvm/CodeGen/RegisterBankInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/DataLayout.h"
+#include "llvm/TargetParser/Triple.h"
 
 #define GET_SUBTARGETINFO_HEADER
 #include "AArch64GenSubtargetInfo.inc"
@@ -33,7 +34,6 @@
 namespace llvm {
 class GlobalValue;
 class StringRef;
-class Triple;
 
 class AArch64Subtarget final : public AArch64GenSubtargetInfo {
 public:


### PR DESCRIPTION
`AArch64Subtarget.h` uses the complete type of `Triple`, but had only forward declared the class, which happend to be included through the following bottom-up path for example: "llvm/TargetParser/Triple.h"
"llvm/MC/MCSubtargetInfo.h"
"llvm/CodeGen/TargetSubtargetInfo.h"