### PR TITLE
Pass TargetMachine from from Clang to `BitcodeWriter`and `ThinLTOBitcodeWriter` pass for thin and fat LTO respectively.

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1173,7 +1173,8 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
             return;
         }
         MPM.addPass(ThinLTOBitcodeWriterPass(
-            *OS, ThinLinkOS ? &ThinLinkOS->os() : nullptr));
+            *OS, ThinLinkOS ? &ThinLinkOS->os() : nullptr,
+            /* ShouldPreserveUseListOrder */ false, TM.get()));
       } else if (Action == Backend_EmitLL) {
         MPM.addPass(PrintModulePass(*OS, "", CodeGenOpts.EmitLLVMUseLists,
                                     /*EmitLTOSummary=*/true));
@@ -1191,7 +1192,7 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
       }
       if (Action == Backend_EmitBC) {
         MPM.addPass(BitcodeWriterPass(*OS, CodeGenOpts.EmitLLVMUseLists,
-                                      EmitLTOSummary));
+                                      EmitLTOSummary, false, TM.get()));
       } else if (Action == Backend_EmitLL) {
         MPM.addPass(PrintModulePass(*OS, "", CodeGenOpts.EmitLLVMUseLists,
                                     EmitLTOSummary));

--- a/clang/test/CodeGen/RISCV/include.c
+++ b/clang/test/CodeGen/RISCV/include.c
@@ -1,0 +1,11 @@
+// RUN: %clang --target=riscv32-unknown-elf -I %S/../Inputs/ -flto %s -c -o %t.full.bc
+// RUN: llvm-dis %t.full.bc -o - | FileCheck %s
+// RUN: %clang --target=riscv32-unknown-elf -I %S/../Inputs/ -flto=thin %s -c -o %t.thin.bc
+// RUN: llvm-dis %t.thin.bc -o - | FileCheck %s
+__asm__(".include \"macros.s\"");
+
+void test() {
+}
+
+// CHECK: module asm ".include \22macros.s\22"
+

--- a/llvm/include/llvm/Analysis/ModuleSummaryAnalysis.h
+++ b/llvm/include/llvm/Analysis/ModuleSummaryAnalysis.h
@@ -27,6 +27,7 @@ class Function;
 class Module;
 class ProfileSummaryInfo;
 class StackSafetyInfo;
+class TargetMachine;
 
 /// Direct function to compute a \c ModuleSummaryIndex from a given module.
 ///
@@ -37,7 +38,7 @@ class StackSafetyInfo;
 LLVM_ABI ModuleSummaryIndex buildModuleSummaryIndex(
     const Module &M,
     std::function<BlockFrequencyInfo *(const Function &F)> GetBFICallback,
-    ProfileSummaryInfo *PSI,
+    ProfileSummaryInfo *PSI, const TargetMachine *TM = nullptr,
     std::function<const StackSafetyInfo *(const Function &F)> GetSSICallback =
         [](const Function &F) -> const StackSafetyInfo * { return nullptr; });
 

--- a/llvm/include/llvm/Bitcode/BitcodeWriter.h
+++ b/llvm/include/llvm/Bitcode/BitcodeWriter.h
@@ -29,6 +29,7 @@ namespace llvm {
 class BitstreamWriter;
 class Module;
 class raw_ostream;
+class TargetMachine;
 
 class BitcodeWriter {
   std::unique_ptr<BitstreamWriter> Stream;
@@ -45,10 +46,13 @@ class BitcodeWriter {
 
   std::vector<Module *> Mods;
 
+  const TargetMachine *TM;
+
 public:
   /// Create a BitcodeWriter that writes to Buffer.
-  LLVM_ABI BitcodeWriter(SmallVectorImpl<char> &Buffer);
-  LLVM_ABI BitcodeWriter(raw_ostream &FS);
+  LLVM_ABI BitcodeWriter(SmallVectorImpl<char> &Buffer,
+                         const TargetMachine *TM = nullptr);
+  LLVM_ABI BitcodeWriter(raw_ostream &FS, const TargetMachine *TM = nullptr);
 
   LLVM_ABI ~BitcodeWriter();
 
@@ -135,7 +139,8 @@ LLVM_ABI void WriteBitcodeToFile(const Module &M, raw_ostream &Out,
                                  bool ShouldPreserveUseListOrder = false,
                                  const ModuleSummaryIndex *Index = nullptr,
                                  bool GenerateHash = false,
-                                 ModuleHash *ModHash = nullptr);
+                                 ModuleHash *ModHash = nullptr,
+                                 const TargetMachine *TM = nullptr);
 
 /// Write the specified thin link bitcode file (i.e., the minimized bitcode
 /// file) to the given raw output stream, where it will be written in a new
@@ -146,7 +151,8 @@ LLVM_ABI void WriteBitcodeToFile(const Module &M, raw_ostream &Out,
 /// bitcode file writing.
 LLVM_ABI void writeThinLinkBitcodeToFile(const Module &M, raw_ostream &Out,
                                          const ModuleSummaryIndex &Index,
-                                         const ModuleHash &ModHash);
+                                         const ModuleHash &ModHash,
+                                         const TargetMachine *TM = nullptr);
 
 /// Write the specified module summary index to the given raw output stream,
 /// where it will be written in a new bitcode block. This is used when

--- a/llvm/include/llvm/Bitcode/BitcodeWriterPass.h
+++ b/llvm/include/llvm/Bitcode/BitcodeWriterPass.h
@@ -22,6 +22,7 @@ class Module;
 class ModulePass;
 class Pass;
 class raw_ostream;
+class TargetMachine;
 
 /// Create and return a pass that writes the module to the specified
 /// ostream. Note that this pass is designed for use with the legacy pass
@@ -31,7 +32,8 @@ class raw_ostream;
 /// reproduced when deserialized.
 LLVM_ABI ModulePass *
 createBitcodeWriterPass(raw_ostream &Str,
-                        bool ShouldPreserveUseListOrder = false);
+                        bool ShouldPreserveUseListOrder = false,
+                        const TargetMachine *TM = nullptr);
 
 /// Check whether a pass is a BitcodeWriterPass.
 LLVM_ABI bool isBitcodeWriterPass(Pass *P);
@@ -45,6 +47,7 @@ class BitcodeWriterPass : public PassInfoMixin<BitcodeWriterPass> {
   bool ShouldPreserveUseListOrder;
   bool EmitSummaryIndex;
   bool EmitModuleHash;
+  const TargetMachine *TM;
 
 public:
   /// Construct a bitcode writer pass around a particular output stream.
@@ -57,9 +60,11 @@ public:
   explicit BitcodeWriterPass(raw_ostream &OS,
                              bool ShouldPreserveUseListOrder = false,
                              bool EmitSummaryIndex = false,
-                             bool EmitModuleHash = false)
+                             bool EmitModuleHash = false,
+                             const TargetMachine *TM = nullptr)
       : OS(OS), ShouldPreserveUseListOrder(ShouldPreserveUseListOrder),
-  EmitSummaryIndex(EmitSummaryIndex), EmitModuleHash(EmitModuleHash) {}
+        EmitSummaryIndex(EmitSummaryIndex), EmitModuleHash(EmitModuleHash),
+        TM(TM) {}
 
   /// Run the bitcode writer pass, and output the module to the selected
   /// output stream.

--- a/llvm/include/llvm/IR/PassManager.h
+++ b/llvm/include/llvm/IR/PassManager.h
@@ -59,6 +59,7 @@ namespace llvm {
 
 class Function;
 class Module;
+class TargetMachine;
 
 // Forward declare the analysis manager template.
 template <typename IRUnitT, typename... ExtraArgTs> class AnalysisManager;

--- a/llvm/include/llvm/Object/IRSymtab.h
+++ b/llvm/include/llvm/Object/IRSymtab.h
@@ -41,6 +41,7 @@ namespace llvm {
 
 struct BitcodeFileContents;
 class StringTableBuilder;
+class TargetMachine;
 
 namespace irsymtab {
 
@@ -164,8 +165,8 @@ struct Header {
 /// Fills in Symtab and StrtabBuilder with a valid symbol and string table for
 /// Mods.
 LLVM_ABI Error build(ArrayRef<Module *> Mods, SmallVector<char, 0> &Symtab,
-                     StringTableBuilder &StrtabBuilder,
-                     BumpPtrAllocator &Alloc);
+                     StringTableBuilder &StrtabBuilder, BumpPtrAllocator &Alloc,
+                     const TargetMachine *TM = nullptr);
 
 /// This represents a symbol that has been read from a storage::Symbol and
 /// possibly a storage::Uncommon.

--- a/llvm/include/llvm/Object/ModuleSymbolTable.h
+++ b/llvm/include/llvm/Object/ModuleSymbolTable.h
@@ -30,6 +30,7 @@ namespace llvm {
 
 class GlobalValue;
 class Module;
+class TargetMachine;
 
 class ModuleSymbolTable {
 public:
@@ -45,7 +46,7 @@ private:
 
 public:
   ArrayRef<Symbol> symbols() const { return SymTab; }
-  LLVM_ABI void addModule(Module *M);
+  LLVM_ABI void addModule(Module *M, const TargetMachine *TM = nullptr);
 
   LLVM_ABI void printSymbolName(raw_ostream &OS, Symbol S) const;
   LLVM_ABI uint32_t getSymbolFlags(Symbol S) const;
@@ -57,7 +58,8 @@ public:
   /// and the associated flags.
   LLVM_ABI static void CollectAsmSymbols(
       const Module &M,
-      function_ref<void(StringRef, object::BasicSymbolRef::Flags)> AsmSymbol);
+      function_ref<void(StringRef, object::BasicSymbolRef::Flags)> AsmSymbol,
+      const TargetMachine *TM = nullptr);
 
   /// Parse inline ASM and collect the symvers directives that are defined in
   /// the current module.

--- a/llvm/include/llvm/Transforms/IPO/EmbedBitcodePass.h
+++ b/llvm/include/llvm/Transforms/IPO/EmbedBitcodePass.h
@@ -45,7 +45,7 @@ public:
   EmbedBitcodePass(bool IsThinLTO, bool EmitLTOSummary)
       : IsThinLTO(IsThinLTO), EmitLTOSummary(EmitLTOSummary) {}
 
-  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 
   static bool isRequired() { return true; }
 };

--- a/llvm/include/llvm/Transforms/IPO/ThinLTOBitcodeWriter.h
+++ b/llvm/include/llvm/Transforms/IPO/ThinLTOBitcodeWriter.h
@@ -22,20 +22,23 @@
 namespace llvm {
 class Module;
 class raw_ostream;
+class TargetMachine;
 
 class ThinLTOBitcodeWriterPass
     : public PassInfoMixin<ThinLTOBitcodeWriterPass> {
   raw_ostream &OS;
   raw_ostream *ThinLinkOS;
   const bool ShouldPreserveUseListOrder;
+  const TargetMachine *TM;
 
 public:
   // Writes bitcode to OS. Also write thin link file to ThinLinkOS, if
   // it's not nullptr.
   ThinLTOBitcodeWriterPass(raw_ostream &OS, raw_ostream *ThinLinkOS,
-                           bool ShouldPreserveUseListOrder = false)
+                           bool ShouldPreserveUseListOrder = false,
+                           const TargetMachine *TM = nullptr)
       : OS(OS), ThinLinkOS(ThinLinkOS),
-        ShouldPreserveUseListOrder(ShouldPreserveUseListOrder) {}
+        ShouldPreserveUseListOrder(ShouldPreserveUseListOrder), TM(TM) {}
 
   LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 

--- a/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
+++ b/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
@@ -8,8 +8,11 @@
 
 #include "llvm/Transforms/IPO/ThinLTOBitcodeWriter.h"
 #include "llvm/Analysis/BasicAliasAnalysis.h"
+#include "llvm/Bitcode/BitcodeWriterPass.h"
+#include "llvm/Analysis/BlockFrequencyInfo.h"
 #include "llvm/Analysis/ModuleSummaryAnalysis.h"
 #include "llvm/Analysis/ProfileSummaryInfo.h"
+#include "llvm/Analysis/StackSafetyAnalysis.h"
 #include "llvm/Analysis/TypeMetadataUtils.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/Constants.h"
@@ -20,6 +23,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Object/ModuleSymbolTable.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/FunctionAttrs.h"
 #include "llvm/Transforms/IPO/FunctionImport.h"
@@ -543,7 +547,8 @@ bool requiresSplit(Module &M) {
 bool writeThinLTOBitcode(raw_ostream &OS, raw_ostream *ThinLinkOS,
                          function_ref<AAResults &(Function &)> AARGetter,
                          Module &M, const ModuleSummaryIndex *Index,
-                         const bool ShouldPreserveUseListOrder) {
+                         const bool ShouldPreserveUseListOrder,
+                         const TargetMachine *TM = nullptr) {
   std::unique_ptr<ModuleSummaryIndex> NewIndex = nullptr;
   // See if this module needs to be split. If so, we try to split it
   // or at least promote type ids to enable WPD.
@@ -567,7 +572,7 @@ bool writeThinLTOBitcode(raw_ostream &OS, raw_ostream *ThinLinkOS,
       // buildModuleSummaryIndex when Module(s) are ready.
       ProfileSummaryInfo PSI(M);
       NewIndex = std::make_unique<ModuleSummaryIndex>(
-          buildModuleSummaryIndex(M, nullptr, &PSI));
+          buildModuleSummaryIndex(M, nullptr, &PSI, TM));
       Index = NewIndex.get();
     }
   }
@@ -579,12 +584,12 @@ bool writeThinLTOBitcode(raw_ostream &OS, raw_ostream *ThinLinkOS,
   // produced for the full link.
   ModuleHash ModHash = {{0}};
   WriteBitcodeToFile(M, OS, ShouldPreserveUseListOrder, Index,
-                     /*GenerateHash=*/true, &ModHash);
+                     /*GenerateHash=*/true, &ModHash, TM);
   // If a minimized bitcode module was requested for the thin link, only
   // the information that is needed by thin link will be written in the
   // given OS.
   if (ThinLinkOS && Index)
-    writeThinLinkBitcodeToFile(M, *ThinLinkOS, *Index, ModHash);
+    writeThinLinkBitcodeToFile(M, *ThinLinkOS, *Index, ModHash, TM);
   return false;
 }
 
@@ -592,18 +597,32 @@ bool writeThinLTOBitcode(raw_ostream &OS, raw_ostream *ThinLinkOS,
 
 PreservedAnalyses
 llvm::ThinLTOBitcodeWriterPass::run(Module &M, ModuleAnalysisManager &AM) {
-  FunctionAnalysisManager &FAM =
-      AM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
 
   M.removeDebugIntrinsicDeclarations();
 
+  FunctionAnalysisManager &FAM =
+      AM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
+  ProfileSummaryInfo &PSI = AM.getResult<ProfileSummaryAnalysis>(M);
+  bool NeedSSI = needsParamAccessSummary(M);
+  std::unique_ptr<ModuleSummaryIndex> NewIndex = nullptr;
+  NewIndex = std::make_unique<ModuleSummaryIndex>(buildModuleSummaryIndex(
+      M,
+      [&FAM](const Function &F) {
+        return &FAM.getResult<BlockFrequencyAnalysis>(
+            *const_cast<Function *>(&F));
+      },
+      &PSI, TM,
+      [&FAM, NeedSSI](const Function &F) -> const StackSafetyInfo * {
+        return NeedSSI ? &FAM.getResult<StackSafetyAnalysis>(
+                             const_cast<Function &>(F))
+                       : nullptr;
+      }));
   bool Changed = writeThinLTOBitcode(
       OS, ThinLinkOS,
       [&FAM](Function &F) -> AAResults & {
         return FAM.getResult<AAManager>(F);
       },
-      M, &AM.getResult<ModuleSummaryIndexAnalysis>(M),
-      ShouldPreserveUseListOrder);
+      M, NewIndex.get(), ShouldPreserveUseListOrder, TM);
 
   return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }


### PR DESCRIPTION
In the initializeRecordStreamer function within the ModuleSymbolTable file, MCTargetOptions are re-initialized, even though they are already populated in BackendUtil.cpp. As a result, during LTO (Link Time Optimization), the IASSearchPaths field of MCOptions—which stores all include paths—is overwritten. This causes the compiler to fail in locating files included via the .include assembly directive.

This patch fixes the above issue.

Fixes #112920