### PR TITLE
[Clang][LoongArch] Fixed incorrect _BitInt(N>64) alignment

### DIFF
--- a/clang/lib/Basic/Targets/LoongArch.h
+++ b/clang/lib/Basic/Targets/LoongArch.h
@@ -60,6 +60,7 @@ public:
     SuitableAlign = 128;
     WCharType = SignedInt;
     WIntType = UnsignedInt;
+    BitIntMaxAlign = 128;
   }
 
   bool setCPU(const std::string &Name) override {

--- a/clang/test/CodeGen/LoongArch/bitint.c
+++ b/clang/test/CodeGen/LoongArch/bitint.c
@@ -12,25 +12,25 @@ void pass_BitInt129(_BitInt(129));
 // LA32-SAME: ) #[[ATTR0:[0-9]+]] {
 // LA32-NEXT:  [[ENTRY:.*:]]
 // LA32-NEXT:    [[L7:%.*]] = alloca i8, align 1
-// LA32-NEXT:    [[L65:%.*]] = alloca i128, align 8
-// LA32-NEXT:    [[L129:%.*]] = alloca i192, align 8
-// LA32-NEXT:    [[BYVAL_TEMP:%.*]] = alloca i128, align 8
-// LA32-NEXT:    [[BYVAL_TEMP3:%.*]] = alloca i192, align 8
+// LA32-NEXT:    [[L65:%.*]] = alloca i128, align 16
+// LA32-NEXT:    [[L129:%.*]] = alloca [32 x i8], align 16
+// LA32-NEXT:    [[BYVAL_TEMP:%.*]] = alloca i128, align 16
+// LA32-NEXT:    [[BYVAL_TEMP3:%.*]] = alloca [32 x i8], align 16
 // LA32-NEXT:    store i8 0, ptr [[L7]], align 1
-// LA32-NEXT:    store i128 0, ptr [[L65]], align 8
-// LA32-NEXT:    store i192 0, ptr [[L129]], align 8
+// LA32-NEXT:    store i128 0, ptr [[L65]], align 16
+// LA32-NEXT:    store i256 0, ptr [[L129]], align 16
 // LA32-NEXT:    [[TMP0:%.*]] = load i8, ptr [[L7]], align 1
 // LA32-NEXT:    [[LOADEDV:%.*]] = trunc i8 [[TMP0]] to i7
 // LA32-NEXT:    call void @pass_BitInt7(i7 noundef signext [[LOADEDV]])
-// LA32-NEXT:    [[TMP1:%.*]] = load i128, ptr [[L65]], align 8
+// LA32-NEXT:    [[TMP1:%.*]] = load i128, ptr [[L65]], align 16
 // LA32-NEXT:    [[LOADEDV1:%.*]] = trunc i128 [[TMP1]] to i65
 // LA32-NEXT:    [[STOREDV:%.*]] = sext i65 [[LOADEDV1]] to i128
-// LA32-NEXT:    store i128 [[STOREDV]], ptr [[BYVAL_TEMP]], align 8
+// LA32-NEXT:    store i128 [[STOREDV]], ptr [[BYVAL_TEMP]], align 16
 // LA32-NEXT:    call void @pass_BitInt65(ptr noundef [[BYVAL_TEMP]])
-// LA32-NEXT:    [[TMP2:%.*]] = load i192, ptr [[L129]], align 8
-// LA32-NEXT:    [[LOADEDV2:%.*]] = trunc i192 [[TMP2]] to i129
-// LA32-NEXT:    [[STOREDV4:%.*]] = sext i129 [[LOADEDV2]] to i192
-// LA32-NEXT:    store i192 [[STOREDV4]], ptr [[BYVAL_TEMP3]], align 8
+// LA32-NEXT:    [[TMP2:%.*]] = load i256, ptr [[L129]], align 16
+// LA32-NEXT:    [[LOADEDV2:%.*]] = trunc i256 [[TMP2]] to i129
+// LA32-NEXT:    [[STOREDV4:%.*]] = sext i129 [[LOADEDV2]] to i256
+// LA32-NEXT:    store i256 [[STOREDV4]], ptr [[BYVAL_TEMP3]], align 16
 // LA32-NEXT:    call void @pass_BitInt129(ptr noundef [[BYVAL_TEMP3]])
 // LA32-NEXT:    ret void
 //
@@ -38,22 +38,22 @@ void pass_BitInt129(_BitInt(129));
 // LA64-SAME: ) #[[ATTR0:[0-9]+]] {
 // LA64-NEXT:  [[ENTRY:.*:]]
 // LA64-NEXT:    [[L7:%.*]] = alloca i8, align 1
-// LA64-NEXT:    [[L65:%.*]] = alloca i128, align 8
-// LA64-NEXT:    [[L129:%.*]] = alloca [24 x i8], align 8
-// LA64-NEXT:    [[BYVAL_TEMP:%.*]] = alloca [24 x i8], align 8
+// LA64-NEXT:    [[L65:%.*]] = alloca i128, align 16
+// LA64-NEXT:    [[L129:%.*]] = alloca i256, align 16
+// LA64-NEXT:    [[BYVAL_TEMP:%.*]] = alloca i256, align 16
 // LA64-NEXT:    store i8 0, ptr [[L7]], align 1
-// LA64-NEXT:    store i128 0, ptr [[L65]], align 8
-// LA64-NEXT:    store i192 0, ptr [[L129]], align 8
+// LA64-NEXT:    store i128 0, ptr [[L65]], align 16
+// LA64-NEXT:    store i256 0, ptr [[L129]], align 16
 // LA64-NEXT:    [[TMP0:%.*]] = load i8, ptr [[L7]], align 1
 // LA64-NEXT:    [[LOADEDV:%.*]] = trunc i8 [[TMP0]] to i7
 // LA64-NEXT:    call void @pass_BitInt7(i7 noundef signext [[LOADEDV]])
-// LA64-NEXT:    [[TMP1:%.*]] = load i128, ptr [[L65]], align 8
+// LA64-NEXT:    [[TMP1:%.*]] = load i128, ptr [[L65]], align 16
 // LA64-NEXT:    [[LOADEDV1:%.*]] = trunc i128 [[TMP1]] to i65
 // LA64-NEXT:    call void @pass_BitInt65(i65 noundef [[LOADEDV1]])
-// LA64-NEXT:    [[TMP2:%.*]] = load i192, ptr [[L129]], align 8
-// LA64-NEXT:    [[LOADEDV2:%.*]] = trunc i192 [[TMP2]] to i129
-// LA64-NEXT:    [[STOREDV:%.*]] = sext i129 [[LOADEDV2]] to i192
-// LA64-NEXT:    store i192 [[STOREDV]], ptr [[BYVAL_TEMP]], align 8
+// LA64-NEXT:    [[TMP2:%.*]] = load i256, ptr [[L129]], align 16
+// LA64-NEXT:    [[LOADEDV2:%.*]] = trunc i256 [[TMP2]] to i129
+// LA64-NEXT:    [[STOREDV:%.*]] = sext i129 [[LOADEDV2]] to i256
+// LA64-NEXT:    store i256 [[STOREDV]], ptr [[BYVAL_TEMP]], align 16
 // LA64-NEXT:    call void @pass_BitInt129(ptr noundef [[BYVAL_TEMP]])
 // LA64-NEXT:    ret void
 //
@@ -78,15 +78,15 @@ void example_BitInt(void) {
 //
 _BitInt(7) return_large_BitInt7(void) { return 0; }
 // LA32-LABEL: define dso_local void @return_large_BitInt65(
-// LA32-SAME: ptr dead_on_unwind noalias writable sret(i128) align 8 [[AGG_RESULT:%.*]]) #[[ATTR0]] {
+// LA32-SAME: ptr dead_on_unwind noalias writable sret(i128) align 16 [[AGG_RESULT:%.*]]) #[[ATTR0]] {
 // LA32-NEXT:  [[ENTRY:.*:]]
 // LA32-NEXT:    [[RESULT_PTR:%.*]] = alloca ptr, align 4
 // LA32-NEXT:    store ptr [[AGG_RESULT]], ptr [[RESULT_PTR]], align 4
-// LA32-NEXT:    store i128 0, ptr [[AGG_RESULT]], align 8
-// LA32-NEXT:    [[TMP0:%.*]] = load i128, ptr [[AGG_RESULT]], align 8
+// LA32-NEXT:    store i128 0, ptr [[AGG_RESULT]], align 16
+// LA32-NEXT:    [[TMP0:%.*]] = load i128, ptr [[AGG_RESULT]], align 16
 // LA32-NEXT:    [[LOADEDV:%.*]] = trunc i128 [[TMP0]] to i65
 // LA32-NEXT:    [[STOREDV:%.*]] = sext i65 [[LOADEDV]] to i128
-// LA32-NEXT:    store i128 [[STOREDV]], ptr [[AGG_RESULT]], align 8
+// LA32-NEXT:    store i128 [[STOREDV]], ptr [[AGG_RESULT]], align 16
 // LA32-NEXT:    ret void
 //
 // LA64-LABEL: define dso_local i65 @return_large_BitInt65(
@@ -96,27 +96,27 @@ _BitInt(7) return_large_BitInt7(void) { return 0; }
 //
 _BitInt(65) return_large_BitInt65(void) { return 0; }
 // LA32-LABEL: define dso_local void @return_large_BitInt129(
-// LA32-SAME: ptr dead_on_unwind noalias writable sret(i192) align 8 [[AGG_RESULT:%.*]]) #[[ATTR0]] {
+// LA32-SAME: ptr dead_on_unwind noalias writable sret([32 x i8]) align 16 [[AGG_RESULT:%.*]]) #[[ATTR0]] {
 // LA32-NEXT:  [[ENTRY:.*:]]
 // LA32-NEXT:    [[RESULT_PTR:%.*]] = alloca ptr, align 4
 // LA32-NEXT:    store ptr [[AGG_RESULT]], ptr [[RESULT_PTR]], align 4
-// LA32-NEXT:    store i192 0, ptr [[AGG_RESULT]], align 8
-// LA32-NEXT:    [[TMP0:%.*]] = load i192, ptr [[AGG_RESULT]], align 8
-// LA32-NEXT:    [[LOADEDV:%.*]] = trunc i192 [[TMP0]] to i129
-// LA32-NEXT:    [[STOREDV:%.*]] = sext i129 [[LOADEDV]] to i192
-// LA32-NEXT:    store i192 [[STOREDV]], ptr [[AGG_RESULT]], align 8
+// LA32-NEXT:    store i256 0, ptr [[AGG_RESULT]], align 16
+// LA32-NEXT:    [[TMP0:%.*]] = load i256, ptr [[AGG_RESULT]], align 16
+// LA32-NEXT:    [[LOADEDV:%.*]] = trunc i256 [[TMP0]] to i129
+// LA32-NEXT:    [[STOREDV:%.*]] = sext i129 [[LOADEDV]] to i256
+// LA32-NEXT:    store i256 [[STOREDV]], ptr [[AGG_RESULT]], align 16
 // LA32-NEXT:    ret void
 //
 // LA64-LABEL: define dso_local void @return_large_BitInt129(
-// LA64-SAME: ptr dead_on_unwind noalias writable sret([24 x i8]) align 8 [[AGG_RESULT:%.*]]) #[[ATTR0]] {
+// LA64-SAME: ptr dead_on_unwind noalias writable sret(i256) align 16 [[AGG_RESULT:%.*]]) #[[ATTR0]] {
 // LA64-NEXT:  [[ENTRY:.*:]]
 // LA64-NEXT:    [[RESULT_PTR:%.*]] = alloca ptr, align 8
 // LA64-NEXT:    store ptr [[AGG_RESULT]], ptr [[RESULT_PTR]], align 8
-// LA64-NEXT:    store i192 0, ptr [[AGG_RESULT]], align 8
-// LA64-NEXT:    [[TMP0:%.*]] = load i192, ptr [[AGG_RESULT]], align 8
-// LA64-NEXT:    [[LOADEDV:%.*]] = trunc i192 [[TMP0]] to i129
-// LA64-NEXT:    [[STOREDV:%.*]] = sext i129 [[LOADEDV]] to i192
-// LA64-NEXT:    store i192 [[STOREDV]], ptr [[AGG_RESULT]], align 8
+// LA64-NEXT:    store i256 0, ptr [[AGG_RESULT]], align 16
+// LA64-NEXT:    [[TMP0:%.*]] = load i256, ptr [[AGG_RESULT]], align 16
+// LA64-NEXT:    [[LOADEDV:%.*]] = trunc i256 [[TMP0]] to i129
+// LA64-NEXT:    [[STOREDV:%.*]] = sext i129 [[LOADEDV]] to i256
+// LA64-NEXT:    store i256 [[STOREDV]], ptr [[AGG_RESULT]], align 16
 // LA64-NEXT:    ret void
 //
 _BitInt(129) return_large_BitInt129(void) { return 0; }

--- a/clang/test/CodeGen/ext-int-cc.c
+++ b/clang/test/CodeGen/ext-int-cc.c
@@ -27,8 +27,8 @@
 // RUN: %clang_cc1 -no-enable-noundef-analysis -triple arm64_32-apple-ios -O3 -disable-llvm-passes -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=AARCH64
 // RUN: %clang_cc1 -no-enable-noundef-analysis -triple arm64_32-apple-ios -target-abi darwinpcs -O3 -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s --check-prefixes=AARCH64DARWIN
 // RUN: %clang_cc1 -no-enable-noundef-analysis -triple arm -O3 -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s --check-prefixes=ARM
-// RUN: %clang_cc1 -no-enable-noundef-analysis -triple loongarch64 -O3 -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s --check-prefixes=LA64
-// RUN: %clang_cc1 -no-enable-noundef-analysis -triple loongarch32 -O3 -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s --check-prefixes=LA32
+// RUN: %clang_cc1 -no-enable-noundef-analysis -triple loongarch64 -O3 -disable-llvm-passes -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=LA64
+// RUN: %clang_cc1 -no-enable-noundef-analysis -triple loongarch32 -O3 -disable-llvm-passes -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=LA32
 
 // Make sure 128 and 64 bit versions are passed like integers.
 void ParamPassing(_BitInt(128) b, _BitInt(64) c) {}
@@ -158,8 +158,8 @@ void ParamPassing4(_BitInt(129) a) {}
 // PPC32-NOT: define{{.*}} void @ParamPassing4(ptr byval(i129) align 8 %{{.+}})
 // AARCH64DARWIN-NOT: define{{.*}} void @ParamPassing4(ptr byval(i129) align 8 %{{.+}})
 // ARM-NOT: define{{.*}} arm_aapcscc void @ParamPassing4(ptr byval(i129) align 8 %{{.+}})
-// LA64-NOT: define{{.*}} void @ParamPassing4(ptr %{{.+}})
-// LA32-NOT: define{{.*}} void @ParamPassing4(ptr %{{.+}})
+// LA64: define{{.*}} void @ParamPassing4(ptr %{{.+}})
+// LA32: define{{.*}} void @ParamPassing4(ptr %{{.+}})
 #endif
 
 _BitInt(63) ReturnPassing(void) { return 0; }
@@ -317,8 +317,8 @@ _BitInt(129) ReturnPassing5(void) { return 0; }
 // PPC32-NOT: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
 // AARCH64DARWIN-NOT: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
 // ARM-NOT: define{{.*}} arm_aapcscc void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
-// LA64-NOT: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
-// LA32-NOT: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
+// LA64: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
+// LA32: define{{.*}} void @ReturnPassing5(ptr dead_on_unwind noalias writable sret
 
 // SparcV9 is odd in that it has a return-size limit of 256, not 128 or 64
 // like other platforms, so test to make sure this behavior will still work.


### PR DESCRIPTION
This patch makes determining alignment and width of BitInt to be target ABI specific and makes it consistent with [Procedure Call Standard for the LoongArch™ Architecture] for LoongArch target
(https://github.com/loongson/la-abi-specs/blob/release/lapcs.adoc).