### PR TITLE
[CIR] Add bitfield offset calculation for big-endian targets

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -150,7 +150,6 @@ struct MissingFeatures {
   static bool cxxabiAppleARM64CXXABI() { return false; }
   static bool cxxabiStructorImplicitParam() { return false; }
   static bool isDiscreteBitFieldABI() { return false; }
-  static bool isBigEndian() { return false; }
 
   // Address class
   static bool addressOffset() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -228,7 +228,8 @@ void CIRRecordLowering::setBitFieldInfo(const FieldDecl *fd,
   // out as packed bits within an integer-sized unit, we can imagine the bits
   // counting from the most-significant-bit instead of the
   // least-significant-bit.
-  assert(!cir::MissingFeatures::isBigEndian());
+  if (dataLayout.isBigEndian())
+    info.offset = info.storageSize - (info.offset + info.size);
 
   info.volatileStorageSize = 0;
   info.volatileOffset = 0;

--- a/clang/test/CIR/CodeGen/bitfields_be.c
+++ b/clang/test/CIR/CodeGen/bitfields_be.c
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1  -triple aarch64_be-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1  -triple aarch64_be-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1  -triple aarch64_be-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+typedef struct {
+    int a : 4;
+    int b : 11;
+    int c : 17;
+} S;
+S s;
+
+// CIR:  !rec_S = !cir.record<struct "S" {!u32i}>
+// LLVM: %struct.S = type { i32 }
+// OGCG: %struct.S = type { i32 }


### PR DESCRIPTION
This PR updates the bitfield offset calculation to correctly handle big-endian architectures.