### PR TITLE
[lldb] Fix object format in the Triple of Mach-O files (approach 3)

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5255,6 +5255,10 @@ void ObjectFileMachO::GetAllArchSpecs(const llvm::MachO::mach_header &header,
   }
 
   if (!found_any) {
+    // Explicitly set the object format to Mach-O if no LC_BUILD_VERSION or
+    // LC_VERSION_MIN_* are found. Without this, the object format will default
+    // to ELF (see `getDefaultFormat()` in `Triple.cpp`), which is wrong.
+    base_triple.setObjectFormat(llvm::Triple::MachO);
     add_triple(base_triple);
   }
 }


### PR DESCRIPTION
**Context**: See previous attempts: #142704, #143633

# Problem
When `ObjectFileMachO` parses a Mach-O file (including yaml data in lldb unit tests) which doesn't have load commands like `LC_BUILD_VERSION` or `LC_VERSION_MIN_*`, its object format is mistakenly reported as `ELF`. Had the load commands existed, they would have caused `ObjectFileMachO` to set the correct OS name into the `Triple` ([here](https://github.com/llvm/llvm-project/blob/52a6492136ef43462c68efa88a0276bb66ee8c52/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp#L5158-L5174) and [here](https://github.com/llvm/llvm-project/blob/52a6492136ef43462c68efa88a0276bb66ee8c52/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp#L5109-L5125)), which would have led to a correct default `MachO` object format in `getDefaultFormat()` ([here](https://github.com/llvm/llvm-project/blob/e37707b1e85cfc07fe75fd6b7e5d41963c52a8ec/llvm/lib/TargetParser/Triple.cpp#L937)).

# Alternative approaches considered
1. Previously, #142704 tries to fix this by setting the correct object format in `ObjectFileMachO::GetAllArchSpecs()` for all input files. However, such wide range of explicit assignment (even when the files have the load commands) led the `Triple` to report "-macho" in its string form, causing change in UI and a test failure which depends on the UI.
2. #143633 updates `getDefaultFormat()`, so that it will return `MachO` when the OS is not set and the vendor is `Apple`. However, it's a change to one of the foundational llvm classes - it's not clear if such impact is worth it.
3. Another approach is to reject such Mach-O files outright. However, there is no a Mach-O spec which states that the load commands are required, plus it is convenient to be able to leave them out when writing tests.

# This patch
This patch tries to strike a good balance of the above:
1. Set the correct object format in `ObjectFileMachO::GetAllArchSpecs()`, but only when the load commands do not exist.  Compared to #142704, this patch minimizes the impacted cases (should be minimal).
2. Fix any existing tests that are broken by this change (should be minimal), by adding the load commands.
3. This patch shouldn't change anything for files/tests which already have the load commands.

# Test
Ran `ninja check-lldb` on Linux and aarch64 macOS. Seems no tests were broken. See [paste](https://pastebin.com/hL3JHxeH).