### PR TITLE
[lldb][DWARF] Only log address range error to verbose channel

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -617,7 +617,8 @@ void DWARFDebugInfoEntry::BuildFunctionAddressRangeTable(
         for (const auto &r : *ranges)
           debug_aranges->AppendRange(GetOffset(), r.LowPC, r.HighPC);
       } else {
-        LLDB_LOG_ERRORV(log, ranges.takeError(), "DIE({1:x}): {0}", GetOffset());
+        LLDB_LOG_ERRORV(log, ranges.takeError(), "DIE({1:x}): {0}",
+                        GetOffset());
       }
     }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -617,7 +617,7 @@ void DWARFDebugInfoEntry::BuildFunctionAddressRangeTable(
         for (const auto &r : *ranges)
           debug_aranges->AppendRange(GetOffset(), r.LowPC, r.HighPC);
       } else {
-        LLDB_LOG_ERROR(log, ranges.takeError(), "DIE({1:x}): {0}", GetOffset());
+        LLDB_LOG_ERRORV(log, ranges.takeError(), "DIE({1:x}): {0}", GetOffset());
       }
     }
 


### PR DESCRIPTION
Currently `LLDB_LOG_ERROR` always logs to the "always-on" channel (which prints to the console; this started with https://github.com/llvm/llvm-project/pull/111911).

Attaching to LLDB on macOS spams the console with a bunch of these messages:
```
...
2025-06-13 10:15:09.965660+0100 lldb[40872:3936672] [lldb] DIE(0x240901): DIE has no address range information
2025-06-13 10:15:09.965667+0100 lldb[40872:3936672] [lldb] DIE(0x240925): DIE has no address range information
2025-06-13 10:15:09.965672+0100 lldb[40872:3936672] [lldb] DIE(0x240942): DIE has no address range information
2025-06-13 10:15:09.965679+0100 lldb[40872:3936672] [lldb] DIE(0x24095e): DIE has no address range information
2025-06-13 10:15:09.965686+0100 lldb[40872:3936672] [lldb] DIE(0x240981): DIE has no address range information
2025-06-13 10:15:09.965694+0100 lldb[40872:3936672] [lldb] DIE(0x240993): DIE has no address range information
2025-06-13 10:15:09.965701+0100 lldb[40872:3936672] [lldb] DIE(0x2409a2): DIE has no address range information
...
```

AFAIU this is not a fatal error, so this patch downgrades it from "always-on" by logging only in "verbose" mode.

It still seems pretty aggressive to log all `LLDB_LOG_ERROR` messages to the console, but this is a stop-gap until we want to do something about it.