### PR TITLE
[Support] Remove an outdated MinGW workaround

### DIFF
--- a/llvm/lib/Support/Windows/Process.inc
+++ b/llvm/lib/Support/Windows/Process.inc
@@ -37,11 +37,6 @@
 //===          and must not be UNIX code
 //===----------------------------------------------------------------------===//
 
-#ifdef __MINGW32__
-// This ban should be lifted when MinGW 1.0+ has defined this value.
-#define _HEAPOK (-2)
-#endif
-
 using namespace llvm;
 
 Process::Pid Process::getProcessId() {


### PR DESCRIPTION
mingw-w64 has had the _HEAPOK define since the initial commits in 2007; unclear when/where it was added for mingw.org headers, but it does seem to exist there as well (at least in versions from 2011).

This workaround stems from 53fbecce6e8b7d1f024e3dc6df4160fe9a577ff1 from 2004 - it is no longer relevant today.