### PR TITLE
Cap IntRange::Width to MaxWidth

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -10540,8 +10540,6 @@ static std::optional<IntRange> TryGetExprRange(ASTContext &C, const Expr *E,
                                                bool Approximate) {
   E = E->IgnoreParens();
 
-  assert(MaxWidth == C.getIntWidth(GetExprType(E)));
-
   // Try a full evaluation first.
   Expr::EvalResult result;
   if (E->EvaluateAsRValue(result, C, InConstantContext))

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -10540,6 +10540,8 @@ static std::optional<IntRange> TryGetExprRange(ASTContext &C, const Expr *E,
                                                bool Approximate) {
   E = E->IgnoreParens();
 
+  assert(MaxWidth == C.getIntWidth(GetExprType(E)));
+
   // Try a full evaluation first.
   Expr::EvalResult result;
   if (E->EvaluateAsRValue(result, C, InConstantContext))
@@ -10805,9 +10807,8 @@ static std::optional<IntRange> TryGetExprRange(ASTContext &C, const Expr *E,
         return std::nullopt;
 
       // If the range was previously non-negative, we need an extra bit for the
-      // sign bit. If the range was not non-negative, we need an extra bit
-      // because the negation of the most-negative value is one bit wider than
-      // that value.
+      // sign bit. Otherwise, we need an extra bit because the negation of the
+      // most-negative value is one bit wider than that value.
       return IntRange(std::min(SubRange->Width + 1, MaxWidth), false);
     }
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -10808,7 +10808,7 @@ static std::optional<IntRange> TryGetExprRange(ASTContext &C, const Expr *E,
       // sign bit. If the range was not non-negative, we need an extra bit
       // because the negation of the most-negative value is one bit wider than
       // that value.
-      return IntRange(SubRange->Width + 1, false);
+      return IntRange(std::min(SubRange->Width + 1, MaxWidth), false);
     }
 
     case UO_Not: {
@@ -10825,7 +10825,9 @@ static std::optional<IntRange> TryGetExprRange(ASTContext &C, const Expr *E,
 
       // The width increments by 1 if the sub-expression cannot be negative
       // since it now can be.
-      return IntRange(SubRange->Width + (int)SubRange->NonNegative, false);
+      return IntRange(
+          std::min(SubRange->Width + (int)SubRange->NonNegative, MaxWidth),
+          false);
     }
 
     default:

--- a/clang/test/Sema/implicit-int-conversion-on-int.c
+++ b/clang/test/Sema/implicit-int-conversion-on-int.c
@@ -48,3 +48,11 @@ unsigned long long test_ull(unsigned long long x) {
 unsigned _BitInt(16) test_unsigned_bit_int(unsigned _BitInt(16) x) {
   return -x;
 }
+
+unsigned test_shift_minus(int i) {
+  return -(1 << i);
+}
+
+unsigned test_shift_not(int i) {
+  return ~(1 << i);
+}


### PR DESCRIPTION
This commit addresses a fallout introduced by #126846.

Previously, TryGetExprRange would return an IntRange that has an active range exceeding the maximum representable range for the expression's underlying type. This led to clang erroneously issuing warnings about implicit conversions losing integer precision.

This commit fixes the bug by capping IntRange::Width to MaxWidth.

rdar://149444029