### PR TITLE
[analyzer] Enforce not making overly complicated symbols

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -91,22 +91,6 @@ public:
   SVal evalMinus(NonLoc val);
   SVal evalComplement(NonLoc val);
 
-  /// Create a new value which represents a binary expression with two non-
-  /// location operands.
-  virtual SVal evalBinOpNN(ProgramStateRef state, BinaryOperator::Opcode op,
-                           NonLoc lhs, NonLoc rhs, QualType resultTy) = 0;
-
-  /// Create a new value which represents a binary expression with two memory
-  /// location operands.
-  virtual SVal evalBinOpLL(ProgramStateRef state, BinaryOperator::Opcode op,
-                           Loc lhs, Loc rhs, QualType resultTy) = 0;
-
-  /// Create a new value which represents a binary expression with a memory
-  /// location and non-location operands. For example, this would be used to
-  /// evaluate a pointer arithmetic operation.
-  virtual SVal evalBinOpLN(ProgramStateRef state, BinaryOperator::Opcode op,
-                           Loc lhs, NonLoc rhs, QualType resultTy) = 0;
-
   /// Evaluates a given SVal. If the SVal has only one possible (integer) value,
   /// that value is returned. Otherwise, returns NULL.
   virtual const llvm::APSInt *getKnownValue(ProgramStateRef state, SVal val) = 0;
@@ -396,6 +380,23 @@ public:
   /// Return a memory region for the 'this' object reference.
   loc::MemRegionVal getCXXThis(const CXXRecordDecl *D,
                                const StackFrameContext *SFC);
