### PR TITLE
[LLDB] Add optional callback function to `TypeMatcher`

### DIFF
--- a/lldb/include/lldb/DataFormatters/FormatCache.h
+++ b/lldb/include/lldb/DataFormatters/FormatCache.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <mutex>
 
+#include "lldb/DataFormatters/FormatClasses.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/lldb-public.h"
 
@@ -32,7 +33,7 @@ private:
   public:
     Entry();
 
-    template<typename ImplSP> bool IsCached();
+    template <typename ImplSP> bool IsCached(FormattersMatchData &match_data);
     bool IsFormatCached();
     bool IsSummaryCached();
     bool IsSyntheticCached();
@@ -54,7 +55,8 @@ private:
 public:
   FormatCache() = default;
 
-  template <typename ImplSP> bool Get(ConstString type, ImplSP &format_impl_sp);
+  template <typename ImplSP>
+  bool Get(FormattersMatchData &match_data, ImplSP &format_impl_sp);
   void Set(ConstString type, lldb::TypeFormatImplSP &format_sp);
   void Set(ConstString type, lldb::TypeSummaryImplSP &summary_sp);
   void Set(ConstString type, lldb::SyntheticChildrenSP &synthetic_sp);

--- a/lldb/include/lldb/DataFormatters/FormatClasses.h
+++ b/lldb/include/lldb/DataFormatters/FormatClasses.h
@@ -154,8 +154,8 @@ public:
   TypeNameSpecifierImpl() = default;
 
   TypeNameSpecifierImpl(llvm::StringRef name,
-                        lldb::FormatterMatchType match_type)
-      : m_match_type(match_type) {
+                        lldb::FormatterMatchType match_type, uint32_t tag = 0)
+      : m_match_type(match_type), m_tag(tag) {
     m_type.m_type_name = std::string(name);
   }
 
@@ -192,6 +192,8 @@ public:
 
   bool IsRegex() { return m_match_type == lldb::eFormatterMatchRegex; }
 
+  uint32_t GetTag() const { return m_tag; }
+
 private:
   lldb::FormatterMatchType m_match_type = lldb::eFormatterMatchExact;
   // TODO: Replace this with TypeAndOrName.
@@ -200,6 +202,7 @@ private:
     CompilerType m_compiler_type;
   };
   TypeOrName m_type;
+  uint32_t m_tag = 0;
 
   TypeNameSpecifierImpl(const TypeNameSpecifierImpl &) = delete;
   const TypeNameSpecifierImpl &

--- a/lldb/include/lldb/DataFormatters/TypeFormat.h
+++ b/lldb/include/lldb/DataFormatters/TypeFormat.h
@@ -151,10 +151,14 @@ public:
 
   virtual std::string GetDescription() = 0;
 
+  CxxTypeValidatorFn *GetTypeValidator() const { return m_validator_fn; }
+  void SetTypeValidator(CxxTypeValidatorFn *value) { m_validator_fn = value; }
+
 protected:
   Flags m_flags;
   uint32_t m_my_revision = 0;
   uint32_t m_ptr_match_depth = 1;
+  CxxTypeValidatorFn *m_validator_fn = nullptr;
 
 private:
   TypeFormatImpl(const TypeFormatImpl &) = delete;

--- a/lldb/include/lldb/DataFormatters/TypeSummary.h
+++ b/lldb/include/lldb/DataFormatters/TypeSummary.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 
+#include "lldb/DataFormatters/TypeValidator.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-public.h"
 
@@ -276,6 +277,9 @@ public:
 
   uint32_t &GetRevision() { return m_my_revision; }
 
+  CxxTypeValidatorFn *GetTypeValidator() const { return m_validator_fn; }
+  void SetTypeValidator(CxxTypeValidatorFn *value) { m_validator_fn = value; }
+
   typedef std::shared_ptr<TypeSummaryImpl> SharedPointer;
 
 protected:
@@ -288,6 +292,7 @@ protected:
 private:
   Kind m_kind;
   uint32_t m_ptr_match_depth = 1;
