### PR TITLE
[bazel] Add //mlir:DialectUtils to TestTransforms for #145376

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -613,6 +613,7 @@ cc_library(
         "//mlir:AffineDialect",
         "//mlir:Analysis",
         "//mlir:ArithDialect",
+        "//mlir:DialectUtils",
         "//mlir:FuncDialect",
         "//mlir:IR",
         "//mlir:InliningUtils",


### PR DESCRIPTION
PR https://github.com/llvm/llvm-project/pull/145376 added #include "mlir/Dialect/Utils/StaticValueUtils.h" to mlir/test/lib/Transforms/TestTransformsOps.cpp . This change fixes the build file. 