### PR TITLE
[OpenMP] Improve performance of ticket lock (x86)

### DIFF
--- a/openmp/runtime/src/kmp_lock.cpp
+++ b/openmp/runtime/src/kmp_lock.cpp
@@ -720,8 +720,6 @@ int __kmp_release_ticket_lock(kmp_ticket_lock_t *lck, kmp_int32 gtid) {
   std::atomic_fetch_add_explicit(&lck->lk.now_serving, 1U,
                                  std::memory_order_release);
 
-  KMP_YIELD(distance >
-            (kmp_uint32)(__kmp_avail_proc ? __kmp_avail_proc : __kmp_xproc));
   return KMP_LOCK_RELEASED;
 }
 

--- a/openmp/runtime/src/kmp_lock.cpp
+++ b/openmp/runtime/src/kmp_lock.cpp
@@ -712,11 +712,6 @@ static int __kmp_test_ticket_lock_with_checks(kmp_ticket_lock_t *lck,
 }
 
 int __kmp_release_ticket_lock(kmp_ticket_lock_t *lck, kmp_int32 gtid) {
-  kmp_uint32 distance = std::atomic_load_explicit(&lck->lk.next_ticket,
-                                                  std::memory_order_relaxed) -
-                        std::atomic_load_explicit(&lck->lk.now_serving,
-                                                  std::memory_order_relaxed);
-
   std::atomic_fetch_add_explicit(&lck->lk.now_serving, 1U,
                                  std::memory_order_release);
 


### PR DESCRIPTION
Ticket lock has a yield operation (shown below) which degrades performance on larger server machines due to an unconditional pause operation.

```
#define KMP_YIELD(cond)                                                        \
  {                                                                            \
    KMP_CPU_PAUSE();                                                           \
    if ((cond) && (KMP_TRY_YIELD))                                             \
      __kmp_yield();                                                           \
  }
```