### PR TITLE
Hexagon: Add libcall declarations for special memcpy

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -368,6 +368,9 @@ def AEABI_MEMCLR : RuntimeLibcall;
 def AEABI_MEMCLR4 : RuntimeLibcall;
 def AEABI_MEMCLR8 : RuntimeLibcall;
 
+// Hexagon calls
+def HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES : RuntimeLibcall;
+
 //--------------------------------------------------------------------
 // Define implementation default libcalls
 //--------------------------------------------------------------------
@@ -1246,6 +1249,9 @@ def __hexagon_fast2_sqrtf : RuntimeLibcallImpl<SQRT_F32>;
 
 // This is the only fast library function for sqrtd.
 def __hexagon_fast2_sqrtdf2 : RuntimeLibcallImpl<SQRT_F64>;
+
+def __hexagon_memcpy_likely_aligned_min32bytes_mult8bytes
+    : RuntimeLibcallImpl<HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES>;
 
 //===----------------------------------------------------------------------===//
 // Mips16 Runtime Libcalls

--- a/llvm/lib/IR/RuntimeLibcalls.cpp
+++ b/llvm/lib/IR/RuntimeLibcalls.cpp
@@ -584,6 +584,10 @@ void RuntimeLibcallsInfo::initLibcalls(const Triple &TT,
       setLibcallImpl(RTLIB::SQRT_F32, RTLIB::__hexagon_fast2_sqrtf);
     else
       setLibcallImpl(RTLIB::SQRT_F32, RTLIB::__hexagon_sqrtf);
+
+    setLibcallImpl(
+        RTLIB::HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES,
+        RTLIB::__hexagon_memcpy_likely_aligned_min32bytes_mult8bytes);
   }
 
   if (TT.getArch() == Triple::ArchType::msp430)

--- a/llvm/lib/Target/Hexagon/HexagonSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonSelectionDAGInfo.cpp
@@ -41,18 +41,20 @@ SDValue HexagonSelectionDAGInfo::EmitTargetCodeForMemcpy(
   Entry.Node = Size;
   Args.push_back(Entry);
 
-  const char *SpecialMemcpyName =
-      "__hexagon_memcpy_likely_aligned_min32bytes_mult8bytes";
+  const char *SpecialMemcpyName = TLI.getLibcallName(
+      RTLIB::HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES);
   const MachineFunction &MF = DAG.getMachineFunction();
   bool LongCalls = MF.getSubtarget<HexagonSubtarget>().useLongCalls();
   unsigned Flags = LongCalls ? HexagonII::HMOTF_ConstExtended : 0;
+
+  CallingConv::ID CC = TLI.getLibcallCallingConv(
+      RTLIB::HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES);
 
   TargetLowering::CallLoweringInfo CLI(DAG);
   CLI.setDebugLoc(dl)
       .setChain(Chain)
       .setLibCallee(
-          TLI.getLibcallCallingConv(RTLIB::MEMCPY),
-          Type::getVoidTy(*DAG.getContext()),
+          CC, Type::getVoidTy(*DAG.getContext()),
           DAG.getTargetExternalSymbol(
               SpecialMemcpyName, TLI.getPointerTy(DAG.getDataLayout()), Flags),
           std::move(Args))


### PR DESCRIPTION
HexagonSelectionDAGInfo was bypassing the ordinary RuntimeLibcallInfo
handling for this case, so define a libcall for it and use it.