### PR TITLE
let Neon builtin function accept a const variable

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5666,11 +5666,12 @@ bool Sema::BuiltinConstantArg(CallExpr *TheCall, int ArgNum,
 
   if (Arg->isTypeDependent() || Arg->isValueDependent()) return false;
 
-  std::optional<llvm::APSInt> R;
-  if (!(R = Arg->getIntegerConstantExpr(Context)))
+  Expr::EvalResult evalRes;
+  if (!Arg->EvaluateAsInt(evalRes, Context)) {
     return Diag(TheCall->getBeginLoc(), diag::err_constant_integer_arg_type)
            << FDecl->getDeclName() << Arg->getSourceRange();
-  Result = *R;
+  }
+  Result = evalRes.Val.getInt();
   return false;
 }
 


### PR DESCRIPTION
`FORCE_INLINE __m128i _mm_sll_epi64(__m128i a, __m128i count)
{
    long long c = count.vect_s64[0];
    const int mc = c;
    __m128i result_m128i;
    if (likely(c >= 0 && c < 64)) {
        result_m128i.vect_s64 = vshlq_n_s64(a.vect_s64, mc);
    } else {
        result_m128i.vect_s64 = vdupq_n_s64(0);
    } 
    return result_m128i;
}`
vshlq_n_s64 is an Neon intrinsics, 2nd parameter of this function needs a const int, however it failed in current CLANG Latest version. This patch used to support this feature which make Neon intrinsics can receive a const int variable instead of literal.