### PR TITLE
[clang-tidy] Add missing colon in the docs of performance-enum-size

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/performance/enum-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/enum-size.rst
@@ -34,7 +34,7 @@ dependent).
 .. code-block:: c++
 
     // AFTER
-    enum Color : std:int8_t {
+    enum Color : std::int8_t {
         RED = -1,
         GREEN = 0,
         BLUE = 1


### PR DESCRIPTION
There is a syntax error in the provided code example - this PR fixes it.

I did a quick search - I could not find similar _typos_.

I do not have a permission to _add_ reviews, so I do this manually:
@PiotrZSL, @dmpolukhin - please have a look.