### PR TITLE
[flang] Allow `cycle` in `target teams distribute [simd]`

### DIFF
--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -76,6 +76,8 @@ public:
         case llvm::omp::Directive::OMPD_distribute_parallel_for:
         case llvm::omp::Directive::OMPD_distribute_simd:
         case llvm::omp::Directive::OMPD_distribute_parallel_for_simd:
+        case llvm::omp::Directive::OMPD_target_teams_distribute:
+        case llvm::omp::Directive::OMPD_target_teams_distribute_simd:
         case llvm::omp::Directive::OMPD_target_teams_distribute_parallel_do:
         case llvm::omp::Directive::
             OMPD_target_teams_distribute_parallel_do_simd:

--- a/flang/test/Semantics/OpenMP/do05-positivecase.f90
+++ b/flang/test/Semantics/OpenMP/do05-positivecase.f90
@@ -57,4 +57,18 @@ program omp_do
     if(i<10) cycle
   end do
   !$omp end target teams distribute parallel do simd
+
+  !$omp target teams distribute 
+  !DEF: /omp_do/OtherConstruct6/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+  do i=1,100
+    !REF: /omp_do/OtherConstruct6/i
+    if(i < 5) cycle
+  end do
+
+  !$omp target teams distribute simd
+  !DEF: /omp_do/OtherConstruct7/i (OmpLinear, OmpPreDetermined) HostAssoc INTEGER(4)
+  do i=1,100
+    !REF: /omp_do/OtherConstruct7/i
+    if(i < 5) cycle
+  end do
 end program omp_do


### PR DESCRIPTION
flang incorrectly issues a semantic erorr when a `cycle` statement is used inside a `target teams distribute [simd]` associated loop. This is not prevented by the spec, therefore this PR allows such construct.