### PR TITLE
[ASan] Recognize WASI as a platform with 64-bit off_t

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -187,10 +187,11 @@ typedef long pid_t;
 typedef int pid_t;
 #endif
 
-#if SANITIZER_FREEBSD || SANITIZER_NETBSD || SANITIZER_APPLE ||             \
+#if SANITIZER_FREEBSD || SANITIZER_NETBSD || SANITIZER_APPLE ||           \
     (SANITIZER_SOLARIS && (defined(_LP64) || _FILE_OFFSET_BITS == 64)) || \
     (SANITIZER_LINUX && !SANITIZER_GLIBC && !SANITIZER_ANDROID) ||        \
-    (SANITIZER_LINUX && (defined(__x86_64__) || defined(__hexagon__)))
+    (SANITIZER_LINUX && (defined(__x86_64__) || defined(__hexagon__))) || \
+    SANITIZER_WASI
 typedef u64 OFF_T;
 #else
 typedef uptr OFF_T;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -191,10 +191,11 @@ typedef long pid_t;
 typedef int pid_t;
 #endif
 
-#if SANITIZER_FREEBSD || SANITIZER_NETBSD || SANITIZER_APPLE ||             \
+#if SANITIZER_FREEBSD || SANITIZER_NETBSD || SANITIZER_APPLE ||           \
     (SANITIZER_SOLARIS && (defined(_LP64) || _FILE_OFFSET_BITS == 64)) || \
     (SANITIZER_LINUX && !SANITIZER_GLIBC && !SANITIZER_ANDROID) ||        \
-    (SANITIZER_LINUX && (defined(__x86_64__) || defined(__hexagon__)))
+    (SANITIZER_LINUX && (defined(__x86_64__) || defined(__hexagon__))) || \
+    SANITIZER_WASI
 typedef u64 OFF_T;
 #else
 typedef uptr OFF_T;


### PR DESCRIPTION
WASI defines `off_t` as 64-bit signed integers to support files larger than 2 GiB. https://github.com/WebAssembly/wasi-libc/blob/wasi-sdk-25/libc-bottom-half/headers/public/__typedef_off_t.h