### PR TITLE
Revert "[llvm] annotate interfaces in llvm/Option and llvm/Remarks for DLL export (#142856)

### DIFF
--- a/llvm/include/llvm/Option/Arg.h
+++ b/llvm/include/llvm/Option/Arg.h
@@ -17,7 +17,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/Option.h"
-#include "llvm/Support/Compiler.h"
 #include <string>
 
 namespace llvm {
@@ -71,16 +70,15 @@ private:
   std::unique_ptr<Arg> Alias;
 
 public:
-  LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
-               const Arg *BaseArg = nullptr);
-  LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
-               const char *Value0, const Arg *BaseArg = nullptr);
-  LLVM_ABI Arg(const Option Opt, StringRef Spelling, unsigned Index,
-               const char *Value0, const char *Value1,
-               const Arg *BaseArg = nullptr);
+  Arg(const Option Opt, StringRef Spelling, unsigned Index,
+      const Arg *BaseArg = nullptr);
+  Arg(const Option Opt, StringRef Spelling, unsigned Index,
+      const char *Value0, const Arg *BaseArg = nullptr);
+  Arg(const Option Opt, StringRef Spelling, unsigned Index,
+      const char *Value0, const char *Value1, const Arg *BaseArg = nullptr);
   Arg(const Arg &) = delete;
   Arg &operator=(const Arg &) = delete;
-  LLVM_ABI ~Arg();
+  ~Arg();
 
   const Option &getOption() const { return Opt; }
 
@@ -136,23 +134,23 @@ public:
   }
 
   /// Append the argument onto the given array as strings.
-  LLVM_ABI void render(const ArgList &Args, ArgStringList &Output) const;
+  void render(const ArgList &Args, ArgStringList &Output) const;
 
   /// Append the argument, render as an input, onto the given
   /// array as strings.
   ///
   /// The distinction is that some options only render their values
   /// when rendered as a input (e.g., Xlinker).
-  LLVM_ABI void renderAsInput(const ArgList &Args, ArgStringList &Output) const;
+  void renderAsInput(const ArgList &Args, ArgStringList &Output) const;
 
-  LLVM_ABI void print(raw_ostream &O) const;
-  LLVM_ABI void dump() const;
+  void print(raw_ostream &O) const;
+  void dump() const;
 
   /// Return a formatted version of the argument and its values, for
   /// diagnostics. Since this is for diagnostics, if this Arg was produced
   /// through an alias, this returns the string representation of the alias
   /// that the user wrote.
-  LLVM_ABI std::string getAsString(const ArgList &Args) const;
+  std::string getAsString(const ArgList &Args) const;
 };
 
 } // end namespace opt

--- a/llvm/include/llvm/Option/ArgList.h
+++ b/llvm/include/llvm/Option/ArgList.h
@@ -11,15 +11,14 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
-#include "llvm/ADT/iterator_range.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/OptSpecifier.h"
 #include "llvm/Option/Option.h"
-#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <cstddef>
 #include <initializer_list>
@@ -140,7 +139,7 @@ private:
 
   /// Get the range of indexes in which options with the specified IDs might
   /// reside, or (0, 0) if there are no such options.
-  LLVM_ABI OptRange getRange(std::initializer_list<OptSpecifier> Ids) const;
+  OptRange getRange(std::initializer_list<OptSpecifier> Ids) const;
 
 protected:
   // Make the default special members protected so they won't be used to slice
@@ -179,7 +178,7 @@ public:
   /// @{
 
   /// append - Append \p A to the arg list.
-  LLVM_ABI void append(Arg *A);
+  void append(Arg *A);
 
   const arglist_type &getArgs() const { return Args; }
 
@@ -228,7 +227,7 @@ public:
   /// @{
 
   /// eraseArg - Remove any option matching \p Id.
-  LLVM_ABI void eraseArg(OptSpecifier Id);
+  void eraseArg(OptSpecifier Id);
 
   /// @}
   /// @name Arg Access
@@ -285,12 +284,11 @@ public:
   /// @{
 
   /// getLastArgValue - Return the value of the last argument, or a default.
-  LLVM_ABI StringRef getLastArgValue(OptSpecifier Id,
-                                     StringRef Default = "") const;
+  StringRef getLastArgValue(OptSpecifier Id, StringRef Default = "") const;
 
   /// getAllArgValues - Get the values of all instances of the given argument
   /// as strings.