+
+protected:
+  /// Create a new value which represents a binary expression with two non-
+  /// location operands.
+  virtual SVal evalBinOpNN(ProgramStateRef state, BinaryOperator::Opcode op,
+                           NonLoc lhs, NonLoc rhs, QualType resultTy) = 0;
+
+  /// Create a new value which represents a binary expression with two memory
+  /// location operands.
+  virtual SVal evalBinOpLL(ProgramStateRef state, BinaryOperator::Opcode op,
+                           Loc lhs, Loc rhs, QualType resultTy) = 0;
+
+  /// Create a new value which represents a binary expression with a memory
+  /// location and non-location operands. For example, this would be used to
+  /// evaluate a pointer arithmetic operation.
+  virtual SVal evalBinOpLN(ProgramStateRef state, BinaryOperator::Opcode op,
+                           Loc lhs, NonLoc rhs, QualType resultTy) = 0;
 };
 
 SValBuilder* createSimpleSValBuilder(llvm::BumpPtrAllocator &alloc,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -57,6 +57,8 @@ class SValBuilder {
 protected:
   ASTContext &Context;
 
+  const AnalyzerOptions &AnOpts;
+
   /// Manager of APSInt values.
   BasicValueFactory BasicVals;
 
@@ -67,8 +69,6 @@ protected:
   MemRegionManager MemMgr;
 
   ProgramStateManager &StateMgr;
-
-  const AnalyzerOptions &AnOpts;
 
   /// The scalar type to use for array indices.
   const QualType ArrayIndexTy;
@@ -326,8 +326,8 @@ public:
   nonloc::SymbolVal makeNonLoc(const SymExpr *lhs, BinaryOperator::Opcode op,
                                const SymExpr *rhs, QualType type);
 
-  NonLoc makeNonLoc(const SymExpr *operand, UnaryOperator::Opcode op,
-                    QualType type);
+  nonloc::SymbolVal makeNonLoc(const SymExpr *operand, UnaryOperator::Opcode op,
+                               QualType type);
 
   /// Create a NonLoc value for cast.
   nonloc::SymbolVal makeNonLoc(const SymExpr *operand, QualType fromTy,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Symbols.def
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Symbols.def
@@ -45,6 +45,7 @@ SYMBOL(SymbolCast, SymExpr)
 
 ABSTRACT_SYMBOL(SymbolData, SymExpr)
   SYMBOL(SymbolConjured, SymbolData)
+  SYMBOL(SymbolOverlyComplex, SymbolData)
   SYMBOL(SymbolDerived, SymbolData)
   SYMBOL(SymbolExtent, SymbolData)
   SYMBOL(SymbolMetadata, SymbolData)

--- a/clang/lib/StaticAnalyzer/Checkers/ContainerModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ContainerModeling.cpp
@@ -1034,16 +1034,18 @@ SymbolRef rebaseSymbol(ProgramStateRef State, SValBuilder &SVB,
                        SymbolRef OrigExpr, SymbolRef OldExpr,
                        SymbolRef NewSym) {
   auto &SymMgr = SVB.getSymbolManager();
-  auto Diff = SVB.evalBinOpNN(State, BO_Sub, nonloc::SymbolVal(OrigExpr),
-                              nonloc::SymbolVal(OldExpr),
-                              SymMgr.getType(OrigExpr));
+  auto Diff =
+      SVB.evalBinOp(State, BO_Sub, nonloc::SymbolVal(OrigExpr),
+                    nonloc::SymbolVal(OldExpr), SymMgr.getType(OrigExpr));
 
   const auto DiffInt = Diff.getAs<nonloc::ConcreteInt>();
   if (!DiffInt)
     return OrigExpr;
 
-  return SVB.evalBinOpNN(State, BO_Add, *DiffInt, nonloc::SymbolVal(NewSym),
-                         SymMgr.getType(OrigExpr)).getAsSymbol();
+  return SVB
+      .evalBinOp(State, BO_Add, *DiffInt, nonloc::SymbolVal(NewSym),
+                 SymMgr.getType(OrigExpr))
+      .getAsSymbol();
 }
 
 bool hasLiveIterators(ProgramStateRef State, const MemRegion *Cont) {

--- a/clang/lib/StaticAnalyzer/Checkers/Iterator.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/Iterator.cpp
@@ -273,9 +273,9 @@ ProgramStateRef assumeNoOverflow(ProgramStateRef State, SymbolRef Sym,
   ProgramStateRef NewState = State;
 
   llvm::APSInt Max = AT.getMaxValue() / AT.getValue(Scale);
-  SVal IsCappedFromAbove = SVB.evalBinOpNN(
-      State, BO_LE, nonloc::SymbolVal(Sym),
-      nonloc::ConcreteInt(BV.getValue(Max)), SVB.getConditionType());
+  SVal IsCappedFromAbove = SVB.evalBinOp(State, BO_LE, nonloc::SymbolVal(Sym),
+                                         nonloc::ConcreteInt(BV.getValue(Max)),
+                                         SVB.getConditionType());
   if (auto DV = IsCappedFromAbove.getAs<DefinedSVal>()) {
     NewState = NewState->assume(*DV, true);
     if (!NewState)
@@ -283,9 +283,9 @@ ProgramStateRef assumeNoOverflow(ProgramStateRef State, SymbolRef Sym,
   }
 
   llvm::APSInt Min = -Max;
-  SVal IsCappedFromBelow = SVB.evalBinOpNN(
-      State, BO_GE, nonloc::SymbolVal(Sym),
-      nonloc::ConcreteInt(BV.getValue(Min)), SVB.getConditionType());
+  SVal IsCappedFromBelow = SVB.evalBinOp(State, BO_GE, nonloc::SymbolVal(Sym),
+                                         nonloc::ConcreteInt(BV.getValue(Min)),
+                                         SVB.getConditionType());
   if (auto DV = IsCappedFromBelow.getAs<DefinedSVal>()) {
     NewState = NewState->assume(*DV, true);
     if (!NewState)

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -1222,9 +1222,8 @@ MallocChecker::performKernelMalloc(const CallEvent &Call, CheckerContext &C,
   NonLoc ZeroFlag = C.getSValBuilder()
                         .makeIntVal(*KernelZeroFlagVal, FlagsEx->getType())
                         .castAs<NonLoc>();
-  SVal MaskedFlagsUC = C.getSValBuilder().evalBinOpNN(State, BO_And,
-                                                      Flags, ZeroFlag,
-                                                      FlagsEx->getType());
+  SVal MaskedFlagsUC = C.getSValBuilder().evalBinOp(
+      State, BO_And, Flags, ZeroFlag, FlagsEx->getType());
   if (MaskedFlagsUC.isUnknownOrUndef())
     return std::nullopt;
   DefinedSVal MaskedFlags = MaskedFlagsUC.castAs<DefinedSVal>();
@@ -1917,7 +1916,7 @@ void MallocChecker::checkTaintedness(CheckerContext &C, const CallEvent &Call,
   NonLoc MaxLength =
       SVB.makeIntVal(MaxValInt / APSIntType(MaxValInt).getValue(4));
   std::optional<NonLoc> SizeNL = SizeSVal.getAs<NonLoc>();
-  auto Cmp = SVB.evalBinOpNN(State, BO_GE, *SizeNL, MaxLength, CmpTy)
+  auto Cmp = SVB.evalBinOp(State, BO_GE, *SizeNL, MaxLength, CmpTy)
                  .getAs<DefinedOrUnknownSVal>();
   if (!Cmp)
     return;

--- a/clang/lib/StaticAnalyzer/Checkers/SetgidSetuidOrderChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/SetgidSetuidOrderChecker.cpp
@@ -101,9 +101,9 @@ ProgramStateRef SetgidSetuidOrderChecker::evalAssume(ProgramStateRef State,
   // too. The "invalid failure check" is a different bug that is not the scope
   // of this checker.)
   auto FailComparison =
-      SVB.evalBinOpNN(State, BO_NE, nonloc::SymbolVal(LastSetuidSym),
-                      SVB.makeIntVal(0, /*isUnsigned=*/false),
-                      SVB.getConditionType())
+      SVB.evalBinOp(State, BO_NE, nonloc::SymbolVal(LastSetuidSym),
+                    SVB.makeIntVal(0, /*isUnsigned=*/false),
+                    SVB.getConditionType())
           .getAs<DefinedOrUnknownSVal>();
   if (!FailComparison)
     return State;

--- a/clang/lib/StaticAnalyzer/Checkers/Taint.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/Taint.cpp
@@ -267,7 +267,7 @@ std::vector<SymbolRef> taint::getTaintedSymbolsImpl(ProgramStateRef State,
 
   // HACK:https://discourse.llvm.org/t/rfc-make-istainted-and-complex-symbols-friends/79570
   if (const auto &Opts = State->getAnalysisManager().getAnalyzerOptions();
-      Sym->computeComplexity() > Opts.MaxTaintedSymbolComplexity) {
+      Sym->complexity() > Opts.MaxTaintedSymbolComplexity) {
     return {};
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/TrustNonnullChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/TrustNonnullChecker.cpp
@@ -66,7 +66,7 @@ public:
                              SVal Cond,
                              bool Assumption) const {
     const SymbolRef CondS = Cond.getAsSymbol();
-    if (!CondS || CondS->computeComplexity() > ComplexityThreshold)
+    if (!CondS || CondS->complexity() > ComplexityThreshold)
       return State;
 
     for (SymbolRef Antecedent : CondS->symbols()) {

--- a/clang/lib/StaticAnalyzer/Checkers/UnixAPIChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UnixAPIChecker.cpp
@@ -277,9 +277,8 @@ void UnixAPIMisuseChecker::CheckOpenVariant(CheckerContext &C,
   NonLoc ocreateFlag = C.getSValBuilder()
                            .makeIntVal(Val_O_CREAT.value(), oflagsEx->getType())
                            .castAs<NonLoc>();
-  SVal maskedFlagsUC = C.getSValBuilder().evalBinOpNN(state, BO_And,
-                                                      oflags, ocreateFlag,
-                                                      oflagsEx->getType());
+  SVal maskedFlagsUC = C.getSValBuilder().evalBinOp(
+      state, BO_And, oflags, ocreateFlag, oflagsEx->getType());
   if (maskedFlagsUC.isUnknownOrUndef())
     return;
   DefinedSVal maskedFlags = maskedFlagsUC.castAs<DefinedSVal>();

--- a/clang/lib/StaticAnalyzer/Checkers/VLASizeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/VLASizeChecker.cpp
@@ -112,7 +112,7 @@ ProgramStateRef VLASizeChecker::checkVLA(CheckerContext &C,
     NonLoc IndexLength =
         SVB.evalCast(SizeD, SizeTy, SizeE->getType()).castAs<NonLoc>();
     // Multiply the array length by the element size.
-    SVal Mul = SVB.evalBinOpNN(State, BO_Mul, ArrSize, IndexLength, SizeTy);
+    SVal Mul = SVB.evalBinOp(State, BO_Mul, ArrSize, IndexLength, SizeTy);
     if (auto MulNonLoc = Mul.getAs<NonLoc>())
       ArrSize = *MulNonLoc;
     else

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -67,7 +67,7 @@ void ExprEngine::VisitBinaryOperator(const BinaryOperator* B,
       if (RightV.isUnknown()) {
         unsigned Count = currBldrCtx->blockCount();
         RightV = svalBuilder.conjureSymbolVal(nullptr, getCFGElementRef(), LCtx,
-                                              Count);
+                                              RHS->getType(), Count);
       }
       // Simulate the effects of a "store":  bind the value of the RHS
       // to the L-Value represented by the LHS.

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -333,22 +333,21 @@ ProgramState::assumeInBoundDual(DefinedOrUnknownSVal Idx,
   nonloc::ConcreteInt Min(BVF.getMinValue(indexTy));
 
   // Adjust the index.
-  SVal newIdx = svalBuilder.evalBinOpNN(this, BO_Add,
-                                        Idx.castAs<NonLoc>(), Min, indexTy);
+  SVal newIdx =
+      svalBuilder.evalBinOp(this, BO_Add, Idx.castAs<NonLoc>(), Min, indexTy);
   if (newIdx.isUnknownOrUndef())
     return {this, this};
 
   // Adjust the upper bound.
-  SVal newBound =
-    svalBuilder.evalBinOpNN(this, BO_Add, UpperBound.castAs<NonLoc>(),
-                            Min, indexTy);
+  SVal newBound = svalBuilder.evalBinOp(
+      this, BO_Add, UpperBound.castAs<NonLoc>(), Min, indexTy);
 
   if (newBound.isUnknownOrUndef())
     return {this, this};
 
   // Build the actual comparison.
-  SVal inBound = svalBuilder.evalBinOpNN(this, BO_LT, newIdx.castAs<NonLoc>(),
-                                         newBound.castAs<NonLoc>(), Ctx.IntTy);
+  SVal inBound = svalBuilder.evalBinOp(this, BO_LT, newIdx.castAs<NonLoc>(),
+                                       newBound.castAs<NonLoc>(), Ctx.IntTy);
   if (inBound.isUnknownOrUndef())
     return {this, this};
 

--- a/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
@@ -612,7 +612,7 @@ SVal SValBuilder::evalIntegralCast(ProgramStateRef state, SVal val,
   // target type.
   QualType CmpTy = getConditionType();
   auto CompVal =
-      evalBinOpNN(state, BO_LE, *AsNonLoc, ToTypeMaxVal, CmpTy).getAs<NonLoc>();
+      evalBinOp(state, BO_LE, *AsNonLoc, ToTypeMaxVal, CmpTy).getAs<NonLoc>();
   if (!CompVal)
     return UnknownVal();
   ProgramStateRef IsNotTruncated, IsTruncated;

--- a/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
@@ -291,9 +291,9 @@ static std::pair<SymbolRef, APSIntPtr> decomposeSymbol(SymbolRef Sym,
 // same signed integral type and no overflows occur (which should be checked
 // by the caller).
 static NonLoc doRearrangeUnchecked(ProgramStateRef State,
-                                   BinaryOperator::Opcode Op,
-                                   SymbolRef LSym, llvm::APSInt LInt,
-                                   SymbolRef RSym, llvm::APSInt RInt) {
+                                   BinaryOperator::Opcode Op, SymbolRef LSym,
+                                   llvm::APSInt LInt, SymbolRef RSym,
+                                   llvm::APSInt RInt) {
   SValBuilder &SVB = State->getStateManager().getSValBuilder();
   BasicValueFactory &BV = SVB.getBasicValueFactory();
   SymbolManager &SymMgr = SVB.getSymbolManager();

--- a/clang/lib/StaticAnalyzer/Core/SymbolManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SymbolManager.cpp
@@ -17,6 +17,7 @@
 #include "clang/Analysis/Analyses/LiveVariables.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Basic/LLVM.h"
+#include "clang/StaticAnalyzer/Core/AnalyzerOptions.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/SVals.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/Store.h"
@@ -150,6 +151,14 @@ void SymbolData::anchor() {}
 
 void SymbolRegionValue::dumpToStream(raw_ostream &os) const {
   os << getKindStr() << getSymbolID() << '<' << getType() << ' ' << R << '>';
+}
+
+SymbolManager::SymbolManager(ASTContext &ctx, BasicValueFactory &bv,
+                             llvm::BumpPtrAllocator &bpalloc,
+                             const AnalyzerOptions &Opts)
+    : SymbolDependencies(16), Alloc(bpalloc), BV(bv), Ctx(ctx),
+      MaxCompComplexity(Opts.MaxSymbolComplexity) {
+  assert(MaxCompComplexity > 0 && "Zero max complexity doesn't make sense");
 }
 
 bool SymExpr::symbol_iterator::operator==(const symbol_iterator &X) const {

--- a/clang/test/Analysis/ArrayBound/brief-tests.c
+++ b/clang/test/Analysis/ArrayBound/brief-tests.c
@@ -183,7 +183,7 @@ struct incomplete;
 char test_comparison_with_extent_symbol(struct incomplete *p) {
   // Previously this was reported as a (false positive) overflow error because
   // the extent symbol of the area pointed by `p` was an unsigned and the '-1'
-  // was converted to its type by `evalBinOpNN`.
+  // was converted to its type by `evalBinOp`.
   return ((char *)p)[-1]; // no-warning
 }
 

--- a/clang/test/Analysis/bitwise-shift-sanity-checks.c
+++ b/clang/test/Analysis/bitwise-shift-sanity-checks.c
@@ -124,7 +124,7 @@ void doubles_cast_to_integer(int *c) {
 
 unsigned int strange_cast(unsigned short sh) {
   // This testcase triggers a bug in the constant folding (it "forgets" the
-  // cast), which is silenced in SimpleSValBuilder::evalBinOpNN() with an ugly
+  // cast), which is silenced in SimpleSValBuilder::evalBinOp() with an ugly
   // workaround, because otherwise it would lead to a false positive from
   // core.UndefinedBinaryOperatorResult.
   unsigned int i;

--- a/clang/test/Analysis/ensure-capped-symbol-complexity.cpp
+++ b/clang/test/Analysis/ensure-capped-symbol-complexity.cpp
@@ -34,7 +34,7 @@ void pumpSymbolComplexity() {
 
   // This dump used to print a hugely complicated symbol, over 800 complexity, taking really long to simplify.
   clang_analyzer_dump(*p);
-  // expected-warning-re@-1 {{{{^}}(complex_${{[0-9]+}}) & 1023}} [debug.ExprInspection]{{$}}}}
+  // expected-warning-re@-1 {{{{^}}conj_${{[0-9]+}}{int, LC{{[0-9]+}}, S{{[0-9]+}}, #{{[0-9]+}}} [debug.ExprInspection]{{$}}}}
 }
 
 void hugelyOverComplicatedSymbol() {
@@ -45,14 +45,10 @@ void hugelyOverComplicatedSymbol() {
   HUNDRED_TIMES(*p = (*p + 1) & 1023;)
   HUNDRED_TIMES(*p = (*p + 1) & 1023;)
   HUNDRED_TIMES(*p = (*p + 1) & 1023;)
-  *p = (*p + 1) & 1023;
-  *p = (*p + 1) & 1023;
-  *p = (*p + 1) & 1023;
-  *p = (*p + 1) & 1023;
 
   // This dump used to print a hugely complicated symbol, over 800 complexity, taking really long to simplify.
   clang_analyzer_dump(*p);
-  // expected-warning-re@-1 {{{{^}}(((complex_${{[0-9]+}}) & 1023) + 1) & 1023 [debug.ExprInspection]{{$}}}}
+  // expected-warning-re@-1 {{{{^}}((((((((conj_${{[0-9]+}}{int, LC{{[0-9]+}}, S{{[0-9]+}}, #{{[0-9]+}}}) + 1) & 1023) + 1) & 1023) + 1) & 1023) + 1) & 1023 [debug.ExprInspection]{{$}}}}
 #undef HUNDRED_TIMES
 #undef TEN_TIMES
 }

--- a/clang/test/Analysis/ensure-capped-symbol-complexity.cpp
+++ b/clang/test/Analysis/ensure-capped-symbol-complexity.cpp
@@ -56,3 +56,38 @@ void hugelyOverComplicatedSymbol() {
 #undef HUNDRED_TIMES
 #undef TEN_TIMES
 }
+
+typedef unsigned long long __attribute__((aligned((8)))) u64a;
+u64a compress64(u64a x, u64a m) {
+  if ((x & m) == 0)
+      return 0;
+  x &= m;
+  u64a mk = ~m << 1;
+  for (unsigned i = 0; i < 6; i++) {
+    u64a mp = mk ^ (mk << 1);
+    mp ^= mp << 2;
+    mp ^= mp << 4;
+    mp ^= mp << 8;
+    mp ^= mp << 16;
+    mp ^= mp << 32;
+    u64a mv = mp & m;
+    m = (m ^ mv) | (mv >> (1 << i));
+    u64a t = x & mv;
+    x = (x ^ t) | (t >> (1 << i));
+    mk = mk & ~mp;
+  }
+  return x;
+}
+void storecompressed512_64bit(u64a *m, u64a *x) {
+  u64a v[8] = {
+    compress64(x[0], m[0]),
+    compress64(x[1], m[1]),
+    compress64(x[2], m[2]),
+    compress64(x[3], m[3]),
+    compress64(x[4], m[4]),
+    compress64(x[5], m[5]),
+    compress64(x[6], m[6]),
+    compress64(x[7], m[7]),
+  };
+  (void)v;
+}

--- a/clang/test/Analysis/ensure-capped-symbol-complexity.cpp
+++ b/clang/test/Analysis/ensure-capped-symbol-complexity.cpp
@@ -1,0 +1,58 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=debug.ExprInspection %s -verify
+
+// RUN: %clang_analyze_cc1 -analyzer-checker=debug.ConfigDumper 2>&1 | FileCheck %s --match-full-lines
+// CHECK: max-symbol-complexity = 35
+
+void clang_analyzer_dump(int v);
+
+void pumpSymbolComplexity() {
+  extern int *p;
+  *p = (*p + 1) & 1023; //  2
+  *p = (*p + 1) & 1023; //  4
+  *p = (*p + 1) & 1023; //  6
+  *p = (*p + 1) & 1023; //  8
+  *p = (*p + 1) & 1023; // 10
+  *p = (*p + 1) & 1023; // 12
+  *p = (*p + 1) & 1023; // 14
+  *p = (*p + 1) & 1023; // 16
+  *p = (*p + 1) & 1023; // 18
+  *p = (*p + 1) & 1023; // 20
+  *p = (*p + 1) & 1023; // 22
+  *p = (*p + 1) & 1023; // 24
+  *p = (*p + 1) & 1023; // 26
+  *p = (*p + 1) & 1023; // 28
+  *p = (*p + 1) & 1023; // 30
+  *p = (*p + 1) & 1023; // 32
+  *p = (*p + 1) & 1023; // 34
+
+  // The complexity of "*p" is below 35, so it's accurate.
+  clang_analyzer_dump(*p);
+  // expected-warning-re@-1 {{{{^\({34}reg}}}}
+
+  // We would increase the complexity over the threshold, thus it'll get simplified.
+  *p = (*p + 1) & 1023; // Would be 36, which is over 35.
+
+  // This dump used to print a hugely complicated symbol, over 800 complexity, taking really long to simplify.
+  clang_analyzer_dump(*p);
+  // expected-warning-re@-1 {{{{^}}(complex_${{[0-9]+}}) & 1023}} [debug.ExprInspection]{{$}}}}
+}
+
+void hugelyOverComplicatedSymbol() {
+#define TEN_TIMES(x) x x x x x x x x x x
+#define HUNDRED_TIMES(x) TEN_TIMES(TEN_TIMES(x))
+  extern int *p;
+  HUNDRED_TIMES(*p = (*p + 1) & 1023;)
+  HUNDRED_TIMES(*p = (*p + 1) & 1023;)
+  HUNDRED_TIMES(*p = (*p + 1) & 1023;)
+  HUNDRED_TIMES(*p = (*p + 1) & 1023;)
+  *p = (*p + 1) & 1023;
+  *p = (*p + 1) & 1023;
+  *p = (*p + 1) & 1023;
+  *p = (*p + 1) & 1023;
+
+  // This dump used to print a hugely complicated symbol, over 800 complexity, taking really long to simplify.
+  clang_analyzer_dump(*p);
+  // expected-warning-re@-1 {{{{^}}(((complex_${{[0-9]+}}) & 1023) + 1) & 1023 [debug.ExprInspection]{{$}}}}
+#undef HUNDRED_TIMES
+#undef TEN_TIMES
+}


### PR DESCRIPTION
Out of the worst 500 entry points, 45 were improved by at least 10%. Out of these 45, 5 were improved by more than 50%. Out of these 45, 2 were improved by more than 80%.

For example, for the
`DelugeFirmware/src/OSLikeStuff/fault_handler/fault_handler.c` TU:
- `printPointers` entry point was improved from 31.1 seconds to 1.1 second (28x).
- `handle_cpu_fault` entry point was improved from 15.5 seconds to 3 seconds (5x).

We had in total 3'037'085 entry points in the test pool. Out of these 390'156 were measured to run over a second.

![asset](https://github.com/user-attachments/assets/7e5df195-debd-4a15-ba5d-361708dfc2b9)

CPP-6182