### PR TITLE
[GlobalISel] Fixes unused variable error in testMOPredicate_MO

### DIFF
--- a/llvm/test/TableGen/GlobalISelEmitter/GlobalISelEmitter.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/GlobalISelEmitter.td
@@ -167,6 +167,7 @@ def HasC : Predicate<"Subtarget->hasC()"> { let RecomputePerFunction = 1; }
 // CHECK-NEXT:    const auto &Operands = State.RecordedOperands; 
 // CHECK-NEXT:    Register Reg = MO.getReg();
 // CHECK-NEXT:    (void)Operands; 
+// CHECK-NEXT:    (void)Reg;
 // CHECK-NEXT:    switch (PredicateID) {
 // CHECK-NEXT:    case GICXXPred_MO_Predicate_leaf: {
 // CHECK-NEXT:       return true;

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -2314,7 +2314,8 @@ void GlobalISelEmitter::emitLeafPredicateFns(raw_ostream &OS) {
       OS,
       "  const auto &Operands = State.RecordedOperands;\n"
       "  Register Reg = MO.getReg();\n"
-      "  (void)Operands;",
+      "  (void)Operands;\n"
+      "  (void)Reg;",
       ArrayRef<const Record *>(MatchedRecords), &getPatFragPredicateEnumName,
       [](const Record *R) {
         return R->getValueAsString("GISelLeafPredicateCode");


### PR DESCRIPTION
Solves unused variable error in generated Global ISel code due to changes from #140935 