### PR TITLE
[ValueTracking] Add subtraction support for setLimitsForBinOp

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9594,15 +9594,12 @@ static void setLimitsForBinOp(const BinaryOperator &BO, APInt &Lower,
         Upper = *C + 1;
       } else if (HasNSW) {
         if (C->isNegative()) {
-          // 'sub nsw -C, x' produces [SINT_MIN, SINT_MAX - (C - 1)].
-          // Because to be negative, C must be - 1, and the highest result is
-          // INT_MIN, so -INT_MIN - 1 is INT_MAX, so it is SINT_MAX - (C - 1),
-          // or SINT_MAX - C + 1
+          // 'sub nsw -C, x' produces [SINT_MIN, -C - SINT_MIN].
           Lower = APInt::getSignedMinValue(Width);
           Upper = *C - APInt::getSignedMaxValue(Width);
         } else {
           // Note that sub 0, INT_MIN is not NSW. It techically is a signed wrap
-          // 'sub nsw C, x' produces [SINT_MIN + 1 + C, SINT_MAX].
+          // 'sub nsw C, x' produces [C - SINT_MAX, SINT_MAX].
           Lower = *C - APInt::getSignedMaxValue(Width);
           Upper = APInt::getSignedMinValue(Width);
         }

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9603,8 +9603,8 @@ static void setLimitsForBinOp(const BinaryOperator &BO, APInt &Lower,
         } else {
           // Note that sub 0, INT_MIN is not NSW. It techically is a signed wrap
           // 'sub nsw C, x' produces [SINT_MIN + 1 + C, SINT_MAX].
-          Lower = APInt::getSignedMinValue(Width) + *C + 1;
-          Upper = APInt::getSignedMaxValue(Width) + 1;
+          Lower = *C - APInt::getSignedMaxValue(Width);
+          Upper = APInt::getSignedMinValue(Width);
         }
       }
     }

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9599,7 +9599,7 @@ static void setLimitsForBinOp(const BinaryOperator &BO, APInt &Lower,
           // INT_MIN, so -INT_MIN - 1 is INT_MAX, so it is SINT_MAX - (C - 1),
           // or SINT_MAX - C + 1
           Lower = APInt::getSignedMinValue(Width);
-          Upper = APInt::getSignedMaxValue(Width) + *C + 2;
+          Upper = *C - APInt::getSignedMaxValue(Width);
         } else {
           // Note that sub 0, INT_MIN is not NSW. It techically is a signed wrap
           // 'sub nsw C, x' produces [SINT_MIN + 1 + C, SINT_MAX].

--- a/llvm/test/Transforms/InstCombine/div.ll
+++ b/llvm/test/Transforms/InstCombine/div.ll
@@ -494,9 +494,7 @@ define <2 x i8> @sdiv_exact_negated_dividend_constant_divisor_vec_splat(<2 x i8>
 
 define i8 @sdiv_negated_dividend_constant_divisor_smin(i8 %x) {
 ; CHECK-LABEL: @sdiv_negated_dividend_constant_divisor_smin(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[X:%.*]], -128
-; CHECK-NEXT:    [[D:%.*]] = zext i1 [[TMP1]] to i8
-; CHECK-NEXT:    ret i8 [[D]]
+; CHECK-NEXT:    ret i8 0
 ;
   %neg = sub nsw i8 0, %x
   %d = sdiv i8 %neg, -128
@@ -505,9 +503,7 @@ define i8 @sdiv_negated_dividend_constant_divisor_smin(i8 %x) {
 
 define <2 x i8> @sdiv_negated_dividend_constant_divisor_vec_splat_smin(<2 x i8> %x) {
 ; CHECK-LABEL: @sdiv_negated_dividend_constant_divisor_vec_splat_smin(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq <2 x i8> [[X:%.*]], splat (i8 -128)
-; CHECK-NEXT:    [[D:%.*]] = zext <2 x i1> [[TMP1]] to <2 x i8>
-; CHECK-NEXT:    ret <2 x i8> [[D]]
+; CHECK-NEXT:    ret <2 x i8> zeroinitializer
 ;
   %neg = sub nsw <2 x i8> zeroinitializer, %x
   %d = sdiv <2 x i8> %neg, <i8 -128, i8 -128>

--- a/llvm/test/Transforms/InstCombine/icmp-sub.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-sub.ll
@@ -290,8 +290,7 @@ define i1 @subC_nsw_ne(i32 %x) {
 ; CHECK-LABEL: @subC_nsw_ne(
 ; CHECK-NEXT:    [[SUBX:%.*]] = sub nsw i32 -2147483647, [[X:%.*]]
 ; CHECK-NEXT:    call void @use(i32 [[SUBX]])
-; CHECK-NEXT:    [[R:%.*]] = icmp ne i32 [[X]], 2147483603
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 true
 ;
   %subx = sub nsw i32 -2147483647, %x
   call void @use(i32 %subx)


### PR DESCRIPTION
We can determine the range from a subtraction if it has nsw or nuw.

https://alive2.llvm.org/ce/z/tXAKVV