### PR TITLE
[Clang][OpenCL] Declare cl_amd_media_ops/cl_amd_media_ops2 builtins with -fdeclare-opencl-builtins

### DIFF
--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -139,6 +139,9 @@ def ArmIntegerDotProductAccumulateInt8         : FunctionExtension<"cl_arm_integ
 def ArmIntegerDotProductAccumulateInt16        : FunctionExtension<"cl_arm_integer_dot_product_accumulate_int16">;
 def ArmIntegerDotProductAccumulateSaturateInt8 : FunctionExtension<"cl_arm_integer_dot_product_accumulate_saturate_int8">;
 
+// AMD extensions.
+def AMDMediaOps : FunctionExtension<"cl_amd_media_ops">;
+
 // Qualified Type.  These map to ASTContext::QualType.
 class QualType<string _TypeExpr, bit _IsAbstract=0> {
   // Expression to obtain the QualType inside OCL2Qual.
@@ -1903,4 +1906,17 @@ let Extension = ArmIntegerDotProductAccumulateSaturateInt8 in {
     def : Builtin<name, [UInt, VectorType<UChar, 4>, VectorType<UChar, 4>, UInt]>;
     def : Builtin<name, [Int, VectorType<Char, 4>, VectorType<Char, 4>, Int]>;
   }
+}
+
+//--------------------------------------------------------------------
+// AMD extensions.
+let Extension = AMDMediaOps in {
+  foreach name = ["amd_bitalign", "amd_bytealign", "amd_lerp", "amd_sadhi", "amd_sad"] in {
+    def : Builtin<name, [GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar]>;
+  }
+  foreach name = ["amd_unpack0", "amd_unpack1", "amd_unpack2", "amd_unpack3"] in {
+    def : Builtin<name, [GenTypeFloatVecAndScalar, GenTypeUIntVecAndScalar]>;
+  }
+  def : Builtin<"amd_pack", [UInt, VectorType<Float, 4>]>;
+  def : Builtin<"amd_sad4", [UInt, VectorType<UInt, 4>, VectorType<UInt, 4>, UInt]>;
 }

--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -141,6 +141,7 @@ def ArmIntegerDotProductAccumulateSaturateInt8 : FunctionExtension<"cl_arm_integ
 
 // AMD extensions.
 def AMDMediaOps : FunctionExtension<"cl_amd_media_ops">;
+def AMDMediaOps2 : FunctionExtension<"cl_amd_media_ops2">;
 
 // Qualified Type.  These map to ASTContext::QualType.
 class QualType<string _TypeExpr, bit _IsAbstract=0> {
@@ -1919,4 +1920,19 @@ let Extension = AMDMediaOps in {
   }
   def : Builtin<"amd_pack", [UInt, VectorType<Float, 4>]>;
   def : Builtin<"amd_sad4", [UInt, VectorType<UInt, 4>, VectorType<UInt, 4>, UInt]>;
+}
+
+let Extension = AMDMediaOps2 in {
+  def : Builtin<"amd_bfe", [GenTypeIntVecAndScalar, GenTypeIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar]>;
+  foreach name = ["amd_bfe", "amd_msad", "amd_sadd", "amd_sadw"] in {
+    def : Builtin<name, [GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar]>;
+  }
+  def : Builtin<"amd_bfm", [GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar]>;
+  foreach name = ["amd_max3", "amd_median3", "amd_min3"] in {
+    foreach gentype = [GenTypeFloatVecAndScalar, GenTypeIntVecAndScalar, GenTypeUIntVecAndScalar] in {
+      def : Builtin<name, [gentype, gentype, gentype, gentype]>;
+    }
+  }
+  def : Builtin<"amd_mqsad", [GenTypeULongVecAndScalar, GenTypeULongVecAndScalar, GenTypeUIntVecAndScalar, GenTypeULongVecAndScalar]>;
+  def : Builtin<"amd_qsad", [GenTypeULongVecAndScalar, GenTypeULongVecAndScalar, GenTypeUIntVecAndScalar, GenTypeULongVecAndScalar]>;
 }

