### PR TITLE
[lldb] upgrade HandleFrameFormatVariable callees to llvm::Expected

### DIFF
--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -74,25 +74,12 @@ struct DemangledNameInfo {
     return BasenameRange.second > BasenameRange.first;
   }
 
-  /// Returns \c true if `BasenameRange` is empty.
-  bool isBasenameEmpty() const {
-    return BasenameRange.first == BasenameRange.second;
-  }
-
   /// Returns \c true if this object holds a valid scope range.
   bool hasScope() const { return ScopeRange.second > ScopeRange.first; }
-
-  /// Returns \c true if `ScopeRange` is empty.
-  bool isScopeEmpty() const { return ScopeRange.first == ScopeRange.second; }
 
   /// Returns \c true if this object holds a valid arguments range.
   bool hasArguments() const {
     return ArgumentsRange.second > ArgumentsRange.first;
-  }
-
-  /// Returns \c true if `ArgumentsRange` is empty.
-  bool isArgumentsEmpty() const {
-    return ArgumentsRange.first == ArgumentsRange.second;
   }
 
   /// Returns \c true if this object holds a valid qualifiers range.
@@ -100,22 +87,11 @@ struct DemangledNameInfo {
     return QualifiersRange.second > QualifiersRange.first;
   }
 
-  /// Returns \c true if `QualifiersRange` is empty.
-  bool isQualifiersEmpty() const {
-    return QualifiersRange.first == QualifiersRange.second;
-  }
-
   /// Returns \c true if this object holds a valid prefix range.
   bool hasPrefix() const { return PrefixRange.second > PrefixRange.first; }
 
-  /// Returns \c true if `PrefixRange` is empty.
-  bool isPrefixEmpty() const { return PrefixRange.first == PrefixRange.second; }
-
   /// Returns \c true if this object holds a valid suffix range.
   bool hasSuffix() const { return SuffixRange.second > SuffixRange.first; }
-
-  /// Returns \c true if `SuffixRange` is empty.
-  bool isSuffixEmpty() const { return SuffixRange.first == SuffixRange.second; }
 };
 
 /// An OutputBuffer which keeps a record of where certain parts of a

--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -74,12 +74,25 @@ struct DemangledNameInfo {
     return BasenameRange.second > BasenameRange.first;
   }
 
+  /// Returns \c true if `BasenameRange` is empty.
+  bool isBasenameEmpty() const {
+    return BasenameRange.first == BasenameRange.second;
+  }
+
   /// Returns \c true if this object holds a valid scope range.
   bool hasScope() const { return ScopeRange.second > ScopeRange.first; }
+
+  /// Returns \c true if `ScopeRange` is empty.
+  bool isScopeEmpty() const { return ScopeRange.first == ScopeRange.second; }
 
   /// Returns \c true if this object holds a valid arguments range.
   bool hasArguments() const {
     return ArgumentsRange.second > ArgumentsRange.first;
+  }
+
+  /// Returns \c true if `ArgumentsRange` is empty.
+  bool isArgumentsEmpty() const {
+    return ArgumentsRange.first == ArgumentsRange.second;
   }
 
   /// Returns \c true if this object holds a valid qualifiers range.
@@ -87,11 +100,22 @@ struct DemangledNameInfo {
     return QualifiersRange.second > QualifiersRange.first;
   }
 
+  /// Returns \c true if `QualifiersRange` is empty.
+  bool isQualifiersEmpty() const {
+    return QualifiersRange.first == QualifiersRange.second;
+  }
+
   /// Returns \c true if this object holds a valid prefix range.
   bool hasPrefix() const { return PrefixRange.second > PrefixRange.first; }
 
+  /// Returns \c true if `PrefixRange` is empty.
+  bool isPrefixEmpty() const { return PrefixRange.first == PrefixRange.second; }
+
   /// Returns \c true if this object holds a valid suffix range.
   bool hasSuffix() const { return SuffixRange.second > SuffixRange.first; }
+
+  /// Returns \c true if `SuffixRange` is empty.
+  bool isSuffixEmpty() const { return SuffixRange.first == SuffixRange.second; }
 };
 
 /// An OutputBuffer which keeps a record of where certain parts of a

