### PR TITLE
[clang-format][NFC] Upgrade IndentBraces option to a struct

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -2539,7 +2539,7 @@ the configuration (without a prefix: ``Auto``).
         foo();
       } while (1);
 
-  * ``bool IndentBraces`` Indent the wrapped braces themselves.
+  * ``IndentBracesOptions IndentBraces`` Controls indenting of wrapped braces.
 
   * ``bool SplitEmptyFunction`` If ``false``, empty function body can be put on a single line.
     This option is used only if the opening brace of the function has

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1355,6 +1355,18 @@ struct FormatStyle {
     BWACS_Always
   };
 
+  /// Options for indenting wrapped braces.
+  struct IndentBracesOptions {
+    /// Indent wrapped braces.
+    bool Enabled;
+    bool operator==(const IndentBracesOptions &R) const {
+      return Enabled == R.Enabled;
+    }
+    bool operator!=(const IndentBracesOptions &R) const {
+      return !(*this == R);
+    }
+  };
+
   /// Precise control over the wrapping of braces.
   /// \code
   ///   # Should be declared this way:
@@ -1545,8 +1557,8 @@ struct FormatStyle {
     ///   } while (1);
     /// \endcode
     bool BeforeWhile;
-    /// Indent the wrapped braces themselves.
-    bool IndentBraces;
+    /// Controls indenting of wrapped braces.
+    IndentBracesOptions IndentBraces;
     /// If ``false``, empty function body can be put on a single line.
     /// This option is used only if the opening brace of the function has
     /// already been wrapped, i.e. the ``AfterFunction`` brace wrapping mode is

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1335,7 +1335,7 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
   }
 
   if (Style.BraceWrapping.BeforeLambdaBody &&
-      Style.BraceWrapping.IndentBraces && Current.is(TT_LambdaLBrace)) {
+      Style.BraceWrapping.IndentBraces.Enabled && Current.is(TT_LambdaLBrace)) {
     const auto From = Style.LambdaBodyIndentation == FormatStyle::LBI_Signature
                           ? CurrentState.Indent
                           : State.FirstIndent;
@@ -2123,7 +2123,8 @@ void ContinuationIndenter::moveStateToNewBlock(LineState &State, bool NewLine) {
   if (Style.LambdaBodyIndentation == FormatStyle::LBI_OuterScope &&
       State.NextToken->is(TT_LambdaLBrace) &&
       !State.Line->MightBeFunctionDecl) {
-    const auto Indent = Style.IndentWidth * Style.BraceWrapping.IndentBraces;
+    const auto Indent =
+        Style.IndentWidth * Style.BraceWrapping.IndentBraces.Enabled;
     State.Stack.back().NestedBlockIndent = State.FirstIndent + Indent;
   }
   unsigned NestedBlockIndent = State.Stack.back().NestedBlockIndent;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -231,6 +231,20 @@ struct ScalarEnumerationTraits<
   }
 };
 
+template <> struct MappingTraits<FormatStyle::IndentBracesOptions> {
+  static void enumInput(IO &IO, FormatStyle::IndentBracesOptions &Value) {
+    // For backward compatibility.
+    IO.enumCase(Value, "false",
+                FormatStyle::IndentBracesOptions({/*Enabled=*/false}));
+    IO.enumCase(Value, "true",
+                FormatStyle::IndentBracesOptions({/*Enabled=*/true}));
+  }
+
+  static void mapping(IO &IO, FormatStyle::IndentBracesOptions &Value) {
+    IO.mapOptional("Enabled", Value.Enabled);
+  }
+};
+
 template <>
 struct ScalarEnumerationTraits<
     FormatStyle::BreakBeforeConceptDeclarationsStyle> {
@@ -1381,7 +1395,7 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
                             /*BeforeElse=*/false,
                             /*BeforeLambdaBody=*/false,
                             /*BeforeWhile=*/false,
-                            /*IndentBraces=*/false,
+                            /*IndentBraces=*/{/*Enabled=*/false},
                             /*SplitEmptyFunction=*/true,
                             /*SplitEmptyRecord=*/true,
                             /*SplitEmptyNamespace=*/true};
