### PR TITLE
[lldb] Properly handle locate module callback when Target change arch

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1706,6 +1706,8 @@ bool Target::SetArchitecture(const ArchSpec &arch_spec, bool set_platform,
         if (PlatformSP arch_platform_sp =
                 GetDebugger().GetPlatformList().GetOrCreate(other, {},
                                                             &platform_arch)) {
+          arch_platform_sp->SetLocateModuleCallback(
+              platform_sp->GetLocateModuleCallback());
           SetPlatform(arch_platform_sp);
           if (platform_arch.IsValid())
             other = platform_arch;


### PR DESCRIPTION
Since this PR: https://github.com/llvm/llvm-project/pull/141670/ We started to override the Platform/Arch for a target if needed. However we may have already registered locate module callback with the old platform. 

This PR will move the locate module callback to the new Platform whenever Target changes architecture.