### PR TITLE
[BPF] Do not allow gotol in the middle of asm insn

### DIFF
--- a/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
+++ b/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
@@ -261,7 +261,6 @@ public:
         .Case("bswap32", true)
         .Case("bswap64", true)
         .Case("goto", true)
-        .Case("gotol", true)
         .Case("ll", true)
         .Case("skb", true)
         .Case("s", true)


### PR DESCRIPTION
Previously I accidentally allowed 'gotol' insn in the middle of asm insn ([1]). But actually 'gotol' is not allowed in the middle of any asm insn, so remove it from isValidIdInMiddle().

  [1] https://github.com/yonghong-song/llvm-project/commit/6c412b6c6faa2dabd8602d35d3f5e796fb1daf80