### PR TITLE
[clang][bytecode] Remove incorrect assertion

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -114,7 +114,6 @@ void Pointer::operator=(Pointer &&P) {
     }
 
     if (Block *Pointee = PointeeStorage.BS.Pointee) {
-      assert(P.block() != this->block());
       Pointee->removePointer(this);
       PointeeStorage.BS.Pointee = nullptr;
       Pointee->cleanup();


### PR DESCRIPTION
P.block() will assert that P is a block pointer, which it doesn't have to be here.