### PR TITLE
[libc++] Remove dead code from <type_traits>

### DIFF
--- a/libcxx/include/__type_traits/add_lvalue_reference.h
+++ b/libcxx/include/__type_traits/add_lvalue_reference.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_ADD_LVALUE_REFERENCE_H
 
 #include <__config>
-#include <__type_traits/is_referenceable.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -18,31 +17,18 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_builtin(__add_lvalue_reference) && !defined(_LIBCPP_COMPILER_GCC)
-
-template <class _Tp>
-using __add_lvalue_reference_t _LIBCPP_NODEBUG = __add_lvalue_reference(_Tp);
-
-#else
-
-template <class _Tp, bool = __is_referenceable_v<_Tp>>
-struct __add_lvalue_reference_impl {
-  using type _LIBCPP_NODEBUG = _Tp;
-};
-template <class _Tp >
-struct __add_lvalue_reference_impl<_Tp, true> {
-  using type _LIBCPP_NODEBUG = _Tp&;
-};
-
-template <class _Tp>
-using __add_lvalue_reference_t = typename __add_lvalue_reference_impl<_Tp>::type;
-
-#endif // __has_builtin(__add_lvalue_reference)
-
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS add_lvalue_reference {
-  using type _LIBCPP_NODEBUG = __add_lvalue_reference_t<_Tp>;
+  using type _LIBCPP_NODEBUG = __add_lvalue_reference(_Tp);
 };
+
+#ifdef _LIBCPP_COMPILER_GCC
+template <class _Tp>
+using __add_lvalue_reference_t _LIBCPP_NODEBUG = typename add_lvalue_reference<_Tp>::type;
+#else
+template <class _Tp>
+using __add_lvalue_reference_t _LIBCPP_NODEBUG = __add_lvalue_reference(_Tp);
+#endif
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>

--- a/libcxx/include/__type_traits/add_pointer.h
+++ b/libcxx/include/__type_traits/add_pointer.h
@@ -20,10 +20,20 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if !defined(_LIBCPP_WORKAROUND_OBJCXX_COMPILER_INTRINSICS) && __has_builtin(__add_pointer) && !defined(_LIBCPP_COMPILER_GCC)
+#if !defined(_LIBCPP_WORKAROUND_OBJCXX_COMPILER_INTRINSICS)
 
 template <class _Tp>
+struct _LIBCPP_NO_SPECIALIZATIONS add_pointer {
+  using type _LIBCPP_NODEBUG = __add_pointer(_Tp);
+};
+
+#  ifdef _LIBCPP_COMPILER_GCC
+template <class _Tp>
+using __add_pointer_t _LIBCPP_NODEBUG = typename add_pointer<_Tp>::type;
+#  else
+template <class _Tp>
 using __add_pointer_t _LIBCPP_NODEBUG = __add_pointer(_Tp);
+#  endif
 
 #else
 template <class _Tp, bool = __is_referenceable_v<_Tp> || is_void<_Tp>::value>
