### PR TITLE
[Flang][OpenMP] Update relevant warnings to emit when OMP >= v5.2

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -834,7 +834,7 @@ private:
   void AddOmpRequiresToScope(Scope &, WithOmpDeclarative::RequiresFlags,
       std::optional<common::OmpMemoryOrderType>);
   void IssueNonConformanceWarning(llvm::omp::Directive D,
-      parser::CharBlock source, unsigned emit_from_version);
+      parser::CharBlock source, unsigned EmitFromVersion);
 
   void CreateImplicitSymbols(const Symbol *symbol);
 
@@ -3134,13 +3134,13 @@ void OmpAttributeVisitor::AddOmpRequiresToScope(Scope &scope,
 }
 
 void OmpAttributeVisitor::IssueNonConformanceWarning(llvm::omp::Directive D,
-    parser::CharBlock source, unsigned emit_from_version) {
+    parser::CharBlock source, unsigned EmitFromVersion) {
   std::string warnStr;
   llvm::raw_string_ostream warnStrOS(warnStr);
   unsigned version{context_.langOptions().OpenMPVersion};
   // We only want to emit the warning when the version being used has the
   // directive deprecated
-  if (version < emit_from_version) {
+  if (version < EmitFromVersion) {
     return;
   }
   warnStrOS << "OpenMP directive "

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -833,8 +833,8 @@ private:
 
   void AddOmpRequiresToScope(Scope &, WithOmpDeclarative::RequiresFlags,
       std::optional<common::OmpMemoryOrderType>);
-  void IssueNonConformanceWarning(
-      llvm::omp::Directive D, parser::CharBlock source);
+  void IssueNonConformanceWarning(llvm::omp::Directive D,
+      parser::CharBlock source, unsigned emit_from_version);
 
   void CreateImplicitSymbols(const Symbol *symbol);
 
@@ -1664,10 +1664,9 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPBlockConstruct &x) {
     // TODO others
     break;
   }
-  if ((beginDir.v == llvm::omp::Directive::OMPD_master ||
-          beginDir.v == llvm::omp::Directive::OMPD_parallel_master) &&
-      context_.langOptions().OpenMPVersion >= 52)
-    IssueNonConformanceWarning(beginDir.v, beginDir.source);
+  if (beginDir.v == llvm::omp::Directive::OMPD_master ||
+      beginDir.v == llvm::omp::Directive::OMPD_parallel_master)
+    IssueNonConformanceWarning(beginDir.v, beginDir.source, 52);
   ClearDataSharingAttributeObjects();
   ClearPrivateDataSharingAttributeObjects();
   ClearAllocateNames();
@@ -1785,13 +1784,12 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPLoopConstruct &x) {
   default:
     break;
   }
-  if ((beginDir.v == llvm::omp::OMPD_master_taskloop ||
-          beginDir.v == llvm::omp::OMPD_master_taskloop_simd ||
-          beginDir.v == llvm::omp::OMPD_parallel_master_taskloop ||
-          beginDir.v == llvm::omp::OMPD_parallel_master_taskloop_simd ||
-          beginDir.v == llvm::omp::Directive::OMPD_target_loop) &&
-      context_.langOptions().OpenMPVersion >= 52)
-    IssueNonConformanceWarning(beginDir.v, beginDir.source);
+  if (beginDir.v == llvm::omp::OMPD_master_taskloop ||
+      beginDir.v == llvm::omp::OMPD_master_taskloop_simd ||
+      beginDir.v == llvm::omp::OMPD_parallel_master_taskloop ||
+      beginDir.v == llvm::omp::OMPD_parallel_master_taskloop_simd ||
+      beginDir.v == llvm::omp::Directive::OMPD_target_loop)
+    IssueNonConformanceWarning(beginDir.v, beginDir.source, 52);
   ClearDataSharingAttributeObjects();
   SetContextAssociatedLoopLevel(GetAssociatedLoopLevelFromClauses(clauseList));
 
