### PR TITLE
[X86] Remove CLDEMOTE from Arrowlake and later hybrid processors

### DIFF
--- a/clang/test/Preprocessor/predefined-arch-macros.c
+++ b/clang/test/Preprocessor/predefined-arch-macros.c
@@ -2556,209 +2556,211 @@
 
 // RUN: %clang -march=sierraforest -m32 -E -dM %s -o - 2>&1 \
 // RUN:     --target=i386 \
-// RUN:   | FileCheck -match-full-lines %s -check-prefix=CHECK_SRF_M32
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M32,CHECK_SRF_M32
 // RUN: %clang -march=grandridge -m32 -E -dM %s -o - 2>&1 \
 // RUN:     --target=i386 \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M32
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M32,CHECK_SRF_M32
 // RUN: %clang -march=arrowlake -m32 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefix=CHECK_SRF_M32
+// RUN:   | FileCheck -match-full-lines %s -check-prefix=CHECK_ARL_M32
 // RUN: %clang -march=arrowlake-s -m32 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M32,CHECK_ARLS_M32
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M32,CHECK_ARLS_M32
 // RUN: %clang -march=lunarlake -m32 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M32,CHECK_ARLS_M32
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M32,CHECK_ARLS_M32
 // RUN: %clang -march=pantherlake -m32 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M32,CHECK_ARLS_M32,CHECK_PTL_M32
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M32,CHECK_ARLS_M32,CHECK_PTL_M32
 // RUN: %clang -march=clearwaterforest -m32 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
 // RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M32,CHECK_ARLS_M32,CHECK_PTL_M32,CHECK_CWF_M32
-// CHECK_SRF_M32: #define __ADX__ 1
-// CHECK_SRF_M32: #define __AES__ 1
-// CHECK_SRF_M32: #define __AVX2__ 1
-// CHECK_SRF_M32-NOT: AVX512
-// CHECK_SRF_M32: #define __AVXIFMA__ 1
-// CHECK_SRF_M32: #define __AVXNECONVERT__ 1
-// CHECK_SRF_M32-NOT: #define __AVXVNNIINT16__ 1
+// CHECK_ARL_M32: #define __ADX__ 1
+// CHECK_ARL_M32: #define __AES__ 1
+// CHECK_ARL_M32: #define __AVX2__ 1
+// CHECK_ARL_M32-NOT: AVX512
+// CHECK_ARL_M32: #define __AVXIFMA__ 1
+// CHECK_ARL_M32: #define __AVXNECONVERT__ 1
+// CHECK_ARL_M32-NOT: #define __AVXVNNIINT16__ 1
 // CHECK_ARLS_M32: #define __AVXVNNIINT16__ 1
-// CHECK_SRF_M32: #define __AVXVNNIINT8__ 1
-// CHECK_SRF_M32: #define __AVXVNNI__ 1
-// CHECK_SRF_M32: #define __AVX__ 1
-// CHECK_SRF_M32: #define __BMI2__ 1
-// CHECK_SRF_M32: #define __BMI__ 1
+// CHECK_ARL_M32: #define __AVXVNNIINT8__ 1
+// CHECK_ARL_M32: #define __AVXVNNI__ 1
+// CHECK_ARL_M32: #define __AVX__ 1
+// CHECK_ARL_M32: #define __BMI2__ 1
+// CHECK_ARL_M32: #define __BMI__ 1
+// CHECK_ARLS_M32-NOT: __CLDEMOTE__
 // CHECK_SRF_M32: #define __CLDEMOTE__ 1
