### PR TITLE
[MLIR] Print more user-friendly error message when generating local reproducer and threading is enabled

### DIFF
--- a/mlir/lib/Pass/PassManagerOptions.cpp
+++ b/mlir/lib/Pass/PassManagerOptions.cpp
@@ -146,6 +146,14 @@ LogicalResult mlir::applyPassManagerCLOptions(PassManager &pm) {
   if (!options.isConstructed())
     return failure();
 
+  if (options->reproducerFile.getNumOccurrences() && options->localReproducer &&
+      pm.getContext()->isMultithreadingEnabled()) {
+    emitError(UnknownLoc::get(pm.getContext()))
+        << "Local crash reproduction may not be used without disabling "
+           "mutli-threading first.";
+    return failure();
+  }
+
   // Generate a reproducer on crash/failure.
   if (options->reproducerFile.getNumOccurrences())
     pm.enableCrashReproducerGeneration(options->reproducerFile,

--- a/mlir/test/mlir-opt/local-reproducer-with-threading.mlir
+++ b/mlir/test/mlir-opt/local-reproducer-with-threading.mlir
@@ -1,5 +1,9 @@
 // Test that attempting to create a local crash reproducer without disabling threading
 // prints an error from the pass manager (as opposed to crashing with a stack trace).
 
-// RUN: mlir-opt --mlir-pass-pipeline-local-reproducer --mlir-pass-pipeline-crash-reproducer=%t 2>&1 %s | FileCheck %s
+// We need to use `||` in the RUN command because lit will fail the test due to mlir-opt
+// returning non-zero status for this test case, however this is the intended behaviour.
+
+// RUN: mlir-opt --mlir-pass-pipeline-local-reproducer --mlir-pass-pipeline-crash-reproducer=%t %s 2>&1 || FileCheck --input-file %s %s
+
 // CHECK: error: Local crash reproduction may not be used without disabling mutli-threading first.

--- a/mlir/test/mlir-opt/local-reproducer-with-threading.mlir
+++ b/mlir/test/mlir-opt/local-reproducer-with-threading.mlir
@@ -1,9 +1,7 @@
 // Test that attempting to create a local crash reproducer without disabling threading
 // prints an error from the pass manager (as opposed to crashing with a stack trace).
 
-// We need to use `||` in the RUN command because lit will fail the test due to mlir-opt
-// returning non-zero status for this test case, however this is the intended behaviour.
+// RUN: mlir-opt --verify-diagnostics --mlir-pass-pipeline-local-reproducer \
+// RUN:          --mlir-pass-pipeline-crash-reproducer=%t %s
 
-// RUN: mlir-opt --mlir-pass-pipeline-local-reproducer --mlir-pass-pipeline-crash-reproducer=%t %s 2>&1 || FileCheck --input-file %s %s
-
-// CHECK: error: Local crash reproduction may not be used without disabling mutli-threading first.
+// expected-error@unknown {{Local crash reproduction may not be used without disabling mutli-threading first.}}

--- a/mlir/test/mlir-opt/local-reproducer-with-threading.mlir
+++ b/mlir/test/mlir-opt/local-reproducer-with-threading.mlir
@@ -1,0 +1,5 @@
+// Test that attempting to create a local crash reproducer without disabling threading
+// prints an error from the pass manager (as opposed to crashing with a stack trace).
+
+// RUN: mlir-opt --mlir-pass-pipeline-local-reproducer --mlir-pass-pipeline-crash-reproducer=%t 2>&1 %s | FileCheck %s
+// CHECK: error: Local crash reproduction may not be used without disabling mutli-threading first.


### PR DESCRIPTION
Currently if you run `mlir-opt` with `--mlir-pass-pipeline-local-reproducer` `--mlir-pass-pipeline-crash-reproducer` and don't provide `--mlir-disable-threading` you will get an LLVM error printed that suggests this is a bug and needs to be reported to LLVM. For example:

```
LLVM ERROR: Local crash reproduction can't be setup on a pass-manager without disabling multi-threading first.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
```


However, according to the local reproducer generation [documentation](https://mlir.llvm.org/docs/PassManagement/#local-reproducer-generation), disabling threading is required in order to generate a local reproducer. The current error message suggests this is a bug despite the MLIR documentation stating that this is a necessary constraint. Not disabling threading in this scenario is a user error so I have changed the error to be a pass manager `emitError` to reflect this.

An error is still printed but not in the same way that asks the user to file a bug report. I think this should help prevent any future confusion, such as what may have arised here https://github.com/llvm/llvm-project/issues/128344

Closes https://github.com/llvm/llvm-project/issues/128344

Unit test added.