### PR TITLE
[lldb] Disable flaky TestDetachResumes.py on Windows x86_64

### DIFF
--- a/lldb/test/API/commands/process/detach-resumes/TestDetachResumes.py
+++ b/lldb/test/API/commands/process/detach-resumes/TestDetachResumes.py
@@ -12,6 +12,11 @@ from lldbsuite.test import lldbutil
 class DetachResumesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIf(
+        oslist=["windows"],
+        archs=["x86_64"],
+        bugnumber="github.com/llvm/llvm-project/issues/144891",
+    )
     def test_detach_resumes(self):
         self.build()
         exe = self.getBuildArtifact()


### PR DESCRIPTION
See #144891 for details.