### PR TITLE
[mlir][generate-test-checks] Do not emit the autogenerated note if it exists

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -208,7 +208,7 @@ def process_source_lines(source_lines, note, args):
     source_segments = [[]]
     for line in source_lines:
         # Remove previous note.
-        if line == note:
+        if line in note:
             continue
         # Remove previous CHECK lines.
         if line.find(args.check_prefix) != -1:


### PR DESCRIPTION
Prior to this PR, the script removed the already existing autogenerated note if we came across a line that was equal to the note. But the default note is multiple lines, so there would never be a match. Instead, check to see if the current line is a substring of the autogenerated note.