### PR TITLE
ARM: Move declaration of supportSplitCSR to be public

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -716,6 +716,11 @@ class VectorType;
       return true;
     }
 
+    bool supportSplitCSR(MachineFunction *MF) const override {
+      return MF->getFunction().getCallingConv() == CallingConv::CXX_FAST_TLS &&
+             MF->getFunction().hasFnAttribute(Attribute::NoUnwind);
+    }
+
     bool hasStandaloneRem(EVT VT) const override {
       return HasStandaloneRem;
     }
@@ -913,11 +918,6 @@ class VectorType;
                             const SDLoc &dl, SelectionDAG &DAG,
                             SmallVectorImpl<SDValue> &InVals, bool isThisReturn,
                             SDValue ThisVal, bool isCmseNSCall) const;
-
-    bool supportSplitCSR(MachineFunction *MF) const override {
-      return MF->getFunction().getCallingConv() == CallingConv::CXX_FAST_TLS &&
-          MF->getFunction().hasFnAttribute(Attribute::NoUnwind);
-    }
 
     void initializeSplitCSR(MachineBasicBlock *Entry) const override;
     void insertCopiesSplitCSR(


### PR DESCRIPTION
This is an implementation of a public method from the base
class, so it should also be public. Avoids unrelated diff
in a future patch.