### PR TITLE
[llvm] re-order LLVM_ABI and extern on NoKernelInfoEndLTO decl

### DIFF
--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <utility>
 
-extern LLVM_ABI llvm::cl::opt<bool> NoKernelInfoEndLTO;
+LLVM_ABI extern llvm::cl::opt<bool> NoKernelInfoEndLTO;
 
 namespace llvm {
 


### PR DESCRIPTION
## Overview
Fix compilation error introduced by #143615. Build failure logs available [here](https://lab.llvm.org/buildbot/#/builders/195/builds/10573)

## Background
On `extern` variable declarations, `LLVM_ABI` must appear before `extern` because `LLVM_ABI` currently resolves to `[[gnu::visibility("default")]]` when building with gcc.

