### PR TITLE
[RISCV] Use StringRef for RequiredExtensions in RVVIntrinsicDef

### DIFF
--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -47,7 +47,7 @@ struct RVVIntrinsicDef {
   std::string BuiltinName;
 
   /// Mapping to RequiredFeatures in riscv_vector.td
-  std::string RequiredExtensions;
+  StringRef RequiredExtensions;
 
   /// Function signature, first element is return type.
   RVVTypes Signature;


### PR DESCRIPTION
This prevents many duplicated copies of required extensions string.
