### PR TITLE
[lldb-dap] Add supported languages in package.json

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -290,7 +290,7 @@
         "language": "d"
       },
       {
-        "language": "fortan"
+        "language": "fortran"
       },
       {
         "language": "fortran-modern"
@@ -318,6 +318,22 @@
       {
         "type": "lldb-dap",
         "label": "LLDB DAP Debugger",
+        "languages": [
+          "ada",
+          "arm",
+          "c",
+          "cpp",
+          "crystal",
+          "d",
+          "fortran",
+          "fortran-modern",
+          "nim",
+          "objective-c",
+          "objectpascal",
+          "pascal",
+          "rust",
+          "swift"
+        ],
         "configurationAttributes": {
           "launch": {
             "required": [


### PR DESCRIPTION
This patch fixes the [problem](https://github.com/llvm/llvm-project/issues/144239). It was caused by missing supported languages list in `package.json`. VSCode uses `guessDebugger` [function](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts#L344) to find supported debuggers based on supported languages in case of opened file. It uses `interestedInLanguage` [function](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/debug/common/debugger.ts#L171) to do that, so we should provide list of supported languages. Also, fixed typo in `fortran`. 

Before:

![image](https://github.com/user-attachments/assets/d2e7d34c-c895-4bc4-a00b-c8cd3b235807)

After:

![image](https://github.com/user-attachments/assets/55ee13dc-d325-4d34-86ce-1dd2c97f7d2e)
