### PR TITLE
[llvm] annotate FileCheckTests interface for DLL export

### DIFF
--- a/llvm/lib/FileCheck/FileCheckImpl.h
+++ b/llvm/lib/FileCheck/FileCheckImpl.h
@@ -98,7 +98,8 @@ public:
 
   /// \returns the value corresponding to string representation \p StrVal
   /// according to the matching format represented by this instance.
-  LLVM_ABI APInt valueFromStringRepr(StringRef StrVal, const SourceMgr &SM) const;
+  LLVM_ABI APInt valueFromStringRepr(StringRef StrVal,
+                                     const SourceMgr &SM) const;
 };
 
 /// Class to represent an overflow error that might result when manipulating a
@@ -116,12 +117,18 @@ public:
 
 /// Performs operation and \returns its result or an error in case of failure,
 /// such as if an overflow occurs.
-LLVM_ABI Expected<APInt> exprAdd(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-LLVM_ABI Expected<APInt> exprSub(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-LLVM_ABI Expected<APInt> exprMul(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-LLVM_ABI Expected<APInt> exprDiv(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-LLVM_ABI Expected<APInt> exprMax(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-LLVM_ABI Expected<APInt> exprMin(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
+LLVM_ABI Expected<APInt> exprAdd(const APInt &Lhs, const APInt &Rhs,
+                                 bool &Overflow);
+LLVM_ABI Expected<APInt> exprSub(const APInt &Lhs, const APInt &Rhs,
+                                 bool &Overflow);
+LLVM_ABI Expected<APInt> exprMul(const APInt &Lhs, const APInt &Rhs,
+                                 bool &Overflow);
+LLVM_ABI Expected<APInt> exprDiv(const APInt &Lhs, const APInt &Rhs,
+                                 bool &Overflow);
+LLVM_ABI Expected<APInt> exprMax(const APInt &Lhs, const APInt &Rhs,
+                                 bool &Overflow);
+LLVM_ABI Expected<APInt> exprMin(const APInt &Lhs, const APInt &Rhs,
+                                 bool &Overflow);
 
 /// Base class representing the AST of a given expression.
 class ExpressionAST {
@@ -455,7 +462,7 @@ public:
   /// \p CmdlineDefines. \returns an error list containing diagnostics against
   /// \p SM for all definition parsing failures, if any, or Success otherwise.
   LLVM_ABI Error defineCmdlineVariables(ArrayRef<StringRef> CmdlineDefines,
-                               SourceMgr &SM);
+                                        SourceMgr &SM);
 
   /// Create @LINE pseudo variable. Value is set when pattern are being
   /// matched.
@@ -658,8 +665,8 @@ public:
   /// is the name of a pseudo variable, or an error holding a diagnostic
   /// against \p SM if parsing fail. If parsing was successful, also strips
   /// \p Str from the variable name.
-  LLVM_ABI static Expected<VariableProperties> parseVariable(StringRef &Str,
-                                                    const SourceMgr &SM);
+  LLVM_ABI static Expected<VariableProperties>
+  parseVariable(StringRef &Str, const SourceMgr &SM);
   /// Parses \p Expr for a numeric substitution block at line \p LineNumber,
   /// or before input is parsed if \p LineNumber is None. Parameter
   /// \p IsLegacyLineExpr indicates whether \p Expr should be a legacy @LINE
@@ -670,7 +677,8 @@ public:
   /// successful, sets \p DefinedNumericVariable to point to the class
   /// representing the numeric variable defined in this numeric substitution
   /// block, or std::nullopt if this block does not define any variable.
-  LLVM_ABI static Expected<std::unique_ptr<Expression>> parseNumericSubstitutionBlock(
+  LLVM_ABI static Expected<std::unique_ptr<Expression>>
+  parseNumericSubstitutionBlock(
       StringRef Expr, std::optional<NumericVariable *> &DefinedNumericVariable,
       bool IsLegacyLineExpr, std::optional<size_t> LineNumber,
       FileCheckPatternContext *Context, const SourceMgr &SM);
@@ -681,8 +689,8 @@ public:
   /// global options that influence the parsing such as whitespace
   /// canonicalization, \p SM provides the SourceMgr used for error reports.
   /// \returns true in case of an error, false otherwise.
-  LLVM_ABI bool parsePattern(StringRef PatternStr, StringRef Prefix, SourceMgr &SM,
-                    const FileCheckRequest &Req);
+  LLVM_ABI bool parsePattern(StringRef PatternStr, StringRef Prefix,
+                             SourceMgr &SM, const FileCheckRequest &Req);
   struct Match {
     size_t Pos;
     size_t Len;
@@ -709,16 +717,18 @@ public:
   LLVM_ABI MatchResult match(StringRef Buffer, const SourceMgr &SM) const;
   /// Prints the value of successful substitutions.
   LLVM_ABI void printSubstitutions(const SourceMgr &SM, StringRef Buffer,
-                          SMRange MatchRange, FileCheckDiag::MatchType MatchTy,
-                          std::vector<FileCheckDiag> *Diags) const;
+                                   SMRange MatchRange,
+                                   FileCheckDiag::MatchType MatchTy,
+                                   std::vector<FileCheckDiag> *Diags) const;
   LLVM_ABI void printFuzzyMatch(const SourceMgr &SM, StringRef Buffer,
-                       std::vector<FileCheckDiag> *Diags) const;
+                                std::vector<FileCheckDiag> *Diags) const;
 
   bool hasVariable() const {
     return !(Substitutions.empty() && VariableDefs.empty());
   }
-  LLVM_ABI void printVariableDefs(const SourceMgr &SM, FileCheckDiag::MatchType MatchTy,
-                         std::vector<FileCheckDiag> *Diags) const;
+  LLVM_ABI void printVariableDefs(const SourceMgr &SM,
+                                  FileCheckDiag::MatchType MatchTy,
+                                  std::vector<FileCheckDiag> *Diags) const;
 
   Check::FileCheckType getCheckTy() const { return CheckTy; }
 
@@ -843,9 +853,10 @@ struct FileCheckString {
       : Pat(std::move(P)), Prefix(S), Loc(L), DagNotStrings(std::move(D)) {}
 
   /// Matches check string and its "not strings" and/or "dag strings".
-  LLVM_ABI size_t Check(const SourceMgr &SM, StringRef Buffer, bool IsLabelScanMode,
-               size_t &MatchLen, FileCheckRequest &Req,
-               std::vector<FileCheckDiag> *Diags) const;
+  LLVM_ABI size_t Check(const SourceMgr &SM, StringRef Buffer,
+                        bool IsLabelScanMode, size_t &MatchLen,
+                        FileCheckRequest &Req,
+                        std::vector<FileCheckDiag> *Diags) const;
 
   /// Verifies that there is a single line in the given \p Buffer. Errors are
   /// reported against \p SM.
@@ -856,15 +867,16 @@ struct FileCheckString {
   /// Verifies that none of the strings in \p NotStrings are found in the given
   /// \p Buffer. Errors are reported against \p SM and diagnostics recorded in
   /// \p Diags according to the verbosity level set in \p Req.
-  LLVM_ABI bool CheckNot(const SourceMgr &SM, StringRef Buffer,
-                const std::vector<const DagNotPrefixInfo *> &NotStrings,
-                const FileCheckRequest &Req,
-                std::vector<FileCheckDiag> *Diags) const;
+  LLVM_ABI bool
+  CheckNot(const SourceMgr &SM, StringRef Buffer,
+           const std::vector<const DagNotPrefixInfo *> &NotStrings,
+           const FileCheckRequest &Req,
+           std::vector<FileCheckDiag> *Diags) const;
   /// Matches "dag strings" and their mixed "not strings".
   LLVM_ABI size_t CheckDag(const SourceMgr &SM, StringRef Buffer,
-                  std::vector<const DagNotPrefixInfo *> &NotStrings,
-                  const FileCheckRequest &Req,
-                  std::vector<FileCheckDiag> *Diags) const;
+                           std::vector<const DagNotPrefixInfo *> &NotStrings,
+                           const FileCheckRequest &Req,
+                           std::vector<FileCheckDiag> *Diags) const;
 };
 
 } // namespace llvm

--- a/llvm/lib/FileCheck/FileCheckImpl.h
+++ b/llvm/lib/FileCheck/FileCheckImpl.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/FileCheck/FileCheck.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/SourceMgr.h"
 #include <map>
@@ -76,7 +77,7 @@ public:
   bool operator!=(Kind OtherValue) const { return !(*this == OtherValue); }
 
   /// \returns the format specifier corresponding to this format as a string.
-  StringRef toString() const;
+  LLVM_ABI StringRef toString() const;
 
   ExpressionFormat() = default;
   explicit ExpressionFormat(Kind Value) : Value(Value), Precision(0){};
@@ -88,23 +89,23 @@ public:
   /// \returns a wildcard regular expression string that matches any value in
   /// the format represented by this instance and no other value, or an error
   /// if the format is NoFormat.
-  Expected<std::string> getWildcardRegex() const;
+  LLVM_ABI Expected<std::string> getWildcardRegex() const;
 
   /// \returns the string representation of \p Value in the format represented
   /// by this instance, or an error if conversion to this format failed or the
   /// format is NoFormat.
-  Expected<std::string> getMatchingString(APInt Value) const;
+  LLVM_ABI Expected<std::string> getMatchingString(APInt Value) const;
 
   /// \returns the value corresponding to string representation \p StrVal
   /// according to the matching format represented by this instance.
-  APInt valueFromStringRepr(StringRef StrVal, const SourceMgr &SM) const;
+  LLVM_ABI APInt valueFromStringRepr(StringRef StrVal, const SourceMgr &SM) const;
 };
 
 /// Class to represent an overflow error that might result when manipulating a
 /// value.
 class OverflowError : public ErrorInfo<OverflowError> {
 public:
-  static char ID;
+  LLVM_ABI static char ID;
 
   std::error_code convertToErrorCode() const override {
     return std::make_error_code(std::errc::value_too_large);
@@ -115,12 +116,12 @@ public:
 
 /// Performs operation and \returns its result or an error in case of failure,
 /// such as if an overflow occurs.
-Expected<APInt> exprAdd(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-Expected<APInt> exprSub(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-Expected<APInt> exprMul(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-Expected<APInt> exprDiv(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-Expected<APInt> exprMax(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
-Expected<APInt> exprMin(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
+LLVM_ABI Expected<APInt> exprAdd(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
+LLVM_ABI Expected<APInt> exprSub(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
+LLVM_ABI Expected<APInt> exprMul(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
+LLVM_ABI Expected<APInt> exprDiv(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
+LLVM_ABI Expected<APInt> exprMax(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
+LLVM_ABI Expected<APInt> exprMin(const APInt &Lhs, const APInt &Rhs, bool &Overflow);
 
 /// Base class representing the AST of a given expression.
 class ExpressionAST {
@@ -169,7 +170,7 @@ private:
   StringRef VarName;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
 
   UndefVarError(StringRef VarName) : VarName(VarName) {}
 
@@ -277,7 +278,7 @@ public:
 
 /// Class representing the use of a numeric variable in the AST of an
 /// expression.
-class NumericVariableUse : public ExpressionAST {
+class LLVM_ABI NumericVariableUse : public ExpressionAST {
 private:
   /// Pointer to the class instance for the variable this use is about.
   NumericVariable *Variable;
@@ -299,7 +300,7 @@ public:
 using binop_eval_t = Expected<APInt> (*)(const APInt &, const APInt &, bool &);
 
 /// Class representing a single binary operation in the AST of an expression.
-class BinaryOperation : public ExpressionAST {
+class LLVM_ABI BinaryOperation : public ExpressionAST {
 private:
   /// Left operand.
   std::unique_ptr<ExpressionAST> LeftOperand;
@@ -371,7 +372,7 @@ public:
   virtual Expected<std::string> getResult() const = 0;
 };
 
-class StringSubstitution : public Substitution {
+class LLVM_ABI StringSubstitution : public Substitution {
 public:
   StringSubstitution(FileCheckPatternContext *Context, StringRef VarName,
                      size_t InsertIdx)
@@ -382,7 +383,7 @@ public:
   Expected<std::string> getResult() const override;
 };
 
-class NumericSubstitution : public Substitution {
+class LLVM_ABI NumericSubstitution : public Substitution {
 private:
   /// Pointer to the class representing the expression whose value is to be
   /// substituted.
@@ -447,24 +448,24 @@ private:
 public:
   /// \returns the value of string variable \p VarName or an error if no such
   /// variable has been defined.
-  Expected<StringRef> getPatternVarValue(StringRef VarName);
+  LLVM_ABI Expected<StringRef> getPatternVarValue(StringRef VarName);
 
   /// Defines string and numeric variables from definitions given on the
   /// command line, passed as a vector of [#]VAR=VAL strings in
   /// \p CmdlineDefines. \returns an error list containing diagnostics against
   /// \p SM for all definition parsing failures, if any, or Success otherwise.
-  Error defineCmdlineVariables(ArrayRef<StringRef> CmdlineDefines,
+  LLVM_ABI Error defineCmdlineVariables(ArrayRef<StringRef> CmdlineDefines,
                                SourceMgr &SM);
 
   /// Create @LINE pseudo variable. Value is set when pattern are being
   /// matched.
-  void createLineVariable();
+  LLVM_ABI void createLineVariable();
 
   /// Undefines local variables (variables whose name does not start with a '$'
   /// sign), i.e. removes them from GlobalVariableTable and from
   /// GlobalNumericVariableTable and also clears the value of numeric
   /// variables.
-  void clearLocalVars();
+  LLVM_ABI void clearLocalVars();
 
 private:
   /// Makes a new numeric variable and registers it for destruction when the
@@ -490,7 +491,7 @@ private:
   SMRange Range;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
 
   ErrorDiagnostic(SMDiagnostic &&Diag, SMRange Range)
       : Diagnostic(Diag), Range(Range) {}
@@ -520,7 +521,7 @@ public:
 
 class NotFoundError : public ErrorInfo<NotFoundError> {
 public:
-  static char ID;
+  LLVM_ABI static char ID;
 
   std::error_code convertToErrorCode() const override {
     return inconvertibleErrorCode();
@@ -544,7 +545,7 @@ public:
 /// a call like \c consumeError.
 class ErrorReported final : public ErrorInfo<ErrorReported> {
 public:
-  static char ID;
+  LLVM_ABI static char ID;
 
   std::error_code convertToErrorCode() const override {
     return inconvertibleErrorCode();
@@ -644,7 +645,7 @@ public:
   FileCheckPatternContext *getContext() const { return Context; }
 
   /// \returns whether \p C is a valid first character for a variable name.
-  static bool isValidVarNameStart(char C);
+  LLVM_ABI static bool isValidVarNameStart(char C);
 
   /// Parsing information about a variable.
   struct VariableProperties {
@@ -657,7 +658,7 @@ public:
   /// is the name of a pseudo variable, or an error holding a diagnostic
   /// against \p SM if parsing fail. If parsing was successful, also strips
   /// \p Str from the variable name.
-  static Expected<VariableProperties> parseVariable(StringRef &Str,
+  LLVM_ABI static Expected<VariableProperties> parseVariable(StringRef &Str,
                                                     const SourceMgr &SM);
   /// Parses \p Expr for a numeric substitution block at line \p LineNumber,
   /// or before input is parsed if \p LineNumber is None. Parameter
@@ -669,7 +670,7 @@ public:
   /// successful, sets \p DefinedNumericVariable to point to the class
   /// representing the numeric variable defined in this numeric substitution
   /// block, or std::nullopt if this block does not define any variable.
-  static Expected<std::unique_ptr<Expression>> parseNumericSubstitutionBlock(
+  LLVM_ABI static Expected<std::unique_ptr<Expression>> parseNumericSubstitutionBlock(
       StringRef Expr, std::optional<NumericVariable *> &DefinedNumericVariable,
       bool IsLegacyLineExpr, std::optional<size_t> LineNumber,
       FileCheckPatternContext *Context, const SourceMgr &SM);
@@ -680,7 +681,7 @@ public:
   /// global options that influence the parsing such as whitespace
   /// canonicalization, \p SM provides the SourceMgr used for error reports.
   /// \returns true in case of an error, false otherwise.
-  bool parsePattern(StringRef PatternStr, StringRef Prefix, SourceMgr &SM,
+  LLVM_ABI bool parsePattern(StringRef PatternStr, StringRef Prefix, SourceMgr &SM,
                     const FileCheckRequest &Req);
   struct Match {
     size_t Pos;
@@ -705,18 +706,18 @@ public:
   /// GlobalNumericVariableTable StringMap in the same class provides the
   /// current values of FileCheck numeric variables and is updated if this
   /// match defines new numeric values.
-  MatchResult match(StringRef Buffer, const SourceMgr &SM) const;
+  LLVM_ABI MatchResult match(StringRef Buffer, const SourceMgr &SM) const;
   /// Prints the value of successful substitutions.
-  void printSubstitutions(const SourceMgr &SM, StringRef Buffer,
+  LLVM_ABI void printSubstitutions(const SourceMgr &SM, StringRef Buffer,
                           SMRange MatchRange, FileCheckDiag::MatchType MatchTy,
                           std::vector<FileCheckDiag> *Diags) const;
-  void printFuzzyMatch(const SourceMgr &SM, StringRef Buffer,
+  LLVM_ABI void printFuzzyMatch(const SourceMgr &SM, StringRef Buffer,
                        std::vector<FileCheckDiag> *Diags) const;
 
   bool hasVariable() const {
     return !(Substitutions.empty() && VariableDefs.empty());
   }
-  void printVariableDefs(const SourceMgr &SM, FileCheckDiag::MatchType MatchTy,
+  LLVM_ABI void printVariableDefs(const SourceMgr &SM, FileCheckDiag::MatchType MatchTy,
                          std::vector<FileCheckDiag> *Diags) const;
 
   Check::FileCheckType getCheckTy() const { return CheckTy; }
@@ -842,25 +843,25 @@ struct FileCheckString {
       : Pat(std::move(P)), Prefix(S), Loc(L), DagNotStrings(std::move(D)) {}
 
   /// Matches check string and its "not strings" and/or "dag strings".
-  size_t Check(const SourceMgr &SM, StringRef Buffer, bool IsLabelScanMode,
+  LLVM_ABI size_t Check(const SourceMgr &SM, StringRef Buffer, bool IsLabelScanMode,
                size_t &MatchLen, FileCheckRequest &Req,
                std::vector<FileCheckDiag> *Diags) const;
 
   /// Verifies that there is a single line in the given \p Buffer. Errors are
   /// reported against \p SM.
-  bool CheckNext(const SourceMgr &SM, StringRef Buffer) const;
+  LLVM_ABI bool CheckNext(const SourceMgr &SM, StringRef Buffer) const;
   /// Verifies that there is no newline in the given \p Buffer. Errors are
   /// reported against \p SM.
-  bool CheckSame(const SourceMgr &SM, StringRef Buffer) const;
+  LLVM_ABI bool CheckSame(const SourceMgr &SM, StringRef Buffer) const;
   /// Verifies that none of the strings in \p NotStrings are found in the given
   /// \p Buffer. Errors are reported against \p SM and diagnostics recorded in
   /// \p Diags according to the verbosity level set in \p Req.
-  bool CheckNot(const SourceMgr &SM, StringRef Buffer,
+  LLVM_ABI bool CheckNot(const SourceMgr &SM, StringRef Buffer,
                 const std::vector<const DagNotPrefixInfo *> &NotStrings,
                 const FileCheckRequest &Req,
                 std::vector<FileCheckDiag> *Diags) const;
   /// Matches "dag strings" and their mixed "not strings".
-  size_t CheckDag(const SourceMgr &SM, StringRef Buffer,
+  LLVM_ABI size_t CheckDag(const SourceMgr &SM, StringRef Buffer,
                   std::vector<const DagNotPrefixInfo *> &NotStrings,
                   const FileCheckRequest &Req,
                   std::vector<FileCheckDiag> *Diags) const;


### PR DESCRIPTION
## Purpose
This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the private `llvm/lib/FileCheck/FileCheckImpl.h` interface, which is used by `FileCheckTests`, with `LLVM_ABI`. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background
This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview
This patch was generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

Unlike other patches in this series, IDS was used to auto-annotate a private header file `llvm/lib/FileCheck/FileCheckImpl.h`. I suspect this header should eventually be co-located with public headers in llvm/include, but that move is out of scope.

## Validation
Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang