### PR TITLE
[GlobalOpt] Use cast instead of dyn_cast. NFC

### DIFF
--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2169,7 +2169,7 @@ static bool tryWidenGlobalArraysUsedByMemcpy(
 
     unsigned NumBytesToCopy = BytesToCopyOp->getZExtValue();
 
-    auto *Alloca = dyn_cast<AllocaInst>(CI->getArgOperand(0));
+    auto *Alloca = cast<AllocaInst>(CI->getArgOperand(0));
     uint64_t DZSize = Alloca->getAllocatedType()->getArrayNumElements();
     uint64_t SZSize = SourceDataArray->getType()->getNumElements();
     unsigned ElementByteWidth = SourceDataArray->getElementByteSize();


### PR DESCRIPTION
The dyn_cast was not checked for null, and the cast is guaranteed to succeed by an earlier check.