### PR TITLE
Default transcript dumping in "statistics dump" to false

### DIFF
--- a/lldb/include/lldb/API/SBStatisticsOptions.h
+++ b/lldb/include/lldb/API/SBStatisticsOptions.h
@@ -57,8 +57,7 @@ public:
   /// a JSON array with all commands the user and/or scripts executed during a
   /// debug session.
   ///
-  /// Defaults to true, unless the `SummaryOnly` mode is enabled, in which case
-  /// this is turned off unless specified.
+  /// Defaults to false.
   void SetIncludeTranscript(bool b);
   bool GetIncludeTranscript() const;
 

--- a/lldb/include/lldb/Target/Statistics.h
+++ b/lldb/include/lldb/Target/Statistics.h
@@ -193,8 +193,7 @@ public:
   bool GetIncludeTranscript() const {
     if (m_include_transcript.has_value())
       return m_include_transcript.value();
-    // `m_include_transcript` has no value set, so return a value based on
-    // `m_summary_only`.
+    // Default to false in both default mode and summary mode.
     return false;
   }
 

--- a/lldb/include/lldb/Target/Statistics.h
+++ b/lldb/include/lldb/Target/Statistics.h
@@ -191,10 +191,7 @@ public:
 
   void SetIncludeTranscript(bool value) { m_include_transcript = value; }
   bool GetIncludeTranscript() const {
-    if (m_include_transcript.has_value())
-      return m_include_transcript.value();
-    // Default to false in both default mode and summary mode.
-    return false;
+    return m_include_transcript.value_or(false);
   }
 
   void SetIncludePlugins(bool value) { m_include_plugins = value; }

--- a/lldb/include/lldb/Target/Statistics.h
+++ b/lldb/include/lldb/Target/Statistics.h
@@ -195,7 +195,7 @@ public:
       return m_include_transcript.value();
     // `m_include_transcript` has no value set, so return a value based on
     // `m_summary_only`.
-    return !GetSummaryOnly();
+    return false;
   }
 
   void SetIncludePlugins(bool value) { m_include_plugins = value; }

--- a/lldb/source/Commands/CommandObjectStats.cpp
+++ b/lldb/source/Commands/CommandObjectStats.cpp
@@ -9,6 +9,7 @@
 #include "CommandObjectStats.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Host/OptionParser.h"
+#include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandOptionArgumentTable.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Interpreter/OptionArgParser.h"
@@ -147,9 +148,18 @@ protected:
     if (!m_options.m_all_targets)
       target = m_exe_ctx.GetTargetPtr();
 
+    // Check if transcript is requested but transcript saving is disabled
+    const StatisticsOptions &stats_options = m_options.GetStatisticsOptions();
+    if (stats_options.GetIncludeTranscript() &&
+        !GetDebugger().GetCommandInterpreter().GetSaveTranscript()) {
+      result.AppendWarning(
+          "transcript requested but none was saved. Enable with "
+          "'settings set interpreter.save-transcript true'");
+    }
+
     result.AppendMessageWithFormatv(
-        "{0:2}", DebuggerStats::ReportStatistics(
-                     GetDebugger(), target, m_options.GetStatisticsOptions()));
+        "{0:2}",
+        DebuggerStats::ReportStatistics(GetDebugger(), target, stats_options));
     result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -1482,13 +1482,15 @@ let Command = "statistics dump" in {
     "this is turned off unless specified. "
     "In default mode, if both '--targets' and '--modules' are 'true', a list "
     "of module identifiers will be added to the 'targets' section.">;
-  def statistics_dump_transcript: Option<"transcript", "t">, Group<1>,
-    Arg<"Boolean">,
-    Desc<"If the setting interpreter.save-transcript is enabled and this "
-    "option is 'true', include a JSON array with all commands the user and/or "
-    "scripts executed during a debug session. "
-    "Defaults to true, unless the '--summary' mode is enabled, in which case "
-    "this is turned off unless specified.">;
+  def statistics_dump_transcript
+      : Option<"transcript", "t">,
+        Group<1>,
+        Arg<"Boolean">,
+        Desc<"If the setting interpreter.save-transcript is enabled and this "
+             "option is 'true', include a JSON array with all commands the "
+             "user and/or "
+             "scripts executed during a debug session. "
+             "Defaults to false. ">;
   def statistics_dump_plugins
       : Option<"plugins", "p">,
         Group<1>,

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -849,6 +849,30 @@ class TestCase(TestBase):
         # The second "statistics dump" in the transcript should have no output
         self.assertNotIn("output", transcript[2])
 
+    def test_transcript_warning_when_disabled(self):
+        """
+        Test that "statistics dump --transcript=true" shows a warning when
+        transcript saving is disabled.
+        """
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        target = self.createTestTarget(file_path=exe)
+        
+        # Ensure transcript saving is disabled (this is the default)
+        self.runCmd("settings set interpreter.save-transcript false")
+        
+        # Request transcript in statistics dump and check for warning
+        interpreter = self.dbg.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        interpreter.HandleCommand("statistics dump --transcript=true", res)
+        self.assertTrue(res.Succeeded())
+        # We should warn about transcript being requested but not saved
+        self.assertIn(
+            "transcript requested but none was saved. Enable with "
+            "'settings set interpreter.save-transcript true'",
+            res.GetError()
+        )
+
     def verify_stats(self, stats, expectation, options):
         for field_name in expectation:
             idx = field_name.find(".")

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -857,10 +857,10 @@ class TestCase(TestBase):
         self.build()
         exe = self.getBuildArtifact("a.out")
         target = self.createTestTarget(file_path=exe)
-        
+
         # Ensure transcript saving is disabled (this is the default)
         self.runCmd("settings set interpreter.save-transcript false")
-        
+
         # Request transcript in statistics dump and check for warning
         interpreter = self.dbg.GetCommandInterpreter()
         res = lldb.SBCommandReturnObject()
@@ -870,7 +870,7 @@ class TestCase(TestBase):
         self.assertIn(
             "transcript requested but none was saved. Enable with "
             "'settings set interpreter.save-transcript true'",
-            res.GetError()
+            res.GetError(),
         )
 
     def verify_stats(self, stats, expectation, options):

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -896,7 +896,7 @@ class TestCase(TestBase):
                     "targets.frameVariable": True,
                     "targets.totalSharedLibraryEventHitCount": True,
                     "modules": True,
-                    "transcript": True,
+                    "transcript": False,
                 },
             },
             {  # Summary mode
@@ -983,6 +983,24 @@ class TestCase(TestBase):
                     "transcript": False,
                 },
             },
