### PR TITLE
[libc++] Avoid including vector in <functional>

### DIFF
--- a/libcxx/include/__functional/boyer_moore_searcher.h
+++ b/libcxx/include/__functional/boyer_moore_searcher.h
@@ -17,12 +17,10 @@
 #include <__config>
 #include <__functional/hash.h>
 #include <__functional/operations.h>
-#include <__iterator/distance.h>
 #include <__iterator/iterator_traits.h>
 #include <__memory/shared_ptr.h>
 #include <__type_traits/make_unsigned.h>
 #include <__utility/pair.h>
-#include <__vector/vector.h>
 #include <array>
 #include <limits>
 #include <unordered_map>
@@ -196,7 +194,7 @@ private:
     if (__count == 0)
       return;
 
-    vector<difference_type> __scratch(__count);
+    auto __scratch = std::make_unique<difference_type[]>(__count);
 
     __compute_bm_prefix(__first, __last, __pred, __scratch);
     for (size_t __i = 0; __i <= __count; ++__i)

--- a/libcxx/include/functional
+++ b/libcxx/include/functional
@@ -599,6 +599,10 @@ POLICY:  For non-variadic implementations, the number of arguments is limited
 #    include <utility>
 #    include <vector>
 #  endif
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 23
+#    include <__vector/vector.h>
+#  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
 
 #endif // _LIBCPP_FUNCTIONAL


### PR DESCRIPTION
`vector` has been used in a very simple way in `boyer_moore_searcher`. We can instead just use `unique_ptr<T[]>`, which is a lot simpler, allowing us to drop the `vector` dependency while not losing any expressiveness in the code. As a nice side effect, this also reduces the time it takes to instantiate the `boyer_moore_searcher` constructor from 26ms to 22ms on my machine.
