### PR TITLE
[mlir][Transforms] Dialect Conversion: Simplify block-inline handling

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2301,7 +2301,7 @@ LogicalResult OperationLegalizer::legalizePatternBlockRewrites(
       continue;
     Block *block = rewrite->getBlock();
     if (isa<BlockTypeConversionRewrite, EraseBlockRewrite,
-            ReplaceBlockArgRewrite>(rewrite))
+            ReplaceBlockArgRewrite, InlineBlockRewrite>(rewrite))
       continue;
     // Only check blocks outside of the current operation.
     Operation *parentOp = block->getParentOp();


### PR DESCRIPTION
When a block is getting inlined, the destination block does not have to be legalized. That's because the signature of the destination block does not change by inlining.

This commit makes the implementation consistent with this comment:
```
  // If the pattern moved or created any blocks, make sure the types of block
  // arguments get legalized.
```


