### PR TITLE
[mlir][vector] Add documentation note on adding new ops

### DIFF
--- a/mlir/docs/Dialects/Vector.md
+++ b/mlir/docs/Dialects/Vector.md
@@ -1,5 +1,8 @@
 # 'vector' Dialect
 
+**Please post an RFC on the [forum](https://llvm.discourse.group/c/mlir/31)
+before adding  any operation in this dialect.**
+
 [TOC]
 
 MLIR supports multi-dimensional `vector` types and custom operations on those


### PR DESCRIPTION
This adds a note requesting that additions of new ops to the Vector
dialect go through an RFC process. The goal is to clarify expectations
for contributors.

Note: this documents an existing (though previously unwritten) convention. See, e.g.:
* https://discourse.llvm.org/t/rfc-adding-vector-to-elements-op-to-the-vector-dialect
* https://discourse.llvm.org/t/rfc-improving-gather-codegen-for-vector-dialect
