### PR TITLE
[LTO] Fix used before intialised warning

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -272,8 +272,9 @@ public:
   // A map from destination modules to lists of imports.
   class ImportListsTy {
   public:
-    ImportListsTy() : EmptyList(ImportIDs) {}
-    ImportListsTy(size_t Size) : EmptyList(ImportIDs), ListsImpl(Size) {}
+    ImportListsTy() : ImportIDs(), EmptyList(ImportIDs) {}
+    ImportListsTy(size_t Size)
+        : ImportIDs(), EmptyList(ImportIDs), ListsImpl(Size) {}
 
     ImportMapTy &operator[](StringRef DestMod) {
       return ListsImpl.try_emplace(DestMod, ImportIDs).first->second;
@@ -293,9 +294,9 @@ public:
     const_iterator end() const { return ListsImpl.end(); }
 
   private:
+    ImportIDTable ImportIDs;
     ImportMapTy EmptyList;
     DenseMap<StringRef, ImportMapTy> ListsImpl;
-    ImportIDTable ImportIDs;
   };
 
   /// The set contains an entry for every global value that the module exports.


### PR DESCRIPTION
For whatever reason I can't reproduce this locally but I can on Compiler Explorer (https://godbolt.org/z/nfv4b83q6) and on our flang gcc bot (https://lab.llvm.org/buildbot/#/builders/130/builds/13683/steps/5/logs/stdio).

In file included from ../llvm-project/llvm/include/llvm/LTO/LTO.h:33,
                 from ../llvm-project/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp:29:
../llvm-project/llvm/include/llvm/Transforms/IPO/FunctionImport.h: In constructor ‘llvm::FunctionImporter::ImportListsTy::ImportListsTy()’: ../llvm-project/llvm/include/llvm/Transforms/IPO/FunctionImport.h:275:33: warning: member ‘llvm::FunctionImporter::ImportListsTy::ImportIDs’ is used uninitialized [-Wuninitialized]
  275 |     ImportListsTy() : EmptyList(ImportIDs) {}
      |                                 ^~~~~~~~~
../llvm-project/llvm/include/llvm/Transforms/IPO/FunctionImport.h: In constructor ‘llvm::FunctionImporter::ImportListsTy::ImportListsTy(size_t)’:
../llvm-project/llvm/include/llvm/Transforms/IPO/FunctionImport.h:276:44: warning: member ‘llvm::FunctionImporter::ImportListsTy::ImportIDs’ is used uninitialized [-Wuninitialized]
  276 |     ImportListsTy(size_t Size) : EmptyList(ImportIDs), ListsImpl(Size) {}
      |                                            ^~~~~~~~~

ImportIDs was being used during construction of EmptyList, before ImportIDs itself had been constructed.