### PR TITLE
[libc++] Disabled unexpected_disabled test in modules build

### DIFF
--- a/libcxx/test/libcxx/depr/exception.unexpected/unexpected_disabled_cpp17.verify.cpp
+++ b/libcxx/test/libcxx/depr/exception.unexpected/unexpected_disabled_cpp17.verify.cpp
@@ -8,6 +8,11 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
+// When built with modules, this test gives diagnostics like declaration of
+// 'unexpected' must be imported from module 'std.expected.unexpected' before
+// it is required. Therefore disable it in this configuration.
+// UNSUPPORTED: clang-modules-build
+
 // test unexpected
 
 #include <exception>


### PR DESCRIPTION
This patch disables unexpected_disabled_cpp17.verify.cpp under clang modules builds because it changes diagnostics criteria post #143423, causing the test to fail.

This patch follows a similar style to
853059a15011fd8b57dd01b5189805fc8408e87f.

This was found when working on trying to land #144033.