### PR TITLE
AArch64: Use reportFatalUsageError for unsupported calling conv

### DIFF
--- a/llvm/test/CodeGen/AArch64/unsupported-cc-call.ll
+++ b/llvm/test/CodeGen/AArch64/unsupported-cc-call.ll
@@ -1,0 +1,8 @@
+; FIXME: This should error:
+; RUN: llc -mtriple=aarch64-- -filetype=null %s
+declare amdgpu_gfx void @amdgpu_gfx_func()
+
+define void @call_amdgpu_gfx_func() {
+  call amdgpu_gfx void @amdgpu_gfx_func()
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/unsupported-cc-func.ll
+++ b/llvm/test/CodeGen/AArch64/unsupported-cc-func.ll
@@ -1,0 +1,6 @@
+; RUN: not llc -mtriple=aarch64-- -filetype=null %s 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: unsupported calling convention
+define amdgpu_gfx void @amdgpu_gfx_func_definition() {
+  ret void
+}

--- a/llvm/test/MC/AArch64/coff-function-type-info.ll
+++ b/llvm/test/MC/AArch64/coff-function-type-info.ll
@@ -1,10 +1,10 @@
-; RUN: llc -mtriple arm64-windows -filetype asm -o - %s \
+    ; RUN: llc -mtriple arm64-windows -filetype asm -o - %s \
 ; RUN:    | FileCheck %s -check-prefix CHECK-ASM
 
 ; RUN: llc -mtriple arm64-windows -filetype obj -o - %s \
 ; RUN:    | llvm-readobj --symbols - | FileCheck %s -check-prefix CHECK-OBJECT
 
-define arm_aapcs_vfpcc void @external() {
+define aarch64_vector_pcs void @external() {
 entry:
   ret void
 }
@@ -15,7 +15,7 @@ entry:
 ; CHECK-ASM: .endef
 ; CHECK-ASM: .globl external
 
-define internal arm_aapcs_vfpcc void @internal() {
+define internal aarch64_vector_pcs void @internal() {
 entry:
   ret void
 }


### PR DESCRIPTION
This probably should emit a DiagnosticInfoUnsupported and use the
default calling convention instead, but then we would need to pass
in the context.

Also move where CCAssignFnForCall is called. It was unnecessarily
called for each argument, so the error wouldn't trigger for functions
with 0 arguments.

This only ensures the error occurs for functions defined with the
calling convention. The error is still missed for outgoing calls
with no arguments. The lowering logic here is convoluted, calling
CCAssignFnForCall for each argument and it does not mirror
LowerFormalArguments so I'm not sure what's going on here.