### PR TITLE
Reland "[clang-tidy] Improve integer comparison by matching valid expressions outside implicitCastExpr for use-integer-sign-comparison"

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -237,6 +237,10 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-designated-initializers>` check by avoiding
   diagnosing designated initializers for ``std::array`` initializations.
 
+- Improved :doc:`modernize-use-integer-sign-comparison
+  <clang-tidy/checks/modernize/use-integer-sign-comparison>` check by matching
+  valid integer expressions not directly wrapped around an implicit cast.
+
 - Improved :doc:`modernize-use-ranges
   <clang-tidy/checks/modernize/use-ranges>` check by updating suppress
   warnings logic for ``nullptr`` in ``std::find``.


### PR DESCRIPTION
Addresses: https://github.com/llvm/llvm-project/issues/127471 
**Originally merged under:   https://github.com/llvm/llvm-project/pull/134188 but reverted due to https://github.com/llvm/llvm-project/issues/143927**

What changed:

1. I’m detecting `callExpr`  not directly wrapped by an implicit cast. where its `sourceExpression`  is of integer type.
2. The check originally counted with the fact that signed integer expressions would have an implicit cast expression for all **comparison cases**, but that doesn’t seem to be correct as shown below.

(For the following snippet. as referenced in #143927)

```cpp
struct A
{
  unsigned size() const;
};

struct B
{
  A a;

  bool foo(const A& a2) const { return (int)a2.size() == size(); //here  }
  int size() const { return (int)a.size(); }
};

```

(see AST):

<img width="881" alt="Screenshot 2025-06-14 at 7 24 20 PM" src="https://github.com/user-attachments/assets/d112b7c3-2217-4195-bfc4-cf4c5b46abd4" />


**Notice how the signed operand is not wrapped by a cast in any way.**