### PR TITLE
[Analysis] Avoid some warnings about exit from noreturn function

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -705,7 +705,7 @@ Improvements to Clang's diagnostics
 - Clang now does not issue a warning about returning from a function declared with
   the ``[[noreturn]]`` attribute when the function body is ended with a call via
   pointer, provided it can be proven that the pointer only points to
-  ``[[noreturn]]`` functions..
+  ``[[noreturn]]`` functions.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -702,6 +702,11 @@ Improvements to Clang's diagnostics
 - Improve the diagnostics for placement new expression when const-qualified
   object was passed as the storage argument. (#GH143708)
 
+- Clang now does not issue a warning about returning from a function declared with
+  the ``[[noreturn]]`` attribute when the function body is ended with a call via
+  pointer, provided it can be proven that the pointer only points to
+  ``[[noreturn]]`` functions..
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -403,6 +403,15 @@ static bool isNoexcept(const FunctionDecl *FD) {
   return false;
 }
 
+/// Checks if the given expression is a reference to a function with
+/// 'noreturn' attribute.
+static bool isReferenceToNoReturn(const Expr *E) {
+  if (auto *DRef = dyn_cast<DeclRefExpr>(E->IgnoreParenCasts()))
+    if (auto *FD = dyn_cast<FunctionDecl>(DRef->getDecl()))
+      return FD->isNoReturn();
+  return false;
+}
+
 /// Checks if the given variable, which is assumed to be a function pointer, is
 /// initialized with a function having 'noreturn' attribute.
 static bool isInitializedWithNoReturn(const VarDecl *VD) {
@@ -410,19 +419,8 @@ static bool isInitializedWithNoReturn(const VarDecl *VD) {
     if (auto *ListInit = dyn_cast<InitListExpr>(Init);
         ListInit && ListInit->getNumInits() > 0)
       Init = ListInit->getInit(0);
-    if (auto *DeclRef = dyn_cast<DeclRefExpr>(Init->IgnoreParenCasts()))
-      if (auto *FD = dyn_cast<FunctionDecl>(DeclRef->getDecl()))
-        return FD->isNoReturn();
+    return isReferenceToNoReturn(Init);
   }
-  return false;
-}
-
-/// Checks if the given expression is a reference to a function with
-/// 'noreturn' attribute.
-static bool isReferenceToNoReturn(const Expr *E) {
-  if (auto *DRef = dyn_cast<DeclRefExpr>(E->IgnoreParenCasts()))
-    if (auto *FD = dyn_cast<FunctionDecl>(DRef->getDecl()))
-      return FD->isNoReturn();
   return false;
 }
 

--- a/clang/test/SemaCXX/noreturn-vars.cpp
+++ b/clang/test/SemaCXX/noreturn-vars.cpp
@@ -1,0 +1,107 @@
+// RUN: %clang_cc1 -fsyntax-only %s -verify
+
+[[noreturn]] extern void noret();
+[[noreturn]] extern void noret2();
+extern void ordinary();
+
+typedef void (*func_type)(void);
+
+// Constant initialization.
+
+void (* const const_fptr)() = noret;
+[[noreturn]] void test_global_const() {
+  const_fptr();
+}
+
+const func_type const_fptr_cast = (func_type)noret2;
+[[noreturn]] void test_global_cast() {
+  const_fptr_cast();
+}
+
+void (* const const_fptr_list)() = {noret};
+[[noreturn]] void test_global_list() {
+  const_fptr_list();
+}
+
+const func_type const_fptr_fcast = func_type(noret2);
+[[noreturn]] void test_global_fcast() {
+  const_fptr_fcast();
+}
+
+[[noreturn]] void test_local_const() {
+  void (* const fptr)() = noret;
+  fptr();
+}
+
+// Global variable assignment.
+void (*global_fptr)() = noret;
+
+[[noreturn]] void test_global_noassign() {
+  global_fptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+[[noreturn]] void test_global_assign() {
+  global_fptr = noret;
+  global_fptr();
+}
+
+[[noreturn]] void test_global_override() {
+  global_fptr = ordinary;
+  global_fptr = noret;
+  global_fptr();
+}
+
+[[noreturn]] void test_global_switch_01(int x) {
+  switch(x) {
+  case 1:
+    global_fptr = noret;
+	break;
+  default:
+    global_fptr = noret2;
+	break;
+  }
+  global_fptr();
+}
+
+[[noreturn]] void test_global_switch_02(int x) {
+  switch(x) {
+  case 1:
+    global_fptr = ordinary;
+	break;
+  default:
+    global_fptr = noret;
+	break;
+  }
+  global_fptr();
+}
+
+// Local variable assignment.
+
+[[noreturn]] void test_local_init() {
+  func_type func_ptr = noret;
+  func_ptr();
+}
+
+[[noreturn]] void test_local_assign() {
+  void (*func_ptr)(void);
+  func_ptr = noret;
+  func_ptr();
+}
+
+// Escaped value.
+
+extern void abc_01(func_type &);
+extern void abc_02(func_type *);
+
+[[noreturn]] void test_escape_ref() {
+  func_type func_ptr = noret;
+  abc_01(func_ptr);
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+[[noreturn]] void test_escape_addr() {
+  func_type func_ptr = noret;
+  abc_02(&func_ptr);
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+

--- a/clang/test/SemaCXX/noreturn-vars.cpp
+++ b/clang/test/SemaCXX/noreturn-vars.cpp
@@ -43,50 +43,171 @@ void (*global_fptr)() = noret;
 [[noreturn]] void test_global_assign() {
   global_fptr = noret;
   global_fptr();
-}
-
-[[noreturn]] void test_global_override() {
-  global_fptr = ordinary;
-  global_fptr = noret;
-  global_fptr();
-}
-
-[[noreturn]] void test_global_switch_01(int x) {
-  switch(x) {
-  case 1:
-    global_fptr = noret;
-	break;
-  default:
-    global_fptr = noret2;
-	break;
-  }
-  global_fptr();
-}
-
-[[noreturn]] void test_global_switch_02(int x) {
-  switch(x) {
-  case 1:
-    global_fptr = ordinary;
-	break;
-  default:
-    global_fptr = noret;
-	break;
-  }
-  global_fptr();
-}
+} // expected-warning {{function declared 'noreturn' should not return}}
 
 // Local variable assignment.
 
-[[noreturn]] void test_local_init() {
+[[noreturn]] void test_init() {
   func_type func_ptr = noret;
   func_ptr();
 }
 
-[[noreturn]] void test_local_assign() {
+[[noreturn]] void test_assign() {
   void (*func_ptr)(void);
   func_ptr = noret;
   func_ptr();
 }
+
+[[noreturn]] void test_override() {
+  func_type func_ptr;
+  func_ptr = ordinary;
+  func_ptr = noret;
+  func_ptr();
+}
+
+[[noreturn]] void test_if_all(int x) {
+  func_type func_ptr;
+  if (x > 0)
+    func_ptr = noret;
+  else
+    func_ptr = noret2;
+  func_ptr();
+}
+
+[[noreturn]] void test_if_mix(int x) {
+  func_type func_ptr;
+  if (x > 0)
+    func_ptr = noret;
+  else
+    func_ptr = ordinary;
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+[[noreturn]] void test_if_opt(int x) {
+  func_type func_ptr = noret;
+  if (x > 0)
+    func_ptr = ordinary;
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+[[noreturn]] void test_if_opt2(int x) {
+  func_type func_ptr = ordinary;
+  if (x > 0)
+    func_ptr = noret;
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+[[noreturn]] void test_if_nest_all(int x, int y) {
+  func_type func_ptr;
+  if (x > 0) {
+    if (y > 0)
+      func_ptr = noret;
+    else
+      func_ptr = noret2;
+  } else {
+    if (y < 0)
+      func_ptr = noret2;
+    else
+      func_ptr = noret;
+  }
+  func_ptr();
+}
+
+[[noreturn]] void test_if_nest_mix(int x, int y) {
+  func_type func_ptr;
+  if (x > 0) {
+    if (y > 0)
+      func_ptr = noret;
+    else
+      func_ptr = noret2;
+  } else {
+    if (y < 0)
+      func_ptr = ordinary;
+    else
+      func_ptr = noret;
+  }
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+[[noreturn]] void test_switch_all(int x) {
+  func_type func_ptr;
+  switch(x) {
+  case 1:
+    func_ptr = noret;
+    break;
+  default:
+    func_ptr = noret2;
+    break;
+  }
+  func_ptr();
+}
+
+[[noreturn]] void test_switch_mix(int x) {
+  func_type func_ptr;
+  switch(x) {
+  case 1:
+    func_ptr = ordinary;
+    break;
+  default:
+    func_ptr = noret;
+    break;
+  }
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+[[noreturn]] void test_switch_fall(int x) {
+  func_type func_ptr;
+  switch(x) {
+  case 1:
+    func_ptr = ordinary;
+  default:
+    func_ptr = noret;
+    break;
+  }
+  func_ptr();
+}
+
+[[noreturn]] void test_switch_all_nest(int x, int y) {
+  func_type func_ptr;
+  switch(x) {
+  case 1:
+    func_ptr = noret;
+    break;
+  default:
+    if (y > 0)
+      func_ptr = noret2;
+    else
+      func_ptr = noret;
+    break;
+  }
+  func_ptr();
+}
+
+[[noreturn]] void test_switch_mix_nest(int x, int y) {
+  func_type func_ptr;
+  switch(x) {
+  case 1:
+    func_ptr = noret;
+    break;
+  default:
+    if (y > 0)
+      func_ptr = noret2;
+    else
+      func_ptr = ordinary;
+    break;
+  }
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+// Function parameters.
+
+[[noreturn]] void test_param(void (*func_ptr)() = noret) {
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
+
+[[noreturn]] void test_const_param(void (* const func_ptr)() = noret) {
+  func_ptr();
+} // expected-warning {{function declared 'noreturn' should not return}}
 
 // Escaped value.
 
@@ -104,4 +225,3 @@ extern void abc_02(func_type *);
   abc_02(&func_ptr);
   func_ptr();
 } // expected-warning {{function declared 'noreturn' should not return}}
-


### PR DESCRIPTION
Compiler sometimes issues warnings on exit from 'noreturn' functions, in the code like:

    [[noreturn]] extern void nonreturnable();
    void (*func_ptr)();
    [[noreturn]] void foo() {
      func_ptr = nonreturnable;
      (*func_ptr)();
    }

where exit cannot take place because the function pointer is actually a pointer to noreturn function.

This change introduces small data analysis that can remove some of the warnings in the cases when compiler can prove that the set of reaching definitions consists of noreturn functions only.