### PR TITLE
Turn LIBC_COPT_STRING_UNSAFE_WIDE_READ on by default

### DIFF
--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -59,7 +59,7 @@
   },
   "string": {
     "LIBC_CONF_STRING_UNSAFE_WIDE_READ": {
-      "value": false,
+      "value": true,
       "doc": "Read more than a byte at a time to perform byte-string operations like strlen."
     },
     "LIBC_CONF_MEMSET_X86_USE_SOFTWARE_PREFETCHING": {


### PR DESCRIPTION
Configure strlen to use unsafe implementation because it is faster.

Because this is undefined behavior it could cause sanitizers to fail.