### PR TITLE
[ARM] Return the correct chain when expanding READ_REGISTER

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -6192,7 +6192,7 @@ static void ExpandREAD_REGISTER(SDNode *N, SmallVectorImpl<SDValue> &Results,
 
   Results.push_back(DAG.getNode(ISD::BUILD_PAIR, DL, MVT::i64, Read.getValue(0),
                     Read.getValue(1)));
-  Results.push_back(Read.getOperand(0));
+  Results.push_back(Read.getValue(2)); // Chain
 }
 
 /// \p BC is a bitcast that is about to be turned into a VMOVDRR.

--- a/llvm/test/CodeGen/ARM/special-reg.ll
+++ b/llvm/test/CodeGen/ARM/special-reg.ll
@@ -25,14 +25,18 @@ entry:
 define i64 @read_volatile_i64_twice() {
 ; ACORE-LABEL: read_volatile_i64_twice:
 ; ACORE:       @ %bb.0: @ %entry
-; ACORE-NEXT:    mov r0, #0
-; ACORE-NEXT:    mov r1, #0
+; ACORE-NEXT:    mrrc p15, #1, r0, r1, c14
+; ACORE-NEXT:    mrrc p15, #1, r2, r3, c14
+; ACORE-NEXT:    eor r0, r2, r0
+; ACORE-NEXT:    eor r1, r3, r1
 ; ACORE-NEXT:    bx lr
 ;
 ; MCORE-LABEL: read_volatile_i64_twice:
 ; MCORE:       @ %bb.0: @ %entry
-; MCORE-NEXT:    movs r0, #0
-; MCORE-NEXT:    movs r1, #0
+; MCORE-NEXT:    mrrc p15, #1, r0, r1, c14
+; MCORE-NEXT:    mrrc p15, #1, r2, r3, c14
+; MCORE-NEXT:    eors r0, r2
+; MCORE-NEXT:    eors r1, r3
 ; MCORE-NEXT:    bx lr
 entry:
   %0 = tail call i64 @llvm.read_volatile_register.i64(metadata !5)


### PR DESCRIPTION
This prevents it CSEing multiple nodes together from "volatile" registers as they would end up with the same chain. The new chain out should be the chain from the new READ_REGISTER node.

Fixes #144845