### PR TITLE
[Offload] Implement `olShutDown`

### DIFF
--- a/offload/liboffload/API/Common.td
+++ b/offload/liboffload/API/Common.td
@@ -176,7 +176,7 @@ def : Function {
   let desc = "Release the resources in use by Offload";
   let details = [
     "This decrements an internal reference count. When this reaches 0, all resources will be released",
-    "Subsequent API calls made after this are not valid"
+    "Subsequent API calls to methods other than `olInit` made after resources are released will return OL_ERRC_UNINITIALIZED"
   ];
   let params = [];
   let returns = [];

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -194,17 +194,16 @@ Error initPlugins() {
 Error olInit_impl() {
   std::lock_guard<std::mutex> Lock{OffloadContextValMutex};
 
-  std::optional<Error> InitResult;
-  if (!isOffloadInitialized()) {
-    OffloadContextVal = new OffloadContext{};
-    InitResult = initPlugins();
+  if (isOffloadInitialized()) {
+    OffloadContext::get().RefCount++;
+    return Plugin::success();
   }
 
+  OffloadContextVal = new OffloadContext{};
+  Error InitResult = initPlugins();
   OffloadContext::get().RefCount++;
 
-  if (InitResult)
-    return std::move(*InitResult);
-  return Error::success();
+  return InitResult;
 }
 
 Error olShutDown_impl() {

--- a/offload/unittests/OffloadAPI/init/olInit.cpp
+++ b/offload/unittests/OffloadAPI/init/olInit.cpp
@@ -15,8 +15,20 @@
 
 struct olInitTest : ::testing::Test {};
 
+TEST_F(olInitTest, Success) {
+  ASSERT_SUCCESS(olInit());
+  ASSERT_SUCCESS(olShutDown());
+}
+
 TEST_F(olInitTest, Uninitialized) {
   ASSERT_ERROR(OL_ERRC_UNINITIALIZED,
                olIterateDevices(
                    [](ol_device_handle_t, void *) { return false; }, nullptr));
+}
+
+TEST_F(olInitTest, RepeatedInit) {
+  for (size_t I = 0; I < 10; I++) {
+    ASSERT_SUCCESS(olInit());
+    ASSERT_SUCCESS(olShutDown());
+  }
 }


### PR DESCRIPTION
`olShutDown` was not properly calling deinit on the platforms, resulting in random segfaults on AMD devices.

As part of this, `olInit` and `olShutDown` now alloc and free the platform list and alloc info list rather than it being static. This allows `olShutDown` to be called within a destructor of a static object (like the tests do) without having to worry about destructor ordering.

~~This flagged up some memory issues, which have been fixed in #143873 . Please ignore the first three commits of this MR.~~ Dependant MR has been merged.