### PR TITLE
[PowerPC] Fix handling of undefs in the PPC::isSplatShuffleMask query

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -2242,7 +2242,7 @@ bool PPC::isSplatShuffleMask(ShuffleVectorSDNode *N, unsigned EltSize) {
       return false;
 
   for (unsigned i = EltSize, e = 16; i != e; i += EltSize) {
-    // An UNDEF element is a sequence of UNDEF bits.
+    // An UNDEF element is a sequence of UNDEF bytes.
     if (N->getMaskElt(i) < 0) {
       for (unsigned j = 1; j != EltSize; ++j)
         if (N->getMaskElt(i + j) >= 0)

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -2242,8 +2242,13 @@ bool PPC::isSplatShuffleMask(ShuffleVectorSDNode *N, unsigned EltSize) {
       return false;
 
   for (unsigned i = EltSize, e = 16; i != e; i += EltSize) {
-    if (N->getMaskElt(i) < 0) continue;
-    for (unsigned j = 0; j != EltSize; ++j)
+    // An UNDEF element is a sequence of UNDEF bits.
+    if (N->getMaskElt(i) < 0) {
+      for (unsigned j = 1; j != EltSize; ++j)
+        if (N->getMaskElt(i+j) >= 0)
+          return false;
+    }
+    else for (unsigned j = 0; j != EltSize; ++j)
       if (N->getMaskElt(i+j) != N->getMaskElt(j))
         return false;
   }

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -2245,12 +2245,12 @@ bool PPC::isSplatShuffleMask(ShuffleVectorSDNode *N, unsigned EltSize) {
     // An UNDEF element is a sequence of UNDEF bits.
     if (N->getMaskElt(i) < 0) {
       for (unsigned j = 1; j != EltSize; ++j)
-        if (N->getMaskElt(i+j) >= 0)
+        if (N->getMaskElt(i + j) >= 0)
           return false;
-    }
-    else for (unsigned j = 0; j != EltSize; ++j)
-      if (N->getMaskElt(i+j) != N->getMaskElt(j))
-        return false;
+    } else
+      for (unsigned j = 0; j != EltSize; ++j)
+        if (N->getMaskElt(i + j) != N->getMaskElt(j))
+          return false;
   }
   return true;
 }

--- a/llvm/test/CodeGen/PowerPC/pr141642.ll
+++ b/llvm/test/CodeGen/PowerPC/pr141642.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mcpu=pwr8 -mtriple=powerpc64le-unknown-linux-gnu -O0 -debug-only=selectiondag -o - < %s 2>&1 | \
+; RUN:  FileCheck %s
+; CHECK-NOT: lxvdsx
+; CHECK-NOT: LD_SPLAT
+
+define weak_odr dso_local void @unpack(ptr noalias noundef %packed_in) local_unnamed_addr {
+entry:
+  %ld = load <2 x i32>, ptr %packed_in, align 2
+  %shuf = shufflevector <2 x i32> %ld, <2 x i32> poison, <4 x i32> <i32 0, i32 1, i32 poison, i32 0>
+  %ie = insertelement <4 x i32> %shuf, i32 7, i32 2
+  store <4 x i32> %shuf, ptr %packed_in, align 2
+  ret void
+}


### PR DESCRIPTION
Currently, the query assumes that a single undef byte implies the rest of the `EltSize - 1` bytes are undefs, but that's not always true.
e.g. isSplatShuffleMask( <0,1,2,3,4,5,6,7,undef,undef,undef,undef,0,1,2,3>,   8) should return false.