### PR TITLE
[CIR][NFC] Fix build problems with [[maybe_unused]]

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenValue.h
+++ b/clang/lib/CIR/CodeGen/CIRGenValue.h
@@ -271,7 +271,7 @@ class AggValueSlot {
   /// destructor for the slot.  Otherwise the code which constructs it should
   /// push the appropriate cleanup.
   LLVM_PREFERRED_TYPE(bool)
-  [[maybe_unused]] unsigned destructedFlag : 1;
+  LLVM_ATTRIBUTE_UNUSED unsigned destructedFlag : 1;
 
   /// This is set to true if the memory in the slot is known to be zero before
   /// the assignment into it.  This means that zero fields don't need to be set.
@@ -290,7 +290,7 @@ class AggValueSlot {
   /// object, it's important that this flag never be set when
   /// evaluating an expression which constructs such an object.
   LLVM_PREFERRED_TYPE(bool)
-  [[maybe_unused]] unsigned aliasedFlag : 1;
+  LLVM_ATTRIBUTE_UNUSED unsigned aliasedFlag : 1;
 
   /// This is set to true if the tail padding of this slot might overlap
   /// another object that may have already been initialized (and whose
@@ -298,7 +298,7 @@ class AggValueSlot {
   /// store up to the dsize of the type. Otherwise we can widen stores to
   /// the size of the type.
   LLVM_PREFERRED_TYPE(bool)
-  [[maybe_unused]] unsigned overlapFlag : 1;
+  LLVM_ATTRIBUTE_UNUSED unsigned overlapFlag : 1;
 
 public:
   enum IsDestructed_t { IsNotDestructed, IsDestructed };


### PR DESCRIPTION
A recent commit introduced the use of [[maybe_unused]] following LLVM_PREFFERED_TYPE(bool) on a member variable declaration. I compiled it with clang 14.0, which doesn't support the `preferred_type` attribute so I didn't notice a problem. However, starting with clang 18.0, this reports an error ("an attribute list cannot appear here") because of the mixing of attribute styles.

This change fixes the problem by replacing [[maybe_unused]] with LLVM_ATTRIBUTE_UNUSED.