### PR TITLE
[LangRef] Cap maximum value of vscale at 2^31-1.

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -4446,6 +4446,7 @@ of elements; vscale is a positive integer that is unknown at compile time
 and the same hardware-dependent constant for all scalable vectors at run
 time. The size of a specific scalable vector type is thus constant within
 IR, even if the exact size in bytes cannot be determined until run time.
+vscale can be at most 2^31-1.
 
 :Examples:
 
@@ -30399,7 +30400,7 @@ Semantics:
 """"""""""
 
 ``vscale`` is a positive value that is constant throughout program
-execution, but is unknown at compile time.
+execution, but is unknown at compile time. The returned value can be at most 2^31-1.
 If the result value does not fit in the result type, then the result is
 a :ref:`poison value <poisonvalues>`.
 


### PR DESCRIPTION
Cap the maximum value of vscale at 2^31-1. This should exceed what is available on actual hardware by far but should be enough to ensure that computing the runtime VF `vscale x V` generated by LoopVectorize won't wrap when using i64 index types, as `V` cannot exceed 2^32. LoopVectorize already assumes it won't wrap, this change tries to back up the assumption in LangRef.