### PR TITLE
[PowerPC][NFC] Update lowering STXVP to STXV in Oct word spilling

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.h
@@ -58,6 +58,11 @@ class PPCRegisterInfo : public PPCGenRegisterInfo {
   DenseMap<unsigned, unsigned> ImmToIdxMap;
   const PPCTargetMachine &TM;
 
+  void spillRegPair(MachineBasicBlock &MBB, MachineBasicBlock::iterator II,
+                    DebugLoc DL, const TargetInstrInfo &TII,
+                    unsigned FrameIndex, bool IsLittleEndian, bool IsKilled,
+                    Register Reg, int Offset) const;
+
 public:
   PPCRegisterInfo(const PPCTargetMachine &TM);
 


### PR DESCRIPTION
Simpliy handling for spilling of acc reg with stx by removing explicit register arithmetic and clean up code gen for register mapping used in stxvp spilling.

Relanding: https://github.com/llvm/llvm-project/pull/142220