### PR TITLE
Fix variable naming style in PPCBoolRetToInt.cpp

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCBoolRetToInt.cpp
+++ b/llvm/lib/Target/PowerPC/PPCBoolRetToInt.cpp
@@ -100,8 +100,8 @@ class PPCBoolRetToInt : public FunctionPass {
       Value *Zero = Constant::getNullValue(IntTy);
       PHINode *Q =
         PHINode::Create(IntTy, P->getNumIncomingValues(), P->getName(), P->getIterator());
-      for (unsigned i = 0; i < P->getNumOperands(); ++i)
-        Q->addIncoming(Zero, P->getIncomingBlock(i));
+      for (unsigned i = 0; i < P->getNumOperands(); ++I)
+        Q->addIncoming(Zero, P->getIncomingBlock(I));
       return Q;
     }
 
@@ -254,8 +254,8 @@ class PPCBoolRetToInt : public FunctionPass {
       // Operands of CallInst/Constant are skipped because they may not be Bool
       // type. For CallInst, their positions are defined by ABI.
       if (First && !isa<CallInst>(First) && !isa<Constant>(First))
-        for (unsigned i = 0; i < First->getNumOperands(); ++i)
-          Second->setOperand(i, BoolToIntMap[First->getOperand(i)]);
+        for (unsigned i = 0; i < First->getNumOperands(); ++I)
+          Second->setOperand(i, BoolToIntMap[First->getOperand(I)]);
     }
 
     Value *IntRetVal = BoolToIntMap[U];


### PR DESCRIPTION
Change loop variable 'i' to 'I' to conform to LLVM coding standards. Variable names should start with an upper case letter according to LLVM coding guidelines.
Fixed locations:
Lines 103-104: for loop variable and usage
Lines 257-258: for loop variable and usage