### PR TITLE
[LTO] Fix System library path in LTO tests on macOS

### DIFF
--- a/llvm/test/tools/lto/discard-value-names.ll
+++ b/llvm/test/tools/lto/discard-value-names.ll
@@ -1,8 +1,8 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macos_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _bar -lSystem -mllvm -lto-discard-value-names
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macos_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _bar -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem -mllvm -lto-discard-value-names
 ; RUN: llvm-dis %t.dylib.lto.opt.bc -o - | FileCheck --check-prefix=DISCARD %s
 
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macos_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _bar -lSystem -mllvm -lto-discard-value-names=false
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macos_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _bar -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem -mllvm -lto-discard-value-names=false
 ; RUN: llvm-dis %t.dylib.lto.opt.bc -o - | FileCheck --check-prefix=KEEP %s
 
 ; The test requires asserts, as it depends on the default value for

--- a/llvm/test/tools/lto/hide-linkonce-odr.ll
+++ b/llvm/test/tools/lto/hide-linkonce-odr.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macosx_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _c -exported_symbol _b  -exported_symbol _GlobLinkonce -lSystem
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macosx_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _c -exported_symbol _b  -exported_symbol _GlobLinkonce -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem
 
 ; RUN: llvm-dis %t.dylib.lto.opt.bc -o - | FileCheck --check-prefix=IR %s
 ; check that @a is no longer a linkonce_odr definition

--- a/llvm/test/tools/lto/no-bitcode.s
+++ b/llvm/test/tools/lto/no-bitcode.s
@@ -2,4 +2,4 @@
 ; libLTO.dylib shouldn't assert on invalid inputs.
 ; RUN: llvm-mc -triple=arm64-apple-ios7.0.0 -filetype=obj -o %t.o
 ; RUN: llvm-ar r %t.a %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.14.0 -dylib -mllvm -O0 -o %t.dylib %t.a -lSystem
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.14.0 -dylib -mllvm -O0 -o %t.dylib %t.a -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem

--- a/llvm/test/tools/lto/opt-level.ll
+++ b/llvm/test/tools/lto/opt-level.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.8.0 -dylib -mllvm -O0 -o %t.dylib %t.o -lSystem
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.8.0 -dylib -mllvm -O0 -o %t.dylib %t.o -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem
 ; RUN: llvm-nm --no-llvm-bc %t.dylib | FileCheck --check-prefix=CHECK-O0 %s
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.8.0 -dylib -mllvm -O2 -o %t.dylib %t.o -lSystem
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.8.0 -dylib -mllvm -O2 -o %t.dylib %t.o -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem
 ; RUN: llvm-nm --no-llvm-bc %t.dylib | FileCheck --check-prefix=CHECK-O2 %s
 
 target triple = "x86_64-apple-macosx10.8.0"

--- a/llvm/test/tools/lto/print-stats.ll
+++ b/llvm/test/tools/lto/print-stats.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.8.0 -dylib -mllvm -stats -o %t.dylib %t.o -lSystem 2>&1 | FileCheck --check-prefix=STATS %s
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.8.0 -dylib -o %t.dylib %t.o -lSystem 2>&1 | FileCheck --allow-empty --check-prefix=NO_STATS %s
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.8.0 -dylib -mllvm -stats -o %t.dylib %t.o -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem 2>&1 | FileCheck --check-prefix=STATS %s
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.8.0 -dylib -o %t.dylib %t.o -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem 2>&1 | FileCheck --allow-empty --check-prefix=NO_STATS %s
 ; REQUIRES: asserts
 
 target triple = "x86_64-apple-macosx10.8.0"


### PR DESCRIPTION
Add explicit SDK library path (-L flag) to the System library in LTO tests
to fix the "library not found for -lSystem" error on macOS. This affects
the following test files:
- tools/lto/print-stats.ll
- tools/lto/hide-linkonce-odr.ll
- tools/lto/discard-value-names.ll
- tools/lto/opt-level.ll
- tools/lto/no-bitcode.s

The tests now explicitly include the path to the macOS SDK's usr/lib directory
to ensure the linker can find the System library during test execution.
