### PR TITLE
[PowePC] using MTVSRBMI instruction instead of constant pool in power10+

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -9580,19 +9580,19 @@ static bool isValidSplatLoad(const PPCSubtarget &Subtarget, const SDValue &Op,
   return false;
 }
 
-bool isValidMtVsrbmi(APInt &BMI, BuildVectorSDNode &BVN) {
+bool isValidMtVsrBmi(APInt &BitMask, BuildVectorSDNode &BVN) {
   unsigned int NumOps = BVN.getNumOperands();
-  assert(NumOps > 0 && "isConstantSplat has 0-size build vector");
+  assert(NumOps > 0 && "Unexpected 0-size build vector");
 
-  BMI.clearAllBits();
+  BitMask.clearAllBits();
   EVT VT = BVN.getValueType(0);
   APInt ConstValue(VT.getSizeInBits(), 0);
 
   unsigned EltWidth = VT.getScalarSizeInBits();
 
-  for (unsigned j = 0; j < NumOps; ++j) {
-    SDValue OpVal = BVN.getOperand(j);
-    unsigned BitPos = j * EltWidth;
+  for (unsigned J = 0; J < NumOps; ++J) {
+    SDValue OpVal = BVN.getOperand(J);
+    unsigned BitPos = J * EltWidth;
     auto *CN = dyn_cast<ConstantSDNode>(OpVal);
 
     if (!CN)
@@ -9601,12 +9601,12 @@ bool isValidMtVsrbmi(APInt &BMI, BuildVectorSDNode &BVN) {
     ConstValue.insertBits(CN->getAPIntValue().zextOrTrunc(EltWidth), BitPos);
   }
 
-  for (unsigned J = 0; J < 16; J++) {
+  for (unsigned J = 0; J < 16; ++J) {
     APInt ExtractValue = ConstValue.extractBits(8, J * 8);
     if (ExtractValue != 0x00 && ExtractValue != 0xFF)
       return false;
     if (ExtractValue == 0xFF)
-      BMI.setBit(J);
+      BitMask.setBit(J);
   }
   return true;
 }
@@ -9623,19 +9623,19 @@ SDValue PPCTargetLowering::LowerBUILD_VECTOR(SDValue Op,
   assert(BVN && "Expected a BuildVectorSDNode in LowerBUILD_VECTOR");
 
   if(Subtarget.hasP10Vector()) {
-    APInt BMI(32, 0);
+    APInt BitMask(32, 0);
     // If the value of the vector is all zeros or all ones,
     // we do not convert it to MTVSRBMI.
     // The xxleqv instruction sets a vector with all ones.
     // The xxlxor instruction sets a vector with all zeros.
-    if (isValidMtVsrbmi(BMI, *BVN) && BMI != 0 && BMI!=0xffff ) {
-      SDValue  SDConstant= DAG.getTargetConstant(BMI, dl, MVT::i32);
+    if (isValidMtVsrBmi(BitMask, *BVN) && BitMask != 0 && BitMask != 0xffff) {
+      SDValue SDConstant = DAG.getTargetConstant(BitMask, dl, MVT::i32);
       MachineSDNode* MSDNode = DAG.getMachineNode(PPC::MTVSRBMI, dl,MVT::v16i8, SDConstant);
-      SDValue  SDV = SDValue(MSDNode,0);
+      SDValue SDV = SDValue(MSDNode, 0);
       EVT DVT = BVN->getValueType(0);
       EVT SVT = SDV.getValueType();
       if (SVT != DVT ) {
-	SDV = DAG.getNode(ISD::BITCAST, dl, DVT, SDV);
+        SDV = DAG.getNode(ISD::BITCAST, dl, DVT, SDV);
       }
       return SDV;
     }

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -9590,15 +9590,15 @@ bool isValidMtVsrBmi(APInt &BitMask, BuildVectorSDNode &BVN) {
 
   unsigned EltWidth = VT.getScalarSizeInBits();
 
-  for (unsigned J = 0; J < NumOps; ++J) {
-    SDValue OpVal = BVN.getOperand(J);
-    unsigned BitPos = J * EltWidth;
+  unsigned BitPos = 0;
+  for (auto OpVal : BVN.op_values()) {
     auto *CN = dyn_cast<ConstantSDNode>(OpVal);
 
     if (!CN)
       return false;
 
     ConstValue.insertBits(CN->getAPIntValue().zextOrTrunc(EltWidth), BitPos);
+    BitPos += EltWidth;
   }
 
   for (unsigned J = 0; J < 16; ++J) {
@@ -9630,7 +9630,8 @@ SDValue PPCTargetLowering::LowerBUILD_VECTOR(SDValue Op,
     // The xxlxor instruction sets a vector with all zeros.
     if (isValidMtVsrBmi(BitMask, *BVN) && BitMask != 0 && BitMask != 0xffff) {
       SDValue SDConstant = DAG.getTargetConstant(BitMask, dl, MVT::i32);
-      MachineSDNode* MSDNode = DAG.getMachineNode(PPC::MTVSRBMI, dl,MVT::v16i8, SDConstant);
+      MachineSDNode *MSDNode =
+          DAG.getMachineNode(PPC::MTVSRBMI, dl, MVT::v16i8, SDConstant);
       SDValue SDV = SDValue(MSDNode, 0);
       EVT DVT = BVN->getValueType(0);
       EVT SVT = SDV.getValueType();

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -9622,7 +9622,7 @@ SDValue PPCTargetLowering::LowerBUILD_VECTOR(SDValue Op,
   BuildVectorSDNode *BVN = dyn_cast<BuildVectorSDNode>(Op.getNode());
   assert(BVN && "Expected a BuildVectorSDNode in LowerBUILD_VECTOR");
 
-  if(Subtarget.hasP10Vector()) {
+  if (Subtarget.hasP10Vector()) {
     APInt BitMask(32, 0);
     // If the value of the vector is all zeros or all ones,
     // we do not convert it to MTVSRBMI.

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -9635,7 +9635,7 @@ SDValue PPCTargetLowering::LowerBUILD_VECTOR(SDValue Op,
       SDValue SDV = SDValue(MSDNode, 0);
       EVT DVT = BVN->getValueType(0);
       EVT SVT = SDV.getValueType();
-      if (SVT != DVT ) {
+      if (SVT != DVT) {
         SDV = DAG.getNode(ISD::BITCAST, dl, DVT, SDV);
       }
       return SDV;

--- a/llvm/test/CodeGen/PowerPC/mtvsrbmi.ll
+++ b/llvm/test/CodeGen/PowerPC/mtvsrbmi.ll
@@ -10,28 +10,13 @@
 ; RUN:   | FileCheck %s --check-prefix=CHECK
 
 define dso_local noundef range(i8 -1, 1) <16 x i8> @_Z5v00FFv() {
-; CHECK:      L..CPI0_0:
-; CHECK-NEXT:   .byte   255                             # 0xff
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
-; CHECK-NEXT:   .byte   0                               # 0x0
+; CHECK-NOT:      L..CPI0_0:
+; CHECK-NOT:   .byte   255                             # 0xff
+; CHECK-NOT:   .byte   0                               # 0x0
 
 ; CHECK-LABEL: _Z5v00FFv:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lwz r3, L..C0(r2) # %const.0
-; CHECK-NEXT:    lxv vs34, 0(r3)
+; CHECK-NEXT:    mtvsrbmi v2, 1
 ; CHECK-NEXT:    blr
 entry:
   ret <16 x i8> <i8 -1, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0>


### PR DESCRIPTION
The instruction MTVSRBMI set 0x00(or 0xFF) to each byte of VSR based on the bits mask. Using the instruction instead of constant pool can reduce the asm code size and instructions in power10.

 