### PR TITLE
[clang][cmake] Don't pass -fno-strict-aliasing for GCC

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -345,9 +345,6 @@ configure_file(
 # Add appropriate flags for GCC
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-common -Woverloaded-virtual")
-  if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
-  endif ()
 
   # Enable -pedantic for Clang even if it's not enabled for LLVM.
   if (NOT LLVM_ENABLE_PEDANTIC)


### PR DESCRIPTION
This was added a long time ago..
* to the Makefiles in 40fee6313df688d43d1f8bbe85bc35161689afca;
* first to CMake in b3ce035c7155644d5bced46c45ae5ac865b7aedc;
* then moved to only apply when building Clang with GCC in c5635a6af7c643169f81145bfae8c895f2207792.

This shouldn't be needed these days. If an issue does arise, it really ought to be documented better and the cause will certainly be different than it was back then.

The two GCC bugs cited in 40fee6313df688d43d1f8bbe85bc35161689afca were:
* https://gcc.gnu.org/PR41874
* https://gcc.gnu.org/PR41838 and both are long-fixed. Not only that, if those issues did come up again, we'd be better off doing -Wno-strict-aliasing where appropriate if there weren't a real code issue or some suppression that was tighter in scope wasn't appropriate.