### PR TITLE
[compiler-rt][sanitizer] Add Windows MIPS32 support

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_win.cpp
@@ -49,6 +49,8 @@ struct SuspendedThreadsListWindows final : public SuspendedThreadsList {
 #    define SP_REG Esp
 #  elif SANITIZER_ARM | SANITIZER_ARM64
 #    define SP_REG Sp
+#  elif SANITIZER_MIPS32
+#    define SP_REG IntSp
 #  else
 #    error Architecture not supported!
 #  endif

--- a/compiler-rt/lib/sanitizer_common/sanitizer_unwind_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_unwind_win.cpp
@@ -75,6 +75,11 @@ void BufferedStackTrace::UnwindSlow(uptr pc, void *context, u32 max_depth) {
   stack_frame.AddrPC.Offset = ctx.Pc;
   stack_frame.AddrFrame.Offset = ctx.R11;
   stack_frame.AddrStack.Offset = ctx.Sp;
+#      elif SANITIZER_MIPS32
+  int machine_type = IMAGE_FILE_MACHINE_R4000;
+  stack_frame.AddrPC.Offset = ctx.Fir;
+  stack_frame.AddrFrame.Offset = ctx.IntS8;
+  stack_frame.AddrStack.Offset = ctx.IntSp;
 #      else
   int machine_type = IMAGE_FILE_MACHINE_I386;
   stack_frame.AddrPC.Offset = ctx.Eip;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -1011,6 +1011,9 @@ void SignalContext::InitPcSpBp() {
 #    if SANITIZER_ARM
   bp = (uptr)context_record->R11;
   sp = (uptr)context_record->Sp;
+#    elif SANITIZER_MIPS32
+  bp = (uptr)context_record->IntS8;
+  sp = (uptr)context_record->IntSp;
 #    else
   bp = (uptr)context_record->Ebp;
   sp = (uptr)context_record->Esp;


### PR DESCRIPTION
As LLVM supports mipsel-windows-gnu and mipsel-windows-msvc triples, also support this configuration in compiler-rt