@@ -2075,9 +2073,7 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPDispatchConstruct &x) {
 }
 
 bool OmpAttributeVisitor::Pre(const parser::OpenMPExecutableAllocate &x) {
-  if (context_.langOptions().OpenMPVersion >= 52) {
-    IssueNonConformanceWarning(llvm::omp::Directive::OMPD_allocate, x.source);
-  }
+  IssueNonConformanceWarning(llvm::omp::Directive::OMPD_allocate, x.source, 52);
 
   PushContext(x.source, llvm::omp::Directive::OMPD_allocate);
   const auto &list{std::get<std::optional<parser::OmpObjectList>>(x.t)};
@@ -3137,11 +3133,16 @@ void OmpAttributeVisitor::AddOmpRequiresToScope(Scope &scope,
   } while (!scopeIter->IsGlobal());
 }
 
-void OmpAttributeVisitor::IssueNonConformanceWarning(
-    llvm::omp::Directive D, parser::CharBlock source) {
+void OmpAttributeVisitor::IssueNonConformanceWarning(llvm::omp::Directive D,
+    parser::CharBlock source, unsigned emit_from_version) {
   std::string warnStr;
   llvm::raw_string_ostream warnStrOS(warnStr);
   unsigned version{context_.langOptions().OpenMPVersion};
+  // We only want to emit the warning when the version being used has the
+  // directive deprecated
+  if (version < emit_from_version) {
+    return;
+  }
   warnStrOS << "OpenMP directive "
             << parser::ToUpperCaseLetters(
                    llvm::omp::getOpenMPDirectiveName(D, version).str())

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1664,8 +1664,9 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPBlockConstruct &x) {
     // TODO others
     break;
   }
-  if (beginDir.v == llvm::omp::Directive::OMPD_master ||
-      beginDir.v == llvm::omp::Directive::OMPD_parallel_master)
+  if ((beginDir.v == llvm::omp::Directive::OMPD_master ||
+          beginDir.v == llvm::omp::Directive::OMPD_parallel_master) &&
+      context_.langOptions().OpenMPVersion >= 52)
     IssueNonConformanceWarning(beginDir.v, beginDir.source);
   ClearDataSharingAttributeObjects();
   ClearPrivateDataSharingAttributeObjects();
@@ -1784,11 +1785,12 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPLoopConstruct &x) {
   default:
     break;
   }
-  if (beginDir.v == llvm::omp::OMPD_master_taskloop ||
-      beginDir.v == llvm::omp::OMPD_master_taskloop_simd ||
-      beginDir.v == llvm::omp::OMPD_parallel_master_taskloop ||
-      beginDir.v == llvm::omp::OMPD_parallel_master_taskloop_simd ||
-      beginDir.v == llvm::omp::Directive::OMPD_target_loop)
+  if ((beginDir.v == llvm::omp::OMPD_master_taskloop ||
+          beginDir.v == llvm::omp::OMPD_master_taskloop_simd ||
+          beginDir.v == llvm::omp::OMPD_parallel_master_taskloop ||
+          beginDir.v == llvm::omp::OMPD_parallel_master_taskloop_simd ||
+          beginDir.v == llvm::omp::Directive::OMPD_target_loop) &&
+      context_.langOptions().OpenMPVersion >= 52)
     IssueNonConformanceWarning(beginDir.v, beginDir.source);
   ClearDataSharingAttributeObjects();
   SetContextAssociatedLoopLevel(GetAssociatedLoopLevelFromClauses(clauseList));
