### PR TITLE
[flang] silence bogus error with BIND(C) variable in hermetic module

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -2958,6 +2958,14 @@ static std::optional<std::string> DefinesGlobalName(const Symbol &symbol) {
   return std::nullopt;
 }
 
+static bool IsSameSymbolFromHermeticModule(
+    const Symbol &symbol, const Symbol &other) {
+  return symbol.name() == other.name() && symbol.owner().IsModule() &&
+      other.owner().IsModule() && symbol.owner() != other.owner() &&
+      symbol.owner().GetName() &&
+      symbol.owner().GetName() == other.owner().GetName();
+}
+
 // 19.2 p2
 void CheckHelper::CheckGlobalName(const Symbol &symbol) {
   if (auto global{DefinesGlobalName(symbol)}) {
@@ -2975,6 +2983,8 @@ void CheckHelper::CheckGlobalName(const Symbol &symbol) {
           (!IsExternalProcedureDefinition(symbol) ||
               !IsExternalProcedureDefinition(other))) {
         // both are procedures/BLOCK DATA, not both definitions
+      } else if (IsSameSymbolFromHermeticModule(symbol, other)) {
+        // Both symbols are the same thing.
       } else if (symbol.has<ModuleDetails>()) {
         Warn(common::LanguageFeature::BenignNameClash, symbol.name(),
             "Module '%s' conflicts with a global name"_port_en_US,

--- a/flang/test/Semantics/modfile76.F90
+++ b/flang/test/Semantics/modfile76.F90
@@ -1,0 +1,24 @@
+!RUN: %flang_fc1 -fsyntax-only -fhermetic-module-files -DSTEP=1 %s
+!RUN: %flang_fc1 -fsyntax-only %s
+
+! Tests that a BIND(C) variable in a module A captured in a hermetic module
+! file USE'd in a module B is not creating bogus complaints about BIND(C) name
+! conflict when both module A and B are later accessed.
+
+#if STEP == 1
+module modfile75a
+  integer, bind(c) :: x
+end
+
+module modfile75b
+  use modfile75a ! capture hermetically
+end
+
+#else
+subroutine test
+  use modfile75a
+  use modfile75b
+  implicit none
+  print *, x
+end subroutine
+#endif


### PR DESCRIPTION
The global name semantic check was firing in a bogus way when BIND(C) variables are in hermetic module.

The added test would fail to compile with error:
```
error: Semantic errors in flang/test/Semantics/modfile76.F90
./modfile75b.mod:6:21: error: Two entities have the same global name 'x'
  integer(4),bind(c)::x
                      ^
./modfile75a.mod:3:21: Conflicting declaration
  integer(4),bind(c)::x
```

Do not raise the error if one of the symbol with the conflicting global name is an "hermetic variant" of the other.