### PR TITLE
[flang][OpenMP] Map device pointers on host device as well

### DIFF
--- a/flang/test/Lower/OpenMP/target-data-if-false.f90
+++ b/flang/test/Lower/OpenMP/target-data-if-false.f90
@@ -1,0 +1,25 @@
+!RUN: %flang_fc1 -emit-llvm -fopenmp %openmp_flags -fopenmp-version=52 %s -o - | FileCheck %s
+
+!Check that this doesn't crash.
+
+!CHECK-LABEL: define void @f00_()
+!CHECK: call i1 @_FortranAioOutputDerivedType
+
+subroutine f00
+  use iso_c_binding
+  type(c_ptr) :: x
+
+!$omp target data use_device_ptr(x) if(.false.)
+  print *, x
+!$omp end target data
+end
+
+!CHECK-LABEL: define void @f01_()
+!CHECK: call i1 @_FortranAioOutputInteger32
+subroutine f01
+  integer :: x
+
+!$omp target data use_device_addr(x) if(.false.)
+  print *, x
+!$omp end target data
+end

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4549,6 +4549,18 @@ convertOmpTargetData(Operation *op, llvm::IRBuilderBase &builder,
       }
       break;
     case BodyGenTy::DupNoPriv:
+      if (info.DevicePtrInfoMap.empty()) {
+        // For host device we still need to do the mapping for codegen,
+        // otherwise it may try to lookup a missing value.
+        if (!ompBuilder->Config.IsTargetDevice.value_or(false)) {
+          mapUseDevice(llvm::OpenMPIRBuilder::DeviceInfoTy::Address,
+                       blockArgIface.getUseDeviceAddrBlockArgs(),
+                       useDeviceAddrVars, mapData);
+          mapUseDevice(llvm::OpenMPIRBuilder::DeviceInfoTy::Pointer,
+                       blockArgIface.getUseDevicePtrBlockArgs(),
+                       useDevicePtrVars, mapData);
+        }
+      }
       // We must always restoreIP regardless of doing anything the caller
       // does not restore it, leading to incorrect (no) branch generation.
       builder.restoreIP(codeGenIP);

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4518,6 +4518,8 @@ convertOmpTargetData(Operation *op, llvm::IRBuilderBase &builder,
   using BodyGenTy = llvm::OpenMPIRBuilder::BodyGenTy;
   auto bodyGenCB = [&](InsertPointTy codeGenIP, BodyGenTy bodyGenType)
       -> llvm::OpenMPIRBuilder::InsertPointOrErrorTy {
+    // We must always restoreIP regardless of doing anything the caller
+    // does not restore it, leading to incorrect (no) branch generation.
     builder.restoreIP(codeGenIP);
     assert(isa<omp::TargetDataOp>(op) &&
            "BodyGen requested for non TargetDataOp");
@@ -4561,9 +4563,6 @@ convertOmpTargetData(Operation *op, llvm::IRBuilderBase &builder,
                        useDevicePtrVars, mapData);
         }
       }
-      // We must always restoreIP regardless of doing anything the caller
-      // does not restore it, leading to incorrect (no) branch generation.
-      builder.restoreIP(codeGenIP);
       break;
     case BodyGenTy::NoPriv:
       // If device info is available then region has already been generated


### PR DESCRIPTION
Given a TARGET DATA construct with USE_DEVICE_PTR(x) and IF(FALSE), the compiler will crash if `x` was used in the body. The cause of the crash is that the MLIR->LLVM codegen tries to look up the translated value of x, but one had not been mapped.

Given an IF clause, the translation will generate an if-then-else construct, with the "else" block corresponding to the false condition, i.e. the host device playing the role of the target device. In that block, still process the USE_DEVICE_ADDR/USE_DEVICE_PTR clauses, which will cause the translation mappings to be created.

Fixes https://github.com/llvm/llvm-project/issues/145558