### PR TITLE
rtsan: Support free_sized and free_aligned_sized from C23

### DIFF
--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -63,6 +63,14 @@
 #define MAYBE_APPEND_64(func) func
 #endif
 
+#if SANITIZER_INTERCEPT_FREE_SIZED
+extern "C" void free_sized(void *ptr, size_t size);
+#endif
+
+#if SANITIZER_INTERCEPT_FREE_ALIGNED_SIZED
+extern "C" void free_aligned_sized(void *ptr, size_t alignment, size_t size);
+#endif
+
 using namespace testing;
 using namespace rtsan_testing;
 using namespace std::chrono_literals;
@@ -148,7 +156,6 @@ TEST(TestRtsanInterceptors, AlignedAllocDiesWhenRealtime) {
   }
 }
 
-// free_sized and free_aligned_sized (both C23) are not yet supported
 TEST(TestRtsanInterceptors, FreeDiesWhenRealtime) {
   void *ptr_1 = malloc(1);
   void *ptr_2 = malloc(1);
@@ -160,10 +167,54 @@ TEST(TestRtsanInterceptors, FreeDiesWhenRealtime) {
   ASSERT_NE(nullptr, ptr_2);
 }
 
+#if SANITIZER_INTERCEPT_FREE_SIZED
+TEST(TestRtsanInterceptors, FreeSizedDiesWhenRealtime) {
+  void *ptr_1 = malloc(1);
+  void *ptr_2 = malloc(1);
+  ExpectRealtimeDeath([ptr_1]() { free_sized(ptr_1, 1); }, "free_sized");
+  ExpectNonRealtimeSurvival([ptr_2]() { free_sized(ptr_2, 1); });
+
+  // Prevent malloc/free pair being optimised out
+  ASSERT_NE(nullptr, ptr_1);
+  ASSERT_NE(nullptr, ptr_2);
+}
+#endif
+
+#if SANITIZER_INTERCEPT_FREE_ALIGNED_SIZED
+TEST(TestRtsanInterceptors, FreeAlignedSizedDiesWhenRealtime) {
+  if (ALIGNED_ALLOC_AVAILABLE()) {
+    void *ptr_1 = aligned_alloc(16, 32);
+    void *ptr_2 = aligned_alloc(16, 32);
+    ExpectRealtimeDeath([ptr_1]() { free_aligned_sized(ptr_1, 16, 32); },
+                        "free_aligned_sized");
+    ExpectNonRealtimeSurvival([ptr_2]() { free_aligned_sized(ptr_2, 16, 32); });
+
+    // Prevent malloc/free pair being optimised out
+    ASSERT_NE(nullptr, ptr_1);
+    ASSERT_NE(nullptr, ptr_2);
+  }
+}
+#endif
+
 TEST(TestRtsanInterceptors, FreeSurvivesWhenRealtimeIfArgumentIsNull) {
   RealtimeInvoke([]() { free(NULL); });
   ExpectNonRealtimeSurvival([]() { free(NULL); });
 }
+
+#if SANITIZER_INTERCEPT_FREE_SIZED
+TEST(TestRtsanInterceptors, FreeSizedSurvivesWhenRealtimeIfArgumentIsNull) {
+  RealtimeInvoke([]() { free_sized(NULL, 0); });
+  ExpectNonRealtimeSurvival([]() { free_sized(NULL, 0); });
+}
+#endif
+
+#if SANITIZER_INTERCEPT_FREE_ALIGNED_SIZED
+TEST(TestRtsanInterceptors,
+     FreeAlignedSizedSurvivesWhenRealtimeIfArgumentIsNull) {
+  RealtimeInvoke([]() { free_aligned_sized(NULL, 0, 0); });
+  ExpectNonRealtimeSurvival([]() { free_aligned_sized(NULL, 0, 0); });
+}
+#endif
 
 TEST(TestRtsanInterceptors, PosixMemalignDiesWhenRealtime) {
   auto Func = []() {

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/free_aligned_sized.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/free_aligned_sized.c
@@ -1,8 +1,10 @@
 // RUN: %clang -std=c23 -O0 %s -o %t && %run %t
-// UNSUPPORTED: asan, hwasan, rtsan, ubsan
+// UNSUPPORTED: asan, hwasan, ubsan
 
 #include <stddef.h>
 #include <stdlib.h>
+
+extern void *aligned_alloc(size_t alignment, size_t size);
 
 extern void free_aligned_sized(void *p, size_t alignment, size_t size);
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/free_sized.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/free_sized.c
@@ -1,10 +1,8 @@
 // RUN: %clang -std=c23 -O0 %s -o %t && %run %t
-// UNSUPPORTED: asan, hwasan, rtsan, ubsan
+// UNSUPPORTED: asan, hwasan, ubsan
 
 #include <stddef.h>
 #include <stdlib.h>
-
-extern void *aligned_alloc(size_t alignment, size_t size);
 
 extern void free_sized(void *p, size_t size);
 


### PR DESCRIPTION
Adds support to RTSan for `free_sized` and `free_aligned_sized` from C23.

Other sanitizers will be handled with their own separate PRs.

For https://github.com/llvm/llvm-project/issues/144435