### PR TITLE
[llvm] annotate remaining Telemetry and ToolDrivers interfaces for DLL export

### DIFF
--- a/llvm/include/llvm/Telemetry/Telemetry.h
+++ b/llvm/include/llvm/Telemetry/Telemetry.h
@@ -144,7 +144,12 @@ public:
 /// monitored and transmitting the data elsewhere.
 class LLVM_ABI Manager {
 public:
+  Manager() = default;
   virtual ~Manager() = default;
+
+  // Explicitly non-copyable.
+  Manager(Manager const&) = delete;
+  Manager& operator=(Manager const&) = delete;
 
   // Dispatch Telemetry data to the Destination(s).
   // The argument is non-const because the Manager may add or remove

--- a/llvm/include/llvm/Telemetry/Telemetry.h
+++ b/llvm/include/llvm/Telemetry/Telemetry.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_TELEMETRY_TELEMETRY_H
 #define LLVM_TELEMETRY_TELEMETRY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <map>
 #include <memory>
@@ -148,8 +148,8 @@ public:
   virtual ~Manager() = default;
 
   // Explicitly non-copyable.
-  Manager(Manager const&) = delete;
-  Manager& operator=(Manager const&) = delete;
+  Manager(Manager const &) = delete;
+  Manager &operator=(Manager const &) = delete;
 
   // Dispatch Telemetry data to the Destination(s).
   // The argument is non-const because the Manager may add or remove

--- a/llvm/include/llvm/Telemetry/Telemetry.h
+++ b/llvm/include/llvm/Telemetry/Telemetry.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_TELEMETRY_TELEMETRY_H
 #define LLVM_TELEMETRY_TELEMETRY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -101,7 +102,7 @@ struct EntryKind {
 /// For example, The LLDB debugger can define a DebugCommandInfo subclass
 /// which has additional fields about the debug-command being instrumented,
 /// such as `CommandArguments` or `CommandName`.
-struct TelemetryInfo {
+struct LLVM_ABI TelemetryInfo {
   // This represents a unique-id, conventionally corresponding to
   // a tool's session - i.e., every time the tool starts until it exits.
   //
@@ -141,7 +142,7 @@ public:
 /// and this framework.
 /// It is responsible for collecting telemetry data from the tool being
 /// monitored and transmitting the data elsewhere.
-class Manager {
+class LLVM_ABI Manager {
 public:
   virtual ~Manager() = default;
 

--- a/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
@@ -17,7 +17,7 @@
 namespace llvm {
 template <typename T> class ArrayRef;
 
-int dlltoolDriverMain(ArrayRef<const char *> ArgsArr);
+LLVM_ABI int dlltoolDriverMain(ArrayRef<const char *> ArgsArr);
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_TOOLDRIVERS_LLVM_DLLTOOL_DLLTOOLDRIVER_H
 #define LLVM_TOOLDRIVERS_LLVM_DLLTOOL_DLLTOOLDRIVER_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 template <typename T> class ArrayRef;
 

--- a/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
@@ -20,7 +20,6 @@ namespace llvm {
 template <typename T> class ArrayRef;
 
 LLVM_ABI int libDriverMain(ArrayRef<const char *> ARgs);
-
 }
 
 #endif

--- a/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
@@ -17,7 +17,7 @@
 namespace llvm {
 template <typename T> class ArrayRef;
 
-int libDriverMain(ArrayRef<const char *> ARgs);
+LLVM_ABI int libDriverMain(ArrayRef<const char *> ARgs);
 
 }
 

--- a/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_TOOLDRIVERS_LLVM_LIB_LIBDRIVER_H
 #define LLVM_TOOLDRIVERS_LLVM_LIB_LIBDRIVER_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 template <typename T> class ArrayRef;
 


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the remaining Telemetry and ToolDrivers interfaces that were missed in, or modified since, previous patches. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS:
- Add `#include "llvm/Support/Compiler.h"`  to files where it was not automatically added by IDS because there were no pre-existing include statements.
- Add default ctor and delete the copy ctor and copy assignment operator in the `Telemetry::Manager` class. This is required because the class is now annotated with `LLVM_ABI` and cannot otherwise be fully instantiated for export.

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang