### PR TITLE
[HLSL][RootSignature] Add `fdx-rootsignature-version` option to specify root signature version

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -41,6 +41,7 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/BinaryFormat/DXContainer.h"
 #include "llvm/Frontend/HLSL/HLSLRootSignature.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Compiler.h"
@@ -5179,6 +5180,8 @@ class HLSLRootSignatureDecl final
                                     llvm::hlsl::rootsig::RootElement> {
   friend TrailingObjects;
 
+  llvm::dxbc::RootSignatureVersion Version;
+
   unsigned NumElems;
 
   llvm::hlsl::rootsig::RootElement *getElems() { return getTrailingObjects(); }
@@ -5188,15 +5191,19 @@ class HLSLRootSignatureDecl final
   }
 
   HLSLRootSignatureDecl(DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+                        llvm::dxbc::RootSignatureVersion Verison,
                         unsigned NumElems);
 
 public:
   static HLSLRootSignatureDecl *
   Create(ASTContext &C, DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+         llvm::dxbc::RootSignatureVersion Version,
          ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements);
 
   static HLSLRootSignatureDecl *CreateDeserialized(ASTContext &C,
                                                    GlobalDeclID ID);
+
+  llvm::dxbc::RootSignatureVersion getVersion() const { return Version; }
 
   ArrayRef<llvm::hlsl::rootsig::RootElement> getRootElements() const {
     return {getElems(), NumElems};

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -5191,7 +5191,7 @@ class HLSLRootSignatureDecl final
   }
 
   HLSLRootSignatureDecl(DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
-                        llvm::dxbc::RootSignatureVersion Verison,
+                        llvm::dxbc::RootSignatureVersion Version,
                         unsigned NumElems);
 
 public:

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -24,6 +24,7 @@
 #include "clang/Basic/Visibility.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/DXContainer.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
 #include <string>
@@ -622,6 +623,10 @@ public:
   // This exists so that we can override the macro value and test our incomplete
   // implementation on real-world examples.
   std::string OpenACCMacroOverride;
+
+  /// The HLSL root signature version for dxil.
+  llvm::dxbc::RootSignatureVersion HLSLRootSigVer =
+      llvm::dxbc::RootSignatureVersion::V1_1;
 
   // Indicates if the wasm-opt binary must be ignored in the case of a
   // WebAssembly target.

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9288,8 +9288,8 @@ def fcgl : DXCFlag<"fcgl">, Alias<emit_pristine_llvm>;
 def enable_16bit_types : DXCFlag<"enable-16bit-types">, Alias<fnative_half_type>,
   HelpText<"Enable 16-bit types and disable min precision types."
            "Available in HLSL 2018 and shader model 6.2.">;
-def fdx_rootsig_version :
-  Joined<["-"], "fdx-rootsig-version=">,
+def fdx_rootsignature_version :
+  Joined<["-"], "fdx-rootsignature-version=">,
   Group<dxc_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Root Signature Version">,
@@ -9299,7 +9299,7 @@ def fdx_rootsig_version :
   MarshallingInfoEnum<LangOpts<"HLSLRootSigVer">, "V1_1">;
 def dxc_rootsig_ver :
   Separate<["/", "-"], "force-rootsig-ver">,
-  Alias<fdx_rootsig_version>,
+  Alias<fdx_rootsignature_version>,
   Group<dxc_Group>,
   Visibility<[DXCOption]>;
 def hlsl_entrypoint : Option<["-"], "hlsl-entry", KIND_SEPARATE>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9288,8 +9288,8 @@ def fcgl : DXCFlag<"fcgl">, Alias<emit_pristine_llvm>;
 def enable_16bit_types : DXCFlag<"enable-16bit-types">, Alias<fnative_half_type>,
   HelpText<"Enable 16-bit types and disable min precision types."
            "Available in HLSL 2018 and shader model 6.2.">;
-def fdx_rootsig_ver :
-  Joined<["-"], "fdx-rootsig-ver=">,
+def fdx_rootsig_version :
+  Joined<["-"], "fdx-rootsig-version=">,
   Group<dxc_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Root Signature Version">,
