### PR TITLE
[llvm-cov] Add FileID to MCDC records of the json code coverage export

### DIFF
--- a/llvm/test/tools/llvm-cov/Inputs/binary-formats.canonical.json
+++ b/llvm/test/tools/llvm-cov/Inputs/binary-formats.canonical.json
@@ -33,4 +33,4 @@ CHECK-SAME:     "mcdc":{"count":0,"covered":0,"notcovered":0,"percent":0},
 CHECK-SAME:     "regions":{"count":1,"covered":1,"notcovered":0,"percent":100}}}
 CHECK-SAME: ],
 CHECK-SAME: "type":"llvm.coverage.json.export"
-CHECK-SAME: "version":"3.0.0"
+CHECK-SAME: "version":"3.0.1"

--- a/llvm/test/tools/llvm-cov/mcdc-export-json.test
+++ b/llvm/test/tools/llvm-cov/mcdc-export-json.test
@@ -1,10 +1,10 @@
 // RUN: llvm-profdata merge %S/Inputs/mcdc-general.proftext -o %t.profdata
 // RUN: llvm-cov export --format=text %S/Inputs/mcdc-general.o -instr-profile %t.profdata | FileCheck %s
 
-// CHECK: 12,7,12,27,2,4,0,5,[true,true,true,true]
-// CHECK: 15,7,15,13,1,2,0,5,[true,true]
-// CHECK: 15,19,15,25,1,1,0,5,[true,false]
-// CHECK: 18,7,19,15,1,3,0,5,[true,true,false,true]
+// CHECK: 12,7,12,27,2,4,0,0,5,[true,true,true,true]
+// CHECK: 15,7,15,13,1,2,0,0,5,[true,true]
+// CHECK: 15,19,15,25,1,1,0,0,5,[true,false]
+// CHECK: 18,7,19,15,1,3,0,0,5,[true,true,false,true]
 // CHECK: "mcdc":{"count":12,"covered":10,"notcovered":2,"percent":83.333333333333343}
 
 Instructions for regenerating the test:

--- a/llvm/tools/llvm-cov/CoverageExporterJson.cpp
+++ b/llvm/tools/llvm-cov/CoverageExporterJson.cpp
@@ -62,7 +62,7 @@
 #include <utility>
 
 /// The semantic version combined as a string.
-#define LLVM_COVERAGE_EXPORT_JSON_STR "3.0.0"
+#define LLVM_COVERAGE_EXPORT_JSON_STR "3.0.1"
 
 /// Unique type identifier for JSON coverage export.
 #define LLVM_COVERAGE_EXPORT_JSON_TYPE_STR "llvm.coverage.json.export"
@@ -113,7 +113,7 @@ json::Array renderMCDCRecord(const coverage::MCDCRecord &Record) {
   const auto [TrueDecisions, FalseDecisions] = Record.getDecisions();
   return json::Array({CMR.LineStart, CMR.ColumnStart, CMR.LineEnd,
                       CMR.ColumnEnd, TrueDecisions, FalseDecisions,
-                      CMR.ExpandedFileID, int64_t(CMR.Kind),
+                      CMR.FileID, CMR.ExpandedFileID, int64_t(CMR.Kind),
                       gatherConditions(Record)});
 }
 


### PR DESCRIPTION
At the moment MCDC Record contains ExpandedFileID. If FileID != ExpandedFileID, the record's lines LineStart and LineEnd relate to the `FileID` file, but the record doesn't contain this id. So we can't distinguish multiple MCDC records with the same lines and columns, but different FileIDs.

This adds FileID to MCDC records as it is done for regions and branches.