### PR TITLE
[IR] Fix warnings

### DIFF
--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -47,11 +47,7 @@ namespace llvm {
     Module &M;
     LLVMContext &VMContext;
 
-    DICompileUnit *CUNode;   ///< The one compile unit created by this DIBuiler.
-    Function *DeclareFn;     ///< llvm.dbg.declare
-    Function *ValueFn;       ///< llvm.dbg.value
-    Function *LabelFn;       ///< llvm.dbg.label
-    Function *AssignFn;      ///< llvm.dbg.assign
+    DICompileUnit *CUNode; ///< The one compile unit created by this DIBuiler.
 
     SmallVector<TrackingMDNodeRef, 4> AllEnumTypes;
     /// Track the RetainTypes, since they can be updated later on.

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -25,8 +25,7 @@ using namespace llvm;
 using namespace llvm::dwarf;
 
 DIBuilder::DIBuilder(Module &m, bool AllowUnresolvedNodes, DICompileUnit *CU)
-    : M(m), VMContext(M.getContext()), CUNode(CU), DeclareFn(nullptr),
-      ValueFn(nullptr), LabelFn(nullptr), AssignFn(nullptr),
+    : M(m), VMContext(M.getContext()), CUNode(CU),
       AllowUnresolvedNodes(AllowUnresolvedNodes) {
   if (CUNode) {
     if (const auto &ETs = CUNode->getEnumTypes())
@@ -1067,10 +1066,6 @@ static void initIRBuilder(IRBuilder<> &Builder, const DILocation *DL,
 static Value *getDbgIntrinsicValueImpl(LLVMContext &VMContext, Value *V) {
   assert(V && "no value passed to dbg intrinsic");
   return MetadataAsValue::get(VMContext, ValueAsMetadata::get(V));
-}
-
-static Function *getDeclareIntrin(Module &M) {
-  return Intrinsic::getOrInsertDeclaration(&M, Intrinsic::dbg_declare);
 }
 
 DbgInstPtr DIBuilder::insertDbgValueIntrinsic(llvm::Value *Val,


### PR DESCRIPTION
This patch fixes:

  llvm/lib/IR/DIBuilder.cpp:1072:18: error: unused function
  'getDeclareIntrin' [-Werror,-Wunused-function]

  llvm/include/llvm/IR/DIBuilder.h:51:15: error: private field
  'DeclareFn' is not used [-Werror,-Wunused-private-field]

  llvm/include/llvm/IR/DIBuilder.h:52:15: error: private field
  'ValueFn' is not used [-Werror,-Wunused-private-field]

  llvm/include/llvm/IR/DIBuilder.h:53:15: error: private field
  'LabelFn' is not used [-Werror,-Wunused-private-field]

  llvm/include/llvm/IR/DIBuilder.h:54:15: error: private field
  'AssignFn' is not used [-Werror,-Wunused-private-field]