-  LLVM_ABI std::vector<std::string> getAllArgValues(OptSpecifier Id) const;
+  std::vector<std::string> getAllArgValues(OptSpecifier Id) const;
 
   /// @}
   /// @name Translation Utilities
@@ -300,21 +298,20 @@ public:
   /// true if the option is present, false if the negation is present, and
   /// \p Default if neither option is given. If both the option and its
   /// negation are present, the last one wins.
-  LLVM_ABI bool hasFlag(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
-  LLVM_ABI bool hasFlagNoClaim(OptSpecifier Pos, OptSpecifier Neg,
-                               bool Default) const;
+  bool hasFlag(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
+  bool hasFlagNoClaim(OptSpecifier Pos, OptSpecifier Neg, bool Default) const;
 
   /// hasFlag - Given an option \p Pos, an alias \p PosAlias and its negative
   /// form \p Neg, return true if the option or its alias is present, false if
   /// the negation is present, and \p Default if none of the options are
   /// given. If multiple options are present, the last one wins.
-  LLVM_ABI bool hasFlag(OptSpecifier Pos, OptSpecifier PosAlias,
-                        OptSpecifier Neg, bool Default) const;
+  bool hasFlag(OptSpecifier Pos, OptSpecifier PosAlias, OptSpecifier Neg,
+               bool Default) const;
 
   /// Given an option Pos and its negative form Neg, render the option if Pos is
   /// present.
-  LLVM_ABI void addOptInFlag(ArgStringList &Output, OptSpecifier Pos,
-                             OptSpecifier Neg) const;
+  void addOptInFlag(ArgStringList &Output, OptSpecifier Pos,
+                    OptSpecifier Neg) const;
   /// Render the option if Neg is present.
   void addOptOutFlag(ArgStringList &Output, OptSpecifier Pos,
                      OptSpecifier Neg) const {
@@ -334,21 +331,18 @@ public:
 
   /// AddAllArgsExcept - Render all arguments matching any of the given ids
   /// and not matching any of the excluded ids.
-  LLVM_ABI void AddAllArgsExcept(ArgStringList &Output,
-                                 ArrayRef<OptSpecifier> Ids,
-                                 ArrayRef<OptSpecifier> ExcludeIds) const;
+  void AddAllArgsExcept(ArgStringList &Output, ArrayRef<OptSpecifier> Ids,
+                        ArrayRef<OptSpecifier> ExcludeIds) const;
   /// Render all arguments matching any of the given ids.
-  LLVM_ABI void addAllArgs(ArgStringList &Output,
-                           ArrayRef<OptSpecifier> Ids) const;
+  void addAllArgs(ArgStringList &Output, ArrayRef<OptSpecifier> Ids) const;
 
   /// AddAllArgs - Render all arguments matching the given ids.
-  LLVM_ABI void AddAllArgs(ArgStringList &Output, OptSpecifier Id0) const;
+  void AddAllArgs(ArgStringList &Output, OptSpecifier Id0) const;
 
   /// AddAllArgValues - Render the argument values of all arguments
   /// matching the given ids.
-  LLVM_ABI void AddAllArgValues(ArgStringList &Output, OptSpecifier Id0,
-                                OptSpecifier Id1 = 0U,
-                                OptSpecifier Id2 = 0U) const;
+  void AddAllArgValues(ArgStringList &Output, OptSpecifier Id0,
+                       OptSpecifier Id1 = 0U, OptSpecifier Id2 = 0U) const;
 
   /// AddAllArgsTranslated - Render all the arguments matching the
   /// given ids, but forced to separate args and using the provided
@@ -356,13 +350,13 @@ public:
   ///
   /// \param Joined - If true, render the argument as joined with
   /// the option specifier.
-  LLVM_ABI void AddAllArgsTranslated(ArgStringList &Output, OptSpecifier Id0,
-                                     const char *Translation,
-                                     bool Joined = false) const;
+  void AddAllArgsTranslated(ArgStringList &Output, OptSpecifier Id0,
+                            const char *Translation,
+                            bool Joined = false) const;
 
   /// ClaimAllArgs - Claim all arguments which match the given
   /// option id.
-  LLVM_ABI void ClaimAllArgs(OptSpecifier Id0) const;
+  void ClaimAllArgs(OptSpecifier Id0) const;
 
   template <typename... OptSpecifiers>
   void claimAllArgs(OptSpecifiers... Ids) const {
@@ -372,7 +366,7 @@ public:
 
   /// ClaimAllArgs - Claim all arguments.
   ///
-  LLVM_ABI void ClaimAllArgs() const;
+  void ClaimAllArgs() const;
   /// @}
   /// @name Arg Synthesis
   /// @{
@@ -387,16 +381,16 @@ public:
 
   /// Create an arg string for (\p LHS + \p RHS), reusing the
   /// string at \p Index if possible.
-  LLVM_ABI const char *GetOrMakeJoinedArgString(unsigned Index, StringRef LHS,
-                                                StringRef RHS) const;
+  const char *GetOrMakeJoinedArgString(unsigned Index, StringRef LHS,
+                                        StringRef RHS) const;
 
-  LLVM_ABI void print(raw_ostream &O) const;
-  LLVM_ABI void dump() const;
+  void print(raw_ostream &O) const;
+  void dump() const;
 
   /// @}
 };
 
-class LLVM_ABI InputArgList final : public ArgList {
+class InputArgList final : public ArgList {
 private:
   /// List of argument strings used by the contained Args.
   ///
@@ -469,7 +463,7 @@ public:
 
 /// DerivedArgList - An ordered collection of driver arguments,
 /// whose storage may be in another argument list.
-class LLVM_ABI DerivedArgList final : public ArgList {
+class DerivedArgList final : public ArgList {
   const InputArgList &BaseArgs;
 
   /// The list of arguments we synthesized.

--- a/llvm/include/llvm/Option/OptSpecifier.h
+++ b/llvm/include/llvm/Option/OptSpecifier.h
@@ -22,7 +22,7 @@ public:
   OptSpecifier() = default;
   explicit OptSpecifier(bool) = delete;
   /*implicit*/ OptSpecifier(unsigned ID) : ID(ID) {}
-  /*implicit*/ LLVM_ABI OptSpecifier(const Option *Opt);
+  /*implicit*/ OptSpecifier(const Option *Opt);
 
   bool isValid() const { return ID != 0; }
 

--- a/llvm/include/llvm/Option/OptTable.h
+++ b/llvm/include/llvm/Option/OptTable.h
@@ -14,7 +14,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringTable.h"
 #include "llvm/Option/OptSpecifier.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/StringSaver.h"
 #include <cassert>
 #include <string>
@@ -51,7 +50,7 @@ public:
 /// be needed at runtime; the OptTable class maintains enough information to
 /// parse command lines without instantiating Options, while letting other
 /// parts of the driver still use Option instances where convenient.
-class LLVM_ABI OptTable {
+class OptTable {
 public:
   /// Entry for a single option instance in the option data table.
   struct Info {
@@ -426,9 +425,9 @@ private:
 /// Specialization of OptTable
 class GenericOptTable : public OptTable {
 protected:
-  LLVM_ABI GenericOptTable(const StringTable &StrTable,
-                           ArrayRef<StringTable::Offset> PrefixesTable,
-                           ArrayRef<Info> OptionInfos, bool IgnoreCase = false);
+  GenericOptTable(const StringTable &StrTable,
+                  ArrayRef<StringTable::Offset> PrefixesTable,
+                  ArrayRef<Info> OptionInfos, bool IgnoreCase = false);
 };
 
 class PrecomputedOptTable : public OptTable {

--- a/llvm/include/llvm/Option/Option.h
+++ b/llvm/include/llvm/Option/Option.h
@@ -13,7 +13,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/OptSpecifier.h"
 #include "llvm/Option/OptTable.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 
@@ -82,7 +81,7 @@ protected:
   const OptTable *Owner;
 
 public:
-  LLVM_ABI Option(const OptTable::Info *Info, const OptTable *Owner);
+  Option(const OptTable::Info *Info, const OptTable *Owner);
 
   bool isValid() const {
     return Info != nullptr;
@@ -214,7 +213,7 @@ public:
   /// Note that matches against options which are an alias should never be
   /// done -- aliases do not participate in matching and so such a query will
   /// always be false.
-  LLVM_ABI bool matches(OptSpecifier ID) const;
+  bool matches(OptSpecifier ID) const;
 
   /// Potentially accept the current argument, returning a new Arg instance,
   /// or 0 if the option does not accept this argument (or the argument is
@@ -228,17 +227,16 @@ public:
   /// underlying storage to represent a Joined argument.
   /// \p GroupedShortOption If true, we are handling the fallback case of
   /// parsing a prefix of the current argument as a short option.
-  LLVM_ABI std::unique_ptr<Arg> accept(const ArgList &Args, StringRef CurArg,
-                                       bool GroupedShortOption,
-                                       unsigned &Index) const;
+  std::unique_ptr<Arg> accept(const ArgList &Args, StringRef CurArg,
+                              bool GroupedShortOption, unsigned &Index) const;
 
 private:
   std::unique_ptr<Arg> acceptInternal(const ArgList &Args, StringRef CurArg,
                                       unsigned &Index) const;
 
 public:
-  LLVM_ABI void print(raw_ostream &O, bool AddNewLine = true) const;
-  LLVM_ABI void dump() const;
+  void print(raw_ostream &O, bool AddNewLine = true) const;
+  void dump() const;
 };
 
 } // end namespace opt

--- a/llvm/include/llvm/Remarks/Remark.h
+++ b/llvm/include/llvm/Remarks/Remark.h
@@ -17,7 +17,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CBindingWrapping.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 #include <string>
@@ -36,7 +35,7 @@ struct RemarkLocation {
   unsigned SourceColumn = 0;
 
   /// Implement operator<< on RemarkLocation.
-  LLVM_ABI void print(raw_ostream &OS) const;
+  void print(raw_ostream &OS) const;
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).
@@ -52,11 +51,11 @@ struct Argument {
   std::optional<RemarkLocation> Loc;
 
   /// Implement operator<< on Argument.
-  LLVM_ABI void print(raw_ostream &OS) const;
+  void print(raw_ostream &OS) const;
   /// Return the value of argument as int.
-  LLVM_ABI std::optional<int> getValAsInt() const;
+  std::optional<int> getValAsInt() const;
   /// Check if the argument value can be parsed as int.
-  LLVM_ABI bool isValInt() const;
+  bool isValInt() const;
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).
@@ -125,13 +124,13 @@ struct Remark {
   Remark &operator=(Remark &&) = default;
 
   /// Return a message composed from the arguments as a string.
-  LLVM_ABI std::string getArgsAsMsg() const;
+  std::string getArgsAsMsg() const;
 
   /// Clone this remark to explicitly ask for a copy.
   Remark clone() const { return *this; }
 
   /// Implement operator<< on Remark.
-  LLVM_ABI void print(raw_ostream &OS) const;
+  void print(raw_ostream &OS) const;
 
 private:
   /// In order to avoid unwanted copies, "delete" the copy constructor.

--- a/llvm/include/llvm/Remarks/RemarkFormat.h
+++ b/llvm/include/llvm/Remarks/RemarkFormat.h
@@ -14,7 +14,6 @@
 #define LLVM_REMARKS_REMARKFORMAT_H
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -26,10 +25,10 @@ constexpr StringLiteral Magic("REMARKS");
 enum class Format { Unknown, YAML, YAMLStrTab, Bitstream };
 
 /// Parse and validate a string for the remark format.
-LLVM_ABI Expected<Format> parseFormat(StringRef FormatStr);
+Expected<Format> parseFormat(StringRef FormatStr);
 
 /// Parse and validate a magic number to a remark format.
-LLVM_ABI Expected<Format> magicToFormat(StringRef Magic);
+Expected<Format> magicToFormat(StringRef Magic);
 
 } // end namespace remarks
 } // end namespace llvm

--- a/llvm/include/llvm/Remarks/RemarkLinker.h
+++ b/llvm/include/llvm/Remarks/RemarkLinker.h
@@ -16,7 +16,6 @@
 #include "llvm/Remarks/Remark.h"
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Remarks/RemarkStringTable.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <memory>
 #include <optional>
@@ -70,7 +69,7 @@ private:
 
 public:
   /// Set a path to prepend to the external file path.
-  LLVM_ABI void setExternalFilePrependPath(StringRef PrependPath);
+  void setExternalFilePrependPath(StringRef PrependPath);
 
   /// Set KeepAllRemarks to \p B.
   void setKeepAllRemarks(bool B) { KeepAllRemarks = B; }
@@ -80,19 +79,19 @@ public:
   /// \p Buffer.
   /// \p Buffer can be either a standalone remark container or just
   /// metadata. This takes care of uniquing and merging the remarks.
-  LLVM_ABI Error link(StringRef Buffer,
-                      std::optional<Format> RemarkFormat = std::nullopt);
+  Error link(StringRef Buffer,
+             std::optional<Format> RemarkFormat = std::nullopt);
 
   /// Link the remarks found in \p Obj by looking for the right section and
   /// calling the method above.
-  LLVM_ABI Error link(const object::ObjectFile &Obj,
-                      std::optional<Format> RemarkFormat = std::nullopt);
+  Error link(const object::ObjectFile &Obj,
+             std::optional<Format> RemarkFormat = std::nullopt);
 
   /// Serialize the linked remarks to the stream \p OS, using the format \p
   /// RemarkFormat.
   /// This clears internal state such as the string table.
   /// Note: this implies that the serialization mode is standalone.
-  LLVM_ABI Error serialize(raw_ostream &OS, Format RemarksFormat) const;
+  Error serialize(raw_ostream &OS, Format RemarksFormat) const;
 
   /// Check whether there are any remarks linked.
   bool empty() const { return Remarks.empty(); }
@@ -110,7 +109,7 @@ public:
 /// Returns a buffer with the contents of the remarks section depending on the
 /// format of the file. If the section doesn't exist, this returns an empty
 /// optional.
-LLVM_ABI Expected<std::optional<StringRef>>
+Expected<std::optional<StringRef>>
 getRemarksSectionContents(const object::ObjectFile &Obj);
 
 } // end namespace remarks

--- a/llvm/include/llvm/Remarks/RemarkParser.h
+++ b/llvm/include/llvm/Remarks/RemarkParser.h
@@ -15,7 +15,6 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Remarks/RemarkFormat.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <memory>
 #include <optional>
@@ -27,7 +26,7 @@ struct Remark;
 
 class EndOfFileError : public ErrorInfo<EndOfFileError> {
 public:
-  LLVM_ABI static char ID;
+  static char ID;
 
   EndOfFileError() = default;
 
@@ -65,7 +64,7 @@ struct ParsedStringTable {
   /// SmallVector for once.
   std::vector<size_t> Offsets;
 
-  LLVM_ABI ParsedStringTable(StringRef Buffer);
+  ParsedStringTable(StringRef Buffer);
   /// Disable copy.
   ParsedStringTable(const ParsedStringTable &) = delete;
   ParsedStringTable &operator=(const ParsedStringTable &) = delete;
@@ -74,17 +73,17 @@ struct ParsedStringTable {
   ParsedStringTable &operator=(ParsedStringTable &&) = default;
 
   size_t size() const { return Offsets.size(); }
-  LLVM_ABI Expected<StringRef> operator[](size_t Index) const;
+  Expected<StringRef> operator[](size_t Index) const;
 };
 
-LLVM_ABI Expected<std::unique_ptr<RemarkParser>>
-createRemarkParser(Format ParserFormat, StringRef Buf);
+Expected<std::unique_ptr<RemarkParser>> createRemarkParser(Format ParserFormat,
+                                                           StringRef Buf);
 
-LLVM_ABI Expected<std::unique_ptr<RemarkParser>>
+Expected<std::unique_ptr<RemarkParser>>
 createRemarkParser(Format ParserFormat, StringRef Buf,
                    ParsedStringTable StrTab);
 
-LLVM_ABI Expected<std::unique_ptr<RemarkParser>> createRemarkParserFromMeta(
+Expected<std::unique_ptr<RemarkParser>> createRemarkParserFromMeta(
     Format ParserFormat, StringRef Buf,
     std::optional<ParsedStringTable> StrTab = std::nullopt,
     std::optional<StringRef> ExternalFilePrependPath = std::nullopt);

--- a/llvm/include/llvm/Remarks/RemarkSerializer.h
+++ b/llvm/include/llvm/Remarks/RemarkSerializer.h
@@ -15,7 +15,6 @@
 
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Remarks/RemarkStringTable.h"
-#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {
@@ -78,12 +77,12 @@ struct MetaSerializer {
 };
 
 /// Create a remark serializer.
-LLVM_ABI Expected<std::unique_ptr<RemarkSerializer>>
+Expected<std::unique_ptr<RemarkSerializer>>
 createRemarkSerializer(Format RemarksFormat, SerializerMode Mode,
                        raw_ostream &OS);
 
 /// Create a remark serializer that uses a pre-filled string table.
-LLVM_ABI Expected<std::unique_ptr<RemarkSerializer>>
+Expected<std::unique_ptr<RemarkSerializer>>
 createRemarkSerializer(Format RemarksFormat, SerializerMode Mode,
                        raw_ostream &OS, remarks::StringTable StrTab);
 

--- a/llvm/include/llvm/Remarks/RemarkStringTable.h
+++ b/llvm/include/llvm/Remarks/RemarkStringTable.h
@@ -18,7 +18,6 @@
 
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
-#include "llvm/Support/Compiler.h"
 #include <vector>
 
 namespace llvm {
@@ -51,22 +50,22 @@ struct StringTable {
   StringTable &operator=(StringTable &&) = default;
 
   /// Construct a string table from a ParsedStringTable.
-  LLVM_ABI StringTable(const ParsedStringTable &Other);
+  StringTable(const ParsedStringTable &Other);
 
   /// Add a string to the table. It returns an unique ID of the string.
-  LLVM_ABI std::pair<unsigned, StringRef> add(StringRef Str);
+  std::pair<unsigned, StringRef> add(StringRef Str);
   /// Modify \p R to use strings from this string table. If the string table
   /// does not contain the strings, it adds them.
-  LLVM_ABI void internalize(Remark &R);
+  void internalize(Remark &R);
   /// Serialize the string table to a stream. It is serialized as a little
   /// endian uint64 (the size of the table in bytes) followed by a sequence of
   /// NULL-terminated strings, where the N-th string is the string with the ID N
   /// in the StrTab map.
-  LLVM_ABI void serialize(raw_ostream &OS) const;
+  void serialize(raw_ostream &OS) const;
   /// Serialize the string table to a vector. This allows users to do the actual
   /// writing to file/memory/other.
   /// The string with the ID == N should be the N-th element in the vector.
-  LLVM_ABI std::vector<StringRef> serialize() const;
+  std::vector<StringRef> serialize() const;
 };
 
 } // end namespace remarks

--- a/llvm/include/llvm/Remarks/YAMLRemarkSerializer.h
+++ b/llvm/include/llvm/Remarks/YAMLRemarkSerializer.h
@@ -14,7 +14,6 @@
 #define LLVM_REMARKS_YAMLREMARKSERIALIZER_H
 
 #include "llvm/Remarks/RemarkSerializer.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/YAMLTraits.h"
 #include <optional>
 
@@ -32,7 +31,7 @@ namespace remarks {
 ///   - <KEY>: <VALUE>
 ///     DebugLoc:        { File: <FILE>, Line: <LINE>, Column: <COL> }
 /// ...
-struct LLVM_ABI YAMLRemarkSerializer : public RemarkSerializer {
+struct YAMLRemarkSerializer : public RemarkSerializer {
   /// The YAML streamer.
   yaml::Output YAMLOutput;
 
@@ -54,7 +53,7 @@ protected:
                        std::optional<StringTable> StrTab = std::nullopt);
 };
 
-struct LLVM_ABI YAMLMetaSerializer : public MetaSerializer {
+struct YAMLMetaSerializer : public MetaSerializer {
   std::optional<StringRef> ExternalFilename;
 
   YAMLMetaSerializer(raw_ostream &OS, std::optional<StringRef> ExternalFilename)
@@ -66,7 +65,7 @@ struct LLVM_ABI YAMLMetaSerializer : public MetaSerializer {
 /// Serialize the remarks to YAML using a string table. An remark entry looks
 /// like the regular YAML remark but instead of string entries it's using
 /// numbers that map to an index in the string table.
-struct LLVM_ABI YAMLStrTabRemarkSerializer : public YAMLRemarkSerializer {
+struct YAMLStrTabRemarkSerializer : public YAMLRemarkSerializer {
   /// Wether we already emitted the metadata in standalone mode.
   /// This should be set to true after the first invocation of `emit`.
   bool DidEmitMeta = false;
@@ -92,7 +91,7 @@ struct LLVM_ABI YAMLStrTabRemarkSerializer : public YAMLRemarkSerializer {
   }
 };
 
-struct LLVM_ABI YAMLStrTabMetaSerializer : public YAMLMetaSerializer {
+struct YAMLStrTabMetaSerializer : public YAMLMetaSerializer {
   /// The string table is part of the metadata.
   const StringTable &StrTab;
 


### PR DESCRIPTION
Trying to resolve a GreenDragon bot [build failure](https://green.lab.llvm.org/job/llvm.org/job/clang-stage2-Rthinlto/833/) : 

This reverts commit 1c8206bd2a12c478128b84799f9fa4fb44cd3d8a.