### PR TITLE
[clan-reply] Backport PTU error recovery to 20.x

### DIFF
--- a/clang/lib/Interpreter/IncrementalParser.cpp
+++ b/clang/lib/Interpreter/IncrementalParser.cpp
@@ -175,7 +175,7 @@ void IncrementalParser::CleanUpPTU(TranslationUnitDecl *MostRecentTU) {
   // FIXME: We should de-allocate MostRecentTU
   for (Decl *D : MostRecentTU->decls()) {
     auto *ND = dyn_cast<NamedDecl>(D);
-    if (!ND)
+    if (!ND || ND->getDeclName().isEmpty())
       continue;
     // Check if we need to clean up the IdResolver chain.
     if (ND->getDeclName().getFETokenInfo() && !D->getLangOpts().ObjC &&

--- a/clang/test/Interpreter/lambda.cpp
+++ b/clang/test/Interpreter/lambda.cpp
@@ -1,7 +1,11 @@
 // REQUIRES: host-supports-jit
 // UNSUPPORTED: system-aix
+// At -O2, somehow "x = 42" appears first when piped into FileCheck,
+// see https://github.com/llvm/llvm-project/issues/143547.
+// UNSUPPORTED: system-windows
 // RUN: cat %s | clang-repl | FileCheck %s
-// RUN: cat %s | clang-repl -Xcc -O2 | FileCheck %s
+// RUN: cat %s | clang-repl -Xcc -Xclang -Xcc -verify -Xcc -O2 | FileCheck %s
+
 extern "C" int printf(const char *, ...);
 
 auto l1 = []() { printf("ONE\n"); return 42; };
@@ -13,5 +17,15 @@ auto r2 = l2();
 // CHECK: TWO
 auto r3 = l2();
 // CHECK: TWO
+
+// Verify non-local lambda capture error is correctly reported
+int x = 42;
+
+// expected-error {{non-local lambda expression cannot have a capture-default}}
+auto capture = [&]() { return x * 2; };
+
+// Ensure interpreter continues and x is still valid
+printf("x = %d\n", x);
+// CHECK: x = 42
 
 %quit


### PR DESCRIPTION
This cherry-picks 3b4c51bb3243a02526313c51207a674139b67a00 and beffd1509af7b12eeab0d5ae85b2f8322e039287 to 20.x.

Which are:
[clang-repl] Fix error recovery while PTU cleanup (#127467)
[clang][Interpreter] Disable part of lambda test on Windows

The latter commit avoids a test failure seen in Windows builds. On main, I turned off one of the RUN lines for Windows, but reviewers on the cherry-pick preferred UNSUPPORTED to disable the whole test.

So I have used UNSUPPORTED in this version for 20.x.