### PR TITLE
[CIR] Add Minimal Destructor Definition Support

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -250,6 +250,10 @@ struct MissingFeatures {
   static bool typeChecks() { return false; }
   static bool weakRefReference() { return false; }
   static bool writebacks() { return false; }
+  static bool appleKext() { return false; }
+  static bool dtorCleanups() { return false; }
+  static bool completeDtors() { return false; }
+  static bool vtableInitialization() { return false; }
 
   // Missing types
   static bool dataMemberType() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.cpp
@@ -41,6 +41,13 @@ void CIRGenCXXABI::buildThisParam(CIRGenFunction &cgf,
   assert(!cir::MissingFeatures::cxxabiThisAlignment());
 }
 
+cir::GlobalLinkageKind CIRGenCXXABI::getCXXDestructorLinkage(
+    GVALinkage linkage, const CXXDestructorDecl *dtor, CXXDtorType dt) const {
+  // Delegate back to cgm by default.
+  return cgm.getCIRLinkageForDeclarator(dtor, linkage,
+                                        /*isConstantVariable=*/false);
+}
+
 mlir::Value CIRGenCXXABI::loadIncomingCXXThis(CIRGenFunction &cgf) {
   ImplicitParamDecl *vd = getThisDecl(cgf);
   Address addr = cgf.getAddrOfLocalVar(vd);

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -72,6 +72,19 @@ public:
   /// Emit constructor variants required by this ABI.
   virtual void emitCXXConstructors(const clang::CXXConstructorDecl *d) = 0;
 
+  /// Emit dtor variants required by this ABI.
+  virtual void emitCXXDestructors(const clang::CXXDestructorDecl *d) = 0;
+
+  /// Returns true if the given destructor type should be emitted as a linkonce
+  /// delegating thunk, regardless of whether the dtor is defined in this TU or
+  /// not.
+  virtual bool useThunkForDtorVariant(const CXXDestructorDecl *dtor,
+                                      CXXDtorType dt) const = 0;
+
+  virtual cir::GlobalLinkageKind
+  getCXXDestructorLinkage(GVALinkage linkage, const CXXDestructorDecl *dtor,
+                          CXXDtorType dt) const;
+
   /// Returns true if the given constructor or destructor is one of the kinds
   /// that the ABI says returns 'this' (only applies when called non-virtually
   /// for destructors).

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -570,7 +570,7 @@ void CIRGenFunction::emitDestructorBody(FunctionArgList &args) {
   // possible to delegate the destructor body to the complete
   // destructor.  Do so.
   if (dtorType == Dtor_Deleting) {
-    cgm.errorNYI("deleting destructor");
+    cgm.errorNYI(dtor->getSourceRange(), "deleting destructor");
     return;
   }
 
@@ -578,7 +578,7 @@ void CIRGenFunction::emitDestructorBody(FunctionArgList &args) {
   // anything else.
   const bool isTryBody = isa_and_nonnull<CXXTryStmt>(body);
   if (isTryBody) {
-    cgm.errorNYI("function-try-block destructor");
+    cgm.errorNYI(dtor->getSourceRange(), "function-try-block destructor");
   }
 
   assert(!cir::MissingFeatures::sanitizers());
@@ -617,7 +617,7 @@ void CIRGenFunction::emitDestructorBody(FunctionArgList &args) {
     assert(!cir::MissingFeatures::vtableInitialization());
 
     if (isTryBody) {
-      cgm.errorNYI("function-try-block destructor");
+      cgm.errorNYI(dtor->getSourceRange(), "function-try-block destructor");
     } else if (body) {
       (void)emitStmt(body, /*useCurrentScope=*/true);
     } else {
@@ -635,7 +635,7 @@ void CIRGenFunction::emitDestructorBody(FunctionArgList &args) {
 
   // Exit the try if applicable.
   if (isTryBody)
-    cgm.errorNYI("function-try-block destructor");
+    cgm.errorNYI(dtor->getSourceRange(), "function-try-block destructor");
 }
 
 /// Given a value of type T* that may not be to a complete object, construct

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -463,7 +463,7 @@ cir::FuncOp CIRGenFunction::generateCode(clang::GlobalDecl gd, cir::FuncOp fn,
     startFunction(gd, retTy, fn, funcType, args, loc, bodyRange.getBegin());
 
     if (isa<CXXDestructorDecl>(funcDecl)) {
-      getCIRGenModule().errorNYI(bodyRange, "C++ destructor definition");
+      emitDestructorBody(args);
     } else if (isa<CXXConstructorDecl>(funcDecl)) {
       emitConstructorBody(args);
     } else if (getLangOpts().CUDA && !getLangOpts().CUDAIsDevice &&
@@ -538,6 +538,104 @@ void CIRGenFunction::emitConstructorBody(FunctionArgList &args) {
                  "emitConstructorBody: emit body statement failed.");
     return;
   }
+}
+
+/// Emits the body of the current destructor.
+void CIRGenFunction::emitDestructorBody(FunctionArgList &args) {
+  const CXXDestructorDecl *dtor = cast<CXXDestructorDecl>(curGD.getDecl());
+  CXXDtorType dtorType = curGD.getDtorType();
+
+  // For an abstract class, non-base destructors are never used (and can't
+  // be emitted in general, because vbase dtors may not have been validated
+  // by Sema), but the Itanium ABI doesn't make them optional and Clang may
+  // in fact emit references to them from other compilations, so emit them
+  // as functions containing a trap instruction.
+  if (dtorType != Dtor_Base && dtor->getParent()->isAbstract()) {
+    SourceLocation loc =
+        dtor->hasBody() ? dtor->getBody()->getBeginLoc() : dtor->getLocation();
+    builder.create<cir::TrapOp>(getLoc(loc));
+    // The corresponding clang/CodeGen logic clears the insertion point here,
+    // but MLIR's builder requires a valid insertion point, so we create a dummy
+    // block (since the trap is a block terminator).
+    builder.createBlock(builder.getBlock()->getParent());
+    return;
+  }
+
+  Stmt *body = dtor->getBody();
+  if (body)
+    assert(!cir::MissingFeatures::incrementProfileCounter());
+
+  // The call to operator delete in a deleting destructor happens
+  // outside of the function-try-block, which means it's always
+  // possible to delegate the destructor body to the complete
+  // destructor.  Do so.
+  if (dtorType == Dtor_Deleting) {
+    cgm.errorNYI("deleting destructor");
+    return;
+  }
+
+  // If the body is a function-try-block, enter the try before
+  // anything else.
+  const bool isTryBody = isa_and_nonnull<CXXTryStmt>(body);
+  if (isTryBody) {
+    cgm.errorNYI("function-try-block destructor");
+  }
+
+  assert(!cir::MissingFeatures::sanitizers());
+  assert(!cir::MissingFeatures::dtorCleanups());
+
+  // If this is the complete variant, just invoke the base variant;
+  // the epilogue will destruct the virtual bases.  But we can't do
+  // this optimization if the body is a function-try-block, because
+  // we'd introduce *two* handler blocks.  In the Microsoft ABI, we
+  // always delegate because we might not have a definition in this TU.
+  switch (dtorType) {
+  case Dtor_Comdat:
+    llvm_unreachable("not expecting a COMDAT");
+  case Dtor_Deleting:
+    llvm_unreachable("already handled deleting case");
+
+  case Dtor_Complete:
+    assert((body || getTarget().getCXXABI().isMicrosoft()) &&
+           "can't emit a dtor without a body for non-Microsoft ABIs");
+
+    assert(!cir::MissingFeatures::dtorCleanups());
+
+    // TODO(cir): A complete destructor is supposed to call the base destructor.
+    // Since we have to emit both dtor kinds we just fall through for now and.
+    // As long as we don't support virtual bases this should be functionally
+    // equivalent.
+    assert(!cir::MissingFeatures::completeDtors());
+
+    // Fallthrough: act like we're in the base variant.
+    [[fallthrough]];
+
+  case Dtor_Base:
+    assert(body);
+
+    assert(!cir::MissingFeatures::dtorCleanups());
+    assert(!cir::MissingFeatures::vtableInitialization());
+
+    if (isTryBody) {
+      cgm.errorNYI("function-try-block destructor");
+    } else if (body) {
+      (void)emitStmt(body, /*useCurrentScope=*/true);
+    } else {
+      assert(dtor->isImplicit() && "bodyless dtor not implicit");
+      // nothing to do besides what's in the epilogue
+    }
+    // -fapple-kext must inline any call to this dtor into
+    // the caller's body.
+    assert(!cir::MissingFeatures::appleKext());
+
+    break;
+  }
+
+  assert(!cir::MissingFeatures::dtorCleanups());
+
+  // Exit the try if applicable.
+  if (isTryBody)
+    cgm.errorNYI("function-try-block destructor");
 }
 
 /// Given a value of type T* that may not be to a complete object, construct

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -830,6 +830,7 @@ public:
   LValue emitCompoundAssignmentLValue(const clang::CompoundAssignOperator *e);
 
   void emitConstructorBody(FunctionArgList &args);
+  void emitDestructorBody(FunctionArgList &args);
 
   mlir::LogicalResult emitContinueStmt(const clang::ContinueStmt &s);
 

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -161,7 +161,6 @@ void CIRGenItaniumCXXABI::emitCXXStructor(GlobalDecl gd) {
   auto *md = cast<CXXMethodDecl>(gd.getDecl());
   StructorCIRGen cirGenType = getCIRGenToUse(cgm, md);
   const auto *cd = dyn_cast<CXXConstructorDecl>(md);
-  const CXXDestructorDecl *dd = cd ? nullptr : cast<CXXDestructorDecl>(md);
 
   if (cd ? gd.getCtorType() == Ctor_Complete
          : gd.getDtorType() == Dtor_Complete) {

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -43,7 +43,16 @@ public:
                                   CIRGenFunction &cgf) override;
 
   void emitCXXConstructors(const clang::CXXConstructorDecl *d) override;
+  void emitCXXDestructors(const clang::CXXDestructorDecl *d) override;
   void emitCXXStructor(clang::GlobalDecl gd) override;
+
+  bool useThunkForDtorVariant(const CXXDestructorDecl *dtor,
+                              CXXDtorType dt) const override {
+    // Itanium does not emit any destructor variant as an inline thunk.
+    // Delegating may occur as an optimization, but all variants are either
+    // emitted with external linkage or as linkonce if they are inline and used.
+    return false;
+  }
 };
 
 } // namespace
@@ -150,17 +159,15 @@ static void emitConstructorDestructorAlias(CIRGenModule &cgm,
 
 void CIRGenItaniumCXXABI::emitCXXStructor(GlobalDecl gd) {
   auto *md = cast<CXXMethodDecl>(gd.getDecl());
-  auto *cd = dyn_cast<CXXConstructorDecl>(md);
-
   StructorCIRGen cirGenType = getCIRGenToUse(cgm, md);
+  const auto *cd = dyn_cast<CXXConstructorDecl>(md);
+  const CXXDestructorDecl *dd = cd ? nullptr : cast<CXXDestructorDecl>(md);
 
-  if (!cd) {
-    cgm.errorNYI(md->getSourceRange(), "CXCABI emit destructor");
-    return;
-  }
-
-  if (gd.getCtorType() == Ctor_Complete) {
-    GlobalDecl baseDecl = gd.getWithCtorType(Ctor_Base);
+  if (cd ? gd.getCtorType() == Ctor_Complete
+         : gd.getDtorType() == Dtor_Complete) {
+    GlobalDecl baseDecl =
+        cd ? gd.getWithCtorType(Ctor_Base) : gd.getWithDtorType(Dtor_Base);
+    ;
 
     if (cirGenType == StructorCIRGen::Alias ||
         cirGenType == StructorCIRGen::COMDAT) {
@@ -195,6 +202,22 @@ void CIRGenItaniumCXXABI::emitCXXConstructors(const CXXConstructorDecl *d) {
     // We don't need to emit the complete ctro if the class is abstract.
     cgm.emitGlobal(GlobalDecl(d, Ctor_Complete));
   }
+}
+
+void CIRGenItaniumCXXABI::emitCXXDestructors(const CXXDestructorDecl *d) {
+  // The destructor used for destructing this as a base class; ignores
+  // virtual bases.
+  cgm.emitGlobal(GlobalDecl(d, Dtor_Base));
+
+  // The destructor used for destructing this as a most-derived class;
+  // call the base destructor and then destructs any virtual bases.
+  cgm.emitGlobal(GlobalDecl(d, Dtor_Complete));
+
+  // The destructor in a virtual table is always a 'deleting'
+  // destructor, which calls the complete destructor and then uses the
+  // appropriate operator delete.
+  if (d->isVirtual())
+    cgm.emitGlobal(GlobalDecl(d, Dtor_Deleting));
 }
 
 /// Return whether the given global decl needs a VTT (virtual table table)

--- a/clang/test/CIR/CodeGen/destructors.cpp
+++ b/clang/test/CIR/CodeGen/destructors.cpp
@@ -48,3 +48,10 @@ struct inline_destructor {
         some_function();
     }
 };
+
+// This inline destructor is not odr-used in this TU.
+// Make sure we don't emit a definition
+
+// CIR-NOT: cir.func {{.*}}inline_destructor{{.*}}
+// LLVM-NOT: define {{.*}}inline_destructor{{.*}}
+// OGCG-NOT: define {{.*}}inline_destructor{{.*}}

--- a/clang/test/CIR/CodeGen/destructors.cpp
+++ b/clang/test/CIR/CodeGen/destructors.cpp
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir -mno-constructor-aliases %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -mno-constructor-aliases -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -mno-constructor-aliases -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+void some_function() noexcept;
+
+struct out_of_line_destructor {
+    int prevent_tail_padding_reuse;
+    ~out_of_line_destructor();
+};
+
+out_of_line_destructor::~out_of_line_destructor() {
+    some_function();
+}
+
+// CIR: !rec_out_of_line_destructor = !cir.record<struct "out_of_line_destructor" {!s32i}>
+
+// CIR: cir.func dso_local @_ZN22out_of_line_destructorD2Ev(%{{.+}}: !cir.ptr<!rec_out_of_line_destructor>
+// CIR:   cir.call @_Z13some_functionv() nothrow : () -> () 
+// CIR:   cir.return 
+
+// LLVM: define dso_local void @_ZN22out_of_line_destructorD2Ev(ptr %{{.+}})
+// LLVM:   call void @_Z13some_functionv()
+// LLVM:   ret void
+
+// OGCG: define dso_local void @_ZN22out_of_line_destructorD2Ev(ptr {{.*}}%{{.+}})
+// OGCG:   call void @_Z13some_functionv()
+// OGCG:   ret void
+
+// CIR: cir.func dso_local @_ZN22out_of_line_destructorD1Ev(%{{.+}}: !cir.ptr<!rec_out_of_line_destructor>
+// CIR:  cir.call @_Z13some_functionv() nothrow : () -> ()
+// CIR:  cir.return
+
+// LLVM: define dso_local void @_ZN22out_of_line_destructorD1Ev(ptr %{{.+}})
+// LLVM:   call void @_Z13some_functionv()
+// LLVM:   ret void
+
+// OGCG: define dso_local void @_ZN22out_of_line_destructorD1Ev(ptr {{.*}}%{{.+}})
+// OGCG:   call void @_ZN22out_of_line_destructorD2Ev
+// OGCG:   ret void
+
+struct inline_destructor {
+    int prevent_tail_padding_reuse;
+    ~inline_destructor() noexcept(false) {
+        some_function();
+    }
+};


### PR DESCRIPTION
This patch upstreams support for writing inline and out of line C++ destructor definitions. Calling a destructor implcitly or explicitly is left for a future patch.

Because of that restriction complete destructors (D2 in Itanium mangling) do not call into the base (D1) destructors yet but simply behave like a base destructor. Deleting (D0) destructor support is not part of this patch.

Destructor aliases aren't supported, either. Because of this compilation with -mno-constructor-aliases may be required to avoid running into NYI errors.