### PR TITLE
[lldb][test] Don't call SBDebugger::Terminate if TestMultipleDebuggers times out

### DIFF
--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -12,8 +12,6 @@ from lldbsuite.test import lldbutil
 class TestMultipleSimultaneousDebuggers(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    # Sometimes times out on Linux, see https://github.com/llvm/llvm-project/issues/101162.
-    @skipIfLinux
     @skipIfNoSBHeaders
     @skipIfWindows
     @skipIfHostIncompatibleWithTarget

--- a/lldb/test/API/api/multiple-debuggers/multi-process-driver.cpp
+++ b/lldb/test/API/api/multiple-debuggers/multi-process-driver.cpp
@@ -299,5 +299,6 @@ int main (int argc, char **argv)
     // We do not call SBDebugger::Terminate() here because it will destroy
     // data that might be being used by threads that are still running. Which
     // would change the timeout into an unrelated crash.
-    exit (1);
+    // _exit instead of exit, to skip more things that could cause a crash.
+    _exit(1);
 }

--- a/lldb/test/API/api/multiple-debuggers/multi-process-driver.cpp
+++ b/lldb/test/API/api/multiple-debuggers/multi-process-driver.cpp
@@ -296,6 +296,8 @@ int main (int argc, char **argv)
                  NUMBER_OF_SIMULTANEOUS_DEBUG_SESSIONS);
     }
 
-    SBDebugger::Terminate();
+    // We do not call SBDebugger::Terminate() here because it will destroy
+    // data that might be being used by threads that are still running. Which
+    // would change the timeout into an unrelated crash.
     exit (1);
 }


### PR DESCRIPTION
Fixes #101162

This test did this:
* SBDebugger::Initialize
* Spawn a bunch of threads that do:
  * SBDebugger::Create
  * some work
  * SBDebugger::Destroy
* Wait on those threads to finish then call SBDebugger::Terminate and exit, or -
* Reach a time limit before all the threads finish, call SBDebugger::Terminate and exit.

The problem was that in the timeout case, calling SBDebugger::Terminate destroys data being used by threads that are still running. I expect this test was expecting said threads to be so broken they were probably stuck, but when the machine is just heavily loaded, one of them might read that data before the whole program exits.

This means what should have been a timeout becomes a crash. Sometimes. Which explains why we saw both timeouts and various signals on the AArch64 Linux bot. It depends on the timings.

So I'm changing it not to call SBDebugger::Terminate in the timeout case. We will have to tweak the timeout value based on what happens on the buildbot, but we will know it's machine load not an lldb bug.

Also use _exit instead of exit, to skip more cleanup that might cause a crash.