### PR TITLE
[libunwind] Don't override LINKER_LANGUAGE

### DIFF
--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -74,6 +74,9 @@ set(LIBUNWIND_SOURCES
 if (CXX_SUPPORTS_NOSTDLIBXX_FLAG)
   add_link_flags_if_supported(-nostdlib++)
 else()
+  if (C_SUPPORTS_NODEFAULTLIBS_FLAG)
+    add_link_flags_if_supported(-nodefaultlibs)
+  endif()
   if (LIBUNWIND_USE_COMPILER_RT)
     add_library_flags("${LIBUNWIND_BUILTINS_LIBRARY}")
   else()
@@ -164,7 +167,6 @@ set_target_properties(unwind_shared
   PROPERTIES
     EXCLUDE_FROM_ALL "$<IF:$<BOOL:${LIBUNWIND_ENABLE_SHARED}>,FALSE,TRUE>"
     LINK_FLAGS "${LIBUNWIND_LINK_FLAGS}"
-    LINKER_LANGUAGE C
     OUTPUT_NAME "${LIBUNWIND_SHARED_OUTPUT_NAME}"
     VERSION     "${LIBUNWIND_LIBRARY_VERSION}"
     SOVERSION   "1"
@@ -211,7 +213,6 @@ set_target_properties(unwind_static
   PROPERTIES
     EXCLUDE_FROM_ALL "$<IF:$<BOOL:${LIBUNWIND_ENABLE_STATIC}>,FALSE,TRUE>"
     LINK_FLAGS "${LIBUNWIND_LINK_FLAGS}"
-    LINKER_LANGUAGE C
     OUTPUT_NAME "${LIBUNWIND_STATIC_OUTPUT_NAME}"
 )
 


### PR DESCRIPTION
libunwind's GCC build fails because it tested `-nostdlib++` flag against C++ linker but then use C linker to perform final linking, while gcc doesn't support this flag but g++ does.

The rationale for setting LINKER_LANGUAGE to C is to avoid pulling in C++ standard libraries. However this is already guaranteed by the combination of `-nostdlib++` and `empty CMAKE_CXX_IMPLICIT_LINK_LIBRARIES`, thus we can safely remove this override.

However, in case `-nostdlib++` is unsupported, we need to use `-nodefaultlibs` and link against rtlib & libc manually.

Closes #98440