### PR TITLE
[NPM] Fix pass registry entry

### DIFF
--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -628,7 +628,7 @@ FUNCTION_PASS_WITH_PARAMS(
     [](SROAOptions PreserveCFG) { return SROAPass(PreserveCFG); },
     parseSROAOptions, "preserve-cfg;modify-cfg")
 FUNCTION_PASS_WITH_PARAMS(
-  "structurizecfg", "StructurizeCFG",
+  "structurize-cfg", "StructurizeCFGPass",
   [](bool SkipUniformRegions) {
     return StructurizeCFGPass(SkipUniformRegions);
   },


### PR DESCRIPTION
Could do something like this to prevent such slips too

```
#define FUNCTION_PASS(..., CREATE_PASS, ...) \
  do { \
    auto lamdba = CREATE_PASS; \
    using ReturnType = decltype(lambda({})); \
    PIC->addClassNameToPassName(ReturnType::name(), NAME); \
          \
  } while(0)
```