### PR TITLE
[bazel] Revert "[bazel] llvm-config.h: Turn on LLVM_ENABLE_PLUGINS" as it fails TensorFlow Windows build

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
+++ b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
@@ -124,9 +124,6 @@
 /* Define to 1 if you have the DIA SDK installed, and to 0 if you don't. */
 #define LLVM_ENABLE_DIA_SDK 0
 
-/* Define if plugins enabled */
-#define LLVM_ENABLE_PLUGINS
-
 /* Define if building LLVM with LLVM_ENABLE_TELEMETRY */
 #define LLVM_ENABLE_TELEMETRY 1
 


### PR DESCRIPTION
Here is the error message

[3,466 / 5,762] 1 / 149 tests; [Sched] Compiling llvm/lib/Support/BinaryStreamError.cpp ... (456 actions, 2 running)
ERROR: C:/t/g5cdusdm/external/llvm-project/llvm/BUILD.bazel:253:11: Compiling llvm/lib/Support/ExtensibleRTTI.cpp [for tool] failed: (Exit 1): clang-cl.exe failed: error executing CppCompile command (from target @@llvm-project//llvm:Support) 
  cd /d C:/t/g5cdusdm/execroot/org_tensorflow
  SET INCLUDE=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\include;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\VS\include;C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt;C:\tools\LLVM\lib\clang\18\include
    SET PATH=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\bin\HostX64\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\VCPackages;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer;C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\bin\Roslyn;C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\\x64;C:\Program Files (x86)\Windows Kits\10\bin\\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\\MSBuild\Current\Bin\amd64;C:\Windows\Microsoft.NET\Framework64\v4.0.30319;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\;;C:\Windows\system32;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\Linux\bin\ConnectionManagerExe
    SET PWD=/proc/self/cwd
    SET TEMP=C:\TMP
    SET TMP=C:\TMP
    SET VSLANG=1033
  C:\tools\LLVM\bin\clang-cl.exe /nologo /DCOMPILER_MSVC /DNOMINMAX /D_WIN32_WINNT=0x0601 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /bigobj /Zm500 /EHsc /wd4351 /wd4291 /wd4250 /wd4996 /Iexternal/llvm-project /Ibazel-out/x64_windows-opt-exec-ST-766941a09caf/bin/external/llvm-project /Iexternal/llvm-project/llvm/include /Ibazel-out/x64_windows-opt-exec-ST-766941a09caf/bin/external/llvm-project/llvm/include /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_CRT_NONSTDC_NO_WARNINGS /D_SCL_SECURE_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS /DUNICODE /D_UNICODE /DLTDL_SHLIB_EXT=".dll" /DLLVM_PLUGIN_EXT=".dll" /DLLVM_NATIVE_ARCH="X86" /DLLVM_NATIVE_ASMPARSER=LLVMInitializeX86AsmParser /DLLVM_NATIVE_ASMPRINTER=LLVMInitializeX86AsmPrinter /DLLVM_NATIVE_DISASSEMBLER=LLVMInitializeX86Disassembler /DLLVM_NATIVE_TARGET=LLVMInitializeX86Target /DLLVM_NATIVE_TARGETINFO=LLVMInitializeX86TargetInfo /DLLVM_NATIVE_TARGETMC=LLVMInitializeX86TargetMC /DLLVM_NATIVE_TARGETMCA=LLVMInitializeX86TargetMCA /DLLVM_HOST_TRIPLE="x86_64-pc-win32" /DLLVM_DEFAULT_TARGET_TRIPLE="x86_64-pc-win32" /DLLVM_VERSION_MAJOR=21 /DLLVM_VERSION_MINOR=0 /DLLVM_VERSION_PATCH=0 /DLLVM_VERSION_STRING="21.0.0git" /D__STDC_LIMIT_MACROS /D__STDC_CONSTANT_MACROS /D__STDC_FORMAT_MACROS /DLLVM_HAS_AArch64_TARGET=1 /DLLVM_HAS_AMDGPU_TARGET=1 /DLLVM_HAS_ARM_TARGET=1 /DLLVM_HAS_NVPTX_TARGET=1 /DLLVM_HAS_PowerPC_TARGET=1 /DLLVM_HAS_RISCV_TARGET=1 /DLLVM_HAS_SystemZ_TARGET=1 /DLLVM_HAS_X86_TARGET=1 /DBLAKE3_USE_NEON=0 /DBLAKE3_NO_AVX2 /DBLAKE3_NO_AVX512 /DBLAKE3_NO_SSE2 /DBLAKE3_NO_SSE41 /showIncludes /MD /O2 /Oy- /DNDEBUG /wd4117 -D__DATE__="redacted" -D__TIMESTAMP__="redacted" -D__TIME__="redacted" -Wno-builtin-macro-redefined /Gy /Gw /W0 /Zc:__cplusplus /D_USE_MATH_DEFINES /d2ReducedOptimizeHugeFunctions -D_ENABLE_EXTENDED_ALIGNED_STORAGE -DWIN32_LEAN_AND_MEAN -DNOGDI /Zc:preprocessor /clang:-Weverything /clang:-Weverything /d2ReducedOptimizeHugeFunctions /std:c++17 /Fobazel-out/x64_windows-opt-exec-ST-766941a09caf/bin/external/llvm-project/llvm/_objs/Support/ExtensibleRTTI.obj /c external/llvm-project/llvm/lib/Support/ExtensibleRTTI.cpp
# Configuration: f85b29406574d83c673497718f542456050c5649ae41eb37a803b7085e15c4ef
# Execution platform: //tensorflow/tools/toolchains/win2022:windows_ltsc2022_clang
external/llvm-project/llvm/lib/Support/ExtensibleRTTI.cpp(12,22): error: definition of dllimport static field not allowed
   12 | char llvm::RTTIRoot::ID = 0;
      |                      ^
external/llvm-project/llvm/include\llvm/Support/ExtensibleRTTI.h(71,7): note: attribute is here
   71 | class LLVM_ABI RTTIRoot {
      |       ^
external/llvm-project/llvm/include\llvm/Support/Compiler.h(205,29): note: expanded from macro 'LLVM_ABI'
  205 | #define LLVM_ABI __declspec(dllimport)
      |                             ^
1 error generated.