### PR TITLE
[Clang][NFC][ByteCode] Initialize Function HasBody in constructor

### DIFF
--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -23,7 +23,7 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
       ParamTypes(std::move(ParamTypes)), Params(std::move(Params)),
       ParamOffsets(std::move(ParamOffsets)), IsValid(false),
       IsFullyCompiled(false), HasThisPointer(HasThisPointer), HasRVO(HasRVO),
-      Defined(false) {
+      HasBody(false), Defined(false) {
   if (const auto *F = dyn_cast<const FunctionDecl *>(Source)) {
     Variadic = F->isVariadic();
     Immediate = F->isImmediateFunction();


### PR DESCRIPTION
Static analysis flagged HasBody as not being initialized during construction. It looks like an oversight in: https://github.com/llvm/llvm-project/pull/139671

This would be a lot simpler with C++20 which allows in class initialization of bit-fields.