### PR TITLE
[clang-tidy] Add option to keep virtual in 'modernize-use-override'

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.h
@@ -29,6 +29,7 @@ private:
   const bool IgnoreDestructors;
   const bool IgnoreTemplateInstantiations;
   const bool AllowOverrideAndFinal;
+  const bool AllowVirtual;
   const StringRef OverrideSpelling;
   const StringRef FinalSpelling;
 };

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-override.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-override.rst
@@ -4,7 +4,8 @@ modernize-use-override
 ======================
 
 Adds ``override`` (introduced in C++11) to overridden virtual functions and
-removes ``virtual`` from those functions as it is not required.
+removes ``virtual`` from those functions (unless the `AllowVirtual` option is
+used).
 
 ``virtual`` on non base class implementations was used to help indicate to the
 user that a function was virtual. C++ compilers did not use the presence of
@@ -39,6 +40,11 @@ Options
    warning/error checking flags requiring ``override`` explicitly on overridden
    members, such as ``gcc -Wsuggest-override``/``gcc -Werror=suggest-override``.
    Default is `false`.
+
+.. option:: AllowVirtual
+
+   If set to `true`, ``virtual`` will not be removed by this check when adding
+   ``override`` or ``final``. Default is `false`.
 
 .. option:: OverrideSpelling
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-allow-virtual.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-allow-virtual.cpp
@@ -1,0 +1,25 @@
+// RUN: %check_clang_tidy %s modernize-use-override %t -- \
+// RUN:   -config="{CheckOptions: {modernize-use-override.AllowVirtual: true}}"
+
+struct Base {
+  virtual ~Base();
+  virtual void a();
+  virtual void b();
+  virtual void c();
+};
+
+struct Derived : public Base {
+  virtual ~Derived() override;
+
+  virtual void a() override;
+  // CHECK-MESSAGES-NOT: warning:
+  // CHECK-FIXES: {{^}}  virtual void a() override;
+
+  virtual void b();
+  // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: add 'override'
+  // CHECK-FIXES: {{^}}  virtual void b() override;
+
+  void c();
+  // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: annotate
+  // CHECK-FIXES: {{^}}  void c() override;
+};


### PR DESCRIPTION
Add a new `AllowVirtual` option to 'modernize-use-override', which does not remove the `virtual` specifier. This is useful because some coding guidelines may suggest to use `virtual ... override` for clarity. See the new unit test for examples.
