### PR TITLE
[JITLink] Include target addend in out-of-range error

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
@@ -421,17 +421,21 @@ Error makeTargetOutOfRangeError(const LinkGraph &G, const Block &B,
     raw_string_ostream ErrStream(ErrMsg);
     Section &Sec = B.getSection();
     ErrStream << "In graph " << G.getName() << ", section " << Sec.getName()
-              << ": relocation target ";
-    if (E.getTarget().hasName()) {
-      ErrStream << "\"" << E.getTarget().getName() << "\"";
-    } else
-      ErrStream << E.getTarget().getSection().getName() << " + "
-                << formatv("{0:x}", E.getOffset());
-    ErrStream << " at address " << formatv("{0:x}", E.getTarget().getAddress());
-    if (E.getAddend())
-      ErrStream << " with addend " << formatv("{0:x}", E.getAddend());
-    ErrStream << " is out of range of " << G.getEdgeKindName(E.getKind())
-              << " fixup at " << formatv("{0:x}", B.getFixupAddress(E)) << " (";
+              << ": relocation target "
+              << formatv("{0:x}", E.getTarget().getAddress() + E.getAddend())
+              << " (";
+    if (E.getTarget().hasName())
+      ErrStream << E.getTarget().getName();
+    else
+      ErrStream << "<anonymous symbol>";
+    if (E.getAddend()) {
+      // Target address includes non-zero added, so break down the arithmetic.
+      ErrStream << formatv(":{0:x}", E.getTarget().getAddress()) << " + "
+                << formatv("{0:x}", E.getAddend());
+    }
+    ErrStream << ") is out of range of " << G.getEdgeKindName(E.getKind())
+              << " fixup at address "
+              << formatv("{0:x}", E.getTarget().getAddress()) << " (";
 
     Symbol *BestSymbolForBlock = nullptr;
     for (auto *Sym : Sec.symbols())

--- a/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
@@ -430,8 +430,8 @@ Error makeTargetOutOfRangeError(const LinkGraph &G, const Block &B,
       ErrStream << "<anonymous symbol>";
     if (E.getAddend()) {
       // Target address includes non-zero added, so break down the arithmetic.
-      ErrStream << formatv(":{0:x}", E.getTarget().getAddress()) << " + "
-                << formatv("{0:x}", E.getAddend());
+      ErrStream << formatv(":{0:x}", E.getTarget().getAddress())
+                << formatv(" + <addend>:{0:x}", E.getAddend());
     }
     ErrStream << ") is out of range of " << G.getEdgeKindName(E.getKind())
               << " fixup at address "

--- a/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
@@ -430,8 +430,8 @@ Error makeTargetOutOfRangeError(const LinkGraph &G, const Block &B,
       ErrStream << "<anonymous symbol>";
     if (E.getAddend()) {
       // Target address includes non-zero added, so break down the arithmetic.
-      ErrStream << formatv(":{0:x}", E.getTarget().getAddress())
-                << formatv(" + <addend>:{0:x}", E.getAddend());
+      ErrStream << formatv(":{0:x}", E.getTarget().getAddress()) << " + "
+                << formatv("{0:x}", E.getAddend());
     }
     ErrStream << ") is out of range of " << G.getEdgeKindName(E.getKind())
               << " fixup at address "

--- a/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
@@ -427,8 +427,10 @@ Error makeTargetOutOfRangeError(const LinkGraph &G, const Block &B,
     } else
       ErrStream << E.getTarget().getSection().getName() << " + "
                 << formatv("{0:x}", E.getOffset());
-    ErrStream << " at address " << formatv("{0:x}", E.getTarget().getAddress())
-              << " is out of range of " << G.getEdgeKindName(E.getKind())
+    ErrStream << " at address " << formatv("{0:x}", E.getTarget().getAddress());
+    if (E.getAddend())
+      ErrStream << " with addend " << formatv("{0:x}", E.getAddend());
+    ErrStream << " is out of range of " << G.getEdgeKindName(E.getKind())
               << " fixup at " << formatv("{0:x}", B.getFixupAddress(E)) << " (";
 
     Symbol *BestSymbolForBlock = nullptr;

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_R_AARCH64_ABS32.yaml
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_R_AARCH64_ABS32.yaml
@@ -11,7 +11,7 @@
 
 # jitlink-check: *{8}xptr = x
 
-# CHECK-ERROR: relocation target "x" {{.*}} is out of range of Pointer32 fixup
+# CHECK-ERROR: relocation target {{.*}} (x) is out of range of Pointer32 fixup
 
 --- !ELF
 FileHeader:

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_16.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_16.s
@@ -8,7 +8,7 @@
 
 # jitlink-check: *{8}P = X
 
-# CHECK-ERROR: relocation target "X" {{.*}} is out of range of Pointer16 fixup
+# CHECK-ERROR: relocation target {{.*}} (X) is out of range of Pointer16 fixup
 
 	.text
 	.section	.text.main,"ax",@progbits

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_32.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_32.s
@@ -8,7 +8,7 @@
 
 # jitlink-check: *{8}P = X
 
-# CHECK-ERROR: relocation target "X" {{.*}} is out of range of Pointer32 fixup
+# CHECK-ERROR: relocation target {{.*}} (X) is out of range of Pointer32 fixup
 
 	.text
 	.section	.text.main,"ax",@progbits

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_8.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_8.s
@@ -8,7 +8,7 @@
 
 # jitlink-check: *{8}P = X
 
-# CHECK-ERROR: relocation target "X" {{.*}} is out of range of Pointer8 fixup
+# CHECK-ERROR: relocation target {{.*}} (X) is out of range of Pointer8 fixup
 
 	.text
 	.section	.text.main,"ax",@progbits

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_SIZE.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_SIZE.s
@@ -7,7 +7,7 @@
 # RUN: llvm-mc -triple=x86_64-unknown-linux -position-independent --defsym=OVERFLOW=1 \
 # RUN:     -filetype=obj -o %t.2.o %s
 # RUN: not llvm-jitlink -noexec %t.2.o 2>&1 | FileCheck %s
-# CHECK: llvm-jitlink error: In graph {{.*}}, section .text: relocation target "main" at address {{.*}} with addend {{.*}} is out of range of Size32 fixup at {{.*}} (main, {{.*}})
+# CHECK: llvm-jitlink error: In graph {{.*}}, section .text: relocation target {{.*}} (main:{{.*}} + {{.*}}) is out of range of Size32 fixup at address {{.*}} (main, {{.*}})
 
 	.text
 	.globl	main

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_SIZE.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_SIZE.s
@@ -7,7 +7,7 @@
 # RUN: llvm-mc -triple=x86_64-unknown-linux -position-independent --defsym=OVERFLOW=1 \
 # RUN:     -filetype=obj -o %t.2.o %s
 # RUN: not llvm-jitlink -noexec %t.2.o 2>&1 | FileCheck %s
-# CHECK: llvm-jitlink error: In graph {{.*}}, section .text: relocation target {{.*}} (main:{{.*}} + <addend>:{{.*}}) is out of range of Size32 fixup at address {{.*}} (main, {{.*}})
+# CHECK: llvm-jitlink error: In graph {{.*}}, section .text: relocation target {{.*}} (main:{{.*}} + {{.*}}) is out of range of Size32 fixup at address {{.*}} (main, {{.*}})
 
 	.text
 	.globl	main

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_SIZE.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_SIZE.s
@@ -7,7 +7,7 @@
 # RUN: llvm-mc -triple=x86_64-unknown-linux -position-independent --defsym=OVERFLOW=1 \
 # RUN:     -filetype=obj -o %t.2.o %s
 # RUN: not llvm-jitlink -noexec %t.2.o 2>&1 | FileCheck %s
-# CHECK: llvm-jitlink error: In graph {{.*}}, section .text: relocation target "main" at address {{.*}} is out of range of Size32 fixup at {{.*}} (main, {{.*}})
+# CHECK: llvm-jitlink error: In graph {{.*}}, section .text: relocation target "main" at address {{.*}} with addend {{.*}} is out of range of Size32 fixup at {{.*}} (main, {{.*}})
 
 	.text
 	.globl	main

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_SIZE.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_SIZE.s
@@ -7,7 +7,7 @@
 # RUN: llvm-mc -triple=x86_64-unknown-linux -position-independent --defsym=OVERFLOW=1 \
 # RUN:     -filetype=obj -o %t.2.o %s
 # RUN: not llvm-jitlink -noexec %t.2.o 2>&1 | FileCheck %s
-# CHECK: llvm-jitlink error: In graph {{.*}}, section .text: relocation target {{.*}} (main:{{.*}} + {{.*}}) is out of range of Size32 fixup at address {{.*}} (main, {{.*}})
+# CHECK: llvm-jitlink error: In graph {{.*}}, section .text: relocation target {{.*}} (main:{{.*}} + <addend>:{{.*}}) is out of range of Size32 fixup at address {{.*}} (main, {{.*}})
 
 	.text
 	.globl	main


### PR DESCRIPTION
When JITLink reports an out-of-range error, the underlying reason could be hidden from the user if it's due to an excessively large target addend. Add non-zero target addend to the message for clarity.