### PR TITLE
Revert "[Cygwin] Define LLVM_ABI for Cygwin (#143222)"

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -209,7 +209,7 @@
 #define LLVM_ABI_FRIEND LLVM_ABI
 #define LLVM_ABI_EXPORT __declspec(dllexport)
 #elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||             \
-    defined(__MVS__) || defined(__CYGWIN__)
+    defined(__MVS__)
 #define LLVM_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define LLVM_ABI_FRIEND
 #define LLVM_TEMPLATE_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT


### PR DESCRIPTION
Flang Merge CI rejects changes to llvm/Support/Compiler.h because precompiled headers aren't rebuilt when their dependencies change.

This reverts commit 60d000496b5485c89c51e64b2b339210d48263be.