### PR TITLE
[RISCV] Implement Feature Bit for Q

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/riscv.c
+++ b/compiler-rt/lib/builtins/cpu_model/riscv.c
@@ -40,6 +40,8 @@ struct {
 #define I_BITMASK (1ULL << 8)
 #define M_GROUPID 0
 #define M_BITMASK (1ULL << 12)
+#define Q_GROUPID 0
+#define Q_BITMASK (1ULL << 16)
 #define V_GROUPID 0
 #define V_BITMASK (1ULL << 21)
 #define ZACAS_GROUPID 0


### PR DESCRIPTION
Follow-up of #143436 and https://github.com/riscv-non-isa/riscv-c-api-doc/pull/107.

The corresponding bitmask in `RISCVFeatures.td` has already been updated in #139369.