### PR TITLE
[clang] Avoid printing overly large integer/_BitInt numbers in static assertion failure diagnostics #71675

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -647,8 +647,8 @@ Improvements to Clang's diagnostics
   #GH69470, #GH59391, #GH58172, #GH46215, #GH45915, #GH45891, #GH44490,
   #GH36703, #GH32903, #GH23312, #GH69874.
 
-- Improved the performance of static assertions envolving large integers by
-  using hex format instead of string.
+- Improved the performance of static assertions involving large integers by
+  using hex format instead of string for particularly large values.
 
   Fixes #GH71675
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -647,7 +647,11 @@ Improvements to Clang's diagnostics
   #GH69470, #GH59391, #GH58172, #GH46215, #GH45915, #GH45891, #GH44490,
   #GH36703, #GH32903, #GH23312, #GH69874.
 
-  
+- Improved the performance of static assertions envolving large integers by
+  using hex format instead of string.
+
+  Fixes #GH71675
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -47,6 +47,7 @@
 #include "clang/Sema/SemaOpenMP.h"
 #include "clang/Sema/Template.h"
 #include "clang/Sema/TemplateDeduction.h"
+#include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
@@ -17575,7 +17576,21 @@ static bool ConvertAPValueToString(const APValue &V, QualType T,
           break;
         }
       }
-      V.getInt().toString(Str);
+
+      llvm::APSInt vInt = V.getInt();
+      if (llvm::APSInt::compareValues(
+              vInt, llvm::APSInt::getUnsigned(
+                        std::numeric_limits<uint64_t>::max())) >= 0 ||
+          vInt < std::numeric_limits<int64_t>::min()) {
+        // The value of cutSize is not special, it is just a number of
+        // characters that gives us enough info without losing readability.
+        const int cutSize = 20;
+        vInt.toString(Str, 16);
+        Str.erase(Str.begin() + cutSize, Str.end() - cutSize);
+        Str.insert(Str.begin() + cutSize, 3, '.');
+      } else {
+        vInt.toString(Str);
+      }
     }
 
     break;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -17577,20 +17577,7 @@ static bool ConvertAPValueToString(const APValue &V, QualType T,
         }
       }
 
-      llvm::APSInt vInt = V.getInt();
-      if (llvm::APSInt::compareValues(
-              vInt, llvm::APSInt::getUnsigned(
-                        std::numeric_limits<uint64_t>::max())) >= 0 ||
-          vInt < std::numeric_limits<int64_t>::min()) {
-        // The value of cutSize is not special, it is just a number of
-        // characters that gives us enough info without losing readability.
-        const int cutSize = 20;
-        vInt.toString(Str, 16);
-        Str.erase(Str.begin() + cutSize, Str.end() - cutSize);
-        Str.insert(Str.begin() + cutSize, 3, '.');
-      } else {
-        vInt.toString(Str);
-      }
+      V.getInt().toStringTruncated(Str);
     }
 
     break;

--- a/clang/test/AST/ByteCode/intap.cpp
+++ b/clang/test/AST/ByteCode/intap.cpp
@@ -87,12 +87,12 @@ typedef unsigned __int128 uint128_t;
 static const __uint128_t UINT128_MAX =__uint128_t(__int128_t(-1L));
 static_assert(UINT128_MAX == -1, "");
 static_assert(UINT128_MAX == 1, ""); // both-error {{static assertion failed}} \
-                                     // both-note {{'340282366920938463463374607431768211455 == 1'}}
+                                     // both-note {{'FFFFFFFFFFFFFFFFFFFF...FFFFFFFFFFFFFFFFFFFF == 1'}}
 
 static const __int128_t INT128_MAX = UINT128_MAX >> (__int128_t)1;
 static_assert(INT128_MAX != 0, "");
 static_assert(INT128_MAX == 0, ""); // both-error {{failed}} \
-                                    // both-note {{evaluates to '170141183460469231731687303715884105727 == 0'}}
+                                    // both-note {{evaluates to '7FFFFFFFFFFFFFFFFFFF...FFFFFFFFFFFFFFFFFFFF == 0'}}
 static const __int128_t INT128_MIN = -INT128_MAX - 1;
 
 
