### PR TITLE
[mlir][affine] Fix min simplification in makeComposedAffineApply

### DIFF
--- a/mlir/test/Transforms/make-composed-folded-affine-apply.mlir
+++ b/mlir/test/Transforms/make-composed-folded-affine-apply.mlir
@@ -1,0 +1,29 @@
+// RUN: mlir-opt --allow-unregistered-dialect --transform-interpreter --split-input-file --verify-diagnostics %s | FileCheck %s
+
+#map = affine_map<()[s0, s1] -> (s1)>
+#map1 = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
+#map2 = affine_map<() -> (1)>
+module {
+  func.func @min_max_full_simplify() -> (index, index) {
+    %0 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+    %1 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+    %2 = affine.min #map()[%0, %1]
+    // Make compose affine affine.apply affine_map<()[s0, s1] -> (s0 ceildiv s1)>()[%2, %0]
+    // No min folder:
+    %3 = affine.apply #map1()[%2, %0]
+    // Min folder on.
+    %4 = affine.apply #map2()
+    return %3, %4 : index, index
+  }
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
+    %op = transform.structured.match ops{["affine.affine_apply"]} in %arg0
+        : (!transform.any_op) -> !transform.any_op
+    %folded = transform.test.make_composed_folded_affine_apply %op
+        : (!transform.any_op) -> !transform.any_op
+    transform.print %folded {name = "folded: " } : !transform.any_op
+    transform.yield
+  }
+}

--- a/mlir/test/Transforms/make-composed-folded-affine-apply.mlir
+++ b/mlir/test/Transforms/make-composed-folded-affine-apply.mlir
@@ -1,29 +1,77 @@
-// RUN: mlir-opt --allow-unregistered-dialect --transform-interpreter --split-input-file --verify-diagnostics %s | FileCheck %s
+// RUN: mlir-opt --transform-interpreter %s | FileCheck %s
 
