### PR TITLE
[Clang] use colon char instead of token name

### DIFF
--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -836,8 +836,7 @@ StmtResult Parser::ParseCaseStatement(ParsedStmtContext StmtCtx,
 
       Diag(ExpectedLoc, diag::err_expected_after)
           << "'case'" << tok::colon
-          << FixItHint::CreateInsertion(ExpectedLoc,
-                                        tok::getTokenName(tok::colon));
+          << FixItHint::CreateInsertion(ExpectedLoc, ":");
 
       ColonLoc = ExpectedLoc;
     }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -836,7 +836,8 @@ StmtResult Parser::ParseCaseStatement(ParsedStmtContext StmtCtx,
 
       Diag(ExpectedLoc, diag::err_expected_after)
           << "'case'" << tok::colon
-          << FixItHint::CreateInsertion(ExpectedLoc, ":");
+          << FixItHint::CreateInsertion(ExpectedLoc,
+                                        tok::getPunctuatorSpelling(tok::colon));
 
       ColonLoc = ExpectedLoc;
     }

--- a/clang/test/FixIt/fixit-macro-expansion-recovery.cpp
+++ b/clang/test/FixIt/fixit-macro-expansion-recovery.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify %s
+// RUN: not %clang_cc1 -fdiagnostics-parseable-fixits -std=c++23 %s 2>&1 | FileCheck %s
+
+#define C(x) case x
+
+void t1(int a) {
+  switch (a) {
+    C(10) // expected-error {{expected ':' after 'case'}}
+  }
+}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-3]]:10-[[@LINE-3]]:10}:":"


### PR DESCRIPTION
Fixes regression of https://github.com/llvm/llvm-project/pull/143460/files#r2144925614