### PR TITLE
[llvm] remove llvm:: qualification from appendLoopsToWorklist extern template instantiations

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -535,12 +535,12 @@ void appendReversedLoopsToWorklist(RangeT &&,
                                    SmallPriorityWorklist<Loop *, 4> &);
 
 extern template LLVM_TEMPLATE_ABI void
-llvm::appendLoopsToWorklist<ArrayRef<Loop *> &>(
+appendLoopsToWorklist<ArrayRef<Loop *> &>(
     ArrayRef<Loop *> &Loops, SmallPriorityWorklist<Loop *, 4> &Worklist);
 
 extern template LLVM_TEMPLATE_ABI void
-llvm::appendLoopsToWorklist<Loop &>(Loop &L,
-                                    SmallPriorityWorklist<Loop *, 4> &Worklist);
+appendLoopsToWorklist<Loop &>(Loop &L,
+                              SmallPriorityWorklist<Loop *, 4> &Worklist);
 
 /// Utility that implements appending of loops onto a worklist given LoopInfo.
 /// Calls the templated utility taking a Range of loops, handing it the Loops


### PR DESCRIPTION
## Purpose
Fix a build break introduced by #143413. This was a copy+paste error where the `llvm::` qualifier was left on the template instantiation declarations that were added. This causes a compile error with the version of the compiler used by the mlir-nvidia-gcc7 build. 
```
/vol/worker/mlir-nvidia/mlir-nvidia-gcc7/llvm.src/llvm/include/llvm/Transforms/Utils/LoopUtils.h:539:72: error: explicit qualification in declaration of ‘void llvm::appendLoopsToWorklist(llvm::ArrayRef<llvm::Loop*>&, llvm::SmallPriorityWorklist<llvm::Loop*, 4>&)’
     ArrayRef<Loop *> &Loops, SmallPriorityWorklist<Loop *, 4> &Worklist);
                                                                        ^
/vol/worker/mlir-nvidia/mlir-nvidia-gcc7/llvm.src/llvm/include/llvm/Transforms/Utils/LoopUtils.h:543:79: error: explicit qualification in declaration of ‘void llvm::appendLoopsToWorklist(llvm::Loop&, llvm::SmallPriorityWorklist<llvm::Loop*, 4>&)’
                                     SmallPriorityWorklist<Loop *, 4> &Worklist);
```