### PR TITLE
CodeGen: Emit error if getRegisterByName fails

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -2460,11 +2460,25 @@ void SelectionDAGISel::Select_READ_REGISTER(SDNode *Op) {
 
   EVT VT = Op->getValueType(0);
   LLT Ty = VT.isSimple() ? getLLTForMVT(VT.getSimpleVT()) : LLT();
-  Register Reg =
-      TLI->getRegisterByName(RegStr->getString().data(), Ty,
-                             CurDAG->getMachineFunction());
-  SDValue New = CurDAG->getCopyFromReg(
-                        Op->getOperand(0), dl, Reg, Op->getValueType(0));
+
+  const MachineFunction &MF = CurDAG->getMachineFunction();
+  Register Reg = TLI->getRegisterByName(RegStr->getString().data(), Ty, MF);
+
+  SDValue New;
+  if (!Reg) {
+    const Function &Fn = MF.getFunction();
+    Fn.getContext().diagnose(DiagnosticInfoGenericWithLoc(
+        "invalid register \"" + Twine(RegStr->getString().data()) +
+            "\" for llvm.read_register",
+        Fn, Op->getDebugLoc()));
+    New =
+        SDValue(CurDAG->getMachineNode(TargetOpcode::IMPLICIT_DEF, dl, VT), 0);
+    ReplaceUses(SDValue(Op, 1), Op->getOperand(0));
+  } else {
+    New =
+        CurDAG->getCopyFromReg(Op->getOperand(0), dl, Reg, Op->getValueType(0));
+  }
+
   New->setNodeId(-1);
   ReplaceUses(Op, New.getNode());
   CurDAG->RemoveDeadNode(Op);
@@ -2478,12 +2492,23 @@ void SelectionDAGISel::Select_WRITE_REGISTER(SDNode *Op) {
   EVT VT = Op->getOperand(2).getValueType();
   LLT Ty = VT.isSimple() ? getLLTForMVT(VT.getSimpleVT()) : LLT();
 
-  Register Reg = TLI->getRegisterByName(RegStr->getString().data(), Ty,
-                                        CurDAG->getMachineFunction());
-  SDValue New = CurDAG->getCopyToReg(
-                        Op->getOperand(0), dl, Reg, Op->getOperand(2));
-  New->setNodeId(-1);
-  ReplaceUses(Op, New.getNode());
+  const MachineFunction &MF = CurDAG->getMachineFunction();
+  Register Reg = TLI->getRegisterByName(RegStr->getString().data(), Ty, MF);
+
+  if (!Reg) {
+    const Function &Fn = MF.getFunction();
+    Fn.getContext().diagnose(DiagnosticInfoGenericWithLoc(
+        "invalid register \"" + Twine(RegStr->getString().data()) +
+            "\" for llvm.write_register",
+        Fn, Op->getDebugLoc()));
+    ReplaceUses(SDValue(Op, 0), Op->getOperand(0));
+  } else {
+    SDValue New =
+        CurDAG->getCopyToReg(Op->getOperand(0), dl, Reg, Op->getOperand(2));
+    New->setNodeId(-1);
+    ReplaceUses(Op, New.getNode());
+  }
+
   CurDAG->RemoveDeadNode(Op);
 }
 

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11977,12 +11977,9 @@ getRegisterByName(const char* RegName, LLT VT, const MachineFunction &MF) const 
     unsigned DwarfRegNum = MRI->getDwarfRegNum(Reg, false);
     if (!Subtarget->isXRegisterReserved(DwarfRegNum) &&
         !MRI->isReservedReg(MF, Reg))
-      Reg = 0;
+      Reg = Register();
   }
