### PR TITLE
[mlir][gpu] Fix bug with GPU hardware intrinsic global location

### DIFF
--- a/mlir/lib/Conversion/GPUCommon/OpToFuncCallLowering.h
+++ b/mlir/lib/Conversion/GPUCommon/OpToFuncCallLowering.h
@@ -164,7 +164,12 @@ public:
     auto parentFunc = op->getParentOfType<FunctionOpInterface>();
     assert(parentFunc && "expected there to be a parent function");
     OpBuilder b(parentFunc);
-    return b.create<LLVMFuncOp>(op->getLoc(), funcName, funcType);
+
+    // Create a valid global location removing any metadata attached to the
+    // location as debug info metadata inside of a function cannot be used
+    // outside of that function.
+    auto globalloc = op->getLoc()->findInstanceOfOrUnknown<FileLineColLoc>();
+    return b.create<LLVMFuncOp>(globalloc, funcName, funcType);
   }
 
   StringRef getFunctionName(Type type, SourceOp op) const {

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-debuginfo.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-debuginfo.mlir
@@ -23,3 +23,12 @@ gpu.module @test_module_1 {
     gpu.return
   }
 }
+
+// Check that debug info metadata from the function is removed from the global location.
+gpu.module @test_module_2 {
+  // CHECK-DAG: llvm.func @__nv_abs(i32) -> i32 loc([[LOC]])
+  func.func @gpu_abs_with_loc(%arg_i32 : i32) -> (i32) {
+    %result32 = math.absi %arg_i32 : i32 loc(fused<#di_subprogram>[#loc])
+    func.return %result32 : i32
+  }
+}


### PR DESCRIPTION
Bug description: Hardware intrinsic functions created during GPU conversion to NVVM may contain debug info metadata from the original function which cannot be used out of that function.