### PR TITLE
XCore: Declare libcalls used for align 4 memcpy

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -371,6 +371,9 @@ def AEABI_MEMCLR8 : RuntimeLibcall;
 // Hexagon calls
 def HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES : RuntimeLibcall;
 
+// XCore calls
+def MEMCPY_ALIGN_4 : RuntimeLibcall;
+
 //--------------------------------------------------------------------
 // Define implementation default libcalls
 //--------------------------------------------------------------------
@@ -1543,6 +1546,12 @@ def _aulldiv : RuntimeLibcallImpl<UDIV_I64>; // CallingConv::X86_StdCall
 def _allrem : RuntimeLibcallImpl<SREM_I64>; // CallingConv::X86_StdCall
 def _aullrem : RuntimeLibcallImpl<UREM_I64>; // CallingConv::X86_StdCall
 def _allmul : RuntimeLibcallImpl<MUL_I64>; // CallingConv::X86_StdCall
+
+//===----------------------------------------------------------------------===//
+// XCore Runtime Libcalls
+//===----------------------------------------------------------------------===//
+
+def __memcpy_4 : RuntimeLibcallImpl<MEMCPY_ALIGN_4>;
 
 //===----------------------------------------------------------------------===//
 // ZOS Runtime Libcalls

--- a/llvm/lib/IR/RuntimeLibcalls.cpp
+++ b/llvm/lib/IR/RuntimeLibcalls.cpp
@@ -595,6 +595,9 @@ void RuntimeLibcallsInfo::initLibcalls(const Triple &TT,
 
   if (TT.isSystemZ() && TT.isOSzOS())
     setZOSLibCallNameOverrides();
+
+  if (TT.getArch() == Triple::ArchType::xcore)
+    setLibcallImpl(RTLIB::MEMCPY_ALIGN_4, RTLIB::__memcpy_4);
 }
 
 bool RuntimeLibcallsInfo::darwinHasExp10(const Triple &TT) {

--- a/llvm/lib/Target/XCore/XCoreSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/XCore/XCoreSelectionDAGInfo.cpp
@@ -39,14 +39,17 @@ SDValue XCoreSelectionDAGInfo::EmitTargetCodeForMemcpy(
     Entry.Node = Src; Args.push_back(Entry);
     Entry.Node = Size; Args.push_back(Entry);
 
+    const char *MemcpyAlign4Name = TLI.getLibcallName(RTLIB::MEMCPY_ALIGN_4);
+    CallingConv::ID CC = TLI.getLibcallCallingConv(RTLIB::MEMCPY_ALIGN_4);
+
     TargetLowering::CallLoweringInfo CLI(DAG);
     CLI.setDebugLoc(dl)
         .setChain(Chain)
-        .setLibCallee(TLI.getLibcallCallingConv(RTLIB::MEMCPY),
-                      Type::getVoidTy(*DAG.getContext()),
-                      DAG.getExternalSymbol(
-                          "__memcpy_4", TLI.getPointerTy(DAG.getDataLayout())),
-                      std::move(Args))
+        .setLibCallee(
+            CC, Type::getVoidTy(*DAG.getContext()),
+            DAG.getExternalSymbol(MemcpyAlign4Name,
+                                  TLI.getPointerTy(DAG.getDataLayout())),
+            std::move(Args))
         .setDiscardResult();
 
     std::pair<SDValue,SDValue> CallResult = TLI.LowerCallTo(CLI);


### PR DESCRIPTION
This usage was hidden in XCoreSelectionDAGInfo and bypassed
the usual libcall system, so define these for later use.