### PR TITLE
SROA generate a noundef instead of splatting a noundef int

### DIFF
--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -3221,12 +3221,16 @@ private:
       return V;
 
     Type *SplatIntTy = Type::getIntNTy(VTy->getContext(), Size * 8);
-    V = IRB.CreateMul(
-        IRB.CreateZExt(V, SplatIntTy, "zext"),
-        IRB.CreateUDiv(Constant::getAllOnesValue(SplatIntTy),
-                       IRB.CreateZExt(Constant::getAllOnesValue(V->getType()),
-                                      SplatIntTy)),
-        "isplat");
+    if (isa<UndefValue>(V)) {
+        V = UndefValue::get(VTy);
+    } else {
+        V = IRB.CreateMul(
+            IRB.CreateZExt(V, SplatIntTy, "zext"),
+            IRB.CreateUDiv(Constant::getAllOnesValue(SplatIntTy),
+                           IRB.CreateZExt(Constant::getAllOnesValue(V->getType()),
+                                          SplatIntTy)),
+            "isplat");
+    }
     return V;
   }
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/145121

This is just a fix for the SROA behavior, and I think that will also avoid what EarlyCSE is doing. Which is a bit unfortunate, because I'd like to be well-motivated to fix both passes.

Where should I add a test for this? I think I should add a regression test, but I don't understand how the tests are organized.