### PR TITLE
[llvm-debuginfo-analyzer] Remove `LVScope::Children` container

### DIFF
--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVObject.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVObject.h
@@ -82,6 +82,8 @@ using LVScopes = SmallVector<LVScope *, 8>;
 using LVSymbols = SmallVector<LVSymbol *, 8>;
 using LVTypes = SmallVector<LVType *, 8>;
 
+using LVElementsView = detail::concat_range<LVElement *const, const LVScopes &,
+                                            const LVTypes &, const LVSymbols &>;
 using LVOffsets = SmallVector<LVOffset, 8>;
 
 // The following DWARF documents detail the 'tombstone' concept:

--- a/llvm/test/tools/llvm-debuginfo-analyzer/COFF/01-coff-print-basic-details.test
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/COFF/01-coff-print-basic-details.test
@@ -19,30 +19,13 @@
 ; level and debug info format.
 
 ; RUN: llvm-debuginfo-analyzer --attribute=level,format \
-; RUN:                         --output-sort=offset \
-; RUN:                         --print=scopes,symbols,types,lines,instructions \
-; RUN:                         %p/Inputs/test-codeview-clang.o 2>&1 | \
-; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
-
-; If `--output-sort=id`, elements are iterated in the order in which they were
-; added (which matches the increasing offset of the reference output).
-; RUN: llvm-debuginfo-analyzer --attribute=level,format \
 ; RUN:                         --output-sort=id \
 ; RUN:                         --print=scopes,symbols,types,lines,instructions \
 ; RUN:                         %p/Inputs/test-codeview-clang.o 2>&1 | \
 ; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
 
-; If `--output-sort=none`, `LVScope::Children` is not sorted; it, however,
-; reflects the order in which elements were added (same as `--output-sort=id`).
-; This is expected to change once #69160 is resolved though.
 ; RUN: llvm-debuginfo-analyzer --attribute=level,format \
-; RUN:                         --output-sort=none \
-; RUN:                         --print=scopes,symbols,types,lines,instructions \
-; RUN:                         %p/Inputs/test-codeview-clang.o 2>&1 | \
-; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
-
-; RUN: llvm-debuginfo-analyzer --attribute=level,format \
-; RUN:                         --output-sort=offset \
+; RUN:                         --output-sort=id \
 ; RUN:                         --print=elements \
 ; RUN:                         %p/Inputs/test-codeview-clang.o 2>&1 | \
 ; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
@@ -80,3 +63,43 @@
 ; ONE-NEXT: [003]                 {Code} 'addq	$0x20, %rsp'
 ; ONE-NEXT: [003]                 {Code} 'retq'
 ; ONE-NEXT: [002]               {TypeAlias} 'INTPTR' -> '* const int'
