### PR TITLE
[ADT] Remove an extraneous variable (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/PointerIntPair.h
+++ b/llvm/include/llvm/ADT/PointerIntPair.h
@@ -206,11 +206,10 @@ struct PointerIntPairInfo {
   }
 
   static intptr_t updateInt(intptr_t OrigValue, intptr_t Int) {
-    intptr_t IntWord = static_cast<intptr_t>(Int);
-    assert((IntWord & ~IntMask) == 0 && "Integer too large for field");
+    assert((Int & ~IntMask) == 0 && "Integer too large for field");
 
     // Preserve all bits other than the ones we are updating.
-    return (OrigValue & ~ShiftedIntMask) | IntWord << IntShift;
+    return (OrigValue & ~ShiftedIntMask) | Int << IntShift;
   }
 };
 


### PR DESCRIPTION
Without this patch, Int and IntWord have the same value and type.
This patch removes the extraneous copy.
