### PR TITLE
[BUG] Fix : #139514

### DIFF
--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -13153,6 +13153,20 @@ TEST_F(FormatTest, BreaksLongVariableDeclarations) {
                getLLVMStyleWithColumns(40));
 }
 
+TEST_F(FormatTest, BreaksBeforeConstWithPointerAlignmentLeftAndColumnLimit) {
+  FormatStyle Style = getLLVMStyle();
+  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.ColumnLimit = 80;
+  verifyFormat(
+      "void foo(\n"
+      "    const MySuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLongTypeName*\n"
+      "        const my_super_super_super_super_super_long_variable_name) {}",
+      "void foo(\n"
+      "    const MySuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLongTypeName* const\n"
+      "        my_super_super_super_super_super_long_variable_name) {}",
+      Style);
+}
+
 TEST_F(FormatTest, BreaksLongDeclarations) {
   verifyFormat("typedef LoooooooooooooooooooooooooooooooooooooooongType\n"
                "    AnotherNameForTheLongType;");


### PR DESCRIPTION
Fixes "#139514"

Description:
This test checks that when formatting a function parameter with a long type name, a pointer, and a const qualifier, clang-format will break the line before the const if needed to respect the ColumnLimit (here, 80), and when PointerAlignment is set to Left.

Inputs:
PointerAlignment = PAS_Left (so the * sticks to the type, not the variable)
ColumnLimit = 80 (so lines should not exceed 80 characters)

Expected Behavior:
The pointer (*) should stay with the type on the first line.
The const qualifier should be moved to the next line with the variable name, so that no line exceeds 80 characters.

Test Details:
The second argument to verifyFormat is the input code (what the user writes).
The first argument is the expected output after formatting.
If clang-format is working correctly, it will break the line before const to keep both lines within the column limit.