### PR TITLE
[libc] Prevent building wchar on MacOS

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -391,6 +391,10 @@ add_subdirectory(fixed_point)
 
 add_subdirectory(time)
 
-add_subdirectory(wchar)
+# Requires access to uchar header which is not on macos
+# Therefore, cannot currently build this on macos in overlay mode
+if(NOT(LIBC_TARGET_OS_IS_DARWIN))
+  add_subdirectory(wchar)
+endif()
 
 add_subdirectory(math)


### PR DESCRIPTION
Prevent building wchar on macos as it depends on uchar.h which isn't available
