### PR TITLE
  [llvm] annotate remaining Support and ADT library interfaces for DLL export

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -673,7 +673,8 @@ private:
   integerPart addSignificand(const IEEEFloat &);
   integerPart subtractSignificand(const IEEEFloat &, integerPart);
   // Exported for IEEEFloatUnitTestHelper.
-  LLVM_ABI lostFraction addOrSubtractSignificand(const IEEEFloat &, bool subtract);
+  LLVM_ABI lostFraction addOrSubtractSignificand(const IEEEFloat &,
+                                                 bool subtract);
   lostFraction multiplySignificand(const IEEEFloat &, IEEEFloat,
                                    bool ignoreAddend = false);
   lostFraction multiplySignificand(const IEEEFloat&);

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -672,7 +672,8 @@ private:
 
   integerPart addSignificand(const IEEEFloat &);
   integerPart subtractSignificand(const IEEEFloat &, integerPart);
-  lostFraction addOrSubtractSignificand(const IEEEFloat &, bool subtract);
+  // Exported for IEEEFloatUnitTestHelper.
+  LLVM_ABI lostFraction addOrSubtractSignificand(const IEEEFloat &, bool subtract);
   lostFraction multiplySignificand(const IEEEFloat &, IEEEFloat,
                                    bool ignoreAddend = false);
   lostFraction multiplySignificand(const IEEEFloat&);

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -561,7 +561,7 @@ public:
   }
 
   /// Overload to compute a hash_code for an APInt value.
-  friend hash_code hash_value(const APInt &Arg);
+  LLVM_ABI friend hash_code hash_value(const APInt &Arg);
 
   /// This function returns a pointer to the internal storage of the APInt.
   /// This is useful for writing out the APInt in binary form without any

--- a/llvm/include/llvm/ADT/DynamicAPInt.h
+++ b/llvm/include/llvm/ADT/DynamicAPInt.h
@@ -212,7 +212,7 @@ public:
   friend DynamicAPInt operator/(int64_t A, const DynamicAPInt &B);
   friend DynamicAPInt operator%(int64_t A, const DynamicAPInt &B);
 
-  friend hash_code hash_value(const DynamicAPInt &x); // NOLINT
+  LLVM_ABI friend hash_code hash_value(const DynamicAPInt &x); // NOLINT
 
   LLVM_ABI void static_assert_layout(); // NOLINT
 

--- a/llvm/include/llvm/Support/ConvertUTF.h
+++ b/llvm/include/llvm/Support/ConvertUTF.h
@@ -346,9 +346,9 @@ LLVM_ABI bool convertUTF32ToUTF8String(ArrayRef<UTF32> Src, std::string &Out);
 LLVM_ABI bool convertUTF8ToUTF16String(StringRef SrcUTF8,
                                        SmallVectorImpl<UTF16> &DstUTF16);
 
