### PR TITLE
[RemoveDIs] Resolve RemoveRedundantDbgInstrs fwd scan FIXME

### DIFF
--- a/llvm/test/Transforms/DCE/dbg-value-removal.ll
+++ b/llvm/test/Transforms/DCE/dbg-value-removal.ll
@@ -4,7 +4,7 @@
 ; All dbg.value with location "!dbg !19" are redundant in the input.
 ; FIXME: We do not handle non-overlapping/overlapping fragments perfectly yet.
 
-define dso_local i16 @main(i16 %a1, i16 %a2) local_unnamed_addr #0 !dbg !7 {
+define dso_local i16 @main(i16 %a1, i16 %a2) local_unnamed_addr !dbg !7 {
 ; CHECK-LABEL: @main(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[BB0:%.*]]
@@ -40,51 +40,46 @@ entry:
   br label %bb0
 
 bb0:
-  call void @llvm.dbg.value(metadata i16 999, metadata !12, metadata !DIExpression()), !dbg !19
-  call void @llvm.dbg.value(metadata i16 996, metadata !13, metadata !DIExpression()), !dbg !19
-  call void @llvm.dbg.value(metadata i16 13, metadata !13, metadata !DIExpression()), !dbg !17
-  call void @llvm.dbg.value(metadata i16 998, metadata !12, metadata !DIExpression(DW_OP_constu, 2, DW_OP_shr, DW_OP_stack_value)), !dbg !19
-  call void @llvm.dbg.value(metadata i16 14, metadata !14, metadata !DIExpression()), !dbg !16
-  call void @llvm.dbg.value(metadata i16 997, metadata !12, metadata !DIExpression()), !dbg !19
-  call void @llvm.dbg.value(metadata i16 13, metadata !13, metadata !DIExpression()), !dbg !16
-  call void @llvm.dbg.value(metadata i16 12, metadata !12, metadata !DIExpression()), !dbg !16
+    #dbg_value(i16 999, !12, !DIExpression(), !19)
+    #dbg_value(i16 996, !13, !DIExpression(), !19)
+    #dbg_value(i16 13, !13, !DIExpression(), !17)
+    #dbg_value(i16 998, !12, !DIExpression(DW_OP_constu, 2, DW_OP_shr, DW_OP_stack_value), !19)
+    #dbg_value(i16 14, !14, !DIExpression(), !16)
+    #dbg_value(i16 997, !12, !DIExpression(), !19)
+    #dbg_value(i16 13, !13, !DIExpression(), !16)
+    #dbg_value(i16 12, !12, !DIExpression(), !16)
   br label %bb1
 
 bb1:
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !14, metadata !DIExpression()), !dbg !16
-  call void @llvm.dbg.value(metadata i16 888, metadata !13, metadata !DIExpression()), !dbg !16
-  call void @llvm.dbg.value(metadata i16 %a2, metadata !12, metadata !DIExpression()), !dbg !16
+    #dbg_value(i16 %a1, !14, !DIExpression(), !16)
+    #dbg_value(i16 888, !13, !DIExpression(), !16)
+    #dbg_value(i16 %a2, !12, !DIExpression(), !16)
   %t1 = call i16 @bar(i16 0)
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !14, metadata !DIExpression()), !dbg !19
-  call void @llvm.dbg.value(metadata i16 %t1, metadata !13, metadata !DIExpression()), !dbg !16
-  call void @llvm.dbg.value(metadata i16 %a2, metadata !12, metadata !DIExpression(DW_OP_constu, 2, DW_OP_shr, DW_OP_stack_value)), !dbg !16
+    #dbg_value(i16 %a1, !14, !DIExpression(), !19)
+    #dbg_value(i16 %t1, !13, !DIExpression(), !16)
+    #dbg_value(i16 %a2, !12, !DIExpression(DW_OP_constu, 2, DW_OP_shr, DW_OP_stack_value), !16)
   br label %bb2
 
 bb2:
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !13, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 8)), !dbg !19
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !13, metadata !DIExpression(DW_OP_LLVM_fragment, 8, 8)), !dbg !19
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !13, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 8)), !dbg !16
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !13, metadata !DIExpression(DW_OP_LLVM_fragment, 8, 8)), !dbg !16
+    #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 0, 8), !19)
+    #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 8, 8), !19)
+    #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 0, 8), !16)
+    #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 8, 8), !16)
   %t2 = call i16 @bar(i16 %t1)
