### PR TITLE
[PowerPC] fixed mtvsrbmi.ll test case error caused by run the update_llc_test_checks.py

### DIFF
--- a/llvm/test/CodeGen/PowerPC/mtvsrbmi.ll
+++ b/llvm/test/CodeGen/PowerPC/mtvsrbmi.ll
@@ -10,15 +10,6 @@
 ; RUN:   | FileCheck %s --check-prefix=CHECK
 
 define dso_local noundef range(i8 -1, 1) <16 x i8> @_Z5v00FFv() {
-; CHECK-LABEL: _Z5v00FFv:
-; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lwz r3, L..C0(r2) # %const.0
-; CHECK-NEXT:    lxv vs34, 0(r3)
-; CHECK-NEXT:    blr
-entry:
-  ret <16 x i8> <i8 -1, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0>
-}
-
 ; CHECK:      L..CPI0_0:
 ; CHECK-NEXT:   .byte   255                             # 0xff
 ; CHECK-NEXT:   .byte   0                               # 0x0
@@ -37,8 +28,11 @@ entry:
 ; CHECK-NEXT:   .byte   0                               # 0x0
 ; CHECK-NEXT:   .byte   0                               # 0x0
 
-; CHECK:      ._Z5v00FFv:
-; CHECK-NEXT: # %bb.0:
-; CHECK-NEXT:   lwz r3, L..C0(r2)
-; CHECK-NEXT:   lxv vs34, 0(r3)
-; CHECK-NEXT:   blr
+; CHECK-LABEL: _Z5v00FFv:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    lwz r3, L..C0(r2) # %const.0
+; CHECK-NEXT:    lxv vs34, 0(r3)
+; CHECK-NEXT:    blr
+entry:
+  ret <16 x i8> <i8 -1, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0>
+}


### PR DESCRIPTION
fixed mtvsrbmi.ll test case error which caused by run the update_llc_test_checks.py