### PR TITLE
[clang][bytecode] Fix IntegralAP::{isMin,isMax}

### DIFF
--- a/clang/lib/AST/ByteCode/IntegralAP.h
+++ b/clang/lib/AST/ByteCode/IntegralAP.h
@@ -163,8 +163,16 @@ public:
       return !getValue().isNonNegative();
     return false;
   }
-  bool isMin() const { return getValue().isMinValue(); }
-  bool isMax() const { return getValue().isMaxValue(); }
+  bool isMin() const {
+    if constexpr (Signed)
+      return getValue().isMinSignedValue();
+    return getValue().isMinValue();
+  }
+  bool isMax() const {
+    if constexpr (Signed)
+      return getValue().isMaxSignedValue();
+    return getValue().isMaxValue();
+  }
   static constexpr bool isSigned() { return Signed; }
   bool isMinusOne() const { return Signed && getValue().isAllOnes(); }
 

--- a/clang/test/AST/ByteCode/intap.cpp
+++ b/clang/test/AST/ByteCode/intap.cpp
@@ -48,6 +48,13 @@ static_assert(DivA / DivB == 2, "");
 constexpr _BitInt(4) DivC = DivA / 0; // both-error {{must be initialized by a constant expression}} \
                                       // both-note {{division by zero}}
 
+constexpr __int128 isMinDiv() {
+  return __int128{0} / __int128{-1};
+}
+static_assert(isMinDiv() == 0, "");
+
+
+
 constexpr _BitInt(7) RemA = 47;
 constexpr _BitInt(6) RemB = 9;
 static_assert(RemA % RemB == 2, "");


### PR DESCRIPTION
We need to take signeness into account here.