### PR TITLE
[llvm-debuginfo-analyzer] Incorrect directory path (.debug_line)

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
@@ -522,14 +522,16 @@ void LVDWARFReader::createLineAndFileRecords(
     for (const DWARFDebugLine::FileNameEntry &Entry :
          Lines->Prologue.FileNames) {
       std::string Directory;
-      if (Lines->getDirectoryForEntry(Entry, Directory))
-        Directory = transformPath(Directory);
+      Lines->getDirectoryForEntry(Entry, Directory);
       if (Directory.empty())
         Directory = std::string(CompileUnit->getCompilationDirectory());
-      std::string File = transformPath(dwarf::toStringRef(Entry.Name));
+      // Take just the filename component, as it may be contain the full
+      // path that would be added to the already existing path in Directory.
+      StringRef File =
+          llvm::sys::path::filename(dwarf::toStringRef(Entry.Name));
       std::string String;
       raw_string_ostream(String) << Directory << "/" << File;
-      CompileUnit->addFilename(String);
+      CompileUnit->addFilename(transformPath(String));
     }
 
   // In DWARF5 the file indexes start at 0;

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/dwarf-duplicated-directory-path.ll
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/dwarf-duplicated-directory-path.ll
@@ -1,0 +1,67 @@
+; REQUIRES: x86-registered-target
+
+; When the 'filename' field in DIFile entry contains the full pathname, such as:
+;
+; !1 = !DIFile(filename: "path/test.cpp", directory: "path")
+;
+; llvm-debuginfo-analyzer displays incorrect information for the directories
+; extracted from the '.debug_line' section, when using '--attribute=directories'
+;
+; llvm-debuginfo-analyzer --attribute=directories --print=scopes test.o
+;
+; {CompileUnit} 'test.cpp'
+;   {Directory} 'path/path'  <------- Duplicated 'path'
+
+; The test case was produced by the following steps:
+; // test.cpp
+; void foo() {
+; }
+
+; 1) clang++ --target=x86_64-pc-linux-gnu -Xclang -disable-O0-optnone
+;            -Xclang -disable-llvm-passes -fno-discard-value-names
+;            -emit-llvm -S -g -O0 test.cpp -o test.ll
+;
+; 2) Manually adding directory information to the DIFile 'filename' field:
+;
+; !1 = !DIFile(filename: "test.cpp", directory: "path")
+; -->
+; !1 = !DIFile(filename: "path/test.cpp", directory: "path")
+
+; RUN: llc --filetype=obj %p/dwarf-duplicated-directory-path.ll \
+; RUN:                    -o %t.dwarf-duplicated-directory-path.o
+
+; RUN: llvm-debuginfo-analyzer --attribute=directories,files               \
+; RUN:                         --print=scopes                              \
+; RUN:                         %t.dwarf-duplicated-directory-path.o 2>&1 | \
+; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
+
+; ONE: Logical View:
+; ONE-NEXT:           {File} '{{.*}}dwarf-duplicated-directory-path.ll{{.*}}'
+; ONE-EMPTY:
+; ONE-NEXT:             {CompileUnit} 'test.cpp'
+; ONE-NEXT:               {Directory} 'path'
+; ONE-NEXT:               {File} 'test.cpp'
+; ONE-NEXT:     1         {Function} extern not_inlined 'foo' -> 'void'
+
+source_filename = "test.cpp"
+target triple = "x86_64-pc-linux-gnu"
+
+define dso_local void @_Z3foov() !dbg !10 {
+entry:
+  ret void, !dbg !13
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "path/test.cpp", directory: "path")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!9 = !{!"clang"}
+!10 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !11, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!11 = !DISubroutineType(types: !12)
+!12 = !{null}
+!13 = !DILocation(line: 2, column: 1, scope: !10)


### PR DESCRIPTION
If any 'name' entry in the 'file_names' table from the .debug_line
section contains directory information, the llvm-debuginfo-analyzer 
tool will display duplicated directory information when using the
'--attribute=directories' option.

.debug_line contents:
Line table prologue:
  ...
include_directories[  0] = "path"
file_names[  0]:
           name: "path/test.cpp"
      dir_index: 0
  ...

the '--attribute=directories' will show:

  {Directory} 'path/path'  <-- Duplicated 'path'