### PR TITLE
Reland "[lldb][target] Add progress report for wait-attaching to proc…

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3546,6 +3546,7 @@ llvm::Expected<TraceSP> Target::GetTraceOrCreate() {
 }
 
 Status Target::Attach(ProcessAttachInfo &attach_info, Stream *stream) {
+  Progress attach_progress("Waiting to attach to process");
   m_stats.SetLaunchOrAttachTime();
   auto state = eStateInvalid;
   auto process_sp = GetProcessSP();

--- a/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
@@ -16,6 +16,28 @@ class TestProgressReporting(TestBase):
             self.broadcaster, lldb.SBDebugger.eBroadcastBitProgress
         )
 
+    def test_wait_attach_progress_reporting(self):
+        """Test that progress reports for wait attaching work as intended."""
+        target = self.dbg.CreateTarget(None)
+
+        # The waiting to attach progress message will get emitted upon
+        # trying to attach, but it's not going to be the event picked
+        # up by checking with fetch_next_event, so go through all emitted
+        # progress events and check that the waiting to attach one was emitted at all.
+        target.AttachToProcessWithName(
+            self.listener,
+            "wait-attach-progress-report",
+            False,
+            lldb.SBError(),
+        )
+        event = lldb.SBEvent()
+        events = []
+        while self.listener.GetNextEventForBroadcaster(self.broadcaster, event):
+            progress_data = lldb.SBDebugger.GetProgressDataFromEvent(event)
+            message = progress_data.GetValueForKey("message").GetStringValue(100)
+            events.append(message)
+        self.assertTrue("Waiting to attach to process" in events)
+
     def test_dwarf_symbol_loading_progress_report(self):
         """Test that we are able to fetch dwarf symbol loading progress events"""
         self.build()


### PR DESCRIPTION
…ess" (#144810)

This relands commit e0933ab5ae4856c4aa188a5ea16716b3a8d0840b. The original commit was causing the test TestCreateAfterAttach.py to fail on ARM Ubuntu bots. It's possible that this could've been happening because the test for wait-attach progress reporting is waiting on a process named "a.out" which could be too generic as multiple other tests (when run in parallel on the bots) could also be using processes named "a.out". This commit changes the wait-attach progress report test to wait on a unique process name.

Original PR description:

This commit adds a progress report when wait-attaching to a process as well as a test for this.

Original PR link: https://github.com/llvm/llvm-project/pull/144768