-// CHECK_SRF_M32: #define __CLFLUSHOPT__ 1
-// CHECK_SRF_M32: #define __CLWB__ 1
-// CHECK_SRF_M32: #define __CMPCCXADD__ 1
-// CHECK_SRF_M32: #define __ENQCMD__ 1
-// CHECK_SRF_M32: #define __F16C__ 1
-// CHECK_SRF_M32: #define __FMA__ 1
-// CHECK_SRF_M32: #define __FSGSBASE__ 1
-// CHECK_SRF_M32: #define __FXSR__ 1
-// CHECK_SRF_M32: #define __GFNI__ 1
-// CHECK_SRF_M32: #define __HRESET__ 1
-// CHECK_SRF_M32: #define __INVPCID__ 1
-// CHECK_SRF_M32: #define __KL__ 1
-// CHECK_SRF_M32: #define __LZCNT__ 1
-// CHECK_SRF_M32: #define __MMX__ 1
-// CHECK_SRF_M32: #define __MOVBE__ 1
-// CHECK_SRF_M32: #define __MOVDIR64B__ 1
-// CHECK_SRF_M32: #define __MOVDIRI__ 1
-// CHECK_SRF_M32: #define __PCLMUL__ 1
-// CHECK_SRF_M32: #define __PCONFIG__ 1
-// CHECK_SRF_M32: #define __PKU__ 1
-// CHECK_SRF_M32: #define __POPCNT__ 1
-// CHECK_SRF_M32-NOT: #define __PREFETCHI__ 1
+// CHECK_ARL_M32: #define __CLFLUSHOPT__ 1
+// CHECK_ARL_M32: #define __CLWB__ 1
+// CHECK_ARL_M32: #define __CMPCCXADD__ 1
+// CHECK_ARL_M32: #define __ENQCMD__ 1
+// CHECK_ARL_M32: #define __F16C__ 1
+// CHECK_ARL_M32: #define __FMA__ 1
+// CHECK_ARL_M32: #define __FSGSBASE__ 1
+// CHECK_ARL_M32: #define __FXSR__ 1
+// CHECK_ARL_M32: #define __GFNI__ 1
+// CHECK_ARL_M32: #define __HRESET__ 1
+// CHECK_ARL_M32: #define __INVPCID__ 1
+// CHECK_ARL_M32: #define __KL__ 1
+// CHECK_ARL_M32: #define __LZCNT__ 1
+// CHECK_ARL_M32: #define __MMX__ 1
+// CHECK_ARL_M32: #define __MOVBE__ 1
+// CHECK_ARL_M32: #define __MOVDIR64B__ 1
+// CHECK_ARL_M32: #define __MOVDIRI__ 1
+// CHECK_ARL_M32: #define __PCLMUL__ 1
+// CHECK_ARL_M32: #define __PCONFIG__ 1
+// CHECK_ARL_M32: #define __PKU__ 1
+// CHECK_ARL_M32: #define __POPCNT__ 1
+// CHECK_ARL_M32-NOT: #define __PREFETCHI__ 1
 // CHECK_ARLS_M32-NOT: #define __PREFETCHI__ 1
 // CHECK_PTL_M32: #define __PREFETCHI__ 1
-// CHECK_SRF_M32: #define __PRFCHW__ 1
-// CHECK_SRF_M32: #define __PTWRITE__ 1
-// CHECK_SRF_M32-NOT: #define __RAOINT__ 1
-// CHECK_SRF_M32: #define __RDPID__ 1
-// CHECK_SRF_M32: #define __RDRND__ 1
-// CHECK_SRF_M32: #define __RDSEED__ 1
-// CHECK_SRF_M32: #define __SERIALIZE__ 1
-// CHECK_SRF_M32: #define __SGX__ 1
-// CHECK_SRF_M32-NOT: #define __SHA512__ 1
+// CHECK_ARL_M32: #define __PRFCHW__ 1
+// CHECK_ARL_M32: #define __PTWRITE__ 1
+// CHECK_ARL_M32-NOT: #define __RAOINT__ 1
+// CHECK_ARL_M32: #define __RDPID__ 1
+// CHECK_ARL_M32: #define __RDRND__ 1
+// CHECK_ARL_M32: #define __RDSEED__ 1
+// CHECK_ARL_M32: #define __SERIALIZE__ 1
+// CHECK_ARL_M32: #define __SGX__ 1
+// CHECK_ARL_M32-NOT: #define __SHA512__ 1
 // CHECK_ARLS_M32: #define __SHA512__ 1
-// CHECK_SRF_M32: #define __SHA__ 1
-// CHECK_SRF_M32: #define __SHSTK__ 1
-// CHECK_SRF_M32-NOT: #define __SM3__ 1
+// CHECK_ARL_M32: #define __SHA__ 1
+// CHECK_ARL_M32: #define __SHSTK__ 1
+// CHECK_ARL_M32-NOT: #define __SM3__ 1
 // CHECK_ARLS_M32: #define __SM3__ 1