@@ -9299,7 +9299,7 @@ def fdx_rootsig_ver :
   MarshallingInfoEnum<LangOpts<"HLSLRootSigVer">, "V1_1">;
 def dxc_rootsig_ver :
   Separate<["/", "-"], "force-rootsig-ver">,
-  Alias<fdx_rootsig_ver>,
+  Alias<fdx_rootsig_version>,
   Group<dxc_Group>,
   Visibility<[DXCOption]>;
 def hlsl_entrypoint : Option<["-"], "hlsl-entry", KIND_SEPARATE>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9288,6 +9288,17 @@ def fcgl : DXCFlag<"fcgl">, Alias<emit_pristine_llvm>;
 def enable_16bit_types : DXCFlag<"enable-16bit-types">, Alias<fnative_half_type>,
   HelpText<"Enable 16-bit types and disable min precision types."
            "Available in HLSL 2018 and shader model 6.2.">;
+def fdx_rootsig_ver :
+  Joined<["-"], "fdx-rootsig-ver=">,
+  Group<dxc_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Root Signature Version">,
+  Values<"rootsig_1_0,rootsig_1_1">,
+  NormalizedValuesScope<"llvm::dxbc::RootSignatureVersion">,
+  NormalizedValues<["V1_0", "V1_1"]>,
+  MarshallingInfoEnum<LangOpts<"HLSLRootSigVer">, "V1_1">;
+def dxc_rootsig_ver : DXCJoinedOrSeparate<"force-rootsig-ver">, Alias<fdx_rootsig_ver>;
+def dxc_rootsig_ver_ : DXCJoinedOrSeparate<"force_rootsig_ver">, Alias<fdx_rootsig_ver>;
 def hlsl_entrypoint : Option<["-"], "hlsl-entry", KIND_SEPARATE>,
                       Group<dxc_Group>,
                       Visibility<[ClangOption, CC1Option]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9297,8 +9297,11 @@ def fdx_rootsig_ver :
   NormalizedValuesScope<"llvm::dxbc::RootSignatureVersion">,
   NormalizedValues<["V1_0", "V1_1"]>,
   MarshallingInfoEnum<LangOpts<"HLSLRootSigVer">, "V1_1">;
