### PR TITLE
[yaml2obj] Report error when the input filename does not exist

### DIFF
--- a/llvm/test/tools/yaml2obj/basic.test
+++ b/llvm/test/tools/yaml2obj/basic.test
@@ -1,0 +1,4 @@
+# Test case when the input file does not exist.
+RUN: not yaml2obj %t.blah 2>&1 | FileCheck -DMSG=%errc_ENOENT --check-prefix=ENOENT %s
+
+ENOENT: yaml2obj: error: {{.*}}.blah: [[MSG]]

--- a/llvm/tools/yaml2obj/yaml2obj.cpp
+++ b/llvm/tools/yaml2obj/yaml2obj.cpp
@@ -117,8 +117,9 @@ int main(int argc, char **argv) {
       argc, argv, "Create an object file from a YAML description", nullptr,
       nullptr, /*LongOptionsUseDoubleDash=*/true);
 
-  auto ErrHandler = [](const Twine &Msg) {
-    WithColor::error(errs(), "yaml2obj") << Msg << "\n";
+  constexpr StringRef ProgName = "yaml2obj";
+  auto ErrHandler = [&](const Twine &Msg) {
+    WithColor::error(errs(), ProgName) << Msg << "\n";
   };
 
   std::error_code EC;
@@ -131,8 +132,10 @@ int main(int argc, char **argv) {
 
   ErrorOr<std::unique_ptr<MemoryBuffer>> Buf =
       MemoryBuffer::getFileOrSTDIN(Input, /*IsText=*/true);
-  if (!Buf)
+  if (std::error_code EC = Buf.getError()) {
+    WithColor::error(errs(), ProgName) << Input << ": " << EC.message() << '\n';
     return 1;
+  }
 
   std::optional<std::string> Buffer =
       preprocess(Buf.get()->getBuffer(), ErrHandler);


### PR DESCRIPTION
I invoked yaml2obj with a mistyped filename and received no error
message. I nearly thought the program had succeeded, but the shell's
exit code prompt tipped me off.