-// CHECK_SRF_M32-NOT: #define __SM4__ 1
+// CHECK_ARL_M32-NOT: #define __SM4__ 1
 // CHECK_ARLS_M32: #define __SM4__ 1
-// CHECK_SRF_M32: #define __SSE2__ 1
-// CHECK_SRF_M32: #define __SSE3__ 1
-// CHECK_SRF_M32: #define __SSE4_1__ 1
-// CHECK_SRF_M32: #define __SSE4_2__ 1
-// CHECK_SRF_M32: #define __SSE_MATH__ 1
-// CHECK_SRF_M32: #define __SSE__ 1
-// CHECK_SRF_M32: #define __SSSE3__ 1
-// CHECK_SRF_M32: #define __UINTR__ 1
-// CHECK_SRF_M32-NOT: #define __USERMSR__ 1
+// CHECK_ARL_M32: #define __SSE2__ 1
+// CHECK_ARL_M32: #define __SSE3__ 1
+// CHECK_ARL_M32: #define __SSE4_1__ 1
+// CHECK_ARL_M32: #define __SSE4_2__ 1
+// CHECK_ARL_M32: #define __SSE_MATH__ 1
+// CHECK_ARL_M32: #define __SSE__ 1
+// CHECK_ARL_M32: #define __SSSE3__ 1
+// CHECK_ARL_M32: #define __UINTR__ 1
+// CHECK_ARL_M32-NOT: #define __USERMSR__ 1
 // CHECK_ARLS_M32-NOT: #define __USERMSR__ 1
 // CHECK_PTL_M32-NOT: #define __USERMSR__ 1
 // CHECK_CWF_M32: #define __USERMSR__ 1
-// CHECK_SRF_M32: #define __VAES__ 1
-// CHECK_SRF_M32: #define __VPCLMULQDQ__ 1
-// CHECK_SRF_M32: #define __WAITPKG__ 1
-// CHECK_SRF_M32: #define __WIDEKL__ 1
-// CHECK_SRF_M32: #define __XSAVEC__ 1
-// CHECK_SRF_M32: #define __XSAVEOPT__ 1
-// CHECK_SRF_M32: #define __XSAVES__ 1
-// CHECK_SRF_M32: #define __XSAVE__ 1
-// CHECK_SRF_M32: #define __corei7 1
-// CHECK_SRF_M32: #define __corei7__ 1
-// CHECK_SRF_M32: #define __i386 1
-// CHECK_SRF_M32: #define __i386__ 1
-// CHECK_SRF_M32: #define __tune_corei7__ 1
-// CHECK_SRF_M32: #define i386 1
+// CHECK_ARL_M32: #define __VAES__ 1
+// CHECK_ARL_M32: #define __VPCLMULQDQ__ 1
+// CHECK_ARL_M32: #define __WAITPKG__ 1
+// CHECK_ARL_M32: #define __WIDEKL__ 1
+// CHECK_ARL_M32: #define __XSAVEC__ 1
+// CHECK_ARL_M32: #define __XSAVEOPT__ 1
+// CHECK_ARL_M32: #define __XSAVES__ 1
+// CHECK_ARL_M32: #define __XSAVE__ 1
+// CHECK_ARL_M32: #define __corei7 1
+// CHECK_ARL_M32: #define __corei7__ 1
+// CHECK_ARL_M32: #define __i386 1
+// CHECK_ARL_M32: #define __i386__ 1
+// CHECK_ARL_M32: #define __tune_corei7__ 1
+// CHECK_ARL_M32: #define i386 1
 
 // RUN: %clang -march=sierraforest -m64 -E -dM %s -o - 2>&1 \
 // RUN:     --target=i386 \
-// RUN:   | FileCheck -match-full-lines %s -check-prefix=CHECK_SRF_M64
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M64,CHECK_SRF_M64
 // RUN: %clang -march=grandridge -m64 -E -dM %s -o - 2>&1 \
 // RUN:     --target=i386 \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M64
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M64,CHECK_SRF_M64
 // RUN: %clang -march=arrowlake -m64 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefix=CHECK_SRF_M64