-def dxc_rootsig_ver : DXCJoinedOrSeparate<"force-rootsig-ver">, Alias<fdx_rootsig_ver>;
-def dxc_rootsig_ver_ : DXCJoinedOrSeparate<"force_rootsig_ver">, Alias<fdx_rootsig_ver>;
+def dxc_rootsig_ver :
+  Separate<["/", "-"], "force-rootsig-ver">,
+  Alias<fdx_rootsig_ver>,
+  Group<dxc_Group>,
+  Visibility<[DXCOption]>;
 def hlsl_entrypoint : Option<["-"], "hlsl-entry", KIND_SEPARATE>,
                       Group<dxc_Group>,
                       Visibility<[ClangOption, CC1Option]>,

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5853,21 +5853,21 @@ bool HLSLBufferDecl::buffer_decls_empty() {
 // HLSLRootSignatureDecl Implementation
 //===----------------------------------------------------------------------===//
 
-HLSLRootSignatureDecl::HLSLRootSignatureDecl(DeclContext *DC,
-                                             SourceLocation Loc,
-                                             IdentifierInfo *ID,
-                                             unsigned NumElems)
+HLSLRootSignatureDecl::HLSLRootSignatureDecl(
+    DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+    llvm::dxbc::RootSignatureVersion Version, unsigned NumElems)
     : NamedDecl(Decl::Kind::HLSLRootSignature, DC, Loc, DeclarationName(ID)),
-      NumElems(NumElems) {}
+      Version(Version), NumElems(NumElems) {}
 
 HLSLRootSignatureDecl *HLSLRootSignatureDecl::Create(
     ASTContext &C, DeclContext *DC, SourceLocation Loc, IdentifierInfo *ID,
+    llvm::dxbc::RootSignatureVersion Version,
     ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements) {
   HLSLRootSignatureDecl *RSDecl =
       new (C, DC,
            additionalSizeToAlloc<llvm::hlsl::rootsig::RootElement>(
                RootElements.size()))
-          HLSLRootSignatureDecl(DC, Loc, ID, RootElements.size());
+          HLSLRootSignatureDecl(DC, Loc, ID, Version, RootElements.size());
   auto *StoredElems = RSDecl->getElems();
   std::uninitialized_copy(RootElements.begin(), RootElements.end(),
                           StoredElems);
@@ -5877,7 +5877,9 @@ HLSLRootSignatureDecl *HLSLRootSignatureDecl::Create(
 HLSLRootSignatureDecl *
 HLSLRootSignatureDecl::CreateDeserialized(ASTContext &C, GlobalDeclID ID) {
   HLSLRootSignatureDecl *Result = new (C, ID)
-      HLSLRootSignatureDecl(nullptr, SourceLocation(), nullptr, /*NumElems=*/0);
+      HLSLRootSignatureDecl(nullptr, SourceLocation(), nullptr,
+                            /*Version*/ llvm::dxbc::RootSignatureVersion::V1_1,
+                            /*NumElems=*/0);
   return Result;
 }
 

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -3041,6 +3041,16 @@ void TextNodeDumper::VisitHLSLBufferDecl(const HLSLBufferDecl *D) {
 void TextNodeDumper::VisitHLSLRootSignatureDecl(
     const HLSLRootSignatureDecl *D) {
   dumpName(D);
+  OS << " version: ";
+  switch (D->getVersion()) {
+  case llvm::dxbc::RootSignatureVersion::V1_0:
+    OS << "1.0";
+    break;
+  case llvm::dxbc::RootSignatureVersion::V1_1:
+    OS << "1.1";
+    break;
+  }
+  OS << ", ";
   llvm::hlsl::rootsig::dumpRootElements(OS, D->getRootElements());
 }
 

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -75,13 +75,10 @@ void addRootSignature(llvm::dxbc::RootSignatureVersion RootSigVer,
   llvm::hlsl::rootsig::MetadataBuilder RSBuilder(Ctx, Elements);
   MDNode *RootSignature = RSBuilder.BuildRootSignature();
 
-  Metadata *Operands[] = {
-      ValueAsMetadata::get(Fn),
-      RootSignature,
-      ConstantAsMetadata::get(
-          Builder.getInt32(llvm::to_underlying(RootSigVer))),
-  };
-  MDNode *FnPairing = MDNode::get(Ctx, Operands);
+  ConstantAsMetadata *Version =
+      ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt32Ty(Ctx), llvm::to_underlying(RootSigVer)));
+  MDNode *MDVals =
+        MDNode::get(Ctx, {ValueAsMetadata::get(Fn), RootSignature, Version});
 
   StringRef RootSignatureValKey = "dx.rootsignatures";
   auto *RootSignatureValMD = M.getOrInsertNamedMetadata(RootSignatureValKey);

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -70,7 +70,6 @@ void addRootSignature(llvm::dxbc::RootSignatureVersion RootSigVer,
                       ArrayRef<llvm::hlsl::rootsig::RootElement> Elements,
                       llvm::Function *Fn, llvm::Module &M) {
   auto &Ctx = M.getContext();
-  IRBuilder<> Builder(Ctx);
 
   llvm::hlsl::rootsig::MetadataBuilder RSBuilder(Ctx, Elements);
   MDNode *RootSignature = RSBuilder.BuildRootSignature();

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -75,10 +75,10 @@ void addRootSignature(llvm::dxbc::RootSignatureVersion RootSigVer,
   llvm::hlsl::rootsig::MetadataBuilder RSBuilder(Ctx, Elements);
   MDNode *RootSignature = RSBuilder.BuildRootSignature();
 
-  ConstantAsMetadata *Version =
-      ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt32Ty(Ctx), llvm::to_underlying(RootSigVer)));
+  ConstantAsMetadata *Version = ConstantAsMetadata::get(ConstantInt::get(
+      llvm::Type::getInt32Ty(Ctx), llvm::to_underlying(RootSigVer)));
   MDNode *MDVals =
-        MDNode::get(Ctx, {ValueAsMetadata::get(Fn), RootSignature, Version});
+      MDNode::get(Ctx, {ValueAsMetadata::get(Fn), RootSignature, Version});
 
   StringRef RootSignatureValKey = "dx.rootsignatures";
   auto *RootSignatureValMD = M.getOrInsertNamedMetadata(RootSignatureValKey);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3835,7 +3835,7 @@ static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
                                          options::OPT_disable_llvm_passes,
                                          options::OPT_fnative_half_type,
                                          options::OPT_hlsl_entrypoint,
-                                         options::OPT_fdx_rootsig_version};
+                                         options::OPT_fdx_rootsignature_version};
   if (!types::isHLSL(InputType))
     return;
   for (const auto &Arg : ForwardedArguments)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3834,7 +3834,8 @@ static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
                                          options::OPT_emit_obj,
                                          options::OPT_disable_llvm_passes,
                                          options::OPT_fnative_half_type,
-                                         options::OPT_hlsl_entrypoint};
+                                         options::OPT_hlsl_entrypoint,
+                                         options::OPT_fdx_rootsig_ver};
   if (!types::isHLSL(InputType))
     return;
   for (const auto &Arg : ForwardedArguments)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3825,17 +3825,18 @@ static void RenderOpenCLOptions(const ArgList &Args, ArgStringList &CmdArgs,
 
 static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
                               types::ID InputType) {
-  const unsigned ForwardedArguments[] = {options::OPT_dxil_validator_version,
-                                         options::OPT_res_may_alias,
-                                         options::OPT_D,
-                                         options::OPT_I,
-                                         options::OPT_O,
-                                         options::OPT_emit_llvm,
-                                         options::OPT_emit_obj,
-                                         options::OPT_disable_llvm_passes,
-                                         options::OPT_fnative_half_type,
-                                         options::OPT_hlsl_entrypoint,
-                                         options::OPT_fdx_rootsignature_version};
+  const unsigned ForwardedArguments[] = {
+      options::OPT_dxil_validator_version,
+      options::OPT_res_may_alias,
+      options::OPT_D,
+      options::OPT_I,
+      options::OPT_O,
+      options::OPT_emit_llvm,
+      options::OPT_emit_obj,
+      options::OPT_disable_llvm_passes,
+      options::OPT_fnative_half_type,
+      options::OPT_hlsl_entrypoint,
+      options::OPT_fdx_rootsignature_version};
   if (!types::isHLSL(InputType))
     return;
   for (const auto &Arg : ForwardedArguments)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3835,7 +3835,7 @@ static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
                                          options::OPT_disable_llvm_passes,
                                          options::OPT_fnative_half_type,
                                          options::OPT_hlsl_entrypoint,
-                                         options::OPT_fdx_rootsig_ver};
+                                         options::OPT_fdx_rootsig_version};
   if (!types::isHLSL(InputType))
     return;
   for (const auto &Arg : ForwardedArguments)

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -297,7 +297,7 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     }
     if (A->getOption().getID() == options::OPT_dxc_rootsig_ver) {
       DAL->AddJoinedArg(nullptr,
-                        Opts.getOption(options::OPT_fdx_rootsig_version),
+                        Opts.getOption(options::OPT_fdx_rootsignature_version),
                         A->getValue());
       A->claim();
       continue;

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -295,8 +295,7 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
       A->claim();
       continue;
     }
