### PR TITLE
[llvm] annotate remaining LLVM interfaces for DLL export

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -117,7 +117,8 @@ static cl::opt<PGOOptions::ColdFuncOpt> ClPGOColdFuncAttr(
                clEnumValN(PGOOptions::ColdFuncOpt::OptNone, "optnone",
                           "Mark cold functions with optnone.")));
 
-LLVM_ABI extern cl::opt<InstrProfCorrelator::ProfCorrelatorKind> ProfileCorrelate;
+LLVM_ABI extern cl::opt<InstrProfCorrelator::ProfCorrelatorKind>
+    ProfileCorrelate;
 } // namespace llvm
 namespace clang {
 extern llvm::cl::opt<bool> ClSanitizeGuardChecks;

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -43,6 +43,7 @@
 #include "llvm/ProfileData/InstrProfCorrelator.h"
 #include "llvm/Support/BuryPointer.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Program.h"
@@ -96,8 +97,6 @@ using namespace llvm;
 #include "llvm/Support/Extension.def"
 
 namespace llvm {
-extern cl::opt<bool> PrintPipelinePasses;
-
 // Experiment to move sanitizers earlier.
 static cl::opt<bool> ClSanitizeOnOptimizerEarlyEP(
     "sanitizer-early-opt-ep", cl::Optional,
@@ -118,7 +117,7 @@ static cl::opt<PGOOptions::ColdFuncOpt> ClPGOColdFuncAttr(
                clEnumValN(PGOOptions::ColdFuncOpt::OptNone, "optnone",
                           "Mark cold functions with optnone.")));
 
-extern cl::opt<InstrProfCorrelator::ProfCorrelatorKind> ProfileCorrelate;
+LLVM_ABI extern cl::opt<InstrProfCorrelator::ProfCorrelatorKind> ProfileCorrelate;
 } // namespace llvm
 namespace clang {
 extern llvm::cl::opt<bool> ClSanitizeGuardChecks;

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -74,10 +74,6 @@
 #include <memory>
 #include <system_error>
 
-namespace llvm {
-extern cl::opt<bool> PrintPipelinePasses;
-} // namespace llvm
-
 using namespace Fortran::frontend;
 
 constexpr llvm::StringLiteral timingIdParse = "Parse";

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -674,7 +674,8 @@ private:
   integerPart addSignificand(const IEEEFloat &);
   integerPart subtractSignificand(const IEEEFloat &, integerPart);
   // Exported for IEEEFloatUnitTestHelper.
-  LLVM_ABI lostFraction addOrSubtractSignificand(const IEEEFloat &, bool subtract);
+  LLVM_ABI lostFraction addOrSubtractSignificand(const IEEEFloat &,
+                                                 bool subtract);
   lostFraction multiplySignificand(const IEEEFloat &, IEEEFloat,
                                    bool ignoreAddend = false);
   lostFraction multiplySignificand(const IEEEFloat&);

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -673,7 +673,8 @@ private:
 
   integerPart addSignificand(const IEEEFloat &);
   integerPart subtractSignificand(const IEEEFloat &, integerPart);
-  lostFraction addOrSubtractSignificand(const IEEEFloat &, bool subtract);
+  // Exported for IEEEFloatUnitTestHelper.
+  LLVM_ABI lostFraction addOrSubtractSignificand(const IEEEFloat &, bool subtract);
   lostFraction multiplySignificand(const IEEEFloat &, IEEEFloat,
                                    bool ignoreAddend = false);
   lostFraction multiplySignificand(const IEEEFloat&);

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -561,7 +561,7 @@ public:
   }
 
   /// Overload to compute a hash_code for an APInt value.
-  friend hash_code hash_value(const APInt &Arg);
+  LLVM_ABI_FRIEND friend hash_code hash_value(const APInt &Arg);
 
   /// This function returns a pointer to the internal storage of the APInt.
   /// This is useful for writing out the APInt in binary form without any

--- a/llvm/include/llvm/ADT/DynamicAPInt.h
+++ b/llvm/include/llvm/ADT/DynamicAPInt.h
@@ -212,7 +212,7 @@ public:
   friend DynamicAPInt operator/(int64_t A, const DynamicAPInt &B);
   friend DynamicAPInt operator%(int64_t A, const DynamicAPInt &B);
 
-  friend hash_code hash_value(const DynamicAPInt &x); // NOLINT
+  LLVM_ABI_FRIEND friend hash_code hash_value(const DynamicAPInt &x); // NOLINT
 
   LLVM_ABI void static_assert_layout(); // NOLINT
 

--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -34,7 +34,7 @@ namespace dxil {
 
 // Returns the resource name from dx_resource_handlefrombinding or
 // dx_resource_handlefromimplicitbinding call
-StringRef getResourceNameFromBindingCall(CallInst *CI);
+LLVM_ABI StringRef getResourceNameFromBindingCall(CallInst *CI);
 
 /// The dx.RawBuffer target extension type
 ///

--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -29,10 +29,10 @@
 #ifndef LLVM_ANALYSIS_IR2VEC_H
 #define LLVM_ANALYSIS_IR2VEC_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/JSON.h"
 #include <map>
@@ -116,7 +116,8 @@ public:
 
   /// Returns true if the embedding is approximately equal to the RHS embedding
   /// within the specified tolerance.
-  LLVM_ABI bool approximatelyEquals(const Embedding &RHS, double Tolerance = 1e-6) const;
+  LLVM_ABI bool approximatelyEquals(const Embedding &RHS,
+                                    double Tolerance = 1e-6) const;
 };
 
 using InstEmbeddingsMap = DenseMap<const Instruction *, Embedding>;
@@ -226,7 +227,7 @@ public:
   LLVM_ABI const ir2vec::Vocab &getVocabulary() const;
   LLVM_ABI unsigned getDimension() const;
   LLVM_ABI bool invalidate(Module &M, const PreservedAnalyses &PA,
-                  ModuleAnalysisManager::Invalidator &Inv) const;
+                           ModuleAnalysisManager::Invalidator &Inv) const;
 };
 
 /// This analysis provides the vocabulary for IR2Vec. The vocabulary provides a

--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -29,6 +29,7 @@
 #ifndef LLVM_ANALYSIS_IR2VEC_H
 #define LLVM_ANALYSIS_IR2VEC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/CommandLine.h"
@@ -57,9 +58,9 @@ enum class IR2VecKind { Symbolic };
 
 namespace ir2vec {
 
-extern cl::opt<float> OpcWeight;
-extern cl::opt<float> TypeWeight;
-extern cl::opt<float> ArgWeight;
+LLVM_ABI extern cl::opt<float> OpcWeight;
+LLVM_ABI extern cl::opt<float> TypeWeight;
+LLVM_ABI extern cl::opt<float> ArgWeight;
 
 /// Embedding is a datatype that wraps std::vector<double>. It provides
 /// additional functionality for arithmetic and comparison operations.
@@ -106,16 +107,16 @@ public:
   const std::vector<double> &getData() const { return Data; }
 
   /// Arithmetic operators
-  Embedding &operator+=(const Embedding &RHS);
-  Embedding &operator-=(const Embedding &RHS);
+  LLVM_ABI Embedding &operator+=(const Embedding &RHS);
+  LLVM_ABI Embedding &operator-=(const Embedding &RHS);
 
   /// Adds Src Embedding scaled by Factor with the called Embedding.
   /// Called_Embedding += Src * Factor
-  Embedding &scaleAndAdd(const Embedding &Src, float Factor);
+  LLVM_ABI Embedding &scaleAndAdd(const Embedding &Src, float Factor);
 
   /// Returns true if the embedding is approximately equal to the RHS embedding
   /// within the specified tolerance.
-  bool approximatelyEquals(const Embedding &RHS, double Tolerance = 1e-6) const;
+  LLVM_ABI bool approximatelyEquals(const Embedding &RHS, double Tolerance = 1e-6) const;
 };
 
 using InstEmbeddingsMap = DenseMap<const Instruction *, Embedding>;
@@ -148,7 +149,7 @@ protected:
   mutable BBEmbeddingsMap BBVecMap;
   mutable InstEmbeddingsMap InstVecMap;
 
-  Embedder(const Function &F, const Vocab &Vocabulary);
+  LLVM_ABI Embedder(const Function &F, const Vocab &Vocabulary);
 
   /// Helper function to compute embeddings. It generates embeddings for all
   /// the instructions and basic blocks in the function F. Logic of computing
@@ -161,38 +162,38 @@ protected:
 
   /// Lookup vocabulary for a given Key. If the key is not found, it returns a
   /// zero vector.
-  Embedding lookupVocab(const std::string &Key) const;
+  LLVM_ABI Embedding lookupVocab(const std::string &Key) const;
 
 public:
   virtual ~Embedder() = default;
 
   /// Factory method to create an Embedder object.
-  static Expected<std::unique_ptr<Embedder>>
+  LLVM_ABI static Expected<std::unique_ptr<Embedder>>
   create(IR2VecKind Mode, const Function &F, const Vocab &Vocabulary);
 
   /// Returns a map containing instructions and the corresponding embeddings for
   /// the function F if it has been computed. If not, it computes the embeddings
   /// for the function and returns the map.
