### PR TITLE
[mlir][Affine] Fix crash in affine-loop-fusion pass by guarding against an empty op list

### DIFF
--- a/mlir/lib/Dialect/Affine/Transforms/LoopFusion.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/LoopFusion.cpp
@@ -1002,6 +1002,8 @@ public:
           if (producerConsumerMemrefs.count(
                   cast<AffineWriteOpInterface>(op).getMemRef()))
             dstMemrefOps.push_back(op);
+        if (dstMemrefOps.empty())
+          continue;
         unsigned dstLoopDepthTest =
             getInnermostCommonLoopDepth(dstMemrefOps) - numSurroundingLoops;
 


### PR DESCRIPTION
Related: #139231

This patch fixes a crash in the affine-loop-fusion pass when `getInnermostCommonLoop` is called with an empty list of operations.

The function expects at least one op to analyze, and passing an empty array of ops causes an assertion failure. This change ensures the pass checks for an empty op array before calling `getInnermostCommonLoop`.

@bondhugula @matthias-springer 