### PR TITLE
[AArch64]Adjust MaxInterleaveFactor for A320

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -176,6 +176,12 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
     MaxBytesForLoopAlignment = 16;
     break;
   case CortexA320:
+    PrefFunctionAlignment = Align(16);
+    VScaleForTuning = 1;
+    PrefLoopAlignment = Align(16);
+    MaxBytesForLoopAlignment = 8;
+    MaxInterleaveFactor = 1;
+    break;
   case CortexA510:
   case CortexA520:
     PrefFunctionAlignment = Align(16);


### PR DESCRIPTION
Investigation has shown that a MaxInterleaveFactor of 1 results in better codegen for A320 than the default value of 2.