### PR TITLE
[mlir] Migrate away from {TypeRange,ValueRange}(std::nullopt) (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
+++ b/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
@@ -243,17 +243,16 @@ def AffineForOp : Affine_Op<"for",
   let regions = (region SizedRegion<1>:$region);
 
   let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "int64_t":$lowerBound, "int64_t":$upperBound,
-      CArg<"int64_t", "1">:$step, CArg<"ValueRange", "std::nullopt">:$iterArgs,
-      CArg<"function_ref<void(OpBuilder &, Location, Value, ValueRange)>",
-           "nullptr">:$bodyBuilder)>,
-    OpBuilder<(ins "ValueRange":$lbOperands, "AffineMap":$lbMap,
-      "ValueRange":$ubOperands, "AffineMap":$ubMap, CArg<"int64_t", "1">:$step,
-      CArg<"ValueRange", "std::nullopt">:$iterArgs,
-      CArg<"function_ref<void(OpBuilder &, Location, Value, ValueRange)>",
-           "nullptr">:$bodyBuilder)>
-  ];
+  let builders =
+      [OpBuilder<(ins "int64_t":$lowerBound, "int64_t":$upperBound,
+           CArg<"int64_t", "1">:$step, CArg<"ValueRange", "{}">:$iterArgs,
+           CArg<"function_ref<void(OpBuilder &, Location, Value, ValueRange)>",
+                "nullptr">:$bodyBuilder)>,
+       OpBuilder<(ins "ValueRange":$lbOperands, "AffineMap":$lbMap,
+           "ValueRange":$ubOperands, "AffineMap":$ubMap,
+           CArg<"int64_t", "1">:$step, CArg<"ValueRange", "{}">:$iterArgs,
+           CArg<"function_ref<void(OpBuilder &, Location, Value, ValueRange)>",
+                "nullptr">:$bodyBuilder)>];
 
   let extraClassDeclaration = [{
     /// Defining the function type we use for building the body of affine.for.
@@ -920,9 +919,7 @@ def AffineYieldOp : Affine_Op<"yield", [Pure, Terminator, ReturnLike,
 
   let arguments = (ins Variadic<AnyType>:$operands);
 
-  let builders = [
-    OpBuilder<(ins), [{ build($_builder, $_state, std::nullopt); }]>
-  ];
+  let builders = [OpBuilder<(ins), [{ build($_builder, $_state, {}); }]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
   let hasVerifier = 1;

--- a/mlir/include/mlir/Dialect/Async/IR/AsyncOps.td
+++ b/mlir/include/mlir/Dialect/Async/IR/AsyncOps.td
@@ -288,7 +288,7 @@ def Async_ReturnOp : Async_Op<"return",
 
   let arguments = (ins Variadic<AnyType>:$operands);
 
-  let builders = [OpBuilder<(ins), [{build($_builder, $_state, std::nullopt);}]>];
+  let builders = [OpBuilder<(ins), [{build($_builder, $_state, {});}]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
   let hasVerifier = 1;

--- a/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
+++ b/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
@@ -385,7 +385,7 @@ def ReturnOp : Func_Op<"return", [Pure, HasParent<"FuncOp">,
   let arguments = (ins Variadic<AnyType>:$operands);
 
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, std::nullopt);
+    build($_builder, $_state, {});
   }]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";

--- a/mlir/include/mlir/Dialect/MLProgram/IR/MLProgramOps.td
+++ b/mlir/include/mlir/Dialect/MLProgram/IR/MLProgramOps.td
@@ -462,7 +462,7 @@ def MLProgram_OutputOp : MLProgram_Op<"output", [
   let arguments = (ins Variadic<AnyType>:$operands);
 
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, std::nullopt);
+    build($_builder, $_state, {});
   }]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
@@ -488,7 +488,7 @@ def MLProgram_ReturnOp : MLProgram_Op<"return", [
   let arguments = (ins Variadic<AnyType>:$operands);
 
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, std::nullopt);
+    build($_builder, $_state, {});
   }]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";

