### PR TITLE
[SimplifyCFG] Transform switch to select when common bits uniquely identify one case

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6234,12 +6234,12 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
     // case 0,2,8,10 -> Cond & 0b1..0101 == 0 ? result : default
     if (isPowerOf2_32(CaseCount)) {
       ConstantInt *MinCaseVal = CaseValues[0];
-      // In case, there are bits, that can only be present in the CaseValues we
+      // If there are bits that are set exclusively by CaseValues, we
       // can transform the switch into a select if the conjunction of
-      // all the values uniquely identify the CaseValues.
+      // all the values uniquely identify CaseValues.
       APInt AndMask = APInt::getAllOnes(MinCaseVal->getBitWidth());
 
-      // Find mininal value and compute the conjuction of the values.
+      // Find the minimum value and compute the and of all the case values.
       for (auto *Case : CaseValues) {
         if (Case->getValue().slt(MinCaseVal->getValue()))
           MinCaseVal = Case;
@@ -6251,7 +6251,7 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
         // Compute the number of bits that are free to vary.
         unsigned FreeBits = Known.countMaxActiveBits() - AndMask.popcount();
         // Compute 2^FreeBits in order to check whether all the possible
-        // combination of the free bits matches the number of cases.
+        // combinations of the free bits matches the number of cases.
         APInt TopBit = APInt::getOneBitSet(
             Condition->getType()->getIntegerBitWidth(), FreeBits);
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6246,7 +6246,7 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
       }
 
       KnownBits Known = computeKnownBits(Condition, DL);
-      unsigned int ConditionWidth = Condition->getType()->getIntegerBitWidth();
+      unsigned ConditionWidth = Condition->getType()->getIntegerBitWidth();
       APInt ActiveBits =
           APInt(ConditionWidth, Known.countMaxActiveBits(), false);
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6250,12 +6250,10 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
       if (!AndMask.isZero() && Known.getMaxValue().uge(AndMask)) {
         // Compute the number of bits that are free to vary.
         unsigned FreeBits = Known.countMaxActiveBits() - AndMask.popcount();
-        // Compute 2^FreeBits in order to check whether all the possible
-        // combinations of the free bits matches the number of cases.
-        APInt TopBit = APInt::getOneBitSet(
-            Condition->getType()->getIntegerBitWidth(), FreeBits);
 
-        if (TopBit == CaseCount) {
+        // Check if the number of values covered by the mask is equal
+        // to the number of cases.
+        if (FreeBits == Log2_32(CaseCount)) {
           Value *And = Builder.CreateAnd(Condition, AndMask);
           Value *Cmp = Builder.CreateICmpEQ(
               And, Constant::getIntegerValue(And->getType(), AndMask));

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6247,8 +6247,8 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
 
       KnownBits Known = computeKnownBits(Condition, DL);
       unsigned int ConditionWidth = Condition->getType()->getIntegerBitWidth();
-      APInt ActiveBits = APInt(ConditionWidth, Known.countMaxActiveBits(),
-                               Condition->getType()->isSingleValueType());
+      APInt ActiveBits =
+          APInt(ConditionWidth, Known.countMaxActiveBits(), false);
 
       APInt One(ConditionWidth, 1, false);
       // To make sure, that the representation of the accepted values is

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6255,11 +6255,10 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
       // actually unique we check, wheter the conjucted bits and the another
       // conjuction with the input value will only be true for exactly CaseCount
       // number times.
-      if ((One << ActiveBits) - (One << (ActiveBits - AndMask.popcount())) ==
-          CaseCount) {
+      if ((One << (ActiveBits - AndMask.popcount())) == CaseCount) {
         Value *And = Builder.CreateAnd(Condition, AndMask);
-        Value *Cmp =
-            Builder.CreateICmpNE(And, Constant::getNullValue(And->getType()));
+        Value *Cmp = Builder.CreateICmpEQ(
+            And, Constant::getIntegerValue(And->getType(), AndMask));
         return Builder.CreateSelect(Cmp, ResultVector[0].first, DefaultResult);
       }
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6245,9 +6245,9 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
           MinCaseVal = Case;
         AndMask &= Case->getValue();
       }
+      KnownBits Known = computeKnownBits(Condition, DL);
 
-      if (!AndMask.isZero()) {
-        KnownBits Known = computeKnownBits(Condition, DL);
+      if (!AndMask.isZero() && Known.getMaxValue().uge(AndMask)) {
         // Compute the number of bits that are free to vary.
         unsigned FreeBits = Known.countMaxActiveBits() - AndMask.popcount();
         // Compute 2^FreeBits in order to check whether all the possible

--- a/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
@@ -309,3 +309,91 @@ end:
   %t0 = phi i8 [ 42, %case1 ], [ 42, %case2 ], [ 44, %case3 ], [ 44, %case4 ]
   ret i8 %t0
 }
+
+define i1 @range0to4odd(i8 range(i8 0, 4) %f) {
+; CHECK-LABEL: @range0to4odd(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i8 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 1, label %bb2
+  i8 3, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @range1to4odd(i8 range(i8 1, 4) %f) {
+; CHECK-LABEL: @range1to4odd(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i8 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 1, label %bb2
+  i8 3, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @range0to8odd(i8 range(i8 0, 8) %f) {
+; CHECK-LABEL: @range0to8odd(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i8 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 1, label %bb2
+  i8 3, label %bb2
+  i8 5, label %bb2
+  i8 7, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @negative_range0to5even(i8 range(i8 0, 5) %f) {
+; CHECK-LABEL: @negative_range0to5even(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = sub i8 [[F:%.*]], 2
+; CHECK-NEXT:    [[SWITCH_AND:%.*]] = and i8 [[TMP0]], -3
+; CHECK-NEXT:    [[SWITCH_SELECTCMP:%.*]] = icmp eq i8 [[SWITCH_AND]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[SWITCH_SELECTCMP]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP1]]
+;
+  switch i8 %f, label %bb1 [
+  i8 2, label %bb2
+  i8 4, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+

--- a/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
@@ -314,7 +314,7 @@ define i1 @range0to4odd(i8 range(i8 0, 4) %f) {
 ; CHECK-LABEL: @range0to4odd(
 ; CHECK-NEXT:  bb3:
 ; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 1
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i8 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[TMP0]], 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
 ; CHECK-NEXT:    ret i1 [[TMP2]]
 ;
@@ -335,7 +335,7 @@ define i1 @range1to4odd(i8 range(i8 1, 4) %f) {
 ; CHECK-LABEL: @range1to4odd(
 ; CHECK-NEXT:  bb3:
 ; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 1
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i8 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[TMP0]], 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
 ; CHECK-NEXT:    ret i1 [[TMP2]]
 ;
@@ -356,7 +356,7 @@ define i1 @range0to8odd(i8 range(i8 0, 8) %f) {
 ; CHECK-LABEL: @range0to8odd(
 ; CHECK-NEXT:  bb3:
 ; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 1
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i8 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[TMP0]], 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
 ; CHECK-NEXT:    ret i1 [[TMP2]]
 ;
@@ -364,6 +364,101 @@ define i1 @range0to8odd(i8 range(i8 0, 8) %f) {
   i8 1, label %bb2
   i8 3, label %bb2
   i8 5, label %bb2
+  i8 7, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @range0to8most_significant_bit(i8 range(i8 0, 8) %f) {
+; CHECK-LABEL: @range0to8most_significant_bit(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 4
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[TMP0]], 4
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 4, label %bb2
+  i8 5, label %bb2
+  i8 6, label %bb2
+  i8 7, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @range0to15_middle_two_bits(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @range0to15_middle_two_bits(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 6
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[TMP0]], 6
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 6, label %bb2
+  i8 7, label %bb2
+  i8 14, label %bb2
+  i8 15, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @negative_range0to15(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @negative_range0to15(
+; CHECK-NEXT:    switch i8 [[F:%.*]], label [[BB3:%.*]] [
+; CHECK-NEXT:      i8 6, label [[BB2:%.*]]
+; CHECK-NEXT:      i8 7, label [[BB2]]
+; CHECK-NEXT:      i8 14, label [[BB2]]
+; CHECK-NEXT:    ]
+; CHECK:       bb2:
+; CHECK-NEXT:    br label [[BB3]]
+; CHECK:       bb3:
+; CHECK-NEXT:    [[_0_SROA_0_0:%.*]] = phi i1 [ true, [[BB2]] ], [ false, [[TMP0:%.*]] ]
+; CHECK-NEXT:    ret i1 [[_0_SROA_0_0]]
+;
+  switch i8 %f, label %bb1 [
+  i8 6, label %bb2
+  i8 7, label %bb2
+  i8 14, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @negative_range0to15_pow_2(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @negative_range0to15_pow_2(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = sub i8 [[F:%.*]], 6
+; CHECK-NEXT:    [[SWITCH_AND:%.*]] = and i8 [[TMP0]], -2
+; CHECK-NEXT:    [[SWITCH_SELECTCMP:%.*]] = icmp eq i8 [[SWITCH_AND]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[SWITCH_SELECTCMP]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP1]]
+;
+  switch i8 %f, label %bb1 [
+  i8 6, label %bb2
   i8 7, label %bb2
   ]
 bb1:

--- a/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
@@ -492,3 +492,108 @@ bb3:
   ret i1 %_0.sroa.0.0
 }
 
+define i1 @range0to15_out_of_range_non_prime(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @range0to15_out_of_range_non_prime(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 6
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[TMP0]], 6
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 6, label %bb2
+  i8 7, label %bb2
+  i8 14, label %bb2
+  i8 15, label %bb2
+  i8 22, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @range0to15_out_of_range_non_prime_more(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @range0to15_out_of_range_non_prime_more(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 6
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[TMP0]], 6
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 6, label %bb2
+  i8 7, label %bb2
+  i8 14, label %bb2
+  i8 15, label %bb2
+  i8 22, label %bb2
+  i8 23, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @negative_range0to15_out_of_range_non_prime(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @negative_range0to15_out_of_range_non_prime(
+; CHECK-NEXT:    switch i8 [[F:%.*]], label [[BB3:%.*]] [
+; CHECK-NEXT:      i8 6, label [[BB2:%.*]]
+; CHECK-NEXT:      i8 14, label [[BB2]]
+; CHECK-NEXT:      i8 15, label [[BB2]]
+; CHECK-NEXT:    ]
+; CHECK:       bb2:
+; CHECK-NEXT:    br label [[BB3]]
+; CHECK:       bb3:
+; CHECK-NEXT:    [[TMP2:%.*]] = phi i1 [ true, [[BB2]] ], [ false, [[TMP0:%.*]] ]
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 6, label %bb2
+  i8 14, label %bb2
+  i8 15, label %bb2
+  i8 23, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @negative_range0to15_out_of_range(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @negative_range0to15_out_of_range(
+; CHECK-NEXT:    switch i8 [[F:%.*]], label [[BB3:%.*]] [
+; CHECK-NEXT:      i8 6, label [[BB2:%.*]]
+; CHECK-NEXT:      i8 7, label [[BB2]]
+; CHECK-NEXT:      i8 14, label [[BB2]]
+; CHECK-NEXT:    ]
+; CHECK:       bb2:
+; CHECK-NEXT:    br label [[BB3]]
+; CHECK:       bb3:
+; CHECK-NEXT:    [[_0_SROA_0_0:%.*]] = phi i1 [ true, [[BB2]] ], [ false, [[TMP0:%.*]] ]
+; CHECK-NEXT:    ret i1 [[_0_SROA_0_0]]
+;
+  switch i8 %f, label %bb1 [
+  i8 6, label %bb2
+  i8 7, label %bb2
+  i8 14, label %bb2
+  i8 150, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+

--- a/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
@@ -492,6 +492,9 @@ bb3:
   ret i1 %_0.sroa.0.0
 }
 
+; Out of range scenarios. Check if the cases, that have a value out of range
+; are eliminated and the optimization is performed.
+
 define i1 @range0to15_out_of_range_non_prime(i8 range(i8 0, 16) %f) {
 ; CHECK-LABEL: @range0to15_out_of_range_non_prime(
 ; CHECK-NEXT:  bb3:
@@ -587,6 +590,26 @@ define i1 @negative_range0to15_out_of_range(i8 range(i8 0, 16) %f) {
   i8 7, label %bb2
   i8 14, label %bb2
   i8 150, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @negative_range0to15_all_out_of_range(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @negative_range0to15_all_out_of_range(
+; CHECK-NEXT:  bb1:
+; CHECK-NEXT:    ret i1 false
+;
+  switch i8 %f, label %bb1 [
+  i8 22, label %bb2
+  i8 23, label %bb2
+  i8 30, label %bb2
+  i8 31, label %bb2
   ]
 bb1:
   br label %bb3

--- a/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
@@ -310,6 +310,96 @@ end:
   ret i8 %t0
 }
 
+define i1 @no_range(i8 %f) {
+; CHECK-LABEL: @no_range(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[F:%.*]], 60
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[TMP0]], 60
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  switch i8 %f, label %bb1 [
+  i8 60, label %bb2
+  i8 61, label %bb2
+  i8 62, label %bb2
+  i8 63, label %bb2
+  i8 124, label %bb2
+  i8 188, label %bb2
+  i8 252, label %bb2
+  i8 189, label %bb2
+  i8 190, label %bb2
+  i8 191, label %bb2
+  i8 125, label %bb2
+  i8 126, label %bb2
+  i8 127, label %bb2
+  i8 253, label %bb2
+  i8 254, label %bb2
+  i8 255, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @negative_no_range(i8 %f) {
+; CHECK-LABEL: @negative_no_range(
+; CHECK-NEXT:    switch i8 [[F:%.*]], label [[BB3:%.*]] [
+; CHECK-NEXT:      i8 52, label [[BB2:%.*]]
+; CHECK-NEXT:      i8 61, label [[BB2]]
+; CHECK-NEXT:      i8 62, label [[BB2]]
+; CHECK-NEXT:      i8 63, label [[BB2]]
+; CHECK-NEXT:      i8 124, label [[BB2]]
+; CHECK-NEXT:      i8 -68, label [[BB2]]
+; CHECK-NEXT:      i8 -4, label [[BB2]]
+; CHECK-NEXT:      i8 -67, label [[BB2]]
+; CHECK-NEXT:      i8 -66, label [[BB2]]
+; CHECK-NEXT:      i8 -65, label [[BB2]]
+; CHECK-NEXT:      i8 125, label [[BB2]]
+; CHECK-NEXT:      i8 126, label [[BB2]]
+; CHECK-NEXT:      i8 127, label [[BB2]]
+; CHECK-NEXT:      i8 -3, label [[BB2]]
+; CHECK-NEXT:      i8 -2, label [[BB2]]
+; CHECK-NEXT:      i8 -1, label [[BB2]]
+; CHECK-NEXT:    ]
+; CHECK:       bb2:
+; CHECK-NEXT:    br label [[BB3]]
+; CHECK:       bb3:
+; CHECK-NEXT:    [[_0_SROA_0_0:%.*]] = phi i1 [ true, [[BB2]] ], [ false, [[TMP0:%.*]] ]
+; CHECK-NEXT:    ret i1 [[_0_SROA_0_0]]
+;
+  switch i8 %f, label %bb1 [
+  i8 52, label %bb2
+  i8 61, label %bb2
+  i8 62, label %bb2
+  i8 63, label %bb2
+  i8 124, label %bb2
+  i8 188, label %bb2
+  i8 252, label %bb2
+  i8 189, label %bb2
+  i8 190, label %bb2
+  i8 191, label %bb2
+  i8 125, label %bb2
+  i8 126, label %bb2
+  i8 127, label %bb2
+  i8 253, label %bb2
+  i8 254, label %bb2
+  i8 255, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+; Using ranges.
+
 define i1 @range0to4odd(i8 range(i8 0, 4) %f) {
 ; CHECK-LABEL: @range0to4odd(
 ; CHECK-NEXT:  bb3:
@@ -482,6 +572,47 @@ define i1 @negative_range0to5even(i8 range(i8 0, 5) %f) {
   switch i8 %f, label %bb1 [
   i8 2, label %bb2
   i8 4, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @range0to15_corner_case(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @range0to15_corner_case(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq i8 [[F:%.*]], 15
+; CHECK-NEXT:    [[DOT:%.*]] = select i1 [[COND]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[DOT]]
+;
+  switch i8 %f, label %bb1 [
+  i8 15, label %bb2
+  ]
+bb1:
+  br label %bb3
+bb2:
+  br label %bb3
+bb3:
+  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %_0.sroa.0.0
+}
+
+define i1 @negative_range0to15_corner_case(i8 range(i8 0, 16) %f) {
+; CHECK-LABEL: @negative_range0to15_corner_case(
+; CHECK-NEXT:  bb3:
+; CHECK-NEXT:    [[SWITCH_SELECTCMP_CASE1:%.*]] = icmp eq i8 [[F:%.*]], 15
+; CHECK-NEXT:    [[SWITCH_SELECTCMP_CASE2:%.*]] = icmp eq i8 [[F]], 8
+; CHECK-NEXT:    [[SWITCH_SELECTCMP:%.*]] = or i1 [[SWITCH_SELECTCMP_CASE1]], [[SWITCH_SELECTCMP_CASE2]]
+; CHECK-NEXT:    [[TMP0:%.*]] = select i1 [[SWITCH_SELECTCMP]], i1 true, i1 false
+; CHECK-NEXT:    ret i1 [[TMP0]]
+;
+  switch i8 %f, label %bb1 [
+  i8 15, label %bb2
+  i8 8,  label %bb2
   ]
 bb1:
   br label %bb3

--- a/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-to-select-two-case.ll
@@ -341,8 +341,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @negative_no_range(i8 %f) {
@@ -394,8 +394,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 ; Using ranges.
@@ -417,8 +417,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @range1to4odd(i8 range(i8 1, 4) %f) {
@@ -438,8 +438,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @range0to8odd(i8 range(i8 0, 8) %f) {
@@ -461,8 +461,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @range0to8most_significant_bit(i8 range(i8 0, 8) %f) {
@@ -484,8 +484,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @range0to15_middle_two_bits(i8 range(i8 0, 16) %f) {
@@ -507,8 +507,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @negative_range0to15(i8 range(i8 0, 16) %f) {
@@ -534,8 +534,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @negative_range0to15_pow_2(i8 range(i8 0, 16) %f) {
@@ -556,8 +556,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @negative_range0to5even(i8 range(i8 0, 5) %f) {
@@ -578,8 +578,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @range0to15_corner_case(i8 range(i8 0, 16) %f) {
@@ -597,8 +597,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @negative_range0to15_corner_case(i8 range(i8 0, 16) %f) {
@@ -619,8 +619,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 ; Out of range scenarios. Check if the cases, that have a value out of range
@@ -646,8 +646,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @range0to15_out_of_range_non_prime_more(i8 range(i8 0, 16) %f) {
@@ -671,8 +671,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @negative_range0to15_out_of_range_non_prime(i8 range(i8 0, 16) %f) {
@@ -699,8 +699,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @negative_range0to15_out_of_range(i8 range(i8 0, 16) %f) {
@@ -727,8 +727,8 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
 
 define i1 @negative_range0to15_all_out_of_range(i8 range(i8 0, 16) %f) {
@@ -747,7 +747,6 @@ bb1:
 bb2:
   br label %bb3
 bb3:
-  %_0.sroa.0.0 = phi i1 [ false, %bb1 ], [ true, %bb2 ]
-  ret i1 %_0.sroa.0.0
+  %phi = phi i1 [ false, %bb1 ], [ true, %bb2 ]
+  ret i1 %phi
 }
-


### PR DESCRIPTION
My attempt to fix #141753 .

This patch introduces a new check, that tries to decide if the conjunction of all the values uniquely identify the accepted values by the switch.

I am also open to different solution. If you think this approach is not the best and have a different idea I would also be happy to implement that.

I was also thinking about addressing this pattern in inst combine. There was a previous commit, that adresses a very similar pattern to this https://github.com/llvm/llvm-project/commit/902acde34198bb11cc758dcf3aee00eb1cb09ceb, 
but I think it would be better if we wouldn't even get to the point of emitting this pattern.
