### PR TITLE
[Apple][NFC] Update macOS aligned version for lit config

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -602,12 +602,12 @@ if config.host_os == "Darwin":
 
     def get_macos_aligned_version(macos_vers):
         platform = config.apple_platform
-        if platform == "osx":
+        macos_major, macos_minor = macos_vers
+
+        if platform == "osx" or macos_major >= 26:
             return macos_vers
 
-        macos_major, macos_minor = macos_vers
         assert macos_major >= 10
-
         if macos_major == 10:  # macOS 10.x
             major = macos_minor
             minor = 0


### PR DESCRIPTION
This updates the aligned version for version 26.

Note: This change is for correctness only and has no functional impact currently. `get_macos_aligned_version` is currently only consumed when substituting flags based on min version.

rdar://152851947