### PR TITLE
[Clang][Attr] Fix possible crash when trying to check for DeviceKernel spelling

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1590,11 +1590,11 @@ def DeviceKernel : DeclOrTypeAttr {
     // list, but here we have the same spelling with unscores and without,
     // so handle that case manually.
       return A.getAttributeSpellingListIndex() == Keyword_kernel ||
-      A.getAttrName()->getName() == "kernel";
+      (A.getAttrName() && A.getAttrName()->getName() == "kernel");
     }
     static inline bool isOpenCLSpelling(const AttributeCommonInfo* A) {
-    if (!A) return false;
-    return isOpenCLSpelling(*A);
+      if (!A) return false;
+      return isOpenCLSpelling(*A);
     }
 }];
 }


### PR DESCRIPTION
I didn't add a test because this can't be reproduced yet in this repo, I reproduced this only in intel's fork with more SYCL support.

I also fixed some formatting.