+
+; RUN: llvm-debuginfo-analyzer --attribute=level,format \
+; RUN:                         --output-sort=none \
+; RUN:                         --print=scopes,symbols,types,lines,instructions \
+; RUN:                         %p/Inputs/test-codeview-clang.o 2>&1 | \
+; RUN: FileCheck --strict-whitespace -check-prefix=ONE-NOSORT %s
+
+; ONE-NOSORT:      Logical View:
+; ONE-NOSORT-NEXT: [000]           {File} 'test-codeview-clang.o' -> COFF-x86-64
+; ONE-NOSORT-EMPTY:
+; ONE-NOSORT-NEXT: [001]             {CompileUnit} 'test.cpp'
+; ONE-NOSORT-NEXT: [002]               {Function} extern not_inlined 'foo' -> 'int'
+; ONE-NOSORT-NEXT: [003]                 {Block}
+; ONE-NOSORT-NEXT: [004]                   {Variable} 'CONSTANT' -> 'const int'
+; ONE-NOSORT-NEXT: [004]     5             {Line}
+; ONE-NOSORT-NEXT: [004]                   {Code} 'movl	$0x7, 0x4(%rsp)'
+; ONE-NOSORT-NEXT: [004]     6             {Line}
+; ONE-NOSORT-NEXT: [004]                   {Code} 'movl	$0x7, 0x1c(%rsp)'
+; ONE-NOSORT-NEXT: [004]                   {Code} 'jmp	0x8'
+; ONE-NOSORT-NEXT: [003]                 {TypeAlias} 'INTEGER' -> 'int'
+; ONE-NOSORT-NEXT: [003]                 {Parameter} 'ParamPtr' -> '* const int'
+; ONE-NOSORT-NEXT: [003]                 {Parameter} 'ParamUnsigned' -> 'unsigned'
+; ONE-NOSORT-NEXT: [003]                 {Parameter} 'ParamBool' -> 'bool'
+; ONE-NOSORT-NEXT: [003]     2           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'subq	$0x20, %rsp'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'andb	$0x1, %r8b'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movb	%r8b, 0x1b(%rsp)'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movl	%edx, 0x14(%rsp)'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movq	%rcx, 0x8(%rsp)'
+; ONE-NOSORT-NEXT: [003]     3           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'testb	$0x1, 0x1b(%rsp)'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'je	0x15'
+; ONE-NOSORT-NEXT: [003]     8           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movl	0x14(%rsp), %eax'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movl	%eax, 0x1c(%rsp)'
+; ONE-NOSORT-NEXT: [003]     9           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movl	0x1c(%rsp), %eax'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'addq	$0x20, %rsp'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'retq'
+; ONE-NOSORT-NEXT: [002]               {TypeAlias} 'INTPTR' -> '* const int'

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/01-dwarf-compare-logical-elements.test
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/01-dwarf-compare-logical-elements.test
@@ -35,8 +35,8 @@
 ; ONE-NEXT:  [002]     1         {TypeAlias} 'INTPTR' -> '* const int'
 ; ONE-NEXT:  [002]     2         {Function} extern not_inlined 'foo' -> 'int'
 ; ONE-NEXT:  [003]                 {Block}
-; ONE-NEXT:  [004]     5             {Variable} 'CONSTANT' -> 'const INTEGER'
 ; ONE-NEXT: +[004]     4             {TypeAlias} 'INTEGER' -> 'int'
+; ONE-NEXT:  [004]     5             {Variable} 'CONSTANT' -> 'const INTEGER'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamBool' -> 'bool'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamPtr' -> 'INTPTR'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamUnsigned' -> 'unsigned int'

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/01-dwarf-print-basic-details.test
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/01-dwarf-print-basic-details.test
@@ -19,31 +19,22 @@
 ; level and debug info format.
 
 ; RUN: llvm-debuginfo-analyzer --attribute=level,format \
-; RUN:                         --output-sort=offset \
-; RUN:                         --print=scopes,symbols,types,lines,instructions \
-; RUN:                         %p/Inputs/test-dwarf-clang.o 2>&1 | \
-; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
-
-; If `--output-sort=id`, elements are iterated in the order in which they
-; were added (which matches the increasing offset of the reference output).
-; RUN: llvm-debuginfo-analyzer --attribute=level,format \
 ; RUN:                         --output-sort=id \
 ; RUN:                         --print=scopes,symbols,types,lines,instructions \
 ; RUN:                         %p/Inputs/test-dwarf-clang.o 2>&1 | \
 ; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
 
-; If `--output-sort=none`, `LVScope::Children` is not sorted; it, however,
-; reflects the order in which elements were added (same as `--output-sort=id`).
-; This is expected to change once #69160 is resolved though.
 ; RUN: llvm-debuginfo-analyzer --attribute=level,format \
-; RUN:                         --output-sort=none \
-; RUN:                         --print=scopes,symbols,types,lines,instructions \
+; RUN:                         --output-sort=id \
+; RUN:                         --print=elements \
 ; RUN:                         %p/Inputs/test-dwarf-clang.o 2>&1 | \
 ; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
 
