### PR TITLE
[BOLT] Synchronize BBHashMap and YamlBBs in BAT mode

### DIFF
--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -2279,12 +2279,11 @@ std::error_code DataAggregator::writeBATYAML(BinaryContext &BC,
       const BoltAddressTranslation::BBHashMapTy &BlockMap =
           BAT->getBBHashMap(FuncAddress);
       YamlBF.Blocks.resize(YamlBF.NumBasicBlocks);
+      for (size_t Idx = 0; Idx != YamlBF.NumBasicBlocks; ++Idx)
+        YamlBF.Blocks[Idx].Index = Idx;
 
-      for (auto &&[Entry, YamlBB] : llvm::zip(BlockMap, YamlBF.Blocks)) {
-        const auto &Block = Entry.second;
-        YamlBB.Hash = Block.Hash;
-        YamlBB.Index = Block.Index;
-      }
+      for (const auto &Block : llvm::make_second_range(BlockMap))
+        YamlBF.Blocks[Block.Index].Hash = Block.Hash;
 
       // Lookup containing basic block offset and index
       auto getBlock = [&BlockMap](uint32_t Offset) {


### PR DESCRIPTION
If some basic blocks are not present in BAT, blocks in BBHashMap and
YamlBF.Blocks may not come in the same order. Decouple the iteration
during initialization.

Test Plan: TBD