--- a/clang/test/SemaOpenCL/amd-media-ops.cl
+++ b/clang/test/SemaOpenCL/amd-media-ops.cl
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header %s
 // expected-no-diagnostics
-// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify=fdecalre -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins %s
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins %s
+// expected-no-diagnostics
 
 #define TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \
     ret test_ ## builtin ## _ ## ret ## _## type (type a) { \
@@ -74,25 +75,25 @@ TEST_1ARG_BUILTIN(amd_unpack1, float, uint)
 TEST_1ARG_BUILTIN(amd_unpack2, float, uint)
 TEST_1ARG_BUILTIN(amd_unpack3, float, uint)
 
-TEST_3ARG_WITH_TYPES_BUILTIN(amd_bfe, int, int, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_bfe, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_2ARG_BUILTIN(amd_bfm, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_bfe, int, int, uint, uint)
+TEST_3ARG_BUILTIN(amd_bfe, uint, uint)
+TEST_2ARG_BUILTIN(amd_bfm, uint, uint)
 
-TEST_3ARG_BUILTIN(amd_max3, float, float) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_max3, int, int) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_max3, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_max3, float, float)
+TEST_3ARG_BUILTIN(amd_max3, int, int)
+TEST_3ARG_BUILTIN(amd_max3, uint, uint)
 
-TEST_3ARG_BUILTIN(amd_median3, float, float) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_median3, int, int) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_median3, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_median3, float, float)
+TEST_3ARG_BUILTIN(amd_median3, int, int)
+TEST_3ARG_BUILTIN(amd_median3, uint, uint)
 
-TEST_3ARG_BUILTIN(amd_min3, float, float) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_min3, int, int) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_min3, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_min3, float, float)
+TEST_3ARG_BUILTIN(amd_min3, int, int)
+TEST_3ARG_BUILTIN(amd_min3, uint, uint)
 
-TEST_3ARG_WITH_TYPES_BUILTIN(amd_mqsad, ulong, ulong, uint, ulong) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_WITH_TYPES_BUILTIN(amd_qsad, ulong, ulong, uint, ulong) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_mqsad, ulong, ulong, uint, ulong)
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_qsad, ulong, ulong, uint, ulong)
 
-TEST_3ARG_BUILTIN(amd_msad, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_sadd, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_sadw, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_msad, uint, uint)
+TEST_3ARG_BUILTIN(amd_sadd, uint, uint)
+TEST_3ARG_BUILTIN(amd_sadw, uint, uint)

--- a/clang/test/SemaOpenCL/amd-media-ops.cl
+++ b/clang/test/SemaOpenCL/amd-media-ops.cl
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header %s
-// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins %s
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -cl-ext=-all,+cl_amd_media_ops,+cl_amd_media_ops2 -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -cl-ext=-all,+cl_amd_media_ops,+cl_amd_media_ops2 -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins
 // expected-no-diagnostics
 
 #define TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \

--- a/clang/test/SemaOpenCL/amd-media-ops.cl
+++ b/clang/test/SemaOpenCL/amd-media-ops.cl
@@ -54,25 +54,25 @@
     TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 8, type_a ## 8, type_b ## 8, type_c ## 8) \
     TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 16, type_a ## 16, type_b ## 16, type_c ## 16)
 
-TEST_3ARG_BUILTIN(amd_bitalign, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_bytealign, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_lerp, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_bitalign, uint, uint)
+TEST_3ARG_BUILTIN(amd_bytealign, uint, uint)
+TEST_3ARG_BUILTIN(amd_lerp, uint, uint)
 
 uint test_amd_pack(float4 a) {
-    return amd_pack(a); // fdecalre-error{{use of undeclared identifier}}
+    return amd_pack(a);
 }
 
 uint test_amd_sad4(uint4 a, uint4 b, uint c) {
-    return amd_sad4(a, b, c); // fdecalre-error{{use of undeclared identifier}}
+    return amd_sad4(a, b, c);
 }
 
