### PR TITLE
[SystemZ] Treat FAKE_USE instructions as instructions without a size

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZLongBranch.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZLongBranch.cpp
@@ -215,7 +215,7 @@ static unsigned getInstSizeInBytes(const MachineInstr &MI,
           // These do not have a size:
           MI.isDebugOrPseudoInstr() || MI.isPosition() || MI.isKill() ||
           MI.isImplicitDef() || MI.getOpcode() == TargetOpcode::MEMBARRIER ||
-          MI.getOpcode() == TargetOpcode::INIT_UNDEF ||
+          MI.getOpcode() == TargetOpcode::INIT_UNDEF || MI.isFakeUse() ||
           // These have a size that may be zero:
           MI.isInlineAsm() || MI.getOpcode() == SystemZ::STACKMAP ||
           MI.getOpcode() == SystemZ::PATCHPOINT ||

--- a/llvm/test/CodeGen/SystemZ/fake-use-size.ll
+++ b/llvm/test/CodeGen/SystemZ/fake-use-size.ll
@@ -1,0 +1,14 @@
+; RUN: llc -O0 < %s -mtriple=s390x-linux-gnu 2>&1 | FileCheck %s
+
+;; Tests that we can handle FAKE_USE instructions, emitting a comment for them
+;; in the resulting assembly.
+
+; CHECK:      .type   idd,@function
+; CHECK:      # %bb.0:
+; CHECK-NEXT: # fake_use:
+
+define double @idd(double %d) {
+entry:
+  notail call void (...) @llvm.fake.use(double %d)
+  ret double %d
+}


### PR DESCRIPTION
This patch fixes an error in which `FAKE_USE` instructions would trigger an assertion in SystemZLongBranch due to them having a size of 0 without being excepted in the assertion that each instruction, other than a set of known 0-size instruction types, should have a non-0 size.

`FAKE_USE` instructions are no-op instructions that are emitted into LLVM by the `-fextend-variable-liveness` clang flag to help preserve the liveness of source variables in optimized code, and therefore they should be understood as being valid size 0 instructions.