### PR TITLE
[llvm-debuginfo-analyzer] Apply various memory savings in Core/LVxxx base classes

### DIFF
--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVElement.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVElement.h
@@ -107,17 +107,17 @@ class LLVM_ABI LVElement : public LVObject {
     IsAnonymous,
     LastEntry
   };
-  // Typed bitvector with properties for this element.
-  LVProperties<Property> Properties;
   static LVElementDispatch Dispatch;
-
-  /// RTTI.
-  const LVSubclassID SubclassID;
 
   // Indexes in the String Pool.
   size_t NameIndex = 0;
   size_t QualifiedNameIndex = 0;
   size_t FilenameIndex = 0;
+
+  // Typed bitvector with properties for this element.
+  LVProperties<Property> Properties;
+  /// RTTI.
+  const LVSubclassID SubclassID;
 
   uint16_t AccessibilityCode : 2; // DW_AT_accessibility.
   uint16_t InlineCode : 2;        // DW_AT_inline.

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVScope.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVScope.h
@@ -473,7 +473,7 @@ class LLVM_ABI LVScopeCompileUnit final : public LVScope {
 
   // Record scope sizes indexed by lexical level.
   // Setting an initial size that will cover a very deep nested scopes.
-  const size_t TotalInitialSize = 8;
+  static constexpr size_t TotalInitialSize = 8;
   using LVTotalsEntry = std::pair<unsigned, float>;
   SmallVector<LVTotalsEntry> Totals;
   // Maximum seen lexical level. It is used to control how many entries
@@ -510,7 +510,7 @@ public:
   void addMapping(LVLine *Line, LVSectionIndex SectionIndex);
   LVLineRange lineRange(LVLocation *Location) const;
 
-  LVNameInfo NameNone = {UINT64_MAX, 0};
+  static constexpr LVNameInfo NameNone = {UINT64_MAX, 0};
   void addPublicName(LVScope *Scope, LVAddress LowPC, LVAddress HighPC) {
     PublicNames.emplace(std::piecewise_construct, std::forward_as_tuple(Scope),
                         std::forward_as_tuple(LowPC, HighPC - LowPC));


### PR DESCRIPTION
This small changelist reduces memory footprint of instances of the Core classes.  Specifically,

- For `LVProperties`, use underlying type of `uint32_t` if there are at most 32 properties to keep track of.  Otherwise, fallback to the generic `std::bitset<N>`.  
The use of `llvm::SmallBitVector` is disregarded in this case, as the upper bound on the size of the bitset can be determined statically (no heap alloc ever needed).
- Reorder members in `LVElement` s.t. padding between members is reduced.
- `LVScopeCompileUnit`: fix a couple of members which should be `static constexpr` instead.

This effectively reduces the sizes of key classes to
|  | `sizeof(T)` before this patch | `sizeof(T)` after this patch | % reduction |
|--------|--------|--------|--------|
| `T = LVObject` | 48 | 40 | 20% |
| `T = LVElement` | 104 | 80 | 30% |
| `T = LVScope` | 176 | 144 | 22.22% |
| `T = LVSymbol` | 176 | 144 | 22.22% |
| `T = LVScopeCompileUnit` | 1016 | 960 | 5.83% |

This, in turn, should have a very visible effect for parsing large debug information files.