+// RUN:   | FileCheck -match-full-lines %s -check-prefix=CHECK_ARL_M64
 // RUN: %clang -march=arrowlake-s -m64 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M64,CHECK_ARLS_M64
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M64,CHECK_ARLS_M64
 // RUN: %clang -march=lunarlake -m64 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M64,CHECK_ARLS_M64
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M64,CHECK_ARLS_M64
 // RUN: %clang -march=pantherlake -m64 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M64,CHECK_ARLS_M64,CHECK_PTL_M64
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M64,CHECK_ARLS_M64,CHECK_PTL_M64
 // RUN: %clang -march=clearwaterforest -m64 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_SRF_M64,CHECK_ARLS_M64,CHECK_PTL_M64,CHECK_CWF_M64
-// CHECK_SRF_M64: #define __ADX__ 1
-// CHECK_SRF_M64: #define __AES__ 1
-// CHECK_SRF_M64: #define __AVX2__ 1
-// CHECK_SRF_M64-NOT: AVX512
-// CHECK_SRF_M64: #define __AVXIFMA__ 1
-// CHECK_SRF_M64: #define __AVXNECONVERT__ 1
-// CHECK_SRF_M64-NOT: #define __AVXVNNIINT16__ 1
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_ARL_M64,CHECK_SRF_M64,CHECK_ARLS_M64,CHECK_PTL_M64,CHECK_CWF_M64
+// CHECK_ARL_M64: #define __ADX__ 1
+// CHECK_ARL_M64: #define __AES__ 1
+// CHECK_ARL_M64: #define __AVX2__ 1
+// CHECK_ARL_M64-NOT: AVX512
+// CHECK_ARL_M64: #define __AVXIFMA__ 1
+// CHECK_ARL_M64: #define __AVXNECONVERT__ 1
+// CHECK_ARL_M64-NOT: #define __AVXVNNIINT16__ 1
 // CHECK_ARLS_M64: #define __AVXVNNIINT16__ 1
-// CHECK_SRF_M64: #define __AVXVNNIINT8__ 1
-// CHECK_SRF_M64: #define __AVXVNNI__ 1
-// CHECK_SRF_M64: #define __AVX__ 1
-// CHECK_SRF_M64: #define __BMI2__ 1
-// CHECK_SRF_M64: #define __BMI__ 1
+// CHECK_ARL_M64: #define __AVXVNNIINT8__ 1
+// CHECK_ARL_M64: #define __AVXVNNI__ 1
+// CHECK_ARL_M64: #define __AVX__ 1
+// CHECK_ARL_M64: #define __BMI2__ 1
+// CHECK_ARL_M64: #define __BMI__ 1
+// CHECK_ARLS_M64-NOT: __CLDEMOTE__
 // CHECK_SRF_M64: #define __CLDEMOTE__ 1