--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -248,12 +248,10 @@ def ForOp : SCF_Op<"for",
   let regions = (region SizedRegion<1>:$region);
 
   let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "Value":$lowerBound, "Value":$upperBound, "Value":$step,
-      CArg<"ValueRange", "std::nullopt">:$initArgs,
+  let builders = [OpBuilder<(ins "Value":$lowerBound, "Value":$upperBound,
+      "Value":$step, CArg<"ValueRange", "{}">:$initArgs,
       CArg<"function_ref<void(OpBuilder &, Location, Value, ValueRange)>",
-           "nullptr">)>
-  ];
+           "nullptr">)>];
 
   let extraClassDeclaration = [{
     using BodyBuilderFn =

--- a/mlir/include/mlir/Dialect/SMT/IR/SMTOps.td
+++ b/mlir/include/mlir/Dialect/SMT/IR/SMTOps.td
@@ -227,7 +227,7 @@ def YieldOp : SMTOp<"yield", [
   let arguments = (ins Variadic<AnyType>:$values);
   let assemblyFormat = "($values^ `:` qualified(type($values)))? attr-dict";
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, std::nullopt);
+    build($_builder, $_state, {});
   }]>];
 }
 

--- a/mlir/include/mlir/Dialect/Shape/IR/ShapeOps.td
+++ b/mlir/include/mlir/Dialect/Shape/IR/ShapeOps.td
@@ -678,9 +678,7 @@ def Shape_YieldOp : Shape_Op<"yield",
 
   let arguments = (ins Variadic<AnyType>:$operands);
 
