### PR TITLE
hwasan: refactor interceptor allocation/deallocation functions

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan.h
+++ b/compiler-rt/lib/hwasan/hwasan.h
@@ -136,6 +136,21 @@ int hwasan_posix_memalign(void **memptr, uptr alignment, uptr size,
                         StackTrace *stack);
 void hwasan_free(void *ptr, StackTrace *stack);
 
+void *hwasan_new(uptr size, StackTrace *stack);
+void *hwasan_new_aligned(uptr size, uptr alignment, StackTrace *stack);
+void *hwasan_new_array(uptr size, StackTrace *stack);
+void *hwasan_new_array_aligned(uptr size, uptr alignment, StackTrace *stack);
+void hwasan_delete(void *ptr, StackTrace *stack);
+void hwasan_delete_aligned(void *ptr, uptr alignment, StackTrace *stack);
+void hwasan_delete_sized(void *ptr, uptr size, StackTrace *stack);
+void hwasan_delete_sized_aligned(void *ptr, uptr size, uptr alignment,
+                                 StackTrace *stack);
+void hwasan_delete_array(void *ptr, StackTrace *stack);
+void hwasan_delete_array_aligned(void *ptr, uptr alignment, StackTrace *stack);
+void hwasan_delete_array_sized(void *ptr, uptr size, StackTrace *stack);
+void hwasan_delete_array_sized_aligned(void *ptr, uptr size, uptr alignment,
+                                       StackTrace *stack);
+
 void InstallAtExitHandler();
 
 #define GET_MALLOC_STACK_TRACE                                            \

--- a/compiler-rt/lib/hwasan/hwasan_allocator.h
+++ b/compiler-rt/lib/hwasan/hwasan_allocator.h
@@ -31,13 +31,20 @@
 
 namespace __hwasan {
 
+enum AllocType {
+  FROM_MALLOC = 1,  // Memory block came from malloc, calloc, realloc, etc.
+  FROM_NEW = 2,     // Memory block came from operator new.
+  FROM_NEW_BR = 3   // Memory block came from operator new [ ]
+};
+
 struct Metadata {
  private:
   atomic_uint64_t alloc_context_id;
   u32 requested_size_low;
   u16 requested_size_high;
   atomic_uint8_t chunk_state;
-  u8 lsan_tag;
+  u8 lsan_tag : 2;
+  u8 alloc_type : 2;
 
  public:
   inline void SetAllocated(u32 stack, u64 size);
@@ -49,6 +56,8 @@ struct Metadata {
   inline u32 GetAllocThreadId() const;
   inline void SetLsanTag(__lsan::ChunkTag tag);
   inline __lsan::ChunkTag GetLsanTag() const;
+  inline void SetAllocType(AllocType type);
+  inline AllocType GetAllocType() const;
 };
 static_assert(sizeof(Metadata) == 16);
 


### PR DESCRIPTION
Do some refactoring to allocation/deallocation interceptors. Expose explicit per-alloc_type functions. This is similar to #145087 for ASan.

NOTE: This change rejects attempts to call `operator new(<some_size>, static_cast<std::align_val_t>(0))`.

For https://github.com/llvm/llvm-project/issues/144435