### PR TITLE
[lldb][rpc] Fix bug in convert script for RPC

### DIFF
--- a/lldb/scripts/convert-lldb-header-to-rpc-header.py
+++ b/lldb/scripts/convert-lldb-header-to-rpc-header.py
@@ -27,7 +27,7 @@ LLDB_LOCAL_INCLUDE_REGEX = re.compile(r'#include "lldb/lldb-\s*', re.M)
 LLDB_NAMESPACE_DEFINITION_REGEX = re.compile(
     r"(?P<comment_marker>//\s*){,1}namespace lldb\s{1}", re.M
 )
-LLDB_NAMESPACE_REGEX = re.compile(r"\s*.+lldb::\s*", re.M)
+LLDB_NAMESPACE_REGEX = re.compile(r"lldb::\s*", re.M)
 
 
 def main():

--- a/lldb/test/Shell/RPC/Scripts/TestConvertScript/CheckLLDBEnumerations.test
+++ b/lldb/test/Shell/RPC/Scripts/TestConvertScript/CheckLLDBEnumerations.test
@@ -13,5 +13,8 @@ CHECK: #define LLDB_RPC_ENUMERATIONS_H
 # Change the namespace to lldb_rpc. Also, the comment that closes the namespace should match the namespace.
 CHECK: namespace lldb_rpc {} // namespace lldb_rpc
 
+# When the lldb namespace is used, the namespace must be replaced with lldb_rpc.
+CHECK: void dummyFunction(lldb_rpc::addr_t) {}
+
 # The comment that closes the include guard should match the guard.
 CHECK: #endif // LLDB_RPC_ENUMERATIONS_H

--- a/lldb/test/Shell/RPC/Scripts/TestConvertScript/Inputs/lldb-enumerations.h
+++ b/lldb/test/Shell/RPC/Scripts/TestConvertScript/Inputs/lldb-enumerations.h
@@ -11,6 +11,9 @@
 // namespace lldb -> namespace lldb_rpc
 namespace lldb {} // namespace lldb
 
+// When the lldb namespace is used, the namespace must be replaced with lldb_rpc.
+void dummyFunction(lldb::addr_t) {}
+
 // The comment that closes the include guard must change in the same way
 // the original guard did:
 // #endif // LLDB_LLDB_ENUMERATIONS_H -> #endif // LLDB_RPC_ENUMERATIONS_H


### PR DESCRIPTION
In the script that's used by RPC to convert LLDB headers to LLDB RPC headers, there's a bug with how it converts namespace usage. An overeager regex pattern caused *all* text before any `lldb::` namespace usage to get replaced with `lldb_rpc::` instead of just the namespace itself. This commit changes that regex pattern to be less overeager and modifies one of the shell tests for this script to actually check that the namespace usage replacement is working correctly.

rdar://154126268