### PR TITLE
[libc] Always provide char8/16/32_t

### DIFF
--- a/libc/include/llvm-libc-types/char16_t.h
+++ b/libc/include/llvm-libc-types/char16_t.h
@@ -9,9 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_CHAR16_T_H
 #define LLVM_LIBC_TYPES_CHAR16_T_H
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #include "../llvm-libc-macros/stdint-macros.h"
 typedef uint_least16_t char16_t;
-#endif
 
 #endif // LLVM_LIBC_TYPES_CHAR16_T_H

--- a/libc/include/llvm-libc-types/char16_t.h
+++ b/libc/include/llvm-libc-types/char16_t.h
@@ -9,7 +9,9 @@
 #ifndef LLVM_LIBC_TYPES_CHAR16_T_H
 #define LLVM_LIBC_TYPES_CHAR16_T_H
 
+#if !(defined(__cplusplus) && defined(__cpp_unicode_characters))
 #include "../llvm-libc-macros/stdint-macros.h"
 typedef uint_least16_t char16_t;
+#endif
 
 #endif // LLVM_LIBC_TYPES_CHAR16_T_H

--- a/libc/include/llvm-libc-types/char32_t.h
+++ b/libc/include/llvm-libc-types/char32_t.h
@@ -9,7 +9,9 @@
 #ifndef LLVM_LIBC_TYPES_CHAR32_T_H
 #define LLVM_LIBC_TYPES_CHAR32_T_H
 
+#if !(defined(__cplusplus) && defined(__cpp_unicode_characters))
 #include "../llvm-libc-macros/stdint-macros.h"
 typedef uint_least32_t char32_t;
+#endif
 
 #endif // LLVM_LIBC_TYPES_CHAR32_T_H

--- a/libc/include/llvm-libc-types/char32_t.h
+++ b/libc/include/llvm-libc-types/char32_t.h
@@ -9,9 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_CHAR32_T_H
 #define LLVM_LIBC_TYPES_CHAR32_T_H
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #include "../llvm-libc-macros/stdint-macros.h"
 typedef uint_least32_t char32_t;
-#endif
 
 #endif // LLVM_LIBC_TYPES_CHAR32_T_H

--- a/libc/include/llvm-libc-types/char8_t.h
+++ b/libc/include/llvm-libc-types/char8_t.h
@@ -9,8 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_CHAR8_T_H
 #define LLVM_LIBC_TYPES_CHAR8_T_H
 
-#if !defined(__cplusplus) && defined(__STDC_VERSION__) &&                      \
-    __STDC_VERSION__ >= 202311L
+#if !(defined(__cplusplus) && defined(__cpp_char8_t))
 typedef unsigned char char8_t;
 #endif
 

--- a/libc/include/llvm-libc-types/char8_t.h
+++ b/libc/include/llvm-libc-types/char8_t.h
@@ -9,6 +9,9 @@
 #ifndef LLVM_LIBC_TYPES_CHAR8_T_H
 #define LLVM_LIBC_TYPES_CHAR8_T_H
 
+// char8_t is only defined as a keyword in C++20, but char16_t and char32_t are
+// defined in C++11. Need to guard all of them so our definitions don't conflict
+// with the compiler's.
 #if !(defined(__cplusplus) && defined(__cpp_char8_t))
 typedef unsigned char char8_t;
 #endif


### PR DESCRIPTION
The current definitions only provide these types if the stdc version is
2023 for char8_t or 2011 for char16/32_t. None of our other types are
currently handled this way. If we want to provide these headers only
under certain circumstances we should add guards to the types in the
public header, since internal code should always have access to these
types.
