### PR TITLE
[RISCV] Add Andes AX45MPV processor definition

### DIFF
--- a/clang/test/Driver/print-enabled-extensions/riscv-andes-ax45mpv.c
+++ b/clang/test/Driver/print-enabled-extensions/riscv-andes-ax45mpv.c
@@ -1,0 +1,33 @@
+// RUN: %clang --target=riscv64 -mcpu=andes-ax45mpv --print-enabled-extensions | FileCheck %s
+// REQUIRES: riscv-registered-target
+
+// CHECK: Extensions enabled for the given RISC-V target
+// CHECK-EMPTY:
+// CHECK-NEXT:     Name                 Version   Description
+// CHECK-NEXT:     i                    2.1       'I' (Base Integer Instruction Set)
+// CHECK-NEXT:     m                    2.0       'M' (Integer Multiplication and Division)
+// CHECK-NEXT:     a                    2.1       'A' (Atomic Instructions)
+// CHECK-NEXT:     f                    2.2       'F' (Single-Precision Floating-Point)
+// CHECK-NEXT:     d                    2.2       'D' (Double-Precision Floating-Point)
+// CHECK-NEXT:     c                    2.0       'C' (Compressed Instructions)
+// CHECK-NEXT:     v                    1.0       'V' (Vector Extension for Application Processors)
+// CHECK-NEXT:     zicsr                2.0       'Zicsr' (CSRs)
+// CHECK-NEXT:     zifencei             2.0       'Zifencei' (fence.i)
+// CHECK-NEXT:     zmmul                1.0       'Zmmul' (Integer Multiplication)
+// CHECK-NEXT:     zaamo                1.0       'Zaamo' (Atomic Memory Operations)
+// CHECK-NEXT:     zalrsc               1.0       'Zalrsc' (Load-Reserved/Store-Conditional)
+// CHECK-NEXT:     zca                  1.0       'Zca' (part of the C extension, excluding compressed floating point loads/stores)
+// CHECK-NEXT:     zcd                  1.0       'Zcd' (Compressed Double-Precision Floating-Point Instructions)
+// CHECK-NEXT:     zve32f               1.0       'Zve32f' (Vector Extensions for Embedded Processors with maximal 32 EEW and F extension)
+// CHECK-NEXT:     zve32x               1.0       'Zve32x' (Vector Extensions for Embedded Processors with maximal 32 EEW)
+// CHECK-NEXT:     zve64d               1.0       'Zve64d' (Vector Extensions for Embedded Processors with maximal 64 EEW, F and D extension)
+// CHECK-NEXT:     zve64f               1.0       'Zve64f' (Vector Extensions for Embedded Processors with maximal 64 EEW and F extension)
+// CHECK-NEXT:     zve64x               1.0       'Zve64x' (Vector Extensions for Embedded Processors with maximal 64 EEW)
+// CHECK-NEXT:     zvl128b              1.0       'Zvl128b' (Minimum Vector Length 128)
+// CHECK-NEXT:     zvl32b               1.0       'Zvl32b' (Minimum Vector Length 32)
+// CHECK-NEXT:     zvl64b               1.0       'Zvl64b' (Minimum Vector Length 64)
+// CHECK-NEXT:     xandesperf           5.0       'XAndesPerf' (Andes Performance Extension)
+// CHECK-EMPTY:
+// CHECK-NEXT: Experimental extensions
+// CHECK-EMPTY:
+// CHECK-NEXT: ISA String: rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0_xandesperf5p0

--- a/clang/test/Driver/riscv-cpus.c
+++ b/clang/test/Driver/riscv-cpus.c
@@ -751,3 +751,11 @@
 
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mtune=andes-ax45 | FileCheck -check-prefix=MTUNE-ANDES-AX45 %s
 // MTUNE-ANDES-AX45: "-tune-cpu" "andes-ax45"
+
+// RUN: %clang --target=riscv64 -### -c %s 2>&1 -mcpu=andes-ax45mpv | FileCheck -check-prefix=MCPU-ANDES-AX45MPV %s
+// COM: The list of extensions are tested in `test/Driver/print-enabled-extensions/riscv-andes-ax45mpv.c`
+// MCPU-ANDES-AX45MPV: "-target-cpu" "andes-ax45mpv"
+// MCPU-ANDES-AX45MPV-SAME: "-target-abi" "lp64d"
+
+// RUN: %clang --target=riscv64 -### -c %s 2>&1 -mtune=andes-ax45mpv | FileCheck -check-prefix=MTUNE-ANDES-AX45MPV %s
+// MTUNE-ANDES-AX45MPV: "-tune-cpu" "andes-ax45mpv"

--- a/clang/test/Misc/target-invalid-cpu-note/riscv.c
+++ b/clang/test/Misc/target-invalid-cpu-note/riscv.c
@@ -29,6 +29,7 @@
 // RISCV64-NEXT: note: valid target CPU values are:
 // RISCV64-SAME: {{^}} andes-ax25
 // RISCV64-SAME: {{^}}, andes-ax45
+// RISCV64-SAME: {{^}}, andes-ax45mpv
 // RISCV64-SAME: {{^}}, andes-nx45
 // RISCV64-SAME: {{^}}, generic-rv64
 // RISCV64-SAME: {{^}}, mips-p8700
@@ -89,6 +90,7 @@
 // TUNE-RISCV64-NEXT: note: valid target CPU values are:
 // TUNE-RISCV64-SAME: {{^}} andes-ax25
 // TUNE-RISCV64-SAME: {{^}}, andes-ax45
+// TUNE-RISCV64-SAME: {{^}}, andes-ax45mpv
 // TUNE-RISCV64-SAME: {{^}}, andes-nx45
 // TUNE-RISCV64-SAME: {{^}}, generic-rv64
 // TUNE-RISCV64-SAME: {{^}}, mips-p8700

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -211,6 +211,7 @@ Changes to the RISC-V Backend
 * `-mcpu=sifive-x390` was added.
 * `-mtune=andes-45-series` was added.
 * Adds assembler support for the Andes `XAndesvbfhcvt` (Andes Vector BFLOAT16 Conversion extension).
+* `-mcpu=andes-ax45mpv` was added.
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -781,3 +781,18 @@ def ANDES_AX45 : RISCVProcessorModel<"andes-ax45",
                                       FeatureStdExtC,
                                       FeatureVendorXAndesPerf],
                                      Andes45TuneFeatures>;
+
+def ANDES_AX45MPV : RISCVProcessorModel<"andes-ax45mpv",
+                                        Andes45Model,
+                                        [Feature64Bit,
+                                         FeatureStdExtI,
+                                         FeatureStdExtZicsr,
+                                         FeatureStdExtZifencei,
+                                         FeatureStdExtM,
+                                         FeatureStdExtA,
+                                         FeatureStdExtF,
+                                         FeatureStdExtD,
+                                         FeatureStdExtC,
+                                         FeatureStdExtV,
+                                         FeatureVendorXAndesPerf],
+                                        Andes45TuneFeatures>;


### PR DESCRIPTION
Andes AX45MPV is 64-bit in-order dual-issue 8-stage pipeline linux-capable CPU implementing the RV64IMAFDCV ISA extension. That is developed by Andes Technology https://www.andestech.com, a RISC-V IP provider.

The overviews for AX45MPV:
https://www.andestech.com/en/products-solutions/andescore-processors/riscv-ax45mpv/

Scheduling model for RVV extension will be implemented a follow-up PR.