### PR TITLE
[NFC][analyzer] Update docs of CodeChecker --ctu-ast-mode

### DIFF
--- a/clang/docs/analyzer/user-docs/CrossTranslationUnit.rst
+++ b/clang/docs/analyzer/user-docs/CrossTranslationUnit.rst
@@ -132,7 +132,7 @@ Once we have set up the `PATH` environment variable and we activated the python 
 
 .. code-block:: bash
 
-  $ CodeChecker analyze --ctu compile_commands.json -o reports
+  $ CodeChecker analyze --ctu --ctu-ast-mode load-from-pch compile_commands.json -o reports
   $ ls -F
   compile_commands.json  foo.cpp  foo.cpp.ast  main.cpp  reports/
   $ tree reports
@@ -318,7 +318,7 @@ Once we have set up the `PATH` environment variable and we activated the python 
 
 .. code-block:: bash
 
-  $ CodeChecker analyze --ctu --ctu-ast-loading-mode on-demand compile_commands.json -o reports
+  $ CodeChecker analyze --ctu compile_commands.json -o reports
   $ ls -F
   compile_commands.json  foo.cpp main.cpp  reports/
   $ tree reports


### PR DESCRIPTION
The documentation of the cross translation unit analysis mentioned a certain flag of `CodeChecker` (an external open source tool that can be used to drive the static analysis), but the information about it was obsolete: apparently the name of the flag, the names of the possible values, and the default value were all changed.

Currently `CodeChecker analyze --help` displays this flag as
```
--ctu-ast-mode {load-from-pch,parse-on-demand}
  Choose the way ASTs are loaded during CTU analysis. Only available if
  CTU mode is enabled. Mode 'load-from-pch' generates PCH format
  serialized ASTs during the 'collect' phase. Mode 'parse-on-demand'
  only generates the invocations needed to parse the ASTs. Mode 'load-
  from-pch' can use significant disk-space for the serialized ASTs,
  while mode 'parse-on-demand' can incur some runtime CPU overhead in
  the second phase of the analysis. (default: parse-on-demand)
```
and I tried to follow this in the commands that I adjusted.

Note that this documentation file probably contains other obsolete details as well, but I didn't try to find or fix them.