### PR TITLE
[libc++] Updated `<version>`'s  `__cpp_lib_constrained_equality` value

### DIFF
--- a/libcxx/include/version
+++ b/libcxx/include/version
@@ -82,8 +82,8 @@ __cpp_lib_constexpr_tuple                               201811L <tuple>
 __cpp_lib_constexpr_typeinfo                            202106L <typeinfo>
 __cpp_lib_constexpr_utility                             201811L <utility>
 __cpp_lib_constexpr_vector                              201907L <vector>
-__cpp_lib_constrained_equality                          202403L <optional> <tuple> <utility>
-                                                                <variant>
+__cpp_lib_constrained_equality                          202411L <expected> <optional> <tuple>
+                                                                <utility> <variant>
 __cpp_lib_containers_ranges                             202202L <deque> <forward_list> <list>
                                                                 <map> <queue> <set>
                                                                 <stack> <string> <unordered_map>
@@ -549,7 +549,7 @@ __cpp_lib_void_t                                        201411L <type_traits>
 #   define __cpp_lib_constexpr_new                      202406L
 # endif
 # define __cpp_lib_constexpr_queue                      202502L
-// # define __cpp_lib_constrained_equality                 202403L
+// # define __cpp_lib_constrained_equality                 202411L
 // # define __cpp_lib_copyable_function                    202306L
 // # define __cpp_lib_debugging                            202311L
 // # define __cpp_lib_default_template_type_for_algorithm_values 202403L

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/expected.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/expected.version.compile.pass.cpp
@@ -20,6 +20,10 @@
 
 #if TEST_STD_VER < 14
 
+#  ifdef __cpp_lib_constrained_equality
+#    error "__cpp_lib_constrained_equality should not be defined before c++26"
+#  endif
+
 #  ifdef __cpp_lib_expected
 #    error "__cpp_lib_expected should not be defined before c++23"
 #  endif
@@ -29,6 +33,10 @@
 #  endif
 
 #elif TEST_STD_VER == 14
+
+#  ifdef __cpp_lib_constrained_equality
+#    error "__cpp_lib_constrained_equality should not be defined before c++26"
+#  endif
 
 #  ifdef __cpp_lib_expected
 #    error "__cpp_lib_expected should not be defined before c++23"
@@ -40,6 +48,10 @@
 
 #elif TEST_STD_VER == 17
 
+#  ifdef __cpp_lib_constrained_equality
+#    error "__cpp_lib_constrained_equality should not be defined before c++26"
+#  endif
+
 #  ifdef __cpp_lib_expected
 #    error "__cpp_lib_expected should not be defined before c++23"
 #  endif
@@ -50,6 +62,10 @@
 
 #elif TEST_STD_VER == 20
 
+#  ifdef __cpp_lib_constrained_equality
+#    error "__cpp_lib_constrained_equality should not be defined before c++26"
+#  endif
+
 #  ifdef __cpp_lib_expected
 #    error "__cpp_lib_expected should not be defined before c++23"
 #  endif
@@ -59,6 +75,10 @@
 #  endif
 
 #elif TEST_STD_VER == 23
+
+#  ifdef __cpp_lib_constrained_equality
+#    error "__cpp_lib_constrained_equality should not be defined before c++26"
+#  endif
 
 #  ifndef __cpp_lib_expected
 #    error "__cpp_lib_expected should be defined in c++23"
@@ -72,6 +92,19 @@
 #  endif
 
 #elif TEST_STD_VER > 23
+
+#  if !defined(_LIBCPP_VERSION)
+#    ifndef __cpp_lib_constrained_equality
+#      error "__cpp_lib_constrained_equality should be defined in c++26"
+#    endif
+#    if __cpp_lib_constrained_equality != 202411L
+#      error "__cpp_lib_constrained_equality should have the value 202411L in c++26"
+#    endif
+#  else
+#    ifdef __cpp_lib_constrained_equality
+#      error "__cpp_lib_constrained_equality should not be defined because it is unimplemented in libc++!"
+#    endif
+#  endif
 
 #  ifndef __cpp_lib_expected
 #    error "__cpp_lib_expected should be defined in c++26"

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/optional.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/optional.version.compile.pass.cpp
@@ -123,8 +123,8 @@
 #    ifndef __cpp_lib_constrained_equality
 #      error "__cpp_lib_constrained_equality should be defined in c++26"
 #    endif
