### PR TITLE
Fix a modules-enabled build CI failure

### DIFF
--- a/llvm/include/llvm/Option/OptSpecifier.h
+++ b/llvm/include/llvm/Option/OptSpecifier.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_OPTION_OPTSPECIFIER_H
 #define LLVM_OPTION_OPTSPECIFIER_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 namespace opt {
 


### PR DESCRIPTION
This is to fix a failure with "-DLLVM_ENABLE_MODULES=ON":
```
  While building module 'LLVM_Option' imported from /llvm-project/llvm/lib/Option/OptTable.cpp:9:
  In file included from <module-includes>:1:
  In file included from /llvm-project/llvm/include/llvm/Option/Arg.h:19:
  In file included from /llvm-project/llvm/include/llvm/Option/Option.h:14:
  /llvm-project/llvm/include/llvm/Option/OptSpecifier.h:25:16: error: unknown type name 'LLVM_ABI'
     25 |   /*implicit*/ LLVM_ABI OptSpecifier(const Option *Opt);
        |                ^
  /llvm-project/llvm/include/llvm/Option/OptSpecifier.h:25:25: error: constructor cannot have a return type
     25 |   /*implicit*/ LLVM_ABI OptSpecifier(const Option *Opt);
        |                         ^~~~~~~~~~~~
  /llvm-project/llvm/lib/Option/OptTable.cpp:9:10: fatal error: could not build module 'LLVM_Option'
      9 | #include "llvm/Option/OptTable.h"
        |  ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
  3 errors generated.
  ```