### PR TITLE
[flang] Show types in DumpEvExpr

### DIFF
--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -39,8 +39,7 @@ public:
   }
 
 private:
-  template <typename T>
-  struct TypeOf {
+  template <typename T> struct TypeOf {
     static constexpr std::string_view name{TypeOf<T>::get()};
     static constexpr std::string_view get() {
       std::string_view v(__PRETTY_FUNCTION__);

--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -40,7 +40,6 @@ public:
 
 private:
   template <typename T> struct TypeOf {
-    static constexpr std::string_view name{TypeOf<T>::get()};
     static constexpr std::string_view get() {
       std::string_view v(__PRETTY_FUNCTION__);
       // Extract the "xyz" from the "pretty function" string:
@@ -59,6 +58,8 @@ private:
       }
       return "";
     }
+
+    static constexpr std::string_view name{TypeOf<T>::get()};
   };
 
   template <typename A, bool C> void Show(const common::Indirection<A, C> &x) {

--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -41,17 +41,27 @@ public:
 private:
   template <typename T> struct TypeOf {
     static constexpr std::string_view get() {
+#if defined(__GNUC__)
       std::string_view v(__PRETTY_FUNCTION__);
       // Extract the "xyz" from the "pretty function" string:
       // "... [with T = xyz; std::string_view = ...]"
       std::string_view front("with T = ");
       std::string_view back("; std::string_view =");
 
+#elif defined(_MSC_VER)
+      std::string_view v(__FUNCSIG__);
+      // Extract the "xyz" from the "pretty function" string:
+      // "... TypeOf<xyz>::get(void)"
+      std::string_view front(" TypeOf<");
+      std::string_view back(">::get(void)");
+
+#else
+      return "";
+#endif
+
       if (auto fpos{v.find(front)}; fpos != v.npos) {
-        // Strip the part "... [with T = "
         v.remove_prefix(fpos + front.size());
         if (auto bpos{v.find(back)}; bpos != v.npos) {
-          // Strip the ending "; std::string_view = ...]"
           v.remove_suffix(v.size() - bpos);
           return v;
         }

--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -38,6 +39,29 @@ public:
   }
 
 private:
+  template <typename T>
+  struct TypeOf {
+    static constexpr std::string_view name{TypeOf<T>::get()};
+    static constexpr std::string_view get() {
+      std::string_view v(__PRETTY_FUNCTION__);
+      // Extract the "xyz" from the "pretty function" string:
+      // "... [with T = xyz; std::string_view = ...]"
+      std::string_view front("with T = ");
+      std::string_view back("; std::string_view =");
+
+      if (auto fpos{v.find(front)}; fpos != v.npos) {
+        // Strip the part "... [with T = "
+        v.remove_prefix(fpos + front.size());
+        if (auto bpos{v.find(back)}; bpos != v.npos) {
+          // Strip the ending "; std::string_view = ...]"
+          v.remove_suffix(v.size() - bpos);
+          return v;
+        }
+      }
+      return "";
+    }
+  };
+
   template <typename A, bool C> void Show(const common::Indirection<A, C> &x) {
     Show(x.value());
   }
@@ -76,7 +100,7 @@ private:
   void Show(const evaluate::NullPointer &);
   template <typename T> void Show(const evaluate::Constant<T> &x) {
     if constexpr (T::category == common::TypeCategory::Derived) {
-      Indent("derived constant");
+      Indent("derived constant "s + std::string(TypeOf<T>::name));
       for (const auto &map : x.values()) {
         for (const auto &pair : map) {
           Show(pair.second.value());
@@ -84,7 +108,7 @@ private:
       }
       Outdent();
     } else {
-      Print("constant");
+      Print("constant "s + std::string(TypeOf<T>::name));
     }
   }
   void Show(const Symbol &symbol);
@@ -102,7 +126,7 @@ private:
   void Show(const evaluate::Substring &x);
   void Show(const evaluate::ComplexPart &x);
   template <typename T> void Show(const evaluate::Designator<T> &x) {
-    Indent("designator");
+    Indent("designator "s + std::string(TypeOf<T>::name));
     Show(x.u);
     Outdent();
   }
@@ -117,7 +141,7 @@ private:
     Outdent();
   }
   template <typename T> void Show(const evaluate::FunctionRef<T> &x) {
-    Indent("function ref");
+    Indent("function ref "s + std::string(TypeOf<T>::name));
     Show(x.proc());
     Show(x.arguments());
     Outdent();
@@ -127,14 +151,14 @@ private:
   }
   template <typename T>
   void Show(const evaluate::ArrayConstructorValues<T> &x) {
-    Indent("array constructor value");
+    Indent("array constructor value "s + std::string(TypeOf<T>::name));
     for (auto &v : x) {
       Show(v);
     }
     Outdent();
   }
   template <typename T> void Show(const evaluate::ImpliedDo<T> &x) {
-    Indent("implied do");
+    Indent("implied do "s + std::string(TypeOf<T>::name));
     Show(x.lower());
     Show(x.upper());
     Show(x.stride());
@@ -148,20 +172,20 @@ private:
   void Show(const evaluate::StructureConstructor &x);
   template <typename D, typename R, typename O>
   void Show(const evaluate::Operation<D, R, O> &op) {
-    Indent("unary op");
+    Indent("unary op "s + std::string(TypeOf<D>::name));
     Show(op.left());
     Outdent();
   }
   template <typename D, typename R, typename LO, typename RO>
   void Show(const evaluate::Operation<D, R, LO, RO> &op) {
-    Indent("binary op");
+    Indent("binary op "s + std::string(TypeOf<D>::name));
     Show(op.left());
     Show(op.right());
     Outdent();
   }
   void Show(const evaluate::Relational<evaluate::SomeType> &x);
   template <typename T> void Show(const evaluate::Expr<T> &x) {
-    Indent("expr T");
+    Indent("expr <" + std::string(TypeOf<T>::name) + ">");
     Show(x.u);
     Outdent();
   }

--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -51,8 +51,8 @@ private:
 #elif defined(_MSC_VER)
       std::string_view v(__FUNCSIG__);
       // Extract the "xyz" from the "pretty function" string:
-      // "... TypeOf<xyz>::get(void)"
-      std::string_view front(" TypeOf<");
+      // "...TypeOf<xyz>::get(void)"
+      std::string_view front("TypeOf<");
       std::string_view back(">::get(void)");
 
 #else

--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -42,6 +42,7 @@ private:
   template <typename T> struct TypeOf {
     static constexpr std::string_view get() {
 #if defined(__GNUC__)
+#define DUMP_EXPR_SHOW_TYPE
       std::string_view v(__PRETTY_FUNCTION__);
       // Extract the "xyz" from the "pretty function" string:
       // "... [with T = xyz; std::string_view = ...]"
@@ -49,16 +50,17 @@ private:
       std::string_view back("; std::string_view =");
 
 #elif defined(_MSC_VER)
+#define DUMP_EXPR_SHOW_TYPE
       std::string_view v(__FUNCSIG__);
       // Extract the "xyz" from the "pretty function" string:
       // "...TypeOf<xyz>::get(void)"
       std::string_view front("TypeOf<");
       std::string_view back(">::get(void)");
 
-#else
-      return "";
 #endif
 
+#if defined(DUMP_EXPR_SHOW_TYPE)
+#undef DUMP_EXPR_SHOW_TYPE
       if (auto fpos{v.find(front)}; fpos != v.npos) {
         v.remove_prefix(fpos + front.size());
         if (auto bpos{v.find(back)}; bpos != v.npos) {
@@ -66,6 +68,8 @@ private:
           return v;
         }
       }
+#endif
+
       return "";
     }
 

--- a/flang/lib/Semantics/dump-expr.cpp
+++ b/flang/lib/Semantics/dump-expr.cpp
@@ -151,7 +151,7 @@ void DumpEvaluateExpr::Show(const evaluate::StructureConstructor &x) {
 }
 
 void DumpEvaluateExpr::Show(const evaluate::Relational<evaluate::SomeType> &x) {
-  Indent("expr some type");
+  Indent("relational some type");
   Show(x.u);
   Outdent();
 }


### PR DESCRIPTION
When dumping evaluate::Expr, show type names which contain a lot of useful information.

For example show
```
expr <Fortran::evaluate::SomeType> {
  expr <Fortran::evaluate::SomeKind<Fortran::common::TypeCategory::Integer>> {
    expr <Fortran::evaluate::Type<Fortran::common::TypeCategory::Integer, 4>> {
      ...
```
instead of
```
expr {
  expr {
    expr {
      ...
```