### PR TITLE
[gtest] Fix building on OpenBSD/sparc64

### DIFF
--- a/third-party/unittest/googletest/src/gtest.cc
+++ b/third-party/unittest/googletest/src/gtest.cc
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <chrono>  // NOLINT
 #include <cmath>
+#include <csignal>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
Cherry pick a patch from 1.15.0

Add missing include for raise(3)
https://github.com/google/googletest/commit/7f036c5563af7d0329f20e8bb42effb04629f0c0