### PR TITLE
Use spelling for clangd missing includes filtering

### DIFF
--- a/clang-tools-extra/clangd/IncludeCleaner.cpp
+++ b/clang-tools-extra/clangd/IncludeCleaner.cpp
@@ -148,7 +148,7 @@ std::vector<Diag> generateMissingIncludeDiagnostics(
     if (SymbolWithMissingInclude.Providers.front().kind() ==
         include_cleaner::Header::Kind::Physical) {
       for (auto &Filter : Angled ? QuotedHeaders : AngledHeaders) {
-        if (Filter(ResolvedPath)) {
+        if (Filter(HeaderRef)) {
           Angled = !Angled;
           break;
         }


### PR DESCRIPTION
As part of https://github.com/llvm/llvm-project/pull/140594, support was added for configuring the inclusion style of clangd's missing includes feature. For filtering the headers, the resolved path of the header was used instead of its spelling. It turns out that the spelling is intentionally used in other components like clang-tidy, leading to inconsistency between the tools. More details [here](https://github.com/llvm/llvm-project/pull/140594#issuecomment-2954770590).