### PR TITLE
[examples] Fix invalid #ifndef LLVM_*_LINK_INTO_TOOLS

### DIFF
--- a/llvm/examples/IRTransforms/SimplifyCFG.cpp
+++ b/llvm/examples/IRTransforms/SimplifyCFG.cpp
@@ -407,7 +407,7 @@ llvm::PassPluginLibraryInfo getExampleIRTransformsPluginInfo() {
           }};
 }
 
-#ifndef LLVM_SIMPLIFYCFG_LINK_INTO_TOOLS
+#ifndef LLVM_EXAMPLEIRTRANSFORMS_LINK_INTO_TOOLS
 extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
 llvmGetPassPluginInfo() {
   return getExampleIRTransformsPluginInfo();


### PR DESCRIPTION
The setting LLVM_SIMPLIFYCFG_LINK_INTO_TOOLS doesn't exist, it's called LLVM_EXAMPLEIRTRANSFORMS_LINK_INTO_TOOLS