### PR TITLE
[mlir][arith][NFC] Remove redundant trait declaration

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -1688,8 +1688,7 @@ def SelectOp : Arith_Op<"select", [Pure,
     AllTypesMatch<["true_value", "false_value", "result"]>,
     BooleanConditionOrMatchingShape<"condition", "result">,
     DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRangesFromOptional"]>,
-    DeclareOpInterfaceMethods<SelectLikeOpInterface>,
-  ] # ElementwiseMappable.traits> {
+    DeclareOpInterfaceMethods<SelectLikeOpInterface>]> {
   let summary = "select operation";
   let description = [{
     The `arith.select` operation chooses one value based on a binary condition


### PR DESCRIPTION
`Arith_Op` already declares the `ElementwiseMappable` traits, so they don't have to be declared for `arith.select`.
