### PR TITLE
[clang][NFC] Remove dead PassTypeToPlacementDelete field

### DIFF
--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -1446,8 +1446,6 @@ namespace {
     unsigned NumPlacementArgs : 30;
     LLVM_PREFERRED_TYPE(AlignedAllocationMode)
     unsigned PassAlignmentToPlacementDelete : 1;
-    LLVM_PREFERRED_TYPE(TypeAwareAllocationMode)
-    unsigned PassTypeToPlacementDelete : 1;
     const FunctionDecl *OperatorDelete;
     RValueTy TypeIdentity;
     ValueTy Ptr;


### PR DESCRIPTION
The CallDeleteDuringNew::PassTypeToPlacementDelete field became unneeded during the many refactorings of P2719 but I didn't actually remove it.