### PR TITLE
[X86] [clang] Add missing check line for diamondrapids (NFC)

### DIFF
--- a/clang/test/CodeGen/attr-target-mv.c
+++ b/clang/test/CodeGen/attr-target-mv.c
@@ -201,6 +201,8 @@ void calls_pr50025c(void) { pr50025c(); }
 // ITANIUM: ret i32 25
 // ITANIUM: define{{.*}} i32 @foo.arch_clearwaterforest()
 // ITANIUM: ret i32 26
+// ITANIUM: define{{.*}} i32 @foo.arch_diamondrapids()
+// ITANIUM: ret i32 27
 // ITANIUM: define{{.*}} i32 @foo()
 // ITANIUM: ret i32 2
 // ITANIUM: define{{.*}} i32 @bar()
@@ -258,6 +260,8 @@ void calls_pr50025c(void) { pr50025c(); }
 // WINDOWS: ret i32 25
 // WINDOWS: define dso_local i32 @foo.arch_clearwaterforest()
 // WINDOWS: ret i32 26
+// WINDOWS: define dso_local i32 @foo.arch_diamondrapids()
+// WINDOWS: ret i32 27
 // WINDOWS: define dso_local i32 @foo()
 // WINDOWS: ret i32 2
 // WINDOWS: define dso_local i32 @bar()


### PR DESCRIPTION
As in title. Without it, the test doesn't check for dmr