### PR TITLE
[libc] Simplify wcscmp

### DIFF
--- a/libc/src/wchar/wcscmp.cpp
+++ b/libc/src/wchar/wcscmp.cpp
@@ -19,12 +19,10 @@ LLVM_LIBC_FUNCTION(int, wcscmp, (const wchar_t *left, const wchar_t *right)) {
   LIBC_CRASH_ON_NULLPTR(left);
   LIBC_CRASH_ON_NULLPTR(right);
 
-  auto comp = [](wchar_t l, wchar_t r) -> int { return l - r; };
-
-  for (; *left && !comp(*left, *right); ++left, ++right)
+  for (; *left && (*left == *right); ++left, ++right)
     ;
 
-  return comp(*left, *right);
+  return *left - *right;
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
The implementation of wcscmp mimicked strcmp, but was more complicated
than necessary. This patch makes it simpler.
