### PR TITLE
[Clang] Add a `value_or` helper to `UnsignedOrNone`

### DIFF
--- a/clang/include/clang/Basic/UnsignedOrNone.h
+++ b/clang/include/clang/Basic/UnsignedOrNone.h
@@ -29,6 +29,14 @@ struct UnsignedOrNone {
   }
   constexpr unsigned toInternalRepresentation() const { return Rep; }
 
+  constexpr unsigned value_or(unsigned val) const {
+    return operator bool() ? **this : val;
+  }
+
+  constexpr UnsignedOrNone value_or(UnsignedOrNone val) const {
+    return operator bool() ? *this : val;
+  }
+
   explicit constexpr operator bool() const { return Rep != 0; }
   unsigned operator*() const {
     assert(operator bool());

--- a/clang/include/clang/Basic/UnsignedOrNone.h
+++ b/clang/include/clang/Basic/UnsignedOrNone.h
@@ -29,12 +29,12 @@ struct UnsignedOrNone {
   }
   constexpr unsigned toInternalRepresentation() const { return Rep; }
 
-  constexpr unsigned value_or(unsigned val) const {
-    return operator bool() ? **this : val;
+  constexpr unsigned value_or(unsigned Val) const {
+    return operator bool() ? **this : Val;
   }
 
-  constexpr UnsignedOrNone value_or(UnsignedOrNone val) const {
-    return operator bool() ? *this : val;
+  constexpr UnsignedOrNone value_or(UnsignedOrNone Val) const {
+    return operator bool() ? *this : Val;
   }
 
   explicit constexpr operator bool() const { return Rep != 0; }


### PR DESCRIPTION
This adds two `value_or` overloads to `UnsignedOrNone`. I’ve had a use for these in something I’m currently working on and thought it might make sense to add them separately. The overload that takes an `UnsignedOrNone` might seem a bit strange at first, but I think it makes sense given how specific this class already is.