### PR TITLE
[libc] Fix ioctl errno inclusion

### DIFF
--- a/libc/src/sys/ioctl/linux/ioctl.cpp
+++ b/libc/src/sys/ioctl/linux/ioctl.cpp
@@ -10,7 +10,7 @@
 
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-#include "src/errno/libc_errno.h"
+#include "src/__support/libc_errno.h"
 #include <stdarg.h>
 #include <sys/syscall.h> // For syscall numbers.
 

--- a/libc/test/src/sys/ioctl/linux/CMakeLists.txt
+++ b/libc/test/src/sys/ioctl/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ add_libc_unittest(
   SRCS
     ioctl_test.cpp
   DEPENDS
-    libc.hdr.ioctl_macros
+    libc.hdr.sys_ioctl_macros
     libc.src.sys.ioctl.ioctl
     libc.src.errno.errno
     libc.src.fcntl.open
@@ -15,3 +15,4 @@ add_libc_unittest(
     libc.src.unistd.read
     libc.src.unistd.write
 )
+

--- a/libc/test/src/sys/ioctl/linux/ioctl_test.cpp
+++ b/libc/test/src/sys/ioctl/linux/ioctl_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/errno/libc_errno.h"
+#include "src/__support/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/sys/ioctl/ioctl.h"
 #include "src/unistd/close.h"


### PR DESCRIPTION
Since errno was moved in
https://github.com/llvm/llvm-project/pull/143187 the code including it
in https://github.com/llvm/llvm-project/pull/141393 was rendered
incorrect. This patch fixes the include and the cmake depends.
