### PR TITLE
[CI] Make issue labeler more robust

### DIFF
--- a/.github/new-issues-labeler.yml
+++ b/.github/new-issues-labeler.yml
@@ -29,7 +29,7 @@
   - '/\bbolt(?!\-)\b/i'
 
 'infra:commit-access-request':
-  - '/Request Commit Access/'
+  - '/request commit access/i'
 
 'false-positive':
   - '\bfalse[- ]positive\b'


### PR DESCRIPTION
The issue labeler handles commit access requests in a case-sensitive manner. This patch expands that to be case-insensitive.