### PR TITLE
[llvm][DWARFLinker] Fix gcc 13 -Wuninitialized warnings

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/OutputSections.h
+++ b/llvm/lib/DWARFLinker/Parallel/OutputSections.h
@@ -181,6 +181,11 @@ struct SectionDescriptor : SectionDescriptorBase {
   /// to the debug section, corresponding to this object.
   uint64_t StartOffset = 0;
 
+protected:
+  /// Section data bits.
+  OutSectionDataTy Contents;
+
+public:
   /// Stream which stores data to the Contents.
   raw_svector_ostream OS;
 
@@ -286,9 +291,6 @@ protected:
   }
 
   LinkingGlobalData &GlobalData;
-
-  /// Section data bits.
-  OutSectionDataTy Contents;
 
   /// Some sections are generated using AsmPrinter. The real section data
   /// located inside elf file in that case. Following fields points to the


### PR DESCRIPTION
A bit awkward that we have to switch from public to protected and back again, but it seemed neater than putting OS all the way down at the bottom. Since it is a public member that you're more likely to be looking for.

llvm-project/llvm/lib/DWARFLinker/Parallel/OutputSections.h:157:67: warning: member ‘llvm::dwarf_linker::parallel::SectionDescriptor::Contents’ is used uninitialized [-Wuninitialized]

Which refers to the use in the constructor:
```
  SectionDescriptor(DebugSectionKind SectionKind, LinkingGlobalData &GlobalData,
                    dwarf::FormParams Format, llvm::endianness Endianess)
      : SectionDescriptorBase(SectionKind, Format, Endianess), OS(Contents),
```
Where Contents is passed to `OS`, before Contents has been constructed.
