### PR TITLE
[RS4GC] Fix some test comments that got clobbered

### DIFF
--- a/llvm/test/Transforms/RewriteStatepointsForGC/base-vector.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/base-vector.ll
@@ -92,8 +92,6 @@ entry:
 }
 
 define ptr addrspace(1) @test4(ptr addrspace(1) %ptr) gc "statepoint-example" {
-; When we can optimize an extractelement from a known
-; index and avoid introducing new base pointer instructions
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[DERIVED:%.*]] = getelementptr i64, ptr addrspace(1) [[PTR:%.*]], i64 16
@@ -120,8 +118,9 @@ entry:
 declare void @use(ptr addrspace(1)) "gc-leaf-function"
 declare void @use_vec(<4 x ptr addrspace(1)>) "gc-leaf-function"
 
+; When we can optimize an extractelement from a known
+; index and avoid introducing new base pointer instructions
 define void @test5(i1 %cnd, ptr addrspace(1) %obj) gc "statepoint-example" {
-; When we fundementally have to duplicate
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr addrspace(1) [[OBJ:%.*]], i64 1
@@ -144,9 +143,8 @@ entry:
   ret void
 }
 
+; When we fundementally have to duplicate
 define void @test6(i1 %cnd, ptr addrspace(1) %obj, i64 %idx) gc "statepoint-example" {
-; A more complicated example involving vector and scalar bases.
-; This is derived from a failing test case when we didn't have correct
 ; insertelement handling.
 ; CHECK-LABEL: @test6(
 ; CHECK-NEXT:  entry:
@@ -170,6 +168,8 @@ entry:
   ret void
 }
 
+; A more complicated example involving vector and scalar bases.
+; This is derived from a failing test case when we didn't have correct
 define ptr addrspace(1) @test7(i1 %cnd, ptr addrspace(1) %obj, ptr addrspace(1) %obj2) gc "statepoint-example" {
 ; CHECK-LABEL: @test7(
 ; CHECK-NEXT:  entry:

--- a/llvm/test/Transforms/RewriteStatepointsForGC/codegen-cond.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/codegen-cond.ll
@@ -1,7 +1,6 @@
 ; RUN: opt -passes=rewrite-statepoints-for-gc -S < %s | FileCheck %s
 
 ; A null test of a single value
-
 define i1 @test(ptr addrspace(1) %p, i1 %rare) gc "statepoint-example" {
 ; CHECK-LABEL: @test
 entry:
@@ -19,7 +18,6 @@ continue:                                         ; preds = %safepoint, %entry
 ; CHECK-DAG: [ %p, %entry ]
 ; CHECK: %cond = icmp
 ; CHECK: br i1 %cond
-; Comparing two pointers
   br i1 %cond, label %taken, label %untaken
 
 taken:                                            ; preds = %continue
@@ -29,6 +27,7 @@ untaken:                                          ; preds = %continue
   ret i1 false
 }
 
+; Comparing two pointers
 define i1 @test2(ptr addrspace(1) %p, ptr addrspace(1) %q, i1 %rare) gc "statepoint-example" {
 ; CHECK-LABEL: @test2
 entry:
@@ -49,8 +48,6 @@ continue:                                         ; preds = %safepoint, %entry
 ; CHECK-DAG: [ %p, %entry ]
 ; CHECK: %cond = icmp
 ; CHECK: br i1 %cond
-; Check that nothing bad happens if already last instruction
-; before terminator
   br i1 %cond, label %taken, label %untaken
 
 taken:                                            ; preds = %continue
@@ -60,6 +57,8 @@ untaken:                                          ; preds = %continue
   ret i1 false
 }
 
+; Check that nothing bad happens if already last instruction
+; before terminator
 define i1 @test3(ptr addrspace(1) %p, ptr addrspace(1) %q, i1 %rare) gc "statepoint-example" {
 ; CHECK-LABEL: @test3
 ; CHECK: gc.statepoint

--- a/llvm/test/Transforms/RewriteStatepointsForGC/liveness-basics.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/liveness-basics.ll
@@ -4,7 +4,6 @@
 
 ; Tests to make sure we consider %obj live in both the taken and untaken
 ; predeccessor of merge.
-
 define ptr addrspace(1) @test1(i1 %cmp, ptr addrspace(1) %obj) gc "statepoint-example" {
 ; CHECK-LABEL: @test1
 entry:
@@ -30,10 +29,10 @@ merge:                                            ; preds = %untaken, %taken
 ; CHECK-LABEL: merge:
 ; CHECK-NEXT: %.0 = phi ptr addrspace(1) [ %obj.relocated, %taken ], [ %obj.relocated2, %untaken ]
 ; CHECK-NEXT: ret ptr addrspace(1) %.0
-; A local kill should not effect liveness in predecessor block
   ret ptr addrspace(1) %obj
 }
 
+; A local kill should not effect liveness in predecessor block
 define ptr addrspace(1) @test2(i1 %cmp, ptr %loc) gc "statepoint-example" {
 ; CHECK-LABEL: @test2
 entry:
@@ -49,8 +48,6 @@ taken:                                            ; preds = %entry
 ; CHECK-NEXT:  gc.statepoint
 ; CHECK-NEXT:  gc.relocate
 ; CHECK-NEXT:  ret ptr addrspace(1) %obj.relocated
-; A local kill should effect values live from a successor phi.  Also, we
-; should only propagate liveness from a phi to the appropriate predecessors.
   %obj = load ptr addrspace(1), ptr %loc
   call void @foo() [ "deopt"() ]
   ret ptr addrspace(1) %obj
@@ -59,6 +56,8 @@ untaken:                                          ; preds = %entry
   ret ptr addrspace(1) null
 }
 
+; A local kill should effect values live from a successor phi.  Also, we
+; should only propagate liveness from a phi to the appropriate predecessors.
 define ptr addrspace(1) @test3(i1 %cmp, ptr %loc) gc "statepoint-example" {
 ; CHECK-LABEL: @test3
 entry:
@@ -80,8 +79,6 @@ untaken:                                          ; preds = %entry
 ; CHECK-LABEL: taken:
 ; CHECK-NEXT: gc.statepoint
 ; CHECK-NEXT: br label %merge
-; A base pointer must be live if it is needed at a later statepoint,
-; even if the base pointer is otherwise unused.
   call void @foo() [ "deopt"() ]
   br label %merge
 
@@ -90,6 +87,8 @@ merge:                                            ; preds = %untaken, %taken
   ret ptr addrspace(1) %phi
 }
 
+; A base pointer must be live if it is needed at a later statepoint,
+; even if the base pointer is otherwise unused.
 define ptr addrspace(1) @test4(i1 %cmp, ptr addrspace(1) %obj) gc "statepoint-example" {
 ; CHECK-LABEL: @test4
 entry:
@@ -105,9 +104,6 @@ entry:
 ; CHECK-NEXT:  %obj.relocated3 =
 ; CHECK-NEXT:  ret ptr addrspace(1) %derived.relocated2
 ;
-; Make sure that a phi def visited during iteration is considered a kill.
-; Also, liveness after base pointer analysis can change based on new uses,
-; not just new defs.
   %derived = getelementptr i64, ptr addrspace(1) %obj, i64 8
   call void @foo() [ "deopt"() ]
   call void @foo() [ "deopt"() ]
@@ -116,6 +112,9 @@ entry:
 
 declare void @consume(...) readonly "gc-leaf-function"
 
+; Make sure that a phi def visited during iteration is considered a kill.
+; Also, liveness after base pointer analysis can change based on new uses,
+; not just new defs.
 define ptr addrspace(1) @test5(i1 %cmp, ptr addrspace(1) %obj) gc "statepoint-example" {
 ; CHECK-LABEL: @test5
 entry:

--- a/llvm/test/Transforms/RewriteStatepointsForGC/preprocess.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/preprocess.ll
@@ -1,10 +1,9 @@
 ; RUN: opt -passes=rewrite-statepoints-for-gc -S < %s | FileCheck %s
 
-; Test to make sure we destroy LCSSA's single entry phi nodes before
-; running liveness
-
 declare void @consume(...) "gc-leaf-function"
 
+; Test to make sure we destroy LCSSA's single entry phi nodes before
+; running liveness
 define void @test6(ptr addrspace(1) %obj) gc "statepoint-example" {
 ; CHECK-LABEL: @test6
 entry:
@@ -16,7 +15,6 @@ next:                                             ; preds = %entry
 ; CHECK-NEXT: gc.relocate
 ; CHECK-NEXT: @consume(ptr addrspace(1) %obj.relocated)
 ; CHECK-NEXT: @consume(ptr addrspace(1) %obj.relocated)
-; Need to delete unreachable gc.statepoint call
   %obj2 = phi ptr addrspace(1) [ %obj, %entry ]
   call void @foo() [ "deopt"() ]
   call void (...) @consume(ptr addrspace(1) %obj2)
@@ -24,11 +22,10 @@ next:                                             ; preds = %entry
   ret void
 }
 
+; Need to delete unreachable gc.statepoint call
 define void @test7() gc "statepoint-example" {
 ; CHECK-LABEL: test7
 ; CHECK-NOT: gc.statepoint
-; Need to delete unreachable gc.statepoint invoke - tested separately given
-; a correct implementation could only remove the instructions, not the block
   ret void
 
 unreached:                                        ; preds = %unreached
@@ -38,6 +35,8 @@ unreached:                                        ; preds = %unreached
   br label %unreached
 }
 
+; Need to delete unreachable gc.statepoint invoke - tested separately given
+; a correct implementation could only remove the instructions, not the block
 define void @test8() gc "statepoint-example" personality ptr undef {
 ; CHECK-LABEL: test8
 ; CHECK-NOT: gc.statepoint

--- a/llvm/test/Transforms/RewriteStatepointsForGC/relocation.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/relocation.ll
@@ -88,11 +88,11 @@ else_branch:                                      ; preds = %bci_0
 ; CHECK-LABEL: else_branch:
 ; CHECK: gc.statepoint
 ; CHECK: gc.relocate
-; We need to end up with a single relocation phi updated from both paths
   call void @foo() [ "deopt"() ]
   br label %join
 
 join:                                             ; preds = %else_branch, %if_branch
+; We need to end up with a single relocation phi updated from both paths
 ; CHECK-LABEL: join:
 ; CHECK: phi ptr addrspace(1)
 ; CHECK-DAG: [ %arg.relocated, %if_branch ]
@@ -246,11 +246,11 @@ inner-loop:                                       ; preds = %inner-loop, %outer-
 
 outer-inc:                                        ; preds = %inner-loop
 ; CHECK-LABEL: outer-inc:
-; This test shows why updating just those uses of the original value being
-; relocated dominated by the inserted relocation is not always sufficient.
   br label %outer-loop
 }
 
+; This test shows why updating just those uses of the original value being
+; relocated dominated by the inserted relocation is not always sufficient.
 define ptr addrspace(1) @test7(ptr addrspace(1) %obj, ptr addrspace(1) %obj2, i1 %condition) gc "statepoint-example" {
 ; CHECK-LABEL: @test7
 entry:
@@ -269,6 +269,9 @@ join:                                             ; preds = %callbb, %entry
 ; CHECK: phi ptr addrspace(1)
 ; CHECK-DAG: [ %obj, %entry ]
 ; CHECK-DAG: [ %obj2.relocated, %callbb ]
+  ; This is a phi outside the dominator region of the new defs inserted by
+  ; the safepoint, BUT we can't stop the search here or we miss the second
+  ; phi below.
   %phi1 = phi ptr addrspace(1) [ %obj, %entry ], [ %obj2, %callbb ]
   br label %join2
 


### PR DESCRIPTION
The commit 0407108 did some transformations on tests for RewriteStatepointsForGC that put some comments out-of-order. At least the `basics.ll` test is referred to by the current LLVM statepoints documentation, so this may have caused confusion to end-users investigating further into statepoint usage.

Additionally, some comments were outright removed that explained potentially non-trivial behaviour of the pass in the tests.

This is my first time ever submitting a patch to LLVM, so please let me know if there's anything I accidentally overlooked. I re-tested all tests to ensure no issues accidentally arose from these changes.