### PR TITLE
[clang][bytecode] Keep the last chunk in InterpStack::clear()

### DIFF
--- a/clang/lib/AST/ByteCode/InterpStack.cpp
+++ b/clang/lib/AST/ByteCode/InterpStack.cpp
@@ -19,14 +19,27 @@
 using namespace clang;
 using namespace clang::interp;
 
-InterpStack::~InterpStack() { clear(); }
-
-void InterpStack::clear() {
+InterpStack::~InterpStack() {
   if (Chunk && Chunk->Next)
     std::free(Chunk->Next);
   if (Chunk)
     std::free(Chunk);
   Chunk = nullptr;
+  StackSize = 0;
+#ifndef NDEBUG
+  ItemTypes.clear();
+#endif
+}
+
+// We keep the last chunk around to reuse.
+void InterpStack::clear() {
+  if (!Chunk)
+    return;
+
+  if (Chunk->Next)
+    std::free(Chunk->Next);
+
+  assert(Chunk);
   StackSize = 0;
 #ifndef NDEBUG
   ItemTypes.clear();


### PR DESCRIPTION
We call clear when checking for potential constant expressions, but that used to free all the chunks. Keep the last one so we don't have to re-allocate it.