@@ -113,14 +113,14 @@ namespace i128 {
   static const __uint128_t UINT128_MAX =__uint128_t(__int128_t(-1L));
   static_assert(UINT128_MAX == -1, "");
   static_assert(UINT128_MAX == 1, ""); // both-error {{static assertion failed}} \
-                                       // both-note {{'340282366920938463463374607431768211455 == 1'}}
+                                       // both-note {{'FFFFFFFFFFFFFFFFFFFF...FFFFFFFFFFFFFFFFFFFF == 1'}}
 
   constexpr uint128_t TooMuch = UINT128_MAX * 2;
 
   static const __int128_t INT128_MAX = UINT128_MAX >> (__int128_t)1;
   static_assert(INT128_MAX != 0, "");
   static_assert(INT128_MAX == 0, ""); // both-error {{failed}} \
-                                      // both-note {{evaluates to '170141183460469231731687303715884105727 == 0'}}
+                                      // both-note {{evaluates to '7FFFFFFFFFFFFFFFFFFF...FFFFFFFFFFFFFFFFFFFF == 0'}}
 
   constexpr int128_t TooMuch2 = INT128_MAX * INT128_MAX; // both-error {{must be initialized by a constant expression}} \
                                                          // both-note {{value 28948022309329048855892746252171976962977213799489202546401021394546514198529 is outside the range of representable}}

--- a/clang/test/Sema/enum.c
+++ b/clang/test/Sema/enum.c
@@ -196,7 +196,7 @@ enum GH59352 { // expected-warning {{enumeration values exceed range of largest 
  BigVal = 66666666666666666666wb
 };
 _Static_assert(BigVal == 66666666666666666666wb); /* expected-error {{static assertion failed due to requirement 'BigVal == 66666666666666666666wb'}}
-                                                     expected-note {{expression evaluates to '11326434445538011818 == 66666666666666666666'}}
+                                                     expected-note {{expression evaluates to '11326434445538011818 == 39D2F941E420AAAAA<U+0000><U+0000><U+0000>...<U+0000><U+0000><U+0000>39D2F941E420AAAAA'}}
                                                    */
 _Static_assert(
     _Generic(BigVal,                             // expected-error {{static assertion failed}}

--- a/clang/test/Sema/enum.c
+++ b/clang/test/Sema/enum.c
@@ -196,7 +196,7 @@ enum GH59352 { // expected-warning {{enumeration values exceed range of largest 
  BigVal = 66666666666666666666wb
 };
 _Static_assert(BigVal == 66666666666666666666wb); /* expected-error {{static assertion failed due to requirement 'BigVal == 66666666666666666666wb'}}
-                                                     expected-note {{expression evaluates to '11326434445538011818 == 39D2F941E420AAAAA<U+0000><U+0000><U+0000>...<U+0000><U+0000><U+0000>39D2F941E420AAAAA'}}
+                                                     expected-note {{expression evaluates to '11326434445538011818 == 66666666666666666666'}}
                                                    */
 _Static_assert(
     _Generic(BigVal,                             // expected-error {{static assertion failed}}

--- a/clang/test/SemaCXX/static-assert.cpp
+++ b/clang/test/SemaCXX/static-assert.cpp
@@ -255,6 +255,12 @@ int f() {
 }
 }
 
+namespace GH71675 {
+constexpr unsigned _BitInt(__BITINT_MAXWIDTH__ >> 6) F = ~0; // expected-warning {{Clang extension}}
+static_assert(F == 1,""); // expected-error {{static assertion failed due to requirement 'F == 1'}} \
+                          // expected-note {{expression evaluates to 'FFFFFFFFFFFFFFFFFFFF...FFFFFFFFFFFFFFFFFFFF == 1'}}
+} // namespace GH71675
+
 namespace Diagnostics {
   /// No notes for literals.
   static_assert(false, ""); // expected-error {{failed}}

--- a/clang/test/SemaCXX/static-assert.cpp
+++ b/clang/test/SemaCXX/static-assert.cpp
@@ -258,7 +258,11 @@ int f() {
 namespace GH71675 {
 constexpr unsigned _BitInt(__BITINT_MAXWIDTH__ >> 6) F = ~0; // expected-warning {{Clang extension}}
 static_assert(F == 1,""); // expected-error {{static assertion failed due to requirement 'F == 1'}} \
-                          // expected-note {{expression evaluates to 'FFFFFFFFFFFFFFFFFFFF...FFFFFFFFFFFFFFFFFFFF == 1'}}
+                          // expected-note {{expression evaluates to '40141321820360630391...65812318570934173695 == 1'}}
+
+constexpr unsigned _BitInt(__BITINT_MAXWIDTH__) G = ~0; // expected-warning {{Clang extension}}
+static_assert(G == 1,""); // expected-error {{static assertion failed due to requirement 'G == 1'}} \
+                          // expected-note {{expression evaluates to '...85551374411818336255 == 1'}}
 } // namespace GH71675
 
 namespace Diagnostics {

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1686,6 +1686,17 @@ public:
                          bool UpperCase = true,
                          bool InsertSeparators = false) const;
 
+  /// Converts an APInt to a string and append it to Str.  Str is commonly a
+  /// SmallString. If Radix > 10, UpperCase determine the case of letter
+  /// digits.
+  /// Very large numbers ar truncated and only the first and last 20 digits will
+  /// be added with an elipsis separating them.
+  LLVM_ABI void toStringTruncated(SmallVectorImpl<char> &Str, unsigned Radix,
+                                  bool Signed, bool truncate = true,
+                                  bool formatAsCLiteral = false,
+                                  bool UpperCase = true,
+                                  bool InsertSeparators = false) const;
+
   /// Considers the APInt to be unsigned and converts it into a string in the
   /// radix given. The radix can be 2, 8, 10 16, or 36.
   void toStringUnsigned(SmallVectorImpl<char> &Str, unsigned Radix = 10) const {

--- a/llvm/include/llvm/ADT/APSInt.h
+++ b/llvm/include/llvm/ADT/APSInt.h
@@ -86,6 +86,12 @@ public:
   }
   using APInt::toString;
 
+  void toStringTruncated(SmallVectorImpl<char> &Str,
+                         unsigned Radix = 10) const {
+    APInt::toStringTruncated(Str, Radix, isSigned());
+  }
+  using APInt::toStringTruncated;
+
   /// If this int is representable using an int64_t.
   bool isRepresentableByInt64() const {
     // For unsigned values with 64 active bits, they technically fit into a


### PR DESCRIPTION
Resolves #71675

Performance comparison between origin code and patched code compiling on a RHEL9.6VM with 8cores and 16GB RAM
compiling sample program
```
#include "stdio.h"
#include "fenv.h"

namespace test {
    constexpr unsigned _BitInt(__BITINT_MAXWIDTH__ >> 6) F = ~0;
    static_assert(F == 1);
}
```
using
`./llvm-project/build/bin/clang++ ut71675.cpp -o ut71675`

**Original code**
user avg over 10 runs - 1.6748
sys avg over 10 runs - 0.0299


**Patched code**
user avg over 10 runs - 0.2149
sys avg over 10 runs - 0.0198