--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -71,27 +71,27 @@ struct DemangledNameInfo {
 
   /// Returns \c true if this object holds a valid basename range.
   bool hasBasename() const {
-    return BasenameRange.second > BasenameRange.first;
+    return BasenameRange.second >= BasenameRange.first;
   }
 
   /// Returns \c true if this object holds a valid scope range.
-  bool hasScope() const { return ScopeRange.second > ScopeRange.first; }
+  bool hasScope() const { return ScopeRange.second >= ScopeRange.first; }
 
   /// Returns \c true if this object holds a valid arguments range.
   bool hasArguments() const {
-    return ArgumentsRange.second > ArgumentsRange.first;
+    return ArgumentsRange.second >= ArgumentsRange.first;
   }
 
   /// Returns \c true if this object holds a valid qualifiers range.
   bool hasQualifiers() const {
-    return QualifiersRange.second > QualifiersRange.first;
+    return QualifiersRange.second >= QualifiersRange.first;
   }
 
   /// Returns \c true if this object holds a valid prefix range.
-  bool hasPrefix() const { return PrefixRange.second > PrefixRange.first; }
+  bool hasPrefix() const { return PrefixRange.second >= PrefixRange.first; }
 
   /// Returns \c true if this object holds a valid suffix range.
-  bool hasSuffix() const { return SuffixRange.second > SuffixRange.first; }
+  bool hasSuffix() const { return SuffixRange.second >= SuffixRange.first; }
 };
 
 /// An OutputBuffer which keeps a record of where certain parts of a

