### PR TITLE
[LLVM] [Support] Disable `ioctl()` terminal size check on Solaris

### DIFF
--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -320,7 +320,7 @@ static unsigned getColumns(int FileID) {
   // instead if it isn't available.
   unsigned Columns = 0;
 
-#ifdef HAVE_SYS_IOCTL_H
+#if defined(HAVE_SYS_IOCTL_H) && !defined(__sun__)
   struct winsize ws;
   if (ioctl(FileID, TIOCGWINSZ, &ws) == 0)
     Columns = ws.ws_col;


### PR DESCRIPTION
#143514 broke the `clang-solaris11-sparcv9` bot; from what I can tell that’s Solaris and according to `SolarisTargetInfo::getOSDefines`, the macro `__sun__` should be defined on Solaris, so check for that and don’t try to query the terminal size if it is defined.

Not sure this is the best solution but hopefully it fixes the bot.