### PR TITLE
[clang] Register all LLVM targets in AllClangUnitTest main

### DIFF
--- a/clang/unittests/AllClangUnitTests.cpp
+++ b/clang/unittests/AllClangUnitTests.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/TargetSelect.h"
+#include "gtest/gtest.h"
 
 // This custom main entry point for the AllClangUnitTests binary registers all
 // tests on startup, so the tests don't become sensitive to target registration

--- a/clang/unittests/AllClangUnitTests.cpp
+++ b/clang/unittests/AllClangUnitTests.cpp
@@ -25,6 +25,5 @@ int main(int argc, char **argv) {
   llvm::InitializeAllAsmPrinters();
   llvm::InitializeAllAsmParsers();
 
-
   return RUN_ALL_TESTS();
 }

--- a/clang/unittests/AllClangUnitTests.cpp
+++ b/clang/unittests/AllClangUnitTests.cpp
@@ -1,0 +1,24 @@
+//===- clang/unittests/AllClangUnitTests.cpp ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/TargetSelect.h"
+
+// This custom main entry point for the AllClangUnitTests binary registers all
+// tests on startup, so the tests don't become sensitive to target registration
+// within the test suite.
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
+
+  return RUN_ALL_TESTS();
+}

--- a/clang/unittests/AllClangUnitTests.cpp
+++ b/clang/unittests/AllClangUnitTests.cpp
@@ -17,8 +17,14 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv);
 
+  // Initialize all levels of target components. Keep this in sync with
+  // cc1_main.
+  llvm::InitializeAllTargetInfos();
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllAsmPrinters();
+  llvm::InitializeAllAsmParsers();
+
 
   return RUN_ALL_TESTS();
 }

--- a/clang/unittests/AllClangUnitTests.cpp
+++ b/clang/unittests/AllClangUnitTests.cpp
@@ -6,24 +6,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/TargetSelect.h"
-#include "gtest/gtest.h"
 
-// This custom main entry point for the AllClangUnitTests binary registers all
-// tests on startup, so the tests don't become sensitive to target registration
-// within the test suite.
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  llvm::cl::ParseCommandLineOptions(argc, argv);
+namespace {
+struct RegisterAllLLVMTargets {
+  RegisterAllLLVMTargets();
+} gv;
+} // namespace
 
-  // Initialize all levels of target components. Keep this in sync with
-  // cc1_main.
+// This dynamic initializer initializes all layers (TargetInfo, MC, CodeGen,
+// AsmPrinter, etc) of all LLVM targets. This matches what cc1_main does on
+// startup, and prevents tests from initializing some of the Target layers,
+// which can interfere with tests that assume that lower target layers are
+// registered if the TargetInfo is registered.
+RegisterAllLLVMTargets::RegisterAllLLVMTargets() {
   llvm::InitializeAllTargetInfos();
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmPrinters();
   llvm::InitializeAllAsmParsers();
-
-  return RUN_ALL_TESTS();
 }

--- a/clang/unittests/CMakeLists.txt
+++ b/clang/unittests/CMakeLists.txt
@@ -117,6 +117,7 @@ get_property(LINK_LIBS GLOBAL PROPERTY CLANG_UNITTEST_LINK_LIBS)
 get_property(LLVM_COMPONENTS GLOBAL PROPERTY CLANG_UNITTEST_LLVM_COMPONENTS)
 add_distinct_clang_unittest(AllClangUnitTests
   ${SRCS}
+  AllClangUnitTests.cpp
   CLANG_LIBS
   ${CLANG_LIBS}
   LINK_LIBS


### PR DESCRIPTION
Addresses feedback in https://github.com/llvm/llvm-project/pull/134196#issuecomment-2970715875

Makes the tests less sensitive to target registration from unrelated test fixtures by registering everything up front.