### PR TITLE
[SPIR-V] Fix LinkageAttribute emission for Vulkan

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -780,7 +780,9 @@ Register SPIRVGlobalRegistry::buildGlobalVariable(
     buildOpDecorate(Reg, MIRBuilder, SPIRV::Decoration::Alignment, {Alignment});
   }
 
-  if (HasLinkageTy)
+  // LinkageAttributes required Linkage capability. This capability is not
+  // supported by Vulkan.
+  if (HasLinkageTy && !ST.isVulkan())
     buildOpDecorate(Reg, MIRBuilder, SPIRV::Decoration::LinkageAttributes,
                     {static_cast<uint32_t>(LinkageType)}, Name);
 

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
@@ -101,6 +101,7 @@ public:
     return TargetTriple.getArch() == Triple::spirv32 ||
            TargetTriple.getArch() == Triple::spirv64;
   }
+  bool isVulkan() const { return TargetTriple.getOS() == Triple::Vulkan; }
   const std::string &getTargetTripleAsStr() const { return TargetTriple.str(); }
   VersionTuple getSPIRVVersion() const { return SPIRVVersion; };
   bool isAtLeastSPIRVVer(VersionTuple VerToCompareTo) const;

--- a/llvm/test/CodeGen/SPIRV/linkage/link-attribute-vk.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage/link-attribute-vk.ll
@@ -1,0 +1,23 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-pixel %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-pixel %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+@sv_position = external thread_local local_unnamed_addr addrspace(7) externally_initialized constant <4 x float>, !spirv.Decorations !0
+
+; CHECK-NOT: OpDecorate %[[#var]] LinkageAttributes "sv_position" Import
+
+; CHECK-DAG: %[[#float:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#float4:]] = OpTypeVector %[[#float]]
+; CHECK-DAG: %[[#type:]] = OpTypePointer Input %[[#float4]]
+; CHECK-DAG: %[[#var:]] = OpVariable %[[#type]] Input
+
+; CHECK-NOT: OpDecorate %[[#var]] LinkageAttributes "sv_position" Import
+
+define void @main() #1 {
+entry:
+  ret void
+}
+
+attributes #1 = { "hlsl.shader"="pixel" }
+
+!0 = !{!1}
+!1 = !{i32 11, i32 0}


### PR DESCRIPTION
Linkage capability is required for LinkageAttribute. This capability could be allowed in Shaders, but the Vulkan environment do not support it so we should not emit this decoration under Vulkan.

This requires #143888 to work.