### PR TITLE
[llvm] include GenericLoopInfoImpl for full implementation

### DIFF
--- a/llvm/include/llvm/Analysis/LoopInfo.h
+++ b/llvm/include/llvm/Analysis/LoopInfo.h
@@ -18,7 +18,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/Compiler.h"
-#include "llvm/Support/GenericLoopInfo.h"
+#include "llvm/Support/GenericLoopInfoImpl.h"
 #include <optional>
 #include <utility>
 


### PR DESCRIPTION
MSVC issues a warning when a an `extern` template instantiation is annotated for DLL export but it does not have the complete template definition. Because the full implementation of `LoopBase` is in `GenericLoopInfoImpl.h` rather than `GenericLoopInfo.h`, MSVC complains whenever `LoopInfo.h` is included. 
```
S:\llvm\llvm-project\llvm\include\llvm/Support/GenericLoopInfo.h(342): warning C4661: 'BlockT *llvm::LoopBase<BlockT,llvm::Loop>::getLoopLatch(void) const': no suitable definition provided for explicit template instantiation request
        with
        [
            BlockT=llvm::BasicBlock
        ]
S:\llvm\llvm-project\llvm\include\llvm/Support/GenericLoopInfo.h(326): note: see declaration of 'llvm::LoopBase<llvm::BasicBlock,llvm::Loop>::getLoopLatch'
```
Everything links fine but the warning is very noisy when building LLVM as a Windows DLL. Interestingly, `clang-cl` does not warn here and is fine with the code as-is.