-// CHECK_SRF_M64: #define __CLFLUSHOPT__ 1
-// CHECK_SRF_M64: #define __CLWB__ 1
-// CHECK_SRF_M64: #define __CMPCCXADD__ 1
-// CHECK_SRF_M64: #define __ENQCMD__ 1
-// CHECK_SRF_M64: #define __F16C__ 1
-// CHECK_SRF_M64: #define __FMA__ 1
-// CHECK_SRF_M64: #define __FSGSBASE__ 1
-// CHECK_SRF_M64: #define __FXSR__ 1
-// CHECK_SRF_M64: #define __GFNI__ 1
-// CHECK_SRF_M64: #define __HRESET__ 1
-// CHECK_SRF_M64: #define __INVPCID__ 1
-// CHECK_SRF_M64: #define __KL__ 1
-// CHECK_SRF_M64: #define __LZCNT__ 1
-// CHECK_SRF_M64: #define __MMX__ 1
-// CHECK_SRF_M64: #define __MOVBE__ 1
-// CHECK_SRF_M64: #define __MOVDIR64B__ 1
-// CHECK_SRF_M64: #define __MOVDIRI__ 1
-// CHECK_SRF_M64: #define __PCLMUL__ 1
-// CHECK_SRF_M64: #define __PCONFIG__ 1
-// CHECK_SRF_M64: #define __PKU__ 1
-// CHECK_SRF_M64: #define __POPCNT__ 1
-// CHECK_SRF_M64-NOT: #define __PREFETCHI__ 1
+// CHECK_ARL_M64: #define __CLFLUSHOPT__ 1
+// CHECK_ARL_M64: #define __CLWB__ 1
+// CHECK_ARL_M64: #define __CMPCCXADD__ 1
+// CHECK_ARL_M64: #define __ENQCMD__ 1
+// CHECK_ARL_M64: #define __F16C__ 1
+// CHECK_ARL_M64: #define __FMA__ 1
+// CHECK_ARL_M64: #define __FSGSBASE__ 1
+// CHECK_ARL_M64: #define __FXSR__ 1
+// CHECK_ARL_M64: #define __GFNI__ 1
+// CHECK_ARL_M64: #define __HRESET__ 1
+// CHECK_ARL_M64: #define __INVPCID__ 1
+// CHECK_ARL_M64: #define __KL__ 1
+// CHECK_ARL_M64: #define __LZCNT__ 1
+// CHECK_ARL_M64: #define __MMX__ 1
+// CHECK_ARL_M64: #define __MOVBE__ 1
+// CHECK_ARL_M64: #define __MOVDIR64B__ 1
+// CHECK_ARL_M64: #define __MOVDIRI__ 1
+// CHECK_ARL_M64: #define __PCLMUL__ 1
+// CHECK_ARL_M64: #define __PCONFIG__ 1
+// CHECK_ARL_M64: #define __PKU__ 1
+// CHECK_ARL_M64: #define __POPCNT__ 1
+// CHECK_ARL_M64-NOT: #define __PREFETCHI__ 1
 // CHECK_ARLS_M64-NOT: #define __PREFETCHI__ 1
 // CHECK_PTL_M64: #define __PREFETCHI__ 1
-// CHECK_SRF_M64: #define __PRFCHW__ 1
-// CHECK_SRF_M64: #define __PTWRITE__ 1
-// CHECK_SRF_M64-NOT: #define __RAOINT__ 1
-// CHECK_SRF_M64: #define __RDPID__ 1
-// CHECK_SRF_M64: #define __RDRND__ 1
-// CHECK_SRF_M64: #define __RDSEED__ 1
-// CHECK_SRF_M64: #define __SERIALIZE__ 1
-// CHECK_SRF_M64: #define __SGX__ 1
-// CHECK_SRF_M64-NOT: #define __SHA512__ 1
+// CHECK_ARL_M64: #define __PRFCHW__ 1
+// CHECK_ARL_M64: #define __PTWRITE__ 1
+// CHECK_ARL_M64-NOT: #define __RAOINT__ 1
+// CHECK_ARL_M64: #define __RDPID__ 1
+// CHECK_ARL_M64: #define __RDRND__ 1
+// CHECK_ARL_M64: #define __RDSEED__ 1
+// CHECK_ARL_M64: #define __SERIALIZE__ 1
+// CHECK_ARL_M64: #define __SGX__ 1
+// CHECK_ARL_M64-NOT: #define __SHA512__ 1
 // CHECK_ARLS_M64: #define __SHA512__ 1
-// CHECK_SRF_M64: #define __SHA__ 1
-// CHECK_SRF_M64: #define __SHSTK__ 1
-// CHECK_SRF_M64-NOT: #define __SM3__ 1
+// CHECK_ARL_M64: #define __SHA__ 1
+// CHECK_ARL_M64: #define __SHSTK__ 1
+// CHECK_ARL_M64-NOT: #define __SM3__ 1
 // CHECK_ARLS_M64: #define __SM3__ 1
-// CHECK_SRF_M64-NOT: #define __SM4__ 1
+// CHECK_ARL_M64-NOT: #define __SM4__ 1
 // CHECK_ARLS_M64: #define __SM4__ 1