-  if (Reg)
-    return Reg;
-  report_fatal_error(Twine("Invalid register name \""
-                              + StringRef(RegName)  + "\"."));
+  return Reg;
 }
 
 SDValue AArch64TargetLowering::LowerADDROFRETURNADDR(SDValue Op,

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -4492,11 +4492,8 @@ Register SITargetLowering::getRegisterByName(const char *RegName, LLT VT,
                      .Case("flat_scratch_lo", AMDGPU::FLAT_SCR_LO)
                      .Case("flat_scratch_hi", AMDGPU::FLAT_SCR_HI)
                      .Default(Register());
-
-  if (Reg == AMDGPU::NoRegister) {
-    report_fatal_error(
-        Twine("invalid register name \"" + StringRef(RegName) + "\"."));
-  }
+  if (!Reg)
+    return Reg;
 
   if (!Subtarget->hasFlatScrRegister() &&
       Subtarget->getRegisterInfo()->regsOverlap(Reg, AMDGPU::FLAT_SCR)) {

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -6166,13 +6166,9 @@ SDValue ARMTargetLowering::LowerFRAMEADDR(SDValue Op, SelectionDAG &DAG) const {
 // this table could be generated automatically from RegInfo.
 Register ARMTargetLowering::getRegisterByName(const char* RegName, LLT VT,
                                               const MachineFunction &MF) const {
-  Register Reg = StringSwitch<unsigned>(RegName)
-                       .Case("sp", ARM::SP)
-                       .Default(0);
-  if (Reg)
-    return Reg;
-  report_fatal_error(Twine("Invalid register name \""
-                              + StringRef(RegName)  + "\"."));
+  return StringSwitch<Register>(RegName)
+      .Case("sp", ARM::SP)
+      .Default(Register());
 }
 
 // Result is 64 bit value so split into two 32 bit values and return as a

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -329,10 +329,7 @@ Register HexagonTargetLowering::getRegisterByName(
                      .Case("cs0", Hexagon::CS0)
                      .Case("cs1", Hexagon::CS1)
                      .Default(Register());
-  if (Reg)
-    return Reg;
-
-  report_fatal_error("Invalid register name global variable");
+  return Reg;
 }
 
 /// LowerCallResult - Lower the result values of an ISD::CALL into the

--- a/llvm/lib/Target/Lanai/LanaiISelLowering.cpp
+++ b/llvm/lib/Target/Lanai/LanaiISelLowering.cpp
@@ -211,7 +211,7 @@ Register LanaiTargetLowering::getRegisterByName(
   const char *RegName, LLT /*VT*/,
   const MachineFunction & /*MF*/) const {
   // Only unallocatable registers should be matched here.
-  Register Reg = StringSwitch<unsigned>(RegName)
+  Register Reg = StringSwitch<Register>(RegName)
                      .Case("pc", Lanai::PC)
                      .Case("sp", Lanai::SP)
                      .Case("fp", Lanai::FP)
@@ -220,11 +220,8 @@ Register LanaiTargetLowering::getRegisterByName(
                      .Case("rr2", Lanai::RR2)
                      .Case("r11", Lanai::R11)
                      .Case("rca", Lanai::RCA)
-                     .Default(0);
-
-  if (Reg)
-    return Reg;
-  report_fatal_error("Invalid register name global variable");
+                     .Default(Register());
+  return Reg;
 }
 
 std::pair<unsigned, const TargetRegisterClass *>

--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -7957,11 +7957,10 @@ LoongArchTargetLowering::getRegisterByName(const char *RegName, LLT VT,
   std::pair<StringRef, StringRef> Name = StringRef(RegName).split('$');
   std::string NewRegName = Name.second.str();
   Register Reg = MatchRegisterAltName(NewRegName);
-  if (Reg == LoongArch::NoRegister)
+  if (!Reg)
     Reg = MatchRegisterName(NewRegName);
-  if (Reg == LoongArch::NoRegister)
-    report_fatal_error(
-        Twine("Invalid register name \"" + StringRef(RegName) + "\"."));
+  if (!Reg)
+    return Reg;
   BitVector ReservedRegs = Subtarget.getRegisterInfo()->getReservedRegs(MF);
   if (!ReservedRegs.test(Reg))
     report_fatal_error(Twine("Trying to obtain non-reserved register \"" +

--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -4969,17 +4969,14 @@ MipsTargetLowering::getRegisterByName(const char *RegName, LLT VT,
                        .Case("$28", Mips::GP_64)
                        .Case("sp", Mips::SP_64)
                        .Default(Register());
-    if (Reg)
-      return Reg;
-  } else {
-    Register Reg = StringSwitch<Register>(RegName)
-                       .Case("$28", Mips::GP)
-                       .Case("sp", Mips::SP)
-                       .Default(Register());
-    if (Reg)
-      return Reg;
+    return Reg;
   }
-  report_fatal_error("Invalid register name global variable");
+
+  Register Reg = StringSwitch<Register>(RegName)
+                     .Case("$28", Mips::GP)
+                     .Case("sp", Mips::SP)
+                     .Default(Register());
+  return Reg;
 }
 
 MachineBasicBlock *MipsTargetLowering::emitLDR_W(MachineInstr &MI,

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -17984,8 +17984,7 @@ Register PPCTargetLowering::getRegisterByName(const char *RegName, LLT VT,
 
   Register Reg = MatchRegisterName(RegName);
   if (!Reg)
-    report_fatal_error(
-        Twine("Invalid global name register \"" + StringRef(RegName) + "\"."));
+    return Reg;
 
   // FIXME: Unable to generate code for `-O2` but okay for `-O0`.
   // Need followup investigation as to why.

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -24563,11 +24563,11 @@ Register
 RISCVTargetLowering::getRegisterByName(const char *RegName, LLT VT,
                                        const MachineFunction &MF) const {
   Register Reg = MatchRegisterAltName(RegName);
-  if (Reg == RISCV::NoRegister)
+  if (!Reg)
     Reg = MatchRegisterName(RegName);
-  if (Reg == RISCV::NoRegister)
-    report_fatal_error(
-        Twine("Invalid register name \"" + StringRef(RegName) + "\"."));
+  if (!Reg)
+    return Reg;
+
   BitVector ReservedRegs = Subtarget.getRegisterInfo()->getReservedRegs(MF);
   if (!ReservedRegs.test(Reg) && !Subtarget.isRegisterReservedByUser(Reg))
     report_fatal_error(Twine("Trying to obtain non-reserved register \"" +

--- a/llvm/lib/Target/Sparc/SparcISelLowering.cpp
+++ b/llvm/lib/Target/Sparc/SparcISelLowering.cpp
@@ -1162,12 +1162,9 @@ Register SparcTargetLowering::getRegisterByName(const char* RegName, LLT VT,
   // make sure that said register is in the reserve list.
   const SparcRegisterInfo *TRI = Subtarget->getRegisterInfo();
   if (!TRI->isReservedReg(MF, Reg))
-    Reg = 0;
+    Reg = Register();
 
-  if (Reg)
-    return Reg;
-
-  report_fatal_error("Invalid register name global variable");
+  return Reg;
 }
 
 // Fixup floating point arguments in the ... part of a varargs call.

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -1713,11 +1713,9 @@ SystemZTargetLowering::getRegisterByName(const char *RegName, LLT VT,
                                                    : SystemZ::NoRegister)
           .Case("r15",
                 Subtarget.isTargetELF() ? SystemZ::R15D : SystemZ::NoRegister)
-          .Default(SystemZ::NoRegister);
+          .Default(Register());
 
-  if (Reg)
-    return Reg;
-  report_fatal_error("Invalid register name global variable");
+  return Reg;
 }
 
 Register SystemZTargetLowering::getExceptionPointerRegister(

--- a/llvm/lib/Target/VE/VEISelLowering.cpp
+++ b/llvm/lib/Target/VE/VEISelLowering.cpp
@@ -563,12 +563,8 @@ Register VETargetLowering::getRegisterByName(const char *RegName, LLT VT,
                      .Case("info", VE::SX17)  // Info area register
                      .Case("got", VE::SX15)   // Global offset table register
                      .Case("plt", VE::SX16) // Procedure linkage table register
-                     .Default(0);
-
-  if (Reg)
-    return Reg;
-
-  report_fatal_error("Invalid register name global variable");
+                     .Default(Register());
+  return Reg;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -28312,10 +28312,7 @@ Register X86TargetLowering::getRegisterByName(const char* RegName, LLT VT,
 #endif
   }
 
-  if (Reg)
-    return Reg;
-
-  report_fatal_error("Invalid register name global variable");
+  return Reg;
 }
 
 SDValue X86TargetLowering::LowerFRAME_TO_ARGS_OFFSET(SDValue Op,

--- a/llvm/test/CodeGen/AArch64/arm64-named-reg-alloc.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-named-reg-alloc.ll
@@ -1,11 +1,11 @@
-; RUN: not --crash llc < %s -mtriple=arm64-apple-darwin 2>&1 | FileCheck %s
-; RUN: not --crash llc < %s -mtriple=arm64-linux-gnueabi 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=arm64-apple-darwin -filetype=null 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=arm64-linux-gnueabi -filetype=null 2>&1 | FileCheck %s
 
 define i32 @get_stack() nounwind {
 entry:
 ; FIXME: Include an allocatable-specific error message
-; CHECK: Invalid register name "x5".
-	%sp = call i32 @llvm.read_register.i32(metadata !0)
+; CHECK: error: <unknown>:0:0: invalid register "x5" for llvm.read_register
+  %sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }
 

--- a/llvm/test/CodeGen/AArch64/arm64-named-reg-notareg.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-named-reg-notareg.ll
@@ -1,10 +1,10 @@
-; RUN: not --crash llc < %s -mtriple=arm64-apple-darwin 2>&1 | FileCheck %s
-; RUN: not --crash llc < %s -mtriple=arm64-linux-gnueabi 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=arm64-apple-darwin 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=arm64-linux-gnueabi 2>&1 | FileCheck %s
 
 define i32 @get_stack() nounwind {
 entry:
-; CHECK: Invalid register name "notareg".
-	%sp = call i32 @llvm.read_register.i32(metadata !0)
+; CHECK: error: <unknown>:0:0: invalid register "notareg" for llvm.read_register
+  %sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }
 

--- a/llvm/test/CodeGen/AMDGPU/read-register-invalid-register.ll
+++ b/llvm/test/CodeGen/AMDGPU/read-register-invalid-register.ll
@@ -1,0 +1,90 @@
+; RUN: not llc -global-isel=0 -mtriple=amdgcn -mcpu=gfx900 -filetype=null < %s 2>&1 | FileCheck --implicit-check-not=error %s
+; RUN: not llc -global-isel=1 -mtriple=amdgcn -mcpu=gfx900 -filetype=null < %s 2>&1 | FileCheck --implicit-check-not=error %s
+
+declare i32 @llvm.read_register.i32(metadata) #0
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_i1(ptr addrspace(1) %out) nounwind {
+  %reg = call i1 @llvm.read_register.i1(metadata !0)
+  store i1 %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_i16(ptr addrspace(1) %out) nounwind {
+  %reg = call i16 @llvm.read_register.i16(metadata !0)
+  store i16 %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_i32(ptr addrspace(1) %out) nounwind {
+  %reg = call i32 @llvm.read_register.i32(metadata !0)
+  store i32 %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_i64(ptr addrspace(1) %out) nounwind {
+  %reg = call i64 @llvm.read_register.i64(metadata !0)
+  store i64 %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_v2i32(ptr addrspace(1) %out) nounwind {
+  %reg = call <2 x i32> @llvm.read_register.v2i32(metadata !0)
+  store <2 x i32> %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_v3i32(ptr addrspace(1) %out) nounwind {
+  %reg = call <3 x i32> @llvm.read_register.v3i32(metadata !0)
+  store <3 x i32> %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_v4i32(ptr addrspace(1) %out) nounwind {
+  %reg = call <4 x i32> @llvm.read_register.v4i32(metadata !0)
+  store <4 x i32> %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_v5i32(ptr addrspace(1) %out) nounwind {
+  %reg = call <5 x i32> @llvm.read_register.v5i32(metadata !0)
+  store <5 x i32> %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_v6i32(ptr addrspace(1) %out) nounwind {
+  %reg = call <6 x i32> @llvm.read_register.v6i32(metadata !0)
+  store <6 x i32> %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_v8i32(ptr addrspace(1) %out) nounwind {
+  %reg = call <8 x i32> @llvm.read_register.v8i32(metadata !0)
+  store <8 x i32> %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_v16i32(ptr addrspace(1) %out) nounwind {
+  %reg = call <16 x i32> @llvm.read_register.v16i32(metadata !0)
+  store <16 x i32> %reg, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.read_register
+define amdgpu_kernel void @test_invalid_register_v32i32(ptr addrspace(1) %out) nounwind {
+  %reg = call <32 x i32> @llvm.read_register.v32i32(metadata !0)
+  store <32 x i32> %reg, ptr addrspace(1) %out
+  ret void
+}
+
+!0 = !{!"not-a-register"}

--- a/llvm/test/CodeGen/AMDGPU/write-register-invalid-register.ll
+++ b/llvm/test/CodeGen/AMDGPU/write-register-invalid-register.ll
@@ -1,0 +1,10 @@
+; RUN: not llc -global-isel=0 -mtriple=amdgcn -mcpu=gfx900 -filetype=null < %s 2>&1 | FileCheck --implicit-check-not=error %s
+; RUN: not llc -global-isel=1 -mtriple=amdgcn -mcpu=gfx900 -filetype=null < %s 2>&1 | FileCheck --implicit-check-not=error %s
+
+; CHECK: error: <unknown>:0:0: invalid register "not-a-register" for llvm.write_register
+define amdgpu_kernel void @test_invalid_write_register_i32() nounwind {
+  call void @llvm.write_register.i32(metadata !0, i32 0)
+  ret void
+}
+
+!0 = !{!"not-a-register"}

--- a/llvm/test/CodeGen/ARM/named-reg-alloc.ll
+++ b/llvm/test/CodeGen/ARM/named-reg-alloc.ll
@@ -1,11 +1,11 @@
-; RUN: not --crash llc < %s -mtriple=arm-apple-darwin 2>&1 | FileCheck %s
-; RUN: not --crash llc < %s -mtriple=arm-linux-gnueabi 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=arm-apple-darwin -filetype=null 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=arm-linux-gnueabi -filetype=null 2>&1 | FileCheck %s
 
 define i32 @get_stack() nounwind {
 entry:
 ; FIXME: Include an allocatable-specific error message
-; CHECK: Invalid register name "r5".
-	%sp = call i32 @llvm.read_register.i32(metadata !0)
+; CHECK: error: <unknown>:0:0: invalid register "r5" for llvm.read_register
+  %sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }
 

--- a/llvm/test/CodeGen/ARM/named-reg-notareg.ll
+++ b/llvm/test/CodeGen/ARM/named-reg-notareg.ll
@@ -1,10 +1,10 @@
-; RUN: not --crash llc < %s -mtriple=arm-apple-darwin 2>&1 | FileCheck %s
-; RUN: not --crash llc < %s -mtriple=arm-linux-gnueabi 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=arm-apple-darwin 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=arm-linux-gnueabi 2>&1 | FileCheck %s
 
 define i32 @get_stack() nounwind {
 entry:
-; CHECK: Invalid register name "notareg".
-	%sp = call i32 @llvm.read_register.i32(metadata !0)
+; CHECK: error: <unknown>:0:0: invalid register "notareg" for llvm.read_register
+  %sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }
 

--- a/llvm/test/CodeGen/ARM/special-reg-acore.ll
+++ b/llvm/test/CodeGen/ARM/special-reg-acore.ll
@@ -1,7 +1,9 @@
 ; RUN: llc < %s -mtriple=arm-none-eabi -mcpu=cortex-a8 2>&1 | FileCheck %s --check-prefix=ACORE
-; RUN: not --crash llc < %s -mtriple=thumb-none-eabi -mcpu=cortex-m4 2>&1 | FileCheck %s --check-prefix=MCORE
+; RUN: not llc < %s -mtriple=thumb-none-eabi -mcpu=cortex-m4 2>&1 | FileCheck %s --check-prefix=MCORE
 
-; MCORE: LLVM ERROR: Invalid register name "cpsr".
+; MCORE: error: <unknown>:0:0: invalid register "cpsr" for llvm.read_register
+; MCORE: error: <unknown>:0:0: invalid register "spsr_cxsf" for llvm.write_register
+
 
 define i32 @read_cpsr() nounwind {
   ; ACORE-LABEL: read_cpsr:

--- a/llvm/test/CodeGen/ARM/special-reg-mcore.ll
+++ b/llvm/test/CodeGen/ARM/special-reg-mcore.ll
@@ -1,9 +1,10 @@
 ; RUN: llc < %s -mtriple=thumb-none-eabi -mcpu=cortex-m4 --show-mc-encoding 2>&1 | FileCheck %s --check-prefix=MCORE
-; RUN: not --crash llc < %s -mtriple=thumb-none-eabi -mcpu=cortex-m3 2>&1 | FileCheck %s --check-prefix=M3CORE
-; RUN: not --crash llc < %s -mtriple=arm-none-eabi -mcpu=cortex-a8 2>&1 | FileCheck %s --check-prefix=ACORE
+; RUN: not llc < %s -mtriple=thumb-none-eabi -mcpu=cortex-m3 2>&1 | FileCheck %s --check-prefix=M3CORE
+; RUN: not llc < %s -mtriple=arm-none-eabi -mcpu=cortex-a8 2>&1 | FileCheck %s --check-prefix=ACORE
 
-; ACORE: LLVM ERROR: Invalid register name "control".
-; M3CORE: LLVM ERROR: Invalid register name "xpsr_nzcvqg".
+; ACORE: error: <unknown>:0:0: invalid register "control" for llvm.write_register
+; M3CORE: error: <unknown>:0:0: invalid register "xpsr_nzcvqg" for llvm.write_register
+
 
 define i32 @read_mclass_registers() nounwind {
 entry:

--- a/llvm/test/CodeGen/ARM/special-reg-v8m-base.ll
+++ b/llvm/test/CodeGen/ARM/special-reg-v8m-base.ll
@@ -1,7 +1,7 @@
-; RUN: not --crash llc < %s -mtriple=thumb-none-eabi -mcpu=cortex-m4 2>&1 | FileCheck %s --check-prefix=V7M
+; RUN: not llc < %s -mtriple=thumb-none-eabi -mcpu=cortex-m4 2>&1 | FileCheck %s --check-prefix=V7M
 ; RUN: llc < %s -mtriple=thumbv8m.base-none-eabi 2>&1 | FileCheck %s
 
-; V7M: LLVM ERROR: Invalid register name "sp_ns".
+; V7M: error: <unknown>:0:0: invalid register "sp_ns" for llvm.read_register
 
 define i32 @read_mclass_registers() nounwind {
 entry:

--- a/llvm/test/CodeGen/ARM/special-reg-v8m-main.ll
+++ b/llvm/test/CodeGen/ARM/special-reg-v8m-main.ll
@@ -1,7 +1,7 @@
-; RUN: not --crash llc < %s -mtriple=thumbv8m.base-none-eabi 2>&1 | FileCheck %s --check-prefix=BASELINE
+; RUN: not llc < %s -mtriple=thumbv8m.base-none-eabi 2>&1 | FileCheck %s --check-prefix=BASELINE
 ; RUN: llc < %s -mtriple=thumbv8m.main-none-eabi -mattr=+dsp 2>&1 | FileCheck %s --check-prefix=MAINLINE
 
-; BASELINE: LLVM ERROR: Invalid register name "faultmask_ns".
+; BASELINE: error: <unknown>:0:0: invalid register "faultmask_ns" for llvm.read_register
 
 define i32 @read_mclass_registers() nounwind {
 entry:

--- a/llvm/test/CodeGen/RISCV/get-register-invalid.ll
+++ b/llvm/test/CodeGen/RISCV/get-register-invalid.ll
@@ -1,8 +1,8 @@
-; RUN: not --crash llc < %s -mtriple=riscv32 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=riscv32 2>&1 | FileCheck %s
 
 define i32 @get_invalid_reg() nounwind {
 entry:
-; CHECK: Invalid register name "notareg".
+; CHECK: error: <unknown>:0:0: invalid register "notareg" for llvm.read_register
   %reg = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %reg
 }

--- a/llvm/test/CodeGen/SPARC/reserved-regs-unavailable.ll
+++ b/llvm/test/CodeGen/SPARC/reserved-regs-unavailable.ll
@@ -1,9 +1,9 @@
-; RUN: not --crash llc -mtriple=sparc64-linux-gnu -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK-RESERVED-L0
+; RUN: not llc -mtriple=sparc64-linux-gnu -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK-RESERVED-L0
 
 ;; Ensure explicit register references for non-reserved registers
 ;; are caught properly.
 
-; CHECK-RESERVED-L0: LLVM ERROR: Invalid register name global variable
+; CHECK-RESERVED-L0: error: <unknown>:0:0: invalid register "l0" for llvm.write_register
 define void @set_reg(i32 zeroext %x) {
 entry:
   tail call void @llvm.write_register.i32(metadata !0, i32 %x)

--- a/llvm/test/CodeGen/X86/named-reg-alloc.ll
+++ b/llvm/test/CodeGen/X86/named-reg-alloc.ll
@@ -1,11 +1,11 @@
-; RUN: not --crash llc < %s -mtriple=x86_64-apple-darwin 2>&1 | FileCheck %s
-; RUN: not --crash llc < %s -mtriple=x86_64-linux-gnueabi 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=x86_64-apple-darwin 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=x86_64-linux-gnueabi 2>&1 | FileCheck %s
 
 define i32 @get_stack() nounwind {
 entry:
 ; FIXME: Include an allocatable-specific error message
-; CHECK: Invalid register name global variable
-	%sp = call i32 @llvm.read_register.i32(metadata !0)
+; CHECK: error: <unknown>:0:0: invalid register "eax" for llvm.read_register
+  %sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }
 

--- a/llvm/test/CodeGen/X86/named-reg-notareg.ll
+++ b/llvm/test/CodeGen/X86/named-reg-notareg.ll
@@ -1,10 +1,10 @@
-; RUN: not --crash llc < %s -mtriple=x86_64-apple-darwin 2>&1 | FileCheck %s
-; RUN: not --crash llc < %s -mtriple=x86_64-linux-gnueabi 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=x86_64-apple-darwin 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=x86_64-linux-gnueabi 2>&1 | FileCheck %s
 
 define i32 @get_stack() nounwind {
 entry:
-; CHECK: Invalid register name global variable
-	%sp = call i32 @llvm.read_register.i32(metadata !0)
+; CHECK: error: <unknown>:0:0: invalid register "notareg" for llvm.read_register
+  %sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }
 


### PR DESCRIPTION
This avoids using report_fatal_error and standardizes the error
message in a subset of the error conditions.