### PR TITLE
[SystemZ][zOS] disable _Float16 support on z/OS

### DIFF
--- a/clang/lib/Basic/Targets/SystemZ.h
+++ b/clang/lib/Basic/Targets/SystemZ.h
@@ -76,6 +76,7 @@ public:
     MinGlobalAlign = 16;
     HasUnalignedAccess = true;
     if (Triple.isOSzOS()) {
+      HasFloat16 = false;
       if (Triple.isArch64Bit()) {
         AddrSpaceMap = &ZOSAddressMap;
       }
@@ -89,6 +90,8 @@ public:
       resetDataLayout("E-m:l-p1:32:32-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-"
                       "a:8:16-n32:64");
     } else {
+      // Support _Float16.
+      HasFloat16 = true;
       TLSSupported = true;
       resetDataLayout("E-m:e-i1:8:16-i8:8:16-i64:64-f128:64"
                       "-v128:64-a:8:16-n32:64");
@@ -102,8 +105,6 @@ public:
     // and instead the backend will promote each half operation to float
     // individually.
     HasLegalHalfType = false;
-    // Support _Float16.
-    HasFloat16 = true;
 
     HasStrictFP = true;
   }

--- a/clang/lib/Basic/Targets/SystemZ.h
+++ b/clang/lib/Basic/Targets/SystemZ.h
@@ -76,7 +76,6 @@ public:
     MinGlobalAlign = 16;
     HasUnalignedAccess = true;
     if (Triple.isOSzOS()) {
-      HasFloat16 = false;
       if (Triple.isArch64Bit()) {
         AddrSpaceMap = &ZOSAddressMap;
       }

--- a/clang/test/Sema/Float16.c
+++ b/clang/test/Sema/Float16.c
@@ -6,6 +6,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -triple aarch64-linux-gnu %s -DHAVE
 // RUN: %clang_cc1 -fsyntax-only -verify -triple riscv32 %s -DHAVE
 // RUN: %clang_cc1 -fsyntax-only -verify -triple riscv64 %s -DHAVE
+// RUN: %clang_cc1 -fsyntax-only -verify -triple s390x-ibm-zos %s
 
 #ifndef HAVE
 // expected-error@+2{{_Float16 is not supported on this target}}

--- a/clang/test/SemaCXX/Float16.cpp
+++ b/clang/test/SemaCXX/Float16.cpp
@@ -4,7 +4,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -triple spir-unknown-unknown %s -DHAVE
 // RUN: %clang_cc1 -fsyntax-only -verify -triple armv7a-linux-gnu %s -DHAVE
 // RUN: %clang_cc1 -fsyntax-only -verify -triple aarch64-linux-gnu %s -DHAVE
-
+// RUN: %clang_cc1 -fsyntax-only -verify -triple s390x-ibm-zos %s
 #ifdef HAVE
 // expected-no-diagnostics
 #endif // HAVE


### PR DESCRIPTION
The new half float type (aka _Float16 ) isn't supported on z/OS.