### PR TITLE
[RISCV] Factor out common SiFive7 scheduling model into an abstraction layer

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
@@ -186,8 +186,1166 @@ class SiFive7AnyToGPRBypass<SchedRead read, int cycles = 2>
                                  WriteIRem, WriteIRem32,
                                  WriteLDB, WriteLDH, WriteLDW, WriteLDD]>;
 
-// SiFive7 machine model for scheduling and other instruction cost heuristics.
-def SiFive7Model : SchedMachineModel {
+// The SiFive7 microarchitecture has three pipelines: A, B, V.
+// Pipe A can handle memory, integer alu and vector operations.
+// Pipe B can handle integer alu, control flow, integer multiply and divide,
+// and floating point computation.
+// The V pipeline is modeled by the VCQ, VA, VL, and VS resources.
+multiclass SiFive7ProcResources {
+  let BufferSize = 0 in {
+    def PipeA     : ProcResource<1>;
+    def PipeB     : ProcResource<1>;
+
+    def IDiv      : ProcResource<1>; // Int Division
+    def FDiv      : ProcResource<1>; // FP Division/Sqrt
+
+    def VA      : ProcResource<1>; // Arithmetic sequencer
+
+    def VL        : ProcResource<1>; // Load sequencer
+    def VS        : ProcResource<1>; // Store sequencer
+    // The VCQ accepts instructions from the the A Pipe and holds them until the
+    // vector unit is ready to dequeue them. The unit dequeues up to one instruction
+    // per cycle, in order, as soon as the sequencer for that type of instruction is
+    // available. This resource is meant to be used for 1 cycle by all vector
+    // instructions, to model that only one vector instruction may be dequeued at a
+    // time. The actual dequeueing into the sequencer is modeled by the VA, VL, and
+    // VS sequencer resources below. Each of them will only accept a single
+    // instruction at a time and remain busy for the number of cycles associated
+    // with that instruction.
+    def VCQ       : ProcResource<1>; // Vector Command Queue
+  }
+
+  def PipeAB : ProcResGroup<[!cast<ProcResource>(NAME#"PipeA"),
+                             !cast<ProcResource>(NAME#"PipeB")]>;
+}
+
+multiclass SiFive7WriteResBase<int VLEN,
+    ProcResourceKind PipeA, ProcResourceKind PipeB, ProcResourceKind PipeAB,
+    ProcResourceKind IDiv, ProcResourceKind FDiv,
+    ProcResourceKind VA, ProcResourceKind VL, ProcResourceKind VS,
+    ProcResourceKind VCQ> {
+
+  // Branching
+  let Latency = 3 in {
+    def : WriteRes<WriteJmp, [PipeB]>;
+    def : WriteRes<WriteJal, [PipeB]>;
+    def : WriteRes<WriteJalr, [PipeB]>;
+  }
+
+  //Short forward branch
+  def : WriteRes<WriteSFB, [PipeA, PipeB]> {
+    let Latency = 3;
+    let NumMicroOps = 2;
+  }
+
+  // Integer arithmetic and logic
+  let Latency = 3 in {
+    def : WriteRes<WriteIALU, [PipeAB]>;
+    def : WriteRes<WriteIALU32, [PipeAB]>;
+    def : WriteRes<WriteShiftImm, [PipeAB]>;
+    def : WriteRes<WriteShiftImm32, [PipeAB]>;
+    def : WriteRes<WriteShiftReg, [PipeAB]>;
+    def : WriteRes<WriteShiftReg32, [PipeAB]>;
+  }
+
+  // Integer multiplication
+  let Latency = 3 in {
+    def : WriteRes<WriteIMul, [PipeB]>;
+    def : WriteRes<WriteIMul32, [PipeB]>;
+  }
+
+  // Integer division
+  def : WriteRes<WriteIDiv, [PipeB, IDiv]> {
+    let Latency = 66;
+    let ReleaseAtCycles = [1, 65];
+  }
+  def : WriteRes<WriteIDiv32,  [PipeB, IDiv]> {
+    let Latency = 34;
+    let ReleaseAtCycles = [1, 33];
+  }
+
+  // Integer remainder
+  def : WriteRes<WriteIRem, [PipeB, IDiv]> {
+    let Latency = 66;
+    let ReleaseAtCycles = [1, 65];
+  }
+  def : WriteRes<WriteIRem32,  [PipeB, IDiv]> {
+    let Latency = 34;
+    let ReleaseAtCycles = [1, 33];
+  }
+
+  // Bitmanip
+  let Latency = 3 in {
+    // Rotates are in the late-B ALU.
+    def : WriteRes<WriteRotateImm, [PipeB]>;
+    def : WriteRes<WriteRotateImm32, [PipeB]>;
+    def : WriteRes<WriteRotateReg, [PipeB]>;
+    def : WriteRes<WriteRotateReg32, [PipeB]>;
+
+    // clz[w]/ctz[w] are in the late-B ALU.
+    def : WriteRes<WriteCLZ, [PipeB]>;
+    def : WriteRes<WriteCLZ32, [PipeB]>;
+    def : WriteRes<WriteCTZ, [PipeB]>;
+    def : WriteRes<WriteCTZ32, [PipeB]>;
+
+    // cpop[w] look exactly like multiply.
+    def : WriteRes<WriteCPOP, [PipeB]>;
+    def : WriteRes<WriteCPOP32, [PipeB]>;
+
+    // orc.b is in the late-B ALU.
+    def : WriteRes<WriteORCB, [PipeB]>;
+
+    // min/max are in the late-B ALU
+    def : WriteRes<WriteIMinMax, [PipeB]>;
+
+    // rev8 is in the late-A and late-B ALUs.
+    def : WriteRes<WriteREV8, [PipeAB]>;
+
+    // shNadd[.uw] is on the early-B and late-B ALUs.
+    def : WriteRes<WriteSHXADD, [PipeB]>;
+    def : WriteRes<WriteSHXADD32, [PipeB]>;
+  }
+
+  // Single-bit instructions
+  // BEXT[I] instruction is available on all ALUs and the other instructions
+  // are only available on the B pipe.
+  let Latency = 3 in {
+    def : WriteRes<WriteSingleBit, [PipeB]>;
+    def : WriteRes<WriteSingleBitImm, [PipeB]>;
+    def : WriteRes<WriteBEXT, [PipeAB]>;
+    def : WriteRes<WriteBEXTI, [PipeAB]>;
+  }
+
+  // Memory
+  def : WriteRes<WriteSTB, [PipeA]>;
+  def : WriteRes<WriteSTH, [PipeA]>;
+  def : WriteRes<WriteSTW, [PipeA]>;
+  def : WriteRes<WriteSTD, [PipeA]>;
+  def : WriteRes<WriteFST16, [PipeA]>;
+  def : WriteRes<WriteFST32, [PipeA]>;
+  def : WriteRes<WriteFST64, [PipeA]>;
+
+  let Latency = 3 in {
+  def : WriteRes<WriteLDB, [PipeA]>;
+  def : WriteRes<WriteLDH, [PipeA]>;
+  def : WriteRes<WriteLDW, [PipeA]>;
+  def : WriteRes<WriteLDD, [PipeA]>;
+  }
+
+  let Latency = 2 in {
+  def : WriteRes<WriteFLD16, [PipeA]>;
+  def : WriteRes<WriteFLD32, [PipeA]>;
+  def : WriteRes<WriteFLD64, [PipeA]>;
+  }
+
+  // Atomic memory
+  def : WriteRes<WriteAtomicSTW, [PipeA]>;
+  def : WriteRes<WriteAtomicSTD, [PipeA]>;
+
+  let Latency = 3 in {
+  def : WriteRes<WriteAtomicW, [PipeA]>;
+  def : WriteRes<WriteAtomicD, [PipeA]>;
+  def : WriteRes<WriteAtomicLDW, [PipeA]>;
+  def : WriteRes<WriteAtomicLDD, [PipeA]>;
+  }
+
+  // Half precision.
+  let Latency = 5 in {
+  def : WriteRes<WriteFAdd16, [PipeB]>;
+  def : WriteRes<WriteFMul16, [PipeB]>;
+  def : WriteRes<WriteFMA16, [PipeB]>;
+  }
+  let Latency = 3 in {
+  def : WriteRes<WriteFSGNJ16, [PipeB]>;
+  def : WriteRes<WriteFMinMax16, [PipeB]>;
+  }
+
+  let Latency = 14, ReleaseAtCycles = [1, 13] in {
+  def :  WriteRes<WriteFDiv16, [PipeB, FDiv]>;
+  def :  WriteRes<WriteFSqrt16, [PipeB, FDiv]>;
+  }
+
+  // Single precision.
+  let Latency = 5 in {
+    def : WriteRes<WriteFAdd32, [PipeB]>;
+    def : WriteRes<WriteFMul32, [PipeB]>;
+    def : WriteRes<WriteFMA32, [PipeB]>;
+  }
+  let Latency = 3 in {
+    def : WriteRes<WriteFSGNJ32, [PipeB]>;
+    def : WriteRes<WriteFMinMax32, [PipeB]>;
+  }
+
+  def : WriteRes<WriteFDiv32, [PipeB, FDiv]> {
+    let Latency = 27;
+    let ReleaseAtCycles = [1, 26];
+  }
+  def : WriteRes<WriteFSqrt32, [PipeB, FDiv]> {
+    let Latency = 27;
+    let ReleaseAtCycles = [1, 26];
+  }
+
+  // Double precision
+  let Latency = 7 in {
+    def : WriteRes<WriteFAdd64, [PipeB]>;
+    def : WriteRes<WriteFMul64, [PipeB]>;
+    def : WriteRes<WriteFMA64, [PipeB]>;
+  }
+  let Latency = 3 in {
+    def : WriteRes<WriteFSGNJ64, [PipeB]>;
+    def : WriteRes<WriteFMinMax64, [PipeB]>;
+  }
+
+  def : WriteRes<WriteFDiv64, [PipeB, FDiv]> {
+    let Latency = 56;
+    let ReleaseAtCycles = [1, 55];
+  }
+  def : WriteRes<WriteFSqrt64, [PipeB, FDiv]> {
+    let Latency = 56;
+    let ReleaseAtCycles = [1, 55];
+  }
+
+  // Conversions
+  let Latency = 3 in {
+  def : WriteRes<WriteFCvtI32ToF16, [PipeB]>;
+  def : WriteRes<WriteFCvtI32ToF32, [PipeB]>;
+  def : WriteRes<WriteFCvtI32ToF64, [PipeB]>;
+  def : WriteRes<WriteFCvtI64ToF16, [PipeB]>;
+  def : WriteRes<WriteFCvtI64ToF32, [PipeB]>;
+  def : WriteRes<WriteFCvtI64ToF64, [PipeB]>;
+  def : WriteRes<WriteFCvtF16ToI32, [PipeB]>;
+  def : WriteRes<WriteFCvtF16ToI64, [PipeB]>;
+  def : WriteRes<WriteFCvtF16ToF32, [PipeB]>;
+  def : WriteRes<WriteFCvtF16ToF64, [PipeB]>;
+  def : WriteRes<WriteFCvtF32ToI32, [PipeB]>;
+  def : WriteRes<WriteFCvtF32ToI64, [PipeB]>;
+  def : WriteRes<WriteFCvtF32ToF16, [PipeB]>;
+  def : WriteRes<WriteFCvtF32ToF64, [PipeB]>;
+  def : WriteRes<WriteFCvtF64ToI32, [PipeB]>;
+  def : WriteRes<WriteFCvtF64ToI64, [PipeB]>;
+  def : WriteRes<WriteFCvtF64ToF16, [PipeB]>;
+  def : WriteRes<WriteFCvtF64ToF32, [PipeB]>;
+
+  def : WriteRes<WriteFClass16, [PipeB]>;
+  def : WriteRes<WriteFClass32, [PipeB]>;
+  def : WriteRes<WriteFClass64, [PipeB]>;
+  def : WriteRes<WriteFCmp16, [PipeB]>;
+  def : WriteRes<WriteFCmp32, [PipeB]>;
+  def : WriteRes<WriteFCmp64, [PipeB]>;
+  def : WriteRes<WriteFMovI16ToF16, [PipeB]>;
+  def : WriteRes<WriteFMovF16ToI16, [PipeB]>;
+  def : WriteRes<WriteFMovI32ToF32, [PipeB]>;
+  def : WriteRes<WriteFMovF32ToI32, [PipeB]>;
+  def : WriteRes<WriteFMovI64ToF64, [PipeB]>;
+  def : WriteRes<WriteFMovF64ToI64, [PipeB]>;
+  }
+
+  // 6. Configuration-Setting Instructions
+  let Latency = 3 in {
+  def : WriteRes<WriteVSETVLI, [PipeA]>;
+  def : WriteRes<WriteVSETIVLI, [PipeA]>;
+  def : WriteRes<WriteVSETVL, [PipeA]>;
+  }
+
+  // 7. Vector Loads and Stores
+  // Unit-stride loads and stores can operate at the full bandwidth of the memory
+  // pipe. The memory pipe is DLEN bits wide on x280.
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVLDE",    [VCQ, VL], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVLDFF",   [VCQ, VL], mx, IsWorstCase>;
+    }
+    let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+    defm : LMULWriteResMX<"WriteVSTE",    [VCQ, VS], mx, IsWorstCase>;
+  }
+
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetMaskLoadStoreCycles<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+    defm : LMULWriteResMX<"WriteVLDM",    [VCQ, VL], mx, IsWorstCase>;
+    let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+    defm : LMULWriteResMX<"WriteVSTM",    [VCQ, VS], mx, IsWorstCase>;
+  }
+
+  // Strided loads and stores operate at one element per cycle and should be
+  // scheduled accordingly. Indexed loads and stores operate at one element per
+  // cycle, and they stall the machine until all addresses have been generated,
+  // so they cannot be scheduled. Indexed and strided loads and stores have LMUL
+  // specific suffixes, but since SEW is already encoded in the name of the
+  // resource, we do not need to use LMULSEWXXX constructors. However, we do
+  // use the SEW from the name to determine the number of Cycles.
+
+  foreach mx = SchedMxList in {
+    defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 8, VLEN>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    defm  : LMULWriteResMXVariant<"WriteVLDS8",  VLDSX0Pred, [VCQ, VL],
+                                         4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
+                                         [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
+    let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVLDUX8", [VCQ, VL], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVLDOX8", [VCQ, VL], mx, IsWorstCase>;
+    }
+    let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVSTS8",  [VCQ, VS], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSTUX8", [VCQ, VS], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSTOX8", [VCQ, VS], mx, IsWorstCase>;
+    }
+  }
+  // TODO: The MxLists need to be filtered by EEW. We only need to support
+  // LMUL >= SEW_min/ELEN. Here, the smallest EEW prevents us from having MF8
+  // since LMUL >= 16/64.
+  foreach mx = ["MF4", "MF2", "M1", "M2", "M4", "M8"] in {
+    defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 16, VLEN>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    defm  : LMULWriteResMXVariant<"WriteVLDS16",  VLDSX0Pred, [VCQ, VL],
+                                         4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
+                                         [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
+    let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVLDUX16", [VCQ, VL], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVLDOX16", [VCQ, VL], mx, IsWorstCase>;
+    }
+    let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVSTS16",  [VCQ, VS], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSTUX16", [VCQ, VS], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSTOX16", [VCQ, VS], mx, IsWorstCase>;
+    }
+  }
+  foreach mx = ["MF2", "M1", "M2", "M4", "M8"] in {
+    defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 32, VLEN>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    defm  : LMULWriteResMXVariant<"WriteVLDS32",  VLDSX0Pred, [VCQ, VL],
+                                         4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
+                                         [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
+    let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVLDUX32", [VCQ, VL], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVLDOX32", [VCQ, VL], mx, IsWorstCase>;
+    }
+    let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVSTS32",  [VCQ, VS], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSTUX32", [VCQ, VS], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSTOX32", [VCQ, VS], mx, IsWorstCase>;
+    }
+  }
+  foreach mx = ["M1", "M2", "M4", "M8"] in {
+    defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 64, VLEN>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    defm  : LMULWriteResMXVariant<"WriteVLDS64",  VLDSX0Pred, [VCQ, VL],
+                                         4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
+                                         [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
+    let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVLDUX64", [VCQ, VL], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVLDOX64", [VCQ, VL], mx, IsWorstCase>;
+    }
+    let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVSTS64",  [VCQ, VS], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSTUX64", [VCQ, VS], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSTOX64", [VCQ, VS], mx, IsWorstCase>;
+    }
+  }
+
+  // VLD*R is LMUL aware
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
+    def : WriteRes<WriteVLD1R,  [VCQ, VL]>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
+    def : WriteRes<WriteVLD2R,  [VCQ, VL]>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
+    def : WriteRes<WriteVLD4R,  [VCQ, VL]>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
+    def : WriteRes<WriteVLD8R,  [VCQ, VL]>;
+  // VST*R is LMUL aware
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
+    def : WriteRes<WriteVST1R,   [VCQ, VS]>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
+    def : WriteRes<WriteVST2R,   [VCQ, VS]>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
+    def : WriteRes<WriteVST4R,   [VCQ, VS]>;
+  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
+    def : WriteRes<WriteVST8R,   [VCQ, VS]>;
+
+  // Segmented Loads and Stores
+  // Unit-stride segmented loads and stores are effectively converted into strided
+  // segment loads and stores. Strided segment loads and stores operate at up to
+  // one segment per cycle if the segment fits within one aligned memory beat.
+  // Indexed segment loads and stores operate at the same rate as strided ones,
+  // but they stall the machine until all addresses have been generated.
+  foreach mx = SchedMxList in {
+    foreach eew = [8, 16, 32, 64] in {
+      defvar Cycles = SiFive7GetCyclesSegmentedSeg2<mx>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+      // Does not chain so set latency high
+      let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULWriteResMX<"WriteVLSEG2e" # eew,   [VCQ, VL], mx, IsWorstCase>;
+        defm : LMULWriteResMX<"WriteVLSEGFF2e" # eew, [VCQ, VL], mx, IsWorstCase>;
+      }
+      let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+      defm : LMULWriteResMX<"WriteVSSEG2e" # eew,   [VCQ, VS], mx, IsWorstCase>;
+      foreach nf=3-8 in {
+        defvar Cycles = SiFive7GetCyclesSegmented<mx, eew, nf, VLEN>.c;
+        defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+        // Does not chain so set latency high
+        let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+          defm : LMULWriteResMX<"WriteVLSEG" # nf # "e" # eew,   [VCQ, VL], mx, IsWorstCase>;
+          defm : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" # eew, [VCQ, VL], mx, IsWorstCase>;
+        }
+        let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+        defm : LMULWriteResMX<"WriteVSSEG" # nf # "e" # eew,   [VCQ, VS], mx, IsWorstCase>;
+      }
+    }
+  }
+  foreach mx = SchedMxList in {
+    foreach nf=2-8 in {
+      foreach eew = [8, 16, 32, 64] in {
+        defvar Cycles = SiFive7GetCyclesSegmented<mx, eew, nf, VLEN>.c;
+        defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+        // Does not chain so set latency high
+        let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+          defm : LMULWriteResMX<"WriteVLSSEG" # nf # "e" # eew,  [VCQ, VL], mx, IsWorstCase>;
+          defm : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" # eew, [VCQ, VL], mx, IsWorstCase>;
+          defm : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" # eew, [VCQ, VL], mx, IsWorstCase>;
+        }
+        let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+          defm : LMULWriteResMX<"WriteVSSSEG" # nf # "e" # eew,  [VCQ, VS], mx, IsWorstCase>;
+          defm : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" # eew, [VCQ, VS], mx, IsWorstCase>;
+          defm : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" # eew, [VCQ, VS], mx, IsWorstCase>;
+        }
+      }
+    }
+  }
+
+  // 11. Vector Integer Arithmetic Instructions
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVIALUV",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIALUX",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIALUI",     [VCQ, VA], mx, IsWorstCase>;
+      // vmadc requires mask
+      defm : LMULWriteResMX<"WriteVICALUV",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVICALUX",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVICALUI",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVICALUMV",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVICALUMX",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVICALUMI",   [VCQ, VA], mx, IsWorstCase>;
+      // min max require merge
+      defm : LMULWriteResMX<"WriteVIMinMaxV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMinMaxX",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMergeV",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMergeX",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMergeI",   [VCQ, VA], mx, IsWorstCase>;
+
+      defm : LMULWriteResMX<"WriteVIMovV",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMovX",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMovI",     [VCQ, VA], mx, IsWorstCase>;
+
+      defm : LMULWriteResMX<"WriteVExtV",      [VCQ, VA], mx, IsWorstCase>;
+    }
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVShiftV",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVShiftX",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVShiftI",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMulV",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMulX",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMulAddV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIMulAddX",  [VCQ, VA], mx, IsWorstCase>;
+    }
+    // Mask results can't chain.
+    let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVICmpV",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVICmpX",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVICmpI",     [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+
+  foreach mx = SchedMxList in {
+    foreach sew = SchedSEWSet<mx>.val in {
+      defvar Cycles = !mul(SiFive7GetDivOrSqrtFactor<sew>.c,
+                           !div(SiFive7GetCyclesOnePerElement<mx, sew, VLEN>.c, 4));
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
+      let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVIDivV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVIDivX", [VCQ, VA], mx, sew, IsWorstCase>;
+      }
+    }
+  }
+
+  // Widening
+  foreach mx = SchedMxListW in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVIWALUV",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIWALUX",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIWALUI",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIWMulV",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIWMulX",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIWMulAddV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIWMulAddX", [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+  // Narrowing
+  foreach mx = SchedMxListW in {
+    defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVNShiftV",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVNShiftX",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVNShiftI",   [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+
+  // 12. Vector Fixed-Point Arithmetic Instructions
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVSALUV",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSALUX",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSALUI",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVAALUV",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVAALUX",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSMulV",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSMulX",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSShiftV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSShiftX", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSShiftI", [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+  // Narrowing
+  foreach mx = SchedMxListW in {
+    defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVNClipV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVNClipX",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVNClipI",  [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+
+  // 13. Vector Floating-Point Instructions
+  foreach mx = SchedMxListF in {
+    foreach sew = SchedSEWSet<mx, isF=1>.val in {
+      defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListF, isF=1>.c;
+      let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVFALUV",  [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFALUF",  [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFMulV",  [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFMulF",  [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFMulAddV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFMulAddF", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFRecpV",   [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFCvtIToFV", [VCQ, VA], mx, sew, IsWorstCase>;
+      }
+      let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVFSgnjV",   [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFSgnjF",   [VCQ, VA], mx, sew, IsWorstCase>;
+        // min max require merge
+        defm : LMULSEWWriteResMXSEW<"WriteVFMinMaxV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFMinMaxF", [VCQ, VA], mx, sew, IsWorstCase>;
+      }
+    }
+  }
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVFCvtFToIV",  [VCQ, VA], mx, IsWorstCase>;
+    }
+    let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVFClassV",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVFMergeV",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVFMovV",      [VCQ, VA], mx, IsWorstCase>;
+    }
+    // Mask results can't chain.
+    let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      // fcmp requires mask
+      defm : LMULWriteResMX<"WriteVFCmpV",      [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVFCmpF",      [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+  foreach mx = SchedMxListF in {
+    foreach sew = SchedSEWSet<mx, isF=1>.val in {
+      defvar Cycles = !mul(SiFive7GetDivOrSqrtFactor<sew>.c,
+                           !div(SiFive7GetCyclesOnePerElement<mx, sew, VLEN>.c, 4));
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListF, 1>.c;
+      let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVFSqrtV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFDivV",  [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFDivF",  [VCQ, VA], mx, sew, IsWorstCase>;
+      }
+    }
+  }
+
+  // Widening
+  foreach mx = SchedMxListW in {
+    foreach sew = SchedSEWSet<mx, isF=0, isWidening=1>.val in {
+      defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListW>.c;
+      let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+      defm : LMULSEWWriteResMXSEW<"WriteVFWCvtIToFV", [VCQ, VA], mx, sew, IsWorstCase>;
+    }
+  }
+  foreach mx = SchedMxListFW in {
+    foreach sew = SchedSEWSet<mx, isF=1, isWidening=1>.val in {
+      defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListFW, isF=1>.c;
+      let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVFWALUV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFWALUF", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFWMulV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFWMulF", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFWMulAddV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFWMulAddF", [VCQ, VA], mx, sew, IsWorstCase>;
+      }
+      defvar CvtCycles = SiFive7GetCyclesDefault<mx>.c;
+      let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, CvtCycles)] in
+      defm "" : LMULSEWWriteResMXSEW<"WriteVFWCvtFToFV", [VCQ, VA], mx, sew, IsWorstCase>;
+    }
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListFW>.c;
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+    defm : LMULWriteResMX<"WriteVFWCvtFToIV", [VCQ, VA], mx, IsWorstCase>;
+  }
+  // Narrowing
+  foreach mx = SchedMxListW in {
+    defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVFNCvtFToIV", [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+  foreach mx = SchedMxListFW in {
+    foreach sew = SchedSEWSet<mx, isF=1, isWidening=1>.val in {
+      defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListFW, isF=1>.c;
+      let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVFNCvtIToFV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFNCvtFToFV", [VCQ, VA], mx, sew, IsWorstCase>;
+      }
+    }
+  }
+
+  // 14. Vector Reduction Operations
+  foreach mx = SchedMxList in {
+    foreach sew = SchedSEWSet<mx>.val in {
+      defvar Cycles = SiFive7GetReductionCycles<mx, sew, VLEN>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
+      let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVIRedV_From", [VCQ, VA],
+                                       mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVIRedMinMaxV_From", [VCQ, VA],
+                                       mx, sew, IsWorstCase>;
+      }
+    }
+  }
+
+  foreach mx = SchedMxListWRed in {
+    foreach sew = SchedSEWSet<mx, 0, 1>.val in {
+      defvar Cycles = SiFive7GetReductionCycles<mx, sew, VLEN>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListWRed>.c;
+      let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
+      defm : LMULSEWWriteResMXSEW<"WriteVIWRedV_From", [VCQ, VA],
+                                     mx, sew, IsWorstCase>;
+    }
+  }
+
+  foreach mx = SchedMxListF in {
+    foreach sew = SchedSEWSet<mx, 1>.val in {
+      defvar RedCycles = SiFive7GetReductionCycles<mx, sew, VLEN>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListF, 1>.c;
+      let Latency = RedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, RedCycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVFRedV_From", [VCQ, VA],
+                                       mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVFRedMinMaxV_From", [VCQ, VA],
+                                       mx, sew, IsWorstCase>;
+      }
+      defvar OrdRedCycles = SiFive7GetOrderedReductionCycles<mx, sew, VLEN>.c;
+      let Latency = OrdRedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, OrdRedCycles)] in
+      defm : LMULSEWWriteResMXSEW<"WriteVFRedOV_From", [VCQ, VA],
+                                     mx, sew, IsWorstCase>;
+    }
+  }
+
+  foreach mx = SchedMxListFWRed in {
+    foreach sew = SchedSEWSet<mx, 1, 1>.val in {
+      defvar RedCycles = SiFive7GetReductionCycles<mx, sew, VLEN>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListFWRed, 1>.c;
+      let Latency = RedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, RedCycles)] in
+      defm : LMULSEWWriteResMXSEW<"WriteVFWRedV_From", [VCQ, VA],
+                                     mx, sew, IsWorstCase>;
+      defvar OrdRedCycles = SiFive7GetOrderedReductionCycles<mx, sew, VLEN>.c;
+      let Latency = OrdRedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, OrdRedCycles)] in
+      defm : LMULSEWWriteResMXSEW<"WriteVFWRedOV_From", [VCQ, VA],
+                                     mx, sew, IsWorstCase>;
+    }
+  }
+
+  // 15. Vector Mask Instructions
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesVMask<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVMALUV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVMPopV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVMFFSV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVMSFSV", [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVIotaV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVIdxV", [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+
+  // 16. Vector Permutation Instructions
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 1)] in {
+    def : WriteRes<WriteVMovSX, [VCQ, VA]>;
+    def : WriteRes<WriteVMovXS, [VCQ, VA]>;
+    def : WriteRes<WriteVMovSF, [VCQ, VA]>;
+    def : WriteRes<WriteVMovFS, [VCQ, VA]>;
+  }
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVRGatherVX",    [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVRGatherVI",    [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+
+  foreach mx = SchedMxList in {
+    foreach sew = SchedSEWSet<mx>.val in {
+      defvar Cycles = SiFive7GetCyclesOnePerElement<mx, sew, VLEN>.c;
+      defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
+      let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+        defm : LMULSEWWriteResMXSEW<"WriteVRGatherVV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVRGatherEI16VV", [VCQ, VA], mx, sew, IsWorstCase>;
+        defm : LMULSEWWriteResMXSEW<"WriteVCompressV", [VCQ, VA], mx, sew, IsWorstCase>;
+      }
+    }
+  }
+
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVSlideUpX",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSlideDownX", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVSlideI",     [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVISlide1X",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVFSlide1F",   [VCQ, VA], mx, IsWorstCase>;
+    }
+  }
+
+  // VMov*V is LMUL Aware
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
+    def : WriteRes<WriteVMov1V,     [VCQ, VA]>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
+    def : WriteRes<WriteVMov2V,     [VCQ, VA]>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
+    def : WriteRes<WriteVMov4V,     [VCQ, VA]>;
+  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
+    def : WriteRes<WriteVMov8V,     [VCQ, VA]>;
+
+  // Others
+  def : WriteRes<WriteCSR, [PipeB]>;
+  def : WriteRes<WriteNop, []>;
+  let Latency = 3 in
+    def : WriteRes<WriteRdVLENB, [PipeB]>;
+
+  def : InstRW<[WriteIALU], (instrs COPY)>;
+
+  // VCIX
+  //
+  // In principle we don't know the latency of any VCIX instructions (they
+  // depends on a particular coprocessor implementation). However, the default
+  // latency of 1 can lead to issues [1]. So instead we set the latency to the
+  // default provided by `SiFive7GetCyclesDefault`. This is still not accurate
+  // and can lead to suboptimal codegen, but should hopefully be a better
+  // starting point.
+  //
+  // [1] https://github.com/llvm/llvm-project/issues/83391
+  foreach mx = SchedMxList in {
+    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
+    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
+    let Latency = Cycles,
+        AcquireAtCycles = [0, 1],
+        ReleaseAtCycles = [1, !add(1, Cycles)] in {
+      defm : LMULWriteResMX<"WriteVC_V_I",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_X",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_IV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_VV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_XV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_IVV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_IVW", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_VVV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_VVW", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_XVV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_V_XVW", [VCQ, VA], mx, IsWorstCase>;
+      foreach f = ["FPR16", "FPR32", "FPR64"] in {
+        defm : LMULWriteResMX<"WriteVC_V_" # f # "V",  [VCQ, VA], mx, IsWorstCase>;
+        defm : LMULWriteResMX<"WriteVC_V_" # f # "VV", [VCQ, VA], mx, IsWorstCase>;
+        defm : LMULWriteResMX<"WriteVC_V_" # f # "VW", [VCQ, VA], mx, IsWorstCase>;
+      }
+      defm : LMULWriteResMX<"WriteVC_I",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_X",   [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_IV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_VV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_XV",  [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_IVV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_IVW", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_VVV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_VVW", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_XVV", [VCQ, VA], mx, IsWorstCase>;
+      defm : LMULWriteResMX<"WriteVC_XVW", [VCQ, VA], mx, IsWorstCase>;
+      foreach f = ["FPR16", "FPR32", "FPR64"] in {
+        defm : LMULWriteResMX<"WriteVC_" # f # "V",  [VCQ, VA], mx, IsWorstCase>;
+        defm : LMULWriteResMX<"WriteVC_" # f # "VV", [VCQ, VA], mx, IsWorstCase>;
+        defm : LMULWriteResMX<"WriteVC_" # f # "VW", [VCQ, VA], mx, IsWorstCase>;
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+
+multiclass SiFive7ReadAdvance {
+  // Bypass and advance
+  def : SiFive7AnyToGPRBypass<ReadJmp>;
+  def : SiFive7AnyToGPRBypass<ReadJalr>;
+  def : ReadAdvance<ReadCSR, 0>;
+  def : SiFive7AnyToGPRBypass<ReadStoreData>;
+  def : ReadAdvance<ReadMemBase, 0>;
+  def : SiFive7AnyToGPRBypass<ReadIALU>;
+  def : SiFive7AnyToGPRBypass<ReadIALU32>;
+  def : SiFive7AnyToGPRBypass<ReadShiftImm>;
+  def : SiFive7AnyToGPRBypass<ReadShiftImm32>;
+  def : SiFive7AnyToGPRBypass<ReadShiftReg>;
+  def : SiFive7AnyToGPRBypass<ReadShiftReg32>;
+  def : ReadAdvance<ReadIDiv, 0>;
+  def : ReadAdvance<ReadIDiv32, 0>;
+  def : ReadAdvance<ReadIRem, 0>;
+  def : ReadAdvance<ReadIRem32, 0>;
+  def : ReadAdvance<ReadIMul, 0>;
+  def : ReadAdvance<ReadIMul32, 0>;
+  def : ReadAdvance<ReadAtomicWA, 0>;
+  def : ReadAdvance<ReadAtomicWD, 0>;
+  def : ReadAdvance<ReadAtomicDA, 0>;
+  def : ReadAdvance<ReadAtomicDD, 0>;
+  def : ReadAdvance<ReadAtomicLDW, 0>;
+  def : ReadAdvance<ReadAtomicLDD, 0>;
+  def : ReadAdvance<ReadAtomicSTW, 0>;
+  def : ReadAdvance<ReadAtomicSTD, 0>;
+  def : ReadAdvance<ReadFStoreData, 0>;
+  def : ReadAdvance<ReadFMemBase, 0>;
+  def : ReadAdvance<ReadFAdd16, 0>;
+  def : ReadAdvance<ReadFAdd32, 0>;
+  def : ReadAdvance<ReadFAdd64, 0>;
+  def : ReadAdvance<ReadFMul16, 0>;
+  def : ReadAdvance<ReadFMA16, 0>;
+  def : ReadAdvance<ReadFMA16Addend, 0>;
+  def : ReadAdvance<ReadFMul32, 0>;
+  def : ReadAdvance<ReadFMul64, 0>;
+  def : ReadAdvance<ReadFMA32, 0>;
+  def : ReadAdvance<ReadFMA32Addend, 0>;
+  def : ReadAdvance<ReadFMA64, 0>;
+  def : ReadAdvance<ReadFMA64Addend, 0>;
+  def : ReadAdvance<ReadFDiv16, 0>;
+  def : ReadAdvance<ReadFDiv32, 0>;
+  def : ReadAdvance<ReadFDiv64, 0>;
+  def : ReadAdvance<ReadFSqrt16, 0>;
+  def : ReadAdvance<ReadFSqrt32, 0>;
+  def : ReadAdvance<ReadFSqrt64, 0>;
+  def : ReadAdvance<ReadFCmp16, 0>;
+  def : ReadAdvance<ReadFCmp32, 0>;
+  def : ReadAdvance<ReadFCmp64, 0>;
+  def : ReadAdvance<ReadFSGNJ16, 0>;
+  def : ReadAdvance<ReadFSGNJ32, 0>;
+  def : ReadAdvance<ReadFSGNJ64, 0>;
+  def : ReadAdvance<ReadFMinMax16, 0>;
+  def : ReadAdvance<ReadFMinMax32, 0>;
+  def : ReadAdvance<ReadFMinMax64, 0>;
+  def : ReadAdvance<ReadFCvtF16ToI32, 0>;
+  def : ReadAdvance<ReadFCvtF16ToI64, 0>;
+  def : ReadAdvance<ReadFCvtF32ToI32, 0>;
+  def : ReadAdvance<ReadFCvtF32ToI64, 0>;
+  def : ReadAdvance<ReadFCvtF64ToI32, 0>;
+  def : ReadAdvance<ReadFCvtF64ToI64, 0>;
+  def : ReadAdvance<ReadFCvtI32ToF16, 0>;
+  def : ReadAdvance<ReadFCvtI32ToF32, 0>;
+  def : ReadAdvance<ReadFCvtI32ToF64, 0>;
+  def : ReadAdvance<ReadFCvtI64ToF16, 0>;
+  def : ReadAdvance<ReadFCvtI64ToF32, 0>;
+  def : ReadAdvance<ReadFCvtI64ToF64, 0>;
+  def : ReadAdvance<ReadFCvtF32ToF64, 0>;
+  def : ReadAdvance<ReadFCvtF64ToF32, 0>;
+  def : ReadAdvance<ReadFCvtF16ToF32, 0>;
+  def : ReadAdvance<ReadFCvtF32ToF16, 0>;
+  def : ReadAdvance<ReadFCvtF16ToF64, 0>;
+  def : ReadAdvance<ReadFCvtF64ToF16, 0>;
+  def : ReadAdvance<ReadFMovF16ToI16, 0>;
+  def : ReadAdvance<ReadFMovI16ToF16, 0>;
+  def : ReadAdvance<ReadFMovF32ToI32, 0>;
+  def : ReadAdvance<ReadFMovI32ToF32, 0>;
+  def : ReadAdvance<ReadFMovF64ToI64, 0>;
+  def : ReadAdvance<ReadFMovI64ToF64, 0>;
+  def : ReadAdvance<ReadFClass16, 0>;
+  def : ReadAdvance<ReadFClass32, 0>;
+  def : ReadAdvance<ReadFClass64, 0>;
+
+  def : SiFive7AnyToGPRBypass<ReadSFBJmp, 0>;
+  def : SiFive7AnyToGPRBypass<ReadSFBALU, 0>;
+
+  // Bitmanip
+  def : SiFive7AnyToGPRBypass<ReadRotateImm>;
+  def : SiFive7AnyToGPRBypass<ReadRotateImm32>;
+  def : SiFive7AnyToGPRBypass<ReadRotateReg>;
+  def : SiFive7AnyToGPRBypass<ReadRotateReg32>;
+  def : SiFive7AnyToGPRBypass<ReadCLZ>;
+  def : SiFive7AnyToGPRBypass<ReadCLZ32>;
+  def : SiFive7AnyToGPRBypass<ReadCTZ>;
+  def : SiFive7AnyToGPRBypass<ReadCTZ32>;
+  def : ReadAdvance<ReadCPOP, 0>;
+  def : ReadAdvance<ReadCPOP32, 0>;
+  def : SiFive7AnyToGPRBypass<ReadORCB>;
+  def : SiFive7AnyToGPRBypass<ReadIMinMax>;
+  def : SiFive7AnyToGPRBypass<ReadREV8>;
+  def : SiFive7AnyToGPRBypass<ReadSHXADD>;
+  def : SiFive7AnyToGPRBypass<ReadSHXADD32>;
+  // Single-bit instructions
+  def : SiFive7AnyToGPRBypass<ReadSingleBit>;
+  def : SiFive7AnyToGPRBypass<ReadSingleBitImm>;
+
+  // 6. Configuration-Setting Instructions
+  def : ReadAdvance<ReadVSETVLI, 2>;
+  def : ReadAdvance<ReadVSETVL, 2>;
+
+  // 7. Vector Loads and Stores
+  def : ReadAdvance<ReadVLDX, 0>;
+  def : ReadAdvance<ReadVSTX, 0>;
+  defm : LMULReadAdvance<"ReadVSTEV", 0>;
+  defm : LMULReadAdvance<"ReadVSTM", 0>;
+  def : ReadAdvance<ReadVLDSX, 0>;
+  def : ReadAdvance<ReadVSTSX, 0>;
+  defm : LMULReadAdvance<"ReadVSTS8V", 0>;
+  defm : LMULReadAdvance<"ReadVSTS16V", 0>;
+  defm : LMULReadAdvance<"ReadVSTS32V", 0>;
+  defm : LMULReadAdvance<"ReadVSTS64V", 0>;
+  defm : LMULReadAdvance<"ReadVLDUXV", 0>;
+  defm : LMULReadAdvance<"ReadVLDOXV", 0>;
+  defm : LMULReadAdvance<"ReadVSTUX8", 0>;
+  defm : LMULReadAdvance<"ReadVSTUX16", 0>;
+  defm : LMULReadAdvance<"ReadVSTUX32", 0>;
+  defm : LMULReadAdvance<"ReadVSTUX64", 0>;
+  defm : LMULReadAdvance<"ReadVSTUXV", 0>;
+  defm : LMULReadAdvance<"ReadVSTUX8V", 0>;
+  defm : LMULReadAdvance<"ReadVSTUX16V", 0>;
+  defm : LMULReadAdvance<"ReadVSTUX32V", 0>;
+  defm : LMULReadAdvance<"ReadVSTUX64V", 0>;
+  defm : LMULReadAdvance<"ReadVSTOX8", 0>;
+  defm : LMULReadAdvance<"ReadVSTOX16", 0>;
+  defm : LMULReadAdvance<"ReadVSTOX32", 0>;
+  defm : LMULReadAdvance<"ReadVSTOX64", 0>;
+  defm : LMULReadAdvance<"ReadVSTOXV", 0>;
+  defm : LMULReadAdvance<"ReadVSTOX8V", 0>;
+  defm : LMULReadAdvance<"ReadVSTOX16V", 0>;
+  defm : LMULReadAdvance<"ReadVSTOX32V", 0>;
+  defm : LMULReadAdvance<"ReadVSTOX64V", 0>;
+  // LMUL Aware
+  def : ReadAdvance<ReadVST1R, 0>;
+  def : ReadAdvance<ReadVST2R, 0>;
+  def : ReadAdvance<ReadVST4R, 0>;
+  def : ReadAdvance<ReadVST8R, 0>;
+
+  // 12. Vector Integer Arithmetic Instructions
+  defm : LMULReadAdvance<"ReadVIALUV", 0>;
+  defm : LMULReadAdvance<"ReadVIALUX", 0>;
+  defm : LMULReadAdvanceW<"ReadVIWALUV", 0>;
+  defm : LMULReadAdvanceW<"ReadVIWALUX", 0>;
+  defm : LMULReadAdvance<"ReadVExtV", 0>;
+  defm : LMULReadAdvance<"ReadVICALUV", 0>;
+  defm : LMULReadAdvance<"ReadVICALUX", 0>;
+  defm : LMULReadAdvance<"ReadVShiftV", 0>;
+  defm : LMULReadAdvance<"ReadVShiftX", 0>;
+  defm : LMULReadAdvanceW<"ReadVNShiftV", 0>;
+  defm : LMULReadAdvanceW<"ReadVNShiftX", 0>;
+  defm : LMULReadAdvance<"ReadVICmpV", 0>;
+  defm : LMULReadAdvance<"ReadVICmpX", 0>;
+  defm : LMULReadAdvance<"ReadVIMinMaxV", 0>;
+  defm : LMULReadAdvance<"ReadVIMinMaxX", 0>;
+  defm : LMULReadAdvance<"ReadVIMulV", 0>;
+  defm : LMULReadAdvance<"ReadVIMulX", 0>;
+  defm : LMULSEWReadAdvance<"ReadVIDivV", 0>;
+  defm : LMULSEWReadAdvance<"ReadVIDivX", 0>;
+  defm : LMULReadAdvanceW<"ReadVIWMulV", 0>;
+  defm : LMULReadAdvanceW<"ReadVIWMulX", 0>;
+  defm : LMULReadAdvance<"ReadVIMulAddV", 0>;
+  defm : LMULReadAdvance<"ReadVIMulAddX", 0>;
+  defm : LMULReadAdvanceW<"ReadVIWMulAddV", 0>;
+  defm : LMULReadAdvanceW<"ReadVIWMulAddX", 0>;
+  defm : LMULReadAdvance<"ReadVIMergeV", 0>;
+  defm : LMULReadAdvance<"ReadVIMergeX", 0>;
+  defm : LMULReadAdvance<"ReadVIMovV", 0>;
+  defm : LMULReadAdvance<"ReadVIMovX", 0>;
+
+  // 13. Vector Fixed-Point Arithmetic Instructions
+  defm : LMULReadAdvance<"ReadVSALUV", 0>;
+  defm : LMULReadAdvance<"ReadVSALUX", 0>;
+  defm : LMULReadAdvance<"ReadVAALUV", 0>;
+  defm : LMULReadAdvance<"ReadVAALUX", 0>;
+  defm : LMULReadAdvance<"ReadVSMulV", 0>;
+  defm : LMULReadAdvance<"ReadVSMulX", 0>;
+  defm : LMULReadAdvance<"ReadVSShiftV", 0>;
+  defm : LMULReadAdvance<"ReadVSShiftX", 0>;
+  defm : LMULReadAdvanceW<"ReadVNClipV", 0>;
+  defm : LMULReadAdvanceW<"ReadVNClipX", 0>;
+
+  // 14. Vector Floating-Point Instructions
+  defm : LMULSEWReadAdvanceF<"ReadVFALUV", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFALUF", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFWALUV", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFWALUF", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFMulV", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFMulF", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFDivV", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFDivF", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFWMulV", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFWMulF", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFMulAddV", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFMulAddF", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFWMulAddV", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFWMulAddF", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFSqrtV", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFRecpV", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFMinMaxV", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFMinMaxF", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFSgnjV", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFSgnjF", 0>;
+  defm : LMULReadAdvance<"ReadVFCmpV", 0>;
+  defm : LMULReadAdvance<"ReadVFCmpF", 0>;
+  defm : LMULReadAdvance<"ReadVFClassV", 0>;
+  defm : LMULReadAdvance<"ReadVFMergeV", 0>;
+  defm : LMULReadAdvance<"ReadVFMergeF", 0>;
+  defm : LMULReadAdvance<"ReadVFMovF", 0>;
+  defm : LMULSEWReadAdvanceF<"ReadVFCvtIToFV", 0>;
+  defm : LMULReadAdvance<"ReadVFCvtFToIV", 0>;
+  defm : LMULSEWReadAdvanceW<"ReadVFWCvtIToFV", 0>;
+  defm : LMULReadAdvanceFW<"ReadVFWCvtFToIV", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFWCvtFToFV", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFNCvtIToFV", 0>;
+  defm : LMULReadAdvanceW<"ReadVFNCvtFToIV", 0>;
+  defm : LMULSEWReadAdvanceFW<"ReadVFNCvtFToFV", 0>;
+
+  // 15. Vector Reduction Operations
+  def : ReadAdvance<ReadVIRedV, 0>;
+  def : ReadAdvance<ReadVIRedV0, 0>;
+  def : ReadAdvance<ReadVIWRedV, 0>;
+  def : ReadAdvance<ReadVIWRedV0, 0>;
+  def : ReadAdvance<ReadVFRedV, 0>;
+  def : ReadAdvance<ReadVFRedV0, 0>;
+  def : ReadAdvance<ReadVFRedOV, 0>;
+  def : ReadAdvance<ReadVFRedOV0, 0>;
+  def : ReadAdvance<ReadVFWRedV, 0>;
+  def : ReadAdvance<ReadVFWRedV0, 0>;
+  def : ReadAdvance<ReadVFWRedOV, 0>;
+  def : ReadAdvance<ReadVFWRedOV0, 0>;
+
+  // 16. Vector Mask Instructions
+  defm : LMULReadAdvance<"ReadVMALUV", 0>;
+  defm : LMULReadAdvance<"ReadVMPopV", 0>;
+  defm : LMULReadAdvance<"ReadVMFFSV", 0>;
+  defm : LMULReadAdvance<"ReadVMSFSV", 0>;
+  defm : LMULReadAdvance<"ReadVIotaV", 0>;
+
+  // 17. Vector Permutation Instructions
+  def : ReadAdvance<ReadVMovXS, 0>;
+  def : ReadAdvance<ReadVMovSX_V, 0>;
+  def : ReadAdvance<ReadVMovSX_X, 0>;
+  def : ReadAdvance<ReadVMovFS, 0>;
+  def : ReadAdvance<ReadVMovSF_V, 0>;
+  def : ReadAdvance<ReadVMovSF_F, 0>;
+  defm : LMULReadAdvance<"ReadVISlideV", 0>;
+  defm : LMULReadAdvance<"ReadVISlideX", 0>;
+  defm : LMULReadAdvance<"ReadVFSlideV", 0>;
+  defm : LMULReadAdvance<"ReadVFSlideF", 0>;
+  defm : LMULSEWReadAdvance<"ReadVRGatherVV_data", 0>;
+  defm : LMULSEWReadAdvance<"ReadVRGatherVV_index", 0>;
+  defm : LMULSEWReadAdvance<"ReadVRGatherEI16VV_data", 0>;
+  defm : LMULSEWReadAdvance<"ReadVRGatherEI16VV_index", 0>;
+  defm : LMULReadAdvance<"ReadVRGatherVX_data", 0>;
+  defm : LMULReadAdvance<"ReadVRGatherVX_index", 0>;
+  defm : LMULReadAdvance<"ReadVRGatherVI_data", 0>;
+  defm : LMULSEWReadAdvance<"ReadVCompressV", 0>;
+  // LMUL Aware
+  def : ReadAdvance<ReadVMov1V, 0>;
+  def : ReadAdvance<ReadVMov2V, 0>;
+  def : ReadAdvance<ReadVMov4V, 0>;
+  def : ReadAdvance<ReadVMov8V, 0>;
+
+  // Others
+  def : ReadAdvance<ReadVMask, 0>;
+  def : ReadAdvance<ReadVPassthru_WorstCase, 0>;
+  foreach mx = SchedMxList in {
+    def : ReadAdvance<!cast<SchedRead>("ReadVPassthru_" # mx), 0>;
+    foreach sew = SchedSEWSet<mx>.val in
+      def : ReadAdvance<!cast<SchedRead>("ReadVPassthru_" # mx  # "_E" # sew), 0>;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+
+/// This multiclass is a "bundle" of (1) processor resources (i.e. pipes) and
+/// (2) WriteRes entries. It's parameterized by config values that will
+/// eventually be supplied by different SchedMachineModels.
+multiclass SiFive7SchedResources<int vlen> {
+  defm SiFive7 : SiFive7ProcResources;
+
+  // Pull out defs from SiFive7ProcResources so we can refer to them by name.
+  defvar SiFive7PipeA = !cast<ProcResource>(NAME # SiFive7PipeA);
+  defvar SiFive7PipeB = !cast<ProcResource>(NAME # SiFive7PipeB);
+  defvar SiFive7PipeAB = !cast<ProcResGroup>(NAME # SiFive7PipeAB);
+  defvar SiFive7IDiv = !cast<ProcResource>(NAME # SiFive7IDiv);
+  defvar SiFive7FDiv = !cast<ProcResource>(NAME # SiFive7FDiv);
+  defvar SiFive7VA = !cast<ProcResource>(NAME # SiFive7VA);
+  defvar SiFive7VL = !cast<ProcResource>(NAME # SiFive7VL);
+  defvar SiFive7VS = !cast<ProcResource>(NAME # SiFive7VS);
+  defvar SiFive7VCQ = !cast<ProcResource>(NAME # SiFive7VCQ);
+
+  // Define WriteRes records that are the same across all SiFive7 derived
+  // SchedModels.
+  defm SiFive7
+      : SiFive7WriteResBase<vlen, SiFive7PipeA, SiFive7PipeB, SiFive7PipeAB,
+                            SiFive7IDiv, SiFive7FDiv,
+                            SiFive7VA, SiFive7VL, SiFive7VS,
+                            SiFive7VCQ>;
+
+  //===----------------------------------------------------------------------===//
+  // Bypass and advance
+
+  defm SiFive7 : SiFive7ReadAdvance;
+  //===----------------------------------------------------------------------===//
+  // Unsupported extensions
+  defm : UnsupportedSchedQ;
+  defm : UnsupportedSchedZabha;
+  defm : UnsupportedSchedZbc;
+  defm : UnsupportedSchedZbkb;
+  defm : UnsupportedSchedZbkx;
+  defm : UnsupportedSchedZfa;
+  defm : UnsupportedSchedZvk;
+}
+
+class SiFive7SchedMachineModel<int vlen> : SchedMachineModel {
   let MicroOpBufferSize = 0; // Explicitly set to zero since SiFive7 is in-order.
   let IssueWidth = 2;        // 2 micro-ops are dispatched per cycle.
   let LoadLatency = 3;
@@ -198,1109 +1356,18 @@ def SiFive7Model : SchedMachineModel {
                              HasStdExtZcmt, HasStdExtZknd, HasStdExtZkne,
                              HasStdExtZknh, HasStdExtZksed, HasStdExtZksh,
                              HasStdExtZkr];
+  int VLEN = vlen;
+
+  string Name = !subst("Model", "", !subst("SiFive7", "", NAME));
 }
 
-// The SiFive7 microarchitecture has three pipelines: A, B, V.
-// Pipe A can handle memory, integer alu and vector operations.
-// Pipe B can handle integer alu, control flow, integer multiply and divide,
-// and floating point computation.
-// The V pipeline is modeled by the VCQ, VA, VL, and VS resources.
-let SchedModel = SiFive7Model in {
-let BufferSize = 0 in {
-def SiFive7PipeA       : ProcResource<1>;
-def SiFive7PipeB       : ProcResource<1>;
-def SiFive7IDiv        : ProcResource<1>; // Int Division
-def SiFive7FDiv        : ProcResource<1>; // FP Division/Sqrt
-def SiFive7VA          : ProcResource<1>; // Arithmetic sequencer
-def SiFive7VL          : ProcResource<1>; // Load sequencer
-def SiFive7VS          : ProcResource<1>; // Store sequencer
-// The VCQ accepts instructions from the the A Pipe and holds them until the
-// vector unit is ready to dequeue them. The unit dequeues up to one instruction
-// per cycle, in order, as soon as the sequencer for that type of instruction is
-// available. This resource is meant to be used for 1 cycle by all vector
-// instructions, to model that only one vector instruction may be dequeued at a
-// time. The actual dequeueing into the sequencer is modeled by the VA, VL, and
-// VS sequencer resources below. Each of them will only accept a single
-// instruction at a time and remain busy for the number of cycles associated
-// with that instruction.
-def SiFive7VCQ         : ProcResource<1>; // Vector Command Queue
-}
-
-def SiFive7PipeAB : ProcResGroup<[SiFive7PipeA, SiFive7PipeB]>;
-
-defvar SiFive7VLEN = 512;
-
-// Branching
-let Latency = 3 in {
-def : WriteRes<WriteJmp, [SiFive7PipeB]>;
-def : WriteRes<WriteJal, [SiFive7PipeB]>;
-def : WriteRes<WriteJalr, [SiFive7PipeB]>;
-}
-
-//Short forward branch
-def : WriteRes<WriteSFB, [SiFive7PipeA, SiFive7PipeB]> {
-  let Latency = 3;
-  let NumMicroOps = 2;
-}
-
-// Integer arithmetic and logic
-let Latency = 3 in {
-def : WriteRes<WriteIALU, [SiFive7PipeAB]>;
-def : WriteRes<WriteIALU32, [SiFive7PipeAB]>;
-def : WriteRes<WriteShiftImm, [SiFive7PipeAB]>;
-def : WriteRes<WriteShiftImm32, [SiFive7PipeAB]>;
-def : WriteRes<WriteShiftReg, [SiFive7PipeAB]>;
-def : WriteRes<WriteShiftReg32, [SiFive7PipeAB]>;
-}
-
-// Integer multiplication
-let Latency = 3 in {
-def : WriteRes<WriteIMul, [SiFive7PipeB]>;
-def : WriteRes<WriteIMul32, [SiFive7PipeB]>;
-}
-
-// Integer division
-def : WriteRes<WriteIDiv, [SiFive7PipeB, SiFive7IDiv]> {
-  let Latency = 66;
-  let ReleaseAtCycles = [1, 65];
-}
-def : WriteRes<WriteIDiv32,  [SiFive7PipeB, SiFive7IDiv]> {
-  let Latency = 34;
-  let ReleaseAtCycles = [1, 33];
-}
-
-// Integer remainder
-def : WriteRes<WriteIRem, [SiFive7PipeB, SiFive7IDiv]> {
-  let Latency = 66;
-  let ReleaseAtCycles = [1, 65];
-}
-def : WriteRes<WriteIRem32,  [SiFive7PipeB, SiFive7IDiv]> {
-  let Latency = 34;
-  let ReleaseAtCycles = [1, 33];
-}
-
-// Bitmanip
-let Latency = 3 in {
-// Rotates are in the late-B ALU.
-def : WriteRes<WriteRotateImm, [SiFive7PipeB]>;
-def : WriteRes<WriteRotateImm32, [SiFive7PipeB]>;
-def : WriteRes<WriteRotateReg, [SiFive7PipeB]>;
-def : WriteRes<WriteRotateReg32, [SiFive7PipeB]>;
-
-// clz[w]/ctz[w] are in the late-B ALU.
-def : WriteRes<WriteCLZ, [SiFive7PipeB]>;
-def : WriteRes<WriteCLZ32, [SiFive7PipeB]>;
-def : WriteRes<WriteCTZ, [SiFive7PipeB]>;
-def : WriteRes<WriteCTZ32, [SiFive7PipeB]>;
-
-// cpop[w] look exactly like multiply.
-def : WriteRes<WriteCPOP, [SiFive7PipeB]>;
-def : WriteRes<WriteCPOP32, [SiFive7PipeB]>;
-
-// orc.b is in the late-B ALU.
-def : WriteRes<WriteORCB, [SiFive7PipeB]>;
-
-// min/max are in the late-B ALU
-def : WriteRes<WriteIMinMax, [SiFive7PipeB]>;
-
-// rev8 is in the late-A and late-B ALUs.
-def : WriteRes<WriteREV8, [SiFive7PipeAB]>;
-
-// shNadd[.uw] is on the early-B and late-B ALUs.
-def : WriteRes<WriteSHXADD, [SiFive7PipeB]>;
-def : WriteRes<WriteSHXADD32, [SiFive7PipeB]>;
-}
-
-// Single-bit instructions
-// BEXT[I] instruction is available on all ALUs and the other instructions
-// are only available on the SiFive7B pipe.
-let Latency = 3 in {
-def : WriteRes<WriteSingleBit, [SiFive7PipeB]>;
-def : WriteRes<WriteSingleBitImm, [SiFive7PipeB]>;
-def : WriteRes<WriteBEXT, [SiFive7PipeAB]>;
-def : WriteRes<WriteBEXTI, [SiFive7PipeAB]>;
-}
-
-// Memory
-def : WriteRes<WriteSTB, [SiFive7PipeA]>;
-def : WriteRes<WriteSTH, [SiFive7PipeA]>;
-def : WriteRes<WriteSTW, [SiFive7PipeA]>;
-def : WriteRes<WriteSTD, [SiFive7PipeA]>;
-def : WriteRes<WriteFST16, [SiFive7PipeA]>;
-def : WriteRes<WriteFST32, [SiFive7PipeA]>;
-def : WriteRes<WriteFST64, [SiFive7PipeA]>;
-
-let Latency = 3 in {
-def : WriteRes<WriteLDB, [SiFive7PipeA]>;
-def : WriteRes<WriteLDH, [SiFive7PipeA]>;
-def : WriteRes<WriteLDW, [SiFive7PipeA]>;
-def : WriteRes<WriteLDD, [SiFive7PipeA]>;
-}
-
-let Latency = 2 in {
-def : WriteRes<WriteFLD16, [SiFive7PipeA]>;
-def : WriteRes<WriteFLD32, [SiFive7PipeA]>;
-def : WriteRes<WriteFLD64, [SiFive7PipeA]>;
-}
-
-// Atomic memory
-def : WriteRes<WriteAtomicSTW, [SiFive7PipeA]>;
-def : WriteRes<WriteAtomicSTD, [SiFive7PipeA]>;
-
-let Latency = 3 in {
-def : WriteRes<WriteAtomicW, [SiFive7PipeA]>;
-def : WriteRes<WriteAtomicD, [SiFive7PipeA]>;
-def : WriteRes<WriteAtomicLDW, [SiFive7PipeA]>;
-def : WriteRes<WriteAtomicLDD, [SiFive7PipeA]>;
-}
-
-// Half precision.
-let Latency = 5 in {
-def : WriteRes<WriteFAdd16, [SiFive7PipeB]>;
-def : WriteRes<WriteFMul16, [SiFive7PipeB]>;
-def : WriteRes<WriteFMA16, [SiFive7PipeB]>;
-}
-let Latency = 3 in {
-def : WriteRes<WriteFSGNJ16, [SiFive7PipeB]>;
-def : WriteRes<WriteFMinMax16, [SiFive7PipeB]>;
-}
-
-let Latency = 14, ReleaseAtCycles = [1, 13] in {
-def :  WriteRes<WriteFDiv16, [SiFive7PipeB, SiFive7FDiv]>;
-def :  WriteRes<WriteFSqrt16, [SiFive7PipeB, SiFive7FDiv]>;
-}
-
-// Single precision.
-let Latency = 5 in {
-def : WriteRes<WriteFAdd32, [SiFive7PipeB]>;
-def : WriteRes<WriteFMul32, [SiFive7PipeB]>;
-def : WriteRes<WriteFMA32, [SiFive7PipeB]>;
-}
-let Latency = 3 in {
-def : WriteRes<WriteFSGNJ32, [SiFive7PipeB]>;
-def : WriteRes<WriteFMinMax32, [SiFive7PipeB]>;
-}
-
-def : WriteRes<WriteFDiv32, [SiFive7PipeB, SiFive7FDiv]> { let Latency = 27;
-                                                         let ReleaseAtCycles = [1, 26]; }
-def : WriteRes<WriteFSqrt32, [SiFive7PipeB, SiFive7FDiv]> { let Latency = 27;
-                                                          let ReleaseAtCycles = [1, 26]; }
-
-// Double precision
-let Latency = 7 in {
-def : WriteRes<WriteFAdd64, [SiFive7PipeB]>;
-def : WriteRes<WriteFMul64, [SiFive7PipeB]>;
-def : WriteRes<WriteFMA64, [SiFive7PipeB]>;
-}
-let Latency = 3 in {
-def : WriteRes<WriteFSGNJ64, [SiFive7PipeB]>;
-def : WriteRes<WriteFMinMax64, [SiFive7PipeB]>;
-}
-
-def : WriteRes<WriteFDiv64, [SiFive7PipeB, SiFive7FDiv]> { let Latency = 56;
-                                                         let ReleaseAtCycles = [1, 55]; }
-def : WriteRes<WriteFSqrt64, [SiFive7PipeB, SiFive7FDiv]> { let Latency = 56;
-                                                          let ReleaseAtCycles = [1, 55]; }
-
-// Conversions
-let Latency = 3 in {
-def : WriteRes<WriteFCvtI32ToF16, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtI32ToF32, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtI32ToF64, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtI64ToF16, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtI64ToF32, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtI64ToF64, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF16ToI32, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF16ToI64, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF16ToF32, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF16ToF64, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF32ToI32, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF32ToI64, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF32ToF16, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF32ToF64, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF64ToI32, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF64ToI64, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF64ToF16, [SiFive7PipeB]>;
-def : WriteRes<WriteFCvtF64ToF32, [SiFive7PipeB]>;
-
-def : WriteRes<WriteFClass16, [SiFive7PipeB]>;
-def : WriteRes<WriteFClass32, [SiFive7PipeB]>;
-def : WriteRes<WriteFClass64, [SiFive7PipeB]>;
-def : WriteRes<WriteFCmp16, [SiFive7PipeB]>;
-def : WriteRes<WriteFCmp32, [SiFive7PipeB]>;
-def : WriteRes<WriteFCmp64, [SiFive7PipeB]>;
-def : WriteRes<WriteFMovI16ToF16, [SiFive7PipeB]>;
-def : WriteRes<WriteFMovF16ToI16, [SiFive7PipeB]>;
-def : WriteRes<WriteFMovI32ToF32, [SiFive7PipeB]>;
-def : WriteRes<WriteFMovF32ToI32, [SiFive7PipeB]>;
-def : WriteRes<WriteFMovI64ToF64, [SiFive7PipeB]>;
-def : WriteRes<WriteFMovF64ToI64, [SiFive7PipeB]>;
-}
-
-// 6. Configuration-Setting Instructions
-let Latency = 3 in {
-def : WriteRes<WriteVSETVLI, [SiFive7PipeA]>;
-def : WriteRes<WriteVSETIVLI, [SiFive7PipeA]>;
-def : WriteRes<WriteVSETVL, [SiFive7PipeA]>;
-}
-
-// 7. Vector Loads and Stores
-// Unit-stride loads and stores can operate at the full bandwidth of the memory
-// pipe. The memory pipe is DLEN bits wide on x280.
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVLDE",    [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDFF",   [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-  }
-  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
-  defm "" : LMULWriteResMX<"WriteVSTE",    [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-}
-
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetMaskLoadStoreCycles<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
-  defm "" : LMULWriteResMX<"WriteVLDM",    [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
-  defm "" : LMULWriteResMX<"WriteVSTM",    [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-}
-
-// Strided loads and stores operate at one element per cycle and should be
-// scheduled accordingly. Indexed loads and stores operate at one element per
-// cycle, and they stall the machine until all addresses have been generated,
-// so they cannot be scheduled. Indexed and strided loads and stores have LMUL
-// specific suffixes, but since SEW is already encoded in the name of the
-// resource, we do not need to use LMULSEWXXX constructors. However, we do
-// use the SEW from the name to determine the number of Cycles.
-
-foreach mx = SchedMxList in {
-  defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 8, SiFive7VLEN>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS8",  VLDSX0Pred, [SiFive7VCQ, SiFive7VL],
-                                       4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
-                                       [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
-  let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVLDUX8", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX8", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-  }
-  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVSTS8",  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX8", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX8", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-  }
-}
-// TODO: The MxLists need to be filtered by EEW. We only need to support
-// LMUL >= SEW_min/ELEN. Here, the smallest EEW prevents us from having MF8
-// since LMUL >= 16/64.
-foreach mx = ["MF4", "MF2", "M1", "M2", "M4", "M8"] in {
-  defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 16, SiFive7VLEN>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS16",  VLDSX0Pred, [SiFive7VCQ, SiFive7VL],
-                                       4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
-                                       [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
-  let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVLDUX16", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX16", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-  }
-  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVSTS16",  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX16", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX16", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-  }
-}
-foreach mx = ["MF2", "M1", "M2", "M4", "M8"] in {
-  defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 32, SiFive7VLEN>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS32",  VLDSX0Pred, [SiFive7VCQ, SiFive7VL],
-                                       4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
-                                       [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
-  let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVLDUX32", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX32", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-  }
-  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVSTS32",  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX32", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX32", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-  }
-}
-foreach mx = ["M1", "M2", "M4", "M8"] in {
-  defvar VLDSX0Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar Cycles = SiFive7GetCyclesOnePerElement<mx, 64, SiFive7VLEN>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  defm SiFive7 : LMULWriteResMXVariant<"WriteVLDS64",  VLDSX0Pred, [SiFive7VCQ, SiFive7VL],
-                                       4, [0, 1], [1, !add(1, VLDSX0Cycles)], !add(3, Cycles),
-                                       [0, 1], [1, !add(1, Cycles)], mx, IsWorstCase>;
-  let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVLDUX64", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX64", [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-  }
-  let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVSTS64",  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX64", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX64", [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-  }
-}
-
-// VLD*R is LMUL aware
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
-  def : WriteRes<WriteVLD1R,  [SiFive7VCQ, SiFive7VL]>;
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
-  def : WriteRes<WriteVLD2R,  [SiFive7VCQ, SiFive7VL]>;
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
-  def : WriteRes<WriteVLD4R,  [SiFive7VCQ, SiFive7VL]>;
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
-  def : WriteRes<WriteVLD8R,  [SiFive7VCQ, SiFive7VL]>;
-// VST*R is LMUL aware
-let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
-  def : WriteRes<WriteVST1R,   [SiFive7VCQ, SiFive7VS]>;
-let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
-  def : WriteRes<WriteVST2R,   [SiFive7VCQ, SiFive7VS]>;
-let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
-  def : WriteRes<WriteVST4R,   [SiFive7VCQ, SiFive7VS]>;
-let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
-  def : WriteRes<WriteVST8R,   [SiFive7VCQ, SiFive7VS]>;
-
-// Segmented Loads and Stores
-// Unit-stride segmented loads and stores are effectively converted into strided
-// segment loads and stores. Strided segment loads and stores operate at up to
-// one segment per cycle if the segment fits within one aligned memory beat.
-// Indexed segment loads and stores operate at the same rate as strided ones,
-// but they stall the machine until all addresses have been generated.
-foreach mx = SchedMxList in {
-  foreach eew = [8, 16, 32, 64] in {
-    defvar Cycles = SiFive7GetCyclesSegmentedSeg2<mx>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-    // Does not chain so set latency high
-    let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULWriteResMX<"WriteVLSEG2e" # eew,   [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVLSEGFF2e" # eew, [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-    }
-    let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
-    defm "" : LMULWriteResMX<"WriteVSSEG2e" # eew,   [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    foreach nf=3-8 in {
-      defvar Cycles = SiFive7GetCyclesSegmented<mx, eew, nf, SiFive7VLEN>.c;
-      defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-      // Does not chain so set latency high
-      let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-        defm "" : LMULWriteResMX<"WriteVLSEG" # nf # "e" # eew,   [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" # eew, [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-      }
-      let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
-      defm "" : LMULWriteResMX<"WriteVSSEG" # nf # "e" # eew,   [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-    }
-  }
-}
-foreach mx = SchedMxList in {
-  foreach nf=2-8 in {
-    foreach eew = [8, 16, 32, 64] in {
-      defvar Cycles = SiFive7GetCyclesSegmented<mx, eew, nf, SiFive7VLEN>.c;
-      defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-      // Does not chain so set latency high
-      let Latency = !add(3, Cycles), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-        defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" # eew,  [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" # eew, [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" # eew, [SiFive7VCQ, SiFive7VL], mx, IsWorstCase>;
-      }
-      let Latency = 1, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-        defm "" : LMULWriteResMX<"WriteVSSSEG" # nf # "e" # eew,  [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" # eew, [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-        defm "" : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" # eew, [SiFive7VCQ, SiFive7VS], mx, IsWorstCase>;
-      }
-    }
-  }
-}
-
-// 11. Vector Integer Arithmetic Instructions
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVIALUV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIALUX",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIALUI",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUI",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUMV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUMX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICALUMI",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMinMaxV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMinMaxX",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMergeV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMergeX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMergeI",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMovV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMovX",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMovI",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVShiftV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVShiftX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVShiftI",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMulV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMulX",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMulAddV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIMulAddX",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-  // Mask results can't chain.
-  let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVICmpV",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICmpX",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVICmpI",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVExtV",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-foreach mx = SchedMxList in {
-  foreach sew = SchedSEWSet<mx>.val in {
-    defvar Cycles = !mul(SiFive7GetDivOrSqrtFactor<sew>.c,
-                         !div(SiFive7GetCyclesOnePerElement<mx, sew, SiFive7VLEN>.c, 4));
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
-    let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVIDivV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVIDivX", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-    }
-  }
-}
-
-// Widening
-foreach mx = SchedMxListW in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVIWALUV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWALUX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWALUI",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWMulV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWMulX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWMulAddV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIWMulAddX", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-// Narrowing
-foreach mx = SchedMxListW in {
-  defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVNShiftV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVNShiftX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVNShiftI",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-
-// 12. Vector Fixed-Point Arithmetic Instructions
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVSALUV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSALUX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSALUI",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVAALUV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVAALUX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSMulV",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSMulX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSShiftV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSShiftX", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSShiftI", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-// Narrowing
-foreach mx = SchedMxListW in {
-  defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVNClipV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVNClipX",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVNClipI",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-
-// 13. Vector Floating-Point Instructions
-foreach mx = SchedMxListF in {
-  foreach sew = SchedSEWSet<mx, isF=1>.val in {
-    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListF, isF=1>.c;
-    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFALUV",  [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFALUF",  [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFMulV",  [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFMulF",  [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFMulAddV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFMulAddF", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFRecpV",   [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFCvtIToFV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-    }
-    let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFMinMaxV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFMinMaxF", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFSgnjV",   [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFSgnjF",   [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-    }
-  }
-}
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVFCvtFToIV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVFClassV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMergeV",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFMovV",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-  // Mask results can't chain.
-  let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVFCmpV",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFCmpF",      [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-foreach mx = SchedMxListF in {
-  foreach sew = SchedSEWSet<mx, isF=1>.val in {
-    defvar Cycles = !mul(SiFive7GetDivOrSqrtFactor<sew>.c,
-                         !div(SiFive7GetCyclesOnePerElement<mx, sew, SiFive7VLEN>.c, 4));
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListF, 1>.c;
-    let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFSqrtV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFDivV",  [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFDivF",  [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-    }
-  }
-}
-
-// Widening
-foreach mx = SchedMxListW in {
-  foreach sew = SchedSEWSet<mx, isF=0, isWidening=1>.val in {
-    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListW>.c;
-    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVFWCvtIToFV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-  }
-}
-foreach mx = SchedMxListFW in {
-  foreach sew = SchedSEWSet<mx, isF=1, isWidening=1>.val in {
-    defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListFW, isF=1>.c;
-    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFWALUV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFWALUF", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFWMulV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFWMulF", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFWMulAddV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFWMulAddF", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFWCvtFToFV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-    }
-  }
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListFW>.c;
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
-  defm "" : LMULWriteResMX<"WriteVFWCvtFToIV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-}
-// Narrowing
-foreach mx = SchedMxListW in {
-  defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxListW>.c;
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVFNCvtFToIV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-foreach mx = SchedMxListFW in {
-  foreach sew = SchedSEWSet<mx, isF=1, isWidening=1>.val in {
-    defvar Cycles = SiFive7GetCyclesNarrowing<mx>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListFW, isF=1>.c;
-    let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFNCvtIToFV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFNCvtFToFV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-    }
-  }
-}
-
-// 14. Vector Reduction Operations
-foreach mx = SchedMxList in {
-  foreach sew = SchedSEWSet<mx>.val in {
-    defvar Cycles = SiFive7GetReductionCycles<mx, sew, SiFive7VLEN>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
-    let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVIRedV_From", [SiFive7VCQ, SiFive7VA],
-                                     mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVIRedMinMaxV_From", [SiFive7VCQ, SiFive7VA],
-                                     mx, sew, IsWorstCase>;
-    }
-  }
-}
-
-foreach mx = SchedMxListWRed in {
-  foreach sew = SchedSEWSet<mx, 0, 1>.val in {
-    defvar Cycles = SiFive7GetReductionCycles<mx, sew, SiFive7VLEN>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListWRed>.c;
-    let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVIWRedV_From", [SiFive7VCQ, SiFive7VA],
-                                   mx, sew, IsWorstCase>;
-  }
-}
-
-foreach mx = SchedMxListF in {
-  foreach sew = SchedSEWSet<mx, 1>.val in {
-    defvar RedCycles = SiFive7GetReductionCycles<mx, sew, SiFive7VLEN>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListF, 1>.c;
-    let Latency = RedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, RedCycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFRedV_From", [SiFive7VCQ, SiFive7VA],
-                                     mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVFRedMinMaxV_From", [SiFive7VCQ, SiFive7VA],
-                                     mx, sew, IsWorstCase>;
-    }
-    defvar OrdRedCycles = SiFive7GetOrderedReductionCycles<mx, sew, SiFive7VLEN>.c;
-    let Latency = OrdRedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, OrdRedCycles)] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVFRedOV_From", [SiFive7VCQ, SiFive7VA],
-                                   mx, sew, IsWorstCase>;
-  }
-}
-
-foreach mx = SchedMxListFWRed in {
-  foreach sew = SchedSEWSet<mx, 1, 1>.val in {
-    defvar RedCycles = SiFive7GetReductionCycles<mx, sew, SiFive7VLEN>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxListFWRed, 1>.c;
-    let Latency = RedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, RedCycles)] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVFWRedV_From", [SiFive7VCQ, SiFive7VA],
-                                   mx, sew, IsWorstCase>;
-    defvar OrdRedCycles = SiFive7GetOrderedReductionCycles<mx, sew, SiFive7VLEN>.c;
-    let Latency = OrdRedCycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, OrdRedCycles)] in
-    defm "" : LMULSEWWriteResMXSEW<"WriteVFWRedOV_From", [SiFive7VCQ, SiFive7VA],
-                                   mx, sew, IsWorstCase>;
-  }
-}
-
-// 15. Vector Mask Instructions
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesVMask<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVMALUV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVMPopV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVMFFSV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVMSFSV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVIotaV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVIdxV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-
-// 16. Vector Permutation Instructions
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 1)] in {
-  def : WriteRes<WriteVMovSX, [SiFive7VCQ, SiFive7VA]>;
-  def : WriteRes<WriteVMovXS, [SiFive7VCQ, SiFive7VA]>;
-  def : WriteRes<WriteVMovSF, [SiFive7VCQ, SiFive7VA]>;
-  def : WriteRes<WriteVMovFS, [SiFive7VCQ, SiFive7VA]>;
-}
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 8, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVRGatherVX",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVRGatherVI",    [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-
-foreach mx = SchedMxList in {
-  foreach sew = SchedSEWSet<mx>.val in {
-    defvar Cycles = SiFive7GetCyclesOnePerElement<mx, sew, SiFive7VLEN>.c;
-    defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
-    let Latency = !add(Cycles, 3), AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-      defm "" : LMULSEWWriteResMXSEW<"WriteVRGatherVV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVRGatherEI16VV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-      defm "" : LMULSEWWriteResMXSEW<"WriteVCompressV", [SiFive7VCQ, SiFive7VA], mx, sew, IsWorstCase>;
-    }
-  }
-}
-
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVSlideUpX",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSlideDownX", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSlideI",     [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVISlide1X",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVFSlide1F",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-  }
-}
-
-// VMov*V is LMUL Aware
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 2)] in
-  def : WriteRes<WriteVMov1V,     [SiFive7VCQ, SiFive7VA]>;
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 4)] in
-  def : WriteRes<WriteVMov2V,     [SiFive7VCQ, SiFive7VA]>;
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 8)] in
-  def : WriteRes<WriteVMov4V,     [SiFive7VCQ, SiFive7VA]>;
-let Latency = 4, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, 16)] in
-  def : WriteRes<WriteVMov8V,     [SiFive7VCQ, SiFive7VA]>;
-
-// Others
-def : WriteRes<WriteCSR, [SiFive7PipeB]>;
-def : WriteRes<WriteNop, []>;
-let Latency = 3 in
-  def : WriteRes<WriteRdVLENB, [SiFive7PipeB]>;
-
-def : InstRW<[WriteIALU], (instrs COPY)>;
-
-// VCIX
-//
-// In principle we don't know the latency of any VCIX instructions (they
-// depends on a particular coprocessor implementation). However, the default
-// latency of 1 can lead to issues [1]. So instead we set the latency to the
-// default provided by `SiFive7GetCyclesDefault`. This is still not accurate
-// and can lead to suboptimal codegen, but should hopefully be a better
-// starting point.
-//
-// [1] https://github.com/llvm/llvm-project/issues/83391
-foreach mx = SchedMxList in {
-  defvar Cycles = SiFive7GetCyclesDefault<mx>.c;
-  defvar IsWorstCase = SiFive7IsWorstCaseMX<mx, SchedMxList>.c;
-  let Latency = Cycles,
-      AcquireAtCycles = [0, 1],
-      ReleaseAtCycles = [1, !add(1, Cycles)] in {
-    defm "" : LMULWriteResMX<"WriteVC_V_I",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_X",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_IV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_VV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_XV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_IVV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_IVW", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_VVV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_VVW", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_XVV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_V_XVW", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    foreach f = ["FPR16", "FPR32", "FPR64"] in {
-      defm "" : LMULWriteResMX<"WriteVC_V_" # f # "V",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVC_V_" # f # "VV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVC_V_" # f # "VW", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    }
-    defm "" : LMULWriteResMX<"WriteVC_I",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_X",   [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_IV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_VV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_XV",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_IVV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_IVW", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_VVV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_VVW", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_XVV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVC_XVW", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    foreach f = ["FPR16", "FPR32", "FPR64"] in {
-      defm "" : LMULWriteResMX<"WriteVC_" # f # "V",  [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVC_" # f # "VV", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVC_" # f # "VW", [SiFive7VCQ, SiFive7VA], mx, IsWorstCase>;
-    }
-  }
-}
-
-//===----------------------------------------------------------------------===//
-
-// Bypass and advance
-def : SiFive7AnyToGPRBypass<ReadJmp>;
-def : SiFive7AnyToGPRBypass<ReadJalr>;
-def : ReadAdvance<ReadCSR, 0>;
-def : SiFive7AnyToGPRBypass<ReadStoreData>;
-def : ReadAdvance<ReadMemBase, 0>;
-def : SiFive7AnyToGPRBypass<ReadIALU>;
-def : SiFive7AnyToGPRBypass<ReadIALU32>;
-def : SiFive7AnyToGPRBypass<ReadShiftImm>;
-def : SiFive7AnyToGPRBypass<ReadShiftImm32>;
-def : SiFive7AnyToGPRBypass<ReadShiftReg>;
-def : SiFive7AnyToGPRBypass<ReadShiftReg32>;
-def : ReadAdvance<ReadIDiv, 0>;
-def : ReadAdvance<ReadIDiv32, 0>;
-def : ReadAdvance<ReadIRem, 0>;
-def : ReadAdvance<ReadIRem32, 0>;
-def : ReadAdvance<ReadIMul, 0>;
-def : ReadAdvance<ReadIMul32, 0>;
-def : ReadAdvance<ReadAtomicWA, 0>;
-def : ReadAdvance<ReadAtomicWD, 0>;
-def : ReadAdvance<ReadAtomicDA, 0>;
-def : ReadAdvance<ReadAtomicDD, 0>;
-def : ReadAdvance<ReadAtomicLDW, 0>;
-def : ReadAdvance<ReadAtomicLDD, 0>;
-def : ReadAdvance<ReadAtomicSTW, 0>;
-def : ReadAdvance<ReadAtomicSTD, 0>;
-def : ReadAdvance<ReadFStoreData, 0>;
-def : ReadAdvance<ReadFMemBase, 0>;
-def : ReadAdvance<ReadFAdd16, 0>;
-def : ReadAdvance<ReadFAdd32, 0>;
-def : ReadAdvance<ReadFAdd64, 0>;
-def : ReadAdvance<ReadFMul16, 0>;
-def : ReadAdvance<ReadFMA16, 0>;
-def : ReadAdvance<ReadFMA16Addend, 0>;
-def : ReadAdvance<ReadFMul32, 0>;
-def : ReadAdvance<ReadFMul64, 0>;
-def : ReadAdvance<ReadFMA32, 0>;
-def : ReadAdvance<ReadFMA32Addend, 0>;
-def : ReadAdvance<ReadFMA64, 0>;
-def : ReadAdvance<ReadFMA64Addend, 0>;
-def : ReadAdvance<ReadFDiv16, 0>;
-def : ReadAdvance<ReadFDiv32, 0>;
-def : ReadAdvance<ReadFDiv64, 0>;
-def : ReadAdvance<ReadFSqrt16, 0>;
-def : ReadAdvance<ReadFSqrt32, 0>;
-def : ReadAdvance<ReadFSqrt64, 0>;
-def : ReadAdvance<ReadFCmp16, 0>;
-def : ReadAdvance<ReadFCmp32, 0>;
-def : ReadAdvance<ReadFCmp64, 0>;
-def : ReadAdvance<ReadFSGNJ16, 0>;
-def : ReadAdvance<ReadFSGNJ32, 0>;
-def : ReadAdvance<ReadFSGNJ64, 0>;
-def : ReadAdvance<ReadFMinMax16, 0>;
-def : ReadAdvance<ReadFMinMax32, 0>;
-def : ReadAdvance<ReadFMinMax64, 0>;
-def : ReadAdvance<ReadFCvtF16ToI32, 0>;
-def : ReadAdvance<ReadFCvtF16ToI64, 0>;
-def : ReadAdvance<ReadFCvtF32ToI32, 0>;
-def : ReadAdvance<ReadFCvtF32ToI64, 0>;
-def : ReadAdvance<ReadFCvtF64ToI32, 0>;
-def : ReadAdvance<ReadFCvtF64ToI64, 0>;
-def : ReadAdvance<ReadFCvtI32ToF16, 0>;
-def : ReadAdvance<ReadFCvtI32ToF32, 0>;
-def : ReadAdvance<ReadFCvtI32ToF64, 0>;
-def : ReadAdvance<ReadFCvtI64ToF16, 0>;
-def : ReadAdvance<ReadFCvtI64ToF32, 0>;
-def : ReadAdvance<ReadFCvtI64ToF64, 0>;
-def : ReadAdvance<ReadFCvtF32ToF64, 0>;
-def : ReadAdvance<ReadFCvtF64ToF32, 0>;
-def : ReadAdvance<ReadFCvtF16ToF32, 0>;
-def : ReadAdvance<ReadFCvtF32ToF16, 0>;
-def : ReadAdvance<ReadFCvtF16ToF64, 0>;
-def : ReadAdvance<ReadFCvtF64ToF16, 0>;
-def : ReadAdvance<ReadFMovF16ToI16, 0>;
-def : ReadAdvance<ReadFMovI16ToF16, 0>;
-def : ReadAdvance<ReadFMovF32ToI32, 0>;
-def : ReadAdvance<ReadFMovI32ToF32, 0>;
-def : ReadAdvance<ReadFMovF64ToI64, 0>;
-def : ReadAdvance<ReadFMovI64ToF64, 0>;
-def : ReadAdvance<ReadFClass16, 0>;
-def : ReadAdvance<ReadFClass32, 0>;
-def : ReadAdvance<ReadFClass64, 0>;
-
-def : SiFive7AnyToGPRBypass<ReadSFBJmp, 0>;
-def : SiFive7AnyToGPRBypass<ReadSFBALU, 0>;
-
-// Bitmanip
-def : SiFive7AnyToGPRBypass<ReadRotateImm>;
-def : SiFive7AnyToGPRBypass<ReadRotateImm32>;
-def : SiFive7AnyToGPRBypass<ReadRotateReg>;
-def : SiFive7AnyToGPRBypass<ReadRotateReg32>;
-def : SiFive7AnyToGPRBypass<ReadCLZ>;
-def : SiFive7AnyToGPRBypass<ReadCLZ32>;
-def : SiFive7AnyToGPRBypass<ReadCTZ>;
-def : SiFive7AnyToGPRBypass<ReadCTZ32>;
-def : ReadAdvance<ReadCPOP, 0>;
-def : ReadAdvance<ReadCPOP32, 0>;
-def : SiFive7AnyToGPRBypass<ReadORCB>;
-def : SiFive7AnyToGPRBypass<ReadIMinMax>;
-def : SiFive7AnyToGPRBypass<ReadREV8>;
-def : SiFive7AnyToGPRBypass<ReadSHXADD>;
-def : SiFive7AnyToGPRBypass<ReadSHXADD32>;
-// Single-bit instructions
-def : SiFive7AnyToGPRBypass<ReadSingleBit>;
-def : SiFive7AnyToGPRBypass<ReadSingleBitImm>;
-
-// 6. Configuration-Setting Instructions
-def : ReadAdvance<ReadVSETVLI, 2>;
-def : ReadAdvance<ReadVSETVL, 2>;
-
-// 7. Vector Loads and Stores
-def : ReadAdvance<ReadVLDX, 0>;
-def : ReadAdvance<ReadVSTX, 0>;
-defm "" : LMULReadAdvance<"ReadVSTEV", 0>;
-defm "" : LMULReadAdvance<"ReadVSTM", 0>;
-def : ReadAdvance<ReadVLDSX, 0>;
-def : ReadAdvance<ReadVSTSX, 0>;
-defm "" : LMULReadAdvance<"ReadVSTS8V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTS16V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTS32V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTS64V", 0>;
-defm "" : LMULReadAdvance<"ReadVLDUXV", 0>;
-defm "" : LMULReadAdvance<"ReadVLDOXV", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUX8", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUX16", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUX32", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUX64", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUXV", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUX8V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUX16V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUX32V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTUX64V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOX8", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOX16", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOX32", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOX64", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOXV", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOX8V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOX16V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOX32V", 0>;
-defm "" : LMULReadAdvance<"ReadVSTOX64V", 0>;
-// LMUL Aware
-def : ReadAdvance<ReadVST1R, 0>;
-def : ReadAdvance<ReadVST2R, 0>;
-def : ReadAdvance<ReadVST4R, 0>;
-def : ReadAdvance<ReadVST8R, 0>;
-
-// 12. Vector Integer Arithmetic Instructions
-defm : LMULReadAdvance<"ReadVIALUV", 0>;
-defm : LMULReadAdvance<"ReadVIALUX", 0>;
-defm : LMULReadAdvanceW<"ReadVIWALUV", 0>;
-defm : LMULReadAdvanceW<"ReadVIWALUX", 0>;
-defm : LMULReadAdvance<"ReadVExtV", 0>;
-defm : LMULReadAdvance<"ReadVICALUV", 0>;
-defm : LMULReadAdvance<"ReadVICALUX", 0>;
-defm : LMULReadAdvance<"ReadVShiftV", 0>;
-defm : LMULReadAdvance<"ReadVShiftX", 0>;
-defm : LMULReadAdvanceW<"ReadVNShiftV", 0>;
-defm : LMULReadAdvanceW<"ReadVNShiftX", 0>;
-defm : LMULReadAdvance<"ReadVICmpV", 0>;
-defm : LMULReadAdvance<"ReadVICmpX", 0>;
-defm : LMULReadAdvance<"ReadVIMinMaxV", 0>;
-defm : LMULReadAdvance<"ReadVIMinMaxX", 0>;
-defm : LMULReadAdvance<"ReadVIMulV", 0>;
-defm : LMULReadAdvance<"ReadVIMulX", 0>;
-defm : LMULSEWReadAdvance<"ReadVIDivV", 0>;
-defm : LMULSEWReadAdvance<"ReadVIDivX", 0>;
-defm : LMULReadAdvanceW<"ReadVIWMulV", 0>;
-defm : LMULReadAdvanceW<"ReadVIWMulX", 0>;
-defm : LMULReadAdvance<"ReadVIMulAddV", 0>;
-defm : LMULReadAdvance<"ReadVIMulAddX", 0>;
-defm : LMULReadAdvanceW<"ReadVIWMulAddV", 0>;
-defm : LMULReadAdvanceW<"ReadVIWMulAddX", 0>;
-defm : LMULReadAdvance<"ReadVIMergeV", 0>;
-defm : LMULReadAdvance<"ReadVIMergeX", 0>;
-defm : LMULReadAdvance<"ReadVIMovV", 0>;
-defm : LMULReadAdvance<"ReadVIMovX", 0>;
-
-// 13. Vector Fixed-Point Arithmetic Instructions
-defm "" : LMULReadAdvance<"ReadVSALUV", 0>;
-defm "" : LMULReadAdvance<"ReadVSALUX", 0>;
-defm "" : LMULReadAdvance<"ReadVAALUV", 0>;
-defm "" : LMULReadAdvance<"ReadVAALUX", 0>;
-defm "" : LMULReadAdvance<"ReadVSMulV", 0>;
-defm "" : LMULReadAdvance<"ReadVSMulX", 0>;
-defm "" : LMULReadAdvance<"ReadVSShiftV", 0>;
-defm "" : LMULReadAdvance<"ReadVSShiftX", 0>;
-defm "" : LMULReadAdvanceW<"ReadVNClipV", 0>;
-defm "" : LMULReadAdvanceW<"ReadVNClipX", 0>;
-
-// 14. Vector Floating-Point Instructions
-defm "" : LMULSEWReadAdvanceF<"ReadVFALUV", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFALUF", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFWALUV", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFWALUF", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFMulV", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFMulF", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFDivV", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFDivF", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFWMulV", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFWMulF", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFMulAddV", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFMulAddF", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFWMulAddV", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFWMulAddF", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFSqrtV", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFRecpV", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFMinMaxV", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFMinMaxF", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFSgnjV", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFSgnjF", 0>;
-defm "" : LMULReadAdvance<"ReadVFCmpV", 0>;
-defm "" : LMULReadAdvance<"ReadVFCmpF", 0>;
-defm "" : LMULReadAdvance<"ReadVFClassV", 0>;
-defm "" : LMULReadAdvance<"ReadVFMergeV", 0>;
-defm "" : LMULReadAdvance<"ReadVFMergeF", 0>;
-defm "" : LMULReadAdvance<"ReadVFMovF", 0>;
-defm "" : LMULSEWReadAdvanceF<"ReadVFCvtIToFV", 0>;
-defm "" : LMULReadAdvance<"ReadVFCvtFToIV", 0>;
-defm "" : LMULSEWReadAdvanceW<"ReadVFWCvtIToFV", 0>;
-defm "" : LMULReadAdvanceFW<"ReadVFWCvtFToIV", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFWCvtFToFV", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFNCvtIToFV", 0>;
-defm "" : LMULReadAdvanceW<"ReadVFNCvtFToIV", 0>;
-defm "" : LMULSEWReadAdvanceFW<"ReadVFNCvtFToFV", 0>;
-
-// 15. Vector Reduction Operations
-def : ReadAdvance<ReadVIRedV, 0>;
-def : ReadAdvance<ReadVIRedV0, 0>;
-def : ReadAdvance<ReadVIWRedV, 0>;
-def : ReadAdvance<ReadVIWRedV0, 0>;
-def : ReadAdvance<ReadVFRedV, 0>;
-def : ReadAdvance<ReadVFRedV0, 0>;
-def : ReadAdvance<ReadVFRedOV, 0>;
-def : ReadAdvance<ReadVFRedOV0, 0>;
-def : ReadAdvance<ReadVFWRedV, 0>;
-def : ReadAdvance<ReadVFWRedV0, 0>;
-def : ReadAdvance<ReadVFWRedOV, 0>;
-def : ReadAdvance<ReadVFWRedOV0, 0>;
-
-// 16. Vector Mask Instructions
-defm "" : LMULReadAdvance<"ReadVMALUV", 0>;
-defm "" : LMULReadAdvance<"ReadVMPopV", 0>;
-defm "" : LMULReadAdvance<"ReadVMFFSV", 0>;
-defm "" : LMULReadAdvance<"ReadVMSFSV", 0>;
-defm "" : LMULReadAdvance<"ReadVIotaV", 0>;
-
-// 17. Vector Permutation Instructions
-def : ReadAdvance<ReadVMovXS, 0>;
-def : ReadAdvance<ReadVMovSX_V, 0>;
-def : ReadAdvance<ReadVMovSX_X, 0>;
-def : ReadAdvance<ReadVMovFS, 0>;
-def : ReadAdvance<ReadVMovSF_V, 0>;
-def : ReadAdvance<ReadVMovSF_F, 0>;
-defm "" : LMULReadAdvance<"ReadVISlideV", 0>;
-defm "" : LMULReadAdvance<"ReadVISlideX", 0>;
-defm "" : LMULReadAdvance<"ReadVFSlideV", 0>;
-defm "" : LMULReadAdvance<"ReadVFSlideF", 0>;
-defm "" : LMULSEWReadAdvance<"ReadVRGatherVV_data", 0>;
-defm "" : LMULSEWReadAdvance<"ReadVRGatherVV_index", 0>;
-defm "" : LMULSEWReadAdvance<"ReadVRGatherEI16VV_data", 0>;
-defm "" : LMULSEWReadAdvance<"ReadVRGatherEI16VV_index", 0>;
-defm "" : LMULReadAdvance<"ReadVRGatherVX_data", 0>;
-defm "" : LMULReadAdvance<"ReadVRGatherVX_index", 0>;
-defm "" : LMULReadAdvance<"ReadVRGatherVI_data", 0>;
-defm "" : LMULSEWReadAdvance<"ReadVCompressV", 0>;
-// LMUL Aware
-def : ReadAdvance<ReadVMov1V, 0>;
-def : ReadAdvance<ReadVMov2V, 0>;
-def : ReadAdvance<ReadVMov4V, 0>;
-def : ReadAdvance<ReadVMov8V, 0>;
-
-// Others
-def : ReadAdvance<ReadVMask, 0>;
-def : ReadAdvance<ReadVPassthru_WorstCase, 0>;
-foreach mx = SchedMxList in {
-  def : ReadAdvance<!cast<SchedRead>("ReadVPassthru_" # mx), 0>;
-  foreach sew = SchedSEWSet<mx>.val in
-    def : ReadAdvance<!cast<SchedRead>("ReadVPassthru_" # mx  # "_E" # sew), 0>;
-}
-
-//===----------------------------------------------------------------------===//
-// Unsupported extensions
-defm : UnsupportedSchedQ;
-defm : UnsupportedSchedZabha;
-defm : UnsupportedSchedZbc;
-defm : UnsupportedSchedZbkb;
-defm : UnsupportedSchedZbkx;
-defm : UnsupportedSchedZfa;
-defm : UnsupportedSchedZvk;
-}
+/// Models
+def SiFive7VLEN512Model : SiFive7SchedMachineModel<512>;
+
+/// Binding models to their scheduling resources.
+let SchedModel = SiFive7VLEN512Model in
+defm !cast<string>(SiFive7VLEN512Model.Name)
+    : SiFive7SchedResources<SiFive7VLEN512Model.VLEN>;
+
+// Some model name aliases.
+defvar SiFive7Model = SiFive7VLEN512Model;

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/div-fdiv.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/div-fdiv.s
@@ -28,14 +28,14 @@ fdiv.s f1, f2, f3
 # CHECK-NEXT:  1      27    26.00                       fdiv.s	ft1, ft2, ft3
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass-c.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass-c.s
@@ -66,14 +66,14 @@ c.jr a0
 # CHECK-NEXT:  1      3     1.00                        jr	a0
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass.s
@@ -214,14 +214,14 @@ jr a0
 # CHECK-NEXT:  1      3     1.00                        jr	a0
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/instruction-tables-tests.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/instruction-tables-tests.s
@@ -35,48 +35,48 @@
 # NISE-NEXT:  Total uOps:        200
 
 # ISF:        Resources:
-# ISF-NEXT:   [0]   - SiFive7FDiv:1
-# ISF-NEXT:   [1]   - SiFive7IDiv:1
-# ISF-NEXT:   [2]   - SiFive7PipeA:1
-# ISF-NEXT:   [3]   - SiFive7PipeAB:2 SiFive7PipeA, SiFive7PipeB
-# ISF-NEXT:   [4]   - SiFive7PipeB:1
-# ISF-NEXT:   [5]   - SiFive7VA:1
-# ISF-NEXT:   [6]   - SiFive7VCQ:1
-# ISF-NEXT:   [7]   - SiFive7VL:1
-# ISF-NEXT:   [8]   - SiFive7VS:1
+# ISF-NEXT:   [0]   - VLEN512SiFive7FDiv:1
+# ISF-NEXT:   [1]   - VLEN512SiFive7IDiv:1
+# ISF-NEXT:   [2]   - VLEN512SiFive7PipeA:1
+# ISF-NEXT:   [3]   - VLEN512SiFive7PipeAB:2 VLEN512SiFive7PipeA, VLEN512SiFive7PipeB
+# ISF-NEXT:   [4]   - VLEN512SiFive7PipeB:1
+# ISF-NEXT:   [5]   - VLEN512SiFive7VA:1
+# ISF-NEXT:   [6]   - VLEN512SiFive7VCQ:1
+# ISF-NEXT:   [7]   - VLEN512SiFive7VL:1
+# ISF-NEXT:   [8]   - VLEN512SiFive7VS:1
 
 # ISFB:       Resources:
-# ISFB-NEXT:  [0]   - SiFive7FDiv:1
-# ISFB-NEXT:  [1]   - SiFive7IDiv:1
-# ISFB-NEXT:  [2]   - SiFive7PipeA:1
-# ISFB-NEXT:  [3]   - SiFive7PipeAB:2 SiFive7PipeA, SiFive7PipeB
-# ISFB-NEXT:  [4]   - SiFive7PipeB:1
-# ISFB-NEXT:  [5]   - SiFive7VA:1
-# ISFB-NEXT:  [6]   - SiFive7VCQ:1
-# ISFB-NEXT:  [7]   - SiFive7VL:1
-# ISFB-NEXT:  [8]   - SiFive7VS:1
+# ISFB-NEXT:  [0]   - VLEN512SiFive7FDiv:1
+# ISFB-NEXT:  [1]   - VLEN512SiFive7IDiv:1
+# ISFB-NEXT:  [2]   - VLEN512SiFive7PipeA:1
+# ISFB-NEXT:  [3]   - VLEN512SiFive7PipeAB:2 VLEN512SiFive7PipeA, VLEN512SiFive7PipeB
+# ISFB-NEXT:  [4]   - VLEN512SiFive7PipeB:1
+# ISFB-NEXT:  [5]   - VLEN512SiFive7VA:1
+# ISFB-NEXT:  [6]   - VLEN512SiFive7VCQ:1
+# ISFB-NEXT:  [7]   - VLEN512SiFive7VL:1
+# ISFB-NEXT:  [8]   - VLEN512SiFive7VS:1
 
 # ISFBE:      Resources:
-# ISFBE-NEXT: [0]   - SiFive7FDiv:1
-# ISFBE-NEXT: [1]   - SiFive7IDiv:1
-# ISFBE-NEXT: [2]   - SiFive7PipeA:1
-# ISFBE-NEXT: [3]   - SiFive7PipeAB:2 SiFive7PipeA, SiFive7PipeB
-# ISFBE-NEXT: [4]   - SiFive7PipeB:1
-# ISFBE-NEXT: [5]   - SiFive7VA:1
-# ISFBE-NEXT: [6]   - SiFive7VCQ:1
-# ISFBE-NEXT: [7]   - SiFive7VL:1
-# ISFBE-NEXT: [8]   - SiFive7VS:1
+# ISFBE-NEXT: [0]   - VLEN512SiFive7FDiv:1
+# ISFBE-NEXT: [1]   - VLEN512SiFive7IDiv:1
+# ISFBE-NEXT: [2]   - VLEN512SiFive7PipeA:1
+# ISFBE-NEXT: [3]   - VLEN512SiFive7PipeAB:2 VLEN512SiFive7PipeA, VLEN512SiFive7PipeB
+# ISFBE-NEXT: [4]   - VLEN512SiFive7PipeB:1
+# ISFBE-NEXT: [5]   - VLEN512SiFive7VA:1
+# ISFBE-NEXT: [6]   - VLEN512SiFive7VCQ:1
+# ISFBE-NEXT: [7]   - VLEN512SiFive7VL:1
+# ISFBE-NEXT: [8]   - VLEN512SiFive7VS:1
 
 # ISFE:       Resources:
-# ISFE-NEXT:  [0]   - SiFive7FDiv:1
-# ISFE-NEXT:  [1]   - SiFive7IDiv:1
-# ISFE-NEXT:  [2]   - SiFive7PipeA:1
-# ISFE-NEXT:  [3]   - SiFive7PipeAB:2 SiFive7PipeA, SiFive7PipeB
-# ISFE-NEXT:  [4]   - SiFive7PipeB:1
-# ISFE-NEXT:  [5]   - SiFive7VA:1
-# ISFE-NEXT:  [6]   - SiFive7VCQ:1
-# ISFE-NEXT:  [7]   - SiFive7VL:1
-# ISFE-NEXT:  [8]   - SiFive7VS:1
+# ISFE-NEXT:  [0]   - VLEN512SiFive7FDiv:1
+# ISFE-NEXT:  [1]   - VLEN512SiFive7IDiv:1
+# ISFE-NEXT:  [2]   - VLEN512SiFive7PipeA:1
+# ISFE-NEXT:  [3]   - VLEN512SiFive7PipeAB:2 VLEN512SiFive7PipeA, VLEN512SiFive7PipeB
+# ISFE-NEXT:  [4]   - VLEN512SiFive7PipeB:1
+# ISFE-NEXT:  [5]   - VLEN512SiFive7VA:1
+# ISFE-NEXT:  [6]   - VLEN512SiFive7VCQ:1
+# ISFE-NEXT:  [7]   - VLEN512SiFive7VL:1
+# ISFE-NEXT:  [8]   - VLEN512SiFive7VS:1
 
 # ISN:        Instruction Info:
 # ISN-NEXT:   [1]: #uOps
@@ -216,20 +216,20 @@
 # NISE-NEXT:  [7]: Encoding Size
 
 # ISF:        [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
-# ISF-NEXT:    1      3     1.00                  U      1     SiFive7PipeA,SiFive7PipeAB                 VSETVLI                    vsetvli	a3, a2, e16, m1, tu, mu	// Comment
-# ISF-NEXT:    1      4     2.00    *                    4     SiFive7VCQ,SiFive7VL[1,3]                  VLM_V                      vlm.v	v4, (a1)
+# ISF-NEXT:    1      3     1.00                  U      1     VLEN512SiFive7PipeA,VLEN512SiFive7PipeAB   VSETVLI                    vsetvli	a3, a2, e16, m1, tu, mu	// Comment
+# ISF-NEXT:    1      4     2.00    *                    4     VLEN512SiFive7VCQ,VLEN512SiFive7VL[1,3]    VLM_V                      vlm.v	v4, (a1)
 
 # ISFB:       [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        [10]   [11]   Instructions:
-# ISFB-NEXT:   1      3     1.00                  U      1     SiFive7PipeA,SiFive7PipeAB                 VSETVLI                                  vsetvli	a3, a2, e16, m1, tu, mu	// Comment
-# ISFB-NEXT:   1      4     2.00    *                    4     SiFive7VCQ,SiFive7VL[1,3]                  VLM_V                                    vlm.v	v4, (a1)
+# ISFB-NEXT:   1      3     1.00                  U      1     VLEN512SiFive7PipeA,VLEN512SiFive7PipeAB   VSETVLI                                  vsetvli	a3, a2, e16, m1, tu, mu	// Comment
+# ISFB-NEXT:   1      4     2.00    *                    4     VLEN512SiFive7VCQ,VLEN512SiFive7VL[1,3]    VLM_V                                    vlm.v	v4, (a1)
 
 # ISFBE:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        [10]   [11]   [12]   Encodings:                    Instructions:
-# ISFBE-NEXT:  1      3     1.00                  U      1     SiFive7PipeA,SiFive7PipeAB                 VSETVLI                                   4     d7 76 86 00                   vsetvli	a3, a2, e16, m1, tu, mu	// Comment
-# ISFBE-NEXT:  1      4     2.00    *                    4     SiFive7VCQ,SiFive7VL[1,3]                  VLM_V                                     4     07 82 b5 02                   vlm.v	v4, (a1)
+# ISFBE-NEXT:  1      3     1.00                  U      1     VLEN512SiFive7PipeA,VLEN512SiFive7PipeAB   VSETVLI                                   4     d7 76 86 00                   vsetvli	a3, a2, e16, m1, tu, mu	// Comment
+# ISFBE-NEXT:  1      4     2.00    *                    4     VLEN512SiFive7VCQ,VLEN512SiFive7VL[1,3]    VLM_V                                     4     07 82 b5 02                   vlm.v	v4, (a1)
 
 # ISFE:       [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        [10]   Encodings:                    Instructions:
-# ISFE-NEXT:   1      3     1.00                  U      1     SiFive7PipeA,SiFive7PipeAB                 VSETVLI                     4     d7 76 86 00                   vsetvli	a3, a2, e16, m1, tu, mu	// Comment
-# ISFE-NEXT:   1      4     2.00    *                    4     SiFive7VCQ,SiFive7VL[1,3]                  VLM_V                       4     07 82 b5 02                   vlm.v	v4, (a1)
+# ISFE-NEXT:   1      3     1.00                  U      1     VLEN512SiFive7PipeA,VLEN512SiFive7PipeAB   VSETVLI                     4     d7 76 86 00                   vsetvli	a3, a2, e16, m1, tu, mu	// Comment
+# ISFE-NEXT:   1      4     2.00    *                    4     VLEN512SiFive7VCQ,VLEN512SiFive7VL[1,3]    VLM_V                       4     07 82 b5 02                   vlm.v	v4, (a1)
 
 # ISNB:       [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    Instructions:
 # ISNB-NEXT:   1      3     1.00                  U                   vsetvli	a3, a2, e16, m1, tu, mu
@@ -256,114 +256,114 @@
 # NISE-NEXT:   1      4     2.00    *                    4     07 82 b5 02                   vlm.v	v4, (a1)
 
 # ISN:        Resources:
-# ISN-NEXT:   [0]   - SiFive7FDiv
-# ISN-NEXT:   [1]   - SiFive7IDiv
-# ISN-NEXT:   [2]   - SiFive7PipeA
-# ISN-NEXT:   [3]   - SiFive7PipeB
-# ISN-NEXT:   [4]   - SiFive7VA
-# ISN-NEXT:   [5]   - SiFive7VCQ
-# ISN-NEXT:   [6]   - SiFive7VL
-# ISN-NEXT:   [7]   - SiFive7VS
+# ISN-NEXT:   [0]   - VLEN512SiFive7FDiv
+# ISN-NEXT:   [1]   - VLEN512SiFive7IDiv
+# ISN-NEXT:   [2]   - VLEN512SiFive7PipeA
+# ISN-NEXT:   [3]   - VLEN512SiFive7PipeB
+# ISN-NEXT:   [4]   - VLEN512SiFive7VA
+# ISN-NEXT:   [5]   - VLEN512SiFive7VCQ
+# ISN-NEXT:   [6]   - VLEN512SiFive7VL
+# ISN-NEXT:   [7]   - VLEN512SiFive7VS
 
 # ISF:        Resources:
-# ISF-NEXT:   [0]   - SiFive7FDiv
-# ISF-NEXT:   [1]   - SiFive7IDiv
-# ISF-NEXT:   [2]   - SiFive7PipeA
-# ISF-NEXT:   [3]   - SiFive7PipeB
-# ISF-NEXT:   [4]   - SiFive7VA
-# ISF-NEXT:   [5]   - SiFive7VCQ
-# ISF-NEXT:   [6]   - SiFive7VL
-# ISF-NEXT:   [7]   - SiFive7VS
+# ISF-NEXT:   [0]   - VLEN512SiFive7FDiv
+# ISF-NEXT:   [1]   - VLEN512SiFive7IDiv
+# ISF-NEXT:   [2]   - VLEN512SiFive7PipeA
+# ISF-NEXT:   [3]   - VLEN512SiFive7PipeB
+# ISF-NEXT:   [4]   - VLEN512SiFive7VA
+# ISF-NEXT:   [5]   - VLEN512SiFive7VCQ
+# ISF-NEXT:   [6]   - VLEN512SiFive7VL
+# ISF-NEXT:   [7]   - VLEN512SiFive7VS
 
 # ISFB:       Resources:
-# ISFB-NEXT:  [0]   - SiFive7FDiv
-# ISFB-NEXT:  [1]   - SiFive7IDiv
-# ISFB-NEXT:  [2]   - SiFive7PipeA
-# ISFB-NEXT:  [3]   - SiFive7PipeB
-# ISFB-NEXT:  [4]   - SiFive7VA
-# ISFB-NEXT:  [5]   - SiFive7VCQ
-# ISFB-NEXT:  [6]   - SiFive7VL
-# ISFB-NEXT:  [7]   - SiFive7VS
+# ISFB-NEXT:  [0]   - VLEN512SiFive7FDiv
+# ISFB-NEXT:  [1]   - VLEN512SiFive7IDiv
+# ISFB-NEXT:  [2]   - VLEN512SiFive7PipeA
+# ISFB-NEXT:  [3]   - VLEN512SiFive7PipeB
+# ISFB-NEXT:  [4]   - VLEN512SiFive7VA
+# ISFB-NEXT:  [5]   - VLEN512SiFive7VCQ
+# ISFB-NEXT:  [6]   - VLEN512SiFive7VL
+# ISFB-NEXT:  [7]   - VLEN512SiFive7VS
 
 # ISFBE:      Resources:
-# ISFBE-NEXT: [0]   - SiFive7FDiv
-# ISFBE-NEXT: [1]   - SiFive7IDiv
-# ISFBE-NEXT: [2]   - SiFive7PipeA
-# ISFBE-NEXT: [3]   - SiFive7PipeB
-# ISFBE-NEXT: [4]   - SiFive7VA
-# ISFBE-NEXT: [5]   - SiFive7VCQ
-# ISFBE-NEXT: [6]   - SiFive7VL
-# ISFBE-NEXT: [7]   - SiFive7VS
+# ISFBE-NEXT: [0]   - VLEN512SiFive7FDiv
+# ISFBE-NEXT: [1]   - VLEN512SiFive7IDiv
+# ISFBE-NEXT: [2]   - VLEN512SiFive7PipeA
+# ISFBE-NEXT: [3]   - VLEN512SiFive7PipeB
+# ISFBE-NEXT: [4]   - VLEN512SiFive7VA
+# ISFBE-NEXT: [5]   - VLEN512SiFive7VCQ
+# ISFBE-NEXT: [6]   - VLEN512SiFive7VL
+# ISFBE-NEXT: [7]   - VLEN512SiFive7VS
 
 # ISFE:       Resources:
-# ISFE-NEXT:  [0]   - SiFive7FDiv
-# ISFE-NEXT:  [1]   - SiFive7IDiv
-# ISFE-NEXT:  [2]   - SiFive7PipeA
-# ISFE-NEXT:  [3]   - SiFive7PipeB
-# ISFE-NEXT:  [4]   - SiFive7VA
-# ISFE-NEXT:  [5]   - SiFive7VCQ
-# ISFE-NEXT:  [6]   - SiFive7VL
-# ISFE-NEXT:  [7]   - SiFive7VS
+# ISFE-NEXT:  [0]   - VLEN512SiFive7FDiv
+# ISFE-NEXT:  [1]   - VLEN512SiFive7IDiv
+# ISFE-NEXT:  [2]   - VLEN512SiFive7PipeA
+# ISFE-NEXT:  [3]   - VLEN512SiFive7PipeB
+# ISFE-NEXT:  [4]   - VLEN512SiFive7VA
+# ISFE-NEXT:  [5]   - VLEN512SiFive7VCQ
+# ISFE-NEXT:  [6]   - VLEN512SiFive7VL
+# ISFE-NEXT:  [7]   - VLEN512SiFive7VS
 
 # ISNB:       Resources:
-# ISNB-NEXT:  [0]   - SiFive7FDiv
-# ISNB-NEXT:  [1]   - SiFive7IDiv
-# ISNB-NEXT:  [2]   - SiFive7PipeA
-# ISNB-NEXT:  [3]   - SiFive7PipeB
-# ISNB-NEXT:  [4]   - SiFive7VA
-# ISNB-NEXT:  [5]   - SiFive7VCQ
-# ISNB-NEXT:  [6]   - SiFive7VL
-# ISNB-NEXT:  [7]   - SiFive7VS
+# ISNB-NEXT:  [0]   - VLEN512SiFive7FDiv
+# ISNB-NEXT:  [1]   - VLEN512SiFive7IDiv
+# ISNB-NEXT:  [2]   - VLEN512SiFive7PipeA
+# ISNB-NEXT:  [3]   - VLEN512SiFive7PipeB
+# ISNB-NEXT:  [4]   - VLEN512SiFive7VA
+# ISNB-NEXT:  [5]   - VLEN512SiFive7VCQ
+# ISNB-NEXT:  [6]   - VLEN512SiFive7VL
+# ISNB-NEXT:  [7]   - VLEN512SiFive7VS
 
 # ISNBE:      Resources:
-# ISNBE-NEXT: [0]   - SiFive7FDiv
-# ISNBE-NEXT: [1]   - SiFive7IDiv
-# ISNBE-NEXT: [2]   - SiFive7PipeA
-# ISNBE-NEXT: [3]   - SiFive7PipeB
-# ISNBE-NEXT: [4]   - SiFive7VA
-# ISNBE-NEXT: [5]   - SiFive7VCQ
-# ISNBE-NEXT: [6]   - SiFive7VL
-# ISNBE-NEXT: [7]   - SiFive7VS
+# ISNBE-NEXT: [0]   - VLEN512SiFive7FDiv
+# ISNBE-NEXT: [1]   - VLEN512SiFive7IDiv
+# ISNBE-NEXT: [2]   - VLEN512SiFive7PipeA
+# ISNBE-NEXT: [3]   - VLEN512SiFive7PipeB
+# ISNBE-NEXT: [4]   - VLEN512SiFive7VA
+# ISNBE-NEXT: [5]   - VLEN512SiFive7VCQ
+# ISNBE-NEXT: [6]   - VLEN512SiFive7VL
+# ISNBE-NEXT: [7]   - VLEN512SiFive7VS
 
 # ISNE:       Resources:
-# ISNE-NEXT:  [0]   - SiFive7FDiv
-# ISNE-NEXT:  [1]   - SiFive7IDiv
-# ISNE-NEXT:  [2]   - SiFive7PipeA
-# ISNE-NEXT:  [3]   - SiFive7PipeB
-# ISNE-NEXT:  [4]   - SiFive7VA
-# ISNE-NEXT:  [5]   - SiFive7VCQ
-# ISNE-NEXT:  [6]   - SiFive7VL
-# ISNE-NEXT:  [7]   - SiFive7VS
+# ISNE-NEXT:  [0]   - VLEN512SiFive7FDiv
+# ISNE-NEXT:  [1]   - VLEN512SiFive7IDiv
+# ISNE-NEXT:  [2]   - VLEN512SiFive7PipeA
+# ISNE-NEXT:  [3]   - VLEN512SiFive7PipeB
+# ISNE-NEXT:  [4]   - VLEN512SiFive7VA
+# ISNE-NEXT:  [5]   - VLEN512SiFive7VCQ
+# ISNE-NEXT:  [6]   - VLEN512SiFive7VL
+# ISNE-NEXT:  [7]   - VLEN512SiFive7VS
 
 # NISB:       Resources:
-# NISB-NEXT:  [0]   - SiFive7FDiv
-# NISB-NEXT:  [1]   - SiFive7IDiv
-# NISB-NEXT:  [2]   - SiFive7PipeA
-# NISB-NEXT:  [3]   - SiFive7PipeB
-# NISB-NEXT:  [4]   - SiFive7VA
-# NISB-NEXT:  [5]   - SiFive7VCQ
-# NISB-NEXT:  [6]   - SiFive7VL
-# NISB-NEXT:  [7]   - SiFive7VS
+# NISB-NEXT:  [0]   - VLEN512SiFive7FDiv
+# NISB-NEXT:  [1]   - VLEN512SiFive7IDiv
+# NISB-NEXT:  [2]   - VLEN512SiFive7PipeA
+# NISB-NEXT:  [3]   - VLEN512SiFive7PipeB
+# NISB-NEXT:  [4]   - VLEN512SiFive7VA
+# NISB-NEXT:  [5]   - VLEN512SiFive7VCQ
+# NISB-NEXT:  [6]   - VLEN512SiFive7VL
+# NISB-NEXT:  [7]   - VLEN512SiFive7VS
 
 # NISBE:      Resources:
-# NISBE-NEXT: [0]   - SiFive7FDiv
-# NISBE-NEXT: [1]   - SiFive7IDiv
-# NISBE-NEXT: [2]   - SiFive7PipeA
-# NISBE-NEXT: [3]   - SiFive7PipeB
-# NISBE-NEXT: [4]   - SiFive7VA
-# NISBE-NEXT: [5]   - SiFive7VCQ
-# NISBE-NEXT: [6]   - SiFive7VL
-# NISBE-NEXT: [7]   - SiFive7VS
+# NISBE-NEXT: [0]   - VLEN512SiFive7FDiv
+# NISBE-NEXT: [1]   - VLEN512SiFive7IDiv
+# NISBE-NEXT: [2]   - VLEN512SiFive7PipeA
+# NISBE-NEXT: [3]   - VLEN512SiFive7PipeB
+# NISBE-NEXT: [4]   - VLEN512SiFive7VA
+# NISBE-NEXT: [5]   - VLEN512SiFive7VCQ
+# NISBE-NEXT: [6]   - VLEN512SiFive7VL
+# NISBE-NEXT: [7]   - VLEN512SiFive7VS
 
 # NISE:       Resources:
-# NISE-NEXT:  [0]   - SiFive7FDiv
-# NISE-NEXT:  [1]   - SiFive7IDiv
-# NISE-NEXT:  [2]   - SiFive7PipeA
-# NISE-NEXT:  [3]   - SiFive7PipeB
-# NISE-NEXT:  [4]   - SiFive7VA
-# NISE-NEXT:  [5]   - SiFive7VCQ
-# NISE-NEXT:  [6]   - SiFive7VL
-# NISE-NEXT:  [7]   - SiFive7VS
+# NISE-NEXT:  [0]   - VLEN512SiFive7FDiv
+# NISE-NEXT:  [1]   - VLEN512SiFive7IDiv
+# NISE-NEXT:  [2]   - VLEN512SiFive7PipeA
+# NISE-NEXT:  [3]   - VLEN512SiFive7PipeB
+# NISE-NEXT:  [4]   - VLEN512SiFive7VA
+# NISE-NEXT:  [5]   - VLEN512SiFive7VCQ
+# NISE-NEXT:  [6]   - VLEN512SiFive7VL
+# NISE-NEXT:  [7]   - VLEN512SiFive7VS
 
 # ISN:        Resource pressure per iteration:
 # ISN-NEXT:   [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/jump.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/jump.s
@@ -36,14 +36,14 @@ ret
 # CHECK-NEXT:  1      3     1.00                        ret
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-lmul-instruments.s
@@ -33,14 +33,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-sew-instruments.s
@@ -34,14 +34,14 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/disable-im.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/disable-im.s
@@ -38,14 +38,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/fractional-lmul-data.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/fractional-lmul-data.s
@@ -34,14 +34,14 @@ vdiv.vv v12, v12, v12
 # CHECK-NEXT:  1      30    30.00                       vdiv.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-at-start.s
@@ -28,14 +28,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-middle.s
@@ -30,14 +30,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     1.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-region.s
@@ -32,14 +32,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-straddles-region.s
@@ -33,14 +33,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-lmul-instruments.s
@@ -42,14 +42,14 @@ vsub.vv v12, v12, v12
 # CHECK-NEXT:  1      4     8.00                        vsub.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-sew-instruments.s
@@ -43,14 +43,14 @@ vdivu.vv v8, v8, v12
 # CHECK-NEXT:  1      112   112.00                      vdivu.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/needs-sew-but-only-lmul.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/needs-sew-but-only-lmul.s
@@ -32,14 +32,14 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/no-vsetvli-to-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/no-vsetvli-to-start.s
@@ -29,14 +29,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/reductions.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/reductions.s
@@ -383,7 +383,7 @@ vfredmin.vs  v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
 # CHECK-NEXT:  1      768   768.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1536   1536.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      1536  1536.00                     vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  1      48    48.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
@@ -448,14 +448,14 @@ vfredmin.vs  v4, v8, v12
 # CHECK-NEXT:  1      46    46.00                       vfredmin.vs	v4, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-at-start.s
@@ -29,14 +29,14 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-middle.s
@@ -30,19 +30,19 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      1920   1920.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      1920  1920.00                     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
 # CHECK-NEXT:  1      912   912.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-region.s
@@ -33,14 +33,14 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-straddles-region.s
@@ -34,14 +34,14 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/strided-load-store.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/strided-load-store.s
@@ -244,14 +244,14 @@ vlse64.v v1, (a1), a2
 # CHECK-NEXT:  1      67    64.00   *                   vlse64.v	v1, (a1), a2
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/strided-load-x0.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/strided-load-x0.s
@@ -82,14 +82,14 @@ vle64.v v1, (a1)
 # CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a1)
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vector-integer-arithmetic.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vector-integer-arithmetic.s
@@ -1284,7 +1284,7 @@ vmv.v.v v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
 # CHECK-NEXT:  1      960   960.00                      vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1920   1920.00                      vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      1920  1920.00                     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  1      30    30.00                       vrem.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
@@ -1521,14 +1521,14 @@ vmv.v.v v4, v12
 # CHECK-NEXT:  1      4     16.00                       vmv.v.v	v4, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vle-vse.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vle-vse.s
@@ -832,14 +832,14 @@ vsm.v    v1, (a0)
 # CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-instrument.s
@@ -31,14 +31,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-sew-instrument.s
@@ -31,14 +31,14 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT:  1      896   896.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-instrument.s
@@ -31,14 +31,14 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-sew-instrument.s
@@ -31,14 +31,14 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT:  1      896   896.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
-# CHECK-NEXT: [0]   - SiFive7FDiv
-# CHECK-NEXT: [1]   - SiFive7IDiv
-# CHECK-NEXT: [2]   - SiFive7PipeA
-# CHECK-NEXT: [3]   - SiFive7PipeB
-# CHECK-NEXT: [4]   - SiFive7VA
-# CHECK-NEXT: [5]   - SiFive7VCQ
-# CHECK-NEXT: [6]   - SiFive7VL
-# CHECK-NEXT: [7]   - SiFive7VS
+# CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
+# CHECK-NEXT: [1]   - VLEN512SiFive7IDiv
+# CHECK-NEXT: [2]   - VLEN512SiFive7PipeA
+# CHECK-NEXT: [3]   - VLEN512SiFive7PipeB
+# CHECK-NEXT: [4]   - VLEN512SiFive7VA
+# CHECK-NEXT: [5]   - VLEN512SiFive7VCQ
+# CHECK-NEXT: [6]   - VLEN512SiFive7VL
+# CHECK-NEXT: [7]   - VLEN512SiFive7VS
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]


### PR DESCRIPTION
In preparation for sifive-x390's scheduling model, which shares quite a lot with the existing SiFive7 scheduling model, this patch factors out some of the components that will share between them.  Notably:

  - Processor resource definitions (i.e. pipes) are factored out into a multiclass, `SiFive7ProcResources`. Similarly, WriteRes entries and bypass entries (i.e. ReadAdvance) are also factored out into their own multiclass: `SiFive7WriteResBase` and `SiFive7ReadAdvance`, respectively.
  - The aforementioned three components, `SiFive7ProcResources`, `SiFive7WriteResBase`, and `SiFive7ReadAdvance` are encapsulated into a bigger multiclass, `SiFive7SchedResources`, which configures these components with parameters passed from the template arguments. An example configure value would be the VLEN.
  - SiFive7's SchedMachineModel carries not only standard fields like issue width, but also the concrete config values corresponding to the processor. For instance, the existing SiFive7 models has VLEN=512, while X390 has VLEN=1024.
  - In the final phase, we "bind" SchedMachineModel from each processor to a SiFive7SchedResources that is instantiated from that SchedMachineModel's config values.

-----
Split out from #143938 