### PR TITLE
[mlir][vector] Add build method for vector.to_elements

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -798,7 +798,7 @@ def Vector_ToElementsOp : Vector_Op<"to_elements", [
     This operation decomposes all the scalar elements from a vector. The
     decomposed scalar elements are returned in row-major order. The number of
     scalar results must match the number of elements in the input vector type.
-    All the result elements have the same result type, which must match the
+    All the result elements have the same type, which must match the
     element type of the input vector. Scalable vectors are not supported.
 
     Examples:
@@ -813,7 +813,7 @@ def Vector_ToElementsOp : Vector_Op<"to_elements", [
     // %0#0 = %v1[0]
     // %0#1 = %v1[1]
 
-    // Decompose a 2-D.
+    // Decompose a 2-D vector.
     %0:6 = vector.to_elements %v2 : vector<2x3xf32>
     // %0#0 = %v2[0, 0]
     // %0#1 = %v2[0, 1]
@@ -835,6 +835,13 @@ def Vector_ToElementsOp : Vector_Op<"to_elements", [
 
   let arguments = (ins AnyVectorOfAnyRank:$source);
   let results = (outs Variadic<AnyType>:$elements);
+
+
+  let builders = [
+    // Build method that infers the result types from `elements`.
+    OpBuilder<(ins "Value":$elements)>,
+  ];
+
   let assemblyFormat = "$source attr-dict `:` type($source)";
   let hasFolder = 1;
 }

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -2417,6 +2417,14 @@ LogicalResult ToElementsOp::fold(FoldAdaptor adaptor,
   return foldToElementsFromElements(*this, results);
 }
 
+void vector::ToElementsOp::build(OpBuilder &builder, OperationState &result, Value elements) {
+  auto vectorType = cast<VectorType>(elements.getType());
+  Type elementType = vectorType.getElementType();
+  int64_t nbElements = vectorType.getNumElements();
+  SmallVector<Type> scalarTypes(nbElements, elementType);
+  build(builder, result, scalarTypes, elements);
+}
+
 //===----------------------------------------------------------------------===//
 // FromElementsOp
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -2417,7 +2417,8 @@ LogicalResult ToElementsOp::fold(FoldAdaptor adaptor,
   return foldToElementsFromElements(*this, results);
 }
 
-void vector::ToElementsOp::build(OpBuilder &builder, OperationState &result, Value elements) {
+void vector::ToElementsOp::build(OpBuilder &builder, OperationState &result,
+                                 Value elements) {
   auto vectorType = cast<VectorType>(elements.getType());
   Type elementType = vectorType.getElementType();
   int64_t nbElements = vectorType.getNumElements();


### PR DESCRIPTION
The default builder (added in  7aecd7eca) requires result types: 

```
build(builder, result, result_types, elements);
```

but these types are uniquely defined by the input vector `elements`. This PR adds a builder to do this mechanical type inference. 

Testing: not obvious how to unit test this, I can wait until this PR can be stacked with something that can use it, if that's preferred 