+; For DWARF, `--output-sort=offset` matches `--output-sort=id`, i.e.,
+; `LVElement`s are always iterated in the order in which they were added.
 ; RUN: llvm-debuginfo-analyzer --attribute=level,format \
 ; RUN:                         --output-sort=offset \
-; RUN:                         --print=elements \
+; RUN:                         --print=scopes,symbols,types,lines,instructions \
 ; RUN:                         %p/Inputs/test-dwarf-clang.o 2>&1 | \
 ; RUN: FileCheck --strict-whitespace -check-prefix=ONE %s
 
@@ -84,3 +75,47 @@
 ; ONE-NEXT: [003]                 {Code} 'retq'
 ; ONE-NEXT: [002]     1         {TypeAlias} 'INTPTR' -> '* const int'
 ; ONE-NEXT: [002]     9         {Line}
+
+; RUN: llvm-debuginfo-analyzer --attribute=level,format \
+; RUN:                         --output-sort=none \
+; RUN:                         --print=scopes,symbols,types,lines,instructions \
+; RUN:                         %p/Inputs/test-dwarf-clang.o 2>&1 | \
+; RUN: FileCheck --strict-whitespace -check-prefix=ONE-NOSORT %s
+
+; ONE-NOSORT:      Logical View:
+; ONE-NOSORT-NEXT: [000]           {File} 'test-dwarf-clang.o' -> elf64-x86-64
+; ONE-NOSORT-EMPTY:
+; ONE-NOSORT-NEXT: [001]             {CompileUnit} 'test.cpp'
+; ONE-NOSORT-NEXT: [002]     2         {Function} extern not_inlined 'foo' -> 'int'
+; ONE-NOSORT-NEXT: [003]                 {Block}
+; ONE-NOSORT-NEXT: [004]     5             {Variable} 'CONSTANT' -> 'const INTEGER'
+; ONE-NOSORT-NEXT: [004]     5             {Line}
+; ONE-NOSORT-NEXT: [004]                   {Code} 'movl	$0x7, -0x1c(%rbp)'
+; ONE-NOSORT-NEXT: [004]     6             {Line}
+; ONE-NOSORT-NEXT: [004]                   {Code} 'movl	$0x7, -0x4(%rbp)'
+; ONE-NOSORT-NEXT: [004]                   {Code} 'jmp	0x6'
+; ONE-NOSORT-NEXT: [003]     4           {TypeAlias} 'INTEGER' -> 'int'
+; ONE-NOSORT-NEXT: [003]     2           {Parameter} 'ParamPtr' -> 'INTPTR'
+; ONE-NOSORT-NEXT: [003]     2           {Parameter} 'ParamUnsigned' -> 'unsigned int'
+; ONE-NOSORT-NEXT: [003]     2           {Parameter} 'ParamBool' -> 'bool'
+; ONE-NOSORT-NEXT: [003]     2           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'pushq	%rbp'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movq	%rsp, %rbp'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movb	%dl, %al'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movq	%rdi, -0x10(%rbp)'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movl	%esi, -0x14(%rbp)'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'andb	$0x1, %al'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movb	%al, -0x15(%rbp)'
+; ONE-NOSORT-NEXT: [003]     3           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'testb	$0x1, -0x15(%rbp)'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'je	0x13'
+; ONE-NOSORT-NEXT: [003]     8           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movl	-0x14(%rbp), %eax'
+; ONE-NOSORT-NEXT: [003]     8           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movl	%eax, -0x4(%rbp)'
+; ONE-NOSORT-NEXT: [003]     9           {Line}
+; ONE-NOSORT-NEXT: [003]                 {Code} 'movl	-0x4(%rbp), %eax'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'popq	%rbp'
+; ONE-NOSORT-NEXT: [003]                 {Code} 'retq'
+; ONE-NOSORT-NEXT: [002]     1         {TypeAlias} 'INTPTR' -> '* const int'
+; ONE-NOSORT-NEXT: [002]     9         {Line}

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/pr-57040-incorrect-function-compare.test
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/pr-57040-incorrect-function-compare.test
@@ -55,8 +55,8 @@
 ; ONE-NEXT:  [002]     1         {TypeAlias} 'INTPTR' -> '* const int'
 ; ONE-NEXT:  [002]     2         {Function} extern not_inlined 'foo' -> 'int'
 ; ONE-NEXT:  [003]                 {Block}
