### PR TITLE
[flang] Don't warn on (0.,0.)**(nonzero noninteger)

### DIFF
--- a/flang/include/flang/Evaluate/complex.h
+++ b/flang/include/flang/Evaluate/complex.h
@@ -45,7 +45,7 @@ public:
         im_.Compare(that.im_) == Relation::Equal;
   }
 
-  constexpr bool IsZero() const { return re_.IsZero() || im_.IsZero(); }
+  constexpr bool IsZero() const { return re_.IsZero() && im_.IsZero(); }
 
   constexpr bool IsInfinite() const {
     return re_.IsInfinite() || im_.IsInfinite();

--- a/flang/lib/Evaluate/fold-implementation.h
+++ b/flang/lib/Evaluate/fold-implementation.h
@@ -2156,7 +2156,14 @@ Expr<T> FoldOperation(FoldingContext &context, Power<T> &&x) {
       }
       return Expr<T>{Constant<T>{power.power}};
     } else {
-      if (auto callable{GetHostRuntimeWrapper<T, T, T>("pow")}) {
+      if (folded->first.IsZero()) {
+        if (folded->second.IsZero()) {
+          context.messages().Say(common::UsageWarning::FoldingException,
+              "REAL/COMPLEX 0**0 is not defined"_warn_en_US);
+        } else {
+          return Expr<T>(Constant<T>{folded->first}); // 0. ** nonzero -> 0.
+        }
+      } else if (auto callable{GetHostRuntimeWrapper<T, T, T>("pow")}) {
         return Expr<T>{
             Constant<T>{(*callable)(context, folded->first, folded->second)}};
       } else if (context.languageFeatures().ShouldWarn(

--- a/flang/test/Semantics/bug1046.f90
+++ b/flang/test/Semantics/bug1046.f90
@@ -1,0 +1,17 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+!WARNING: INTEGER(4) 0**0 is not defined
+print *, 0**0
+!WARNING: REAL/COMPLEX 0**0 is not defined
+print *, 0**0.
+!WARNING: invalid argument on power with INTEGER exponent
+print *, 0.0**0
+!WARNING: REAL/COMPLEX 0**0 is not defined
+print *, 0.0**0.
+!WARNING: invalid argument on power with INTEGER exponent
+print *, (0.0, 0.0)**0
+!WARNING: REAL/COMPLEX 0**0 is not defined
+print *, (0.0, 0.0)**0.
+print *, (0.0, 0.0)**2.5
+end
+
+


### PR DESCRIPTION
Folding hands complex exponentiations with constant arguments off to the native libm, and on a least on host, this can produce spurious warnings about division by zero and invalid arguments.  Handle the case of a zero base specially to avoid that, and also emit better warnings for the undefined 0.**0 and (0.,0.)**0 cases. And add a test for these warnings and the existing related ones.