### PR TITLE
Revert "[X86][NFC] Use std::move to avoid copy"

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -41266,7 +41266,7 @@ static SDValue combineX86ShufflesRecursively(
     resolveTargetShuffleFromZeroables(OpMask, OpUndef, OpZero,
                                       ResolveKnownZeros);
 
-    Mask = std::move(OpMask);
+    Mask = OpMask;
     Ops.append(OpInputs.begin(), OpInputs.end());
   } else {
     resolveTargetShuffleFromZeroables(OpMask, OpUndef, OpZero);


### PR DESCRIPTION
Reverts llvm/llvm-project#141455