### PR TITLE
[lldb] Fix AppleObjCDeclVendor for classes which have no methods

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -552,9 +552,9 @@ bool ClassDescriptorV2::Describe(
     } else {
       std::optional<method_list_t> base_method_list =
           GetMethodList(process, class_ro->m_baseMethods_ptr);
-      if (base_method_list)
-        if (!ProcessMethodList(instance_method_func, *base_method_list))
-          return false;
+      if (base_method_list &&
+          !ProcessMethodList(instance_method_func, *base_method_list))
+        return false;
     }
   }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -552,10 +552,9 @@ bool ClassDescriptorV2::Describe(
     } else {
       std::optional<method_list_t> base_method_list =
           GetMethodList(process, class_ro->m_baseMethods_ptr);
-      if (!base_method_list)
-        return false;
-      if (!ProcessMethodList(instance_method_func, *base_method_list))
-        return false;
+      if (base_method_list)
+        if (!ProcessMethodList(instance_method_func, *base_method_list))
+          return false;
     }
   }
 

--- a/lldb/test/API/lang/objc/class-without-methods/Makefile
+++ b/lldb/test/API/lang/objc/class-without-methods/Makefile
@@ -1,0 +1,5 @@
+OBJC_SOURCES := Point.m main.m
+include Makefile.rules
+
+# Only objc metadata, no debug info, for Point.m
+Point.o: CFLAGS_EXTRAS += -g0

--- a/lldb/test/API/lang/objc/class-without-methods/Point.h
+++ b/lldb/test/API/lang/objc/class-without-methods/Point.h
@@ -1,0 +1,8 @@
+#import <objc/NSObject.h>
+
+@interface Point : NSObject {
+@public
+  float _x;
+  float _y;
+}
+@end

--- a/lldb/test/API/lang/objc/class-without-methods/Point.h
+++ b/lldb/test/API/lang/objc/class-without-methods/Point.h
@@ -1,8 +1,4 @@
 #import <objc/NSObject.h>
 
-@interface Point : NSObject {
-@public
-  float _x;
-  float _y;
-}
+@interface Point : NSObject
 @end

--- a/lldb/test/API/lang/objc/class-without-methods/Point.m
+++ b/lldb/test/API/lang/objc/class-without-methods/Point.m
@@ -1,0 +1,4 @@
+#import "Point.h"
+
+@implementation Point
+@end

--- a/lldb/test/API/lang/objc/class-without-methods/Point.m
+++ b/lldb/test/API/lang/objc/class-without-methods/Point.m
@@ -1,4 +1,7 @@
 #import "Point.h"
 
-@implementation Point
+@implementation Point {
+  float _x;
+  float _y;
+}
 @end

--- a/lldb/test/API/lang/objc/class-without-methods/TestObjCClassWithoutMethods.py
+++ b/lldb/test/API/lang/objc/class-without-methods/TestObjCClassWithoutMethods.py
@@ -8,4 +8,4 @@ class TestCase(TestBase):
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
-        self.expect("frame var -P1 p", substrs=["_x = 11", "_y = 22"])
+        self.expect("frame var -P1 p", substrs=["_x = 0", "_y = 0"])

--- a/lldb/test/API/lang/objc/class-without-methods/TestObjCClassWithoutMethods.py
+++ b/lldb/test/API/lang/objc/class-without-methods/TestObjCClassWithoutMethods.py
@@ -1,0 +1,11 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+        self.expect("frame var -P1 p", substrs=["_x = 11", "_y = 22"])

--- a/lldb/test/API/lang/objc/class-without-methods/main.m
+++ b/lldb/test/API/lang/objc/class-without-methods/main.m
@@ -2,8 +2,6 @@
 
 int main() {
   Point *p = [Point new];
-  p->_x = 11;
-  p->_y = 22;
   // break here
   return 0;
 }

--- a/lldb/test/API/lang/objc/class-without-methods/main.m
+++ b/lldb/test/API/lang/objc/class-without-methods/main.m
@@ -1,0 +1,9 @@
+#import "Point.h"
+
+int main() {
+  Point *p = [Point new];
+  p->_x = 11;
+  p->_y = 22;
+  // break here
+  return 0;
+}


### PR DESCRIPTION
Fix the rare case where an ObjC class has ivars but no methods. The fix is to not early
return when a class has no method list.
