### PR TITLE
[OpenMP] Use "standalone" include path if clang is not being built

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -126,7 +126,7 @@ option(OPENMP_ENABLE_LIBOMPTARGET "Enable building libomptarget for offloading."
 option(OPENMP_ENABLE_LIBOMP_PROFILING "Enable time profiling for libomp." OFF)
 
 # Header install location
-if(NOT LLVM_TREE_AVAILABLE)
+if(NOT LLVM_TREE_AVAILABLE OR NOT Clang_DIR)
   set(LIBOMP_HEADERS_INSTALL_PATH "${CMAKE_INSTALL_INCLUDEDIR}")
 else()
   include(GetClangResourceDir)

--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -11,7 +11,7 @@
 include(ExtendPath)
 
 # The generated headers will be placed in clang's resource directory if present.
-if(NOT LLVM_TREE_AVAILABLE)
+if(NOT LLVM_TREE_AVAILABLE OR NOT Clang_DIR)
   set(LIBOMP_HEADERS_INTDIR ${CMAKE_CURRENT_BINARY_DIR})
 else()
   set(LIBOMP_HEADERS_INTDIR ${LLVM_BINARY_DIR}/${LIBOMP_HEADERS_INSTALL_PATH})


### PR DESCRIPTION
If clang is not being built as part of this build, install headers into
`include` rather than `lib/clang/21/include` (the latter, in clangless
builds, will not be automatically included in search paths).

This, combined with #143390 , allows builds that include OpenMP but not
clang to build successfully.
