### PR TITLE
AArch64: Do not use report_fatal_error for pauth reloc errors

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -2254,15 +2254,19 @@ AArch64AsmPrinter::lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
   uint64_t KeyID = CPA.getKey()->getZExtValue();
   // We later rely on valid KeyID value in AArch64PACKeyIDToString call from
   // AArch64AuthMCExpr::printImpl, so fail fast.
-  if (KeyID > AArch64PACKey::LAST)
-    report_fatal_error("AArch64 PAC Key ID '" + Twine(KeyID) +
-                       "' out of range [0, " +
-                       Twine((unsigned)AArch64PACKey::LAST) + "]");
+  if (KeyID > AArch64PACKey::LAST) {
+    CPA.getContext().emitError("AArch64 PAC Key ID '" + Twine(KeyID) +
+                               "' out of range [0, " +
+                               Twine((unsigned)AArch64PACKey::LAST) + "]");
+    KeyID = 0;
+  }
 
   uint64_t Disc = CPA.getDiscriminator()->getZExtValue();
-  if (!isUInt<16>(Disc))
-    report_fatal_error("AArch64 PAC Discriminator '" + Twine(Disc) +
-                       "' out of range [0, 0xFFFF]");
+  if (!isUInt<16>(Disc)) {
+    CPA.getContext().emitError("AArch64 PAC Discriminator '" + Twine(Disc) +
+                               "' out of range [0, 0xFFFF]");
+    Disc = 0;
+  }
 
   // Finally build the complete @AUTH expr.
   return AArch64AuthMCExpr::create(Sym, Disc, AArch64PACKey::ID(KeyID),

--- a/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
@@ -139,38 +139,39 @@
 
 ;--- err-key.ll
 
-; RUN: not --crash llc < err-key.ll -mtriple arm64e-apple-darwin 2>&1 \
+; RUN: not llc < err-key.ll -mtriple arm64e-apple-darwin 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-KEY
-; RUN: not --crash llc < err-key.ll -mtriple aarch64-elf -mattr=+pauth 2>&1 \
+; RUN: not llc < err-key.ll -mtriple aarch64-elf -mattr=+pauth 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-KEY
 
-; RUN: not --crash llc < err-key.ll -mtriple arm64e-apple-darwin \
+; RUN: not llc < err-key.ll -mtriple arm64e-apple-darwin \
 ; RUN:   -global-isel -verify-machineinstrs -global-isel-abort=1  2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-KEY
-; RUN: not --crash llc < err-key.ll -mtriple aarch64-elf -mattr=+pauth \
+; RUN: not llc < err-key.ll -mtriple aarch64-elf -mattr=+pauth \
 ; RUN:   -global-isel -verify-machineinstrs -global-isel-abort=1 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-KEY
 
-; CHECK-ERR-KEY: LLVM ERROR: AArch64 PAC Key ID '4' out of range [0, 3]
+; CHECK-ERR-KEY: error: AArch64 PAC Key ID '4' out of range [0, 3]
+
 
 @g = external global i32
 @g.ref.4.0 = constant ptr ptrauth (ptr @g, i32 4, i64 0)
 
 ;--- err-disc.ll
 
-; RUN: not --crash llc < err-disc.ll -mtriple arm64e-apple-darwin 2>&1 \
+; RUN: not llc < err-disc.ll -mtriple arm64e-apple-darwin 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-DISC
-; RUN: not --crash llc < err-disc.ll -mtriple aarch64-elf -mattr=+pauth 2>&1 \
+; RUN: not llc < err-disc.ll -mtriple aarch64-elf -mattr=+pauth 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-DISC
 
-; RUN: not --crash llc < err-disc.ll -mtriple arm64e-apple-darwin \
+; RUN: not llc < err-disc.ll -mtriple arm64e-apple-darwin \
 ; RUN:   -global-isel -verify-machineinstrs -global-isel-abort=1  2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-DISC
-; RUN: not --crash llc < err-disc.ll -mtriple aarch64-elf -mattr=+pauth \
+; RUN: not llc < err-disc.ll -mtriple aarch64-elf -mattr=+pauth \
 ; RUN:   -global-isel -verify-machineinstrs -global-isel-abort=1 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-DISC
 
-; CHECK-ERR-DISC: LLVM ERROR: AArch64 PAC Discriminator '65536' out of range [0, 0xFFFF]
+; CHECK-ERR-DISC: error: AArch64 PAC Discriminator '65536' out of range [0, 0xFFFF]
 
 @g = external global i32
 @g.ref.ia.65536 = constant ptr ptrauth (ptr @g, i32 0, i64 65536)


### PR DESCRIPTION
This handling could be better. The wording doesn't follow the
error message guidance, and ideally we would emit with a reference
the the global variable (but we are currently missing an existing
DiagnosticInfo for a global reference. This case might call for
a custom ConstantPointerAuth kind).

Additionally this could stop using split-file since each error
case no longer aborts the compilation, and thus the different cases
can coexist in the same file.