### PR TITLE
[SelectionDAG] Enable softening of FAKE_USE float operands

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
@@ -1113,6 +1113,9 @@ bool DAGTypeLegalizer::SoftenFloatOperand(SDNode *N, unsigned OpNo) {
 
   case ISD::BITCAST:     Res = SoftenFloatOp_BITCAST(N); break;
   case ISD::BR_CC:       Res = SoftenFloatOp_BR_CC(N); break;
+  case ISD::FAKE_USE:
+    Res = SoftenFloatOp_FAKE_USE(N);
+    break;
   case ISD::STRICT_FP_TO_FP16:
   case ISD::FP_TO_FP16:  // Same as FP_ROUND for softening purposes
   case ISD::FP_TO_BF16:
@@ -1167,6 +1170,12 @@ SDValue DAGTypeLegalizer::SoftenFloatOp_BITCAST(SDNode *N) {
   SDValue Op0 = GetSoftenedFloat(N->getOperand(0));
 
   return DAG.getNode(ISD::BITCAST, SDLoc(N), N->getValueType(0), Op0);
+}
+
+SDValue DAGTypeLegalizer::SoftenFloatOp_FAKE_USE(SDNode *N) {
+  SDValue Op = GetSoftenedFloat(N->getOperand(1));
+
+  return DAG.getNode(ISD::FAKE_USE, SDLoc(N), MVT::Other, N->getOperand(0), Op);
 }
 
 SDValue DAGTypeLegalizer::SoftenFloatOp_FP_ROUND(SDNode *N) {

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.h
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.h
@@ -639,6 +639,7 @@ private:
   SDValue SoftenFloatOp_Unary(SDNode *N, RTLIB::Libcall LC);
   SDValue SoftenFloatOp_BITCAST(SDNode *N);
   SDValue SoftenFloatOp_BR_CC(SDNode *N);
+  SDValue SoftenFloatOp_FAKE_USE(SDNode *N);
   SDValue SoftenFloatOp_FP_ROUND(SDNode *N);
   SDValue SoftenFloatOp_FP_TO_XINT(SDNode *N);
   SDValue SoftenFloatOp_FP_TO_XINT_SAT(SDNode *N);

--- a/llvm/test/CodeGen/AVR/intrinsics/soften-fake-use.ll
+++ b/llvm/test/CodeGen/AVR/intrinsics/soften-fake-use.ll
@@ -1,0 +1,9 @@
+; RUN: llc -O0 < %s -mtriple=avr 2>&1 --stop-after=finalize-isel | FileCheck %s
+
+;; Tests that we can soften float operands to llvm.fake.use intrinsics.
+
+define double @idd(double %d) {
+entry:
+  notail call void (...) @llvm.fake.use(double %d)
+  ret double %d
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/137308.

FAKE_USE nodes in SelectionDAG currently support all applicable legalizations except for softening of float operands; this patch implements float operand softening, preventing errors when legalizing FAKE_USEs.