### PR TITLE
[MSan] Fix wrong unpoison size in SignalAction

### DIFF
--- a/compiler-rt/lib/msan/msan_interceptors.cpp
+++ b/compiler-rt/lib/msan/msan_interceptors.cpp
@@ -1127,7 +1127,7 @@ static void SignalAction(int signo, void *si, void *uc) {
   SignalHandlerScope signal_handler_scope;
   ScopedThreadLocalStateBackup stlsb;
   UnpoisonParam(3);
-  __msan_unpoison(si, sizeof(__sanitizer_sigaction));
+  __msan_unpoison(si, sizeof(__sanitizer_siginfo));
   __msan_unpoison(uc, ucontext_t_sz(uc));
 
   typedef void (*sigaction_cb)(int, void *, void *);


### PR DESCRIPTION
MSan should unpoison the parameters of extended signal handlers. 
However, MSan unpoisoned the second parameter with the wrong size 
`sizeof(__sanitizer_sigaction)`, inconsistent with its real type 
`siginfo_t`.

This commit fixes this issue by correcting the size to 
`sizeof(__sanitizer_siginfo)`.