### PR TITLE
IR/Verifier: Do not allow kernel to kernel calls.

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3632,21 +3632,12 @@ void Verifier::visitCallBase(CallBase &Call) {
     Check(Callee->getValueType() == FTy,
           "Intrinsic called with incompatible signature", Call);
 
-  // Verify if the calling convention of the callee is callable.
-  Check(isCallableCC(Call.getCallingConv()),
-        "calling convention does not permit calls", Call);
-
   // Find the actual CC of the callee from the Module.
   CallingConv::ID CalleeCC = Call.getParent()->getParent()->getParent()
       ->getFunction(Call.getCalledFunction()->getName())->getCallingConv();
-  // Verify that a kernel does not call another kernel.
-  if (CalleeCC == CallingConv::AMDGPU_KERNEL ||
-      CalleeCC == CallingConv::SPIR_KERNEL) {
-    CallingConv::ID CallerCC = Call.getParent()->getParent()->getCallingConv();
-    Check(CallerCC != CallingConv::AMDGPU_KERNEL &&
-          CallerCC != CallingConv::SPIR_KERNEL,
-          "a kernel may not call a kernel", Call.getParent()->getParent());
-  }
+  // Verify if the calling convention of the callee is callable.
+  Check(isCallableCC(CalleeCC),
+        "calling convention does not permit calls", Call);
 
   // Disallow passing/returning values with alignment higher than we can
   // represent.

--- a/llvm/test/Verifier/AMDGPU/kernel-recursivecall.ll
+++ b/llvm/test/Verifier/AMDGPU/kernel-recursivecall.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+
+define amdgpu_kernel void @kernel(ptr addrspace(1) %out, i32 %n) {
+entry:
+; CHECK: a kernel may not call a kernel
+; CHECK-NEXT: ptr @kernel
+  call void @kernel(ptr addrspace(1) %out, i32 %n)
+  ret void
+}

--- a/llvm/test/Verifier/AMDGPU/kernel-recursivecall.ll
+++ b/llvm/test/Verifier/AMDGPU/kernel-recursivecall.ll
@@ -1,9 +1,9 @@
-; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: not llvm-as %s -disable-output 2>&1 | FileCheck %s
 
 define amdgpu_kernel void @kernel(ptr addrspace(1) %out, i32 %n) {
 entry:
-; CHECK: a kernel may not call a kernel
-; CHECK-NEXT: ptr @kernel
+; CHECK: calling convention does not permit calls
+; CHECK-NEXT: call void @kernel(ptr addrspace(1) %out, i32 %n)
   call void @kernel(ptr addrspace(1) %out, i32 %n)
   ret void
 }


### PR DESCRIPTION
Allowing a kernel to call another kernel is invalid. This extends the Verifier to recognize this fact. The calling convention is retrieved from the module because it may not be labeling the callsite.