### PR TITLE
[dsymutil] Fix line table sequence mapping for stmt_sequence attributes

### DIFF
--- a/llvm/test/tools/dsymutil/ARM/stmt-seq-macho.test
+++ b/llvm/test/tools/dsymutil/ARM/stmt-seq-macho.test
@@ -4,7 +4,12 @@
 # RUN: yaml2obj %t/stmt_seq_macho.exe.yaml -o %t/stmt_seq_macho.exe
 # RUN: yaml2obj %t/stmt_seq_macho.o.yaml   -o %t/stmt_seq_macho.o
 # RUN: dsymutil --flat --verify-dwarf=none -oso-prepend-path %t %t/stmt_seq_macho.exe -o %t/stmt_seq_macho.dSYM
-# RUN: llvm-dwarfdump --debug-info --debug-line -v %t/stmt_seq_macho.dSYM | sort | FileCheck %s -check-prefix=CHECK_DSYM
+# RUN: llvm-dwarfdump --debug-info --debug-line -v %t/stmt_seq_macho.dSYM > %t/stmt_seq_macho.dSYM.txt
+# RUN: cat %t/stmt_seq_macho.dSYM.txt | sort | FileCheck %s -check-prefix=CHECK_DSYM
+# RUN: cat %t/stmt_seq_macho.dSYM.txt | FileCheck %s -check-prefix=CHECK_NO_INVALID_OFFSET
+
+# CHECK_NO_INVALID_OFFSET-NOT: DW_AT_LLVM_stmt_sequence{{.*}}0xffffffff
+
 
 # CHECK_DSYM: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset] ([[OFFSET1:(0x[0-9a-f]+)]])
 # CHECK_DSYM: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset] ([[OFFSET2:(0x[0-9a-f]+)]])


### PR DESCRIPTION
This commit resolves an issue in dsymutil where `DW_AT_LLVM_stmt_sequence` attributes were incorrectly patched during the `.debug_line table` rewrite. This led to invalid offsets being written to the DWARF, severing the crucial link between a function's DIE and its specific line entries. 

The root cause was the patching logic's sole reliance on the `DWARFDebugLine::LineTable` parser's `LT->Sequences` output. This parser does not reliably identify every sequence start, as it was not designed for the current DW_AT_LLVM_stmt_sequence model where each function has its own distinct sequence, which may not start with a new address range.

This patch implements a more resilient, hybrid mapping strategy. It first populates a map with the sequences the parser correctly identifies. It then adds to this map by manually reconstructing all sequence boundaries, identifying the start of the table and every row following an end_sequence flag. These boundaries are correlated with a sorted list of all `DW_AT_LLVM_stmt_sequence` attributes, ensuring a complete and accurate mapping from original to new offsets, even with partial matches.

The existing `stmt-seq-macho.test` actually exhibited this issue - so we can just add an additional check to ensure the issue is fixed. 