### PR TITLE
Fix string_length function so that it always returns.

### DIFF
--- a/libc/src/string/string_utils.h
+++ b/libc/src/string/string_utils.h
@@ -90,12 +90,11 @@ template <typename T> LIBC_INLINE size_t string_length(const T *src) {
   // string a block at a time.
   if constexpr (cpp::is_same_v<T, char>)
     return string_length_wide_read<unsigned int>(src);
-#else
+#endif
   size_t length;
   for (length = 0; *src; ++src, ++length)
     ;
   return length;
-#endif
 }
 
 template <typename Word>


### PR DESCRIPTION
Previously setting LIBC_COPT_STRING_UNSAFE_WIDE_READ would cause a build error because there is a path in the ifdef that doesn't return anything.