### PR TITLE
[AArch64] Lower jump table cases threshold to 10

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -73,7 +73,7 @@ static cl::opt<AArch64PAuth::AuthCheckMethod>
                                cl::values(AUTH_CHECK_METHOD_CL_VALUES_LR));
 
 static cl::opt<unsigned> AArch64MinimumJumpTableEntries(
-    "aarch64-min-jump-table-entries", cl::init(13), cl::Hidden,
+    "aarch64-min-jump-table-entries", cl::init(10), cl::Hidden,
     cl::desc("Set minimum number of entries to use a jump table on AArch64"));
 
 static cl::opt<unsigned> AArch64StreamingHazardSize(

--- a/llvm/test/CodeGen/AArch64/min-jump-table.ll
+++ b/llvm/test/CodeGen/AArch64/min-jump-table.ll
@@ -105,7 +105,7 @@ entry:
 ; CHECK4-NEXT: Jump Tables:
 ; CHECK8-NEXT: Jump Tables:
 ; CHECK12-NEXT: Jump Tables:
-; CHECK-DEFAULT-NOT: {{^}}Jump Tables:
+; CHECK-DEFAULT: {{^}}Jump Tables:
 
 bb1: tail call void @ext(i32 1, i32 0) br label %return
 bb2: tail call void @ext(i32 2, i32 2) br label %return


### PR DESCRIPTION
Previous stabs at this setting (https://github.com/llvm/llvm-project/pull/71166) hypertuned it for SPEC2017, but Clang's own compilation can benefit from a slightly lower threshold, yielding a 0.3% improvement in compile time, while still not regressing SPEC.

Most notable beneficiaries of this change are:
 - `llvm::Instruction::getNumSuccessors` (11 cases)
 - `llvm::Instruction::getSuccessor` (11 cases)
 
Test Suite with a bootstrapped build:
```
Tests: 4316
Metric: compile_time

Program                                       compile_time             
                                              lhs          rhs    diff 
SingleSour...ce/UnitTests/SignlessTypes/div     0.02         0.02  3.0%
SingleSour.../UnitTests/SignlessTypes/cast2     0.02         0.02  2.8%
SingleSource/Benchmarks/Misc/flops-4            0.02         0.02  1.9%
SingleSour...ebra/solvers/cholesky/cholesky     0.05         0.05  1.8%
SingleSour...tTests/2020-01-06-coverage-006     0.02         0.02  1.7%
SingleSour...ce/Benchmarks/Stanford/FloatMM     0.03         0.03  1.7%
SingleSour...9-04-16-BitfieldInitialization     0.02         0.02  1.7%
SingleSour...nitTests/2003-07-08-BitOpsTest     0.02         0.02  1.7%
MultiSourc...marks/Prolangs-C++/vcirc/vcirc     0.02         0.02  1.6%
MultiSourc...Prolangs-C/fixoutput/fixoutput     0.05         0.05  1.5%
SingleSour...h/stencils/jacobi-1d/jacobi-1d     0.04         0.04  1.4%
MultiSourc...rks/Prolangs-C++/office/office     0.28         0.28  1.4%
SingleSour...arks/Adobe-C++/functionobjects     0.39         0.40  1.3%
SingleSour...Tests/2003-10-29-ScalarReplBug     0.02         0.02  1.2%
SingleSour...arks/Adobe-C++/stepanov_vector     0.41         0.42  1.2%
                           Geomean difference                     -0.3%
      compile_time                         
l/r            lhs          rhs        diff
count  4316.000000  4316.000000  469.000000
mean   0.057747     0.057595    -0.003034  
std    0.544528     0.543139     0.007625  
min    0.000000     0.000000    -0.035294  
25%    0.000000     0.000000    -0.007006  
50%    0.000000     0.000000    -0.003257  
75%    0.000000     0.000000     0.000000  
max    18.295300    18.252500    0.030151
```