-#map = affine_map<()[s0, s1] -> (s1)>
-#map1 = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
-#map2 = affine_map<() -> (1)>
-module {
-  func.func @min_max_full_simplify() -> (index, index) {
-    %0 = test.value_with_bounds {max = 64 : index, min = 32 : index}
-    %1 = test.value_with_bounds {max = 64 : index, min = 32 : index}
-    %2 = affine.min #map()[%0, %1]
-    // Make compose affine affine.apply affine_map<()[s0, s1] -> (s0 ceildiv s1)>()[%2, %0]
-    // No min folder:
-    %3 = affine.apply #map1()[%2, %0]
-    // Min folder on.
-    %4 = affine.apply #map2()
-    return %3, %4 : index, index
-  }
+#map = affine_map<()[s0, s1] -> (s0, s1, 128)>
+#map1 = affine_map<()[s0, s1] -> (s0 ceildiv 128 + s0 ceildiv s1)>
+#map2 = affine_map<()[s0, s1, s2] -> (s0, s1 + s2)>
+#map3 = affine_map<()[s0, s1, s2, s3] -> (3 * (s0 ceildiv s3) + s0 ceildiv (s1 + s2))>
+#map4 = affine_map<()[s0, s1] -> (s1)>
+#map5 = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
+#map6 = affine_map<()[s0, s1] -> (s0, s1, -128)>
+// CHECK-DAG: #[[MAP1:.*]] = affine_map<()[s0, s1] -> (s0 ceildiv 128 + s0 ceildiv s1)>
+// CHECK-DAG: #[[MAP5:.*]] = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
+
+// These test checks the `affine::makeComposedFoldedAffineApply` function when
+// `composeAffineMin == true`.
+
+// Check the apply gets simplified.
+// CHECK: @apply_simplification
+func.func @apply_simplification_1() -> index {
+  %0 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  %1 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  %2 = affine.min #map()[%0, %1]
+  // CHECK-NOT: affine.apply
+  // CHECK: arith.constant 2 : index
+  %3 = affine.apply #map1()[%2, %1]
+  return %3 : index
+}
+
+// Check the simplification can match non-trivial affine expressions like s1 + s2.
+func.func @apply_simplification_2() -> index {
+  %0 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  %1 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  %2 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  %3 = affine.min #map2()[%0, %1, %2]
+  // CHECK-NOT: affine.apply
+  // CHECK: arith.constant 4 : index
+  %4 = affine.apply #map3()[%3, %1, %2, %0]
+  return %4 : index
+}
+
+// Check there's no simplification.
+// The apply cannot be simplified because `s1 = %0` doesn't appear in the input min.
+// CHECK: @no_simplification_0
+func.func @no_simplification_0() -> index {
+  // CHECK: %[[V0:.*]] = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  // CHECK: %[[V1:.*]] = test.value_with_bounds {max = 64 : index, min = 16 : index}
+  // CHECK: %[[V2:.*]] = affine.min #{{.*}}()[%[[V0]], %[[V1]]]
+  // CHECK: %[[V3:.*]] = affine.apply #[[MAP5]]()[%[[V2]], %[[V0]]]
+  // CHECK: return %[[V3]] : index
+  %0 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  %1 = test.value_with_bounds {max = 64 : index, min = 16 : index}
+  %2 = affine.min #map4()[%0, %1]
+  %3 = affine.apply #map5()[%2, %0]
+  return %3 : index
+}
+
+// The apply cannot be simplified because the min cannot be proven to be greater than 0.
+// CHECK: @no_simplification_1
+func.func @no_simplification_1() -> index {
+  // CHECK: %[[V0:.*]] = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  // CHECK: %[[V1:.*]] = test.value_with_bounds {max = 64 : index, min = 16 : index}
+  // CHECK: %[[V2:.*]] = affine.min #{{.*}}()[%[[V0]], %[[V1]]]
+  // CHECK: %[[V3:.*]] = affine.apply #[[MAP1]]()[%[[V2]], %[[V1]]]
+  // CHECK: return %[[V3]] : index
+  %0 = test.value_with_bounds {max = 64 : index, min = 32 : index}
+  %1 = test.value_with_bounds {max = 64 : index, min = 16 : index}
+  %2 = affine.min #map6()[%0, %1]
+  %3 = affine.apply #map1()[%2, %1]
+  return %3 : index
 }
 
 module attributes {transform.with_named_sequence} {
-  transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op = transform.structured.match ops{["affine.affine_apply"]} in %arg0
-        : (!transform.any_op) -> !transform.any_op
-    %folded = transform.test.make_composed_folded_affine_apply %op
-        : (!transform.any_op) -> !transform.any_op
-    transform.print %folded {name = "folded: " } : !transform.any_op
-    transform.yield
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["affine.apply"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.test.make_composed_folded_affine_apply %0 : (!transform.any_op) -> !transform.any_op
+    transform.yield 
   }
 }

--- a/mlir/test/lib/Transforms/TestTransformsOps.cpp
+++ b/mlir/test/lib/Transforms/TestTransformsOps.cpp
@@ -70,15 +70,21 @@ transform::TestMakeComposedFoldedAffineApply::applyToOne(
       rewriter, loc, affineApplyOp.getAffineMap(),
       getAsOpFoldResult(affineApplyOp.getOperands()),
       /*composeAffineMin=*/true);
-  if (auto v = llvm::dyn_cast_if_present<Value>(ofr)) {
-    results.push_back(v.getDefiningOp());
+  Value result;
+  if (auto v = dyn_cast<Value>(ofr)) {
+    result = v;
   } else {
-    results.push_back(rewriter.create<arith::ConstantIndexOp>(
-        loc, getConstantIntValue(ofr).value()));
+    result = rewriter.create<arith::ConstantIndexOp>(
+        loc, getConstantIntValue(ofr).value());
   }
+  results.push_back(result.getDefiningOp());
+  rewriter.replaceOp(affineApplyOp, result);
   return DiagnosedSilenceableFailure::success();
 }
 
+//===----------------------------------------------------------------------===//
+// Extension
+//===----------------------------------------------------------------------===//
 namespace {
 
 class TestTransformsDialectExtension

--- a/mlir/test/lib/Transforms/TestTransformsOps.td
+++ b/mlir/test/lib/Transforms/TestTransformsOps.td
@@ -62,6 +62,7 @@ def TestMoveValueDefns :
 //===----------------------------------------------------------------------===//
 // Test affine functionality.
 //===----------------------------------------------------------------------===//
+
 def TestMakeComposedFoldedAffineApply :
     Op<Transform_Dialect, "test.make_composed_folded_affine_apply",
         [FunctionalStyleTransformOpTrait, 
@@ -72,15 +73,11 @@ def TestMakeComposedFoldedAffineApply :
   let description = [{
     Rewrite an affine_apply by using the makeComposedFoldedAffineApply API.
   }];
-
   let arguments = (ins TransformHandleTypeInterface:$op);
-  
   let results = (outs TransformHandleTypeInterface:$composed);
-
   let assemblyFormat = [{
     $op attr-dict `:` functional-type(operands, results)
   }];
-
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,

--- a/mlir/test/lib/Transforms/TestTransformsOps.td
+++ b/mlir/test/lib/Transforms/TestTransformsOps.td
@@ -59,5 +59,35 @@ def TestMoveValueDefns :
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Test affine functionality.
+//===----------------------------------------------------------------------===//
+def TestMakeComposedFoldedAffineApply :
+    Op<Transform_Dialect, "test.make_composed_folded_affine_apply",
+        [FunctionalStyleTransformOpTrait, 
+         MemoryEffectsOpInterface,
+         TransformOpInterface,
+         TransformEachOpTrait,
+         ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Rewrite an affine_apply by using the makeComposedFoldedAffineApply API.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$op);
+  
+  let results = (outs TransformHandleTypeInterface:$composed);
+
+  let assemblyFormat = [{
+    $op attr-dict `:` functional-type(operands, results)
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::affine::AffineApplyOp affineApplyOp,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
 
 #endif // TEST_TRANSFORM_OPS


### PR DESCRIPTION
This patch fixes a bug discovered in the `affine::makeComposedFoldedAffineApply` function when `composeAffineMin == true`. The bug happened because the simplification assumed the symbols appearing in the `affine.apply` op corresponded to symbols in the `affine.min` op, and that's not always the case. For example:

```mlir
#map = affine_map<()[s0, s1] -> (s1)>
#map1 = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
module {
  func.func @min_max_full_simplify() -> index {
    %0 = test.value_with_bounds {max = 64 : index, min = 32 : index}
    %1 = test.value_with_bounds {max = 64 : index, min = 32 : index}
    %2 = affine.min #map()[%0, %1]
    %3 = affine.apply #map1()[%2, %0]
    return %3 : index
  }
}
```

This patch also introduces the test `make_composed_folded_affine_apply` transform operation to test this simplification. It also adds tests ensuring we get correct behavior. 
