### PR TITLE
[CIR][NFC] Fix an unused variable warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -171,7 +171,7 @@ void CIRGenFunction::emitDelegateCallArg(CallArgList &args,
 
   QualType type = param->getType();
 
-  if (const auto *rd = type->getAsCXXRecordDecl()) {
+  if (type->getAsCXXRecordDecl()) {
     cgm.errorNYI(param->getSourceRange(),
                  "emitDelegateCallArg: record argument");
     return;


### PR DESCRIPTION
This fixes a warning where a variable assigned in 'if' statement wasn't referenced again.