@@ -38,12 +48,12 @@ struct __add_pointer_impl<_Tp, false> {
 template <class _Tp>
 using __add_pointer_t = typename __add_pointer_impl<_Tp>::type;
 
-#endif // !defined(_LIBCPP_WORKAROUND_OBJCXX_COMPILER_INTRINSICS) && __has_builtin(__add_pointer)
-
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS add_pointer {
   using type _LIBCPP_NODEBUG = __add_pointer_t<_Tp>;
 };
+
+#endif // !defined(_LIBCPP_WORKAROUND_OBJCXX_COMPILER_INTRINSICS)
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>

--- a/libcxx/include/__type_traits/add_rvalue_reference.h
+++ b/libcxx/include/__type_traits/add_rvalue_reference.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_ADD_RVALUE_REFERENCE_H
 
 #include <__config>
-#include <__type_traits/is_referenceable.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -18,31 +17,18 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_builtin(__add_rvalue_reference) && !defined(_LIBCPP_COMPILER_GCC)
-
-template <class _Tp>
-using __add_rvalue_reference_t _LIBCPP_NODEBUG = __add_rvalue_reference(_Tp);
-
-#else
-
-template <class _Tp, bool = __is_referenceable_v<_Tp> >
-struct __add_rvalue_reference_impl {
-  using type _LIBCPP_NODEBUG = _Tp;
-};
-template <class _Tp >
-struct __add_rvalue_reference_impl<_Tp, true> {
-  using type _LIBCPP_NODEBUG = _Tp&&;
-};
-
-template <class _Tp>
-using __add_rvalue_reference_t = typename __add_rvalue_reference_impl<_Tp>::type;
-
-#endif // __has_builtin(__add_rvalue_reference)
-
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS add_rvalue_reference {
-  using type _LIBCPP_NODEBUG = __add_rvalue_reference_t<_Tp>;
+  using type _LIBCPP_NODEBUG = __add_rvalue_reference(_Tp);
 };
+
+#ifdef _LIBCPP_COMPILER_GCC
+template <class _Tp>
+using __add_rvalue_reference_t _LIBCPP_NODEBUG = typename add_rvalue_reference<_Tp>::type;
+#else
+template <class _Tp>
+using __add_rvalue_reference_t _LIBCPP_NODEBUG = __add_rvalue_reference(_Tp);
+#endif
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>

--- a/libcxx/include/__type_traits/decay.h
+++ b/libcxx/include/__type_traits/decay.h
@@ -10,14 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_DECAY_H
 
 #include <__config>
-#include <__type_traits/add_pointer.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_function.h>
-#include <__type_traits/is_referenceable.h>
-#include <__type_traits/remove_cv.h>
-#include <__type_traits/remove_extent.h>
-#include <__type_traits/remove_reference.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -25,42 +17,18 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_builtin(__decay) && !defined(_LIBCPP_COMPILER_GCC)
-template <class _Tp>
-using __decay_t _LIBCPP_NODEBUG = __decay(_Tp);
-
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS decay {
-  using type _LIBCPP_NODEBUG = __decay_t<_Tp>;
+  using type _LIBCPP_NODEBUG = __decay(_Tp);
 };
 
+#ifdef _LIBCPP_COMPILER_GCC
+template <class _Tp>
+using __decay_t _LIBCPP_NODEBUG = typename decay<_Tp>::type;
 #else
-template <class _Up, bool>
-struct __decay {
-  using type _LIBCPP_NODEBUG = __remove_cv_t<_Up>;
-};
-
-template <class _Up>
-struct __decay<_Up, true> {
-public:
-  using type _LIBCPP_NODEBUG =
-      __conditional_t<is_array<_Up>::value,
-                      __add_pointer_t<__remove_extent_t<_Up> >,
-                      __conditional_t<is_function<_Up>::value, typename add_pointer<_Up>::type, __remove_cv_t<_Up> > >;
-};
-
 template <class _Tp>
-struct decay {
-private:
-  using _Up _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tp>;
-
-public:
-  using type _LIBCPP_NODEBUG = typename __decay<_Up, __is_referenceable_v<_Up> >::type;
-};
-
-template <class _Tp>
-using __decay_t = typename decay<_Tp>::type;
-#endif // __has_builtin(__decay)
+using __decay_t _LIBCPP_NODEBUG = __decay(_Tp);
+#endif
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>

--- a/libcxx/include/__type_traits/has_unique_object_representation.h
+++ b/libcxx/include/__type_traits/has_unique_object_representation.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
-#include <__type_traits/remove_all_extents.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -23,12 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS has_unique_object_representations
-    // TODO: We work around a Clang and GCC bug in __has_unique_object_representations by using remove_all_extents
-    //       even though it should not be necessary. This was reported to the compilers:
-    //         - Clang: https://github.com/llvm/llvm-project/issues/95311
-    //         - GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115476
-    //       remove_all_extents_t can be removed once all the compilers we support have fixed this bug.
-    : public integral_constant<bool, __has_unique_object_representations(remove_all_extents_t<_Tp>)> {};
+    : integral_constant<bool, __has_unique_object_representations(_Tp)> {};
 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool has_unique_object_representations_v =

--- a/libcxx/include/__type_traits/is_array.h
+++ b/libcxx/include/__type_traits/is_array.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_IS_ARRAY_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -19,32 +18,13 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_builtin(__is_array) &&                                                                                       \
-    (!defined(_LIBCPP_COMPILER_CLANG_BASED) || (defined(_LIBCPP_CLANG_VER) && _LIBCPP_CLANG_VER >= 1900))
-
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_array : _BoolConstant<__is_array(_Tp)> {};
 
-#  if _LIBCPP_STD_VER >= 17
+#if _LIBCPP_STD_VER >= 17
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_array_v = __is_array(_Tp);
-#  endif
-
-#else
-
-template <class _Tp>
-struct is_array : public false_type {};
-template <class _Tp>
-struct is_array<_Tp[]> : public true_type {};
-template <class _Tp, size_t _Np>
-struct is_array<_Tp[_Np]> : public true_type {};
-
-#  if _LIBCPP_STD_VER >= 17
-template <class _Tp>
-inline constexpr bool is_array_v = is_array<_Tp>::value;
-#  endif
-
-#endif // __has_builtin(__is_array)
+#endif
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/is_const.h
+++ b/libcxx/include/__type_traits/is_const.h
@@ -18,29 +18,13 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_builtin(__is_const)
-
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_const : _BoolConstant<__is_const(_Tp)> {};
 
-#  if _LIBCPP_STD_VER >= 17
+#if _LIBCPP_STD_VER >= 17
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_const_v = __is_const(_Tp);
-#  endif
-
-#else
-
-template <class _Tp>
-struct is_const : public false_type {};
-template <class _Tp>
-struct is_const<_Tp const> : public true_type {};
-
-#  if _LIBCPP_STD_VER >= 17
-template <class _Tp>
-inline constexpr bool is_const_v = is_const<_Tp>::value;
-#  endif
-
-#endif // __has_builtin(__is_const)
+#endif
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/is_pointer.h
+++ b/libcxx/include/__type_traits/is_pointer.h
@@ -11,15 +11,12 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
-#include <__type_traits/remove_cv.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
-
-#if __has_builtin(__is_pointer)
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_pointer : _BoolConstant<__is_pointer(_Tp)> {};
@@ -28,36 +25,6 @@ struct _LIBCPP_NO_SPECIALIZATIONS is_pointer : _BoolConstant<__is_pointer(_Tp)> 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_pointer_v = __is_pointer(_Tp);
 #  endif
-
-#else // __has_builtin(__is_pointer)
-
-template <class _Tp>
-struct __libcpp_is_pointer : false_type {};
-template <class _Tp>
-struct __libcpp_is_pointer<_Tp*> : true_type {};
-
-template <class _Tp>
-struct __libcpp_remove_objc_qualifiers {
-  typedef _Tp type;
-};
-#  if __has_feature(objc_arc)
-// clang-format off
-template <class _Tp> struct __libcpp_remove_objc_qualifiers<_Tp __strong> { typedef _Tp type; };
-template <class _Tp> struct __libcpp_remove_objc_qualifiers<_Tp __weak> { typedef _Tp type; };
-template <class _Tp> struct __libcpp_remove_objc_qualifiers<_Tp __autoreleasing> { typedef _Tp type; };
-template <class _Tp> struct __libcpp_remove_objc_qualifiers<_Tp __unsafe_unretained> { typedef _Tp type; };
-// clang-format on
-#  endif
-
-template <class _Tp>
-struct is_pointer : __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
-
-#  if _LIBCPP_STD_VER >= 17
-template <class _Tp>
-inline constexpr bool is_pointer_v = is_pointer<_Tp>::value;
-#  endif
-
-#endif // __has_builtin(__is_pointer)
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/is_volatile.h
+++ b/libcxx/include/__type_traits/is_volatile.h
@@ -18,29 +18,13 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_builtin(__is_volatile)
-
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_volatile : _BoolConstant<__is_volatile(_Tp)> {};
 
-#  if _LIBCPP_STD_VER >= 17
+#if _LIBCPP_STD_VER >= 17
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_volatile_v = __is_volatile(_Tp);
-#  endif
-
-#else
-
-template <class _Tp>
-struct is_volatile : public false_type {};
-template <class _Tp>
-struct is_volatile<_Tp volatile> : public true_type {};
-
-#  if _LIBCPP_STD_VER >= 17
-template <class _Tp>
-inline constexpr bool is_volatile_v = is_volatile<_Tp>::value;
-#  endif
-
-#endif // __has_builtin(__is_volatile)
+#endif
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/remove_all_extents.h
+++ b/libcxx/include/__type_traits/remove_all_extents.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_REMOVE_ALL_EXTENTS_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -18,31 +17,18 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_builtin(__remove_all_extents) && !defined(_LIBCPP_COMPILER_GCC)
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS remove_all_extents {
   using type _LIBCPP_NODEBUG = __remove_all_extents(_Tp);
 };
 
+#ifdef _LIBCPP_COMPILER_GCC
 template <class _Tp>
-using __remove_all_extents_t _LIBCPP_NODEBUG = __remove_all_extents(_Tp);
+using __remove_all_extents_t _LIBCPP_NODEBUG = typename remove_all_extents<_Tp>::type;
 #else
 template <class _Tp>
-struct remove_all_extents {
-  typedef _Tp type;
-};
-template <class _Tp>
-struct remove_all_extents<_Tp[]> {
-  typedef typename remove_all_extents<_Tp>::type type;
-};
-template <class _Tp, size_t _Np>
-struct remove_all_extents<_Tp[_Np]> {
-  typedef typename remove_all_extents<_Tp>::type type;
-};
-
-template <class _Tp>
-using __remove_all_extents_t = typename remove_all_extents<_Tp>::type;
-#endif // __has_builtin(__remove_all_extents)
+using __remove_all_extents_t _LIBCPP_NODEBUG = __remove_all_extents(_Tp);
+#endif
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>

--- a/libcxx/include/__type_traits/remove_extent.h
+++ b/libcxx/include/__type_traits/remove_extent.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_REMOVE_EXTENT_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -18,31 +17,18 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_builtin(__remove_extent) && !defined(_LIBCPP_COMPILER_GCC)
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS remove_extent {
   using type _LIBCPP_NODEBUG = __remove_extent(_Tp);
 };
 
+#ifdef _LIBCPP_COMPILER_GCC
 template <class _Tp>
-using __remove_extent_t _LIBCPP_NODEBUG = __remove_extent(_Tp);
+using __remove_extent_t _LIBCPP_NODEBUG = typename remove_extent<_Tp>::type;
 #else
 template <class _Tp>
-struct remove_extent {
-  typedef _Tp type;
-};
-template <class _Tp>
-struct remove_extent<_Tp[]> {
-  typedef _Tp type;
-};
-template <class _Tp, size_t _Np>
-struct remove_extent<_Tp[_Np]> {
-  typedef _Tp type;
-};
-
-template <class _Tp>
-using __remove_extent_t = typename remove_extent<_Tp>::type;
-#endif // __has_builtin(__remove_extent)
+using __remove_extent_t _LIBCPP_NODEBUG = __remove_extent(_Tp);
+#endif
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>


### PR DESCRIPTION
Since we've upgraded to GCC 15 now, we can remove a bunch of dead code from `<type_traits>`.
