### PR TITLE
[mlir][arith] Add back ElementwiseMappable to `arith.trunci`

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -1271,7 +1271,7 @@ def Arith_ScalingExtFOp
 // TruncIOp
 //===----------------------------------------------------------------------===//
 
-def Arith_TruncIOp : Op<Arith_Dialect, "trunci",
+def Arith_TruncIOp : Arith_Op<"trunci",
     [Pure, SameOperandsAndResultShape, SameInputOutputTensorDims,
      DeclareOpInterfaceMethods<CastOpInterface>,
      DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>,


### PR DESCRIPTION
This trait was accidentally dropped in #144863.