### PR TITLE
[LLDB] Warn about truncated DWARF section names on Windows

### DIFF
--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -1053,11 +1053,22 @@ void ObjectFilePECOFF::CreateSections(SectionList &unified_section_list) {
     m_sections_up->AddSection(header_sp);
     unified_section_list.AddSection(header_sp);
 
+    std::vector<llvm::StringRef> truncated_dwarf_sections;
     const uint32_t nsects = m_sect_headers.size();
     for (uint32_t idx = 0; idx < nsects; ++idx) {
       llvm::StringRef sect_name = GetSectionName(m_sect_headers[idx]);
       ConstString const_sect_name(sect_name);
       SectionType section_type = GetSectionType(sect_name, m_sect_headers[idx]);
+
+      // Detect unknown sections matching ".debug_*"
+      // In PECOFF files, the section name in the section header can only
+      // contain 8 bytes. If a section name doesn't fit there, it can be
+      // extended in the string table. Since, officially, executable images
+      // don't have a string table, the default link.exe truncates section names
+      // to fit in the section header.
+      if (section_type == eSectionTypeOther && sect_name.size() == 8 &&
+          sect_name.starts_with(".debug_"))
+        truncated_dwarf_sections.emplace_back(sect_name);
 
       SectionSP section_sp(new Section(
           module_sp,       // Module to which this section belongs
@@ -1088,6 +1099,16 @@ void ObjectFilePECOFF::CreateSections(SectionList &unified_section_list) {
       m_sections_up->AddSection(section_sp);
       unified_section_list.AddSection(section_sp);
     }
+
+    if (!truncated_dwarf_sections.empty())
+      module_sp->ReportWarning(
+          "contains {} DWARF sections with truncated names ({}).\nWindows "
+          "executable (PECOFF) images produced by the default link.exe don't "
+          "include the required section names. A third party linker like "
+          "lld-link is required (compile with -fuse-ld=lld-link when using "
+          "Clang)",
+          truncated_dwarf_sections.size(),
+          llvm::join(truncated_dwarf_sections, ", "));
   }
 }
 

--- a/lldb/test/Shell/ObjectFile/PECOFF/lit.local.cfg
+++ b/lldb/test/Shell/ObjectFile/PECOFF/lit.local.cfg
@@ -1,1 +1,1 @@
-config.suffixes = ['.yaml', '.test']
+config.suffixes = ['.yaml', '.test', '.c']

--- a/lldb/test/Shell/ObjectFile/PECOFF/truncated-dwarf.c
+++ b/lldb/test/Shell/ObjectFile/PECOFF/truncated-dwarf.c
@@ -1,0 +1,7 @@
+// REQUIRES: target-windows
+// RUN: %build --compiler=clang-cl --force-dwarf-symbols --force-ms-link -o %t.exe -- %s
+// RUN: %lldb -f %t.exe 2>&1 | FileCheck %s
+
+int main(void) {}
+
+// CHECK: warning: {{.*}} contains 4 DWARF sections with truncated names (.debug_{{[a-z]}}, .debug_{{[a-z]}}, .debug_{{[a-z]}}, .debug_{{[a-z]}})

--- a/lldb/test/Shell/helper/build.py
+++ b/lldb/test/Shell/helper/build.py
@@ -169,6 +169,22 @@ parser.add_argument(
     help="Specify the C/C++ standard.",
 )
 
+parser.add_argument(
+    "--force-dwarf-symbols",
+    dest="force_dwarf_symbols",
+    action="store_true",
+    default=False,
+    help="When compiling with clang-cl on Windows, use DWARF instead of CodeView",
+)
+
+parser.add_argument(
+    "--force-ms-link",
+    dest="force_ms_link",
+    action="store_true",
+    default=False,
+    help="When compiling with clang-cl on Windows, always use link.exe",
+)
+
 
 args = parser.parse_args(args=sys.argv[1:])
 
@@ -375,15 +391,20 @@ class MsvcBuilder(Builder):
                     )
 
         if self.mode == "link" or self.mode == "compile-and-link":
-            self.linker = (
-                self._find_linker("link")
-                if toolchain_type == "msvc"
-                else self._find_linker("lld-link", args.tools_dir)
-            )
+            if toolchain_type == "msvc" or args.force_ms_link:
+                search_paths = []
+                if toolchain_type != "msvc":
+                    search_paths.append(
+                        os.path.dirname(find_executable("cl", args.tools_dir))
+                    )
+                self.linker = self._find_linker("link", search_paths)
+            else:
+                self.linker = self._find_linker("lld-link", args.tools_dir)
             if not self.linker:
                 raise ValueError("Unable to find an appropriate linker.")
 
         self.compile_env, self.link_env = self._get_visual_studio_environment()
+        self.force_dwarf_symbols = args.force_dwarf_symbols
 
     def _find_linker(self, name, search_paths=[]):
         compiler_dir = os.path.dirname(self.compiler)
@@ -674,6 +695,8 @@ class MsvcBuilder(Builder):
             args.append("/GR-")
         args.append("/Z7")
         if self.toolchain_type == "clang-cl":
+            if self.force_dwarf_symbols:
+                args.append("-gdwarf")
             args.append("-Xclang")
             args.append("-fkeep-static-consts")
             args.append("-fms-compatibility-version=19")

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -417,6 +417,8 @@ Makes programs 10x faster by doing Special New Thing.
 * A new `diagnostics report` command (aliased `bugreport`) assembles a diagnostics bundle and files
   a pre-filled GitHub issue, pointing at the bundle to attach. The GitHub reporter is built by
   default and can be disabled with the `LLDB_ENABLE_GITHUB_BUG_REPORTER=OFF` CMake option.
+* LLDB now detects when the names of known DWARF sections in a PECOFF file have
+  been truncated by link.exe on Windows, and advises the user how to avoid this.
 
 #### Deprecated APIs
 


### PR DESCRIPTION
Linking executables with DWARF sections on Windows with the default link.exe will truncate the section names, as [section names in PE/COFF executable images can't be longer than 8 bytes officially](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers). There's no warning about this. When trying to debug these executables in LLDB, no debug info will be loaded, because LLDB won't find the required sections and it doesn't find CodeView debug info. There's no warning here, either (this PR adds one).

Other linkers like lld-link, however, support creating these sections and GDB/LLDB and Microsoft's dumpbin utility are able to pick them up.

I ran into this myself while playing around with LLDB:

- Compile some file with Clang and use DWARF: `clang-cl foo.c -gdwarf -o foo.exe`
- Open in LLDB `lldb foo.exe`
- Break at line 10: `b foo.c:10` ⚡ → "Unable to resolve breakpoint to any actual locations." (because no debug info is loaded)

The fix would be to pass `-fuse-ld=lld-link` to Clang.

---

This PR adds a warning when LLDB detects truncated DWARF sections (i.e. sections matching `.debug_*`):

```
warning: (x86_64) foo.exe contains 5 DWARF sections with truncated names (.debug_a, .debug_i, .debug_r, .debug_s, .debug_l).
Windows executable (PECOFF) images produced by the default link.exe can't include the required section names. A third party linker like lld-link is required (compile with -fuse-ld=lld-link when using Clang).
```

I included the additional note, because to get to this point, one would have to have used Clang on windows-msvc (on MinGW, the default linker doesn't truncate the names), so they should have lld-link available as well.