-  const InstEmbeddingsMap &getInstVecMap() const;
+  LLVM_ABI const InstEmbeddingsMap &getInstVecMap() const;
 
   /// Returns a map containing basic block and the corresponding embeddings for
   /// the function F if it has been computed. If not, it computes the embeddings
   /// for the function and returns the map.
-  const BBEmbeddingsMap &getBBVecMap() const;
+  LLVM_ABI const BBEmbeddingsMap &getBBVecMap() const;
 
   /// Returns the embedding for a given basic block in the function F if it has
   /// been computed. If not, it computes the embedding for the basic block and
   /// returns it.
-  const Embedding &getBBVector(const BasicBlock &BB) const;
+  LLVM_ABI const Embedding &getBBVector(const BasicBlock &BB) const;
 
   /// Computes and returns the embedding for the current function.
-  const Embedding &getFunctionVector() const;
+  LLVM_ABI const Embedding &getFunctionVector() const;
 };
 
 /// Class for computing the Symbolic embeddings of IR2Vec.
 /// Symbolic embeddings are constructed based on the entity-level
 /// representations obtained from the Vocabulary.
-class SymbolicEmbedder : public Embedder {
+class LLVM_ABI SymbolicEmbedder : public Embedder {
 private:
   /// Utility function to compute the embedding for a given type.
   Embedding getTypeEmbedding(const Type *Ty) const;
@@ -219,12 +220,12 @@ class IR2VecVocabResult {
 
 public:
   IR2VecVocabResult() = default;
-  IR2VecVocabResult(ir2vec::Vocab &&Vocabulary);
+  LLVM_ABI IR2VecVocabResult(ir2vec::Vocab &&Vocabulary);
 
   bool isValid() const { return Valid; }
-  const ir2vec::Vocab &getVocabulary() const;
-  unsigned getDimension() const;
-  bool invalidate(Module &M, const PreservedAnalyses &PA,
+  LLVM_ABI const ir2vec::Vocab &getVocabulary() const;
+  LLVM_ABI unsigned getDimension() const;
+  LLVM_ABI bool invalidate(Module &M, const PreservedAnalyses &PA,
                   ModuleAnalysisManager::Invalidator &Inv) const;
 };
 
@@ -237,12 +238,12 @@ class IR2VecVocabAnalysis : public AnalysisInfoMixin<IR2VecVocabAnalysis> {
   void emitError(Error Err, LLVMContext &Ctx);
 
 public:
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
   IR2VecVocabAnalysis() = default;
-  explicit IR2VecVocabAnalysis(const ir2vec::Vocab &Vocab);
-  explicit IR2VecVocabAnalysis(ir2vec::Vocab &&Vocab);
+  LLVM_ABI explicit IR2VecVocabAnalysis(const ir2vec::Vocab &Vocab);
+  LLVM_ABI explicit IR2VecVocabAnalysis(ir2vec::Vocab &&Vocab);
   using Result = IR2VecVocabResult;
-  Result run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI Result run(Module &M, ModuleAnalysisManager &MAM);
 };
 
 /// This pass prints the IR2Vec embeddings for instructions, basic blocks, and
@@ -253,7 +254,7 @@ class IR2VecPrinterPass : public PassInfoMixin<IR2VecPrinterPass> {
 
 public:
   explicit IR2VecPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
   static bool isRequired() { return true; }
 };
 

--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -311,11 +311,11 @@ LLVM_ABI std::optional<bool> computeKnownFPSignBit(const Value *V,
 
 /// Return true if the sign bit of the FP value can be ignored by the user when
 /// the value is zero.
-bool canIgnoreSignBitOfZero(const Use &U);
+LLVM_ABI bool canIgnoreSignBitOfZero(const Use &U);
 
 /// Return true if the sign bit of the FP value can be ignored by the user when
 /// the value is NaN.
-bool canIgnoreSignBitOfNaN(const Use &U);
+LLVM_ABI bool canIgnoreSignBitOfNaN(const Use &U);
 
 /// If the specified value can be set by repeating the same byte in memory,
 /// return the i8 value that it is represented with. This is true for all i8

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -181,7 +181,7 @@ enum class DescriptorRangeType : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<DescriptorRangeType>> getDescriptorRangeTypes();
+LLVM_ABI ArrayRef<EnumEntry<DescriptorRangeType>> getDescriptorRangeTypes();
 
 #define ROOT_PARAMETER(Val, Enum)                                              \
   case Val:                                                                    \

--- a/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h
@@ -609,6 +609,15 @@ public:
   virtual bool isTypeIsValidForThisReturn(EVT Ty) const { return false; }
 };
 
+extern template LLVM_ABI void
+CallLowering::setArgFlags<Function>(CallLowering::ArgInfo &Arg, unsigned OpIdx,
+                                    const DataLayout &DL,
+                                    const Function &FuncInfo) const;
+
+extern template LLVM_ABI void
+CallLowering::setArgFlags<CallBase>(CallLowering::ArgInfo &Arg, unsigned OpIdx,
+                                    const DataLayout &DL,
+                                    const CallBase &FuncInfo) const;
 } // end namespace llvm
 
 #endif // LLVM_CODEGEN_GLOBALISEL_CALLLOWERING_H

--- a/llvm/include/llvm/CodeGenTypes/LowLevelType.h
+++ b/llvm/include/llvm/CodeGenTypes/LowLevelType.h
@@ -26,6 +26,7 @@
 #ifndef LLVM_CODEGEN_LOWLEVELTYPE_H
 #define LLVM_CODEGEN_LOWLEVELTYPE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/CodeGenTypes/MachineValueType.h"
 #include "llvm/Support/Debug.h"
@@ -140,7 +141,7 @@ public:
   explicit constexpr LLT()
       : IsScalar(false), IsPointer(false), IsVector(false), RawData(0) {}
 
-  explicit LLT(MVT VT);
+  LLVM_ABI explicit LLT(MVT VT);
 
   constexpr bool isValid() const { return IsScalar || RawData != 0; }
   constexpr bool isScalar() const { return IsScalar; }
@@ -282,7 +283,7 @@ public:
       return scalar(getScalarSizeInBits());
   }
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;

--- a/llvm/include/llvm/CodeGenTypes/LowLevelType.h
+++ b/llvm/include/llvm/CodeGenTypes/LowLevelType.h
@@ -26,9 +26,9 @@
 #ifndef LLVM_CODEGEN_LOWLEVELTYPE_H
 #define LLVM_CODEGEN_LOWLEVELTYPE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/CodeGenTypes/MachineValueType.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include <cassert>
 

--- a/llvm/include/llvm/CodeGenTypes/MachineValueType.h
+++ b/llvm/include/llvm/CodeGenTypes/MachineValueType.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CODEGEN_MACHINEVALUETYPE_H
 #define LLVM_CODEGEN_MACHINEVALUETYPE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
@@ -65,10 +66,10 @@ namespace llvm {
     bool operator<=(const MVT& S) const { return SimpleTy <= S.SimpleTy; }
 
     /// Support for debugging, callable in GDB: VT.dump()
-    void dump() const;
+    LLVM_ABI void dump() const;
 
     /// Implement operator<<.
-    void print(raw_ostream &OS) const;
+    LLVM_ABI void print(raw_ostream &OS) const;
 
     /// Return true if this is a valid simple valuetype.
     bool isValid() const {
@@ -509,11 +510,11 @@ namespace llvm {
     /// otherwise they are invalid.
     /// NB: This includes pointer types, which require a DataLayout to convert
     /// to a concrete value type.
-    static MVT getVT(Type *Ty, bool HandleUnknown = false);
+    LLVM_ABI static MVT getVT(Type *Ty, bool HandleUnknown = false);
 
     /// Returns an APFloat semantics tag appropriate for the value type. If this
     /// is a vector type, the element semantics are returned.
-    const fltSemantics &getFltSemantics() const;
+    LLVM_ABI const fltSemantics &getFltSemantics() const;
 
   public:
     /// SimpleValueType Iteration

--- a/llvm/include/llvm/CodeGenTypes/MachineValueType.h
+++ b/llvm/include/llvm/CodeGenTypes/MachineValueType.h
@@ -16,8 +16,8 @@
 #ifndef LLVM_CODEGEN_MACHINEVALUETYPE_H
 #define LLVM_CODEGEN_MACHINEVALUETYPE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/TypeSize.h"

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIPrinter.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIPrinter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCFIPRINTER_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCFIPRINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFCFIProgram.h"
 
 namespace llvm {
@@ -17,7 +18,7 @@ struct DIDumpOptions;
 
 namespace dwarf {
 
-void printCFIProgram(const CFIProgram &P, raw_ostream &OS,
+LLVM_ABI void printCFIProgram(const CFIProgram &P, raw_ostream &OS,
                      const DIDumpOptions &DumpOpts, unsigned IndentLevel,
                      std::optional<uint64_t> Address);
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIPrinter.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIPrinter.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCFIPRINTER_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCFIPRINTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFCFIProgram.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -19,8 +19,9 @@ struct DIDumpOptions;
 namespace dwarf {
 
 LLVM_ABI void printCFIProgram(const CFIProgram &P, raw_ostream &OS,
-                     const DIDumpOptions &DumpOpts, unsigned IndentLevel,
-                     std::optional<uint64_t> Address);
+                              const DIDumpOptions &DumpOpts,
+                              unsigned IndentLevel,
+                              std::optional<uint64_t> Address);
 
 } // end namespace dwarf
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIProgram.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIProgram.h
@@ -106,11 +106,11 @@ public:
   };
 
   /// Get the OperandType as a "const char *".
-  static const char *operandTypeString(OperandType OT);
+  LLVM_ABI static const char *operandTypeString(OperandType OT);
 
   /// Retrieve the array describing the types of operands according to the enum
   /// above. This is indexed by opcode.
-  static ArrayRef<OperandType[MaxOperands]> getOperandTypes();
+  LLVM_ABI static ArrayRef<OperandType[MaxOperands]> getOperandTypes();
 
 private:
   std::vector<Instruction> Instructions;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
@@ -187,7 +187,8 @@ public:
   /// \param OS to this stream
   /// \param GetNameForDWARFReg callback to return dwarf register name
   LLVM_ABI static void print(const DWARFExpression *E, raw_ostream &OS,
-                    DIDumpOptions DumpOpts, DWARFUnit *U, bool IsEH = false);
+                             DIDumpOptions DumpOpts, DWARFUnit *U,
+                             bool IsEH = false);
 
   /// Print the expression in a format intended to be compact and useful to a
   /// user, but not perfectly unambiguous, or capable of representing every
@@ -199,9 +200,10 @@ public:
   /// \param GetNameForDWARFReg callback to return dwarf register name
   ///
   /// \returns true if the expression was successfully printed
-  LLVM_ABI static bool printCompact(const DWARFExpression *E, raw_ostream &OS,
-                           std::function<StringRef(uint64_t RegNum, bool IsEH)>
-                               GetNameForDWARFReg = nullptr);
+  LLVM_ABI static bool printCompact(
+      const DWARFExpression *E, raw_ostream &OS,
+      std::function<StringRef(uint64_t RegNum, bool IsEH)> GetNameForDWARFReg =
+          nullptr);
 
   /// Pretty print a register opcode and operands.
   /// \param U within the context of this Dwarf unit, if any.
@@ -212,8 +214,9 @@ public:
   ///
   /// returns true if the Op was successfully printed
   LLVM_ABI static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
-                                    DIDumpOptions DumpOpts, uint8_t Opcode,
-                                    ArrayRef<uint64_t> Operands);
+                                             DIDumpOptions DumpOpts,
+                                             uint8_t Opcode,
+                                             ArrayRef<uint64_t> Operands);
 
 private:
   static bool printOp(const DWARFExpression::Operation *Op, raw_ostream &OS,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
@@ -186,7 +186,7 @@ public:
   /// \param E to be printed
   /// \param OS to this stream
   /// \param GetNameForDWARFReg callback to return dwarf register name
-  static void print(const DWARFExpression *E, raw_ostream &OS,
+  LLVM_ABI static void print(const DWARFExpression *E, raw_ostream &OS,
                     DIDumpOptions DumpOpts, DWARFUnit *U, bool IsEH = false);
 
   /// Print the expression in a format intended to be compact and useful to a
@@ -199,7 +199,7 @@ public:
   /// \param GetNameForDWARFReg callback to return dwarf register name
   ///
   /// \returns true if the expression was successfully printed
-  static bool printCompact(const DWARFExpression *E, raw_ostream &OS,
+  LLVM_ABI static bool printCompact(const DWARFExpression *E, raw_ostream &OS,
                            std::function<StringRef(uint64_t RegNum, bool IsEH)>
                                GetNameForDWARFReg = nullptr);
 
@@ -211,7 +211,7 @@ public:
   /// \param Operands to the opcode
   ///
   /// returns true if the Op was successfully printed
-  static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
+  LLVM_ABI static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
                                     DIDumpOptions DumpOpts, uint8_t Opcode,
                                     ArrayRef<uint64_t> Operands);
 

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSourceLanguage.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSourceLanguage.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSOURCELANGUAGE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSOURCELANGUAGE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -52,7 +53,7 @@ struct LVSourceLanguage {
 
   bool isValid() const { return Language != Invalid; }
   TaggedLanguage get() const { return Language; }
-  StringRef getName() const;
+  LLVM_ABI StringRef getName() const;
 
 private:
   TaggedLanguage Language = Invalid;

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSourceLanguage.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSourceLanguage.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSOURCELANGUAGE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSOURCELANGUAGE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace logicalview {

--- a/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COFF_H
 #define LLVM_EXECUTIONENGINE_ORC_COFF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -31,7 +32,7 @@ class COFFImportFileScanner {
 public:
   COFFImportFileScanner(std::set<std::string> &ImportedDynamicLibraries)
       : ImportedDynamicLibraries(ImportedDynamicLibraries) {}
-  Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
+  LLVM_ABI Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
                             size_t Index) const;
 
 private:

--- a/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
@@ -32,8 +32,8 @@ class COFFImportFileScanner {
 public:
   COFFImportFileScanner(std::set<std::string> &ImportedDynamicLibraries)
       : ImportedDynamicLibraries(ImportedDynamicLibraries) {}
-  LLVM_ABI Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
-                            size_t Index) const;
+  LLVM_ABI Expected<bool>
+  operator()(object::Archive &A, MemoryBufferRef MemberBuf, size_t Index) const;
 
 private:
   std::set<std::string> &ImportedDynamicLibraries;

--- a/llvm/include/llvm/Frontend/Directive/Spelling.h
+++ b/llvm/include/llvm/Frontend/Directive/Spelling.h
@@ -8,6 +8,7 @@
 #ifndef LLVM_FRONTEND_DIRECTIVE_SPELLING_H
 #define LLVM_FRONTEND_DIRECTIVE_SPELLING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 
@@ -33,7 +34,7 @@ struct Spelling {
   VersionRange Versions;
 };
 
-StringRef FindName(llvm::iterator_range<const Spelling *>, unsigned Version);
+LLVM_ABI StringRef FindName(llvm::iterator_range<const Spelling *>, unsigned Version);
 
 } // namespace llvm::directive
 

--- a/llvm/include/llvm/Frontend/Directive/Spelling.h
+++ b/llvm/include/llvm/Frontend/Directive/Spelling.h
@@ -8,9 +8,9 @@
 #ifndef LLVM_FRONTEND_DIRECTIVE_SPELLING_H
 #define LLVM_FRONTEND_DIRECTIVE_SPELLING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/Compiler.h"
 
 #include <limits>
 #include <tuple>
@@ -34,7 +34,8 @@ struct Spelling {
   VersionRange Versions;
 };
 
-LLVM_ABI StringRef FindName(llvm::iterator_range<const Spelling *>, unsigned Version);
+LLVM_ABI StringRef FindName(llvm::iterator_range<const Spelling *>,
+                            unsigned Version);
 
 } // namespace llvm::directive
 

--- a/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
+++ b/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
@@ -63,7 +63,7 @@ enum ProfileInstrKind {
 };
 
 // Default filename used for profile generation.
-std::string getDefaultProfileGenName();
+LLVM_ABI std::string getDefaultProfileGenName();
 } // end namespace llvm::driver
 
 #endif

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
@@ -93,7 +93,8 @@ public:
 
   // Returns a reference to the first RangeInfo that overlaps with
   // [Info.LowerBound;Info.UpperBound], or, std::nullopt if there is no overlap
-  LLVM_ABI std::optional<const RangeInfo *> getOverlapping(const RangeInfo &Info) const;
+  LLVM_ABI std::optional<const RangeInfo *>
+  getOverlapping(const RangeInfo &Info) const;
 
   // Return the mapped RangeInfo at X or nullptr if no mapping exists
   LLVM_ABI const RangeInfo *lookup(uint32_t X) const;

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
@@ -93,10 +93,10 @@ public:
 
   // Returns a reference to the first RangeInfo that overlaps with
   // [Info.LowerBound;Info.UpperBound], or, std::nullopt if there is no overlap
-  std::optional<const RangeInfo *> getOverlapping(const RangeInfo &Info) const;
+  LLVM_ABI std::optional<const RangeInfo *> getOverlapping(const RangeInfo &Info) const;
 
   // Return the mapped RangeInfo at X or nullptr if no mapping exists
-  const RangeInfo *lookup(uint32_t X) const;
+  LLVM_ABI const RangeInfo *lookup(uint32_t X) const;
 
   // Insert the required (sub-)intervals such that the interval of [a;b] =
   // [Info.LowerBound, Info.UpperBound] is covered and points to a valid
@@ -124,7 +124,7 @@ public:
   // Returns a reference to the first RangeInfo that overlaps with
   // [Info.LowerBound;Info.UpperBound], or, std::nullopt if there is no overlap
   // (equivalent to getOverlapping)
-  std::optional<const RangeInfo *> insert(const RangeInfo &Info);
+  LLVM_ABI std::optional<const RangeInfo *> insert(const RangeInfo &Info);
 };
 
 } // namespace rootsig