-; ONE-NEXT:  [004]     5             {Variable} 'CONSTANT' -> 'const INTEGER'
 ; ONE-NEXT: +[004]     4             {TypeAlias} 'INTEGER' -> 'int'
+; ONE-NEXT:  [004]     5             {Variable} 'CONSTANT' -> 'const INTEGER'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamBool' -> 'bool'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamPtr' -> 'INTPTR'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamUnsigned' -> 'unsigned int'

--- a/llvm/test/tools/llvm-debuginfo-analyzer/WebAssembly/01-wasm-compare-logical-elements.test
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/WebAssembly/01-wasm-compare-logical-elements.test
@@ -38,8 +38,8 @@
 ; ONE-NEXT:  [002]     1         {TypeAlias} 'INTPTR' -> '* const int'
 ; ONE-NEXT:  [002]     2         {Function} extern not_inlined 'foo' -> 'int'
 ; ONE-NEXT:  [003]                 {Block}
-; ONE-NEXT:  [004]     5             {Variable} 'CONSTANT' -> 'const INTEGER'
 ; ONE-NEXT: +[004]     4             {TypeAlias} 'INTEGER' -> 'int'
+; ONE-NEXT:  [004]     5             {Variable} 'CONSTANT' -> 'const INTEGER'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamBool' -> 'bool'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamPtr' -> 'INTPTR'
 ; ONE-NEXT:  [003]     2           {Parameter} 'ParamUnsigned' -> 'unsigned int'

--- a/llvm/unittests/DebugInfo/LogicalView/DWARFReaderTest.cpp
+++ b/llvm/unittests/DebugInfo/LogicalView/DWARFReaderTest.cpp
@@ -163,13 +163,12 @@ void checkUnspecifiedParameters(LVReader *Reader) {
   LVPublicNames::const_iterator IterNames = PublicNames.cbegin();
   LVScope *Function = (*IterNames).first;
   EXPECT_EQ(Function->getName(), "foo_printf");
-  const LVElements *Elements = Function->getChildren();
-  ASSERT_NE(Elements, nullptr);
+  const LVElementsView Elements = Function->getChildren();
   // foo_printf is a variadic function whose prototype is
   // `int foo_printf(const char *, ...)`, where the '...' is represented by a
   // DW_TAG_unspecified_parameters, i.e. we expect to find at least one child
   // for which getIsUnspecified() returns true.
-  EXPECT_TRUE(llvm::any_of(*Elements, [](const LVElement *elt) {
+  EXPECT_TRUE(llvm::any_of(Elements, [](const LVElement *elt) {
     return elt->getIsSymbol() &&
            static_cast<const LVSymbol *>(elt)->getIsUnspecified();
   }));
@@ -183,8 +182,8 @@ void checkScopeModule(LVReader *Reader) {
   EXPECT_EQ(Root->getFileFormatName(), "Mach-O 64-bit x86-64");
   EXPECT_EQ(Root->getName(), DwarfClangModule);
 
-  ASSERT_NE(CompileUnit->getChildren(), nullptr);
-  LVElement *FirstChild = *(CompileUnit->getChildren()->begin());
+  LVElement *FirstChild = *(CompileUnit->getChildren().begin());
+  ASSERT_NE(FirstChild, nullptr);
   EXPECT_EQ(FirstChild->getIsScope(), 1);
   LVScopeModule *Module = static_cast<LVScopeModule *>(FirstChild);
   EXPECT_EQ(Module->getIsModule(), 1);


### PR DESCRIPTION
Remove the `LVScope::Children` container and use `llvm::concat()` instead to return a view over the types, symbols, and sub-scopes contained in a given `LVScope`.

Fixes #69160.