### PR TITLE
[WholeProgramDevirt] Add check for AvailableExternal and give up icall.branch.funnel

### DIFF
--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -1093,7 +1093,7 @@ bool DevirtModule::tryFindVirtualCallTargets(
     std::vector<VirtualCallTarget> &TargetsForSlot,
     const std::set<TypeMemberInfo> &TypeMemberInfos, uint64_t ByteOffset,
     ModuleSummaryIndex *ExportSummary) {
-  bool hasAvailableExternally = false;
+  bool HasAvailableExternally = false;
   for (const TypeMemberInfo &TM : TypeMemberInfos) {
     if (!TM.Bits->GV->isConstant())
       return false;
@@ -1106,11 +1106,11 @@ bool DevirtModule::tryFindVirtualCallTargets(
 
     // Record if the first GV is AvailableExternally
     if (TargetsForSlot.empty())
-      hasAvailableExternally = TM.Bits->GV->hasAvailableExternallyLinkage();
+      HasAvailableExternally = TM.Bits->GV->hasAvailableExternallyLinkage();
 
     // When the first GV is AvailableExternally, check if all other GVs are
     // also AvailableExternally. If they are not the same, return false.
-    if (!TargetsForSlot.empty() && hasAvailableExternally &&
+    if (!TargetsForSlot.empty() && HasAvailableExternally &&
         !TM.Bits->GV->hasAvailableExternallyLinkage())
       return false;
 

--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -1456,7 +1456,17 @@ void DevirtModule::tryICallBranchFunnel(
   if (!HasNonDevirt)
     return;
 
-  // If any GV is AvailableExternally, drop to generate branch.funnel
+  // If any GV is AvailableExternally, not to generate branch.funnel.
+  // NOTE: It is to avoid crash in LowerTypeTest.
+  // If the branch.funnel is generated, because GV.isDeclarationForLinker(),
+  // in LowerTypeTestsModule::lower(), its GlobalTypeMember would NOT
+  // be saved in GlobalTypeMembers[&GV]. Then crash happens in
+  // buildBitSetsFromDisjointSet due to GlobalTypeMembers[&GV] is NULL.
+  // Even doing experiment to save it in GlobalTypeMembers[&GV] and
+  // making GlobalTypeMembers[&GV] be not NULL, crash could avoid from
+  // buildBitSetsFromDisjointSet. But still report_fatal_error in Verifier
+  // or SelectionDAGBuilder later, because operands linkage type consistency
+  // check of icall.branch.funnel can not pass.
   for (auto &T : TargetsForSlot) {
     if (T.TM->Bits->GV->hasAvailableExternallyLinkage())
       return;

--- a/llvm/test/Transforms/WholeProgramDevirt/availableexternal-check.ll
+++ b/llvm/test/Transforms/WholeProgramDevirt/availableexternal-check.ll
@@ -26,13 +26,14 @@ target triple = "x86_64-unknown-linux"
 
 declare ptr @_ZNKSt9exception4whatEv()
 
-define i64 @_Z4testPSt9exception() {
-  %1 = call i1 @llvm.type.test(ptr null, metadata !"_ZTSSt9exception")
-  tail call void @llvm.assume(i1 %1)
-  %2 = getelementptr i8, ptr null, i64 16
-  %3 = load ptr, ptr %2, align 8
-  %4 = tail call ptr %3(ptr null)
-  ret i64 0
+define ptr @_Z4testPSt9exception() {
+  %1 = load ptr, ptr null, align 8
+  %2 = call i1 @llvm.type.test(ptr %1, metadata !"_ZTSSt9exception")
+  tail call void @llvm.assume(i1 %2)
+  %3 = getelementptr i8, ptr %1, i64 16
+  %4 = load ptr, ptr %3, align 8
+  %5 = tail call ptr %4(ptr null)
+  ret ptr %5
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write)

--- a/llvm/test/Transforms/WholeProgramDevirt/availableexternal-check.ll
+++ b/llvm/test/Transforms/WholeProgramDevirt/availableexternal-check.ll
@@ -8,7 +8,7 @@
 ; };
 ; long test(std::exception *p) {
 ;   const char* ch = p->what();
-;   return std::strlen(ch);
+;   ...;
 ; }
 ;
 ; Build command is "clang++ -O2 -target x86_64-unknown-linux -flto=thin \
@@ -21,8 +21,8 @@
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux"
 
-@_ZTVSt9exception = available_externally constant { [5 x ptr] } { [5 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZNKSt9exception4whatEv] }, !type !0, !type !1, !vcall_visibility !2
-@_ZTV1A.0 = constant [5 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZNK1A4whatEv], !type !3, !type !4, !type !5, !type !6, !vcall_visibility !2
+@_ZTVSt9exception = available_externally constant { [5 x ptr] } { [5 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZNKSt9exception4whatEv] }, !type !0, !type !1
+@_ZTV1A.0 = constant [5 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZNK1A4whatEv], !type !3, !type !4, !type !5, !type !6
 
 declare ptr @_ZNKSt9exception4whatEv()
 
@@ -50,7 +50,6 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 
 !0 = !{i64 16, !"_ZTSSt9exception"}
 !1 = !{i64 32, !"_ZTSMSt9exceptionKDoFPKcvE.virtual"}
-!2 = !{i64 1}
 !3 = !{i32 16, !"_ZTS1A"}
 !4 = !{i32 32, !"_ZTSM1AKDoFPKcvE.virtual"}
 !5 = !{i32 16, !"_ZTSSt9exception"}

--- a/llvm/test/Transforms/WholeProgramDevirt/availableexternal-check.ll
+++ b/llvm/test/Transforms/WholeProgramDevirt/availableexternal-check.ll
@@ -1,0 +1,57 @@
+; RUN: opt -S -passes=wholeprogramdevirt -whole-program-visibility %s | FileCheck %s
+
+; This test is reduced from C++ code like this:
+; class A :public std::exception {
+; public:
+;   A() {};
+;   const char* what () const throw () {return "A";}
+; };
+; long test(std::exception *p) {
+;   const char* ch = p->what();
+;   return std::strlen(ch);
+; }
+;
+; Build command is "clang++ -O2 -target x86_64-unknown-linux -flto=thin \
+; -fwhole-program-vtables -static-libstdc++  -Wl,-plugin-opt=-whole-program-visibility"
+;
+; _ZTVSt9exception's visibility is 1 (Linkage Unit), and available_externally.
+; But another vtable _ZTV1A.0 is not available_externally.
+; They should not do devirtualization because they are in different linkage type.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux"
+
+@_ZTVSt9exception = available_externally constant { [5 x ptr] } { [5 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZNKSt9exception4whatEv] }, !type !0, !type !1, !vcall_visibility !2
+@_ZTV1A.0 = constant [5 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZNK1A4whatEv], !type !3, !type !4, !type !5, !type !6, !vcall_visibility !2
+
+declare ptr @_ZNKSt9exception4whatEv()
+
+define i64 @_Z4testPSt9exception() {
+  %1 = call i1 @llvm.type.test(ptr null, metadata !"_ZTSSt9exception")
+  tail call void @llvm.assume(i1 %1)
+  %2 = getelementptr i8, ptr null, i64 16
+  %3 = load ptr, ptr %2, align 8
+  %4 = tail call ptr %3(ptr null)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write)
+declare void @llvm.assume(i1 noundef) #0
+
+declare ptr @_ZNK1A4whatEv()
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i1 @llvm.type.test(ptr, metadata) #1
+
+; CHECK-NOT: call void (...) @llvm.icall.branch.funnel
+
+attributes #0 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+!0 = !{i64 16, !"_ZTSSt9exception"}
+!1 = !{i64 32, !"_ZTSMSt9exceptionKDoFPKcvE.virtual"}
+!2 = !{i64 1}
+!3 = !{i32 16, !"_ZTS1A"}
+!4 = !{i32 32, !"_ZTSM1AKDoFPKcvE.virtual"}
+!5 = !{i32 16, !"_ZTSSt9exception"}
+!6 = !{i32 32, !"_ZTSMSt9exceptionKDoFPKcvE.virtual"}

--- a/llvm/test/Transforms/WholeProgramDevirt/availableexternal-check.ll
+++ b/llvm/test/Transforms/WholeProgramDevirt/availableexternal-check.ll
@@ -11,12 +11,11 @@
 ;   ...;
 ; }
 ;
-; Build command is "clang++ -O2 -target x86_64-unknown-linux -flto=thin \
+; Build command is "clang++ -O2 -target x86_64-unknown-linux -flto=full \
 ; -fwhole-program-vtables -static-libstdc++  -Wl,-plugin-opt=-whole-program-visibility"
 ;
 ; _ZTVSt9exception's visibility is 1 (Linkage Unit), and available_externally.
-; But another vtable _ZTV1A.0 is not available_externally.
-; They should not do devirtualization because they are in different linkage type.
+; If any GV is available_externally, icall.branch.funnel should not be generated.
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux"


### PR DESCRIPTION
When a customer class inherits from a libc++ class, and is built with
"-flto  -fwhole-program-vtables -static-libstdc++ \
 -Wl,-plugin-opt=-whole-program-visibility", the libc++ class's vtable is
available_externally, meanwhile the customer class vtable is private. And
both of them are !vcall_visibility == Linkage Unit.
In this case, icall.branch.funnel might be generated.

But the icall.branch.funnel would cause crash in LowerTypeTests because
available_externally Global_Object's GlobalTypeMember would not be
saved and finally leads to a NULL GlobalTypeMember which causes a crash.
Even saving the available_externally GO's GlobalTypeMember so that it is
not NULL to avoid the crash in LowerTypeTests, it still will crash in
SelectionDAGBuilder or Verifier, because operands linkage type consistency
check of icall.branch.funnel can not pass.

So any one of available externally vtable would stop to generate icall.branch.funnel.
This patch fixes FullLTO mode and split-LTO-unit ThinLTO mode.