### PR TITLE
[KeyInstr] Fully support mixed key/non-key inlining modes

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2081,8 +2081,8 @@ void DwarfDebug::beginInstruction(const MachineInstr *MI) {
 
   // There may be a mixture of scopes using and not using Key Instructions.
   // Not-Key-Instructions functions inlined into Key Instructions functions
-  // should use not-key is_stmt handling. Key instructions functions inlined
-  // into not-key-instructions functions should use Key Instructions is_stmt
+  // should use not-key is_stmt handling. Key Instructions functions inlined
+  // into Not-Key-Instructions functions should use Key Instructions is_stmt
   // handling.
   bool ScopeUsesKeyInstructions =
       KeyInstructionsAreStmts && DL &&
@@ -2663,7 +2663,7 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
       *MF, Asm->OutStreamer->getContext().getDwarfCompileUnitID());
 
   // Run both `findForceIsStmtInstrs` and `computeKeyInstructions` because
-  // not-key-instructions functions may be inlined into key-instructions
+  // Not-Key-Instructions functions may be inlined into Key Instructions
   // functions and vice versa.
   if (KeyInstructionsAreStmts)
     computeKeyInstructions(MF);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2081,13 +2081,12 @@ void DwarfDebug::beginInstruction(const MachineInstr *MI) {
 
   // There may be a mixture of scopes using and not using Key Instructions.
   // Not-Key-Instructions functions inlined into Key Instructions functions
-  // should use not-key is_stmt handling. Key Instructions functions inlined
-  // into not-key-instructions functions currently fall back to not-key
-  // handling to avoid having to run computeKeyInstructions for all functions
-  // (which will impact non-key-instructions builds).
-  // TODO: Investigate the performance impact of doing that.
+  // should use not-key is_stmt handling. Key instructions functions inlined
+  // into not-key-instructions functions should use Key Instructions is_stmt
+  // handling.
   bool ScopeUsesKeyInstructions =
-      KeyInstructionsAreStmts && DL && SP->getKeyInstructionsEnabled();
+      KeyInstructionsAreStmts && DL &&
+      DL->getScope()->getSubprogram()->getKeyInstructionsEnabled();
 
   bool IsKey = false;
   if (ScopeUsesKeyInstructions && DL && DL.getLine())
@@ -2663,17 +2662,12 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
   PrologEndLoc = emitInitialLocDirective(
       *MF, Asm->OutStreamer->getContext().getDwarfCompileUnitID());
 
-  // If this function wasn't built with Key Instructions but has a function
-  // inlined into it that was, we treat the inlined instance as if it wasn't
-  // built with Key Instructions. If this function was built with Key
-  // Instructions but a function inlined into it wasn't then we continue to use
-  // Key Instructions for this function and fall back to non-key behaviour for
-  // the inlined function (except it doesn't benefit from
-  // findForceIsStmtInstrs).
-  if (KeyInstructionsAreStmts && SP->getKeyInstructionsEnabled())
+  // Run both `findForceIsStmtInstrs` and `computeKeyInstructions` because
+  // not-key-instructions functions may be inlined into key-instructions
+  // functions and vice versa.
+  if (KeyInstructionsAreStmts)
     computeKeyInstructions(MF);
-  else
-    findForceIsStmtInstrs(MF);
+  findForceIsStmtInstrs(MF);
 }
 
 unsigned

--- a/llvm/test/DebugInfo/KeyInstructions/X86/dwarf-inline-modes.mir
+++ b/llvm/test/DebugInfo/KeyInstructions/X86/dwarf-inline-modes.mir
@@ -79,18 +79,12 @@ body:             |
     ; OBJ-NEXT: 2a: movl $0x3, %eax
     ; OBJ-NEXT: 2f: retq
     ;
-    ; TODO: Currently key inlined into not-key is treated as not-key. Investigate
-    ; performance implications of honouring the flag in this scenario.
-    ;
     ;           Address            Line   Column File   ISA Discriminator OpIndex Flags
     ;           ------------------ ------ ------ ------ --- ------------- ------- -------------
     ; DBG-NEXT: 0x0000000000000020      1      0      0   0             0       0  is_stmt prologue_end
-    ; DBG-NEXT: 0x0000000000000025      2      0      0   0             0       0  is_stmt
+    ; DBG-NEXT: 0x0000000000000025      2      0      0   0             0       0
     ; DBG-NEXT: 0x000000000000002a      3      0      0   0             0       0  is_stmt
     ; DBG-NEXT: 0x000000000000002f      3      0      0   0             0       0
-    ;
-    ; NOTE: The `is_stmt` comments at the end of the lines reflects what we want
-    ; to see if the TODO above is resolved.
     ;
     $eax = MOV32ri 1,  debug-location !DILocation(line: 1, scope: !9)                                            ; is_stmt (prologue_end)
     $eax = MOV32ri 2,  debug-location !DILocation(line: 2, scope: !5, inlinedAt: !11, atomGroup: 1, atomRank: 2)


### PR DESCRIPTION
Patch 3/4 adding bitcode support, though the final patch doesn't depend on this one. Ignore the 1st commit in this PR (I'll rebase once the parent commit is merged).

See summary in #144104 which this patch depends on. There's a cost to doing the right thing here, these numbers are for non-key-instructions builds:

https://llvm-compile-time-tracker.com/compare.php?from=bbdb9a446a87de0e3fc45a4016ceec41edb5c51b&to=25537e1b9cd4a50dd1b8575b5ad3ba250b7c0c12&stat=instructions%3Au

```

stage1-O3  stage1-ReleaseThinLTO  stage1-ReleaseLTO-g  stage1-O0-g  stage1-aarch64-O3  stage1-aarch64-O0-g  stage2-O3  stage2-O0-g  stage2-clang
61255M (+0.00%)  77455M (-0.01%)  89419M (+0.03%)  18868M (+0.16%)  68697M (-0.01%)  23070M (+0.10%)  53401M (-0.00%)  16533M (+0.16%)  34128875M (-0.00%)
```