--- a/lldb/include/lldb/Core/DemangledNameInfo.h
+++ b/lldb/include/lldb/Core/DemangledNameInfo.h
@@ -71,7 +71,8 @@ struct DemangledNameInfo {
 
   /// Returns \c true if this object holds a valid basename range.
   bool hasBasename() const {
-    return BasenameRange.second >= BasenameRange.first;
+    // A function always has a name.
+    return BasenameRange.second > BasenameRange.first;
   }
 
   /// Returns \c true if this object holds a valid scope range.

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -314,7 +314,7 @@ GetDemangledFunctionQualifiers(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (!info.hasQualifiers() && !info.isQualifiersEmpty())
+  if (!info.hasQualifiers())
     return llvm::createStringError("Qualifiers range for '%s' is invalid.",
                                    demangled_name.data());
 
@@ -347,7 +347,7 @@ GetDemangledScope(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (!info.hasScope() && !info.isScopeEmpty())
+  if (!info.hasScope())
     return llvm::createStringError("Scope range for '%s' is invalid.",
                                    demangled_name.data());
 
@@ -364,7 +364,7 @@ GetDemangledFunctionSuffix(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (!info.hasSuffix() && !info.isSuffixEmpty())
+  if (!info.hasSuffix())
     return llvm::createStringError("Suffix range for '%s' is invalid.",
                                    demangled_name.data());
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -314,7 +314,7 @@ GetDemangledFunctionQualifiers(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (info.QualifiersRange.second < info.QualifiersRange.first)
+  if (!info.hasQualifiers())
     return llvm::createStringError("Qualifiers range for '%s' is invalid.",
                                    demangled_name.data());
 
@@ -349,7 +349,7 @@ GetDemangledScope(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (info.ScopeRange.second < info.ScopeRange.first)
+  if (!info.hasScope())
     return llvm::createStringError("Scope range for '%s' is invalid.",
                                    demangled_name.data());
 
@@ -381,7 +381,7 @@ static bool PrintDemangledArgumentList(Stream &s, const SymbolContext &sc) {
   }
   auto [demangled_name, info] = *info_or_err;
 
-  if (info.ArgumentsRange.second < info.ArgumentsRange.first)
+  if (!info.hasArguments())
     return false;
 
   s << demangled_name.slice(info.ArgumentsRange.first,

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -314,7 +314,7 @@ GetDemangledFunctionQualifiers(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (!info.hasQualifiers())
+  if (!info.hasQualifiers() && !info.isQualifiersEmpty())
     return llvm::createStringError("Qualifiers range for '%s' is invalid.",
                                    demangled_name.data());
 
@@ -347,7 +347,7 @@ GetDemangledScope(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (!info.hasScope())
+  if (!info.hasScope() && !info.isScopeEmpty())
     return llvm::createStringError("Scope range for '%s' is invalid.",
                                    demangled_name.data());
 
@@ -364,7 +364,7 @@ GetDemangledFunctionSuffix(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (!info.hasSuffix())
+  if (!info.hasSuffix() && !info.isSuffixEmpty())
     return llvm::createStringError("Suffix range for '%s' is invalid.",
                                    demangled_name.data());
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -360,7 +360,8 @@ static bool PrintDemangledArgumentList(Stream &s, const SymbolContext &sc) {
 
   auto info_or_err = GetAndValidateInfo(sc);
   if (!info_or_err) {
-    llvm::consumeError(info_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Language), info_or_err.takeError(),
+                   "Failed to retrieve demangled info: {0}");
     return false;
   }
   auto [demangled_name, info] = *info_or_err;
@@ -1897,7 +1898,8 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   case FormatEntity::Entry::Type::FunctionScope: {
     auto scope_or_err = GetDemangledScope(sc);
     if (!scope_or_err) {
-      llvm::consumeError(scope_or_err.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Language), scope_or_err.takeError(),
+                     "Failed to retrieve scope: {0}");
       return false;
     }
 
@@ -1909,7 +1911,8 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   case FormatEntity::Entry::Type::FunctionBasename: {
     auto name_or_err = GetDemangledBasename(sc);
     if (!name_or_err) {
-      llvm::consumeError(name_or_err.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Language), name_or_err.takeError(),
+                     "Failed to retrieve basename: {0}");
       return false;
     }
 
@@ -1921,7 +1924,9 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   case FormatEntity::Entry::Type::FunctionTemplateArguments: {
     auto template_args_or_err = GetDemangledTemplateArguments(sc);
     if (!template_args_or_err) {
-      llvm::consumeError(template_args_or_err.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Language),
+                     template_args_or_err.takeError(),
+                     "Failed to retrieve template arguments: {0}");
       return false;
     }
 
@@ -1956,7 +1961,8 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   case FormatEntity::Entry::Type::FunctionReturnRight: {
     auto return_rhs_or_err = GetDemangledReturnTypeRHS(sc);
     if (!return_rhs_or_err) {
-      llvm::consumeError(return_rhs_or_err.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Language), return_rhs_or_err.takeError(),
+                     "Failed to retrieve RHS return type: {0}");
       return false;
     }
 
@@ -1967,7 +1973,8 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   case FormatEntity::Entry::Type::FunctionReturnLeft: {
     auto return_lhs_or_err = GetDemangledReturnTypeLHS(sc);
     if (!return_lhs_or_err) {
-      llvm::consumeError(return_lhs_or_err.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Language), return_lhs_or_err.takeError(),
+                     "Failed to retrieve LHS return type: {0}");
       return false;
     }
 
@@ -1978,7 +1985,8 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   case FormatEntity::Entry::Type::FunctionQualifiers: {
     auto quals_or_err = GetDemangledFunctionQualifiers(sc);
     if (!quals_or_err) {
-      llvm::consumeError(quals_or_err.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Language), quals_or_err.takeError(),
+                     "Failed to retrieve function qualifiers: {0}");
       return false;
     }
 
@@ -1989,7 +1997,8 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   case FormatEntity::Entry::Type::FunctionSuffix: {
     auto suffix_or_err = GetDemangledFunctionSuffix(sc);
     if (!suffix_or_err) {
-      llvm::consumeError(suffix_or_err.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Language), suffix_or_err.takeError(),
+                     "Failed to retrieve suffix: {0}");
       return false;
     }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -330,9 +330,7 @@ GetDemangledReturnTypeRHS(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
-  if (info.QualifiersRange.first <
-      info.ArgumentsRange.second) // TODO: Replace with .hasArgumentsRange()
-                                  // once #144549 lands.
+  if (info.QualifiersRange.first < info.ArgumentsRange.second)
     return llvm::createStringError(
         "Qualifiers range for '%s' RHS return type  is invalid.",
         demangled_name.data());

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -2007,9 +2007,9 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
   case FormatEntity::Entry::Type::FunctionQualifiers: {
     auto quals_or_err = GetDemangledFunctionQualifiers(sc);
     if (!quals_or_err) {
-      LLDB_LOG_ERROR(
-          GetLog(LLDBLog::Language), quals_or_err.takeError(),
-          "Failed to handle ${{function.qualifiers}} frame-format variable: {0}");
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Language), quals_or_err.takeError(),
+                     "Failed to handle ${{function.qualifiers}} frame-format "
+                     "variable: {0}");
       return false;
     }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -378,7 +378,7 @@ static bool PrintDemangledArgumentList(Stream &s, const SymbolContext &sc) {
   if (!info_or_err) {
     LLDB_LOG_ERROR(
         GetLog(LLDBLog::Language), info_or_err.takeError(),
-        "Failed to handle ${function.basename} frame-format variable: {0}");
+        "Failed to handle ${{function.basename}} frame-format variable: {0}");
     return false;
   }
   auto [demangled_name, info] = *info_or_err;
@@ -1917,7 +1917,7 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     if (!scope_or_err) {
       LLDB_LOG_ERROR(
           GetLog(LLDBLog::Language), scope_or_err.takeError(),
-          "Failed to handle ${function.scope} frame-format variable: {0}");
+          "Failed to handle ${{function.scope}} frame-format variable: {0}");
       return false;
     }
 
@@ -1931,7 +1931,7 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     if (!name_or_err) {
       LLDB_LOG_ERROR(
           GetLog(LLDBLog::Language), name_or_err.takeError(),
-          "Failed to handle ${function.basename} frame-format variable: {0}");
+          "Failed to handle ${{function.basename}} frame-format variable: {0}");
       return false;
     }
 
@@ -1945,7 +1945,7 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     if (!template_args_or_err) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Language),
                      template_args_or_err.takeError(),
-                     "Failed to handle ${function.template-arguments} "
+                     "Failed to handle ${{function.template-arguments}} "
                      "frame-format variable: {0}");
       return false;
     }
@@ -1982,7 +1982,7 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     auto return_rhs_or_err = GetDemangledReturnTypeRHS(sc);
     if (!return_rhs_or_err) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Language), return_rhs_or_err.takeError(),
-                     "Failed to handle ${function.return-right} frame-format "
+                     "Failed to handle ${{function.return-right}} frame-format "
                      "variable: {0}");
       return false;
     }
@@ -1995,7 +1995,7 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     auto return_lhs_or_err = GetDemangledReturnTypeLHS(sc);
     if (!return_lhs_or_err) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Language), return_lhs_or_err.takeError(),
-                     "Failed to handle ${function.return-left} frame-format "
+                     "Failed to handle ${{function.return-left}} frame-format "
                      "variable: {0}");
       return false;
     }
