### PR TITLE
[Driver] Fix Arm/AArch64 Link Argument tests

### DIFF
--- a/clang/test/Driver/aarch64-toolchain.c
+++ b/clang/test/Driver/aarch64-toolchain.c
@@ -135,7 +135,8 @@
 
 // AARCH64-BAREMETAL-COMPILER-RT: "{{.*}}crt0.o"
 // AARCH64-BAREMETAL-COMPILER-RT: "{{.*}}clang_rt.crtbegin.o"
-// AARCH64-BAREMETAL-COMPILER-RT: "--start-group" "{{.*}}libclang_rt.builtins.a" "-lc" "-lgloss" "--end-group"
+// AARCH64-BAREMETAL-COMPILER-RT: "--start-group" "{{.*}}libclang_rt.builtins.a"
+// AARCH64-BAREMETAL-COMPILER-RT: "-lc" "-lgloss" "--end-group"
 // AARCH64-BAREMETAL-COMPILER-RT: "{{.*}}clang_rt.crtend.o"
 
 // RUN: %clang -### %s -fuse-ld= \

--- a/clang/test/Driver/arm-toolchain.c
+++ b/clang/test/Driver/arm-toolchain.c
@@ -136,7 +136,8 @@
 
 // ARM-BAREMETAL-COMPILER-RT: "{{.*}}crt0.o"
 // ARM-BAREMETAL-COMPILER-RT: "{{.*}}clang_rt.crtbegin.o"
-// ARM-BAREMETAL-COMPILER-RT: "--start-group" "{{.*}}libclang_rt.builtins.a" "-lc" "-lgloss" "--end-group"
+// ARM-BAREMETAL-COMPILER-RT: "--start-group" "{{.*}}libclang_rt.builtins.a"
+// ARM-BAREMETAL-COMPILER-RT: "-lc" "-lgloss" "--end-group"
 // ARM-BAREMETAL-COMPILER-RT: "{{.*}}clang_rt.crtend.o"
 
 // RUN: %clang -### %s -fuse-ld= \


### PR DESCRIPTION
The openmp-offload-amdgpu-runtime-2 bot specifies default rtlib of compiler-rt, but default unwindlib of libgcc. Change the tests to accept that there may be `"--as-needed" "-lgcc_s" "--no-as-needed"` between `libclang_rt.builtins.a` and `-lc`.

Relates to #121830