-// CHECK_SRF_M64: #define __SSE2_MATH__ 1
-// CHECK_SRF_M64: #define __SSE2__ 1
-// CHECK_SRF_M64: #define __SSE3__ 1
-// CHECK_SRF_M64: #define __SSE4_1__ 1
-// CHECK_SRF_M64: #define __SSE4_2__ 1
-// CHECK_SRF_M64: #define __SSE_MATH__ 1
-// CHECK_SRF_M64: #define __SSE__ 1
-// CHECK_SRF_M64: #define __SSSE3__ 1
-// CHECK_SRF_M64: #define __UINTR__ 1
-// CHECK_SRF_M64-NOT: #define __USERMSR__ 1
+// CHECK_ARL_M64: #define __SSE2_MATH__ 1
+// CHECK_ARL_M64: #define __SSE2__ 1
+// CHECK_ARL_M64: #define __SSE3__ 1
+// CHECK_ARL_M64: #define __SSE4_1__ 1
+// CHECK_ARL_M64: #define __SSE4_2__ 1
+// CHECK_ARL_M64: #define __SSE_MATH__ 1
+// CHECK_ARL_M64: #define __SSE__ 1
+// CHECK_ARL_M64: #define __SSSE3__ 1
+// CHECK_ARL_M64: #define __UINTR__ 1
+// CHECK_ARL_M64-NOT: #define __USERMSR__ 1
 // CHECK_ARLS_M64-NOT: #define __USERMSR__ 1
 // CHECK_PTL_M64-NOT: #define __USERMSR__ 1
 // CHECK_CWF_M64: #define __USERMSR__ 1
-// CHECK_SRF_M64: #define __VAES__ 1
-// CHECK_SRF_M64: #define __VPCLMULQDQ__ 1
-// CHECK_SRF_M64: #define __WAITPKG__ 1
-// CHECK_SRF_M64: #define __WIDEKL__ 1
-// CHECK_SRF_M64: #define __XSAVEC__ 1
-// CHECK_SRF_M64: #define __XSAVEOPT__ 1
-// CHECK_SRF_M64: #define __XSAVES__ 1
-// CHECK_SRF_M64: #define __XSAVE__ 1
-// CHECK_SRF_M64: #define __amd64 1
-// CHECK_SRF_M64: #define __amd64__ 1
-// CHECK_SRF_M64: #define __corei7 1
-// CHECK_SRF_M64: #define __corei7__ 1
-// CHECK_SRF_M64: #define __tune_corei7__ 1
-// CHECK_SRF_M64: #define __x86_64 1
-// CHECK_SRF_M64: #define __x86_64__ 1
+// CHECK_ARL_M64: #define __VAES__ 1
+// CHECK_ARL_M64: #define __VPCLMULQDQ__ 1
+// CHECK_ARL_M64: #define __WAITPKG__ 1
+// CHECK_ARL_M64: #define __WIDEKL__ 1
+// CHECK_ARL_M64: #define __XSAVEC__ 1
+// CHECK_ARL_M64: #define __XSAVEOPT__ 1
+// CHECK_ARL_M64: #define __XSAVES__ 1
+// CHECK_ARL_M64: #define __XSAVE__ 1
+// CHECK_ARL_M64: #define __amd64 1
+// CHECK_ARL_M64: #define __amd64__ 1
+// CHECK_ARL_M64: #define __corei7 1
+// CHECK_ARL_M64: #define __corei7__ 1
+// CHECK_ARL_M64: #define __tune_corei7__ 1
+// CHECK_ARL_M64: #define __x86_64 1
+// CHECK_ARL_M64: #define __x86_64__ 1
 
 // RUN: %clang -march=geode -m32 -E -dM %s -o - 2>&1 \
 // RUN:     -target i386-unknown-linux \

--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -1304,16 +1304,20 @@ def ProcessorFeatures {
                                       TuningPOPCNTFalseDeps,
                                       TuningInsertVZEROUPPER];
 
