### PR TITLE
[MLIR][NFC] Declare RuntimeVerifiableOpInterface for memref ops that have an implementation 

### DIFF
--- a/mlir/lib/Dialect/MemRef/IR/MemRefDialect.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefDialect.cpp
@@ -52,8 +52,9 @@ void mlir::memref::MemRefDialect::initialize() {
   declarePromisedInterface<ConvertToLLVMPatternInterface, MemRefDialect>();
   declarePromisedInterfaces<bufferization::AllocationOpInterface, AllocOp,
                             AllocaOp, ReallocOp>();
-  declarePromisedInterfaces<RuntimeVerifiableOpInterface, CastOp, ExpandShapeOp,
-                            LoadOp, ReinterpretCastOp, StoreOp, SubViewOp>();
+  declarePromisedInterfaces<RuntimeVerifiableOpInterface, AssumeAlignmentOp,
+                            AtomicRMWOp, CastOp, CopyOp, DimOp, ExpandShapeOp,
+                            GenericAtomicRMWOp, LoadOp, StoreOp, SubViewOp>();
   declarePromisedInterfaces<ValueBoundsOpInterface, AllocOp, AllocaOp, CastOp,
                             DimOp, GetGlobalOp, RankOp, SubViewOp>();
   declarePromisedInterface<DestructurableTypeInterface, MemRefType>();


### PR DESCRIPTION
Previously running `-generate-runtime-verification` on an IR containing `memref.reinterpret_cast` would crash because its implementation of the `RuntimeVerifiableOpInterface` was removed in https://github.com/llvm/llvm-project/pull/132547 but its associated entry in `declarePromisedInterface` was never removed.

This causes an error when you try and run `-generate-runtime-verification` on an IR containing `memref.reinterpret_cast` that looks like

```
LLVM ERROR: checking for an interface (`mlir::RuntimeVerifiableOpInterface`) that was promised by dialect 'memref' but never implemented. This is generally an indication that the dialect extension implementing the interface was never registered.
```
as reported in https://github.com/llvm/llvm-project/issues/144028.

In this PR I also added all the ops that do have implementations of this interface in `mlir/lib/Dialect/MemRef/Transforms/RuntimeOpVerification.cpp` to the `declarePromisedInterface` for consistency.

Fixes https://github.com/llvm/llvm-project/issues/144028