### PR TITLE
Add warning for blocks capturing {'this', raw pointers, references}

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -1641,6 +1641,17 @@ def warn_implicitly_retains_self : Warning <
   "block implicitly retains 'self'; explicitly mention 'self' to indicate "
   "this is intended behavior">,
   InGroup<DiagGroup<"implicit-retain-self">>, DefaultIgnore;
+def warn_blocks_capturing_this : Warning<"block implicitly captures 'this'">,
+                                 InGroup<DiagGroup<"blocks-capturing-this">>,
+                                 DefaultIgnore;
+def warn_blocks_capturing_reference
+    : Warning<"block implicitly captures a C++ reference">,
+      InGroup<DiagGroup<"blocks-capturing-reference">>,
+      DefaultIgnore;
+def warn_blocks_capturing_raw_pointer
+    : Warning<"block implicitly captures a raw pointer">,
+      InGroup<DiagGroup<"blocks-capturing-raw-pointer">>,
+      DefaultIgnore;
 def warn_arc_possible_repeated_use_of_weak : Warning <
   "weak %select{variable|property|implicit property|instance variable}0 %1 may "
   "be accessed multiple times in this %select{function|method|block|lambda}2 "

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -8227,6 +8227,22 @@ public:
     }
   };
 
+  /// Store information about a diagnosable block catpure.
+  struct BlockCapture {
+    /// Enumeration representing types of block captures that may be
+    /// diagnosable because they could be problematic.
+    enum CaptureType {
+      Self,
+      This,
+      Reference,
+      RawPointer,
+    };
+
+    SourceLocation Loc;
+    const BlockDecl *BD;
+    CaptureType Type;
+  };
+
   /// Check an argument list for placeholders that we won't try to
   /// handle later.
   bool CheckArgsForPlaceholders(MultiExprArg args);
@@ -8243,8 +8259,7 @@ public:
 
   /// List of SourceLocations where 'self' is implicitly retained inside a
   /// block.
-  llvm::SmallVector<std::pair<SourceLocation, const BlockDecl *>, 1>
-      ImplicitlyRetainedSelfLocs;
+  llvm::SmallVector<BlockCapture, 1> DiagnosableBlockCaptures;
 
   /// Do an explicit extend of the given block pointer if we're in ARC.
   void maybeExtendBlockObject(ExprResult &E);

--- a/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/clang/lib/Sema/SemaDeclObjC.cpp
@@ -367,7 +367,7 @@ HasExplicitOwnershipAttr(Sema &S, ParmVarDecl *Param) {
 /// and user declared, in the method definition's AST.
 void SemaObjC::ActOnStartOfObjCMethodDef(Scope *FnBodyScope, Decl *D) {
   ASTContext &Context = getASTContext();
-  SemaRef.ImplicitlyRetainedSelfLocs.clear();
+  SemaRef.DiagnosableBlockCaptures.clear();
   assert((SemaRef.getCurMethodDecl() == nullptr) && "Methodparsing confused");
   ObjCMethodDecl *MDecl = dyn_cast_or_null<ObjCMethodDecl>(D);
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -16536,6 +16536,11 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
   // Set the captured variables on the block.
   SmallVector<BlockDecl::Capture, 4> Captures;
   for (Capture &Cap : BSI->Captures) {
+    if (Cap.isThisCapture()) {
+      DiagnosableBlockCaptures.push_back(
+          Sema::BlockCapture{Cap.getLocation(), BD, Sema::BlockCapture::This});
+    }
+
     if (Cap.isInvalid() || Cap.isThisCapture())
       continue;
     // Cap.getVariable() is always a VarDecl because
@@ -16593,6 +16598,14 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
           CopyExpr = Result.get();
         }
       }
+    }
+
+    QualType Type = Cap.getCaptureType();
+    if (Type->isPointerOrReferenceType()) {
+      DiagnosableBlockCaptures.push_back(Sema::BlockCapture{
+          Cap.getLocation(), BD,
+          Type->isReferenceType() ? Sema::BlockCapture::Reference
+                                  : Sema::BlockCapture::RawPointer});
     }
 
     BlockDecl::Capture NewCap(Var, Cap.isBlockCapture(), Cap.isNested(),

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -4913,8 +4913,10 @@ ExprResult SemaObjC::BuildIvarRefExpr(Scope *S, SourceLocation Loc,
       SemaRef.getCurFunction()->recordUseOfWeak(Result);
   }
   if (getLangOpts().ObjCAutoRefCount && !SemaRef.isUnevaluatedContext())
-    if (const BlockDecl *BD = SemaRef.CurContext->getInnermostBlockDecl())
-      SemaRef.ImplicitlyRetainedSelfLocs.push_back({Loc, BD});
+    if (const BlockDecl *BD = SemaRef.CurContext->getInnermostBlockDecl()) {
+      SemaRef.DiagnosableBlockCaptures.push_back(
+          Sema::BlockCapture{Loc, BD, Sema::BlockCapture::Self});
+    }
 
   return Result;
 }

