### PR TITLE
[MLIR][MPI] adding MLIRDLTIDialect when linking MLIRMPIDialect

### DIFF
--- a/mlir/lib/Dialect/MPI/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/MPI/IR/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_dialect_library(MLIRMPIDialect
 
   LINK_LIBS PUBLIC
   MLIRDialect
+  MLIRDLTIDialect
   MLIRIR
   MLIRMemRefDialect
   MLIRInferTypeOpInterface


### PR DESCRIPTION
Fixing buildbot errors on some platforms like 
```
undefined reference to `mlir::dlti::query(mlir::Operation*, llvm::ArrayRef<llvm::StringRef>, bool)'
```
Introduced in #144716 