### PR TITLE
[flang][OpenMP] Remove experimental warning

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -143,8 +143,8 @@ def warn_drv_unsupported_option_for_processor : Warning<
 def warn_drv_unsupported_openmp_library : Warning<
   "the library '%0=%1' is not supported, OpenMP will not be enabled">,
   InGroup<OptionIgnored>;
-def warn_openmp_experimental : Warning<
-  "OpenMP support in flang is still experimental">,
+def warn_openmp_incomplete : Warning<
+  "OpenMP support for version %0 in flang is still incomplete">,
   InGroup<ExperimentalOption>;
 
 def err_drv_invalid_thread_model_for_target : Error<

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -11,6 +11,7 @@
 
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Driver/CommonArgs.h"
+#include "clang/Driver/OptionUtils.h"
 #include "clang/Driver/Options.h"
 #include "llvm/Frontend/Debug/Options.h"
 #include "llvm/Support/Path.h"
@@ -772,6 +773,13 @@ static void renderRemarksOptions(const ArgList &Args, ArgStringList &CmdArgs,
   }
 }
 
+static std::string OpenMPVersionToString(int Version) {
+  int Major = Version / 10;
+  int Minor = Version % 10;
+
+  return llvm::Twine{Major}.concat(".").concat(llvm::Twine{Minor}).str();
+}
+
 void Flang::ConstructJob(Compilation &C, const JobAction &JA,
                          const InputInfo &Output, const InputInfoList &Inputs,
                          const ArgList &Args, const char *LinkingOutput) const {
@@ -906,9 +914,14 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
       if (Args.hasArg(options::OPT_fopenmp_force_usm))
         CmdArgs.push_back("-fopenmp-force-usm");
-      // TODO: OpenMP support isn't "done" yet, so for now we warn that it
-      // is experimental.
-      D.Diag(diag::warn_openmp_experimental);
+
+      // TODO: OpenMP support for newer versions of the standard is incomplete.
+      if (int Version =
+              getLastArgIntValue(Args, options::OPT_fopenmp_version_EQ, 0)) {
+        if (Version >= 40)
+          D.Diag(diag::warn_openmp_incomplete)
+              << OpenMPVersionToString(Version);
+      }
 
       // FIXME: Clang supports a whole bunch more flags here.
       break;

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -11,7 +11,6 @@
 
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Driver/CommonArgs.h"
-#include "clang/Driver/OptionUtils.h"
 #include "clang/Driver/Options.h"
 #include "llvm/Frontend/Debug/Options.h"
 #include "llvm/Support/Path.h"
@@ -773,13 +772,6 @@ static void renderRemarksOptions(const ArgList &Args, ArgStringList &CmdArgs,
   }
 }
 
-static std::string OpenMPVersionToString(int Version) {
-  int Major = Version / 10;
-  int Minor = Version % 10;
-
-  return llvm::Twine{Major}.concat(".").concat(llvm::Twine{Minor}).str();
-}
-
 void Flang::ConstructJob(Compilation &C, const JobAction &JA,
                          const InputInfo &Output, const InputInfoList &Inputs,
                          const ArgList &Args, const char *LinkingOutput) const {
@@ -914,14 +906,6 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
       if (Args.hasArg(options::OPT_fopenmp_force_usm))
         CmdArgs.push_back("-fopenmp-force-usm");
-
-      // TODO: OpenMP support for newer versions of the standard is incomplete.
-      if (int Version =
-              getLastArgIntValue(Args, options::OPT_fopenmp_version_EQ, 0)) {
-        if (Version >= 40)
-          D.Diag(diag::warn_openmp_incomplete)
-              << OpenMPVersionToString(Version);
-      }
 
       // FIXME: Clang supports a whole bunch more flags here.
       break;

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1138,8 +1138,9 @@ static bool parseOpenMPArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
   unsigned numErrorsBefore = diags.getNumErrors();
   llvm::Triple t(res.getTargetOpts().triple);
 
-  // By default OpenMP is set to 3.1 version
-  res.getLangOpts().OpenMPVersion = 31;
+  constexpr unsigned newestFullySupported = 31;
+  // By default OpenMP is set to the most recent fully supported version
+  res.getLangOpts().OpenMPVersion = newestFullySupported;
   res.getFrontendOpts().features.Enable(
       Fortran::common::LanguageFeature::OpenMP);
   if (auto *arg =
@@ -1164,6 +1165,9 @@ static bool parseOpenMPArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
     if (!value.getAsInteger(/*radix=*/10, version)) {
       if (llvm::is_contained(ompVersions, version)) {
         res.getLangOpts().OpenMPVersion = version;
+
+        if (version > newestFullySupported)
+          diags.Report(clang::diag::warn_openmp_incomplete) << version;
       } else if (llvm::is_contained(oldVersions, version)) {
         const unsigned diagID =
             diags.getCustomDiagID(clang::DiagnosticsEngine::Warning,

--- a/flang/test/Driver/fopenmp.f90
+++ b/flang/test/Driver/fopenmp.f90
@@ -74,6 +74,6 @@
 ! CHECK-LD-ANYMD: "{{.*}}ld{{(.exe)?}}"
 ! CHECK-LD-ANYMD: "-l{{(omp|gomp|iomp5md)}}"
 !
-! RUN: %flang -fopenmp -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-EXPERIMENTAL
+! RUN: %flang -fopenmp -fopenmp-version=40 -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-EXPERIMENTAL
 !
-! CHECK-EXPERIMENTAL: flang{{.*}}: warning: OpenMP support in flang is still experimental
+! CHECK-EXPERIMENTAL: flang{{.*}}: warning: OpenMP support for version 4.0 in flang is still incomplete

--- a/flang/test/Driver/fopenmp.f90
+++ b/flang/test/Driver/fopenmp.f90
@@ -74,6 +74,6 @@
 ! CHECK-LD-ANYMD: "{{.*}}ld{{(.exe)?}}"
 ! CHECK-LD-ANYMD: "-l{{(omp|gomp|iomp5md)}}"
 !
-! RUN: %flang -fopenmp -fopenmp-version=40 -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-INCOMPLETE
+! RUN: %flang -fopenmp -fopenmp-version=40 -c %s -S -o - 2>&1 | FileCheck %s --check-prefix=CHECK-INCOMPLETE
 !
-! CHECK-INCOMPLETE: flang{{.*}}: warning: OpenMP support for version 4.0 in flang is still incomplete
+! CHECK-INCOMPLETE: warning: OpenMP support for version 40 in flang is still incomplete

--- a/flang/test/Driver/fopenmp.f90
+++ b/flang/test/Driver/fopenmp.f90
@@ -74,6 +74,6 @@
 ! CHECK-LD-ANYMD: "{{.*}}ld{{(.exe)?}}"
 ! CHECK-LD-ANYMD: "-l{{(omp|gomp|iomp5md)}}"
 !
-! RUN: %flang -fopenmp -fopenmp-version=40 -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-EXPERIMENTAL
+! RUN: %flang -fopenmp -fopenmp-version=40 -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-INCOMPLETE
 !
-! CHECK-EXPERIMENTAL: flang{{.*}}: warning: OpenMP support for version 4.0 in flang is still incomplete
+! CHECK-INCOMPLETE: flang{{.*}}: warning: OpenMP support for version 4.0 in flang is still incomplete


### PR DESCRIPTION
RFC: https://discourse.llvm.org/t/rfc-removing-the-openmp-experimental-warning-for-llvm-21/86455

Fixes: #110008

There are a handful of open issues still to resolve before this can go out of draft. See the linked issue.