--- a/clang/test/SemaObjCXX/warn-blocks-capturing-pointers.mm
+++ b/clang/test/SemaObjCXX/warn-blocks-capturing-pointers.mm
@@ -1,0 +1,103 @@
+// RUN: %clang_cc1 -x objective-c++ -std=c++11 -fobjc-arc -fblocks -Wblocks-capturing-this -Wblocks-capturing-reference -Wblocks-capturing-raw-pointer -Wimplicit-retain-self -verify %s
+
+typedef void (^BlockTy)();
+
+void noescapeFunc(__attribute__((noescape)) BlockTy);
+void escapeFunc(BlockTy);
+
+@interface Root @end
+
+@interface I : Root
+- (void)foo;
+@end
+
+class F {
+ public:
+  void Foo() const;
+  void FooAsync(F* p, F& r, I* i) {
+    escapeFunc(
+        ^{
+          Foo(); // expected-warning {{block implicitly captures 'this'}}
+          p->Foo(); // expected-warning {{block implicitly captures a raw pointer}}
+          r.Foo(); // expected-warning {{block implicitly captures a C++ reference}}
+          [i foo];
+        });
+
+    ([=, &r]() {
+      escapeFunc(
+          ^{
+            Foo(); // expected-warning {{block implicitly captures 'this'}}
+            p->Foo(); // expected-warning {{block implicitly captures a raw pointer}}
+            r.Foo(); // expected-warning {{block implicitly captures a C++ reference}}
+            [i foo];
+          });
+    })();
+
+    escapeFunc(
+        ^{
+          ([=]() {
+            Foo(); // expected-warning {{block implicitly captures 'this'}}
+            p->Foo(); // expected-warning {{block implicitly captures a raw pointer}}
+            r.Foo();  // expected-warning {{block implicitly captures a C++ reference}}
+            [i foo];
+          })();
+        });
+
+    noescapeFunc(
+        ^{
+          Foo();
+          p->Foo();
+          r.Foo();
+          [i foo];
+        });
+  }
+};
+
+@implementation I {
+  int _bar;
+}
+
+- (void)doSomethingWithPtr:(F*)p
+                       ref:(F&)r
+                       obj:(I*)i {
+    escapeFunc(
+        ^{
+          (void)_bar; // expected-warning {{block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior}}
+          p->Foo(); // expected-warning {{block implicitly captures a raw pointer}}
+          r.Foo(); // expected-warning {{block implicitly captures a C++ reference}}
+          [i foo];
+        });
+
+    ([=, &r]() {
+      escapeFunc(
+          ^{
+            (void)_bar; // expected-warning {{block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior}}
+            p->Foo(); // expected-warning {{block implicitly captures a raw pointer}}
+            r.Foo(); // expected-warning {{block implicitly captures a C++ reference}}
+            [i foo];
+          });
+    })();
+
+    escapeFunc(
+        ^{
+          ([=]() {
+            (void)_bar; // expected-warning {{block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior}}
+            p->Foo(); // expected-warning {{block implicitly captures a raw pointer}}
+            r.Foo(); // expected-warning {{block implicitly captures a C++ reference}}
+            [i foo];
+          })();
+        });
+
+    noescapeFunc(
+        ^{
+          (void)_bar;
+          p->Foo();
+          r.Foo();
+          [i foo];
+        });
+}
+
+- (void)foo {
+}
+
+@end


### PR DESCRIPTION
Add three new warning that reports when blocks captures 'this', a raw pointer (i.e. not a pointer to a reference counted object) or a reference.

Those warnings can be used in Objective-C++ to detect blocks that create potentially unsafe capture (as the captured pointer can be dangling by the time the block is captured).

To reduce the false positive, no warning is emitted if the block is detected as not escaping.

The three warnings are:
- -Wblocks-capturing-this
- -Wblocks-capturing-reference
- -Wblocks-capturing-raw-pointer

Fixes issue #143924.