### PR TITLE
[InstCombine] Treat identical operands as one in pushFreezeToPreventPoisonFromPropagating

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -4902,7 +4902,9 @@ InstCombinerImpl::pushFreezeToPreventPoisonFromPropagating(FreezeInst &OrigFI) {
   Use *MaybePoisonOperand = nullptr;
   for (Use &U : OrigOpInst->operands()) {
     if (isa<MetadataAsValue>(U.get()) ||
-        isGuaranteedNotToBeUndefOrPoison(U.get()))
+        isGuaranteedNotToBeUndefOrPoison(U.get()) ||
+        // Treat identical operands as a single operand.
+        (MaybePoisonOperand && MaybePoisonOperand->get() == U.get()))
       continue;
     if (!MaybePoisonOperand)
       MaybePoisonOperand = &U;

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -4900,14 +4900,13 @@ InstCombinerImpl::pushFreezeToPreventPoisonFromPropagating(FreezeInst &OrigFI) {
   // to the operand. So we first find the operand that is not guaranteed to be
   // poison.
   Value *MaybePoisonOperand = nullptr;
-  for (Use &U : OrigOpInst->operands()) {
-    if (isa<MetadataAsValue>(U.get()) ||
-        isGuaranteedNotToBeUndefOrPoison(U.get()) ||
+  for (Value *V : OrigOpInst->operands()) {
+    if (isa<MetadataAsValue>(V) || isGuaranteedNotToBeUndefOrPoison(V) ||
         // Treat identical operands as a single operand.
-        (MaybePoisonOperand && MaybePoisonOperand == U.get()))
+        (MaybePoisonOperand && MaybePoisonOperand == V))
       continue;
     if (!MaybePoisonOperand)
-      MaybePoisonOperand = U.get();
+      MaybePoisonOperand = V;
     else
       return nullptr;
   }

--- a/llvm/test/Transforms/InstCombine/freeze.ll
+++ b/llvm/test/Transforms/InstCombine/freeze.ll
@@ -142,6 +142,17 @@ define i32 @early_freeze_test3(i32 %v1) {
   ret i32 %v4.fr
 }
 
+define i32 @early_freeze_test4(i32 %v1) {
+; CHECK-LABEL: @early_freeze_test4(
+; CHECK-NEXT:    [[V2:%.*]] = mul i32 [[V1_FR:%.*]], [[V1_FR]]
+; CHECK-NEXT:    [[V2_FR:%.*]] = freeze i32 [[V2]]
+; CHECK-NEXT:    ret i32 [[V2_FR]]
+;
+  %v2 = mul i32 %v1, %v1
+  %v2.fr = freeze i32 %v2
+  ret i32 %v2.fr
+}
+
 ; If replace all dominated uses of v to freeze(v).
 
 define void @freeze_dominated_uses_test1(i32 %v) {

--- a/llvm/test/Transforms/InstCombine/freeze.ll
+++ b/llvm/test/Transforms/InstCombine/freeze.ll
@@ -144,9 +144,9 @@ define i32 @early_freeze_test3(i32 %v1) {
 
 define i32 @early_freeze_test4(i32 %v1) {
 ; CHECK-LABEL: @early_freeze_test4(
-; CHECK-NEXT:    [[V2:%.*]] = mul i32 [[V1_FR:%.*]], [[V1_FR]]
-; CHECK-NEXT:    [[V2_FR:%.*]] = freeze i32 [[V2]]
-; CHECK-NEXT:    ret i32 [[V2_FR]]
+; CHECK-NEXT:    [[V2_FR:%.*]] = freeze i32 [[V2:%.*]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i32 [[V2_FR]], [[V2_FR]]
+; CHECK-NEXT:    ret i32 [[V3]]
 ;
   %v2 = mul i32 %v1, %v1
   %v2.fr = freeze i32 %v2


### PR DESCRIPTION
To push a freeze through an instruction, only one operand may produce
poison. However, this currently fails for identical operands which are
treated as separate. This patch fixes this by treating them as a single
operand.

Thanks to @david-arm for help with this.