### PR TITLE
[MLIR] Incorrect track of usedKey in setPropertiesFromParsedAttr

### DIFF
--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3179,7 +3179,7 @@ def TestOpWithPropertiesAndInferredType
   ]> {
   let assemblyFormat = "$lhs prop-dict attr-dict";
 
-  let arguments = (ins I32Attr:$lhs, IntProp<"int64_t">:$rhs);
+  let arguments = (ins I32Attr:$lhs, IntProp<"int64_t">:$rhs, OptionalAttr<UnitAttr>: $packed);
   let results = (outs AnyType:$result);
 }
 

--- a/mlir/test/mlir-tblgen/op-format.mlir
+++ b/mlir/test/mlir-tblgen/op-format.mlir
@@ -516,8 +516,8 @@ test.format_infer_variadic_type_from_non_variadic %i64, %i64 : i64
 // CHECK: test.with_properties_and_attr 16 < {rhs = 16 : i64}>
 test.with_properties_and_attr 16 <{rhs = 16 : i64}>
 
-// CHECK: test.with_properties_and_inferred_type 16 < {rhs = 16 : i64}>
-%should_be_i32 = test.with_properties_and_inferred_type 16 <{rhs = 16 : i64}>
+// CHECK: test.with_properties_and_inferred_type 16 < {packed, rhs = 16 : i64}>
+%should_be_i32 = test.with_properties_and_inferred_type 16 <{packed, rhs = 16 : i64}>
 // Assert through the verifier that its inferred as i32.
 test.format_all_types_match_var %should_be_i32, %i32 : i32
 

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -1365,7 +1365,7 @@ if (attr && ::mlir::failed(setFromAttr(prop.{1}, attr, emitError)))
 auto &propStorage = prop.{0};
 auto {0}AttrName = StringAttr::get(ctx, "{0}");
 auto attr = dict.get({0}AttrName);
-usedKeys.insert(StringAttr::get(ctx, "{1}"));
+usedKeys.insert({0}AttrName);
 if (attr || /*isRequired=*/{1}) {{
   if (!attr) {{
     emitError() << "expected key entry for {0} in DictionaryAttr to set "


### PR DESCRIPTION
Currently, the generated `setPropertiesFromParsedAttr` uses `usrdKey` to track "true" or "false" instead of attribute name, e.g., `usedKeys.insert(StringAttr::get(ctx, "true"));`. I am not sure whether it is a typo or designed to retire the use of attribute for property. Can someone help to check?

I will create a test if it is confirmed a typo. Otherwise, I will drop the PR.