### PR TITLE
[coro][NFC] Move switch basic block to beginning of coroutine

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -703,6 +703,7 @@ void coro::BaseCloner::replaceEntryBlock() {
     auto *SwitchBB =
         cast<BasicBlock>(VMap[Shape.SwitchLowering.ResumeEntryBlock]);
     Builder.CreateBr(SwitchBB);
+    SwitchBB->moveAfter(Entry);
     break;
   }
   case coro::ABI::Async:


### PR DESCRIPTION
This makes the code flow when reading the LLVM IR of a split coroutine a bit more natural. It does not change anything from an end-user perspective but makes debugging the CoroSplit pass slightly easier.