### PR TITLE
[libc++] Remove trailing newline from _LIBCPP_ASSERTION_HANDLER calls

### DIFF
--- a/libcxx/include/__assert
+++ b/libcxx/include/__assert
@@ -20,8 +20,8 @@
 #define _LIBCPP_ASSERT(expression, message)                                                                            \
   (__builtin_expect(static_cast<bool>(expression), 1)                                                                  \
        ? (void)0                                                                                                       \
-       : _LIBCPP_ASSERTION_HANDLER(__FILE__ ":" _LIBCPP_TOSTRING(__LINE__) ": assertion " _LIBCPP_TOSTRING(            \
-             expression) " failed: " message "\n"))
+       : _LIBCPP_ASSERTION_HANDLER(                                                                                    \
+             __FILE__ ":" _LIBCPP_TOSTRING(__LINE__) ": assertion " _LIBCPP_TOSTRING(expression) " failed: " message))
 
 // WARNING: __builtin_assume can currently inhibit optimizations. Only add assumptions with a clear
 // optimization intent. See https://discourse.llvm.org/t/llvm-assume-blocks-optimization/71609 for a

--- a/libcxx/src/verbose_abort.cpp
+++ b/libcxx/src/verbose_abort.cpp
@@ -30,6 +30,9 @@ _LIBCPP_WEAK void __libcpp_verbose_abort(char const* format, ...) noexcept {
     va_list list;
     va_start(list, format);
     std::vfprintf(stderr, format, list);
+    // Callers of `__libcpp_verbose_abort` do not include a newline but when
+    // writing the message to stderr we need to include one.
+    std::fputc('\n', stderr);
     va_end(list);
   }
 

--- a/libcxx/test/support/check_assertion.h
+++ b/libcxx/test/support/check_assertion.h
@@ -340,7 +340,7 @@ void std::__libcpp_verbose_abort(char const* format, ...) noexcept {
 
   std::fprintf(stderr, "%s\n", Marker);
   std::vfprintf(stderr, format, args);
-  std::fprintf(stderr, "%s", Marker);
+  std::fprintf(stderr, "\n%s", Marker);
 
   va_end(args);
 


### PR DESCRIPTION
This newline was originally added in https://reviews.llvm.org/D142184 but I think updating `__libcpp_verbose_abort` to add newline instead is more consistent, and works for other callers of `_LIBCPP_VERBOSE_ABORT`.

The `_LIBCPP_ASSERTION_HANDLER` calls through to either `_LIBCPP_VERBOSE_ABORT` macro or the `__builtin_verbose_trap`. From what I can tell neither of these function expect a trailing newline (at least none of the usage of `_LIBCPP_VERBOSE_ABORT` or `__builtin_verbose_trap` that I can find include a trailing newline except `_LIBCPP_ASSERTION_HANDLER`).

I noticed this discrepancy when working on
https://github.com/emscripten-core/emscripten/pull/24543