-TEST_3ARG_BUILTIN(amd_sadhi, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_3ARG_BUILTIN(amd_sad, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_sadhi, uint, uint)
+TEST_3ARG_BUILTIN(amd_sad, uint, uint)
 
-TEST_1ARG_BUILTIN(amd_unpack0, float, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_1ARG_BUILTIN(amd_unpack1, float, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_1ARG_BUILTIN(amd_unpack2, float, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
-TEST_1ARG_BUILTIN(amd_unpack3, float, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_1ARG_BUILTIN(amd_unpack0, float, uint)
+TEST_1ARG_BUILTIN(amd_unpack1, float, uint)
+TEST_1ARG_BUILTIN(amd_unpack2, float, uint)
+TEST_1ARG_BUILTIN(amd_unpack3, float, uint)
 
 TEST_3ARG_WITH_TYPES_BUILTIN(amd_bfe, int, int, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
 TEST_3ARG_BUILTIN(amd_bfe, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}

--- a/clang/test/SemaOpenCL/amd-media-ops.cl
+++ b/clang/test/SemaOpenCL/amd-media-ops.cl
@@ -1,6 +1,10 @@
 // RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -cl-ext=-all,+cl_amd_media_ops,+cl_amd_media_ops2 -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header
 // RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -cl-ext=-all,+cl_amd_media_ops,+cl_amd_media_ops2 -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins
 // expected-no-diagnostics
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -cl-ext=-all,+cl_amd_media_ops2 -verify=ops  -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -cl-ext=-all,+cl_amd_media_ops  -verify=ops2 -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -cl-ext=-all,+cl_amd_media_ops2 -verify=ops  -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -cl-ext=-all,+cl_amd_media_ops  -verify=ops2 -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins
 
 #define TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \
     ret test_ ## builtin ## _ ## ret ## _## type (type a) { \
@@ -54,45 +58,46 @@
     TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 8, type_a ## 8, type_b ## 8, type_c ## 8) \
     TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 16, type_a ## 16, type_b ## 16, type_c ## 16)
 
-TEST_3ARG_BUILTIN(amd_bitalign, uint, uint)
-TEST_3ARG_BUILTIN(amd_bytealign, uint, uint)
-TEST_3ARG_BUILTIN(amd_lerp, uint, uint)
+TEST_3ARG_BUILTIN(amd_bitalign, uint, uint) // ops-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_bytealign, uint, uint) // ops-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_lerp, uint, uint) // ops-error 6 {{use of undeclared identifier}}
 
 uint test_amd_pack(float4 a) {
-    return amd_pack(a);
+    return amd_pack(a); // ops-error{{use of undeclared identifier}}
 }
 
 uint test_amd_sad4(uint4 a, uint4 b, uint c) {
-    return amd_sad4(a, b, c);
+    return amd_sad4(a, b, c); // ops-error{{use of undeclared identifier}}
 }
 
-TEST_3ARG_BUILTIN(amd_sadhi, uint, uint)
-TEST_3ARG_BUILTIN(amd_sad, uint, uint)
+TEST_3ARG_BUILTIN(amd_sadhi, uint, uint)// ops-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_sad, uint, uint) // ops-error 6 {{use of undeclared identifier}}
 
-TEST_1ARG_BUILTIN(amd_unpack0, float, uint)
-TEST_1ARG_BUILTIN(amd_unpack1, float, uint)
-TEST_1ARG_BUILTIN(amd_unpack2, float, uint)
-TEST_1ARG_BUILTIN(amd_unpack3, float, uint)
 
-TEST_3ARG_WITH_TYPES_BUILTIN(amd_bfe, int, int, uint, uint)
-TEST_3ARG_BUILTIN(amd_bfe, uint, uint)
-TEST_2ARG_BUILTIN(amd_bfm, uint, uint)
+TEST_1ARG_BUILTIN(amd_unpack0, float, uint) // ops-error 6 {{use of undeclared identifier}}
+TEST_1ARG_BUILTIN(amd_unpack1, float, uint) // ops-error 6 {{use of undeclared identifier}}
+TEST_1ARG_BUILTIN(amd_unpack2, float, uint) // ops-error 6 {{use of undeclared identifier}}
+TEST_1ARG_BUILTIN(amd_unpack3, float, uint) // ops-error 6 {{use of undeclared identifier}}
 
-TEST_3ARG_BUILTIN(amd_max3, float, float)
-TEST_3ARG_BUILTIN(amd_max3, int, int)
-TEST_3ARG_BUILTIN(amd_max3, uint, uint)
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_bfe, int, int, uint, uint) // ops2-error 6 {{use of undeclared identifier}} #amd_bfe0
+TEST_3ARG_BUILTIN(amd_bfe, uint, uint) // ops2-error 6 {{use of undeclared identifier}} #amd_bfe1
+TEST_2ARG_BUILTIN(amd_bfm, uint, uint) // ops2-error 6 {{use of undeclared identifier}}
 
-TEST_3ARG_BUILTIN(amd_median3, float, float)
-TEST_3ARG_BUILTIN(amd_median3, int, int)
-TEST_3ARG_BUILTIN(amd_median3, uint, uint)
+TEST_3ARG_BUILTIN(amd_max3, float, float) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_max3, int, int) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_max3, uint, uint) // ops2-error 6 {{use of undeclared identifier}}
 
-TEST_3ARG_BUILTIN(amd_min3, float, float)
-TEST_3ARG_BUILTIN(amd_min3, int, int)
-TEST_3ARG_BUILTIN(amd_min3, uint, uint)
+TEST_3ARG_BUILTIN(amd_median3, float, float) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_median3, int, int) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_median3, uint, uint) // ops2-error 6 {{use of undeclared identifier}}
 
-TEST_3ARG_WITH_TYPES_BUILTIN(amd_mqsad, ulong, ulong, uint, ulong)
-TEST_3ARG_WITH_TYPES_BUILTIN(amd_qsad, ulong, ulong, uint, ulong)
+TEST_3ARG_BUILTIN(amd_min3, float, float) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_min3, int, int) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_min3, uint, uint) // ops2-error 6 {{use of undeclared identifier}}
 
