### PR TITLE
MC,AsmPrinter: Report redefinition error instead of crashing in more cases

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1081,13 +1081,6 @@ void AsmPrinter::emitFunctionHeader() {
 /// function.  This can be overridden by targets as required to do custom stuff.
 void AsmPrinter::emitFunctionEntryLabel() {
   CurrentFnSym->redefineIfPossible();
-
-  // The function label could have already been emitted if two symbols end up
-  // conflicting due to asm renaming.  Detect this and emit an error.
-  if (CurrentFnSym->isVariable())
-    report_fatal_error("'" + Twine(CurrentFnSym->getName()) +
-                       "' is a protected alias");
-
   OutStreamer->emitLabel(CurrentFnSym);
 
   if (TM.getTargetTriple().isOSBinFormatELF()) {

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -569,7 +569,8 @@ void MCAsmStreamer::emitLabel(MCSymbol *Symbol, SMLoc Loc) {
   // FIXME: Fix CodeGen/AArch64/arm64ec-varargs.ll. emitLabel is followed by
   // setVariableValue, leading to an assertion failure if setOffset(0) is
   // called.
-  if (getContext().getObjectFileType() != MCContext::IsCOFF)
+  if (!Symbol->isVariable() &&
+      getContext().getObjectFileType() != MCContext::IsCOFF)
     Symbol->setOffset(0);
 
   Symbol->print(OS, MAI);

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -225,6 +225,10 @@ void MCObjectStreamer::emitCFIEndProcImpl(MCDwarfFrameInfo &Frame) {
 
 void MCObjectStreamer::emitLabel(MCSymbol *Symbol, SMLoc Loc) {
   MCStreamer::emitLabel(Symbol, Loc);
+  // If Symbol is a non-redefiniable variable, emitLabel has reported an error.
+  // Bail out.
+  if (Symbol->isVariable())
+    return;
 
   getAssembler().registerSymbol(*Symbol);
 

--- a/llvm/test/CodeGen/X86/equiv_with_fndef.ll
+++ b/llvm/test/CodeGen/X86/equiv_with_fndef.ll
@@ -1,4 +1,4 @@
-; RUN: not --crash llc < %s 2>&1 | FileCheck %s
+; RUN: not llc < %s 2>&1 | FileCheck %s
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
@@ -7,4 +7,4 @@ module asm ".equiv pselect, __pselect"
 define void @pselect() {
   ret void
 }
-; CHECK: 'pselect' is a protected alias
+; CHECK: <unknown>:0: error: symbol 'pselect' is already defined

--- a/llvm/test/MC/AsmParser/redef-err.s
+++ b/llvm/test/MC/AsmParser/redef-err.s
@@ -12,3 +12,7 @@ l:
 
 .equiv a, undef
 # CHECK: [[#@LINE-1]]:11: error: redefinition of 'a'
+
+.equiv b, undef
+b:
+# CHECK: [[#@LINE-1]]:1: error: symbol 'b' is already defined


### PR DESCRIPTION
* Fix the crash for `.equiv b, undef; b:` (.equiv equates a symbol to an expression and reports an error if the symbol was already defined).
* Remove redundant isVariable check from emitFunctionEntryLabel
