### PR TITLE
[RISCV] Add Tied operands in Xqcicm instructions and changes to handle a single tied operand in source DAG and instruction

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -596,17 +596,20 @@ class QCILICC<bits<3> funct3, bits<2> funct2, DAGOperand InTyRs2, string opcodes
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class QCIMVCC<bits<3> funct3, string opcodestr>
-    : RVInstR4<0b00, funct3, OPC_CUSTOM_2, (outs GPRNoX0:$rd),
-               (ins GPRNoX0:$rs1, GPRNoX0:$rs2, GPRNoX0:$rs3),
-               opcodestr, "$rd, $rs1, $rs2, $rs3">;
+    : RVInstR4<0b00, funct3, OPC_CUSTOM_2, (outs GPRNoX0:$rd_wb),
+               (ins GPRNoX0:$rd, GPRNoX0:$rs1, GPRNoX0:$rs2, GPRNoX0:$rs3),
+               opcodestr, "$rd, $rs1, $rs2, $rs3"> {
+  let Constraints = "$rd = $rd_wb";
+}
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class QCIMVCCI<bits<3> funct3, string opcodestr, DAGOperand immType>
-    : RVInstR4<0b10, funct3, OPC_CUSTOM_2, (outs GPRNoX0:$rd),
-               (ins GPRNoX0:$rs1, immType:$imm, GPRNoX0:$rs3),
+    : RVInstR4<0b10, funct3, OPC_CUSTOM_2, (outs GPRNoX0:$rd_wb),
+               (ins GPRNoX0:$rd, GPRNoX0:$rs1, immType:$imm, GPRNoX0:$rs3),
                opcodestr, "$rd, $rs1, $imm, $rs3"> {
   bits<5> imm;
-
+  
+  let Constraints = "$rd = $rd_wb";
   let rs2 = imm;
 }
 

--- a/llvm/test/MC/RISCV/xqcicm-valid.s
+++ b/llvm/test/MC/RISCV/xqcicm-valid.s
@@ -137,8 +137,7 @@ qc.mvltui x9, x9, 1, x12
 
 # Following instruction should not be compressed
 
-# CHECK-NOALIAS: qc.c.mveqz s1, a2
-# CHECK-ALIAS: qc.mveqi s1, s1, 0, a2
-# CHECK-ENC: encoding: [0x06,0xae]
+# CHECK-INST: qc.mveqi a0, s1, 0, a2
+# CHECK-ENC: encoding: [0x5b,0x85,0x04,0x64]
 qc.mveqi x10, x9, 0, x12
 

--- a/llvm/test/MC/RISCV/xqcicm-valid.s
+++ b/llvm/test/MC/RISCV/xqcicm-valid.s
@@ -135,3 +135,10 @@ qc.mveqi x9, x9, 0, x12
 # CHECK-ENC: encoding: [0x06,0xae]
 qc.mvltui x9, x9, 1, x12
 
+# Following instruction should not be compressed
+
+# CHECK-NOALIAS: qc.c.mveqz s1, a2
+# CHECK-ALIAS: qc.mveqi s1, s1, 0, a2
+# CHECK-ENC: encoding: [0x06,0xae]
+qc.mveqi x10, x9, 0, x12
+


### PR DESCRIPTION
Tied Operands change is required for adding codegen patterns for Qualcomm uC Xqcicm instructions
which will be done in a follow-up PR. This change leads to one of instructions getting compressed even
when it shouldn't be. This case was not covered in #143660. Added changes to correctly handle this case.