### PR TITLE
[DFAJumpThreading] Prevent pass from using too much memory.

### DIFF
--- a/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
@@ -618,6 +618,8 @@ private:
 
     VisitedBlocks UniqueBlocks;
     for (auto *IncomingBB : Phi->blocks()) {
+      if(Res.size() >= MaxNumPaths)
+        break;
       if (!UniqueBlocks.insert(IncomingBB).second)
         continue;
       if (!SwitchOuterLoop->contains(IncomingBB))
@@ -657,6 +659,8 @@ private:
             getPathsFromStateDefMap(StateDef, IncomingPhi, VB);
         for (ThreadingPath &Path : PredPaths) {
           Path.push_back(PhiBB);
+          if(Res.size() >= MaxNumPaths)
+            break;
           Res.push_back(std::move(Path));
         }
         continue;
@@ -679,6 +683,10 @@ private:
           ThreadingPath NewPath(Path);
           NewPath.appendExcludingFirst(IPath);
           NewPath.push_back(PhiBB);
+          if(Res.size() >= MaxNumPaths) {
+            VB.erase(PhiBB);
+            return Res;
+	  }
           Res.push_back(NewPath);
         }
       }

--- a/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
@@ -618,7 +618,7 @@ private:
 
     VisitedBlocks UniqueBlocks;
     for (auto *IncomingBB : Phi->blocks()) {
-      if(Res.size() >= MaxNumPaths)
+      if (Res.size() >= MaxNumPaths)
         break;
       if (!UniqueBlocks.insert(IncomingBB).second)
         continue;
@@ -659,7 +659,7 @@ private:
             getPathsFromStateDefMap(StateDef, IncomingPhi, VB);
         for (ThreadingPath &Path : PredPaths) {
           Path.push_back(PhiBB);
-          if(Res.size() >= MaxNumPaths)
+          if (Res.size() >= MaxNumPaths)
             break;
           Res.push_back(std::move(Path));
         }
@@ -683,10 +683,10 @@ private:
           ThreadingPath NewPath(Path);
           NewPath.appendExcludingFirst(IPath);
           NewPath.push_back(PhiBB);
-          if(Res.size() >= MaxNumPaths) {
+          if (Res.size() >= MaxNumPaths) {
             VB.erase(PhiBB);
             return Res;
-	  }
+          }
           Res.push_back(NewPath);
         }
       }


### PR DESCRIPTION
The limit 'dfa-max-num-paths' that is used to control number of enumerated paths was not checked against inside getPathsFromStateDefMap. It may lead to large memory consumption for complex enough switch statements.