### PR TITLE
[Support] Simplify CTLog2 (NFC)

### DIFF
--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -328,8 +328,7 @@ inline bool isShiftedMask_64(uint64_t Value, unsigned &MaskIdx,
 /// Compile time Log2.
 /// Valid only for positive powers of two.
 template <size_t kValue> constexpr size_t CTLog2() {
-  static_assert(kValue > 0 && llvm::isPowerOf2_64(kValue),
-                "Value is not a valid power of 2");
+  static_assert(llvm::isPowerOf2_64(kValue), "Value is not a valid power of 2");
   return 1 + CTLog2<kValue / 2>();
 }
 


### PR DESCRIPTION
We can drop kValue > 0 in CTLog2 because llvm::isPowerOf2_64 returns
false on input 0.
