### PR TITLE
[flang][OpenMP] Don't crash on iterator modifier in declare mapper

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1801,9 +1801,9 @@ void OmpVisitor::ProcessMapperSpecifier(const parser::OmpMapperSpecifier &spec,
   Walk(std::get<parser::TypeSpec>(spec.t));
   auto &varName{std::get<parser::Name>(spec.t)};
   DeclareObjectEntity(varName);
+  EndDeclTypeSpec();
 
   Walk(clauses);
-  EndDeclTypeSpec();
   PopScope();
 }
 

--- a/flang/test/Lower/OpenMP/Todo/declare-mapper-iterator.f90
+++ b/flang/test/Lower/OpenMP/Todo/declare-mapper-iterator.f90
@@ -1,0 +1,11 @@
+!RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -o - %s 2>&1 | FileCheck %s
+
+!CHECK: Support for iterator modifiers is not implemented yet
+subroutine f(arg)
+  type :: s
+    integer :: a(10)
+  end type
+  type(s) :: arg(:)
+
+  !$omp declare mapper(m: s :: v) map(mapper(m), iterator(i = 1:10): v%a(i))
+end


### PR DESCRIPTION
Both the declare mapper directive argument, and the iterator modifier can contain declaration-type-spec, so make sure that the processing of one ends before processing of the other begins in semantic analysis.