@@ -1451,7 +1465,7 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
         /*BeforeElse=*/true,
         /*BeforeLambdaBody=*/true,
         /*BeforeWhile=*/true,
-        /*IndentBraces=*/true,
+        /*IndentBraces=*/{/*Enabled=*/true},
         /*SplitEmptyFunction=*/true,
         /*SplitEmptyRecord=*/true,
         /*SplitEmptyNamespace=*/true};
@@ -1551,7 +1565,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
                              /*BeforeElse=*/false,
                              /*BeforeLambdaBody=*/false,
                              /*BeforeWhile=*/false,
-                             /*IndentBraces=*/false,
+                             /*IndentBraces=*/{/*Enabled=*/false},
                              /*SplitEmptyFunction=*/true,
                              /*SplitEmptyRecord=*/true,
                              /*SplitEmptyNamespace=*/true};

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -135,7 +135,7 @@ public:
       : CompoundStatementIndenter(Parser, LineLevel,
                                   Style.BraceWrapping.AfterControlStatement ==
                                       FormatStyle::BWACS_Always,
-                                  Style.BraceWrapping.IndentBraces) {}
+                                  Style.BraceWrapping.IndentBraces.Enabled) {}
   CompoundStatementIndenter(UnwrappedLineParser *Parser, unsigned &LineLevel,
                             bool WrapBrace, bool IndentBrace)
       : LineLevel(LineLevel), OldLineLevel(LineLevel) {
@@ -3349,9 +3349,9 @@ void UnwrappedLineParser::parseLabel(bool LeftAlignLabel) {
   if (!Style.IndentCaseBlocks && CommentsBeforeNextToken.empty() &&
       FormatTok->is(tok::l_brace)) {
 
-    CompoundStatementIndenter Indenter(this, Line->Level,
-                                       Style.BraceWrapping.AfterCaseLabel,
-                                       Style.BraceWrapping.IndentBraces);
+    CompoundStatementIndenter Indenter(
+        this, Line->Level, Style.BraceWrapping.AfterCaseLabel,
+        Style.BraceWrapping.IndentBraces.Enabled);
     parseBlock();
     if (FormatTok->is(tok::kw_break)) {
       if (Style.BraceWrapping.AfterControlStatement ==

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -235,7 +235,6 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, BeforeElse);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, BeforeLambdaBody);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, BeforeWhile);
-  CHECK_PARSE_NESTED_BOOL(BraceWrapping, IndentBraces);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyFunction);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyRecord);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, SplitEmptyNamespace);
@@ -756,6 +755,23 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("BraceWrapping:\n"
               "  AfterControlStatement: false",
               BraceWrapping.AfterControlStatement, FormatStyle::BWACS_Never);
+
+  Style.BraceWrapping.IndentBraces.Enabled = false;
+  CHECK_PARSE("BraceWrapping:\n"
+              "  IndentBraces:\n"
+              "    Enabled: true",
+              BraceWrapping.IndentBraces.Enabled, true);
+  CHECK_PARSE("BraceWrapping:\n"
+              "  IndentBraces:\n"
+              "    Enabled: false",
+              BraceWrapping.IndentBraces.Enabled, false);
+  // For backward compatibility:
+  CHECK_PARSE("BraceWrapping:\n"
+              "  IndentBraces: true",
+              BraceWrapping.IndentBraces.Enabled, true);
+  CHECK_PARSE("BraceWrapping:\n"
+              "  IndentBraces: false",
+              BraceWrapping.IndentBraces.Enabled, false);
 
   Style.BreakAfterReturnType = FormatStyle::RTBS_All;
   CHECK_PARSE("BreakAfterReturnType: None", BreakAfterReturnType,


### PR DESCRIPTION
This allows for more suboptions to be added in the future to give more control of brace indenting.