### PR TITLE
[llvm] Use "= delete" to delete constructors (NFC)

### DIFF
--- a/llvm/unittests/ADT/TestGraph.h
+++ b/llvm/unittests/ADT/TestGraph.h
@@ -24,14 +24,13 @@ namespace llvm {
 template <unsigned N>
 class Graph {
 private:
-  // Disable copying.
-  Graph(const Graph&);
-  Graph& operator=(const Graph&);
-
   static void ValidateIndex(unsigned Idx) {
     assert(Idx < N && "Invalid node index!");
   }
 public:
+  // Disable copying.
+  Graph(const Graph &) = delete;
+  Graph &operator=(const Graph &) = delete;
 
   /// NodeSubset - A subset of the graph's nodes.
   class NodeSubset {
@@ -169,11 +168,12 @@ public:
     /// yet been visited.
     NodeSubset Children;
 
-    ChildIterator(); // Disable default constructor.
   protected:
     ChildIterator(NodeType *F, NodeSubset C) : FirstNode(F), Children(C) {}
 
   public:
+    ChildIterator() = delete; // Disable default constructor.
+
     /// ChildIterator - Copy constructor.
     ChildIterator(const ChildIterator &other) = default;
     ChildIterator &operator=(const ChildIterator &other) = default;

--- a/llvm/unittests/Support/Casting.cpp
+++ b/llvm/unittests/Support/Casting.cpp
@@ -24,13 +24,11 @@ template <typename T> IllegalCast *cast(...) { return nullptr; }
 //
 struct bar {
   bar() {}
+  bar(const bar &) = delete;
   struct foo *baz();
   struct foo *caz();
   struct foo *daz();
   struct foo *naz();
-
-private:
-  bar(const bar &);
 };
 struct foo {
   foo(const bar &) {}


### PR DESCRIPTION
None of the constructors touched in this patch has a corresponding
definition.  This patch explicitly deletes them with "= delete" while
moving them to the public section of respective classes.  Note that "=
delete" itself serves as documentation.

Identified with modernize-use-equals-delete.
