### PR TITLE
[Hexagon/LoopIdiom] Protect test against O2 changes

### DIFF
--- a/llvm/test/CodeGen/Hexagon/loop-idiom/pmpy-mod.ll
+++ b/llvm/test/CodeGen/Hexagon/loop-idiom/pmpy-mod.ll
@@ -1,9 +1,5 @@
-; Run -O2 to make sure that all the usual optimizations do happen before
-; the Hexagon loop idiom recognition runs. This is to check that we still
-; get this opportunity regardless of what happens before.
-
-; RUN: opt -O2 -S < %s | FileCheck %s
-; RUN: opt -passes='default<O2>' -S < %s | FileCheck %s
+; RUN: opt -p 'instcombine,simplifycfg,loop-rotate,loop(hexagon-loop-idiom)' \
+; RUN:   -S %s | FileCheck %s
 
 target triple = "hexagon"
 target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"


### PR DESCRIPTION
Protect the pmpy-mod.ll test against O2 pipeline changes, by changing the opt invocation to call exactly the prerequisite passes before calling hexagon-loop-idiom. The context for this change is that a HashRecognize analysis was recently added to LLVM, and the optimization of CRC loops will soon be enabled by default, which would cause pmpy-mod.ll to fail, since the CRC loop would be optimized by a table-lookup before HexagonLoopIdiom has a chance to optimize it using pmpy instructions. HexagonLoopIdiom should probably be removed in the future, preferring the generic middle-end optimization performed by using HashRecognize.

-- 8< --
See https://github.com/llvm/llvm-project/pull/143208.