### PR TITLE
[CIR] Fix NYI AAPCS bit-fields by skipping unsupported case

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -778,10 +778,8 @@ void CIRRecordLowering::computeVolatileBitfields() {
       !cirGenTypes.getCGModule().getCodeGenOpts().AAPCSBitfieldWidth)
     return;
 
-  for ([[maybe_unused]] auto &I : bitFields) {
+  for ([[maybe_unused]] auto &I : bitFields)
     assert(!cir::MissingFeatures::armComputeVolatileBitfields());
-    cirGenTypes.getCGModule().errorNYI("NYI AAPCS bit-fields");
-  }
 }
 
 void CIRRecordLowering::accumulateBases(const CXXRecordDecl *cxxRecordDecl) {

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -778,8 +778,7 @@ void CIRRecordLowering::computeVolatileBitfields() {
       !cirGenTypes.getCGModule().getCodeGenOpts().AAPCSBitfieldWidth)
     return;
 
-  for ([[maybe_unused]] auto &I : bitFields)
-    assert(!cir::MissingFeatures::armComputeVolatileBitfields());
+  assert(!cir::MissingFeatures::armComputeVolatileBitfields());
 }
 
 void CIRRecordLowering::accumulateBases(const CXXRecordDecl *cxxRecordDecl) {


### PR DESCRIPTION
This PR addresses the error mentioned in https://github.com/llvm/llvm-project/pull/145067#issuecomment-3001104015, which occurs on ARM when handling an unsupported bit-field case. The patch removes the error and replaces it with an assert, marking the missing feature.