### PR TITLE
[clang][analyzer] Update python dependency versions

### DIFF
--- a/clang/utils/analyzer/requirements.txt
+++ b/clang/utils/analyzer/requirements.txt
@@ -1,6 +1,6 @@
 graphviz
 humanize
 matplotlib
-pandas
-psutil
+pandas>=1.0.4
+psutil>=5.6.6
 seaborn


### PR DESCRIPTION
We need to make sure we aren't vulnerable to [PYSEC-2020-73](https://osv.dev/vulnerability/PYSEC-2020-73) and [PYSEC-2019-41](https://osv.dev/vulnerability/PYSEC-2019-41).