### PR TITLE
[MLIR] Use mlir_target_link_libraries with MLIRTestIRDLToCppDialect

### DIFF
--- a/mlir/test/lib/Dialect/TestIRDLToCpp/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/TestIRDLToCpp/CMakeLists.txt
@@ -7,8 +7,9 @@ add_mlir_library(MLIRTestIRDLToCppDialect
 
   DEPENDS
   TestIRDLToCppGen
+)
 
-  LINK_LIBS PUBLIC
+mlir_target_link_libraries(MLIRTestIRDLToCppDialect PUBLIC
   MLIRIR
   MLIRPass
   MLIRTransforms


### PR DESCRIPTION
Replace LINK_LIBS with mlir_target_link_libraries.
Fixes #143246.

Suggested-by: Nikita Popov <npopov@redhat.com>