### PR TITLE
[HLSL][RootSignature] Plug-in serialization and add full sample testcase

### DIFF
--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -5,29 +5,61 @@
 // the Attr AST Node is created succesfully. If an invalid root signature was
 // passed in then we would exit out of Sema before the Attr is created.
 
-#define SampleRS \
-  "DescriptorTable( " \
-  "  CBV(b1), " \
-  "  SRV(t1, numDescriptors = 8, " \
-  "          flags = DESCRIPTORS_VOLATILE), " \
-  "  UAV(u1, numDescriptors = 0, " \
-  "          flags = DESCRIPTORS_VOLATILE) " \
-  "), " \
-  "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
+#define SampleRS "RootFlags( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT | " \
+                             "DENY_VERTEX_SHADER_ROOT_ACCESS), " \
+                 "CBV(b0, space = 1, flags = DATA_STATIC), " \
+                 "SRV(t0), " \
+                 "UAV(u0), " \
+                 "DescriptorTable( CBV(b1), " \
+                                   "SRV(t1, numDescriptors = 8, " \
+                                   "        flags = DESCRIPTORS_VOLATILE), " \
+                                   "UAV(u1, numDescriptors = unbounded, " \
+                                   "        flags = DESCRIPTORS_VOLATILE)), " \
+                 "DescriptorTable(Sampler(s0, space=1, numDescriptors = 4)), " \
+                 "RootConstants(num32BitConstants=3, b10), " \
+                 "StaticSampler(s1)," \
+                 "StaticSampler(s2, " \
+                                 "addressU = TEXTURE_ADDRESS_CLAMP, " \
+                                 "filter = FILTER_MIN_MAG_MIP_LINEAR )"
 
 // CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[SAMPLE_RS_DECL:__hlsl_rootsig_decl_\d*]]
 // CHECK-SAME: RootElements{
-// CHECK-SAME:   CBV(b1, numDescriptors = 1, space = 0,
-// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = DataStaticWhileSetAtExecute),
-// CHECK-SAME:   SRV(t1, numDescriptors = 8, space = 0,
-// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile),
-// CHECK-SAME:   UAV(u1, numDescriptors = 0, space = 0,
-// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile),
-// CHECK-SAME:   DescriptorTable(numClauses = 3, visibility = All),
-// CHECK-SAME:   Sampler(s0, numDescriptors = 4, space = 1,
-// CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = None),
-// CHECK-SAME:   DescriptorTable(numClauses = 1, visibility = All)
-// CHECK-SAME: }
+// CHECK-SAME: RootFlags(AllowInputAssemblerInputLayout | DenyVertexShaderRootAccess),
+// CHECK-SAME: RootCBV(b0,
+// CHECK-SAME:   space = 1, visibility = All, flags = DataStatic
+// CHECK-SAME: ),
+// CHECK-SAME: RootSRV(t0,
+// CHECK-SAME:   space = 0, visibility = All, flags = DataStaticWhileSetAtExecute
+// CHECK-SAME: ),
+// CHECK-SAME: RootUAV(
+// CHECK-SAME:   u0, space = 0, visibility = All, flags = DataVolatile
+// CHECK-SAME: ),
+// CHECK-SAME: CBV(
+// CHECK-SAME:   b1, numDescriptors = 1, space = 0, offset = DescriptorTableOffsetAppend, flags = DataStaticWhileSetAtExecute
+// CHECK-SAME: ),
+// CHECK-SAME: SRV(
+// CHECK-SAME:   t1, numDescriptors = 8, space = 0, offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile
+// CHECK-SAME: ),
+// CHECK-SAME: UAV(
+// CHECK-SAME:   u1, numDescriptors = 4294967295, space = 0, offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile
+// CHECK-SAME: ),
+// CHECK-SAME: DescriptorTable(
+// CHECK-SAME:   numClauses = 3, visibility = All
+// CHECK-SAME: ),
+// CHECK-SAME: Sampler(
+// CHECK-SAME:   s0, numDescriptors = 4, space = 1, offset = DescriptorTableOffsetAppend, flags = None
+// CHECK-SAME: ),
+// CHECK-SAME: DescriptorTable(
+// CHECK-SAME:   numClauses = 1, visibility = All
+// CHECK-SAME: ),
+// CHECK-SAME: RootConstants(
+// CHECK-SAME:   num32BitConstants = 3, b10, space = 0, visibility = All
+// CHECK-SAME: ),
+// CHECK-SAME: StaticSampler(
+// CHECK-SAME:   s1, filter = Anisotropic, addressU = Wrap, addressV = Wrap, addressW = Wrap,
+// CHECK-SAME:   mipLODBias = 0.000000e+00, maxAnisotropy = 16, comparisonFunc = LessEqual,
+// CHECK-SAME:   borderColor = OpaqueWhite, minLOD = 0.000000e+00, maxLOD = 3.402823e+38, space = 0, visibility = All
+// CHECK-SAME: )}
 
 // CHECK: -RootSignatureAttr 0x{{.*}} {{.*}} [[SAMPLE_RS_DECL]]
 [RootSignature(SampleRS)]
