### PR TITLE
[llvm] update a few llvm unit tests to link statically

### DIFF
--- a/llvm/lib/Testing/Support/CMakeLists.txt
+++ b/llvm/lib/Testing/Support/CMakeLists.txt
@@ -20,6 +20,23 @@ add_llvm_library(LLVMTestingSupport
 
 target_link_libraries(LLVMTestingSupport PRIVATE llvm_gtest)
 
+add_llvm_library(LLVMTestingSupportStatic
+  Error.cpp
+  SupportHelpers.cpp
+
+  ${BUILDTREE_ONLY}
+
+  ADDITIONAL_HEADER_DIRS
+  ${LLVM_MAIN_INCLUDE_DIR}/llvm/Testing/Support
+
+  LINK_COMPONENTS
+  Support
+
+  DISABLE_LLVM_LINK_LLVM_DYLIB
+  )
+
+target_link_libraries(LLVMTestingSupportStatic PRIVATE llvm_gtest)
+
 # This is to avoid the error in gtest-death-test-internal.h
 # (150,16): error: 'Create' overrides a member function but
 # is not marked 'override' [-Werror,-Wsuggest-override]

--- a/llvm/unittests/CodeGen/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CMakeLists.txt
@@ -48,8 +48,10 @@ add_llvm_unittest(CodeGenTests
   TestAsmPrinter.cpp
   MLRegAllocDevelopmentFeatures.cpp
   X86MCInstLowerTest.cpp
+
+  DISABLE_LLVM_LINK_LLVM_DYLIB
   )
 
 add_subdirectory(GlobalISel)
 
-target_link_libraries(CodeGenTests PRIVATE LLVMTestingSupport)
+target_link_libraries(CodeGenTests PRIVATE LLVMTestingSupportStatic)

--- a/llvm/unittests/DebugInfo/DWARF/CMakeLists.txt
+++ b/llvm/unittests/DebugInfo/DWARF/CMakeLists.txt
@@ -28,6 +28,8 @@ add_llvm_unittest(DebugInfoDWARFTests
   DWARFFormValueTest.cpp
   DWARFListTableTest.cpp
   DWARFLocationExpressionTest.cpp
+
+  DISABLE_LLVM_LINK_LLVM_DYLIB
   )
 
-target_link_libraries(DebugInfoDWARFTests PRIVATE LLVMTestingSupport)
+target_link_libraries(DebugInfoDWARFTests PRIVATE LLVMTestingSupportStatic)

--- a/llvm/unittests/DebugInfo/LogicalView/CMakeLists.txt
+++ b/llvm/unittests/DebugInfo/LogicalView/CMakeLists.txt
@@ -22,6 +22,8 @@ add_llvm_unittest_with_input_files(DebugInfoLogicalViewTests
   LogicalElementsTest.cpp
   StringPoolTest.cpp
   WarningInternalTest.cpp
+
+  DISABLE_LLVM_LINK_LLVM_DYLIB
   )
 
-target_link_libraries(DebugInfoLogicalViewTests PRIVATE LLVMTestingSupport)
+target_link_libraries(DebugInfoLogicalViewTests PRIVATE LLVMTestingSupportStatic)

--- a/llvm/unittests/FileCheck/CMakeLists.txt
+++ b/llvm/unittests/FileCheck/CMakeLists.txt
@@ -5,6 +5,8 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(FileCheckTests
   FileCheckTest.cpp
+
+  DISABLE_LLVM_LINK_LLVM_DYLIB
 )
 
-target_link_libraries(FileCheckTests PRIVATE LLVMTestingSupport)
+target_link_libraries(FileCheckTests PRIVATE LLVMTestingSupportStatic)

--- a/llvm/unittests/TableGen/CMakeLists.txt
+++ b/llvm/unittests/TableGen/CMakeLists.txt
@@ -13,6 +13,8 @@ add_llvm_unittest(TableGenTests
   AutomataTest.cpp
   CodeExpanderTest.cpp
   ParserEntryPointTest.cpp
+
+  DISABLE_LLVM_LINK_LLVM_DYLIB
   )
 
 target_link_libraries(TableGenTests PRIVATE LLVMTableGenCommon LLVMTableGen)

--- a/llvm/unittests/Transforms/Vectorize/CMakeLists.txt
+++ b/llvm/unittests/Transforms/Vectorize/CMakeLists.txt
@@ -15,4 +15,6 @@ add_llvm_unittest(VectorizeTests
   VPlanPatternMatchTest.cpp
   VPlanSlpTest.cpp
   VPlanVerifierTest.cpp
+
+  DISABLE_LLVM_LINK_LLVM_DYLIB
   )


### PR DESCRIPTION
## Purpose
Apply a few CMake changes so that LLVM unit tests can still build/run when LLVM is built as a Windows DLL.

## Background
The effort to build LLVM as a WIndows DLL is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307).

Some LLVM unit tests use internal/private symbols that are not part of LLVM's public interface. When building LLVM as a DLL or shared library with default hidden symbol visibility, the symbols are not available when the unit test links against the DLL or shared library.

This problem can be solved in one of two ways:
1. Export the private symbols from the DLL.
2. Link the unit tests against the intermediate static libraries instead of the final LLVM DLL.

This PR applies option 2 because there is already precedence for it in the codebase. This solution is arguably more correct than exporting internal interfaces as public. The only downside is that the unit tests do not validate correctness of the LLVM DLL, but this is arguably not the purpose of a unit test anyway.

## Overview
This PR makes the following changes:
- Adds a new test library `LLVMTestingSupportStatic` which is identical to the existing `LLVMTestingSupport` library but it statically links its LLVM dependencies by passing the `DISABLE_LLVM_LINK_LLVM_DYLIB` argument to `add_llvm_library`.
- Updates `CodeGenTests`, `DebugInfoDWARFTests`, `DebugInfoLogicalViewTests`, and `FileCheckTests` to link against the new `LLVMTestingSupportStatic` library and to link their LLVM dependencies statically using `DISABLE_LLVM_LINK_LLVM_DYLIB`.
- Updates `TableGenTests` and `VectorizeTests` to link their LLVM dependencies statically using `DISABLE_LLVM_LINK_LLVM_DYLIB`.