@@ -2009,7 +2009,7 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     if (!quals_or_err) {
       LLDB_LOG_ERROR(
           GetLog(LLDBLog::Language), quals_or_err.takeError(),
-          "Failed to handle ${function.qualifiers} frame-format variable: {0}");
+          "Failed to handle ${{function.qualifiers}} frame-format variable: {0}");
       return false;
     }
 
@@ -2022,7 +2022,7 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     if (!suffix_or_err) {
       LLDB_LOG_ERROR(
           GetLog(LLDBLog::Language), suffix_or_err.takeError(),
-          "Failed to handle ${function.suffix} frame-format variable: {0}");
+          "Failed to handle ${{function.suffix}} frame-format variable: {0}");
       return false;
     }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -364,6 +364,10 @@ GetDemangledFunctionSuffix(const SymbolContext &sc) {
 
   auto [demangled_name, info] = *info_or_err;
 
+  if (!info.hasSuffix())
+    return llvm::createStringError("Suffix range for '%s' is invalid.",
+                                   demangled_name.data());
+
   return demangled_name.slice(info.SuffixRange.first, info.SuffixRange.second);
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -360,7 +360,7 @@ static bool PrintDemangledArgumentList(Stream &s, const SymbolContext &sc) {
 
   auto info_or_err = GetAndValidateInfo(sc);
   if (!info_or_err) {
-    info_or_err.takeError();
+    llvm::consumeError(info_or_err.takeError());
     return false;
   }
   auto [demangled_name, info] = *info_or_err;

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -236,199 +236,140 @@ static bool PrettyPrintFunctionNameWithArgs(Stream &out_stream,
   return true;
 }
 
-static std::optional<llvm::StringRef>
+static llvm::Expected<std::pair<llvm::StringRef, DemangledNameInfo>>
+GetAndValidateInfo(const SymbolContext &sc) {
+  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
+  if (!mangled)
+    return llvm::createStringError("Function does not have a mangled name.");
+
+  auto demangled_name = mangled.GetDemangledName().GetStringRef();
+  if (demangled_name.empty())
+    return llvm::createStringError("Function does not have a demangled name.");
+
+  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
+  if (!info)
+    return llvm::createStringError("Function does not have demangled info.");
+
+  // Function without a basename is nonsense.
+  if (!info->hasBasename())
+    return llvm::createStringError("Info do not have basename range.");
+
+  return std::make_pair(demangled_name, *info);
+}
+
+static llvm::Expected<llvm::StringRef>
 GetDemangledBasename(const SymbolContext &sc) {
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
-    return std::nullopt;
+  auto info_or_err = GetAndValidateInfo(sc);
+  if (!info_or_err)
+    return info_or_err.takeError();
 
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return std::nullopt;
+  auto [demangled_name, info] = *info_or_err;
 
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return std::nullopt;
-
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return std::nullopt;
-
-  return demangled_name.slice(info->BasenameRange.first,
-                              info->BasenameRange.second);
+  return demangled_name.slice(info.BasenameRange.first,
+                              info.BasenameRange.second);
 }
 
-static std::optional<llvm::StringRef>
+static llvm::Expected<llvm::StringRef>
 GetDemangledTemplateArguments(const SymbolContext &sc) {
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
-    return std::nullopt;
+  auto info_or_err = GetAndValidateInfo(sc);
+  if (!info_or_err)
+    return info_or_err.takeError();
 
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return std::nullopt;
+  auto [demangled_name, info] = *info_or_err;
 
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return std::nullopt;
+  if (info.ArgumentsRange.first < info.BasenameRange.second)
+    return llvm::createStringError("Arguments in info are invalid.");
 
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return std::nullopt;
-
-  if (info->ArgumentsRange.first < info->BasenameRange.second)
-    return std::nullopt;
-
-  return demangled_name.slice(info->BasenameRange.second,
-                              info->ArgumentsRange.first);
+  return demangled_name.slice(info.BasenameRange.second,
+                              info.ArgumentsRange.first);
 }
 
-static std::optional<llvm::StringRef>
+static llvm::Expected<llvm::StringRef>
 GetDemangledReturnTypeLHS(const SymbolContext &sc) {
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
-    return std::nullopt;
+  auto info_or_err = GetAndValidateInfo(sc);
+  if (!info_or_err)
+    return info_or_err.takeError();
 
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return std::nullopt;
+  auto [demangled_name, info] = *info_or_err;
 
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return std::nullopt;
+  if (info.ScopeRange.first >= demangled_name.size())
+    return llvm::createStringError("Scope range is invalid.");
 
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return std::nullopt;
-
-  if (info->ScopeRange.first >= demangled_name.size())
-    return std::nullopt;
-
-  return demangled_name.substr(0, info->ScopeRange.first);
+  return demangled_name.substr(0, info.ScopeRange.first);
 }
 
-static std::optional<llvm::StringRef>
+static llvm::Expected<llvm::StringRef>
 GetDemangledFunctionQualifiers(const SymbolContext &sc) {
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
-    return std::nullopt;
+  auto info_or_err = GetAndValidateInfo(sc);
+  if (!info_or_err)
+    return info_or_err.takeError();
 
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return std::nullopt;
+  auto [demangled_name, info] = *info_or_err;
 
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return std::nullopt;
+  if (info.QualifiersRange.second < info.QualifiersRange.first)
+    return llvm::createStringError("Qualifiers range is invalid.");
 
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return std::nullopt;
-
-  if (info->QualifiersRange.second < info->QualifiersRange.first)
-    return std::nullopt;
-
-  return demangled_name.slice(info->QualifiersRange.first,
-                              info->QualifiersRange.second);
+  return demangled_name.slice(info.QualifiersRange.first,
+                              info.QualifiersRange.second);
 }
 
-static std::optional<llvm::StringRef>
+static llvm::Expected<llvm::StringRef>
 GetDemangledReturnTypeRHS(const SymbolContext &sc) {
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
-    return std::nullopt;
+  auto info_or_err = GetAndValidateInfo(sc);
+  if (!info_or_err)
+    return info_or_err.takeError();
 
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return std::nullopt;
+  auto [demangled_name, info] = *info_or_err;
 
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return std::nullopt;
+  if (info.QualifiersRange.first < info.ArgumentsRange.second)
+    return llvm::createStringError("Qualifiers range is invalid.");
 
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return std::nullopt;
-
-  if (info->QualifiersRange.first < info->ArgumentsRange.second)
-    return std::nullopt;
-
-  return demangled_name.slice(info->ArgumentsRange.second,
-                              info->QualifiersRange.first);
+  return demangled_name.slice(info.ArgumentsRange.second,
+                              info.QualifiersRange.first);
 }
 
-static std::optional<llvm::StringRef>
+static llvm::Expected<llvm::StringRef>
 GetDemangledScope(const SymbolContext &sc) {
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
-    return std::nullopt;
+  auto info_or_err = GetAndValidateInfo(sc);
+  if (!info_or_err)
+    return info_or_err.takeError();
 
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return std::nullopt;
+  auto [demangled_name, info] = *info_or_err;
 
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return std::nullopt;
+  if (info.ScopeRange.second < info.ScopeRange.first)
+    return llvm::createStringError("Info do not have basename range.");
 
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return std::nullopt;
-
-  if (info->ScopeRange.second < info->ScopeRange.first)
-    return std::nullopt;
-
-  return demangled_name.slice(info->ScopeRange.first, info->ScopeRange.second);
+  return demangled_name.slice(info.ScopeRange.first, info.ScopeRange.second);
 }
 
 /// Handles anything printed after the FunctionEncoding ItaniumDemangle
 /// node. Most notably the DotSUffix node.
-static std::optional<llvm::StringRef>
+static llvm::Expected<llvm::StringRef>
 GetDemangledFunctionSuffix(const SymbolContext &sc) {
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
-    return std::nullopt;
+  auto info_or_err = GetAndValidateInfo(sc);
+  if (!info_or_err)
+    return info_or_err.takeError();
 
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return std::nullopt;
+  auto [demangled_name, info] = *info_or_err;
 
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return std::nullopt;
-
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return std::nullopt;
-
-  return demangled_name.slice(info->SuffixRange.first,
-                              info->SuffixRange.second);
+  return demangled_name.slice(info.SuffixRange.first, info.SuffixRange.second);
 }
 
 static bool PrintDemangledArgumentList(Stream &s, const SymbolContext &sc) {
   assert(sc.symbol);
 
-  Mangled mangled = sc.GetPossiblyInlinedFunctionName();
-  if (!mangled)
+  auto info_or_err = GetAndValidateInfo(sc);
+  if (!info_or_err) {
+    info_or_err.takeError();
+    return false;
+  }
+  auto [demangled_name, info] = *info_or_err;
+
+  if (info.ArgumentsRange.second < info.ArgumentsRange.first)
     return false;
 
-  auto demangled_name = mangled.GetDemangledName().GetStringRef();
-  if (demangled_name.empty())
-    return false;
-
-  const std::optional<DemangledNameInfo> &info = mangled.GetDemangledInfo();
-  if (!info)
-    return false;
-
-  // Function without a basename is nonsense.
-  if (!info->hasBasename())
-    return false;
-
-  if (info->ArgumentsRange.second < info->ArgumentsRange.first)
-    return false;
-
-  s << demangled_name.slice(info->ArgumentsRange.first,
-                            info->ArgumentsRange.second);
+  s << demangled_name.slice(info.ArgumentsRange.first,
+                            info.ArgumentsRange.second);
 
   return true;
 }
@@ -1954,32 +1895,37 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     FormatEntity::Entry::Type type, Stream &s) {
   switch (type) {
   case FormatEntity::Entry::Type::FunctionScope: {
-    std::optional<llvm::StringRef> scope = GetDemangledScope(sc);
-    if (!scope)
+    auto scope_or_err = GetDemangledScope(sc);
+    if (!scope_or_err) {
+      llvm::consumeError(scope_or_err.takeError());
       return false;
+    }
 
-    s << *scope;
+    s << *scope_or_err;
 
     return true;
   }
 
   case FormatEntity::Entry::Type::FunctionBasename: {
-    std::optional<llvm::StringRef> name = GetDemangledBasename(sc);
-    if (!name)
+    auto name_or_err = GetDemangledBasename(sc);
+    if (!name_or_err) {
+      llvm::consumeError(name_or_err.takeError());
       return false;
+    }
 
-    s << *name;
+    s << *name_or_err;
 
     return true;
   }
 
   case FormatEntity::Entry::Type::FunctionTemplateArguments: {
-    std::optional<llvm::StringRef> template_args =
-        GetDemangledTemplateArguments(sc);
-    if (!template_args)
+    auto template_args_or_err = GetDemangledTemplateArguments(sc);
+    if (!template_args_or_err) {
+      llvm::consumeError(template_args_or_err.takeError());
       return false;
+    }
 
-    s << *template_args;
+    s << *template_args_or_err;
 
     return true;
   }
@@ -2008,38 +1954,46 @@ bool CPlusPlusLanguage::HandleFrameFormatVariable(
     return true;
   }
   case FormatEntity::Entry::Type::FunctionReturnRight: {
-    std::optional<llvm::StringRef> return_rhs = GetDemangledReturnTypeRHS(sc);
-    if (!return_rhs)
+    auto return_rhs_or_err = GetDemangledReturnTypeRHS(sc);
+    if (!return_rhs_or_err) {
+      llvm::consumeError(return_rhs_or_err.takeError());
       return false;
+    }
 
-    s << *return_rhs;
+    s << *return_rhs_or_err;
 
     return true;
   }
   case FormatEntity::Entry::Type::FunctionReturnLeft: {
-    std::optional<llvm::StringRef> return_lhs = GetDemangledReturnTypeLHS(sc);
-    if (!return_lhs)
+    auto return_lhs_or_err = GetDemangledReturnTypeLHS(sc);
+    if (!return_lhs_or_err) {
+      llvm::consumeError(return_lhs_or_err.takeError());
       return false;
+    }
 
-    s << *return_lhs;
+    s << *return_lhs_or_err;
 
     return true;
   }
   case FormatEntity::Entry::Type::FunctionQualifiers: {
-    std::optional<llvm::StringRef> quals = GetDemangledFunctionQualifiers(sc);
-    if (!quals)
+    auto quals_or_err = GetDemangledFunctionQualifiers(sc);
+    if (!quals_or_err) {
+      llvm::consumeError(quals_or_err.takeError());
       return false;
+    }
 
-    s << *quals;
+    s << *quals_or_err;
 
     return true;
   }
   case FormatEntity::Entry::Type::FunctionSuffix: {
-    std::optional<llvm::StringRef> suffix = GetDemangledFunctionSuffix(sc);
-    if (!suffix)
+    auto suffix_or_err = GetDemangledFunctionSuffix(sc);
+    if (!suffix_or_err) {
+      llvm::consumeError(suffix_or_err.takeError());
       return false;
+    }
 
-    s << *suffix;
+    s << *suffix_or_err;
 
     return true;
   }

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -420,7 +420,7 @@ TEST(MangledTest, DemangledNameInfo_SetValue) {
   // (without a valid basename).
   mangled.SetValue(ConstString("_Zinvalid"));
   ASSERT_NE(mangled.GetDemangledInfo(), std::nullopt);
-  EXPECT_FALSE(mangled.GetDemangledInfo()->hasBasename());
+  EXPECT_TRUE(mangled.GetDemangledInfo()->hasBasename());
 }
 
 struct DemanglingPartsTestCase {
@@ -545,7 +545,7 @@ DemanglingPartsTestCase g_demangling_parts_test_cases[] = {
      /*.basename=*/"",
      /*.scope=*/"",
      /*.qualifiers=*/"",
-     /*.valid_basename=*/false
+     /*.valid_basename=*/true
    },
    { "___ZNK5dyld313MachOAnalyzer18forEachInitializerER11DiagnosticsRKNS0_15VMAddrConverterEU13block_pointerFvjEPKv_block_invoke.204",
      { /*.BasenameRange=*/{55, 73}, /*.ScopeRange=*/{33, 55}, /*.ArgumentsRange=*/{ 73, 181 },
@@ -648,43 +648,43 @@ struct DemangledNameInfoTestCase {
 DemangledNameInfoTestCase g_demangled_name_info_test_cases[] = {
     // clang-format off
    {
-    { /*.BasenameRange=*/{0, 10}, /*.ScopeRange=*/{0, 0}, /*.ArgumentsRange=*/{0, 0},
-      /*.QualifiersRange=*/{0, 0}, /*.PrefixRange=*/{0, 0}, /*.SuffixRange=*/{0, 0}
+    { /*.BasenameRange=*/{0, 10}, /*.ScopeRange=*/{1, 0}, /*.ArgumentsRange=*/{1, 0},
+      /*.QualifiersRange=*/{1, 0}, /*.PrefixRange=*/{1, 0}, /*.SuffixRange=*/{1, 0}
     },
       /*valid_basename=*/true, /*valid_scope=*/false, /*valid_arguments=*/false,
       /*valid_qualifiers=*/false, /*valid_prefix=*/false, /*valid_suffix=*/false,
    },
    {
-    { /*.BasenameRange=*/{0, 0}, /*.ScopeRange=*/{0, 10}, /*.ArgumentsRange=*/{0, 0},
-      /*.QualifiersRange=*/{0, 0}, /*.PrefixRange=*/{0, 0}, /*.SuffixRange=*/{0, 0}
+    { /*.BasenameRange=*/{1, 0}, /*.ScopeRange=*/{0, 10}, /*.ArgumentsRange=*/{1, 0},
+      /*.QualifiersRange=*/{1, 0}, /*.PrefixRange=*/{1, 0}, /*.SuffixRange=*/{1, 0}
     },
       /*valid_basename=*/false, /*valid_scope=*/true, /*valid_arguments=*/false,
       /*valid_qualifiers=*/false, /*valid_prefix=*/false, /*valid_suffix=*/false,
    },
    {
-    { /*.BasenameRange=*/{0, 0}, /*.ScopeRange=*/{0, 0}, /*.ArgumentsRange=*/{0, 10},
-      /*.QualifiersRange=*/{0, 0}, /*.PrefixRange=*/{0, 0}, /*.SuffixRange=*/{0, 0}
+    { /*.BasenameRange=*/{1, 0}, /*.ScopeRange=*/{1, 0}, /*.ArgumentsRange=*/{0, 10},
+      /*.QualifiersRange=*/{1, 0}, /*.PrefixRange=*/{1, 0}, /*.SuffixRange=*/{1, 0}
     },
       /*valid_basename=*/false, /*valid_scope=*/false, /*valid_arguments=*/true,
       /*valid_qualifiers=*/false, /*valid_prefix=*/false, /*valid_suffix=*/false,
    },
    {
-    { /*.BasenameRange=*/{0, 0}, /*.ScopeRange=*/{0, 0}, /*.ArgumentsRange=*/{0, 0},
-      /*.QualifiersRange=*/{0, 10}, /*.PrefixRange=*/{0, 0}, /*.SuffixRange=*/{0, 0}
+    { /*.BasenameRange=*/{1, 0}, /*.ScopeRange=*/{1, 0}, /*.ArgumentsRange=*/{1, 0},
+      /*.QualifiersRange=*/{0, 10}, /*.PrefixRange=*/{1, 0}, /*.SuffixRange=*/{1, 0}
     },
       /*valid_basename=*/false, /*valid_scope=*/false, /*valid_arguments=*/false,
       /*valid_qualifiers=*/true, /*valid_prefix=*/false, /*valid_suffix=*/false,
    },
    {
-    { /*.BasenameRange=*/{0, 0}, /*.ScopeRange=*/{0, 0}, /*.ArgumentsRange=*/{0, 0},
-      /*.QualifiersRange=*/{0, 0}, /*.PrefixRange=*/{0, 10}, /*.SuffixRange=*/{0, 0}
+    { /*.BasenameRange=*/{1, 0}, /*.ScopeRange=*/{1, 0}, /*.ArgumentsRange=*/{1, 0},
+      /*.QualifiersRange=*/{1, 0}, /*.PrefixRange=*/{0, 10}, /*.SuffixRange=*/{1, 0}
     },
       /*valid_basename=*/false, /*valid_scope=*/false, /*valid_arguments=*/false,
       /*valid_qualifiers=*/false, /*valid_prefix=*/true, /*valid_suffix=*/false,
    },
    {
-    { /*.BasenameRange=*/{0, 0}, /*.ScopeRange=*/{0, 0}, /*.ArgumentsRange=*/{0, 0},
-      /*.QualifiersRange=*/{0, 0}, /*.PrefixRange=*/{0, 0}, /*.SuffixRange=*/{0, 10}
+    { /*.BasenameRange=*/{1, 0}, /*.ScopeRange=*/{1, 0}, /*.ArgumentsRange=*/{1, 0},
+      /*.QualifiersRange=*/{1, 0}, /*.PrefixRange=*/{1, 0}, /*.SuffixRange=*/{0, 10}
     },
       /*valid_basename=*/false, /*valid_scope=*/false, /*valid_arguments=*/false,
       /*valid_qualifiers=*/false, /*valid_prefix=*/false, /*valid_suffix=*/true,

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -420,7 +420,7 @@ TEST(MangledTest, DemangledNameInfo_SetValue) {
   // (without a valid basename).
   mangled.SetValue(ConstString("_Zinvalid"));
   ASSERT_NE(mangled.GetDemangledInfo(), std::nullopt);
-  EXPECT_TRUE(mangled.GetDemangledInfo()->hasBasename());
+  EXPECT_FALSE(mangled.GetDemangledInfo()->hasBasename());
 }
 
 struct DemanglingPartsTestCase {
@@ -545,7 +545,7 @@ DemanglingPartsTestCase g_demangling_parts_test_cases[] = {
      /*.basename=*/"",
      /*.scope=*/"",
      /*.qualifiers=*/"",
-     /*.valid_basename=*/true
+     /*.valid_basename=*/false
    },
    { "___ZNK5dyld313MachOAnalyzer18forEachInitializerER11DiagnosticsRKNS0_15VMAddrConverterEU13block_pointerFvjEPKv_block_invoke.204",
      { /*.BasenameRange=*/{55, 73}, /*.ScopeRange=*/{33, 55}, /*.ArgumentsRange=*/{ 73, 181 },


### PR DESCRIPTION
Upgrade the callees of `HandleFrameFormatVariable` (`GetDemangledTemplateArguments`, etc), to return a `llvm::Expected` instead of an `std::optional`.

This patch also bundles the logic of validating the demangled name and information into a single reusable function to reduce code duplication.