### PR TITLE
[DWARF] Fix redundant DW_AT_ prefix in HANDLE_DW_AT definition for `INTEL_other_endian`

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -475,7 +475,7 @@ HANDLE_DW_AT(0x2029, HP_is_result_param, 0, HP)
 // HANDLE_DW_AT(0x2004, CPQ_split_lifetimes_rtn, 0, COMPAQ)
 // HANDLE_DW_AT(0x2005, CPQ_prologue_length, 0, COMPAQ)
 
-HANDLE_DW_AT(0x2026, DW_AT_INTEL_other_endian, 0, INTEL)
+HANDLE_DW_AT(0x2026, INTEL_other_endian, 0, INTEL)
 
 // Green Hills.
 HANDLE_DW_AT(0x2083, GHS_rsm, 0, GHS)


### PR DESCRIPTION
The prefix 'DW_AT_' is automatically added by macro expansion in consumers of Dwarf.def.  Having it explicitly in the macro argument results in duplicated naming such as DW_AT_DW_AT_INTEL_other_endian.