### PR TITLE
[Clang] Fix fix-it hint regression from #143460

### DIFF
--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -836,8 +836,7 @@ StmtResult Parser::ParseCaseStatement(ParsedStmtContext StmtCtx,
 
       Diag(ExpectedLoc, diag::err_expected_after)
           << "'case'" << tok::colon
-          << FixItHint::CreateInsertion(ExpectedLoc,
-                                        tok::getTokenName(tok::colon));
+          << FixItHint::CreateInsertion(ExpectedLoc, ":");
 
       ColonLoc = ExpectedLoc;
     }

--- a/clang/test/FixIt/fixit-punctuator-spelling.cpp
+++ b/clang/test/FixIt/fixit-punctuator-spelling.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+
+void f(int x) {
+  switch (x) {
+    case 1 // expected-error {{expected ':' after 'case'}}
+      break;
+  }
+}
+// CHECK: fix-it:"{{.*}}":{6:11-6:11}:":"

--- a/clang/test/Parser/switch-recovery.cpp
+++ b/clang/test/Parser/switch-recovery.cpp
@@ -236,6 +236,9 @@ namespace GH143216 {
 int f(int x) {
   switch (x) {
   case FOO // expected-error {{expected ':' after 'case'}}
+           // CHECK: {{^}}  case FOO
+           // CHECK: {{^}}          ^
+           // CHECK: {{^}}          :
     return 0;
   default:
     return 1;

--- a/clang/test/Parser/switch-recovery.cpp
+++ b/clang/test/Parser/switch-recovery.cpp
@@ -236,9 +236,6 @@ namespace GH143216 {
 int f(int x) {
   switch (x) {
   case FOO // expected-error {{expected ':' after 'case'}}
-           // CHECK: {{^}}  case FOO
-           // CHECK: {{^}}          ^
-           // CHECK: {{^}}          :
     return 0;
   default:
     return 1;


### PR DESCRIPTION
Following #143460, `:` began displaying as `colon` in the fix-it hint for a `case` with a missing colon, as is visible in the description of (the separate bug) #144052.

This PR simply reverts a line that didn't need to be changed.