### PR TITLE
[llvm] annotate WindowsDriver and WIndowsManifest interfaces for DLL export

### DIFF
--- a/llvm/include/llvm/WindowsDriver/MSVCPaths.h
+++ b/llvm/include/llvm/WindowsDriver/MSVCPaths.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_WINDOWSDRIVER_MSVCPATHS_H
 #define LLVM_WINDOWSDRIVER_MSVCPATHS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
 #include <string>
@@ -45,50 +45,56 @@ LLVM_ABI const char *archToLegacyVCArch(llvm::Triple::ArchType Arch);
 // Similar to the above function, but for DevDiv internal builds.
 LLVM_ABI const char *archToDevDivInternalArch(llvm::Triple::ArchType Arch);
 
-LLVM_ABI bool appendArchToWindowsSDKLibPath(int SDKMajor, llvm::SmallString<128> LibPath,
-                                   llvm::Triple::ArchType Arch,
-                                   std::string &path);
+LLVM_ABI bool appendArchToWindowsSDKLibPath(int SDKMajor,
+                                            llvm::SmallString<128> LibPath,
+                                            llvm::Triple::ArchType Arch,
+                                            std::string &path);
 
 // Get the path to a specific subdirectory in the current toolchain for
 // a given target architecture.
 // VS2017 changed the VC toolchain layout, so this should be used instead
 // of hardcoding paths.
-LLVM_ABI std::string getSubDirectoryPath(SubDirectoryType Type, ToolsetLayout VSLayout,
-                                const std::string &VCToolChainPath,
-                                llvm::Triple::ArchType TargetArch,
-                                llvm::StringRef SubdirParent = "");
+LLVM_ABI std::string getSubDirectoryPath(SubDirectoryType Type,
+                                         ToolsetLayout VSLayout,
+                                         const std::string &VCToolChainPath,
+                                         llvm::Triple::ArchType TargetArch,
+                                         llvm::StringRef SubdirParent = "");
 
 // Check if the Include path of a specified version of Visual Studio contains
 // specific header files. If not, they are probably shipped with Universal CRT.
-LLVM_ABI bool useUniversalCRT(ToolsetLayout VSLayout, const std::string &VCToolChainPath,
-                     llvm::Triple::ArchType TargetArch,
-                     llvm::vfs::FileSystem &VFS);
+LLVM_ABI bool useUniversalCRT(ToolsetLayout VSLayout,
+                              const std::string &VCToolChainPath,
+                              llvm::Triple::ArchType TargetArch,
+                              llvm::vfs::FileSystem &VFS);
 
 /// Get Windows SDK installation directory.
 LLVM_ABI bool getWindowsSDKDir(vfs::FileSystem &VFS,
+                               std::optional<llvm::StringRef> WinSdkDir,
+                               std::optional<llvm::StringRef> WinSdkVersion,
+                               std::optional<llvm::StringRef> WinSysRoot,
+                               std::string &Path, int &Major,
+                               std::string &WindowsSDKIncludeVersion,
+                               std::string &WindowsSDKLibVersion);
+
+LLVM_ABI bool
+getUniversalCRTSdkDir(vfs::FileSystem &VFS,
                       std::optional<llvm::StringRef> WinSdkDir,
                       std::optional<llvm::StringRef> WinSdkVersion,
                       std::optional<llvm::StringRef> WinSysRoot,
-                      std::string &Path, int &Major,
-                      std::string &WindowsSDKIncludeVersion,
-                      std::string &WindowsSDKLibVersion);
-
-LLVM_ABI bool getUniversalCRTSdkDir(vfs::FileSystem &VFS,
-                           std::optional<llvm::StringRef> WinSdkDir,
-                           std::optional<llvm::StringRef> WinSdkVersion,
-                           std::optional<llvm::StringRef> WinSysRoot,
-                           std::string &Path, std::string &UCRTVersion);
+                      std::string &Path, std::string &UCRTVersion);
 
 // Check command line arguments to try and find a toolchain.
-LLVM_ABI bool findVCToolChainViaCommandLine(
-    vfs::FileSystem &VFS, std::optional<llvm::StringRef> VCToolsDir,
-    std::optional<llvm::StringRef> VCToolsVersion,
-    std::optional<llvm::StringRef> WinSysRoot, std::string &Path,
-    ToolsetLayout &VSLayout);
+LLVM_ABI bool
+findVCToolChainViaCommandLine(vfs::FileSystem &VFS,
+                              std::optional<llvm::StringRef> VCToolsDir,
+                              std::optional<llvm::StringRef> VCToolsVersion,
+                              std::optional<llvm::StringRef> WinSysRoot,
+                              std::string &Path, ToolsetLayout &VSLayout);
 
 // Check various environment variables to try and find a toolchain.
-LLVM_ABI bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS, std::string &Path,
-                                   ToolsetLayout &VSLayout);
+LLVM_ABI bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS,
+                                            std::string &Path,
+                                            ToolsetLayout &VSLayout);
 
 // Query the Setup Config server for installs, then pick the newest version
 // and find its default VC toolchain. If `VCToolsVersion` is specified, that
@@ -104,7 +110,8 @@ findVCToolChainViaSetupConfig(vfs::FileSystem &VFS,
 // Look in the registry for Visual Studio installs, and use that to get
 // a toolchain path. VS2017 and newer don't get added to the registry.
 // So if we find something here, we know that it's an older version.
-LLVM_ABI bool findVCToolChainViaRegistry(std::string &Path, ToolsetLayout &VSLayout);
+LLVM_ABI bool findVCToolChainViaRegistry(std::string &Path,
+                                         ToolsetLayout &VSLayout);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/WindowsDriver/MSVCPaths.h
+++ b/llvm/include/llvm/WindowsDriver/MSVCPaths.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_WINDOWSDRIVER_MSVCPATHS_H
 #define LLVM_WINDOWSDRIVER_MSVCPATHS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/TargetParser/Triple.h"
@@ -36,15 +37,15 @@ enum class ToolsetLayout {
 // Windows SDKs and VC Toolchains group their contents into subdirectories based
 // on the target architecture. This function converts an llvm::Triple::ArchType
 // to the corresponding subdirectory name.
-const char *archToWindowsSDKArch(llvm::Triple::ArchType Arch);
+LLVM_ABI const char *archToWindowsSDKArch(llvm::Triple::ArchType Arch);
 
 // Similar to the above function, but for Visual Studios before VS2017.
-const char *archToLegacyVCArch(llvm::Triple::ArchType Arch);
+LLVM_ABI const char *archToLegacyVCArch(llvm::Triple::ArchType Arch);
 
 // Similar to the above function, but for DevDiv internal builds.
-const char *archToDevDivInternalArch(llvm::Triple::ArchType Arch);
+LLVM_ABI const char *archToDevDivInternalArch(llvm::Triple::ArchType Arch);
 
-bool appendArchToWindowsSDKLibPath(int SDKMajor, llvm::SmallString<128> LibPath,
+LLVM_ABI bool appendArchToWindowsSDKLibPath(int SDKMajor, llvm::SmallString<128> LibPath,
                                    llvm::Triple::ArchType Arch,
                                    std::string &path);
 
@@ -52,19 +53,19 @@ bool appendArchToWindowsSDKLibPath(int SDKMajor, llvm::SmallString<128> LibPath,
 // a given target architecture.
 // VS2017 changed the VC toolchain layout, so this should be used instead
 // of hardcoding paths.
-std::string getSubDirectoryPath(SubDirectoryType Type, ToolsetLayout VSLayout,
+LLVM_ABI std::string getSubDirectoryPath(SubDirectoryType Type, ToolsetLayout VSLayout,
                                 const std::string &VCToolChainPath,
                                 llvm::Triple::ArchType TargetArch,
                                 llvm::StringRef SubdirParent = "");
 
 // Check if the Include path of a specified version of Visual Studio contains
 // specific header files. If not, they are probably shipped with Universal CRT.
-bool useUniversalCRT(ToolsetLayout VSLayout, const std::string &VCToolChainPath,
+LLVM_ABI bool useUniversalCRT(ToolsetLayout VSLayout, const std::string &VCToolChainPath,
                      llvm::Triple::ArchType TargetArch,
                      llvm::vfs::FileSystem &VFS);
 
 /// Get Windows SDK installation directory.
-bool getWindowsSDKDir(vfs::FileSystem &VFS,
+LLVM_ABI bool getWindowsSDKDir(vfs::FileSystem &VFS,
                       std::optional<llvm::StringRef> WinSdkDir,
                       std::optional<llvm::StringRef> WinSdkVersion,
                       std::optional<llvm::StringRef> WinSysRoot,
@@ -72,21 +73,21 @@ bool getWindowsSDKDir(vfs::FileSystem &VFS,
                       std::string &WindowsSDKIncludeVersion,
                       std::string &WindowsSDKLibVersion);
 
-bool getUniversalCRTSdkDir(vfs::FileSystem &VFS,
+LLVM_ABI bool getUniversalCRTSdkDir(vfs::FileSystem &VFS,
                            std::optional<llvm::StringRef> WinSdkDir,
                            std::optional<llvm::StringRef> WinSdkVersion,
                            std::optional<llvm::StringRef> WinSysRoot,
                            std::string &Path, std::string &UCRTVersion);
 
 // Check command line arguments to try and find a toolchain.
-bool findVCToolChainViaCommandLine(
+LLVM_ABI bool findVCToolChainViaCommandLine(
     vfs::FileSystem &VFS, std::optional<llvm::StringRef> VCToolsDir,
     std::optional<llvm::StringRef> VCToolsVersion,
     std::optional<llvm::StringRef> WinSysRoot, std::string &Path,
     ToolsetLayout &VSLayout);
 
 // Check various environment variables to try and find a toolchain.
-bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS, std::string &Path,
+LLVM_ABI bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS, std::string &Path,
                                    ToolsetLayout &VSLayout);
 
 // Query the Setup Config server for installs, then pick the newest version
@@ -95,7 +96,7 @@ bool findVCToolChainViaEnvironment(vfs::FileSystem &VFS, std::string &Path,
 //
 // This is the preferred way to discover new Visual Studios, as they're no
 // longer listed in the registry.
-bool
+LLVM_ABI bool
 findVCToolChainViaSetupConfig(vfs::FileSystem &VFS,
                               std::optional<llvm::StringRef> VCToolsVersion,
                               std::string &Path, ToolsetLayout &VSLayout);
@@ -103,7 +104,7 @@ findVCToolChainViaSetupConfig(vfs::FileSystem &VFS,
 // Look in the registry for Visual Studio installs, and use that to get
 // a toolchain path. VS2017 and newer don't get added to the registry.
 // So if we find something here, we know that it's an older version.
-bool findVCToolChainViaRegistry(std::string &Path, ToolsetLayout &VSLayout);
+LLVM_ABI bool findVCToolChainViaRegistry(std::string &Path, ToolsetLayout &VSLayout);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
+++ b/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
@@ -37,7 +37,8 @@ namespace windows_manifest {
 
 LLVM_ABI bool isAvailable();
 
-class LLVM_ABI WindowsManifestError : public ErrorInfo<WindowsManifestError, ECError> {
+class LLVM_ABI WindowsManifestError
+    : public ErrorInfo<WindowsManifestError, ECError> {
 public:
   static char ID;
   WindowsManifestError(const Twine &Msg);

--- a/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
+++ b/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
@@ -25,6 +25,7 @@
 #ifndef LLVM_WINDOWSMANIFEST_WINDOWSMANIFESTMERGER_H
 #define LLVM_WINDOWSMANIFEST_WINDOWSMANIFESTMERGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -34,9 +35,9 @@ class MemoryBufferRef;
 
 namespace windows_manifest {
 
-bool isAvailable();
+LLVM_ABI bool isAvailable();
 
-class WindowsManifestError : public ErrorInfo<WindowsManifestError, ECError> {
+class LLVM_ABI WindowsManifestError : public ErrorInfo<WindowsManifestError, ECError> {
 public:
   static char ID;
   WindowsManifestError(const Twine &Msg);
@@ -48,13 +49,13 @@ private:
 
 class WindowsManifestMerger {
 public:
-  WindowsManifestMerger();
-  ~WindowsManifestMerger();
-  Error merge(MemoryBufferRef Manifest);
+  LLVM_ABI WindowsManifestMerger();
+  LLVM_ABI ~WindowsManifestMerger();
+  LLVM_ABI Error merge(MemoryBufferRef Manifest);
 
   // Returns vector containing merged xml manifest, or uninitialized vector for
   // empty manifest.
-  std::unique_ptr<MemoryBuffer> getMergedManifest();
+  LLVM_ABI std::unique_ptr<MemoryBuffer> getMergedManifest();
 
 private:
   class WindowsManifestMergerImpl;


### PR DESCRIPTION
## Purpose
This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the WindowsDriver and WindowsManifest interfaces. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background
This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview
These changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

## Validation
Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang