### PR TITLE
[lldb] Fix object format in the Triple of Mach-O files (approach 2)

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5148,7 +5148,6 @@ void ObjectFileMachO::GetAllArchSpecs(const llvm::MachO::mach_header &header,
   llvm::Triple base_triple = base_arch.GetTriple();
   base_triple.setOS(llvm::Triple::UnknownOS);
   base_triple.setOSName(llvm::StringRef());
-  base_triple.setObjectFormat(llvm::Triple::MachO);
 
   if (header.filetype == MH_PRELOAD) {
     if (header.cputype == CPU_TYPE_ARM) {

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5148,6 +5148,7 @@ void ObjectFileMachO::GetAllArchSpecs(const llvm::MachO::mach_header &header,
   llvm::Triple base_triple = base_arch.GetTriple();
   base_triple.setOS(llvm::Triple::UnknownOS);
   base_triple.setOSName(llvm::StringRef());
+  base_triple.setObjectFormat(llvm::Triple::MachO);
 
   if (header.filetype == MH_PRELOAD) {
     if (header.cputype == CPU_TYPE_ARM) {

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -94,4 +94,58 @@ TEST_F(ObjectFileMachOTest, IndirectSymbolsInTheSharedCache) {
   for (size_t i = 0; i < 10; i++)
     OF->ParseSymtab(symtab);
 }
+
+TEST_F(ObjectFileMachOTest, ObjectFileFormatWithoutLoadCommand) {
+  // A Mach-O file without the load command LC_BUILD_VERSION.
+  const char *yamldata = R"(
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x0100000C
+  cpusubtype:      0x00000000
+  filetype:        0x00000001
+  ncmds:           1
+  sizeofcmds:      152
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         152
+    segname:         __TEXT
+    vmaddr:          0
+    vmsize:          4
+    fileoff:         184
+    filesize:        4
+    maxprot:         7
+    initprot:        7
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0000000000000000
+        content:         'AABBCCDD'
+        size:            4
+        offset:          184
+        align:           0
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+...
+)";
+  
+  // Perform setup.
+  llvm::Expected<TestFile> file = TestFile::fromYaml(yamldata);
+  EXPECT_THAT_EXPECTED(file, llvm::Succeeded());
+  auto module_sp = std::make_shared<Module>(file->moduleSpec());
+  ASSERT_NE(module_sp, nullptr);
+  auto object_file = module_sp->GetObjectFile();
+  ASSERT_NE(object_file, nullptr);
+
+  // Verify that the object file is recognized as Mach-O.
+  ASSERT_EQ(object_file->GetArchitecture().GetTriple().getObjectFormat(), llvm::Triple::MachO);
+}
 #endif

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -136,7 +136,7 @@ LoadCommands:
         reserved3:       0x00000000
 ...
 )";
-  
+
   // Perform setup.
   llvm::Expected<TestFile> file = TestFile::fromYaml(yamldata);
   EXPECT_THAT_EXPECTED(file, llvm::Succeeded());
@@ -146,6 +146,7 @@ LoadCommands:
   ASSERT_NE(object_file, nullptr);
 
   // Verify that the object file is recognized as Mach-O.
-  ASSERT_EQ(object_file->GetArchitecture().GetTriple().getObjectFormat(), llvm::Triple::MachO);
+  ASSERT_EQ(object_file->GetArchitecture().GetTriple().getObjectFormat(),
+            llvm::Triple::MachO);
 }
 #endif

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -95,7 +95,7 @@ TEST_F(ObjectFileMachOTest, IndirectSymbolsInTheSharedCache) {
     OF->ParseSymtab(symtab);
 }
 
-TEST_F(ObjectFileMachOTest, ObjectFileFormatWithoutLoadCommand) {
+TEST_F(ObjectFileMachOTest, ObjectFormatWithoutVersionLoadCommand) {
   // A Mach-O file without the load command LC_BUILD_VERSION.
   const char *yamldata = R"(
 --- !mach-o

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -933,6 +933,9 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
     case Triple::Win32:
     case Triple::UEFI:
       return Triple::COFF;
+    case Triple::UnknownOS:
+      return T.getVendor() == Triple::Apple ? Triple::MachO : Triple::ELF;
+      // Intentional leak into the default case for additional logic.
     default:
       return T.isOSDarwin() ? Triple::MachO : Triple::ELF;
     }

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -935,7 +935,6 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
       return Triple::COFF;
     case Triple::UnknownOS:
       return T.getVendor() == Triple::Apple ? Triple::MachO : Triple::ELF;
-      // Intentional leak into the default case for additional logic.
     default:
       return T.isOSDarwin() ? Triple::MachO : Triple::ELF;
     }

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -2579,6 +2579,13 @@ TEST(TripleTest, FileFormat) {
   EXPECT_EQ(Triple::SPIRV, Triple("spirv32-apple-macosx").getObjectFormat());
   EXPECT_EQ(Triple::SPIRV, Triple("spirv64-apple-macosx").getObjectFormat());
   EXPECT_EQ(Triple::DXContainer, Triple("dxil-apple-macosx").getObjectFormat());
+
+  EXPECT_EQ(Triple::MachO, Triple("aarch64-apple-macosx").getObjectFormat());
+  EXPECT_EQ(Triple::MachO, Triple("x86_64-apple-macosx").getObjectFormat());
+  EXPECT_EQ(Triple::MachO, Triple("aarch64-apple").getObjectFormat());
+  EXPECT_EQ(Triple::MachO, Triple("x86_64-apple").getObjectFormat());
+  EXPECT_EQ(Triple::ELF, Triple("aarch64").getObjectFormat());
+  EXPECT_EQ(Triple::ELF, Triple("x86_64").getObjectFormat());
 }
 
 TEST(TripleTest, NormalizeWindows) {


### PR DESCRIPTION
**Context**: See previous attempt #142704

**TL;DR**: If a Mach-O file (including those yaml data in lldb unit tests) doesn't have load commands like `LC_BUILD_VERSION` or `LC_VERSION_MIN_*`, they are mistakenly reported as `ELF` (as in their `Triple`) when they are parsed by `ObjectFileMachO`. If the load commands existed, they would have caused `ObjectFileMachO` to set the correct OS name into the `Triple` [here](https://github.com/llvm/llvm-project/blob/52a6492136ef43462c68efa88a0276bb66ee8c52/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp#L5158-L5174) and [here](https://github.com/llvm/llvm-project/blob/52a6492136ef43462c68efa88a0276bb66ee8c52/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp#L5109-L5125), which would have led to a correct default `MachO` object format. Previously, #142704 tries to fix this by setting the correct object format in `ObjectFileMachO::GetAllArchSpecs`. However, it seems such explicit assignment cause the `Triple` to report "-macho" in its string form, causing change in UI and a test failure which depends on the UI.

So we are dealing with the following constraints:
1. The UI cannot be changed. IIUC, this means the fix cannot set the object format explicitly. I.e. the fix has to be in `Triple`'s `getDefaultFormat()`, changing the returned default format based on the `Triple`'s other fields.
2. In `getDefaultFormat()`, at least in the case that I tested (see added unit test), the `OS` is not set.
3. The `Vendor` is set to `Apple`. This is because `ObjectFileMachO::GetAllArchSpecs()` calls `ArchSpec::SetArchitecture()` ([code](https://github.com/llvm/llvm-project/blob/1bf4702d2bbaad522886dfbab913a8dd6efe3b85/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp#L5059)), which sets the vendor ([code](https://github.com/llvm/llvm-project/blob/1bf4702d2bbaad522886dfbab913a8dd6efe3b85/lldb/source/Utility/ArchSpec.cpp#L892)).
4. Since the above code will always set the arch type to `eArchTypeMachO`, which will always lead to the vendor to be set as `Apple`, it seems to be a consistent way to detect mach-o object format.

This patch doesn't change the main logic flow of `getDefaultFormat()` - it still first look at CPU arch, then OS. The change is that, when we look at OS and it's `UnknownOS`, then we further look at vendor and return `MachO` if the vendor is `Apple`.

---

An **alternative approach** is to:
1. Claim that LLDB don't support Mach-O files which don't have the said version load commands (i.e. undetermined behavior).
2. In all LLDB tests which uses Mach-O, make sure they have version load commands.