### PR TITLE
[CIR] Remove redundant operation trait and use AllTypesMatch instead

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
@@ -33,31 +33,6 @@
 #include "clang/CIR/Interfaces/CIROpInterfaces.h"
 #include "clang/CIR/MissingFeatures.h"
 
-namespace mlir {
-namespace OpTrait {
-
-namespace impl {
-// These functions are out-of-line implementations of the methods in the
-// corresponding trait classes.  This avoids them being template
-// instantiated/duplicated.
-LogicalResult verifySameFirstOperandAndResultType(Operation *op);
-} // namespace impl
-
-/// This class provides verification for ops that are known to have the same
-/// first operand and result type.
-///
-template <typename ConcreteType>
-class SameFirstOperandAndResultType
-    : public TraitBase<ConcreteType, SameFirstOperandAndResultType> {
-public:
-  static llvm::LogicalResult verifyTrait(Operation *op) {
-    return impl::verifySameFirstOperandAndResultType(op);
-  }
-};
-
-} // namespace OpTrait
-} // namespace mlir
-
 using BuilderCallbackRef =
     llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)>;
 using BuilderOpStateCallbackRef = llvm::function_ref<void(

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -81,13 +81,6 @@ class CIR_Op<string mnemonic, list<Trait> traits = []> :
     Op<CIR_Dialect, mnemonic, traits>, LLVMLoweringInfo;
 
 //===----------------------------------------------------------------------===//
-// CIR Op Traits
-//===----------------------------------------------------------------------===//
-
-def SameFirstOperandAndResultType :
-  NativeOpTrait<"SameFirstOperandAndResultType">;
-
-//===----------------------------------------------------------------------===//
 // CastOp
 //===----------------------------------------------------------------------===//
 
@@ -243,7 +236,7 @@ def CastOp : CIR_Op<"cast",
 //===----------------------------------------------------------------------===//
 
 def PtrStrideOp : CIR_Op<"ptr_stride",
-                         [Pure, SameFirstOperandAndResultType]> {
+                         [Pure, AllTypesMatch<["base", "result"]>]> {
   let summary = "Pointer access with stride";
   let description = [{
     Given a base pointer as first operand, provides a new pointer after applying

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1374,25 +1374,6 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
   }
 }
 
-//===----------------------------------------------------------------------===//
-// CIR defined traits
-//===----------------------------------------------------------------------===//
-
-LogicalResult
-mlir::OpTrait::impl::verifySameFirstOperandAndResultType(Operation *op) {
-  if (failed(verifyAtLeastNOperands(op, 1)) || failed(verifyOneResult(op)))
-    return failure();
-
-  const Type type = op->getResult(0).getType();
-  const Type opType = op->getOperand(0).getType();
-
-  if (type != opType)
-    return op->emitOpError()
-           << "requires the same type for first operand and result";
-
-  return success();
-}
-
 // TODO(CIR): The properties of functions that require verification haven't
 // been implemented yet.
 mlir::LogicalResult cir::FuncOp::verify() { return success(); }


### PR DESCRIPTION
This mirrors incubator changes from https://github.com/llvm/clangir/pull/1679