### PR TITLE
[libc++][C++03] Fix tests which only fail due to incorrect includes

### DIFF
--- a/libcxx/test/extensions/libcxx/depr/depr.c.headers/extern_c.pass.cpp
+++ b/libcxx/test/extensions/libcxx/depr/depr.c.headers/extern_c.pass.cpp
@@ -10,13 +10,9 @@
 // that we don't want to support and can't support with LSV enabled.
 // UNSUPPORTED: clang-modules-build
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // Sometimes C++'s <foo.h> headers get included within extern "C" contexts. This
 // is ill-formed (no diagnostic required), per [using.headers]p3, but we permit
 // it as an extension.
-
-#include <__config>
 
 extern "C" {
 #include <assert.h>

--- a/libcxx/test/libcxx-03/algorithms/half_positive.pass.cpp
+++ b/libcxx/test/libcxx-03/algorithms/half_positive.pass.cpp
@@ -11,9 +11,7 @@
 // __half_positive divides an integer number by 2 as unsigned number for known types.
 // It can be an important optimization for lower bound, for example.
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__algorithm/half_positive.h>
+#include <__cxx03/__algorithm/half_positive.h>
 #include <cassert>
 #include <cstddef>
 #include <limits>

--- a/libcxx/test/libcxx-03/assertions/default_verbose_abort.pass.cpp
+++ b/libcxx/test/libcxx-03/assertions/default_verbose_abort.pass.cpp
@@ -9,9 +9,7 @@
 // Test that the default verbose termination function aborts the program.
 // XFAIL: availability-verbose_abort-missing
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__verbose_abort>
+#include <__cxx03/__verbose_abort>
 #include <csignal>
 #include <cstdlib>
 

--- a/libcxx/test/libcxx-03/assertions/modes/none.pass.cpp
+++ b/libcxx/test/libcxx-03/assertions/modes/none.pass.cpp
@@ -11,9 +11,7 @@
 
 // REQUIRES: libcpp-hardening-mode=none
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__assert>
+#include <__cxx03/__assert>
 #include <cassert>
 
 bool executed_condition = false;

--- a/libcxx/test/libcxx-03/assertions/single_expression.pass.cpp
+++ b/libcxx/test/libcxx-03/assertions/single_expression.pass.cpp
@@ -10,9 +10,7 @@
 // This is useful so we can use them  in places that require an expression, such as
 // in a constructor initializer list.
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__assert>
+#include <__cxx03/__assert>
 #include <cassert>
 
 void f() {

--- a/libcxx/test/libcxx-03/containers/associative/tree_balance_after_insert.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/associative/tree_balance_after_insert.pass.cpp
@@ -13,9 +13,7 @@
 // void
 // __tree_balance_after_insert(_NodePtr __root, _NodePtr __x)
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__tree>
+#include <__cxx03/__tree>
 #include <cassert>
 
 #include "test_macros.h"

--- a/libcxx/test/libcxx-03/containers/associative/tree_key_value_traits.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/associative/tree_key_value_traits.pass.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__tree>
+#include <__cxx03/__tree>
 #include <map>
 #include <set>
 #include <type_traits>

--- a/libcxx/test/libcxx-03/containers/associative/tree_left_rotate.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/associative/tree_left_rotate.pass.cpp
@@ -13,9 +13,7 @@
 // void
 // __tree_left_rotate(_NodePtr __x);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__tree>
+#include <__cxx03/__tree>
 #include <cassert>
 
 #include "test_macros.h"

--- a/libcxx/test/libcxx-03/containers/associative/tree_remove.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/associative/tree_remove.pass.cpp
@@ -13,9 +13,7 @@
 // void
 // __tree_remove(_NodePtr __root, _NodePtr __z)
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__tree>
+#include <__cxx03/__tree>
 #include <cassert>
 
 #include "test_macros.h"

--- a/libcxx/test/libcxx-03/containers/associative/tree_right_rotate.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/associative/tree_right_rotate.pass.cpp
@@ -13,9 +13,7 @@
 // void
 // __tree_right_rotate(_NodePtr __x);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__tree>
+#include <__cxx03/__tree>
 #include <cassert>
 
 #include "test_macros.h"

--- a/libcxx/test/libcxx-03/containers/unord/key_value_traits.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/unord/key_value_traits.pass.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__hash_table>
+#include <__cxx03/__hash_table>
 #include <unordered_map>
 #include <unordered_set>
 #include <type_traits>

--- a/libcxx/test/libcxx-03/containers/unord/next_prime.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/unord/next_prime.pass.cpp
@@ -16,9 +16,7 @@
 
 // If n == 0, return 0, else return the lowest prime greater than or equal to n
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__hash_table>
+#include <__cxx03/__hash_table>
 #include <cassert>
 #include <cstddef>
 

--- a/libcxx/test/libcxx-03/iterators/aliasing_iterator.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/aliasing_iterator.pass.cpp
@@ -8,9 +8,7 @@
 
 // ADDITIONAL_COMPILE_FLAGS(clang): -Wprivate-header
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__iterator/aliasing_iterator.h>
+#include <__cxx03/__iterator/aliasing_iterator.h>
 #include <cassert>
 
 struct NonTrivial {

--- a/libcxx/test/libcxx-03/iterators/bounded_iter/arithmetic.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/bounded_iter/arithmetic.pass.cpp
@@ -11,9 +11,7 @@
 //
 // Arithmetic operators
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__iterator/bounded_iter.h>
+#include <__cxx03/__iterator/bounded_iter.h>
 #include <cstddef>
 
 #include "test_iterators.h"

--- a/libcxx/test/libcxx-03/iterators/bounded_iter/pointer_traits.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/bounded_iter/pointer_traits.pass.cpp
@@ -11,9 +11,7 @@
 //
 // std::pointer_traits specialization
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__iterator/bounded_iter.h>
+#include <__cxx03/__iterator/bounded_iter.h>
 #include <cassert>
 #include <cstddef>
 #include <memory>

--- a/libcxx/test/libcxx-03/iterators/bounded_iter/types.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/bounded_iter/types.compile.pass.cpp
@@ -11,9 +11,7 @@
 //
 // Nested types
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__iterator/bounded_iter.h>
+#include <__cxx03/__iterator/bounded_iter.h>
 #include <cstddef>
 #include <iterator>
 #include <type_traits>

--- a/libcxx/test/libcxx-03/memory/allocation_guard.pass.cpp
+++ b/libcxx/test/libcxx-03/memory/allocation_guard.pass.cpp
@@ -12,12 +12,10 @@
 // To allow checking that self-move works correctly.
 // ADDITIONAL_COMPILE_FLAGS: -Wno-self-move
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // template<class _Alloc>
 // struct __allocation_guard;
 
-#include <__memory/allocation_guard.h>
+#include <__cxx03/__memory/allocation_guard.h>
 #include <cassert>
 #include <type_traits>
 #include <utility>

--- a/libcxx/test/libcxx-03/memory/swap_allocator.pass.cpp
+++ b/libcxx/test/libcxx-03/memory/swap_allocator.pass.cpp
@@ -7,14 +7,12 @@
 //===----------------------------------------------------------------------===//
 //
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // <memory>
 
 // template <typename _Alloc>
 // void __swap_allocator(_Alloc& __a1, _Alloc& __a2);
 
-#include <__memory/swap_allocator.h>
+#include <__cxx03/__memory/swap_allocator.h>
 #include <cassert>
 #include <memory>
 #include <utility>

--- a/libcxx/test/libcxx-03/numerics/clamp_to_integral.pass.cpp
+++ b/libcxx/test/libcxx-03/numerics/clamp_to_integral.pass.cpp
@@ -12,9 +12,7 @@
 // closest representable value for the specified integer type, or
 // numeric_limits<IntT>::max()/min() if the value isn't representable.
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__random/clamp_to_integral.h>
+#include <__cxx03/__random/clamp_to_integral.h>
 #include <cassert>
 #include <cmath>
 #include <limits>

--- a/libcxx/test/libcxx-03/strings/c.strings/constexpr_memmove.pass.cpp
+++ b/libcxx/test/libcxx-03/strings/c.strings/constexpr_memmove.pass.cpp
@@ -19,9 +19,7 @@
 // and is_trivially_XXX_assignable), so we use some funky types to test these
 // corner cases.
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__string/constexpr_c_functions.h>
+#include <__cxx03/__string/constexpr_c_functions.h>
 #include <cassert>
 #include <cstdint>
 #include <type_traits>

--- a/libcxx/test/libcxx-03/type_traits/is_trivially_comparable.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/type_traits/is_trivially_comparable.compile.pass.cpp
@@ -6,11 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__type_traits/conditional.h>
-#include <__type_traits/is_equality_comparable.h>
-#include <__type_traits/is_signed.h>
+#include <__cxx03/__type_traits/conditional.h>
+#include <__cxx03/__type_traits/is_equality_comparable.h>
+#include <__cxx03/__type_traits/is_signed.h>
 #include <cstdint>
 
 enum Enum : int {};

--- a/libcxx/test/libcxx-03/type_traits/is_trivially_relocatable.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/type_traits/is_trivially_relocatable.compile.pass.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__type_traits/is_trivially_relocatable.h>
+#include <__cxx03/__type_traits/is_trivially_relocatable.h>
 #include <array>
 #include <deque>
 #include <exception>

--- a/libcxx/test/libcxx-03/utilities/exception_guard.odr.sh.cpp
+++ b/libcxx/test/libcxx-03/utilities/exception_guard.odr.sh.cpp
@@ -9,8 +9,6 @@
 // This test relies on `typeid` and thus requires `-frtti`.
 // UNSUPPORTED: no-rtti
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // Make sure that we don't get ODR violations with __exception_guard when
 // linking together TUs compiled with different values of -f[no-]exceptions.
 
@@ -19,7 +17,7 @@
 // RUN: %{cxx} %{flags} %{link_flags} -o %t.exe %t.except.o %t.noexcept.o
 // RUN: %{run}
 
-#include <__utility/exception_guard.h>
+#include <__cxx03/__utility/exception_guard.h>
 #include <cassert>
 #include <cstring>
 #include <typeinfo>

--- a/libcxx/test/libcxx-03/utilities/is_pointer_in_range.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/is_pointer_in_range.pass.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__utility/is_pointer_in_range.h>
+#include <__cxx03/__utility/is_pointer_in_range.h>
 #include <cassert>
 
 #include "test_macros.h"

--- a/libcxx/test/libcxx-03/utilities/is_valid_range.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/is_valid_range.pass.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__utility/is_valid_range.h>
+#include <__cxx03/__utility/is_valid_range.h>
 #include <cassert>
 
 #include "test_macros.h"

--- a/libcxx/test/libcxx-03/utilities/meta/meta_base.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/meta/meta_base.pass.cpp
@@ -7,15 +7,13 @@
 //===----------------------------------------------------------------------===//
 //
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include "test_macros.h"
 
 TEST_CLANG_DIAGNOSTIC_IGNORED("-Wprivate-header")
-#include <__type_traits/conjunction.h>
-#include <__type_traits/disjunction.h>
-#include <__type_traits/is_valid_expansion.h>
-#include <__type_traits/negation.h>
+#include <__cxx03/__type_traits/conjunction.h>
+#include <__cxx03/__type_traits/disjunction.h>
+#include <__cxx03/__type_traits/is_valid_expansion.h>
+#include <__cxx03/__type_traits/negation.h>
 #include <cassert>
 #include <type_traits>
 #include <utility>

--- a/libcxx/test/libcxx-03/utilities/no_destroy.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/no_destroy.pass.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__utility/no_destroy.h>
+#include <__cxx03/__utility/no_destroy.h>
 #include <cassert>
 
 #include "test_macros.h"

--- a/libcxx/test/libcxx-03/utilities/utility/private_constructor_tag.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/utility/private_constructor_tag.compile.pass.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // struct __private_constructor_tag{};
 
 // The private constructor tag is intended to be a trivial type that can easily
@@ -15,7 +13,7 @@
 //
 // Tests whether the type is trivial.
 
-#include <__utility/private_constructor_tag.h>
+#include <__cxx03/__utility/private_constructor_tag.h>
 #include <type_traits>
 
 static_assert(std::is_trivially_copyable<std::__private_constructor_tag>::value, "");

--- a/libcxx/test/selftest/test_macros.pass.cpp
+++ b/libcxx/test/selftest/test_macros.pass.cpp
@@ -8,9 +8,6 @@
 //
 // Test the "test_macros.h" header.
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
-#include <__config>
 #include "test_macros.h"
 
 #ifndef TEST_STD_VER


### PR DESCRIPTION
Quite a few of the frozen header tests only fail because the include path is incorrect due to copying the headers. This patch fixes the tests where that's the only problem.

This is part of https://discourse.llvm.org/t/rfc-freezing-c-03-headers-in-libc.
