### PR TITLE
[LLDB] Add SI_USER and SI_KERNEL to Linux signals

### DIFF
--- a/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
@@ -65,6 +65,10 @@
 // See siginfo.h in the Linux Kernel, these codes can be sent for any signal.
 #define ADD_LINUX_SIGNAL(signo, name, ...)                                     \
   AddSignal(signo, name, __VA_ARGS__);                                         \
+  ADD_SIGCODE(signo, signo, SI_USER, 0, "sent by kill, sigsend or raise",      \
+              SignalCodePrintOption::Sender);                                  \
+  ADD_SIGCODE(signo, signo, SI_KERNEL, 0x80, "sent by kernel",                 \
+              SignalCodePrintOption::Sender);                                  \
   ADD_SIGCODE(signo, signo, SI_QUEUE, -1, "sent by sigqueue",                  \
               SignalCodePrintOption::Sender);                                  \
   ADD_SIGCODE(signo, signo, SI_TIMER, -2, "sent by timer expiration",          \

--- a/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
@@ -67,7 +67,7 @@
   AddSignal(signo, name, __VA_ARGS__);                                         \
   ADD_SIGCODE(signo, signo, SI_USER, 0, "sent by kill, sigsend or raise",      \
               SignalCodePrintOption::Sender);                                  \
-  ADD_SIGCODE(signo, signo, SI_KERNEL, 0x80, "sent by kernel",                 \
+  ADD_SIGCODE(signo, signo, SI_KERNEL, 0x80, "sent by kernel (SI_KERNEL)",     \
               SignalCodePrintOption::Sender);                                  \
   ADD_SIGCODE(signo, signo, SI_QUEUE, -1, "sent by sigqueue",                  \
               SignalCodePrintOption::Sender);                                  \


### PR DESCRIPTION
@dmpots and I were investigating a crash when he was developing LLDB earlier. When I loaded the core I was surprised to see LLDB didn't have information for the SI_CODE. Upon inspection we had an si_code of `128`, which is the decimal of SI_KERNEL at `0x80`. 

These were overlooked in my last addition of the negative si_codes, and this patch adds SI_USER and SI_KERNEL to the list, covering us for all the codes available to all signals.

[Linux reference link](https://github.com/torvalds/linux/blob/74b4cc9b8780bfe8a3992c9ac0033bf22ac01f19/include/uapi/asm-generic/siginfo.h#L175)

![image](https://github.com/user-attachments/assets/52fa58e6-13d4-48a1-8d82-184c07a47db8)

I kept the code naming the same as what is defined in the Linux source code. SI_KERNEL to my understanding usually indicates something went awry in the Kernel itself, but I think adding that additional detail would not be helpful to most users. @DavidSpickett I'd appreciate your insight into that.