-    if (A->getOption().getID() == options::OPT_dxc_rootsig_ver ||
-        A->getOption().getID() == options::OPT_dxc_rootsig_ver_) {
+    if (A->getOption().getID() == options::OPT_dxc_rootsig_ver) {
       DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_fdx_rootsig_ver),
                         A->getValue());
       A->claim();

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -295,6 +295,14 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
       A->claim();
       continue;
     }
+    if (A->getOption().getID() == options::OPT_dxc_rootsig_ver ||
+        A->getOption().getID() == options::OPT_dxc_rootsig_ver_) {
+      DAL->AddJoinedArg(nullptr,
+                        Opts.getOption(options::OPT_fdx_rootsig_ver),
+                        A->getValue());
+      A->claim();
+      continue;
+    }
     if (A->getOption().getID() == options::OPT__SLASH_O) {
       StringRef OStr = A->getValue();
       if (OStr == "d") {

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -296,7 +296,8 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
       continue;
     }
     if (A->getOption().getID() == options::OPT_dxc_rootsig_ver) {
-      DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_fdx_rootsig_ver),
+      DAL->AddJoinedArg(nullptr,
+                        Opts.getOption(options::OPT_fdx_rootsig_version),
                         A->getValue());
       A->claim();
       continue;

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -297,8 +297,7 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     }
     if (A->getOption().getID() == options::OPT_dxc_rootsig_ver ||
         A->getOption().getID() == options::OPT_dxc_rootsig_ver_) {
-      DAL->AddJoinedArg(nullptr,
-                        Opts.getOption(options::OPT_fdx_rootsig_ver),
+      DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_fdx_rootsig_ver),
                         A->getValue());
       A->claim();
       continue;

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -636,9 +636,9 @@ static bool FixupInvocation(CompilerInvocation &Invocation,
     Diags.Report(diag::err_drv_argument_not_allowed_with)
         << "-hlsl-entry" << GetInputKindName(IK);
 
-  if (Args.hasArg(OPT_fdx_rootsig_version) && !LangOpts.HLSL)
+  if (Args.hasArg(OPT_fdx_rootsignature_version) && !LangOpts.HLSL)
     Diags.Report(diag::err_drv_argument_not_allowed_with)
-        << "-fdx-rootsig-version" << GetInputKindName(IK);
+        << "-fdx-rootsignature-version" << GetInputKindName(IK);
 
   if (Args.hasArg(OPT_fgpu_allow_device_init) && !LangOpts.HIP)
     Diags.Report(diag::warn_ignored_hip_only_option)

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -636,9 +636,9 @@ static bool FixupInvocation(CompilerInvocation &Invocation,
     Diags.Report(diag::err_drv_argument_not_allowed_with)
         << "-hlsl-entry" << GetInputKindName(IK);
 
-  if (Args.hasArg(OPT_fdx_rootsig_ver) && !LangOpts.HLSL)
+  if (Args.hasArg(OPT_fdx_rootsig_version) && !LangOpts.HLSL)
     Diags.Report(diag::err_drv_argument_not_allowed_with)
-        << "-fdx-rootsig-ver" << GetInputKindName(IK);
+        << "-fdx-rootsig-version" << GetInputKindName(IK);
 
   if (Args.hasArg(OPT_fgpu_allow_device_init) && !LangOpts.HIP)
     Diags.Report(diag::warn_ignored_hip_only_option)

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -636,6 +636,10 @@ static bool FixupInvocation(CompilerInvocation &Invocation,
     Diags.Report(diag::err_drv_argument_not_allowed_with)
         << "-hlsl-entry" << GetInputKindName(IK);
 
+  if (Args.hasArg(OPT_fdx_rootsig_ver) && !LangOpts.HLSL)
+    Diags.Report(diag::err_drv_argument_not_allowed_with)
+        << "-fdx-rootsig-ver" << GetInputKindName(IK);
+
   if (Args.hasArg(OPT_fgpu_allow_device_init) && !LangOpts.HIP)
     Diags.Report(diag::warn_ignored_hip_only_option)
         << Args.getLastArg(OPT_fgpu_allow_device_init)->getAsString(Args);

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1067,7 +1067,7 @@ void SemaHLSL::ActOnFinishRootSignatureDecl(
 
   auto *SignatureDecl = HLSLRootSignatureDecl::Create(
       SemaRef.getASTContext(), /*DeclContext=*/SemaRef.CurContext, Loc,
-      DeclIdent, Elements);
+      DeclIdent, SemaRef.getLangOpts().HLSLRootSigVer, Elements);
 
   if (handleRootSignatureDecl(SignatureDecl, Loc))
     return;

--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -1,10 +1,10 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
 // RUN:  -disable-llvm-passes -o - %s | FileCheck %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
-// RUN:  -fdx-rootsig-ver=rootsig_1_0 \
+// RUN:  -fdx-rootsig-version=rootsig_1_0 \
 // RUN:  -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CHECK-V1_0
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
-// RUN:  -fdx-rootsig-ver=rootsig_1_1 \
+// RUN:  -fdx-rootsig-version=rootsig_1_1 \
 // RUN:  -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CHECK-V1_1
 
 // This test ensures that the sample root signature is parsed without error and

--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -1,5 +1,11 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
 // RUN:  -disable-llvm-passes -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
+// RUN:  -fdx-rootsig-ver=rootsig_1_0 \
+// RUN:  -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CHECK-V1_0
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
+// RUN:  -fdx-rootsig-ver=rootsig_1_1 \
+// RUN:  -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CHECK-V1_1
 
 // This test ensures that the sample root signature is parsed without error and
 // the Attr AST Node is created succesfully. If an invalid root signature was
@@ -16,6 +22,8 @@
   "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
 
 // CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[SAMPLE_RS_DECL:__hlsl_rootsig_decl_\d*]]
+// CHECK-V1_0: version: 1.0,
+// CHECK-V1_1: version: 1.1,
 // CHECK-SAME: RootElements{
 // CHECK-SAME:   CBV(b1, numDescriptors = 1, space = 0,
 // CHECK-SAME:     offset = DescriptorTableOffsetAppend, flags = DataStaticWhileSetAtExecute),

--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -1,10 +1,10 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
 // RUN:  -disable-llvm-passes -o - %s | FileCheck %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
-// RUN:  -fdx-rootsig-version=rootsig_1_0 \
+// RUN:  -fdx-rootsignature-version=rootsig_1_0 \
 // RUN:  -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CHECK-V1_0
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
-// RUN:  -fdx-rootsig-version=rootsig_1_1 \
+// RUN:  -fdx-rootsignature-version=rootsig_1_1 \
 // RUN:  -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CHECK-V1_1
 
 // This test ensures that the sample root signature is parsed without error and

--- a/clang/test/Driver/dxc_hlsl-rootsig-ver.hlsl
+++ b/clang/test/Driver/dxc_hlsl-rootsig-ver.hlsl
@@ -1,0 +1,25 @@
+// RUN: %clang_dxc -T cs_6_0 -fcgl %s | FileCheck %s --check-prefix=CHECK-V1_1
+
+// RUN: %clang_dxc -T cs_6_0 -fcgl -force-rootsig-ver rootsig_1_0 %s | FileCheck %s --check-prefix=CHECK-V1_0
+// RUN: %clang_dxc -T cs_6_0 -fcgl -force-rootsig-ver rootsig_1_1 %s | FileCheck %s --check-prefix=CHECK-V1_1
+
+// RUN: %clang_dxc -T cs_6_0 -fcgl -force_rootsig_ver rootsig_1_0 %s | FileCheck %s --check-prefix=CHECK-V1_0
+// RUN: %clang_dxc -T cs_6_0 -fcgl -force_rootsig_ver rootsig_1_1 %s | FileCheck %s --check-prefix=CHECK-V1_1
+
+// RUN: %clang_dxc -T cs_6_0 -fcgl -force-rootsig-verrootsig_1_0 %s | FileCheck %s --check-prefix=CHECK-V1_0
+// RUN: %clang_dxc -T cs_6_0 -fcgl -force-rootsig-verrootsig_1_1 %s | FileCheck %s --check-prefix=CHECK-V1_1
+
+// RUN: %clang_dxc -T cs_6_0 -fcgl -force_rootsig_verrootsig_1_0 %s | FileCheck %s --check-prefix=CHECK-V1_0
+// RUN: %clang_dxc -T cs_6_0 -fcgl -force_rootsig_verrootsig_1_1 %s | FileCheck %s --check-prefix=CHECK-V1_1
+
+// Test to demonstrate that we can specify the root-signature versions
+
+// CHECK: !dx.rootsignatures = !{![[#EMPTY_ENTRY:]]}
+// CHECK: ![[#EMPTY_ENTRY]] = !{ptr @EmptyEntry, ![[#EMPTY:]],
+// CHECK-V1_0: i32 1}
+// CHECK-V1_1: i32 2}
+// CHECK: ![[#EMPTY]] = !{}
+
+[shader("compute"), RootSignature("")]
+[numthreads(1,1,1)]
+void EmptyEntry() {}

--- a/clang/test/Driver/dxc_hlsl-rootsig-ver.hlsl
+++ b/clang/test/Driver/dxc_hlsl-rootsig-ver.hlsl
@@ -3,15 +3,6 @@
 // RUN: %clang_dxc -T cs_6_0 -fcgl -force-rootsig-ver rootsig_1_0 %s | FileCheck %s --check-prefix=CHECK-V1_0
 // RUN: %clang_dxc -T cs_6_0 -fcgl -force-rootsig-ver rootsig_1_1 %s | FileCheck %s --check-prefix=CHECK-V1_1
 
-// RUN: %clang_dxc -T cs_6_0 -fcgl -force_rootsig_ver rootsig_1_0 %s | FileCheck %s --check-prefix=CHECK-V1_0
-// RUN: %clang_dxc -T cs_6_0 -fcgl -force_rootsig_ver rootsig_1_1 %s | FileCheck %s --check-prefix=CHECK-V1_1
-
-// RUN: %clang_dxc -T cs_6_0 -fcgl -force-rootsig-verrootsig_1_0 %s | FileCheck %s --check-prefix=CHECK-V1_0
-// RUN: %clang_dxc -T cs_6_0 -fcgl -force-rootsig-verrootsig_1_1 %s | FileCheck %s --check-prefix=CHECK-V1_1
-
-// RUN: %clang_dxc -T cs_6_0 -fcgl -force_rootsig_verrootsig_1_0 %s | FileCheck %s --check-prefix=CHECK-V1_0
-// RUN: %clang_dxc -T cs_6_0 -fcgl -force_rootsig_verrootsig_1_1 %s | FileCheck %s --check-prefix=CHECK-V1_1
-
 // Test to demonstrate that we can specify the root-signature versions
 
 // CHECK: !dx.rootsignatures = !{![[#EMPTY_ENTRY:]]}

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -750,6 +750,12 @@ struct DescriptorRange : public v1::DescriptorRange {
 } // namespace v2
 } // namespace RTS0
 
+// D3D_ROOT_SIGNATURE_VERSION
+enum class RootSignatureVersion {
+  V1_0 = 0x1,
+  V1_1 = 0x2,
+};
+
 } // namespace dxbc
 } // namespace llvm
 


### PR DESCRIPTION
This pr provides the ability to specify the root signature version as a compiler option and to retain this in the root signature decl.

It also updates the methods to serialize the version when dumping the declaration and to output the version when generating the metadata.

- Update `DXContainer.hI` to define the root signature versions
- Update `Options.td` and `LangOpts.h` to define the `fdx-rootsignature-version` compiler option
- Update `Options.td` to provide an alias `force-rootsig-ver` in clang-dxc
- Update `Decl.[h|cpp]` and `SeamHLSL.cpp` so that `RootSignatureDecl` will retain its version type
- Updates `CGHLSLRuntime.cpp` to generate the extra metadata field
- Add tests to illustrate

Resolves https://github.com/llvm/llvm-project/issues/126557.

Note: this does not implement validation based on versioning. https://github.com/llvm/llvm-project/issues/129940 is required to retrieve the version and use it for validations.