### PR TITLE
[flang] Check definability for logical INQUIRE specifiers

### DIFF
--- a/flang/lib/Semantics/check-io.cpp
+++ b/flang/lib/Semantics/check-io.cpp
@@ -478,6 +478,8 @@ void IoChecker::Enter(const parser::InquireSpec::LogVar &spec) {
     specKind = IoSpecKind::Pending;
     break;
   }
+  CheckForDefinableVariable(std::get<parser::ScalarLogicalVariable>(spec.t),
+      parser::ToUpperCaseLetters(common::EnumToString(specKind)));
   SetSpecifier(specKind);
 }
 

--- a/flang/test/Semantics/bug144453.f90
+++ b/flang/test/Semantics/bug144453.f90
@@ -1,0 +1,10 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1
+function func(immutable)
+  logical func
+  logical, intent(in) :: immutable
+  !No warning about an undefined function result should appear
+  INQUIRE(file="/usr/local/games/adventure", EXIST=func)
+  !ERROR: EXIST variable 'immutable' is not definable
+  !BECAUSE: 'immutable' is an INTENT(IN) dummy argument
+  INQUIRE(file="/usr/local/games/adventure", EXIST=immutable)
+end


### PR DESCRIPTION
check-io.cpp was missing checks for the definability of logical-valued specifiers in INQUIRE statements (e.g. EXIST=), and therefore also not noting the definitions of those variables.  This could lead to bogus warnings about undefined function result variables, and also to missed errors about immutable objects appearing in those specifiers.

Fixes https://github.com/llvm/llvm-project/issues/144453.