### PR TITLE
[IPO] Use std::tie to implement operator< (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/WholeProgramDevirt.h
+++ b/llvm/include/llvm/Transforms/IPO/WholeProgramDevirt.h
@@ -113,7 +113,7 @@ struct TypeMemberInfo {
   uint64_t Offset;
 
   bool operator<(const TypeMemberInfo &other) const {
-    return Bits < other.Bits || (Bits == other.Bits && Offset < other.Offset);
+    return std::tie(Bits, Offset) < std::tie(other.Bits, other.Offset);
   }
 };
 


### PR DESCRIPTION
std::tie facilitates lexicographical comparisons through std::tuple's
built-in operator<.
