### PR TITLE
[Serialization] Fix source location data loss during decoding.

### DIFF
--- a/clang/unittests/Serialization/SourceLocationEncodingTest.cpp
+++ b/clang/unittests/Serialization/SourceLocationEncodingTest.cpp
@@ -104,6 +104,8 @@ TEST(SourceLocationEncoding, Sequence) {
 
   roundTrip(
       {123 | MacroBit, 1, 9, Biggest, Big, Big + 1, 0, MacroBit | Big, 0});
+
+  roundTrip({1, (1u << 30) + 1});
 }
 
 } // namespace


### PR DESCRIPTION
The delta encoding can produce values up to 33 bits, but the current decoding logic only preserves the lower 32 bits, potentially causing data loss.

This patch fixes the issue by preserving the lower 33 bits for the encode.