-bool IsSingleCodeUnitUTF8Codepoint(unsigned);
-bool IsSingleCodeUnitUTF16Codepoint(unsigned);
-bool IsSingleCodeUnitUTF32Codepoint(unsigned);
+LLVM_ABI bool IsSingleCodeUnitUTF8Codepoint(unsigned);
+LLVM_ABI bool IsSingleCodeUnitUTF16Codepoint(unsigned);
+LLVM_ABI bool IsSingleCodeUnitUTF32Codepoint(unsigned);
 
 #if defined(_WIN32)
 namespace sys {

--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_SUPPORT_KNOWNFPCLASS_H
 #define LLVM_SUPPORT_KNOWNFPCLASS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FloatingPointMode.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {
@@ -218,7 +218,8 @@ struct KnownFPClass {
   ///
   /// This assumes a copy-like operation and will replace any currently known
   /// information.
-  LLVM_ABI void propagateCanonicalizingSrc(const KnownFPClass &Src, DenormalMode Mode);
+  LLVM_ABI void propagateCanonicalizingSrc(const KnownFPClass &Src,
+                                           DenormalMode Mode);
 
   void resetAll() { *this = KnownFPClass(); }
 };

--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_KNOWNFPCLASS_H
 #define LLVM_SUPPORT_KNOWNFPCLASS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include <optional>
 
@@ -78,13 +79,13 @@ struct KnownFPClass {
   /// Return true if it's know this can never be interpreted as a zero. This
   /// extends isKnownNeverZero to cover the case where the assumed
   /// floating-point mode for the function interprets denormals as zero.
-  bool isKnownNeverLogicalZero(DenormalMode Mode) const;
+  LLVM_ABI bool isKnownNeverLogicalZero(DenormalMode Mode) const;
 
   /// Return true if it's know this can never be interpreted as a negative zero.
-  bool isKnownNeverLogicalNegZero(DenormalMode Mode) const;
+  LLVM_ABI bool isKnownNeverLogicalNegZero(DenormalMode Mode) const;
 
   /// Return true if it's know this can never be interpreted as a positive zero.
-  bool isKnownNeverLogicalPosZero(DenormalMode Mode) const;
+  LLVM_ABI bool isKnownNeverLogicalPosZero(DenormalMode Mode) const;
 
   static constexpr FPClassTest OrderedLessThanZeroMask =
       fcNegSubnormal | fcNegNormal | fcNegInf;
@@ -209,7 +210,7 @@ struct KnownFPClass {
   ///
   /// This assumes a copy-like operation and will replace any currently known
   /// information.
-  void propagateDenormal(const KnownFPClass &Src, DenormalMode Mode);
+  LLVM_ABI void propagateDenormal(const KnownFPClass &Src, DenormalMode Mode);
 
   /// Report known classes if \p Src is evaluated through a potentially
   /// canonicalizing operation. We can assume signaling nans will not be
@@ -217,7 +218,7 @@ struct KnownFPClass {
   ///
   /// This assumes a copy-like operation and will replace any currently known
   /// information.
-  void propagateCanonicalizingSrc(const KnownFPClass &Src, DenormalMode Mode);
+  LLVM_ABI void propagateCanonicalizingSrc(const KnownFPClass &Src, DenormalMode Mode);
 
   void resetAll() { *this = KnownFPClass(); }
 };

--- a/llvm/include/llvm/Support/ProgramStack.h
+++ b/llvm/include/llvm/Support/ProgramStack.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_PROGRAMSTACK_H
 #define LLVM_SUPPORT_PROGRAMSTACK_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 
 // LLVM_HAS_SPLIT_STACKS is exposed in the header because CrashRecoveryContext
@@ -28,12 +29,12 @@ namespace llvm {
 ///
 /// The value is not guaranteed to point to anything specific. It can be used to
 /// estimate how much stack space has been used since the previous call.
-uintptr_t getStackPointer();
+LLVM_ABI uintptr_t getStackPointer();
 
 /// \returns the default stack size for this platform.
 ///
 /// Based on \p RLIMIT_STACK or the equivalent.
-unsigned getDefaultStackSize();
+LLVM_ABI unsigned getDefaultStackSize();
 
 /// Runs Fn on a new stack of at least the given size.
 ///
@@ -42,7 +43,7 @@ unsigned getDefaultStackSize();
 ///
 /// The preferred implementation is split stacks on platforms that have a good
 /// debugging experience for them. On other platforms a new thread is used.
-void runOnNewStack(unsigned StackSize, function_ref<void()> Fn);
+LLVM_ABI void runOnNewStack(unsigned StackSize, function_ref<void()> Fn);
 
 template <typename R, typename... Ts>
 std::enable_if_t<!std::is_same_v<R, void>, R>

--- a/llvm/include/llvm/Support/ProgramStack.h
+++ b/llvm/include/llvm/Support/ProgramStack.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_PROGRAMSTACK_H
 #define LLVM_SUPPORT_PROGRAMSTACK_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Compiler.h"
 
 // LLVM_HAS_SPLIT_STACKS is exposed in the header because CrashRecoveryContext
 // needs to know if it's running on another thread or not.

--- a/llvm/include/llvm/Support/TextEncoding.h
+++ b/llvm/include/llvm/Support/TextEncoding.h
@@ -15,10 +15,10 @@
 #ifndef LLVM_SUPPORT_TEXT_ENCODING_H
 #define LLVM_SUPPORT_TEXT_ENCODING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 
 #include <string>
@@ -94,7 +94,7 @@ public:
   /// \param[in] To the target character encoding
   /// \return a TextEncodingConverter instance or an error code
   LLVM_ABI static ErrorOr<TextEncodingConverter> create(TextEncoding From,
-                                               TextEncoding To);
+                                                        TextEncoding To);
 
   /// Creates a TextEncodingConverter instance.
   /// Returns std::errc::invalid_argument in case the requested conversion is
@@ -102,7 +102,8 @@ public:
   /// \param[in] From name of the source character encoding
   /// \param[in] To name of the target character encoding
   /// \return a TextEncodingConverter instance or an error code
-  LLVM_ABI static ErrorOr<TextEncodingConverter> create(StringRef From, StringRef To);
+  LLVM_ABI static ErrorOr<TextEncodingConverter> create(StringRef From,
+                                                        StringRef To);
 
   TextEncodingConverter(const TextEncodingConverter &) = delete;
   TextEncodingConverter &operator=(const TextEncodingConverter &) = delete;

--- a/llvm/include/llvm/Support/TextEncoding.h
+++ b/llvm/include/llvm/Support/TextEncoding.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_SUPPORT_TEXT_ENCODING_H
 #define LLVM_SUPPORT_TEXT_ENCODING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/config.h"
@@ -92,7 +93,7 @@ public:
   /// \param[in] From the source character encoding
   /// \param[in] To the target character encoding
   /// \return a TextEncodingConverter instance or an error code
-  static ErrorOr<TextEncodingConverter> create(TextEncoding From,
+  LLVM_ABI static ErrorOr<TextEncodingConverter> create(TextEncoding From,
                                                TextEncoding To);
 
   /// Creates a TextEncodingConverter instance.
@@ -101,7 +102,7 @@ public:
   /// \param[in] From name of the source character encoding
   /// \param[in] To name of the target character encoding
   /// \return a TextEncodingConverter instance or an error code
-  static ErrorOr<TextEncodingConverter> create(StringRef From, StringRef To);
+  LLVM_ABI static ErrorOr<TextEncodingConverter> create(StringRef From, StringRef To);
 
   TextEncodingConverter(const TextEncodingConverter &) = delete;
   TextEncodingConverter &operator=(const TextEncodingConverter &) = delete;

--- a/llvm/include/llvm/Support/Timer.h
+++ b/llvm/include/llvm/Support/Timer.h
@@ -258,7 +258,7 @@ public:
 
 private:
   friend class Timer;
-  friend void PrintStatisticsJSON(raw_ostream &OS);
+  LLVM_ABI friend void PrintStatisticsJSON(raw_ostream &OS);
   void addTimer(Timer &T);
   void removeTimer(Timer &T);
   void prepareToPrintList(bool reset_time = false);


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the remaining LLVM Support and ADT interfaces that were missed in, or modified since, previous patches. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS:
- Annotate the private method `IEEEFloat::addOrSubtractSignificand` with `LLVM_ABI` because it is used by a unit test friend class.
- Annotate several `friend` function declarations with `LLVM_ABI_FRIEND` since the corresponding function declarations are annotated with `LLVM_ABI` (required by MSVC).

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang