### PR TITLE
AMDGPU: Use reportFatalUsageError for unhandled calling conventions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -1142,7 +1142,7 @@ CCAssignFn *AMDGPUCallLowering::CCAssignFnForCall(CallingConv::ID CC,
   case CallingConv::AMDGPU_KERNEL:
   case CallingConv::SPIR_KERNEL:
   default:
-    report_fatal_error("Unsupported calling convention for call");
+    reportFatalUsageError("unsupported calling convention for call");
   }
 }
 
@@ -1169,7 +1169,7 @@ CCAssignFn *AMDGPUCallLowering::CCAssignFnForReturn(CallingConv::ID CC,
   case CallingConv::Cold:
     return RetCC_AMDGPU_Func;
   default:
-    report_fatal_error("Unsupported calling convention.");
+    reportFatalUsageError("unsupported calling convention");
   }
 }
 

--- a/llvm/lib/Target/AMDGPU/R600ISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/R600ISelLowering.cpp
@@ -1448,7 +1448,7 @@ CCAssignFn *R600TargetLowering::CCAssignFnForCall(CallingConv::ID CC,
   case CallingConv::AMDGPU_LS:
     return CC_R600;
   default:
-    report_fatal_error("Unsupported calling convention.");
+    reportFatalUsageError("unsupported calling convention");
   }
 }
 

--- a/llvm/test/CodeGen/AMDGPU/unsupported-calling-conv-call.ll
+++ b/llvm/test/CodeGen/AMDGPU/unsupported-calling-conv-call.ll
@@ -1,0 +1,7 @@
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -filetype=null %s 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: unsupported calling convention
+define void @caller(ptr %func) {
+  call aarch64_sve_vector_pcs void %func()
+  ret void
+}

--- a/llvm/test/CodeGen/AMDGPU/unsupported-calling-conv-func.ll
+++ b/llvm/test/CodeGen/AMDGPU/unsupported-calling-conv-func.ll
@@ -1,0 +1,6 @@
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -filetype=null %s 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: unsupported calling convention
+define aarch64_sve_vector_pcs void @func() {
+  ret void
+}


### PR DESCRIPTION
Should switch this to DiagnosticInfo and use the default calling
convention, but that would require passing in the context.