### PR TITLE
[flang][common] return ENUM_CLASS names definition to original state

### DIFF
--- a/flang/include/flang/Common/enum-class.h
+++ b/flang/include/flang/Common/enum-class.h
@@ -62,14 +62,13 @@ constexpr std::array<std::string_view, ITEMS> EnumNames(const char *p) {
   enum class NAME { __VA_ARGS__ }; \
   [[maybe_unused]] static constexpr std::size_t NAME##_enumSize{ \
       ::Fortran::common::CountEnumNames(#__VA_ARGS__)}; \
-  [[maybe_unused]] static constexpr std::array<std::string_view, \
-      NAME##_enumSize> NAME##_names{ \
-      ::Fortran::common::EnumNames<NAME##_enumSize>(#__VA_ARGS__)}; \
   [[maybe_unused]] static inline std::size_t EnumToInt(NAME e) { \
     return static_cast<std::size_t>(e); \
   } \
   [[maybe_unused]] static inline std::string_view EnumToString(NAME e) { \
-    return NAME##_names[static_cast<std::size_t>(e)]; \
+    static const constexpr auto names{ \
+        ::Fortran::common::EnumNames<NAME##_enumSize>(#__VA_ARGS__)}; \
+    return names[static_cast<std::size_t>(e)]; \
   } \
   [[maybe_unused]] inline void ForEach##NAME(std::function<void(NAME)> f) { \
     for (std::size_t i{0}; i < NAME##_enumSize; ++i) { \


### PR DESCRIPTION
This PR simply reverts a few lines in bf60aa1c551ef5de62fd1d1cdcbff58cba55cacd to their state in bcba39a56fd4e1debe3854d564c3e03bf0a50ee6 so that they are constant for some of the build tests that require it. This should fix the breakage caused by #142022. 