### PR TITLE
[libc] build fix: always use our char8_t headers even in overlay mode

### DIFF
--- a/libc/hdr/types/char8_t.h
+++ b/libc/hdr/types/char8_t.h
@@ -9,14 +9,6 @@
 #ifndef LLVM_LIBC_HDR_TYPES_CHAR8_T_H
 #define LLVM_LIBC_HDR_TYPES_CHAR8_T_H
 
-#ifdef LIBC_FULL_BUILD
-
 #include "include/llvm-libc-types/char8_t.h"
-
-#else // overlay mode
-
-#include "hdr/uchar_overlay.h"
-
-#endif // LLVM_LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_CHAR8_T_H

--- a/libc/src/__support/wchar/character_converter.cpp
+++ b/libc/src/__support/wchar/character_converter.cpp
@@ -71,7 +71,7 @@ ErrorOr<char8_t> CharacterConverter::pop_utf8() {
 
   // Shift to get the next 6 bits from the utf32 encoding
   const char32_t shift_amount =
-      (state->total_bytes - state->bytes_processed - 1) * ENCODED_BITS_PER_UTF8;
+      static_cast<char32_t>((state->total_bytes - state->bytes_processed - 1) * ENCODED_BITS_PER_UTF8);
   if (state->bytes_processed == 0) {
     /*
       Choose the correct set of most significant bits to encode the length

--- a/libc/src/__support/wchar/character_converter.cpp
+++ b/libc/src/__support/wchar/character_converter.cpp
@@ -70,8 +70,8 @@ ErrorOr<char8_t> CharacterConverter::pop_utf8() {
   char32_t output;
 
   // Shift to get the next 6 bits from the utf32 encoding
-  const char32_t shift_amount =
-      static_cast<char32_t>((state->total_bytes - state->bytes_processed - 1) * ENCODED_BITS_PER_UTF8);
+  const size_t shift_amount =
+      (state->total_bytes - state->bytes_processed - 1) * ENCODED_BITS_PER_UTF8;
   if (state->bytes_processed == 0) {
     /*
       Choose the correct set of most significant bits to encode the length


### PR DESCRIPTION
Build fix caused by certain platforms not providing char8_t when expected
Temporary fix to just always use our own definition, even in overlay mode. 
