### PR TITLE
Revert "Turn LIBC_COPT_STRING_UNSAFE_WIDE_READ on by default"

### DIFF
--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -59,7 +59,7 @@
   },
   "string": {
     "LIBC_CONF_STRING_UNSAFE_WIDE_READ": {
-      "value": true,
+      "value": false,
       "doc": "Read more than a byte at a time to perform byte-string operations like strlen."
     },
     "LIBC_CONF_MEMSET_X86_USE_SOFTWARE_PREFETCHING": {


### PR DESCRIPTION
Reverts llvm/llvm-project#144163 because for some reason I didn't realize there are ASan tests.