### PR TITLE
 [llvm] annotate remaining BinaryFormat and DebugInfo library interfaces for DLL export

### DIFF
--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -186,7 +186,7 @@ enum class DescriptorRangeType : uint32_t {
 #include "DXContainerConstants.def"
 };
 
-ArrayRef<EnumEntry<DescriptorRangeType>> getDescriptorRangeTypes();
+LLVM_ABI ArrayRef<EnumEntry<DescriptorRangeType>> getDescriptorRangeTypes();
 
 #define ROOT_PARAMETER(Val, Enum)                                              \
   case Val:                                                                    \

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIPrinter.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIPrinter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCFIPRINTER_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCFIPRINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFCFIProgram.h"
 
 namespace llvm {
@@ -17,7 +18,7 @@ struct DIDumpOptions;
 
 namespace dwarf {
 
-void printCFIProgram(const CFIProgram &P, raw_ostream &OS,
+LLVM_ABI void printCFIProgram(const CFIProgram &P, raw_ostream &OS,
                      const DIDumpOptions &DumpOpts, unsigned IndentLevel,
                      std::optional<uint64_t> Address);
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIPrinter.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIPrinter.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFCFIPRINTER_H
 #define LLVM_DEBUGINFO_DWARF_DWARFCFIPRINTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/DWARFCFIProgram.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -19,8 +19,9 @@ struct DIDumpOptions;
 namespace dwarf {
 
 LLVM_ABI void printCFIProgram(const CFIProgram &P, raw_ostream &OS,
-                     const DIDumpOptions &DumpOpts, unsigned IndentLevel,
-                     std::optional<uint64_t> Address);
+                              const DIDumpOptions &DumpOpts,
+                              unsigned IndentLevel,
+                              std::optional<uint64_t> Address);
 
 } // end namespace dwarf
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIProgram.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFCFIProgram.h
@@ -106,11 +106,11 @@ public:
   };
 
   /// Get the OperandType as a "const char *".
-  static const char *operandTypeString(OperandType OT);
+  LLVM_ABI static const char *operandTypeString(OperandType OT);
 
   /// Retrieve the array describing the types of operands according to the enum
   /// above. This is indexed by opcode.
-  static ArrayRef<OperandType[MaxOperands]> getOperandTypes();
+  LLVM_ABI static ArrayRef<OperandType[MaxOperands]> getOperandTypes();
 
 private:
   std::vector<Instruction> Instructions;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
@@ -187,7 +187,8 @@ public:
   /// \param OS to this stream
   /// \param GetNameForDWARFReg callback to return dwarf register name
   LLVM_ABI static void print(const DWARFExpression *E, raw_ostream &OS,
-                    DIDumpOptions DumpOpts, DWARFUnit *U, bool IsEH = false);
+                             DIDumpOptions DumpOpts, DWARFUnit *U,
+                             bool IsEH = false);
 
   /// Print the expression in a format intended to be compact and useful to a
   /// user, but not perfectly unambiguous, or capable of representing every
@@ -199,9 +200,10 @@ public:
   /// \param GetNameForDWARFReg callback to return dwarf register name
   ///
   /// \returns true if the expression was successfully printed
-  LLVM_ABI static bool printCompact(const DWARFExpression *E, raw_ostream &OS,
-                           std::function<StringRef(uint64_t RegNum, bool IsEH)>
-                               GetNameForDWARFReg = nullptr);
+  LLVM_ABI static bool printCompact(
+      const DWARFExpression *E, raw_ostream &OS,
+      std::function<StringRef(uint64_t RegNum, bool IsEH)> GetNameForDWARFReg =
+          nullptr);
 
   /// Pretty print a register opcode and operands.
   /// \param U within the context of this Dwarf unit, if any.
@@ -212,8 +214,9 @@ public:
   ///
   /// returns true if the Op was successfully printed
   LLVM_ABI static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
-                                    DIDumpOptions DumpOpts, uint8_t Opcode,
-                                    ArrayRef<uint64_t> Operands);
+                                             DIDumpOptions DumpOpts,
+                                             uint8_t Opcode,
+                                             ArrayRef<uint64_t> Operands);
 
 private:
   static bool printOp(const DWARFExpression::Operation *Op, raw_ostream &OS,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
@@ -186,7 +186,7 @@ public:
   /// \param E to be printed
   /// \param OS to this stream
   /// \param GetNameForDWARFReg callback to return dwarf register name
-  static void print(const DWARFExpression *E, raw_ostream &OS,
+  LLVM_ABI static void print(const DWARFExpression *E, raw_ostream &OS,
                     DIDumpOptions DumpOpts, DWARFUnit *U, bool IsEH = false);
 
   /// Print the expression in a format intended to be compact and useful to a
@@ -199,7 +199,7 @@ public:
   /// \param GetNameForDWARFReg callback to return dwarf register name
   ///
   /// \returns true if the expression was successfully printed
-  static bool printCompact(const DWARFExpression *E, raw_ostream &OS,
+  LLVM_ABI static bool printCompact(const DWARFExpression *E, raw_ostream &OS,
                            std::function<StringRef(uint64_t RegNum, bool IsEH)>
                                GetNameForDWARFReg = nullptr);
 
@@ -211,7 +211,7 @@ public:
   /// \param Operands to the opcode
   ///
   /// returns true if the Op was successfully printed
-  static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
+  LLVM_ABI static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
                                     DIDumpOptions DumpOpts, uint8_t Opcode,
                                     ArrayRef<uint64_t> Operands);
 

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSourceLanguage.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSourceLanguage.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSOURCELANGUAGE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSOURCELANGUAGE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
@@ -52,7 +53,7 @@ struct LVSourceLanguage {
 
   bool isValid() const { return Language != Invalid; }
   TaggedLanguage get() const { return Language; }
-  StringRef getName() const;
+  LLVM_ABI StringRef getName() const;
 
 private:
   TaggedLanguage Language = Invalid;

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSourceLanguage.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSourceLanguage.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSOURCELANGUAGE_H
 #define LLVM_DEBUGINFO_LOGICALVIEW_CORE_LVSOURCELANGUAGE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace logicalview {


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the remaining LLVM BinaryFormat and DebugInfo interfaces that were missed in, or modified since, previous patches. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview

These changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang