### PR TITLE
[mlir] [python] Fixed the return type of `MemRefType.get_strides_and_offset`

### DIFF
--- a/mlir/python/mlir/_mlir_libs/_mlir/ir.pyi
+++ b/mlir/python/mlir/_mlir_libs/_mlir/ir.pyi
@@ -2119,7 +2119,7 @@ class MemRefType(ShapedType):
         """
     @property
     def typeid(self) -> TypeID: ...
-    def get_strides_and_offset(self) -> tuple[list[int], list[int]]:
+    def get_strides_and_offset(self) -> tuple[list[int], int]:
         """
         The strides and offset of the MemRef type.
         """


### PR DESCRIPTION
Previously, the return type for `offset` was `list[int]`, which clearly is not right.