### PR TITLE
[ORC] Drop unused LinkGraphLinkingLayer::Plugin::notifyLoaded method.

### DIFF
--- a/llvm/examples/OrcV2Examples/LLJITWithObjectLinkingLayerPlugin/LLJITWithObjectLinkingLayerPlugin.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithObjectLinkingLayerPlugin/LLJITWithObjectLinkingLayerPlugin.cpp
@@ -70,10 +70,6 @@ public:
     Config.PostPrunePasses.push_back(printGraph);
   }
 
-  void notifyLoaded(MaterializationResponsibility &MR) override {
-    outs() << "Loading object defining " << MR.getSymbols() << "\n";
-  }
-
   Error notifyEmitted(MaterializationResponsibility &MR) override {
     outs() << "Emitted object defining " << MR.getSymbols() << "\n";
     return Error::success();

--- a/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h
@@ -63,7 +63,6 @@ public:
                                      jitlink::JITLinkContext &Ctx,
                                      MemoryBufferRef InputObject) {}
 
-    virtual void notifyLoaded(MaterializationResponsibility &MR) {}
     virtual Error notifyEmitted(MaterializationResponsibility &MR) {
       return Error::success();
     }

--- a/llvm/lib/ExecutionEngine/Orc/LinkGraphLinkingLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LinkGraphLinkingLayer.cpp
@@ -207,7 +207,6 @@ public:
     if (auto Err = MR->notifyResolved(InternedResult))
       return Err;
 
-    notifyLoaded();
     return Error::success();
   }
 
@@ -242,11 +241,6 @@ public:
         [this](LinkGraph &G) { return registerDependencies(G); });
 
     return Error::success();
-  }
-
-  void notifyLoaded() {
-    for (auto &P : Plugins)
-      P->notifyLoaded(*MR);
   }
 
   Error notifyEmitted(jitlink::JITLinkMemoryManager::FinalizedAlloc FA) {


### PR DESCRIPTION
This method was included in the original Plugin API as a counterpart to JITEventListener::notifyLoaded but was never used.