### PR TITLE
[llvm] annotate `LLVMCloneModule` for export

### DIFF
--- a/llvm/lib/Transforms/Utils/CloneModule.cpp
+++ b/llvm/lib/Transforms/Utils/CloneModule.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm-c/Core.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Transforms/Utils/Cloning.h"


### PR DESCRIPTION
## Purpose
This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the implementation of `LLVMCloneModule ` with `LLVM_ABI` to match its declaration in `llvm-c/Core.h`. The annotation currently has no meaningful impact on the LLVM build; however, it is  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background
This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Validation
Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang