### PR TITLE
[llvm] annotate remaining ExecutionEngine, Frontend, and TargetParser interfaces for DLL export

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COFF_H
 #define LLVM_EXECUTIONENGINE_ORC_COFF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -31,7 +32,7 @@ class COFFImportFileScanner {
 public:
   COFFImportFileScanner(std::set<std::string> &ImportedDynamicLibraries)
       : ImportedDynamicLibraries(ImportedDynamicLibraries) {}
-  Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
+  LLVM_ABI Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
                             size_t Index) const;
 
 private:

--- a/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
@@ -32,8 +32,8 @@ class COFFImportFileScanner {
 public:
   COFFImportFileScanner(std::set<std::string> &ImportedDynamicLibraries)
       : ImportedDynamicLibraries(ImportedDynamicLibraries) {}
-  LLVM_ABI Expected<bool> operator()(object::Archive &A, MemoryBufferRef MemberBuf,
-                            size_t Index) const;
+  LLVM_ABI Expected<bool>
+  operator()(object::Archive &A, MemoryBufferRef MemberBuf, size_t Index) const;
 
 private:
   std::set<std::string> &ImportedDynamicLibraries;

--- a/llvm/include/llvm/Frontend/Directive/Spelling.h
+++ b/llvm/include/llvm/Frontend/Directive/Spelling.h
@@ -8,6 +8,7 @@
 #ifndef LLVM_FRONTEND_DIRECTIVE_SPELLING_H
 #define LLVM_FRONTEND_DIRECTIVE_SPELLING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 
@@ -33,7 +34,7 @@ struct Spelling {
   VersionRange Versions;
 };
 
-StringRef FindName(llvm::iterator_range<const Spelling *>, unsigned Version);
+LLVM_ABI StringRef FindName(llvm::iterator_range<const Spelling *>, unsigned Version);
 
 } // namespace llvm::directive
 

--- a/llvm/include/llvm/Frontend/Directive/Spelling.h
+++ b/llvm/include/llvm/Frontend/Directive/Spelling.h
@@ -8,9 +8,9 @@
 #ifndef LLVM_FRONTEND_DIRECTIVE_SPELLING_H
 #define LLVM_FRONTEND_DIRECTIVE_SPELLING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/Compiler.h"
 
 #include <limits>
 #include <tuple>
@@ -34,7 +34,8 @@ struct Spelling {
   VersionRange Versions;
 };
 
-LLVM_ABI StringRef FindName(llvm::iterator_range<const Spelling *>, unsigned Version);
+LLVM_ABI StringRef FindName(llvm::iterator_range<const Spelling *>,
+                            unsigned Version);
 
 } // namespace llvm::directive
 

--- a/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
+++ b/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
@@ -63,7 +63,7 @@ enum ProfileInstrKind {
 };
 
 // Default filename used for profile generation.
-std::string getDefaultProfileGenName();
+LLVM_ABI std::string getDefaultProfileGenName();
 } // end namespace llvm::driver
 
 #endif

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
@@ -97,13 +97,13 @@ public:
 
   // Returns a reference to the first RangeInfo that overlaps with
   // [Info.LowerBound;Info.UpperBound], or, std::nullopt if there is no overlap
-  std::optional<const RangeInfo *> getOverlapping(const RangeInfo &Info) const;
+  LLVM_ABI std::optional<const RangeInfo *> getOverlapping(const RangeInfo &Info) const;
 
   // Return the mapped RangeInfo at X or nullptr if no mapping exists
-  const RangeInfo *lookup(uint32_t X) const;
+  LLVM_ABI const RangeInfo *lookup(uint32_t X) const;
 
   // Removes all entries of the ResourceRange
-  void clear();
+  LLVM_ABI void clear();
 
   // Insert the required (sub-)intervals such that the interval of [a;b] =
   // [Info.LowerBound, Info.UpperBound] is covered and points to a valid
@@ -131,7 +131,7 @@ public:
   // Returns a reference to the first RangeInfo that overlaps with
   // [Info.LowerBound;Info.UpperBound], or, std::nullopt if there is no overlap
   // (equivalent to getOverlapping)
-  std::optional<const RangeInfo *> insert(const RangeInfo &Info);
+  LLVM_ABI std::optional<const RangeInfo *> insert(const RangeInfo &Info);
 };
 
 } // namespace rootsig

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignatureUtils.h
@@ -97,7 +97,8 @@ public:
 
   // Returns a reference to the first RangeInfo that overlaps with
   // [Info.LowerBound;Info.UpperBound], or, std::nullopt if there is no overlap
-  LLVM_ABI std::optional<const RangeInfo *> getOverlapping(const RangeInfo &Info) const;
+  LLVM_ABI std::optional<const RangeInfo *>
+  getOverlapping(const RangeInfo &Info) const;
 
   // Return the mapped RangeInfo at X or nullptr if no mapping exists
   LLVM_ABI const RangeInfo *lookup(uint32_t X) const;

--- a/llvm/include/llvm/TargetParser/TargetParser.h
+++ b/llvm/include/llvm/TargetParser/TargetParser.h
@@ -214,7 +214,7 @@ struct BasicSubtargetSubTypeKV {
   }
 };
 
-std::optional<llvm::StringMap<bool>>
+LLVM_ABI std::optional<llvm::StringMap<bool>>
 getCPUDefaultTargetFeatures(StringRef CPU,
                             ArrayRef<BasicSubtargetSubTypeKV> ProcDesc,
                             ArrayRef<BasicSubtargetFeatureKV> ProcFeatures);


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the remaining LLVM ExecutionEngine, Frontend, and TargetParser interfaces that were missed in, or modified since, previous patches. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview

These changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang