### PR TITLE
[OpenMP][clang] declare mapper: fix handling of nested types

### DIFF
--- a/clang/include/clang/Sema/SemaOpenMP.h
+++ b/clang/include/clang/Sema/SemaOpenMP.h
@@ -283,7 +283,7 @@ public:
   /// mapper' construct.
   QualType ActOnOpenMPDeclareMapperType(SourceLocation TyLoc,
                                         TypeResult ParsedType);
-  /// Called on start of '#pragma omp declare mapper'.
+  /// Called for '#pragma omp declare mapper'.
   DeclGroupPtrTy ActOnOpenMPDeclareMapperDirective(
       Scope *S, DeclContext *DC, DeclarationName Name, QualType MapperType,
       SourceLocation StartLoc, DeclarationName VN, AccessSpecifier AS,

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -576,6 +576,7 @@ Parser::ParseOpenMPDeclareMapperDirective(AccessSpecifier AS) {
     return DeclGroupPtrTy();
   }
 
+  Scope *OuterScope = getCurScope();
   // Enter scope.
   DeclarationNameInfo DirName;
   SourceLocation Loc = Tok.getLocation();
@@ -614,12 +615,17 @@ Parser::ParseOpenMPDeclareMapperDirective(AccessSpecifier AS) {
     IsCorrect = false;
   }
 
+  // This needs to be called within the scope because
+  // processImplicitMapsWithDefaultMappers may add clauses when analyzing nested
+  // types. The scope used for calling ActOnOpenMPDeclareMapperDirective,
+  // however, needs to be the outer one, otherwise declared mappers don't become
+  // visible.
+  DeclGroupPtrTy DG = Actions.OpenMP().ActOnOpenMPDeclareMapperDirective(
+      OuterScope, Actions.getCurLexicalContext(), MapperId, MapperType,
+      Range.getBegin(), VName, AS, MapperVarRef.get(), Clauses);
   // Exit scope.
   Actions.OpenMP().EndOpenMPDSABlock(nullptr);
   OMPDirectiveScope.Exit();
-  DeclGroupPtrTy DG = Actions.OpenMP().ActOnOpenMPDeclareMapperDirective(
-      getCurScope(), Actions.getCurLexicalContext(), MapperId, MapperType,
-      Range.getBegin(), VName, AS, MapperVarRef.get(), Clauses);
   if (!IsCorrect)
     return DeclGroupPtrTy();
 


### PR DESCRIPTION
Fix a crash that happened during parsing of a "declare mapper" construct for a struct that contains an element for which we also declared a custom default mapper.

Note: the history of this issue is as follows:
- Initially, `ParseOpenMPDeclareMapperDirective()` called *two* functions for acting on the declare mapper directive: `ActOnOpenMPDeclareMapperDirectiveStart()` and `ActOnOpenMPDeclareMapperDirectiveEnd()`. These functions were called before/after entering/exiting the parsing scope. In https://reviews.llvm.org/D83261, these functions were merged to `ActOnOpenMPDeclareMapperDirective()`, which is called after exiting the parsing scope.
- https://reviews.llvm.org/D92195 added support for nested default mappers by adding `processImplicitMapsWithDefaultMappers()`. This function is called in `ActOnOpenMPDeclareMapperDirective()`. It is also called by `ActOnOpenMPExecutableDirective()`, which is by itself unrelated to my PR, but it's noteworthy that `ActOnOpenMPExecutableDirective()` is called by `ParseOpenMPExecutableDirective()` **within** the parsing scope. That's why `processImplicitMapsWithDefaultMappers()` can add clauses without problems there. For `ActOnOpenMPDeclareMapperDirective()`, my PR fixes the problem that clauses cannot be added without parsing scope. Otherwise, the `DSAStack` is empty due to no current directive present, which leads to a crash of the compiler.