### PR TITLE
[SPIRV] enable and copy device implementation for logb and scalbn builtins

### DIFF
--- a/clang/lib/CodeGen/Targets/SPIR.cpp
+++ b/clang/lib/CodeGen/Targets/SPIR.cpp
@@ -46,6 +46,7 @@ public:
   CommonSPIRTargetCodeGenInfo(std::unique_ptr<ABIInfo> ABIInfo)
       : TargetCodeGenInfo(std::move(ABIInfo)) {}
 
+  bool supportsLibCall() const override { return false; }
   LangAS getASTAllocaAddressSpace() const override {
     return getLangASFromTargetAS(
         getABIInfo().getDataLayout().getAllocaAddrSpace());


### PR DESCRIPTION
Copied from previous AMDGPU implementation commit 77de8a0, PR #129347