--- a/llvm/include/llvm/Support/ConvertUTF.h
+++ b/llvm/include/llvm/Support/ConvertUTF.h
@@ -346,9 +346,9 @@ LLVM_ABI bool convertUTF32ToUTF8String(ArrayRef<UTF32> Src, std::string &Out);
 LLVM_ABI bool convertUTF8ToUTF16String(StringRef SrcUTF8,
                                        SmallVectorImpl<UTF16> &DstUTF16);
 
-bool IsSingleCodeUnitUTF8Codepoint(unsigned);
-bool IsSingleCodeUnitUTF16Codepoint(unsigned);
-bool IsSingleCodeUnitUTF32Codepoint(unsigned);
+LLVM_ABI bool IsSingleCodeUnitUTF8Codepoint(unsigned);
+LLVM_ABI bool IsSingleCodeUnitUTF16Codepoint(unsigned);
+LLVM_ABI bool IsSingleCodeUnitUTF32Codepoint(unsigned);
 
 #if defined(_WIN32)
 namespace sys {

--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_SUPPORT_KNOWNFPCLASS_H
 #define LLVM_SUPPORT_KNOWNFPCLASS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FloatingPointMode.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {
@@ -218,7 +218,8 @@ struct KnownFPClass {
   ///
   /// This assumes a copy-like operation and will replace any currently known
   /// information.
-  LLVM_ABI void propagateCanonicalizingSrc(const KnownFPClass &Src, DenormalMode Mode);
+  LLVM_ABI void propagateCanonicalizingSrc(const KnownFPClass &Src,
+                                           DenormalMode Mode);
 
   void resetAll() { *this = KnownFPClass(); }
 };

--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_KNOWNFPCLASS_H
 #define LLVM_SUPPORT_KNOWNFPCLASS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include <optional>
 
@@ -78,13 +79,13 @@ struct KnownFPClass {
   /// Return true if it's know this can never be interpreted as a zero. This
   /// extends isKnownNeverZero to cover the case where the assumed
   /// floating-point mode for the function interprets denormals as zero.
-  bool isKnownNeverLogicalZero(DenormalMode Mode) const;
+  LLVM_ABI bool isKnownNeverLogicalZero(DenormalMode Mode) const;
 
   /// Return true if it's know this can never be interpreted as a negative zero.
-  bool isKnownNeverLogicalNegZero(DenormalMode Mode) const;
+  LLVM_ABI bool isKnownNeverLogicalNegZero(DenormalMode Mode) const;
 
   /// Return true if it's know this can never be interpreted as a positive zero.
-  bool isKnownNeverLogicalPosZero(DenormalMode Mode) const;
+  LLVM_ABI bool isKnownNeverLogicalPosZero(DenormalMode Mode) const;
 
   static constexpr FPClassTest OrderedLessThanZeroMask =
       fcNegSubnormal | fcNegNormal | fcNegInf;
@@ -209,7 +210,7 @@ struct KnownFPClass {
   ///
   /// This assumes a copy-like operation and will replace any currently known
   /// information.
-  void propagateDenormal(const KnownFPClass &Src, DenormalMode Mode);
+  LLVM_ABI void propagateDenormal(const KnownFPClass &Src, DenormalMode Mode);
 
   /// Report known classes if \p Src is evaluated through a potentially
   /// canonicalizing operation. We can assume signaling nans will not be
@@ -217,7 +218,7 @@ struct KnownFPClass {
   ///
   /// This assumes a copy-like operation and will replace any currently known
   /// information.
-  void propagateCanonicalizingSrc(const KnownFPClass &Src, DenormalMode Mode);
+  LLVM_ABI void propagateCanonicalizingSrc(const KnownFPClass &Src, DenormalMode Mode);
 
   void resetAll() { *this = KnownFPClass(); }
 };

--- a/llvm/include/llvm/Support/ProgramStack.h
+++ b/llvm/include/llvm/Support/ProgramStack.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_PROGRAMSTACK_H
 #define LLVM_SUPPORT_PROGRAMSTACK_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 
 // LLVM_HAS_SPLIT_STACKS is exposed in the header because CrashRecoveryContext
@@ -28,12 +29,12 @@ namespace llvm {
 ///
 /// The value is not guaranteed to point to anything specific. It can be used to
 /// estimate how much stack space has been used since the previous call.
-uintptr_t getStackPointer();
+LLVM_ABI uintptr_t getStackPointer();
 
 /// \returns the default stack size for this platform.
 ///
 /// Based on \p RLIMIT_STACK or the equivalent.
-unsigned getDefaultStackSize();
+LLVM_ABI unsigned getDefaultStackSize();
 
 /// Runs Fn on a new stack of at least the given size.
 ///
@@ -42,7 +43,7 @@ unsigned getDefaultStackSize();
 ///
 /// The preferred implementation is split stacks on platforms that have a good
 /// debugging experience for them. On other platforms a new thread is used.
-void runOnNewStack(unsigned StackSize, function_ref<void()> Fn);
+LLVM_ABI void runOnNewStack(unsigned StackSize, function_ref<void()> Fn);
 
 template <typename R, typename... Ts>
 std::enable_if_t<!std::is_same_v<R, void>, R>

--- a/llvm/include/llvm/Support/ProgramStack.h
+++ b/llvm/include/llvm/Support/ProgramStack.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_PROGRAMSTACK_H
 #define LLVM_SUPPORT_PROGRAMSTACK_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Compiler.h"
 
 // LLVM_HAS_SPLIT_STACKS is exposed in the header because CrashRecoveryContext
 // needs to know if it's running on another thread or not.

--- a/llvm/include/llvm/Support/TextEncoding.h
+++ b/llvm/include/llvm/Support/TextEncoding.h
@@ -15,10 +15,10 @@
 #ifndef LLVM_SUPPORT_TEXT_ENCODING_H
 #define LLVM_SUPPORT_TEXT_ENCODING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 
 #include <string>
@@ -94,7 +94,7 @@ public:
   /// \param[in] To the target character encoding
   /// \return a TextEncodingConverter instance or an error code
   LLVM_ABI static ErrorOr<TextEncodingConverter> create(TextEncoding From,
-                                               TextEncoding To);
+                                                        TextEncoding To);
 
   /// Creates a TextEncodingConverter instance.
   /// Returns std::errc::invalid_argument in case the requested conversion is
@@ -102,7 +102,8 @@ public:
   /// \param[in] From name of the source character encoding
   /// \param[in] To name of the target character encoding
   /// \return a TextEncodingConverter instance or an error code
-  LLVM_ABI static ErrorOr<TextEncodingConverter> create(StringRef From, StringRef To);
+  LLVM_ABI static ErrorOr<TextEncodingConverter> create(StringRef From,
+                                                        StringRef To);
 
   TextEncodingConverter(const TextEncodingConverter &) = delete;
   TextEncodingConverter &operator=(const TextEncodingConverter &) = delete;

--- a/llvm/include/llvm/Support/TextEncoding.h
+++ b/llvm/include/llvm/Support/TextEncoding.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_SUPPORT_TEXT_ENCODING_H
 #define LLVM_SUPPORT_TEXT_ENCODING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/config.h"
@@ -92,7 +93,7 @@ public:
   /// \param[in] From the source character encoding
   /// \param[in] To the target character encoding
   /// \return a TextEncodingConverter instance or an error code
-  static ErrorOr<TextEncodingConverter> create(TextEncoding From,
+  LLVM_ABI static ErrorOr<TextEncodingConverter> create(TextEncoding From,
                                                TextEncoding To);
 
   /// Creates a TextEncodingConverter instance.
@@ -101,7 +102,7 @@ public:
   /// \param[in] From name of the source character encoding
   /// \param[in] To name of the target character encoding
   /// \return a TextEncodingConverter instance or an error code
-  static ErrorOr<TextEncodingConverter> create(StringRef From, StringRef To);
+  LLVM_ABI static ErrorOr<TextEncodingConverter> create(StringRef From, StringRef To);
 
   TextEncodingConverter(const TextEncodingConverter &) = delete;
   TextEncodingConverter &operator=(const TextEncodingConverter &) = delete;

--- a/llvm/include/llvm/Support/Timer.h
+++ b/llvm/include/llvm/Support/Timer.h
@@ -258,7 +258,7 @@ public:
 
 private:
   friend class Timer;
-  friend void PrintStatisticsJSON(raw_ostream &OS);
+  LLVM_ABI_FRIEND friend void PrintStatisticsJSON(raw_ostream &OS);
   void addTimer(Timer &T);
   void removeTimer(Timer &T);
   void prepareToPrintList(bool reset_time = false);

--- a/llvm/include/llvm/Telemetry/Telemetry.h
+++ b/llvm/include/llvm/Telemetry/Telemetry.h
@@ -144,7 +144,12 @@ public:
 /// monitored and transmitting the data elsewhere.
 class LLVM_ABI Manager {
 public:
+  Manager() = default;
   virtual ~Manager() = default;
+
+  // Explicitly non-copyable.
+  Manager(Manager const&) = delete;
+  Manager& operator=(Manager const&) = delete;
 
   // Dispatch Telemetry data to the Destination(s).
   // The argument is non-const because the Manager may add or remove

--- a/llvm/include/llvm/Telemetry/Telemetry.h
+++ b/llvm/include/llvm/Telemetry/Telemetry.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_TELEMETRY_TELEMETRY_H
 #define LLVM_TELEMETRY_TELEMETRY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <map>
 #include <memory>
@@ -148,8 +148,8 @@ public:
   virtual ~Manager() = default;
 
   // Explicitly non-copyable.
-  Manager(Manager const&) = delete;
-  Manager& operator=(Manager const&) = delete;
+  Manager(Manager const &) = delete;
+  Manager &operator=(Manager const &) = delete;
 
   // Dispatch Telemetry data to the Destination(s).
   // The argument is non-const because the Manager may add or remove

--- a/llvm/include/llvm/Telemetry/Telemetry.h
+++ b/llvm/include/llvm/Telemetry/Telemetry.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_TELEMETRY_TELEMETRY_H
 #define LLVM_TELEMETRY_TELEMETRY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -101,7 +102,7 @@ struct EntryKind {
 /// For example, The LLDB debugger can define a DebugCommandInfo subclass
 /// which has additional fields about the debug-command being instrumented,
 /// such as `CommandArguments` or `CommandName`.
-struct TelemetryInfo {
+struct LLVM_ABI TelemetryInfo {
   // This represents a unique-id, conventionally corresponding to
   // a tool's session - i.e., every time the tool starts until it exits.
   //
@@ -141,7 +142,7 @@ public:
 /// and this framework.
 /// It is responsible for collecting telemetry data from the tool being
 /// monitored and transmitting the data elsewhere.
-class Manager {
+class LLVM_ABI Manager {
 public:
   virtual ~Manager() = default;
 

--- a/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
@@ -17,7 +17,7 @@
 namespace llvm {
 template <typename T> class ArrayRef;
 
-int dlltoolDriverMain(ArrayRef<const char *> ArgsArr);
+LLVM_ABI int dlltoolDriverMain(ArrayRef<const char *> ArgsArr);
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_TOOLDRIVERS_LLVM_DLLTOOL_DLLTOOLDRIVER_H
 #define LLVM_TOOLDRIVERS_LLVM_DLLTOOL_DLLTOOLDRIVER_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 template <typename T> class ArrayRef;
 

--- a/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
@@ -20,7 +20,6 @@ namespace llvm {
 template <typename T> class ArrayRef;
 
 LLVM_ABI int libDriverMain(ArrayRef<const char *> ARgs);
-
 }
 
 #endif

--- a/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
@@ -17,7 +17,7 @@
 namespace llvm {
 template <typename T> class ArrayRef;
 
-int libDriverMain(ArrayRef<const char *> ARgs);
+LLVM_ABI int libDriverMain(ArrayRef<const char *> ARgs);
 
 }
 

--- a/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_TOOLDRIVERS_LLVM_LIB_LIBDRIVER_H
 #define LLVM_TOOLDRIVERS_LLVM_LIB_LIBDRIVER_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 template <typename T> class ArrayRef;
 

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -6349,7 +6349,7 @@ struct AAInvariantLoadPointer : public AbstractAttribute {
   }
 
   /// Create an abstract attribute view for the position \p IRP.
-  static AAInvariantLoadPointer &createForPosition(const IRPosition &IRP,
+  LLVM_ABI static AAInvariantLoadPointer &createForPosition(const IRPosition &IRP,
                                                    Attributor &A);
 
   /// Return true if the pointer's contents are known to remain invariant.
@@ -6373,7 +6373,7 @@ struct AAInvariantLoadPointer : public AbstractAttribute {
   }
 
   /// Unique ID (due to the unique address).
-  static const char ID;
+  LLVM_ABI static const char ID;
 };
 
 /// An abstract interface for address space information.

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -6349,8 +6349,8 @@ struct AAInvariantLoadPointer : public AbstractAttribute {
   }
 
   /// Create an abstract attribute view for the position \p IRP.
-  LLVM_ABI static AAInvariantLoadPointer &createForPosition(const IRPosition &IRP,
-                                                   Attributor &A);
+  LLVM_ABI static AAInvariantLoadPointer &
+  createForPosition(const IRPosition &IRP, Attributor &A);
 
   /// Return true if the pointer's contents are known to remain invariant.
   virtual bool isKnownInvariant() const = 0;

--- a/llvm/include/llvm/WindowsDriver/MSVCPaths.h
+++ b/llvm/include/llvm/WindowsDriver/MSVCPaths.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_WINDOWSDRIVER_MSVCPATHS_H
 #define LLVM_WINDOWSDRIVER_MSVCPATHS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
 #include <string>
@@ -45,50 +45,56 @@ LLVM_ABI const char *archToLegacyVCArch(llvm::Triple::ArchType Arch);
 // Similar to the above function, but for DevDiv internal builds.
 LLVM_ABI const char *archToDevDivInternalArch(llvm::Triple::ArchType Arch);
 
-LLVM_ABI bool appendArchToWindowsSDKLibPath(int SDKMajor, llvm::SmallString<128> LibPath,
-                                   llvm::Triple::ArchType Arch,
-                                   std::string &path);
+LLVM_ABI bool appendArchToWindowsSDKLibPath(int SDKMajor,
+                                            llvm::SmallString<128> LibPath,
+                                            llvm::Triple::ArchType Arch,
+                                            std::string &path);
 
 // Get the path to a specific subdirectory in the current toolchain for
 // a given target architecture.
 // VS2017 changed the VC toolchain layout, so this should be used instead
 // of hardcoding paths.
-LLVM_ABI std::string getSubDirectoryPath(SubDirectoryType Type, ToolsetLayout VSLayout,
-                                const std::string &VCToolChainPath,
-                                llvm::Triple::ArchType TargetArch,
-                                llvm::StringRef SubdirParent = "");
+LLVM_ABI std::string getSubDirectoryPath(SubDirectoryType Type,
+                                         ToolsetLayout VSLayout,
+                                         const std::string &VCToolChainPath,
+                                         llvm::Triple::ArchType TargetArch,
+                                         llvm::StringRef SubdirParent = "");
 
 // Check if the Include path of a specified version of Visual Studio contains
 // specific header files. If not, they are probably shipped with Universal CRT.
-LLVM_ABI bool useUniversalCRT(ToolsetLayout VSLayout, const std::string &VCToolChainPath,
-                     llvm::Triple::ArchType TargetArch,
-                     llvm::vfs::FileSystem &VFS);
+LLVM_ABI bool useUniversalCRT(ToolsetLayout VSLayout,
+                              const std::string &VCToolChainPath,
+                              llvm::Triple::ArchType TargetArch,
+                              llvm::vfs::FileSystem &VFS);
 
 /// Get Windows SDK installation directory.
 LLVM_ABI bool getWindowsSDKDir(vfs::FileSystem &VFS,
+                               std::optional<llvm::StringRef> WinSdkDir,
+                               std::optional<llvm::StringRef> WinSdkVersion,
+                               std::optional<llvm::StringRef> WinSysRoot,
+                               std::string &Path, int &Major,
+                               std::string &WindowsSDKIncludeVersion,
+                               std::string &WindowsSDKLibVersion);
+
+LLVM_ABI bool
+getUniversalCRTSdkDir(vfs::FileSystem &VFS,
                       std::optional<llvm::StringRef> WinSdkDir,
                       std::optional<llvm::StringRef> WinSdkVersion,
                       std::optional<llvm::StringRef> WinSysRoot,
-                      std::string &Path, int &Major,
-                      std::string &WindowsSDKIncludeVersion,
-                      std::string &WindowsSDKLibVersion);
-
-LLVM_ABI bool getUniversalCRTSdkDir(vfs::FileSystem &VFS,
-                           std::optional<llvm::StringRef> WinSdkDir,
-                           std::optional<llvm::StringRef> WinSdkVersion,
-                           std::optional<llvm::StringRef> WinSysRoot,
-                           std::string &Path, std::string &UCRTVersion);
+                      std::string &Path, std::string &UCRTVersion);
 
 // Check command line arguments to try and find a toolchain.
-LLVM_ABI bool findVCToolChainViaCommandLine(
-    vfs::FileSystem &VFS, std::optional<llvm::StringRef> VCToolsDir,
-    std::optional<llvm::StringRef> VCToolsVersion,
-    std::optional<llvm::StringRef> WinSysRoot, std::string &Path,
-    ToolsetLayout &VSLayout);
+LLVM_ABI bool
+findVCToolChainViaCommandLine(vfs::FileSystem &VFS,
+                              std::optional<llvm::StringRef> VCToolsDir,
+                              std::optional<llvm::StringRef> VCToolsVersion,
+                              std::optional<llvm::StringRef> WinSysRoot,
+                              std::string &Path, ToolsetLayout &VSLayout);
 
 // Check various environment variables to try and find a toolchain.
-LLVM_ABI bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS, std::string &Path,
-                                   ToolsetLayout &VSLayout);
+LLVM_ABI bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS,
+                                            std::string &Path,
+                                            ToolsetLayout &VSLayout);
 
 // Query the Setup Config server for installs, then pick the newest version
 // and find its default VC toolchain. If `VCToolsVersion` is specified, that
@@ -104,7 +110,8 @@ findVCToolChainViaSetupConfig(vfs::FileSystem &VFS,
 // Look in the registry for Visual Studio installs, and use that to get
 // a toolchain path. VS2017 and newer don't get added to the registry.
 // So if we find something here, we know that it's an older version.
-LLVM_ABI bool findVCToolChainViaRegistry(std::string &Path, ToolsetLayout &VSLayout);
+LLVM_ABI bool findVCToolChainViaRegistry(std::string &Path,
+                                         ToolsetLayout &VSLayout);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/WindowsDriver/MSVCPaths.h
+++ b/llvm/include/llvm/WindowsDriver/MSVCPaths.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_WINDOWSDRIVER_MSVCPATHS_H
 #define LLVM_WINDOWSDRIVER_MSVCPATHS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/TargetParser/Triple.h"
@@ -36,15 +37,15 @@ enum class ToolsetLayout {
 // Windows SDKs and VC Toolchains group their contents into subdirectories based
 // on the target architecture. This function converts an llvm::Triple::ArchType
 // to the corresponding subdirectory name.
-const char *archToWindowsSDKArch(llvm::Triple::ArchType Arch);
+LLVM_ABI const char *archToWindowsSDKArch(llvm::Triple::ArchType Arch);
 
 // Similar to the above function, but for Visual Studios before VS2017.
-const char *archToLegacyVCArch(llvm::Triple::ArchType Arch);
+LLVM_ABI const char *archToLegacyVCArch(llvm::Triple::ArchType Arch);
 
 // Similar to the above function, but for DevDiv internal builds.
-const char *archToDevDivInternalArch(llvm::Triple::ArchType Arch);
+LLVM_ABI const char *archToDevDivInternalArch(llvm::Triple::ArchType Arch);
 
-bool appendArchToWindowsSDKLibPath(int SDKMajor, llvm::SmallString<128> LibPath,
+LLVM_ABI bool appendArchToWindowsSDKLibPath(int SDKMajor, llvm::SmallString<128> LibPath,
                                    llvm::Triple::ArchType Arch,
                                    std::string &path);
 
@@ -52,19 +53,19 @@ bool appendArchToWindowsSDKLibPath(int SDKMajor, llvm::SmallString<128> LibPath,
 // a given target architecture.
 // VS2017 changed the VC toolchain layout, so this should be used instead
 // of hardcoding paths.
-std::string getSubDirectoryPath(SubDirectoryType Type, ToolsetLayout VSLayout,
+LLVM_ABI std::string getSubDirectoryPath(SubDirectoryType Type, ToolsetLayout VSLayout,
                                 const std::string &VCToolChainPath,
                                 llvm::Triple::ArchType TargetArch,
                                 llvm::StringRef SubdirParent = "");
 
 // Check if the Include path of a specified version of Visual Studio contains
 // specific header files. If not, they are probably shipped with Universal CRT.
-bool useUniversalCRT(ToolsetLayout VSLayout, const std::string &VCToolChainPath,
+LLVM_ABI bool useUniversalCRT(ToolsetLayout VSLayout, const std::string &VCToolChainPath,
                      llvm::Triple::ArchType TargetArch,
                      llvm::vfs::FileSystem &VFS);
 
 /// Get Windows SDK installation directory.
-bool getWindowsSDKDir(vfs::FileSystem &VFS,
+LLVM_ABI bool getWindowsSDKDir(vfs::FileSystem &VFS,
                       std::optional<llvm::StringRef> WinSdkDir,
                       std::optional<llvm::StringRef> WinSdkVersion,
                       std::optional<llvm::StringRef> WinSysRoot,
@@ -72,21 +73,21 @@ bool getWindowsSDKDir(vfs::FileSystem &VFS,
                       std::string &WindowsSDKIncludeVersion,
                       std::string &WindowsSDKLibVersion);
 
-bool getUniversalCRTSdkDir(vfs::FileSystem &VFS,
+LLVM_ABI bool getUniversalCRTSdkDir(vfs::FileSystem &VFS,
                            std::optional<llvm::StringRef> WinSdkDir,
                            std::optional<llvm::StringRef> WinSdkVersion,
                            std::optional<llvm::StringRef> WinSysRoot,
                            std::string &Path, std::string &UCRTVersion);
 
 // Check command line arguments to try and find a toolchain.
-bool findVCToolChainViaCommandLine(
+LLVM_ABI bool findVCToolChainViaCommandLine(
     vfs::FileSystem &VFS, std::optional<llvm::StringRef> VCToolsDir,
     std::optional<llvm::StringRef> VCToolsVersion,
     std::optional<llvm::StringRef> WinSysRoot, std::string &Path,
     ToolsetLayout &VSLayout);
 
 // Check various environment variables to try and find a toolchain.
-bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS, std::string &Path,
+LLVM_ABI bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS, std::string &Path,
                                    ToolsetLayout &VSLayout);
 
 // Query the Setup Config server for installs, then pick the newest version
@@ -95,7 +96,7 @@ bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS, std::string &Path,
 //
 // This is the preferred way to discover new Visual Studios, as they're no
 // longer listed in the registry.
-bool
+LLVM_ABI bool
 findVCToolChainViaSetupConfig(vfs::FileSystem &VFS,
                               std::optional<llvm::StringRef> VCToolsVersion,
                               std::string &Path, ToolsetLayout &VSLayout);
@@ -103,7 +104,7 @@ findVCToolChainViaSetupConfig(vfs::FileSystem &VFS,
 // Look in the registry for Visual Studio installs, and use that to get
 // a toolchain path. VS2017 and newer don't get added to the registry.
 // So if we find something here, we know that it's an older version.
-bool findVCToolChainViaRegistry(std::string &Path, ToolsetLayout &VSLayout);
+LLVM_ABI bool findVCToolChainViaRegistry(std::string &Path, ToolsetLayout &VSLayout);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
+++ b/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
@@ -37,7 +37,8 @@ namespace windows_manifest {
 
 LLVM_ABI bool isAvailable();
 
-class LLVM_ABI WindowsManifestError : public ErrorInfo<WindowsManifestError, ECError> {
+class LLVM_ABI WindowsManifestError
+    : public ErrorInfo<WindowsManifestError, ECError> {
 public:
   static char ID;
   WindowsManifestError(const Twine &Msg);

--- a/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
+++ b/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
@@ -25,6 +25,7 @@
 #ifndef LLVM_WINDOWSMANIFEST_WINDOWSMANIFESTMERGER_H
 #define LLVM_WINDOWSMANIFEST_WINDOWSMANIFESTMERGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -34,9 +35,9 @@ class MemoryBufferRef;
 
 namespace windows_manifest {
 
-bool isAvailable();
+LLVM_ABI bool isAvailable();
 
-class WindowsManifestError : public ErrorInfo<WindowsManifestError, ECError> {
+class LLVM_ABI WindowsManifestError : public ErrorInfo<WindowsManifestError, ECError> {
 public:
   static char ID;
   WindowsManifestError(const Twine &Msg);
@@ -48,13 +49,13 @@ private:
 
 class WindowsManifestMerger {
 public:
-  WindowsManifestMerger();
-  ~WindowsManifestMerger();
-  Error merge(MemoryBufferRef Manifest);
+  LLVM_ABI WindowsManifestMerger();
+  LLVM_ABI ~WindowsManifestMerger();
+  LLVM_ABI Error merge(MemoryBufferRef Manifest);
 
   // Returns vector containing merged xml manifest, or uninitialized vector for
   // empty manifest.
-  std::unique_ptr<MemoryBuffer> getMergedManifest();
+  LLVM_ABI std::unique_ptr<MemoryBuffer> getMergedManifest();
 
 private:
   class WindowsManifestMergerImpl;

--- a/llvm/lib/CodeGen/GlobalMergeFunctions.cpp
+++ b/llvm/lib/CodeGen/GlobalMergeFunctions.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Analysis/ModuleSummaryAnalysis.h"
 #include "llvm/CGData/CodeGenData.h"
 #include "llvm/CGData/CodeGenDataWriter.h"
+#include "llvm/CodeGen/Passes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/StructuralHash.h"
 #include "llvm/InitializePasses.h"

--- a/llvm/lib/CodeGen/MachineDomTreeUpdater.cpp
+++ b/llvm/lib/CodeGen/MachineDomTreeUpdater.cpp
@@ -14,21 +14,22 @@
 #include "llvm/CodeGen/MachineDomTreeUpdater.h"
 #include "llvm/Analysis/GenericDomTreeUpdaterImpl.h"
 #include "llvm/CodeGen/MachinePostDominators.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
-template class GenericDomTreeUpdater<
+template class LLVM_EXPORT_TEMPLATE GenericDomTreeUpdater<
     MachineDomTreeUpdater, MachineDominatorTree, MachinePostDominatorTree>;
 
-template void
+template LLVM_EXPORT_TEMPLATE void
 GenericDomTreeUpdater<MachineDomTreeUpdater, MachineDominatorTree,
                       MachinePostDominatorTree>::recalculate(MachineFunction
                                                                  &MF);
 
-template void GenericDomTreeUpdater<
+template LLVM_EXPORT_TEMPLATE void GenericDomTreeUpdater<
     MachineDomTreeUpdater, MachineDominatorTree,
     MachinePostDominatorTree>::applyUpdatesImpl</*IsForward=*/true>();
-template void GenericDomTreeUpdater<
+template LLVM_EXPORT_TEMPLATE void GenericDomTreeUpdater<
     MachineDomTreeUpdater, MachineDominatorTree,
     MachinePostDominatorTree>::applyUpdatesImpl</*IsForward=*/false>();
 

--- a/llvm/lib/CodeGen/MachineDominators.cpp
+++ b/llvm/lib/CodeGen/MachineDominators.cpp
@@ -37,23 +37,28 @@ static cl::opt<bool, true> VerifyMachineDomInfoX(
 
 namespace llvm {
 template class LLVM_EXPORT_TEMPLATE DomTreeNodeBase<MachineBasicBlock>;
-template class LLVM_EXPORT_TEMPLATE DominatorTreeBase<MachineBasicBlock, false>; // DomTreeBase
+template class LLVM_EXPORT_TEMPLATE
+    DominatorTreeBase<MachineBasicBlock, false>; // DomTreeBase
 
 namespace DomTreeBuilder {
 template LLVM_EXPORT_TEMPLATE void Calculate<MBBDomTree>(MBBDomTree &DT);
-template LLVM_EXPORT_TEMPLATE void CalculateWithUpdates<MBBDomTree>(MBBDomTree &DT, MBBUpdates U);
+template LLVM_EXPORT_TEMPLATE void
+CalculateWithUpdates<MBBDomTree>(MBBDomTree &DT, MBBUpdates U);
 
-template LLVM_EXPORT_TEMPLATE void InsertEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
-                                     MachineBasicBlock *To);
+template LLVM_EXPORT_TEMPLATE void
+InsertEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
+                       MachineBasicBlock *To);
 
-template LLVM_EXPORT_TEMPLATE void DeleteEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
-                                     MachineBasicBlock *To);
+template LLVM_EXPORT_TEMPLATE void
+DeleteEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
+                       MachineBasicBlock *To);
 
-template LLVM_EXPORT_TEMPLATE void ApplyUpdates<MBBDomTree>(MBBDomTree &DT, MBBDomTreeGraphDiff &,
-                                       MBBDomTreeGraphDiff *);
+template LLVM_EXPORT_TEMPLATE void
+ApplyUpdates<MBBDomTree>(MBBDomTree &DT, MBBDomTreeGraphDiff &,
+                         MBBDomTreeGraphDiff *);
 
-template LLVM_EXPORT_TEMPLATE bool Verify<MBBDomTree>(const MBBDomTree &DT,
-                                 MBBDomTree::VerificationLevel VL);
+template LLVM_EXPORT_TEMPLATE bool
+Verify<MBBDomTree>(const MBBDomTree &DT, MBBDomTree::VerificationLevel VL);
 } // namespace DomTreeBuilder
 }
 

--- a/llvm/lib/CodeGen/MachineDominators.cpp
+++ b/llvm/lib/CodeGen/MachineDominators.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Pass.h"
 #include "llvm/PassRegistry.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/GenericDomTreeConstruction.h"
 
 using namespace llvm;
@@ -35,23 +36,23 @@ static cl::opt<bool, true> VerifyMachineDomInfoX(
     cl::desc("Verify machine dominator info (time consuming)"));
 
 namespace llvm {
-template class DomTreeNodeBase<MachineBasicBlock>;
-template class DominatorTreeBase<MachineBasicBlock, false>; // DomTreeBase
+template class LLVM_EXPORT_TEMPLATE DomTreeNodeBase<MachineBasicBlock>;
+template class LLVM_EXPORT_TEMPLATE DominatorTreeBase<MachineBasicBlock, false>; // DomTreeBase
 
 namespace DomTreeBuilder {
-template void Calculate<MBBDomTree>(MBBDomTree &DT);
-template void CalculateWithUpdates<MBBDomTree>(MBBDomTree &DT, MBBUpdates U);
+template LLVM_EXPORT_TEMPLATE void Calculate<MBBDomTree>(MBBDomTree &DT);
+template LLVM_EXPORT_TEMPLATE void CalculateWithUpdates<MBBDomTree>(MBBDomTree &DT, MBBUpdates U);
 
-template void InsertEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
+template LLVM_EXPORT_TEMPLATE void InsertEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
                                      MachineBasicBlock *To);
 
-template void DeleteEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
+template LLVM_EXPORT_TEMPLATE void DeleteEdge<MBBDomTree>(MBBDomTree &DT, MachineBasicBlock *From,
                                      MachineBasicBlock *To);
 
-template void ApplyUpdates<MBBDomTree>(MBBDomTree &DT, MBBDomTreeGraphDiff &,
+template LLVM_EXPORT_TEMPLATE void ApplyUpdates<MBBDomTree>(MBBDomTree &DT, MBBDomTreeGraphDiff &,
                                        MBBDomTreeGraphDiff *);
 
-template bool Verify<MBBDomTree>(const MBBDomTree &DT,
+template LLVM_EXPORT_TEMPLATE bool Verify<MBBDomTree>(const MBBDomTree &DT,
                                  MBBDomTree::VerificationLevel VL);
 } // namespace DomTreeBuilder
 }

--- a/llvm/lib/CodeGen/MachineLoopInfo.cpp
+++ b/llvm/lib/CodeGen/MachineLoopInfo.cpp
@@ -22,13 +22,14 @@
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/PassRegistry.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/GenericLoopInfoImpl.h"
 
 using namespace llvm;
 
 // Explicitly instantiate methods in LoopInfoImpl.h for MI-level Loops.
-template class llvm::LoopBase<MachineBasicBlock, MachineLoop>;
-template class llvm::LoopInfoBase<MachineBasicBlock, MachineLoop>;
+template class LLVM_EXPORT_TEMPLATE llvm::LoopBase<MachineBasicBlock, MachineLoop>;
+template class LLVM_EXPORT_TEMPLATE llvm::LoopInfoBase<MachineBasicBlock, MachineLoop>;
 
 AnalysisKey MachineLoopAnalysis::Key;
 

--- a/llvm/lib/CodeGen/MachineLoopInfo.cpp
+++ b/llvm/lib/CodeGen/MachineLoopInfo.cpp
@@ -28,8 +28,10 @@
 using namespace llvm;
 
 // Explicitly instantiate methods in LoopInfoImpl.h for MI-level Loops.
-template class LLVM_EXPORT_TEMPLATE llvm::LoopBase<MachineBasicBlock, MachineLoop>;
-template class LLVM_EXPORT_TEMPLATE llvm::LoopInfoBase<MachineBasicBlock, MachineLoop>;
+template class LLVM_EXPORT_TEMPLATE
+    llvm::LoopBase<MachineBasicBlock, MachineLoop>;
+template class LLVM_EXPORT_TEMPLATE
+    llvm::LoopInfoBase<MachineBasicBlock, MachineLoop>;
 
 AnalysisKey MachineLoopAnalysis::Key;
 

--- a/llvm/lib/CodeGen/MachinePassManager.cpp
+++ b/llvm/lib/CodeGen/MachinePassManager.cpp
@@ -17,19 +17,20 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManagerImpl.h"
+#include "llvm/Support/Compiler.h"
 
 using namespace llvm;
 
 AnalysisKey FunctionAnalysisManagerMachineFunctionProxy::Key;
 
 namespace llvm {
-template class AnalysisManager<MachineFunction>;
+template class LLVM_EXPORT_TEMPLATE AnalysisManager<MachineFunction>;
 template class PassManager<MachineFunction>;
-template class InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
+template class LLVM_EXPORT_TEMPLATE InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
                                          Module>;
-template class InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
+template class LLVM_EXPORT_TEMPLATE InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
                                          Function>;
-template class OuterAnalysisManagerProxy<ModuleAnalysisManager,
+template class LLVM_EXPORT_TEMPLATE OuterAnalysisManagerProxy<ModuleAnalysisManager,
                                          MachineFunction>;
 } // namespace llvm
 

--- a/llvm/lib/CodeGen/MachinePassManager.cpp
+++ b/llvm/lib/CodeGen/MachinePassManager.cpp
@@ -26,12 +26,12 @@ AnalysisKey FunctionAnalysisManagerMachineFunctionProxy::Key;
 namespace llvm {
 template class LLVM_EXPORT_TEMPLATE AnalysisManager<MachineFunction>;
 template class PassManager<MachineFunction>;
-template class LLVM_EXPORT_TEMPLATE InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
-                                         Module>;
-template class LLVM_EXPORT_TEMPLATE InnerAnalysisManagerProxy<MachineFunctionAnalysisManager,
-                                         Function>;
-template class LLVM_EXPORT_TEMPLATE OuterAnalysisManagerProxy<ModuleAnalysisManager,
-                                         MachineFunction>;
+template class LLVM_EXPORT_TEMPLATE
+    InnerAnalysisManagerProxy<MachineFunctionAnalysisManager, Module>;
+template class LLVM_EXPORT_TEMPLATE
+    InnerAnalysisManagerProxy<MachineFunctionAnalysisManager, Function>;
+template class LLVM_EXPORT_TEMPLATE
+    OuterAnalysisManagerProxy<ModuleAnalysisManager, MachineFunction>;
 } // namespace llvm
 
 bool FunctionAnalysisManagerMachineFunctionProxy::Result::invalidate(

--- a/llvm/lib/CodeGen/MachinePostDominators.cpp
+++ b/llvm/lib/CodeGen/MachinePostDominators.cpp
@@ -18,21 +18,21 @@
 using namespace llvm;
 
 namespace llvm {
-template class DominatorTreeBase<MachineBasicBlock, true>; // PostDomTreeBase
+template class LLVM_EXPORT_TEMPLATE DominatorTreeBase<MachineBasicBlock, true>; // PostDomTreeBase
 
 namespace DomTreeBuilder {
 
-template void Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
-template void InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT,
+template LLVM_EXPORT_TEMPLATE void Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
+template LLVM_EXPORT_TEMPLATE void InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT,
                                          MachineBasicBlock *From,
                                          MachineBasicBlock *To);
-template void DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT,
+template LLVM_EXPORT_TEMPLATE void DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT,
                                          MachineBasicBlock *From,
                                          MachineBasicBlock *To);
-template void ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT,
+template LLVM_EXPORT_TEMPLATE void ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT,
                                            MBBPostDomTreeGraphDiff &,
                                            MBBPostDomTreeGraphDiff *);
-template bool Verify<MBBPostDomTree>(const MBBPostDomTree &DT,
+template LLVM_EXPORT_TEMPLATE bool Verify<MBBPostDomTree>(const MBBPostDomTree &DT,
                                      MBBPostDomTree::VerificationLevel VL);
 
 } // namespace DomTreeBuilder

--- a/llvm/lib/CodeGen/MachinePostDominators.cpp
+++ b/llvm/lib/CodeGen/MachinePostDominators.cpp
@@ -18,22 +18,25 @@
 using namespace llvm;
 
 namespace llvm {
-template class LLVM_EXPORT_TEMPLATE DominatorTreeBase<MachineBasicBlock, true>; // PostDomTreeBase
+template class LLVM_EXPORT_TEMPLATE
+    DominatorTreeBase<MachineBasicBlock, true>; // PostDomTreeBase
 
 namespace DomTreeBuilder {
 
-template LLVM_EXPORT_TEMPLATE void Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
-template LLVM_EXPORT_TEMPLATE void InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT,
-                                         MachineBasicBlock *From,
-                                         MachineBasicBlock *To);
-template LLVM_EXPORT_TEMPLATE void DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT,
-                                         MachineBasicBlock *From,
-                                         MachineBasicBlock *To);
-template LLVM_EXPORT_TEMPLATE void ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT,
-                                           MBBPostDomTreeGraphDiff &,
-                                           MBBPostDomTreeGraphDiff *);
-template LLVM_EXPORT_TEMPLATE bool Verify<MBBPostDomTree>(const MBBPostDomTree &DT,
-                                     MBBPostDomTree::VerificationLevel VL);
+template LLVM_EXPORT_TEMPLATE void
+Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
+template LLVM_EXPORT_TEMPLATE void
+InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT, MachineBasicBlock *From,
+                           MachineBasicBlock *To);
+template LLVM_EXPORT_TEMPLATE void
+DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT, MachineBasicBlock *From,
+                           MachineBasicBlock *To);
+template LLVM_EXPORT_TEMPLATE void
+ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT, MBBPostDomTreeGraphDiff &,
+                             MBBPostDomTreeGraphDiff *);
+template LLVM_EXPORT_TEMPLATE bool
+Verify<MBBPostDomTree>(const MBBPostDomTree &DT,
+                       MBBPostDomTree::VerificationLevel VL);
 
 } // namespace DomTreeBuilder
 extern bool VerifyMachineDomInfo;

--- a/llvm/lib/CodeGen/RegAllocScore.cpp
+++ b/llvm/lib/CodeGen/RegAllocScore.cpp
@@ -23,12 +23,12 @@
 #include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
-cl::opt<double> CopyWeight("regalloc-copy-weight", cl::init(0.2), cl::Hidden);
-cl::opt<double> LoadWeight("regalloc-load-weight", cl::init(4.0), cl::Hidden);
-cl::opt<double> StoreWeight("regalloc-store-weight", cl::init(1.0), cl::Hidden);
-cl::opt<double> CheapRematWeight("regalloc-cheap-remat-weight", cl::init(0.2),
+LLVM_ABI cl::opt<double> CopyWeight("regalloc-copy-weight", cl::init(0.2), cl::Hidden);
+LLVM_ABI cl::opt<double> LoadWeight("regalloc-load-weight", cl::init(4.0), cl::Hidden);
+LLVM_ABI cl::opt<double> StoreWeight("regalloc-store-weight", cl::init(1.0), cl::Hidden);
+LLVM_ABI cl::opt<double> CheapRematWeight("regalloc-cheap-remat-weight", cl::init(0.2),
                                  cl::Hidden);
-cl::opt<double> ExpensiveRematWeight("regalloc-expensive-remat-weight",
+LLVM_ABI cl::opt<double> ExpensiveRematWeight("regalloc-expensive-remat-weight",
                                      cl::init(1.0), cl::Hidden);
 #define DEBUG_TYPE "regalloc-score"
 

--- a/llvm/lib/CodeGen/RegAllocScore.cpp
+++ b/llvm/lib/CodeGen/RegAllocScore.cpp
@@ -23,13 +23,16 @@
 #include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
-LLVM_ABI cl::opt<double> CopyWeight("regalloc-copy-weight", cl::init(0.2), cl::Hidden);
-LLVM_ABI cl::opt<double> LoadWeight("regalloc-load-weight", cl::init(4.0), cl::Hidden);
-LLVM_ABI cl::opt<double> StoreWeight("regalloc-store-weight", cl::init(1.0), cl::Hidden);
-LLVM_ABI cl::opt<double> CheapRematWeight("regalloc-cheap-remat-weight", cl::init(0.2),
-                                 cl::Hidden);
+LLVM_ABI cl::opt<double> CopyWeight("regalloc-copy-weight", cl::init(0.2),
+                                    cl::Hidden);
+LLVM_ABI cl::opt<double> LoadWeight("regalloc-load-weight", cl::init(4.0),
+                                    cl::Hidden);
+LLVM_ABI cl::opt<double> StoreWeight("regalloc-store-weight", cl::init(1.0),
+                                     cl::Hidden);
+LLVM_ABI cl::opt<double> CheapRematWeight("regalloc-cheap-remat-weight",
+                                          cl::init(0.2), cl::Hidden);
 LLVM_ABI cl::opt<double> ExpensiveRematWeight("regalloc-expensive-remat-weight",
-                                     cl::init(1.0), cl::Hidden);
+                                              cl::init(1.0), cl::Hidden);
 #define DEBUG_TYPE "regalloc-score"
 
 RegAllocScore &RegAllocScore::operator+=(const RegAllocScore &Other) {

--- a/llvm/lib/Transforms/Utils/CloneModule.cpp
+++ b/llvm/lib/Transforms/Utils/CloneModule.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm-c/Core.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Transforms/Utils/Cloning.h"

--- a/llvm/tools/llvm-profgen/ProfileGenerator.cpp
+++ b/llvm/tools/llvm-profgen/ProfileGenerator.cpp
@@ -108,8 +108,6 @@ using namespace llvm;
 using namespace sampleprof;
 
 namespace llvm {
-extern cl::opt<int> ProfileSummaryCutoffHot;
-extern cl::opt<bool> UseContextLessSummary;
 
 namespace sampleprof {
 

--- a/llvm/unittests/Analysis/MemoryProfileInfoTest.cpp
+++ b/llvm/unittests/Analysis/MemoryProfileInfoTest.cpp
@@ -14,6 +14,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/SourceMgr.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -23,7 +24,7 @@
 using namespace llvm;
 using namespace llvm::memprof;
 
-extern cl::opt<bool> MemProfKeepAllNotColdContexts;
+LLVM_ABI extern cl::opt<bool> MemProfKeepAllNotColdContexts;
 
 namespace {
 


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the remaining LLVM interface that was missed in, or modified since, previous patches. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS:
- Remove local `extern` declarations of `llvm::PrintPipelinePasses` because it is already correctly declared with an `LLVM_ABI` annotation in `llvm\Passes\PassBuilder.h`. Leaving these declarations results in a gcc compile warning unless they are also annotated with `LLVM_ABI`.
- Similarly, remove local `extern` declarations of `ProfileSummaryCutoffHot` and `UseContextLessSummary` from `llvm/tools/llvm-profgen/ProfileGenerator.cpp` since they are declared with `LLVM_ABI` in `llvm\ProfileData\ProfileCommon.h`.
- Annotate the private method `IEEEFloat::addOrSubtractSignificand` with `LLVM_ABI` because it is used by a unit test friend class.
- Annotate several `friend` function declarations with `LLVM_ABI_FRIEND` since the corresponding function declarations are annotated with `LLVM_ABI` (required by MSVC).
- Explicitly instantiate `CallLowering::setArgFlags` template method instances in `CodeGen/GlobalISel/CallLowering.h` and annotate them with `LLVM_ABI`. These methods are already explicitly instantiated in `lib/CodeGen/GlobalISel/CallLowering.cpp` but were not `extern` declared in the header.
- Add default ctor and delete the copy ctor and copy assignment operator in the `Telemetry::Manager` class. This is required because the class is now annotated with `LLVM_ABI` and cannot otherwise be fully instantiated for export.
- Annotate a small number of symbol declarations in implementation files with `LLVM_ABI`. These symbols are referenced by tools/tests but not declared in headers.
- Annotate several explicit template instantiations with `LLVM_EXPORT_TEMPLATE`.

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang