### PR TITLE
Revert "[lit] cleanup unused imports"

### DIFF
--- a/lld/test/Unit/lit.cfg.py
+++ b/lld/test/Unit/lit.cfg.py
@@ -3,6 +3,7 @@
 # Configuration file for the 'lit' test runner.
 
 import os
+import subprocess
 
 import lit.formats
 

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -9,6 +9,8 @@ import shutil
 import subprocess
 import sys
 
+import lit.formats
+
 # name: The name of this test suite.
 config.name = "lldb-api"
 

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -7,9 +7,12 @@ import re
 import shutil
 import site
 import subprocess
+import sys
 
-import lit.util
+import lit.formats
 from lit.llvm import llvm_config
+from lit.llvm.subst import FindTool
+from lit.llvm.subst import ToolSubst
 
 site.addsitedir(os.path.dirname(__file__))
 from helper import toolchain

--- a/lldb/test/lit.cfg.py
+++ b/lldb/test/lit.cfg.py
@@ -2,6 +2,9 @@
 
 import os
 
+import lit.formats
+from lit.llvm import llvm_config
+
 # This is the top level configuration. Most of these configuration options will
 # be overriden by individual lit configuration files in the test
 # subdirectories. Anything configured here will *not* be loaded when pointing

--- a/llvm/utils/lit/lit/LitConfig.py
+++ b/llvm/utils/lit/lit/LitConfig.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
-
 import inspect
 import os
+import platform
 import sys
 
+import lit.Test
+import lit.formats
+import lit.TestingConfig
 import lit.util
-
 
 # LitConfig must be a new style class for properties to work
 class LitConfig(object):

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+import errno
+import io
+import itertools
 import getopt
 import os, signal, subprocess, sys
 import re
@@ -9,7 +12,10 @@ import shlex
 import shutil
 import tempfile
 import threading
+import typing
 from typing import Optional, Tuple
+
+import io
 
 try:
     from StringIO import StringIO

--- a/llvm/utils/lit/lit/discovery.py
+++ b/llvm/utils/lit/lit/discovery.py
@@ -6,8 +6,8 @@ import copy
 import os
 import sys
 
-from lit import Test, util
 from lit.TestingConfig import TestingConfig
+from lit import LitConfig, Test, util
 
 
 def chooseConfigFileFromDir(dir, config_names):

--- a/llvm/utils/lit/lit/worker.py
+++ b/llvm/utils/lit/lit/worker.py
@@ -12,6 +12,8 @@ import time
 import traceback
 
 import lit.Test
+import lit.util
+
 
 _lit_config = None
 _parallelism_semaphores = None


### PR DESCRIPTION
Reverts llvm/llvm-project#143930 as it causes build failures: https://github.com/llvm/llvm-project/pull/143930#issuecomment-2969115461