+            {  # Default mode without modules and with transcript
+                "command_options": " --modules=false --transcript=true",
+                "api_options": {
+                    "SetIncludeModules": False,
+                    "SetIncludeTranscript": True,
+                },
+                "expect": {
+                    "commands": True,
+                    "targets": True,
+                    "targets.moduleIdentifiers": False,
+                    "targets.breakpoints": True,
+                    "targets.expressionEvaluation": True,
+                    "targets.frameVariable": True,
+                    "targets.totalSharedLibraryEventHitCount": True,
+                    "modules": False,
+                    "transcript": True,
+                },
+            },
             {  # Default mode without modules
                 "command_options": " --modules=false",
                 "api_options": {
@@ -997,6 +1015,23 @@ class TestCase(TestBase):
                     "targets.frameVariable": True,
                     "targets.totalSharedLibraryEventHitCount": True,
                     "modules": False,
+                    "transcript": False,
+                },
+            },
+            {  # Default mode with transcript
+                "command_options": " --transcript=true",
+                "api_options": {
+                    "SetIncludeTranscript": True,
+                },
+                "expect": {
+                    "commands": True,
+                    "targets": True,
+                    "targets.moduleIdentifiers": True,
+                    "targets.breakpoints": True,
+                    "targets.expressionEvaluation": True,
+                    "targets.frameVariable": True,
+                    "targets.totalSharedLibraryEventHitCount": True,
+                    "modules": True,
                     "transcript": True,
                 },
             },


### PR DESCRIPTION
### Summary
Currently, if the setting `interpreter.save-transcript` is enabled, whenever we call "statistics dump", it'll default to reporting a huge list of transcripts which can be a bit noisy. This is because the current check `GetIncludeTranscript` returns `!GetSummaryOnly()` by default if no specific transcript-setting option is given in the statistics dump command (ie. `statistics dump --transcripts=false` or `statistics dump --transcripts=true`). Then when `interpreter.save-transcript` is enabled, this saves a list of transcripts, and the transcript list ends up getting logged by default.

These changes default the option to log transcripts in the `statistics dump` command to "false". This can still be enabled via the `--transcripts` option if users want to see a transcript. Since `interpreter.save-transcript` is false by default, the main delta is that if `interpreter.save-transcript` is true and summary mode is false, we now disable saving the transcript.

This also adds a warning to 'statistics dump --transcript=true' when
interpreter.save-transcript is disabled, which should help users understand
why transcript data is empty.

### Testing

#### Manual testing
Tested with `settings set interpreter.save-transcript true` enabled at startup on a toy hello-world program:
```
(lldb) settings set interpreter.save-transcript true
(lldb) target create "/home/qxy11/hello-world/a.out"
Current executable set to '/home/qxy11/hello-world/a.out' (x86_64).
(lldb) statistics dump
{
  /* no transcript */
}
(lldb) statistics dump --transcript=true
{
"transcript": [
    {
      "command": "statistics dump",
      "commandArguments": "",
      "commandName": "statistics dump",
      "durationInSeconds": 0.0019650000000000002,
      "error": "",
      "output": "{...
    },
    {
      "command": "statistics dump --transcript=true",
      "commandArguments": "--transcript=true",
      "commandName": "statistics dump",
      "timestampInEpochSeconds": 1750720021
    }
  ]
}
```
Without `settings set interpreter.save-transcript true`:
```
(lldb) target create "/home/qxy11/hello-world/a.out"
Current executable set to '/home/qxy11/hello-world/a.out' (x86_64).
(lldb) statistics dump
{
  /* no transcript */
}
(lldb) statistics dump --transcript=true
{
  /* no transcript */
}
warning: transcript requested but none was saved. Enable with 'settings set interpreter.save-transcript true'
```

#### Unit tests
Changed unit tests to account for new expected default behavior to `false`, and added a couple new tests around expected behavior with `--transcript=true`.
```
lldb-dotest -p TestStats ~/llvm-sand/external/llvm-project/lldb/test/API/commands/statistics/basic/
```
