### PR TITLE
[RISCV][NFC] Zce always implies/requires Zca

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -455,7 +455,8 @@ def HasStdExtZcmt : Predicate<"Subtarget->hasStdExtZcmt()">,
 def FeatureStdExtZce
     : RISCVExtension<1, 0,
                      "Compressed extensions for microcontrollers",
-                     [FeatureStdExtZcb, FeatureStdExtZcmp, FeatureStdExtZcmt]>;
+                     [FeatureStdExtZca, FeatureStdExtZcb, FeatureStdExtZcmp,
+                      FeatureStdExtZcmt]>;
 
 def HasStdExtCOrZcfOrZce
     : Predicate<"Subtarget->hasStdExtC() || Subtarget->hasStdExtZcf() ||"


### PR DESCRIPTION
According to the spec, Zce:
- On RV32 without F: includes Zca, Zcb, Zcmp, Zcmt
- On RV32 with F: includes Zca, Zcb, Zcmp, Zcmt and Zcf
- On RV64: Zca, Zcb, Zcmp, Zcmt.

In these cases, Zce always implies Zca, Zcb, Zcmp, and Zcmt, so I have added it to the list of Implied/Required extensions, where it wasn't included before. The RV32f rule is implemented in RISCVISAInfo.cpp already.

This is NFC, because TableGen expands these implications transitively, which was eventually picking up Zca via any of the other three.