### PR TITLE
[BOLT] Ensure remember and restore CFIs are in the same list

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1663,6 +1663,9 @@ public:
       Offset = I->first;
     }
     assert(I->first == Offset && "CFI pointing to unknown instruction");
+    // When dealing with RememberState, we place this CFI in FrameInstructions.
+    // We want to ensure RememberState and RestoreState CFIs are in the same
+    // list in order to properly populate the StateStack.
     if (I == Instructions.begin() &&
         Inst.getOperation() != MCCFIInstruction::OpRememberState) {
       CIEFrameInstructions.emplace_back(std::forward<MCCFIInstruction>(Inst));

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1663,7 +1663,8 @@ public:
       Offset = I->first;
     }
     assert(I->first == Offset && "CFI pointing to unknown instruction");
-    if (I == Instructions.begin() && Inst.getOperation() != MCCFIInstruction::OpRememberState) {
+    if (I == Instructions.begin() &&
+        Inst.getOperation() != MCCFIInstruction::OpRememberState) {
       CIEFrameInstructions.emplace_back(std::forward<MCCFIInstruction>(Inst));
       return;
     }

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1663,7 +1663,7 @@ public:
       Offset = I->first;
     }
     assert(I->first == Offset && "CFI pointing to unknown instruction");
-    if (I == Instructions.begin()) {
+    if (I == Instructions.begin() && Inst.getOperation() != MCCFIInstruction::OpRememberState) {
       CIEFrameInstructions.emplace_back(std::forward<MCCFIInstruction>(Inst));
       return;
     }

--- a/bolt/test/AArch64/cfi-state-list.test
+++ b/bolt/test/AArch64/cfi-state-list.test
@@ -5,9 +5,6 @@
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
 # RUN: llvm-bolt %t.exe -o %t.bolt 2>&1 | FileCheck %s
 
-# CHECK: BOLT-INFO: Target architecture: aarch64
-# CHECK: BOLT-INFO: enabling relocation mode
-# CHECK-NOT: llvm-bolt:
 # CHECK: BOLT-INFO: Starting stub-insertion pass
 
 .text
@@ -16,54 +13,22 @@
 
 main:
 .cfi_startproc
-.cfi_def_cfa_offset 16
-.cfi_offset x30, -8
 .cfi_remember_state
-mov	x9, #0x3ff0000000000000
-mov	x8, x0
-stp	x30, x9, [sp, #-0x10]!
-add	x3, sp, #0x8
-mov	x0, x1
-mov	x1, x2
-mov	x2, x8
-bl main
-fcmp	d0, #0.0
-b.ne main+0x34
-
-mov	w0, wzr
-ldr	x30, [sp], #0x10
-.cfi_def_cfa_offset 0
-.cfi_restore x30
-
-ret
-.cfi_restore_state
-.cfi_remember_state
-
-fmov	x8, d0
-mov	x9, #0x7ff0000000000000
-and	x8, x8, #0x7fffffffffffffff
-cmp	x8, x9
-b.lt main+0x5c
-fcmp	d0, #0.0
-mov	w8, #-0x1
-csinc	w0, w8, wzr, le
-ldr	x30, [sp], #0x10
-.cfi_def_cfa_offset 0
-.cfi_restore x30
-
-ret
-nop
-.cfi_restore_state
-
-ldr	d2, [sp, #0x8]
-mov	x8, #0x3cb0000000000000
-fabs	d1, d0
-fcmp	d0, #0.0
-fmov	d3, x8
-mov	w8, #-0x1
-csinc	w0, w8, wzr, le
-fmul	d2, d2, d3
-fcmp	d1, d2
-b.ls main+0x28
-b main+0x2c
+  mov	w0, wzr
+  b.ne .L1
+.L0:
+  mov	w0, wzr
+.L1:
+  cmp	x0, #0
+  b.lt .L2
+.L2:
+  nop
+  .cfi_restore_state
+  mov	x8, xzr
+  b.ls .L0
+  ret
 .cfi_endproc
+    .size main, .-main
+
+## Force relocation mode.
+  .reloc 0, R_AARCH64_NONE

--- a/bolt/test/AArch64/cfi-state-list.test
+++ b/bolt/test/AArch64/cfi-state-list.test
@@ -1,0 +1,69 @@
+// This test checks that BOLT does not split remember and restore CFI states
+// into different lists, which would cause an assertion failure.
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt 2>&1 | FileCheck %s
+
+# CHECK: BOLT-INFO: Target architecture: aarch64
+# CHECK: BOLT-INFO: enabling relocation mode
+# CHECK-NOT: llvm-bolt:
+# CHECK: BOLT-INFO: Starting stub-insertion pass
+
+.text
+.global main
+.type main, %function
+
+main:
+.cfi_startproc
+.cfi_def_cfa_offset 16
+.cfi_offset x30, -8
+.cfi_remember_state
+mov	x9, #0x3ff0000000000000
+mov	x8, x0
+stp	x30, x9, [sp, #-0x10]!
+add	x3, sp, #0x8
+mov	x0, x1
+mov	x1, x2
+mov	x2, x8
+bl main
+fcmp	d0, #0.0
+b.ne main+0x34
+
+mov	w0, wzr
+ldr	x30, [sp], #0x10
+.cfi_def_cfa_offset 0
+.cfi_restore x30
+
+ret
+.cfi_restore_state
+.cfi_remember_state
+
+fmov	x8, d0
+mov	x9, #0x7ff0000000000000
+and	x8, x8, #0x7fffffffffffffff
+cmp	x8, x9
+b.lt main+0x5c
+fcmp	d0, #0.0
+mov	w8, #-0x1
+csinc	w0, w8, wzr, le
+ldr	x30, [sp], #0x10
+.cfi_def_cfa_offset 0
+.cfi_restore x30
+
+ret
+nop
+.cfi_restore_state
+
+ldr	d2, [sp, #0x8]
+mov	x8, #0x3cb0000000000000
+fabs	d1, d0
+fcmp	d0, #0.0
+fmov	d3, x8
+mov	w8, #-0x1
+csinc	w0, w8, wzr, le
+fmul	d2, d2, d3
+fcmp	d1, d2
+b.ls main+0x28
+b main+0x2c
+.cfi_endproc


### PR DESCRIPTION
In `addCFIInstruction`, we split the CFI information between `CFIInstrMapType CIEFrameInstructions` and `CFIInstrMapType FrameInstructions`. In some cases we can end up with the remember CFI in `CIEFrameInstructions` and the restore CFI in `FrameInstructions`. This patch adds a check to make sure we do not split remember and restore states and fixes https://github.com/llvm/llvm-project/issues/133501.