### PR TITLE
[libcxx] Initialize vcruntime __std_exception_data in the exception copy ctor

### DIFF
--- a/libcxx/include/__exception/exception.h
+++ b/libcxx/include/__exception/exception.h
@@ -48,7 +48,7 @@ public:
     __data_._DoFree = true;
   }
 
-  exception(exception const&) _NOEXCEPT {}
+  exception(exception const&) _NOEXCEPT : __data_() {}
 
   exception& operator=(exception const&) _NOEXCEPT { return *this; }
 


### PR DESCRIPTION
This fixes failures in a number of tests, in the
clang-cl-no-vcruntime configuration (where libcxx provides dummy, no-op replacements of some vcruntime base exception classes), if building with optimization enabled.

Previously, with optimization enabled, the compiler concluded that these fields would be uninitialized at the points of asserts in the tests.

This fixes the following tests in this configuration:

    llvm-libc++-shared-no-vcruntime-clangcl.cfg.in :: std/language.support/support.dynamic/alloc.errors/bad.alloc/bad_alloc.pass.cpp
    llvm-libc++-shared-no-vcruntime-clangcl.cfg.in :: std/language.support/support.dynamic/alloc.errors/new.badlength/bad_array_new_length.pass.cpp
    llvm-libc++-shared-no-vcruntime-clangcl.cfg.in :: std/language.support/support.exception/bad.exception/bad_exception.pass.cpp
    llvm-libc++-shared-no-vcruntime-clangcl.cfg.in :: std/language.support/support.exception/exception/exception.pass.cpp
    llvm-libc++-shared-no-vcruntime-clangcl.cfg.in :: std/language.support/support.rtti/bad.cast/bad_cast.pass.cpp
    llvm-libc++-shared-no-vcruntime-clangcl.cfg.in :: std/language.support/support.rtti/bad.typeid/bad_typeid.pass.cpp