### PR TITLE
[Triple][CodeGen] Fix `Triple::isTargetEHABICompatible()` for NetBSD

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -914,7 +914,7 @@ public:
             getEnvironment() == Triple::GNUEABIHFT64 ||
             getEnvironment() == Triple::OpenHOS ||
             getEnvironment() == Triple::MuslEABIHF || isAndroid()) &&
-           isOSBinFormatELF();
+           isOSBinFormatELF() && !isOSNetBSD();
   }
 
   // ARM EABI is the bare-metal EABI described in ARM ABI documents and

--- a/llvm/test/CodeGen/ARM/eh-resume.ll
+++ b/llvm/test/CodeGen/ARM/eh-resume.ll
@@ -4,6 +4,8 @@
 ; RUN: llc < %s -mtriple=armv7k-apple-watchos -arm-atomic-cfg-tidy=0 | FileCheck %s -check-prefix=WATCHABI
 ; RUN: llc < %s -mtriple=armv7-none-gnueabihf -arm-atomic-cfg-tidy=0 | FileCheck %s -check-prefix=EABI
 ; RUN: llc < %s -mtriple=armv7-none-none -arm-atomic-cfg-tidy=0 | FileCheck %s -check-prefix=ABI
+; RUN: llc < %s -mtriple=armv7-netbsd-none -arm-atomic-cfg-tidy=0 | FileCheck %s -check-prefix=NETBSD
+; RUN: llc < %s -mtriple=armv7-netbsd-eabihf -arm-atomic-cfg-tidy=0 | FileCheck %s -check-prefix=NETBSD
 
 declare void @func()
 
@@ -27,3 +29,4 @@ lpad:
 ; WATCHABI: __Unwind_Resume
 ; EABI: __cxa_end_cleanup
 ; ABI: _Unwind_Resume
+; NETBSD: _Unwind_Resume

--- a/llvm/test/CodeGen/ARM/ehabi.ll
+++ b/llvm/test/CodeGen/ARM/ehabi.ll
@@ -258,31 +258,34 @@ declare void @_ZSt9terminatev()
 ; DWARF-V7-FP:    .cfi_startproc
 ; DWARF-V7-FP:    .cfi_personality 0, __gxx_personality_v0
 ; DWARF-V7-FP:    .cfi_lsda 0, .Lexception0
-; DWARF-V7-FP:    push {r11, lr}
-; DWARF-V7-FP:    .cfi_def_cfa_offset 8
+; DWARF-V7-FP:    push {r4, r10, r11, lr}
+; DWARF-V7-FP:    .cfi_def_cfa_offset 16
 ; DWARF-V7-FP:    .cfi_offset lr, -4
 ; DWARF-V7-FP:    .cfi_offset r11, -8
-; DWARF-V7-FP:    mov r11, sp
-; DWARF-V7-FP:    .cfi_def_cfa_register r11
+; DWARF-V7-FP:    .cfi_offset r10, -12
+; DWARF-V7-FP:    .cfi_offset r4, -16
+; DWARF-V7-FP:    add r11, sp, #8
+; DWARF-V7-FP:    .cfi_def_cfa r11, 8
 ; DWARF-V7-FP:    vpush {d8, d9, d10, d11, d12}
-; DWARF-V7-FP:    .cfi_offset d12, -16
-; DWARF-V7-FP:    .cfi_offset d11, -24
-; DWARF-V7-FP:    .cfi_offset d10, -32
-; DWARF-V7-FP:    .cfi_offset d9, -40
+; DWARF-V7-FP:    .cfi_offset d12, -24
+; DWARF-V7-FP:    .cfi_offset d11, -32
+; DWARF-V7-FP:    .cfi_offset d10, -40
+; DWARF-V7-FP:    .cfi_offset d9, -48
+; DWARF-V7-FP:    .cfi_offset d8, -56
 ; DWARF-V7-FP:    sub sp, sp, #24
-; DWARF-V7-FP:    sub sp, r11, #40
+; DWARF-V7-FP:    sub sp, r11, #48
 ; DWARF-V7-FP:    vpop {d8, d9, d10, d11, d12}
-; DWARF-V7-FP:    pop {r11, pc}
+; DWARF-V7-FP:    pop {r4, r10, r11, pc}
 ; DWARF-V7-FP:    .cfi_endproc
 
 ; DWARF-V7-FP-ELIM-LABEL: _Z4testiiiiiddddd:
 ; DWARF-V7-FP-ELIM:    .cfi_startproc
 ; DWARF-V7-FP-ELIM:    .cfi_personality 0, __gxx_personality_v0
 ; DWARF-V7-FP-ELIM:    .cfi_lsda 0, .Lexception0
-; DWARF-V7-FP-ELIM:    push {r11, lr}
+; DWARF-V7-FP-ELIM:    push {r4, lr}
 ; DWARF-V7-FP-ELIM:    .cfi_def_cfa_offset 8
 ; DWARF-V7-FP-ELIM:    .cfi_offset lr, -4
-; DWARF-V7-FP-ELIM:    .cfi_offset r11, -8
+; DWARF-V7-FP-ELIM:    .cfi_offset r4, -8
 ; DWARF-V7-FP-ELIM:    vpush {d8, d9, d10, d11, d12}
 ; DWARF-V7-FP-ELIM:    .cfi_offset d12, -16
 ; DWARF-V7-FP-ELIM:    .cfi_offset d11, -24
@@ -292,7 +295,7 @@ declare void @_ZSt9terminatev()
 ; DWARF-V7-FP-ELIM:    .cfi_def_cfa_offset 72
 ; DWARF-V7-FP-ELIM:    add sp, sp, #24
 ; DWARF-V7-FP-ELIM:    vpop {d8, d9, d10, d11, d12}
-; DWARF-V7-FP-ELIM:    pop {r11, pc}
+; DWARF-V7-FP-ELIM:    pop {r4, pc}
 ; DWARF-V7-FP-ELIM:    .cfi_endproc
 
 ; DWARF-WIN-FP-ELIM-LABEL: _Z4testiiiiiddddd:


### PR DESCRIPTION
Even for EABI, NetBSD uses DWARF EH, not EHABI. This change matches the Clang frontend behavior, and fixes link errors caused by incorrect references to `__cxa_end_cleanup` rather than `_Unwind_Resume`.

With this change and #143055, I was able to run [zig-bootstrap](https://github.com/ziglang/zig-bootstrap) to completion for `arm-netbsd10.1-eabihf`.