-TEST_3ARG_BUILTIN(amd_msad, uint, uint)
-TEST_3ARG_BUILTIN(amd_sadd, uint, uint)
-TEST_3ARG_BUILTIN(amd_sadw, uint, uint)
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_mqsad, ulong, ulong, uint, ulong) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_qsad, ulong, ulong, uint, ulong) // ops2-error 6 {{use of undeclared identifier}}
+
+TEST_3ARG_BUILTIN(amd_msad, uint, uint) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_sadd, uint, uint) // ops2-error 6 {{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_sadw, uint, uint) // ops2-error 6 {{use of undeclared identifier}}

--- a/clang/test/SemaOpenCL/amd-media-ops.cl
+++ b/clang/test/SemaOpenCL/amd-media-ops.cl
@@ -1,0 +1,98 @@
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header %s
+// expected-no-diagnostics
+// RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify=fdecalre -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins %s
+
+#define TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \
+    ret test_ ## builtin ## _ ## ret ## _## type (type a) { \
+        return builtin(a); \
+    }
+
+#define TEST_2ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \
+    ret test_ ## builtin ## _ ## ret ## _## type (type a, type b) { \
+        return builtin(a, b); \
+    }
+
+#define TEST_3ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \
+    ret test_ ## builtin ## _ ## ret ## _ ## type (type a, type b, type c) { \
+        return builtin(a, b, c); \
+    }
+
+#define TEST_1ARG_BUILTIN(builtin, ret, type) \
+    TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \
+    TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret ## 2, type ## 2) \
+    TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret ## 3, type ## 3) \
+    TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret ## 4, type ## 4) \
+    TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret ## 8, type ## 8) \
+    TEST_1ARG_BUILTIN_WITH_TYPE(builtin, ret ## 16, type ## 16)
+
+#define TEST_2ARG_BUILTIN(builtin, ret, type) \
+    TEST_2ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \
+    TEST_2ARG_BUILTIN_WITH_TYPE(builtin, ret ## 2, type ## 2) \
+    TEST_2ARG_BUILTIN_WITH_TYPE(builtin, ret ## 3, type ## 3) \
+    TEST_2ARG_BUILTIN_WITH_TYPE(builtin, ret ## 4, type ## 4) \
+    TEST_2ARG_BUILTIN_WITH_TYPE(builtin, ret ## 8, type ## 8) \
+    TEST_2ARG_BUILTIN_WITH_TYPE(builtin, ret ## 16, type ## 16)
+
+#define TEST_3ARG_BUILTIN(builtin, ret, type) \
+    TEST_3ARG_BUILTIN_WITH_TYPE(builtin, ret, type) \
+    TEST_3ARG_BUILTIN_WITH_TYPE(builtin, ret ## 2, type ## 2) \
+    TEST_3ARG_BUILTIN_WITH_TYPE(builtin, ret ## 3, type ## 3) \
+    TEST_3ARG_BUILTIN_WITH_TYPE(builtin, ret ## 4, type ## 4) \
+    TEST_3ARG_BUILTIN_WITH_TYPE(builtin, ret ## 8, type ## 8) \
+    TEST_3ARG_BUILTIN_WITH_TYPE(builtin, ret ## 16, type ## 16)
+
+#define TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret, type_a, type_b, type_c) \
+    ret test_ ## builtin ## _ ## ret ## _ ## type_a ## _ ## type_b ## _ ## type_c (type_a a, type_b b, type_c c) { \
+        return builtin(a, b, c); \
+    }
+
+#define TEST_3ARG_WITH_TYPES_BUILTIN(builtin, ret, type_a, type_b, type_c) \
+    TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret, type_a, type_b, type_c) \
+    TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 2, type_a ## 2, type_b ## 2, type_c ## 2) \
+    TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 3, type_a ## 3, type_b ## 3, type_c ## 3) \
+    TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 4, type_a ## 4, type_b ## 4, type_c ## 4) \
+    TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 8, type_a ## 8, type_b ## 8, type_c ## 8) \
+    TEST_3ARG_BUILTIN_WITH_TYPES(builtin, ret ## 16, type_a ## 16, type_b ## 16, type_c ## 16)
+
+TEST_3ARG_BUILTIN(amd_bitalign, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_bytealign, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_lerp, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+
+uint test_amd_pack(float4 a) {
+    return amd_pack(a); // fdecalre-error{{use of undeclared identifier}}
+}
+
+uint test_amd_sad4(uint4 a, uint4 b, uint c) {
+    return amd_sad4(a, b, c); // fdecalre-error{{use of undeclared identifier}}
+}
+
+TEST_3ARG_BUILTIN(amd_sadhi, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_sad, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+
+TEST_1ARG_BUILTIN(amd_unpack0, float, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_1ARG_BUILTIN(amd_unpack1, float, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_1ARG_BUILTIN(amd_unpack2, float, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_1ARG_BUILTIN(amd_unpack3, float, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_bfe, int, int, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_bfe, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_2ARG_BUILTIN(amd_bfm, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+
+TEST_3ARG_BUILTIN(amd_max3, float, float) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_max3, int, int) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_max3, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+
+TEST_3ARG_BUILTIN(amd_median3, float, float) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_median3, int, int) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_median3, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+
+TEST_3ARG_BUILTIN(amd_min3, float, float) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_min3, int, int) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_min3, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_mqsad, ulong, ulong, uint, ulong) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_WITH_TYPES_BUILTIN(amd_qsad, ulong, ulong, uint, ulong) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+
+TEST_3ARG_BUILTIN(amd_msad, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_sadd, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}
+TEST_3ARG_BUILTIN(amd_sadw, uint, uint) // fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}} fdecalre-error{{use of undeclared identifier}}

--- a/clang/test/SemaOpenCL/amd-media-ops.cl
+++ b/clang/test/SemaOpenCL/amd-media-ops.cl
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header %s
-// expected-no-diagnostics
 // RUN: %clang_cc1 %s -triple amdgcn-unknown-unknown -verify -pedantic -Wconversion -Werror -fsyntax-only -cl-std=CL -finclude-default-header -fdeclare-opencl-builtins %s
 // expected-no-diagnostics
 


### PR DESCRIPTION
cl_amd_media_ops/cl_amd_media_ops2 builtins are currently not declared with -fdeclare-opencl-builtins.

This patch adds support for these builtins.