### PR TITLE
Fix tests failing on fuchsia clang x86_64 builders

### DIFF
--- a/clang/test/Driver/aarch64-toolchain-extra.c
+++ b/clang/test/Driver/aarch64-toolchain-extra.c
@@ -3,6 +3,7 @@
 // The tests here are similar to those in aarch64-toolchain.c, however
 // these tests need to create symlinks to test directory trees in order to
 // set up the environment and therefore shell support is required.
+// XFAIL: target={{.*}}-fuchsia{{.*}}
 // REQUIRES: shell
 // UNSUPPORTED: system-windows
 

--- a/clang/test/Driver/aarch64-toolchain.c
+++ b/clang/test/Driver/aarch64-toolchain.c
@@ -1,3 +1,4 @@
+// XFAIL: target={{.*}}-fuchsia{{.*}}
 // UNSUPPORTED: system-windows
 
 // RUN: %clang -### %s -fuse-ld= \

--- a/clang/test/Driver/arm-toolchain-extra.c
+++ b/clang/test/Driver/arm-toolchain-extra.c
@@ -3,6 +3,7 @@
 // The tests here are similar to those in arm-toolchain.c, however
 // these tests need to create symlinks to test directory trees in order to
 // set up the environment and therefore shell support is required.
+// XFAIL: target={{.*}}-fuchsia{{.*}}
 // REQUIRES: shell
 // UNSUPPORTED: system-windows
 

--- a/clang/test/Driver/arm-toolchain.c
+++ b/clang/test/Driver/arm-toolchain.c
@@ -1,3 +1,4 @@
+// XFAIL: target={{.*}}-fuchsia{{.*}}
 // UNSUPPORTED: system-windows
 
 // RUN: %clang -### %s -fuse-ld= \


### PR DESCRIPTION
Fuchsia sets CLANG_DEFAULT_UNWINDLIB to libunwind. As a result, when rtlib is set to libgcc and unwindlib is not explicitly specified, tests using Fuchsia as the default platform will fail. To address this, the affected tests are now xfailed

This change fixes the following tests introduced in https://github.com/llvm/llvm-project/commit/45ea46c44636094e9fcdbbeabfd11f9d0fad5e38:

clang/test/Driver/aarch64-toolchain-extra.c
clang/test/Driver/arm-toolchain-extra.c
clang/test/Driver/aarch64-toolchain.c
clang/test/Driver/arm-toolchain.c