### PR TITLE
[flang][driver] add ability to look up feature flags without setting them

### DIFF
--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -81,8 +81,9 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;
-using Warning = std::variant<LanguageFeature, UsageWarning>;
-using WarningAndEnabled = std::pair<Warning, bool>;
+using LanguageFeatureOrWarning = std::variant<LanguageFeature, UsageWarning>;
+using LanguageControlFlag =
+    std::pair<LanguageFeatureOrWarning, /*shouldEnable=*/bool>;
 
 class LanguageFeatureControl {
 public:
@@ -96,11 +97,11 @@ public:
   void EnableWarning(UsageWarning w, bool yes = true) {
     warnUsage_.set(w, yes);
   }
-  void EnableWarning(Warning warning, bool yes = true) {
-    if (std::holds_alternative<LanguageFeature>(warning)) {
-      EnableWarning(std::get<LanguageFeature>(warning), yes);
+  void EnableWarning(LanguageFeatureOrWarning flag, bool yes = true) {
+    if (std::holds_alternative<LanguageFeature>(flag)) {
+      EnableWarning(std::get<LanguageFeature>(flag), yes);
     } else {
-      EnableWarning(std::get<UsageWarning>(warning), yes);
+      EnableWarning(std::get<UsageWarning>(flag), yes);
     }
   }
   void WarnOnAllNonstandard(bool yes = true);
@@ -126,7 +127,7 @@ public:
   bool ShouldWarn(UsageWarning w) const { return warnUsage_.test(w); }
   // Cli options
   // Find a warning by its Cli spelling, i.e. '[no-]warning-name'.
-  std::optional<WarningAndEnabled> FindWarning(std::string_view input);
+  std::optional<LanguageControlFlag> FindWarning(std::string_view input);
   // Take a string from the Cli and apply it to the LanguageFeatureControl.
   // Return true if the option was recognized (and hence applied).
   bool EnableWarning(std::string_view input);

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -81,6 +81,8 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;
+using Warning = std::variant<LanguageFeature, UsageWarning>;
+using WarningAndEnabled = std::pair<Warning, bool>;
 
 class LanguageFeatureControl {
 public:
@@ -93,6 +95,13 @@ public:
   }
   void EnableWarning(UsageWarning w, bool yes = true) {
     warnUsage_.set(w, yes);
+  }
+  void EnableWarning(Warning warning, bool yes = true) {
+    if (std::holds_alternative<LanguageFeature>(warning)) {
+      EnableWarning(std::get<LanguageFeature>(warning), yes);
+    } else {
+      EnableWarning(std::get<UsageWarning>(warning), yes);
+    }
   }
   void WarnOnAllNonstandard(bool yes = true);
   bool IsWarnOnAllNonstandard() const { return warnAllLanguage_; }
@@ -116,9 +125,11 @@ public:
   bool ShouldWarn(LanguageFeature f) const { return warnLanguage_.test(f); }
   bool ShouldWarn(UsageWarning w) const { return warnUsage_.test(w); }
   // Cli options
+  // Find a warning by its Cli spelling, i.e. '[no-]warning-name'.
+  std::optional<WarningAndEnabled> FindWarning(std::string input);
   // Take a string from the Cli and apply it to the LanguageFeatureControl.
   // Return true if the option was recognized (and hence applied).
-  bool ApplyCliOption(std::string input);
+  bool EnableWarning(std::string input);
   // The add and replace functions are not currently used but are provided
   // to allow a flexible many-to-one mapping from Cli spellings to enum values.
   // Taking a string by value because the functions own this string after the

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -126,10 +126,10 @@ public:
   bool ShouldWarn(UsageWarning w) const { return warnUsage_.test(w); }
   // Cli options
   // Find a warning by its Cli spelling, i.e. '[no-]warning-name'.
-  std::optional<WarningAndEnabled> FindWarning(std::string input);
+  std::optional<WarningAndEnabled> FindWarning(std::string_view input);
   // Take a string from the Cli and apply it to the LanguageFeatureControl.
   // Return true if the option was recognized (and hence applied).
-  bool EnableWarning(std::string input);
+  bool EnableWarning(std::string_view input);
   // The add and replace functions are not currently used but are provided
   // to allow a flexible many-to-one mapping from Cli spellings to enum values.
   // Taking a string by value because the functions own this string after the

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1011,7 +1011,7 @@ static bool parseDiagArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
       if (wArg == "error") {
         res.setWarnAsErr(true);
         // -W(no-)<feature>
-      } else if (!features.ApplyCliOption(wArg)) {
+      } else if (!features.EnableWarning(wArg)) {
         const unsigned diagID = diags.getCustomDiagID(
             clang::DiagnosticsEngine::Error, "Unknown diagnostic option: -W%0");
         diags.Report(diagID) << wArg;

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -152,19 +152,19 @@ LanguageFeatureControl::LanguageFeatureControl() {
 }
 
 std::optional<std::pair<Warning, bool>> LanguageFeatureControl::FindWarning(
-    std::string input) {
+    std::string_view input) {
   bool negated{false};
   if (input.size() > 3 && input.substr(0, 3) == "no-") {
     negated = true;
     input = input.substr(3);
   }
-  if (auto it{cliOptions_.find(input)}; it != cliOptions_.end()) {
+  if (auto it{cliOptions_.find(std::string{input})}; it != cliOptions_.end()) {
     return std::make_pair(it->second, !negated);
   }
   return std::nullopt;
 }
 
-bool LanguageFeatureControl::EnableWarning(std::string input) {
+bool LanguageFeatureControl::EnableWarning(std::string_view input) {
   if (auto warningAndEnabled{FindWarning(input)}) {
     EnableWarning(warningAndEnabled->first, warningAndEnabled->second);
     return true;

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -151,22 +151,23 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnLanguage_.set(LanguageFeature::NullActualForAllocatable);
 }
 
-// Take a string from the Cli and apply it to the LanguageFeatureControl.
-bool LanguageFeatureControl::ApplyCliOption(std::string input) {
+std::optional<std::pair<Warning, bool>> LanguageFeatureControl::FindWarning(
+    std::string input) {
   bool negated{false};
   if (input.size() > 3 && input.substr(0, 3) == "no-") {
     negated = true;
     input = input.substr(3);
   }
   if (auto it{cliOptions_.find(input)}; it != cliOptions_.end()) {
-    if (std::holds_alternative<LanguageFeature>(it->second)) {
-      EnableWarning(std::get<LanguageFeature>(it->second), !negated);
-      return true;
-    }
-    if (std::holds_alternative<UsageWarning>(it->second)) {
-      EnableWarning(std::get<UsageWarning>(it->second), !negated);
-      return true;
-    }
+    return std::make_pair(it->second, !negated);
+  }
+  return std::nullopt;
+}
+
+bool LanguageFeatureControl::EnableWarning(std::string input) {
+  if (auto warningAndEnabled{FindWarning(input)}) {
+    EnableWarning(warningAndEnabled->first, warningAndEnabled->second);
+    return true;
   }
   return false;
 }

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -151,7 +151,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnLanguage_.set(LanguageFeature::NullActualForAllocatable);
 }
 
-std::optional<std::pair<Warning, bool>> LanguageFeatureControl::FindWarning(
+std::optional<LanguageControlFlag> LanguageFeatureControl::FindWarning(
     std::string_view input) {
   bool negated{false};
   if (input.size() > 3 && input.substr(0, 3) == "no-") {


### PR DESCRIPTION
This just adds some convenience methods to feature control and rewrites old code in terms of those methods. Also cleans up some names that I just realize were overloads of another method.