### PR TITLE
[lldb] Add support for NoneType to decorator skipIfBuildType

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1155,7 +1155,7 @@ def skipIfBuildType(types: list[str]):
     """
     types = [name.lower() for name in types]
     return unittest.skipIf(
-        configuration.cmake_build_type != None &&
+        configuration.cmake_build_type is not None and
         configuration.cmake_build_type.lower() in types,
         "skip on {} build type(s)".format(", ".join(types)),
     )

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1155,7 +1155,7 @@ def skipIfBuildType(types: list[str]):
     """
     types = [name.lower() for name in types]
     return unittest.skipIf(
-        configuration.cmake_build_type is not None and
-        configuration.cmake_build_type.lower() in types,
+        configuration.cmake_build_type is not None
+        and configuration.cmake_build_type.lower() in types,
         "skip on {} build type(s)".format(", ".join(types)),
     )

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1155,6 +1155,7 @@ def skipIfBuildType(types: list[str]):
     """
     types = [name.lower() for name in types]
     return unittest.skipIf(
+        configuration.cmake_build_type != None &&
         configuration.cmake_build_type.lower() in types,
         "skip on {} build type(s)".format(", ".join(types)),
     )


### PR DESCRIPTION
Currently if cmake_build_type is None we error with `AttributeError: 'NoneType' object has no attribute 'lower'` if the decorator skipIfBuildType is used. This fixes the issue by first checking that cmake_build_type is not None.