### PR TITLE
[ExtractAPI] Include `virtual` keyword for methods

### DIFF
--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -883,6 +883,9 @@ DeclarationFragments DeclarationFragmentsBuilder::getFragmentsForCXXMethod(
   if (Method->isVolatile())
     Fragments.append("volatile", DeclarationFragments::FragmentKind::Keyword)
         .appendSpace();
+  if (Method->isVirtual())
+    Fragments.append("virtual", DeclarationFragments::FragmentKind::Keyword)
+        .appendSpace();
 
   // Build return type
   DeclarationFragments After;

--- a/clang/test/ExtractAPI/methods.cpp
+++ b/clang/test/ExtractAPI/methods.cpp
@@ -45,10 +45,18 @@ class Foo {
   // GETCOUNT-NEXT: ]
 
   // RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix SETL
-  void setLength(int length) noexcept;
+  virtual void setLength(int length) noexcept;
   // SETL: "!testRelLabel": "memberOf $ c:@S@Foo@F@setLength#I# $ c:@S@Foo"
   // SETL-LABEL: "!testLabel": "c:@S@Foo@F@setLength#I#"
   // SETL:      "declarationFragments": [
+  // SETL-NEXT:   {
+  // SETL-NEXT:     "kind": "keyword",
+  // SETL-NEXT:     "spelling": "virtual"
+  // SETL-NEXT:   },
+  // SETL-NEXT:   {
+  // SETL-NEXT:     "kind": "text",
+  // SETL-NEXT:     "spelling": " "
+  // SETL-NEXT:   },
   // SETL-NEXT:   {
   // SETL-NEXT:     "kind": "typeIdentifier",
   // SETL-NEXT:     "preciseIdentifier": "c:v",


### PR DESCRIPTION
This information was being left out of the symbol graph.

rdar://131780883