### PR TITLE
[objcopy][coff] Place section name first in strtab

### DIFF
--- a/llvm/lib/ObjCopy/COFF/COFFWriter.cpp
+++ b/llvm/lib/ObjCopy/COFF/COFFWriter.cpp
@@ -120,8 +120,11 @@ void COFFWriter::layoutSections() {
 
 Expected<size_t> COFFWriter::finalizeStringTable() {
   for (const auto &S : Obj.getSections())
-    if (S.Name.size() > COFF::NameSize)
-      StrTabBuilder.add(S.Name);
+    if (S.Name.size() > COFF::NameSize) {
+      // Put the section name at the start of strtab to ensure its offset is
+      // less than Max7DecimalOffset. Otherwise, lldb/gdb will not read it.
+      StrTabBuilder.add(S.Name, /*Priority=*/UINT8_MAX);
+    }
 
   for (const auto &S : Obj.getSymbols())
     if (S.Name.size() > COFF::NameSize)

--- a/llvm/test/tools/llvm-objcopy/COFF/string-table.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/string-table.test
@@ -4,9 +4,10 @@
 # RUN: llvm-readobj --string-table %t1 | FileCheck %s
 
 # CHECK:      StringTable {
-# CHECK-NEXT:   Length: 26
+# CHECK-NEXT:   Length: 37
 # CHECK-NEXT:   [     4] .debug_str
 # CHECK-NEXT:   [     f] symbol_zzz
+# CHECK-NEXT:   [    1a] symbol_aaa
 # CHECK-NEXT: }
 
 --- !COFF
@@ -16,6 +17,12 @@ sections:
   - Name:            .text
     Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
 symbols:
+  - Name:            symbol_aaa
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
   - Name:            symbol_zzz
     Value:           0
     SectionNumber:   1

--- a/llvm/test/tools/llvm-objcopy/COFF/string-table.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/string-table.test
@@ -5,8 +5,8 @@
 
 # CHECK:      StringTable {
 # CHECK-NEXT:   Length: 26
-# CHECK-NEXT:   [     4] symbol_zzz
-# CHECK-NEXT:   [     f] .debug_str
+# CHECK-NEXT:   [     4] .debug_str
+# CHECK-NEXT:   [     f] symbol_zzz
 # CHECK-NEXT: }
 
 --- !COFF

--- a/llvm/test/tools/llvm-objcopy/COFF/string-table.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/string-table.test
@@ -10,6 +10,7 @@
 # CHECK-NEXT:   [    1a] symbol_aaa
 # CHECK-NEXT: }
 
+# Symbol or section name is added into strtab only if it exceeds 8 characters.
 --- !COFF
 header:
   Machine:         IMAGE_FILE_MACHINE_AMD64

--- a/llvm/test/tools/llvm-objcopy/COFF/string-table.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/string-table.test
@@ -1,0 +1,24 @@
+# RUN: yaml2obj %s -o %t
+# RUN: touch %t.sec
+# RUN: llvm-objcopy --add-section=.debug_str=%t.sec %t %t1
+# RUN: llvm-readobj --string-table %t1 | FileCheck %s
+
+# CHECK:      StringTable {
+# CHECK-NEXT:   Length: 26
+# CHECK-NEXT:   [     4] symbol_zzz
+# CHECK-NEXT:   [     f] .debug_str
+# CHECK-NEXT: }
+
+--- !COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name:            .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+symbols:
+  - Name:            symbol_zzz
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL

--- a/llvm/test/tools/llvm-objcopy/COFF/string-table.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/string-table.test
@@ -1,3 +1,6 @@
+## Show that section names appear before symbol names in the COFF strtab.
+## These names are only added to the strtab if they exceed 8 characters.
+
 # RUN: yaml2obj %s -o %t
 # RUN: touch %t.sec
 # RUN: llvm-objcopy --add-section=.debug_str=%t.sec %t %t1
@@ -10,7 +13,6 @@
 # CHECK-NEXT:   [    1a] symbol_aaa
 # CHECK-NEXT: }
 
-# Symbol or section name is added into strtab only if it exceeds 8 characters.
 --- !COFF
 header:
   Machine:         IMAGE_FILE_MACHINE_AMD64


### PR DESCRIPTION
The prioritized string table builder was introduced in 9cc9efc. This
patch sets highest priority for the section name to place it at the
start of string table to avoid the issue described in 4d2eda2.