-  let builders = [OpBuilder<(ins),
-    [{ build($_builder, $_state, std::nullopt); }]>
-  ];
+  let builders = [OpBuilder<(ins), [{ build($_builder, $_state, {}); }]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
   let hasVerifier = 1;

--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
@@ -251,8 +251,7 @@ lowerAsEntryFunction(gpu::GPUFuncOp funcOp, const TypeConverter &typeConverter,
   }
   auto newFuncOp = rewriter.create<spirv::FuncOp>(
       funcOp.getLoc(), funcOp.getName(),
-      rewriter.getFunctionType(signatureConverter.getConvertedTypes(),
-                               std::nullopt));
+      rewriter.getFunctionType(signatureConverter.getConvertedTypes(), {}));
   for (const auto &namedAttr : funcOp->getAttrs()) {
     if (namedAttr.getName() == funcOp.getFunctionTypeAttrName() ||
         namedAttr.getName() == SymbolTable::getSymbolAttrName())

--- a/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
@@ -636,7 +636,7 @@ SymbolRefAttr PatternLowering::generateRewriter(
   builder.setInsertionPointToEnd(rewriterModule.getBody());
   auto rewriterFunc = builder.create<pdl_interp::FuncOp>(
       pattern.getLoc(), "pdl_generated_rewriter",
-      builder.getFunctionType(std::nullopt, std::nullopt));
+      builder.getFunctionType({}, {}));
   rewriterSymbolTable.insert(rewriterFunc);
 
   // Generate the rewriter function body.
@@ -703,7 +703,7 @@ SymbolRefAttr PatternLowering::generateRewriter(
   // Update the signature of the rewrite function.
   rewriterFunc.setType(builder.getFunctionType(
       llvm::to_vector<8>(rewriterFunc.front().getArgumentTypes()),
-      /*results=*/std::nullopt));
+      /*results=*/{}));
 
   builder.create<pdl_interp::FinalizeOp>(rewriter.getLoc());
   return SymbolRefAttr::get(
@@ -990,7 +990,7 @@ void PDLToPDLInterpPass::runOnOperation() {
   auto matcherFunc = builder.create<pdl_interp::FuncOp>(
       module.getLoc(), pdl_interp::PDLInterpDialect::getMatcherFunctionName(),
       builder.getFunctionType(builder.getType<pdl::OperationType>(),
-                              /*results=*/std::nullopt),
+                              /*results=*/{}),
       /*attrs=*/std::nullopt);
 
   // Create a nested module to hold the functions invoked for rewriting the IR

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -2302,7 +2302,7 @@ void WarpExecuteOnLane0Op::build(OpBuilder &builder, OperationState &result,
                                  TypeRange resultTypes, Value laneId,
                                  int64_t warpSize) {
   build(builder, result, resultTypes, laneId, warpSize,
-        /*operands=*/std::nullopt, /*argTypes=*/std::nullopt);
+        /*operands=*/{}, /*argTypes=*/{});
 }
 
 void WarpExecuteOnLane0Op::build(OpBuilder &builder, OperationState &result,

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -769,7 +769,7 @@ LoopNest mlir::scf::buildLoopNest(
     ValueRange steps,
     function_ref<void(OpBuilder &, Location, ValueRange)> bodyBuilder) {
   // Delegate to the main function by wrapping the body builder.
-  return buildLoopNest(builder, loc, lbs, ubs, steps, std::nullopt,
+  return buildLoopNest(builder, loc, lbs, ubs, steps, {},
                        [&bodyBuilder](OpBuilder &nestedBuilder,
                                       Location nestedLoc, ValueRange ivs,
                                       ValueRange) -> ValueVector {

--- a/mlir/lib/Dialect/SPIRV/Transforms/LowerABIAttributesPass.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/LowerABIAttributesPass.cpp
@@ -282,8 +282,8 @@ LogicalResult ProcessInterfaceVarABI::matchAndRewrite(
 
   // Creates a new function with the update signature.
   rewriter.modifyOpInPlace(funcOp, [&] {
-    funcOp.setType(rewriter.getFunctionType(
-        signatureConverter.getConvertedTypes(), std::nullopt));
+    funcOp.setType(
+        rewriter.getFunctionType(signatureConverter.getConvertedTypes(), {}));
   });
   return success();
 }

--- a/mlir/unittests/Debug/FileLineColLocBreakpointManagerTest.cpp
+++ b/mlir/unittests/Debug/FileLineColLocBreakpointManagerTest.cpp
@@ -23,9 +23,9 @@ static Operation *createOp(MLIRContext *context, Location loc,
                            StringRef operationName,
                            unsigned int numRegions = 0) {
   context->allowUnregisteredDialects();
-  return Operation::create(loc, OperationName(operationName, context),
-                           std::nullopt, std::nullopt, std::nullopt,
-                           OpaqueProperties(nullptr), std::nullopt, numRegions);
+  return Operation::create(loc, OperationName(operationName, context), {}, {},
+                           std::nullopt, OpaqueProperties(nullptr),
+                           std::nullopt, numRegions);
 }
 
 namespace {

--- a/mlir/unittests/IR/OperationSupportTest.cpp
+++ b/mlir/unittests/IR/OperationSupportTest.cpp
@@ -44,7 +44,7 @@ TEST(OperandStorageTest, NonResizable) {
   EXPECT_EQ(user->getNumOperands(), 1u);
 
   // Removing is okay.
-  user->setOperands(std::nullopt);
+  user->setOperands({});
   EXPECT_EQ(user->getNumOperands(), 0u);
 
   // Destroy the operations.
@@ -68,7 +68,7 @@ TEST(OperandStorageTest, Resizable) {
   EXPECT_EQ(user->getNumOperands(), 1u);
 
   // Removing is okay.
-  user->setOperands(std::nullopt);
+  user->setOperands({});
   EXPECT_EQ(user->getNumOperands(), 0u);
 
   // Adding more operands is okay.
@@ -236,7 +236,7 @@ TEST(OperationFormatPrintTest, CanPrintNameAsPrefix) {
   context.allowUnregisteredDialects();
   Operation *op = Operation::create(
       NameLoc::get(StringAttr::get(&context, "my_named_loc")),
-      OperationName("t.op", &context), builder.getIntegerType(16), std::nullopt,
+      OperationName("t.op", &context), builder.getIntegerType(16), {},
       std::nullopt, nullptr, std::nullopt, 0);
 
   std::string str;

--- a/mlir/unittests/Pass/AnalysisManagerTest.cpp
+++ b/mlir/unittests/Pass/AnalysisManagerTest.cpp
@@ -63,9 +63,8 @@ TEST(AnalysisManagerTest, FineGrainFunctionAnalysisPreservation) {
 
   // Create a function and a module.
   OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
-  func::FuncOp func1 =
-      func::FuncOp::create(builder.getUnknownLoc(), "foo",
-                           builder.getFunctionType(std::nullopt, std::nullopt));
+  func::FuncOp func1 = func::FuncOp::create(builder.getUnknownLoc(), "foo",
+                                            builder.getFunctionType({}, {}));
   func1.setPrivate();
   module->push_back(func1);
 
@@ -94,9 +93,8 @@ TEST(AnalysisManagerTest, FineGrainChildFunctionAnalysisPreservation) {
 
   // Create a function and a module.
   OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
-  func::FuncOp func1 =
-      func::FuncOp::create(builder.getUnknownLoc(), "foo",
-                           builder.getFunctionType(std::nullopt, std::nullopt));
+  func::FuncOp func1 = func::FuncOp::create(builder.getUnknownLoc(), "foo",
+                                            builder.getFunctionType({}, {}));
   func1.setPrivate();
   module->push_back(func1);
 

--- a/mlir/unittests/Pass/PassManagerTest.cpp
+++ b/mlir/unittests/Pass/PassManagerTest.cpp
@@ -63,9 +63,8 @@ TEST(PassManagerTest, OpSpecificAnalysis) {
   // Create a module with 2 functions.
   OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
   for (StringRef name : {"secret", "not_secret"}) {
-    auto func = func::FuncOp::create(
-        builder.getUnknownLoc(), name,
-        builder.getFunctionType(std::nullopt, std::nullopt));
+    auto func = func::FuncOp::create(builder.getUnknownLoc(), name,
+                                     builder.getFunctionType({}, {}));
     func.setPrivate();
     module->push_back(func);
   }
@@ -125,9 +124,8 @@ TEST(PassManagerTest, ExecutionAction) {
 
   // Create a module with 2 functions.
   OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
-  auto f =
-      func::FuncOp::create(builder.getUnknownLoc(), "process_me_once",
-                           builder.getFunctionType(std::nullopt, std::nullopt));
+  auto f = func::FuncOp::create(builder.getUnknownLoc(), "process_me_once",
+                                builder.getFunctionType({}, {}));
   f.setPrivate();
   module->push_back(f);
 

--- a/mlir/unittests/Transforms/DialectConversion.cpp
+++ b/mlir/unittests/Transforms/DialectConversion.cpp
@@ -14,8 +14,8 @@ using namespace mlir;
 static Operation *createOp(MLIRContext *context) {
   context->allowUnregisteredDialects();
   return Operation::create(
-      UnknownLoc::get(context), OperationName("foo.bar", context), std::nullopt,
-      std::nullopt, std::nullopt, /*properties=*/nullptr, std::nullopt, 0);
+      UnknownLoc::get(context), OperationName("foo.bar", context), {}, {},
+      std::nullopt, /*properties=*/nullptr, std::nullopt, 0);
 }
 
 namespace {


### PR DESCRIPTION
ArrayRef has a constructor that accepts std::nullopt.  This
constructor dates back to the days when we still had llvm::Optional.

Since the use of std::nullopt outside the context of std::optional is
kind of abuse and not intuitive to new comers, I would like to move
away from the constructor and eventually remove it.

This patch migrates away from TypeRagne(std::nullopt) and
ValueRange(std::nullopt).
