### PR TITLE
[flang][cmake] Don't pass -fno-strict-aliasing for GCC either

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -421,7 +421,7 @@ endif()
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
 
   if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing -fno-semantic-interposition")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-semantic-interposition")
   else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument -Wstring-conversion \
           -Wcovered-switch-default")


### PR DESCRIPTION
This is the same as 4ed10db85919d3d87bf0b3353340b58354a75994 with the same rationale, but for Flang, I strongly suspect it was just pulled in from Clang, see https://github.com/flang-compiler/f18/pull/6#issuecomment-364155817.