### PR TITLE
[TargetParser] Increase MAX_SUBTARGET_FEATURES to 384

### DIFF
--- a/llvm/include/llvm/TargetParser/SubtargetFeature.h
+++ b/llvm/include/llvm/TargetParser/SubtargetFeature.h
@@ -32,7 +32,7 @@ namespace llvm {
 class raw_ostream;
 class Triple;
 
-const unsigned MAX_SUBTARGET_WORDS = 5;
+const unsigned MAX_SUBTARGET_WORDS = 6;
 const unsigned MAX_SUBTARGET_FEATURES = MAX_SUBTARGET_WORDS * 64;
 
 /// Container class for subtarget features.


### PR DESCRIPTION
There are 314 features in RISC-V backend, which is about to exceed
the maxinum 320 as there are some ongoing new extensions.

We increase the `MAX_SUBTARGET_FEATURES` to 384 so that we won't
surprise anyone.
