### PR TITLE
[MLIR][FuncToLLVM] Propagate no_inline attribute

### DIFF
--- a/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
+++ b/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
@@ -62,6 +62,7 @@ using namespace mlir;
 static constexpr StringRef varargsAttrName = "func.varargs";
 static constexpr StringRef linkageAttrName = "llvm.linkage";
 static constexpr StringRef barePtrAttrName = "llvm.bareptr";
+static constexpr StringRef noInlineAttr = "no_inline";
 
 /// Return `true` if the `op` should use bare pointer calling convention.
 static bool shouldUseBarePtrCallConv(Operation *op,
@@ -379,6 +380,11 @@ mlir::convertFuncOpToLLVMFuncOp(FunctionOpInterface funcOp,
         {LLVM::ModRefInfo::NoModRef, LLVM::ModRefInfo::NoModRef,
          LLVM::ModRefInfo::NoModRef});
     newFuncOp.setMemoryEffectsAttr(memoryAttr);
+  }
+
+  // Propagate no_inline attributes
+  if (funcOp->hasAttr(noInlineAttr)) {
+    newFuncOp->setAttr(noInlineAttr, rewriter.getUnitAttr());
   }
 
   // Propagate argument/result attributes to all converted arguments/result

--- a/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
+++ b/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
@@ -62,7 +62,7 @@ using namespace mlir;
 static constexpr StringRef varargsAttrName = "func.varargs";
 static constexpr StringRef linkageAttrName = "llvm.linkage";
 static constexpr StringRef barePtrAttrName = "llvm.bareptr";
-static constexpr StringRef noInlineAttr = "no_inline";
+static constexpr StringRef noInlineAttrName = "no_inline";
 
 /// Return `true` if the `op` should use bare pointer calling convention.
 static bool shouldUseBarePtrCallConv(Operation *op,
@@ -383,9 +383,7 @@ mlir::convertFuncOpToLLVMFuncOp(FunctionOpInterface funcOp,
   }
 
   // Propagate no_inline attributes
-  if (funcOp->hasAttr(noInlineAttr)) {
-    newFuncOp->setAttr(noInlineAttr, rewriter.getUnitAttr());
-  }
+  newFuncOp.setNoInline(funcOp->hasAttr(noInlineAttrName));
 
   // Propagate argument/result attributes to all converted arguments/result
   // obtained after converting a given original argument/result.

--- a/mlir/test/Conversion/FuncToLLVM/convert-funcs.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/convert-funcs.mlir
@@ -96,3 +96,11 @@ func.func private @badllvmlinkage(i32) attributes { "llvm.linkage" = 3 : i64 } /
 func.func @variadic_func(%arg0: i32) attributes { "func.varargs" = true, "llvm.emit_c_interface" } {
   return
 }
+
+// -----
+
+// Check that no_inline attribute is propagated from func::FuncOp to LLVM::LLVMFuncOp
+// CHECK-LABEL: llvm.func @func_with_noinline(%arg0: i32) attributes {no_inline}
+func.func @func_with_noinline(%arg0: i32) attributes { no_inline } {
+  return
+}


### PR DESCRIPTION
This commit fixes the no_inline attribute propagation from func::FuncOp to LLVM::LLVMFuncOp and adds corresponding test coverage. After the change, functions marked with no_inline in the func dialect maintain this optimization hint when lowered to LLVM IR.