### PR TITLE
[libc] Fix feature check for riscv

### DIFF
--- a/libc/src/__support/macros/properties/cpu_features.h
+++ b/libc/src/__support/macros/properties/cpu_features.h
@@ -61,15 +61,15 @@
 
 #if defined(__riscv_flen)
 // https://github.com/riscv-non-isa/riscv-c-api-doc/blob/main/src/c-api.adoc
-#if (__riscv_flen & 0x10)
+#if (__riscv_arch_test && __riscv_zfhmin)
 #define LIBC_TARGET_CPU_HAS_RISCV_FPU_HALF
 #define LIBC_TARGET_CPU_HAS_FPU_HALF
 #endif // LIBC_TARGET_CPU_HAS_RISCV_FPU_HALF
-#if (__riscv_flen & 0x20)
+#if (__riscv_flen >= 32)
 #define LIBC_TARGET_CPU_HAS_RISCV_FPU_FLOAT
 #define LIBC_TARGET_CPU_HAS_FPU_FLOAT
 #endif // LIBC_TARGET_CPU_HAS_RISCV_FPU_FLOAT
-#if (__riscv_flen & 0x40)
+#if (__riscv_flen >= 64)
 #define LIBC_TARGET_CPU_HAS_RISCV_FPU_DOUBLE
 #define LIBC_TARGET_CPU_HAS_FPU_DOUBLE
 #endif // LIBC_TARGET_CPU_HAS_RISCV_FPU_DOUBLE


### PR DESCRIPTION
This PR fixes the feature detection for RISC-V floating-point support in LLVM's libc implementation.

The `__riscv_flen` macro represents the floating-point register width in bits (32, 64, or 128). Since Extension D is specifically documented as implying F, we can use simple >= comparisons to detect them. 

For half-precision support, the implementation checks for the Zfhmin extension as RVA22 and RVA23 profiles only require Zfhmin rather than the full Zfh extension. Zfh also implies Zfhmin, so checking for Zfhmin should cover all cases.