+  CxxTypeValidatorFn *m_validator_fn = nullptr;
   TypeSummaryImpl(const TypeSummaryImpl &) = delete;
   const TypeSummaryImpl &operator=(const TypeSummaryImpl &) = delete;
 };

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -277,12 +277,17 @@ public:
 
   void SetPtrMatchDepth(uint32_t value) { m_ptr_match_depth = value; }
 
+  CxxTypeValidatorFn *GetTypeValidator() const { return m_validator_fn; }
+  void SetTypeValidator(CxxTypeValidatorFn *value) { m_validator_fn = value; }
+
 protected:
   uint32_t m_my_revision = 0;
   Flags m_flags;
   uint32_t m_ptr_match_depth = 1;
 
 private:
+  CxxTypeValidatorFn *m_validator_fn = nullptr;
+
   SyntheticChildren(const SyntheticChildren &) = delete;
   const SyntheticChildren &operator=(const SyntheticChildren &) = delete;
 };

--- a/lldb/include/lldb/DataFormatters/TypeValidator.h
+++ b/lldb/include/lldb/DataFormatters/TypeValidator.h
@@ -1,0 +1,20 @@
+//===-- TypeValidator.h -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_DATAFORMATTERS_TYPEVALIDATOR_H
+#define LLDB_DATAFORMATTERS_TYPEVALIDATOR_H
+
+#include "lldb/Symbol/CompilerType.h"
+
+namespace lldb_private {
+
+using CxxTypeValidatorFn = bool(const CompilerType &);
+
+} // namespace lldb_private
+
+#endif // LLDB_DATAFORMATTERS_TYPEVALIDATOR_H

--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -657,7 +657,7 @@ ImplSP FormatManager::GetCached(FormattersMatchData &match_data) {
   if (match_data.GetTypeForCache()) {
     LLDB_LOGF(log, "\n\n" FORMAT_LOG("Looking into cache for type %s"),
               match_data.GetTypeForCache().AsCString("<invalid>"));
-    if (m_format_cache.Get(match_data.GetTypeForCache(), retval_sp)) {
+    if (m_format_cache.Get(match_data, retval_sp)) {
       if (log) {
         LLDB_LOGF(log, FORMAT_LOG("Cache search success. Returning."));
         LLDB_LOGV(log, "Cache hits: {0} - Cache Misses: {1}",

--- a/lldb/source/DataFormatters/LanguageCategory.cpp
+++ b/lldb/source/DataFormatters/LanguageCategory.cpp
@@ -40,7 +40,7 @@ bool LanguageCategory::Get(FormattersMatchData &match_data,
     return false;
 
   if (match_data.GetTypeForCache()) {
-    if (m_format_cache.Get(match_data.GetTypeForCache(), retval_sp))
+    if (m_format_cache.Get(match_data, retval_sp))
       return (bool)retval_sp;
   }
 


### PR DESCRIPTION
To be able to have multiple formatters that match on the same type name but for different types, this adds a callback that can be specified, which is called with the match candidate. As [mentlerd pointed out](https://discourse.llvm.org/t/formatting-msvc-stl-types/86667/12?u=nerixyz), it's similar to passing `--recognizer-function`. This isn't implemented as another match type, because the `TypeMatcher` still needs to have _some_ name for [`GetMatchString`](https://github.com/llvm/llvm-project/blob/f1575de4c5de9268f92eea1641af755a477e4ee4/lldb/include/lldb/DataFormatters/FormattersContainer.h#L120-L126).

The only use I currently see here is for the C++ STL, specifically libstdc++ and MSVC's STL.
In https://github.com/llvm/llvm-project/pull/143177, I used this to add formatters for `std::string` and friends from MSVC's STL.

One potential issue of adding the callback here is that the summary/synthetic will be cached for a type name - disregarding the callback. The scenario here would be two shared libraries that use a different type with the same name and two formatters (e.g. they use two different standard libraries). Once the first type was formatted, its formatter is cached. Now, the second type will always be formatted with the wrong formatter (the cached one), even though the callback for the cached one wouldn't match.
For one, `--recognizer-function` has the same issue and secondly, I don't think this is really realistic.