### PR TITLE
[VPlan] Remove VPPredInstPHIRecipe::useScalars

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -2951,13 +2951,6 @@ public:
   void print(raw_ostream &O, const Twine &Indent,
              VPSlotTracker &SlotTracker) const override;
 #endif
-
-  /// Returns true if the recipe uses scalars of operand \p Op.
-  bool usesScalars(const VPValue *Op) const override {
-    assert(is_contained(operands(), Op) &&
-           "Op must be an operand of the recipe");
-    return true;
-  }
 };
 
 /// A common base class for widening memory operations. An optional mask can be


### PR DESCRIPTION
It uses the vector value of its operand if possible. Use the default definition in VPUser, which is false since onlyFirstLaneUsed is false.

From the discussion at https://github.com/llvm/llvm-project/pull/142594#discussion_r2140339682

I don't think this is strictly NFC but I couldn't really think of a way to come up for a test case for it