### PR TITLE
[lldb] Fix race condition in Process::WaitForProcessToStop()

### DIFF
--- a/lldb/include/lldb/Utility/Listener.h
+++ b/lldb/include/lldb/Utility/Listener.h
@@ -53,6 +53,13 @@ public:
 
   void AddEvent(lldb::EventSP &event);
 
+  /// Transfers all events matching the specified broadcaster and type to the
+  /// destination listener. This can be useful when setting up a hijack listener,
+  /// to ensure that no relevant events are missed.
+  void MoveEvents(lldb::ListenerSP destination,
+                  Broadcaster *broadcaster, // nullptr for any broadcaster
+                  uint32_t event_type_mask);
+
   void Clear();
 
   const char *GetName() { return m_name.c_str(); }

--- a/lldb/unittests/Utility/ListenerTest.cpp
+++ b/lldb/unittests/Utility/ListenerTest.cpp
@@ -150,3 +150,84 @@ TEST(ListenerTest, StartStopListeningForEventSpec) {
   ASSERT_EQ(event_sp->GetBroadcaster(), &broadcaster1);
   ASSERT_FALSE(listener_sp->GetEvent(event_sp, std::chrono::seconds(0)));
 }
+
+TEST(ListenerTest, MoveEventsOnHijackAndRestore) {
+  Broadcaster broadcaster(nullptr, "test-broadcaster");
+  const uint32_t event_mask = 1;
+  EventSP event_sp;
+
+  // Create the original listener and start listening.
+  ListenerSP original_listener = Listener::MakeListener("original-listener");
+  ASSERT_EQ(event_mask, original_listener->StartListeningForEvents(&broadcaster,
+                                                                   event_mask));
+  broadcaster.SetPrimaryListener(original_listener);
+
+  // Queue two events to original listener, but do not consume them yet.
+  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask, nullptr);
+
+  // Hijack.
+  ListenerSP hijack_listener = Listener::MakeListener("hijack-listener");
+  broadcaster.HijackBroadcaster(hijack_listener, event_mask);
+
+  // The events should have been moved to the hijack listener.
+  EXPECT_FALSE(original_listener->GetEvent(event_sp, std::chrono::seconds(0)));
+  EXPECT_TRUE(hijack_listener->GetEvent(event_sp, std::chrono::seconds(0)));
+  EXPECT_TRUE(hijack_listener->GetEvent(event_sp, std::chrono::seconds(0)));
+
+  // Queue two events while hijacked, but do not consume them yet.
+  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask, nullptr);
+
+  // Restore the original listener.
+  broadcaster.RestoreBroadcaster();
+
+  // The events queued while hijacked should have been moved back to the
+  // original listener.
+  EXPECT_FALSE(hijack_listener->GetEvent(event_sp, std::chrono::seconds(0)));
+  EXPECT_TRUE(original_listener->GetEvent(event_sp, std::chrono::seconds(0)));
+  EXPECT_TRUE(original_listener->GetEvent(event_sp, std::chrono::seconds(0)));
+}
+
+TEST(ListenerTest, MoveEventsBetweenHijackers) {
+  Broadcaster broadcaster(nullptr, "test-broadcaster");
+  const uint32_t event_mask = 1;
+  EventSP event_sp;
+
+  // Create the original listener and start listening.
+  ListenerSP original_listener = Listener::MakeListener("original-listener");
+  ASSERT_EQ(event_mask, original_listener->StartListeningForEvents(&broadcaster,
+                                                                   event_mask));
+  broadcaster.SetPrimaryListener(original_listener);
+
+  // First hijack.
+  ListenerSP hijack_listener1 = Listener::MakeListener("hijack-listener1");
+  broadcaster.HijackBroadcaster(hijack_listener1, event_mask);
+
+  // Queue two events while hijacked, but do not consume
+  // them yet.
+  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask, nullptr);
+
+  // Second hijack.
+  ListenerSP hijack_listener2 = Listener::MakeListener("hijack-listener2");
+  broadcaster.HijackBroadcaster(hijack_listener2, event_mask);
+
+  // The second hijacker should have the events now.
+  EXPECT_FALSE(hijack_listener1->GetEvent(event_sp, std::chrono::seconds(0)));
+  EXPECT_TRUE(hijack_listener2->GetEvent(event_sp, std::chrono::seconds(0)));
+  EXPECT_TRUE(hijack_listener2->GetEvent(event_sp, std::chrono::seconds(0)));
+
+  // Queue two events while hijacked with second hijacker, but do not consume
+  // them yet.
+  broadcaster.BroadcastEvent(event_mask, nullptr);
+  broadcaster.BroadcastEvent(event_mask, nullptr);
+
+  // Restore the previous hijacker.
+  broadcaster.RestoreBroadcaster();
+
+  // The first hijacker should now have the events.
+  EXPECT_FALSE(hijack_listener2->GetEvent(event_sp, std::chrono::seconds(0)));
+  EXPECT_TRUE(hijack_listener1->GetEvent(event_sp, std::chrono::seconds(0)));
+  EXPECT_TRUE(hijack_listener1->GetEvent(event_sp, std::chrono::seconds(0)));
+}


### PR DESCRIPTION
This PR addresses a race condition encountered when using LLDB through the Python scripting interface.

I'm relatively new to LLDB, so feedback is very welcome, especially if there's a more appropriate way to address this issue.

### Bug Description

When running a script that repeatedly calls `debugger.GetListener().WaitForEvent()` in a loop, and at some point invokes `process.Kill()` from within that loop to terminate the session, a race condition can occur if `process.Kill()` is called around the same time a breakpoint is hit.

### Race Condition Details

The issue arises when the following sequence of events happens:

1. The process's **private state** transitions to `stopped` when the breakpoint is hit.
2. `process.Kill()` calls `Process::Destroy()`, which invokes `Process::WaitForProcessToStop()`. At this point:
   - `private_state = stopped`
   - `public_state = running` (the public state has not yet been updated)
3. The **public stop event** is broadcast **before** the hijack listener is installed.
4. As a result, the stop event is delivered to the **non-hijack listener**.
5. The interrupt request sent by `Process::StopForDestroyOrDetach()` is ignored because the process is already stopped (`private_state = stopped`).
6. No public stop event reaches the hijack listener.
7. `Process::WaitForProcessToStop()` hangs waiting for a public stop event, but the event is never received.
8. `process.Kill()` times out after 20 seconds

### Fix Summary

This patch modifies `Process::WaitForProcessToStop()` to ensure that any pending events in the non-hijack listener queue are processed before checking the hijack listener. This guarantees that any missed public state change events are handled, preventing the hang.


### Additional Context

A discussion of this issue, including a script to reproduce the bug, can be found here: 
 [LLDB hangs when killing process at the same time a breakpoint is hit](https://discourse.llvm.org/t/lldb-hangs-when-killing-process-at-the-same-time-a-breakpoint-is-hit)