### PR TITLE
[clang][dataflow] Expose simple access to child StorageLocation presence.

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/StorageLocation.h
+++ b/clang/include/clang/Analysis/FlowSensitive/StorageLocation.h
@@ -168,6 +168,8 @@ public:
     return {Children.begin(), Children.end()};
   }
 
+  bool hasChild(const ValueDecl &D) const { return Children.contains(&D); }
+
 private:
   FieldToLoc Children;
   SyntheticFieldMap SyntheticFields;


### PR DESCRIPTION
`getChild` does not offer this knowledge, and a map lookup is significantly cheaper than iteration over `children()`.