### PR TITLE
[llvm] build Blake3 source with LLVM_EXPORTS defined

### DIFF
--- a/llvm/lib/Support/BLAKE3/CMakeLists.txt
+++ b/llvm/lib/Support/BLAKE3/CMakeLists.txt
@@ -85,3 +85,9 @@ endif()
 add_library(LLVMSupportBlake3 OBJECT EXCLUDE_FROM_ALL ${LLVM_BLAKE3_FILES})
 set_target_properties(LLVMSupportBlake3 PROPERTIES FOLDER "LLVM/Libraries")
 llvm_update_compile_flags(LLVMSupportBlake3)
+if(LLVM_BUILD_LLVM_DYLIB OR BUILD_SHARED_LIBS)
+  # Since LLVMSupportBlake3 is not defined using llvm_add_library(), we must
+  # define LLVM_EXPORTS here so its public interface is annotated with
+  # __declspec(dllexport) when building as a DLL on Windows.
+  target_compile_definitions(LLVMSupportBlake3 PRIVATE LLVM_EXPORTS)
+endif()


### PR DESCRIPTION
## Purpose
This patch ensures that the BLAKE3 implementation in the LLVM Support library exports its public interface with `__declspec(dllexport)` when building LLVM as a Windows DLL.

## Background
The effort to support building LLVM as a Windows DLL is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307).

## Overview
Replicate [this logic](https://github.com/llvm/llvm-project/blob/main/llvm/cmake/modules/AddLLVM.cmake#L662-L664) from `llvm_add_library()` for the `LLVMSupportBlake3` target. Without this change, the `llvm_blake_` functions will only be annotated with `__declspec(dllimport)` when building LLVM as a Windows DLL which leads to inconsistent DLL linkage warnings from MSVC and `clang-cl`.