### PR TITLE
[Instrumentation] Drop "const" from a return type (NFC)

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
@@ -245,7 +245,7 @@ namespace {
   // to the block.
   class GCOVLines : public GCOVRecord {
   public:
-    const StringRef getFilename() { return Filename; }
+    StringRef getFilename() { return Filename; }
 
     void addLine(uint32_t Line) {
       assert(Line != 0 && "Line zero is not a valid real line number.");


### PR DESCRIPTION
We don't need to put a const on a return type.
