### PR TITLE
[mlir][vector] Hoist transfer pairs when the source is AssumeAlignmentOp

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Hoisting.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Hoisting.h
@@ -27,8 +27,8 @@ namespace linalg {
 ///   dominated by the transfer_write (i.e. no aliasing between the write and
 ///   the read across the loop)
 ///   4. The source operands for vector.transfer_{read|write} do not originate
-///   from Ops implementing ViewLikeOpInterface (to reduce the risk of
-///   aliasing).
+///   from ops implementing ViewLikeOpInterface (to reduce the risk of
+///   aliasing), except memref::AssumeAlignmentOp.
 ///   5. If `verifyNonZeroTrip` is true, then the lower bound of the loop must
 ///   be statically smaller than the upper bound of the loop, guaranteeing that
 ///   the loop body will execute at least once.
@@ -39,8 +39,8 @@ namespace linalg {
 ///
 /// TODO: To further improve hoisting opportunities, fold aliasing memref
 /// operations into respective vector.transfer{read|write} operations and
-/// avoid using ops implementing ViewLikeOpInterface as the source for transfer
-/// Ops.
+/// avoid using ops implementing ViewLikeOpInterface, except
+/// memref::AssumeAlignmentOp, as the source for transfer ops.
 ///
 /// WARNING: This hoisting does not model parallelism and is generally incorrect
 /// when used on distributed loops with memref semantics!


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/ffb9bbfd0745dc22e1fd6edd7b62f72b91f4f6de makes memref::AssumeAlignmentOp be ViewLikeOp, which disables the hoisting support when AssumeAlignmentOp is present. In the past, it is not an issue because the op does not have a result. After the op has a result, the hoisting is not working if transfer ops operate on AssumeAlignmentOp.