### PR TITLE
[AVR] Fix incorrect selection of post indexed addresses

### DIFF
--- a/llvm/lib/Target/AVR/AVRISelLowering.cpp
+++ b/llvm/lib/Target/AVR/AVRISelLowering.cpp
@@ -1114,8 +1114,8 @@ bool AVRTargetLowering::getPostIndexedAddressParts(SDNode *N, SDNode *Op,
       if (AVR::isProgramMemoryAccess(LD))
         return false;
 
-    // FIXME: We temporarily apply a test which prevents generating incorrect code
-    // (see https://github.com/llvm/llvm-project/issues/143247 )
+    // FIXME: We temporarily apply a test which prevents generating incorrect
+    // code (see https://github.com/llvm/llvm-project/issues/143247 )
     // until we determined and fixed the root cause.
     if (Op->getOperand(0)->hasOneUse())
       return false;

--- a/llvm/lib/Target/AVR/AVRISelLowering.cpp
+++ b/llvm/lib/Target/AVR/AVRISelLowering.cpp
@@ -1114,14 +1114,22 @@ bool AVRTargetLowering::getPostIndexedAddressParts(SDNode *N, SDNode *Op,
       if (AVR::isProgramMemoryAccess(LD))
         return false;
 
-    // FIXME: We temporarily apply a test which prevents generating incorrect
-    // code (see https://github.com/llvm/llvm-project/issues/143247 )
-    // until we determined and fixed the root cause.
-    if (Op->getOperand(0)->hasOneUse())
+    SDValue Ptr;
+    if (LoadSDNode *LD = dyn_cast<LoadSDNode>(N)) {
+      Ptr = LD->getBasePtr();
+    } else if (StoreSDNode *ST = dyn_cast<StoreSDNode>(N)) {
+      Ptr = ST->getBasePtr();
+    } else
       return false;
 
     Base = Op->getOperand(0);
     Offset = DAG.getConstant(RHSC, DL, MVT::i8);
+
+    // Post-indexing updates the base, so it's not a valid transform
+    // if that's not the same as the load's pointer.
+    if (Ptr != Base)
+      return false;
+
     AM = ISD::POST_INC;
 
     return true;

--- a/llvm/lib/Target/AVR/AVRISelLowering.cpp
+++ b/llvm/lib/Target/AVR/AVRISelLowering.cpp
@@ -1114,6 +1114,12 @@ bool AVRTargetLowering::getPostIndexedAddressParts(SDNode *N, SDNode *Op,
       if (AVR::isProgramMemoryAccess(LD))
         return false;
 
+    // FIXME: We temporarily apply a test which prevents generating incorrect code
+    // (see https://github.com/llvm/llvm-project/issues/143247 )
+    // until we determined and fixed the root cause.
+    if (Op->getOperand(0)->hasOneUse())
+      return false;
+
     Base = Op->getOperand(0);
     Offset = DAG.getConstant(RHSC, DL, MVT::i8);
     AM = ISD::POST_INC;

--- a/llvm/test/CodeGen/AVR/issue-145040.ll
+++ b/llvm/test/CodeGen/AVR/issue-145040.ll
@@ -1,0 +1,23 @@
+; RUN: llc < %s -O=2 -mtriple=avr-none --mcpu=avr128db28 -verify-machineinstrs | FileCheck %s
+
+declare dso_local void @nil(i16 noundef) local_unnamed_addr addrspace(1) #1
+!3 = !{!4, !4, i64 0}
+!4 = !{!"omnipotent char", !5, i64 0}
+!5 = !{!"Simple C/C++ TBAA"}
+
+define void @complex_sbi() {
+; CHECK: sbi 1, 7
+entry:
+  br label %while.cond
+while.cond:                                       ; preds = %while.cond, %entry
+  %s.0 = phi i16 [ 0, %entry ], [ %inc, %while.cond ]
+  %inc = add nuw nsw i16 %s.0, 1
+  %0 = load volatile i8, ptr inttoptr (i16 1 to ptr), align 1, !tbaa !3
+  %or = or i8 %0, -128
+  store volatile i8 %or, ptr inttoptr (i16 1 to ptr), align 1, !tbaa !3
+  %and = and i16 %inc, 15
+  %add = add nuw nsw i16 %and, 1
+  tail call addrspace(1) void @nil(i16 noundef %add) #2
+  br label %while.cond
+}
+


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/143247

For testing this PR I used the following code:

```
#if 1
#define PA      0x1 // Bad
#else
#define PA      0x2 // Good
#endif

volatile char *const PORT = (char *const) PA;

extern void nil(short);

void bug()
{
  short s= 0;
 
  while (1) {
    s++;
    *PORT = *PORT | 0x80;
    nil((s & 0xF) + PA);
  }
}

unsigned
demo_post (unsigned short value, unsigned short *buffer, unsigned short *bufend)
{
  unsigned short *tmp;

  for (tmp = buffer; tmp < bufend; tmp++)
    value -= *tmp;

  return value;
}

const char *
demo_2 (const char *in, char *out)
{
  while (1)
    {
      if (*in == 'a')
        {
          const char *p = in + 1;
          while (*p == 'x')
            ++p;
          if (*p == 'b')
            return p;
          while (in < p)
            *out++ = *in++;
        }
    }
}
```

It contains the code which triggers the original bug and two demo functions which still emit post/pre-index code triggered by `getPostIndexedAddressParts`.

When comparing the generated assembly the only difference is in the generated code for `bug()`

```
16,17c16,17
<       ldi     r24, 0
<       ldi     r25, 0
---
>       ldi     r26, 0
>       ldi     r27, 0
20,25c20,26
<       sbi     1, 7
<       adiw    r24, 1
<       movw    r16, r24
<       andi    r24, 15
<       andi    r25, 0
<       adiw    r24, 1
---
>       ld      r24, X+
>       ori     r24, -128
>       movw    r16, r26
>       andi    r26, 15
>       andi    r27, 0
>       st      X+, r24
>       movw    r24, r26
27c28
<       movw    r24, r16
---
>       movw    r26, r16
```

For future reference, I examined tests from the gcc torture collection, and determined that only the few following tests (from 1930 tests) generate pre/post index code:

```
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/20000412-6.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/20011126-2.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/980205.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/990524-1.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/pr20601-1.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/pr38051.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/pr44852.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/pr44942.c
#$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/pr67037.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/stdarg-2.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/stdarg-3.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/va-arg-22.c
$C -O2 -target avr-none $M -S gcc/gcc/testsuite/gcc.c-torture/execute/va-arg-26.c
```

The commented out test crashes clang, as do many others.

So for some reason, the AVR pre/post index only is generated in a few cases, less then I would expect, but that is not related to this PR.

The reason why this PR is effective for the specific `bug()` code generation is not clear to me.

The fix can be suboptimal, but it only removes a certain case of optimization which is incorrect for the `bug()` code, so there is minimal danger of a regression. I would really appreciate any feedback from experienced LLVM contributors about the root cause or alternative ways to handle the issue.

