### PR TITLE
DAG: Move get_dynamic_area_offset type check to IR verifier

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14597,7 +14597,7 @@ Semantics:
       compile-time-known constant value.
 
       The return value type of :ref:`llvm.get.dynamic.area.offset <int_get_dynamic_area_offset>`
-      must match the target's default address space's (address space 0) pointer type.
+      must match the target's :ref:`alloca address space <alloca_addrspace>` type.
 
 '``llvm.prefetch``' Intrinsic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -7320,13 +7320,7 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
     return;
   case Intrinsic::get_dynamic_area_offset: {
     SDValue Op = getRoot();
-    EVT PtrTy = TLI.getFrameIndexTy(DAG.getDataLayout());
     EVT ResTy = TLI.getValueType(DAG.getDataLayout(), I.getType());
-    // Result type for @llvm.get.dynamic.area.offset should match PtrTy for
-    // target.
-    if (PtrTy.getFixedSizeInBits() < ResTy.getFixedSizeInBits())
-      report_fatal_error("Wrong result type for @llvm.get.dynamic.area.offset"
-                         " intrinsic!");
     Res = DAG.getNode(ISD::GET_DYNAMIC_AREA_OFFSET, sdl, DAG.getVTList(ResTy),
                       Op);
     DAG.setRoot(Op);

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6061,6 +6061,15 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
           "va_start called in a non-varargs function");
     break;
   }
+  case Intrinsic::get_dynamic_area_offset: {
+    auto *IntTy = dyn_cast<IntegerType>(Call.getType());
+    Check(IntTy && DL.getPointerSizeInBits(DL.getAllocaAddrSpace()) ==
+                       IntTy->getBitWidth(),
+          "get_dynamic_area_offset result type must be scalar integer matching "
+          "alloca address space width",
+          Call);
+    break;
+  }
   case Intrinsic::vector_reduce_and:
   case Intrinsic::vector_reduce_or:
   case Intrinsic::vector_reduce_xor:

--- a/llvm/test/Verifier/get_dynamic_area_offset.ll
+++ b/llvm/test/Verifier/get_dynamic_area_offset.ll
@@ -1,0 +1,30 @@
+; RUN: not llvm-as -disable-output %s 2>&1 | FileCheck %s
+
+target datalayout = "p0:64:64-p5:32:32-A5"
+
+declare i64 @llvm.get.dynamic.area.offset.i64()
+
+; CHECK: get_dynamic_area_offset result type must be scalar integer matching alloca address space width
+; CHECK-NEXT: %res = call i64 @llvm.get.dynamic.area.offset.i64()
+define i64 @test_dynamic_area_too_big() {
+  %res = call i64 @llvm.get.dynamic.area.offset.i64()
+  ret i64 %res
+}
+
+declare i16 @llvm.get.dynamic.area.offset.i16()
+
+; CHECK: get_dynamic_area_offset result type must be scalar integer matching alloca address space width
+; CHECK-NEXT: %res = call i16 @llvm.get.dynamic.area.offset.i16()
+define i16 @test_dynamic_area_too_small() {
+  %res = call i16 @llvm.get.dynamic.area.offset.i16()
+  ret i16 %res
+}
+
+declare <2 x i32> @llvm.get.dynamic.area.offset.v2i32()
+
+; CHECK: get_dynamic_area_offset result type must be scalar integer matching alloca address space width
+; CHECK-NEXT: %res = call <2 x i32> @llvm.get.dynamic.area.offset.v2i32()
+define <2 x i32> @test_dynamic_area_vector() {
+  %res = call <2 x i32> @llvm.get.dynamic.area.offset.v2i32()
+  ret <2 x i32> %res
+}


### PR DESCRIPTION
Also fix the LangRef to match the implementation. This was checking
against the alloca address space size rather than the default address
space.

The check was also more permissive than the LangRef. The error
check permitted any size less than the pointer size; follow the
stricter wording of the LangRef.