### PR TITLE
[llvm] explicitly link llvm-jitlink-executor with ExecutionEngine

### DIFF
--- a/llvm/tools/llvm-jitlink/llvm-jitlink-executor/CMakeLists.txt
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-executor/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(LLVM_LINK_COMPONENTS
+  ExecutionEngine
   OrcShared
   OrcTargetProcess
   Support


### PR DESCRIPTION
## Overview
Explicitly link `llvm-jitlink-executor` with `ExecutionEngine` to avoid link failures when building LLVM as a Windows DLL. This link dependency should probably have always been declared here, but didn't matter when building against an LLVM static library because it was (presumably) picked up as a transitive dependency.

This change is required to enable the Windows DLL build because `llvm-jitlink-executor` is declared using `add_llvm_utility` which invokes `add_llvm_executable` with [`DISABLE_LLVM_LINK_LLVM_DYLIB`](https://github.com/llvm/llvm-project/blob/main/llvm/cmake/modules/AddLLVM.cmake#L500-L502) so it links statically against its dependencies instead of against the main LLVM library.

## Background
The effort to support building LLVM as a Windows DLL is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307).