### PR TITLE
[bazel] Add //mlir:IR to Support for #144897

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -4845,7 +4845,10 @@ cc_library(
     ]),
     hdrs = glob(["include/mlir/Support/*.h"]),
     includes = ["include"],
-    deps = ["//llvm:Support"],
+    deps = [
+        "//llvm:Support"
+        "//mlir:IR",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
PR https://github.com/llvm/llvm-project/pull/144897 added #include "mlir/IR/Visitors.h" to mlir/include/mlir/Support/StateStack.h. This change fixes the build file.