### PR TITLE
[asan][AIX] Set allocator size and beginning

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -198,7 +198,11 @@ const uptr kAllocatorSpace = ~(uptr)0;
 #    endif  // SANITIZER_APPLE
 
 #    if defined(__powerpc64__)
+#      if SANITIZER_AIX
+const uptr kAllocatorSize = 1ULL << 38;  // 256G.
+#      else
 const uptr kAllocatorSize  =  0x20000000000ULL;  // 2T.
+#      endif
 typedef DefaultSizeClassMap SizeClassMap;
 #    elif defined(__aarch64__) && SANITIZER_ANDROID
 // Android needs to support 39, 42 and 48 bit VMA.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary32.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary32.h
@@ -288,6 +288,7 @@ class SizeClassAllocator32 {
   uptr ComputeRegionId(uptr mem) const {
     if (SANITIZER_SIGN_EXTENDED_ADDRESSES)
       mem &= (kSpaceSize - 1);
+    mem -= kSpaceBeg;
     const uptr res = mem >> kRegionSizeLog;
     CHECK_LT(res, kNumPossibleRegions);
     return res;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
@@ -319,7 +319,11 @@
 #endif
 
 // The first address that can be returned by mmap.
-#define SANITIZER_MMAP_BEGIN 0
+#if SANITIZER_AIX && SANITIZER_WORDSIZE == 64
+# define SANITIZER_MMAP_BEGIN 0x0a00000000000000ULL
+#else
+# define SANITIZER_MMAP_BEGIN 0
+#endif
 
 // The range of addresses which can be returned my mmap.
 // FIXME: this value should be different on different platforms.  Larger values

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
@@ -320,7 +320,7 @@
 
 // The first address that can be returned by mmap.
 #if SANITIZER_AIX && SANITIZER_WORDSIZE == 64
-#  define SANITIZER_MMAP_BEGIN 0x0a00000000000000ULL
+#  define SANITIZER_MMAP_BEGIN 0x0a00'0000'0000'0000ULL
 #else
 #  define SANITIZER_MMAP_BEGIN 0
 #endif

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
@@ -320,9 +320,9 @@
 
 // The first address that can be returned by mmap.
 #if SANITIZER_AIX && SANITIZER_WORDSIZE == 64
-# define SANITIZER_MMAP_BEGIN 0x0a00000000000000ULL
+#  define SANITIZER_MMAP_BEGIN 0x0a00000000000000ULL
 #else
-# define SANITIZER_MMAP_BEGIN 0
+#  define SANITIZER_MMAP_BEGIN 0
 #endif
 
 // The range of addresses which can be returned my mmap.


### PR DESCRIPTION
On 64-bit AIX, set allocator size to 256G and set beginning to 0x0a00000000000000.

Issue: #138916