### PR TITLE
[mlir][Transforms] Dialect Conversion: Do not overwrite mapping

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -144,6 +144,8 @@ struct ConversionValueMapping {
   template <typename OldVal, typename NewVal>
   std::enable_if_t<IsValueVector<OldVal>::value && IsValueVector<NewVal>::value>
   map(OldVal &&oldVal, NewVal &&newVal) {
+    assert(mapping.find(oldVal) == mapping.end() &&
+           "attempting to overwrite mapping");
     LLVM_DEBUG({
       ValueVector next(newVal);
       while (true) {


### PR DESCRIPTION
This commit adds an assertion to check that the `ConversionValueMapping` is not silently overwritten. Doing so would indicate a bug in the conversion driver or incorrect API usage.
