### PR TITLE
[compiler-rt] [Fuzzer] Fix ARMv7 test link failure by linking unwinder

### DIFF
--- a/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
+++ b/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
@@ -35,6 +35,26 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
    COMPILER_RT_LIBCXXABI_PATH)
   list(APPEND LIBFUZZER_UNITTEST_CFLAGS -nostdinc++ -fno-exceptions)
   list(APPEND LIBFUZZER_UNITTEST_LINK_FLAGS -nostdlib++ -fno-exceptions)
+
+  # When we use -nostdlib++, we remove the default C++ runtime which normally
+  # provides the stack unwinding symbols (like __aeabi_unwind_cpp_pr0).
+  # We must now manually find and link a suitable unwinder library.
+  set(FUZZER_UNWINDER_LIBS)
+  if(COMPILER_RT_USE_LLVM_UNWINDER)
+    # Prefer LLVM's own libunwind.
+    list(APPEND FUZZER_UNWINDER_LIBS ${COMPILER_RT_UNWINDER_LINK_LIBS})
+  elseif(COMPILER_RT_HAS_GCC_S_LIB)
+    # As a fallback, use the shared libgcc_s library.
+    list(APPEND FUZZER_UNWINDER_LIBS gcc_s)
+  elseif(COMPILER_RT_HAS_GCC_LIB)
+    # As a final fallback, use the static libgcc library.
+    list(APPEND FUZZER_UNWINDER_LIBS gcc)
+  else()
+    message(FATAL_ERROR "Building fuzzer tests with -nostdlib++ requires a suitable unwinder (libunwind or libgcc_s) but none was found.")
+  endif()
+  # Add the detected unwinder library to our link flags.
+  list(APPEND LIBFUZZER_UNITTEST_LINK_FLAGS ${FUZZER_UNWINDER_LIBS})
+
 endif()
 
 if ("-fvisibility=hidden" IN_LIST LIBFUZZER_CFLAGS)

--- a/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
+++ b/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
@@ -49,8 +49,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
   elseif(COMPILER_RT_HAS_GCC_LIB)
     # As a final fallback, use the static libgcc library.
     list(APPEND FUZZER_UNWINDER_LIBS gcc)
-  else()
-    message(FATAL_ERROR "Building fuzzer tests with -nostdlib++ requires a suitable unwinder (libunwind or libgcc_s) but none was found.")
+  elseif(NOT COMPILER_RT_USE_BUILTINS_LIBRARY)
+    # If no unwinder is found and we aren't using the builtins library
+    message(FATAL_ERROR "Fuzzer tests require a suitable unwinder, but none was found.")
   endif()
   # Add the detected unwinder library to our link flags.
   list(APPEND LIBFUZZER_UNITTEST_LINK_FLAGS ${FUZZER_UNWINDER_LIBS})


### PR DESCRIPTION
compiler-rt/lib/fuzzer/tests build was failing on armv7, with undefined references to unwinder symbols, such as __aeabi_unwind_cpp_pr0.

This occurs because the test is built with `-nostdlib++` but `libunwind` is not explicitly linked to the final test executable.

This patch resolves the issue by adding CMake logic to explicitly link the required unwinder to the fuzzer tests, inspired by the same solution used to fix Scudo build failures by https://reviews.llvm.org/D142888.