### PR TITLE
[lldb-dap] Fix flaky test

### DIFF
--- a/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
+++ b/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
@@ -101,7 +101,9 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         # Interrupt the server which should disconnect all clients.
         process.send_signal(signal.SIGINT)
 
-        self.dap_server.wait_for_terminated()
+        # Wait for both events since they can happen in any order.
+        self.dap_server.wait_for_event(["terminated", "exited"])
+        self.dap_server.wait_for_event(["terminated", "exited"])
         self.assertIsNotNone(
             self.dap_server.exit_status,
             "Process exited before interrupting lldb-dap server",

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -351,8 +351,6 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
                      << " disconnected failed: "
                      << llvm::toString(std::move(error)) << "\n";
       }
-      // Close the socket to ensure the DAP::Loop read finishes.
-      sock->Close();
     }
   }
 


### PR DESCRIPTION
This patch fixes a possible data race between main and event handler threads. Terminated event can be sent from `Disconnect` function or event handler. Consequently, there are some possible sequences of events. We must check events twice, because without getting an exited event, `exit_status` will be None. But, we don't know the order of events (for example, we can get terminated event before exited event), so we check events by filter. It is correct, because terminated event will be sent only once (guarded by `llvm::call_once`).

This patch moved from [145010](https://github.com/llvm/llvm-project/pull/145010) and based on idea from this [comment](https://github.com/llvm/llvm-project/pull/145010#discussion_r2159637210).