### PR TITLE
[lldb][DWARF] Support retrieving DW_FORM_implicit_const value with DWARFDebugInfoEntry::GetAttributeValue

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -403,6 +403,9 @@ dw_offset_t DWARFDebugInfoEntry::GetAttributeValue(
       const dw_offset_t attr_offset = offset;
       form_value.SetUnit(cu);
       form_value.SetForm(abbrevDecl->getFormByIndex(idx));
+      if (abbrevDecl->getAttrIsImplicitConstByIndex(idx))
+        form_value.SetValue(abbrevDecl->getAttrImplicitConstValueByIndex(idx));
+
       if (form_value.ExtractValue(data, &offset)) {
         if (end_attr_offset_ptr)
           *end_attr_offset_ptr = offset;

--- a/lldb/unittests/SymbolFile/DWARF/DWARFDIETest.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFDIETest.cpp
@@ -395,6 +395,64 @@ DWARF:
               testing::ElementsAre(make_struct("struct_t")));
 }
 
+TEST(DWARFDIETest, GetAttributeValue_ImplicitConst) {
+  // Make sure we can correctly retrieve the value of an attribute
+  // that has a DW_FORM_implicit_const form.
+
+  const char *yamldata = R"(
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_386
+DWARF:
+  debug_str:
+    - ''
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+        - Code:            0x2
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+            - Attribute:       DW_AT_object_pointer
+              Form:            DW_FORM_implicit_const
+              Value:           5
+  debug_info:
+    - Version:         5
+      UnitType:        DW_UT_compile
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+        - AbbrCode:        0x2
+          Values:
+            - Value:           0xDEADBEEFDEADBEEF
+              CStr:            func
+        - AbbrCode:        0x0)";
+
+  YAMLModuleTester t(yamldata);
+  auto *symbol_file =
+      llvm::cast<SymbolFileDWARF>(t.GetModule()->GetSymbolFile());
+  DWARFUnit *unit = symbol_file->DebugInfo().GetUnitAtIndex(0);
+  ASSERT_TRUE(unit);
+
+  DWARFDIE subprogram = unit->DIE().GetFirstChild();
+  ASSERT_TRUE(subprogram);
+  dw_offset_t end_attr_offset;
+  DWARFFormValue form_value;
+  dw_offset_t offset = subprogram.GetDIE()->GetAttributeValue(
+      unit, DW_AT_object_pointer, form_value, &end_attr_offset);
+  EXPECT_EQ(form_value.Unsigned(), 5U);
+  EXPECT_GT(offset, 0U);
+  EXPECT_GT(end_attr_offset, 0U);
+}
+
 struct GetAttributesTestFixture : public testing::TestWithParam<dw_attr_t> {};
 
 TEST_P(GetAttributesTestFixture, TestGetAttributes_IterationOrder) {


### PR DESCRIPTION
`DWARFFormValue::ExtractValue` has nothing to extract for `DW_FORM_implicit_const` since the value is stored in the abbreviation. `DWARFFormValue` expects the user to have set the value of the implicit_const. This patch does so in `GetAttributeValue`.