### PR TITLE
[clang] Fix __builtin_mul_overflow for big _BitInts

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -2356,7 +2356,7 @@ EmitCheckedMixedSignMultiply(CodeGenFunction &CGF, const clang::Expr *Op1,
   llvm::Type *OpTy = Signed->getType();
   llvm::Value *Zero = llvm::Constant::getNullValue(OpTy);
   Address ResultPtr = CGF.EmitPointerWithAlignment(ResultArg);
-  llvm::Type *ResTy = ResultPtr.getElementType();
+  llvm::Type *ResTy = CGF.getTypes().ConvertType(ResultQTy);
   unsigned OpWidth = std::max(Op1Info.Width, Op2Info.Width);
 
   // Take the absolute value of the signed operand.

--- a/clang/test/CodeGen/builtins-overflow.c
+++ b/clang/test/CodeGen/builtins-overflow.c
@@ -604,3 +604,15 @@ long long test_mixed_sign_mul_overflow_extend_unsigned(int x, unsigned y) {
     return LongLongErrorCode;
   return result;
 }
+
+_BitInt(65) test_mixed_sign_mul_overflow_bitint(unsigned _BitInt(65) y, _BitInt(119) a) {
+// CHECK: call { i119, i1 } @llvm.umul.with.overflow.i119
+// CHECK: select i1 %{{.*}}, i119 %{{.*}}, i119 %{{.*}}
+// CHECK: trunc i119
+// CHECK: zext i65
+// CHECK: store
+  unsigned _BitInt(65) result;
+  if (__builtin_mul_overflow(a, y, &result))
+    return LongLongErrorCode;
+  return result;
+}


### PR DESCRIPTION
For long enough _BitInt types we use different types for memory, storing-loading and other operations. Makes sure it is correct for mixed sign __builtin_mul_overflow cases. Using pointer element type as a result type doesn't work, because it will be "in-memory" type which is usually bigger than "operations" type and that caused crashes because clang was trying to emit trunc to a bigger type.

Fixes https://github.com/llvm/llvm-project/issues/144771