-#    if __cpp_lib_constrained_equality != 202403L
-#      error "__cpp_lib_constrained_equality should have the value 202403L in c++26"
+#    if __cpp_lib_constrained_equality != 202411L
+#      error "__cpp_lib_constrained_equality should have the value 202411L in c++26"
 #    endif
 #  else
 #    ifdef __cpp_lib_constrained_equality

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/tuple.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/tuple.version.compile.pass.cpp
@@ -274,8 +274,8 @@
 #    ifndef __cpp_lib_constrained_equality
 #      error "__cpp_lib_constrained_equality should be defined in c++26"
 #    endif
-#    if __cpp_lib_constrained_equality != 202403L
-#      error "__cpp_lib_constrained_equality should have the value 202403L in c++26"
+#    if __cpp_lib_constrained_equality != 202411L
+#      error "__cpp_lib_constrained_equality should have the value 202411L in c++26"
 #    endif
 #  else
 #    ifdef __cpp_lib_constrained_equality

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/utility.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/utility.version.compile.pass.cpp
@@ -405,8 +405,8 @@
 #    ifndef __cpp_lib_constrained_equality
 #      error "__cpp_lib_constrained_equality should be defined in c++26"
 #    endif
-#    if __cpp_lib_constrained_equality != 202403L
-#      error "__cpp_lib_constrained_equality should have the value 202403L in c++26"
+#    if __cpp_lib_constrained_equality != 202411L
+#      error "__cpp_lib_constrained_equality should have the value 202411L in c++26"
 #    endif
 #  else
 #    ifdef __cpp_lib_constrained_equality

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/variant.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/variant.version.compile.pass.cpp
@@ -103,8 +103,8 @@
 #    ifndef __cpp_lib_constrained_equality
 #      error "__cpp_lib_constrained_equality should be defined in c++26"
 #    endif
-#    if __cpp_lib_constrained_equality != 202403L
-#      error "__cpp_lib_constrained_equality should have the value 202403L in c++26"
+#    if __cpp_lib_constrained_equality != 202411L
+#      error "__cpp_lib_constrained_equality should have the value 202411L in c++26"
 #    endif
 #  else
 #    ifdef __cpp_lib_constrained_equality

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
@@ -6548,8 +6548,8 @@
 #    ifndef __cpp_lib_constrained_equality
 #      error "__cpp_lib_constrained_equality should be defined in c++26"
 #    endif
-#    if __cpp_lib_constrained_equality != 202403L
-#      error "__cpp_lib_constrained_equality should have the value 202403L in c++26"
+#    if __cpp_lib_constrained_equality != 202411L
+#      error "__cpp_lib_constrained_equality should have the value 202411L in c++26"
 #    endif
 #  else
 #    ifdef __cpp_lib_constrained_equality

--- a/libcxx/utils/generate_feature_test_macro_components.py
+++ b/libcxx/utils/generate_feature_test_macro_components.py
@@ -426,8 +426,11 @@ feature_test_macros = [
         },
         {
             "name": "__cpp_lib_constrained_equality",
-            "values": {"c++26": 202403}, # P2944R3: Comparisons for reference_wrapper
-            "headers": ["optional", "tuple", "utility", "variant"],
+            "values": {
+                # "c++26": 202403,  # P2944R3: Comparisons for reference_wrapper
+                "c++26": 202411,  # P3379R0: Constrain std::expected equality operators
+            },
+            "headers": ["expected", "optional", "tuple", "utility", "variant"],
             "unimplemented": True,
         },
         {


### PR DESCRIPTION
[P3379R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3379r0.html) updates `__cpp_lib_constrained_equality` value

Split off as a separate patch as per review comment: https://github.com/llvm/llvm-project/pull/139368#pullrequestreview-2916040573