@@ -44,14 +76,23 @@ void same_rs_main() {}
 // link to the same root signature declaration
 
 #define SampleSameRS \
-  "DescriptorTable( " \
-  "  CBV(b1), " \
-  "  SRV(t1, numDescriptors = 8, " \
-  "          flags = DESCRIPTORS_VOLATILE), " \
-  "  UAV(u1, numDescriptors = 0, " \
-  "          flags = DESCRIPTORS_VOLATILE) " \
-  "), " \
-  "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
+   "RootFlags( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT | " \
+               "DENY_VERTEX_SHADER_ROOT_ACCESS), " \
+   "CBV(b0, space = 1, flags = DATA_STATIC), " \
+   "SRV(t0), " \
+   "UAV(u0), " \
+   "DescriptorTable( CBV(b1), " \
+                     "SRV(t1, numDescriptors = 8, " \
+                     "        flags = DESCRIPTORS_VOLATILE), " \
+                     "UAV(u1, numDescriptors = unbounded, " \
+                     "        flags = DESCRIPTORS_VOLATILE)), " \
+   "DescriptorTable(Sampler(s0, space=1, numDescriptors = 4)), " \
+   "RootConstants(num32BitConstants=3, b10), " \
+   "StaticSampler(s1)," \
+   "StaticSampler(s2, " \
+                   "addressU = TEXTURE_ADDRESS_CLAMP, " \
+                   "filter = FILTER_MIN_MAG_MIP_LINEAR )"
+
 
 // CHECK: -RootSignatureAttr 0x{{.*}} {{.*}} [[SAMPLE_RS_DECL]]
 [RootSignature(SampleSameRS)]

--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -41,7 +41,7 @@
 // CHECK-SAME:   t1, numDescriptors = 8, space = 0, offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile
 // CHECK-SAME: ),
 // CHECK-SAME: UAV(
-// CHECK-SAME:   u1, numDescriptors = 4294967295, space = 0, offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile
+// CHECK-SAME:   u1, numDescriptors = unbounded, space = 0, offset = DescriptorTableOffsetAppend, flags = DescriptorsVolatile
 // CHECK-SAME: ),
 // CHECK-SAME: DescriptorTable(
 // CHECK-SAME:   numClauses = 3, visibility = All

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
@@ -44,6 +44,8 @@ LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
                                  const StaticSampler &StaticSampler);
 
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const RootElement &Element);
+
 LLVM_ABI void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements);
 
 class MetadataBuilder {

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
@@ -338,24 +338,12 @@ template <class... Ts> OverloadedVisit(Ts...) -> OverloadedVisit<Ts...>;
 
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
   const auto Visitor = OverloadedVisit{
-      [&OS](const RootFlags &Flags) -> raw_ostream& {
-        return OS << Flags;
-      },
-      [&OS](const RootConstants &Constants) -> raw_ostream& {
-        return OS << Constants;
-      },
-      [&OS](const RootDescriptor &Descriptor) -> raw_ostream& {
-        return OS << Descriptor;
-      },
-      [&OS](const DescriptorTableClause &Clause) -> raw_ostream& {
-        return OS << Clause;
-      },
-      [&OS](const DescriptorTable &Table) -> raw_ostream& {
-        return OS << Table;
-      },
-      [&OS](const StaticSampler &Sampler) -> raw_ostream& {
-        return OS << Sampler;
-      },
+      [&OS](const RootFlags &Flags) { OS << Flags; },
+      [&OS](const RootConstants &Constants) { OS << Constants; },
+      [&OS](const RootDescriptor &Descriptor) { OS << Descriptor; },
+      [&OS](const DescriptorTableClause &Clause) { OS << Clause; },
+      [&OS](const DescriptorTable &Table) { OS << Table; },
+      [&OS](const StaticSampler &Sampler) { OS << Sampler; },
   };
 
   OS << " RootElements{";

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
@@ -339,7 +339,7 @@ template <class... Ts> OverloadedVisit(Ts...) -> OverloadedVisit<Ts...>;
 
 } // namespace
 
-void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
+raw_ostream &operator<<(raw_ostream &OS, const RootElement &Element) {
   const auto Visitor = OverloadedVisit{
       [&OS](const RootFlags &Flags) { OS << Flags; },
       [&OS](const RootConstants &Constants) { OS << Constants; },
@@ -348,14 +348,17 @@ void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
       [&OS](const DescriptorTable &Table) { OS << Table; },
       [&OS](const StaticSampler &Sampler) { OS << Sampler; },
   };
+  std::visit(Visitor, Element);
+  return OS;
+}
 
+void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
   OS << " RootElements{";
   bool First = true;
   for (const RootElement &Element : Elements) {
     if (!First)
       OS << ",";
-    OS << " ";
-    std::visit(Visitor, Element);
+    OS << " " << Element;
     First = false;
   }
   OS << "}";

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignatureUtils.cpp
@@ -287,9 +287,12 @@ raw_ostream &operator<<(raw_ostream &OS, const DescriptorTable &Table) {
 }
 
 raw_ostream &operator<<(raw_ostream &OS, const DescriptorTableClause &Clause) {
-  OS << Clause.Type << "(" << Clause.Reg
-     << ", numDescriptors = " << Clause.NumDescriptors
-     << ", space = " << Clause.Space << ", offset = ";
+  OS << Clause.Type << "(" << Clause.Reg << ", numDescriptors = ";
+  if (Clause.NumDescriptors == NumDescriptorsUnbounded)
+    OS << "unbounded";
+  else
+    OS << Clause.NumDescriptors;
+  OS << ", space = " << Clause.Space << ", offset = ";
   if (Clause.Offset == DescriptorTableOffsetAppend)
     OS << "DescriptorTableOffsetAppend";
   else

--- a/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
+++ b/llvm/unittests/Frontend/HLSLRootSignatureDumpTest.cpp
@@ -34,7 +34,7 @@ TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
   DescriptorTableClause Clause;
   Clause.Type = ClauseType::SRV;
   Clause.Reg = {RegisterType::TReg, 0};
-  Clause.NumDescriptors = 2;
+  Clause.NumDescriptors = NumDescriptorsUnbounded;
   Clause.Space = 42;
   Clause.Offset = 3;
   Clause.Flags = DescriptorRangeFlags::None;
@@ -44,8 +44,8 @@ TEST(HLSLRootSignatureTest, DescriptorSRVClauseDump) {
   OS << Clause;
   OS.flush();
 
-  std::string Expected =
-      "SRV(t0, numDescriptors = 2, space = 42, offset = 3, flags = None)";
+  std::string Expected = "SRV(t0, numDescriptors = unbounded, space = 42, "
+                         "offset = 3, flags = None)";
   EXPECT_EQ(Out, Expected);
 }
 


### PR DESCRIPTION
This pr extends `dumpRootElements` to invoke the print methods of all `RootElement`s now that they are all implemented.

Extends the `RootSignatures-AST.hlsl` testcase to have a root element of each type being parsed, constructed to the in-memory representation mode and then being dumped as part of the AST dump.

- Update `HLSLRootSignatureUtils.cpp` to extend `dumpRootElements`
- Extend `AST/HLSL/RootSigantures-AST.hlsl` testcase
- Defines the helper `operator<<` for `RootElement`
- Small correction to the output of `numDescriptors` to be `unbounded` in special case

Resolves https://github.com/llvm/llvm-project/issues/124595.