-  // Sierraforest
-  list<SubtargetFeature> SRFAdditionalFeatures = [FeatureCMPCCXADD,
+  // Arrowlake
+  list<SubtargetFeature> ARLAdditionalFeatures = [FeatureCMPCCXADD,
                                                   FeatureAVXIFMA,
                                                   FeatureAVXNECONVERT,
                                                   FeatureENQCMD,
                                                   FeatureUINTR,
-                                                  FeatureCLDEMOTE,
                                                   FeatureAVXVNNIINT8];
+  list<SubtargetFeature> ARLFeatures =
+    !listconcat(ADLFeatures, ARLAdditionalFeatures);
+
+  // Sierraforest
+  list<SubtargetFeature> SRFAdditionalFeatures = [FeatureCLDEMOTE];
   list<SubtargetFeature> SRFFeatures =
-    !listconcat(ADLFeatures, SRFAdditionalFeatures);
+    !listconcat(ARLFeatures, SRFAdditionalFeatures);
 
   // Arrowlake S
   list<SubtargetFeature> ARLSAdditionalFeatures = [FeatureAVXVNNIINT16,
@@ -1321,7 +1325,7 @@ def ProcessorFeatures {
                                                    FeatureSM3,
                                                    FeatureSM4];
   list<SubtargetFeature> ARLSFeatures =
-    !listconcat(SRFFeatures, ARLSAdditionalFeatures);
+    !listconcat(ARLFeatures, ARLSAdditionalFeatures);
 
   // Pantherlake
   list<SubtargetFeature> PTLAdditionalFeatures = [FeaturePREFETCHI];
@@ -1330,10 +1334,10 @@ def ProcessorFeatures {
 
 
   // Clearwaterforest
-  list<SubtargetFeature> CWFAdditionalFeatures = [FeaturePREFETCHI,
+  list<SubtargetFeature> CWFAdditionalFeatures = [FeatureCLDEMOTE,
                                                   FeatureUSERMSR];
   list<SubtargetFeature> CWFFeatures =
-    !listconcat(ARLSFeatures, CWFAdditionalFeatures);
+    !listconcat(PTLFeatures, CWFAdditionalFeatures);
 
   // Knights Landing
   list<SubtargetFeature> KNLFeatures = [FeatureX87,
@@ -1861,7 +1865,7 @@ def : ProcModel<"raptorlake", AlderlakePModel,
 def : ProcModel<"meteorlake", AlderlakePModel,
                 ProcessorFeatures.ADLFeatures, ProcessorFeatures.ADLTuning>;
 def : ProcModel<"arrowlake", AlderlakePModel,
-                ProcessorFeatures.SRFFeatures, ProcessorFeatures.ADLTuning>;
+                ProcessorFeatures.ARLFeatures, ProcessorFeatures.ADLTuning>;
 foreach P = ["arrowlake-s", "arrowlake_s", "lunarlake"] in {
 def : ProcModel<P, AlderlakePModel,
                 ProcessorFeatures.ARLSFeatures, ProcessorFeatures.ADLTuning>;

--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -1334,10 +1334,14 @@ def ProcessorFeatures {
 
 
   // Clearwaterforest
-  list<SubtargetFeature> CWFAdditionalFeatures = [FeatureCLDEMOTE,
+  list<SubtargetFeature> CWFAdditionalFeatures = [FeaturePREFETCHI,
+                                                  FeatureAVXVNNIINT16,
+                                                  FeatureSHA512,
+                                                  FeatureSM3,
+                                                  FeatureSM4,
                                                   FeatureUSERMSR];
   list<SubtargetFeature> CWFFeatures =
-    !listconcat(PTLFeatures, CWFAdditionalFeatures);
+    !listconcat(SRFFeatures, CWFAdditionalFeatures);
 
   // Knights Landing
   list<SubtargetFeature> KNLFeatures = [FeatureX87,

--- a/llvm/lib/TargetParser/X86TargetParser.cpp
+++ b/llvm/lib/TargetParser/X86TargetParser.cpp
@@ -167,15 +167,17 @@ constexpr FeatureBitset FeaturesAlderlake =
     FeatureSERIALIZE | FeatureSHSTK | FeatureVAES | FeatureVPCLMULQDQ |
     FeatureMOVDIR64B | FeatureMOVDIRI | FeatureWAITPKG | FeatureAVXVNNI |
     FeatureHRESET | FeatureWIDEKL;
-constexpr FeatureBitset FeaturesSierraforest =
+constexpr FeatureBitset FeaturesArrowlake =
     FeaturesAlderlake | FeatureCMPCCXADD | FeatureAVXIFMA | FeatureUINTR |
-    FeatureCLDEMOTE | FeatureENQCMD | FeatureAVXNECONVERT | FeatureAVXVNNIINT8;
-constexpr FeatureBitset FeaturesArrowlakeS = FeaturesSierraforest |
+    FeatureENQCMD | FeatureAVXNECONVERT | FeatureAVXVNNIINT8;
+constexpr FeatureBitset FeaturesSierraforest =
+    FeaturesArrowlake | FeatureCLDEMOTE;
+constexpr FeatureBitset FeaturesArrowlakeS = FeaturesArrowlake |
     FeatureAVXVNNIINT16 | FeatureSHA512 | FeatureSM3 | FeatureSM4;
 constexpr FeatureBitset FeaturesPantherlake =
     FeaturesArrowlakeS | FeaturePREFETCHI;
 constexpr FeatureBitset FeaturesClearwaterforest =
-    FeaturesArrowlakeS | FeatureUSERMSR | FeaturePREFETCHI;
+    FeaturesPantherlake | FeatureUSERMSR | FeatureCLDEMOTE;
 
 // Geode Processor.
 constexpr FeatureBitset FeaturesGeode =
@@ -367,7 +369,7 @@ constexpr ProcInfo Processors[] = {
   // Meteorlake microarchitecture based processors.
   { {"meteorlake"}, CK_Meteorlake, FEATURE_AVX2, FeaturesAlderlake, 'p', false },
   // Arrowlake microarchitecture based processors.
-  { {"arrowlake"}, CK_Arrowlake, FEATURE_AVX2, FeaturesSierraforest, 'p', false },
+  { {"arrowlake"}, CK_Arrowlake, FEATURE_AVX2, FeaturesArrowlake, 'p', false },
   { {"arrowlake-s"}, CK_ArrowlakeS, FEATURE_AVX2, FeaturesArrowlakeS, '\0', false },
   { {"arrowlake_s"}, CK_ArrowlakeS, FEATURE_AVX2, FeaturesArrowlakeS, 'p', true },
   // Lunarlake microarchitecture based processors.

--- a/llvm/lib/TargetParser/X86TargetParser.cpp
+++ b/llvm/lib/TargetParser/X86TargetParser.cpp
@@ -172,8 +172,9 @@ constexpr FeatureBitset FeaturesArrowlake =
     FeatureENQCMD | FeatureAVXNECONVERT | FeatureAVXVNNIINT8;
 constexpr FeatureBitset FeaturesSierraforest =
     FeaturesArrowlake | FeatureCLDEMOTE;
-constexpr FeatureBitset FeaturesArrowlakeS = FeaturesArrowlake |
-    FeatureAVXVNNIINT16 | FeatureSHA512 | FeatureSM3 | FeatureSM4;
+constexpr FeatureBitset FeaturesArrowlakeS =
+    FeaturesArrowlake | FeatureAVXVNNIINT16 | FeatureSHA512 | FeatureSM3 |
+    FeatureSM4;
 constexpr FeatureBitset FeaturesPantherlake =
     FeaturesArrowlakeS | FeaturePREFETCHI;
 constexpr FeatureBitset FeaturesClearwaterforest =

--- a/llvm/lib/TargetParser/X86TargetParser.cpp
+++ b/llvm/lib/TargetParser/X86TargetParser.cpp
@@ -178,7 +178,8 @@ constexpr FeatureBitset FeaturesArrowlakeS =
 constexpr FeatureBitset FeaturesPantherlake =
     FeaturesArrowlakeS | FeaturePREFETCHI;
 constexpr FeatureBitset FeaturesClearwaterforest =
-    FeaturesPantherlake | FeatureUSERMSR | FeatureCLDEMOTE;
+    FeaturesSierraforest | FeatureAVXVNNIINT16 | FeatureSHA512 | FeatureSM3 |
+    FeatureSM4 | FeaturePREFETCHI | FeatureUSERMSR;
 
 // Geode Processor.
 constexpr FeatureBitset FeaturesGeode =


### PR DESCRIPTION
Decouple Arrowlake from Sierraforest because the later has CLDEMOTE feature.