-  call void @llvm.dbg.value(metadata i16 %t2, metadata !13, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 8)), !dbg !16
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !13, metadata !DIExpression(DW_OP_LLVM_fragment, 8, 8)), !dbg !19
+    #dbg_value(i16 %t2, !13, !DIExpression(DW_OP_LLVM_fragment, 0, 8), !16)
+    #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 8, 8), !19)
   br label %bb3
 
 bb3:
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !13, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 8)), !dbg !19
-  call void @llvm.dbg.value(metadata i16 %a1, metadata !13, metadata !DIExpression()), !dbg !16
+    #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 0, 8), !19)
+    #dbg_value(i16 %a1, !13, !DIExpression(), !16)
   br label %exit
 
 exit:
   ret i16 %t2
 }
 
-declare void @llvm.dbg.value(metadata, metadata, metadata) #1
-declare i16 @bar(i16) #2
-
-attributes #0 = { noinline nounwind }
-attributes #1 = { nounwind readnone speculatable willreturn }
-attributes #2 = { noinline nounwind readnone }
+declare i16 @bar(i16)
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4, !5}

--- a/llvm/test/Transforms/DCE/dbg-value-removal.ll
+++ b/llvm/test/Transforms/DCE/dbg-value-removal.ll
@@ -23,6 +23,8 @@ define dso_local i16 @main(i16 %a1, i16 %a2) local_unnamed_addr !dbg !7 {
 ; CHECK-NEXT:      #dbg_value(i16 [[A2]], [[META12]], !DIExpression(DW_OP_constu, 2, DW_OP_shr, DW_OP_stack_value), [[META18]])
 ; CHECK-NEXT:    br label [[BB2:%.*]]
 ; CHECK:       bb2:
+; CHECK-NEXT:      #dbg_declare(i16 %a1, !19, !DIExpression(), [[META18]])
+; CHECK-NEXT:      #dbg_label([[META21:![0-9]+]], [[META18]])
 ; CHECK-NEXT:      #dbg_value(i16 [[A1]], [[META13]], !DIExpression(DW_OP_LLVM_fragment, 0, 8), [[META18]])
 ; CHECK-NEXT:      #dbg_value(i16 [[A1]], [[META13]], !DIExpression(DW_OP_LLVM_fragment, 8, 8), [[META18]])
 ; CHECK-NEXT:    [[T2:%.*]] = call i16 @bar(i16 [[T1]])
@@ -63,6 +65,9 @@ bb1:
 bb2:
     #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 0, 8), !19)
     #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 8, 8), !19)
+    ; Check dbg_declare and dbg_label don't interfere with the backward scan.
+    #dbg_declare(i16 %a1, !21, !DIExpression(), !16)
+    #dbg_label(!20, !16)
     #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 0, 8), !16)
     #dbg_value(i16 %a1, !13, !DIExpression(DW_OP_LLVM_fragment, 8, 8), !16)
   %t2 = call i16 @bar(i16 %t1)
@@ -105,3 +110,5 @@ declare i16 @bar(i16)
 !17 = !DILocation(line: 0, scope: !7, inlinedAt: !18)
 !18 = !DILocation(line: 1, scope: !7)
 !19 = !DILocation(line: 77, scope: !7)
+!20 = !DILabel(scope: !7, name: "label", file: !1, line: 3)
+!21 = !DILocalVariable(name: "z", scope: !7, file: !1, line: 10, type: !10)


### PR DESCRIPTION
These FIXMEs were added to keep the dbg_record implementation identical to the dbg intrinsic versions, which have since been removed. I don't think there's any reason for the old behaviour; my understanding is it was a minor bug no one got round to fixing.

I've upgraded the test to be written with dbg_records while I'm here.