### PR TITLE
[libc] Fix bug in LIBC_CONF_ERRNO_MODE being undefined

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -107,7 +107,7 @@ function(_get_compile_options_from_config output_var)
   endif()
 
   if(LIBC_CONF_ERRNO_MODE)
-    set(APPEND config_options "-DLIBC_ERRNO_MODE=${LIBC_CONF_ERRNO_MODE}")
+    list(APPEND config_options "-DLIBC_ERRNO_MODE=${LIBC_CONF_ERRNO_MODE}")
   endif()
 
   set(${output_var} ${config_options} PARENT_SCOPE)


### PR DESCRIPTION
A typo, set() instead of list() would cause the build to not define LIBC_CONF_ERRNO_MODE, which would cause the wrong configuration to be used.