### PR TITLE
[ORC] Apply MachO::CPU_SUBTYPE_MASK to comparison in getDylibInterfac…

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/GetDylibInterface.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/GetDylibInterface.cpp
@@ -41,7 +41,8 @@ Expected<SymbolNameSet> getDylibInterfaceFromDylib(ExecutionSession &ES,
   else if (auto *MachOUni =
                dyn_cast<object::MachOUniversalBinary>(BinFile->get())) {
     for (auto &O : MachOUni->objects()) {
-      if (O.getCPUType() == *CPUType && O.getCPUSubType() == *CPUSubType) {
+      if (O.getCPUType() == *CPUType &&
+          (O.getCPUSubType() & ~MachO::CPU_SUBTYPE_MASK) == *CPUSubType) {
         if (auto Obj = O.getAsObjectFile())
           MachOFile = std::move(*Obj);
         else

--- a/llvm/test/ExecutionEngine/JITLink/Generic/Inputs/MachO_Universal_libFoo_dylib.yaml
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/Inputs/MachO_Universal_libFoo_dylib.yaml
@@ -1,0 +1,350 @@
+--- !fat-mach-o
+
+# Contains two slices (arm64e and x86-64) for libfoo.dylib, each containing the
+# following:
+#
+# int foo(void) { return 0; }
+
+FatHeader:
+  magic:           0xCAFEBABE
+  nfat_arch:       2
+FatArchs:
+  - cputype:         0x1000007
+    cpusubtype:      0x3
+    offset:          0x1000
+    size:            4200
+    align:           12
+  - cputype:         0x100000C
+    cpusubtype:      0x80000002
+    offset:          0x4000
+    size:            16784
+    align:           14
+Slices:
+  - !mach-o
+    FileHeader:
+      magic:           0xFEEDFACF
+      cputype:         0x1000007
+      cpusubtype:      0x3
+      filetype:        0x6
+      ncmds:           13
+      sizeofcmds:      568
+      flags:           0x100085
+      reserved:        0x0
+    LoadCommands:
+      - cmd:             LC_SEGMENT_64
+        cmdsize:         152
+        segname:         __TEXT
+        vmaddr:          0
+        vmsize:          4096
+        fileoff:         0
+        filesize:        4096
+        maxprot:         5
+        initprot:        5
+        nsects:          1
+        flags:           0
+        Sections:
+          - sectname:        __text
+            segname:         __TEXT
+            addr:            0x2A0
+            size:            3
+            offset:          0x2A0
+            align:           4
+            reloff:          0x0
+            nreloc:          0
+            flags:           0x80000400
+            reserved1:       0x0
+            reserved2:       0x0
+            reserved3:       0x0
+            content:         31C0C3
+      - cmd:             LC_SEGMENT_64
+        cmdsize:         72
+        segname:         __LINKEDIT
+        vmaddr:          4096
+        vmsize:          4096
+        fileoff:         4096
+        filesize:        104
+        maxprot:         1
+        initprot:        1
+        nsects:          0
+        flags:           0
+      - cmd:             LC_ID_DYLIB
+        cmdsize:         48
+        dylib:
+          name:            24
+          timestamp:       1
+          current_version: 0
+          compatibility_version: 0
+        Content:         libfoo.x86-64.dylib
+        ZeroPadBytes:    5
+      - cmd:             LC_DYLD_CHAINED_FIXUPS
+        cmdsize:         16
+        dataoff:         4096
+        datasize:        48
+      - cmd:             LC_DYLD_EXPORTS_TRIE
+        cmdsize:         16
+        dataoff:         4144
+        datasize:        24
+      - cmd:             LC_SYMTAB
+        cmdsize:         24
+        symoff:          4176
+        nsyms:           1
+        stroff:          4192
+        strsize:         8
+      - cmd:             LC_DYSYMTAB
+        cmdsize:         80
+        ilocalsym:       0
+        nlocalsym:       0
+        iextdefsym:      0
+        nextdefsym:      1
+        iundefsym:       1
+        nundefsym:       0
+        tocoff:          0
+        ntoc:            0
+        modtaboff:       0
+        nmodtab:         0
+        extrefsymoff:    0
+        nextrefsyms:     0
+        indirectsymoff:  0
+        nindirectsyms:   0
+        extreloff:       0
+        nextrel:         0
+        locreloff:       0
+        nlocrel:         0
+      - cmd:             LC_UUID
+        cmdsize:         24
+        uuid:            A29E87C8-EF8B-3721-B0D3-9749DEBEEBBB
+      - cmd:             LC_BUILD_VERSION
+        cmdsize:         32
+        platform:        1
+        minos:           983040
+        sdk:             984320
+        ntools:          1
+        Tools:
+          - tool:            3
+            version:         76481792
+      - cmd:             LC_SOURCE_VERSION
+        cmdsize:         16
+        version:         0
+      - cmd:             LC_LOAD_DYLIB
+        cmdsize:         56
+        dylib:
+          name:            24
+          timestamp:       2
+          current_version: 88539136
+          compatibility_version: 65536
+        Content:         '/usr/lib/libSystem.B.dylib'
+        ZeroPadBytes:    6
+      - cmd:             LC_FUNCTION_STARTS
+        cmdsize:         16
+        dataoff:         4168
+        datasize:        8
+      - cmd:             LC_DATA_IN_CODE
+        cmdsize:         16
+        dataoff:         4176
+        datasize:        0
+    LinkEditData:
+      ExportTrie:
+        TerminalSize:    0
+        NodeOffset:      0
+        Name:            ''
+        Flags:           0x0
+        Address:         0x0
+        Other:           0x0
+        ImportName:      ''
+        Children:
+          - TerminalSize:    3
+            NodeOffset:      12
+            Name:            _foo
+            Flags:           0x0
+            Address:         0x2A0
+            Other:           0x0
+            ImportName:      ''
+      NameList:
+        - n_strx:          2
+          n_type:          0xF
+          n_sect:          1
+          n_desc:          0
+          n_value:         672
+      StringTable:
+        - ' '
+        - _foo
+        - ''
+      FunctionStarts:  [ 0x2A0 ]
+      ChainedFixups:   [ 0x0, 0x0, 0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x2C, 
+                         0x0, 0x0, 0x0, 0x2C, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                         0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                         0x0, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+  - !mach-o
+    FileHeader:
+      magic:           0xFEEDFACF
+      cputype:         0x100000C
+      cpusubtype:      0x80000002
+      filetype:        0x6
+      ncmds:           14
+      sizeofcmds:      664
+      flags:           0x100085
+      reserved:        0x0
+    LoadCommands:
+      - cmd:             LC_SEGMENT_64
+        cmdsize:         232
+        segname:         __TEXT
+        vmaddr:          0
+        vmsize:          16384
+        fileoff:         0
+        filesize:        16384
+        maxprot:         5
+        initprot:        5
+        nsects:          2
+        flags:           0
+        Sections:
+          - sectname:        __text
+            segname:         __TEXT
+            addr:            0x2D8
+            size:            8
+            offset:          0x2D8
+            align:           2
+            reloff:          0x0
+            nreloc:          0
+            flags:           0x80000400
+            reserved1:       0x0
+            reserved2:       0x0
+            reserved3:       0x0
+            content:         00008052C0035FD6
+          - sectname:        __unwind_info
+            segname:         __TEXT
+            addr:            0x2E0
+            size:            88
+            offset:          0x2E0
+            align:           2
+            reloff:          0x0
+            nreloc:          0
+            flags:           0x0
+            reserved1:       0x0
+            reserved2:       0x0
+            reserved3:       0x0
+            content:         010000001C000000000000001C000000000000001C00000002000000D80200004000000040000000E00200000000000040000000000000000000000000000000030000000C00010010000100000000000000000200000000
+      - cmd:             LC_SEGMENT_64
+        cmdsize:         72
+        segname:         __LINKEDIT
+        vmaddr:          16384
+        vmsize:          16384
+        fileoff:         16384
+        filesize:        400
+        maxprot:         1
+        initprot:        1
+        nsects:          0
+        flags:           0
+      - cmd:             LC_ID_DYLIB
+        cmdsize:         48
+        dylib:
+          name:            24
+          timestamp:       1
+          current_version: 0
+          compatibility_version: 0
+        Content:         libfoo.arm64e.dylib
+        ZeroPadBytes:    5
+      - cmd:             LC_DYLD_CHAINED_FIXUPS
+        cmdsize:         16
+        dataoff:         16384
+        datasize:        48
+      - cmd:             LC_DYLD_EXPORTS_TRIE
+        cmdsize:         16
+        dataoff:         16432
+        datasize:        24
+      - cmd:             LC_SYMTAB
+        cmdsize:         24
+        symoff:          16464
+        nsyms:           1
+        stroff:          16480
+        strsize:         8
+      - cmd:             LC_DYSYMTAB
+        cmdsize:         80
+        ilocalsym:       0
+        nlocalsym:       0
+        iextdefsym:      0
+        nextdefsym:      1
+        iundefsym:       1
+        nundefsym:       0
+        tocoff:          0
+        ntoc:            0
+        modtaboff:       0
+        nmodtab:         0
+        extrefsymoff:    0
+        nextrefsyms:     0
+        indirectsymoff:  0
+        nindirectsyms:   0
+        extreloff:       0
+        nextrel:         0
+        locreloff:       0
+        nlocrel:         0
+      - cmd:             LC_UUID
+        cmdsize:         24
+        uuid:            0220C592-2D73-3642-B893-B7DA8FCD396C
+      - cmd:             LC_BUILD_VERSION
+        cmdsize:         32
+        platform:        1
+        minos:           983040
+        sdk:             984320
+        ntools:          1
+        Tools:
+          - tool:            3
+            version:         76481792
+      - cmd:             LC_SOURCE_VERSION
+        cmdsize:         16
+        version:         0
+      - cmd:             LC_LOAD_DYLIB
+        cmdsize:         56
+        dylib:
+          name:            24
+          timestamp:       2
+          current_version: 88539136
+          compatibility_version: 65536
+        Content:         '/usr/lib/libSystem.B.dylib'
+        ZeroPadBytes:    6
+      - cmd:             LC_FUNCTION_STARTS
+        cmdsize:         16
+        dataoff:         16456
+        datasize:        8
+      - cmd:             LC_DATA_IN_CODE
+        cmdsize:         16
+        dataoff:         16464
+        datasize:        0
+      - cmd:             LC_CODE_SIGNATURE
+        cmdsize:         16
+        dataoff:         16496
+        datasize:        288
+    LinkEditData:
+      ExportTrie:
+        TerminalSize:    0
+        NodeOffset:      0
+        Name:            ''
+        Flags:           0x0
+        Address:         0x0
+        Other:           0x0
+        ImportName:      ''
+        Children:
+          - TerminalSize:    3
+            NodeOffset:      12
+            Name:            _foo
+            Flags:           0x0
+            Address:         0x2D8
+            Other:           0x0
+            ImportName:      ''
+      NameList:
+        - n_strx:          2
+          n_type:          0xF
+          n_sect:          1
+          n_desc:          0
+          n_value:         728
+      StringTable:
+        - ' '
+        - _foo
+        - ''
+      FunctionStarts:  [ 0x2D8 ]
+      ChainedFixups:   [ 0x0, 0x0, 0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x2C, 
+                         0x0, 0x0, 0x0, 0x2C, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                         0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                         0x0, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+...

--- a/llvm/test/ExecutionEngine/JITLink/Generic/MachO_universal_binaries_weak_library.ll
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/MachO_universal_binaries_weak_library.ll
@@ -1,0 +1,19 @@
+; RUN: rm -rf %t && mkdir %t
+; RUN: yaml2obj -o %t/libFoo.dylib %S/Inputs/MachO_Universal_libFoo_dylib.yaml
+; RUN: llc -filetype=obj -mtriple arm64e-apple-macosx -o %t/main.o %s
+; RUN: llvm-jitlink -noexec -triple arm64e-apple-macosx %t/main.o -weak_library \
+; RUN:     %t/libFoo.dylib
+;
+; REQUIRES: x86-registered-target && aarch64-registered-target
+;
+; Check MachO universal binary handling in the orc::getDylibInterfaceFromDylib
+; function, including that the cpusubtype field is masked correctly (for arm64e
+; slices this field will have the MachO::CPU_SUBTYPE_LIB64 flag set in the high
+; bits -- the subtype will fail to match unless it's masked out).
+
+declare i32 @foo()
+
+define i32 @main(i32 %argc, ptr %argv) {
+entry:
+  ret i32 ptrtoint (ptr @foo to i32)
+}


### PR DESCRIPTION
…eFromDylib.

When comparing CPU subtypes from slices in a MachO universal binary we need to apply the MachO::CPU_SUBTYPE_MASK to mask out any flags in the high bits, otherwise we might fail to correctly match a slice and return a spurious "does not contain slice" error.

rdar://153913779