### PR TITLE
[NFC][DebugInfo] Make MDNodeKeyImpl<DILocation>::Column 16 bits

### DIFF
--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -311,7 +311,7 @@ template <> struct MDNodeKeyImpl<MDTuple> : MDNodeOpsKey {
 /// DenseMapInfo for DILocation.
 template <> struct MDNodeKeyImpl<DILocation> {
   unsigned Line;
-  unsigned Column;
+  uint16_t Column;
   Metadata *Scope;
   Metadata *InlinedAt;
   bool ImplicitCode;

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -320,7 +320,7 @@ template <> struct MDNodeKeyImpl<DILocation> {
   uint64_t AtomRank : 3;
 #endif
 
-  MDNodeKeyImpl(unsigned Line, unsigned Column, Metadata *Scope,
+  MDNodeKeyImpl(unsigned Line, uint16_t Column, Metadata *Scope,
                 Metadata *InlinedAt, bool ImplicitCode, uint64_t AtomGroup,
                 uint8_t AtomRank)
       : Line(Line), Column(Column), Scope(Scope), InlinedAt(InlinedAt),


### PR DESCRIPTION
Column is limited to 16 bits in several places in the compiler: https://github.com/llvm/llvm-project/blob/a3c7d461456f2da25c1d119b6686773f675e313e/llvm/lib/IR/DebugInfoMetadata.cpp#L87
  https://github.com/llvm/llvm-project/blob/a3c7d461456f2da25c1d119b6686773f675e313e/llvm/lib/AsmParser/LLParser.cpp#L4706

Slight compile time improvement due to reducing `hash_combine` workload in `MDNodeKeyImpl<DILocation>::getHashValue()`.

https://llvm-compile-time-tracker.com/compare.php?from=2b7b0e178259a910355631d7d648c89052000872&to=89490929c34f45842df1588cf78d836f51c2c222&stat=instructions%3Au

(positively affects compile time regardless of whether Key Instructions is enabled)