@@ -2073,7 +2075,10 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPDispatchConstruct &x) {
 }
 
 bool OmpAttributeVisitor::Pre(const parser::OpenMPExecutableAllocate &x) {
-  IssueNonConformanceWarning(llvm::omp::Directive::OMPD_allocate, x.source);
+  if (context_.langOptions().OpenMPVersion >= 52) {
+    IssueNonConformanceWarning(llvm::omp::Directive::OMPD_allocate, x.source);
+  }
+
   PushContext(x.source, llvm::omp::Directive::OMPD_allocate);
   const auto &list{std::get<std::optional<parser::OmpObjectList>>(x.t)};
   if (list) {

--- a/flang/test/Semantics/OpenMP/allocate-align01.f90
+++ b/flang/test/Semantics/OpenMP/allocate-align01.f90
@@ -1,6 +1,6 @@
 ! REQUIRES: openmp_runtime
 
-! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags -fopenmp-version=51
+! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags -fopenmp-version=52
 ! OpenMP Version 5.2
 ! The allocate clause's allocator modifier must be of type allocator_handle
 ! and the align modifier must be constant, positive integer expression

--- a/flang/test/Semantics/OpenMP/allocate01.f90
+++ b/flang/test/Semantics/OpenMP/allocate01.f90
@@ -1,6 +1,6 @@
 ! REQUIRES: openmp_runtime
 
-! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags
+! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags -fopenmp-version=52
 ! OpenMP Version 5.0
 ! 2.11.3 allocate Directive
 ! The allocate directive must appear in the same scope as the declarations of

--- a/flang/test/Semantics/OpenMP/allocate02.f90
+++ b/flang/test/Semantics/OpenMP/allocate02.f90
@@ -16,11 +16,9 @@ use omp_lib
   !ERROR: At most one ALLOCATOR clause can appear on the ALLOCATE directive
   !$omp allocate(x, y) allocator(omp_default_mem_alloc) allocator(omp_default_mem_alloc)
 
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !$omp allocate(darray) allocator(omp_default_mem_alloc)
       allocate ( darray(a, b) )
 
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !ERROR: At most one ALLOCATOR clause can appear on the ALLOCATE directive
   !$omp allocate(darray) allocator(omp_default_mem_alloc) allocator(omp_default_mem_alloc)
       allocate ( darray(a, b) )

--- a/flang/test/Semantics/OpenMP/allocate03.f90
+++ b/flang/test/Semantics/OpenMP/allocate03.f90
@@ -18,7 +18,6 @@ use omp_lib
   !ERROR: A variable that is part of another variable (as an array or structure element) cannot appear on the ALLOCATE directive
   !$omp allocate(my_var%array)
 
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !ERROR: A variable that is part of another variable (as an array or structure element) cannot appear on the ALLOCATE directive
   !$omp allocate(darray, my_var%array) allocator(omp_default_mem_alloc)
     allocate ( darray(a, b) )

--- a/flang/test/Semantics/OpenMP/allocate05.f90
+++ b/flang/test/Semantics/OpenMP/allocate05.f90
@@ -13,13 +13,11 @@ use omp_lib
   real, dimension (:,:), allocatable :: darray
 
   !$omp target
-      !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
       !$omp allocate allocator(omp_default_mem_alloc)
           allocate ( darray(a, b) )
   !$omp end target
 
   !$omp target
-      !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
       !ERROR: ALLOCATE directives that appear in a TARGET region must specify an allocator clause
       !$omp allocate
           allocate ( darray(a, b) )

--- a/flang/test/Semantics/OpenMP/allocate06.f90
+++ b/flang/test/Semantics/OpenMP/allocate06.f90
@@ -14,7 +14,6 @@ use omp_lib
   !ERROR: List items specified in the ALLOCATE directive must not have the ALLOCATABLE attribute unless the directive is associated with an ALLOCATE statement
   !$omp allocate(darray) allocator(omp_default_mem_alloc)
 
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !$omp allocate(darray) allocator(omp_default_mem_alloc)
     allocate(darray(a, b))
 

--- a/flang/test/Semantics/OpenMP/allocate09.f90
+++ b/flang/test/Semantics/OpenMP/allocate09.f90
@@ -12,28 +12,23 @@ use omp_lib
   integer, dimension(:), allocatable :: a, b, c, d, e, f, &
                                         g, h, i, j, k, l
 
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !$omp allocate(a) allocator(omp_default_mem_alloc)
     allocate(a(1), b(2))
 
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !$omp allocate(c, d) allocator(omp_default_mem_alloc)
     allocate(c(3), d(4))
 
   !$omp allocate(e) allocator(omp_default_mem_alloc)
   !$omp allocate(f, g) allocator(omp_default_mem_alloc)
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !$omp allocate
     allocate(e(5), f(6), g(7))
 
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !ERROR: Object 'i' in ALLOCATE directive not found in corresponding ALLOCATE statement
   !$omp allocate(h, i) allocator(omp_default_mem_alloc)
     allocate(h(8))
 
   !ERROR: Object 'j' in ALLOCATE directive not found in corresponding ALLOCATE statement
   !$omp allocate(j, k) allocator(omp_default_mem_alloc)
-  !WARNING: OpenMP directive ALLOCATE has been deprecated, please use ALLOCATORS instead.
   !$omp allocate(l) allocator(omp_default_mem_alloc)
     allocate(k(9), l(10))
 

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -1,6 +1,6 @@
 ! REQUIRES: openmp_runtime
 
-! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags %openmp_module_flag -fopenmp-version=51
+! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags %openmp_module_flag -fopenmp-version=52
 use omp_lib
 ! Check OpenMP clause validity for the following directives:
 !
@@ -502,6 +502,7 @@ use omp_lib
   !$omp taskyield
   !$omp barrier
   !$omp taskwait
+  !WARNING: SOURCE dependence type is deprecated in OpenMP v5.2
   !ERROR: The SINK and SOURCE dependence types can only be used with the ORDERED directive, used here in the TASKWAIT construct
   !$omp taskwait depend(source)
   ! !$omp taskwait depend(sink:i-1)
@@ -509,12 +510,18 @@ use omp_lib
   ! !$omp target update from(arrayA) to(arrayB)
   ! !$omp target exit data map(from:arrayA) map(delete:arrayB)
   !$omp flush (c)
+  !WARNING: The syntax "FLUSH clause (object, ...)" has been deprecated, use "FLUSH(object, ...) clause" instead
   !$omp flush acq_rel
+  !WARNING: The syntax "FLUSH clause (object, ...)" has been deprecated, use "FLUSH(object, ...) clause" instead
   !$omp flush release
+  !WARNING: The syntax "FLUSH clause (object, ...)" has been deprecated, use "FLUSH(object, ...) clause" instead
   !$omp flush acquire
+  !WARNING: The syntax "FLUSH clause (object, ...)" has been deprecated, use "FLUSH(object, ...) clause" instead
   !ERROR: If memory-order-clause is RELEASE, ACQUIRE, or ACQ_REL, list items must not be specified on the FLUSH directive
   !$omp flush release (c)
+  !WARNING: The syntax "FLUSH clause (object, ...)" has been deprecated, use "FLUSH(object, ...) clause" instead
   !$omp flush seq_cst
+  !WARNING: The syntax "FLUSH clause (object, ...)" has been deprecated, use "FLUSH(object, ...) clause" instead
   !ERROR: RELAXED clause is not allowed on the FLUSH directive
   !$omp flush relaxed
 

--- a/flang/test/Semantics/OpenMP/deprecation.f90
+++ b/flang/test/Semantics/OpenMP/deprecation.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp -Werror
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp -Werror -fopenmp-version=52
 
 ! Check for deprecation of master directive and its combined/composite variants
 

--- a/flang/test/Semantics/OpenMP/flush02.f90
+++ b/flang/test/Semantics/OpenMP/flush02.f90
@@ -78,7 +78,6 @@ use omp_lib
 
   !$omp parallel num_threads(4)
     array = (/1, 2, 3, 4, 5, 6, 7, 8, 9, 10/)
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !$omp master
       !$omp flush (array)
     !$omp end master

--- a/flang/test/Semantics/OpenMP/nested-barrier.f90
+++ b/flang/test/Semantics/OpenMP/nested-barrier.f90
@@ -75,7 +75,6 @@ program omp_nest_barrier
   end do
   !$omp end critical
 
-  !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
   !$omp master
   do i = 1, 10
     k = k + 1
@@ -108,7 +107,6 @@ program omp_nest_barrier
   end do
   !$omp end ordered
 
-  !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
   !$omp master
   do i = 1, 10
     !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.

--- a/flang/test/Semantics/OpenMP/nested-master.f90
+++ b/flang/test/Semantics/OpenMP/nested-master.f90
@@ -9,7 +9,6 @@ program omp_nest_master
   !$omp do
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -17,7 +16,6 @@ program omp_nest_master
   end do
 
   !$omp sections 
-  !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
   !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     do i = 1, 10
@@ -27,7 +25,6 @@ program omp_nest_master
   !$omp end sections
 
   !$omp single 
-  !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
   !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     do i = 1, 10
@@ -41,7 +38,6 @@ program omp_nest_master
   !$omp task
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -52,7 +48,6 @@ program omp_nest_master
   !$omp taskloop
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -63,7 +58,6 @@ program omp_nest_master
   !$omp target parallel do simd
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct, the `SCAN` construct and the `ORDERED` construct with the `SIMD` clause.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
@@ -75,7 +69,6 @@ program omp_nest_master
   !$omp critical
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !$omp master
     j = j -1
     !$omp end master
@@ -85,7 +78,6 @@ program omp_nest_master
   !$omp ordered
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !$omp master
     j = j -1
     !$omp end master
@@ -99,7 +91,6 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
       !$omp master
       j = j -1
       !$omp end master
@@ -116,7 +107,6 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
       !$omp master
       j = j -1
       !$omp end master
@@ -133,7 +123,6 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
       !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
       !$omp master
       j = j -1
@@ -151,7 +140,6 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
       !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
       !$omp master
       j = j -1

--- a/flang/test/Semantics/OpenMP/nested-teams.f90
+++ b/flang/test/Semantics/OpenMP/nested-teams.f90
@@ -42,7 +42,6 @@ program main
   !$omp end teams
   end do
 
-  !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
   !$omp master
   !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
   !$omp teams

--- a/flang/test/Semantics/OpenMP/ordered-simd.f90
+++ b/flang/test/Semantics/OpenMP/ordered-simd.f90
@@ -95,7 +95,6 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP CRITICAL  
     C =  C - A * B
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !$OMP MASTER
     DO I = 1,N
       !ERROR: `ORDERED` region may not be closely nested inside of `CRITICAL`, `ORDERED`, explicit `TASK` or `TASKLOOP` region.
@@ -108,7 +107,6 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP ORDERED  
     C =  C - A * B
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !$OMP MASTER
     DO I = 1,N
       !ERROR: `ORDERED` region may not be closely nested inside of `CRITICAL`, `ORDERED`, explicit `TASK` or `TASKLOOP` region.
@@ -121,7 +119,6 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP TASK  
     C =  C - A * B
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$OMP MASTER
     DO I = 1,N
@@ -136,7 +133,6 @@ SUBROUTINE ORDERED_BAD(N)
   !$OMP TASKLOOP
   DO J= 1,N  
     C =  C - A * B
-    !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$OMP MASTER
     DO I = 1,N

--- a/flang/test/Semantics/OpenMP/parallel-master-goto.f90
+++ b/flang/test/Semantics/OpenMP/parallel-master-goto.f90
@@ -7,7 +7,6 @@ do i = 1, 2
 !ERROR: invalid branch leaving an OpenMP structured block
   goto 10
 end do
-!WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead.
 !$omp master
 10 print *, i
 !$omp end master


### PR DESCRIPTION
There has been a number of deprecation warnings that have been added to Flang, however these features are only deprecated when the OpenMP Version being used is 5.2 or later. Previously, flang did not consider the version with the warnings so would always be emitted.

Flang now ensures warnings are emitted for the appropriate version of OpenMP, and tests are updated to reflect this change.