### PR TITLE
[OpenMP] Add `OPENMP_INCLUDE_TESTS`

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -17,6 +17,8 @@ else()
   set(OPENMP_STANDALONE_BUILD FALSE)
 endif()
 
+option(OPENMP_INCLUDE_TESTS "Generate and build openmp tests." ${LLVM_INCLUDE_TESTS})
+
 # Must go below project(..)
 include(GNUInstallDirs)
 
@@ -104,7 +106,9 @@ include(config-ix)
 include(HandleOpenMPOptions)
 
 # Set up testing infrastructure.
-include(OpenMPTesting)
+if(OPENMP_INCLUDE_TESTS)
+  include(OpenMPTesting)
+endif()
 
 set(OPENMP_TEST_FLAGS "" CACHE STRING
   "Extra compiler flags to send to the test compiler.")
@@ -164,4 +168,6 @@ add_subdirectory(libompd)
 add_subdirectory(docs)
 
 # Now that we have seen all testsuites, create the check-openmp target.
-construct_check_openmp_target()
+if(OPENMP_INCLUDE_TESTS)
+  construct_check_openmp_target()
+endif()

--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -13,11 +13,11 @@ list(INSERT CMAKE_MODULE_PATH 0
 if (OPENMP_STANDALONE_BUILD OR "${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   set(OPENMP_STANDALONE_BUILD TRUE)
   project(openmp C CXX ASM)
+  option(OPENMP_INCLUDE_TESTS "Generate and build openmp tests." ON)
 else()
   set(OPENMP_STANDALONE_BUILD FALSE)
+  option(OPENMP_INCLUDE_TESTS "Generate and build openmp tests." ${LLVM_INCLUDE_TESTS})
 endif()
-
-option(OPENMP_INCLUDE_TESTS "Generate and build openmp tests." ${LLVM_INCLUDE_TESTS})
 
 # Must go below project(..)
 include(GNUInstallDirs)

--- a/openmp/README.rst
+++ b/openmp/README.rst
@@ -123,6 +123,10 @@ Options for all Libraries
   Compiler to use for testing. Defaults to the compiler that was also used for
   building. Will default to flang if build is in-tree.
 
+**OPENMP_INCLUDE_TESTS** = ``${LLVM_INCLUDE_TESTS}``
+  Enable generation and build of test suite. Defaults to ``LLVM_INCLUDE_TESTS``
+  if built as part of LLVM, otherwise defaults to ``ON``.
+
 **OPENMP_LLVM_TOOLS_DIR** = ``/path/to/built/llvm/tools``
   Additional path to search for LLVM tools needed by tests.
 

--- a/openmp/libompd/CMakeLists.txt
+++ b/openmp/libompd/CMakeLists.txt
@@ -18,9 +18,9 @@ if(LIBOMP_OMPD_SUPPORT)
     add_subdirectory(src)
     if(LIBOMP_OMPD_GDB_SUPPORT)
         add_subdirectory(gdb-plugin)
-		# GDB is required to run the tests
-		if (GDB_FOUND)
-	        add_subdirectory(test)
-		endif()
+        # GDB is required to run the tests
+        if (GDB_FOUND AND OPENMP_INCLUDE_TESTS)
+            add_subdirectory(test)
+        endif()
     endif()
 endif()

--- a/openmp/runtime/CMakeLists.txt
+++ b/openmp/runtime/CMakeLists.txt
@@ -468,7 +468,9 @@ if(${OPENMP_STANDALONE_BUILD})
 endif()
 
 add_subdirectory(src)
-add_subdirectory(test)
+if(OPENMP_INCLUDE_TESTS)
+  add_subdirectory(test)
+endif()
 
 # make these variables available for tools:
 set(LIBOMP_LIBRARY_DIR ${LIBOMP_LIBRARY_DIR} PARENT_SCOPE)

--- a/openmp/tools/archer/CMakeLists.txt
+++ b/openmp/tools/archer/CMakeLists.txt
@@ -34,5 +34,7 @@ if(LIBOMP_OMPT_SUPPORT AND LIBOMP_ARCHER_SUPPORT)
     LIBRARY DESTINATION ${OPENMP_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${OPENMP_INSTALL_LIBDIR})
 
-  add_subdirectory(tests)
+  if(OPENMP_INCLUDE_TESTS)
+    add_subdirectory(tests)
+  endif()
 endif()

--- a/openmp/tools/multiplex/CMakeLists.txt
+++ b/openmp/tools/multiplex/CMakeLists.txt
@@ -6,5 +6,7 @@ if(LIBOMP_OMPT_SUPPORT)
 
   install(FILES ompt-multiplex.h DESTINATION "${LIBOMP_HEADERS_INSTALL_PATH}")
 
-  add_subdirectory(tests)
+  if(OPENMP_INCLUDE_TESTS)
+    add_subdirectory(tests)
+  endif()
 endif()


### PR DESCRIPTION
This is a cmake variable which, if set to `OFF`, will disable building/configuring of
tests. It defaults to the value of `LLVM_INCLUDE_TESTS`.
