### PR TITLE
AMDGPU/MC: Try harder to evaluate absolute MC expressions

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
@@ -255,13 +255,9 @@ AMDGPUMCCodeEmitter::getLitEncoding(const MCOperand &MO,
                                     const MCSubtargetInfo &STI) const {
   int64_t Imm;
   if (MO.isExpr()) {
-    const auto *C = dyn_cast<MCConstantExpr>(MO.getExpr());
-    if (!C)
+    if (!MO.getExpr()->evaluateAsAbsolute(Imm))
       return 255;
-
-    Imm = C->getValue();
   } else {
-
     assert(!MO.isDFPImm());
 
     if (!MO.isImm())


### PR DESCRIPTION
This is a follow-up to commit 24c860547e8 ("AMDGPU/MC: Fix emitting absolute expressions (#136789)").

In some downstream work, we end up with an MCTargetExpr that is a maximum (AGVK_Max) in an instruction operand. getMachineOpValueCommon recognizes the absolute nature of the expression and doesn't emit a fixup. getLitEncoding needs to be aligned with this decision, else we end up with a 0 immediate without a corresponding fixup.

Note that evaluateAsAbsolute checks for MCConstantExpr as a fast path, so this accepts strictly more cases than before.

I've tried several ways to write a test for this without success. The challenge is that there is no upstream way to generate this kind of expression in an instruction operand natively, and trying to create one via inline assembly fails because the assembly parser evaluates the expression to a constant during parsing.