### PR TITLE
[libc] Fix bugs found when testing with all headers

### DIFF
--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -734,7 +734,7 @@ functions:
       - type: float128
       - type: float128
       - type: float128
-    guards: LIBC_TYPES_HAS_FLOAT128
+    guard: LIBC_TYPES_HAS_FLOAT128
   - name: ffmal
     standards:
       - stdc

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -109,24 +109,24 @@ functions:
       - stdc
     return_type: wchar_t *
     arguments: 
-      - type: __restrict wchar_t *
-      - type: const __restrict wchar_t *
+      - type: wchar_t *__restrict 
+      - type: const wchar_t *__restrict
       - type: size_t
   - name: wcsncpy
     standards:
       - stdc
     return_type: wchar_t *
     arguments:
-      - type: __restrict wchar_t *
-      - type: const __restrict wchar_t *
+      - type: wchar_t *__restrict
+      - type: const wchar_t *__restrict
       - type: size_t
   - name: wcscat
     standards:
       - stdc
     return_type: wchar_t *
     arguments: 
-      - type: __restrict wchar_t *
-      - type: const __restrict wchar_t *
+      - type: wchar_t *__restrict
+      - type: const wchar_t *__restrict
   - name: wcsstr
     standards:
       - stdc
@@ -139,13 +139,13 @@ functions:
       - stdc
     return_type: wchar_t *
     arguments:
-      - type: __restrict wchar_t *
-      - type: const __restrict wchar_t *
+      - type: wchar_t *__restrict
+      - type: const wchar_t *__restrict
       - type: size_t
   - name: wcscpy
     standards:
       - stdc
     return_type: wchar_t *
     arguments:
-      - type: __restrict wchar_t *
-      - type: const __restrict wchar_t *
+      - type: wchar_t *__restrict
+      - type: const wchar_t *__restrict

--- a/libc/test/src/stdio/printf_core/converter_test.cpp
+++ b/libc/test/src/stdio/printf_core/converter_test.cpp
@@ -256,32 +256,3 @@ TEST_F(LlvmLibcPrintfConverterTest, OctConversion) {
   ASSERT_EQ(writer.get_chars_written(), 4);
 }
 
-TEST_F(LlvmLibcPrintfConverterTest, FloatConversionSimple) {
-
-  LIBC_NAMESPACE::printf_core::FormatSection section;
-  section.has_conv = true;
-  section.raw_string = "%f";
-  section.conv_name = 'f';
-  section.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(1.234567);
-  LIBC_NAMESPACE::printf_core::convert(&writer, section);
-
-  wb.buff[wb.buff_cur] = '\0';
-  ASSERT_STREQ(str, "1.234567");
-  ASSERT_EQ(writer.get_chars_written(), 8);
-}
-
-TEST_F(LlvmLibcPrintfConverterTest, FloatConversionPrecisionHigh) {
-
-  LIBC_NAMESPACE::printf_core::FormatSection section;
-  section.has_conv = true;
-  section.raw_string = "%12.3f";
-  section.conv_name = 'f';
-  section.min_width = 12;
-  section.precision = 3;
-  section.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(0.000123);
-  LIBC_NAMESPACE::printf_core::convert(&writer, section);
-
-  wb.buff[wb.buff_cur] = '\0';
-  ASSERT_STREQ(str, "       0.000");
-  ASSERT_EQ(writer.get_chars_written(), 12);
-}

--- a/libc/test/src/stdio/printf_core/converter_test.cpp
+++ b/libc/test/src/stdio/printf_core/converter_test.cpp
@@ -124,7 +124,7 @@ TEST_F(LlvmLibcPrintfConverterTest, StringConversionSimple) {
 TEST_F(LlvmLibcPrintfConverterTest, StringConversionPrecisionHigh) {
   LIBC_NAMESPACE::printf_core::FormatSection high_precision_conv;
   high_precision_conv.has_conv = true;
-  high_precision_conv.raw_string = "%4s";
+  high_precision_conv.raw_string = "%.4s";
   high_precision_conv.conv_name = 's';
   high_precision_conv.precision = 4;
   high_precision_conv.conv_val_ptr = const_cast<char *>("456");
@@ -254,4 +254,34 @@ TEST_F(LlvmLibcPrintfConverterTest, OctConversion) {
   wb.buff[wb.buff_cur] = '\0';
   ASSERT_STREQ(str, "1234");
   ASSERT_EQ(writer.get_chars_written(), 4);
+}
+
+TEST_F(LlvmLibcPrintfConverterTest, FloatConversionSimple) {
+
+  LIBC_NAMESPACE::printf_core::FormatSection section;
+  section.has_conv = true;
+  section.raw_string = "%f";
+  section.conv_name = 'f';
+  section.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(1.234567);
+  LIBC_NAMESPACE::printf_core::convert(&writer, section);
+
+  wb.buff[wb.buff_cur] = '\0';
+  ASSERT_STREQ(str, "1.234567");
+  ASSERT_EQ(writer.get_chars_written(), 8);
+}
+
+TEST_F(LlvmLibcPrintfConverterTest, FloatConversionPrecisionHigh) {
+
+  LIBC_NAMESPACE::printf_core::FormatSection section;
+  section.has_conv = true;
+  section.raw_string = "%12.3f";
+  section.conv_name = 'f';
+  section.min_width = 12;
+  section.precision = 3;
+  section.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(0.000123);
+  LIBC_NAMESPACE::printf_core::convert(&writer, section);
+
+  wb.buff[wb.buff_cur] = '\0';
+  ASSERT_STREQ(str, "       0.000");
+  ASSERT_EQ(writer.get_chars_written(), 12);
 }

--- a/libc/test/src/stdio/printf_core/converter_test.cpp
+++ b/libc/test/src/stdio/printf_core/converter_test.cpp
@@ -255,4 +255,3 @@ TEST_F(LlvmLibcPrintfConverterTest, OctConversion) {
   ASSERT_STREQ(str, "1234");
   ASSERT_EQ(writer.get_chars_written(), 4);
 }
-


### PR DESCRIPTION
Fixes a couple of bugs found when building. The PR to enable the headers can be found here: #144114.

- math.yaml: float128 guard
- wchar.yaml: __restrict keyword order