### PR TITLE
[C23][Parser] Accept single variadic parameter function declarator in type name

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -295,6 +295,8 @@ C23 Feature Support
   type. Fixes #GH140887
 - Documented `WG14 N3006 <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3006.htm>`_
   which clarified how Clang is handling underspecified object declarations.
+- Clang now accepts single variadic parameter in type-name. It's a part of
+  `WG14 N2975 <https://open-std.org/JTC1/SC22/WG14/www/docs/n2975.pdf>`_
 
 C11 Feature Support
 ^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7048,7 +7048,8 @@ void Parser::ParseParenDeclarator(Declarator &D) {
     // paren, because we haven't seen the identifier yet.
     isGrouping = true;
   } else if (Tok.is(tok::r_paren) || // 'int()' is a function.
-             (getLangOpts().CPlusPlus && Tok.is(tok::ellipsis) &&
+             ((getLangOpts().CPlusPlus || getLangOpts().C23) &&
+              Tok.is(tok::ellipsis) &&
               NextToken().is(tok::r_paren)) || // C++ int(...)
              isDeclarationSpecifier(
                  ImplicitTypenameContext::No) || // 'int(int)' is a function.

--- a/clang/test/C/C23/n2975.c
+++ b/clang/test/C/C23/n2975.c
@@ -51,3 +51,15 @@ void use(void) {
   // ...including conversion errors.
   fp other_local = diag; // expected-error {{incompatible function pointer types initializing 'fp' (aka 'void (*)(...)') with an expression of type 'void (int, int, ...)'}}
 }
+
+// int(...) not parsed as variadic function type.
+// https://github.com/llvm/llvm-project/issues/145250
+int va_fn(...);  // expected-warning {{'...' as the only parameter of a function is incompatible with C standards before C23}}
+
+// As typeof() argument
+typeof(int(...))*fn_ptr = &va_fn;  // expected-warning {{'...' as the only parameter of a function is incompatible with C standards before C23}} \
+                                   // expected-warning {{'typeof' is incompatible with C standards before C23}}
+
+// As _Generic association type
+int i = _Generic(typeof(va_fn), int(...):1);  // expected-warning {{'...' as the only parameter of a function is incompatible with C standards before C23}} \
+                                              // expected-warning {{'typeof' is incompatible with C standards before C23}}


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/145250.

This PR makes clang accept single variadic parameter function declarator in type name.
Eg.
```c
int va_fn(...); // ok

// As typeof() argument
typeof(int(...))*fn_ptr = &va_fn;  // ok

// As _Generic association type
int i = _Generic(typeof(va_fn), int(...):1); // ok
```
