### PR TITLE
[mlir] Migrate away from ArrayRef(std::nullopt) (NFC)

### DIFF
--- a/mlir/include/mlir/CAPI/Wrap.h
+++ b/mlir/include/mlir/CAPI/Wrap.h
@@ -44,7 +44,7 @@ static llvm::ArrayRef<CppTy> unwrapList(size_t size, CTy *first,
       "incompatible C and C++ types");
 
   if (size == 0)
-    return std::nullopt;
+    return {};
 
   assert(storage.empty() && "expected to populate storage");
   storage.reserve(size);

--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
@@ -360,12 +360,13 @@ def PDL_OperationOp : PDL_Op<"operation", [AttrSizedOperandSegments]> {
     (`->` `(` $typeValues^ `:` type($typeValues) `)`)? attr-dict
   }];
 
-  let builders = [
-    OpBuilder<(ins CArg<"std::optional<StringRef>", "std::nullopt">:$name,
-      CArg<"ValueRange", "std::nullopt">:$operandValues,
-      CArg<"ArrayRef<StringRef>", "std::nullopt">:$attrNames,
-      CArg<"ValueRange", "std::nullopt">:$attrValues,
-      CArg<"ValueRange", "std::nullopt">:$resultTypes), [{
+  let builders =
+      [OpBuilder<(ins CArg<"std::optional<StringRef>", "std::nullopt">:$name,
+                     CArg<"ValueRange", "{}">:$operandValues,
+                     CArg<"ArrayRef<StringRef>", "{}">:$attrNames,
+                     CArg<"ValueRange", "{}">:$attrValues,
+                     CArg<"ValueRange", "{}">:$resultTypes),
+                 [{
       auto nameAttr = name ? $_builder.getStringAttr(*name) : StringAttr();
       build($_builder, $_state, $_builder.getType<OperationType>(), nameAttr,
             operandValues, attrValues, $_builder.getStrArrayAttr(attrNames),

--- a/mlir/include/mlir/IR/BuiltinAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinAttributes.td
@@ -535,9 +535,8 @@ def Builtin_DictionaryAttr : Builtin_Attr<"Dictionary", "dictionary"> {
     ```
   }];
   let parameters = (ins ArrayRefParameter<"NamedAttribute", "">:$value);
-  let builders = [
-    AttrBuilder<(ins CArg<"ArrayRef<NamedAttribute>", "std::nullopt">:$value)>
-  ];
+  let builders = [AttrBuilder<(
+      ins CArg<"ArrayRef<NamedAttribute>", "{}">:$value)>];
   let extraClassDeclaration = [{
     using ValueType = ArrayRef<NamedAttribute>;
 

--- a/mlir/include/mlir/Support/StorageUniquer.h
+++ b/mlir/include/mlir/Support/StorageUniquer.h
@@ -97,7 +97,7 @@ public:
     template <typename T>
     ArrayRef<T> copyInto(ArrayRef<T> elements) {
       if (elements.empty())
-        return std::nullopt;
+        return {};
       auto result = allocator.Allocate<T>(elements.size());
       llvm::uninitialized_copy(elements, result);
       return ArrayRef<T>(result, elements.size());

--- a/mlir/lib/Interfaces/FunctionInterfaces.cpp
+++ b/mlir/lib/Interfaces/FunctionInterfaces.cpp
@@ -44,14 +44,14 @@ function_interface_impl::getResultAttrDict(FunctionOpInterface op,
 ArrayRef<NamedAttribute>
 function_interface_impl::getArgAttrs(FunctionOpInterface op, unsigned index) {
   auto argDict = getArgAttrDict(op, index);
-  return argDict ? argDict.getValue() : std::nullopt;
+  return argDict ? argDict.getValue() : ArrayRef<NamedAttribute>();
 }
 
 ArrayRef<NamedAttribute>
 function_interface_impl::getResultAttrs(FunctionOpInterface op,
                                         unsigned index) {
   auto resultDict = getResultAttrDict(op, index);
-  return resultDict ? resultDict.getValue() : std::nullopt;
+  return resultDict ? resultDict.getValue() : ArrayRef<NamedAttribute>();
 }
 
 /// Get either the argument or result attributes array.

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -2883,8 +2883,9 @@ Parser::validateOperationOperands(SMRange loc, std::optional<StringRef> name,
                                   SmallVectorImpl<ast::Expr *> &operands) {
   return validateOperationOperandsOrResults(
       "operand", loc, odsOp ? odsOp->getLoc() : std::optional<SMRange>(), name,
-      operands, odsOp ? odsOp->getOperands() : std::nullopt, valueTy,
-      valueRangeTy);
+      operands,
+      odsOp ? odsOp->getOperands() : ArrayRef<pdll::ods::OperandOrResult>(),
+      valueTy, valueRangeTy);
 }
 
 LogicalResult
@@ -2893,7 +2894,9 @@ Parser::validateOperationResults(SMRange loc, std::optional<StringRef> name,
                                  SmallVectorImpl<ast::Expr *> &results) {
   return validateOperationOperandsOrResults(
       "result", loc, odsOp ? odsOp->getLoc() : std::optional<SMRange>(), name,
-      results, odsOp ? odsOp->getResults() : std::nullopt, typeTy, typeRangeTy);
+      results,
+      odsOp ? odsOp->getResults() : ArrayRef<pdll::ods::OperandOrResult>(),
+      typeTy, typeRangeTy);
 }
 
 void Parser::checkOperationResultTypeInferrence(SMRange loc, StringRef opName,

--- a/mlir/lib/Tools/mlir-pdll-lsp-server/PDLLServer.cpp
+++ b/mlir/lib/Tools/mlir-pdll-lsp-server/PDLLServer.cpp
@@ -1044,7 +1044,8 @@ public:
     const ods::Operation *odsOp =
         opName ? odsContext.lookupOperation(*opName) : nullptr;
     codeCompleteOperationOperandOrResultSignature(
-        opName, odsOp, odsOp ? odsOp->getOperands() : std::nullopt,
+        opName, odsOp,
+        odsOp ? odsOp->getOperands() : ArrayRef<ods::OperandOrResult>(),
         currentNumOperands, "operand", "Value");
   }
 
@@ -1053,7 +1054,8 @@ public:
     const ods::Operation *odsOp =
         opName ? odsContext.lookupOperation(*opName) : nullptr;
     codeCompleteOperationOperandOrResultSignature(
-        opName, odsOp, odsOp ? odsOp->getResults() : std::nullopt,
+        opName, odsOp,
+        odsOp ? odsOp->getResults() : ArrayRef<ods::OperandOrResult>(),
         currentNumResults, "result", "Type");
   }
 

--- a/mlir/test/lib/Dialect/Test/TestAttributes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestAttributes.cpp
@@ -194,7 +194,7 @@ void TestSubElementsAccessAttr::print(::mlir::AsmPrinter &printer) const {
 ArrayRef<uint64_t> TestExtern1DI64ElementsAttr::getElements() const {
   if (auto *blob = getHandle().getBlob())
     return blob->getDataAs<uint64_t>();
-  return std::nullopt;
+  return {};
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
ArrayRef has a constructor that accepts std::nullopt.  This
constructor dates back to the days when we still had llvm::Optional.

Since the use of std::nullopt outside the context of std::optional is
kind of abuse and not intuitive to new comers, I would like to move
away from the constructor and eventually remove it.

This patch takes care of the mlir side of the migration, starting with
straightforward places like "return std::nullopt;" and ternally
expressions involving std::nullopt.
