### PR TITLE
[llvm][CFI] Ensure COFF comdat renaming applies for imported functions

### DIFF
--- a/llvm/test/Transforms/LowerTypeTests/Inputs/import-thinlto-funcs.yaml
+++ b/llvm/test/Transforms/LowerTypeTests/Inputs/import-thinlto-funcs.yaml
@@ -1,0 +1,5 @@
+---
+CfiFunctionDefs:
+  - f1
+  - f2
+...

--- a/llvm/test/Transforms/LowerTypeTests/cfi-coff-comdat-rename.ll
+++ b/llvm/test/Transforms/LowerTypeTests/cfi-coff-comdat-rename.ll
@@ -1,5 +1,6 @@
 ; REQUIRES: x86-registered-target
 ; RUN: opt -S -passes=lowertypetests %s | FileCheck %s
+; RUN: opt -S -passes=lowertypetests -lowertypetests-summary-action=import -lowertypetests-read-summary=%p/Inputs/import-thinlto-funcs.yaml %s | FileCheck %s
 
 ;; This is a check to assert we don't crash with:
 ;;
@@ -7,6 +8,7 @@
 ;;
 ;; So this just needs to exit normally.
 ; RUN: opt -S -passes=lowertypetests %s | llc -asm-verbose=false
+; RUN: opt -S -passes=lowertypetests -lowertypetests-summary-action=import -lowertypetests-read-summary=%p/Inputs/import-thinlto-funcs.yaml %s | llc -asm-verbose=false
 
 target datalayout = "e-p:64:64"
 target triple = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
I ran into the same issue as
https://github.com/llvm/llvm-project/pull/139962 regarding the comdat corresponding to a renamed key function but for thinlto. My last patch had not considered the thinlto case, so this applies the same fix for imported functions.