### PR TITLE
[lldb][target] Add progress report for wait-attaching to process

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3546,6 +3546,7 @@ llvm::Expected<TraceSP> Target::GetTraceOrCreate() {
 }
 
 Status Target::Attach(ProcessAttachInfo &attach_info, Stream *stream) {
+  Progress attach_progress("Waiting to attach to process");
   m_stats.SetLaunchOrAttachTime();
   auto state = eStateInvalid;
   auto process_sp = GetProcessSP();

--- a/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
@@ -2,6 +2,7 @@
 Test that we are able to broadcast and receive progress events from lldb
 """
 import lldb
+import threading
 
 import lldbsuite.test.lldbutil as lldbutil
 
@@ -15,6 +16,36 @@ class TestProgressReporting(TestBase):
         self.listener = lldbutil.start_listening_from(
             self.broadcaster, lldb.SBDebugger.eBroadcastBitProgress
         )
+
+    def test_wait_attach_progress_reporting(self):
+        """Test that progress reports for wait attaching work as intended."""
+        self.build()
+        target = self.dbg.CreateTarget(None)
+
+        # Wait attach to a process, then check to see that a progress report was created
+        # and that its message is correct for waiting to attach to a process.
+        class AttachThread(threading.Thread):
+            def __init__(self, target):
+                threading.Thread.__init__(self)
+                self.target = target
+
+            def run(self):
+                self.target.AttachToProcessWithName(
+                    lldb.SBListener(), "a.out", True, lldb.SBError()
+                )
+
+        thread = AttachThread(target)
+        thread.start()
+
+        event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)
+        progress_data = lldb.SBDebugger.GetProgressDataFromEvent(event)
+        message = progress_data.GetValueForKey("message").GetStringValue(100)
+        self.assertEqual(message, "Waiting to attach to process")
+
+        # Interrupt the process attach to keep the test from stalling.
+        target.process.SendAsyncInterrupt()
+
+        thread.join()
 
     def test_dwarf_symbol_loading_progress_report(self):
         """Test that we are able to fetch dwarf symbol loading progress events"""


### PR DESCRIPTION
This commit adds a progress report when wait-attaching to a process as well as a test for this.