### PR TITLE
[llvm-cov] Export decision coverage to output json

### DIFF
--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -494,6 +494,9 @@ public:
     return TV[TestVectorIndex].first[PosToID[Condition]];
   }
 
+  /// Return the executed test vectors.
+  const TestVectors &getTV() const { return TV; }
+
   /// Return the Result evaluation for an executed test vector.
   /// See MCDCRecordProcessor::RecordTestVector().
   CondState getTVResult(unsigned TestVectorIndex) {

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -31,6 +31,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <iterator>
@@ -494,8 +495,16 @@ public:
     return TV[TestVectorIndex].first[PosToID[Condition]];
   }
 
-  /// Return the executed test vectors.
-  const TestVectors &getTV() const { return TV; }
+  /// Return the number of True and False decisions for all executed test
+  /// vectors.
+  std::pair<unsigned, unsigned> getDecisions() const {
+    const unsigned TrueDecisions =
+        std::count_if(TV.begin(), TV.end(), [](const auto &TestVec) {
+          return TestVec.second == CondState::MCDC_True;
+        });
+
+    return {TrueDecisions, TV.size() - TrueDecisions};
+  }
 
   /// Return the Result evaluation for an executed test vector.
   /// See MCDCRecordProcessor::RecordTestVector().

--- a/llvm/tools/llvm-cov/CoverageExporterJson.cpp
+++ b/llvm/tools/llvm-cov/CoverageExporterJson.cpp
@@ -62,7 +62,7 @@
 #include <utility>
 
 /// The semantic version combined as a string.
-#define LLVM_COVERAGE_EXPORT_JSON_STR "2.0.1"
+#define LLVM_COVERAGE_EXPORT_JSON_STR "3.0.0"
 
 /// Unique type identifier for JSON coverage export.
 #define LLVM_COVERAGE_EXPORT_JSON_TYPE_STR "llvm.coverage.json.export"
@@ -108,10 +108,22 @@ json::Array gatherConditions(const coverage::MCDCRecord &Record) {
   return Conditions;
 }
 
+std::pair<unsigned, unsigned> getDecisions(const coverage::MCDCRecord &Record) {
+  const coverage::MCDCRecord::TestVectors &TestVectors = Record.getTV();
+  const unsigned TrueConditions =
+      std::count_if(TestVectors.begin(), TestVectors.end(), [](const auto &TV) {
+        return TV.second == coverage::MCDCRecord::CondState::MCDC_True;
+      });
+
+  return {TrueConditions, TestVectors.size() - TrueConditions};
+}
+
 json::Array renderMCDCRecord(const coverage::MCDCRecord &Record) {
   const llvm::coverage::CounterMappingRegion &CMR = Record.getDecisionRegion();
+  const auto [TrueConditions, FalseConditions] = getDecisions(Record);
   return json::Array({CMR.LineStart, CMR.ColumnStart, CMR.LineEnd,
-                      CMR.ColumnEnd, CMR.ExpandedFileID, int64_t(CMR.Kind),
+                      CMR.ColumnEnd, TrueConditions, FalseConditions,
+                      CMR.ExpandedFileID, int64_t(CMR.Kind),
                       gatherConditions(Record)});
 }
 

--- a/llvm/tools/llvm-cov/CoverageExporterJson.cpp
+++ b/llvm/tools/llvm-cov/CoverageExporterJson.cpp
@@ -108,21 +108,11 @@ json::Array gatherConditions(const coverage::MCDCRecord &Record) {
   return Conditions;
 }
 
-std::pair<unsigned, unsigned> getDecisions(const coverage::MCDCRecord &Record) {
-  const coverage::MCDCRecord::TestVectors &TestVectors = Record.getTV();
-  const unsigned TrueConditions =
-      std::count_if(TestVectors.begin(), TestVectors.end(), [](const auto &TV) {
-        return TV.second == coverage::MCDCRecord::CondState::MCDC_True;
-      });
-
-  return {TrueConditions, TestVectors.size() - TrueConditions};
-}
-
 json::Array renderMCDCRecord(const coverage::MCDCRecord &Record) {
   const llvm::coverage::CounterMappingRegion &CMR = Record.getDecisionRegion();
-  const auto [TrueConditions, FalseConditions] = getDecisions(Record);
+  const auto [TrueDecisions, FalseDecisions] = Record.getDecisions();
   return json::Array({CMR.LineStart, CMR.ColumnStart, CMR.LineEnd,
-                      CMR.ColumnEnd, TrueConditions, FalseConditions,
+                      CMR.ColumnEnd, TrueDecisions, FalseDecisions,
                       CMR.ExpandedFileID, int64_t(CMR.Kind),
                       gatherConditions(Record)});
 }


### PR DESCRIPTION
This commit adds decision coverage to the JSON output of llvm-cov, as discussed here: [Missing Decision Coverage (DC) in output json](https://discourse.llvm.org/t/missing-decision-coverage-dc-in-output-json/86783) with @evodius96 
