### PR TITLE
[lldb] Implement priority system for symbol locator plugin

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -431,7 +431,8 @@ public:
       SymbolLocatorDownloadObjectAndSymbolFile download_object_symbol_file =
           nullptr,
       SymbolLocatorFindSymbolFileInBundle find_symbol_file_in_bundle = nullptr,
-      DebuggerInitializeCallback debugger_init_callback = nullptr);
+      DebuggerInitializeCallback debugger_init_callback = nullptr,
+      SymbolLocatorGetPriority get_priority_callback = nullptr);
 
   static bool UnregisterPlugin(SymbolLocatorCreateInstance create_callback);
 

--- a/lldb/include/lldb/Symbol/SymbolLocator.h
+++ b/lldb/include/lldb/Symbol/SymbolLocator.h
@@ -14,6 +14,9 @@
 
 namespace lldb_private {
 
+// Default priority for symbol locator plugins. Lower values are favored first.
+static constexpr uint32_t kDefaultSymbolLocatorPriority = 2;
+
 class SymbolLocator : public PluginInterface {
 public:
   SymbolLocator() = default;

--- a/lldb/include/lldb/lldb-private-interfaces.h
+++ b/lldb/include/lldb/lldb-private-interfaces.h
@@ -100,6 +100,7 @@ typedef std::optional<FileSpec> (*SymbolLocatorLocateExecutableSymbolFile)(
 typedef bool (*SymbolLocatorDownloadObjectAndSymbolFile)(
     ModuleSpec &module_spec, Status &error, bool force_lookup,
     bool copy_executable);
+typedef uint64_t (*SymbolLocatorGetPriority)();
 using BreakpointHitCallback =
     std::function<bool(void *baton, StoppointCallbackContext *context,
                        lldb::user_id_t break_id, lldb::user_id_t break_loc_id)>;

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfodProperties.td
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfodProperties.td
@@ -10,4 +10,7 @@ let Definition = "symbollocatordebuginfod" in {
   def Timeout : Property<"timeout", "UInt64">,
     DefaultUnsignedValue<0>,
     Desc<"Timeout (in seconds) for requests made to a DEBUGINFOD server. A value of zero means we use the debuginfod default timeout: DEBUGINFOD_TIMEOUT if the environment variable is set and 90 seconds otherwise.">;
+  def Priority : Property<"priority", "UInt64">,
+    DefaultUnsignedValue<2>,
+    Desc<"The priority order for this symbol locator plugin when multiple symbol locators are available. Lower values indicate higher priority. The default symbol locator priority is 2">;
 }


### PR DESCRIPTION
In the context if locate_module callback is registered and debuginfod is enabled.
If debuginfod symbol locator is called first then we are double downloading the debuginfo file through locate module callback and debuginfod.

To fix this, we want to a way to define the priority of a plugin, so that we can adjust the order of each plugin gets called at runtime.

```
(lldb)settings set plugin.symbol-locator.debuginfod.priority 1
(lldb) image list
...
[  4] 581109F0-138B-AD5B-2E0B-1EB3E5174353-632286CF 0x00007f977c600000 /tmp/symbol_cache/581109f0138bad5b2e0b1eb3e5174353632286cf/libcrypto.so.1.1 
      /home/hyubo/.cache/llvm-debuginfod/client/llvmcache-581109f0138bad5b2e0b1eb3e5174353632286cf-libcrypto.so.1.1.debuginfo
```
Debuginfod plugin is prioritized

```
(lldb)settings set plugin.symbol-locator.debuginfod.priority 3
(lldb) image list
...
[  4] 581109F0-138B-AD5B-2E0B-1EB3E5174353-632286CF 0x00007f977c600000 /tmp/symbol_cache/581109f0138bad5b2e0b1eb3e5174353632286cf/libcrypto.so.1.1 
      /tmp/symbol_cache/581109f0138bad5b2e0b1eb3e5174353632286cf/libcrypto.so.1.1.debuginfo
```
Default plugin is prioritized, local debuginfo is used.