### PR TITLE
Fix `pragma-comment.c` test failing on false match

### DIFF
--- a/clang/test/CodeGen/pragma-comment.c
+++ b/clang/test/CodeGen/pragma-comment.c
@@ -32,3 +32,6 @@
 // ELF: ![[space]] = !{!"with space"}
 // ELF-NOT: bar
 // ELF-NOT: foo
+// This following match prevents the clang version metadata from matching the forbidden 'foo' and 'bar' tokens.
+// This can happen if the clang version string contains a Git repo URL that includes one of those substrings.
+// ELF-LABEL: !"clang version


### PR DESCRIPTION
Sometimes the forbidden text `foo` or `bar` could appear in the Clang version string metadata. Treating the version string as a `CHECK-LABEL:` prevents this.

Fixes #145453
