### PR TITLE
[KeyInstr][Clang][NFC] Don't set -dwarf-use-key-instructions

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4631,11 +4631,8 @@ renderDebugOptions(const ToolChain &TC, const Driver &D, const llvm::Triple &T,
   }
 
   if (Args.hasFlag(options::OPT_gkey_instructions,
-                   options::OPT_gno_key_instructions, false)) {
+                   options::OPT_gno_key_instructions, false))
     CmdArgs.push_back("-gkey-instructions");
-    CmdArgs.push_back("-mllvm");
-    CmdArgs.push_back("-dwarf-use-key-instructions");
-  }
 
   if (EmitCodeView) {
     CmdArgs.push_back("-gcodeview");

--- a/clang/test/DebugInfo/KeyInstructions/flag.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/flag.cpp
@@ -3,16 +3,16 @@
 //// Default: Off.
 // RUN: %clang -### -target x86_64 -c -gdwarf %s 2>&1 | FileCheck %s --check-prefixes=NO-KEY-INSTRUCTIONS
 
-//// Help hidden.
+// KEY-INSTRUCTIONS: "-gkey-instructions"
+// NO-KEY-INSTRUCTIONS-NOT: key-instructions
+
+//// Help hidden: flag should not be visible.
 // RUN: %clang --help | FileCheck %s --check-prefix=HELP
 // HELP-NOT: key-instructions
 
-// KEY-INSTRUCTIONS: "-gkey-instructions"
-
-// NO-KEY-INSTRUCTIONS-NOT: key-instructions
-
-// RUN: %clang_cc1 %s -triple x86_64-linux-gnu -debug-info-kind=line-tables-only -emit-llvm -o - | FileCheck %s --check-prefix=SMOKETEST-OFF
+// Smoke test: check for Key Instructions keywords in the IR.
 void f() {}
+// RUN: %clang_cc1 %s -triple x86_64-linux-gnu -debug-info-kind=line-tables-only -emit-llvm -o - | FileCheck %s --check-prefix=SMOKETEST-OFF
 // SMOKETEST-OFF-NOT: keyInstructions:
 // SMOKETEST-OFF-NOT: atomGroup
 

--- a/clang/test/DebugInfo/KeyInstructions/flag.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/flag.cpp
@@ -4,18 +4,18 @@
 // RUN: %clang -### -target x86_64 -c -gdwarf %s 2>&1 | FileCheck %s --check-prefixes=NO-KEY-INSTRUCTIONS
 
 //// Help hidden.
-// RUN %clang --help | FileCheck %s --check-prefix=HELP
+// RUN: %clang --help | FileCheck %s --check-prefix=HELP
 // HELP-NOT: key-instructions
 
 // KEY-INSTRUCTIONS: "-gkey-instructions"
 
 // NO-KEY-INSTRUCTIONS-NOT: key-instructions
 
-// RUN %clang %s | FileCheck %s --check-prefix=SMOKETEST-OFF
+// RUN: %clang_cc1 %s -triple x86_64-linux-gnu -debug-info-kind=line-tables-only -emit-llvm -o - | FileCheck %s --check-prefix=SMOKETEST-OFF
 void f() {}
-// SMOKETEST-OFF-NOT: keyInstructions
+// SMOKETEST-OFF-NOT: keyInstructions:
 // SMOKETEST-OFF-NOT: atomGroup
 
-// RUN %clang %s -gkey-instructions | FileCheck %s --check-prefix=SMOKETEST-ON
+// RUN: %clang_cc1 %s -triple x86_64-linux-gnu -gkey-instructions -debug-info-kind=line-tables-only -emit-llvm -o - | FileCheck %s --check-prefix=SMOKETEST-ON
 // SMOKETEST-ON: keyInstructions: true
 // SMOKETEST-ON: atomGroup: 1

--- a/clang/test/DebugInfo/KeyInstructions/flag.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/flag.cpp
@@ -8,8 +8,14 @@
 // HELP-NOT: key-instructions
 
 // KEY-INSTRUCTIONS: "-gkey-instructions"
-// KEY-INSTRUCTIONS: "-mllvm" "-dwarf-use-key-instructions"
 
 // NO-KEY-INSTRUCTIONS-NOT: key-instructions
 
-//// TODO: Add smoke test once some functionality has been added.
+// RUN %clang %s | FileCheck %s --check-prefix=SMOKETEST-OFF
+void f() {}
+// SMOKETEST-OFF-NOT: keyInstructions
+// SMOKETEST-OFF-NOT: atomGroup
+
+// RUN %clang %s -gkey-instructions | FileCheck %s --check-prefix=SMOKETEST-ON
+// SMOKETEST-ON: keyInstructions: true
+// SMOKETEST-ON: atomGroup: 1


### PR DESCRIPTION
Once #144104 lands the flag is true by default (because each DISubprogram will track whether or not it's using key instructions).