### PR TITLE
[Mips][ASM] Optimize SW+ADDIU

### DIFF
--- a/llvm/test/MC/Mips/sw-add-bne.s
+++ b/llvm/test/MC/Mips/sw-add-bne.s
@@ -1,0 +1,13 @@
+# RUN: llvm-mc -assemble -mcpu=mips32r6 -arch=mipsel -filetype=obj %s -o tmp.o
+# RUN: llvm-objdump -d tmp.o | FileCheck %s --check-prefix=MIPSELR6
+
+# MIPSELR6:      00000000 <xxx>:
+# MIPSELR6-NEXT: addiu $2, $2, 0x4 <xxx+0x4>
+# MIPSELR6-NEXT: sw $4, -0x4($2)
+# MIPSELR6-NEXT: bne $2, $3, 0x0 <xxx>
+# MIPSELR6-NEXT: nop <xxx>
+xxx:
+$BB0_1:                                 # %for.body
+        sw      $4, 0($2)
+        addiu   $2, $2, 4
+        bne     $2, $3, $BB0_1


### PR DESCRIPTION
We want to optimize
```
           sw      $4, 0($2)
           addiu   $2, $2, 4
           bne     $2, $3, $BB0_1
```
to
```     
         addiu   $2, $2, 4
         sw      $4, -4($2)
         bne     $2, $3, $BB0_1
```
so that the sw can be placed into delay slot.

Fix #132685.