### PR TITLE
[ConstantFolding] Handle reading from type padding

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -432,9 +432,9 @@ bool ReadDataFromGlobal(Constant *C, uint64_t ByteOffset, unsigned char *CurPtr,
   assert(ByteOffset <= DL.getTypeAllocSize(C->getType()) &&
          "Out of range access");
 
-  // Trying to read type padding.
+  // Reading type padding, return zero.
   if (ByteOffset >= DL.getTypeStoreSize(C->getType()))
-    return false;
+    return true;
 
   // If this element is zero or undefined, we can just return since *CurPtr is
   // zero initialized.

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -432,6 +432,10 @@ bool ReadDataFromGlobal(Constant *C, uint64_t ByteOffset, unsigned char *CurPtr,
   assert(ByteOffset <= DL.getTypeAllocSize(C->getType()) &&
          "Out of range access");
 
+  // Trying to read type padding.
+  if (ByteOffset >= DL.getTypeStoreSize(C->getType()))
+    return false;
+
   // If this element is zero or undefined, we can just return since *CurPtr is
   // zero initialized.
   if (isa<ConstantAggregateZero>(C) || isa<UndefValue>(C))

--- a/llvm/test/Transforms/InstSimplify/ConstProp/loads.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/loads.ll
@@ -441,3 +441,41 @@ define i128 @load-128bit(){
   %1 = load i128, ptr @global128, align 4
   ret i128 %1
 }
+
+
+@i40_struct = constant { i40, i8 } { i40 0, i8 1 }
+@i40_array = constant [2 x i40] [i40 0, i40 1]
+
+define i8 @load_i40_struct_padding() {
+; CHECK-LABEL: @load_i40_struct_padding(
+; CHECK-NEXT:    [[V:%.*]] = load i8, ptr getelementptr (i8, ptr @i40_struct, i64 6), align 1
+; CHECK-NEXT:    ret i8 [[V]]
+;
+  %v = load i8, ptr getelementptr (i8, ptr @i40_struct, i64 6)
+  ret i8 %v
+}
+
+define i16 @load_i40_struct_partial_padding() {
+; CHECK-LABEL: @load_i40_struct_partial_padding(
+; CHECK-NEXT:    ret i16 0
+;
+  %v = load i16, ptr getelementptr (i8, ptr @i40_struct, i64 4)
+  ret i16 %v
+}
+
+define i8 @load_i40_array_padding() {
+; CHECK-LABEL: @load_i40_array_padding(
+; CHECK-NEXT:    [[V:%.*]] = load i8, ptr getelementptr (i8, ptr @i40_array, i64 6), align 1
+; CHECK-NEXT:    ret i8 [[V]]
+;
+  %v = load i8, ptr getelementptr (i8, ptr @i40_array, i64 6)
+  ret i8 %v
+}
+
+define i16 @load_i40_array_partial_padding() {
+; CHECK-LABEL: @load_i40_array_partial_padding(
+; CHECK-NEXT:    ret i16 0
+;
+  %v = load i16, ptr getelementptr (i8, ptr @i40_array, i64 4)
+  ret i16 %v
+}

--- a/llvm/test/Transforms/InstSimplify/ConstProp/loads.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/loads.ll
@@ -448,8 +448,7 @@ define i128 @load-128bit(){
 
 define i8 @load_i40_struct_padding() {
 ; CHECK-LABEL: @load_i40_struct_padding(
-; CHECK-NEXT:    [[V:%.*]] = load i8, ptr getelementptr (i8, ptr @i40_struct, i64 6), align 1
-; CHECK-NEXT:    ret i8 [[V]]
+; CHECK-NEXT:    ret i8 0
 ;
   %v = load i8, ptr getelementptr (i8, ptr @i40_struct, i64 6)
   ret i8 %v
@@ -465,8 +464,7 @@ define i16 @load_i40_struct_partial_padding() {
 
 define i8 @load_i40_array_padding() {
 ; CHECK-LABEL: @load_i40_array_padding(
-; CHECK-NEXT:    [[V:%.*]] = load i8, ptr getelementptr (i8, ptr @i40_array, i64 6), align 1
-; CHECK-NEXT:    ret i8 [[V]]
+; CHECK-NEXT:    ret i8 0
 ;
   %v = load i8, ptr getelementptr (i8, ptr @i40_array, i64 6)
   ret i8 %v


### PR DESCRIPTION
ReadDataFromGlobal() did not handle reads from the padding of types (in the sense of type store size != type alloc size, rather than struct padding).

Return zero in that case.

Fixes https://github.com/llvm/llvm-project/issues/144279.