### PR TITLE
Fix min_vec_size.ll test for changes in vector-combine

### DIFF
--- a/llvm/test/CodeGen/DirectX/min_vec_size.ll
+++ b/llvm/test/CodeGen/DirectX/min_vec_size.ll
@@ -6,8 +6,7 @@ target triple = "dxil-unknown-shadermodel6.7-library"
 ; Make sure vec combine min vec size is 1 instead of 4 for float.
 ; CHECK:@foo()
 ; CHECK-NEXT:%[[LD:[0-9]+]] = load <1 x float>, ptr @a, align 8
-; CHECK-NEXT:%insert = shufflevector <1 x float> %[[LD]], <1 x float> poison, <2 x i32> <i32 0, i32 poison>
-; CHECK-NEXT:%shuffle = shufflevector <2 x float> %insert, <2 x float> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:%shuffle = shufflevector <1 x float> %1, <1 x float> poison, <2 x i32> zeroinitializer
 ; CHECK-NEXT:ret <2 x float> %shuffle
 
 @a = external local_unnamed_addr constant float

--- a/llvm/test/CodeGen/DirectX/min_vec_size.ll
+++ b/llvm/test/CodeGen/DirectX/min_vec_size.ll
@@ -6,7 +6,7 @@ target triple = "dxil-unknown-shadermodel6.7-library"
 ; Make sure vec combine min vec size is 1 instead of 4 for float.
 ; CHECK:@foo()
 ; CHECK-NEXT:%[[LD:[0-9]+]] = load <1 x float>, ptr @a, align 8
-; CHECK-NEXT:%shuffle = shufflevector <1 x float> %1, <1 x float> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:%shuffle = shufflevector <1 x float> %[[LD]], <1 x float> poison, <2 x i32> zeroinitializer
 ; CHECK-NEXT:ret <2 x float> %shuffle
 
 @a = external local_unnamed_addr constant float


### PR DESCRIPTION
Running the `vector-combine` pass on this test now produces a single shuffle on a loaded `<1 x float>` instead of an insert into a `<2 x float>` followed by a shuffle.

This test change matches changes in other tests in PR #144690, which introduced the optimization.