### PR TITLE
Revert "[lldb][target] Add progress report for wait-attaching to process"

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3546,7 +3546,6 @@ llvm::Expected<TraceSP> Target::GetTraceOrCreate() {
 }
 
 Status Target::Attach(ProcessAttachInfo &attach_info, Stream *stream) {
-  Progress attach_progress("Waiting to attach to process");
   m_stats.SetLaunchOrAttachTime();
   auto state = eStateInvalid;
   auto process_sp = GetProcessSP();

--- a/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
@@ -2,7 +2,6 @@
 Test that we are able to broadcast and receive progress events from lldb
 """
 import lldb
-import threading
 
 import lldbsuite.test.lldbutil as lldbutil
 
@@ -16,36 +15,6 @@ class TestProgressReporting(TestBase):
         self.listener = lldbutil.start_listening_from(
             self.broadcaster, lldb.SBDebugger.eBroadcastBitProgress
         )
-
-    def test_wait_attach_progress_reporting(self):
-        """Test that progress reports for wait attaching work as intended."""
-        self.build()
-        target = self.dbg.CreateTarget(None)
-
-        # Wait attach to a process, then check to see that a progress report was created
-        # and that its message is correct for waiting to attach to a process.
-        class AttachThread(threading.Thread):
-            def __init__(self, target):
-                threading.Thread.__init__(self)
-                self.target = target
-
-            def run(self):
-                self.target.AttachToProcessWithName(
-                    lldb.SBListener(), "a.out", True, lldb.SBError()
-                )
-
-        thread = AttachThread(target)
-        thread.start()
-
-        event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)
-        progress_data = lldb.SBDebugger.GetProgressDataFromEvent(event)
-        message = progress_data.GetValueForKey("message").GetStringValue(100)
-        self.assertEqual(message, "Waiting to attach to process")
-
-        # Interrupt the process attach to keep the test from stalling.
-        target.process.SendAsyncInterrupt()
-
-        thread.join()
 
     def test_dwarf_symbol_loading_progress_report(self):
         """Test that we are able to fetch dwarf symbol loading progress events"""


### PR DESCRIPTION
This is breaking TestCreateAfterAttach.py on Ubuntu:

```
======================================================================
FAIL: test_create_after_attach_dwo (TestCreateAfterAttach.CreateAfterAttachTestCase.test_create_after_attach_dwo)
   Test thread creation after process attach.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 1804, in test_method
    return attrvalue(self)
           ^^^^^^^^^^^^^^^
  File "/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/llvm-project/lldb/packages/Python/lldbsuite/test/decorators.py", line 149, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/llvm-project/lldb/test/API/functionalities/thread/create_after_attach/TestCreateAfterAttach.py", line 36, in test_create_after_attach
    self.runCmd("process attach -p " + str(pid))
  File "/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 1005, in runCmd
    self.assertTrue(self.res.Succeeded(), msg + output)
AssertionError: False is not true : Command 'process attach -p 1474309' did not return successfully
Error output:
error: attach failed: lost connection
```

on the buildbots for lldb-remote-linux-ubuntu, lldb-arm-ubuntu, lldb-aarch64-ubuntu, lldb-arm-ubuntu.