### PR TITLE
[mlir][SparseTensor] Re-enable tests on AArch64

### DIFF
--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/dense_output_bf16.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/dense_output_bf16.mlir
@@ -28,8 +28,6 @@
 // REDEFINE: %{sparsifier_opts} = enable-runtime-library=false vl=2 reassociate-fp-reductions=true enable-index-optimizations=true
 // RUN: %{compile} | %{run} | FileCheck %s
 
-// UNSUPPORTED: target=aarch64{{.*}}
-
 #SparseVector = #sparse_tensor.encoding<{map = (d0) -> (d0 : compressed)}>
 #DenseVector = #sparse_tensor.encoding<{map = (d0) -> (d0 : dense)}>
 

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_sum_bf16.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_sum_bf16.mlir
@@ -30,8 +30,6 @@
 // Do the same run, but now with  VLA vectorization.
 // RUN: %if mlir_arm_sve_tests %{ %{compile_sve} | %{run_sve} | FileCheck %s %}
 
-// UNSUPPORTED: target=aarch64{{.*}}, mlir_arm_emulator
-
 !Filename = !llvm.ptr
 
 #SparseMatrix = #sparse_tensor.encoding<{


### PR DESCRIPTION
These tests were disabled in https://reviews.llvm.org/D136273, due to:
* https://github.com/llvm/llvm-project/issues/58465

That issue has now been resolved, so we should be able to re-enable
these tests.

**NOTE:** Currently blocked by https://github.com/llvm/llvm-project/issues/143386